### PR TITLE
fix(exec): map sandbox /workspace workdir to host path [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sandbox/Exec workdir mapping: resolve container-side workdirs under `/workspace` back to host workspace paths (including nested directories), so `exec` no longer falls back incorrectly when callers pass container paths. (#30711)
 - Cron/Failure alerts: add configurable repeated-failure alerting with per-job overrides and Web UI cron editor support (`inherit|disabled|custom` with threshold/cooldown/channel/target fields). (#24789) Thanks xbrak.
 - Cron/Isolated model defaults: resolve isolated cron `subagents.model` (including object-form `primary`) through allowlist-aware model selection so isolated cron runs honor subagent model defaults unless explicitly overridden by job payload model. (#11474) Thanks @AnonO6.
 - Cron/Isolated sessions list: persist the intended pre-run model/provider on isolated cron session entries so `sessions_list` reflects payload/session model overrides even when runs fail before post-run telemetry persistence. (#21279) Thanks @altaywtf.

--- a/src/agents/bash-tools.resolve-sandbox-workdir.test.ts
+++ b/src/agents/bash-tools.resolve-sandbox-workdir.test.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { BashSandboxConfig } from "./bash-tools.shared.js";
+import { resolveSandboxWorkdir } from "./bash-tools.shared.js";
+
+describe("resolveSandboxWorkdir", () => {
+  let tempRoot = "";
+  let sandbox: BashSandboxConfig;
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    const workspaceDir = path.join(tempRoot, "workspace");
+    await fs.mkdir(path.join(workspaceDir, "nested", "dir"), { recursive: true });
+    sandbox = {
+      containerName: "sandbox-test",
+      workspaceDir,
+      containerWorkdir: "/workspace",
+    };
+  });
+
+  afterEach(async () => {
+    if (tempRoot) {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("maps container root workdir to host workspace directory", async () => {
+    const warnings: string[] = [];
+    const resolved = await resolveSandboxWorkdir({
+      workdir: "/workspace",
+      sandbox,
+      warnings,
+    });
+
+    expect(resolved.hostWorkdir).toBe(sandbox.workspaceDir);
+    expect(resolved.containerWorkdir).toBe("/workspace");
+    expect(warnings).toEqual([]);
+  });
+
+  it("maps nested container workdir to corresponding host path", async () => {
+    const warnings: string[] = [];
+    const resolved = await resolveSandboxWorkdir({
+      workdir: "/workspace/nested/dir",
+      sandbox,
+      warnings,
+    });
+
+    expect(resolved.hostWorkdir).toBe(path.join(sandbox.workspaceDir, "nested", "dir"));
+    expect(resolved.containerWorkdir).toBe("/workspace/nested/dir");
+    expect(warnings).toEqual([]);
+  });
+
+  it("falls back to workspace root when container path is outside mapped workspace", async () => {
+    const warnings: string[] = [];
+    const resolved = await resolveSandboxWorkdir({
+      workdir: "/workspace-two",
+      sandbox,
+      warnings,
+    });
+
+    expect(resolved.hostWorkdir).toBe(sandbox.workspaceDir);
+    expect(resolved.containerWorkdir).toBe(sandbox.containerWorkdir);
+    expect(warnings).toEqual([
+      'Warning: workdir "/workspace-two" is unavailable; using "' + sandbox.workspaceDir + '".',
+    ]);
+  });
+});

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -14,6 +14,31 @@ export type BashSandboxConfig = {
   env?: Record<string, string>;
 };
 
+function mapContainerWorkdirToHost(params: {
+  workdir: string;
+  sandbox: BashSandboxConfig;
+}): { hostWorkdir: string; containerWorkdir: string } | null {
+  const requestedContainerPath = path.posix.normalize(params.workdir.replace(/\\/g, "/"));
+  if (!path.posix.isAbsolute(requestedContainerPath)) {
+    return null;
+  }
+  const containerRoot = path.posix.normalize(params.sandbox.containerWorkdir);
+  const relativeToRoot = path.posix.relative(containerRoot, requestedContainerPath);
+  if (
+    relativeToRoot !== "" &&
+    (relativeToRoot.startsWith("..") || path.posix.isAbsolute(relativeToRoot))
+  ) {
+    return null;
+  }
+  const hostWorkdir = relativeToRoot
+    ? path.join(params.sandbox.workspaceDir, ...relativeToRoot.split("/"))
+    : params.sandbox.workspaceDir;
+  return {
+    hostWorkdir,
+    containerWorkdir: requestedContainerPath,
+  };
+}
+
 export function buildSandboxEnv(params: {
   defaultPath: string;
   paramsEnv?: Record<string, string>;
@@ -86,6 +111,14 @@ export async function resolveSandboxWorkdir(params: {
 }) {
   const fallback = params.sandbox.workspaceDir;
   try {
+    const mappedContainerWorkdir = mapContainerWorkdirToHost(params);
+    if (mappedContainerWorkdir) {
+      const stats = await fs.stat(mappedContainerWorkdir.hostWorkdir);
+      if (!stats.isDirectory()) {
+        throw new Error("workdir is not a directory");
+      }
+      return mappedContainerWorkdir;
+    }
     const resolved = await assertSandboxPath({
       filePath: params.workdir,
       cwd: process.cwd(),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: sandbox `exec` validates `workdir` on the host side only, so container paths like `/workspace` or `/workspace/subdir` are treated as unavailable and incorrectly fall back.
- Why it matters: callers that correctly use container paths (especially in sandbox mode) get warning/fallback behavior and may execute in the wrong directory.
- What changed: `resolveSandboxWorkdir` now maps absolute container paths under `containerWorkdir` (default `/workspace`) back to the host workspace before validation.
- What changed: added regression tests for `/workspace`, `/workspace/nested/dir`, and outside-root container path fallback behavior.
- What did NOT change (scope boundary): this PR does **not** address the separate stdout-loss-on-background-transition part of #30711.

AI-assisted: Yes (Codex). Testing degree: fully tested for this change scope.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30711
- Related #30513

## User-visible / Behavior Changes

- In sandbox mode, `exec` now correctly accepts `/workspace` and `/workspace/...` workdirs and maps them to the host workspace path instead of warning/fallbacking.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): sandbox exec tool path resolution
- Relevant config (redacted): sandbox `containerWorkdir: "/workspace"`, `workspaceAccess: "rw"`

### Steps

1. Resolve sandbox workdir with `/workspace` and `/workspace/nested/dir`.
2. Verify mapped host path points into host workspace root/subdir and preserves container workdir path.
3. Resolve `/workspace-two` and verify warning + fallback behavior remains unchanged.

### Expected

- `/workspace` and descendants map host↔container correctly.
- Outside-root container paths still fallback with warning.

### Actual

- New regression tests pass for all three scenarios.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm exec oxfmt --check CHANGELOG.md src/agents/bash-tools.shared.ts src/agents/bash-tools.resolve-sandbox-workdir.test.ts`
- `pnpm exec oxlint --type-aware src/agents/bash-tools.shared.ts src/agents/bash-tools.resolve-sandbox-workdir.test.ts`
- `pnpm exec vitest run src/agents/bash-tools.resolve-sandbox-workdir.test.ts src/agents/bash-tools.build-docker-exec-args.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: root and nested `/workspace` path mapping into host workspace; fallback path for out-of-root container path.
- Edge cases checked: keeps existing warning/fallback for `/workspace-two`.
- What you did **not** verify: end-to-end sandbox background execution behavior for stdout capture.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/bash-tools.shared.ts` and associated test/changelog entry.
- Known bad symptoms reviewers should watch for: incorrect mapping for custom container workdir roots.

## Risks and Mitigations

- Risk: false-positive mapping for absolute paths that are not under the configured container workdir.
  - Mitigation: mapping only applies when `path.posix.relative(containerWorkdir, requested)` stays within root; outside paths preserve old fallback behavior.
