### PR TITLE
fix(agents): treat Anthropic HTTP 402 as rate limit instead of billing

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -100,6 +100,26 @@ describe("failover-error", () => {
     expect(err?.provider).toBe("anthropic");
   });
 
+  it("treats Anthropic 402 as rate_limit instead of billing (#30484)", () => {
+    expect(
+      resolveFailoverReasonFromError({ status: 402 }, { provider: "anthropic" }),
+    ).toBe("rate_limit");
+    // Non-Anthropic 402 should still be billing
+    expect(resolveFailoverReasonFromError({ status: 402 })).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({ status: 402 }, { provider: "openai" }),
+    ).toBe("billing");
+  });
+
+  it("coerces Anthropic 402 to rate_limit failover error", () => {
+    const err = coerceToFailoverError(
+      { status: 402, message: "Payment Required" },
+      { provider: "anthropic", model: "claude-opus-4-6" },
+    );
+    expect(err?.reason).toBe("rate_limit");
+    expect(err?.provider).toBe("anthropic");
+  });
+
   it("describes non-Error values consistently", () => {
     const described = describeFailoverError(123);
     expect(described.message).toBe("123");

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -151,13 +151,20 @@ export function isTimeoutError(err: unknown): boolean {
   return hasTimeoutHint(cause) || hasTimeoutHint(reason);
 }
 
-export function resolveFailoverReasonFromError(err: unknown): FailoverReason | null {
+export function resolveFailoverReasonFromError(
+  err: unknown,
+  context?: { provider?: string },
+): FailoverReason | null {
   if (isFailoverError(err)) {
     return err.reason;
   }
 
   const status = getStatusCode(err);
   if (status === 402) {
+    // Anthropic Claude Max plan uses HTTP 402 for rate limits, not billing.
+    if (context?.provider?.toLowerCase().trim() === "anthropic") {
+      return "rate_limit";
+    }
     return "billing";
   }
   if (status === 429) {
@@ -195,7 +202,10 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   return classifyFailoverReason(message);
 }
 
-export function describeFailoverError(err: unknown): {
+export function describeFailoverError(
+  err: unknown,
+  context?: { provider?: string },
+): {
   message: string;
   reason?: FailoverReason;
   status?: number;
@@ -212,7 +222,7 @@ export function describeFailoverError(err: unknown): {
   const message = getErrorMessage(err) || String(err);
   return {
     message,
-    reason: resolveFailoverReasonFromError(err) ?? undefined,
+    reason: resolveFailoverReasonFromError(err, context) ?? undefined,
     status: getStatusCode(err),
     code: getErrorCode(err),
   };
@@ -229,7 +239,7 @@ export function coerceToFailoverError(
   if (isFailoverError(err)) {
     return err;
   }
-  const reason = resolveFailoverReasonFromError(err);
+  const reason = resolveFailoverReasonFromError(err, context);
   if (!reason) {
     return null;
   }

--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -59,6 +59,16 @@ describe("cron schedule", () => {
     expect(next).toBe(anchor + 30_000);
   });
 
+  it("never returns a past timestamp for Asia/Shanghai daily schedule (#30351)", () => {
+    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+      nowMs,
+    );
+    expect(next).toBeDefined();
+    expect(next!).toBeGreaterThan(nowMs);
+  });
+
   describe("cron with specific seconds (6-field pattern)", () => {
     // Pattern: fire at exactly second 0 of minute 0 of hour 12 every day
     const dailyNoon = { kind: "cron" as const, expr: "0 0 12 * * *", tz: "UTC" };


### PR DESCRIPTION
## Summary

- **Problem:** Anthropic's Claude Max plan returns HTTP 402 for rate limits, but OpenClaw treats all 402 responses as billing errors, showing a misleading "API key has run out of credits" warning.
- **Why it matters:** Max plan users with valid billing see scary billing error messages and lose retry/backoff behavior when they're simply rate limited.
- **What changed:** `src/agents/failover-error.ts` — `resolveFailoverReasonFromError`, `describeFailoverError`, and `coerceToFailoverError` now accept optional `context.provider`. When provider is `anthropic` and status is 402, the reason is `rate_limit` instead of `billing`.
- **What did NOT change:** Non-Anthropic 402 handling (still treated as billing), message-based billing detection, or retry logic itself.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30484

## User-visible / Behavior Changes

- Anthropic Claude Max users no longer see "API key has run out of credits" when rate limited
- 402 errors from Anthropic now trigger retry/backoff (same as 429) instead of a terminal billing error
- Non-Anthropic providers (OpenAI, Google, etc.) still treat 402 as billing error

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js v22
- Integration/channel: Any channel using Anthropic Claude Max plan

### Steps

1. Use Anthropic Claude Max plan API key
2. Hit rate limit (heavy usage within 5-hour window)
3. Anthropic returns HTTP 402

### Expected

- OpenClaw treats it as rate limit, retries with backoff

### Actual

- Before fix: Shows "API key has run out of credits" billing error
- After fix: Treated as rate limit with retry/backoff

## Evidence

```
✓ src/agents/failover-error.test.ts (15 tests) 4ms
  ✓ treats Anthropic 402 as rate_limit instead of billing (#30484)
  ✓ coerces Anthropic 402 to rate_limit failover error
```

## Human Verification (required)

- Verified scenarios: All 15 tests pass (13 existing + 2 new)
- Edge cases checked: Non-Anthropic 402 still returns billing, Anthropic 429 unchanged
- What I did **not** verify: Live Anthropic Max plan rate limit response

## Compatibility / Migration

- Backward compatible? `Yes` — new `context` parameter is optional
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/failover-error.ts`
- Known bad symptoms: Anthropic billing errors would be misclassified as rate limits (but Anthropic uses 400-series errors for actual billing problems, not 402)

## Risks and Mitigations

If Anthropic changes 402 semantics to mean actual billing errors in the future, this would misclassify them. However, Anthropic's documented billing errors use different status codes and explicit error messages that the message-based detection would still catch.
