### PR TITLE
fix(delivery): make queue recovery max retries configurable [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Outbound/Delivery queue: add `delivery.maxRetries` config support so recovery uses a configurable retry cap (default `5`) before moving entries to `delivery-queue/failed`. (#30496)
 - Agents/Sessions list transcript paths: handle missing/non-string/relative `sessions.list.path` values and per-agent `{agentId}` templates when deriving `transcriptPath`, so cross-agent session listings resolve to concrete agent session files instead of workspace-relative paths. (#24775) Thanks @martinfrancois.
 - Android/Voice screen TTS: stream assistant speech via ElevenLabs WebSocket in Talk Mode, stop cleanly on speaker mute/barge-in, and ignore stale out-of-order stream events. (#29521) Thanks @gregmousseau.
 - Web UI/Cron: include configured agent model defaults/fallbacks in cron model suggestions so scheduled-job model autocomplete reflects configured models. (#29709)

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -75,6 +75,29 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts delivery.maxRetries", () => {
+    const res = validateConfigObject({
+      delivery: {
+        maxRetries: 3,
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects negative delivery.maxRetries", () => {
+    const res = validateConfigObject({
+      delivery: {
+        maxRetries: -1,
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("delivery.maxRetries");
+    }
+  });
+
   it("rejects unsafe iMessage remoteHost", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -105,6 +105,13 @@ export type OpenClawConfig = {
   session?: SessionConfig;
   web?: WebConfig;
   channels?: ChannelsConfig;
+  delivery?: {
+    /**
+     * Max delivery retry attempts before an entry is moved to delivery-queue/failed.
+     * Default: 5.
+     */
+    maxRetries?: number;
+  };
   cron?: CronConfig;
   hooks?: HooksConfig;
   discovery?: DiscoveryConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -369,6 +369,12 @@ export const OpenClawSchema = z
     commands: CommandsSchema,
     approvals: ApprovalsSchema,
     session: SessionSchema,
+    delivery: z
+      .object({
+        maxRetries: z.number().int().min(0).optional(),
+      })
+      .strict()
+      .optional(),
     cron: z
       .object({
         enabled: z.boolean().optional(),

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -58,6 +58,18 @@ export type RecoverySummary = {
   deferredBackoff: number;
 };
 
+export function resolveDeliveryMaxRetries(cfg: OpenClawConfig): number {
+  const configuredMaxRetries = cfg.delivery?.maxRetries;
+  if (
+    typeof configuredMaxRetries === "number" &&
+    Number.isInteger(configuredMaxRetries) &&
+    configuredMaxRetries >= 0
+  ) {
+    return configuredMaxRetries;
+  }
+  return MAX_RETRIES;
+}
+
 function resolveQueueDir(stateDir?: string): string {
   const base = stateDir ?? resolveStateDir();
   return path.join(base, QUEUE_DIRNAME);
@@ -273,7 +285,7 @@ export interface RecoveryLogger {
 
 /**
  * On gateway startup, scan the delivery queue and retry any pending entries.
- * Uses exponential backoff and moves entries that exceed MAX_RETRIES to failed/.
+ * Uses exponential backoff and moves entries that exceed max retries to failed/.
  */
 export async function recoverPendingDeliveries(opts: {
   deliver: DeliverFn;
@@ -294,6 +306,7 @@ export async function recoverPendingDeliveries(opts: {
   opts.log.info(`Found ${pending.length} pending delivery entries — starting recovery`);
 
   const deadline = Date.now() + (opts.maxRecoveryMs ?? 60_000);
+  const maxRetries = resolveDeliveryMaxRetries(opts.cfg);
 
   let recovered = 0;
   let failed = 0;
@@ -307,9 +320,9 @@ export async function recoverPendingDeliveries(opts: {
       opts.log.warn(`Recovery time budget exceeded — ${deferred} entries deferred to next restart`);
       break;
     }
-    if (entry.retryCount >= MAX_RETRIES) {
+    if (entry.retryCount >= maxRetries) {
       opts.log.warn(
-        `Delivery ${entry.id} exceeded max retries (${entry.retryCount}/${MAX_RETRIES}) — moving to failed/`,
+        `Delivery ${entry.id} exceeded max retries (${entry.retryCount}/${maxRetries}) — moving to failed/`,
       );
       try {
         await moveToFailed(entry.id, opts.stateDir);

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -265,7 +265,7 @@ describe("delivery-queue", () => {
   });
 
   describe("recoverPendingDeliveries", () => {
-    const baseCfg = {};
+    const baseCfg: OpenClawConfig = {};
     const createLog = () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() });
     const enqueueCrashRecoveryEntries = async () => {
       await enqueueDelivery({ channel: "whatsapp", to: "+1", payloads: [{ text: "a" }] }, tmpDir);
@@ -292,15 +292,17 @@ describe("delivery-queue", () => {
       deliver,
       log = createLog(),
       maxRecoveryMs,
+      cfg = baseCfg,
     }: {
       deliver: ReturnType<typeof vi.fn>;
       log?: ReturnType<typeof createLog>;
       maxRecoveryMs?: number;
+      cfg?: OpenClawConfig;
     }) => {
       const result = await recoverPendingDeliveries({
         deliver: deliver as DeliverFn,
         log,
-        cfg: baseCfg,
+        cfg,
         stateDir: tmpDir,
         ...(maxRecoveryMs === undefined ? {} : { maxRecoveryMs }),
       });
@@ -340,6 +342,27 @@ describe("delivery-queue", () => {
       expect(result.deferredBackoff).toBe(0);
 
       // Entry should be in failed/ directory.
+      const failedDir = path.join(tmpDir, "delivery-queue", "failed");
+      expect(fs.existsSync(path.join(failedDir, `${id}.json`))).toBe(true);
+    });
+
+    it("respects delivery.maxRetries override during recovery", async () => {
+      const id = await enqueueDelivery(
+        { channel: "whatsapp", to: "+1", payloads: [{ text: "a" }] },
+        tmpDir,
+      );
+      setEntryState(id, { retryCount: 2 });
+
+      const deliver = vi.fn();
+      const { result } = await runRecovery({
+        deliver,
+        cfg: { delivery: { maxRetries: 2 } },
+      });
+
+      expect(deliver).not.toHaveBeenCalled();
+      expect(result.skippedMaxRetries).toBe(1);
+      expect(result.deferredBackoff).toBe(0);
+
       const failedDir = path.join(tmpDir, "delivery-queue", "failed");
       expect(fs.existsSync(path.join(failedDir, `${id}.json`))).toBe(true);
     });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: delivery-queue recovery used a hardcoded `MAX_RETRIES=5`, so operators could not tune retry cutoff for their reliability profile.
- Why it matters: in outage scenarios, teams may want faster failover to `delivery-queue/failed` (or a longer retry horizon) without patching source.
- What changed: added `delivery.maxRetries` config support (validated in schema/types) and wired recovery to honor that value, defaulting to `5` when unset.
- What did NOT change (scope boundary): no change to backoff schedule, no `failedDir` path customization, no channel-specific retry semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30496

## User-visible / Behavior Changes

Operators can now configure queue-recovery retry cutoff via:

```json
{
  "delivery": {
    "maxRetries": 3
  }
}
```

Recovery now moves entries with `retryCount >= delivery.maxRetries` into `delivery-queue/failed`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): outbound delivery queue recovery
- Relevant config (redacted): `delivery.maxRetries`

### Steps

1. Configure `delivery.maxRetries` in config (for example `2`).
2. Create a queued delivery entry with `retryCount` at or above configured threshold.
3. Run recovery.
4. Verify entry is moved to `delivery-queue/failed` without redelivery attempt.

### Expected

- Recovery uses configured retry cap and skips redelivery once threshold is reached.

### Actual

- New recovery behavior matches configured cap; default remains `5` when config is absent.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm exec oxfmt --check CHANGELOG.md src/config/types.openclaw.ts src/config/zod-schema.ts src/config/config.schema-regressions.test.ts src/infra/outbound/delivery-queue.ts src/infra/outbound/outbound.test.ts`
- `pnpm exec vitest run src/config/config.schema-regressions.test.ts src/infra/outbound/outbound.test.ts`
- `pnpm build`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified schema acceptance/rejection for `delivery.maxRetries` (`>=0` accepted, negative rejected).
- Verified recovery max-retry branch now honors config override and moves entries to `failed/` once threshold is met.
- Verified existing default-threshold behavior remains intact (tests still pass with `MAX_RETRIES` default).
- What you did **not** verify: live multi-channel outage simulation against external providers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Optional config addition only
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: remove `delivery.maxRetries` from config to use default behavior, or revert this PR commit.
- Files/config to restore: `src/infra/outbound/delivery-queue.ts` and config schema/type updates.
- Known bad symptoms reviewers should watch for: entries moving to failed too early when `delivery.maxRetries` is intentionally low.

## Risks and Mitigations

- Risk:
  - Misconfigured low retry limit can move entries to `failed/` sooner than expected.
  - Mitigation:
    - Config is explicit and validated as non-negative integer; default remains unchanged at `5`.

AI-assisted: Yes (Codex). Testing degree: fully tested for this change scope.
