### PR TITLE
fix(mattermost): pass mediaLocalRoots to loadWebMedia for workspace file uploads

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -279,10 +279,11 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
       });
       return { channel: "mattermost", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, replyToId }) => {
+    sendMedia: async ({ to, text, mediaUrl, mediaLocalRoots, accountId, replyToId }) => {
       const result = await sendMessageMattermost(to, text, {
         accountId: accountId ?? undefined,
         mediaUrl,
+        mediaLocalRoots,
         replyToId: replyToId ?? undefined,
       });
       return { channel: "mattermost", ...result };

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -16,6 +16,7 @@ export type MattermostSendOpts = {
   baseUrl?: string;
   accountId?: string;
   mediaUrl?: string;
+  mediaLocalRoots?: readonly string[];
   replyToId?: string;
 };
 
@@ -176,7 +177,9 @@ export async function sendMessageMattermost(
   const mediaUrl = opts.mediaUrl?.trim();
   if (mediaUrl) {
     try {
-      const media = await core.media.loadWebMedia(mediaUrl);
+      const media = await core.media.loadWebMedia(mediaUrl, {
+        localRoots: opts.mediaLocalRoots,
+      });
       const fileInfo = await uploadMattermostFile(client, {
         channelId,
         buffer: media.buffer,


### PR DESCRIPTION
## Problem

When sending media files via the message tool on the Mattermost channel, file attachments from agent workspace directories are silently dropped. `loadWebMedia` is called without `localRoots`, so it falls back to `getDefaultMediaLocalRoots()` which explicitly excludes `workspace-*` directories.

The upload error is caught silently and the send degrades to text-only without any indication of failure.

## Fix

Pass `mediaLocalRoots` from the `sendMedia` callback through `MattermostSendOpts` into the `loadWebMedia` call, consistent with how Discord and other channels handle workspace media sends.

### Changes
- `extensions/mattermost/src/channel.ts`: Destructure `mediaLocalRoots` in `sendMedia` and forward it
- `extensions/mattermost/src/mattermost/send.ts`: Add `mediaLocalRoots` to `MattermostSendOpts`, pass `localRoots` to `loadWebMedia`

Closes #30830