### PR TITLE
fix(mattermost): pass localRoots to loadWebMedia for agent workspace paths (fixes #30830)

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -279,10 +279,11 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
       });
       return { channel: "mattermost", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, replyToId }) => {
+    sendMedia: async ({ to, text, mediaUrl, accountId, replyToId, mediaLocalRoots }) => {
       const result = await sendMessageMattermost(to, text, {
         accountId: accountId ?? undefined,
         mediaUrl,
+        mediaLocalRoots,
         replyToId: replyToId ?? undefined,
       });
       return { channel: "mattermost", ...result };

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -16,6 +16,7 @@ export type MattermostSendOpts = {
   baseUrl?: string;
   accountId?: string;
   mediaUrl?: string;
+  mediaLocalRoots?: readonly string[];
   replyToId?: string;
 };
 
@@ -174,9 +175,12 @@ export async function sendMessageMattermost(
   let fileIds: string[] | undefined;
   let uploadError: Error | undefined;
   const mediaUrl = opts.mediaUrl?.trim();
+  const mediaLocalRoots = opts.mediaLocalRoots;
   if (mediaUrl) {
     try {
-      const media = await core.media.loadWebMedia(mediaUrl);
+      const media = await core.media.loadWebMedia(mediaUrl, {
+        localRoots: mediaLocalRoots?.length ? mediaLocalRoots : undefined,
+      });
       const fileInfo = await uploadMattermostFile(client, {
         channelId,
         buffer: media.buffer,


### PR DESCRIPTION
The Mattermost plugin was silently failing to upload media files when the mediaUrl was a local path from the agent workspace. This is because loadWebMedia requires localRoots to be passed for security (CVE-2026-26321).

This fix:
- Adds mediaLocalRoots to MattermostSendOpts type
- Passes mediaLocalRoots from channel.ts sendMedia to sendMessageMattermost
- Passes localRoots to loadWebMedia call in send.ts

This follows the same pattern used by other plugins (feishu, discord, telegram, slack, signal, etc.) that already properly pass localRoots.

Fixes #30830