### PR TITLE
refactor(control-ui): extract gateway reconnect timing constants [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/Gateway reconnect tuning: replace inline reconnect/backoff magic numbers with named constants (`initial`, `multiplier`, `max`, and connect queue delay) so reconnect behavior is easier to audit and tune safely. (#30402)
 - Slack/Bot attachment-only messages: when `allowBots: true`, bot messages with empty `text` now include non-forwarded attachment `text`/`fallback` content so webhook alerts are not silently dropped. (#27616)
 - Slack/Security ingress mismatch guard: drop slash-command and interaction payloads when app/team identifiers do not match the active Slack account context (including nested `team.id` interaction payloads), preventing cross-app or cross-workspace payload injection into system-event handling. (#29091) Thanks @Solvely-Colin.
 - Cron/Failure alerts: add configurable repeated-failure alerting with per-job overrides and Web UI cron editor support (`inherit|disabled|custom` with threshold/cooldown/channel/target fields). (#24789) Thanks xbrak.

--- a/src/ui/gateway-reconnect-constants.test.ts
+++ b/src/ui/gateway-reconnect-constants.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONNECT_QUEUE_DELAY_MS,
+  RECONNECT_BACKOFF_MULTIPLIER,
+  RECONNECT_INITIAL_BACKOFF_MS,
+  RECONNECT_MAX_BACKOFF_MS,
+} from "../../ui/src/ui/gateway.ts";
+
+describe("gateway reconnect constants", () => {
+  it("keeps reconnect timings positive and bounded", () => {
+    expect(RECONNECT_INITIAL_BACKOFF_MS).toBeGreaterThan(0);
+    expect(RECONNECT_MAX_BACKOFF_MS).toBeGreaterThan(RECONNECT_INITIAL_BACKOFF_MS);
+    expect(RECONNECT_BACKOFF_MULTIPLIER).toBeGreaterThan(1);
+    expect(CONNECT_QUEUE_DELAY_MS).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -90,6 +90,10 @@ export type GatewayBrowserClientOptions = {
 
 // 4008 = application-defined code (browser rejects 1008 "Policy Violation")
 const CONNECT_FAILED_CLOSE_CODE = 4008;
+export const RECONNECT_INITIAL_BACKOFF_MS = 800;
+export const RECONNECT_BACKOFF_MULTIPLIER = 1.7;
+export const RECONNECT_MAX_BACKOFF_MS = 15_000;
+export const CONNECT_QUEUE_DELAY_MS = 750;
 
 export class GatewayBrowserClient {
   private ws: WebSocket | null = null;
@@ -99,7 +103,7 @@ export class GatewayBrowserClient {
   private connectNonce: string | null = null;
   private connectSent = false;
   private connectTimer: number | null = null;
-  private backoffMs = 800;
+  private backoffMs = RECONNECT_INITIAL_BACKOFF_MS;
   private pendingConnectError: GatewayErrorInfo | undefined;
 
   constructor(private opts: GatewayBrowserClientOptions) {}
@@ -147,7 +151,10 @@ export class GatewayBrowserClient {
       return;
     }
     const delay = this.backoffMs;
-    this.backoffMs = Math.min(this.backoffMs * 1.7, 15_000);
+    this.backoffMs = Math.min(
+      this.backoffMs * RECONNECT_BACKOFF_MULTIPLIER,
+      RECONNECT_MAX_BACKOFF_MS,
+    );
     window.setTimeout(() => this.connect(), delay);
   }
 
@@ -257,7 +264,7 @@ export class GatewayBrowserClient {
             scopes: hello.auth.scopes ?? [],
           });
         }
-        this.backoffMs = 800;
+        this.backoffMs = RECONNECT_INITIAL_BACKOFF_MS;
         this.opts.onHello?.(hello);
       })
       .catch((err: unknown) => {
@@ -355,6 +362,6 @@ export class GatewayBrowserClient {
     }
     this.connectTimer = window.setTimeout(() => {
       void this.sendConnect();
-    }, 750);
+    }, CONNECT_QUEUE_DELAY_MS);
   }
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `GatewayBrowserClient` reconnect logic used raw timing literals (`800`, `1.7`, `15_000`, `750`) inline.
- Why it matters: reconnect behavior was harder to understand, audit, and tune safely because values were repeated and unnamed.
- What changed: extracted reconnect timing values into named constants and replaced inline usages in initialization, backoff growth/cap, reset on connect, and connect queue delay.
- What did NOT change (scope boundary): no reconnect algorithm change, no protocol/auth behavior change, no websocket frame handling change.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30402
- Related #30467

## User-visible / Behavior Changes

None (behavior-preserving refactor).

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Control UI Gateway client
- Relevant config (redacted): N/A

### Steps

1. Inspect `ui/src/ui/gateway.ts` reconnect logic.
2. Verify initial/cap/multiplier/queue delay values are defined as named constants.
3. Run formatting, lint, unit test, and full build.

### Expected

- Reconnect timings are centralized as named constants and existing behavior remains unchanged.

### Actual

- Constants are extracted and wired to all previous call sites; checks pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing checks run locally:

- `pnpm exec oxfmt --check ui/src/ui/gateway.ts src/ui/gateway-reconnect-constants.test.ts CHANGELOG.md`
- `pnpm exec oxlint --type-aware ui/src/ui/gateway.ts src/ui/gateway-reconnect-constants.test.ts`
- `pnpm exec vitest run src/ui/gateway-reconnect-constants.test.ts`
- `pnpm build`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reconnect constants are positive/bounded and used consistently in all reconnect code paths.
- Edge cases checked: reset path after successful `connect`, capped exponential growth path in `scheduleReconnect`, and deferred connect queue path.
- What you did **not** verify: manual browser devtools network offline/online session for reconnect timing observation in this cycle.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `ui/src/ui/gateway.ts` and related test/changelog line.
- Known bad symptoms reviewers should watch for: unexpected reconnect pacing (too fast/too slow) due incorrect constant wiring.

## Risks and Mitigations

- Risk: accidental numeric drift if constants are later edited independently.
  - Mitigation: added a unit test asserting key relationships (positive, bounded, multiplier > 1).
