### PR TITLE
feat: add Privatemode confidential computing provider + no-animal-violence linting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,13 @@ OPENCLAW_GATEWAY_TOKEN=change-me-to-a-long-random-token
 # MINIMAX_API_KEY=...
 # SYNTHETIC_API_KEY=...
 
+# Privatemode - confidential computing / end-to-end encrypted inference
+# Requires the privatemode-proxy to be running (default: http://localhost:8080).
+# Start proxy: docker run -p 8080:8080 ghcr.io/edgelesssys/privatemode/privatemode-proxy:latest
+# Then set your Privatemode API key here. The proxy handles encryption transparently.
+# Docs: https://docs.privatemode.ai/guides/proxy-configuration
+# PRIVATEMODE_API_KEY=pm-...
+
 # -----------------------------------------------------------------------------
 # Channels (only set what you enable)
 # -----------------------------------------------------------------------------
@@ -78,3 +85,4 @@ OPENCLAW_GATEWAY_TOKEN=change-me-to-a-long-random-token
 # ELEVENLABS_API_KEY=...
 # XI_API_KEY=...  # alias for ElevenLabs
 # DEEPGRAM_API_KEY=...
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,3 +129,10 @@ repos:
         language: system
         pass_filenames: false
         types: [swift]
+
+  # Animal-friendly language — detect speciesist idioms and suggest inclusive alternatives
+  - repo: https://github.com/open-paws/no-animal-violence-pre-commit
+    rev: v0.1.0
+    hooks:
+      - id: speciesist-language
+        exclude: '^(dist/|vendor/|CHANGELOG\.md$|pnpm-lock\.yaml$)'

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -55,6 +55,7 @@ See [Venice AI](/providers/venice).
 - [Hugging Face (Inference)](/providers/huggingface)
 - [Ollama (local models)](/providers/ollama)
 - [vLLM (local models)](/providers/vllm)
+- [Privatemode (confidential computing)](/providers/privatemode)
 - [Qianfan](/providers/qianfan)
 - [NVIDIA](/providers/nvidia)
 

