### PR TITLE
feat(web_fetch): add per-call timeoutSeconds override

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -308,6 +308,7 @@ Fetch a URL and extract readable content.
 - `url` (required, http/https only)
 - `extractMode` (`markdown` | `text`)
 - `maxChars` (truncate long pages)
+- `timeoutSeconds` (optional per-call timeout override)
 
 Notes:
 
@@ -316,6 +317,7 @@ Notes:
 - `web_fetch` sends a Chrome-like User-Agent and `Accept-Language` by default; override `userAgent` if needed.
 - `web_fetch` blocks private/internal hostnames and re-checks redirects (limit with `maxRedirects`).
 - `maxChars` is clamped to `tools.web.fetch.maxCharsCap`.
+- `timeoutSeconds` resolves by precedence: tool argument -> `tools.web.fetch.timeoutSeconds` -> default (30s).
 - `web_fetch` caps the downloaded response body size to `tools.web.fetch.maxResponseBytes` before parsing; oversized responses are truncated and include a warning.
 - `web_fetch` is best-effort extraction; some sites will need the browser tool.
 - See [Firecrawl](/tools/firecrawl) for key setup and service details.

--- a/docs/zh-CN/tools/web.md
+++ b/docs/zh-CN/tools/web.md
@@ -243,6 +243,7 @@ await web_search({
 - `url`（必需，仅限 http/https）
 - `extractMode`（`markdown` | `text`）
 - `maxChars`（截断长页面）
+- `timeoutSeconds`（可选，单次调用超时覆盖）
 
 注意：
 
@@ -250,6 +251,7 @@ await web_search({
 - Firecrawl 请求使用机器人规避模式并默认缓存结果。
 - `web_fetch` 默认发送类 Chrome 的 User-Agent 和 `Accept-Language`；如需要可覆盖 `userAgent`。
 - `web_fetch` 阻止私有/内部主机名并重新检查重定向（用 `maxRedirects` 限制）。
+- `timeoutSeconds` 优先级：工具参数 -> `tools.web.fetch.timeoutSeconds` -> 默认值（30s）。
 - `web_fetch` 是尽力提取；某些网站需要浏览器工具。
 - 参见 [Firecrawl](/tools/firecrawl) 了解密钥设置和服务详情。
 - 响应会被缓存（默认 15 分钟）以减少重复获取。

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -255,10 +255,17 @@ export function resolveWebFetchDetail(args: unknown): string | undefined {
     typeof record.maxChars === "number" && Number.isFinite(record.maxChars) && record.maxChars > 0
       ? Math.floor(record.maxChars)
       : undefined;
+  const timeoutSeconds =
+    typeof record.timeoutSeconds === "number" &&
+    Number.isFinite(record.timeoutSeconds) &&
+    record.timeoutSeconds > 0
+      ? Math.floor(record.timeoutSeconds)
+      : undefined;
 
   const suffix = [
     mode ? `mode ${mode}` : undefined,
     maxChars !== undefined ? `max ${maxChars} chars` : undefined,
+    timeoutSeconds !== undefined ? `timeout ${timeoutSeconds}s` : undefined,
   ]
     .filter((value): value is string => Boolean(value))
     .join(", ");

--- a/src/agents/tool-display.json
+++ b/src/agents/tool-display.json
@@ -302,7 +302,7 @@
     "web_fetch": {
       "emoji": "📄",
       "title": "Web Fetch",
-      "detailKeys": ["url", "extractMode", "maxChars"]
+      "detailKeys": ["url", "extractMode", "maxChars", "timeoutSeconds"]
     },
     "whatsapp_login": {
       "emoji": "🟢",

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -88,6 +88,22 @@ describe("tool display details", () => {
     expect(detail).toBe('for "OpenClaw docs" (top 3)');
   });
 
+  it("formats web_fetch detail with timeout when provided", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "web_fetch",
+        args: {
+          url: "https://example.com",
+          extractMode: "text",
+          maxChars: 3000,
+          timeoutSeconds: 9,
+        },
+      }),
+    );
+
+    expect(detail).toBe("from https://example.com (mode text, max 3000 chars, timeout 9s)");
+  });
+
   it("summarizes exec commands with context", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -60,6 +60,12 @@ const WebFetchSchema = Type.Object({
       minimum: 100,
     }),
   ),
+  timeoutSeconds: Type.Optional(
+    Type.Number({
+      description: "Per-call timeout in seconds (overrides tools.web.fetch.timeoutSeconds).",
+      minimum: 1,
+    }),
+  ),
 });
 
 type WebFetchConfig = NonNullable<OpenClawConfig["tools"]>["web"] extends infer Web
