### PR TITLE
fix(test): Windows path compat for expandHomePrefix test

### DIFF
--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -182,7 +182,8 @@ describe("tilde expansion in file tools", () => {
     process.env.HOME = fakeHome;
     try {
       const result = expandHomePrefix("~/file.txt");
-      expect(result).toBe(`${fakeHome}/file.txt`);
+      // path.resolve normalises the HOME value, so the expectation must match
+      expect(result).toBe(`${path.resolve(fakeHome)}/file.txt`);
     } finally {
       process.env.HOME = originalHome;
     }


### PR DESCRIPTION
## Summary

- The `expandHomePrefix respects process.env.HOME changes` test in `src/infra/fs-safe.test.ts` fails on every Windows CI run
- Root cause: `resolveEffectiveHomeDir` calls `path.resolve()` which normalises `/tmp/fake-home-test` to `C:\tmp\fake-home-test` on Windows, but the test expectation compared against the raw Unix string
- Fix: wrap the expected HOME path in `path.resolve()` so it matches on both platforms

## Impact

This failure currently **blocks `checks-windows` on every open PR**, including:
- #30687, #30627, #27876, #26880, #26331, #24583

Merging this will unblock the Windows CI shard for all of them.

## Test plan

- [ ] `checks-windows` shard 1 passes (previously: `expected 'C:\tmp\fake-home-test/file.txt' to be '/tmp/fake-home-test/file.txt'`)
- [ ] Linux/macOS CI unaffected (`path.resolve` is a no-op for absolute Unix paths)