### PR TITLE
fix(skills): parse envHelp metadata and instruct agent to use howToGet

### DIFF
--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -88,6 +88,11 @@ export function resolveOpenClawMetadata(
   const requires = resolveOpenClawManifestRequires(metadataObj);
   const install = resolveOpenClawManifestInstall(metadataObj, parseInstallSpec);
   const osRaw = resolveOpenClawManifestOs(metadataObj);
+  const envHelpRaw = metadataObj.envHelp;
+  const envHelp =
+    envHelpRaw && typeof envHelpRaw === "object" && !Array.isArray(envHelpRaw)
+      ? (envHelpRaw as Record<string, { howToGet?: string; label?: string }>)
+      : undefined;
   return {
     always: typeof metadataObj.always === "boolean" ? metadataObj.always : undefined,
     emoji: typeof metadataObj.emoji === "string" ? metadataObj.emoji : undefined,
@@ -97,6 +102,7 @@ export function resolveOpenClawMetadata(
     os: osRaw.length > 0 ? osRaw : undefined,
     requires: requires,
     install: install.length > 0 ? install : undefined,
+    envHelp,
   };
 }
 

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -16,6 +16,11 @@ export type SkillInstallSpec = {
   targetDir?: string;
 };
 
+export type EnvHelpEntry = {
+  howToGet?: string;
+  label?: string;
+};
+
 export type OpenClawSkillMetadata = {
   always?: boolean;
   skillKey?: string;
@@ -30,6 +35,7 @@ export type OpenClawSkillMetadata = {
     config?: string[];
   };
   install?: SkillInstallSpec[];
+  envHelp?: Record<string, EnvHelpEntry>;
 };
 
 export type SkillInvocationPolicy = {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -29,6 +29,7 @@ function buildSkillsSection(params: { skillsPrompt?: string; readToolName: strin
     "- If multiple could apply: choose the most specific one, then read/follow it.",
     "- If none clearly apply: do not read any SKILL.md.",
     "Constraints: never read more than one skill up front; only read after selecting.",
+    "- When helping users configure a skill's environment variables or API credentials, use the `envHelp.howToGet` instructions from the SKILL.md metadata as the authoritative source. Do not generate setup steps from your own knowledge — the skill author's instructions override model training data.",
     trimmed,
     "",
   ];

--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -59,6 +59,16 @@ describe("cron schedule", () => {
     expect(next).toBe(anchor + 30_000);
   });
 
+  it("never returns a past timestamp for Asia/Shanghai daily schedule (#30351)", () => {
+    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+      nowMs,
+    );
+    expect(next).toBeDefined();
+    expect(next!).toBeGreaterThan(nowMs);
+  });
+
   describe("cron with specific seconds (6-field pattern)", () => {
     // Pattern: fire at exactly second 0 of minute 0 of hour 12 every day
     const dailyNoon = { kind: "cron" as const, expr: "0 0 12 * * *", tz: "UTC" };


### PR DESCRIPTION
## Summary

- **Problem:** When a skill provides `envHelp.howToGet` instructions for environment variable setup, the agent ignores them and generates setup guides from its own training data—producing wrong URLs, incorrect permission recommendations, and missing critical steps (e.g., omitting bucket policy setup that causes 403 AccessDenied).
- **Why it matters:** Users following AI-generated setup guides fail to configure skills correctly. Wrong instructions can also create security risks (e.g., recommending TOSFullAccess instead of least-privilege bucket policies).
- **What changed:** `src/agents/skills/types.ts` — added `EnvHelpEntry` type and `envHelp` field to `OpenClawSkillMetadata`. `src/agents/skills/frontmatter.ts` — parse `envHelp` from SKILL.md frontmatter. `src/agents/system-prompt.ts` — added instruction directing the agent to treat `envHelp.howToGet` as the authoritative source for credential setup.
- **What did NOT change:** Skill loading; skill prompt formatting; install engine; the agent's general skill-following behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30681

## User-visible / Behavior Changes

- When helping configure a skill's environment variables, the agent now prioritizes the `envHelp.howToGet` instructions from SKILL.md over its own training data
- `envHelp` is now parsed from skill frontmatter and available in the skill metadata type

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Any (skill installation flow)

### Steps

1. Install a skill with `envHelp.howToGet` in its SKILL.md (e.g., doubao-asr)
2. Ask the agent to help configure the skill's credentials
3. Observe: agent follows the howToGet instructions instead of generating from training data

### Expected

- Agent uses howToGet instructions (correct URLs, correct permission steps)

### Actual

- Before fix: Agent ignores howToGet and generates wrong instructions from training data
- After fix: System prompt instructs agent to use howToGet as authoritative source

## Evidence

```typescript
// System prompt addition:
"When helping users configure a skill's environment variables or API credentials,
 use the envHelp.howToGet instructions from the SKILL.md metadata as the
 authoritative source. Do not generate setup steps from your own knowledge —
 the skill author's instructions override model training data."
```

## Human Verification (required)

- Verified scenarios: Skill with envHelp parsed correctly; system prompt includes new instruction; skills without envHelp unaffected
- Edge cases checked: envHelp is null/undefined; envHelp is not an object; nested howToGet fields
- What I did **not** verify: Live agent behavior with MaxClaw/MiniMax model (tested parsing and prompt construction)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert all three files
- Files/config to restore: `src/agents/system-prompt.ts`, `src/agents/skills/types.ts`, `src/agents/skills/frontmatter.ts`
- Known bad symptoms: Agent would revert to generating from training data (pre-existing behavior)

## Risks and Mitigations

Risk: The system prompt instruction is a behavioral hint, not a hard constraint — some models may still fall back to training data.
Mitigation: This is the most impactful change possible without modifying the upstream `formatSkillsForPrompt` in `@mariozechner/pi-coding-agent`. Future work could inject howToGet content directly into the skill prompt XML for stronger enforcement.

