### PR TITLE
fix(matrix): keep recent pre-restart messages after reconnect

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -140,3 +140,143 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
     );
   });
 });
+
+function createStartupGraceFixture(params: { startupMs: number; startupGraceMs: number }) {
+  const recordInboundSession = vi.fn().mockResolvedValue(undefined);
+  const core = {
+    channel: {
+      pairing: {
+        readAllowFromStore: vi.fn().mockResolvedValue([]),
+      },
+      routing: {
+        resolveAgentRoute: vi.fn().mockReturnValue({
+          agentId: "main",
+          accountId: undefined,
+          sessionKey: "agent:main:matrix:channel:!room:example.org",
+          mainSessionKey: "agent:main:main",
+        }),
+      },
+      session: {
+        resolveStorePath: vi.fn().mockReturnValue("/tmp/openclaw-test-session.json"),
+        readSessionUpdatedAt: vi.fn().mockReturnValue(123),
+        recordInboundSession,
+      },
+      reply: {
+        resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+        formatInboundEnvelope: vi.fn().mockImplementation((input: { body: string }) => input.body),
+        formatAgentEnvelope: vi.fn().mockImplementation((input: { body: string }) => input.body),
+        finalizeInboundContext: vi.fn().mockImplementation((ctx: Record<string, unknown>) => ctx),
+        resolveHumanDelayConfig: vi.fn().mockReturnValue(undefined),
+        createReplyDispatcherWithTyping: vi.fn().mockReturnValue({
+          dispatcher: {},
+          replyOptions: {},
+          markDispatchIdle: vi.fn(),
+        }),
+        withReplyDispatcher: vi
+          .fn()
+          .mockResolvedValue({ queuedFinal: false, counts: { final: 0, partial: 0, tool: 0 } }),
+      },
+      commands: {
+        shouldHandleTextCommands: vi.fn().mockReturnValue(true),
+      },
+      text: {
+        hasControlCommand: vi.fn().mockReturnValue(false),
+        resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
+      },
+    },
+    system: {
+      enqueueSystemEvent: vi.fn(),
+    },
+  } as unknown as PluginRuntime;
+  const runtime = {
+    error: vi.fn(),
+  } as unknown as RuntimeEnv;
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+  } as unknown as RuntimeLogger;
+  const client = {
+    getUserId: vi.fn().mockResolvedValue("@bot:matrix.example.org"),
+  } as unknown as MatrixClient;
+  const handler = createMatrixRoomMessageHandler({
+    client,
+    core,
+    cfg: {},
+    runtime,
+    logger,
+    logVerboseMessage: vi.fn(),
+    allowFrom: [],
+    roomsConfig: undefined,
+    mentionRegexes: [],
+    groupPolicy: "open",
+    replyToMode: "first",
+    threadReplies: "inbound",
+    dmEnabled: true,
+    dmPolicy: "open",
+    textLimit: 4000,
+    mediaMaxBytes: 5 * 1024 * 1024,
+    startupMs: params.startupMs,
+    startupGraceMs: params.startupGraceMs,
+    directTracker: {
+      isDirectMessage: vi.fn().mockResolvedValue(false),
+    },
+    getRoomInfo: vi.fn().mockResolvedValue({
+      name: "Dev Room",
+      canonicalAlias: "#dev:matrix.example.org",
+      altAliases: [],
+    }),
+    getMemberDisplayName: vi.fn().mockResolvedValue("Bu"),
+    accountId: undefined,
+  });
+  return { handler, recordInboundSession };
+}
+
+describe("createMatrixRoomMessageHandler startup grace handling", () => {
+  it("processes recent pre-start Matrix events within grace window", async () => {
+    const startupMs = 1_000_000;
+    const startupGraceMs = 10 * 60_000;
+    const { handler, recordInboundSession } = createStartupGraceFixture({
+      startupMs,
+      startupGraceMs,
+    });
+    const event = {
+      type: EventType.RoomMessage,
+      event_id: "$event-recent",
+      sender: "@bu:matrix.example.org",
+      origin_server_ts: startupMs - 5_000,
+      content: {
+        msgtype: "m.text",
+        body: "recent before restart",
+        "m.mentions": { user_ids: ["@bot:matrix.example.org"] },
+      },
+    } as unknown as MatrixRawEvent;
+
+    await handler("!room:example.org", event);
+
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops stale Matrix events older than startup grace window", async () => {
+    const startupMs = 1_000_000;
+    const startupGraceMs = 10 * 60_000;
+    const { handler, recordInboundSession } = createStartupGraceFixture({
+      startupMs,
+      startupGraceMs,
+    });
+    const event = {
+      type: EventType.RoomMessage,
+      event_id: "$event-stale",
+      sender: "@bu:matrix.example.org",
+      origin_server_ts: startupMs - startupGraceMs - 1,
+      content: {
+        msgtype: "m.text",
+        body: "stale before restart",
+        "m.mentions": { user_ids: ["@bot:matrix.example.org"] },
+      },
+    } as unknown as MatrixRawEvent;
+
+    await handler("!room:example.org", event);
+
+    expect(recordInboundSession).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -36,6 +36,7 @@ export type MonitorMatrixOpts = {
 };
 
 const DEFAULT_MEDIA_MAX_MB = 20;
+const MATRIX_RESTART_STARTUP_GRACE_MS = 10 * 60_000;
 
 export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promise<void> {
   if (isBunRuntime()) {
@@ -268,7 +269,9 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   const mediaMaxMb = opts.mediaMaxMb ?? accountConfig.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
   const mediaMaxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;
   const startupMs = Date.now();
-  const startupGraceMs = 0;
+  // Keep a bounded replay window after reconnect/restart so recent in-flight
+  // messages are not dropped by strict timestamp filtering.
+  const startupGraceMs = MATRIX_RESTART_STARTUP_GRACE_MS;
   const directTracker = createDirectRoomTracker(client, { log: logVerboseMessage });
   registerMatrixAutoJoin({ client, cfg, runtime });
   const warnedEncryptedRooms = new Set<string>();


### PR DESCRIPTION
## Summary

- **Problem:** Matrix monitor used `startupGraceMs=0`, so any event with a server timestamp earlier than gateway start time was dropped, including messages sent seconds before a restart.
- **Why it matters:** Users can send messages during restart/reconnect windows and never get replies because those events are silently filtered out.
- **What changed:** Matrix monitor now uses a bounded startup grace window (10 minutes) and includes regression tests that verify recent pre-start events are accepted while stale ones are still dropped.
- **What did NOT change:** Mention policy, allowlist policy, routing/session logic, and non-startup event handling remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30670

## User-visible / Behavior Changes

- Matrix messages sent shortly before gateway restart are now processed after reconnect instead of being dropped immediately.
- Very old backlog events outside the grace window are still filtered.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js 24.x
- Integration/channel: Matrix monitor inbound event filtering

### Steps

1. Create a Matrix room message event with `origin_server_ts` just before `startupMs`.
2. Run Matrix room handler with startup grace configured.
3. Repeat with an event older than grace window.

### Expected

- Recent pre-start event is processed; stale event is dropped.

### Actual

- Before fix: both pre-start events were dropped when grace was 0.
- After fix: only stale events are dropped.

## Evidence

- `pnpm exec vitest run extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts`

## Human Verification (required)

- Verified scenarios: pre-start event inside grace window is recorded; stale event outside grace window is not recorded.
- Edge cases checked: startup timestamp filter still blocks stale backlog.
- What I did **not** verify: end-to-end Matrix reconnect behavior against a live homeserver.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `extensions/matrix/src/matrix/monitor/index.ts`, `extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts`.
- Known bad symptoms: Matrix replies may skip recent messages around restart again.

## Risks and Mitigations

- Risk: larger grace may process a small amount of older backlog after restart.
- Mitigation: grace is bounded (10 minutes), and stale events beyond the window remain filtered.