--- a/docs/providers/privatemode.md
+++ b/docs/providers/privatemode.md
@@ -1,3 +1,11 @@
+---
+summary: "Run OpenClaw with Privatemode confidential computing inference"
+read_when:
+  - You want end-to-end encrypted inference via Privatemode
+  - You need to configure the Privatemode proxy with OpenClaw
+title: "Privatemode"
+---
+
 # Privatemode
 
 [Privatemode](https://privatemode.ai) is a confidential computing inference service that provides end-to-end encryption for your prompts and completions. Unlike standard cloud APIs, not even Privatemode as the service provider can read your data. It exposes an OpenAI-compatible API via a local proxy that handles encryption transparently.
@@ -47,11 +55,11 @@ export PRIVATEMODE_API_KEY=pm-your-key-here
 
 ## Supported models
 
-| Model ID | Name | Modalities | Notes |
-|---|---|---|---|
-| `gemma-3-27b` | Gemma 3 27B | text, image | Multimodal |
-| `gpt-oss-120b` | GPT-OSS 120B | text | Large context |
-| `qwen3-coder-30b-a3b` | Qwen3-Coder 30B-A3B | text | Reasoning, coding |
+| Model ID                | Name                 | Modalities  | Notes             |
+| ----------------------- | -------------------- | ----------- | ----------------- |
+| `gemma-3-27b`           | Gemma 3 27B          | text, image | Multimodal        |
+| `gpt-oss-120b`          | GPT-OSS 120B         | text        | Large context     |
+| `qwen3-coder-30b-a3b`   | Qwen3-Coder 30B-A3B  | text        | Reasoning, coding |
 
 Privatemode also supports embeddings (`qwen3-embedding-4b`) and speech-to-text (`whisper-large-v3`, `voxtral-mini-3b`), though these are not yet wired into OpenClaw's provider model list.
 

--- a/docs/providers/privatemode.md
+++ b/docs/providers/privatemode.md
@@ -1,0 +1,166 @@
+# Privatemode
+
+[Privatemode](https://privatemode.ai) is a confidential computing inference service that provides end-to-end encryption for your prompts and completions. Unlike standard cloud APIs, not even Privatemode as the service provider can read your data. It exposes an OpenAI-compatible API via a local proxy that handles encryption transparently.
+
+## How it works
+
+Privatemode uses confidential computing (hardware-based trusted execution environments) to ensure your data is encrypted before it leaves your machine. You run the `privatemode-proxy` locally; all requests from OpenClaw pass through it and are encrypted end-to-end before reaching Privatemode's inference backend.
+
+```
+OpenClaw → privatemode-proxy (localhost:8080) → [encrypted] → Privatemode backend
+```
+
+## Prerequisites
+
+You need a Privatemode account and API key. Sign up at [privatemode.ai](https://privatemode.ai).
+
+The `privatemode-proxy` must be running before starting OpenClaw. The fastest way is Docker:
+
+```bash
+docker run -p 8080:8080 ghcr.io/edgelesssys/privatemode/privatemode-proxy:latest
+```
+
+Or with your API key pre-configured so you don't need to pass it per-request:
+
+```bash
+docker run -p 8080:8080 ghcr.io/edgelesssys/privatemode/privatemode-proxy:latest \
+  --apiKey "$PRIVATEMODE_API_KEY"
+```
+
+See the [proxy configuration guide](https://docs.privatemode.ai/guides/proxy-configuration) for TLS, Kubernetes, and other deployment options.
+
+## Quick setup
+
+**Step 1:** Start the proxy:
+
+```bash
+docker run -p 8080:8080 ghcr.io/edgelesssys/privatemode/privatemode-proxy:latest
+```
+
+**Step 2:** Set your API key:
+
+```bash
+export PRIVATEMODE_API_KEY=pm-your-key-here
+```
+
+**Step 3:** Start OpenClaw — the `privatemode` provider is auto-detected.
+
+## Supported models
+
+| Model ID | Name | Modalities | Notes |
+|---|---|---|---|
+| `gemma-3-27b` | Gemma 3 27B | text, image | Multimodal |
+| `gpt-oss-120b` | GPT-OSS 120B | text | Large context |
+| `qwen3-coder-30b-a3b` | Qwen3-Coder 30B-A3B | text | Reasoning, coding |
+
+Privatemode also supports embeddings (`qwen3-embedding-4b`) and speech-to-text (`whisper-large-v3`, `voxtral-mini-3b`), though these are not yet wired into OpenClaw's provider model list.
+
+## Configuration
+
+### Environment variable (simplest)
+
+```bash
+PRIVATEMODE_API_KEY=pm-your-key-here
+```
+
+OpenClaw auto-discovers the provider and loads the default model list above.
+
+### Explicit `openclaw.json` config
+
+Use explicit config to override the proxy URL (e.g. if running on a different port), add custom models, or pin a specific model:
+
+```json
+{
+  "models": {
+    "providers": {
+      "privatemode": {
+        "baseUrl": "http://localhost:8080/v1",
+        "apiKey": "${PRIVATEMODE_API_KEY}",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "gpt-oss-120b",
+            "name": "GPT-OSS 120B",
+            "reasoning": false,
+            "input": ["text"],
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 128000,
+            "maxTokens": 8192
+          }
+        ]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "privatemode/gpt-oss-120b"
+      }
+    }
+  }
+}
+```
+
+### Default model
+
+Reference Privatemode models with the `privatemode/` prefix:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "privatemode/gpt-oss-120b",
+        "fallbacks": ["privatemode/gemma-3-27b"]
+      }
+    }
+  }
+}
+```
+
+## Custom proxy port
+
+If you run the proxy on a port other than `8080`, set `baseUrl` explicitly:
+
+```json
+{
+  "models": {
+    "providers": {
+      "privatemode": {
+        "baseUrl": "http://localhost:9090/v1",
+        "apiKey": "${PRIVATEMODE_API_KEY}",
+        "api": "openai-completions"
+      }
+    }
+  }
+}
+```
+
+## Docker Compose
+
+To run the privatemode proxy alongside OpenClaw in Docker Compose, add this service to your `docker-compose.yml`:
+
+```yaml
+services:
+  privatemode-proxy:
+    image: ghcr.io/edgelesssys/privatemode/privatemode-proxy:latest
+    ports:
+      - "8080:8080"
+    command: ["--apiKey", "${PRIVATEMODE_API_KEY}"]
+    restart: unless-stopped
+```
+
+Then set the `baseUrl` to `http://privatemode-proxy:8080/v1` in your `openclaw.json` when OpenClaw runs in the same compose network.
+
+## Security notes
+
+- The proxy performs cryptographic attestation of the Privatemode deployment before sending any data. Prompts are only encrypted after verification succeeds.
+- The proxy requires outbound access to `api.privatemode.ai:443` and `cdn.confidential.cloud:443`.
+- All costs default to `$0` since pricing is handled by Privatemode independently.
+
+## References
+
+- [Privatemode documentation](https://docs.privatemode.ai)
+- [Proxy configuration guide](https://docs.privatemode.ai/guides/proxy-configuration)
+- [Proxy source code](https://github.com/edgelesssys/privatemode-public)
+- [Available models](https://docs.privatemode.ai/models/overview)

--- a/docs/providers/privatemode.md
+++ b/docs/providers/privatemode.md
@@ -55,11 +55,11 @@ export PRIVATEMODE_API_KEY=pm-your-key-here
 
 ## Supported models
 
-| Model ID                | Name                 | Modalities  | Notes             |
-| ----------------------- | -------------------- | ----------- | ----------------- |
-| `gemma-3-27b`           | Gemma 3 27B          | text, image | Multimodal        |
-| `gpt-oss-120b`          | GPT-OSS 120B         | text        | Large context     |
-| `qwen3-coder-30b-a3b`   | Qwen3-Coder 30B-A3B  | text        | Reasoning, coding |
+| Model ID              | Name                | Modalities  | Notes             |
+| --------------------- | ------------------- | ----------- | ----------------- |
+| `gemma-3-27b`         | Gemma 3 27B         | text, image | Multimodal        |
+| `gpt-oss-120b`        | GPT-OSS 120B        | text        | Large context     |
+| `qwen3-coder-30b-a3b` | Qwen3-Coder 30B-A3B | text        | Reasoning, coding |
 
 Privatemode also supports embeddings (`qwen3-embedding-4b`) and speech-to-text (`whisper-large-v3`, `voxtral-mini-3b`), though these are not yet wired into OpenClaw's provider model list.
 

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -323,6 +323,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     ollama: "OLLAMA_API_KEY",
     vllm: "VLLM_API_KEY",
     kilocode: "KILOCODE_API_KEY",
+    privatemode: "PRIVATEMODE_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) {

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -176,6 +176,20 @@ const VLLM_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
+// Privatemode - confidential computing / end-to-end encrypted inference proxy.
+// Exposes an OpenAI-compatible API at http://localhost:8080/v1 (default).
+// Run the proxy first: docker run -p 8080:8080 ghcr.io/edgelesssys/privatemode/privatemode-proxy:latest
+// Docs: https://docs.privatemode.ai/guides/proxy-configuration
+const PRIVATEMODE_BASE_URL = "http://localhost:8080/v1";
+const PRIVATEMODE_DEFAULT_CONTEXT_WINDOW = 128000;
+const PRIVATEMODE_DEFAULT_MAX_TOKENS = 8192;
+const PRIVATEMODE_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
 export const QIANFAN_BASE_URL = "https://qianfan.baidubce.com/v2";
 export const QIANFAN_DEFAULT_MODEL_ID = "deepseek-v3.2";
 const QIANFAN_DEFAULT_CONTEXT_WINDOW = 98304;
@@ -822,6 +836,43 @@ async function buildVllmProvider(params?: {
   };
 }
 
+export function buildPrivatemodeProvider(params?: { baseUrl?: string }): ProviderConfig {
+  const baseUrl = (params?.baseUrl?.trim() || PRIVATEMODE_BASE_URL).replace(/\/+$/, "");
+  return {
+    baseUrl,
+    api: "openai-completions",
+    models: [
+      {
+        id: "gemma-3-27b",
+        name: "Gemma 3 27B",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: PRIVATEMODE_DEFAULT_COST,
+        contextWindow: PRIVATEMODE_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: PRIVATEMODE_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "gpt-oss-120b",
+        name: "GPT-OSS 120B",
+        reasoning: false,
+        input: ["text"],
+        cost: PRIVATEMODE_DEFAULT_COST,
+        contextWindow: PRIVATEMODE_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: PRIVATEMODE_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "qwen3-coder-30b-a3b",
+        name: "Qwen3-Coder 30B-A3B",
+        reasoning: true,
+        input: ["text"],
+        cost: PRIVATEMODE_DEFAULT_COST,
+        contextWindow: PRIVATEMODE_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: PRIVATEMODE_DEFAULT_MAX_TOKENS,
+      },
+    ],
+  };
+}
+
 export function buildQianfanProvider(): ProviderConfig {
   return {
     baseUrl: QIANFAN_BASE_URL,
@@ -1068,6 +1119,24 @@ export async function resolveImplicitProviders(params: {
     }
   }
 
+  // Privatemode provider - confidential computing proxy (opt-in via env/profile).
+  // Requires the privatemode-proxy to be running locally before use.
+  // See: https://docs.privatemode.ai/guides/proxy-configuration
+  if (!params.explicitProviders?.privatemode) {
+    const privatemodeEnvVar = resolveEnvApiKeyVarName("privatemode");
+    const privatemodeProfileKey = resolveApiKeyFromProfiles({
+      provider: "privatemode",
+      store: authStore,
+    });
+    const privatemodeKey = privatemodeEnvVar ?? privatemodeProfileKey;
+    if (privatemodeKey) {
+      providers.privatemode = {
+        ...buildPrivatemodeProvider(),
+        apiKey: privatemodeKey,
+      };
+    }
+  }
+
   const togetherKey =
     resolveEnvApiKeyVarName("together") ??
     resolveApiKeyFromProfiles({ provider: "together", store: authStore });
@@ -1210,3 +1279,4 @@ export async function resolveImplicitBedrockProvider(params: {
     models,
   } satisfies ProviderConfig;
 }
+

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -1279,4 +1279,3 @@ export async function resolveImplicitBedrockProvider(params: {
     models,
   } satisfies ProviderConfig;
 }
-


### PR DESCRIPTION
## Summary

- Adds [Privatemode](https://privatemode.ai) as a provider — end-to-end encrypted inference via their OpenAI-compatible local proxy. Auto-detected via `PRIVATEMODE_API_KEY`, supports `gemma-3-27b`, `gpt-oss-120b`, `qwen3-coder-30b-a3b`.
- Adds [`no-animal-violence-pre-commit`](https://github.com/open-paws/no-animal-violence-pre-commit) hook to `.pre-commit-config.yaml` — flags speciesist idioms with inclusive alternatives, matching openclaw's existing pre-commit setup.
- Fixes 2 `whitelist` → `allowlist` instances in `CHANGELOG.md` caught by the linter.

## Changes

- `src/agents/models-config.providers.ts` — `buildPrivatemodeProvider()` + implicit `PRIVATEMODE_API_KEY` resolution (same pattern as vllm, nvidia, together, etc.)
- `.env.example` — documents `PRIVATEMODE_API_KEY`
- `docs/providers/privatemode.md` — setup guide, config examples, Docker Compose snippet
- `docs/providers/index.md` — adds Privatemode to provider list
- `.pre-commit-config.yaml` — adds `speciesist-language` hook from `open-paws/no-animal-violence-pre-commit@v0.1.0`
- `CHANGELOG.md` — `whitelist` → `allowlist` (2 instances)

## How Privatemode works

The [privatemode-proxy](https://github.com/edgelesssys/privatemode-public) runs locally and serves an OpenAI-compatible endpoint at `http://localhost:8080/v1`. It attests the Privatemode deployment using confidential computing, then encrypts all outbound requests before they leave the machine.

```bash
# Start proxy
docker run -p 8080:8080 ghcr.io/edgelesssys/privatemode/privatemode-proxy:latest

# Set key — provider is auto-detected
export PRIVATEMODE_API_KEY=pm-your-key
```

## Test plan

- [ ] `PRIVATEMODE_API_KEY=pm-... openclaw` — verify `privatemode/*` models appear
- [ ] `prek run --all-files` — verify `speciesist-language` hook runs clean