### PR TITLE
fix(discord): log attachment download failures and add fetch timeout

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -59,6 +59,16 @@ describe("cron schedule", () => {
     expect(next).toBe(anchor + 30_000);
   });
 
+  it("never returns a past timestamp for Asia/Shanghai daily schedule (#30351)", () => {
+    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+      nowMs,
+    );
+    expect(next).toBeDefined();
+    expect(next!).toBeGreaterThan(nowMs);
+  });
+
   describe("cron with specific seconds (6-field pattern)", () => {
     // Pattern: fire at exactly second 0 of minute 0 of hour 12 every day
     const dailyNoon = { kind: "cron" as const, expr: "0 0 12 * * *", tz: "UTC" };

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -2,6 +2,7 @@ import type { ChannelType, Client, Message } from "@buape/carbon";
 import { StickerFormatType, type APIAttachment, type APIStickerItem } from "discord-api-types/v10";
 import { buildMediaPayload } from "../../channels/plugins/media-payload.js";
 import { logVerbose } from "../../globals.js";
+import { getLogger } from "../../logging/logger.js";
 import { fetchRemoteMedia, type FetchLike } from "../../media/fetch.js";
 import { saveMediaBuffer } from "../../media/store.js";
 
@@ -228,6 +229,7 @@ async function appendResolvedMediaFromAttachments(params: {
         filePathHint: attachment.filename ?? attachment.url,
         maxBytes: params.maxBytes,
         fetchImpl: params.fetchImpl,
+        timeoutMs: 60_000,
       });
       const saved = await saveMediaBuffer(
         fetched.buffer,
@@ -242,7 +244,7 @@ async function appendResolvedMediaFromAttachments(params: {
       });
     } catch (err) {
       const id = attachment.id ?? attachment.url;
-      logVerbose(`${params.errorPrefix} ${id}: ${String(err)}`);
+      getLogger().warn({ err, attachmentId: id }, `${params.errorPrefix} ${id}: ${String(err)}`);
     }
   }
 }
@@ -320,6 +322,7 @@ async function appendResolvedMediaFromStickers(params: {
           filePathHint: candidate.fileName,
           maxBytes: params.maxBytes,
           fetchImpl: params.fetchImpl,
+          timeoutMs: 60_000,
         });
         const saved = await saveMediaBuffer(
           fetched.buffer,
@@ -339,7 +342,10 @@ async function appendResolvedMediaFromStickers(params: {
       }
     }
     if (lastError) {
-      logVerbose(`${params.errorPrefix} ${sticker.id}: ${formatStickerError(lastError)}`);
+      getLogger().warn(
+        { err: lastError, stickerId: sticker.id },
+        `${params.errorPrefix} ${sticker.id}: ${formatStickerError(lastError)}`,
+      );
     }
   }
 }

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -31,6 +31,7 @@ type FetchMediaOptions = {
   filePathHint?: string;
   maxBytes?: number;
   maxRedirects?: number;
+  timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
 };
@@ -87,6 +88,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     filePathHint,
     maxBytes,
     maxRedirects,
+    timeoutMs,
     ssrfPolicy,
     lookupFn,
   } = options;
@@ -100,6 +102,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
       fetchImpl,
       init: requestInit,
       maxRedirects,
+      timeoutMs,
       policy: ssrfPolicy,
       lookupFn,
     });


### PR DESCRIPTION
## Summary

- **Problem:** Discord attachment download errors are caught and logged via `logVerbose`, which is a no-op in production. Failed attachments are silently skipped, and users receive no error or feedback — the agent gets a placeholder like `"<media:document> (1 file)"` with no actual media attached.
- **Why it matters:** Users send PDFs/images expecting the agent to process them, but get no response and no indication the attachment was dropped. Silent failures are impossible to debug.
- **What changed:** `src/discord/monitor/message-utils.ts` — upgraded error logging from `logVerbose` to `getLogger().warn()` for both attachment and sticker download failures; added 60-second fetch timeout via `timeoutMs` parameter. `src/media/fetch.ts` — added `timeoutMs` to `FetchMediaOptions` and passed it through to `fetchWithSsrFGuard`.
- **What did NOT change:** The overall attachment processing flow; successful downloads; the media payload builder; sticker format resolution logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30741

## User-visible / Behavior Changes

- Attachment download failures are now always logged (warn level) regardless of verbose mode
- Downloads that hang longer than 60 seconds are aborted with a timeout error instead of blocking indefinitely

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same Discord CDN fetches, just with timeout)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime: Node.js
- Integration/channel: Discord

### Steps

1. Send a message with a PDF attachment in a Discord channel monitored by OpenClaw
2. If the Discord CDN is slow or flaky, the download may fail
3. Check the gateway log for a warn-level message about the download failure

### Expected

- Failed downloads are logged at warn level
- Downloads time out after 60 seconds instead of hanging indefinitely

### Actual

- Before fix: Failures silently swallowed; no log in production
- After fix: Failures logged with attachment ID and error details

## Evidence

```typescript
// Before: errors only logged when verbose mode is on
} catch (err) {
  const id = attachment.id ?? attachment.url;
  logVerbose(`${params.errorPrefix} ${id}: ${String(err)}`);
}

// After: errors always logged at warn level
} catch (err) {
  const id = attachment.id ?? attachment.url;
  getLogger().warn({ err, attachmentId: id }, `${params.errorPrefix} ${id}: ${String(err)}`);
}
```

## Human Verification (required)

- Verified scenarios: Successful attachment download; failed download logged at warn; sticker download with timeout
- Edge cases checked: Empty attachment list; all attachments fail; mixed success/failure
- What I did **not** verify: Live Discord CDN timeout (tested code path only)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert both files
- Files/config to restore: `src/discord/monitor/message-utils.ts`, `src/media/fetch.ts`
- Known bad symptoms: N/A — only adds logging and timeout

## Risks and Mitigations

60-second timeout is generous enough for large files over slow connections. If too aggressive, the `timeoutMs` parameter can be increased.

