### PR TITLE
fix(acpx): make doctor resilient to nvs PATH gaps

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -1,0 +1,42 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { injectNodeRuntimePath } from "./process.js";
+
+describe("injectNodeRuntimePath", () => {
+  it("prepends the current node runtime directory when missing", () => {
+    const env: NodeJS.ProcessEnv = { PATH: ["/usr/bin", "/bin"].join(path.delimiter) };
+    const execPath = "/Users/lidan/.nvs/default/bin/node";
+
+    const next = injectNodeRuntimePath({ env, execPath });
+
+    expect(next.PATH).toBe(
+      ["/Users/lidan/.nvs/default/bin", "/usr/bin", "/bin"].join(path.delimiter),
+    );
+    expect(env.PATH).toBe(["/usr/bin", "/bin"].join(path.delimiter));
+  });
+
+  it("keeps existing PATH key casing", () => {
+    const env: NodeJS.ProcessEnv = { Path: ["/usr/bin", "/bin"].join(path.delimiter) };
+    const execPath = "/Users/lidan/.nvs/default/bin/node";
+
+    const next = injectNodeRuntimePath({ env, execPath });
+
+    expect(next.Path).toBe(
+      ["/Users/lidan/.nvs/default/bin", "/usr/bin", "/bin"].join(path.delimiter),
+    );
+    expect(next.PATH).toBeUndefined();
+  });
+
+  it("does not duplicate runtime dir when already present", () => {
+    const runtimeDir = "/Users/lidan/.nvs/default/bin";
+    const env: NodeJS.ProcessEnv = {
+      PATH: [runtimeDir, "/usr/bin", "/bin"].join(path.delimiter),
+    };
+    const execPath = `${runtimeDir}/node`;
+
+    const next = injectNodeRuntimePath({ env, execPath });
+
+    expect(next).toBe(env);
+    expect(next.PATH).toBe([runtimeDir, "/usr/bin", "/bin"].join(path.delimiter));
+  });
+});

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -14,6 +14,55 @@ type ResolvedSpawnCommand = {
   shell?: boolean;
 };
 
+function resolvePathEnvKey(env: NodeJS.ProcessEnv): string {
+  const found = Object.keys(env).find((key) => key.toLowerCase() === "path");
+  return found ?? "PATH";
+}
+
+function hasPathSegment(pathValue: string, segment: string): boolean {
+  if (!pathValue || !segment) {
+    return false;
+  }
+  const expected = process.platform === "win32" ? segment.toLowerCase() : segment;
+  return pathValue.split(path.delimiter).some((entryRaw) => {
+    const entry = entryRaw.trim();
+    if (!entry) {
+      return false;
+    }
+    const normalized = process.platform === "win32" ? entry.toLowerCase() : entry;
+    return normalized === expected;
+  });
+}
+
+/**
+ * Ensure PATH includes the current Node runtime directory.
+ *
+ * This keeps `#!/usr/bin/env node` binaries (for example plugin-local `.bin/acpx`)
+ * executable even when the parent process PATH comes from a GUI/daemon context that
+ * omits user-managed Node locations (nvs/nvm/fnm/asdf).
+ */
+export function injectNodeRuntimePath(params?: {
+  env?: NodeJS.ProcessEnv;
+  execPath?: string;
+}): NodeJS.ProcessEnv {
+  const env = params?.env ?? process.env;
+  const execPath = params?.execPath ?? process.execPath;
+  const runtimeDir = path.dirname(execPath || "");
+  if (!runtimeDir) {
+    return env;
+  }
+  const pathKey = resolvePathEnvKey(env);
+  const currentPath = String(env[pathKey] ?? "");
+  if (hasPathSegment(currentPath, runtimeDir)) {
+    return env;
+  }
+  const nextPath = currentPath ? `${runtimeDir}${path.delimiter}${currentPath}` : runtimeDir;
+  return {
+    ...env,
+    [pathKey]: nextPath,
+  };
+}
+
 function resolveSpawnCommand(params: { command: string; args: string[] }): ResolvedSpawnCommand {
   if (process.platform !== "win32") {
     return { command: params.command, args: params.args };
@@ -53,7 +102,7 @@ export function spawnWithResolvedCommand(params: {
 
   return spawn(resolved.command, resolved.args, {
     cwd: params.cwd,
-    env: process.env,
+    env: injectNodeRuntimePath(),
     stdio: ["pipe", "pipe", "pipe"],
     shell: resolved.shell,
   });


### PR DESCRIPTION
## Summary

- **Problem:** ACPX doctor/runtime checks can report backend-unavailable when `acpx` is executable but its `#!/usr/bin/env node` shebang cannot find `node` because PATH in GUI/daemon contexts omits nvs-managed Node directories.
- **Why it matters:** `/acp doctor` fails for valid installs, especially with nvs/nvm/fnm-style node layouts, and blocks ACP onboarding.
- **What changed:** ACPX spawn path now injects the current runtime Node directory (`dirname(process.execPath)`) into PATH (without duplication) before launching subprocesses.
- **What did NOT change:** No change to ACP command semantics, backend selection, or install/update logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30623

## User-visible / Behavior Changes

- `/acp doctor` is more reliable on environments where PATH lacks user-managed Node dirs, because ACPX subprocesses can now resolve `node` from the current runtime directory.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js + Vitest
- Integration/channel: ACPX runtime subprocess launcher

### Steps

1. Simulate env PATH without runtime node dir.
2. Inject runtime path and verify it prepends exactly once and preserves PATH key casing.
3. Run ACPX runtime tests to ensure no regression in command execution.

### Expected

- Shebang-based ACPX binaries can still resolve node via injected runtime dir.

### Actual

- Before fix: doctor could fail with backend-unavailable due to missing node in PATH.
- After fix: subprocess env receives runtime node dir, enabling stable invocation.

## Evidence

- `pnpm exec vitest run extensions/acpx/src/runtime-internals/process.test.ts extensions/acpx/src/runtime.test.ts`

## Human Verification (required)

- Verified scenarios: runtime dir prepend, case-preserving PATH key handling, no-duplicate behavior.
- Edge cases checked: unchanged env object when runtime dir already present.
- What I did **not** verify: live nvs setup on the reporter’s exact machine.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `extensions/acpx/src/runtime-internals/process.ts` (+ test file).
- Known bad symptoms: PATH ordering surprises (mitigated by prepend-only and no duplication).

## Risks and Mitigations

- Risk: PATH mutation might affect downstream command resolution precedence.
- Mitigation: only prepends current runtime node dir; leaves all existing PATH entries intact.
