### PR TITLE
fix(matrix): remove member-count fallback from DM detection

### DIFF
--- a/extensions/matrix/src/matrix/monitor/direct.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.ts
@@ -83,12 +83,6 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
         return true;
       }
 
-      const memberCount = await resolveMemberCount(roomId);
-      if (memberCount === 2) {
-        log(`matrix: dm detected via member count room=${roomId} members=${memberCount}`);
-        return true;
-      }
-
       const selfUserId = params.selfUserId ?? (await ensureSelfUserId());
       const directViaState =
         (await hasDirectFlag(roomId, senderId)) || (await hasDirectFlag(roomId, selfUserId ?? ""));
@@ -97,6 +91,7 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
         return true;
       }
 
+      const memberCount = await resolveMemberCount(roomId);
       log(`matrix: dm check room=${roomId} result=group members=${memberCount ?? "unknown"}`);
       return false;
     },


### PR DESCRIPTION
## Problem

`createDirectRoomTracker` falls back to treating any 2-person room as a DM based solely on `memberCount === 2`. This conflicts with the Matrix spec, which designates DMs via explicit `m.direct` account data and `is_direct` member state.

When a user has multiple 2-person rooms with the same participants (e.g., a bot room and a topic-specific room), both are incorrectly classified as DMs, causing duplicate or out-of-context message routing.

## Fix

Remove the `memberCount === 2` fallback from `isDirectMessage()`. DM detection now relies only on:
1. `client.dms.isDm()` — checks `m.direct` account data
2. `hasDirectFlag()` — checks `is_direct` on `m.room.member` state events

This aligns with the Matrix spec and prevents false-positive DM classification of regular 2-person rooms.

Closes #30645