### PR TITLE
fix(models): keep openai gpt-5.3-codex on openai provider [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/OpenAI Codex routing: stop remapping `openai/gpt-5.3-codex` to `openai-codex`, and add forward-compat fallback support for `openai` provider `gpt-5.3-codex` model resolution. (#30844)
 - Agents/Sessions list transcript paths: handle missing/non-string/relative `sessions.list.path` values and per-agent `{agentId}` templates when deriving `transcriptPath`, so cross-agent session listings resolve to concrete agent session files instead of workspace-relative paths. (#24775) Thanks @martinfrancois.
 - Android/Voice screen TTS: stream assistant speech via ElevenLabs WebSocket in Talk Mode, stop cleanly on speaker mute/barge-in, and ignore stale out-of-order stream events. (#29521) Thanks @gregmousseau.
 - Web UI/Cron: include configured agent model defaults/fallbacks in cron model suggestions so scheduled-job model autocomplete reflects configured models. (#29709)

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -174,7 +174,7 @@ async function expectSkippedUnavailableProvider(params: {
 }
 
 describe("runWithModelFallback", () => {
-  it("normalizes openai gpt-5.3 codex to openai-codex before running", async () => {
+  it("keeps openai gpt-5.3 codex on openai before running", async () => {
     const cfg = makeCfg();
     const run = vi.fn().mockResolvedValueOnce("ok");
 
@@ -187,7 +187,7 @@ describe("runWithModelFallback", () => {
 
     expect(result.result).toBe("ok");
     expect(run).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledWith("openai-codex", "gpt-5.3-codex");
+    expect(run).toHaveBeenCalledWith("openai", "gpt-5.3-codex");
   });
 
   it("falls back on unrecognized errors when candidates remain", async () => {

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -48,7 +48,7 @@ function cloneFirstTemplateModel(params: {
   return undefined;
 }
 
-const CODEX_GPT53_ELIGIBLE_PROVIDERS = new Set(["openai-codex", "github-copilot"]);
+const CODEX_GPT53_ELIGIBLE_PROVIDERS = new Set(["openai", "openai-codex", "github-copilot"]);
 
 function resolveOpenAICodexGpt53FallbackModel(
   provider: string,
@@ -76,12 +76,17 @@ function resolveOpenAICodexGpt53FallbackModel(
     } as Model<Api>);
   }
 
+  const api = normalizedProvider === "openai" ? "openai-responses" : "openai-codex-responses";
+  const baseUrl =
+    normalizedProvider === "openai"
+      ? "https://api.openai.com/v1"
+      : "https://chatgpt.com/backend-api";
   return normalizeModelCompat({
     id: trimmedModelId,
     name: trimmedModelId,
-    api: "openai-codex-responses",
+    api,
     provider: normalizedProvider,
-    baseUrl: "https://chatgpt.com/backend-api",
+    baseUrl,
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -70,17 +70,17 @@ describe("model-selection", () => {
       });
     });
 
-    it("normalizes openai gpt-5.3 codex refs to openai-codex provider", () => {
+    it("keeps openai gpt-5.3 codex refs on the openai provider", () => {
       expect(parseModelRef("openai/gpt-5.3-codex", "anthropic")).toEqual({
-        provider: "openai-codex",
+        provider: "openai",
         model: "gpt-5.3-codex",
       });
       expect(parseModelRef("gpt-5.3-codex", "openai")).toEqual({
-        provider: "openai-codex",
+        provider: "openai",
         model: "gpt-5.3-codex",
       });
       expect(parseModelRef("openai/gpt-5.3-codex-codex", "anthropic")).toEqual({
-        provider: "openai-codex",
+        provider: "openai",
         model: "gpt-5.3-codex-codex",
       });
     });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -27,7 +27,6 @@ const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
   "sonnet-4.6": "claude-sonnet-4-6",
   "sonnet-4.5": "claude-sonnet-4-5",
 };
-const OPENAI_CODEX_OAUTH_MODEL_PREFIXES = ["gpt-5.3-codex"] as const;
 
 function normalizeAliasKey(value: string): string {
   return value.trim().toLowerCase();
@@ -133,25 +132,9 @@ function normalizeProviderModelId(provider: string, model: string): string {
   return model;
 }
 
-function shouldUseOpenAICodexProvider(provider: string, model: string): boolean {
-  if (provider !== "openai") {
-    return false;
-  }
-  const normalized = model.trim().toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  return OPENAI_CODEX_OAUTH_MODEL_PREFIXES.some(
-    (prefix) => normalized === prefix || normalized.startsWith(`${prefix}-`),
-  );
-}
-
 export function normalizeModelRef(provider: string, model: string): ModelRef {
   const normalizedProvider = normalizeProviderId(provider);
   const normalizedModel = normalizeProviderModelId(normalizedProvider, model.trim());
-  if (shouldUseOpenAICodexProvider(normalizedProvider, normalizedModel)) {
-    return { provider: "openai-codex", model: normalizedModel };
-  }
   return { provider: normalizedProvider, model: normalizedModel };
 }
 

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -7,10 +7,12 @@ vi.mock("../pi-model-discovery.js", () => ({
 
 import { buildInlineProviderModels, resolveModel } from "./model.js";
 import {
+  buildOpenAIForwardCompatExpectation,
   buildOpenAICodexForwardCompatExpectation,
   GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
   GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
   makeModel,
+  mockOpenAITemplateModel,
   mockGoogleGeminiCliFlashTemplateModel,
   mockGoogleGeminiCliProTemplateModel,
   mockOpenAICodexTemplateModel,
@@ -47,6 +49,14 @@ describe("pi embedded model e2e smoke", () => {
     const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent");
     expect(result.error).toBeUndefined();
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.3-codex"));
+  });
+
+  it("builds an openai forward-compat fallback for gpt-5.3-codex", () => {
+    mockOpenAITemplateModel();
+
+    const result = resolveModel("openai", "gpt-5.3-codex", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(buildOpenAIForwardCompatExpectation("gpt-5.3-codex"));
   });
 
   it("keeps unknown-model errors for non-forward-compat IDs", () => {

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -25,6 +25,27 @@ export const OPENAI_CODEX_TEMPLATE_MODEL = {
   maxTokens: 128000,
 };
 
+export const OPENAI_TEMPLATE_MODEL = {
+  id: "gpt-5.2-codex",
+  name: "GPT-5.2 Codex",
+  provider: "openai",
+  api: "openai-responses",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text", "image"] as const,
+  cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+  contextWindow: 272000,
+  maxTokens: 128000,
+};
+
+export function mockOpenAITemplateModel(): void {
+  mockDiscoveredModel({
+    provider: "openai",
+    modelId: "gpt-5.2-codex",
+    templateModel: OPENAI_TEMPLATE_MODEL,
+  });
+}
+
 export function mockOpenAICodexTemplateModel(): void {
   mockDiscoveredModel({
     provider: "openai-codex",
@@ -41,6 +62,20 @@ export function buildOpenAICodexForwardCompatExpectation(
     id,
     api: "openai-codex-responses",
     baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    contextWindow: 272000,
+    maxTokens: 128000,
+  };
+}
+
+export function buildOpenAIForwardCompatExpectation(
+  id: string = "gpt-5.3-codex",
+): Partial<typeof OPENAI_TEMPLATE_MODEL> & { provider: string; id: string } {
+  return {
+    provider: "openai",
+    id,
+    api: "openai-responses",
+    baseUrl: "https://api.openai.com/v1",
     reasoning: true,
     contextWindow: 272000,
     maxTokens: 128000,

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -8,9 +8,11 @@ vi.mock("../pi-model-discovery.js", () => ({
 import type { OpenClawConfig } from "../../config/config.js";
 import { buildInlineProviderModels, resolveModel } from "./model.js";
 import {
+  buildOpenAIForwardCompatExpectation,
   buildOpenAICodexForwardCompatExpectation,
   makeModel,
   mockDiscoveredModel,
+  mockOpenAITemplateModel,
   mockOpenAICodexTemplateModel,
   resetMockDiscoverModels,
 } from "./model.test-harness.js";
@@ -233,6 +235,15 @@ describe("resolveModel", () => {
 
     expect(result.error).toBeUndefined();
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.3-codex"));
+  });
+
+  it("builds an openai fallback for gpt-5.3-codex", () => {
+    mockOpenAITemplateModel();
+
+    const result = resolveModel("openai", "gpt-5.3-codex", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(buildOpenAIForwardCompatExpectation("gpt-5.3-codex"));
   });
 
   it("builds an anthropic forward-compat fallback for claude-opus-4-6", () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openai/gpt-5.3-codex` was force-normalized to `openai-codex/gpt-5.3-codex`, which pushes API-key users into Codex OAuth flow and can fail with token/account extraction errors.
- Why it matters: users explicitly selecting `openai` provider should not be silently rerouted to a different provider/auth path.
- What changed: removed hard remap from model normalization; `openai/gpt-5.3-codex` now stays on `openai`.
- What changed (forward-compat): added `openai` provider support for `gpt-5.3-codex` forward-compat model fallback (using `openai-responses` / `https://api.openai.com/v1`), while preserving existing `openai-codex`/`github-copilot` behavior.
- What did NOT change (scope boundary): no change to `openai-codex/*` explicit refs, no auth-profile format changes, no provider usage accounting schema changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30844

## User-visible / Behavior Changes

- `openai/gpt-5.3-codex` now remains on provider `openai` instead of being rerouted to `openai-codex`.
- Forward-compat fallback can now resolve `openai` provider `gpt-5.3-codex` via template cloning.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: openai / openai-codex
- Integration/channel (if any): model selection + embedded runner model resolution
- Relevant config (redacted): `agents.defaults.model.primary: openai/gpt-5.3-codex`

### Steps

1. Set primary model to `openai/gpt-5.3-codex`.
2. Resolve model reference and fallback candidate path.
3. Verify provider remains `openai` and forward-compat fallback resolves model metadata.

### Expected

- No forced provider swap to `openai-codex` when user explicitly uses `openai`.
- `openai` fallback model for `gpt-5.3-codex` remains resolvable.

### Actual

- Updated behavior and tests confirm `openai` is preserved and fallback resolution succeeds.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm exec oxfmt --check CHANGELOG.md src/agents/model-selection.ts src/agents/model-selection.test.ts src/agents/model-fallback.test.ts src/agents/model-forward-compat.ts src/agents/pi-embedded-runner/model.test-harness.ts src/agents/pi-embedded-runner/model.forward-compat.test.ts src/agents/pi-embedded-runner/model.test.ts`
- `pnpm exec vitest run src/agents/model-selection.test.ts src/agents/model-fallback.test.ts src/agents/pi-embedded-runner/model.forward-compat.test.ts src/agents/pi-embedded-runner/model.test.ts`
- `pnpm exec vitest run src/gateway/session-utils.test.ts src/commands/agent.acp.test.ts src/commands/sessions.model-resolution.test.ts`
- `pnpm exec vitest run src/agents/model-auth.profiles.test.ts src/commands/models/list.list-command.forward-compat.test.ts`
- `pnpm build`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified model parsing/normalization now preserves `openai` for `gpt-5.3-codex` refs.
- Verified fallback runner uses `openai` candidate (not forced `openai-codex`) for `gpt-5.3-codex`.
- Verified embedded runner forward-compat resolution works for both `openai` and `openai-codex` providers.
- What you did **not** verify: live end-to-end API calls against production OpenAI and Codex OAuth accounts in this cycle.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/model-selection.ts` and `src/agents/model-forward-compat.ts`.
- Known bad symptoms reviewers should watch for: explicit `openai/gpt-5.3-codex` unexpectedly routing back to `openai-codex` or unresolved unknown-model errors for `openai/gpt-5.3-codex`.

## Risks and Mitigations

- Risk:
  - Deployments relying on implicit historical remap from `openai` to `openai-codex` for `gpt-5.3-codex` could observe provider behavior change.
  - Mitigation:
    - Explicit `openai-codex/*` refs are unchanged; forward-compat fallback now supports `openai` provider path with dedicated tests.

AI-assisted: Yes (Codex). Testing degree: fully tested for this change scope.
