### PR TITLE
fix(matrix): preserve m.mentions for outbound user pings

### DIFF
--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -236,3 +236,53 @@ describe("sendMessageMatrix threads", () => {
     });
   });
 });
+
+describe("sendMessageMatrix mentions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mediaKindFromMimeMock.mockReturnValue("image");
+    isVoiceCompatibleAudioMock.mockReturnValue(false);
+    setMatrixRuntime(runtimeStub);
+  });
+
+  it("adds m.mentions.user_ids for mentioned Matrix user IDs in text messages", async () => {
+    const { client, sendMessage } = makeClient();
+
+    await sendMessageMatrix(
+      "room:!room:example",
+      "hello @alice:matrix.example.org, ping @bob:matrix.org",
+      {
+        client,
+      },
+    );
+
+    const content = sendMessage.mock.calls[0]?.[1] as {
+      "m.mentions"?: { user_ids?: string[] };
+    };
+    expect(content["m.mentions"]).toEqual({
+      user_ids: ["@alice:matrix.example.org", "@bob:matrix.org"],
+    });
+  });
+
+  it("deduplicates repeated mentions and keeps mention metadata on media captions", async () => {
+    const { client, sendMessage } = makeClient();
+
+    await sendMessageMatrix(
+      "room:!room:example",
+      "cc @alice:matrix.example.org and @alice:matrix.example.org",
+      {
+        client,
+        mediaUrl: "file:///tmp/photo.png",
+      },
+    );
+
+    const content = sendMessage.mock.calls[0]?.[1] as {
+      "m.mentions"?: { user_ids?: string[] };
+      msgtype?: string;
+    };
+    expect(content.msgtype).toBe("m.image");
+    expect(content["m.mentions"]).toEqual({
+      user_ids: ["@alice:matrix.example.org"],
+    });
+  });
+});

