### PR TITLE
fix: add elevated config for Telegram channel (issue #30609)

### DIFF
--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -239,6 +239,10 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
       blockStreaming: true,
     },
     outbound: DEFAULT_OUTBOUND_TEXT_CHUNK_LIMIT_4000,
+    elevated: {
+      allowFromFallback: ({ cfg }) =>
+        cfg.channels?.telegram?.allowFrom ?? cfg.channels?.telegram?.dm?.allowFrom,
+    },
     config: {
       resolveAllowFrom: ({ cfg, accountId }) =>
         stringifyAllowFrom(resolveTelegramAccount({ cfg, accountId }).config.allowFrom ?? []),


### PR DESCRIPTION
## Summary

This fix adds the missing `elevated` configuration for the Telegram channel in `src/channels/dock.ts`. The issue was that the Telegram channel was missing the `allowFromFallback` configuration that other channels (like Discord) have, causing browser/crawling tools to fail with "permission denied" when accessed via Telegram, even when the user is explicitly whitelisted in `channels.telegram.allowFrom`.

## Changes

- Added `elevated` config to the Telegram dock entry in `src/channels/dock.ts`
- The config uses `allowFromFallback` to fall back to `cfg.channels?.telegram?.allowFrom` or `cfg.channels?.telegram?.dm?.allowFrom` when checking elevated tool permissions

This follows the same pattern as the Discord channel configuration which already has this `elevated` config.

## Testing

- The fix follows the existing pattern used by the Discord channel
- Users who have configured `channels.telegram.allowFrom` should now be able to use browser/crawling tools via Telegram

Fixes openclaw/openclaw#30609