### PR TITLE
fix(telegram): check chat allowlist before sender allowlist in group policy

### DIFF
--- a/src/telegram/group-access.policy-access.test.ts
+++ b/src/telegram/group-access.policy-access.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { TelegramAccountConfig } from "../config/types.js";
+import { evaluateTelegramGroupPolicyAccess } from "./group-access.js";
+
+/**
+ * Minimal stubs shared across tests.
+ */
+const baseCfg = {
+  channels: { telegram: {} },
+} as unknown as OpenClawConfig;
+
+const baseTelegramCfg: TelegramAccountConfig = {
+  groupPolicy: "allowlist",
+} as unknown as TelegramAccountConfig;
+
+const emptyAllow = { entries: [], hasWildcard: false, hasEntries: false, invalidEntries: [] };
+const senderAllow = {
+  entries: ["111"],
+  hasWildcard: false,
+  hasEntries: true,
+  invalidEntries: [],
+};
+
+describe("evaluateTelegramGroupPolicyAccess – chat allowlist vs sender allowlist ordering", () => {
+  it("allows a group explicitly listed in groups config even when no allowFrom entries exist", () => {
+    // Issue #30613: a group configured with a dedicated entry (groupConfig set)
+    // should be allowed even without any allowFrom / groupAllowFrom entries.
+    const result = evaluateTelegramGroupPolicyAccess({
+      isGroup: true,
+      chatId: "-100123456",
+      cfg: baseCfg,
+      telegramCfg: baseTelegramCfg,
+      effectiveGroupAllow: emptyAllow,
+      senderId: "999",
+      senderUsername: "user",
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: true,
+        allowed: true,
+        groupConfig: { requireMention: false }, // dedicated entry — not just wildcard
+      }),
+      enforcePolicy: true,
+      useTopicAndGroupOverrides: false,
+      enforceAllowlistAuthorization: true,
+      allowEmptyAllowlistEntries: false,
+      requireSenderForAllowlistAuthorization: true,
+      checkChatAllowlist: true,
+    });
+
+    expect(result).toEqual({ allowed: true, groupPolicy: "allowlist" });
+  });
+
+  it("still blocks when only wildcard match and no allowFrom entries", () => {
+    // groups: { "*": ... } with no allowFrom → wildcard does NOT bypass sender checks.
+    const result = evaluateTelegramGroupPolicyAccess({
+      isGroup: true,
+      chatId: "-100123456",
+      cfg: baseCfg,
+      telegramCfg: baseTelegramCfg,
+      effectiveGroupAllow: emptyAllow,
+      senderId: "999",
+      senderUsername: "user",
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: true,
+        allowed: true,
+        groupConfig: undefined, // wildcard match only — no dedicated entry
+      }),
+      enforcePolicy: true,
+      useTopicAndGroupOverrides: false,
+      enforceAllowlistAuthorization: true,
+      allowEmptyAllowlistEntries: false,
+      requireSenderForAllowlistAuthorization: true,
+      checkChatAllowlist: true,
+    });
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "group-policy-allowlist-empty",
+      groupPolicy: "allowlist",
+    });
+  });
+
+  it("rejects a group NOT in groups config", () => {
+    const result = evaluateTelegramGroupPolicyAccess({
+      isGroup: true,
+      chatId: "-100999999",
+      cfg: baseCfg,
+      telegramCfg: baseTelegramCfg,
+      effectiveGroupAllow: emptyAllow,
+      senderId: "999",
+      senderUsername: "user",
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: true,
+        allowed: false,
+      }),
+      enforcePolicy: true,
+      useTopicAndGroupOverrides: false,
+      enforceAllowlistAuthorization: true,
+      allowEmptyAllowlistEntries: false,
+      requireSenderForAllowlistAuthorization: true,
+      checkChatAllowlist: true,
+    });
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "group-chat-not-allowed",
+      groupPolicy: "allowlist",
+    });
+  });
+
+  it("still enforces sender allowlist when checkChatAllowlist is disabled", () => {
+    const result = evaluateTelegramGroupPolicyAccess({
+      isGroup: true,
+      chatId: "-100123456",
+      cfg: baseCfg,
+      telegramCfg: baseTelegramCfg,
+      effectiveGroupAllow: emptyAllow,
+      senderId: "999",
+      senderUsername: "user",
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: true,
+        allowed: true,
+        groupConfig: { requireMention: false },
+      }),
+      enforcePolicy: true,
+      useTopicAndGroupOverrides: false,
+      enforceAllowlistAuthorization: true,
+      allowEmptyAllowlistEntries: false,
+      requireSenderForAllowlistAuthorization: true,
+      checkChatAllowlist: false,
+    });
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "group-policy-allowlist-empty",
+      groupPolicy: "allowlist",
+    });
+  });
+
+  it("blocks unauthorized sender even when chat is explicitly allowed and sender entries exist", () => {
+    const result = evaluateTelegramGroupPolicyAccess({
+      isGroup: true,
+      chatId: "-100123456",
+      cfg: baseCfg,
+      telegramCfg: baseTelegramCfg,
+      effectiveGroupAllow: senderAllow, // entries: ["111"]
+      senderId: "222", // not in senderAllow.entries
+      senderUsername: "other",
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: true,
+        allowed: true,
+        groupConfig: { requireMention: false },
+      }),
+      enforcePolicy: true,
+      useTopicAndGroupOverrides: false,
+      enforceAllowlistAuthorization: true,
+      allowEmptyAllowlistEntries: false,
+      requireSenderForAllowlistAuthorization: true,
+      checkChatAllowlist: true,
+    });
+
+    // Chat is explicitly allowed, but sender entries exist and sender is not in them.
+    expect(result).toEqual({
+      allowed: false,
+      reason: "group-policy-allowlist-unauthorized",
+      groupPolicy: "allowlist",
+    });
+  });
+
+  it("allows when groupPolicy is open regardless of allowlist state", () => {
+    const result = evaluateTelegramGroupPolicyAccess({
+      isGroup: true,
+      chatId: "-100123456",
+      cfg: baseCfg,
+      telegramCfg: { groupPolicy: "open" } as unknown as TelegramAccountConfig,
+      effectiveGroupAllow: emptyAllow,
+      senderId: "999",
+      senderUsername: "user",
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: false,
+        allowed: false,
+      }),
+      enforcePolicy: true,
+      useTopicAndGroupOverrides: false,
+      enforceAllowlistAuthorization: true,
+      allowEmptyAllowlistEntries: false,
+      requireSenderForAllowlistAuthorization: true,
+      checkChatAllowlist: true,
+    });
+
+    expect(result).toEqual({ allowed: true, groupPolicy: "open" });
+  });
+
+  it("rejects when groupPolicy is disabled", () => {
+    const result = evaluateTelegramGroupPolicyAccess({
+      isGroup: true,
+      chatId: "-100123456",
+      cfg: baseCfg,
+      telegramCfg: { groupPolicy: "disabled" } as unknown as TelegramAccountConfig,
+      effectiveGroupAllow: emptyAllow,
+      senderId: "999",
+      senderUsername: "user",
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: false,
+        allowed: false,
+      }),
+      enforcePolicy: true,
+      useTopicAndGroupOverrides: false,
+      enforceAllowlistAuthorization: true,
+      allowEmptyAllowlistEntries: false,
+      requireSenderForAllowlistAuthorization: true,
+      checkChatAllowlist: true,
+    });
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "group-policy-disabled",
+      groupPolicy: "disabled",
+    });
+  });
+
+  it("allows non-group messages without any checks", () => {
+    const result = evaluateTelegramGroupPolicyAccess({
+      isGroup: false,
+      chatId: "12345",
+      cfg: baseCfg,
+      telegramCfg: baseTelegramCfg,
+      effectiveGroupAllow: emptyAllow,
+      senderId: "999",
+      senderUsername: "user",
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: true,
+        allowed: false,
+      }),
+      enforcePolicy: true,
+      useTopicAndGroupOverrides: false,
+      enforceAllowlistAuthorization: true,
+      allowEmptyAllowlistEntries: false,
+      requireSenderForAllowlistAuthorization: true,
+      checkChatAllowlist: true,
+    });
+
+    expect(result).toEqual({ allowed: true, groupPolicy: "allowlist" });
+  });
+
+  it("allows authorized sender in wildcard-matched group with sender entries", () => {
+    const result = evaluateTelegramGroupPolicyAccess({
+      isGroup: true,
+      chatId: "-100123456",
+      cfg: baseCfg,
+      telegramCfg: baseTelegramCfg,
+      effectiveGroupAllow: senderAllow, // entries: ["111"]
+      senderId: "111", // IS in senderAllow.entries
+      senderUsername: "user",
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: true,
+        allowed: true,
+        groupConfig: undefined, // wildcard only
+      }),
+      enforcePolicy: true,
+      useTopicAndGroupOverrides: false,
+      enforceAllowlistAuthorization: true,
+      allowEmptyAllowlistEntries: false,
+      requireSenderForAllowlistAuthorization: true,
+      checkChatAllowlist: true,
+    });
+
+    expect(result).toEqual({ allowed: true, groupPolicy: "allowlist" });
+  });
+});


