### PR TITLE
fix(usage): prevent negative token counts for OpenAI-format cache stats

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -59,6 +59,16 @@ describe("cron schedule", () => {
     expect(next).toBe(anchor + 30_000);
   });
 
+  it("never returns a past timestamp for Asia/Shanghai daily schedule (#30351)", () => {
+    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+      nowMs,
+    );
+    expect(next).toBeDefined();
+    expect(next!).toBeGreaterThan(nowMs);
+  });
+
   describe("cron with specific seconds (6-field pattern)", () => {
     // Pattern: fire at exactly second 0 of minute 0 of hour 12 every day
     const dailyNoon = { kind: "cron" as const, expr: "0 0 12 * * *", tz: "UTC" };


### PR DESCRIPTION
## Summary

- **Problem:** Token counting shows negative values and incorrect cache statistics when using OpenAI-compatible API format (e.g. Claude via OpenAI-format proxy). `derivePromptTokens` double-counts cached tokens because `prompt_tokens` already includes them.
- **Why it matters:** Users see confusing negative token counts in the UI, making usage monitoring unreliable.
- **What changed:** `normalizeUsage` in `src/agents/usage.ts` now detects OpenAI-style cache fields (`prompt_tokens` + `cached_tokens`/`prompt_tokens_details.cached_tokens`) and subtracts cache from the total to derive the uncached `input` portion. Clamped to zero to prevent negatives.
- **What did NOT change:** Anthropic-style `input_tokens` (already uncached) is unaffected. Output tokens, total, and all other usage fields unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30765

## User-visible / Behavior Changes

- Token counts will no longer show negative values for OpenAI-format API responses
- Cache statistics (cache read, uncached input) will be correct for Moonshot/Kimi/OpenAI providers
- `derivePromptTokens` (input + cacheRead + cacheWrite) will return the correct total prompt tokens

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 10
- Runtime: Node.js
- Integration/channel: OpenAI-compatible API

### Steps

1. Configure OpenClaw with an OpenAI-compatible API that returns `prompt_tokens` and `cached_tokens`/`prompt_tokens_details.cached_tokens`
2. Send messages and observe token usage display

### Expected

- All token counts are non-negative
- Cache hit rate and uncached input are correct

### Actual

- Before fix: Negative input tokens, inflated prompt totals (double-counted cache)
- After fix: Correct non-negative values

## Evidence

Semantic difference between providers:
- **Anthropic**: `input_tokens` = uncached only. Total = input + cache_read + cache_write.
- **OpenAI/Moonshot/Kimi**: `prompt_tokens` = total (includes cached). `cached_tokens` is a subset.

Old behavior for Kimi K2 (`prompt_tokens: 1113, cached_tokens: 1024`):
- `input = 1113`, `cacheRead = 1024`
- `derivePromptTokens = 1113 + 1024 = 2137` (wrong, double-counted)

New behavior:
- `input = 1113 - 1024 = 89` (uncached portion)
- `derivePromptTokens = 89 + 1024 = 1113` (correct total)

Tests updated and all 20 pass:
```
✓ src/agents/usage.test.ts (20 tests) 3ms
```

## Human Verification (required)

- Verified scenarios: Anthropic format, OpenAI format, Moonshot cached_tokens, Kimi K2 prompt_tokens_details
- Edge cases checked: cached_tokens > prompt_tokens (clamped to 0), no cache tokens (pass-through), prompt_tokens without cache (unchanged)
- What I did **not** verify: Live API calls with actual OpenAI-format proxy

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the commit
- Files/config to restore: `src/agents/usage.ts`, `src/agents/usage.test.ts`
- Known bad symptoms: Token counts would revert to double-counting for OpenAI-format APIs

## Risks and Mitigations

- Risk: Some proxy/middleware might send `prompt_tokens` as uncached (like Anthropic). Mitigation: The fix only subtracts when both `prompt_tokens` and cache fields exist together, and uses `Math.max(0, ...)` to prevent negatives. If `input_tokens` is present (Anthropic native field), it takes precedence.

