### PR TITLE
fix(telegram): resume polling from persisted offset on restart

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -59,6 +59,16 @@ describe("cron schedule", () => {
     expect(next).toBe(anchor + 30_000);
   });
 
+  it("never returns a past timestamp for Asia/Shanghai daily schedule (#30351)", () => {
+    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+      nowMs,
+    );
+    expect(next).toBeDefined();
+    expect(next!).toBeGreaterThan(nowMs);
+  });
+
   describe("cron with specific seconds (6-field pattern)", () => {
     // Pattern: fire at exactly second 0 of minute 0 of hour 12 every day
     const dailyNoon = { kind: "cron" as const, expr: "0 0 12 * * *", tz: "UTC" };

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -143,14 +143,29 @@ export function createTelegramBot(opts: TelegramBotOptions) {
 
   const bot = new Bot(opts.token, client ? { client } : undefined);
   bot.api.config.use(apiThrottler());
+
+  const initialUpdateId =
+    typeof opts.updateOffset?.lastUpdateId === "number" ? opts.updateOffset.lastUpdateId : null;
+
+  if (initialUpdateId !== null) {
+    const minOffset = initialUpdateId + 1;
+    bot.api.config.use((prev, method, payload, signal) => {
+      if (method === "getUpdates") {
+        const p = payload as Record<string, unknown>;
+        if (typeof p.offset !== "number" || p.offset < minOffset) {
+          p.offset = minOffset;
+        }
+      }
+      return prev(method, payload, signal);
+    });
+  }
+
   // Catch all errors from bot middleware to prevent unhandled rejections
   bot.catch((err) => {
     runtime.error?.(danger(`telegram bot error: ${formatUncaughtError(err)}`));
   });
 
   const recentUpdates = createTelegramUpdateDedupe();
-  const initialUpdateId =
-    typeof opts.updateOffset?.lastUpdateId === "number" ? opts.updateOffset.lastUpdateId : null;
 
   // Track update_ids that have entered the middleware pipeline but have not completed yet.
   // This includes updates that are "queued" behind sequentialize(...) for a chat/topic key.


### PR DESCRIPTION
## Summary

- **Problem:** When the gateway crashes or restarts, Telegram messages received during downtime (or queued but not yet processed) are permanently lost. The grammY runner's internal update fetcher starts with `offset=0` and advances the offset immediately after receiving updates—before they are processed—confirming them with Telegram on the next `getUpdates` call.
- **Why it matters:** Users send messages during gateway downtime expecting a response when it comes back, but those messages are silently dropped with no indication.
- **What changed:** `src/telegram/bot.ts` — added a grammY API transformer that enforces a minimum offset on `getUpdates` calls based on the persisted safe watermark. On restart, the runner resumes from the last safely-processed update ID instead of from zero.
- **What did NOT change:** The existing `shouldSkipUpdate` dedup middleware; the `maybePersistSafeWatermark` watermark logic; the grammY runner configuration; the polling cycle restart logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30647

## User-visible / Behavior Changes

- Messages sent during gateway downtime are now replayed on restart instead of being permanently lost
- The first `getUpdates` call after restart starts from the last safely-processed offset

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same `getUpdates` API, just different offset parameter)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 22.04
- Runtime: Node.js 22
- Integration/channel: Telegram (long polling)

### Steps

1. Start gateway with Telegram long polling
2. Send a message via Telegram
3. Kill/restart the gateway process
4. On restart, observe that the message is replayed (not lost)

### Expected

- Messages from before the crash are replayed on restart

### Actual

- Before fix: Messages confirmed by the runner before processing are permanently lost
- After fix: Runner starts from persisted watermark, preventing premature confirmation

## Evidence

```typescript
// The grammY runner internally does:
//   offset = 0; // always starts at 0
//   updates = getUpdates({ offset });
//   offset = lastUpdateId + 1; // confirms immediately
//
// The fix adds a transformer that enforces the persisted minimum:
if (initialUpdateId !== null) {
  const minOffset = initialUpdateId + 1;
  bot.api.config.use((prev, method, payload, signal) => {
    if (method === "getUpdates") {
      const p = payload as Record<string, unknown>;
      if (typeof p.offset !== "number" || p.offset < minOffset) {
        p.offset = minOffset;
      }
    }
    return prev(method, payload, signal);
  });
}
```

## Human Verification (required)

- Verified scenarios: Restart with persisted offset; no persisted offset (first boot); transformer only applies to getUpdates method
- Edge cases checked: `initialUpdateId` is null (no-op); transformer does not affect other API methods; existing dedup still works
- What I did **not** verify: Live crash/restart with real Telegram messages (tested logic path only)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the transformer block in `bot.ts`
- Files/config to restore: `src/telegram/bot.ts`
- Known bad symptoms: Duplicate message processing on restart (harmless due to existing dedup middleware)

## Risks and Mitigations

Risk: On restart, Telegram may re-deliver some updates that were already processed (between persisted watermark and the runner's internal offset at crash time).
Mitigation: The existing `shouldSkipUpdate` middleware filters these out using the persisted watermark, preventing duplicate processing.

