### PR TITLE
fix(control-ui): make cron suggestion sorting compatible without toSorted [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/Cron suggestions: replace `toSorted` usage in app render suggestion lists with a browser-compatible sorted helper so older browsers without `Array.prototype.toSorted` no longer crash to blank UI. (#30467)
 - Slack/Bot attachment-only messages: when `allowBots: true`, bot messages with empty `text` now include non-forwarded attachment `text`/`fallback` content so webhook alerts are not silently dropped. (#27616)
 - Slack/Security ingress mismatch guard: drop slash-command and interaction payloads when app/team identifiers do not match the active Slack account context (including nested `team.id` interaction payloads), preventing cross-app or cross-workspace payload injection into system-event handling. (#29091) Thanks @Solvely-Colin.
 - Cron/Failure alerts: add configurable repeated-failure alerting with per-job overrides and Web UI cron editor support (`inherit|disabled|custom` with threshold/cooldown/channel/target fields). (#24789) Thanks xbrak.

--- a/src/ui/sort-suggestions.test.ts
+++ b/src/ui/sort-suggestions.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { sortSuggestions } from "../../ui/src/ui/sort-suggestions.ts";
+
+describe("sortSuggestions", () => {
+  it("sorts values with locale ordering and does not mutate input arrays", () => {
+    const input = ["gamma", "beta", "alpha"];
+
+    const sorted = sortSuggestions(input);
+
+    expect(sorted).toEqual(["alpha", "beta", "gamma"]);
+    expect(input).toEqual(["gamma", "beta", "alpha"]);
+  });
+
+  it("supports iterable values such as Set", () => {
+    expect(sortSuggestions(new Set(["z", "a", "m"]))).toEqual(["a", "m", "z"]);
+  });
+});

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -66,6 +66,7 @@ import {
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
+import { sortSuggestions } from "./sort-suggestions.ts";
 import { resolveConfiguredCronModelSuggestions } from "./views/agents-utils.ts";
 import { renderAgents } from "./views/agents.ts";
 import { renderChannels } from "./views/channels.ts";
@@ -166,7 +167,7 @@ export function renderApp(state: AppViewState) {
     state.agentsList?.defaultId ??
     state.agentsList?.agents?.[0]?.id ??
     null;
-  const cronAgentSuggestions = Array.from(
+  const cronAgentSuggestions = sortSuggestions(
     new Set(
       [
         ...(state.agentsList?.agents?.map((entry) => entry.id.trim()) ?? []),
@@ -175,8 +176,8 @@ export function renderApp(state: AppViewState) {
           .filter(Boolean),
       ].filter(Boolean),
     ),
-  ).toSorted((a, b) => a.localeCompare(b));
-  const cronModelSuggestions = Array.from(
+  );
+  const cronModelSuggestions = sortSuggestions(
     new Set(
       [
         ...state.cronModelSuggestions,
@@ -191,7 +192,7 @@ export function renderApp(state: AppViewState) {
           .filter(Boolean),
       ].filter(Boolean),
     ),
-  ).toSorted((a, b) => a.localeCompare(b));
+  );
   const visibleCronJobs = getVisibleCronJobs(state);
   const selectedDeliveryChannel =
     state.cronForm.deliveryChannel && state.cronForm.deliveryChannel.trim()

--- a/ui/src/ui/sort-suggestions.ts
+++ b/ui/src/ui/sort-suggestions.ts
@@ -1,0 +1,13 @@
+type StringArrayWithToSorted = string[] & {
+  toSorted?: (compareFn?: (left: string, right: string) => number) => string[];
+};
+
+export function sortSuggestions(values: Iterable<string>): string[] {
+  const list = Array.from(values);
+  const withToSorted = list as StringArrayWithToSorted;
+  if (typeof withToSorted.toSorted === "function") {
+    return withToSorted.toSorted((left, right) => left.localeCompare(right));
+  }
+  // eslint-disable-next-line unicorn/no-array-sort -- fallback for browsers that do not implement Array.prototype.toSorted.
+  return [...list].sort((left, right) => left.localeCompare(right));
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Control UI cron suggestion generation in `ui/src/ui/app-render.ts` used `Array.prototype.toSorted`, which is missing in older browsers and can crash render with `TypeError`.
- Why it matters: a missing `toSorted` support causes blank UI on affected browsers (reported in #30467).
- What changed: moved cron suggestion sorting to a compatibility helper that uses `toSorted` when available and falls back to non-mutating `Array#sort` when not.
- What did NOT change (scope boundary): no changes to cron filtering logic, no changes to suggestion data sources, and no changes outside suggestion sorting.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30467
- Related #30402

## User-visible / Behavior Changes

Control UI no longer depends on browser-native `Array.prototype.toSorted` for cron suggestion rendering; older browsers can render without the previous fatal error.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Control UI
- Relevant config (redacted): N/A

### Steps

1. Build suggestion lists in `renderApp` using cron jobs + model suggestions.
2. Route sorting through compatibility helper (`sortSuggestions`).
3. Run regression tests and build checks.

### Expected

- Suggestion lists remain sorted and deterministic.
- No hard runtime dependency on `Array.prototype.toSorted` in `app-render.ts`.

### Actual

- Sorting now uses compatibility helper with fallback path; tests and build pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing checks run locally:

- `pnpm exec oxfmt --check ui/src/ui/app-render.ts ui/src/ui/sort-suggestions.ts src/ui/sort-suggestions.test.ts CHANGELOG.md`
- `pnpm exec oxlint --type-aware ui/src/ui/app-render.ts ui/src/ui/sort-suggestions.ts src/ui/sort-suggestions.test.ts`
- `pnpm exec vitest run src/ui/sort-suggestions.test.ts`
- `pnpm build`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: cron suggestion lists still sort correctly; helper supports arrays and sets; input arrays remain unchanged.
- Edge cases checked: fallback path for environments without `toSorted` is present and non-mutating.
- What you did **not** verify: manual live browser run on a Windows 7 old Chrome instance in this cycle.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `ui/src/ui/app-render.ts`, `ui/src/ui/sort-suggestions.ts`, related test/changelog entries.
- Known bad symptoms reviewers should watch for: unsorted or unstable cron suggestion list order.

## Risks and Mitigations

- Risk: locale-based ordering differences across runtimes.
  - Mitigation: same `localeCompare` strategy is retained from previous implementation.
