### PR TITLE
fix: guard launchd restart helper result before .ok access

### DIFF
--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -37,7 +37,7 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
     // bypass ThrottleInterval delays for intentional restarts.
     if (process.platform === "darwin" && process.env.OPENCLAW_LAUNCHD_LABEL?.trim()) {
       const restart = triggerOpenClawRestart();
-      if (!restart.ok) {
+      if (restart && !restart.ok) {
         return {
           mode: "failed",
           detail: restart.detail ?? "launchctl kickstart failed",


### PR DESCRIPTION
## Summary
- guard the launchd helper result in `restartGatewayProcessWithFreshPid` before reading `.ok`
- avoid runtime TypeError when the helper is mocked or otherwise returns an unexpected value

## Testing
- pnpm build
- pnpm format:check
- pnpm tsgo
- pnpm lint
- pnpm test

## AI-assisted
- This PR was prepared with AI assistance.