### PR TITLE
fix(reply): dedupe followup queue message ids across drain cycles [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/Followup queue dedupe: keep a short-lived delivered-message-id cache across drain cycles so busy-window retries do not re-enqueue and redeliver the same inbound message repeatedly. (#30604) Thanks @liuxiaopai-ai.
 - Cron/One-shot reliability: retry transient one-shot failures with bounded backoff and configurable retry policy before disabling. (#24435) Thanks .
 - Gateway/Cron auditability: add gateway info logs for successful cron create, update, and remove operations. (#25090) Thanks .
 - Cron/Schedule errors: notify users when a job is auto-disabled after repeated schedule computation failures. (#29098) Thanks .

--- a/src/auto-reply/reply/queue/dedupe.ts
+++ b/src/auto-reply/reply/queue/dedupe.ts
@@ -1,0 +1,50 @@
+import { createDedupeCache } from "../../../infra/dedupe.js";
+import type { FollowupRun } from "./types.js";
+
+const DELIVERED_FOLLOWUP_DEDUPE_TTL_MS = 20 * 60_000;
+const DELIVERED_FOLLOWUP_DEDUPE_MAX = 5000;
+
+const deliveredFollowupCache = createDedupeCache({
+  ttlMs: DELIVERED_FOLLOWUP_DEDUPE_TTL_MS,
+  maxSize: DELIVERED_FOLLOWUP_DEDUPE_MAX,
+});
+
+function buildDeliveredFollowupDedupeKey(queueKey: string, run: FollowupRun): string | null {
+  const cleanedQueueKey = queueKey.trim();
+  const messageId = run.messageId?.trim();
+  if (!cleanedQueueKey || !messageId) {
+    return null;
+  }
+
+  const channel = run.originatingChannel?.trim().toLowerCase() ?? "";
+  const to = run.originatingTo?.trim() ?? "";
+  const accountId = run.originatingAccountId?.trim() ?? "";
+  const threadId =
+    run.originatingThreadId !== undefined && run.originatingThreadId !== null
+      ? String(run.originatingThreadId).trim()
+      : "";
+
+  return [cleanedQueueKey, channel, to, accountId, threadId, messageId]
+    .filter((segment) => segment.length > 0)
+    .join("|");
+}
+
+export function wasDeliveredFollowupRun(queueKey: string, run: FollowupRun, now?: number): boolean {
+  const key = buildDeliveredFollowupDedupeKey(queueKey, run);
+  if (!key) {
+    return false;
+  }
+  return deliveredFollowupCache.peek(key, now);
+}
+
+export function markDeliveredFollowupRun(queueKey: string, run: FollowupRun, now?: number): void {
+  const key = buildDeliveredFollowupDedupeKey(queueKey, run);
+  if (!key) {
+    return;
+  }
+  deliveredFollowupCache.check(key, now);
+}
+
+export function resetDeliveredFollowupDedupe(): void {
+  deliveredFollowupCache.clear();
+}

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -10,6 +10,7 @@ import {
   waitForQueueDebounce,
 } from "../../../utils/queue-helpers.js";
 import { isRoutableChannel } from "../route-reply.js";
+import { markDeliveredFollowupRun } from "./dedupe.js";
 import { FOLLOWUP_QUEUES } from "./state.js";
 import type { FollowupRun } from "./types.js";
 
@@ -72,7 +73,10 @@ export function scheduleFollowupDrain(
             collectState,
             isCrossChannel,
             items: queue.items,
-            run: runFollowup,
+            run: async (item) => {
+              await runFollowup(item);
+              markDeliveredFollowupRun(key, item);
+            },
           });
           if (collectDrainResult === "empty") {
             break;
@@ -102,6 +106,9 @@ export function scheduleFollowupDrain(
             enqueuedAt: Date.now(),
             ...routing,
           });
+          for (const item of items) {
+            markDeliveredFollowupRun(key, item);
+          }
           queue.items.splice(0, items.length);
           if (summary) {
             clearQueueSummaryState(queue);
@@ -126,6 +133,7 @@ export function scheduleFollowupDrain(
                 originatingAccountId: item.originatingAccountId,
                 originatingThreadId: item.originatingThreadId,
               });
+              markDeliveredFollowupRun(key, item);
             }))
           ) {
             break;
@@ -134,7 +142,12 @@ export function scheduleFollowupDrain(
           continue;
         }
 
-        if (!(await drainNextQueueItem(queue.items, runFollowup))) {
+        if (
+          !(await drainNextQueueItem(queue.items, async (item) => {
+            await runFollowup(item);
+            markDeliveredFollowupRun(key, item);
+          }))
+        ) {
           break;
         }
       }

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -1,4 +1,5 @@
 import { applyQueueDropPolicy, shouldSkipQueueItem } from "../../../utils/queue-helpers.js";
+import { wasDeliveredFollowupRun } from "./dedupe.js";
 import { getExistingFollowupQueue, getFollowupQueue } from "./state.js";
 import type { FollowupRun, QueueDedupeMode, QueueSettings } from "./types.js";
 
@@ -29,6 +30,10 @@ export function enqueueFollowupRun(
   settings: QueueSettings,
   dedupeMode: QueueDedupeMode = "message-id",
 ): boolean {
+  if (wasDeliveredFollowupRun(key, run)) {
+    return false;
+  }
+
   const queue = getFollowupQueue(key, settings);
   const dedupe =
     dedupeMode === "none"

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -690,6 +690,61 @@ describe("followup queue deduplication", () => {
     expect(calls[0]?.prompt).toContain("[Queued messages while agent was busy]");
   });
 
+  it("deduplicates message ids that were already delivered in a prior drain", async () => {
+    const key = `test-dedup-delivered-message-id-${Date.now()}`;
+    const calls: FollowupRun[] = [];
+    const done = createDeferred<void>();
+    const settings: QueueSettings = {
+      mode: "collect",
+      debounceMs: 0,
+      cap: 50,
+      dropPolicy: "summarize",
+    };
+
+    const first = enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "first",
+        messageId: "m1",
+        originatingChannel: "discord",
+        originatingTo: "channel:123",
+      }),
+      settings,
+    );
+    expect(first).toBe(true);
+
+    scheduleFollowupDrain(key, async (run) => {
+      calls.push(run);
+      done.resolve();
+    });
+    await done.promise;
+
+    const duplicateAfterDrain = enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "duplicate-after-drain",
+        messageId: "m1",
+        originatingChannel: "discord",
+        originatingTo: "channel:123",
+      }),
+      settings,
+    );
+    expect(duplicateAfterDrain).toBe(false);
+
+    const sameMessageDifferentRoute = enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "same-message-different-route",
+        messageId: "m1",
+        originatingChannel: "discord",
+        originatingTo: "channel:999",
+      }),
+      settings,
+    );
+    expect(sameMessageDifferentRoute).toBe(true);
+    expect(calls).toHaveLength(1);
+  });
+
   it("deduplicates exact prompt when routing matches and no message id", async () => {
     const key = `test-dedup-whatsapp-${Date.now()}`;
     const settings: QueueSettings = {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: followup queue deduplication only checked items currently in `queue.items`, so once a message was drained/shifted out, the same provider `messageId` could be re-enqueued and delivered again.
- Why it matters: while an agent is busy, retries or repeated inbound delivery can cause duplicate `[Queued messages while agent was busy]` content across drain cycles.
- What changed: added a short-lived delivered-message dedupe cache (`20m` TTL) keyed by queue/session + routing metadata + `messageId`; enqueue now skips messages that were already delivered recently, and drain marks successfully delivered items.
- What did NOT change (scope boundary): no prompt-based dedupe policy change, no queue mode semantics change, and no behavior change for items without provider `messageId`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30604
- Related #30581

## User-visible / Behavior Changes

When a channel re-delivers the same inbound message while the agent is busy, OpenClaw now avoids re-enqueuing/re-sending that already-delivered queued message for a short window.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): followup queue pipeline
- Relevant config (redacted): followup queue `mode: collect`

### Steps

1. Enqueue a followup run with routing metadata + provider `messageId`.
2. Drain the queue once (run is delivered and removed from `queue.items`).
3. Attempt to enqueue another run with the same routing + `messageId`.

### Expected

- Second enqueue is rejected as duplicate across drain cycles.

### Actual

- Before fix: second enqueue was accepted because only in-memory queued items were checked.
- After fix: second enqueue is rejected; same `messageId` on a different route is still allowed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: cross-drain dedupe for same route + same `messageId`; no false positive for same `messageId` on different route.
- Edge cases checked: items without `messageId` are unaffected; normal queue drain and abort queue tests still pass.
- What you did **not** verify: live channel behavior under long-running real provider retry conditions.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/auto-reply/reply/queue/dedupe.ts`, `src/auto-reply/reply/queue/enqueue.ts`, `src/auto-reply/reply/queue/drain.ts`.
- Known bad symptoms reviewers should watch for: queued followup runs with distinct messages being unexpectedly skipped within the dedupe window.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - A provider that reuses `messageId` for distinct messages on the same route within 20 minutes could be over-deduped.
  - Mitigation:
    - Key includes route metadata and message ID, TTL is bounded (20m), and behavior only applies when explicit `messageId` exists.

AI-assisted: Yes.
