### PR TITLE
fix(config): tolerate legacy discord channel keys from config writes

### DIFF
--- a/src/config/config.discord.test.ts
+++ b/src/config/config.discord.test.ts
@@ -85,4 +85,60 @@ describe("config discord", () => {
       ).toBe(true);
     }
   });
+
+  it("strips unsupported discord channel keys from legacy config writes", async () => {
+    await withTempHomeConfig(
+      {
+        channels: {
+          discord: {
+            guilds: {
+              "123": {
+                channels: {
+                  general: {
+                    allow: true,
+                    model: "anthropic/claude-sonnet-4-5",
+                    groupPolicy: "open",
+                    allowFrom: ["user:123"],
+                  },
+                },
+              },
+            },
+            accounts: {
+              work: {
+                guilds: {
+                  "999": {
+                    channels: {
+                      ops: {
+                        allow: true,
+                        model: "anthropic/claude-opus-4-5",
+                        groupPolicy: "allowlist",
+                        allowFrom: ["user:999"],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      async () => {
+        const cfg = loadConfig();
+        const baseChannel = cfg.channels?.discord?.guilds?.["123"]?.channels?.general as
+          | Record<string, unknown>
+          | undefined;
+        expect(baseChannel?.allow).toBe(true);
+        expect(baseChannel && "model" in baseChannel).toBe(false);
+        expect(baseChannel && "groupPolicy" in baseChannel).toBe(false);
+        expect(baseChannel && "allowFrom" in baseChannel).toBe(false);
+
+        const accountChannel = cfg.channels?.discord?.accounts?.work?.guilds?.["999"]?.channels
+          ?.ops as Record<string, unknown> | undefined;
+        expect(accountChannel?.allow).toBe(true);
+        expect(accountChannel && "model" in accountChannel).toBe(false);
+        expect(accountChannel && "groupPolicy" in accountChannel).toBe(false);
+        expect(accountChannel && "allowFrom" in accountChannel).toBe(false);
+      },
+    );
+  });
 });

--- a/src/config/legacy.migrations.part-1.ts
+++ b/src/config/legacy.migrations.part-1.ts
@@ -399,6 +399,78 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_1: LegacyConfigMigration[] = [
     },
   },
   {
+    id: "channels.discord.guild-channel-unsupported-keys",
+    describe:
+      "Strip unsupported channels.discord.guilds.*.channels.* keys written by legacy config writes",
+    apply: (raw, changes) => {
+      const channels = getRecord(raw.channels);
+      const discord = getRecord(channels?.discord);
+      if (!channels || !discord) {
+        return;
+      }
+
+      const stripGuildChannelKeys = (owner: Record<string, unknown>) => {
+        const guilds = getRecord(owner.guilds);
+        if (!guilds) {
+          return 0;
+        }
+        let removed = 0;
+        for (const [guildId, guildValue] of Object.entries(guilds)) {
+          const guild = getRecord(guildValue);
+          if (!guild) {
+            continue;
+          }
+          const guildChannels = getRecord(guild.channels);
+          if (!guildChannels) {
+            continue;
+          }
+          for (const [channelId, channelValue] of Object.entries(guildChannels)) {
+            const channel = getRecord(channelValue);
+            if (!channel) {
+              continue;
+            }
+            const hadModel = hasOwnKey(channel, "model");
+            const hadGroupPolicy = hasOwnKey(channel, "groupPolicy");
+            const hadAllowFrom = hasOwnKey(channel, "allowFrom");
+            if (!hadModel && !hadGroupPolicy && !hadAllowFrom) {
+              continue;
+            }
+            delete channel.model;
+            delete channel.groupPolicy;
+            delete channel.allowFrom;
+            guildChannels[channelId] = channel;
+            removed += Number(hadModel) + Number(hadGroupPolicy) + Number(hadAllowFrom);
+          }
+          guild.channels = guildChannels;
+          guilds[guildId] = guild;
+        }
+        owner.guilds = guilds;
+        return removed;
+      };
+
+      let removedKeys = stripGuildChannelKeys(discord);
+      const accounts = getRecord(discord.accounts);
+      if (accounts) {
+        for (const [accountId, accountValue] of Object.entries(accounts)) {
+          const account = getRecord(accountValue);
+          if (!account) {
+            continue;
+          }
+          removedKeys += stripGuildChannelKeys(account);
+          accounts[accountId] = account;
+        }
+        discord.accounts = accounts;
+      }
+      if (removedKeys > 0) {
+        channels.discord = discord;
+        raw.channels = channels;
+        changes.push(
+          "Removed unsupported channels.discord.guilds.*.channels.* keys (model/groupPolicy/allowFrom).",
+        );
+      }
+    },
+  },
+  {
     id: "routing.allowFrom->channels.whatsapp.allowFrom",
     describe: "Move routing.allowFrom to channels.whatsapp.allowFrom",
     apply: (raw, changes) => {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -357,8 +357,18 @@ export const DiscordGuildChannelSchema = z
     systemPrompt: z.string().optional(),
     includeThreadStarter: z.boolean().optional(),
     autoThread: z.boolean().optional(),
+    // Compatibility-only keys written by older Discord config-write flows.
+    // They are accepted to keep config loading stable, then stripped from
+    // the normalized config because runtime does not read them at channel scope.
+    model: z.string().optional(),
+    groupPolicy: GroupPolicySchema.optional(),
+    allowFrom: DiscordIdListSchema.optional(),
   })
-  .strict();
+  .strict()
+  .transform((value) => {
+    const { model: _model, groupPolicy: _groupPolicy, allowFrom: _allowFrom, ...rest } = value;
+    return rest;
+  });
 
 export const DiscordGuildSchema = z
   .object({


### PR DESCRIPTION
## Summary

- **Problem:** Older Discord config-write flows can persist `model`, `groupPolicy`, and `allowFrom` under `channels.discord.guilds.*.channels.*`, but Discord channel schema rejected those keys and made config load fail.
- **Why it matters:** Invalid config blocks gateway startup/restart, so one malformed write can break the runtime pipeline.
- **What changed:** `DiscordGuildChannelSchema` now accepts those legacy keys for compatibility and strips them during normalization; legacy migration also removes them from disk during `doctor --fix`.
- **What did NOT change:** Discord runtime behavior/model routing logic at channel scope is unchanged; this is a compatibility + stability fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30633

## User-visible / Behavior Changes

- Configs containing legacy Discord channel keys (`model`/`groupPolicy`/`allowFrom`) no longer fail validation during startup.
- `openclaw doctor --fix` now cleans those legacy keys from config files.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js 24.x
- Integration/channel: Discord config schema + legacy migrations

### Steps

1. Add `model`, `groupPolicy`, and `allowFrom` under `channels.discord.guilds.<guild>.channels.<channel>` (or account-scoped guild channel config).
2. Load config / start gateway.
3. Run `doctor --fix` to validate migration cleanup.

### Expected

- Config load succeeds and legacy keys do not survive normalized runtime config.

### Actual

- Before fix: validation fails with unrecognized-key errors.
- After fix: config loads successfully; legacy keys are tolerated then stripped.

## Evidence

- `pnpm exec vitest run src/config/config.discord.test.ts src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts src/config/config.dm-policy-alias.test.ts`
- `pnpm exec vitest run src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.test.ts`

## Human Verification (required)

- Verified scenarios: top-level and account-scoped Discord guild channel legacy keys are stripped on load.
- Edge cases checked: existing valid channel keys remain intact; legacy migration only mutates when those specific keys exist.
- What I did **not** verify: full interactive Discord onboarding flow end-to-end in a live server.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No` (automatic compatibility + doctor migration cleanup)

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `src/config/zod-schema.providers-core.ts`, `src/config/legacy.migrations.part-1.ts`, tests.
- Known bad symptoms: Discord config with legacy keys may become invalid again and block startup.

## Risks and Mitigations

- Risk: silently tolerating legacy keys could hide misconfigured model routing intent.
- Mitigation: keys are stripped from normalized config and explicitly removed by legacy migration during doctor cleanup.
