### PR TITLE
fix(agents): make embedded connection errors actionable

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -117,6 +117,13 @@ describe("formatAssistantErrorText", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");
   });
+
+  it("rewrites generic connection errors into actionable guidance", () => {
+    const msg = makeAssistantError("Connection error.");
+    const formatted = formatAssistantErrorText(msg);
+    expect(formatted).toContain("unable to reach the model provider");
+    expect(formatted).toContain("network/VPN/proxy");
+  });
 });
 
 describe("formatRawAssistantErrorForUi", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -534,6 +534,13 @@ export function formatAssistantErrorText(
     return "LLM request timed out.";
   }
 
+  if (/^connection error\.?$/i.test(raw)) {
+    return (
+      "Connection error: unable to reach the model provider. " +
+      "Check network/VPN/proxy settings and provider endpoint configuration, then retry."
+    );
+  }
+
   if (isBillingErrorMessage(raw)) {
     return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
   }


### PR DESCRIPTION
## Summary

- **Problem:** Embedded agent runs can terminate with a generic `Connection error.` message, which provides little guidance and is hard to diagnose.
- **Impact:** Users see opaque failures in lifecycle logs/status (for example `embedded run agent end ... error=Connection error.`) and cannot quickly identify likely remediation steps.
- **Fix:** Add explicit `Connection error` rewrite in `formatAssistantErrorText` to provide actionable provider-reachability guidance.
- **Coverage:** Added regression test for `Connection error.` normalization in `formatassistanterrortext` tests.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30025

## User-visible / Behavior Changes

- Generic embedded-run `Connection error.` failures now render as actionable guidance: check network/VPN/proxy and provider endpoint configuration.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js + Vitest
- Area: Embedded agent error formatting

### Steps

1. Feed `formatAssistantErrorText` an assistant error payload with `errorMessage="Connection error."`.
2. Validate rewritten output is actionable and no longer opaque.

### Expected

- User-facing error includes provider reachability guidance.

### Actual

- Before fix: plain `Connection error.` string.
- After fix: clear troubleshooting copy.

## Evidence

- `pnpm exec vitest run src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`

## Human Verification (required)

- Verified new rewrite path with unit test coverage.
- Not validated against every provider-specific transport failure variant.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert this PR commit.
- Affected files: `src/agents/pi-embedded-helpers/errors.ts`, `src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`.

## Risks and Mitigations

- Risk: Some generic connection failures may need more specific provider-level hints.
- Mitigation: This change improves baseline guidance without altering error classification or retry behavior.
