### PR TITLE
fix(reply): retry empty text-only model responses once [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gemini/Empty replies: retry once when model output contains only empty/whitespace text payloads, and surface a fallback user-visible error when retry also returns empty text to avoid silent/stuck reply flows. (#30616) Thanks @liuxiaopai-ai.
 - Cron/Isolated sessions list: persist the intended pre-run model/provider on isolated cron session entries so `sessions_list` reflects payload/session model overrides even when runs fail before post-run telemetry persistence. (#21279) Thanks @altaywtf.
 - Cron/One-shot reliability: retry transient one-shot failures with bounded backoff and configurable retry policy before disabling. (#24435) Thanks .
 - Gateway/Cron auditability: add gateway info logs for successful cron create, update, and remove operations. (#25090) Thanks .

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -69,6 +69,30 @@ export type AgentRunLoopResult =
     }
   | { kind: "final"; payload: ReplyPayload };
 
+function isRenderableReplyPayload(payload: ReplyPayload): boolean {
+  if (typeof payload.text === "string" && payload.text.trim().length > 0) {
+    return true;
+  }
+  if (payload.mediaUrl || (payload.mediaUrls?.length ?? 0) > 0) {
+    return true;
+  }
+  if (payload.audioAsVoice || payload.channelData) {
+    return true;
+  }
+  return false;
+}
+
+function isLikelyEmptyTextOnlyResponse(payloads: ReplyPayload[]): boolean {
+  if (payloads.length === 0) {
+    return false;
+  }
+  const hasTextPayload = payloads.some((payload) => typeof payload.text === "string");
+  if (!hasTextPayload) {
+    return false;
+  }
+  return !payloads.some(isRenderableReplyPayload);
+}
+
 export async function runAgentTurnWithFallback(params: {
   commandBody: string;
   followupRun: FollowupRun;
@@ -125,6 +149,7 @@ export async function runAgentTurnWithFallback(params: {
   let fallbackAttempts: RuntimeFallbackAttempt[] = [];
   let didResetAfterCompactionFailure = false;
   let didRetryTransientHttpError = false;
+  let didRetryEmptyTextResponse = false;
 
   while (true) {
     try {
@@ -443,9 +468,11 @@ export async function runAgentTurnWithFallback(params: {
       // Some embedded runs surface context overflow as an error payload instead of throwing.
       // Treat those as a session-level failure and auto-recover by starting a fresh session.
       const embeddedError = runResult.meta?.error;
+      const isEmbeddedContextOverflow =
+        Boolean(embeddedError) && isContextOverflowError(embeddedError.message);
       if (
         embeddedError &&
-        isContextOverflowError(embeddedError.message) &&
+        isEmbeddedContextOverflow &&
         !didResetAfterCompactionFailure &&
         (await params.resetSessionAfterCompactionFailure(embeddedError.message))
       ) {
@@ -467,6 +494,22 @@ export async function runAgentTurnWithFallback(params: {
             },
           };
         }
+      }
+
+      if (!isEmbeddedContextOverflow && isLikelyEmptyTextOnlyResponse(runResult.payloads ?? [])) {
+        if (!didRetryEmptyTextResponse) {
+          didRetryEmptyTextResponse = true;
+          defaultRuntime.error(
+            "Embedded agent returned empty text-only payload; retrying once before surfacing fallback.",
+          );
+          continue;
+        }
+        return {
+          kind: "final",
+          payload: {
+            text: "⚠️ Model returned an empty reply. Please try again.",
+          },
+        };
       }
 
       break;

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -591,6 +591,39 @@ describe("runReplyAgent typing (heartbeat)", () => {
     vi.useRealTimers();
   });
 
+  it("retries once when model returns empty/whitespace-only text payloads", async () => {
+    let calls = 0;
+    state.runEmbeddedPiAgentMock.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return { payloads: [{ text: "  \n  " }], meta: {} };
+      }
+      return { payloads: [{ text: "final after retry" }], meta: {} };
+    });
+
+    const { run } = createMinimalRun({ typingMode: "message" });
+    const res = await run();
+
+    expect(calls).toBe(2);
+    expect(res).toMatchObject({ text: "final after retry" });
+  });
+
+  it("surfaces a fallback error when retry still returns empty text payloads", async () => {
+    let calls = 0;
+    state.runEmbeddedPiAgentMock.mockImplementation(async () => {
+      calls += 1;
+      return { payloads: [{ text: "\n\t" }], meta: {} };
+    });
+
+    const { run } = createMinimalRun({ typingMode: "message" });
+    const res = await run();
+
+    expect(calls).toBe(2);
+    expect(res).toMatchObject({
+      text: "⚠️ Model returned an empty reply. Please try again.",
+    });
+  });
+
   it("delivers tool results in order even when dispatched concurrently", async () => {
     const deliveryOrder: string[] = [];
     const onToolResult = vi.fn(async (payload: { text?: string }) => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: some model runs (reported with Gemini extended thinking) can complete with payloads that contain only empty/whitespace text, producing no renderable reply.
- Why it matters: this can lead to silent/no-output turns and user-visible stuck behavior around reply/typing expectations.
- What changed: detect empty-text-only payload sets in `runAgentTurnWithFallback`, retry once automatically, and if retry still returns empty text-only output, return an explicit fallback error payload.
- What did NOT change (scope boundary): no provider-specific transport changes, no Telegram-specific API logic changes, and no behavior change for context-overflow payload fallbacks.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30616
- Related #27172

## User-visible / Behavior Changes

When a run returns only empty/whitespace text payloads, OpenClaw now retries once; if still empty, it responds with `⚠️ Model returned an empty reply. Please try again.` instead of silently producing no reply.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: generic embedded-run path (Gemini-compatible symptom)
- Integration/channel (if any): auto-reply main run pipeline
- Relevant config (redacted): N/A

### Steps

1. Mock/model-run returns payloads containing only empty/whitespace text.
2. Execute `runReplyAgent`.
3. Observe retry behavior and final payload.

### Expected

- First empty-text-only response triggers one retry.
- If retry is non-empty, that response is used.
- If retry is still empty, return explicit fallback error text.

### Actual

- Before fix: empty-text-only payloads could result in silent/no-output behavior.
- After fix: deterministic retry + fallback path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: two new tests for retry-success and retry-fallback paths; full `agent-runner.runreplyagent.test.ts` suite passes.
- Edge cases checked: existing context-overflow whitespace fallback test still passes (no regression).
- What you did **not** verify: live Telegram channel run with real Gemini API behavior under production latency.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/auto-reply/reply/agent-runner-execution.ts`, `src/auto-reply/reply/agent-runner.runreplyagent.test.ts`.
- Known bad symptoms reviewers should watch for: legitimate non-empty responses being incorrectly classified as empty-text-only.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Rare payloads with meaningful non-text-only fields could be misclassified if future payload shapes change.
  - Mitigation:
    - Renderability check keeps media/channelData/audio paths as renderable and excludes context-overflow fallback branch from this retry logic.

AI-assisted: Yes.
