### PR TITLE
fix(gateway): accept unix-second device signature timestamps

### DIFF
--- a/src/gateway/server.auth.test.ts
+++ b/src/gateway/server.auth.test.ts
@@ -1119,6 +1119,58 @@ describe("gateway server auth/connect", () => {
     }
   });
 
+  test("accepts control ui device signatures that use unix-seconds signedAt", async () => {
+    testState.gatewayControlUi = undefined;
+    testState.gatewayAuth = { mode: "token", token: "secret" };
+    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+    try {
+      await withGatewayServer(async ({ port }) => {
+        const ws = await openWs(port, { origin: originForPort(port) });
+        const challengeNonce = await readConnectChallengeNonce(ws);
+        expect(challengeNonce).toBeTruthy();
+        const nowSeconds = Math.floor(Date.now() / 1000);
+        const { randomUUID } = await import("node:crypto");
+        const os = await import("node:os");
+        const path = await import("node:path");
+        const scopes = [
+          "operator.admin",
+          "operator.read",
+          "operator.write",
+          "operator.approvals",
+          "operator.pairing",
+        ];
+        const { device } = await createSignedDevice({
+          token: "secret",
+          scopes,
+          clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+          clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
+          identityPath: path.join(
+            os.tmpdir(),
+            `openclaw-controlui-seconds-device-${randomUUID()}.json`,
+          ),
+          signedAtMs: nowSeconds,
+          nonce: String(challengeNonce),
+        });
+        const res = await connectReq(ws, {
+          token: "secret",
+          scopes,
+          device,
+          client: {
+            ...CONTROL_UI_CLIENT,
+          },
+        });
+        expect(res.ok).toBe(true);
+        expect(res.error?.message ?? "").not.toContain("device signature expired");
+        const health = await rpcReq(ws, "health");
+        expect(health.ok).toBe(true);
+        ws.close();
+      });
+    } finally {
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("device token auth matrix", async () => {
     const { server, ws, port, prevToken } = await startServerWithClient("secret");
     const { deviceToken, deviceIdentityPath } = await ensurePairedDeviceTokenForCurrentIdentity(ws);

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -91,6 +91,13 @@ type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 const DEVICE_SIGNATURE_SKEW_MS = 2 * 60 * 1000;
 const BROWSER_ORIGIN_LOOPBACK_RATE_LIMIT_IP = "198.18.0.1";
 
+function normalizeDeviceSignedAtForSkew(signedAt: number): number {
+  // Backward compatibility: some older clients may send Unix seconds instead of
+  // Unix milliseconds. Keep signature verification payload unchanged, but
+  // normalize only for freshness/skew checks.
+  return signedAt > 0 && signedAt < 1_000_000_000_000 ? signedAt * 1000 : signedAt;
+}
+
 type HandshakeBrowserSecurityContext = {
   hasBrowserOriginHeader: boolean;
   enforceOriginCheckForAnyClient: boolean;
@@ -644,9 +651,11 @@ export function attachGatewayWsMessageHandler(params: {
             return;
           }
           const signedAt = device.signedAt;
+          const signedAtForSkew =
+            typeof signedAt === "number" ? normalizeDeviceSignedAtForSkew(signedAt) : signedAt;
           if (
             typeof signedAt !== "number" ||
-            Math.abs(Date.now() - signedAt) > DEVICE_SIGNATURE_SKEW_MS
+            Math.abs(Date.now() - signedAtForSkew) > DEVICE_SIGNATURE_SKEW_MS
           ) {
             rejectDeviceAuthInvalid("device-signature-stale", "device signature expired");
             return;


### PR DESCRIPTION
## Summary
- Normalize `device.signedAt` for freshness checks when clients send Unix seconds instead of milliseconds.
- Keep signature payload verification behavior unchanged (only skew comparison is normalized).
- Add regression test covering Control UI connection with unix-seconds `signedAt`.

## Test plan
- `pnpm exec vitest run src/gateway/server.auth.test.ts -t "unix-seconds signedAt|stale device identity"`

Closes #29287
