### PR TITLE
fix(edit-tool): return accurate error for paths outside workspace root

### DIFF
--- a/src/agents/pi-tools.read.host-edit-access.test.ts
+++ b/src/agents/pi-tools.read.host-edit-access.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 type CapturedEditOperations = {
   access: (absolutePath: string) => Promise<void>;
+  readFile: (absolutePath: string) => Promise<Buffer>;
 };
 
 const mocks = vi.hoisted(() => ({
@@ -63,4 +64,25 @@ describe("createHostWorkspaceEditTool host access mapping", () => {
       ).rejects.toMatchObject({ code: "EACCES" });
     },
   );
+
+  it("access() succeeds for direct outside-workspace paths so readFile() can emit the accurate error (regression: #30724)", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-access-test-"));
+    const workspaceDir = path.join(tmpDir, "workspace");
+    const outsideDir = path.join(tmpDir, "outside");
+    const outsideFile = path.join(outsideDir, "secret.txt");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(outsideDir, { recursive: true });
+    await fs.writeFile(outsideFile, "secret", "utf8");
+
+    createHostWorkspaceEditTool(workspaceDir, { workspaceOnly: true });
+    expect(mocks.operations).toBeDefined();
+
+    // access() must NOT throw "File not found" — the file exists, just outside workspace.
+    await expect(mocks.operations!.access(outsideFile)).resolves.toBeUndefined();
+
+    // readFile() must throw the accurate "Path escapes workspace root" error.
+    await expect(mocks.operations!.readFile(outsideFile)).rejects.toThrow(
+      /Path escapes workspace root/,
+    );
+  });
 });

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -843,7 +843,22 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
       });
     },
     access: async (absolutePath: string) => {
-      const relative = toRelativePathInRoot(root, absolutePath);
+      let relative: string;
+      try {
+        relative = toRelativePathInRoot(root, absolutePath);
+      } catch {
+        // Path is outside the workspace root (no symlink involved). Don't throw here —
+        // pi-coding-agent converts any access() error to a generic "File not found" message.
+        // Instead, only verify the file exists on disk so that readFile() can emit the
+        // accurate "Path escapes workspace root" error when called (issue #30724).
+        const resolved = path.resolve(absolutePath);
+        try {
+          await fs.access(resolved);
+        } catch {
+          throw createFsAccessError("ENOENT", absolutePath);
+        }
+        return;
+      }
       try {
         const opened = await openFileWithinRoot({
           rootDir: root,


### PR DESCRIPTION
Fixes #30724

## Summary

The `Edit` tool returned a misleading `File not found` error when given an absolute path outside the agent's workspace root (e.g. an orchestrator agent editing a file in a sub-agent workspace). `Write` correctly emits `Path escapes workspace root` in the same situation.

## Root Cause

`pi-coding-agent`'s `createEditTool` wraps **any** error thrown from `ops.access()` as `File not found`:

```js
try {
    await ops.access(absolutePath);
} catch {
    reject(new Error(`File not found: ${path}`));  // swallows all errors
    return;
}
```

In the workspace-only path of `createHostEditOperations`, `access()` called `toRelativePathInRoot()` **before** its own try/catch. For outside-workspace paths, `toRelativePathInRoot()` throws `"Path escapes workspace root: …"` — which propagated out of `access()` and got silently swallowed by the pi-coding-agent wrapper into `"File not found"`.

## Fix

When `toRelativePathInRoot()` throws (direct outside-workspace path), `access()` now only verifies the file exists on disk via plain `fs.access()` and returns successfully. The next step — `readFile()` — calls `toRelativePathInRoot()` itself, which throws `"Path escapes workspace root"`. The pi-coding-agent **outer** catch handler propagates this error verbatim.

```
Before: access() → "Path escapes workspace root" → wrapped as "File not found" ❌
After:  access() → ok → readFile() → "Path escapes workspace root" propagated ✅
```

Symlink-escape detection (where `toRelativePathInRoot()` succeeds but `openFileWithinRoot()` detects an outside-workspace symlink) is **unchanged** — `access()` still throws EACCES for that case.

## Changes

- **`src/agents/pi-tools.read.ts`**: In `createHostEditOperations`, catch the `toRelativePathInRoot()` throw in `access()`, do a plain existence check, and defer workspace enforcement to `readFile()`.
- **`src/agents/pi-tools.read.host-edit-access.test.ts`**: Add regression test verifying `access()` resolves and `readFile()` rejects with `"Path escapes workspace root"` for a direct outside-workspace path.

## Testing

```
pnpm vitest run src/agents/pi-tools.read.host-edit-access.test.ts
✓ src/agents/pi-tools.read.host-edit-access.test.ts (2 tests)
```