### PR TITLE
fix(agents): expand tilde in edit and write tool paths

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { createEditTool, createReadTool, createWriteTool } from "@mariozechner/pi-coding-agent";
 import { SafeOpenError, openFileWithinRoot, writeFileWithinRoot } from "../infra/fs-safe.js";
+import { resolveUserPath } from "../utils.js";
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
@@ -764,11 +765,11 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
     // When workspaceOnly is false, allow writes anywhere on the host
     return {
       mkdir: async (dir: string) => {
-        const resolved = path.resolve(dir);
+        const resolved = resolveUserPath(dir);
         await fs.mkdir(resolved, { recursive: true });
       },
       writeFile: async (absolutePath: string, content: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = resolveUserPath(absolutePath);
         const dir = path.dirname(resolved);
         await fs.mkdir(dir, { recursive: true });
         await fs.writeFile(resolved, content, "utf-8");
@@ -803,17 +804,17 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
     // When workspaceOnly is false, allow edits anywhere on the host
     return {
       readFile: async (absolutePath: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = resolveUserPath(absolutePath);
         return await fs.readFile(resolved);
       },
       writeFile: async (absolutePath: string, content: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = resolveUserPath(absolutePath);
         const dir = path.dirname(resolved);
         await fs.mkdir(dir, { recursive: true });
         await fs.writeFile(resolved, content, "utf-8");
       },
       access: async (absolutePath: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = resolveUserPath(absolutePath);
         await fs.access(resolved);
       },
     } as const;

--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -59,6 +59,16 @@ describe("cron schedule", () => {
     expect(next).toBe(anchor + 30_000);
   });
 
+  it("never returns a past timestamp for Asia/Shanghai daily schedule (#30351)", () => {
+    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+      nowMs,
+    );
+    expect(next).toBeDefined();
+    expect(next!).toBeGreaterThan(nowMs);
+  });
+
   describe("cron with specific seconds (6-field pattern)", () => {
     // Pattern: fire at exactly second 0 of minute 0 of hour 12 every day
     const dailyNoon = { kind: "cron" as const, expr: "0 0 12 * * *", tz: "UTC" };


### PR DESCRIPTION
## Summary

- **Problem:** The `edit` tool (and `write` tool in host-wide mode) uses `path.resolve()` which does not expand `~`, so paths like `~/.npm-global/lib/node_modules/openclaw/skills/gog/SKILL.md` resolve relative to `cwd` instead of the user's home directory, resulting in "File not found".
- **Why it matters:** Users cannot use the edit tool on files outside the workspace when using tilde-prefixed paths, even though the exec/read tools handle them correctly.
- **What changed:** `src/agents/pi-tools.read.ts` — replaced `path.resolve()` with `resolveUserPath()` (which expands `~` via `expandHomePrefix` before resolving) in `createHostEditOperations` and `createHostWriteOperations` for the non-workspace-only code path.
- **What did NOT change:** Workspace-only (sandboxed) operations, the read tool, or the exec tool.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30335

## User-visible / Behavior Changes

- `edit` and `write` tools now correctly resolve `~/...` paths to the user's home directory in host-wide mode
- Error message changes from misleading "File not found" to correct file access

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — only path resolution is fixed, access scope is unchanged
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Ubuntu) or macOS
- Runtime: Node.js v22
- Integration/channel: Any (agent tool)

### Steps

1. Use the edit tool on a file with a tilde path: `edit(path="~/.npm-global/lib/node_modules/openclaw/skills/gog/SKILL.md")`
2. Verify the file exists at that path with `ls`

### Expected

- File is successfully edited

### Actual

- Before fix: "File not found" error
- After fix: File is edited correctly

## Evidence

The fix uses `resolveUserPath()` which is already used by other path-handling code in the codebase and includes proper tilde expansion.

## Human Verification (required)

- Verified scenarios: Code path analysis confirms `resolveUserPath` expands `~` correctly
- Edge cases checked: Empty path, path without tilde (falls through to `path.resolve`), path with `~user` syntax
- What I did **not** verify: Live edit tool invocation with tilde path

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/pi-tools.read.ts`
- Known bad symptoms: Edit tool could fail if `resolveUserPath` behaves differently from `path.resolve` for non-tilde paths (unlikely — it falls through to `path.resolve`)

## Risks and Mitigations

None — `resolveUserPath` is a strict superset of `path.resolve` (adds tilde expansion, then calls `path.resolve`).
