### PR TITLE
fix(agents): sanitize NO_REPLY fallback tool-trace leakage [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/NO_REPLY fallback: sanitize leaked internal tool-trace text (`assistant to=functions...`) before mirroring messaging-tool output, so malformed internal envelopes are never sent to user-visible channels. (#30704)
 - Cron/Failure alerts: add configurable repeated-failure alerting with per-job overrides and Web UI cron editor support (`inherit|disabled|custom` with threshold/cooldown/channel/target fields). (#24789) Thanks xbrak.
 - Cron/Isolated model defaults: resolve isolated cron `subagents.model` (including object-form `primary`) through allowlist-aware model selection so isolated cron runs honor subagent model defaults unless explicitly overridden by job payload model. (#11474) Thanks @AnonO6.
 - Cron/Isolated sessions list: persist the intended pre-run model/provider on isolated cron session entries so `sessions_list` reflects payload/session model overrides even when runs fail before post-run telemetry persistence. (#21279) Thanks @altaywtf.

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -28,4 +28,26 @@ describe("resolveSilentReplyFallbackText", () => {
       }),
     ).toBe("NO_REPLY");
   });
+
+  it("keeps NO_REPLY when fallback text is only leaked internal tool trace", () => {
+    expect(
+      resolveSilentReplyFallbackText({
+        text: "NO_REPLY",
+        messagingToolSentTexts: [
+          'NO_REPLY +#+#+#+#+#+assistant to=functions.olvid_list_groups recipient_name=functions.olvid_list_groups json {"olvidChannelAccountId":""}',
+        ],
+      }),
+    ).toBe("NO_REPLY");
+  });
+
+  it("keeps user-facing prefix and strips leaked internal tool trace suffix", () => {
+    expect(
+      resolveSilentReplyFallbackText({
+        text: "NO_REPLY",
+        messagingToolSentTexts: [
+          'Sent to group successfully. assistant to=functions.olvid_list_groups recipient_name=functions.olvid_list_groups json {"olvidChannelAccountId":""}',
+        ],
+      }),
+    ).toBe("Sent to group successfully.");
+  });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -16,6 +16,7 @@ import {
   extractThinkingFromTaggedText,
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
+  stripDowngradedToolCallText,
 } from "./pi-embedded-utils.js";
 
 const stripTrailingDirective = (text: string): string => {
@@ -41,6 +42,21 @@ function emitReasoningEnd(ctx: EmbeddedPiSubscribeContext) {
   void ctx.params.onReasoningEnd?.();
 }
 
+const INTERNAL_TOOL_TRACE_RE = /\bassistant\s+to=functions\.[\w.-]+/i;
+
+function sanitizeSilentReplyFallbackText(text: string): string {
+  const withoutDowngradedMarkers = stripDowngradedToolCallText(text);
+  const withoutLeadingSilentToken = withoutDowngradedMarkers.replace(
+    /^\s*NO_REPLY\b(?:[:\s-]+)?/i,
+    "",
+  );
+  const traceStart = withoutLeadingSilentToken.search(INTERNAL_TOOL_TRACE_RE);
+  const candidate =
+    traceStart >= 0 ? withoutLeadingSilentToken.slice(0, traceStart) : withoutLeadingSilentToken;
+  const cleaned = candidate.trim();
+  return /[\p{L}\p{N}]/u.test(cleaned) ? cleaned : "";
+}
+
 export function resolveSilentReplyFallbackText(params: {
   text: string;
   messagingToolSentTexts: string[];
@@ -53,7 +69,11 @@ export function resolveSilentReplyFallbackText(params: {
   if (!fallback) {
     return params.text;
   }
-  return fallback;
+  const sanitizedFallback = sanitizeSilentReplyFallbackText(fallback);
+  if (!sanitizedFallback) {
+    return params.text;
+  }
+  return sanitizedFallback;
 }
 
 export function handleMessageStart(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `NO_REPLY` fallback could mirror leaked internal tool-trace fragments (for example `assistant to=functions... recipient_name...`) into user-visible outbound messages.
- Why it matters: this exposes internal orchestration text to end users and creates confusing channel output.
- What changed: sanitize fallback text in `resolveSilentReplyFallbackText` by removing downgraded tool-call markers, stripping `NO_REPLY` prefixes, and dropping trailing `assistant to=functions...` trace content.
- What changed: added regression tests for trace-only and mixed user-prefix + trace suffix fallback payloads.
- What did NOT change (scope boundary): did not alter normal assistant message rendering, tool execution behavior, or non-`NO_REPLY` paths.

AI-assisted: Yes (Codex). Testing degree: fully tested for this change scope.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30704
- Related #30692

## User-visible / Behavior Changes

- Internal tool-trace artifacts in `NO_REPLY` fallback text are no longer echoed into user-visible channel messages.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22
- Model/provider: N/A (unit-level)
- Integration/channel (if any): agent embedded subscribe fallback path
- Relevant config (redacted): default test config

### Steps

1. Feed `resolveSilentReplyFallbackText` with `text: "NO_REPLY"` and fallback content containing leaked `assistant to=functions...` trace.
2. Validate that trace-only fallback resolves to `NO_REPLY` (suppressed), and mixed content keeps only user-facing prefix.
3. Run targeted unit tests and lint/format checks.

### Expected

- Internal trace fragments are stripped from `NO_REPLY` fallback output.
- User-facing prefixes remain intact when present.

### Actual

- New regression tests pass for both trace-only and mixed fallback cases.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm exec oxfmt --check CHANGELOG.md src/agents/pi-embedded-subscribe.handlers.messages.ts src/agents/pi-embedded-subscribe.handlers.messages.test.ts`
- `pnpm exec oxlint --type-aware src/agents/pi-embedded-subscribe.handlers.messages.ts src/agents/pi-embedded-subscribe.handlers.messages.test.ts`
- `pnpm exec vitest run src/agents/pi-embedded-subscribe.handlers.messages.test.ts`
- `pnpm exec vitest run src/agents/pi-embedded-utils.test.ts src/agents/pi-embedded-subscribe.handlers.messages.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: NO_REPLY fallback with leaked internal trace only; NO_REPLY fallback with user text prefix plus leaked trace suffix.
- Edge cases checked: punctuation-only leftovers after sanitization are treated as empty and do not get emitted.
- What you did **not** verify: live Olvid channel end-to-end reproduction.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/pi-embedded-subscribe.handlers.messages.ts` and related test/changelog line.
- Known bad symptoms reviewers should watch for: unintended stripping if fallback text intentionally contains `assistant to=functions` literal text.

## Risks and Mitigations

- Risk: over-stripping fallback text when a legitimate message includes tool-trace-like tokens.
  - Mitigation: sanitization is scoped only to `NO_REPLY` fallback path and preserves user-facing prefix content before trace markers.
