### PR TITLE
feat(slack): follow threads where bot was previously mentioned

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -672,6 +672,8 @@ export const FIELD_HELP: Record<string, string> = {
     "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
   "channels.slack.thread.initialHistoryLimit":
     "Maximum number of existing Slack thread messages to fetch when starting a new thread session (default: 20, set to 0 to disable).",
+  "channels.slack.thread.followMentionedThreads":
+    "If true, the bot responds to all replies in threads where it was previously invoked, without requiring @mention in each reply (default: false).",
   "channels.mattermost.botToken":
     "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
   "channels.mattermost.baseUrl":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -730,6 +730,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.slack.thread.historyScope": "Slack Thread History Scope",
   "channels.slack.thread.inheritParent": "Slack Thread Parent Inheritance",
   "channels.slack.thread.initialHistoryLimit": "Slack Thread Initial History Limit",
+  "channels.slack.thread.followMentionedThreads": "Slack Follow Mentioned Threads",
   "channels.mattermost.botToken": "Mattermost Bot Token",
   "channels.mattermost.baseUrl": "Mattermost Base URL",
   "channels.mattermost.configWrites": "Mattermost Config Writes",

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -77,6 +77,8 @@ export type SlackThreadConfig = {
   inheritParent?: boolean;
   /** Maximum number of thread messages to fetch as context when starting a new thread session (default: 20). Set to 0 to disable thread history fetching. */
   initialHistoryLimit?: number;
+  /** If true, the bot responds to all replies in threads where it was mentioned in the root message, without requiring @mention in each reply. Default: false. */
+  followMentionedThreads?: boolean;
 };
 
 export type SlackAccountConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -724,6 +724,7 @@ export const SlackThreadSchema = z
     historyScope: z.enum(["thread", "channel"]).optional(),
     inheritParent: z.boolean().optional(),
     initialHistoryLimit: z.number().int().min(0).optional(),
+    followMentionedThreads: z.boolean().optional(),
   })
   .strict();
 

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -90,6 +90,7 @@ export type SlackMonitorContext = {
   ackReactionScope: string;
   mediaMaxBytes: number;
   removeAckAfterReply: boolean;
+  threadFollowMentionedThreads: boolean;
 
   logger: ReturnType<typeof getChildLogger>;
   markMessageSeen: (channelId: string | undefined, ts?: string) => boolean;
@@ -152,6 +153,7 @@ export function createSlackMonitorContext(params: {
   ackReactionScope: string;
   mediaMaxBytes: number;
   removeAckAfterReply: boolean;
+  threadFollowMentionedThreads: boolean;
 }): SlackMonitorContext {
   const channelHistories = new Map<string, HistoryEntry[]>();
   const logger = getChildLogger({ module: "slack-auto-reply" });
@@ -415,6 +417,7 @@ export function createSlackMonitorContext(params: {
     ackReactionScope: params.ackReactionScope,
     mediaMaxBytes: params.mediaMaxBytes,
     removeAckAfterReply: params.removeAckAfterReply,
+    threadFollowMentionedThreads: params.threadFollowMentionedThreads,
     logger,
     markMessageSeen,
     shouldDropMismatchedSlackEvent,

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -82,6 +82,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       ackReactionScope: "group-mentions",
       mediaMaxBytes: 1024,
       removeAckAfterReply: false,
+      threadFollowMentionedThreads: false,
     });
   }
 
@@ -333,6 +334,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       ackReactionScope: "group-mentions",
       mediaMaxBytes: 1024,
       removeAckAfterReply: false,
+      threadFollowMentionedThreads: false,
     });
     // oxlint-disable-next-line typescript/no-explicit-any
     slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
@@ -416,6 +418,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       ackReactionScope: "group-mentions",
       mediaMaxBytes: 1024,
       removeAckAfterReply: false,
+      threadFollowMentionedThreads: false,
     });
     // oxlint-disable-next-line typescript/no-explicit-any
     slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
@@ -657,6 +660,7 @@ describe("prepareSlackMessage sender prefix", () => {
       ackReactionScope: "off",
       mediaMaxBytes: 1000,
       removeAckAfterReply: false,
+      threadFollowMentionedThreads: false,
       logger: { info: vi.fn(), warn: vi.fn() },
       markMessageSeen: () => false,
       shouldDropMismatchedSlackEvent: () => false,

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -44,6 +44,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     defaultRequireMention?: boolean;
     replyToMode?: "off" | "all";
     channelsConfig?: Record<string, { systemPrompt: string }>;
+    threadFollowMentionedThreads?: boolean;
   }) {
     return createSlackMonitorContext({
       cfg: params.cfg,
@@ -82,7 +83,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       ackReactionScope: "group-mentions",
       mediaMaxBytes: 1024,
       removeAckAfterReply: false,
-      threadFollowMentionedThreads: false,
+      threadFollowMentionedThreads: params.threadFollowMentionedThreads ?? false,
     });
   }
 
@@ -568,6 +569,47 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("user follow-up");
     expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("current message");
     expect(replies).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not follow unrelated thread replies when only a base channel session exists", async () => {
