### PR TITLE
fix(subagents): strip trailing NO_REPLY from announce output [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Cron/Isolated model defaults: resolve isolated cron `subagents.model` (including object-form `primary`) through allowlist-aware model selection so isolated cron runs honor subagent model defaults unless explicitly overridden by job payload model. (#11474) Thanks @AnonO6.
+- Subagent/Cron announce delivery: strip trailing `NO_REPLY` sentinel lines from completion findings before formatting/sending so announce chunking cannot leak literal `NO_REPLY` messages to user channels. (#30692) Thanks @liuxiaopai-ai.
 - Cron/Isolated sessions list: persist the intended pre-run model/provider on isolated cron session entries so `sessions_list` reflects payload/session model overrides even when runs fail before post-run telemetry persistence. (#21279) Thanks @altaywtf.
 - Cron/One-shot reliability: retry transient one-shot failures with bounded backoff and configurable retry policy before disabling. (#24435) Thanks .
 - Gateway/Cron auditability: add gateway info logs for successful cron create, update, and remove operations. (#25090) Thanks .

--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -452,6 +452,27 @@ describe("subagent announce formatting", () => {
     expect(agentSpy).not.toHaveBeenCalled();
   });
 
+  it("strips trailing NO_REPLY token from cron completion delivery text", async () => {
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-direct-completion-trailing-no-reply",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "telegram", to: "telegram:1234", accountId: "acct-1" },
+      ...defaultOutcomeAnnounce,
+      announceType: "cron job",
+      expectsCompletionMessage: true,
+      roundOneReply: "Daily summary ready.\n\nNO_REPLY",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpy).not.toHaveBeenCalled();
+    const call = sendSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
+    expect(call?.params?.message).toContain("Daily summary ready.");
+    expect(call?.params?.message).not.toContain("NO_REPLY");
+  });
+
   it("retries completion direct send on transient channel-unavailable errors", async () => {
     sendSpy
       .mockRejectedValueOnce(new Error("Error: No active WhatsApp Web listener (account: default)"))

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -72,7 +72,7 @@ function buildCompletionDeliveryMessage(params: {
   outcome?: SubagentRunOutcome;
   announceType?: SubagentAnnounceType;
 }): string {
-  const findingsText = params.findings.trim();
+  const findingsText = stripTrailingSilentReplyLine(params.findings);
   if (isAnnounceSkip(findingsText)) {
     return "";
   }
@@ -100,6 +100,25 @@ function buildCompletionDeliveryMessage(params: {
     return header;
   }
   return `${header}\n\n${findingsText}`;
+}
+
+function stripTrailingSilentReplyLine(text: string): string {
+  const lines = text.split(/\r?\n/);
+  let end = lines.length - 1;
+  while (end >= 0 && !(lines[end] ?? "").trim()) {
+    end -= 1;
+  }
+  if (end < 0) {
+    return "";
+  }
+  if (((lines[end] ?? "").trim().toUpperCase() ?? "") !== SILENT_REPLY_TOKEN.toUpperCase()) {
+    return text.trim();
+  }
+  const stripped = lines.slice(0, end);
+  while (stripped.length > 0 && !(stripped.at(-1) ?? "").trim()) {
+    stripped.pop();
+  }
+  return stripped.join("\n").trim();
 }
 
 function summarizeDeliveryError(error: unknown): string {
@@ -1214,7 +1233,7 @@ export async function runSubagentAnnounceFlow(params: {
     const taskLabel = params.label || params.task || "task";
     const subagentName = resolveAgentIdFromSessionKey(params.childSessionKey);
     const announceSessionId = childSessionId || "unknown";
-    const findings = reply || "(no output)";
+    const findings = stripTrailingSilentReplyLine(reply || "") || "(no output)";
     let completionMessage = "";
     let triggerMessage = "";
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: announce outputs like `...\n\nNO_REPLY` were not treated as silent, and chunked/direct completion delivery could leak `NO_REPLY` as a visible user message.
- Why it matters: cron/subagent completion notifications can send confusing literal control tokens to user channels (reported on Telegram).
- What changed: strip trailing standalone `NO_REPLY` lines from announce findings before building completion/internal messages, while preserving existing full-text `NO_REPLY` suppression behavior.
- What did NOT change (scope boundary): no change to core silent-token matching semantics (`isSilentReplyText`), no delivery routing change, and no queue mode behavior change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30692
- Related #27387

## User-visible / Behavior Changes

Completion announcements no longer leak a literal trailing `NO_REPLY` line into channel messages.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: announce flow formatting path
- Integration/channel (if any): cron/subagent completion delivery
- Relevant config (redacted): announce delivery mode

### Steps

1. Run announce flow with completion reply text ending in `\n\nNO_REPLY`.
2. Trigger completion-mode direct send path.
3. Inspect outbound completion message text.

### Expected

- Completion message contains findings text but no literal `NO_REPLY` line.

### Actual

- Before fix: token could leak as visible trailing line.
- After fix: trailing standalone token is stripped.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added `strips trailing NO_REPLY token from cron completion delivery text` regression; full `subagent-announce.format.test.ts` suite passes.
- Edge cases checked: full-token-only `NO_REPLY` suppression tests remain intact.
- What you did **not** verify: live cron announce on Telegram in a production deployment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/subagent-announce.ts`, `src/agents/subagent-announce.format.test.ts`.
- Known bad symptoms reviewers should watch for: valid findings text unexpectedly truncated if last non-empty line should literally be `NO_REPLY`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - A legitimate result whose final standalone line is exactly `NO_REPLY` will now be stripped from completion text.
  - Mitigation:
    - Stripping is intentionally narrow (trailing standalone line only), and this line is reserved as a control sentinel in announce workflows.

AI-assisted: Yes.
