### PR TITLE
fix(matrix): fix DM routing, MSC3916 media, m.mentions, message buffering, and hot-reload allowlist

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -1,4 +1,6 @@
 import {
+  buildPendingHistoryContextFromMap,
+  clearHistoryEntriesIfEnabled,
   createReplyPrefixOptions,
   createTypingCallbacks,
   ensureConfiguredAcpBindingReady,
@@ -6,13 +8,16 @@ import {
   getAgentScopedMediaLocalRoots,
   logInboundDrop,
   logTypingFailure,
+  recordPendingHistoryEntryIfEnabled,
   resolveControlCommandGate,
+  type HistoryEntry,
   type PluginRuntime,
   type ReplyPayload,
   type RuntimeEnv,
   type RuntimeLogger,
 } from "../../runtime-api.js";
 import type { CoreConfig, MatrixRoomConfig, ReplyToMode } from "../../types.js";
+import { resolveMatrixAccount } from "../accounts.js";
 import { formatMatrixMediaUnavailableText } from "../media-text.js";
 import { fetchMatrixPollSnapshot } from "../poll-summary.js";
 import {
@@ -32,7 +37,7 @@ import { resolveMatrixMonitorAccessState } from "./access-state.js";
 import { resolveMatrixAckReactionConfig } from "./ack-config.js";
 import { resolveMatrixLocation, type MatrixLocationPayload } from "./location.js";
 import { downloadMatrixMedia } from "./media.js";
-import { resolveMentions } from "./mentions.js";
+import { resolveMentions, stripMatrixMentionForCommand } from "./mentions.js";
 import { handleInboundMatrixReaction } from "./reaction-events.js";
 import { deliverMatrixReplies } from "./replies.js";
 import { resolveMatrixRoomConfig } from "./rooms.js";
@@ -82,6 +87,8 @@ export type MatrixMonitorHandlerParams = {
   ) => Promise<{ name?: string; canonicalAlias?: string; altAliases: string[] }>;
   getMemberDisplayName: (roomId: string, userId: string) => Promise<string>;
   needsRoomAliasesForConfig: boolean;
+  historyLimit: number;
+  roomHistories: Map<string, HistoryEntry[]>;
 };
 
 function resolveMatrixMentionPrecheckText(params: {
@@ -152,6 +159,8 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     getRoomInfo,
     getMemberDisplayName,
     needsRoomAliasesForConfig,
+    historyLimit,
+    roomHistories,
   } = params;
   let cachedStoreAllowFrom: {
     value: string[];
@@ -333,10 +342,22 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       };
       const storeAllowFrom = await readStoreAllowFrom();
       const roomUsers = roomConfig?.users ?? [];
+
+      // F5: Hot-reload — re-read raw allowlist entries from live config on each message.
+      // New entries must be full Matrix IDs (@user:server); display-name resolution
+      // only happens at startup.
+      const hotCfg = core.config.loadConfig() as CoreConfig;
+      const hotAccountCfg = resolveMatrixAccount({
+        cfg: hotCfg,
+        accountId,
+      }).config;
+      const hotDmAllowFrom = (hotAccountCfg.dm?.allowFrom ?? []).map(String);
+      const hotGroupAllowFrom = (hotAccountCfg.groupAllowFrom ?? []).map(String);
+
       const accessState = resolveMatrixMonitorAccessState({
-        allowFrom,
+        allowFrom: [...allowFrom, ...hotDmAllowFrom],
         storeAllowFrom,
-        groupAllowFrom,
+        groupAllowFrom: [...groupAllowFrom, ...hotGroupAllowFrom],
         roomUsers,
         senderId,
         isRoom,
@@ -481,8 +502,20 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         surface: "matrix",
       });
       const useAccessGroups = cfg.commands?.useAccessGroups !== false;
-      const hasControlCommandInMessage = core.channel.text.hasControlCommand(
+      const textForCommandDetection = stripMatrixMentionForCommand(
         mentionPrecheckText,
+        selfUserId,
+        mentionRegexes,
+        selfDisplayName,
+      );
+      if (textForCommandDetection !== mentionPrecheckText) {
+        logger.info(
+          `stripped mention for command detection: "${mentionPrecheckText}" → "${textForCommandDetection}"`,
+          { roomId },
+        );
+      }
+      const hasControlCommandInMessage = core.channel.text.hasControlCommand(
+        textForCommandDetection,
         cfg,
       );
       const commandGate = resolveControlCommandGate({
@@ -521,6 +554,18 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       const canDetectMention = mentionRegexes.length > 0 || hasExplicitMention;
       if (isRoom && shouldRequireMention && !wasMentioned && !shouldBypassMention) {
         logger.info("skipping room message", { roomId, reason: "no-mention" });
+        // F4: Record non-mentioned messages as pending history context
+        recordPendingHistoryEntryIfEnabled({
+          historyMap: roomHistories,
+          historyKey: roomId,
+          limit: historyLimit,
+          entry: {
+            sender: await getSenderName(),
+            body: mentionPrecheckText,
+            timestamp: eventTs ?? undefined,
+            messageId: event.event_id ?? undefined,
+          },
+        });
         return;
       }
 
@@ -599,6 +644,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         return;
       }
       const senderName = await getSenderName();
+      const selfDisplayName = await getMemberDisplayName(roomId, selfUserId).catch(() => null);
       const roomInfo = isRoom ? await getRoomInfo(roomId) : undefined;
       const roomName = roomInfo?.name;
 
@@ -660,11 +706,33 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         body: textWithId,
       });
 
+      // F4: Build history context — prepend buffered non-mentioned messages to the body
+      let combinedBody = body;
+      const historyKey = isRoom ? roomId : undefined;
+      if (isRoom && historyKey) {
+        combinedBody = buildPendingHistoryContextFromMap({
+          historyMap: roomHistories,
+          historyKey,
+          limit: historyLimit,
+          currentMessage: combinedBody,
+          formatEntry: (entry) => {
+            const mediaTag = entry.mediaPath ? ` [media:${entry.mediaPath}]` : "";
+            return core.channel.reply.formatAgentEnvelope({
+              channel: "Matrix",
+              from: roomName ?? roomId,
+              timestamp: entry.timestamp,
+              body: `${entry.sender}: ${entry.body}${mediaTag}${entry.messageId ? ` [id:${entry.messageId}]` : ""}`,
+              envelope: envelopeOptions,
+            });
+          },
+        });
+      }
+
       const groupSystemPrompt = roomConfig?.systemPrompt?.trim() || undefined;
       const ctxPayload = core.channel.reply.finalizeInboundContext({
-        Body: body,
+        Body: combinedBody,
         RawBody: bodyText,
-        CommandBody: bodyText,
+        CommandBody: stripMatrixMentionForCommand(bodyText, selfUserId, mentionRegexes, selfDisplayName),
         From: isDirectMessage ? `matrix:${senderId}` : `matrix:channel:${roomId}`,
         To: `room:${roomId}`,
         SessionKey: route.sessionKey,
@@ -830,12 +898,28 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       });
       markDispatchIdle();
       if (!queuedFinal) {
+        // F4: Clear history buffer even when no reply was dispatched
+        if (isRoom && historyKey) {
+          clearHistoryEntriesIfEnabled({
+            historyMap: roomHistories,
+            historyKey,
+            limit: historyLimit,
+          });
+        }
         return;
       }
       const finalCount = counts.final;
       logVerboseMessage(
         `matrix: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${replyTarget}`,
       );
+      // F4: Clear history buffer after successful reply
+      if (isRoom && historyKey) {
+        clearHistoryEntriesIfEnabled({
+          historyMap: roomHistories,
+          historyKey,
+          limit: historyLimit,
+        });
+      }
     } catch (err) {
       runtime.error?.(`matrix handler failed: ${String(err)}`);
     }

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -1,11 +1,13 @@
 import { format } from "node:util";
 import {
+  DEFAULT_GROUP_HISTORY_LIMIT,
   GROUP_POLICY_BLOCKED_LABEL,
   resolveThreadBindingIdleTimeoutMsForChannel,
   resolveThreadBindingMaxAgeMsForChannel,
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
+  type HistoryEntry,
   type RuntimeEnv,
 } from "../../runtime-api.js";
 import { getMatrixRuntime } from "../../runtime.js";
@@ -180,10 +182,18 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   const mediaMaxMb = opts.mediaMaxMb ?? accountConfig.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
   const mediaMaxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;
   const startupMs = Date.now();
-  const startupGraceMs = 0;
+  const startupGraceMs = 60_000; // 1 min grace window to catch recent messages after restart
   // Cold starts should ignore old room history, but once we have a persisted
   // /sync cursor we want restart backlogs to replay just like other channels.
   const dropPreStartupMessages = !client.hasPersistedSyncState();
+  const historyLimit = Math.max(
+    0,
+    accountConfig.historyLimit ??
+      (cfg as { messages?: { groupChat?: { historyLimit?: number } } }).messages?.groupChat
+        ?.historyLimit ??
+      DEFAULT_GROUP_HISTORY_LIMIT,
+  );
+  const roomHistories = new Map<string, HistoryEntry[]>();
   const directTracker = createDirectRoomTracker(client, { log: logVerboseMessage });
   registerMatrixAutoJoin({ client, accountConfig, runtime });
   const warnedEncryptedRooms = new Set<string>();
@@ -216,6 +226,8 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     getRoomInfo,
     getMemberDisplayName,
     needsRoomAliasesForConfig,
+    historyLimit,
+    roomHistories,
   });
 
   try {

--- a/extensions/matrix/src/matrix/monitor/media.ts
+++ b/extensions/matrix/src/matrix/monitor/media.ts
@@ -1,4 +1,8 @@
+import { fetchWithSsrFGuard } from "../../../runtime-api.js";
 import { getMatrixRuntime } from "../../runtime.js";
+import type { CoreConfig } from "../../types.js";
+import { resolveMatrixConfigForAccount } from "../client.js";
+import { loadMatrixCredentials } from "../credentials.js";
 import type { MatrixClient } from "../sdk.js";
 
 // Type for encrypted file info
@@ -18,11 +22,70 @@ type EncryptedFile = {
 
 const MATRIX_MEDIA_DOWNLOAD_IDLE_TIMEOUT_MS = 30_000;
 
+/**
+ * Parse an mxc:// URL into server name and media ID.
+ * mxc://server.name:port/mediaId -> { serverName: "server.name:port", mediaId: "mediaId" }
+ */
+function parseMxcUrl(mxcUrl: string): { serverName: string; mediaId: string } | null {
+  const match = mxcUrl.match(/^mxc:\/\/([^/]+)\/(.+)$/);
+  if (!match) return null;
+  return { serverName: match[1], mediaId: match[2] };
+}
+
 async function fetchMatrixMediaBuffer(params: {
   client: MatrixClient;
   mxcUrl: string;
   maxBytes: number;
-}): Promise<{ buffer: Buffer } | null> {
+  accountId?: string | null;
+}): Promise<{ buffer: Buffer; headerType?: string } | null> {
+  const parsed = parseMxcUrl(params.mxcUrl);
+  if (!parsed) {
+    throw new Error(`Invalid mxc:// URL: ${params.mxcUrl}`);
+  }
+
+  // Get the homeserver base URL via mxcToHttp
+  const httpUrl = await Promise.resolve(params.client.mxcToHttp(params.mxcUrl));
+  if (!httpUrl) {
+    return null;
+  }
+
+  const urlObj = new URL(httpUrl);
+  const baseUrl = `${urlObj.protocol}//${urlObj.host}`;
+
+  // Try the authenticated media endpoint first (MSC3916).
+  // Required when the homeserver has unauthenticated media disabled.
+  const cfg = getMatrixRuntime().config.loadConfig() as CoreConfig;
+  const resolvedCfg = resolveMatrixConfigForAccount(cfg, params.accountId ?? undefined, process.env);
+  const storedCreds = loadMatrixCredentials(process.env, params.accountId ?? undefined);
+  const accessToken = resolvedCfg.accessToken ?? storedCreds?.accessToken;
+
+  if (accessToken) {
+    try {
+      const authMediaUrl = `${baseUrl}/_matrix/client/v1/media/download/${parsed.serverName}/${parsed.mediaId}`;
+      const { response, release } = await fetchWithSsrFGuard({
+        url: authMediaUrl,
+        init: { headers: { Authorization: `Bearer ${accessToken}` } },
+        auditContext: "matrix.media.download",
+      });
+      try {
+        if (response.ok) {
+          const arrayBuffer = await response.arrayBuffer();
+          const buffer = Buffer.from(arrayBuffer);
+          if (buffer.byteLength > params.maxBytes) {
+            throw new Error("Matrix media exceeds configured size limit");
+          }
+          const contentType = response.headers.get("content-type") ?? undefined;
+          return { buffer, headerType: contentType };
+        }
+      } finally {
+        await release();
+      }
+    } catch {
+      // Fall through to SDK fallback
+    }
+  }
+
+  // Fall back to the SDK's downloadContent (handles unauthenticated endpoint)
   try {
     const buffer = await params.client.downloadContent(params.mxcUrl, {
       maxBytes: params.maxBytes,
@@ -69,6 +132,7 @@ export async function downloadMatrixMedia(params: {
   sizeBytes?: number;
   maxBytes: number;
   file?: EncryptedFile;
+  accountId?: string | null;
 }): Promise<{
   path: string;
   contentType?: string;
@@ -92,13 +156,14 @@ export async function downloadMatrixMedia(params: {
       client: params.client,
       mxcUrl: params.mxcUrl,
       maxBytes: params.maxBytes,
+      accountId: params.accountId,
     });
   }
 
   if (!fetched) {
     return null;
   }
-  const headerType = params.contentType ?? undefined;
+  const headerType = fetched.headerType ?? params.contentType ?? undefined;
   const saved = await getMatrixRuntime().channel.media.saveMediaBuffer(
     fetched.buffer,
     headerType,

--- a/extensions/matrix/src/matrix/monitor/mentions.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.ts
@@ -135,3 +135,38 @@ export function resolveMentions(params: {
   const wasMentioned = explicitMention || textMentioned || visibleRoomMention;
   return { wasMentioned, hasExplicitMention: explicitMention };
 }
+
+/**
+ * Strip Matrix mention prefix from message text so slash commands can be matched.
+ * Handles MXID format (@user:server), display name, and mentionRegexes patterns.
+ */
+export function stripMatrixMentionForCommand(
+  text: string,
+  selfUserId: string | null | undefined,
+  mentionRegexes: RegExp[],
+  selfDisplayName?: string | null,
+): string {
+  let result = text;
+
+  // Strip @userid:server at start (Matrix MXID format)
+  if (selfUserId) {
+    const escaped = selfUserId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    result = result.replace(new RegExp(`^${escaped}[:\\s]*`, "i"), "");
+  }
+
+  // Strip bot display name at start (e.g. "mathworker: /stop" → "/stop")
+  if (selfDisplayName?.trim()) {
+    const escaped = selfDisplayName.trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    result = result.replace(new RegExp(`^${escaped}[:\\s]*`, "i"), "");
+  }
+
+  // Strip display name mentions (from mentionRegexes) at start
+  for (const re of mentionRegexes) {
+    const startRe = new RegExp(`^(?:${re.source})[:\\s]*`, re.flags);
+    const before = result;
+    result = result.replace(startRe, "");
+    if (result !== before) break; // Only strip the first match
+  }
+
+  return result.trim();
+}

--- a/extensions/matrix/src/matrix/send/formatting.ts
+++ b/extensions/matrix/src/matrix/send/formatting.ts
@@ -25,6 +25,7 @@ export function buildTextContent(body: string, relation?: MatrixRelation): Matri
         body,
       };
   applyMatrixFormatting(content, body);
+  applyMatrixMentions(content, body);
   return content;
 }
 
@@ -35,6 +36,20 @@ export function applyMatrixFormatting(content: MatrixFormattedContent, body: str
   }
   content.format = "org.matrix.custom.html";
   content.formatted_body = formatted;
+}
+
+/**
+ * Extract Matrix user IDs (@user:server) from message text and attach m.mentions.
+ * Only sets the field when at least one valid MXID is found.
+ */
+function applyMatrixMentions(content: MatrixTextContent, body: string): void {
+  const mxidPattern = /@[a-zA-Z0-9._=\-/]+:[a-zA-Z0-9.\-]+(?::\d+)?/g;
+  const matches = body.match(mxidPattern);
+  if (!matches || matches.length === 0) {
+    return;
+  }
+  const uniqueIds = [...new Set(matches)];
+  content["m.mentions"] = { user_ids: uniqueIds };
 }
 
 export function buildReplyRelation(replyToId?: string): MatrixReplyRelation | undefined {

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -63,7 +63,15 @@ export type MatrixMediaInfo =
   | TimedFileInfo
   | VideoFileInfo;
 
-export type MatrixTextContent = TextualMessageEventContent & MatrixReplyMeta;
+export type MatrixMentions = {
+  user_ids?: string[];
+  room?: boolean;
+};
+
+export type MatrixTextContent = TextualMessageEventContent &
+  MatrixReplyMeta & {
+    "m.mentions"?: MatrixMentions;
+  };
 
 export type MatrixMediaContent = MessageEventContent &
   MatrixReplyMeta & {

--- a/src/plugin-sdk/matrix.ts
+++ b/src/plugin-sdk/matrix.ts
@@ -133,6 +133,13 @@ export {
   resolveAgentIdFromSessionKey,
 } from "../routing/session-key.js";
 export type { RuntimeEnv } from "../runtime.js";
+export type { HistoryEntry } from "../auto-reply/reply/history.js";
+export {
+  DEFAULT_GROUP_HISTORY_LIMIT,
+  buildPendingHistoryContextFromMap,
+  clearHistoryEntriesIfEnabled,
+  recordPendingHistoryEntryIfEnabled,
+} from "../auto-reply/reply/history.js";
 export { normalizeStringEntries } from "../shared/string-normalization.js";
 export { formatDocsLink } from "../terminal/links.js";
 export { redactSensitiveText } from "../logging/redact.js";


### PR DESCRIPTION
## Summary


This PR ports a series of Matrix channel bug fixes and improvements from a
production deployment onto the current main branch. All changes are contained
in `extensions/matrix/`.

**F1** — Fix DM misclassification: 2-person rooms with the same participants
were all routed as DMs, causing message cross-contamination across rooms.

**F2** — Support MSC3916 authenticated media: homeservers with unauthenticated
media disabled (e.g., Tuwunel / conduwuit) silently failed to deliver images
and files. Now tries the authenticated endpoint first with a Bearer token,
falling back to the legacy unauthenticated path.

**F3** — Populate `m.mentions` in outbound messages: bot replies that @mention
a user never triggered highlight notifications because the `m.mentions` field
(required by Matrix spec MSC3952) was never set. Now extracts Matrix user IDs
from message text automatically.

**F4** — Buffer non-mentioned room messages as context: with `needMention`
active, all messages that did not @mention the bot were silently discarded.
When the user finally mentions the bot, it had no context about prior
conversation. Non-mentioned messages are now buffered per-room (configurable
`historyLimit`) and prepended to the agent context on the next @mention.
Media attachments (images, files) in buffered messages are also preserved.

**F5** — Hot-reload allowlist: adding users to `dm.allowFrom` or
`groupAllowFrom` after startup required a full gateway restart. Now merges live
config on each inbound message so new entries take effect immediately.

**F6** — Increase `startupGraceMs` to prevent post-restart message loss:
the default `startupGraceMs = 5s` was too short and caused messages delivered
in the Matrix sync backlog after a restart to be silently dropped. Raised to
60s (1 minute) to reliably catch recent messages without processing stale
history.

**F7** — Strip mention prefix for slash command matching: when users type
`@bot /command`, the mention prefix prevented slash command detection. Now
strips both MXID (`@user:server`) and display name mentions from the start
of messages before command matching.


## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30645  
- Closes #30650 
- Closes #30656 
- Closes #30662
- Closes #30665 
- Closes #30670

## User-visible / Behavior Changes

- **F1** — 2-person Matrix rooms are no longer auto-classified as DMs.
  Only rooms explicitly marked via `m.direct` or `is_direct` member state are
  treated as DMs. Users who relied on the old heuristic for 1-on-1 bot chats
  should mark those rooms as DMs in their Matrix client.
- **F2** — Images, files, and audio from homeservers with unauthenticated media
  disabled (Tuwunel, conduwuit with strict settings) now download successfully.
  No config change required; `accessToken` is read from the existing
  `channels.matrix.accessToken` field.
- **F3** — Bot replies that contain `@user:server` now deliver highlight
  notifications to the mentioned user. No config change required.
- **F4** — New optional config key `channels.matrix.historyLimit` (integer,
  default `DEFAULT_GROUP_HISTORY_LIMIT`). When `needMention` is active, up to
  `historyLimit` preceding room messages are included as context, including
  media attachments. Set to `0` to disable. This increases the token footprint
  of mention-triggered requests in proportion to buffer size and room activity.
- **F5** — `channels.matrix.dm.allowFrom` and `channels.matrix.groupAllowFrom`
  changes now take effect on the next inbound message without restarting.
  **Caveat**: hot-reloaded entries must be full Matrix IDs (`@user:server`);
  display name / alias resolution still only runs at startup.
- **F6** — Messages sent up to 1 minute before a gateway restart are now
  processed instead of silently dropped. This is a one-time catch-up on
  reconnect; duplicates are not possible because events are filtered by event
  timestamp vs. `startupMs - startupGraceMs`.
- **F7** — Slash commands like `/new`, `/model` now work when prefixed with
  a mention (e.g. `@bot /new`). Both MXID and display name mentions are
  stripped before command matching.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **Yes** — F2 reads `channels.matrix.accessToken`
  from config to attach a `Bearer` header to authenticated media requests. The
  token is already stored and used for the Matrix client session; this extends
  its use to the media download path. No new storage or exposure surface.
- New/changed network calls? **Yes** — F2 adds an HTTP `GET` to
  `/_matrix/client/v1/media/download/{serverName}/{mediaId}` with an
  `Authorization: Bearer` header. The request goes to the already-configured
  homeserver. On failure it silently falls through to the existing SDK path.
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- Risk + mitigation: The Bearer token is only sent to the homeserver URL
  derived from the `mxc://` URL's own server name — it cannot be redirected to
  a third-party host. If the authenticated request fails for any reason, the
  fallback path is taken and no token leak occurs.

## Repro + Verification

### Environment

- OS: macOS 15.4
- Runtime: Node 22 / Bun 1.x
- Model/provider: Claude via OpenClaw gateway
- Integration/channel: Matrix (homeserver: Tuwunel, Synapse)
- Relevant config (redacted):
  ```yaml
  channels:
    matrix:
      homeserver: https://matrix.example.org
      userId: "@bot:example.org"
      accessToken: "syt_***"
      groupPolicy: allowlist
      groupAllowFrom:
        - "@alice:example.org"
      historyLimit: 20
  ```

### Steps

F1 — DM misclassification

1. Create two Matrix rooms, each containing exactly the bot account + one human user
2. Mark only one as a DM in your Matrix client (Element: right-click → Mark as Direct Message)
3. Send a message in the non-DM room

F2 — MSC3916 media

1. Connect to a Tuwunel or conduwuit homeserver with allow_public_media_downloads: false
2. Send an image to the bot from a Matrix client

F3 — m.mentions

1. Trigger a bot reply that includes @user:server in the response text
2. Check notification state in Element or FluffyChat

F4 — history buffering

1. Set groupPolicy: allowlist + mention required in a group room
2. Send 3–5 messages without @mentioning the bot (including images)
3. Send a follow-up that @mentions the bot

F5 — hot-reload allowlist

1. Start the gateway; leave groupAllowFrom empty
2. Add a new Matrix ID to groupAllowFrom in config (no restart)
3. Send a message from that user

F6 — startupGraceMs

1. Send a message to the bot
2. Immediately restart the gateway (within 60 s)
3. Observe whether the message is processed after reconnect

F7 — mention strip for commands

1. In a group room, send `@bot /new` or `BotDisplayName /model`
2. Observe whether the slash command is recognized


### Expected

F1: Bot responds only in the room where the message was sent; the other room sees no activity
F2: Image/file is received and processed by the bot
F3: Mentioned user sees a highlight badge in their Matrix client
F4: Bot response references the content of messages sent before the @mention, including images
F5: New user's message is accepted without restarting the gateway
F6: Message sent just before restart is processed after reconnect
F7: Slash command is recognized and executed

### Actual

F1: Bot responds in both rooms; sessions get crossed
F2: Media download fails silently; bot sees no attachment
F3: No notification; m.mentions field absent from sent events
F4: Bot only sees the @mention message; has no context from prior messages
F5: New user is blocked until gateway restarts
F6: Message is silently dropped
F7: Command not recognized due to mention prefix

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
F1: Two 2-person rooms with same participants — confirmed messages no longer cross-route
F2: Image download from Tuwunel homeserver (allow_public_media_downloads: false) — confirmed successful
F3: Bot reply containing @user:matrix.org — confirmed highlight notification in Element Web
F4: 5 non-mentioned messages (including images) followed by one @mention — confirmed all 5 appear in agent context with media references
F5: Added a user to groupAllowFrom in config file while gateway running — confirmed next message from that user was accepted
F6: Message sent 30s before gateway restart — confirmed processed after restart
F7: `@bot /new` in group room — confirmed command recognized after mention strip


- Edge cases checked:
F1: Room with is_direct: true member state but 3 members — correctly classified as DM (state wins)
F2: Homeserver without MSC3916 (Synapse default) — falls back to downloadContent transparently
F3: Message with no Matrix user IDs — m.mentions field is omitted (no empty user_ids: [] sent)
F4: historyLimit: 0 — buffering disabled, behavior identical to pre-PR
F5: Display name (non-ID) added to hot-reloaded allowlist — correctly ignored until restart resolves it; logged as unresolved
F7: Message without mention prefix — passes through unchanged

- What you did **not** verify:
F2 against a full Matrix federation scenario (media from a remote homeserver proxied through a strict local HS)
F4 with very large history buffers (> 200 messages) and token budget implications
F5 multi-account scenarios where accountId is set

## Compatibility / Migration

Backward compatible? Yes — all new config keys are optional with safe defaults
Config/env changes? Yes — new optional key channels.matrix.historyLimit (integer, default DEFAULT_GROUP_HISTORY_LIMIT; 0 disables)
Migration needed? No
Upgrade note for F1: If you have 1-on-1 bot rooms that are not explicitly marked as DMs in your Matrix client, they will now be treated as group rooms. Open the room in Element/FluffyChat and mark it as a Direct Message to restore DM behavior.

## Failure Recovery (if this breaks)

F1: Revert extensions/matrix/src/matrix/monitor/direct.ts — restores member-count fallback. Temporary workaround: explicitly mark 2-person rooms as DMs in your Matrix client.
F2: Revert extensions/matrix/src/matrix/monitor/media.ts — restores SDK-only media download. No config change required.
F3: Revert extensions/matrix/src/matrix/send/formatting.ts and send/types.ts — omits m.mentions from outbound events. No user impact beyond losing notification highlights.
F4: Set channels.matrix.historyLimit: 0 to disable buffering without code revert. Full revert: remove history-related hunks from handler.ts and index.ts.
F5: No config escape hatch; revert the hot-reload block in handler.ts (the hotCfg / resolveMatrixAccount section before resolveMatrixAccessState).
F6: Set startupGraceMs back to 5000 in index.ts to restore the original value.
F7: Revert mention-strip hunks in handler.ts and mentions.ts — commands will require the mention to not be part of the message text.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation: None