### PR TITLE
fix(matrix): buffer mention-gated room context before bot ping

### DIFF
--- a/extensions/matrix/src/config-schema.ts
+++ b/extensions/matrix/src/config-schema.ts
@@ -52,6 +52,7 @@ export const MatrixConfigSchema = z.object({
   textChunkLimit: z.number().optional(),
   chunkMode: z.enum(["length", "newline"]).optional(),
   responsePrefix: z.string().optional(),
+  mentionContextBufferLimit: z.number().int().positive().optional(),
   mediaMaxMb: z.number().optional(),
   autoJoin: z.enum(["always", "allowlist", "off"]).optional(),
   autoJoinAllowlist: z.array(allowFromEntry).optional(),

--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -1,6 +1,7 @@
 import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import type { PluginRuntime, RuntimeEnv, RuntimeLogger } from "openclaw/plugin-sdk";
 import { describe, expect, it, vi } from "vitest";
+import { setMatrixRuntime } from "../../runtime.js";
 import { createMatrixRoomMessageHandler } from "./handler.js";
 import { EventType, type MatrixRawEvent } from "./types.js";
 
@@ -52,6 +53,9 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
         commands: {
           shouldHandleTextCommands: vi.fn().mockReturnValue(true),
         },
+        mentions: {
+          matchesMentionPatterns: vi.fn().mockReturnValue(false),
+        },
         text: {
           hasControlCommand: vi.fn().mockReturnValue(false),
           resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
@@ -61,6 +65,7 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
         enqueueSystemEvent: vi.fn(),
       },
     } as unknown as PluginRuntime;
+    setMatrixRuntime(core);
 
     const runtime = {
       error: vi.fn(),
@@ -138,5 +143,146 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
         }),
       }),
     );
+  });
+});
+
+describe("createMatrixRoomMessageHandler mention context buffering", () => {
+  it("prepends buffered non-mentioned room context when mention arrives, then clears it", async () => {
+    const recordInboundSession = vi.fn().mockResolvedValue(undefined);
+    const core = {
+      channel: {
+        pairing: {
+          readAllowFromStore: vi.fn().mockResolvedValue([]),
+        },
+        routing: {
+          resolveAgentRoute: vi.fn().mockReturnValue({
+            agentId: "main",
+            accountId: undefined,
+            sessionKey: "agent:main:matrix:channel:!room:example.org",
+            mainSessionKey: "agent:main:main",
+          }),
+        },
+        session: {
+          resolveStorePath: vi.fn().mockReturnValue("/tmp/openclaw-test-session.json"),
+          readSessionUpdatedAt: vi.fn().mockReturnValue(123),
+          recordInboundSession,
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+          formatInboundEnvelope: vi
+            .fn()
+            .mockImplementation((input: { body: string }) => input.body),
+          formatAgentEnvelope: vi.fn().mockImplementation((input: { body: string }) => input.body),
+          finalizeInboundContext: vi.fn().mockImplementation((ctx: Record<string, unknown>) => ctx),
+          resolveHumanDelayConfig: vi.fn().mockReturnValue(undefined),
+          createReplyDispatcherWithTyping: vi.fn().mockReturnValue({
+            dispatcher: {},
+            replyOptions: {},
+            markDispatchIdle: vi.fn(),
+          }),
+          withReplyDispatcher: vi
+            .fn()
+            .mockResolvedValue({ queuedFinal: false, counts: { final: 0, partial: 0, tool: 0 } }),
+        },
+        commands: {
+          shouldHandleTextCommands: vi.fn().mockReturnValue(true),
+        },
+        mentions: {
+          matchesMentionPatterns: vi.fn().mockReturnValue(false),
+        },
+        text: {
+          hasControlCommand: vi.fn().mockReturnValue(false),
+          resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
+        },
+      },
+      system: {
+        enqueueSystemEvent: vi.fn(),
+      },
+    } as unknown as PluginRuntime;
+    setMatrixRuntime(core);
+    const runtime = {
+      error: vi.fn(),
+    } as unknown as RuntimeEnv;
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as RuntimeLogger;
+    const client = {
+      getUserId: vi.fn().mockResolvedValue("@bot:matrix.example.org"),
+    } as unknown as MatrixClient;
+    const handler = createMatrixRoomMessageHandler({
+      client,
+      core,
+      cfg: {},
+      runtime,
+      logger,
+      logVerboseMessage: vi.fn(),
+      allowFrom: [],
+      roomsConfig: undefined,
+      mentionRegexes: [],
+      groupPolicy: "open",
+      replyToMode: "first",
+      threadReplies: "inbound",
+      dmEnabled: true,
+      dmPolicy: "open",
+      textLimit: 4000,
+      mentionContextBufferLimit: 5,
+      mediaMaxBytes: 5 * 1024 * 1024,
+      startupMs: Date.now(),
+      startupGraceMs: 60_000,
+      directTracker: {
+        isDirectMessage: vi.fn().mockResolvedValue(false),
+      },
+      getRoomInfo: vi.fn().mockResolvedValue({
+        name: "Dev Room",
+        canonicalAlias: "#dev:matrix.example.org",
+        altAliases: [],
+      }),
+      getMemberDisplayName: vi.fn().mockResolvedValue("Bu"),
+      accountId: undefined,
+    });
+
+    await handler("!room:example.org", {
+      type: EventType.RoomMessage,
+      event_id: "$buffered",
+      sender: "@bu:matrix.example.org",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body: "we deployed v2 and error rates are rising",
+      },
+    } as unknown as MatrixRawEvent);
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(recordInboundSession).not.toHaveBeenCalled();
+
+    await handler("!room:example.org", {
+      type: EventType.RoomMessage,
+      event_id: "$mention1",
+      sender: "@bu:matrix.example.org",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body: "please summarize and suggest mitigation",
+        "m.mentions": { user_ids: ["@bot:matrix.example.org"] },
+      },
+    } as unknown as MatrixRawEvent);
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
+    expect(recordInboundSession.mock.calls[0]?.[0]?.ctx?.BodyForAgent).toBe(
+      "Bu (bu): we deployed v2 and error rates are rising\nBu (bu): please summarize and suggest mitigation",
+    );
+
+    await handler("!room:example.org", {
+      type: EventType.RoomMessage,
+      event_id: "$mention2",
+      sender: "@bu:matrix.example.org",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body: "status now?",
+        "m.mentions": { user_ids: ["@bot:matrix.example.org"] },
+      },
+    } as unknown as MatrixRawEvent);
+    expect(recordInboundSession).toHaveBeenCalledTimes(2);
+    expect(recordInboundSession.mock.calls[1]?.[0]?.ctx?.BodyForAgent).toBe("Bu (bu): status now?");
   });
 });

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -57,6 +57,7 @@ export type MatrixMonitorHandlerParams = {
   dmEnabled: boolean;
   dmPolicy: "open" | "pairing" | "allowlist" | "disabled";
   textLimit: number;
+  mentionContextBufferLimit?: number;
   mediaMaxBytes: number;
   startupMs: number;
   startupGraceMs: number;
@@ -91,6 +92,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     dmEnabled,
     dmPolicy,
     textLimit,
+    mentionContextBufferLimit = 20,
     mediaMaxBytes,
     startupMs,
     startupGraceMs,
@@ -105,6 +107,32 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     channel: "matrix",
     accountId: resolvedAccountId,
   });
