### PR TITLE
fix(telegram): pass media file_id into getFile for document attachments [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/Document media resolution: pass the inbound media `file_id` into `getFile` during media fetch so document attachments resolve against the intended file and preserve `<media:document>` handling in media-only turns. (#7116)
 - Slack/Bot attachment-only messages: when `allowBots: true`, bot messages with empty `text` now include non-forwarded attachment `text`/`fallback` content so webhook alerts are not silently dropped. (#27616)
 - Slack/Security ingress mismatch guard: drop slash-command and interaction payloads when app/team identifiers do not match the active Slack account context (including nested `team.id` interaction payloads), preventing cross-app or cross-workspace payload injection into system-event handling. (#29091) Thanks @Solvely-Colin.
 - Cron/Failure alerts: add configurable repeated-failure alerting with per-job overrides and Web UI cron editor support (`inherit|disabled|custom` with threshold/cooldown/channel/target fields). (#24789) Thanks xbrak.

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -31,7 +31,7 @@ const MAX_MEDIA_BYTES = 10_000_000;
 const BOT_TOKEN = "tok123";
 
 function makeCtx(
-  mediaField: "voice" | "audio" | "photo" | "video",
+  mediaField: "voice" | "audio" | "photo" | "video" | "document",
   getFile: TelegramContext["getFile"],
 ): TelegramContext {
   const msg: Record<string, unknown> = {
@@ -50,6 +50,14 @@ function makeCtx(
   }
   if (mediaField === "video") {
     msg.video = { file_id: "vid1", duration: 10, file_unique_id: "u3" };
+  }
+  if (mediaField === "document") {
+    msg.document = {
+      file_id: "d1",
+      file_unique_id: "u4",
+      file_name: "report.pdf",
+      mime_type: "application/pdf",
+    };
   }
   return {
     message: msg as unknown as Message,
@@ -202,5 +210,29 @@ describe("resolveMedia getFile retry", () => {
     const result = await expectTransientGetFileRetrySuccess();
     // Should retry transient errors.
     expect(result).not.toBeNull();
+  });
+
+  it("passes document file_id into getFile and keeps document placeholder", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "documents/report.pdf" });
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("%PDF-1.4\n"),
+      contentType: "application/pdf",
+      fileName: "report.pdf",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/report.pdf",
+      contentType: "application/pdf",
+    });
+
+    const result = await resolveMedia(makeCtx("document", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+
+    expect(getFile).toHaveBeenCalledWith("d1");
+    expect(result).toEqual(
+      expect.objectContaining({
+        path: "/tmp/report.pdf",
+        contentType: "application/pdf",
+        placeholder: "<media:document>",
+      }),
+    );
   });
 });

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -419,7 +419,7 @@ export async function resolveMedia(
 
   let file: { file_path?: string };
   try {
-    file = await retryAsync(() => ctx.getFile(), {
+    file = await retryAsync(() => ctx.getFile(m.file_id), {
       attempts: 3,
       minDelayMs: 1000,
       maxDelayMs: 4000,

--- a/src/telegram/bot/types.ts
+++ b/src/telegram/bot/types.ts
@@ -11,7 +11,7 @@ export type TelegramStreamMode = "off" | "partial" | "block";
 export type TelegramContext = {
   message: Message;
   me?: UserFromGetMe;
-  getFile: () => Promise<{ file_path?: string }>;
+  getFile: (fileId?: string) => Promise<{ file_path?: string }>;
 };
 
 /** Telegram sticker metadata for context enrichment and caching. */


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram media resolution called `ctx.getFile()` without passing the inbound media id, which can fail to resolve document attachments consistently.
- Why it matters: users sending files as Telegram document attachments can hit media resolution failures before agent processing.
- What changed: pass `m.file_id` into `ctx.getFile(m.file_id)`, widen `TelegramContext.getFile` typing to accept an optional `fileId`, and add a regression test covering document attachments.
- What did NOT change (scope boundary): no changes to non-Telegram channels, no changes to fetch retry policy/backoff values, and no change to placeholder behavior beyond validating existing `<media:document>` handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #7116
- Related #30592

## User-visible / Behavior Changes

Telegram document attachments now resolve against the intended inbound `file_id`, reducing false media-resolution failures for attachment-only turns.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram Bot
- Relevant config (redacted): Bot token configured for test mocks only

### Steps

1. Create a Telegram message context containing `document.file_id = "d1"`.
2. Run `resolveMedia(...)` with mocked `getFile`, `fetchRemoteMedia`, and `saveMediaBuffer`.
3. Assert the resolver calls `getFile("d1")` and preserves `<media:document>` placeholder metadata.

### Expected

- Resolver should pass the inbound document `file_id` to Telegram `getFile` and return normalized media metadata.

### Actual

- Before this fix, `getFile` was called without the media id; after this fix, `getFile("d1")` is used.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing checks run locally:

- `pnpm exec oxfmt --check src/telegram/bot/types.ts src/telegram/bot/delivery.ts src/telegram/bot/delivery.resolve-media-retry.test.ts CHANGELOG.md`
- `pnpm exec oxlint --type-aware src/telegram/bot/types.ts src/telegram/bot/delivery.ts src/telegram/bot/delivery.resolve-media-retry.test.ts`
- `pnpm exec vitest run src/telegram/bot/delivery.resolve-media-retry.test.ts`
- `pnpm build`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: document media context resolves successfully, `getFile` receives inbound `file_id`, and output includes document placeholder + MIME/path metadata.
- Edge cases checked: retry path still functions (existing retry tests remain passing), and non-document media test coverage remains intact.
- What you did **not** verify: live Telegram API integration against a real bot token in this PR cycle.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/telegram/bot/delivery.ts`, `src/telegram/bot/types.ts`, and related test/changelog lines.
- Known bad symptoms reviewers should watch for: Telegram media fetch requests no longer accepting optional fileId in typed wrappers.

## Risks and Mitigations

- Risk: `TelegramContext.getFile` type widening could impact strict wrappers that typed `getFile` as no-arg only.
  - Mitigation: function argument is optional (`fileId?: string`), and call sites that ignore parameters remain compatible.
