### PR TITLE
feat(telegram): expose message_id and sender_id in DM inbound metadata

### DIFF
--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -90,14 +90,12 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const timestampStr = formatConversationTimestamp(ctx.Timestamp);
 
   const conversationInfo = {
-    message_id: isDirect ? undefined : messageId,
-    message_id_full: isDirect
-      ? undefined
-      : messageIdFull && messageIdFull !== messageId
-        ? messageIdFull
-        : undefined,
+    // Always include message_id so agents can reference messages for actions
+    // like deleteMessage, even in DMs (e.g. Telegram security workflows) (#30649).
+    message_id: messageId,
+    message_id_full: messageIdFull && messageIdFull !== messageId ? messageIdFull : undefined,
     reply_to_id: isDirect ? undefined : safeTrim(ctx.ReplyToId),
-    sender_id: isDirect ? undefined : safeTrim(ctx.SenderId),
+    sender_id: safeTrim(ctx.SenderId),
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
     sender: isDirect
       ? undefined


### PR DESCRIPTION
## Problem
Telegram DM inbound metadata omits `message_id` and `sender_id`, unlike Discord which includes them. This prevents agents from using `deleteMessage` actions on Telegram DMs — critical for security workflows where sensitive content (credentials, keys) should be auto-deleted after processing.

Fixes #30649

## Changes
- Modified `buildInboundUserContextPrefix()` in `inbound-meta.ts` to always include `message_id`, `message_id_full`, and `sender_id` regardless of chat type
- Previously these fields were excluded for DM chats (`isDirect === true`) to reduce prompt size

## Before (Telegram DM)
```json
{"timestamp": "Sun 2026-03-01 20:54 GMT+8"}
```

## After (Telegram DM)
```json
{"message_id": "12345", "sender_id": "8183829769", "timestamp": "Sun 2026-03-01 20:54 GMT+8"}
```

## Impact
- Minimal prompt size increase (~30 tokens for DMs)
- Enables `deleteMessage` and message-referencing workflows for all channels in DMs