### PR TITLE
fix(telegram): expose direct message ids in inbound metadata [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Cron/Isolated model defaults: resolve isolated cron `subagents.model` (including object-form `primary`) through allowlist-aware model selection so isolated cron runs honor subagent model defaults unless explicitly overridden by job payload model. (#11474) Thanks @AnonO6.
+- Telegram/Inbound metadata: include `message_id`/`message_id_full` and `sender_id` in direct-chat conversation metadata so same-turn message actions (for example delete) can target Telegram inbound messages consistently with channel workflows. (#30649) Thanks @liuxiaopai-ai.
 - Cron/Isolated sessions list: persist the intended pre-run model/provider on isolated cron session entries so `sessions_list` reflects payload/session model overrides even when runs fail before post-run telemetry persistence. (#21279) Thanks @altaywtf.
 - Cron/One-shot reliability: retry transient one-shot failures with bounded backoff and configurable retry policy before disabling. (#24435) Thanks .
 - Gateway/Cron auditability: add gateway info logs for successful cron create, update, and remove operations. (#25090) Thanks .

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -111,6 +111,23 @@ describe("buildInboundUserContextPrefix", () => {
     expect(text).toBe("");
   });
 
+  it("includes message identifiers for Telegram direct chats", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      OriginatingChannel: "telegram",
+      Provider: "telegram",
+      Surface: "telegram",
+      MessageSid: "short-id",
+      MessageSidFull: "provider-full-id",
+      SenderId: "8183829769",
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["message_id"]).toBe("short-id");
+    expect(conversationInfo["message_id_full"]).toBe("provider-full-id");
+    expect(conversationInfo["sender_id"]).toBe("8183829769");
+  });
+
   it("does not treat group chats as direct based on sender id", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "group",

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -31,6 +31,15 @@ function formatConversationTimestamp(value: unknown): string | undefined {
   }
 }
 
+function isTelegramContext(ctx: TemplateContext): boolean {
+  const channel = (
+    safeTrim(ctx.OriginatingChannel) ??
+    safeTrim(ctx.Surface) ??
+    safeTrim(ctx.Provider)
+  )?.toLowerCase();
+  return channel === "telegram";
+}
+
 export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
@@ -84,24 +93,25 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const blocks: string[] = [];
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
+  const includeDirectIdentifiers = isDirect && isTelegramContext(ctx);
+  const includeConversationIdentifiers = !isDirect || includeDirectIdentifiers;
 
   const messageId = safeTrim(ctx.MessageSid);
   const messageIdFull = safeTrim(ctx.MessageSidFull);
   const timestampStr = formatConversationTimestamp(ctx.Timestamp);
 
   const conversationInfo = {
-    message_id: isDirect ? undefined : messageId,
-    message_id_full: isDirect
-      ? undefined
-      : messageIdFull && messageIdFull !== messageId
+    message_id: includeConversationIdentifiers ? messageId : undefined,
+    message_id_full:
+      includeConversationIdentifiers && messageIdFull && messageIdFull !== messageId
         ? messageIdFull
         : undefined,
-    reply_to_id: isDirect ? undefined : safeTrim(ctx.ReplyToId),
-    sender_id: isDirect ? undefined : safeTrim(ctx.SenderId),
+    reply_to_id: includeConversationIdentifiers ? safeTrim(ctx.ReplyToId) : undefined,
+    sender_id: includeConversationIdentifiers ? safeTrim(ctx.SenderId) : undefined,
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
-    sender: isDirect
-      ? undefined
-      : (safeTrim(ctx.SenderE164) ?? safeTrim(ctx.SenderId) ?? safeTrim(ctx.SenderUsername)),
+    sender: includeConversationIdentifiers
+      ? (safeTrim(ctx.SenderE164) ?? safeTrim(ctx.SenderId) ?? safeTrim(ctx.SenderUsername))
+      : undefined,
     timestamp: timestampStr,
     group_subject: safeTrim(ctx.GroupSubject),
     group_channel: safeTrim(ctx.GroupChannel),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: direct Telegram inbound context omitted `message_id`/`sender_id`, which blocks same-turn message actions (e.g. delete) that require the inbound message identifier.
- Why it matters: security workflows (such as redact/store/delete) cannot reliably target the just-received Telegram message.
- What changed: in inbound conversation metadata, keep direct-chat identifier suppression by default, but allow Telegram direct chats to include `message_id`, `message_id_full`, `reply_to_id`, `sender_id`, and resolved `sender`.
- What did NOT change (scope boundary): system prompt metadata remains cache-stable (no per-turn IDs there), and non-Telegram direct channels keep existing suppression behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30649
- Related #27253

## User-visible / Behavior Changes

Telegram DM conversation metadata now includes message identifiers and sender ID so agent actions can reference inbound Telegram messages in the same turn.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram inbound context metadata
- Relevant config (redacted): Telegram channel enabled

### Steps

1. Build inbound user context for a direct Telegram message with `MessageSid`/`SenderId` set.
2. Parse `Conversation info` metadata block.
3. Compare with non-Telegram direct chat behavior.

### Expected

- Telegram direct: `message_id`, `message_id_full`, `sender_id` present when provided.
- Other direct chats: existing behavior unchanged (identifiers hidden).

### Actual

- Before fix: Telegram direct metadata omitted message IDs.
- After fix: Telegram direct metadata includes IDs and sender fields.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: new `inbound-meta` regression test for Telegram direct ID inclusion; existing direct-chat suppression and other inbound-meta tests remain green.
- Edge cases checked: `message_id_full` only appears when different from `message_id`.
- What you did **not** verify: live Telegram end-to-end delete action using produced metadata.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/auto-reply/reply/inbound-meta.ts`, `src/auto-reply/reply/inbound-meta.test.ts`.
- Known bad symptoms reviewers should watch for: unexpected identifier exposure in non-Telegram direct channels.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Telegram direct metadata now carries additional per-turn identifiers that some prompt consumers may start depending on.
  - Mitigation:
    - Scope is limited to Telegram direct chats only; system prompt metadata remains unchanged and tests cover non-Telegram direct suppression.

AI-assisted: Yes.
