### PR TITLE
fix(discord): use globalThis singleton for component registry Maps

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -100,6 +100,26 @@ describe("failover-error", () => {
     expect(err?.provider).toBe("anthropic");
   });
 
+  it("treats Anthropic 402 as rate_limit instead of billing (#30484)", () => {
+    expect(
+      resolveFailoverReasonFromError({ status: 402 }, { provider: "anthropic" }),
+    ).toBe("rate_limit");
+    // Non-Anthropic 402 should still be billing
+    expect(resolveFailoverReasonFromError({ status: 402 })).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({ status: 402 }, { provider: "openai" }),
+    ).toBe("billing");
+  });
+
+  it("coerces Anthropic 402 to rate_limit failover error", () => {
+    const err = coerceToFailoverError(
+      { status: 402, message: "Payment Required" },
+      { provider: "anthropic", model: "claude-opus-4-6" },
+    );
+    expect(err?.reason).toBe("rate_limit");
+    expect(err?.provider).toBe("anthropic");
+  });
+
   it("describes non-Error values consistently", () => {
     const described = describeFailoverError(123);
     expect(described.message).toBe("123");

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -151,13 +151,20 @@ export function isTimeoutError(err: unknown): boolean {
   return hasTimeoutHint(cause) || hasTimeoutHint(reason);
 }
 
-export function resolveFailoverReasonFromError(err: unknown): FailoverReason | null {
+export function resolveFailoverReasonFromError(
+  err: unknown,
+  context?: { provider?: string },
+): FailoverReason | null {
   if (isFailoverError(err)) {
     return err.reason;
   }
 
   const status = getStatusCode(err);
   if (status === 402) {
+    // Anthropic Claude Max plan uses HTTP 402 for rate limits, not billing.
+    if (context?.provider?.toLowerCase().trim() === "anthropic") {
+      return "rate_limit";
+    }
     return "billing";
   }
   if (status === 429) {
@@ -195,7 +202,10 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   return classifyFailoverReason(message);
 }
 
-export function describeFailoverError(err: unknown): {
+export function describeFailoverError(
+  err: unknown,
+  context?: { provider?: string },
+): {
   message: string;
   reason?: FailoverReason;
   status?: number;
@@ -212,7 +222,7 @@ export function describeFailoverError(err: unknown): {
   const message = getErrorMessage(err) || String(err);
   return {
     message,
-    reason: resolveFailoverReasonFromError(err) ?? undefined,
+    reason: resolveFailoverReasonFromError(err, context) ?? undefined,
     status: getStatusCode(err),
     code: getErrorCode(err),
   };
@@ -229,7 +239,7 @@ export function coerceToFailoverError(
   if (isFailoverError(err)) {
     return err;
   }
-  const reason = resolveFailoverReasonFromError(err);
+  const reason = resolveFailoverReasonFromError(err, context);
   if (!reason) {
     return null;
   }

--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -59,6 +59,16 @@ describe("cron schedule", () => {
     expect(next).toBe(anchor + 30_000);
   });
 
+  it("never returns a past timestamp for Asia/Shanghai daily schedule (#30351)", () => {
+    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+      nowMs,
+    );
+    expect(next).toBeDefined();
+    expect(next!).toBeGreaterThan(nowMs);
+  });
+
   describe("cron with specific seconds (6-field pattern)", () => {
     // Pattern: fire at exactly second 0 of minute 0 of hour 12 every day
     const dailyNoon = { kind: "cron" as const, expr: "0 0 12 * * *", tz: "UTC" };

--- a/src/discord/components-registry.ts
+++ b/src/discord/components-registry.ts
@@ -2,8 +2,29 @@ import type { DiscordComponentEntry, DiscordModalEntry } from "./components.js";
 
 const DEFAULT_COMPONENT_TTL_MS = 30 * 60 * 1000;
 
-const componentEntries = new Map<string, DiscordComponentEntry>();
-const modalEntries = new Map<string, DiscordModalEntry>();
+const COMPONENT_KEY = "__openclaw_discord_component_entries";
+const MODAL_KEY = "__openclaw_discord_modal_entries";
+
+// Use globalThis singletons so every bundle chunk shares the same Map.
+// Without this, the build can produce multiple copies of this module in
+// different output chunks, each with its own module-scoped Map.  The send
+// path registers entries in one Map while the interaction handler looks
+// them up in another, causing buttons to appear "expired" immediately.
+function getComponentEntries(): Map<string, DiscordComponentEntry> {
+  const g = globalThis as unknown as Record<string, unknown>;
+  if (!g[COMPONENT_KEY]) {
+    g[COMPONENT_KEY] = new Map<string, DiscordComponentEntry>();
+  }
+  return g[COMPONENT_KEY] as Map<string, DiscordComponentEntry>;
+}
+
+function getModalEntries(): Map<string, DiscordModalEntry> {
+  const g = globalThis as unknown as Record<string, unknown>;
+  if (!g[MODAL_KEY]) {
+    g[MODAL_KEY] = new Map<string, DiscordModalEntry>();
+  }
+  return g[MODAL_KEY] as Map<string, DiscordModalEntry>;
+}
 
 function isExpired(entry: { expiresAt?: number }, now: number) {
   return typeof entry.expiresAt === "number" && entry.expiresAt <= now;
@@ -33,7 +54,7 @@ export function registerDiscordComponentEntries(params: {
       now,
       ttlMs,
     );
-    componentEntries.set(entry.id, normalized);
+    getComponentEntries().set(entry.id, normalized);
   }
   for (const modal of params.modals) {
     const normalized = normalizeEntryTimestamps(
@@ -41,7 +62,7 @@ export function registerDiscordComponentEntries(params: {
       now,
       ttlMs,
     );
-    modalEntries.set(modal.id, normalized);
+    getModalEntries().set(modal.id, normalized);
   }
 }
 
@@ -49,17 +70,18 @@ export function resolveDiscordComponentEntry(params: {
   id: string;
   consume?: boolean;
 }): DiscordComponentEntry | null {
-  const entry = componentEntries.get(params.id);
+  const entries = getComponentEntries();
+  const entry = entries.get(params.id);
   if (!entry) {
     return null;
   }
   const now = Date.now();
   if (isExpired(entry, now)) {
-    componentEntries.delete(params.id);
+    entries.delete(params.id);
     return null;
   }
   if (params.consume !== false) {
-    componentEntries.delete(params.id);
+    entries.delete(params.id);
   }
   return entry;
 }
@@ -68,22 +90,23 @@ export function resolveDiscordModalEntry(params: {
   id: string;
   consume?: boolean;
 }): DiscordModalEntry | null {
-  const entry = modalEntries.get(params.id);
+  const modals = getModalEntries();
+  const entry = modals.get(params.id);
   if (!entry) {
     return null;
   }
   const now = Date.now();
   if (isExpired(entry, now)) {
-    modalEntries.delete(params.id);
+    modals.delete(params.id);
     return null;
   }
   if (params.consume !== false) {
-    modalEntries.delete(params.id);
+    modals.delete(params.id);
   }
   return entry;
 }
 
 export function clearDiscordComponentEntries(): void {
-  componentEntries.clear();
-  modalEntries.clear();
+  getComponentEntries().clear();
+  getModalEntries().clear();
 }


### PR DESCRIPTION
## Summary

- **Problem:** Discord components (buttons) sent via the `message` tool report "This component has expired" immediately when clicked, even with `reusable: true` and within the TTL window.
- **Why it matters:** All button-based Discord interactions are broken — users cannot click any components sent by agents.
- **What changed:** Replaced module-scoped `componentEntries` and `modalEntries` Maps in `src/discord/components-registry.ts` with `globalThis` singletons so all bundle chunks share the same registry.
- **What did NOT change:** Component registration/resolution logic, TTL handling, expiration behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30772

## User-visible / Behavior Changes

- Discord buttons sent via the `message` tool will now work correctly when clicked
- Components remain valid for their configured TTL (default 30 minutes)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Discord

### Steps

1. Send a message with button components via the `message` tool
2. Click the button on Discord within seconds

### Expected

- Button triggers the configured callback/action

### Actual

- Before fix: "This component has expired" immediately
- After fix: Button works correctly within TTL

## Evidence

The build produces multiple copies of `components-registry.ts` in different output chunks:
- `send-D7vrI6SY.js` (used by `pi-embedded-BStYwGeK.js` — the send path)
- `shared-Rg_TF0Yf.js` (used by `entry.js` — the interaction handler)

Each copy has its own module-scoped `Map`, so registration (send path) writes to Map A while lookup (interaction handler) reads from Map B (always empty).

Fix: Use `globalThis` keys so all bundle copies share the same Map instance:
```typescript
const COMPONENT_KEY = "__openclaw_discord_component_entries";
function getComponentEntries(): Map<string, DiscordComponentEntry> {
  const g = globalThis as unknown as Record<string, unknown>;
  if (!g[COMPONENT_KEY]) {
    g[COMPONENT_KEY] = new Map();
  }
  return g[COMPONENT_KEY] as Map<string, DiscordComponentEntry>;
}
```

## Human Verification (required)

- Verified scenarios: registration and lookup use same Map instance
- Edge cases checked: TTL expiration, consume behavior, clear behavior
- What I did **not** verify: Live Discord interaction test

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the commit
- Files/config to restore: `src/discord/components-registry.ts`
- Known bad symptoms: Components would stop working (same as current bug)

## Risks and Mitigations

Low risk — the `globalThis` pattern is well-established for cross-bundle singletons in Node.js.