+  const pendingMentionContextByRoom = new Map<string, string[]>();
+
+  const bufferMentionContext = (params: {
+    roomId: string;
+    senderLabel: string;
+    bodyText: string;
+  }) => {
+    const line = `${params.senderLabel}: ${params.bodyText}`.trim();
+    if (!line) {
+      return;
+    }
+    const existing = pendingMentionContextByRoom.get(params.roomId) ?? [];
+    const next = [...existing, line];
+    if (next.length > mentionContextBufferLimit) {
+      next.splice(0, next.length - mentionContextBufferLimit);
+    }
+    pendingMentionContextByRoom.set(params.roomId, next);
+  };
+
+  const consumeMentionContext = (roomId: string): string[] => {
+    const existing = pendingMentionContextByRoom.get(roomId) ?? [];
+    if (existing.length > 0) {
+      pendingMentionContextByRoom.delete(roomId);
+    }
+    return existing;
+  };
 
   return async (roomId: string, event: MatrixRawEvent) => {
     try {
@@ -410,9 +438,16 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         hasControlCommandInMessage;
       const canDetectMention = mentionRegexes.length > 0 || hasExplicitMention;
       if (isRoom && shouldRequireMention && !wasMentioned && !shouldBypassMention) {
+        bufferMentionContext({
+          roomId,
+          senderLabel,
+          bodyText,
+        });
         logger.info("skipping room message", { roomId, reason: "no-mention" });
         return;
       }
+      const bufferedRoomContextLines =
+        isRoom && shouldRequireMention && wasMentioned ? consumeMentionContext(roomId) : [];
 
       const messageId = event.event_id ?? "";
       const replyToEventId = content["m.relates_to"]?.["m.in_reply_to"]?.event_id;
@@ -510,6 +545,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           isDirectMessage,
           bodyText,
           senderLabel,
+          bufferedRoomContextLines,
         }),
         RawBody: bodyText,
         CommandBody: bodyText,

--- a/extensions/matrix/src/matrix/monitor/inbound-body.test.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-body.test.ts
@@ -70,4 +70,17 @@ describe("resolveMatrixBodyForAgent", () => {
       }),
     ).toBe("Bu (bu): show me my commits");
   });
