### PR TITLE
fix: strip trailing NO_REPLY token from announce delivery

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,5 +1,9 @@
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import {
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+  stripTrailingSilentToken,
+} from "../auto-reply/tokens.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
 import {
@@ -1169,6 +1173,9 @@ export async function runSubagentAnnounceFlow(params: {
     if (isSilentReplyText(reply, SILENT_REPLY_TOKEN)) {
       return true;
     }
+
+    // Strip trailing NO_REPLY that weaker models append after substantive content (#30692).
+    reply = stripTrailingSilentToken(reply, SILENT_REPLY_TOKEN) ?? reply;
 
     if (!outcome) {
       outcome = { status: "unknown" };

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -56,3 +56,40 @@ describe("isSilentReplyPrefixText", () => {
     expect(isSilentReplyPrefixText("NO-")).toBe(false);
   });
 });
+
+import { stripTrailingSilentToken } from "./tokens.js";
+
+describe("stripTrailingSilentToken", () => {
+  it("strips trailing NO_REPLY after substantive content", () => {
+    const text = "Here is a summary of the weather.\n\nNO_REPLY";
+    expect(stripTrailingSilentToken(text)).toBe("Here is a summary of the weather.");
+  });
+
+  it("strips trailing NO_REPLY with extra whitespace", () => {
+    const text = "Content here\n  NO_REPLY  ";
+    expect(stripTrailingSilentToken(text)).toBe("Content here");
+  });
+
+  it("does not strip when NO_REPLY is the entire text", () => {
+    expect(stripTrailingSilentToken("NO_REPLY")).toBe("NO_REPLY");
+    expect(stripTrailingSilentToken("  NO_REPLY  ")).toBe("  NO_REPLY  ");
+  });
+
+  it("does not strip NO_REPLY embedded in content", () => {
+    const text = "This is NO_REPLY related content";
+    expect(stripTrailingSilentToken(text)).toBe(text);
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(stripTrailingSilentToken(undefined)).toBeUndefined();
+  });
+
+  it("returns empty string as-is", () => {
+    expect(stripTrailingSilentToken("")).toBe("");
+  });
+
+  it("works with custom token", () => {
+    const text = "Done checking.\nHEARTBEAT_OK";
+    expect(stripTrailingSilentToken(text, "HEARTBEAT_OK")).toBe("Done checking.");
+  });
+});

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -36,3 +36,25 @@ export function isSilentReplyPrefixText(
   }
   return token.toUpperCase().startsWith(normalized);
 }
+
+/**
+ * Strip a trailing NO_REPLY token from text that contains substantive content.
+ * Weaker models sometimes append NO_REPLY after real output (e.g. announce
+ * delivery). When the text is chunked for sending, the trailing token would
+ * otherwise leak as a visible message (#30692).
+ */
+export function stripTrailingSilentToken(
+  text: string | undefined,
+  token: string = SILENT_REPLY_TOKEN,
+): string | undefined {
+  if (!text) {
+    return text;
+  }
+  const escaped = escapeRegExp(token);
+  // Remove the token only when it appears as the last non-whitespace segment,
+  // separated from preceding content by at least one newline.
+  const re = new RegExp(`\\n\\s*${escaped}\\s*$`);
+  const stripped = text.replace(re, "");
+  // Only return the stripped version if there is substantive content left.
+  return stripped.trim() ? stripped : text;
+}


### PR DESCRIPTION
Fixes #30692

## Problem
Weaker models (e.g. Claude 3.5 Haiku) sometimes append `NO_REPLY` after substantive content in announce delivery. The full text doesn't match `isSilentReplyText()` (which requires the entire text to be `NO_REPLY`), so when chunked for sending, the trailing token leaks as a visible message to the user.

## Solution
Add `stripTrailingSilentToken()` to `tokens.ts` that removes a trailing `NO_REPLY` only when it appears as the last line after real content (separated by a newline). Applied in the announce path before delivery.

## Changes
- `src/auto-reply/tokens.ts`: New `stripTrailingSilentToken()` function
- `src/agents/subagent-announce.ts`: Apply strip after `isSilentReplyText` check
- `src/auto-reply/tokens.test.ts`: 7 new test cases

All existing tests pass.