### PR TITLE
fix(edit): return accurate error for paths outside workspace root

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -843,7 +843,18 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
       });
     },
     access: async (absolutePath: string) => {
-      const relative = toRelativePathInRoot(root, absolutePath);
+      let relative: string;
+      try {
+        relative = toRelativePathInRoot(root, absolutePath);
+      } catch {
+        // toRelativePathInRoot throws "Path escapes workspace root" for paths outside the workspace
+        // We need to convert this to an EACCES error so pi-coding-agent's createEditTool
+        // can distinguish it from ENOENT (file not found) and show the correct error message.
+        const accessError = createFsAccessError("EACCES", absolutePath);
+        // Preserve the original error message for better debugging
+        accessError.message = `Path escapes workspace root: ${absolutePath}`;
+        throw accessError;
+      }
       try {
         const opened = await openFileWithinRoot({
           rootDir: root,

--- a/src/agents/pi-tools.read.workspace-escape-error.test.ts
+++ b/src/agents/pi-tools.read.workspace-escape-error.test.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type CapturedEditOperations = {
+  access: (absolutePath: string) => Promise<void>;
+};
+
+const mocks = vi.hoisted(() => ({
+  operations: undefined as CapturedEditOperations | undefined,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mariozechner/pi-coding-agent")>();
+  return {
+    ...actual,
+    createEditTool: (_cwd: string, options?: { operations?: CapturedEditOperations }) => {
+      mocks.operations = options?.operations;
+      return {
+        name: "edit",
+        description: "test edit tool",
+        parameters: { type: "object", properties: {} },
+        execute: async () => ({
+          content: [{ type: "text" as const, text: "ok" }],
+        }),
+      };
+    },
+  };
+});
+
+const { createHostWorkspaceEditTool } = await import("./pi-tools.read.js");
+
+describe("createHostWorkspaceEditTool workspace escape error", () => {
+  let tmpDir = "";
+
+  afterEach(async () => {
+    mocks.operations = undefined;
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = "";
+    }
+  });
+
+  it("access throws EACCES with correct message for paths outside workspace", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-escape-test-"));
+    const workspaceDir = path.join(tmpDir, "workspace");
+    const outsideDir = path.join(tmpDir, "outside");
+
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(outsideDir, { recursive: true });
+
+    // Create a file outside the workspace
+    const outsideFile = path.join(outsideDir, "test.txt");
+    await fs.writeFile(outsideFile, "content");
+
+    createHostWorkspaceEditTool(workspaceDir, { workspaceOnly: true });
+    expect(mocks.operations).toBeDefined();
+
+    // Attempt to access a file outside the workspace
+    let error: NodeJS.ErrnoException | undefined;
+    try {
+      await mocks.operations!.access(outsideFile);
+    } catch (e) {
+      error = e as NodeJS.ErrnoException;
+    }
+
+    expect(error).toBeDefined();
+    expect(error?.code).toBe("EACCES");
+    expect(error?.message).toContain("Path escapes workspace root");
+    expect(error?.message).toContain(outsideFile);
+  });
+
+  it("access throws ENOENT for non-existent files inside workspace", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-escape-test-"));
+    const workspaceDir = path.join(tmpDir, "workspace");
+
+    await fs.mkdir(workspaceDir, { recursive: true });
+
+    createHostWorkspaceEditTool(workspaceDir, { workspaceOnly: true });
+    expect(mocks.operations).toBeDefined();
+
+    // Attempt to access a non-existent file inside the workspace
+    let error: NodeJS.ErrnoException | undefined;
+    try {
+      await mocks.operations!.access(path.join(workspaceDir, "non-existent.txt"));
+    } catch (e) {
+      error = e as NodeJS.ErrnoException;
+    }
+
+    expect(error).toBeDefined();
+    expect(error?.code).toBe("ENOENT");
+  });
+
+  it("access succeeds for existing files inside workspace", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-escape-test-"));
+    const workspaceDir = path.join(tmpDir, "workspace");
+
+    await fs.mkdir(workspaceDir, { recursive: true });
+
+    // Create a file inside the workspace
+    const testFile = path.join(workspaceDir, "test.txt");
+    await fs.writeFile(testFile, "content");
+
+    createHostWorkspaceEditTool(workspaceDir, { workspaceOnly: true });
+    expect(mocks.operations).toBeDefined();
+
+    // Should not throw
+    await expect(mocks.operations!.access(testFile)).resolves.toBeUndefined();
+  });
+
+  it("access throws EACCES for paths with directory traversal outside workspace", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-escape-test-"));
+    const workspaceDir = path.join(tmpDir, "workspace");
+    const outsideDir = path.join(tmpDir, "outside");
+
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(outsideDir, { recursive: true });
+
+    // Create a file outside the workspace
+    await fs.writeFile(path.join(outsideDir, "test.txt"), "content");
+
+    createHostWorkspaceEditTool(workspaceDir, { workspaceOnly: true });
+    expect(mocks.operations).toBeDefined();
+
+    // Attempt to access using ../ traversal
+    let error: NodeJS.ErrnoException | undefined;
+    try {
+      await mocks.operations!.access(path.join(workspaceDir, "..", "outside", "test.txt"));
+    } catch (e) {
+      error = e as NodeJS.ErrnoException;
+    }
+
+    expect(error).toBeDefined();
+    expect(error?.code).toBe("EACCES");
+    expect(error?.message).toContain("Path escapes workspace root");
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** The Edit tool returned a misleading `File not found` error when given an absolute path outside the agent's workspace root. This was because `toRelativePathInRoot` throws `"Path escapes workspace root"` but the error was not being converted to an EACCES error code.
- **Why it matters:** Users get confusing error messages when trying to edit files outside their workspace, making it hard to understand the actual issue.
- **What changed:** Modified the `access` function in `createHostEditOperations` to catch the `toRelativePathInRoot` error and convert it to an EACCES error with a clear message, allowing `pi-coding-agent`'s `createEditTool` to distinguish it from ENOENT (file not found).
- **What did NOT change:** The overall file access behavior and security model remain unchanged.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Fixes #30724
- Related to #30711

## User-visible / Behavior Changes

- Edit tool now returns `Path escapes workspace root: <path>` instead of `File not found` when attempting to edit files outside the workspace.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js 24.x

### Steps

1. Attempt to edit a file outside the workspace:
   ```json
   { "tool": "edit", "path": "/path/outside/workspace/file.txt", "oldText": "a", "newText": "b" }
   ```

### Expected

- Error message should indicate the path is outside the workspace.

### Actual

- Before fix: `File not found: /path/outside/workspace/file.txt`
- After fix: `Path escapes workspace root: /path/outside/workspace/file.txt`

## Evidence

Commands run:
- `pnpm exec vitest run src/agents/pi-tools.read.workspace-escape-error.test.ts`
- `pnpm exec vitest run src/agents/pi-tools.read.host-edit-access.test.ts`
- `pnpm exec oxlint --type-aware src/agents/pi-tools.read.ts`
- `pnpm exec oxfmt --check src/agents/pi-tools.read.ts`

## Human Verification

- Verified scenarios: editing files outside workspace, editing non-existent files inside workspace, editing existing files inside workspace.
- Edge cases checked: directory traversal (`../outside/file.txt`).
- What I did **not** verify: Live multi-agent orchestration scenarios.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery

- How to disable/revert: revert this PR commit.
- Files/config to restore: `src/agents/pi-tools.read.ts`
- Known bad symptoms: Edit tool returns misleading error messages again.

## Risks and Mitigations

- Risk: None identified. This change only improves error messaging without affecting functionality.

---

Contributed by @Jimmy-xuzimo