+
+  it("prepends buffered room context lines for mention-gated rooms", () => {
+    expect(
+      resolveMatrixBodyForAgent({
+        isDirectMessage: false,
+        bodyText: "what should we do next?",
+        senderLabel: "Bu (bu)",
+        bufferedRoomContextLines: ["Alice (alice): we deployed v2", "Tom (tom): errors are rising"],
+      }),
+    ).toBe(
+      "Alice (alice): we deployed v2\nTom (tom): errors are rising\nBu (bu): what should we do next?",
+    );
+  });
 });

--- a/extensions/matrix/src/matrix/monitor/inbound-body.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-body.ts
@@ -20,9 +20,17 @@ export function resolveMatrixBodyForAgent(params: {
   isDirectMessage: boolean;
   bodyText: string;
   senderLabel: string;
+  bufferedRoomContextLines?: string[];
 }): string {
   if (params.isDirectMessage) {
     return params.bodyText;
+  }
+  const bufferedContext = (params.bufferedRoomContextLines ?? [])
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+  if (bufferedContext) {
+    return `${bufferedContext}\n${params.senderLabel}: ${params.bodyText}`;
   }
   return `${params.senderLabel}: ${params.bodyText}`;
 }

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -36,6 +36,7 @@ export type MonitorMatrixOpts = {
 };
 
 const DEFAULT_MEDIA_MAX_MB = 20;
+const DEFAULT_MENTION_CONTEXT_BUFFER_LIMIT = 20;
 
 export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promise<void> {
   if (isBunRuntime()) {
@@ -265,6 +266,10 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   const dmPolicyRaw = dmConfig?.policy ?? "pairing";
   const dmPolicy = allowlistOnly && dmPolicyRaw !== "disabled" ? "allowlist" : dmPolicyRaw;
   const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "matrix");
+  const mentionContextBufferLimit = Math.max(
+    1,
+    Math.floor(accountConfig.mentionContextBufferLimit ?? DEFAULT_MENTION_CONTEXT_BUFFER_LIMIT),
+  );
   const mediaMaxMb = opts.mediaMaxMb ?? accountConfig.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
   const mediaMaxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;
   const startupMs = Date.now();
@@ -291,6 +296,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     dmEnabled,
     dmPolicy,
     textLimit,
+    mentionContextBufferLimit,
     mediaMaxBytes,
     startupMs,
     startupGraceMs,

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -79,6 +79,8 @@ export type MatrixConfig = {
   chunkMode?: "length" | "newline";
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
+  /** Max number of non-mentioned room messages buffered as mention context. Default: 20. */
+  mentionContextBufferLimit?: number;
   /** Max outbound media size in MB. */
   mediaMaxMb?: number;
   /** Auto-join invites (always|allowlist|off). Default: always. */


### PR DESCRIPTION
## Summary

- **Problem:** In Matrix mention-gated rooms, non-mentioned messages were dropped entirely, so when users finally mentioned the bot, the model lacked recent conversational context.
- **Why it matters:** Replies after a mention can be inaccurate or abrupt because the agent only sees the triggering ping and misses preceding discussion.
- **What changed:** Added a bounded, per-room mention-context buffer that stores recent non-mentioned messages and prepends them to `BodyForAgent` once a mention arrives, then consumes the buffer to avoid stale carry-over.
- **What did NOT change:** Mention policy behavior (still mention-gated), routing/session key behavior, and command authorization policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30662

## User-visible / Behavior Changes

- Matrix mention-gated rooms now retain a bounded amount of pre-mention context for the next mentioned message.
- Added `mentionContextBufferLimit` (optional, positive integer) for Matrix config; default is 20 buffered lines per room.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js 24.x
- Integration/channel: Matrix monitor mention gating

### Steps

1. Send a room message without mentioning the bot in a mention-gated Matrix room.
2. Send a second room message that mentions the bot.
3. Send a third mention message to verify old buffered context does not persist.

### Expected

- Second message’s `BodyForAgent` includes buffered prior room context.
- Third message includes only current content (buffer consumed).

### Actual

- Before fix: second message only included the mention text.
- After fix: second message includes buffered context + current mention text; subsequent mentions do not carry stale context.

## Evidence

- `pnpm exec vitest run extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts extensions/matrix/src/matrix/monitor/inbound-body.test.ts`

## Human Verification (required)

- Verified scenarios: buffered non-mention context appears on first mention and is cleared afterward.
- Edge cases checked: direct messages are unchanged; buffered context lines are bounded by configured limit.
- What I did **not** verify: full end-to-end Matrix homeserver replay behavior under heavy concurrent room traffic.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Optional` (`mentionContextBufferLimit`)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: set `mentionContextBufferLimit` to a small value or revert this PR.
- Files/config to restore: `extensions/matrix/src/matrix/monitor/handler.ts`, `extensions/matrix/src/matrix/monitor/inbound-body.ts`.
- Known bad symptoms: mention replies may lose immediate room context again.

## Risks and Mitigations

- Risk: buffered context could inject extra lines into prompt unexpectedly in noisy rooms.
- Mitigation: per-room bounded buffer with configurable positive limit and consume-on-mention semantics to prevent indefinite accumulation.
