### PR TITLE
fix(gateway): prefer runtime version over stale service env [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Docs: https://docs.openclaw.ai
 
 - Cron/Isolated model defaults: resolve isolated cron `subagents.model` (including object-form `primary`) through allowlist-aware model selection so isolated cron runs honor subagent model defaults unless explicitly overridden by job payload model. (#11474) Thanks @AnonO6.
 - Cron/Isolated sessions list: persist the intended pre-run model/provider on isolated cron session entries so `sessions_list` reflects payload/session model overrides even when runs fail before post-run telemetry persistence. (#21279) Thanks @altaywtf.
+- Gateway/Version presence: prefer runtime package/bundled version sources over stale `OPENCLAW_SERVICE_VERSION` when publishing gateway self/version metadata, so Control UI and `openclaw status` reflect the upgraded app version without requiring service reinstall. (#30689) Thanks @liuxiaopai-ai.
 - Cron/One-shot reliability: retry transient one-shot failures with bounded backoff and configurable retry policy before disabling. (#24435) Thanks .
 - Gateway/Cron auditability: add gateway info logs for successful cron create, update, and remove operations. (#25090) Thanks .
 - Cron/Schedule errors: notify users when a job is auto-disabled after repeated schedule computation failures. (#29098) Thanks .

--- a/src/infra/system-presence.version.test.ts
+++ b/src/infra/system-presence.version.test.ts
@@ -17,7 +17,7 @@ async function withPresenceModule<T>(
 }
 
 describe("system-presence version fallback", () => {
-  it("uses OPENCLAW_SERVICE_VERSION when OPENCLAW_VERSION is not set", async () => {
+  it("prefers npm_package_version over OPENCLAW_SERVICE_VERSION when OPENCLAW_VERSION is not set", async () => {
     await withPresenceModule(
       {
         OPENCLAW_SERVICE_VERSION: "2.4.6-service",
@@ -25,15 +25,16 @@ describe("system-presence version fallback", () => {
       },
       ({ listSystemPresence }) => {
         const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
-        expect(selfEntry?.version).toBe("2.4.6-service");
+        expect(selfEntry?.version).toBe("1.0.0-package");
       },
     );
   });
 
-  it("prefers OPENCLAW_VERSION over OPENCLAW_SERVICE_VERSION", async () => {
+  it("prefers OPENCLAW_VERSION over OPENCLAW_BUNDLED_VERSION and OPENCLAW_SERVICE_VERSION", async () => {
     await withPresenceModule(
       {
         OPENCLAW_VERSION: "9.9.9-cli",
+        OPENCLAW_BUNDLED_VERSION: "8.8.8-bundled",
         OPENCLAW_SERVICE_VERSION: "2.4.6-service",
         npm_package_version: "1.0.0-package",
       },
@@ -44,10 +45,26 @@ describe("system-presence version fallback", () => {
     );
   });
 
+  it("prefers OPENCLAW_BUNDLED_VERSION over OPENCLAW_SERVICE_VERSION when runtime version env is missing", async () => {
+    await withPresenceModule(
+      {
+        OPENCLAW_VERSION: " ",
+        OPENCLAW_BUNDLED_VERSION: "3.3.3-bundled",
+        OPENCLAW_SERVICE_VERSION: "2.4.6-service",
+        npm_package_version: "\t",
+      },
+      ({ listSystemPresence }) => {
+        const selfEntry = listSystemPresence().find((entry) => entry.reason === "self");
+        expect(selfEntry?.version).toBe("3.3.3-bundled");
+      },
+    );
+  });
+
   it("uses npm_package_version when OPENCLAW_VERSION and OPENCLAW_SERVICE_VERSION are blank", async () => {
     await withPresenceModule(
       {
         OPENCLAW_VERSION: " ",
+        OPENCLAW_BUNDLED_VERSION: " ",
         OPENCLAW_SERVICE_VERSION: "\t",
         npm_package_version: "1.0.0-package",
       },

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -94,42 +94,54 @@ describe("version resolution", () => {
     expect(resolveVersionFromModuleUrl("not-a-valid-url")).toBeNull();
   });
 
-  it("prefers OPENCLAW_VERSION over service and package versions", () => {
+  it("prefers OPENCLAW_VERSION over bundled, package, and service versions", () => {
     expect(
       resolveRuntimeServiceVersion({
         OPENCLAW_VERSION: "9.9.9",
+        OPENCLAW_BUNDLED_VERSION: "8.8.8",
         OPENCLAW_SERVICE_VERSION: "2.2.2",
         npm_package_version: "1.1.1",
       }),
     ).toBe("9.9.9");
   });
 
-  it("uses service and package fallbacks and ignores blank env values", () => {
+  it("prefers bundled/package/runtime versions over service env and ignores blank values", () => {
     expect(
       resolveRuntimeServiceVersion({
         OPENCLAW_VERSION: "   ",
+        OPENCLAW_BUNDLED_VERSION: " ",
         OPENCLAW_SERVICE_VERSION: "  2.0.0  ",
         npm_package_version: "1.0.0",
       }),
-    ).toBe("2.0.0");
+    ).toBe("1.0.0");
 
     expect(
       resolveRuntimeServiceVersion({
         OPENCLAW_VERSION: " ",
+        OPENCLAW_BUNDLED_VERSION: " 3.3.3 ",
+        OPENCLAW_SERVICE_VERSION: "\t",
+        npm_package_version: " 1.0.0-package ",
+      }),
+    ).toBe("3.3.3");
+
+    const runtimeVersion = resolveVersionFromModuleUrl(import.meta.url);
+    expect(runtimeVersion).toBeTruthy();
+    expect(
+      resolveRuntimeServiceVersion({
+        OPENCLAW_VERSION: "",
+        OPENCLAW_BUNDLED_VERSION: "",
+        OPENCLAW_SERVICE_VERSION: "2.0.0-service",
+        npm_package_version: " ",
+      }),
+    ).toBe(runtimeVersion);
+
+    expect(
+      resolveRuntimeServiceVersion({
+        OPENCLAW_VERSION: " ",
+        OPENCLAW_BUNDLED_VERSION: "\t",
         OPENCLAW_SERVICE_VERSION: "\t",
         npm_package_version: " 1.0.0-package ",
       }),
     ).toBe("1.0.0-package");
-
-    expect(
-      resolveRuntimeServiceVersion(
-        {
-          OPENCLAW_VERSION: "",
-          OPENCLAW_SERVICE_VERSION: " ",
-          npm_package_version: "",
-        },
-        "fallback",
-      ),
-    ).toBe("fallback");
   });
 });

--- a/src/version.ts
+++ b/src/version.ts
@@ -71,6 +71,8 @@ export function resolveVersionFromModuleUrl(moduleUrl: string): string | null {
   );
 }
 
+const RUNTIME_MODULE_VERSION = resolveVersionFromModuleUrl(import.meta.url) ?? undefined;
+
 export type RuntimeVersionEnv = {
   [key: string]: string | undefined;
 };
@@ -82,8 +84,10 @@ export function resolveRuntimeServiceVersion(
   return (
     firstNonEmpty(
       env["OPENCLAW_VERSION"],
-      env["OPENCLAW_SERVICE_VERSION"],
+      env["OPENCLAW_BUNDLED_VERSION"],
       env["npm_package_version"],
+      RUNTIME_MODULE_VERSION,
+      env["OPENCLAW_SERVICE_VERSION"],
     ) ?? fallback
   );
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: gateway self/version metadata preferred `OPENCLAW_SERVICE_VERSION`, which can stay stale after `openclaw update` when the service unit was not regenerated.
- Why it matters: `openclaw status`, websocket `hello-ok.server.version`, and Control UI dashboard can display an old app version even though the runtime has been upgraded.
- What changed: `resolveRuntimeServiceVersion` now prefers runtime version sources in this order: `OPENCLAW_VERSION` -> `OPENCLAW_BUNDLED_VERSION` -> `npm_package_version` -> runtime module/package version -> `OPENCLAW_SERVICE_VERSION`.
- What did NOT change (scope boundary): no service install/update behavior changes; this PR only fixes version source precedence used by runtime metadata reporting.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30689

## User-visible / Behavior Changes

When the runtime binary/package is upgraded but `OPENCLAW_SERVICE_VERSION` is stale, gateway status/dashboard now reflects the actual upgraded runtime version.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): gateway self presence + ws hello metadata
- Relevant config (redacted): stale `OPENCLAW_SERVICE_VERSION` simulation in tests

### Steps

1. Set stale service env value plus newer package/runtime version source.
2. Initialize system presence / resolve runtime service version.
3. Check resolved version in self presence.

### Expected

- Runtime version sources win over stale `OPENCLAW_SERVICE_VERSION`.

### Actual

- Before fix: stale service env could win.
- After fix: runtime/package/bundled values are preferred.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `src/version.test.ts` and `src/infra/system-presence.version.test.ts` cover precedence order and stale-service fallback behavior.
- Edge cases checked: blank env values; bundled override; runtime module fallback path.
- What you did **not** verify: end-to-end Linux systemd reinstall/update flow on a live host.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/version.ts`, `src/version.test.ts`, `src/infra/system-presence.version.test.ts`.
- Known bad symptoms reviewers should watch for: runtime metadata unexpectedly preferring service env over runtime/package version again.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Environments that intentionally relied on `OPENCLAW_SERVICE_VERSION` overriding runtime/package metadata will now see runtime/bundled/package values first.
  - Mitigation:
    - `OPENCLAW_VERSION` still remains the highest-priority explicit override, and `OPENCLAW_SERVICE_VERSION` remains as final fallback.

AI-assisted: Yes.
