### PR TITLE
fix(reply): dedupe restart drain error floods per route [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/Restart drain errors: deduplicate repeated `Gateway is draining for restart` failure replies per route for a short window so restart bursts no longer flood channels with identical error messages. (#30643) Thanks @liuxiaopai-ai.
 - Cron/Isolated sessions list: persist the intended pre-run model/provider on isolated cron session entries so `sessions_list` reflects payload/session model overrides even when runs fail before post-run telemetry persistence. (#21279) Thanks @altaywtf.
 - Cron/One-shot reliability: retry transient one-shot failures with bounded backoff and configurable retry policy before disabling. (#24435) Thanks .
 - Gateway/Cron auditability: add gateway info logs for successful cron create, update, and remove operations. (#25090) Thanks .

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -20,6 +20,7 @@ import {
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
+import { createDedupeCache } from "../../infra/dedupe.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
   isMarkdownCapableMessageChannel,
@@ -68,6 +69,50 @@ export type AgentRunLoopResult =
       directlySentBlockKeys?: Set<string>;
     }
   | { kind: "final"; payload: ReplyPayload };
+
+const GATEWAY_DRAINING_REPLY_TTL_MS = 15_000;
+const GATEWAY_DRAINING_REPLY_MAX = 5000;
+
+const gatewayDrainingReplyDedupe = createDedupeCache({
+  ttlMs: GATEWAY_DRAINING_REPLY_TTL_MS,
+  maxSize: GATEWAY_DRAINING_REPLY_MAX,
+});
+
+function isGatewayDrainingErrorMessage(message: string): boolean {
+  return /gateway is draining for restart;\s*new tasks are not accepted/i.test(message);
+}
+
+function buildGatewayDrainingReplyDedupeKey(params: {
+  sessionCtx: TemplateContext;
+  sessionKey?: string;
+}): string | null {
+  const channel = (
+    params.sessionCtx.OriginatingChannel ??
+    params.sessionCtx.Provider ??
+    params.sessionCtx.Surface
+  )
+    ?.trim()
+    .toLowerCase();
+  const to = (
+    params.sessionCtx.OriginatingTo ??
+    params.sessionCtx.To ??
+    params.sessionCtx.From ??
+    params.sessionKey
+  )?.trim();
+  if (!channel || !to) {
+    return null;
+  }
+  const accountId = params.sessionCtx.AccountId?.trim() ?? "";
+  const threadId =
+    params.sessionCtx.MessageThreadId !== undefined && params.sessionCtx.MessageThreadId !== null
+      ? String(params.sessionCtx.MessageThreadId).trim()
+      : "";
+  return [channel, to, accountId, threadId].filter(Boolean).join("|");
+}
+
+export function resetGatewayDrainingReplyDedupe(): void {
+  gatewayDrainingReplyDedupe.clear();
+}
 
 export async function runAgentTurnWithFallback(params: {
   commandBody: string;
@@ -476,6 +521,7 @@ export async function runAgentTurnWithFallback(params: {
       const isCompactionFailure = isCompactionFailureError(message);
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
+      const isGatewayDraining = isGatewayDrainingErrorMessage(message);
       const isTransientHttp = isTransientHttpError(message);
 
       if (
@@ -561,6 +607,22 @@ export async function runAgentTurnWithFallback(params: {
           setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
         });
         continue;
+      }
+
+      if (isGatewayDraining) {
+        const dedupeKey = buildGatewayDrainingReplyDedupeKey({
+          sessionCtx: params.sessionCtx,
+          sessionKey: params.sessionKey,
+        });
+        if (dedupeKey && gatewayDrainingReplyDedupe.check(dedupeKey)) {
+          logVerbose(`Suppressed duplicate restart-drain error reply for ${dedupeKey}`);
+          return {
+            kind: "final",
+            payload: {
+              text: SILENT_REPLY_TOKEN,
+            },
+          };
+        }
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -7,7 +7,9 @@ import * as sessions from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
 import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
 import type { TemplateContext } from "../templating.js";
+import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions } from "../types.js";
+import { resetGatewayDrainingReplyDedupe } from "./agent-runner-execution.js";
 import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queue.js";
 import { createMockTypingController } from "./test-helpers.js";
 
@@ -87,6 +89,7 @@ beforeEach(() => {
   state.runEmbeddedPiAgentMock.mockClear();
   state.runCliAgentMock.mockClear();
   vi.mocked(enqueueFollowupRun).mockClear();
+  resetGatewayDrainingReplyDedupe();
   vi.stubEnv("OPENCLAW_TEST_FAST", "1");
 });
 
@@ -1353,6 +1356,23 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
       expect(persisted.main).toBeDefined();
     });
+  });
+
+  it("suppresses duplicate restart-drain failure replies for the same route", async () => {
+    const drainError = "Gateway is draining for restart; new tasks are not accepted";
+    state.runEmbeddedPiAgentMock.mockImplementation(async () => {
+      throw new Error(drainError);
+    });
+
+    const firstRun = createMinimalRun({});
+    const first = await firstRun.run();
+    expect(first).toMatchObject({
+      text: expect.stringContaining("Gateway is draining for restart"),
+    });
+
+    const secondRun = createMinimalRun({});
+    const second = await secondRun.run();
+    expect(second).toMatchObject({ text: SILENT_REPLY_TOKEN });
   });
 
   it("still replies even if session reset fails to persist", async () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: during gateway restart drain windows, each rejected inbound task could emit the same `Gateway is draining for restart; new tasks are not accepted` failure reply back to the channel.
- Why it matters: busy channels can receive dozens/hundreds of identical error messages in seconds.
- What changed: added a short-lived route-level dedupe cache for this specific drain error; first occurrence is delivered, subsequent duplicates in the same route window are converted to `NO_REPLY` (suppressed downstream).
- What did NOT change (scope boundary): no queue semantics change, no restart/drain lifecycle change, and no suppression for other error classes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30643
- Related #27407

## User-visible / Behavior Changes

On restart drain bursts, channels receive one explicit drain failure notification per route in the short dedupe window instead of repeated identical failures.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): auto-reply error handling path
- Relevant config (redacted): N/A

### Steps

1. Trigger `runReplyAgent` failures with `Gateway is draining for restart; new tasks are not accepted` for the same route.
2. Observe first reply payload.
3. Trigger same failure again immediately for same route.

### Expected

- First failure returns user-visible drain error.
- Duplicate immediate failure for same route is suppressed.

### Actual

- Before fix: each failure emitted full error payload.
- After fix: first emits full payload; duplicates emit `NO_REPLY` sentinel.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: new regression test `suppresses duplicate restart-drain failure replies for the same route` and full `agent-runner.runreplyagent.test.ts` pass.
- Edge cases checked: dedupe cache reset in test isolation; non-drain errors continue using existing behavior.
- What you did **not** verify: live end-to-end iMessage restart storm on a production-like gateway.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/auto-reply/reply/agent-runner-execution.ts`, `src/auto-reply/reply/agent-runner.runreplyagent.test.ts`.
- Known bad symptoms reviewers should watch for: drain errors unexpectedly suppressed for distinct routes within the dedupe TTL.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Distinct conversations that share the same route tuple could be deduped during the 15s window.
  - Mitigation:
    - Dedupe key includes channel/destination/account/thread and TTL is intentionally short and scoped to the specific drain error signature.

AI-assisted: Yes.
