### PR TITLE
hooks: unify internal + plugin hook registries to fix 5 systemic bugs

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -73,7 +73,9 @@ export function handleAutoCompactionEnd(
             messageCount: ctx.params.session.messages?.length ?? 0,
             compactedCount: ctx.getCompactionCount(),
           },
-          {},
+          {
+            sessionKey: ctx.params.sessionKey,
+          },
         )
         .catch((err) => {
           ctx.log.warn(`after_compaction hook failed: ${String(err)}`);

--- a/src/hooks/dispatch-unified.ts
+++ b/src/hooks/dispatch-unified.ts
@@ -1,0 +1,141 @@
+/**
+ * Unified dispatch helpers for overlapping hook events.
+ *
+ * Three events are dispatched through both the internal hook system
+ * (HOOK.md discovery) and the plugin typed hook system. This module
+ * co-locates the dual dispatch so each call site only needs one function.
+ */
+
+import { createInternalHookEvent, triggerInternalHook } from "./internal-hooks.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+
+/**
+ * Emit a message_received event through both hook systems.
+ */
+export function emitMessageReceived(params: {
+  from: string;
+  content: string;
+  timestamp?: number;
+  channelId: string;
+  accountId?: string;
+  conversationId?: string;
+  messageId?: string;
+  sessionKey?: string;
+  metadata?: Record<string, unknown>;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("message_received")) {
+    void hookRunner
+      .runMessageReceived(
+        {
+          from: params.from,
+          content: params.content,
+          timestamp: params.timestamp,
+          metadata: params.metadata ?? {},
+        },
+        {
+          channelId: params.channelId,
+          accountId: params.accountId,
+          conversationId: params.conversationId,
+        },
+      )
+      .catch(() => {});
+  }
+
+  if (params.sessionKey) {
+    void triggerInternalHook(
+      createInternalHookEvent("message", "received", params.sessionKey, {
+        from: params.from,
+        content: params.content,
+        timestamp: params.timestamp,
+        channelId: params.channelId,
+        accountId: params.accountId,
+        conversationId: params.conversationId,
+        messageId: params.messageId,
+        metadata: params.metadata ?? {},
+      }),
+    ).catch(() => {});
+  }
+}
+
+/**
+ * Emit a message_sent event through both hook systems.
+ */
+export function emitMessageSent(params: {
+  to: string;
+  content: string;
+  success: boolean;
+  error?: string;
+  channelId: string;
+  accountId?: string;
+  conversationId?: string;
+  messageId?: string;
+  sessionKey?: string;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("message_sent")) {
+    void hookRunner
+      .runMessageSent(
+        {
+          to: params.to,
+          content: params.content,
+          success: params.success,
+          ...(params.error ? { error: params.error } : {}),
+        },
+        {
+          channelId: params.channelId,
+          accountId: params.accountId,
+          conversationId: params.conversationId ?? params.to,
+        },
+      )
+      .catch(() => {});
+  }
+
+  if (params.sessionKey) {
+    void triggerInternalHook(
+      createInternalHookEvent("message", "sent", params.sessionKey, {
+        to: params.to,
+        content: params.content,
+        success: params.success,
+        ...(params.error ? { error: params.error } : {}),
+        channelId: params.channelId,
+        accountId: params.accountId,
+        conversationId: params.conversationId ?? params.to,
+        messageId: params.messageId,
+      }),
+    ).catch(() => {});
+  }
+}
+
+/**
+ * Emit gateway startup through both hook systems.
+ *
+ * Fires both hooks synchronously (no setTimeout). Must be called after
+ * hook loading completes to avoid the race condition in #30784.
+ */
+export function emitGatewayStartup(params: {
+  port: number;
+  cfg?: unknown;
+  deps?: unknown;
+  workspaceDir?: string;
+  internalHooksEnabled?: boolean;
+}): void {
+  // Plugin hook
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("gateway_start")) {
+    void hookRunner
+      .runGatewayStart({ port: params.port }, { port: params.port })
+      .catch(() => {});
+  }
+
+  // Internal hook — no setTimeout, fire immediately after hooks are loaded
+  if (params.internalHooksEnabled) {
+    void triggerInternalHook(
+      createInternalHookEvent("gateway", "startup", "gateway:startup", {
+        cfg: params.cfg,
+        deps: params.deps,
+        workspaceDir: params.workspaceDir,
+      }),
+    ).catch(() => {});
+  }
+}

--- a/src/hooks/dispatch-unified.ts
+++ b/src/hooks/dispatch-unified.ts
@@ -6,8 +6,8 @@
  * co-locates the dual dispatch so each call site only needs one function.
  */
 
-import { createInternalHookEvent, triggerInternalHook } from "./internal-hooks.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { createInternalHookEvent, triggerInternalHook } from "./internal-hooks.js";
 
 /**
  * Emit a message_received event through both hook systems.
@@ -31,7 +31,10 @@ export function emitMessageReceived(params: {
           from: params.from,
           content: params.content,
           timestamp: params.timestamp,
-          metadata: params.metadata ?? {},
+          metadata: {
+            ...params.metadata,
+            ...(params.messageId ? { messageId: params.messageId } : {}),
+          },
         },
         {
           channelId: params.channelId,
@@ -123,9 +126,7 @@ export function emitGatewayStartup(params: {
   // Plugin hook
   const hookRunner = getGlobalHookRunner();
   if (hookRunner?.hasHooks("gateway_start")) {
-    void hookRunner
-      .runGatewayStart({ port: params.port }, { port: params.port })
-      .catch(() => {});
+    void hookRunner.runGatewayStart({ port: params.port }, { port: params.port }).catch(() => {});
   }
 
   // Internal hook — no setTimeout, fire immediately after hooks are loaded

--- a/src/hooks/dispatch-unified.ts
+++ b/src/hooks/dispatch-unified.ts
@@ -6,6 +6,7 @@
  * co-locates the dual dispatch so each call site only needs one function.
  */
 
+import { logVerbose } from "../globals.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { createInternalHookEvent, triggerInternalHook } from "./internal-hooks.js";
 
@@ -42,7 +43,9 @@ export function emitMessageReceived(params: {
           conversationId: params.conversationId,
         },
       )
-      .catch(() => {});
+      .catch((err) => {
+        logVerbose(`dispatch-unified: message_received plugin hook failed: ${String(err)}`);
+      });
   }
 
   if (params.sessionKey) {
@@ -91,7 +94,9 @@ export function emitMessageSent(params: {
           conversationId: params.conversationId ?? params.to,
         },
       )
-      .catch(() => {});
+      .catch((err) => {
+        logVerbose(`dispatch-unified: message_sent plugin hook failed: ${String(err)}`);
+      });
   }
 
   if (params.sessionKey) {
@@ -126,7 +131,11 @@ export function emitGatewayStartup(params: {
   // Plugin hook
   const hookRunner = getGlobalHookRunner();
   if (hookRunner?.hasHooks("gateway_start")) {
-    void hookRunner.runGatewayStart({ port: params.port }, { port: params.port }).catch(() => {});
+    void hookRunner
+      .runGatewayStart({ port: params.port }, { port: params.port })
+      .catch((err) => {
+        logVerbose(`dispatch-unified: gateway_start plugin hook failed: ${String(err)}`);
+      });
   }
 
   // Internal hook — no setTimeout, fire immediately after hooks are loaded

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -25,7 +25,7 @@ function resolveHookSource(source: string): HookSource {
     case "openclaw-bundled": return "bundled";
     case "openclaw-managed": return "managed";
     case "openclaw-workspace": return "workspace";
-    case "openclaw-plugin": return "plugin";
+    case "openclaw-plugin": return "workspace";
     default: return "config";
   }
 }

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -262,7 +262,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
 
     for (const event of normalizedEvents) {
-      registerInternalHook(event, handler);
+      registerInternalHook(event, handler, "plugin");
     }
   };
 


### PR DESCRIPTION
## Summary

Fixes #30784 — The codebase has two independent hook systems with overlapping responsibilities and duplicated module-level singleton state. This PR fixes all 5 systemic bugs from the same root cause.

### What changed

- **Bundler-safe singletons**: `internal-hooks.ts` and `hook-runner-global.ts` now use `globalThis[Symbol.for()]` instead of module-level variables — same pattern as `plugins/runtime.ts`. Hooks survive Rolldown chunk splitting.
- **Source-scoped clearing**: Every registered hook now carries source metadata (`"bundled"`, `"workspace"`, `"managed"`, `"config"`, `"plugin"`). `clearInternalHooksBySource()` preserves plugin hooks during hot-reload.
- **Unified dispatch helpers**: New `src/hooks/dispatch-unified.ts` — `emitMessageReceived()`, `emitMessageSent()`, `emitGatewayStartup()` — replaces 15-30 lines of manual dual-dispatch per call site.
- **gateway:startup race fix**: Removed `setTimeout(250)`, both hooks now fire together via `emitGatewayStartup()` after sidecars are fully loaded.
- **sessions.reset before_reset**: Gateway RPC handler now fires the plugin `before_reset` hook (matching `commands-core.ts` behavior).
- **after_compaction sessionKey**: Context now includes `sessionKey` (matching `before_compaction`).

### Files

| File | Change |
|------|--------|
| `src/hooks/dispatch-unified.ts` | **New** — unified dispatch helpers |
| `src/hooks/internal-hooks.ts` | globalThis singleton, source metadata, source-scoped clearing |
| `src/plugins/hook-runner-global.ts` | globalThis singleton |
| `src/hooks/loader.ts` | Pass hook source to registerInternalHook |
| `src/plugins/registry.ts` | Pass `"plugin"` source to registerInternalHook |
| `src/gateway/server-startup.ts` | Source-scoped clear, remove setTimeout race |
| `src/gateway/server.impl.ts` | Use emitGatewayStartup dispatch helper |
| `src/auto-reply/reply/dispatch-from-config.ts` | Use emitMessageReceived dispatch helper |
| `src/infra/outbound/deliver.ts` | Use emitMessageSent dispatch helper |
| `src/gateway/server-methods/sessions.ts` | Add missing before_reset plugin hook |
| `src/agents/pi-embedded-subscribe.handlers.compaction.ts` | Add missing sessionKey to after_compaction |

**1 new file, 10 modified. ~160 LOC new. Backward compatible** — no changes to HookRunner facade, existing hook handler signatures, or the 24 typed hook definitions.

## Test plan

- [ ] Verify `registerInternalHook` with 2 args still works (backward compat)
- [ ] Verify plugin hooks survive `clearInternalHooksBySource(["bundled", "workspace", "managed", "config"])`
- [ ] Verify gateway startup fires both internal and plugin hooks without race condition
- [ ] Verify `/reset` from gateway RPC fires `before_reset` plugin hook
- [ ] Verify `after_compaction` hook receives `sessionKey` in context
- [ ] Run existing hook test suite (`src/hooks/internal-hooks.test.ts`)
- [ ] Run existing plugin hooks test (`src/plugins/wired-hooks-compaction.test.ts`)