### PR TITLE
docs(faq): add Windows exec garbled-output troubleshooting

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -30,6 +30,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   - [How long does install and onboarding usually take?](#how-long-does-install-and-onboarding-usually-take)
   - [Installer stuck? How do I get more feedback?](#installer-stuck-how-do-i-get-more-feedback)
   - [Windows install says git not found or openclaw not recognized](#windows-install-says-git-not-found-or-openclaw-not-recognized)
+  - [Windows exec output shows garbled Chinese text what should I do](#windows-exec-output-shows-garbled-chinese-text-what-should-i-do)
   - [The docs didn't answer my question - how do I get a better answer?](#the-docs-didnt-answer-my-question-how-do-i-get-a-better-answer)
   - [How do I install OpenClaw on Linux?](#how-do-i-install-openclaw-on-linux)
   - [How do I install OpenClaw on a VPS?](#how-do-i-install-openclaw-on-a-vps)
@@ -583,6 +584,32 @@ Two common Windows issues:
 
 If you want the smoothest Windows setup, use **WSL2** instead of native Windows.
 Docs: [Windows](/platforms/windows).
+
+### Windows exec output shows garbled Chinese text what should I do
+
+This is usually a console code page mismatch on native Windows shells.
+
+Symptoms:
+- `system.run`/`exec` output renders Chinese as mojibake
+- The same command looks fine in another terminal profile
+
+Quick workaround in PowerShell:
+
+```powershell
+chcp 65001
+[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false)
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+```
+
+Then restart the Gateway and retry your command:
+
+```powershell
+openclaw gateway restart
+```
+
+If you still reproduce this on latest OpenClaw, track/report it in:
+- [Issue #30640](https://github.com/openclaw/openclaw/issues/30640)
 
 ### The docs didn't answer my question how do I get a better answer
 


### PR DESCRIPTION
## Summary\nAdd a focused FAQ entry for native Windows users who see garbled Chinese output from system.run/exec due to console code-page mismatch.\n\n## What changed\n- Added a new FAQ item in table of contents\n- Added a troubleshooting section with:\n  - symptom checklist\n  - PowerShell UTF-8 workaround (chcp 65001, InputEncoding, OutputEncoding, $OutputEncoding)\n  - restart command (openclaw gateway restart)\n  - reference link to issue #30640\n\n## Why\nThis comes up frequently in native Windows PowerShell environments and currently requires digging through issues. A short FAQ path reduces support churn and gives users a deterministic first fix path.\n\n## Scope\nDocs-only change (docs/help/faq.md) with no runtime behavior changes.