+    const { storePath } = makeTmpStorePath();
+    const cfg = {
+      session: { store: storePath },
+      channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+    } as OpenClawConfig;
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "slack",
+      accountId: "default",
+      teamId: "T1",
+      peer: { kind: "channel", id: "C123" },
+    });
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({ [route.sessionKey]: { updatedAt: Date.now() } }, null, 2),
+    );
+
+    const slackCtx = createInboundSlackCtx({
+      cfg,
+      defaultRequireMention: true,
+      replyToMode: "all",
+      threadFollowMentionedThreads: true,
+    });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createThreadAccount(),
+      createThreadReplyMessage({
+        text: "unrelated thread reply without mention",
+        ts: "301.000",
+        thread_ts: "300.000",
+        parent_user_id: "U2",
+      }),
+    );
+
+    expect(prepared).toBeNull();
   });
 
   it("includes thread_ts and parent_user_id metadata in thread replies", async () => {

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -204,12 +204,9 @@ export async function prepareSlackMessage(params: {
           canResolveExplicit: Boolean(ctx.botUserId),
         },
       }));
-  // Check if bot already has an active session for this thread (used for followMentionedThreads).
-  // We check both the thread-specific session key AND the base (channel) session key because
-  // when a user @mentions the bot in a top-level channel message, the session is recorded under
-  // the base key. The bot replies in a thread, but the thread-specific key is never created.
-  // On the follow-up message in that thread, we need to find the base session to know the bot
-  // was engaged.
+  // Check if bot already has an active session for this specific thread
+  // (used for followMentionedThreads). Base channel sessions do not imply
+  // bot participation in every thread in that channel.
   const threadFollowImplicit = Boolean(
     ctx.threadFollowMentionedThreads &&
     !isDirectMessage &&
@@ -219,10 +216,7 @@ export async function prepareSlackMessage(params: {
       const storePath = resolveStorePath(ctx.cfg.session?.store, {
         agentId: route.agentId,
       });
-      return (
-        readSessionUpdatedAt({ storePath, sessionKey }) != null ||
-        readSessionUpdatedAt({ storePath, sessionKey: baseSessionKey }) != null
-      );
+      return readSessionUpdatedAt({ storePath, sessionKey }) != null;
     })(),
   );
   const implicitMention = Boolean(

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -204,11 +204,32 @@ export async function prepareSlackMessage(params: {
           canResolveExplicit: Boolean(ctx.botUserId),
         },
       }));
+  // Check if bot already has an active session for this thread (used for followMentionedThreads).
+  // We check both the thread-specific session key AND the base (channel) session key because
+  // when a user @mentions the bot in a top-level channel message, the session is recorded under
+  // the base key. The bot replies in a thread, but the thread-specific key is never created.
+  // On the follow-up message in that thread, we need to find the base session to know the bot
+  // was engaged.
+  const threadFollowImplicit = Boolean(
+    ctx.threadFollowMentionedThreads &&
+    !isDirectMessage &&
+    isThreadReply &&
+    threadTs &&
+    (() => {
+      const storePath = resolveStorePath(ctx.cfg.session?.store, {
+        agentId: route.agentId,
+      });
+      return (
+        readSessionUpdatedAt({ storePath, sessionKey }) != null ||
+        readSessionUpdatedAt({ storePath, sessionKey: baseSessionKey }) != null
+      );
+    })(),
+  );
   const implicitMention = Boolean(
     !isDirectMessage &&
     ctx.botUserId &&
     message.thread_ts &&
-    message.parent_user_id === ctx.botUserId,
+    (message.parent_user_id === ctx.botUserId || threadFollowImplicit),
   );
 
   const sender = message.user ? await ctx.resolveUserName(message.user) : null;

--- a/src/slack/monitor/monitor.test.ts
+++ b/src/slack/monitor/monitor.test.ts
@@ -119,6 +119,7 @@ const baseParams = () => ({
   threadHistoryScope: "thread" as const,
   threadInheritParent: false,
   removeAckAfterReply: false,
+  threadFollowMentionedThreads: false,
 });
 
 type ThreadStarterClient = Parameters<typeof resolveSlackThreadStarter>[0]["client"];

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -130,6 +130,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
   const mediaMaxBytes = (opts.mediaMaxMb ?? slackCfg.mediaMaxMb ?? 20) * 1024 * 1024;
   const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
+  const threadFollowMentionedThreads = slackCfg.thread?.followMentionedThreads ?? false;
 
   const receiver =
     slackMode === "http"
@@ -228,6 +229,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     ackReactionScope,
     mediaMaxBytes,
     removeAckAfterReply,
+    threadFollowMentionedThreads,
   });
 
   const handleSlackMessage = createSlackMessageHandler({ ctx, account });


### PR DESCRIPTION
## Summary

When `channels.slack.thread.followMentionedThreads` is enabled, the bot responds to **all replies in threads where it has an active session** — without requiring `@mention` in every reply.

## Problem

Currently, when a user `@mentions` the bot in a Slack channel and a threaded conversation starts, the user must `@mention` the bot in **every single reply** to keep the conversation going. This is unnatural — in a thread that's clearly a conversation with the bot, having to re-mention it each time adds friction.

## Solution

A new opt-in config option:
```
channels.slack.thread.followMentionedThreads: true  # default: false
```

When enabled, thread replies are treated as implicit mentions if the bot already has an active session for that thread. This checks both the thread-specific session key and the base (channel) session key, so it works whether the bot was first invoked via `@mention` in the thread or in the parent message.

## Changes

- **Config**: Added `channels.slack.thread.followMentionedThreads` (boolean, default `false`)
- **Runtime**: Before evaluating implicit mentions, checks if the bot has an active session for the current thread via `readSessionUpdatedAt`
- **Tests**: Updated mock contexts in prepare and monitor test suites

## Scope

9 files changed, +38 / -1. No breaking changes, fully opt-in, off by default.