### PR TITLE
feat(telegram): inline buttons for exec approvals

### DIFF
--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -209,3 +209,112 @@ describe("telegramPlugin duplicate token guard", () => {
     );
   });
 });
+
+describe("telegramPlugin.outbound.sendPayload", () => {
+  it("forwards buttons to sendMessageTelegram when channelData.telegram.buttons is set (no media)", async () => {
+    const sendMessageTelegram = vi.fn(async () => ({ messageId: "tg-payload-1" }));
+    setTelegramRuntime({
+      channel: { telegram: { sendMessageTelegram } },
+    } as unknown as PluginRuntime);
+
+    const buttons = [[{ text: "Yes", callback_data: "/approve abc allow-once" }]];
+    const result = await telegramPlugin.outbound!.sendPayload!({
+      cfg: createCfg(),
+      to: "99999",
+      text: "Approve?",
+      payload: { text: "Approve?", channelData: { telegram: { buttons } } },
+      accountId: "ops",
+    });
+
+    expect(sendMessageTelegram).toHaveBeenCalledOnce();
+    expect(sendMessageTelegram).toHaveBeenCalledWith(
+      "99999",
+      "Approve?",
+      expect.objectContaining({ buttons }),
+    );
+    expect(result).toMatchObject({ channel: "telegram", messageId: "tg-payload-1" });
+  });
+
+  it("attaches buttons only to first send when multiple mediaUrls are present", async () => {
+    const sendMessageTelegram = vi.fn(
+      async (_to: string, _text: string, opts: { mediaUrl?: string }) => ({
+        messageId: `tg-${opts.mediaUrl ?? "text"}`,
+      }),
+    );
+    setTelegramRuntime({
+      channel: { telegram: { sendMessageTelegram } },
+    } as unknown as PluginRuntime);
+
+    const buttons = [[{ text: "OK", callback_data: "/approve xyz allow-always" }]];
+    await telegramPlugin.outbound!.sendPayload!({
+      cfg: createCfg(),
+      to: "55555",
+      text: "See images",
+      payload: {
+        text: "See images",
+        mediaUrls: ["/tmp/img1.png", "/tmp/img2.png"],
+        channelData: { telegram: { buttons } },
+      },
+      accountId: "ops",
+    });
+
+    expect(sendMessageTelegram).toHaveBeenCalledTimes(2);
+    // First call: text + buttons
+    expect(sendMessageTelegram).toHaveBeenNthCalledWith(
+      1,
+      "55555",
+      "See images",
+      expect.objectContaining({ buttons, mediaUrl: "/tmp/img1.png" }),
+    );
+    // Second call: no text, no buttons
+    expect(sendMessageTelegram).toHaveBeenNthCalledWith(
+      2,
+      "55555",
+      "",
+      expect.not.objectContaining({ buttons }),
+    );
+  });
+
+  it("forwards silent flag to sendMessageTelegram", async () => {
+    const sendMessageTelegram = vi.fn(async () => ({ messageId: "tg-s1" }));
+    setTelegramRuntime({
+      channel: { telegram: { sendMessageTelegram } },
+    } as unknown as PluginRuntime);
+
+    await telegramPlugin.outbound!.sendPayload!({
+      cfg: createCfg(),
+      to: "99999",
+      text: "silent approval",
+      payload: { text: "silent approval", channelData: { telegram: { buttons: [] } } },
+      silent: true,
+    });
+
+    expect(sendMessageTelegram).toHaveBeenCalledWith(
+      "99999",
+      "silent approval",
+      expect.objectContaining({ silent: true }),
+    );
+  });
+
+  it("sends without buttons when channelData is absent", async () => {
+    const sendMessageTelegram = vi.fn(async () => ({ messageId: "tg-payload-plain" }));
+    setTelegramRuntime({
+      channel: { telegram: { sendMessageTelegram } },
+    } as unknown as PluginRuntime);
+
+    const result = await telegramPlugin.outbound!.sendPayload!({
+      cfg: createCfg(),
+      to: "11111",
+      text: "plain text",
+      payload: { text: "plain text" },
+      accountId: "ops",
+    });
+
+    expect(sendMessageTelegram).toHaveBeenCalledOnce();
+    const callOpts = (sendMessageTelegram.mock.calls as unknown[][])[0]?.[2] as
+      | Record<string, unknown>
+      | undefined;
+    expect(callOpts?.buttons).toBeUndefined();
+    expect(result).toMatchObject({ channel: "telegram" });
+  });
+});

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -371,6 +371,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
       return { channel: "telegram", ...result };
     },
     sendPayload: async ({
+      cfg,
       to,
       payload,
       mediaLocalRoots,
@@ -398,6 +399,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
       if (mediaUrls.length === 0) {
         const result = await send(to, text, {
           verbose: false,
+          cfg,
           messageThreadId,
           replyToMessageId,
           accountId: accountId ?? undefined,
@@ -416,6 +418,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         const isFirst = i === 0;
         finalResult = await send(to, isFirst ? text : "", {
           verbose: false,
+          cfg,
           messageThreadId,
           replyToMessageId,
           accountId: accountId ?? undefined,

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -38,6 +38,7 @@ import {
   type ChannelPlugin,
   type OpenClawConfig,
   type ResolvedTelegramAccount,
+  type TelegramInlineButtons,
   type TelegramProbe,
 } from "openclaw/plugin-sdk/telegram";
 import { getTelegramRuntime } from "./runtime.js";
@@ -367,6 +368,63 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         silent: silent ?? undefined,
       });
       return { channel: "telegram", ...result };
+    },
+    sendPayload: async ({
+      to,
+      payload,
+      mediaLocalRoots,
+      accountId,
+      deps,
+      replyToId,
+      threadId,
+      silent,
+    }) => {
+      const send = deps?.sendTelegram ?? getTelegramRuntime().channel.telegram.sendMessageTelegram;
+      const replyToMessageId = parseTelegramReplyToMessageId(replyToId);
+      const messageThreadId = parseTelegramThreadId(threadId);
+      const telegramData = payload.channelData?.telegram as
+        | { buttons?: TelegramInlineButtons; quoteText?: string }
+        | undefined;
+      const quoteText =
+        typeof telegramData?.quoteText === "string" ? telegramData.quoteText : undefined;
+      const text = payload.text ?? "";
+      const mediaUrls = payload.mediaUrls?.length
+        ? payload.mediaUrls
+        : payload.mediaUrl
+          ? [payload.mediaUrl]
+          : [];
+
+      if (mediaUrls.length === 0) {
+        const result = await send(to, text, {
+          verbose: false,
+          messageThreadId,
+          replyToMessageId,
+          accountId: accountId ?? undefined,
+          buttons: telegramData?.buttons,
+          quoteText,
+          mediaLocalRoots,
+          silent: silent ?? undefined,
+        });
+        return { channel: "telegram", ...result };
+      }
+
+      // Telegram allows reply_markup on media; attach buttons only to first send.
+      let finalResult: Awaited<ReturnType<typeof send>> | undefined;
+      for (let i = 0; i < mediaUrls.length; i += 1) {
+        const mediaUrl = mediaUrls[i];
+        const isFirst = i === 0;
+        finalResult = await send(to, isFirst ? text : "", {
+          verbose: false,
+          messageThreadId,
+          replyToMessageId,
+          accountId: accountId ?? undefined,
+          mediaUrl,
+          mediaLocalRoots,
+          silent: silent ?? undefined,
+          ...(isFirst ? { buttons: telegramData?.buttons, quoteText } : {}),
+        });
+      }
+      return { channel: "telegram", ...(finalResult ?? { messageId: "unknown", chatId: to }) };
     },
     sendPoll: async ({ cfg, to, poll, accountId, threadId, silent, isAnonymous }) =>
       await getTelegramRuntime().channel.telegram.sendPollTelegram(to, poll, {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -327,6 +327,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
     chunker: (text, limit) => getTelegramRuntime().channel.text.chunkMarkdownText(text, limit),
     chunkerMode: "markdown",
     textChunkLimit: 4000,
+    prependTextChunksToPayload: true,
     pollMaxOptions: 10,
     sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, silent }) => {
       const send = deps?.sendTelegram ?? getTelegramRuntime().channel.telegram.sendMessageTelegram;

--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -44,6 +44,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
   chunker: markdownToTelegramHtmlChunks,
   chunkerMode: "markdown",
   textChunkLimit: 4000,
+  prependTextChunksToPayload: true,
   sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId }) => {
     const { send, baseOpts } = resolveTelegramSendContext({
       cfg,

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -118,6 +118,10 @@ export type ChannelOutboundAdapter = {
     accountId?: string | null;
     mode?: ChannelOutboundTargetMode;
   }) => { ok: true; to: string } | { ok: false; error: Error };
+  /** When true, long text in sendPayload calls is pre-chunked via sendText before
+   *  the final chunk is passed to sendPayload with channelData attached. Adapters
+   *  that control their own payload ordering (e.g. Line) should leave this unset. */
+  prependTextChunksToPayload?: boolean;
   sendPayload?: (ctx: ChannelOutboundPayloadContext) => Promise<OutboundDeliveryResult>;
   sendText?: (ctx: ChannelOutboundContext) => Promise<OutboundDeliveryResult>;
   sendMedia?: (ctx: ChannelOutboundContext) => Promise<OutboundDeliveryResult>;

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -20,11 +20,18 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+type DeliveryPayload = { text?: string; channelData?: Record<string, unknown> };
+
+function getFirstDelivery(deliver: ReturnType<typeof vi.fn>): {
+  params: { payloads?: DeliveryPayload[] } | undefined;
+  payload: DeliveryPayload | undefined;
+} {
+  const params = deliver.mock.calls[0]?.[0] as { payloads?: DeliveryPayload[] } | undefined;
+  return { params, payload: params?.payloads?.[0] };
+}
+
 function getFirstDeliveryText(deliver: ReturnType<typeof vi.fn>): string {
-  const firstCall = deliver.mock.calls[0]?.[0] as
-    | { payloads?: Array<{ text?: string }> }
-    | undefined;
-  return firstCall?.payloads?.[0]?.text ?? "";
+  return getFirstDelivery(deliver).payload?.text ?? "";
 }
 
 const TARGETS_CFG = {
@@ -336,5 +343,157 @@ describe("exec approval forwarder", () => {
     ).resolves.toBe(true);
 
     expect(getFirstDeliveryText(deliver)).toContain("Command:\n````\necho ```danger```\n````");
+  });
+
+  it("attaches three inline approval buttons to the request message", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+
+    const { payload } = getFirstDelivery(deliver);
+    const buttons = (payload?.channelData?.telegram as { buttons?: unknown[] } | undefined)
+      ?.buttons;
+    expect(Array.isArray(buttons)).toBe(true);
+    const row = buttons?.[0] as Array<{ text: string; callback_data: string }> | undefined;
+    expect(row).toHaveLength(3);
+    expect(row?.[0]).toMatchObject({
+      text: "Allow once",
+      callback_data: `/approve ${baseRequest.id} allow-once`,
+    });
+    expect(row?.[1]).toMatchObject({
+      text: "Always allow",
+      callback_data: `/approve ${baseRequest.id} allow-always`,
+    });
+    expect(row?.[2]).toMatchObject({
+      text: "Deny",
+      callback_data: `/approve ${baseRequest.id} deny`,
+    });
+  });
+
+  it("keeps all callback_data values within the 64-byte Telegram limit", async () => {
+    vi.useFakeTimers();
+    const longId = "a".repeat(36); // typical UUID length
+    const request = { ...baseRequest, id: longId };
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+
+    await expect(forwarder.handleRequested(request)).resolves.toBe(true);
+
+    const { payload } = getFirstDelivery(deliver);
+    const row = (payload?.channelData?.telegram as { buttons?: unknown[] } | undefined)
+      ?.buttons?.[0] as Array<{ callback_data: string }> | undefined;
+    expect(row).toBeDefined();
+    for (const btn of row ?? []) {
+      const bytes = Buffer.byteLength(btn.callback_data, "utf8");
+      expect(bytes).toBeLessThanOrEqual(64);
+    }
+  });
+
+  it("still attaches buttons when ID produces exactly 64-byte callback_data", async () => {
+    vi.useFakeTimers();
+    // "/approve " (9) + 42 chars + " allow-always" (13) = 64 bytes exactly
+    const exactId = "a".repeat(42);
+    const request = { ...baseRequest, id: exactId };
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+
+    await expect(forwarder.handleRequested(request)).resolves.toBe(true);
+
+    const { payload } = getFirstDelivery(deliver);
+    const buttons = (payload?.channelData?.telegram as { buttons?: unknown[] } | undefined)
+      ?.buttons;
+    expect(buttons).toBeDefined();
+    expect(Array.isArray(buttons)).toBe(true);
+    expect(buttons).toHaveLength(1);
+  });
+
+  it("does not attach buttons to resolved messages", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+
+    await forwarder.handleRequested(baseRequest);
+    deliver.mockClear();
+
+    await forwarder.handleResolved({
+      id: baseRequest.id,
+      decision: "allow-once",
+      resolvedBy: "telegram:123",
+      ts: 2000,
+    });
+
+    const { payload } = getFirstDelivery(deliver);
+    expect(payload?.channelData).toBeUndefined();
+  });
+
+  it("does not attach buttons to expired messages", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+
+    await forwarder.handleRequested(baseRequest);
+    deliver.mockClear();
+
+    await vi.runAllTimersAsync();
+
+    const { payload } = getFirstDelivery(deliver);
+    expect(payload?.channelData).toBeUndefined();
+  });
+
+  it("does not attach channelData to non-Telegram targets", async () => {
+    vi.useFakeTimers();
+    const cfg = {
+      approvals: {
+        exec: { enabled: true, mode: "targets", targets: [{ channel: "slack", to: "U1" }] },
+      },
+    } as OpenClawConfig;
+    const { deliver, forwarder } = createForwarder({ cfg });
+
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+
+    const { payload } = getFirstDelivery(deliver);
+    expect(payload?.channelData).toBeUndefined();
+  });
+
+  it("includes all optional request fields in message text", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+
+    await expect(
+      forwarder.handleRequested({
+        ...baseRequest,
+        request: {
+          ...baseRequest.request,
+          cwd: "/workspace",
+          nodeId: "node-42",
+          envKeys: ["FOO", "BAR"],
+          host: "myhost",
+          agentId: "agent-x",
+          security: "high",
+          ask: "Are you sure?",
+        },
+      }),
+    ).resolves.toBe(true);
+
+    const text = getFirstDeliveryText(deliver);
+    expect(text).toContain("CWD: /workspace");
+    expect(text).toContain("Node: node-42");
+    expect(text).toContain("Env overrides: FOO, BAR");
+    expect(text).toContain("Host: myhost");
+    expect(text).toContain("Agent: agent-x");
+    expect(text).toContain("Security: high");
+    expect(text).toContain("Ask: Are you sure?");
+  });
+
+  it("falls back to no buttons when approval ID exceeds 64-byte callback_data limit", async () => {
+    vi.useFakeTimers();
+    // /approve <id> allow-always = 9 + id.length + 13 bytes; id > 42 chars pushes it over 64
+    const oversizedId = "x".repeat(43);
+    const request = { ...baseRequest, id: oversizedId };
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+
+    await expect(forwarder.handleRequested(request)).resolves.toBe(true);
+
+    const { payload } = getFirstDelivery(deliver);
+    // Text fallback still present; buttons absent
+    expect(payload?.text).toContain("Reply with: /approve");
+    expect(payload?.channelData).toBeUndefined();
   });
 });

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -8,6 +8,7 @@ import type {
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAccountId, parseAgentSessionKey } from "../routing/session-key.js";
 import { compileSafeRegex, testRegexWithBoundedInput } from "../security/safe-regex.js";
