### PR TITLE
fix(agents): avoid blank tool names from stream trim

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -177,6 +177,31 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     expect(result).toBe(finalMessage);
     expect(baseFn).toHaveBeenCalledTimes(1);
   });
+
+  it("does not collapse whitespace-only tool names to empty strings", async () => {
+    const partialToolCall = { type: "toolCall", name: "   " };
+    const finalToolCall = { type: "toolCall", name: "\t  " };
+    const event = {
+      type: "toolcall_delta",
+      partial: { role: "assistant", content: [partialToolCall] },
+    };
+    const finalMessage = { role: "assistant", content: [finalToolCall] };
+    const baseFn = vi.fn(() => createFakeStream({ events: [event], resultMessage: finalMessage }));
+
+    const wrappedFn = wrapStreamFnTrimToolCallNames(baseFn as never);
+    const stream = wrappedFn({} as never, {} as never, {} as never) as Awaited<
+      ReturnType<typeof wrappedFn>
+    >;
+
+    for await (const _item of stream) {
+      // drain
+    }
+    await stream.result();
+
+    expect(partialToolCall.name).toBe("   ");
+    expect(finalToolCall.name).toBe("\t  ");
+    expect(baseFn).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("isOllamaCompatProvider", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -242,7 +242,10 @@ function trimWhitespaceFromToolCallNamesInMessage(message: unknown): void {
       continue;
     }
     const trimmed = typedBlock.name.trim();
-    if (trimmed !== typedBlock.name) {
+    // Keep whitespace-only names untouched here: some providers stream
+    // incomplete tool-call names that would otherwise collapse to "", which
+    // then propagates as toolName="" and triggers "Tool not found" loops.
+    if (trimmed && trimmed !== typedBlock.name) {
       typedBlock.name = trimmed;
     }
   }


### PR DESCRIPTION
## Summary

- **Problem:** Stream-time tool-call name normalization trimmed whitespace-only names to an empty string, which could propagate as `toolName=""` and surface repeated `Tool not found` failures in active sessions.
- **Why it matters:** Once empty tool names enter the live run path, tool execution becomes unstable and users can lose tool I/O in channels like Telegram DM mid-session.
- **What changed:** Adjusted stream tool-name trimming to only rewrite when the trimmed name is non-empty, preserving whitespace-only placeholders instead of collapsing them to empty names.
- **What did NOT change:** Tool allowlist/policy logic, session transcript repair flow, and tool execution dispatch contract.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30723

## User-visible / Behavior Changes

- Reduces cases where tool calls degrade into empty-name executions (`toolName=""`) after malformed/partial stream chunks.
- Stabilizes in-session tool routing behavior after transient tool-call stream anomalies.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js 24.x
- Component: embedded runner stream tool-call normalization

### Steps

1. Stream an assistant tool-call block with a whitespace-only tool name.
2. Apply wrapped stream function (`wrapStreamFnTrimToolCallNames`).
3. Observe transformed tool-call names in both partial and final message paths.

### Expected

- Whitespace-only names should **not** be rewritten to `""`.

### Actual

- Before fix: whitespace-only names were trimmed to empty strings.
- After fix: whitespace-only names remain unchanged; only non-empty trimmed names are rewritten.

## Evidence

- `pnpm exec vitest run src/agents/pi-embedded-runner/run/attempt.test.ts`

## Human Verification (required)

- Verified scenarios: non-empty padded tool names are trimmed; whitespace-only names are not collapsed.
- Edge cases checked: async stream function wrapper path still trims normal names.
- What I did **not** verify: full Telegram end-to-end reproduction with live session JSONL artifact from reporter.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts`, related test file.
- Known bad symptoms: reappearance of empty tool names in streamed tool calls.

## Risks and Mitigations

- Risk: some malformed provider outputs may still produce invalid non-empty names.
- Mitigation: this change specifically prevents empty-name collapse; existing tool validation/repair still handles invalid names elsewhere.
