### PR TITLE
fix(tts): honor explicit configured provider over persisted prefs [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TTS/OpenAI provider precedence: honor explicit `messages.tts.provider` from config before persisted `/tts` provider preferences so configured OpenAI `model`/`voice` settings are not bypassed by stale runtime preferences. (#22005)
 - Slack/Security ingress mismatch guard: drop slash-command and interaction payloads when app/team identifiers do not match the active Slack account context (including nested `team.id` interaction payloads), preventing cross-app or cross-workspace payload injection into system-event handling. (#29091) Thanks @Solvely-Colin.
 - Cron/Failure alerts: add configurable repeated-failure alerting with per-job overrides and Web UI cron editor support (`inherit|disabled|custom` with threshold/cooldown/channel/target fields). (#24789) Thanks xbrak.
 - Cron/Isolated model defaults: resolve isolated cron `subagents.model` (including object-form `primary`) through allowlist-aware model selection so isolated cron runs honor subagent model defaults unless explicitly overridden by job payload model. (#11474) Thanks @AnonO6.

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { completeSimple, type AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { getApiKeyForModel } from "../agents/model-auth.js";
@@ -396,6 +399,17 @@ describe("tts", () => {
       messages: { tts: {} },
     };
 
+    function withPrefsFile<T>(prefs: Record<string, unknown>, run: (prefsPath: string) => T): T {
+      const dir = mkdtempSync(path.join(tmpdir(), "openclaw-tts-provider-"));
+      const prefsPath = path.join(dir, "tts.json");
+      writeFileSync(prefsPath, JSON.stringify(prefs, null, 2), "utf8");
+      try {
+        return run(prefsPath);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+
     it("selects provider based on available API keys", () => {
       const cases = [
         {
@@ -434,6 +448,31 @@ describe("tts", () => {
           expect(provider).toBe(testCase.expected);
         });
       }
+    });
+
+    it("prefers explicit config provider over persisted prefs provider", () => {
+      const config = resolveTtsConfig({
+        ...baseCfg,
+        messages: {
+          tts: {
+            provider: "openai",
+          },
+        },
+      });
+
+      withPrefsFile({ tts: { provider: "edge" } }, (prefsPath) => {
+        const provider = getTtsProvider(config, prefsPath);
+        expect(provider).toBe("openai");
+      });
+    });
+
+    it("uses persisted prefs provider when config provider is not explicitly set", () => {
+      const config = resolveTtsConfig(baseCfg);
+
+      withPrefsFile({ tts: { provider: "elevenlabs" } }, (prefsPath) => {
+        const provider = getTtsProvider(config, prefsPath);
+        expect(provider).toBe("elevenlabs");
+      });
     });
   });
 

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -428,11 +428,11 @@ export function setTtsEnabled(prefsPath: string, enabled: boolean): void {
 
 export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): TtsProvider {
   const prefs = readPrefs(prefsPath);
-  if (prefs.tts?.provider) {
-    return prefs.tts.provider;
-  }
   if (config.providerSource === "config") {
     return config.provider;
+  }
+  if (prefs.tts?.provider) {
+    return prefs.tts.provider;
   }
 
   if (resolveTtsApiKey(config, "openai")) {


### PR DESCRIPTION
## Summary
- Make `getTtsProvider` honor explicit `messages.tts.provider` config before persisted `/tts` provider preferences.
- Preserve existing fallback behavior when no explicit provider is configured (prefs provider, then API-key based auto-selection).
- Add regression tests for both precedence paths, and update `CHANGELOG.md` in Unreleased fixes.

Closes #22005

## Security Impact
- None. This only changes provider selection precedence for TTS and adds tests.

## Repro
1. Configure `messages.tts.provider=openai` with `messages.tts.openai.model` and `messages.tts.openai.voice`.
2. Ensure persisted TTS prefs file contains `tts.provider=edge` (or `elevenlabs`).
3. Trigger TTS.

## Expected
- Explicit config provider (`openai`) is used, so configured `model` and `voice` apply.

## Actual before this PR
- Persisted prefs provider could override explicit config provider, bypassing OpenAI `model` and `voice` settings.

## Verification
- `pnpm exec oxfmt --check src/tts/tts.ts src/tts/tts.test.ts CHANGELOG.md`
- `pnpm exec oxlint --type-aware src/tts/tts.ts src/tts/tts.test.ts`
- `pnpm exec vitest run src/tts/tts.test.ts`
- `pnpm build`
- `pnpm check` *(fails in this environment due missing optional extension dependencies unrelated to this change, e.g. `@opentelemetry/*`, `@vector-im/matrix-bot-sdk`, `@twurple/*`)*

## Scope Boundary
- Does not change TTS synthesis payload building, directive parsing, or provider fallback order beyond explicit-config precedence.
