### PR TITLE
fix(sessions): persist default model identity for /models checkmark

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -59,6 +59,16 @@ describe("cron schedule", () => {
     expect(next).toBe(anchor + 30_000);
   });
 
+  it("never returns a past timestamp for Asia/Shanghai daily schedule (#30351)", () => {
+    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+      nowMs,
+    );
+    expect(next).toBeDefined();
+    expect(next!).toBeGreaterThan(nowMs);
+  });
+
   describe("cron with specific seconds (6-field pattern)", () => {
     // Pattern: fire at exactly second 0 of minute 0 of hour 12 every day
     const dailyNoon = { kind: "cron" as const, expr: "0 0 12 * * *", tz: "UTC" };

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -63,6 +63,33 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect((entry.updatedAt ?? 0) > before).toBe(true);
   });
 
+  it("persists default model on entry so /models menu shows checkmark (#30476)", () => {
+    const before = Date.now() - 5_000;
+    const entry: SessionEntry = {
+      sessionId: "sess-default",
+      updatedAt: before,
+      modelProvider: "openai",
+      model: "gpt-5.2",
+      providerOverride: "openai",
+      modelOverride: "gpt-5.2",
+    };
+
+    const result = applyModelOverrideToSessionEntry({
+      entry,
+      selection: {
+        provider: "google",
+        model: "gemini-3-flash-preview",
+        isDefault: true,
+      },
+    });
+
+    expect(result.updated).toBe(true);
+    expect(entry.providerOverride).toBeUndefined();
+    expect(entry.modelOverride).toBeUndefined();
+    expect(entry.modelProvider).toBe("google");
+    expect(entry.model).toBe("gemini-3-flash-preview");
+  });
+
   it("retains aligned runtime model fields when selection and runtime already match", () => {
     const before = Date.now() - 5_000;
     const entry: SessionEntry = {

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -42,15 +42,21 @@ export function applyModelOverrideToSessionEntry(params: {
   }
 
   // Model overrides supersede previously recorded runtime model identity.
-  // If runtime fields are stale (or the override changed), clear them so status
-  // surfaces reflect the selected model immediately.
+  // When switching to the default model, persist the default's identity so
+  // /models menu and status surfaces can still show a checkmark (#30476).
+  // For non-default overrides, clear stale runtime fields so status reflects
+  // the selected model immediately.
   const runtimeModel = typeof entry.model === "string" ? entry.model.trim() : "";
   const runtimeProvider = typeof entry.modelProvider === "string" ? entry.modelProvider.trim() : "";
   const runtimePresent = runtimeModel.length > 0 || runtimeProvider.length > 0;
   const runtimeAligned =
     runtimeModel === selection.model &&
     (runtimeProvider.length === 0 || runtimeProvider === selection.provider);
-  if (runtimePresent && (selectionUpdated || !runtimeAligned)) {
+  if (selection.isDefault && selectionUpdated) {
+    entry.model = selection.model;
+    entry.modelProvider = selection.provider;
+    updated = true;
+  } else if (runtimePresent && (selectionUpdated || !runtimeAligned)) {
     if (entry.model !== undefined) {
       delete entry.model;
       updated = true;


### PR DESCRIPTION
## Summary

- **Problem:** When switching back to the default/primary model via the `/models` menu, the checkmark disappears. The gateway correctly switches the model, but the menu cannot determine which model is active.
- **Why it matters:** Users see no checkmark on any model, creating confusion about which model is selected.
- **What changed:** `src/sessions/model-overrides.ts` — when switching to the default model (`isDefault: true`), persist `selection.model` and `selection.provider` on the session entry instead of deleting them, so status surfaces and `/models` menu can show the active model.
- **What did NOT change:** Non-default override behavior, auth profile overrides, or fallback notice clearing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30476

## User-visible / Behavior Changes

The `/models` menu now correctly shows a checkmark on the primary/default model after switching back to it.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js v22
- Integration/channel: Telegram, Discord, or any channel with /models

### Steps

1. Set `google/gemini-3-flash-preview` as primary model
2. Use `/models` to switch to another model (e.g. claude-haiku-4-5)
3. Use `/models` to switch back to gemini-3-flash-preview
4. Open `/models` menu again

### Expected

- Checkmark appears next to gemini-3-flash-preview

### Actual

- Before fix: Checkmark missing (no model appears selected)
- After fix: Checkmark correctly shown on the default model

## Evidence

```
✓ src/sessions/model-overrides.test.ts (4 tests) 2ms
  ✓ persists default model on entry so /models menu shows checkmark (#30476)
```

## Human Verification (required)

- Verified scenarios: All 4 tests pass (3 existing + 1 new regression test)
- Edge cases checked: Default switch, non-default switch, aligned runtime fields
- What I did **not** verify: Live menu rendering in Telegram/Discord

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/sessions/model-overrides.ts`
- Known bad symptoms: Session entry carries stale model name if default config changes between restarts

## Risks and Mitigations

None — the change only affects the `isDefault` path which previously cleared model identity entirely.
