### PR TITLE
fix(acp): thread images through ACP dispatch pipeline

### DIFF
--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -38,6 +38,7 @@ export async function resolveManagerRuntimeCapabilities(params: {
   return {
     controls: [...controls].toSorted(),
     ...(normalizedKeys.length > 0 ? { configOptionKeys: normalizedKeys } : {}),
+    ...(reported?.supportsImages != null ? { supportsImages: reported.supportsImages } : {}),
   };
 }
 

--- a/src/acp/runtime/types.ts
+++ b/src/acp/runtime/types.ts
@@ -61,6 +61,8 @@ export type AcpRuntimeCapabilities = {
    * Empty/undefined means "backend accepts keys, but did not advertise a strict list".
    */
   configOptionKeys?: string[];
+  /** Whether the runtime can consume image content in turn input. */
+  supportsImages?: boolean;
 };
 
 export type AcpRuntimeStatus = {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -10,6 +10,7 @@ import {
   resolveSessionIdentityFromMeta,
 } from "../../acp/runtime/session-identity.js";
 import { readAcpSessionEntry } from "../../acp/runtime/session-meta.js";
+import type { ImageContent } from "../../commands/agent/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
@@ -189,6 +190,7 @@ export async function tryDispatchAcpReply(params: {
   cfg: OpenClawConfig;
   dispatcher: ReplyDispatcher;
   sessionKey?: string;
+  images?: ImageContent[];
   inboundAudio: boolean;
   sessionTtsAuto?: TtsAutoMode;
   ttsChannel?: string;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1863,6 +1863,68 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("threads image-only messages through ACP dispatch instead of short-circuiting", async () => {
+    setNoAbort();
+    const runtime = createAcpRuntime([
+      { type: "text_delta", text: "I see an image" },
+      { type: "done" },
+    ]);
+    acpMocks.readAcpSessionEntry.mockReturnValue({
+      sessionKey: "agent:codex-acp:session-1",
+      storeSessionKey: "agent:codex-acp:session-1",
+      cfg: {},
+      storePath: "/tmp/mock-sessions.json",
+      entry: {},
+      acp: {
+        backend: "acpx",
+        agent: "codex",
+        runtimeSessionName: "runtime:1",
+        mode: "persistent",
+        state: "idle",
+        lastActivityAt: Date.now(),
+      },
+    });
+    acpMocks.requireAcpRuntimeBackend.mockReturnValue({
+      id: "acpx",
+      runtime,
+    });
+
+    const cfg = {
+      acp: {
+        enabled: true,
+        dispatch: { enabled: true },
+      },
+    } as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    // No text body — image-only message
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      SessionKey: "agent:codex-acp:session-1",
+    });
+    const testImage = { type: "image" as const, data: "base64data", mimeType: "image/jpeg" };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyOptions: { images: [testImage] },
+      replyResolver: vi.fn(),
+    });
+
+    // runtime.runTurn was called (not short-circuited as acp_empty_prompt)
+    expect(runtime.runTurn).toHaveBeenCalledTimes(1);
+    // images were passed through to the runtime
+    const runTurnInput = (runtime.runTurn as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(runTurnInput).toBeDefined();
+    // The AcpSessionManager wraps the runtime call, so images arrive via
+    // the manager's runTurn input. Verify the runtime was actually invoked
+    // (which means the empty-prompt guard did not fire).
+    expect(dispatcher.sendBlockReply).toHaveBeenCalled();
+  });
+
   it("suppresses isReasoning payloads from final replies (WhatsApp channel)", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -168,7 +168,10 @@ function setNoAbort() {
   mocks.tryFastAbortFromMessage.mockResolvedValue(noAbortResult);
 }
 
-function createAcpRuntime(events: Array<Record<string, unknown>>) {
+function createAcpRuntime(
+  events: Array<Record<string, unknown>>,
+  opts?: { supportsImages?: boolean },
+) {
   return {
     ensureSession: vi.fn(
       async (input: { sessionKey: string; mode: string; agent: string }) =>
@@ -185,6 +188,14 @@ function createAcpRuntime(events: Array<Record<string, unknown>>) {
     }),
     cancel: vi.fn(async () => {}),
     close: vi.fn(async () => {}),
+    ...(opts?.supportsImages != null
+      ? {
+          getCapabilities: vi.fn(async () => ({
+            controls: [],
+            supportsImages: opts.supportsImages,
+          })),
+        }
+      : {}),
   };
 }
 
@@ -1865,10 +1876,10 @@ describe("dispatchReplyFromConfig", () => {
 
   it("threads image-only messages through ACP dispatch instead of short-circuiting", async () => {
     setNoAbort();
-    const runtime = createAcpRuntime([
-      { type: "text_delta", text: "I see an image" },
-      { type: "done" },
-    ]);
+    const runtime = createAcpRuntime(
+      [{ type: "text_delta", text: "I see an image" }, { type: "done" }],
+      { supportsImages: true },
+    );
     acpMocks.readAcpSessionEntry.mockReturnValue({
       sessionKey: "agent:codex-acp:session-1",
       storeSessionKey: "agent:codex-acp:session-1",

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -343,6 +343,7 @@ export async function dispatchReplyFromConfig(params: {
       cfg,
       dispatcher,
       sessionKey: acpDispatchSessionKey,
+      images: params.replyOptions?.images,
       inboundAudio,
       sessionTtsAuto,
       ttsChannel,

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -130,6 +130,8 @@ export type { OpenClawConfig } from "../config/config.js";
 export type { OpenClawConfig as ClawdbotConfig } from "../config/config.js";
 export { isDangerousNameMatchingEnabled } from "../config/dangerous-name-matching.js";
 
+export type { ImageContent } from "../commands/agent/types.js";
+
 export type { FileLockHandle, FileLockOptions } from "./file-lock.js";
 export { acquireFileLock, withFileLock } from "./file-lock.js";
 export {


### PR DESCRIPTION
## Status: Superseded by upstream

The core changes in this PR have been superseded by upstream's `attachments` refactor on `main`:

- **Empty-prompt guard** — upstream now checks `!promptText && attachments.length === 0` via `resolveAcpAttachments(ctx)` ✅
- **Image threading through ACP dispatch** — upstream's `resolveAcpAttachments` reads image files from message context, converts to base64 `AcpTurnAttachment` objects, and passes them through the full dispatch chain ✅
- **Type plumbing** (`AcpRunTurnInput.attachments`, `AcpRuntimeTurnInput.attachments`) — already on `main` ✅

### Remaining diff (minor)

- `supportsImages` capability on `AcpRuntimeCapabilities` — allows runtimes to advertise image support
- `ImageContent` re-export from `plugin-sdk`
- Test for image-only ACP dispatch

These are small additions that could go in a follow-up if still needed, but the bug this PR was created to fix is already resolved upstream.

**Recommendation:** close this PR.

---

<details>
<summary>Original description</summary>

Fix silent discard of image-only messages sent via channels using ACP dispatch. Add `images` field to ACP turn input types. Fix empty-prompt guard to also consider images (not just text). Pass images through the full dispatch chain.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)