### PR TITLE
fix(webchat): treat attachment-only image turns as media-bearing [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Web UI/Attachment-only chat sends: treat inbound `chat.send` `opts.images` as media-bearing turns in reply preflight so image-only Web UI messages no longer return "I didn't receive any text" before agent run starts. (#30818)
 - Slack/Bot attachment-only messages: when `allowBots: true`, bot messages with empty `text` now include non-forwarded attachment `text`/`fallback` content so webhook alerts are not silently dropped. (#27616)
 - Slack/Security ingress mismatch guard: drop slash-command and interaction payloads when app/team identifiers do not match the active Slack account context (including nested `team.id` interaction payloads), preventing cross-app or cross-workspace payload injection into system-event handling. (#29091) Thanks @Solvely-Colin.
 - Cron/Failure alerts: add configurable repeated-failure alerting with per-job overrides and Web UI cron editor support (`inherit|disabled|custom` with threshold/cooldown/channel/target fields). (#24789) Thanks xbrak.

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -171,6 +171,32 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.prompt).toContain("[User sent media without caption]");
   });
 
+  it("treats opts.images as media when inbound context has no MediaPath", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "webchat",
+        },
+        opts: {
+          images: [
+            {
+              type: "image",
+              mimeType: "image/png",
+              data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=",
+            },
+          ],
+        },
+      }),
+    );
+    expect(result).toEqual({ text: "ok" });
+
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call).toBeTruthy();
+    expect(call?.followupRun.prompt).toContain("[User sent media without caption]");
+  });
+
   it("keeps thread history context on follow-up turns", async () => {
     const result = await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -303,7 +303,9 @@ export async function runPreparedReply(
     : [inboundUserContext, baseBodyFinal].filter(Boolean).join("\n\n");
   const baseBodyTrimmed = baseBodyForPrompt.trim();
   const hasMediaAttachment = Boolean(
-    sessionCtx.MediaPath || (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0),
+    sessionCtx.MediaPath ||
+    (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0) ||
+    (opts?.images && opts.images.length > 0),
   );
   if (!baseBodyTrimmed && !hasMediaAttachment) {
     await typing.onReplyStart();


### PR DESCRIPTION
## Summary

- Problem: `chat.send` image-only Web UI turns can be rejected early as "no text" in reply preflight even when `opts.images` is present.
- Why it matters: users who paste/send only an image in Control UI can get `I didn't receive any text in your message...` before the agent run starts.
- What changed: include `opts.images` in media-presence detection in `runPreparedReply`, and add regression coverage for media-only turns carried via `opts.images`.
- What did NOT change (scope boundary): no transport/protocol changes to `chat.send` payloads, no model selection changes, no attachment parsing changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30818
- Related #21983

## User-visible / Behavior Changes

- Image-only Web UI chat turns no longer short-circuit to the empty-text response when images are present via `opts.images`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local node/pnpm
- Model/provider: N/A (unit-level)
- Integration/channel (if any): webchat path (`chat.send` -> `runPreparedReply`)
- Relevant config (redacted): default test config

### Steps

1. Build a reply context with empty body and no `MediaPath`/`MediaPaths`.
2. Pass image attachment through `opts.images`.
3. Run `runPreparedReply`.

### Expected

- Run proceeds as media-only turn and calls agent runner.

### Actual

- Before fix: empty-text response path could trigger.
- After fix: media-only path proceeds and prompt includes `[User sent media without caption]`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing test:
- `pnpm exec vitest run src/auto-reply/reply/get-reply-run.media-only.test.ts`

## Human Verification (required)

- Verified scenarios:
  - Added regression test for `opts.images` media-only flow.
  - Ran targeted lint/format checks and full build.
- Edge cases checked:
  - Existing no-text/no-media behavior remains covered by existing test in same suite.
- What you did **not** verify:
  - End-to-end browser/manual Web UI run in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `896c13ed08`.
- Files/config to restore:
  - `src/auto-reply/reply/get-reply-run.ts`
  - `src/auto-reply/reply/get-reply-run.media-only.test.ts`
  - `CHANGELOG.md`
- Known bad symptoms reviewers should watch for:
  - Media-only turns unexpectedly returning empty-text fallback again.

## Risks and Mitigations

- Risk: non-media paths unintentionally treated as media-bearing.
  - Mitigation: guard only checks `opts.images.length > 0`; existing no-media regression test remains in suite.
