### PR TITLE
fix(channels): cleanup ack reactions on NO_REPLY turns

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -448,6 +448,31 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   if (!anyReplyDelivered) {
     await draftStream.clear();
+    // Clean up ack reaction on NO_REPLY turns so the reaction does not
+    // remain stuck indefinitely (#30585).
+    removeAckReactionAfterReply({
+      removeAfterReply: ctx.removeAckAfterReply,
+      ackReactionPromise: prepared.ackReactionPromise,
+      ackReactionValue: prepared.ackReactionValue,
+      remove: () =>
+        removeSlackReaction(
+          message.channel,
+          prepared.ackReactionMessageTs ?? "",
+          prepared.ackReactionValue,
+          {
+            token: ctx.botToken,
+            client: ctx.app.client,
+          },
+        ),
+      onError: (err) => {
+        logAckFailure({
+          log: logVerbose,
+          channel: "slack",
+          target: `${message.channel}/${message.ts}`,
+          error: err,
+        });
+      },
+    });
     if (prepared.isRoomish) {
       clearHistoryEntriesIfEnabled({
         historyMap: ctx.channelHistories,

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1479,6 +1479,60 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
+  it("removes ack reaction on NO_REPLY when removeAckAfterReply is enabled", async () => {
+    const reactionApi = vi.fn().mockResolvedValue(undefined);
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ackReactionPromise: Promise.resolve(true),
+        reactionApi,
+        removeAckAfterReply: true,
+      }),
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(reactionApi).toHaveBeenCalledWith(123, 456, []);
+  });
+
+  it("does not remove ack reaction on NO_REPLY when removeAckAfterReply is disabled", async () => {
+    const reactionApi = vi.fn().mockResolvedValue(undefined);
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ackReactionPromise: Promise.resolve(true),
+        reactionApi,
+        removeAckAfterReply: false,
+      }),
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(reactionApi).not.toHaveBeenCalled();
+  });
+
+  it("does not remove ack reaction on NO_REPLY when ack was not sent", async () => {
+    const reactionApi = vi.fn().mockResolvedValue(undefined);
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ackReactionPromise: Promise.resolve(false),
+        reactionApi,
+        removeAckAfterReply: true,
+      }),
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(reactionApi).not.toHaveBeenCalled();
+  });
+
   it("falls back when all finals are skipped and clears preview", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -695,6 +695,28 @@ export const dispatchTelegramMessage = async ({
   }
 
   if (!hasFinalResponse) {
+    // Clean up ack reaction on NO_REPLY turns when there is no
+    // status-reaction controller so the reaction does not remain
+    // stuck indefinitely (#30585).
+    if (!statusReactionController) {
+      removeAckReactionAfterReply({
+        removeAfterReply: removeAckAfterReply,
+        ackReactionPromise,
+        ackReactionValue: ackReactionPromise ? "ack" : null,
+        remove: () => reactionApi?.(chatId, msg.message_id ?? 0, []) ?? Promise.resolve(),
+        onError: (err) => {
+          if (!msg.message_id) {
+            return;
+          }
+          logAckFailure({
+            log: logVerbose,
+            channel: "telegram",
+            target: `${chatId}/${msg.message_id}`,
+            error: err,
+          });
+        },
+      });
+    }
     clearGroupHistory();
     return;
   }


### PR DESCRIPTION
### Summary

When `messages.removeAckAfterReply` is enabled, the ack reaction (e.g. the thumbs-up emoji placed on a user's message to acknowledge receipt) should be removed after the agent finishes its turn — including turns that end with **NO_REPLY**. Currently, both the Telegram and Slack dispatchers skip the `removeAckReactionAfterReply` call on NO_REPLY paths, leaving orphaned ack reactions stuck on the original message indefinitely.

Fixes #30585.

### Root Cause

Both dispatchers share the same structural bug: the NO_REPLY early-return exits **before** the `removeAckReactionAfterReply` call site.

**Telegram** (`src/telegram/bot-message-dispatch.ts`):

```ts
// Before fix — line 697
if (!hasFinalResponse) {
  clearGroupHistory();
  return;            // ← exits here, removeAckReactionAfterReply never reached
}
```

**Slack** (`src/slack/monitor/message-handler/dispatch.ts`):

```ts
// Before fix — line 416
if (!anyReplyDelivered) {
  await draftStream.clear();
  // ... history cleanup ...
  return;            // ← exits here, removeAckReactionAfterReply never reached
}
```

### Fix

This PR adds the missing `removeAckReactionAfterReply` calls to the NO_REPLY early-return paths in both channels, using the **complete parameter set** (`ackReactionValue`, `remove`, `onError`) that mirrors the existing success-path calls.

| File | Change |
|------|--------|
| `src/telegram/bot-message-dispatch.ts` | Added `removeAckReactionAfterReply` inside the `!hasFinalResponse` block, guarded by `!statusReactionController` (the status-reaction controller handles its own cleanup via `setError()`). |
| `src/slack/monitor/message-handler/dispatch.ts` | Added `removeAckReactionAfterReply` inside the `!anyReplyDelivered` block, before the early return. No additional guard needed since Slack does not use a status-reaction controller in this path. |
| `src/telegram/bot-message-dispatch.test.ts` | Added 3 new test cases (see below). |

### Testing

Three new tests added to `src/telegram/bot-message-dispatch.test.ts`:

| Test | Asserts |
|------|---------|
| `removes ack reaction on NO_REPLY when removeAckAfterReply is enabled` | `reactionApi` is called with the correct chat/message/empty-reaction args |
| `does not remove ack reaction on NO_REPLY when removeAckAfterReply is disabled` | `reactionApi` is **not** called |
| `does not remove ack reaction on NO_REPLY when ack was not sent` | `reactionApi` is **not** called (ack promise resolved `false`) |

