### PR TITLE
fix(cron): mark delivered announce retries as successful runs

### DIFF
--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -220,6 +220,28 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
+  it("treats delivered announce runs as success even when transient error payloads exist", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const deps = createCliDeps();
+      mockAgentPayloads([
+        { text: "⚠️ ✉️ Message failed", isError: true },
+        { text: "Final weather summary" },
+      ]);
+
+      const res = await runExplicitTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.error).toBeUndefined();
+      expect(res.delivered).toBe(true);
+      expect(res.deliveryAttempted).toBe(true);
+    });
+  });
+
   it("reports not-delivered when best-effort structured outbound sends all fail", async () => {
     await expectBestEffortTelegramNotDelivered({
       text: "caption",

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -48,7 +48,7 @@ import {
   isExternalHookSession,
 } from "../../security/external-content.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
-import type { CronJob, CronRunOutcome, CronRunTelemetry } from "../types.js";
+import type { CronJob, CronRunOutcome, CronRunStatus, CronRunTelemetry } from "../types.js";
 import {
   dispatchCronDelivery,
   matchesMessagingToolDeliveryTarget,
@@ -577,10 +577,15 @@ export async function runCronIsolatedAgentTurn(params: {
   const embeddedRunError = hasErrorPayload
     ? (lastErrorPayloadText ?? "cron isolated run returned an error payload")
     : undefined;
-  const resolveRunOutcome = (params?: { delivered?: boolean; deliveryAttempted?: boolean }) =>
-    withRunSession({
-      status: hasErrorPayload ? "error" : "ok",
-      ...(hasErrorPayload
+  const resolveRunOutcome = (params?: { delivered?: boolean; deliveryAttempted?: boolean }) => {
+    // Some providers can emit transient error payloads during announce delivery retries
+    // even when final channel delivery succeeds. Treat final delivered=true as success
+    // to keep cron status aligned with user-visible delivery outcome.
+    const deliveredSuccess = hasErrorPayload && params?.delivered === true;
+    const status: CronRunStatus = deliveredSuccess ? "ok" : hasErrorPayload ? "error" : "ok";
+    return withRunSession({
+      status,
+      ...(status === "error"
         ? { error: embeddedRunError ?? "cron isolated run returned an error payload" }
         : {}),
       summary,
@@ -589,6 +594,7 @@ export async function runCronIsolatedAgentTurn(params: {
       deliveryAttempted: params?.deliveryAttempted,
       ...telemetry,
     });
+  };
 
   // Skip delivery for heartbeat-only responses (HEARTBEAT_OK with no real content).
   const ackMaxChars = resolveHeartbeatAckMaxChars(agentCfg);


### PR DESCRIPTION
## Summary

- **Problem:** Isolated cron announce runs can contain transient error payloads (for example early "message failed" artifacts) even when final delivery succeeds.
- **Regression impact:** Cron state can incorrectly record `lastStatus=error` and show failure copy while `lastDelivered=true` and `lastDeliveryStatus=delivered`.
- **Fix:** When final delivery is confirmed (`delivered=true`), treat transient error-payload runs as success in `runCronIsolatedAgentTurn`.
- **Coverage:** Added a regression test ensuring delivered announce runs with transient error payloads are marked `ok` without `error` text.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28964

## User-visible / Behavior Changes

- Cron job runs no longer report false failure status when announce delivery ultimately succeeds after transient error payloads.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js + Vitest
- Area: Cron isolated agent announce delivery state

### Steps

1. Simulate isolated cron announce payloads containing an early `isError=true` message followed by final content.
2. Ensure announce delivery reports success.
3. Verify run result status remains `ok` and no error is surfaced.

### Expected

- Delivered runs are marked successful (`status=ok`) even when transient error payloads are present.

### Actual

- Before fix: delivered runs could be marked `error` due to payload-level `isError` detection.
- After fix: delivered runs are recorded as successful.

## Evidence

- `pnpm exec vitest run src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts`

## Human Verification (required)

- Verified delivered=true + transient error payload path.
- Confirmed regression test asserts `status=ok`, `error=undefined`, `delivered=true`.
- Not manually verified against a live Telegram channel environment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert this PR commit.
- Affected files: `src/cron/isolated-agent/run.ts`, `src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts`.

## Risks and Mitigations

- Risk: true failure payloads might be masked when `delivered=true`.
- Mitigation: behavior only changes for runs with confirmed delivery success, aligning status with user-visible outcome.
