### PR TITLE
fix(tools): expand tilde in toRelativePathInRoot path validation

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { createEditTool, createReadTool, createWriteTool } from "@mariozechner/pi-coding-agent";
 import { SafeOpenError, openFileWithinRoot, writeFileWithinRoot } from "../infra/fs-safe.js";
+import { expandHomePrefix } from "../infra/home-dir.js";
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
@@ -868,8 +869,8 @@ function toRelativePathInRoot(
   candidate: string,
   options?: { allowRoot?: boolean },
 ): string {
-  const rootResolved = path.resolve(root);
-  const resolved = path.resolve(candidate);
+  const rootResolved = path.resolve(expandHomePrefix(root));
+  const resolved = path.resolve(expandHomePrefix(candidate));
   const relative = path.relative(rootResolved, resolved);
   if (relative === "" || relative === ".") {
     if (options?.allowRoot) {

--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -59,6 +59,16 @@ describe("cron schedule", () => {
     expect(next).toBe(anchor + 30_000);
   });
 
+  it("never returns a past timestamp for Asia/Shanghai daily schedule (#30351)", () => {
+    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+      nowMs,
+    );
+    expect(next).toBeDefined();
+    expect(next!).toBeGreaterThan(nowMs);
+  });
+
   describe("cron with specific seconds (6-field pattern)", () => {
     // Pattern: fire at exactly second 0 of minute 0 of hour 12 every day
     const dailyNoon = { kind: "cron" as const, expr: "0 0 12 * * *", tz: "UTC" };


### PR DESCRIPTION
## Summary

- **Problem:** Write tool in isolated cron `agentTurn` jobs reports failure (`lastRunStatus: "error"`) even when files are successfully created on disk. `consecutiveErrors` increments indefinitely.
- **Why it matters:** Every isolated cron job that writes memory files (e.g. morning standups) shows persistent error state despite working correctly, making monitoring unreliable.
- **What changed:** `toRelativePathInRoot` in `src/agents/pi-tools.read.ts` now applies `expandHomePrefix()` to both `root` and `candidate` before `path.resolve()`, matching the expansion already done in `fs-safe.ts`.
- **What did NOT change:** `writeFileWithinRoot` in `fs-safe.ts` (already handles tilde), no other tool paths affected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30773

## User-visible / Behavior Changes

- Cron jobs writing to `~/agents/.../memory/` paths will no longer show false errors
- `lastRunStatus` will correctly report `"ok"` when files are written successfully
- `consecutiveErrors` will not increment on successful writes

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu (Linux 6.17.0-14-generic x64)
- Runtime: Node.js
- Integration/channel: Cron (isolated agentTurn)

### Steps

1. Create a cron job with `sessionTarget: "isolated"` and `payload.kind: "agentTurn"`
2. Instruct agent to write to `~/agents/<project>/memory/DATE.md`
3. Observe cron job state

### Expected

- File is written AND `lastRunStatus: "ok"`

### Actual

- Before fix: File is written BUT `lastRunStatus: "error"`, `consecutiveErrors` increments
- After fix: File is written AND `lastRunStatus: "ok"`

## Evidence

Root cause: `path.resolve("~/agents/...")` treats `~` as a literal directory name, producing `$CWD/~/agents/...` instead of `/home/user/agents/...`. The path verification then fails with "Path escapes workspace root" even though `writeFileWithinRoot` (which does expand `~`) succeeded.

Fix adds `expandHomePrefix()` call before `path.resolve()`:
```typescript
const rootResolved = path.resolve(expandHomePrefix(root));
const resolved = path.resolve(expandHomePrefix(candidate));
```

## Human Verification (required)

- Verified scenarios: tilde paths resolve correctly after fix, non-tilde paths unaffected
- Edge cases checked: absolute paths, relative paths without tilde
- What I did **not** verify: Windows-specific path handling

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the commit
- Files/config to restore: `src/agents/pi-tools.read.ts`
- Known bad symptoms: Write tool path validation would break for tilde paths

## Risks and Mitigations

None — `expandHomePrefix` is already used extensively throughout the codebase for the same purpose.