+import type { TelegramInlineButtons } from "../telegram/button-types.js";
 import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
@@ -22,6 +23,10 @@ import { deliverOutboundPayloads } from "./outbound/deliver.js";
 import { resolveSessionDeliveryTarget } from "./outbound/targets.js";
 
 const log = createSubsystemLogger("gateway/exec-approvals");
+
+// Telegram limits callback_data to 64 bytes; buttons are omitted when the ID would exceed this.
+const TELEGRAM_CALLBACK_DATA_MAX_BYTES = 64;
+
 export type { ExecApprovalRequest, ExecApprovalResolved };
 
 type ForwardTarget = ExecApprovalForwardTarget & { source: "session" | "target" };
@@ -159,7 +164,10 @@ function formatApprovalCommand(command: string): { inline: boolean; text: string
   return { inline: false, text: `${fence}\n${command}\n${fence}` };
 }
 
-function buildRequestMessage(request: ExecApprovalRequest, nowMs: number) {
+function buildRequestMessage(
+  request: ExecApprovalRequest,
+  nowMs: number,
+): { text: string; buttons: TelegramInlineButtons } {
   const lines: string[] = ["🔒 Exec approval required", `ID: ${request.id}`];
   const command = formatApprovalCommand(request.request.command);
   if (command.inline) {
@@ -192,7 +200,21 @@ function buildRequestMessage(request: ExecApprovalRequest, nowMs: number) {
   const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMs) / 1000));
   lines.push(`Expires in: ${expiresIn}s`);
   lines.push("Reply with: /approve <id> allow-once|allow-always|deny");
-  return lines.join("\n");
+  // Build inline buttons only when every callback_data fits within Telegram's 64-byte limit.
+  // The longest value is "/approve <id> allow-always"; fall back to text-only when an
+  // unusually long ID would exceed the limit.
+  const longestCallbackData = `/approve ${request.id} allow-always`;
+  const buttons: TelegramInlineButtons =
+    Buffer.byteLength(longestCallbackData, "utf8") <= TELEGRAM_CALLBACK_DATA_MAX_BYTES
+      ? [
+          [
+            { text: "Allow once", callback_data: `/approve ${request.id} allow-once` },
+            { text: "Always allow", callback_data: `/approve ${request.id} allow-always` },
+            { text: "Deny", callback_data: `/approve ${request.id} deny` },
+          ],
+        ]
+      : [];
+  return { text: lines.join("\n"), buttons };
 }
 
 function decisionLabel(decision: ExecApprovalDecision): string {
@@ -262,6 +284,7 @@ async function deliverToTargets(params: {
   cfg: OpenClawConfig;
   targets: ForwardTarget[];
   text: string;
+  buttons?: TelegramInlineButtons;
   deliver: typeof deliverOutboundPayloads;
   shouldSend?: () => boolean;
 }) {
@@ -280,7 +303,15 @@ async function deliverToTargets(params: {
         to: target.to,
         accountId: target.accountId,
         threadId: target.threadId,
-        payloads: [{ text: params.text }],
+        payloads: [
+          {
+            text: params.text,
+            channelData:
+              params.buttons?.length && channel === "telegram"
+                ? { telegram: { buttons: params.buttons } }
+                : undefined,
+          },
+        ],
       });
     } catch (err) {
       log.error(`exec approvals: failed to deliver to ${channel}:${target.to}: ${String(err)}`);
@@ -378,11 +409,12 @@ export function createExecApprovalForwarder(
       return false;
     }
 
-    const text = buildRequestMessage(request, nowMs());
+    const { text, buttons } = buildRequestMessage(request, nowMs());
     void deliverToTargets({
       cfg,
       targets: filteredTargets,
       text,
+      buttons,
       deliver,
       shouldSend: () => pending.get(request.id) === pendingEntry,
     }).catch((err) => {

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -293,6 +293,7 @@ describe("deliverOutboundPayloads", () => {
 
     await deliverTelegramPayload({
       sendTelegram,
+      cfg: { channels: { telegram: { botToken: "tok-1", textChunkLimit: 4000 } } },
       payload: {
         text: "<b>hello</b>",
         channelData: { telegram: { buttons: [] } },
@@ -926,6 +927,75 @@ describe("deliverOutboundPayloads", () => {
       }),
     );
     expect(results).toEqual([{ channel: "matrix", messageId: "mx-1" }]);
+  });
+
+  it("chunks text before sendPayload and attaches buttons only to the last chunk", async () => {
+    const sendTelegram = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "m1", chatId: "c1" })
+      .mockResolvedValueOnce({ messageId: "m2", chatId: "c1" });
+    const buttons = [[{ text: "OK", callback_data: "ok" }]];
+
+    await withEnvAsync({ TELEGRAM_BOT_TOKEN: "" }, async () => {
+      await deliverOutboundPayloads({
+        cfg: telegramChunkConfig, // textChunkLimit: 2
+        channel: "telegram",
+        to: "123",
+        payloads: [{ text: "abcd", channelData: { telegram: { buttons } } }],
+        deps: { sendTelegram },
+      });
+    });
+
+    expect(sendTelegram).toHaveBeenCalledTimes(2);
+    // first chunk: sendText path, no buttons
+    expect(sendTelegram.mock.calls[0][2]).not.toHaveProperty("buttons");
+    // last chunk: sendPayload path, buttons attached
+    expect(sendTelegram.mock.calls[1][2]).toMatchObject({ buttons });
+  });
+
+  it("does not pre-chunk sendPayload text when prependTextChunksToPayload is unset", async () => {
+    const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-chunk" });
+    const sendText = vi.fn();
+    const sendMedia = vi.fn();
+    // Adapter has chunker + sendPayload but NOT prependTextChunksToPayload
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              deliveryMode: "direct",
+              chunker: (text, limit) => {
+                const chunks: string[] = [];
+                for (let i = 0; i < text.length; i += limit) {
+                  chunks.push(text.slice(i, i + limit));
+                }
+                return chunks;
+              },
+              textChunkLimit: 2,
+              sendPayload,
+              sendText,
+              sendMedia,
+            },
+          }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: { channels: { matrix: { textChunkLimit: 2 } } },
+      channel: "matrix",
+      to: "!room:1",
+      payloads: [{ text: "abcd", channelData: { custom: true } }],
+    });
+
+    // sendText should NOT be called for leading chunks
+    expect(sendText).not.toHaveBeenCalled();
+    // sendPayload should receive the full text unchanged
+    expect(sendPayload).toHaveBeenCalledOnce();
+    expect(sendPayload).toHaveBeenCalledWith(expect.objectContaining({ text: "abcd" }));
   });
 
   it("falls back to one sendText call for multi-media payloads when sendMedia is omitted", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -98,6 +98,7 @@ type ChannelHandler = {
   chunkerMode?: "text" | "markdown";
   textChunkLimit?: number;
   supportsMedia: boolean;
+  prependTextChunksToPayload?: boolean;
   sendPayload?: (
     payload: ReplyPayload,
     overrides?: {
@@ -171,6 +172,7 @@ function createPluginHandler(
     chunkerMode,
     textChunkLimit: outbound.textChunkLimit,
     supportsMedia: Boolean(sendMedia),
+    prependTextChunksToPayload: outbound.prependTextChunksToPayload,
     sendPayload: outbound.sendPayload
       ? async (payload, overrides) =>
           outbound.sendPayload!({
@@ -714,7 +716,23 @@ async function deliverOutboundPayloadsCore(
         threadId: params.threadId ?? undefined,
       };
       if (handler.sendPayload && effectivePayload.channelData) {
-        const delivery = await handler.sendPayload(effectivePayload, sendOverrides);
+        let payloadForSend = effectivePayload;
+        // When text exceeds the chunk limit, send leading chunks as plain text and
+        // attach channelData only to the final chunk to preserve inline buttons.
+        // Only adapters that opt in via prependTextChunksToPayload get this behavior;
+        // others (e.g. Line) control payload ordering internally in sendPayload.
+        if (handler.prependTextChunksToPayload && handler.chunker && textLimit !== undefined) {
+          const fullText = effectivePayload.text ?? "";
+          const chunks = handler.chunker(fullText, textLimit);
+          if (chunks.length > 1) {
+            for (const chunk of chunks.slice(0, -1)) {
+              throwIfAborted(abortSignal);
+              results.push(await handler.sendText(chunk, sendOverrides));
+            }
+            payloadForSend = { ...effectivePayload, text: chunks.at(-1) ?? "" };
+          }
+        }
+        const delivery = await handler.sendPayload(payloadForSend, sendOverrides);
         results.push(delivery);
         emitMessageSent({
           success: true,

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -708,6 +708,7 @@ export {
   parseTelegramThreadId,
 } from "../telegram/outbound-params.js";
 export { type TelegramProbe } from "../telegram/probe.js";
+export { type TelegramInlineButtons, type TelegramInlineButton } from "../telegram/button-types.js";
 
 // Channel: Signal
 export {

--- a/src/plugin-sdk/telegram.ts
+++ b/src/plugin-sdk/telegram.ts
@@ -66,3 +66,5 @@ export { telegramOnboardingAdapter } from "../channels/plugins/onboarding/telegr
 export { TelegramConfigSchema } from "../config/zod-schema.providers-core.js";
 
 export { buildTokenChannelStatusSummary } from "./status-helpers.js";
+
+export type { TelegramInlineButtons, TelegramInlineButton } from "../telegram/button-types.js";

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1110,6 +1110,7 @@ export const registerTelegramHandlers = ({
         const cbIsForum = callbackMessage.chat.is_forum === true;
         const authContext = await resolveTelegramEventAuthorizationContext({
           chatId: cbChatId,
+          isGroup: cbIsGroup,
           isForum: cbIsForum,
           messageThreadId: cbMessageThreadId,
         });
@@ -1172,21 +1173,13 @@ export const registerTelegramHandlers = ({
         authContext: eventAuthContext,
         senderAuth: senderAuthorization,
       } = await resolveCallbackSenderAuth(inlineButtonsScope);
+      const senderId = callback.from?.id ? String(callback.from.id) : "";
       if (inlineButtonsScope === "dm" && isGroup) {
         return;
       }
       if (inlineButtonsScope === "group" && !isGroup) {
         return;
       }
-
-      const messageThreadId = callbackMessage.message_thread_id;
-      const isForum = callbackMessage.chat.is_forum === true;
-      const eventAuthContext = await resolveTelegramEventAuthorizationContext({
-        chatId,
-        isGroup,
-        isForum,
-        messageThreadId,
-      });
       const { resolvedThreadId, dmThreadId, storeAllowFrom, groupConfig } = eventAuthContext;
       const requireTopic = (groupConfig as { requireTopic?: boolean } | undefined)?.requireTopic;
       if (!isGroup && requireTopic === true && dmThreadId == null) {
@@ -1195,19 +1188,6 @@ export const registerTelegramHandlers = ({
         );
         return;
       }
-      const senderId = callback.from?.id ? String(callback.from.id) : "";
-      const senderUsername = callback.from?.username ?? "";
-      const authorizationMode: TelegramEventAuthorizationMode =
-        inlineButtonsScope === "allowlist" ? "callback-allowlist" : "callback-scope";
-      const senderAuthorization = authorizeTelegramEventSender({
-        chatId,
-        chatTitle: callbackMessage.chat.title,
-        isGroup,
-        senderId,
-        senderUsername,
-        mode: authorizationMode,
-        context: eventAuthContext,
-      });
       if (!senderAuthorization.allowed) {
         return;
       }

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1099,6 +1099,63 @@ export const registerTelegramHandlers = ({
         return await bot.api.sendMessage(callbackMessage.chat.id, text, params);
       };
 
+      // Resolve chat properties + sender authorization for a callback query.
+      // Shared by the exec-approval handler and the general inline-buttons handler
+      // so both stay in sync when auth logic changes.
+      const resolveCallbackSenderAuth = async (buttonsScope: string) => {
+        const cbChatId = callbackMessage.chat.id;
+        const cbIsGroup =
+          callbackMessage.chat.type === "group" || callbackMessage.chat.type === "supergroup";
+        const cbMessageThreadId = callbackMessage.message_thread_id;
+        const cbIsForum = callbackMessage.chat.is_forum === true;
+        const authContext = await resolveTelegramEventAuthorizationContext({
+          chatId: cbChatId,
+          isForum: cbIsForum,
+          messageThreadId: cbMessageThreadId,
+        });
+        const senderAuth = authorizeTelegramEventSender({
+          chatId: cbChatId,
+          chatTitle: callbackMessage.chat.title,
+          isGroup: cbIsGroup,
+          senderId: callback.from?.id ? String(callback.from.id) : "",
+          senderUsername: callback.from?.username ?? "",
+          mode: buttonsScope === "allowlist" ? "callback-allowlist" : "callback-scope",
+          context: authContext,
+        });
+        return {
+          chatId: cbChatId,
+          isGroup: cbIsGroup,
+          isForum: cbIsForum,
+          messageThreadId: cbMessageThreadId,
+          authContext,
+          senderAuth,
+        };
+      };
+
+      // Exec approval buttons bypass the general inlineButtonsScope gate —
+      // they are always routed regardless of the model-selection buttons setting.
+      // Auth mode mirrors the regular callback handler: use callback-allowlist when the
+      // account is configured for allowlist-only inline buttons so DM policy is enforced,
+      // otherwise use callback-scope (message visibility implies authorization).
+      if (data.startsWith("/approve ")) {
+        const buttonsScope = resolveTelegramInlineButtonsScope({ cfg, accountId });
+        const { authContext, senderAuth } = await resolveCallbackSenderAuth(buttonsScope);
+        if (senderAuth.allowed) {
+          const syntheticMessage = buildSyntheticTextMessage({
+            base: callbackMessage,
+            from: callback.from,
+            text: data,
+          });
+          await processMessage(
+            buildSyntheticContext(ctx, syntheticMessage),
+            [],
+            authContext.storeAllowFrom,
+            { forceWasMentioned: true, messageIdOverride: callback.id },
+          );
+        }
+        return;
+      }
+
       const inlineButtonsScope = resolveTelegramInlineButtonsScope({
         cfg,
         accountId,
@@ -1107,9 +1164,14 @@ export const registerTelegramHandlers = ({
         return;
       }
 
-      const chatId = callbackMessage.chat.id;
-      const isGroup =
-        callbackMessage.chat.type === "group" || callbackMessage.chat.type === "supergroup";
+      const {
+        chatId,
+        isGroup,
+        isForum,
+        messageThreadId,
+        authContext: eventAuthContext,
+        senderAuth: senderAuthorization,
+      } = await resolveCallbackSenderAuth(inlineButtonsScope);
       if (inlineButtonsScope === "dm" && isGroup) {
         return;
       }

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -467,6 +467,182 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-compact-2");
   });
 
+  it("routes /approve callback_data as a message even when inlineButtonsScope is off", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+
+    createTelegramBot({
+      token: "tok",
+      config: {
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            capabilities: { inlineButtons: "off" },
+          },
+        },
+      },
+    });
+    const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    expect(callbackHandler).toBeDefined();
+
+    const approvalUuid = "12345678-1234-1234-1234-123456789abc";
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-approve-1",
+        data: `/approve ${approvalUuid} allow-once`,
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 50,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    // replySpy = getReplyFromConfig mock; it fires for synthesised messages routed through processMessage
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const [msgCtx] = replySpy.mock.calls[0] ?? [];
+    // MsgContext.Body contains the envelope + command text
+    expect((msgCtx as { Body?: string })?.Body).toContain(`/approve ${approvalUuid} allow-once`);
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-1");
+  });
+
+  it("blocks /approve callback from unauthorized sender when inlineButtons is allowlist", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+    readChannelAllowFromStore.mockResolvedValue([]);
+
+    createTelegramBot({
+      token: "tok",
+      config: {
+        channels: {
+          telegram: {
+            dmPolicy: "allowlist",
+            allowFrom: [],
+            capabilities: { inlineButtons: "allowlist" },
+          },
+        },
+      },
+    });
+    const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    expect(callbackHandler).toBeDefined();
+
+    const approvalUuid = "12345678-1234-1234-1234-123456789abc";
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-approve-unauth",
+        data: `/approve ${approvalUuid} allow-once`,
+        from: { id: 999, first_name: "Eve", username: "eve_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 51,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).not.toHaveBeenCalled();
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-unauth");
+  });
+
+  it("routes /approve callback from authorized sender when inlineButtons is allowlist", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+    readChannelAllowFromStore.mockResolvedValue(["9"]);
+
+    createTelegramBot({
+      token: "tok",
+      config: {
+        channels: {
+          telegram: {
+            dmPolicy: "allowlist",
+            allowFrom: ["9"],
+            capabilities: { inlineButtons: "allowlist" },
+          },
+        },
+      },
+    });
+    const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    expect(callbackHandler).toBeDefined();
+
+    const approvalUuid = "12345678-1234-1234-1234-123456789abc";
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-approve-auth",
+        data: `/approve ${approvalUuid} allow-once`,
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 52,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-auth");
+  });
+
+  it("routes /approve callback in a group even when inlineButtons is dm-only", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+
+    createTelegramBot({
+      token: "tok",
+      config: {
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            capabilities: { inlineButtons: "dm" },
+            groupPolicy: "open",
+            groups: { "*": { requireMention: false } },
+          },
+        },
+      },
+    });
+    const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    expect(callbackHandler).toBeDefined();
+
+    const approvalUuid = "12345678-1234-1234-1234-123456789abc";
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-approve-group",
+        data: `/approve ${approvalUuid} deny`,
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: -100999, type: "supergroup", title: "Ops Group" },
+          date: 1736380800,
+          message_id: 52,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    // Normal callbacks in a group are blocked when inlineButtons is "dm";
+    // approval callbacks must bypass that gate and reach processMessage.
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const [msgCtx] = replySpy.mock.calls[0] ?? [];
+    expect((msgCtx as { Body?: string })?.Body).toContain(`/approve ${approvalUuid} deny`);
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-group");
+  });
+
   it("includes sender identity in group envelope headers", async () => {
     onSpy.mockClear();
     replySpy.mockClear();


### PR DESCRIPTION
## Summary

Exec approval request messages sent via Telegram now include three inline
buttons (Allow once / Always allow / Deny) so users can act without typing
the `/approve` command manually.

- Problem: Telegram approval messages were text-only; users had to copy the
  ID and type `/approve <id> allow-once|allow-always|deny`, which is friction
  on mobile.
- Why it matters: Inline buttons are the standard Telegram UX for confirmation
  flows; skipping them made exec approvals feel broken compared to Discord.
  Also reported as a regression when `inlineButtons: "all"` was added for model
  selection but approval routing did not follow (#23856).
- What changed: `buildRequestMessage` in `exec-approval-forwarder.ts` now
  returns `{ text, buttons }` and attaches `channelData.telegram.buttons` to
  the outbound payload only when the target channel is `telegram`. The callback
  handler in `bot-handlers.ts` intercepts `/approve …` callback data **before**
  the `inlineButtonsScope` gate, routes it through the existing `processMessage`
  path, and returns early — zero new parsing code.
- What did NOT change: Approval logic, command parsing, session/account
  isolation, non-Telegram channels, Discord forwarding suppression logic
  (no second delivery path exists for Telegram approvals), multi-account
  isolation (each bot token is a distinct Telegram account; callbacks are
  routed by the platform to the originating bot).

### Backward compatibility

Inline buttons fall back to text-only if the approval ID would produce a
`callback_data` value longer than the Telegram 64-byte hard limit (checked
via `Buffer.byteLength`). Non-Telegram targets are unaffected — no `channelData`
is attached.

### Community workaround and known gap

A third-party plugin ([telegram-approval-buttons](https://github.com/JairFC/openclaw-telegram-approval-buttons),
discussion #22417) has been filling this gap with 200+ weekly npm downloads as of the
linked discussion. That plugin ships this feature as user-installable code; this PR
moves it into core so no extra install step is required.

The community plugin also does two things this PR does not:

1. **Post-resolution message edit** — after a button is tapped, the plugin edits the
   original message to remove the inline keyboard and show the outcome (approved /
   denied). Without this, the buttons remain visible after the decision, and a second
   tap on an already-resolved approval will reach the `/approve` handler and get a
   "not found / expired" reply.
2. **Explicit timeout cleanup** — the plugin listens for approval expiry and removes
   buttons proactively. Our implementation relies on the `/approve` handler returning
   an error for expired IDs; the buttons stay on the message until the chat is scrolled
   past.

Both are follow-up improvements; neither blocks the core feature. The 64-byte
`callback_data` limit guard (fallback to text-only) already prevents the most
critical failure mode.

### Files changed (7 files, +552 / -8)

| File | Change |
|------|--------|
| `src/infra/exec-approval-forwarder.ts` | `buildRequestMessage` returns `{ text, buttons }` with inline keyboard; `deliverToTargets` attaches `channelData.telegram.buttons` for Telegram targets only; `TELEGRAM_CALLBACK_DATA_MAX_BYTES` hoisted to module scope |
| `src/infra/exec-approval-forwarder.test.ts` | 8 new tests covering button attachment, 64-byte limit enforcement, exact 64-byte boundary, fallback, non-Telegram suppression, optional-fields message text |
| `src/telegram/bot-handlers.ts` | `/approve` callback bypass added before `inlineButtonsScope` gate; auth mirrors the existing callback-allowlist/callback-scope modes |
| `src/telegram/bot.test.ts` | 4 new tests: bypass when scope is off, auth block when allowlist, allowlist-authorized sender, group routing when dm-only |
| `extensions/telegram/src/channel.ts` | Add `sendPayload` to the telegram extension plugin's outbound adapter; use canonical `TelegramInlineButtons` type imported from plugin-sdk |
| `extensions/telegram/src/channel.test.ts` | 3 new tests: sendPayload with buttons (no media), sendPayload with buttons (multi-media), sendPayload without channelData |
| `src/plugin-sdk/index.ts` | Export `TelegramInlineButtons` and `TelegramInlineButton` so extension authors can import the canonical types |

Note: `src/channels/plugins/outbound/telegram.ts` is a pre-existing **test fixture**
(not the production adapter). It already had `sendPayload` on `main`; this branch does
not modify it. The production outbound adapter is the `outbound` object inlined in
`extensions/telegram/src/channel.ts`.

## AI Assistance

- [x] Mark as AI-assisted in the PR title or description
- [x] Note the degree of testing (untested / lightly tested / fully tested)
- [x] Include prompts or session logs if possible (super helpful!)
- [x] Confirm you understand what the code does

**Tool:** Claude Code (claude-sonnet-4-6) via CLI, pair-programmed with the author.

**Degree of testing:** Fully tested — 15 new unit tests covering button attachment,
64-byte limit enforcement (including exact boundary), allowlist auth, sendPayload
variants, and non-Telegram suppression. All tests verified passing locally.
Live end-to-end verification on Docker deployment (Linux, real Telegram bot).

**Session logs:** Full Claude Code session transcript available locally (not published to avoid
including personal identifiers).

**Author understanding:** I reviewed all generated code and understand
the delivery pipeline wiring (`deliver.ts:551` gateway), the callback handler
bypass scope (`data.startsWith("/approve ")`), the 64-byte guard logic, and the
`sendPayload` extension point in the telegram plugin.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR


- Closes #22078 , #23856 , #24086 
- Supersedes #24144
- Addresses Closed Issues (stale, ...) #15262 , #16111 , #3934 , #15504 , #4565 , #15472 ,  #9229 (partially addressed)
- Linked Discussion https://github.com/openclaw/openclaw/discussions/22417 

## User-visible / Behavior Changes

Telegram exec approval request messages now display three inline keyboard
buttons. Tapping a button triggers the same `/approve` flow as typing the
command. No config change required.

When `inlineButtons` is set to `dm-only`, `off`, or `allowlist`, approval
buttons still appear and work — only the general model-selection buttons are
gated by that setting.

## Security Impact (required)

- New permissions/capabilities? No — buttons are an additional UI surface for
  an existing feature; no new approval decisions or permissions are introduced.
- Secrets/tokens handling changed? No
- New/changed network calls? No — same Telegram `sendMessage` call, with an
  `inline_keyboard` attachment.
- Command/tool execution surface changed? Yes — the `callback_query` handler
  now processes `/approve` data before the `inlineButtonsScope` gate. Auth is
  enforced identically to the existing callback handler: `callback-allowlist`
  mode when `inlineButtons: "allowlist"`, otherwise `callback-scope` (message
  visibility implies authorization). An unauthorized sender's tap is silently
  dropped.
- Data access scope changed? No
- Risk + mitigation: The pre-gate bypass is intentional and scoped tightly to
  `data.startsWith("/approve ")`. Any other callback data falls through to the
  existing gated handler. Auth is not skipped — it uses the same
  `authorizeTelegramEventSender` call with the appropriate mode.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Docker
- Model/provider: autorouter/standard
- Integration/channel: Telegram bot
- Relevant config (redacted): exec approval targets configured, `inlineButtons`
  unset (default)

### Steps

1. Issue a command that triggers exec approval (e.g., a shell tool call on a
   gateway with exec approval enabled).
2. Observe the Telegram message from the bot.
3. Tap "Allow once", "Always allow", or "Deny".

### Expected

- Message displays three inline buttons below the approval text.
- Tapping a button approves or denies the request without typing a command.
- The bot replies confirming the decision.

### Actual

- Buttons appear on the message.
- Tapping "Allow once" triggers `/approve <id> allow-once` through the normal
  approval path.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets  (gateway INFO level does not capture sendMessage payload)
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Live end-to-end confirmed: exec approval request produced three inline buttons in
Telegram; tapping "Allow once" resolved the approval. See Human Verification above.

<img width="484" height="405" alt="Telegram-Approval-With-Buttons" src="https://github.com/user-attachments/assets/fc2fb53c-57f9-404c-992c-92d494723054" />

15 new tests, all passing:

```
src/infra/exec-approval-forwarder.test.ts  (8 new)
  - attaches three inline approval buttons to the request message
  - keeps all callback_data values within the 64-byte Telegram limit
  - still attaches buttons when ID produces exactly 64-byte callback_data
  - does not attach buttons to resolved messages
  - does not attach buttons to expired messages
  - does not attach channelData to non-Telegram targets
  - includes all optional request fields in message text
  - falls back to no buttons when approval ID exceeds 64-byte callback_data limit

src/telegram/bot.test.ts  (4 new)
  - routes /approve callback_data as a message even when inlineButtonsScope is off
  - blocks /approve callback from unauthorized sender when inlineButtons is allowlist
  - routes /approve callback from authorized sender when inlineButtons is allowlist
  - routes /approve callback in a group even when inlineButtons is dm-only

extensions/telegram/src/channel.test.ts  (3 new)
  - forwards buttons to sendMessageTelegram when channelData.telegram.buttons is set (no media)
  - attaches buttons only to first send when multiple mediaUrls are present
  - sends without buttons when channelData is absent
```

Full test run result: 72 tests pass (44 bot.test.ts, 20 exec-approval-forwarder.test.ts, 8 channel.test.ts).

## Human Verification (required)

- Verified scenarios: tests confirm button attachment, 64-byte limit guard,
  non-Telegram suppression, auth enforcement under each inlineButtons mode.
- Edge cases checked: ID at 64-byte boundary (passes), ID over limit (falls
  back to text-only), unauthorized sender (silently dropped), group chat
  (routed when not dm-only).
- Live end-to-end verified (Docker deployment, linux):
  agent asked via Telegram to write a Python Hello World program;
  exec approval message arrived with three inline buttons; tapping
  "Allow once" resolved the approval and the agent proceeded.
  Both DM and a group forwarding target received the buttons.

  Gateway log trace (INFO level; Telegram sendMessage payload is not
  logged at this level):

  ```
  [exec] elevated command python3 hello_world.py
  [ws] ⇄ res ✓ exec.approval.waitDecision 4366ms
  ```

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert quickly: revert the feat commit; approval messages
  return to text-only and the callback bypass is removed.
- Files/config to restore: `src/infra/exec-approval-forwarder.ts`,
  `src/telegram/bot-handlers.ts`, `extensions/telegram/src/channel.ts`,
  `src/plugin-sdk/index.ts`.
- Known bad symptoms: buttons appear but tapping has no effect (would indicate
  the `/approve` bypass block is not reached — check that `data.startsWith`
  comparison matches the command prefix exactly).

## Risks and Mitigations

- Risk: `/approve` bypass before `inlineButtonsScope` could be widened
  inadvertently in a future refactor.
  - Mitigation: the bypass is explicitly scoped to `data.startsWith("/approve ")`
    with a space, and returns early before any other handling. Covered by tests
    that confirm scope-off and dm-only modes still route approval callbacks.