### PR TITLE
fix(gateway): ignore interfaces without ip addresses in mdns

### DIFF
--- a/src/infra/bonjour.ts
+++ b/src/infra/bonjour.ts
@@ -1,3 +1,4 @@
+import os from "os";
 import { logDebug, logWarn } from "../logger.js";
 import { getLogger } from "../logging.js";
 import { ignoreCiaoCancellationRejection } from "./bonjour-ciao.js";
@@ -36,6 +37,38 @@ function isDisabledByEnv() {
     return true;
   }
   return false;
+}
+
+function getInterfacesWithIp() {
+  const interfaces = os.networkInterfaces();
+  const validInterfaces: string[] = [];
+
+  for (const [name, addresses] of Object.entries(interfaces)) {
+    if (!addresses) {
+      continue;
+    }
+
+    // Check if interface has at least one valid IP address
+    const hasValidIp = addresses.some((addr) => {
+      // Skip internal addresses and link-local addresses
+      if (addr.internal) {
+        return false;
+      }
+      if (addr.family === "IPv4" && addr.address.startsWith("169.254.")) {
+        return false;
+      }
+      if (addr.family === "IPv6" && addr.address.startsWith("fe80:")) {
+        return false;
+      }
+      return true;
+    });
+
+    if (hasValidIp) {
+      validInterfaces.push(name);
+    }
+  }
+
+  return validInterfaces;
 }
 
 function safeServiceName(name: string) {
@@ -89,7 +122,10 @@ export async function startGatewayBonjourAdvertiser(
   }
 
   const { getResponder, Protocol } = await import("@homebridge/ciao");
-  const responder = getResponder();
+  const validInterfaces = getInterfacesWithIp();
+  const responder = getResponder({
+    interface: validInterfaces.length > 0 ? validInterfaces : undefined,
+  });
 
   // mDNS service instance names are single DNS labels; dots in hostnames (like
   // `Mac.localdomain`) can confuse some resolvers/browsers and break discovery.


### PR DESCRIPTION
## 问题描述
OpenClaw Gateway 在启动时，如果环境中存在没有 IP 地址的网卡（比如虚拟网卡、未启用的网卡），会因为依赖的 @homebridge/ciao 库尝试在所有网卡上绑定而导致启动失败。

## 修复方案
通过过滤出具有有效 IP 地址的网卡，仅在这些网卡上启动 mDNS 服务，避免在无 IP 网卡上绑定失败。

## 关键修改
1. 添加网卡过滤函数，跳过内部地址和链路本地地址
2. 修改 Responder 创建逻辑，仅在有效网卡上启动 mDNS 服务
3. 保留 fallback 逻辑，当所有网卡都无有效 IP 时使用默认行为