### PR TITLE
fix(memory): serialize local embedding context calls [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/Local embeddings: serialize `node-llama-cpp` embedding-context calls across concurrent query/batch requests to avoid deadlock-style stalls during `memory index` runs. (#30713)
 - Cron/Failure alerts: add configurable repeated-failure alerting with per-job overrides and Web UI cron editor support (`inherit|disabled|custom` with threshold/cooldown/channel/target fields). (#24789) Thanks xbrak.
 - Cron/Isolated model defaults: resolve isolated cron `subagents.model` (including object-form `primary`) through allowlist-aware model selection so isolated cron runs honor subagent model defaults unless explicitly overridden by job payload model. (#11474) Thanks @AnonO6.
 - Cron/Isolated sessions list: persist the intended pre-run model/provider on isolated cron session entries so `sessions_list` reflects payload/session model overrides even when runs fail before post-run telemetry persistence. (#21279) Thanks @altaywtf.

--- a/src/memory/embeddings.test.ts
+++ b/src/memory/embeddings.test.ts
@@ -469,6 +469,37 @@ describe("local embedding normalization", () => {
       expect(magnitude).toBeCloseTo(1.0, 5);
     }
   });
+
+  it("serializes local embedding context calls across concurrent batch/query requests", async () => {
+    let activeCalls = 0;
+    let maxActiveCalls = 0;
+    const getEmbeddingFor = vi.fn(async () => {
+      activeCalls += 1;
+      maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      activeCalls -= 1;
+      return { vector: new Float32Array([1, 0, 0]) };
+    });
+
+    importNodeLlamaCppMock.mockResolvedValue({
+      getLlama: async () => ({
+        loadModel: vi.fn().mockResolvedValue({
+          createEmbeddingContext: vi.fn().mockResolvedValue({
+            getEmbeddingFor,
+          }),
+        }),
+      }),
+      resolveModelFile: async () => "/fake/model.gguf",
+      LlamaLogLevel: { error: 0 },
+    });
+
+    const result = await createLocalProviderForTest();
+    const provider = requireProvider(result);
+    await Promise.all([provider.embedBatch(["text1", "text2"]), provider.embedQuery("text3")]);
+
+    expect(getEmbeddingFor).toHaveBeenCalledTimes(3);
+    expect(maxActiveCalls).toBe(1);
+  });
 });
 
 describe("FTS-only fallback when no provider available", () => {

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -105,6 +105,7 @@ async function createLocalEmbeddingProvider(
   let llama: Llama | null = null;
   let embeddingModel: LlamaModel | null = null;
   let embeddingContext: LlamaEmbeddingContext | null = null;
+  let embeddingCallLock: Promise<void> = Promise.resolve();
 
   const ensureContext = async () => {
     if (!llama) {
@@ -120,24 +121,39 @@ async function createLocalEmbeddingProvider(
     return embeddingContext;
   };
 
+  const withEmbeddingCallLock = async <T>(fn: () => Promise<T>): Promise<T> => {
+    let release: (() => void) | undefined;
+    const wait = embeddingCallLock;
+    embeddingCallLock = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await wait;
+    try {
+      return await fn();
+    } finally {
+      release?.();
+    }
+  };
+
   return {
     id: "local",
     model: modelPath,
-    embedQuery: async (text) => {
-      const ctx = await ensureContext();
-      const embedding = await ctx.getEmbeddingFor(text);
-      return sanitizeAndNormalizeEmbedding(Array.from(embedding.vector));
-    },
-    embedBatch: async (texts) => {
-      const ctx = await ensureContext();
-      const embeddings = await Promise.all(
-        texts.map(async (text) => {
+    embedQuery: async (text) =>
+      await withEmbeddingCallLock(async () => {
+        const ctx = await ensureContext();
+        const embedding = await ctx.getEmbeddingFor(text);
+        return sanitizeAndNormalizeEmbedding(Array.from(embedding.vector));
+      }),
+    embedBatch: async (texts) =>
+      await withEmbeddingCallLock(async () => {
+        const ctx = await ensureContext();
+        const embeddings: number[][] = [];
+        for (const text of texts) {
           const embedding = await ctx.getEmbeddingFor(text);
-          return sanitizeAndNormalizeEmbedding(Array.from(embedding.vector));
-        }),
-      );
-      return embeddings;
-    },
+          embeddings.push(sanitizeAndNormalizeEmbedding(Array.from(embedding.vector)));
+        }
+        return embeddings;
+      }),
   };
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: local memory embedding calls can overlap on the same `node-llama-cpp` embedding context, which can lead to stall-like behavior during `memory index` (reported as repeated batch-start logs with no progress).
- Why it matters: indexing can appear hung indefinitely, with no chunks/files progressing.
- What changed: added a per-provider async lock around local `embedQuery` / `embedBatch` operations so embedding-context calls are serialized.
- What changed: local `embedBatch` now processes inputs under the same lock and includes concurrency regression coverage to prevent reintroducing overlapping calls.
- What did NOT change (scope boundary): did not change remote provider batching logic or `memory sync` scheduling flow.

AI-assisted: Yes (Codex). Testing degree: fully tested for this change scope.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30713
- Related #30711

## User-visible / Behavior Changes

- `openclaw memory index` with local embeddings is hardened against embedding-context concurrency stalls.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22
- Model/provider: local embedding provider (`node-llama-cpp` mocked in tests)
- Integration/channel (if any): memory indexer local embedding path
- Relevant config (redacted): `memorySearch.provider = "local"`

### Steps

1. Create local embedding provider and trigger concurrent `embedBatch` + `embedQuery` calls.
2. Ensure embedding-context function `getEmbeddingFor` never overlaps concurrently.
3. Run full `src/memory/embeddings.test.ts` suite.

### Expected

- Local embedding-context calls execute one at a time.
- Existing local embedding normalization behavior remains unchanged.

### Actual

- New regression test confirms max concurrent context calls stays at 1.
- Full embeddings test suite passes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm exec oxfmt --check CHANGELOG.md src/memory/embeddings.ts src/memory/embeddings.test.ts`
- `pnpm exec oxlint --type-aware src/memory/embeddings.ts src/memory/embeddings.test.ts`
- `pnpm exec vitest run src/memory/embeddings.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: concurrent batch/query local embedding requests are serialized; existing normalization tests still pass.
- Edge cases checked: lock release path runs correctly through async completion and keeps call ordering deterministic.
- What you did **not** verify: live long-running local indexing on a real large memory corpus.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/memory/embeddings.ts` and `src/memory/embeddings.test.ts`.
- Known bad symptoms reviewers should watch for: slower local embedding throughput under heavy parallel indexing.

## Risks and Mitigations

- Risk: local embedding throughput may reduce due to serialization.
  - Mitigation: scope limited to local provider where context safety is prioritized over parallel throughput; remote providers remain unchanged.
