### PR TITLE
fix: internal hooks handlers stored in globalThis to survive bundle chunk boundaries

### DIFF
--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -110,8 +110,25 @@ export interface InternalHookEvent {
 
 export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | void;
 
-/** Registry of hook handlers by event key */
-const handlers = new Map<string, InternalHookHandler[]>();
+/**
+ * Registry of hook handlers by event key - stored in globalThis to survive bundle chunk boundaries.
+ * When the bundler splits code into multiple chunks, each chunk may get its own copy of
+ * module-level variables. Using globalThis ensures all chunks share the same handler registry.
+ */
+const GLOBAL_KEY = "__openclawInternalHookHandlers" as const;
+
+declare global {
+  // eslint-disable-next-line no-var -- must be var for globalThis augmentation
+  var __openclawInternalHookHandlers: Map<string, InternalHookHandler[]> | undefined;
+}
+
+function getGlobalHandlers(): Map<string, InternalHookHandler[]> {
+  if (!globalThis[GLOBAL_KEY]) {
+    globalThis[GLOBAL_KEY] = new Map<string, InternalHookHandler[]>();
+  }
+  return globalThis[GLOBAL_KEY];
+}
+
 const log = createSubsystemLogger("internal-hooks");
 
 /**
@@ -134,6 +151,7 @@ const log = createSubsystemLogger("internal-hooks");
  * ```
  */
 export function registerInternalHook(eventKey: string, handler: InternalHookHandler): void {
+  const handlers = getGlobalHandlers();
   if (!handlers.has(eventKey)) {
     handlers.set(eventKey, []);
   }
@@ -147,6 +165,7 @@ export function registerInternalHook(eventKey: string, handler: InternalHookHand
  * @param handler - The handler function to remove
  */
 export function unregisterInternalHook(eventKey: string, handler: InternalHookHandler): void {
+  const handlers = getGlobalHandlers();
   const eventHandlers = handlers.get(eventKey);
   if (!eventHandlers) {
     return;
@@ -167,14 +186,14 @@ export function unregisterInternalHook(eventKey: string, handler: InternalHookHa
  * Clear all registered hooks (useful for testing)
  */
 export function clearInternalHooks(): void {
-  handlers.clear();
+  getGlobalHandlers().clear();
 }
 
 /**
  * Get all registered event keys (useful for debugging)
  */
 export function getRegisteredEventKeys(): string[] {
-  return Array.from(handlers.keys());
+  return Array.from(getGlobalHandlers().keys());
 }
 
 /**
@@ -190,6 +209,7 @@ export function getRegisteredEventKeys(): string[] {
  * @param event - The event to trigger
  */
 export async function triggerInternalHook(event: InternalHookEvent): Promise<void> {
+  const handlers = getGlobalHandlers();
   const typeHandlers = handlers.get(event.type) ?? [];
   const specificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
 


### PR DESCRIPTION
## Summary

Fixes #30624 - Internal hook `message:sent` never fires due to split `handlers` Map between bundle chunks.

## Root Cause

The internal hook system (handlers Map, registerInternalHook, triggerInternalHook) was defined as a module-level variable. When bundled into multiple chunks, each chunk got its own handlers Map instance, causing hooks registered in one chunk to be invisible to triggers in another chunk.

## Solution

Store the handlers Map in globalThis (`globalThis.__openclawHookHandlers`) to ensure a single shared instance across all bundle chunks.

## Testing

- All 29 existing internal-hooks tests pass