### PR TITLE
fix(launchd): stabilize status during print/list race windows

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS } from "./launchd-plist.js";
 import {
   installLaunchAgent,
+  isLaunchAgentLoaded,
   isLaunchAgentListed,
   parseLaunchctlPrint,
+  readLaunchAgentRuntime,
   repairLaunchAgentBootstrap,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
@@ -14,6 +16,8 @@ const state = vi.hoisted(() => ({
   launchctlCalls: [] as string[][],
   listOutput: "",
   printOutput: "",
+  printStderr: "",
+  printCode: 0,
   bootstrapError: "",
   dirs: new Set<string>(),
   files: new Map<string, string>(),
@@ -39,7 +43,7 @@ vi.mock("./exec-file.js", () => ({
       return { stdout: state.listOutput, stderr: "", code: 0 };
     }
     if (call[0] === "print") {
-      return { stdout: state.printOutput, stderr: "", code: 0 };
+      return { stdout: state.printOutput, stderr: state.printStderr, code: state.printCode };
     }
     if (call[0] === "bootstrap" && state.bootstrapError) {
       return { stdout: "", stderr: state.bootstrapError, code: 1 };
@@ -78,6 +82,8 @@ beforeEach(() => {
   state.launchctlCalls.length = 0;
   state.listOutput = "";
   state.printOutput = "";
+  state.printStderr = "";
+  state.printCode = 0;
   state.bootstrapError = "";
   state.dirs.clear();
   state.files.clear();
@@ -116,6 +122,28 @@ describe("launchctl list detection", () => {
       env: { HOME: "/Users/test", OPENCLAW_PROFILE: "default" },
     });
     expect(listed).toBe(false);
+  });
+
+  it("falls back to launchctl list when print reports missing service", async () => {
+    state.printCode = 1;
+    state.printStderr = 'Could not find service "ai.openclaw.gateway" in domain for user gui: 501';
+    state.listOutput = "123 0 ai.openclaw.gateway\n";
+    const loaded = await isLaunchAgentLoaded({
+      env: { HOME: "/Users/test", OPENCLAW_PROFILE: "default" },
+    });
+    expect(loaded).toBe(true);
+  });
+
+  it("treats list-present label as stopped runtime when print is temporarily missing", async () => {
+    state.printCode = 1;
+    state.printStderr = 'Could not find service "ai.openclaw.gateway" in domain for user gui: 501';
+    state.listOutput = "123 0 ai.openclaw.gateway\n";
+    const env = { HOME: "/Users/test", OPENCLAW_PROFILE: "default" };
+    state.files.set(resolveLaunchAgentPlistPath(env), "<plist/>");
+
+    const runtime = await readLaunchAgentRuntime(env);
+    expect(runtime.status).toBe("stopped");
+    expect(runtime.missingUnit).toBe(false);
   });
 });
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -146,11 +146,27 @@ export function parseLaunchctlPrint(output: string): LaunchctlPrintInfo {
   return info;
 }
 
+function launchctlListContainsLabel(output: string, label: string): boolean {
+  return output.split(/\r?\n/).some((line) => line.trim().split(/\s+/).at(-1) === label);
+}
+
 export async function isLaunchAgentLoaded(args: GatewayServiceEnvArgs): Promise<boolean> {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: args.env });
   const res = await execLaunchctl(["print", `${domain}/${label}`]);
-  return res.code === 0;
+  if (res.code === 0) {
+    return true;
+  }
+  if (!isLaunchctlNotLoaded(res)) {
+    return false;
+  }
+  // launchctl print can intermittently return "service not found" during
+  // launchd transitions while the label is still present in launchctl list.
+  const listed = await execLaunchctl(["list"]);
+  if (listed.code !== 0) {
+    return false;
+  }
+  return launchctlListContainsLabel(listed.stdout, label);
 }
 
 export async function isLaunchAgentListed(args: GatewayServiceEnvArgs): Promise<boolean> {
@@ -159,7 +175,7 @@ export async function isLaunchAgentListed(args: GatewayServiceEnvArgs): Promise<
   if (res.code !== 0) {
     return false;
   }
-  return res.stdout.split(/\r?\n/).some((line) => line.trim().split(/\s+/).at(-1) === label);
+  return launchctlListContainsLabel(res.stdout, label);
 }
 
 export async function launchAgentPlistExists(env: GatewayServiceEnv): Promise<boolean> {
@@ -179,6 +195,18 @@ export async function readLaunchAgentRuntime(
   const label = resolveLaunchAgentLabel({ env });
   const res = await execLaunchctl(["print", `${domain}/${label}`]);
   if (res.code !== 0) {
+    const plistExists = await launchAgentPlistExists(env);
+    // During restart windows launchctl print can be stale while launchctl list
+    // still reports the label. Treat that as a loaded-but-not-running state.
+    const listed = await isLaunchAgentListed({ env });
+    if (listed) {
+      return {
+        status: "stopped",
+        detail: (res.stderr || res.stdout).trim() || undefined,
+        missingUnit: false,
+        cachedLabel: !plistExists,
+      };
+    }
     return {
       status: "unknown",
       detail: (res.stderr || res.stdout).trim() || undefined,


### PR DESCRIPTION
## Summary
- Add launchctl list fallback when launchctl print temporarily reports `service not found`.
- Use fallback both in `isLaunchAgentLoaded()` and `readLaunchAgentRuntime()` to reduce status flapping.
- Keep missing-unit behavior for true absent-label cases.

## Test plan
- `pnpm exec vitest run src/daemon/launchd.test.ts`

Closes #29883
