### PR TITLE
fix(browser): retry chrome act when target tab is stale

### DIFF
--- a/src/agents/tools/browser-tool.test.ts
+++ b/src/agents/tools/browser-tool.test.ts
@@ -467,3 +467,43 @@ describe("browser tool external content wrapping", () => {
     });
   });
 });
+
+describe("browser tool act stale target recovery", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    configMocks.loadConfig.mockReturnValue({ browser: {} });
+    nodesUtilsMocks.listNodes.mockResolvedValue([]);
+  });
+
+  it("retries chrome act once without targetId when tab id is stale", async () => {
+    browserActionsMocks.browserAct
+      .mockRejectedValueOnce(new Error("404: tab not found"))
+      .mockResolvedValueOnce({ ok: true });
+
+    const tool = createBrowserTool();
+    const result = await tool.execute?.("call-1", {
+      action: "act",
+      profile: "chrome",
+      request: {
+        action: "click",
+        targetId: "stale-tab",
+        ref: "btn-1",
+      },
+    });
+
+    expect(browserActionsMocks.browserAct).toHaveBeenCalledTimes(2);
+    expect(browserActionsMocks.browserAct).toHaveBeenNthCalledWith(
+      1,
+      undefined,
+      expect.objectContaining({ targetId: "stale-tab", action: "click", ref: "btn-1" }),
+      expect.objectContaining({ profile: "chrome" }),
+    );
+    expect(browserActionsMocks.browserAct).toHaveBeenNthCalledWith(
+      2,
+      undefined,
+      expect.not.objectContaining({ targetId: expect.anything() }),
+      expect.objectContaining({ profile: "chrome" }),
+    );
+    expect(result?.details).toMatchObject({ ok: true });
+  });
+});

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -815,6 +815,29 @@ export function createBrowserTool(opts?: {
           } catch (err) {
             const msg = String(err);
             if (msg.includes("404:") && msg.includes("tab not found") && profile === "chrome") {
+              const targetId =
+                typeof request.targetId === "string" ? request.targetId.trim() : undefined;
+              // Some Chrome relay targetIds can go stale between snapshots and actions.
+              // Retry once without targetId to let relay use the currently attached tab.
+              if (targetId) {
+                const retryRequest = { ...request };
+                delete retryRequest.targetId;
+                try {
+                  const retryResult = proxyRequest
+                    ? await proxyRequest({
+                        method: "POST",
+                        path: "/act",
+                        profile,
+                        body: retryRequest,
+                      })
+                    : await browserAct(baseUrl, retryRequest as Parameters<typeof browserAct>[1], {
+                        profile,
+                      });
+                  return jsonResult(retryResult);
+                } catch {
+                  // Fall through to explicit stale-target guidance.
+                }
+              }
               const tabs = proxyRequest
                 ? ((
                     (await proxyRequest({


### PR DESCRIPTION
## Summary
- Add stale-tab recovery for browser `action=act` with `profile=chrome`.
- Retry once without `targetId` when relay returns `404: tab not found`.
- Preserve existing explicit guidance when retry still fails.

## Test plan
- `pnpm exec vitest run src/agents/tools/browser-tool.test.ts`

Closes #29386