@@ -724,10 +730,6 @@ export function createWebFetchTool(options?: {
   const firecrawlBaseUrl = resolveFirecrawlBaseUrl(firecrawl);
   const firecrawlOnlyMainContent = resolveFirecrawlOnlyMainContent(firecrawl);
   const firecrawlMaxAgeMs = resolveFirecrawlMaxAgeMsOrDefault(firecrawl);
-  const firecrawlTimeoutSeconds = resolveTimeoutSeconds(
-    firecrawl?.timeoutSeconds ?? fetch?.timeoutSeconds,
-    DEFAULT_TIMEOUT_SECONDS,
-  );
   const userAgent =
     (fetch && "userAgent" in fetch && typeof fetch.userAgent === "string" && fetch.userAgent) ||
     DEFAULT_FETCH_USER_AGENT;
@@ -743,7 +745,12 @@ export function createWebFetchTool(options?: {
       const url = readStringParam(params, "url", { required: true });
       const extractMode = readStringParam(params, "extractMode") === "text" ? "text" : "markdown";
       const maxChars = readNumberParam(params, "maxChars", { integer: true });
+      const timeoutSeconds = readNumberParam(params, "timeoutSeconds", { integer: true });
       const maxCharsCap = resolveFetchMaxCharsCap(fetch);
+      const resolvedTimeoutSeconds = resolveTimeoutSeconds(
+        timeoutSeconds ?? fetch?.timeoutSeconds,
+        DEFAULT_TIMEOUT_SECONDS,
+      );
       const result = await runWebFetch({
         url,
         extractMode,
@@ -754,7 +761,7 @@ export function createWebFetchTool(options?: {
         ),
         maxResponseBytes,
         maxRedirects: resolveMaxRedirects(fetch?.maxRedirects, DEFAULT_FETCH_MAX_REDIRECTS),
-        timeoutSeconds: resolveTimeoutSeconds(fetch?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
+        timeoutSeconds: resolvedTimeoutSeconds,
         cacheTtlMs: resolveCacheTtlMs(fetch?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
         userAgent,
         readabilityEnabled,
@@ -765,7 +772,10 @@ export function createWebFetchTool(options?: {
         firecrawlMaxAgeMs,
         firecrawlProxy: "auto",
         firecrawlStoreInCache: true,
-        firecrawlTimeoutSeconds,
+        firecrawlTimeoutSeconds: resolveTimeoutSeconds(
+          timeoutSeconds ?? firecrawl?.timeoutSeconds ?? fetch?.timeoutSeconds,
+          DEFAULT_TIMEOUT_SECONDS,
+        ),
       });
       return jsonResult(result);
     },

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -377,7 +377,9 @@ describe("web_fetch extraction fallbacks", () => {
     const fetchSpy = installMockFetch((input: RequestInfo | URL) => {
       const url = requestUrl(input);
       if (url.includes("api.firecrawl.dev/v2/scrape")) {
-        return Promise.resolve(firecrawlResponse("firecrawl timeout override")) as Promise<Response>;
+        return Promise.resolve(
+          firecrawlResponse("firecrawl timeout override"),
+        ) as Promise<Response>;
       }
       return Promise.resolve(
         htmlResponse("<!doctype html><html><head></head><body></body></html>", url),
@@ -408,7 +410,9 @@ describe("web_fetch extraction fallbacks", () => {
     const fetchSpy = installMockFetch((input: RequestInfo | URL) => {
       const url = requestUrl(input);
       if (url.includes("api.firecrawl.dev/v2/scrape")) {
-        return Promise.resolve(firecrawlResponse("firecrawl configured timeout")) as Promise<Response>;
+        return Promise.resolve(
+          firecrawlResponse("firecrawl configured timeout"),
+        ) as Promise<Response>;
       }
       return Promise.resolve(
         htmlResponse("<!doctype html><html><head></head><body></body></html>", url),

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -118,6 +118,23 @@ function createFetchTool(fetchOverrides: Record<string, unknown> = {}) {
   });
 }
 
+function readTimeoutFromRequestBody(body: unknown): number | undefined {
+  if (typeof body !== "string") {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return undefined;
+  }
+  const timeout = (parsed as Record<string, unknown>).timeout;
+  return typeof timeout === "number" ? timeout : undefined;
+}
+
 async function captureToolErrorMessage(params: {
   tool: ReturnType<typeof createWebFetchTool>;
   url: string;
@@ -401,9 +418,8 @@ describe("web_fetch extraction fallbacks", () => {
       requestUrl(call[0]).includes("/v2/scrape"),
     );
     expect(firecrawlCall).toBeTruthy();
-    const init = firecrawlCall?.[1] as RequestInit | undefined;
-    const body = JSON.parse(String(init?.body ?? "{}")) as { timeout?: number };
-    expect(body.timeout).toBe(7_000);
+    const init = firecrawlCall?.[1];
+    expect(readTimeoutFromRequestBody(init?.body)).toBe(7_000);
   });
 
   it("uses configured firecrawl timeout when per-call timeoutSeconds is omitted", async () => {
@@ -433,9 +449,8 @@ describe("web_fetch extraction fallbacks", () => {
       requestUrl(call[0]).includes("/v2/scrape"),
     );
     expect(firecrawlCall).toBeTruthy();
-    const init = firecrawlCall?.[1] as RequestInit | undefined;
-    const body = JSON.parse(String(init?.body ?? "{}")) as { timeout?: number };
-    expect(body.timeout).toBe(45_000);
+    const init = firecrawlCall?.[1];
+    expect(readTimeoutFromRequestBody(init?.body)).toBe(45_000);
   });
 
   it("throws when readability is disabled and firecrawl is unavailable", async () => {

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -151,6 +151,12 @@ describe("web_fetch extraction fallbacks", () => {
     vi.restoreAllMocks();
   });
 
+  it("exposes timeoutSeconds in web_fetch schema", () => {
+    const tool = createFetchTool();
+    const schema = tool?.parameters as { properties?: Record<string, { type?: string }> };
+    expect(schema.properties?.timeoutSeconds?.type).toBe("number");
+  });
+
   it("wraps fetched text with external content markers", async () => {
     installMockFetch((input: RequestInfo | URL) =>
       Promise.resolve({
@@ -331,6 +337,101 @@ describe("web_fetch extraction fallbacks", () => {
     const init = firecrawlCall?.[1];
     const authHeader = new Headers(init?.headers).get("Authorization");
     expect(authHeader).toBe("Bearer firecrawl-test-key");
+  });
+
+  it("applies per-call timeoutSeconds override to direct fetch", async () => {
+    vi.useFakeTimers();
+    try {
+      installMockFetch(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            const onAbort = () => reject(new Error("aborted by timeout"));
+            if (init?.signal?.aborted) {
+              onAbort();
+              return;
+            }
+            init?.signal?.addEventListener("abort", onAbort, { once: true });
+          }),
+      );
+
+      const tool = createFetchTool({
+        timeoutSeconds: 60,
+        firecrawl: { enabled: false },
+      });
+      expect(tool).toBeTruthy();
+
+      const execution = tool?.execute?.("call", {
+        url: "https://example.com/timeout",
+        timeoutSeconds: 1,
+      });
+      const timeoutAssertion = expect(execution).rejects.toThrow("aborted by timeout");
+
+      await vi.advanceTimersByTimeAsync(1_100);
+      await timeoutAssertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("applies per-call timeoutSeconds override to firecrawl fallback", async () => {
+    const fetchSpy = installMockFetch((input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.includes("api.firecrawl.dev/v2/scrape")) {
+        return Promise.resolve(firecrawlResponse("firecrawl timeout override")) as Promise<Response>;
+      }
+      return Promise.resolve(
+        htmlResponse("<!doctype html><html><head></head><body></body></html>", url),
+      ) as Promise<Response>;
+    });
+
+    const tool = createFetchTool({
+      timeoutSeconds: 60,
+      firecrawl: { apiKey: "firecrawl-test", timeoutSeconds: 45 },
+    });
+
+    const result = await tool?.execute?.("call", {
+      url: "https://example.com/firecrawl-timeout-override",
+      timeoutSeconds: 7,
+    });
+    expect(result?.details).toMatchObject({ extractor: "firecrawl" });
+
+    const firecrawlCall = fetchSpy.mock.calls.find((call) =>
+      requestUrl(call[0]).includes("/v2/scrape"),
+    );
+    expect(firecrawlCall).toBeTruthy();
+    const init = firecrawlCall?.[1] as RequestInit | undefined;
+    const body = JSON.parse(String(init?.body ?? "{}")) as { timeout?: number };
+    expect(body.timeout).toBe(7_000);
+  });
+
+  it("uses configured firecrawl timeout when per-call timeoutSeconds is omitted", async () => {
+    const fetchSpy = installMockFetch((input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.includes("api.firecrawl.dev/v2/scrape")) {
+        return Promise.resolve(firecrawlResponse("firecrawl configured timeout")) as Promise<Response>;
+      }
+      return Promise.resolve(
+        htmlResponse("<!doctype html><html><head></head><body></body></html>", url),
+      ) as Promise<Response>;
+    });
+
+    const tool = createFetchTool({
+      timeoutSeconds: 60,
+      firecrawl: { apiKey: "firecrawl-test", timeoutSeconds: 45 },
+    });
+
+    const result = await tool?.execute?.("call", {
+      url: "https://example.com/firecrawl-timeout-config",
+    });
+    expect(result?.details).toMatchObject({ extractor: "firecrawl" });
+
+    const firecrawlCall = fetchSpy.mock.calls.find((call) =>
+      requestUrl(call[0]).includes("/v2/scrape"),
+    );
+    expect(firecrawlCall).toBeTruthy();
+    const init = firecrawlCall?.[1] as RequestInit | undefined;
+    const body = JSON.parse(String(init?.body ?? "{}")) as { timeout?: number };
+    expect(body.timeout).toBe(45_000);
   });
 
   it("throws when readability is disabled and firecrawl is unavailable", async () => {

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -182,7 +182,9 @@ describe("tilde expansion in file tools", () => {
     process.env.HOME = fakeHome;
     try {
       const result = expandHomePrefix("~/file.txt");
-      expect(result).toBe(`${fakeHome}/file.txt`);
+      expect(path.normalize(result)).toBe(
+        path.normalize(path.join(path.resolve(fakeHome), "file.txt")),
+      );
     } finally {
       process.env.HOME = originalHome;
     }


### PR DESCRIPTION
## Summary
- add optional 	imeoutSeconds to web_fetch tool parameters
- resolve timeout precedence as: tool arg -> 	ools.web.fetch.timeoutSeconds -> default 30s
- apply same per-call timeout override to Firecrawl fallback timeout
- update tool display details to include 	imeoutSeconds
- update docs in English and Chinese

## Tests
- pnpm vitest run src/agents/tools/web-tools.fetch.test.ts src/agents/tool-display.test.ts
- Result: 2 files passed, 39 tests passed

## Compatibility
- default behavior is unchanged when 	imeoutSeconds is not provided