### PR TITLE
fix(telegram): preserve /models checkmark when returning to default model [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/Model menu selection marker: when opening a provider list after a cross-provider selection, use provider-matching default model fallback for checkmark rendering so switching back to default primary still shows the active model marker. (#30476)
 - Slack/Bot attachment-only messages: when `allowBots: true`, bot messages with empty `text` now include non-forwarded attachment `text`/`fallback` content so webhook alerts are not silently dropped. (#27616)
 - Slack/Security ingress mismatch guard: drop slash-command and interaction payloads when app/team identifiers do not match the active Slack account context (including nested `team.id` interaction payloads), preventing cross-app or cross-workspace payload injection into system-event handling. (#29091) Thanks @Solvely-Colin.
 - Cron/Failure alerts: add configurable repeated-failure alerting with per-job overrides and Web UI cron editor support (`inherit|disabled|custom` with threshold/cooldown/channel/target fields). (#24789) Thanks xbrak.

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1201,6 +1201,7 @@ export const registerTelegramHandlers = ({
             provider,
             models,
             currentModel,
+            defaultModel: `${modelData.resolvedDefault.provider}/${modelData.resolvedDefault.model}`,
             currentPage: safePage,
             totalPages,
             pageSize,

--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -177,6 +177,20 @@ describe("buildModelsKeyboard", () => {
     }
   });
 
+  it("falls back to provider-matching default model when current model points to another provider", () => {
+    const result = buildModelsKeyboard({
+      provider: "google",
+      models: ["gemini-3-flash-preview", "gemini-2.5-pro"],
+      currentModel: "anthropic/claude-sonnet-4",
+      defaultModel: "google/gemini-3-flash-preview",
+      currentPage: 1,
+      totalPages: 1,
+    });
+
+    expect(result[0]?.[0]?.text).toBe("gemini-3-flash-preview ✓");
+    expect(result[1]?.[0]?.text).toBe("gemini-2.5-pro");
+  });
+
   it("keeps short display IDs untouched and truncates overly long IDs", () => {
     const cases = [
       {

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -25,6 +25,7 @@ export type ModelsKeyboardParams = {
   provider: string;
   models: readonly string[];
   currentModel?: string;
+  defaultModel?: string;
   currentPage: number;
   totalPages: number;
   pageSize?: number;
@@ -32,6 +33,22 @@ export type ModelsKeyboardParams = {
 
 const MODELS_PAGE_SIZE = 8;
 const MAX_CALLBACK_DATA_BYTES = 64;
+
+function resolveModelIdForProvider(provider: string, modelRef?: string): string | undefined {
+  const trimmed = modelRef?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const slashIndex = trimmed.indexOf("/");
+  if (slashIndex <= 0 || slashIndex >= trimmed.length - 1) {
+    return trimmed;
+  }
+  const refProvider = trimmed.slice(0, slashIndex).trim().toLowerCase();
+  if (refProvider !== provider.toLowerCase()) {
+    return undefined;
+  }
+  return trimmed.slice(slashIndex + 1);
+}
 
 /**
  * Parse a model callback_data string into a structured object.
@@ -113,7 +130,7 @@ export function buildProviderKeyboard(providers: ProviderInfo[]): ButtonRow[] {
  * Build model list keyboard with pagination and back button.
  */
 export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
-  const { provider, models, currentModel, currentPage, totalPages } = params;
+  const { provider, models, currentModel, currentPage, totalPages, defaultModel } = params;
   const pageSize = params.pageSize ?? MODELS_PAGE_SIZE;
 
   if (models.length === 0) {
@@ -128,9 +145,9 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const pageModels = models.slice(startIndex, endIndex);
 
   // Model buttons - one per row
-  const currentModelId = currentModel?.includes("/")
-    ? currentModel.split("/").slice(1).join("/")
-    : currentModel;
+  const currentModelId =
+    resolveModelIdForProvider(provider, currentModel) ??
+    resolveModelIdForProvider(provider, defaultModel);
 
   for (const model of pageModels) {
     const callbackData = `mdl_sel_${provider}/${model}`;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram `/models` inline keyboard can lose the active checkmark after switching back to the default primary model.
- Why it matters: users see no selected model marker even though model selection succeeded, which is confusing and looks broken.
- What changed: model button rendering now resolves the active model per provider and can fall back to a provider-matching default model when current model points to another provider.
- What did NOT change (scope boundary): no change to model switching command semantics (`/model`), no change to catalog loading or pagination behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30476
- Related #30592

## User-visible / Behavior Changes

Telegram `/models` provider lists now keep showing the active checkmark when the active selection is the default model for that provider.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): default model configured in agent defaults

### Steps

1. Build Telegram model keyboard for provider `google` with `currentModel` set to another provider (`anthropic/...`).
2. Provide `defaultModel` for current provider (`google/gemini-3-flash-preview`).
3. Verify rendered buttons mark the default provider model with `✓`.

### Expected

- Provider list shows a checkmark on the active default model when current model reference is cross-provider.

### Actual

- Before fix, no checkmark was shown in this state.
- After fix, checkmark correctly appears on provider-matching default model.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing checks run locally:

- `pnpm exec oxfmt --check src/telegram/model-buttons.ts src/telegram/model-buttons.test.ts src/telegram/bot-handlers.ts CHANGELOG.md`
- `pnpm exec oxlint --type-aware src/telegram/model-buttons.ts src/telegram/model-buttons.test.ts src/telegram/bot-handlers.ts`
- `pnpm exec vitest run src/telegram/model-buttons.test.ts`
- `pnpm build`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: provider-matching model still gets `✓` for explicit current model; cross-provider current model now falls back to default provider model checkmark.
- Edge cases checked: model refs without provider prefix still behave as before; pagination/back buttons unaffected.
- What you did **not** verify: end-to-end Telegram live interaction with a real bot token in this cycle.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/telegram/model-buttons.ts`, `src/telegram/bot-handlers.ts`, related tests/changelog.
- Known bad symptoms reviewers should watch for: wrong checkmark on model lists when browsing providers.

## Risks and Mitigations

- Risk: fallback could mark a wrong model if malformed refs are passed.
  - Mitigation: provider-aware parsing only accepts fallback when provider matches current keyboard provider.
