### PR TITLE
fix: check chat allowlist before sender allowlist in Telegram group policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,11 @@ RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
 
 USER node
 COPY --chown=node:node . .
+# Fix permissions on extensions and config directories to prevent security warnings.
+# Docker COPY preserves original permissions, which may be too permissive (e.g., 777 on directories).
+# OpenClaw blocks plugins from world-writable paths for security.
+RUN find /app/extensions /app/.agent /app/.agents -type d -exec chmod 755 {} \; 2>/dev/null || true && \
+    find /app/extensions /app/.agent /app/.agents -type f -exec chmod 644 {} \; 2>/dev/null || true
 RUN pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -33,8 +33,13 @@ export function listFeishuAccountIds(cfg: ClawdbotConfig): string[] {
 
 /**
  * Resolve the default account ID.
+ * Honors channels.feishu.defaultAccount if configured.
  */
 export function resolveDefaultFeishuAccountId(cfg: ClawdbotConfig): string {
+  const feishuConfig = cfg.channels?.feishu as FeishuConfig | undefined;
+  if (feishuConfig?.defaultAccount?.trim()) {
+    return feishuConfig.defaultAccount.trim();
+  }
   const ids = listFeishuAccountIds(cfg);
   if (ids.includes(DEFAULT_ACCOUNT_ID)) {
     return DEFAULT_ACCOUNT_ID;
@@ -63,8 +68,8 @@ function resolveAccountConfig(
 function mergeFeishuAccountConfig(cfg: ClawdbotConfig, accountId: string): FeishuConfig {
   const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
 
-  // Extract base config (exclude accounts field to avoid recursion)
-  const { accounts: _ignored, ...base } = feishuCfg ?? {};
+  // Extract base config (exclude accounts and defaultAccount fields to avoid recursion and incorrect inheritance)
+  const { accounts: _ignored, defaultAccount: _ignored2, ...base } = feishuCfg ?? {};
 
   // Get account-specific overrides
   const account = resolveAccountConfig(cfg, accountId) ?? {};
@@ -99,12 +104,17 @@ export function resolveFeishuCredentials(cfg?: FeishuConfig): {
 
 /**
  * Resolve a complete Feishu account with merged config.
+ * When accountId is not provided, uses resolveDefaultFeishuAccountId to honor
+ * channels.feishu.defaultAccount configuration.
  */
 export function resolveFeishuAccount(params: {
   cfg: ClawdbotConfig;
   accountId?: string | null;
 }): ResolvedFeishuAccount {
-  const accountId = normalizeAccountId(params.accountId);
+  // If accountId is explicitly provided, normalize it; otherwise use configured default
+  const accountId = params.accountId?.trim()
+    ? normalizeAccountId(params.accountId)
+    : resolveDefaultFeishuAccountId(params.cfg);
   const feishuCfg = params.cfg.channels?.feishu as FeishuConfig | undefined;
 
   // Base enabled state (top-level)

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -213,6 +213,8 @@ export const FeishuConfigSchema = z
     resolveSenderNames: z.boolean().optional().default(true),
     // Multi-account configuration
     accounts: z.record(z.string(), FeishuAccountConfigSchema.optional()).optional(),
+    // Default account ID for outbound messages without explicit accountId
+    defaultAccount: z.string().optional(),
   })
   .strict()
   .superRefine((value, ctx) => {

--- a/extensions/feishu/src/targets.ts
+++ b/extensions/feishu/src/targets.ts
@@ -24,18 +24,28 @@ export function normalizeFeishuTarget(raw: string): string | null {
     return null;
   }
 
+  // Strip optional provider prefix (e.g., "feishu:")
+  let remaining = trimmed;
   const lowered = trimmed.toLowerCase();
-  if (lowered.startsWith("chat:")) {
-    return trimmed.slice("chat:".length).trim() || null;
-  }
-  if (lowered.startsWith("user:")) {
-    return trimmed.slice("user:".length).trim() || null;
-  }
-  if (lowered.startsWith("open_id:")) {
-    return trimmed.slice("open_id:".length).trim() || null;
+  if (lowered.startsWith("feishu:")) {
+    remaining = trimmed.slice("feishu:".length).trim();
+    if (!remaining) {
+      return null;
+    }
   }
 
-  return trimmed;
+  const lowerRemaining = remaining.toLowerCase();
+  if (lowerRemaining.startsWith("chat:")) {
+    return remaining.slice("chat:".length).trim() || null;
+  }
+  if (lowerRemaining.startsWith("user:")) {
+    return remaining.slice("user:".length).trim() || null;
+  }
+  if (lowerRemaining.startsWith("open_id:")) {
+    return remaining.slice("open_id:".length).trim() || null;
+  }
+
+  return remaining;
 }
 
 export function formatFeishuTarget(id: string, type?: FeishuIdType): string {
@@ -64,6 +74,11 @@ export function looksLikeFeishuId(raw: string): boolean {
   const trimmed = raw.trim();
   if (!trimmed) {
     return false;
+  }
+
+  // Accept provider-prefixed forms: feishu:user:..., feishu:chat:..., feishu:open_id:...
+  if (/^feishu:/i.test(trimmed)) {
+    return true;
   }
   if (/^(chat|user|open_id):/i.test(trimmed)) {
     return true;

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -11,8 +11,8 @@ import {
   type ChannelPlugin,
   type OpenClawConfig,
   type ChannelSetupInput,
+  waitForAbortSignal,
 } from "openclaw/plugin-sdk";
-import { waitForAbortSignal } from "../../../src/infra/abort-signal.js";
 import {
   listNextcloudTalkAccountIds,
   resolveDefaultNextcloudTalkAccountId,

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -87,6 +87,26 @@ describe("failover-error", () => {
     );
   });
 
+  // Issue #30484: HTTP 402 from Anthropic Max plan can indicate rate limit, not billing error
+  it("HTTP 402 with rate limit message returns rate_limit (not billing)", () => {
+    expect(resolveFailoverReasonFromError({ status: 402, message: "rate limit exceeded" })).toBe(
+      "rate_limit",
+    );
+    expect(resolveFailoverReasonFromError({ status: 402, message: "too many requests" })).toBe(
+      "rate_limit",
+    );
+    expect(resolveFailoverReasonFromError({ status: 402, message: "429 rate limit" })).toBe(
+      "rate_limit",
+    );
+    expect(resolveFailoverReasonFromError({ status: 402, message: "quota exceeded" })).toBe(
+      "rate_limit",
+    );
+    // Pure billing 402 should still return billing
+    expect(resolveFailoverReasonFromError({ status: 402, message: "payment required" })).toBe(
+      "billing",
+    );
+  });
+
   it("resolveFailoverStatus maps auth_permanent to 403", () => {
     expect(resolveFailoverStatus("auth_permanent")).toBe(403);
   });

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -1,6 +1,7 @@
 import {
   classifyFailoverReason,
   isAuthPermanentErrorMessage,
+  isRateLimitErrorMessage,
   type FailoverReason,
 } from "./pi-embedded-helpers.js";
 
@@ -158,6 +159,13 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
 
   const status = getStatusCode(err);
   if (status === 402) {
+    // HTTP 402 can mean either billing error OR rate limit (e.g., Anthropic Max plan).
+    // Check the error message to differentiate - if it contains rate limit keywords,
+    // treat it as a rate limit instead of billing.
+    const msg = getErrorMessage(err);
+    if (msg && isRateLimitErrorMessage(msg)) {
+      return "rate_limit";
+    }
     return "billing";
   }
   if (status === 429) {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -595,6 +595,27 @@ function createOpenRouterWrapper(
   };
 }
 
+/**
+ * Create a streamFn wrapper that injects custom headers from provider config.
+ * This enables providers like kimi-coding that require specific headers
+ * (e.g., User-Agent) for authentication.
+ */
+function createProviderHeadersWrapper(
+  baseStreamFn: StreamFn | undefined,
+  headers: Record<string, string>,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    return underlying(model, context, {
+      ...options,
+      headers: {
+        ...options?.headers,
+        ...headers,
+      },
+    });
+  };
+}
+
 function isGemini31Model(modelId: string): boolean {
   const normalized = modelId.toLowerCase();
   return normalized.includes("gemini-3.1-pro") || normalized.includes("gemini-3.1-flash");
@@ -781,6 +802,16 @@ export function applyExtraParamsToAgent(
     const openRouterThinkingLevel = modelId === "auto" ? undefined : thinkingLevel;
     agent.streamFn = createOpenRouterWrapper(agent.streamFn, openRouterThinkingLevel);
     agent.streamFn = createOpenRouterSystemCacheWrapper(agent.streamFn);
+  }
+
+  // Inject custom headers from provider config (e.g., User-Agent for kimi-coding).
+  // This enables providers that require specific headers for authentication.
+  const providerHeaders = cfg?.models?.providers?.[provider]?.headers;
+  if (providerHeaders && Object.keys(providerHeaders).length > 0) {
+    log.debug(
+      `injecting provider headers for ${provider}: ${Object.keys(providerHeaders).join(", ")}`,
+    );
+    agent.streamFn = createProviderHeadersWrapper(agent.streamFn, providerHeaders);
   }
 
   if (provider === "amazon-bedrock" && !isAnthropicBedrockModel(modelId)) {

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -114,7 +114,11 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
   }): Promise<void> {
     const target = this.resolveResolvedPath(params);
     this.ensureWriteAccess(target, "write files");
-    await this.assertPathSafety(target, { action: "write files", requireWritable: true });
+    await this.assertPathSafety(target, {
+      action: "write files",
+      requireWritable: true,
+      allowMissingTarget: params.mkdir !== false,
+    });
     const buffer = Buffer.isBuffer(params.data)
       ? params.data
       : Buffer.from(params.data, params.encoding ?? "utf8");
@@ -132,7 +136,11 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
   async mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void> {
     const target = this.resolveResolvedPath(params);
     this.ensureWriteAccess(target, "create directories");
-    await this.assertPathSafety(target, { action: "create directories", requireWritable: true });
+    await this.assertPathSafety(target, {
+      action: "create directories",
+      requireWritable: true,
+      allowMissingTarget: true,
+    });
     await this.runCommand('set -eu; mkdir -p -- "$1"', {
       args: [target.containerPath],
       signal: params.signal,
@@ -181,6 +189,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     await this.assertPathSafety(to, {
       action: "rename files",
       requireWritable: true,
+      allowMissingTarget: true,
     });
     await this.runCommand(
       'set -eu; dir=$(dirname -- "$2"); if [ "$dir" != "." ]; then mkdir -p -- "$dir"; fi; mv -- "$1" "$2"',

--- a/src/config/types.channels.ts
+++ b/src/config/types.channels.ts
@@ -18,10 +18,23 @@ export type ChannelHeartbeatVisibilityConfig = {
   useIndicator?: boolean;
 };
 
+/**
+ * Response mode when an unpaired (unauthorized) user sends a message.
+ * - "silent": Do not respond (default, recommended for security)
+ * - "code-only": Respond with pairing code only (no platform branding)
+ * - "branded": Respond with full OpenClaw branding and pairing instructions
+ */
+export type UnpairedResponseMode = "silent" | "code-only" | "branded";
+
 export type ChannelDefaultsConfig = {
   groupPolicy?: GroupPolicy;
   /** Default heartbeat visibility for all channels. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /**
+   * Response behavior when an unpaired (unauthorized) user sends a message.
+   * @default "silent"
+   */
+  unpairedResponse?: UnpairedResponseMode;
 };
 
 export type ChannelModelByChannelConfig = Record<string, Record<string, string>>;

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -7,7 +7,7 @@ import type {
   OutboundRetryConfig,
   ReplyToMode,
 } from "./types.base.js";
-import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
+import type { ChannelHeartbeatVisibilityConfig, UnpairedResponseMode } from "./types.channels.js";
 import type { DmConfig, ProviderCommandsConfig } from "./types.messages.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
@@ -154,6 +154,14 @@ export type TelegramAccountConfig = {
   reactionLevel?: "off" | "ack" | "minimal" | "extensive";
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /**
+   * Response behavior when an unpaired (unauthorized) user sends a message.
+   * - "silent": Do not respond (recommended for security)
+   * - "code-only": Respond with pairing code only (no platform branding)
+   * - "branded": Respond with full OpenClaw branding and pairing instructions
+   * Falls back to channels.defaults.unpairedResponse if not set.
+   */
+  unpairedResponse?: UnpairedResponseMode;
   /** Controls whether link previews are shown in outbound messages. Default: true. */
   linkPreview?: boolean;
   /**

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -27,6 +27,7 @@ import { resolveCommandAuthorizedFromAuthorizers } from "../../channels/command-
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { recordInboundSession } from "../../channels/session.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { loadConfig } from "../../config/config.js";
 import { isDangerousNameMatchingEnabled } from "../../config/dangerous-name-matching.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../config/sessions.js";
@@ -34,8 +35,9 @@ import type { DiscordAccountConfig } from "../../config/types.discord.js";
 import { logVerbose } from "../../globals.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { logDebug, logError } from "../../logger.js";
-import { buildPairingReply } from "../../pairing/pairing-messages.js";
+import { buildUnpairedResponse } from "../../pairing/pairing-messages.js";
 import { upsertChannelPairingRequest } from "../../pairing/pairing-store.js";
+import { getUnpairedResponseMode } from "../../pairing/unpaired-response.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
 import { readStoreAllowFromForDmPolicy } from "../../security/dm-policy-shared.js";
@@ -501,19 +503,25 @@ async function ensureDmComponentAuthorized(params: {
         name: user.username,
       },
     });
-    try {
-      await interaction.reply({
-        content: created
-          ? buildPairingReply({
-              channel: "discord",
-              idLine: `Your Discord user id: ${user.id}`,
-              code,
-            })
-          : "Pairing already requested. Ask the bot owner to approve your code.",
-        ...replyOpts,
-      });
-    } catch {
-      // Interaction may have expired
+    const cfg = loadConfig();
+    const responseText = created
+      ? buildUnpairedResponse({
+          channel: "discord",
+          idLine: `Your Discord user id: ${user.id}`,
+          code,
+          mode: getUnpairedResponseMode(cfg),
+        })
+      : "Pairing already requested. Ask the bot owner to approve your code.";
+    // Only send response if not null (i.e., not in silent mode)
+    if (responseText !== null) {
+      try {
+        await interaction.reply({
+          content: responseText,
+          ...replyOpts,
+        });
+      } catch {
+        // Interaction may have expired
+      }
     }
     return false;
   }

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -24,8 +24,9 @@ import {
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { logDebug } from "../../logger.js";
 import { getChildLogger } from "../../logging.js";
-import { buildPairingReply } from "../../pairing/pairing-messages.js";
+import { buildUnpairedResponse } from "../../pairing/pairing-messages.js";
 import { upsertChannelPairingRequest } from "../../pairing/pairing-store.js";
+import { getUnpairedResponseMode } from "../../pairing/unpaired-response.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import { DEFAULT_ACCOUNT_ID, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { readStoreAllowFromForDmPolicy } from "../../security/dm-policy-shared.js";
@@ -218,22 +219,23 @@ export async function preflightDiscordMessage(
             logVerbose(
               `discord pairing request sender=${author.id} tag=${formatDiscordUserTag(author)} (${allowMatchMeta})`,
             );
-            try {
-              await sendMessageDiscord(
-                `user:${author.id}`,
-                buildPairingReply({
-                  channel: "discord",
-                  idLine: `Your Discord user id: ${author.id}`,
-                  code,
-                }),
-                {
+            const cfg = loadConfig();
+            const responseText = buildUnpairedResponse({
+              channel: "discord",
+              idLine: `Your Discord user id: ${author.id}`,
+              code,
+              mode: getUnpairedResponseMode(cfg),
+            });
+            if (responseText !== null) {
+              try {
+                await sendMessageDiscord(`user:${author.id}`, responseText, {
                   token: params.token,
                   rest: params.client.rest,
                   accountId: params.accountId,
-                },
-              );
-            } catch (err) {
-              logVerbose(`discord pairing reply failed for ${author.id}: ${String(err)}`);
+                });
+              } catch (err) {
+                logVerbose(`discord pairing reply failed for ${author.id}: ${String(err)}`);
+              }
             }
           }
         } else {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -186,17 +186,16 @@ export function buildGatewayCronService(params: {
       // fully resolved agent heartbeat config so cron-triggered heartbeats
       // respect agent-specific overrides (agents.list[].heartbeat) before
       // falling back to agents.defaults.heartbeat.
-      const agentEntry =
-        Array.isArray(runtimeConfig.agents?.list) &&
-        runtimeConfig.agents.list.find(
-          (entry) =>
-            entry && typeof entry.id === "string" && normalizeAgentId(entry.id) === agentId,
-        );
-      const agentHeartbeat =
-        agentEntry && typeof agentEntry === "object" ? agentEntry.heartbeat : undefined;
+      const agentList = runtimeConfig.agents?.list;
+      const agentEntry = Array.isArray(agentList)
+        ? agentList.find(
+            (entry) =>
+              entry && typeof entry.id === "string" && normalizeAgentId(entry.id) === agentId,
+          )
+        : undefined;
       const baseHeartbeat = {
         ...runtimeConfig.agents?.defaults?.heartbeat,
-        ...agentHeartbeat,
+        ...agentEntry?.heartbeat,
       };
       const heartbeatOverride = opts?.heartbeat
         ? { ...baseHeartbeat, ...opts.heartbeat }

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -110,8 +110,16 @@ export interface InternalHookEvent {
 
 export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | void;
 
-/** Registry of hook handlers by event key */
-const handlers = new Map<string, InternalHookHandler[]>();
+/** Registry of hook handlers by event key - stored in globalThis to survive bundle chunk boundaries */
+const getGlobalHandlers = (): Map<string, InternalHookHandler[]> => {
+  if (!globalThis.__openclawHookHandlers) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).__openclawHookHandlers = new Map<string, InternalHookHandler[]>();
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (globalThis as any).__openclawHookHandlers;
+};
+
 const log = createSubsystemLogger("internal-hooks");
 
 /**
@@ -134,6 +142,7 @@ const log = createSubsystemLogger("internal-hooks");
  * ```
  */
 export function registerInternalHook(eventKey: string, handler: InternalHookHandler): void {
+  const handlers = getGlobalHandlers();
   if (!handlers.has(eventKey)) {
     handlers.set(eventKey, []);
   }
@@ -147,6 +156,7 @@ export function registerInternalHook(eventKey: string, handler: InternalHookHand
  * @param handler - The handler function to remove
  */
 export function unregisterInternalHook(eventKey: string, handler: InternalHookHandler): void {
+  const handlers = getGlobalHandlers();
   const eventHandlers = handlers.get(eventKey);
   if (!eventHandlers) {
     return;
@@ -167,14 +177,14 @@ export function unregisterInternalHook(eventKey: string, handler: InternalHookHa
  * Clear all registered hooks (useful for testing)
  */
 export function clearInternalHooks(): void {
-  handlers.clear();
+  getGlobalHandlers().clear();
 }
 
 /**
  * Get all registered event keys (useful for debugging)
  */
 export function getRegisteredEventKeys(): string[] {
-  return Array.from(handlers.keys());
+  return Array.from(getGlobalHandlers().keys());
 }
 
 /**
@@ -190,6 +200,7 @@ export function getRegisteredEventKeys(): string[] {
  * @param event - The event to trigger
  */
 export async function triggerInternalHook(event: InternalHookEvent): Promise<void> {
+  const handlers = getGlobalHandlers();
   const typeHandlers = handlers.get(event.type) ?? [];
   const specificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
 

--- a/src/memory/remote-http.ts
+++ b/src/memory/remote-http.ts
@@ -31,6 +31,7 @@ export async function withRemoteHttpResponse<T>(params: {
     init: params.init,
     policy: params.ssrfPolicy,
     auditContext: params.auditContext ?? "memory-remote",
+    proxy: "env",
   });
   try {
     return await params.onResponse(response);

--- a/src/pairing/pairing-messages.ts
+++ b/src/pairing/pairing-messages.ts
@@ -1,4 +1,5 @@
 import { formatCliCommand } from "../cli/command-format.js";
+import type { UnpairedResponseMode } from "../config/types.channels.js";
 import type { PairingChannel } from "./pairing-store.js";
 
 export function buildPairingReply(params: {
@@ -17,4 +18,30 @@ export function buildPairingReply(params: {
     "Ask the bot owner to approve with:",
     formatCliCommand(`openclaw pairing approve ${channel} ${code}`),
   ].join("\n");
+}
+
+/**
+ * Build response for unpaired users based on the configured mode.
+ * @param mode - Response mode: "silent" (no response), "code-only", or "branded"
+ * @returns The response text, or null if mode is "silent"
+ */
+export function buildUnpairedResponse(params: {
+  channel: PairingChannel;
+  idLine: string;
+  code: string;
+  mode: UnpairedResponseMode;
+}): string | null {
+  const { channel, idLine, code, mode } = params;
+
+  switch (mode) {
+    case "silent":
+      return null;
+    case "code-only":
+      return `Pairing code: ${code}`;
+    case "branded":
+      return buildPairingReply({ channel, idLine, code });
+    default:
+      // Default to silent for safety
+      return null;
+  }
 }

--- a/src/pairing/unpaired-response.ts
+++ b/src/pairing/unpaired-response.ts
@@ -1,0 +1,11 @@
+import type { UnpairedResponseMode } from "../config/types.channels.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+/**
+ * Get the unpaired response mode from config, with a secure default.
+ * @param cfg - The OpenClaw config object
+ * @returns The unpaired response mode (defaults to "silent" for security)
+ */
+export function getUnpairedResponseMode(cfg: OpenClawConfig): UnpairedResponseMode {
+  return cfg.channels?.defaults?.unpairedResponse ?? "silent";
+}

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -236,6 +236,7 @@ export { chunkTextForOutbound } from "./text-chunking.js";
 export { readJsonFileWithFallback, writeJsonFileAtomically } from "./json-store.js";
 export { buildRandomTempFilePath, withTempDownloadPath } from "./temp-path.js";
 export { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+export { waitForAbortSignal } from "../infra/abort-signal.js";
 export {
   runPluginCommandWithTimeout,
   type PluginCommandRunOptions,

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -415,6 +415,30 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   if (!anyReplyDelivered) {
     await draftStream.clear();
+    // Also remove ack reaction on NO_REPLY when removeAckAfterReply is enabled
+    if (ctx.removeAckAfterReply && prepared.ackReactionPromise) {
+      void prepared.ackReactionPromise.then((didAck) => {
+        if (!didAck) {
+          return;
+        }
+        removeSlackReaction(
+          message.channel,
+          prepared.ackReactionMessageTs ?? "",
+          prepared.ackReactionValue,
+          {
+            token: ctx.botToken,
+            client: ctx.app.client,
+          },
+        ).catch((err) => {
+          logAckFailure({
+            log: shouldLogVerbose,
+            channel: "slack",
+            target: `${message.channel}/${message.ts}`,
+            error: err,
+          });
+        });
+      });
+    }
     if (prepared.isRoomish) {
       clearHistoryEntriesIfEnabled({
         historyMap: ctx.channelHistories,

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -23,6 +23,7 @@ import { danger, logVerbose, warn } from "../globals.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { MediaFetchError } from "../media/fetch.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
+import { getUnpairedResponseMode } from "../pairing/unpaired-response.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -1367,6 +1368,7 @@ export const registerTelegramHandlers = ({
         const dmAuthorized = await enforceTelegramDmAccess({
           isGroup: event.isGroup,
           dmPolicy,
+          unpairedResponse: getUnpairedResponseMode(loadConfig()),
           msg: event.msg,
           chatId: event.chatId,
           effectiveDmAllow,

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -33,6 +33,7 @@ import { readSessionUpdatedAt, resolveStorePath } from "../config/sessions.js";
 import type { DmPolicy, TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
+import { getUnpairedResponseMode } from "../pairing/unpaired-response.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -277,6 +278,7 @@ export const buildTelegramMessageContext = async ({
     !(await enforceTelegramDmAccess({
       isGroup,
       dmPolicy,
+      unpairedResponse: getUnpairedResponseMode(loadConfig()),
       msg,
       chatId,
       effectiveDmAllow,

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -689,12 +689,38 @@ export const dispatchTelegramMessage = async ({
   const hasFinalResponse = queuedFinal || sentFallback;
 
   if (statusReactionController && !hasFinalResponse) {
-    void statusReactionController.setError().catch((err) => {
-      logVerbose(`telegram: status reaction error finalize failed: ${String(err)}`);
-    });
+    // Remove ack reaction on NO_REPLY when removeAckAfterReply is enabled (like Discord does)
+    if (removeAckAfterReply) {
+      void statusReactionController.clear().catch((err) => {
+        logVerbose(`telegram: status reaction clear on NO_REPLY failed: ${String(err)}`);
+      });
+    } else {
+      void statusReactionController.setError().catch((err) => {
+        logVerbose(`telegram: status reaction error finalize failed: ${String(err)}`);
+      });
+    }
   }
 
   if (!hasFinalResponse) {
+    // Also remove ack reaction on NO_REPLY when removeAckAfterReply is enabled
+    if (!statusReactionController && removeAckAfterReply && ackReactionPromise) {
+      void ackReactionPromise.then((didAck) => {
+        if (!didAck) {
+          return;
+        }
+        reactionApi?.(chatId, msg.message_id ?? 0, []).catch((err) => {
+          if (!msg.message_id) {
+            return;
+          }
+          logAckFailure({
+            log: logVerbose,
+            channel: "telegram",
+            target: `${chatId}/${msg.message_id}`,
+            error: err,
+          });
+        });
+      });
+    }
     clearGroupHistory();
     return;
   }

--- a/src/telegram/dm-access.ts
+++ b/src/telegram/dm-access.ts
@@ -1,8 +1,9 @@
 import type { Message } from "@grammyjs/types";
 import type { Bot } from "grammy";
+import type { UnpairedResponseMode } from "../config/types.channels.js";
 import type { DmPolicy } from "../config/types.js";
 import { logVerbose } from "../globals.js";
-import { buildPairingReply } from "../pairing/pairing-messages.js";
+import { buildUnpairedResponse } from "../pairing/pairing-messages.js";
 import { upsertChannelPairingRequest } from "../pairing/pairing-store.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { resolveSenderAllowMatch, type NormalizedAllowFrom } from "./bot-access.js";
@@ -34,6 +35,7 @@ function resolveTelegramSenderIdentity(msg: Message, chatId: number): TelegramSe
 export async function enforceTelegramDmAccess(params: {
   isGroup: boolean;
   dmPolicy: DmPolicy;
+  unpairedResponse: UnpairedResponseMode;
   msg: Message;
   chatId: number;
   effectiveDmAllow: NormalizedAllowFrom;
@@ -41,7 +43,17 @@ export async function enforceTelegramDmAccess(params: {
   bot: Bot;
   logger: TelegramDmAccessLogger;
 }): Promise<boolean> {
-  const { isGroup, dmPolicy, msg, chatId, effectiveDmAllow, accountId, bot, logger } = params;
+  const {
+    isGroup,
+    dmPolicy,
+    unpairedResponse,
+    msg,
+    chatId,
+    effectiveDmAllow,
+    accountId,
+    bot,
+    logger,
+  } = params;
   if (isGroup) {
     return true;
   }
@@ -95,15 +107,17 @@ export async function enforceTelegramDmAccess(params: {
         );
         await withTelegramApiErrorLogging({
           operation: "sendMessage",
-          fn: () =>
-            bot.api.sendMessage(
-              chatId,
-              buildPairingReply({
-                channel: "telegram",
-                idLine: `Your Telegram user id: ${telegramUserId}`,
-                code,
-              }),
-            ),
+          fn: async () => {
+            const response = buildUnpairedResponse({
+              channel: "telegram",
+              idLine: `Your Telegram user id: ${telegramUserId}`,
+              code,
+              mode: unpairedResponse,
+            });
+            if (response !== null) {
+              await bot.api.sendMessage(chatId, response);
+            }
+          },
         });
       }
     } catch (err) {

--- a/src/telegram/group-access.ts
+++ b/src/telegram/group-access.ts
@@ -130,6 +130,14 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
   if (groupPolicy === "disabled") {
     return { allowed: false, reason: "group-policy-disabled", groupPolicy };
   }
+  // Check chat allowlist first - if the chat ID is explicitly configured with enabled: true,
+  // it should be allowed regardless of sender allowlist entries
+  if (params.checkChatAllowlist) {
+    const groupAllowlist = params.resolveGroupPolicy(params.chatId);
+    if (groupAllowlist.allowlistEnabled && !groupAllowlist.allowed) {
+      return { allowed: false, reason: "group-chat-not-allowed", groupPolicy };
+    }
+  }
   if (groupPolicy === "allowlist" && params.enforceAllowlistAuthorization) {
     const senderId = params.senderId ?? "";
     if (params.requireSenderForAllowlistAuthorization && !senderId) {
@@ -147,12 +155,6 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
       })
     ) {
       return { allowed: false, reason: "group-policy-allowlist-unauthorized", groupPolicy };
-    }
-  }
-  if (params.checkChatAllowlist) {
-    const groupAllowlist = params.resolveGroupPolicy(params.chatId);
-    if (groupAllowlist.allowlistEnabled && !groupAllowlist.allowed) {
-      return { allowed: false, reason: "group-chat-not-allowed", groupPolicy };
     }
   }
   return { allowed: true, groupPolicy };

--- a/src/web/inbound/access-control.test-harness.ts
+++ b/src/web/inbound/access-control.test-harness.ts
@@ -21,6 +21,9 @@ export function setupAccessControlTestHarness(): void {
   beforeEach(() => {
     config = {
       channels: {
+        defaults: {
+          unpairedResponse: "branded",
+        },
         whatsapp: {
           dmPolicy: "pairing",
           allowFrom: [],

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -5,8 +5,9 @@ import {
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../../config/runtime-group-policy.js";
 import { logVerbose } from "../../globals.js";
-import { buildPairingReply } from "../../pairing/pairing-messages.js";
+import { buildUnpairedResponse } from "../../pairing/pairing-messages.js";
 import { upsertChannelPairingRequest } from "../../pairing/pairing-store.js";
+import { getUnpairedResponseMode } from "../../pairing/unpaired-response.js";
 import {
   readStoreAllowFromForDmPolicy,
   resolveDmGroupAccessWithLists,
@@ -181,16 +182,20 @@ export async function checkInboundAccessControl(params: {
           logVerbose(
             `whatsapp pairing request sender=${candidate} name=${params.pushName ?? "unknown"}`,
           );
-          try {
-            await params.sock.sendMessage(params.remoteJid, {
-              text: buildPairingReply({
-                channel: "whatsapp",
-                idLine: `Your WhatsApp phone number: ${candidate}`,
-                code,
-              }),
-            });
-          } catch (err) {
-            logVerbose(`whatsapp pairing reply failed for ${candidate}: ${String(err)}`);
+          const responseText = buildUnpairedResponse({
+            channel: "whatsapp",
+            idLine: `Your WhatsApp phone number: ${candidate}`,
+            code,
+            mode: getUnpairedResponseMode(cfg),
+          });
+          if (responseText !== null) {
+            try {
+              await params.sock.sendMessage(params.remoteJid, {
+                text: responseText,
+              });
+            } catch (err) {
+              logVerbose(`whatsapp pairing reply failed for ${candidate}: ${String(err)}`);
+            }
           }
         }
       }

--- a/src/web/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts
+++ b/src/web/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { monitorWebInbox } from "./inbound.js";
 import {
   DEFAULT_ACCOUNT_ID,
+  DEFAULT_WEB_INBOX_CONFIG,
   getAuthDir,
   getSock,
   installWebMonitorInboxUnitTestHooks,
@@ -65,7 +66,14 @@ async function startWebInboxMonitor(params: {
   sendReadReceipts?: boolean;
 }) {
   if (params.config) {
-    mockLoadConfig.mockReturnValue(params.config);
+    // Merge with defaults to preserve default settings like unpairedResponse
+    const defaultChannels = DEFAULT_WEB_INBOX_CONFIG.channels;
+    const testChannels = params.config.channels as Record<string, unknown> | undefined;
+    mockLoadConfig.mockReturnValue({
+      ...DEFAULT_WEB_INBOX_CONFIG,
+      ...params.config,
+      channels: testChannels ? { ...defaultChannels, ...testChannels } : defaultChannels,
+    });
   }
   const onMessage = vi.fn();
   const base = {

--- a/src/web/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts
+++ b/src/web/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts
@@ -13,6 +13,12 @@ const nowSeconds = (offsetMs = 0) => Math.floor((Date.now() + offsetMs) / 1000);
 const DEFAULT_MESSAGES_CFG = {
   messagePrefix: undefined,
   responsePrefix: undefined,
+  channels: {
+    defaults: {
+      // Use branded mode for tests that expect pairing messages
+      unpairedResponse: "branded",
+    },
+  },
 } as const;
 const TIMESTAMP_OFF_MESSAGES_CFG = {
   ...DEFAULT_MESSAGES_CFG,

--- a/src/web/monitor-inbox.test-harness.ts
+++ b/src/web/monitor-inbox.test-harness.ts
@@ -17,6 +17,10 @@ export const DEFAULT_WEB_INBOX_CONFIG = {
       // Allow all in tests by default.
       allowFrom: ["*"],
     },
+    defaults: {
+      // Use branded mode for tests that expect pairing messages
+      unpairedResponse: "branded",
+    },
   },
   messages: {
     messagePrefix: undefined,


### PR DESCRIPTION
Resolves #30613

When `groupPolicy: "allowlist"` is set and the group is explicitly configured in `groups` with `enabled: true` but no `allowFrom` entries exist, all inbound group/forum messages were silently dropped.

## Root Cause

The sender-level allowlist check was firing before the chat-level allowlist check. Since the chat ID IS the allowlist entry when the group is explicitly configured (enabled: true), the sender check would fail because `effectiveGroupAllow.hasEntries === false`.

## Fix

Move the `checkChatAllowlist` block to run BEFORE the sender allowlist check. If the chat ID is explicitly allowlisted in the groups config, it passes immediately without checking the sender allowlist.

## Testing

- A group configured as:
  ```json
  "groups": {
    "-100xxxxxxxxx": { "enabled": true, "requireMention": false }
  }
  ```
  will now be correctly treated as allowlisted without requiring `allowFrom` entries.