### PR TITLE
fix(subagents): allow session_status in sub-agent sessions

### DIFF
--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -139,6 +139,17 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
     expect(isToolAllowedByPolicyName("memory_get", policy)).toBe(false);
   });
 
+  it("allows session_status in subagents for date/time awareness and model info (regression: #30685)", () => {
+    // session_status was previously denied for all subagents.  Sub-agents need it to
+    // answer time-related questions and inspect their own model/usage — neither of which
+    // poses a coordination risk since the tool operates on the subagent's own session.
+    const policy = resolveSubagentToolPolicy(baseCfg, 1);
+    expect(isToolAllowedByPolicyName("session_status", policy)).toBe(true);
+    // Depth-2 leaf should also be allowed
+    const leafPolicy = resolveSubagentToolPolicy(baseCfg, 2);
+    expect(isToolAllowedByPolicyName("session_status", leafPolicy)).toBe(true);
+  });
+
   it("depth-2 leaf denies sessions_spawn", () => {
     const policy = resolveSubagentToolPolicy(baseCfg, 2);
     expect(isToolAllowedByPolicyName("sessions_spawn", policy)).toBe(false);

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -49,8 +49,7 @@ const SUBAGENT_TOOL_DENY_ALWAYS = [
   "agents_list",
   // Interactive setup - not a task
   "whatsapp_login",
-  // Status/scheduling - main agent coordinates
-  "session_status",
+  // Scheduling - subagents should not create cron jobs; main agent coordinates
   "cron",
   // Memory - pass relevant info in spawn prompt instead
   "memory_search",


### PR DESCRIPTION
## Summary

Fixes #30685

`session_status` was listed in `SUBAGENT_TOOL_DENY_ALWAYS` under the comment *"Status/scheduling — main agent coordinates"*. This caused the tool to be unavailable in all sub-agent runtime lanes while remaining available in the main session, creating a tool-surface mismatch.

## Root Cause

`src/agents/pi-tools.policy.ts` — `SUBAGENT_TOOL_DENY_ALWAYS`:

```ts
// Status/scheduling - main agent coordinates
"session_status",  // ← denied for all subagents
"cron",
```

## Why the Denial Is Too Broad

| Concern | Status |
|---|---|
| Sub-agent changes parent model | ✅ Not possible — `session_status` model override is scoped to its own session |
| Sub-agents create cron jobs | ✅ `cron` remains denied (separate entry) |
| Sub-agent reads own usage/model | ❌ Useful — should be allowed |
| Sub-agent gets current date/time | ❌ This is the primary way agents learn the date — should be allowed |

## Fix

Remove `"session_status"` from `SUBAGENT_TOOL_DENY_ALWAYS`. The scheduling concern is handled by keeping `cron` denied. The comment is updated to reflect that only cron scheduling is restricted.

## Changes

- **`src/agents/pi-tools.policy.ts`**: Remove `session_status` from `SUBAGENT_TOOL_DENY_ALWAYS`; update comment.
- **`src/agents/pi-tools.policy.test.ts`**: Add regression test verifying `session_status` is allowed for both depth-1 and depth-2 sub-agents.

## Testing

- All 24 `pi-tools.policy.test.ts` tests pass ✅
- `pnpm build` ✅  `pnpm check` (0 errors, 0 warnings) ✅