### PR TITLE
fix(node-host): decode Windows exec output with active code page

### DIFF
--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { GatewayClient } from "../gateway/client.js";
@@ -31,6 +31,16 @@ import type {
 const OUTPUT_CAP = 200_000;
 const OUTPUT_EVENT_TAIL = 20_000;
 const DEFAULT_NODE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+const WINDOWS_CODEPAGE_ENCODING_MAP: Record<number, string> = {
+  65001: "utf-8",
+  54936: "gb18030",
+  936: "gbk",
+  950: "big5",
+  932: "shift_jis",
+  949: "euc-kr",
+  1252: "windows-1252",
+};
+let cachedWindowsConsoleEncoding: string | null | undefined;
 
 const execHostEnforced = process.env.OPENCLAW_NODE_EXEC_HOST?.trim().toLowerCase() === "app";
 const execHostFallbackAllowed =
@@ -92,6 +102,65 @@ function truncateOutput(raw: string, maxChars: number): { text: string; truncate
   return { text: `... (truncated) ${raw.slice(raw.length - maxChars)}`, truncated: true };
 }
 
+export function parseWindowsCodePage(raw: string): number | null {
+  if (!raw) {
+    return null;
+  }
+  const match = raw.match(/\b(\d{3,5})\b/);
+  if (!match?.[1]) {
+    return null;
+  }
+  const codePage = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(codePage) || codePage <= 0) {
+    return null;
+  }
+  return codePage;
+}
+
+function resolveWindowsConsoleEncoding(): string | null {
+  if (process.platform !== "win32") {
+    return null;
+  }
+  if (cachedWindowsConsoleEncoding !== undefined) {
+    return cachedWindowsConsoleEncoding;
+  }
+  try {
+    const result = spawnSync("cmd.exe", ["/d", "/s", "/c", "chcp"], {
+      windowsHide: true,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const raw = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+    const codePage = parseWindowsCodePage(raw);
+    cachedWindowsConsoleEncoding =
+      codePage !== null ? (WINDOWS_CODEPAGE_ENCODING_MAP[codePage] ?? null) : null;
+  } catch {
+    cachedWindowsConsoleEncoding = null;
+  }
+  return cachedWindowsConsoleEncoding;
+}
+
+export function decodeCapturedOutputBuffer(params: {
+  buffer: Buffer;
+  platform?: NodeJS.Platform;
+  windowsEncoding?: string | null;
+}): string {
+  const utf8 = params.buffer.toString("utf8");
+  const platform = params.platform ?? process.platform;
+  if (platform !== "win32") {
+    return utf8;
+  }
+  const encoding = params.windowsEncoding ?? resolveWindowsConsoleEncoding();
+  if (!encoding || encoding.toLowerCase() === "utf-8") {
+    return utf8;
+  }
+  try {
+    return new TextDecoder(encoding).decode(params.buffer);
+  } catch {
+    return utf8;
+  }
+}
+
 function redactExecApprovals(file: ExecApprovalsFile): ExecApprovalsFile {
   const socketPath = file.socket?.path?.trim();
   return {
@@ -126,12 +195,13 @@ async function runCommand(
   timeoutMs: number | undefined,
 ): Promise<RunResult> {
   return await new Promise((resolve) => {
-    let stdout = "";
-    let stderr = "";
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
     let outputLen = 0;
     let truncated = false;
     let timedOut = false;
     let settled = false;
+    const windowsEncoding = resolveWindowsConsoleEncoding();
 
     const child = spawn(argv[0], argv.slice(1), {
       cwd,
@@ -147,12 +217,11 @@ async function runCommand(
       }
       const remaining = OUTPUT_CAP - outputLen;
       const slice = chunk.length > remaining ? chunk.subarray(0, remaining) : chunk;
-      const str = slice.toString("utf8");
       outputLen += slice.length;
       if (target === "stdout") {
-        stdout += str;
+        stdoutChunks.push(slice);
       } else {
-        stderr += str;
+        stderrChunks.push(slice);
       }
       if (chunk.length > remaining) {
         truncated = true;
@@ -182,6 +251,14 @@ async function runCommand(
       if (timer) {
         clearTimeout(timer);
       }
+      const stdout = decodeCapturedOutputBuffer({
+        buffer: Buffer.concat(stdoutChunks),
+        windowsEncoding,
+      });
+      const stderr = decodeCapturedOutputBuffer({
+        buffer: Buffer.concat(stderrChunks),
+        windowsEncoding,
+      });
       resolve({
         exitCode,
         timedOut,


### PR DESCRIPTION
## Summary

- **Problem:** `exec` / `system.run` output was always decoded as UTF-8, so Windows shells running on legacy code pages (for example CP936/GBK) rendered Chinese text as garbled characters.
- **Why it matters:** Users can run commands successfully but cannot trust tool output, which blocks debugging and file verification workflows on Windows.
- **What changed:** `src/node-host/invoke.ts` now resolves the active Windows console code page (`chcp`) once per process and decodes captured stdout/stderr buffers with the matching encoding before returning results.
- **What did NOT change:** Command execution policy, allowlist/security checks, and non-Windows decoding behavior remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30640

## User-visible / Behavior Changes

- On Windows, `system.run`/`exec` output now preserves non-UTF-8 console text (e.g. GBK Chinese output) instead of showing replacement characters.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev) + Windows code page behavior validated via unit tests
- Runtime: Node.js 24.x
- Integration/channel: node-host `system.run` path

### Steps

1. On Windows with code page 936, execute a command that emits Chinese text through `exec`/`system.run`.
2. Observe output rendering before vs after this patch.

### Expected

- Output keeps original Chinese characters.

### Actual

- Before fix: output contained garbled characters (`�`/乱码).
- After fix: output is decoded with the active console code page and renders correctly.

## Evidence

- `pnpm exec vitest run src/node-host/invoke.sanitize-env.test.ts`
- `pnpm exec vitest run src/node-host/invoke-system-run.test.ts`

## Human Verification (required)

- Verified scenarios: code page parsing from `chcp` output; GBK decoding path; existing node-host system-run tests.
- Edge cases checked: unknown/unsupported encoding falls back to UTF-8; non-Windows platforms remain UTF-8.
- What I did **not** verify: live manual run on a physical Windows machine in this environment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `src/node-host/invoke.ts` and test updates.
- Known bad symptoms: Windows output may revert to UTF-8-only decoding and show mojibake again.

## Risks and Mitigations

- Risk: `chcp` output may be unavailable in some shells.
- Mitigation: decoding safely falls back to UTF-8 when code page resolution fails.
