### PR TITLE
feat(feishu): add image message support

### DIFF
--- a/extensions/feishu/README.md
+++ b/extensions/feishu/README.md
@@ -1,0 +1,18 @@
+# Feishu Extension
+
+## Image Message Support
+
+Send images to Feishu chats:
+
+```typescript
+import { sendImageFeishu } from '@openclaw/feishu';
+
+await sendImageFeishu({
+  cfg,
+  to: 'chat:oc_xxx',
+  imagePath: '/path/to/image.jpg',
+});
+```
+
+Supports: JPG, PNG (max 20MB)
+

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -64,8 +64,45 @@ describe("getMessageFeishu", () => {
         messageId: "om_1",
         chatId: "oc_1",
         contentType: "interactive",
-        content: "hello markdown\nhello div",
+        content: "hello markdown
+hello div",
       }),
     );
   });
 });
+
+// Image message tests
+describe('sendImageFeishu', () => {
+  const mockImageClient = {
+    im: {
+      image: { create: vi.fn() },
+      message: { create: vi.fn(), reply: vi.fn() },
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateFeishuClient.mockReturnValue(mockImageClient);
+  });
+
+  it('should upload and send image', async () => {
+    const { sendImageFeishu } = await import('./send.js');
+    
+    mockImageClient.im.image.create.mockResolvedValueOnce({
+      code: 0, data: { image_key: 'img_test123' },
+    });
+    mockImageClient.im.message.create.mockResolvedValueOnce({
+      code: 0, data: { message_id: 'om_img_123', create_time: '1234567890' },
+    });
+
+    const result = await sendImageFeishu({
+      cfg: { feishu: { appId: 'test', appSecret: 'secret' } } as any,
+      to: 'chat:test-id',
+      imagePath: '/test/image.jpg',
+    });
+
+    expect(result.messageId).toBe('om_img_123');
+    expect(mockImageClient.im.image.create).toHaveBeenCalled();
+  });
+});
+

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -331,3 +331,81 @@ export async function editMessageFeishu(params: {
     throw new Error(`Feishu message edit failed: ${response.msg || `code ${response.code}`}`);
   }
 }
+
+
+export type SendFeishuImageParams = {
+  cfg: ClawdbotConfig;
+  to: string;
+  imagePath: string;
+  replyToMessageId?: string;
+  replyInThread?: boolean;
+  accountId?: string;
+};
+
+/**
+ * Upload image to Feishu and get image key
+ */
+async function uploadImageFeishu(params: {
+  client: ReturnType<typeof createFeishuClient>;
+  imagePath: string;
+}): Promise<string> {
+  const { client, imagePath } = params;
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+
+  const imageData = fs.readFileSync(imagePath);
+  const imageType = path.extname(imagePath).slice(1).toLowerCase() || "jpg";
+  const mimeType = imageType === "png" ? "image/png" : "image/jpeg";
+
+  const response = await client.im.image.create({
+    data: {
+      image: new Blob([imageData]),
+      image_type: mimeType,
+    } as unknown as Record<string, unknown>,
+  });
+
+  if (response.code !== 0 || !response.data?.image_key) {
+    throw new Error(`Feishu image upload failed: ${response.msg || `code ${response.code}`}`);
+  }
+
+  return response.data.image_key as string;
+}
+
+/**
+ * Send an image message to Feishu
+ */
+export async function sendImageFeishu(params: SendFeishuImageParams): Promise<FeishuSendResult> {
+  const { cfg, to, imagePath, replyToMessageId, replyInThread, accountId } = params;
+  const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
+
+  // Upload image to get image_key
+  const imageKey = await uploadImageFeishu({ client, imagePath });
+
+  const content = JSON.stringify({
+    image_key: imageKey,
+  });
+
+  if (replyToMessageId) {
+    const response = await client.im.message.reply({
+      path: { message_id: replyToMessageId },
+      data: {
+        content,
+        msg_type: "image",
+        ...(replyInThread ? { reply_in_thread: true } : {}),
+      },
+    });
+    assertFeishuMessageApiSuccess(response, "Feishu image reply failed");
+    return toFeishuSendResult(response, receiveId);
+  }
+
+  const response = await client.im.message.create({
+    params: { receive_id_type: receiveIdType },
+    data: {
+      receive_id: receiveId,
+      content,
+      msg_type: "image",
+    },
+  });
+  assertFeishuMessageApiSuccess(response, "Feishu image send failed");
+  return toFeishuSendResult(response, receiveId);
+}


### PR DESCRIPTION
## Feishu: Add image message support

### Problem
Currently, OpenClaw's Feishu extension only supports text/post messages. Users cannot send images through the `message` tool.

### Solution
Add image message support to Feishu extension:

1. **New function: `sendImageFeishu`**
   - Upload image to Feishu API to get `image_key`
   - Send message with `msg_type: "image"`

2. **API endpoints used:**
   - `POST /open-apis/im/v1/images` - Upload image
   - `POST /open-apis/im/v1/messages` - Send image message

3. **Usage:**
   ```typescript
   await sendImageFeishu({
     cfg,
     to: "chat:xxx",
     imagePath: "/path/to/image.jpg"
   });
   ```

### Changes
- `extensions/feishu/src/send.ts`: Add `sendImageFeishu` function
- `extensions/feishu/src/index.ts`: Export new function
- Add image upload and message sending logic

### Testing
- [ ] Test image upload
- [ ] Test image message sending
- [ ] Test with different image formats (jpg, png)

### References
- Feishu API: https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create
- Image upload: https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/image/create

Fixes #29922
