### PR TITLE
fix(subagents): deliver completion announce when subagent replies with NO_REPLY

### DIFF
--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -442,7 +442,11 @@ describe("subagent announce formatting", () => {
     expect(sessionsDeleteSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("suppresses completion delivery when subagent reply is NO_REPLY", async () => {
+  it("still delivers completion announce when subagent reply is NO_REPLY (regression: #30642)", async () => {
+    // A subagent may reply NO_REPLY to suppress a redundant channel message (e.g. it
+    // already delivered results via a tool call).  The announce flow must NOT be
+    // skipped entirely: the parent session still needs the completion signal so
+    // multi-agent orchestration can advance past the finished subagent.
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:test",
       childRunId: "run-direct-completion-no-reply",
@@ -455,7 +459,10 @@ describe("subagent announce formatting", () => {
     });
 
     expect(didAnnounce).toBe(true);
-    expect(sendSpy).not.toHaveBeenCalled();
+    // Completion signal delivered with neutral placeholder text (not suppressed)
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    const sentCall = sendSpy.mock.calls[0]?.[0] as { params?: { message?: string } } | undefined;
+    expect(sentCall?.params?.message ?? "").toContain("(completed without additional output)");
     expect(agentSpy).not.toHaveBeenCalled();
   });
 

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1187,7 +1187,13 @@ export async function runSubagentAnnounceFlow(params: {
       return true;
     }
     if (isSilentReplyText(reply, SILENT_REPLY_TOKEN)) {
-      return true;
+      // The subagent intentionally suppressed its channel reply (e.g. it already
+      // delivered results via tool calls and used NO_REPLY to avoid a duplicate
+      // message).  However, we must NOT skip the announce entirely: the parent
+      // session needs the completion signal to advance multi-agent workflows.
+      // Replace the silent token with a neutral placeholder so the announce flow
+      // continues and injects the completion event into the requester session.
+      reply = "(completed without additional output)";
     }
 
     if (!outcome) {


### PR DESCRIPTION
## Summary

Fixes #30642

When a subagent's final text is `NO_REPLY` (SILENT_REPLY_TOKEN), the `runSubagentAnnounceFlow` function was returning early — silently skipping the entire announce. This broke multi-agent orchestration: the parent/director session never received the completion signal and would hang indefinitely waiting for a subagent that had already finished.

## Root Cause

`NO_REPLY` serves two independent purposes that were incorrectly coupled:

1. **Suppress channel message delivery** — the subagent already delivered results via tool calls (e.g. `message` tool to send a Discord embed) and wants to avoid a duplicate outbound message.
2. **Signal completion to the parent session** — the parent orchestrator needs to know the subagent finished so it can advance the workflow.

The old code treated both as one: if the reply was `NO_REPLY`, skip the announce entirely (`return true`). The parent never got the completion event.

## Fix

Instead of skipping, replace `NO_REPLY` with a neutral placeholder `"(completed without additional output)"` and continue the announce flow. The parent session receives the completion event. The parent agent then decides whether to relay anything to the end user (and will suppress redundant messages with its own `NO_REPLY` if needed).

The `isAnnounceSkip` path (ANNOUNCE_SKIP_TOKEN) is unchanged — that token is the explicit "skip the announce entirely" marker and is unaffected.

## Changes

- **`src/agents/subagent-announce.ts`**: Replace silent-token early return with neutral placeholder text; continue announce delivery.
- **`src/agents/subagent-announce.format.test.ts`**: Update the existing `NO_REPLY` test to reflect correct new behavior (announce IS delivered with placeholder text); add regression comment referencing #30642.

## Testing

- All 50 `subagent-announce.format.test.ts` tests pass ✅
- All related announce tests pass (`subagent-announce-dispatch`, `subagent-announce-queue`, `subagent-announce.timeout`, `subagent-registry.announce-loop-guard`) ✅
- `pnpm build` ✅ `pnpm check` (0 errors, 0 warnings) ✅