--- a/extensions/matrix/src/matrix/send/formatting.ts
+++ b/extensions/matrix/src/matrix/send/formatting.ts
@@ -4,6 +4,7 @@ import {
   MsgType,
   RelationType,
   type MatrixFormattedContent,
+  type MatrixMentions,
   type MatrixMediaMsgType,
   type MatrixRelation,
   type MatrixReplyRelation,
@@ -12,6 +13,8 @@ import {
 } from "./types.js";
 
 const getCore = () => getMatrixRuntime();
+const MATRIX_USER_ID_IN_TEXT_RE =
+  /(^|[\s([{<"'])(@[A-Za-z0-9._=+\-/]+:[A-Za-z0-9.-]+(?::\d+)?)(?=$|[\s)\]}>",'!.?;:])/g;
 
 export function buildTextContent(body: string, relation?: MatrixRelation): MatrixTextContent {
   const content: MatrixTextContent = relation
@@ -25,6 +28,7 @@ export function buildTextContent(body: string, relation?: MatrixRelation): Matri
         body,
       };
   applyMatrixFormatting(content, body);
+  applyMatrixMentions(content, body);
   return content;
 }
 
@@ -35,6 +39,35 @@ export function applyMatrixFormatting(content: MatrixFormattedContent, body: str
   }
   content.format = "org.matrix.custom.html";
   content.formatted_body = formatted;
+}
+
+export function resolveMentionedUserIds(body: string): string[] {
+  if (!body) {
+    return [];
+  }
+  MATRIX_USER_ID_IN_TEXT_RE.lastIndex = 0;
+  const mentionSet = new Set<string>();
+  for (const match of body.matchAll(MATRIX_USER_ID_IN_TEXT_RE)) {
+    const userId = match[2]?.trim();
+    if (userId) {
+      mentionSet.add(userId);
+    }
+  }
+  return [...mentionSet];
+}
+
+export function applyMatrixMentions(
+  content: MatrixFormattedContent & { "m.mentions"?: MatrixMentions },
+  body: string,
+): void {
+  const userIds = resolveMentionedUserIds(body);
+  if (userIds.length === 0) {
+    return;
+  }
+  content["m.mentions"] = {
+    ...(content["m.mentions"] ?? {}),
+    user_ids: userIds,
+  };
 }
 
 export function buildReplyRelation(replyToId?: string): MatrixReplyRelation | undefined {

--- a/extensions/matrix/src/matrix/send/media.ts
+++ b/extensions/matrix/src/matrix/send/media.ts
@@ -7,7 +7,7 @@ import type {
   VideoFileInfo,
 } from "@vector-im/matrix-bot-sdk";
 import { getMatrixRuntime } from "../../runtime.js";
-import { applyMatrixFormatting } from "./formatting.js";
+import { applyMatrixFormatting, applyMatrixMentions } from "./formatting.js";
 import {
   type MatrixMediaContent,
   type MatrixMediaInfo,
@@ -104,6 +104,7 @@ export function buildMediaContent(params: {
     base["m.relates_to"] = params.relation;
   }
   applyMatrixFormatting(base, params.body);
+  applyMatrixMentions(base, params.body);
   return base;
 }
 

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -51,13 +51,21 @@ export type MatrixReplyMeta = {
   "m.relates_to"?: MatrixRelation;
 };
 
+export type MatrixMentions = {
+  user_ids?: string[];
+  room?: boolean;
+};
+
 export type MatrixMediaInfo =
   | FileWithThumbnailInfo
   | DimensionalFileInfo
   | TimedFileInfo
   | VideoFileInfo;
 
-export type MatrixTextContent = TextualMessageEventContent & MatrixReplyMeta;
+export type MatrixTextContent = TextualMessageEventContent &
+  MatrixReplyMeta & {
+    "m.mentions"?: MatrixMentions;
+  };
 
 export type MatrixMediaContent = MessageEventContent &
   MatrixReplyMeta & {
@@ -65,6 +73,7 @@ export type MatrixMediaContent = MessageEventContent &
     url?: string;
     file?: EncryptedFile;
     filename?: string;
+    "m.mentions"?: MatrixMentions;
     "org.matrix.msc3245.voice"?: Record<string, never>;
     "org.matrix.msc1767.audio"?: { duration: number };
   };
@@ -106,4 +115,5 @@ export type MediaKind = "image" | "audio" | "video" | "document" | "unknown";
 export type MatrixFormattedContent = MessageEventContent & {
   format?: string;
   formatted_body?: string;
+  "m.mentions"?: MatrixMentions;
 };


### PR DESCRIPTION
## Summary

- **Problem:** Matrix outbound messages sent by OpenClaw did not include `m.mentions.user_ids`, so modern Matrix clients often failed to trigger mention-highlight notifications for `@user:server` pings.
- **Why it matters:** Mentioned users may miss urgent bot messages because clients rely on `m.mentions` metadata rather than plain-text scanning.
- **What changed:** Added mention extraction for outbound text and media caption bodies, populate `m.mentions.user_ids`, and deduplicate repeated user IDs.
- **What did NOT change:** Thread/reply relation behavior, markdown formatting pipeline, and media upload/encryption flow.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30656

## User-visible / Behavior Changes

- Outbound Matrix messages containing `@user:server` now include `m.mentions.user_ids`.
- Mention metadata is preserved for both plain text sends and media-caption sends.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js 24.x
- Integration/channel: Matrix send pipeline (`sendMessageMatrix`)

### Steps

1. Send a Matrix message containing one or more `@user:server` mentions through OpenClaw.
2. Inspect outbound event content passed to Matrix client send API.
3. Repeat with media + caption containing mentions.

### Expected

- Outbound content includes `m.mentions.user_ids` with deduplicated mentioned user IDs.

### Actual

- Before fix: no `m.mentions` field was emitted.
- After fix: `m.mentions.user_ids` is present for text and media-caption sends.

## Evidence

- `pnpm exec vitest run extensions/matrix/src/matrix/send.test.ts`

## Human Verification (required)

- Verified scenarios: text mention metadata, deduped repeated mention metadata, media-caption mention metadata.
- Edge cases checked: messages without user IDs keep previous behavior (no injected mention payload).
- What I did **not** verify: live homeserver push/highlight UX across multiple Matrix client apps.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `extensions/matrix/src/matrix/send/formatting.ts`, `extensions/matrix/src/matrix/send/media.ts`.
- Known bad symptoms: mention highlights may stop triggering in clients again.

## Risks and Mitigations

- Risk: regex mention parsing might miss uncommon Matrix ID forms.
- Mitigation: parser targets standard `@localpart:server` IDs and keeps behavior additive (no mention payload if no match).