### PR DESCRIPTION
### Summary

Fixes #30613. When `groupPolicy: "allowlist"` is set, this change ensures that the chat-level allowlist check (i.e., whether the group is explicitly listed in the `groups` config) is evaluated **before** the sender-level allowlist check (`allowEmptyAllowlistEntries`).

This prevents messages from being silently dropped in groups that are explicitly configured but have no `allowFrom` or `groupAllowFrom` entries.

### Root Cause

In `evaluateTelegramGroupPolicyAccess`, the sender-level `allowEmptyAllowlistEntries` check was performed before the `checkChatAllowlist` block. This meant that if a group was explicitly listed in the `groups` config (which should make it allowed) but had no `allowFrom` entries, the function would short-circuit and return `allowed: false` with reason `group-policy-allowlist-empty` before ever checking if the chat itself was on the allowlist.

```ts
// Before (bug): sender check fires first and short-circuits
if (!params.allowEmptyAllowlistEntries && !params.effectiveGroupAllow.hasEntries)
  return { allowed: false, reason: "group-policy-allowlist-empty" };

// The chat-level check never runs:
if (params.checkChatAllowlist) { ... }
```

### Fix

1. **Reorder checks**: the `checkChatAllowlist` block is moved before the sender-level authorization block.
2. **Distinguish explicit vs. wildcard**: a `chatExplicitlyAllowed` flag is set only when `resolveGroupPolicy` finds a dedicated `groupConfig` for the chat ID. A `"*"` wildcard match alone does **not** set this flag, so sender-level filtering still applies for wildcard-matched groups.
3. **Conditional skip**: the `allowEmptyAllowlistEntries` guard is skipped when `chatExplicitlyAllowed` is true. If sender-level entries exist, the sender is still checked against them.

### Testing

- Added `group-access.policy-access.test.ts` with 9 test cases covering explicit entry, wildcard, sender override, and edge-case scenarios.

### Changed Files

| File | Change |
|------|--------|
| `src/telegram/group-access.ts` | Reordered checks, added `chatExplicitlyAllowed` flag |
| `src/telegram/group-access.policy-access.test.ts` | New: 9 test cases |
