### PR TITLE
feat(feishu-doc): add configurable create permission grants [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Docs: https://docs.openclaw.ai
 - Config/Doctor group allowlist diagnostics: align `groupPolicy: "allowlist"` warnings with per-channel runtime semantics by excluding Google Chat sender-list checks and by warning when no-fallback channels (for example iMessage) omit `groupAllowFrom`, with regression coverage. (#28477) Thanks @tonydehnke.
 - Onboarding/Custom providers: use Azure OpenAI-specific verification auth/payload shape (`api-key`, deployment-path chat completions payload) when probing Azure endpoints so valid Azure custom-provider setup no longer fails preflight. (#29421) Thanks @kunalk16.
 - Feishu/Docx editing tools: add `feishu_doc` positional insert, table row/column operations, table-cell merge, and color-text updates; switch markdown write/append/insert to Descendant API insertion with large-document batching; and harden image uploads for data URI/base64/local-path inputs with strict validation and routing-safe upload metadata. (#29411) Thanks @Elarwei001.
+- Feishu/Doc create permission grants: support generic `feishu_doc create` permission grant parameters (`grant_member_type`, `grant_member_id`, `grant_perm_type`) and add account-level default grant config (`docCreateGrantMemberType`, `docCreateGrantMemberId`, `docCreateGrantPermType`) so newly created docs can auto-grant edit/full access to target users/departments. (#30595)
 
 ## 2026.2.26
 

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -581,28 +581,42 @@ Full configuration: [Gateway configuration](/gateway/configuration)
 
 Key options:
 
-| Setting                                           | Description                     | Default          |
-| ------------------------------------------------- | ------------------------------- | ---------------- |
-| `channels.feishu.enabled`                         | Enable/disable channel          | `true`           |
-| `channels.feishu.domain`                          | API domain (`feishu` or `lark`) | `feishu`         |
-| `channels.feishu.connectionMode`                  | Event transport mode            | `websocket`      |
-| `channels.feishu.verificationToken`               | Required for webhook mode       | -                |
-| `channels.feishu.webhookPath`                     | Webhook route path              | `/feishu/events` |
-| `channels.feishu.webhookHost`                     | Webhook bind host               | `127.0.0.1`      |
-| `channels.feishu.webhookPort`                     | Webhook bind port               | `3000`           |
-| `channels.feishu.accounts.<id>.appId`             | App ID                          | -                |
-| `channels.feishu.accounts.<id>.appSecret`         | App Secret                      | -                |
-| `channels.feishu.accounts.<id>.domain`            | Per-account API domain override | `feishu`         |
-| `channels.feishu.dmPolicy`                        | DM policy                       | `pairing`        |
-| `channels.feishu.allowFrom`                       | DM allowlist (open_id list)     | -                |
-| `channels.feishu.groupPolicy`                     | Group policy                    | `open`           |
-| `channels.feishu.groupAllowFrom`                  | Group allowlist                 | -                |
-| `channels.feishu.groups.<chat_id>.requireMention` | Require @mention                | `true`           |
-| `channels.feishu.groups.<chat_id>.enabled`        | Enable group                    | `true`           |
-| `channels.feishu.textChunkLimit`                  | Message chunk size              | `2000`           |
-| `channels.feishu.mediaMaxMb`                      | Media size limit                | `30`             |
-| `channels.feishu.streaming`                       | Enable streaming card output    | `true`           |
-| `channels.feishu.blockStreaming`                  | Enable block streaming          | `true`           |
+| Setting                                           | Description                                                                        | Default          |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------- | ---------------- |
+| `channels.feishu.enabled`                         | Enable/disable channel                                                             | `true`           |
+| `channels.feishu.domain`                          | API domain (`feishu` or `lark`)                                                    | `feishu`         |
+| `channels.feishu.connectionMode`                  | Event transport mode                                                               | `websocket`      |
+| `channels.feishu.verificationToken`               | Required for webhook mode                                                          | -                |
+| `channels.feishu.webhookPath`                     | Webhook route path                                                                 | `/feishu/events` |
+| `channels.feishu.webhookHost`                     | Webhook bind host                                                                  | `127.0.0.1`      |
+| `channels.feishu.webhookPort`                     | Webhook bind port                                                                  | `3000`           |
+| `channels.feishu.accounts.<id>.appId`             | App ID                                                                             | -                |
+| `channels.feishu.accounts.<id>.appSecret`         | App Secret                                                                         | -                |
+| `channels.feishu.accounts.<id>.domain`            | Per-account API domain override                                                    | `feishu`         |
+| `channels.feishu.dmPolicy`                        | DM policy                                                                          | `pairing`        |
+| `channels.feishu.allowFrom`                       | DM allowlist (open_id list)                                                        | -                |
+| `channels.feishu.groupPolicy`                     | Group policy                                                                       | `open`           |
+| `channels.feishu.groupAllowFrom`                  | Group allowlist                                                                    | -                |
+| `channels.feishu.groups.<chat_id>.requireMention` | Require @mention                                                                   | `true`           |
+| `channels.feishu.groups.<chat_id>.enabled`        | Enable group                                                                       | `true`           |
+| `channels.feishu.textChunkLimit`                  | Message chunk size                                                                 | `2000`           |
+| `channels.feishu.mediaMaxMb`                      | Media size limit                                                                   | `30`             |
+| `channels.feishu.streaming`                       | Enable streaming card output                                                       | `true`           |
+| `channels.feishu.blockStreaming`                  | Enable block streaming                                                             | `true`           |
+| `channels.feishu.docCreateGrantMemberType`        | Default `feishu_doc create` grant member type (`openid`, `opendepartmentid`, etc.) | -                |
+| `channels.feishu.docCreateGrantMemberId`          | Default `feishu_doc create` grant member id                                        | -                |
+| `channels.feishu.docCreateGrantPermType`          | Default `feishu_doc create` grant permission (`view`, `edit`, `full_access`)       | -                |
+
+You can set these defaults per account as well:
+
+- `channels.feishu.accounts.<id>.docCreateGrantMemberType`
+- `channels.feishu.accounts.<id>.docCreateGrantMemberId`
+- `channels.feishu.accounts.<id>.docCreateGrantPermType`
+
+For one-off document creation calls, `feishu_doc` also supports:
+
+- `grant_member_type`, `grant_member_id`, `grant_perm_type`
+- legacy compatibility fields: `owner_open_id`, `owner_perm_type`
 
 ---
 

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -137,4 +137,25 @@ describe("FeishuConfigSchema optimization flags", () => {
     expect(result.accounts?.main?.typingIndicator).toBe(false);
     expect(result.accounts?.main?.resolveSenderNames).toBe(false);
   });
+
+  it("accepts default doc create permission grant settings", () => {
+    const result = FeishuConfigSchema.parse({
+      docCreateGrantMemberType: "openid",
+      docCreateGrantMemberId: "ou_default_editor",
+      docCreateGrantPermType: "edit",
+      accounts: {
+        main: {
+          docCreateGrantMemberType: "opendepartmentid",
+          docCreateGrantMemberId: "od_root_department",
+          docCreateGrantPermType: "edit",
+        },
+      },
+    });
+    expect(result.docCreateGrantMemberType).toBe("openid");
+    expect(result.docCreateGrantMemberId).toBe("ou_default_editor");
+    expect(result.docCreateGrantPermType).toBe("edit");
+    expect(result.accounts?.main?.docCreateGrantMemberType).toBe("opendepartmentid");
+    expect(result.accounts?.main?.docCreateGrantMemberId).toBe("od_root_department");
+    expect(result.accounts?.main?.docCreateGrantPermType).toBe("edit");
+  });
 });

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -112,6 +112,19 @@ const GroupSessionScopeSchema = z
  */
 const TopicSessionModeSchema = z.enum(["disabled", "enabled"]).optional();
 const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();
+const DocCreateGrantMemberTypeSchema = z
+  .enum([
+    "email",
+    "openid",
+    "unionid",
+    "openchat",
+    "opendepartmentid",
+    "userid",
+    "groupid",
+    "wikispaceid",
+  ])
+  .optional();
+const DocCreateGrantPermTypeSchema = z.enum(["view", "edit", "full_access"]).optional();
 
 /**
  * Reply-in-thread mode for group chats.
@@ -165,6 +178,9 @@ const FeishuSharedConfigShape = {
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),
+  docCreateGrantMemberType: DocCreateGrantMemberTypeSchema,
+  docCreateGrantMemberId: z.string().optional(),
+  docCreateGrantPermType: DocCreateGrantPermTypeSchema,
 };
 
 /**

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -29,6 +29,35 @@ export const FeishuDocSchema = Type.Union([
     action: Type.Literal("create"),
     title: Type.String({ description: "Document title" }),
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
+    grant_member_type: Type.Optional(
+      Type.Union(
+        [
+          Type.Literal("email"),
+          Type.Literal("openid"),
+          Type.Literal("unionid"),
+          Type.Literal("openchat"),
+          Type.Literal("opendepartmentid"),
+          Type.Literal("userid"),
+          Type.Literal("groupid"),
+          Type.Literal("wikispaceid"),
+        ],
+        {
+          description:
+            "Permission grant member type. Use with grant_member_id. For backward compatibility, owner_open_id still works.",
+        },
+      ),
+    ),
+    grant_member_id: Type.Optional(
+      Type.String({
+        description:
+          "Permission grant member id. For organization-wide edit, use your tenant root opendepartmentid.",
+      }),
+    ),
+    grant_perm_type: Type.Optional(
+      Type.Union([Type.Literal("view"), Type.Literal("edit"), Type.Literal("full_access")], {
+        description: "Permission type for grant_member_id/member_type (default: full_access)",
+      }),
+    ),
     owner_open_id: Type.Optional(
       Type.String({ description: "Open ID of the user to grant ownership permission" }),
     ),

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -443,6 +443,95 @@ describe("feishu_doc image fetch hardening", () => {
     expect(result.details.owner_permission_added).toBeUndefined();
   });
 
+  it("supports generic create permission grant parameters", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDocTools({
+      config: {
+        channels: {
+          feishu: {
+            appId: "app_id",
+            appSecret: "app_secret",
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    const feishuDocTool = registerTool.mock.calls
+      .map((call) => call[0])
+      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
+      .find((tool) => tool.name === "feishu_doc");
+    expect(feishuDocTool).toBeDefined();
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "create",
+      title: "Demo",
+      grant_member_type: "opendepartmentid",
+      grant_member_id: "od_root",
+      grant_perm_type: "edit",
+    });
+
+    expect(permissionMemberCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          member_type: "opendepartmentid",
+          member_id: "od_root",
+          perm: "edit",
+        }),
+      }),
+    );
+    expect(result.details.permission_added).toBe(true);
+    expect(result.details.permission_member_type).toBe("opendepartmentid");
+    expect(result.details.permission_member_id).toBe("od_root");
+    expect(result.details.permission_perm_type).toBe("edit");
+    expect(result.details.owner_permission_added).toBeUndefined();
+  });
+
+  it("uses configured default create permission grant when params are omitted", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDocTools({
+      config: {
+        channels: {
+          feishu: {
+            appId: "app_id",
+            appSecret: "app_secret",
+            docCreateGrantMemberType: "openid",
+            docCreateGrantMemberId: "ou_default_editor",
+            docCreateGrantPermType: "edit",
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    const feishuDocTool = registerTool.mock.calls
+      .map((call) => call[0])
+      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
+      .find((tool) => tool.name === "feishu_doc");
+    expect(feishuDocTool).toBeDefined();
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "create",
+      title: "Demo",
+    });
+
+    expect(permissionMemberCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          member_type: "openid",
+          member_id: "ou_default_editor",
+          perm: "edit",
+        }),
+      }),
+    );
+    expect(result.details.permission_added).toBe(true);
+    expect(result.details.owner_permission_added).toBe(true);
+    expect(result.details.owner_open_id).toBe("ou_default_editor");
+    expect(result.details.owner_perm_type).toBe("edit");
+  });
+
   it("returns an error when create response omits document_id", async () => {
     documentCreateMock.mockResolvedValueOnce({
       code: 0,

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -33,6 +33,17 @@ function json(data: unknown) {
   };
 }
 
+type DrivePermissionMemberType =
+  | "email"
+  | "openid"
+  | "unionid"
+  | "openchat"
+  | "opendepartmentid"
+  | "userid"
+  | "groupid"
+  | "wikispaceid";
+type DrivePermissionType = "view" | "edit" | "full_access";
+
 /** Extract image URLs from markdown content */
 function extractImageUrls(markdown: string): string[] {
   const regex = /!\[[^\]]*\]\(([^)]+)\)/g;
@@ -751,8 +762,11 @@ async function createDoc(
   client: Lark.Client,
   title: string,
   folderToken?: string,
-  ownerOpenId?: string,
-  ownerPermType: "view" | "edit" | "full_access" = "full_access",
+  permissionGrant?: {
+    memberType: DrivePermissionMemberType;
+    memberId: string;
+    permType: DrivePermissionType;
+  },
 ) {
   const res = await client.docx.document.create({
     data: { title, folder_token: folderToken },
@@ -765,23 +779,22 @@ async function createDoc(
   if (!docToken) {
     throw new Error("Document creation succeeded but no document_id was returned");
   }
-  let ownerPermissionAdded = false;
+  let permissionAdded = false;
 
-  // Auto add owner permission if ownerOpenId is provided
-  if (docToken && ownerOpenId) {
+  if (docToken && permissionGrant) {
     try {
       await client.drive.permissionMember.create({
         path: { token: docToken },
         params: { type: "docx", need_notification: false },
         data: {
-          member_type: "openid",
-          member_id: ownerOpenId,
-          perm: ownerPermType,
+          member_type: permissionGrant.memberType,
+          member_id: permissionGrant.memberId,
+          perm: permissionGrant.permType,
         },
       });
-      ownerPermissionAdded = true;
+      permissionAdded = true;
     } catch (err) {
-      console.warn("Failed to add owner permission (non-critical):", err);
+      console.warn("Failed to add document permission grant (non-critical):", err);
     }
   }
 
@@ -789,11 +802,18 @@ async function createDoc(
     document_id: docToken,
     title: doc?.title,
     url: `https://feishu.cn/docx/${docToken}`,
-    ...(ownerOpenId &&
-      ownerPermissionAdded && {
+    ...(permissionGrant &&
+      permissionAdded && {
+        permission_added: true,
+        permission_member_type: permissionGrant.memberType,
+        permission_member_id: permissionGrant.memberId,
+        permission_perm_type: permissionGrant.permType,
+      }),
+    ...(permissionGrant?.memberType === "openid" &&
+      permissionAdded && {
         owner_permission_added: true,
-        owner_open_id: ownerOpenId,
-        owner_perm_type: ownerPermType,
+        owner_open_id: permissionGrant.memberId,
+        owner_perm_type: permissionGrant.permType,
       }),
   };
 }
@@ -1246,6 +1266,45 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
     1024 *
     1024;
 
+  const getDocCreatePermissionGrant = (
+    params: FeishuDocExecuteParams,
+    defaultAccountId?: string,
+  ):
+    | {
+        memberType: DrivePermissionMemberType;
+        memberId: string;
+        permType: DrivePermissionType;
+      }
+    | undefined => {
+    const accountConfig = resolveFeishuToolAccount({
+      api,
+      executeParams: params,
+      defaultAccountId,
+    }).config;
+    const explicitMemberId = params.action === "create" ? params.grant_member_id?.trim() : "";
+    const legacyOwnerOpenId = params.action === "create" ? params.owner_open_id?.trim() : "";
+    const configuredMemberId = accountConfig.docCreateGrantMemberId?.trim() ?? "";
+    const memberId = explicitMemberId || legacyOwnerOpenId || configuredMemberId;
+    if (!memberId) {
+      return undefined;
+    }
+    const memberType: DrivePermissionMemberType =
+      (params.action === "create" ? params.grant_member_type : undefined) ??
+      (legacyOwnerOpenId ? "openid" : undefined) ??
+      accountConfig.docCreateGrantMemberType ??
+      "openid";
+    const permType: DrivePermissionType =
+      (params.action === "create" ? params.grant_perm_type : undefined) ??
+      (params.action === "create" ? params.owner_perm_type : undefined) ??
+      accountConfig.docCreateGrantPermType ??
+      "full_access";
+    return {
+      memberType,
+      memberId,
+      permType,
+    };
+  };
+
   // Main document tool with action-based dispatch
   if (toolsCfg.doc) {
     api.registerTool(
@@ -1295,16 +1354,10 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                       api.logger,
                     ),
                   );
-                case "create":
-                  return json(
-                    await createDoc(
-                      client,
-                      p.title,
-                      p.folder_token,
-                      p.owner_open_id,
-                      p.owner_perm_type,
-                    ),
-                  );
+                case "create": {
+                  const permissionGrant = getDocCreatePermissionGrant(p, defaultAccountId);
+                  return json(await createDoc(client, p.title, p.folder_token, permissionGrant));
+                }
                 case "list_blocks":
                   return json(await listBlocks(client, p.doc_token));
                 case "get_block":


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `feishu_doc` document creation can grant permissions only through per-call `owner_open_id`, with no account-level default and no generic member-type grant fields.
- Why it matters: users creating docs repeatedly must manually set grants each time, and cannot directly express non-user targets (for example department-based sharing) from create payloads.
- What changed: added generic create grant fields (`grant_member_type`, `grant_member_id`, `grant_perm_type`) and account/top-level defaults (`docCreateGrantMemberType`, `docCreateGrantMemberId`, `docCreateGrantPermType`) for automatic post-create permission grants.
- What did NOT change (scope boundary): no changes to non-create actions; no changes to existing `feishu_perm` tool behavior; legacy `owner_open_id`/`owner_perm_type` remains supported.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30595
- Related #30578

## User-visible / Behavior Changes

- `feishu_doc` `create` now accepts:
  - `grant_member_type`
  - `grant_member_id`
  - `grant_perm_type`
- Feishu channel config now supports defaults for doc-create permission grants:
  - `docCreateGrantMemberType`
  - `docCreateGrantMemberId`
  - `docCreateGrantPermType`
- Docs updated in `docs/channels/feishu.md`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js / vitest
- Model/provider: N/A
- Integration/channel (if any): Feishu plugin (`extensions/feishu`)
- Relevant config (redacted): `channels.feishu.docCreateGrant*`

### Steps

1. Register `feishu_doc` tool with Feishu plugin config.
2. Run `action: "create"` with `grant_member_*` fields.
3. Run `action: "create"` without grant fields but with `docCreateGrant*` config defaults.

### Expected

- Permission member grant is attempted after doc creation using explicit fields or defaults.
- Legacy `owner_open_id` compatibility remains intact.

### Actual

- Added regression coverage confirms generic grant payloads and config defaults are applied.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - generic create grant params path (`grant_member_*`) works.
  - config-default grant path (`docCreateGrant*`) works.
  - legacy owner fields still report owner details for `openid` grants.
- Edge cases checked:
  - omitting all grant fields and defaults skips permission grant.
  - grant failure remains non-fatal and does not block doc creation.
- What you did **not** verify:
  - live Feishu tenant integration against production APIs.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `4ed22e765a`.
- Files/config to restore:
  - `extensions/feishu/src/doc-schema.ts`
  - `extensions/feishu/src/docx.ts`
  - `extensions/feishu/src/config-schema.ts`
  - `extensions/feishu/src/docx.test.ts`
  - `extensions/feishu/src/config-schema.test.ts`
  - `docs/channels/feishu.md`
  - `CHANGELOG.md`
- Known bad symptoms reviewers should watch for:
  - missing permission grant fields in create response/details.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Misconfigured default grant IDs could apply unintended sharing to newly created docs.
  - Mitigation:
    - Defaults are opt-in; explicit per-call params override defaults; behavior documented in channel docs.
