### PR TITLE
fix(channels): remove ack reaction when agent returns NO_REPLY

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -448,6 +448,30 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   if (!anyReplyDelivered) {
     await draftStream.clear();
+    // Remove ack reaction even when agent returns NO_REPLY (fixes #30585)
+    removeAckReactionAfterReply({
+      removeAfterReply: ctx.removeAckAfterReply,
+      ackReactionPromise: prepared.ackReactionPromise,
+      ackReactionValue: prepared.ackReactionValue,
+      remove: () =>
+        removeSlackReaction(
+          message.channel,
+          prepared.ackReactionMessageTs ?? "",
+          prepared.ackReactionValue,
+          {
+            token: ctx.botToken,
+            client: ctx.app.client,
+          },
+        ),
+      onError: (err) => {
+        logAckFailure({
+          log: logVerbose,
+          channel: "slack",
+          target: `${message.channel}/${message.ts}`,
+          error: err,
+        });
+      },
+    });
     if (prepared.isRoomish) {
       clearHistoryEntriesIfEnabled({
         historyMap: ctx.channelHistories,

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -695,6 +695,26 @@ export const dispatchTelegramMessage = async ({
   }
 
   if (!hasFinalResponse) {
+    // Remove ack reaction even when agent returns NO_REPLY (fixes #30585)
+    if (!statusReactionController) {
+      removeAckReactionAfterReply({
+        removeAfterReply: removeAckAfterReply,
+        ackReactionPromise,
+        ackReactionValue: ackReactionPromise ? "ack" : null,
+        remove: () => reactionApi?.(chatId, msg.message_id ?? 0, []) ?? Promise.resolve(),
+        onError: (err) => {
+          if (!msg.message_id) {
+            return;
+          }
+          logAckFailure({
+            log: logVerbose,
+            channel: "telegram",
+            target: `${chatId}/${msg.message_id}`,
+            error: err,
+          });
+        },
+      });
+    }
     clearGroupHistory();
     return;
   }


### PR DESCRIPTION
## Summary

Fixes #30585

When `removeAckAfterReply` is enabled, the ack reaction (e.g. 👀) was only removed after a successful reply. If the agent decided not to reply (NO_REPLY), the reaction remained permanently stuck on the message.

## Changes

- **Telegram** (`bot-message-dispatch.ts`): Added `removeAckReactionAfterReply()` call in the `!hasFinalResponse` early-return path, mirroring the existing cleanup for typing indicators.
- **Slack** (`dispatch.ts`): Added the same `removeAckReactionAfterReply()` call in the `!anyReplyDelivered` early-return path.
- **Discord**: Already handles this correctly via its `statusReactionController` finally block — no changes needed.

## Testing

1. Configure `ackReaction` with `removeAckAfterReply: true` and `ackReactionScope: "group-mentions"`
2. Mention the bot with a message it will NO_REPLY to
3. Verify the ack reaction is removed after the run ends

The fix reuses the existing `removeAckReactionAfterReply` utility, which gracefully handles missing promises/values and logs failures via `logAckFailure`.