### PR TITLE
fix(telegram): send fallback reply when model returns empty text to clear typing

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -675,10 +675,11 @@ export const dispatchTelegramMessage = async ({
   }
   let sentFallback = false;
   const deliverySummary = deliveryState.snapshot();
-  if (
-    !deliverySummary.delivered &&
-    (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0)
-  ) {
+  // Send a fallback message when no reply was delivered. This covers:
+  // - Non-silent replies that were skipped or failed
+  // - Empty text responses from models (e.g. Gemini returning "" with stopReason "stop")
+  //   where no deliver callback fires at all, leaving typing stuck (#30616)
+  if (!deliverySummary.delivered && !queuedFinal) {
     const result = await deliverReplies({
       replies: [{ text: EMPTY_RESPONSE_FALLBACK }],
       ...deliveryBaseOptions,


### PR DESCRIPTION
## Problem
When using Gemini models with extended thinking, the model occasionally returns a successful response (`stopReason: "stop"`) but with an empty text field (`""`). This causes the Telegram bot to get stuck showing the typing indicator indefinitely — no reply is ever sent.

The empty text gets normalized to `null` by `normalizeReplyPayload`, so no `deliver` callback fires. The delivery state tracker never records any activity (delivered=0, skipped=0, failed=0), and the existing fallback condition only triggers when `skippedNonSilent > 0 || failedNonSilent > 0`.

Fixes #30616

## Changes
- Simplified the empty-response fallback condition in `bot-message-dispatch.ts` to trigger whenever `!delivered && !queuedFinal`, covering the zero-activity case
- This sends `"No response generated. Please try again."` and clears the typing indicator

## Impact
- Telegram users will see a clear error message instead of an infinite typing indicator
- No change for normal responses — the `delivered` flag is set before this check