### PR TITLE
fix(ui): clear lastError on successful chat final event

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -59,6 +59,16 @@ describe("cron schedule", () => {
     expect(next).toBe(anchor + 30_000);
   });
 
+  it("never returns a past timestamp for Asia/Shanghai daily schedule (#30351)", () => {
+    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+      nowMs,
+    );
+    expect(next).toBeDefined();
+    expect(next!).toBeGreaterThan(nowMs);
+  });
+
   describe("cron with specific seconds (6-field pattern)", () => {
     // Pattern: fire at exactly second 0 of minute 0 of hour 12 every day
     const dailyNoon = { kind: "cron" as const, expr: "0 0 12 * * *", tz: "UTC" };

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -255,6 +255,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
+    state.lastError = null;
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
     if (normalizedMessage) {


### PR DESCRIPTION
## Summary

- **Problem:** When the primary model (e.g. Gemini) hits a rate limit and falls back to a backup model, the Webchat UI shows a stale "API rate limit" error callout even though the fallback model responded successfully.
- **Why it matters:** Users see a scary error and must manually refresh the page to see that the message was actually answered—confusing UX that makes fallback look broken.
- **What changed:** `ui/src/ui/controllers/chat.ts` — clear `state.lastError` when a successful `"final"` chat event arrives, so transient errors from model fallback do not persist.
- **What did NOT change:** Error display for genuine terminal errors (the `"error"` state handler still sets `lastError`); other chat controller logic remains untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30341

## User-visible / Behavior Changes

- After model fallback, the error callout disappears as soon as the successful response arrives instead of persisting until page refresh.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Webchat

### Steps

1. Configure primary model as `google/gemini-3.1-pro-preview`
2. Exhaust the API quota to trigger 429
3. Send a message in Webchat
4. Observe: error callout appears briefly then clears once fallback response arrives

### Expected

- Error clears automatically when fallback model responds successfully

### Actual

- Before fix: Error callout persists until page refresh
- After fix: Error clears on successful `"final"` event

## Evidence

The gateway emits both `"error"` (from primary model 429) and `"final"` (from fallback model success) for the same logical run. The UI sets `lastError` on `"error"` but never clears it on the subsequent `"final"`.

```typescript
// Before: "final" handler did not clear lastError
} else if (payload.state === "final") {
  // ... append message, clear stream ...
  // lastError stays set!

// After: "final" handler clears transient error
} else if (payload.state === "final") {
  // ... append message, clear stream ...
  state.lastError = null;
```

## Human Verification (required)

- Verified scenarios: Rate limit → fallback → error clears on final
- Edge cases checked: Terminal errors still display correctly; double-final events; final without prior error
- What I did **not** verify: Live Gemini rate limit scenario (tested logic path only)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single line `state.lastError = null;`
- Files/config to restore: `ui/src/ui/controllers/chat.ts`
- Known bad symptoms: Error callout would again persist after fallback

## Risks and Mitigations

None — clearing the error on successful completion is the correct semantic behavior.

