### PR TITLE
fix(failover): classify Anthropic Max 402 rate limits as rate_limit, not billing

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -30,6 +30,13 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 402, message: "insufficient credits" })).toBe(
       "billing",
     );
+    // "try again" in billing context must NOT be misclassified as rate_limit (#30687)
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "insufficient credits, try again after adding funds",
+      }),
+    ).toBe("billing");
     expect(resolveFailoverReasonFromError({ statusCode: "429" })).toBe("rate_limit");
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -155,11 +155,16 @@ export function isTimeoutError(err: unknown): boolean {
  * Detect rate-limit semantics in a 402 response.
  * Anthropic Max plan returns HTTP 402 when hitting plan rate limits,
  * but the error body contains rate-limit language (e.g. "rate limit",
- * "too many requests", "usage limit", "try again") rather than billing
- * language ("insufficient", "credits", "balance").
+ * "too many requests", "usage limit") rather than billing language
+ * ("insufficient", "credits", "balance").
+ *
+ * NOTE: bare "try again" was intentionally excluded because it can appear
+ * in billing errors such as "insufficient credits, try again after adding
+ * funds".  The remaining patterns are sufficient for known rate-limit
+ * responses.
  */
 const RATE_LIMIT_402_RE =
-  /rate.limit|too many requests|usage.limit|try again|retry.after|throttl|capacity|overloaded/i;
+  /rate.limit|too many requests|usage.limit|retry.after|throttl|capacity|overloaded/i;
 
 function isRateLimitLike402(msg: string): boolean {
   return RATE_LIMIT_402_RE.test(msg);


### PR DESCRIPTION
## Problem

Anthropic Max plan ($100/mo) returns HTTP 402 when hitting plan rate limits, but OpenClaw unconditionally classifies all 402s as billing errors. This shows a misleading warning:

> ⚠️ API provider returned a billing error — your API key has run out of credits

...to users who have active credits and valid billing. The actual issue is a temporary rate limit.

Fixes #30484.

## Solution

Before classifying a 402 as `billing`, check the error message for rate-limit indicators:
- `rate limit`, `too many requests`, `usage limit`
- `retry after`, `throttle`, `capacity`, `overloaded`

If rate-limit language is found, classify as `rate_limit` instead (which triggers retry/backoff rather than a billing warning).

Plain 402s without rate-limit language (e.g. `insufficient credits`) continue to classify as `billing`.

## Changes

- `src/agents/failover-error.ts`: Add `isRateLimitLike402()` check before billing classification
- `src/agents/failover-error.test.ts`: 4 new test cases (3 rate-limit 402s + 1 plain billing 402)

## Testing

All 13 tests pass. New cases:
- `{ status: 402, message: "rate limit exceeded" }` → `rate_limit` ✅
- `{ status: 402, message: "too many requests" }` → `rate_limit` ✅
- `{ status: 402, message: "usage limit reached, retry after 30s" }` → `rate_limit` ✅
- `{ status: 402, message: "insufficient credits" }` → `billing` ✅
- `{ status: 402 }` (no message) → `billing` ✅ (existing test)