### PR TITLE
fix(models): normalize auth profile env templates for apiKey fallback [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Docs: https://docs.openclaw.ai
 - Config/Doctor group allowlist diagnostics: align `groupPolicy: "allowlist"` warnings with per-channel runtime semantics by excluding Google Chat sender-list checks and by warning when no-fallback channels (for example iMessage) omit `groupAllowFrom`, with regression coverage. (#28477) Thanks @tonydehnke.
 - Slack/Disabled channel startup: skip Slack monitor socket startup entirely when `channels.slack.enabled=false` (including configs that still contain valid tokens), preventing disabled accounts from opening websocket connections. (#30586)
 - Onboarding/Custom providers: use Azure OpenAI-specific verification auth/payload shape (`api-key`, deployment-path chat completions payload) when probing Azure endpoints so valid Azure custom-provider setup no longer fails preflight. (#29421) Thanks @kunalk16.
+- Models/Auth profiles: normalize `${ENV_VAR}` templates found in `auth-profiles.json` API key/token fields when inferring provider `apiKey` fallbacks, so model providers no longer receive literal `${...}` credentials from profile-sourced defaults. (#7254)
 - Feishu/Docx editing tools: add `feishu_doc` positional insert, table row/column operations, table-cell merge, and color-text updates; switch markdown write/append/insert to Descendant API insertion with large-document batching; and harden image uploads for data URI/base64/local-path inputs with strict validation and routing-safe upload metadata. (#29411) Thanks @Elarwei001.
 
 ## 2026.2.26

--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -88,6 +88,70 @@ describe("models-config", () => {
       }
     });
   });
+
+  it("fills missing provider.apiKey from auth profile ${ENV} template", async () => {
+    await withTempHome(async () => {
+      const prevKey = process.env.MINIMAX_API_KEY;
+      process.env.MINIMAX_API_KEY = "sk-minimax-from-auth-profile";
+      try {
+        const agentDir = resolveOpenClawAgentDir();
+        await fs.mkdir(agentDir, { recursive: true });
+        await fs.writeFile(
+          path.join(agentDir, "auth-profiles.json"),
+          JSON.stringify(
+            {
+              version: 1,
+              profiles: {
+                "minimax:default": {
+                  type: "api_key",
+                  provider: "minimax",
+                  key: "${MINIMAX_API_KEY}",
+                },
+              },
+            },
+            null,
+            2,
+          ),
+          "utf8",
+        );
+
+        const cfg: OpenClawConfig = {
+          models: {
+            providers: {
+              minimax: {
+                baseUrl: "https://api.minimax.io/anthropic",
+                api: "anthropic-messages",
+                models: [
+                  {
+                    id: "MiniMax-M2.1",
+                    name: "MiniMax M2.1",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 200000,
+                    maxTokens: 8192,
+                  },
+                ],
+              },
+            },
+          },
+        };
+
+        await ensureOpenClawModelsJson(cfg, agentDir);
+
+        const parsed = await readGeneratedModelsJson<{
+          providers: Record<string, { apiKey?: string }>;
+        }>();
+        expect(parsed.providers.minimax?.apiKey).toBe("MINIMAX_API_KEY");
+      } finally {
+        if (prevKey === undefined) {
+          delete process.env.MINIMAX_API_KEY;
+        } else {
+          process.env.MINIMAX_API_KEY = prevKey;
+        }
+      }
+    });
+  });
   it("merges providers by default", async () => {
     await withTempHome(async () => {
       const agentDir = resolveOpenClawAgentDir();

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -415,7 +415,7 @@ function resolveApiKeyFromProfiles(params: {
     }
     if (cred.type === "api_key") {
       if (cred.key?.trim()) {
-        return cred.key;
+        return normalizeApiKeyConfig(cred.key);
       }
       const keyRef = coerceSecretRef(cred.keyRef);
       if (keyRef?.source === "env" && keyRef.id.trim()) {
@@ -425,7 +425,7 @@ function resolveApiKeyFromProfiles(params: {
     }
     if (cred.type === "token") {
       if (cred.token?.trim()) {
-        return cred.token;
+        return normalizeApiKeyConfig(cred.token);
       }
       const tokenRef = coerceSecretRef(cred.tokenRef);
       if (tokenRef?.source === "env" && tokenRef.id.trim()) {


### PR DESCRIPTION
## Summary
- Normalize `${ENV_VAR}` templates in `auth-profiles.json` `key`/`token` fields when inferring provider `apiKey` fallbacks in models config generation.
- Keep existing `keyRef` / `tokenRef` behavior unchanged.
- Add regression test proving `auth-profiles.json` with `key: "${MINIMAX_API_KEY}"` generates provider `apiKey: "MINIMAX_API_KEY"` (instead of literal `${...}`).
- Update `CHANGELOG.md` Unreleased fixes.

Closes #7254

## Security Impact
- None. This change only normalizes credential template syntax before provider fallback inference.

## Repro
1. Put this in `auth-profiles.json`:
   - `"key": "${MINIMAX_API_KEY}"`
2. Leave provider `apiKey` unset in models config (provider has models).
3. Generate models config.

## Expected
- Fallback infers `apiKey` from env-var name (`MINIMAX_API_KEY`), not literal `${MINIMAX_API_KEY}`.

## Actual before this PR
- Literal `${MINIMAX_API_KEY}` could flow into provider fallback path and later auth usage.

## Verification
- `pnpm exec oxfmt --check src/agents/models-config.providers.ts src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts CHANGELOG.md`
- `pnpm exec oxlint --type-aware src/agents/models-config.providers.ts src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts`
- `pnpm exec vitest run src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts`
- `pnpm build`

## Scope Boundary
- Does not change auth profile persistence format.
- Does not change `keyRef`/`tokenRef` resolution logic.
- Does not alter provider fallback order.
