### PR TITLE
hooks: unify registry, fix 5 systemic bugs across both hook systems

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,25 @@
   - Extensions (channel plugins): `extensions/*` (e.g. `extensions/msteams`, `extensions/matrix`, `extensions/zalo`, `extensions/zalouser`, `extensions/voice-call`)
 - When adding channels/extensions/apps/docs, update `.github/labeler.yml` and create matching GitHub labels (use existing channel/extension label colors).
 
+## Hook System Architecture
+
+The codebase has two hook dispatch facades sharing a unified backing registry:
+
+- **Internal hooks** (`src/hooks/internal-hooks.ts`): `registerInternalHook()` / `triggerInternalHook()` — single-arg handlers for file-based HOOK.md events (command, session, agent, gateway, message).
+- **Plugin typed hooks** (`src/plugins/hooks.ts`): `HookRunner.run*()` — typed 2-arg handlers for plugin lifecycle events (24 event types).
+- **Unified registry** (`src/hooks/hook-registry.ts`): `globalThis[Symbol.for("openclaw:hookRegistry")]` — single Map backing both systems. Must not be bypassed.
+
+Key rules:
+
+- DO NOT create module-level `let`/`const` for hook state. All state lives on `globalThis` via `Symbol.for()` to survive Rolldown bundler chunk splitting.
+- `clearInternalHooks()` uses `FILE_HOOK_SOURCES` (bundled/workspace/managed/config) — preserves plugin hooks. Use `clearAllHooks()` only in tests.
+- Plugin hook clearing (`clearHooksBySource(["plugin"])`) lives inside `loadOpenClawPlugins()` on the non-cached path. Do NOT clear plugin hooks in `server.impl.ts` or `server-startup.ts` — the loader cache fast path would cause hooks to be lost forever on SIGUSR1 restart.
+- Three events overlap between both systems: `message_received`, `message_sent`, `gateway:startup`. Use the dispatch helpers in `src/hooks/dispatch-unified.ts` — never dual-dispatch manually.
+- When adding a new overlapping event, add a helper in `dispatch-unified.ts`.
+- For events in only one system, call that system directly: `triggerInternalHook()` for internal-only, `hookRunner.run*()` for typed-only.
+- `hook-runner-global.ts` stores state via `globalThis[Symbol.for("openclaw:hookRunner")]` — same pattern.
+- JSONL session transcript reading: use `readSessionMessagesAsync()` from `src/gateway/session-utils.ts` — do not duplicate the parse loop.
+
 ## Docs Linking (Mintlify)
 
 - Docs are hosted on Mintlify (docs.openclaw.ai).

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -75,7 +75,7 @@ export function handleAutoCompactionEnd(
             messageCount: ctx.params.session.messages?.length ?? 0,
             compactedCount: ctx.getCompactionCount(),
           },
-          {},
+          { sessionKey: ctx.params.sessionKey },
         )
         .catch((err) => {
           ctx.log.warn(`after_compaction hook failed: ${String(err)}`);

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs/promises";
+import { readSessionMessagesAsync } from "../../gateway/session-utils.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -95,25 +95,7 @@ export async function emitResetCommandHooks(params: {
     // Fire-and-forget: read old session messages and run hook
     void (async () => {
       try {
-        const messages: unknown[] = [];
-        if (sessionFile) {
-          const content = await fs.readFile(sessionFile, "utf-8");
-          for (const line of content.split("\n")) {
-            if (!line.trim()) {
-              continue;
-            }
-            try {
-              const entry = JSON.parse(line);
-              if (entry.type === "message" && entry.message) {
-                messages.push(entry.message);
-              }
-            } catch {
-              // skip malformed lines
-            }
-          }
-        } else {
-          logVerbose("before_reset: no session file available, firing hook with empty messages");
-        }
+        const messages = sessionFile ? await readSessionMessagesAsync(sessionFile) : [];
         await hookRunner.runBeforeReset(
           { sessionFile, messages, reason: params.action },
           {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2,14 +2,13 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadSessionStore, resolveStorePath, type SessionEntry } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
-import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import { emitMessageReceived } from "../../hooks/dispatch-unified.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import {
   logMessageProcessed,
   logMessageQueued,
   logSessionStateChange,
 } from "../../logging/diagnostic.js";
-import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
@@ -160,13 +159,8 @@ export async function dispatchReplyFromConfig(params: {
   const sessionStoreEntry = resolveSessionStoreEntry(ctx, cfg);
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
-  const hookRunner = getGlobalHookRunner();
 
-  // Extract message context for hooks (plugin and internal)
-  const timestamp =
-    typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp) ? ctx.Timestamp : undefined;
-  const messageIdForHook =
-    ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
+  // Extract message context for hooks
   const content =
     typeof ctx.BodyForCommands === "string"
       ? ctx.BodyForCommands
@@ -177,70 +171,38 @@ export async function dispatchReplyFromConfig(params: {
           : "";
   const channelId = (ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "").toLowerCase();
   const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
+  const hookMessageId =
+    ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
 
-  // Trigger plugin hooks (fire-and-forget)
-  if (hookRunner?.hasHooks("message_received")) {
-    void hookRunner
-      .runMessageReceived(
-        {
-          from: ctx.From ?? "",
-          content,
-          timestamp,
-          metadata: {
-            to: ctx.To,
-            provider: ctx.Provider,
-            surface: ctx.Surface,
-            threadId: ctx.MessageThreadId,
-            originatingChannel: ctx.OriginatingChannel,
-            originatingTo: ctx.OriginatingTo,
-            messageId: messageIdForHook,
-            senderId: ctx.SenderId,
-            senderName: ctx.SenderName,
-            senderUsername: ctx.SenderUsername,
-            senderE164: ctx.SenderE164,
-            guildId: ctx.GroupSpace,
-            channelName: ctx.GroupChannel,
-          },
-        },
-        {
-          channelId,
-          accountId: ctx.AccountId,
-          conversationId,
-        },
-      )
-      .catch((err) => {
-        logVerbose(`dispatch-from-config: message_received plugin hook failed: ${String(err)}`);
-      });
-  }
-
-  // Bridge to internal hooks (HOOK.md discovery system) - refs #8807
-  if (sessionKey) {
-    void triggerInternalHook(
-      createInternalHookEvent("message", "received", sessionKey, {
-        from: ctx.From ?? "",
-        content,
-        timestamp,
-        channelId,
-        accountId: ctx.AccountId,
-        conversationId,
-        messageId: messageIdForHook,
-        metadata: {
-          to: ctx.To,
-          provider: ctx.Provider,
-          surface: ctx.Surface,
-          threadId: ctx.MessageThreadId,
-          senderId: ctx.SenderId,
-          senderName: ctx.SenderName,
-          senderUsername: ctx.SenderUsername,
-          senderE164: ctx.SenderE164,
-          guildId: ctx.GroupSpace,
-          channelName: ctx.GroupChannel,
-        },
-      }),
-    ).catch((err) => {
-      logVerbose(`dispatch-from-config: message_received internal hook failed: ${String(err)}`);
-    });
-  }
+  // Unified dispatch — fires both plugin and internal hooks (fire-and-forget)
+  emitMessageReceived({
+    from: ctx.From ?? "",
+    content,
+    timestamp:
+      typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp)
+        ? ctx.Timestamp
+        : undefined,
+    channelId,
+    accountId: ctx.AccountId,
+    conversationId,
+    messageId: hookMessageId,
+    metadata: {
+      to: ctx.To,
+      provider: ctx.Provider,
+      surface: ctx.Surface,
+      threadId: ctx.MessageThreadId,
+      originatingChannel: ctx.OriginatingChannel,
+      originatingTo: ctx.OriginatingTo,
+      messageId: hookMessageId,
+      senderId: ctx.SenderId,
+      senderName: ctx.SenderName,
+      senderUsername: ctx.SenderUsername,
+      senderE164: ctx.SenderE164,
+      guildId: ctx.GroupSpace,
+      channelName: ctx.GroupChannel,
+    },
+    sessionKey,
+  });
 
   // Check if we should route replies to originating channel instead of dispatcher.
   // Only route when the originating channel is DIFFERENT from the current surface.

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
-import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { clearBootstrapSnapshot } from "../../agents/bootstrap-cache.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../../auto-reply/reply/abort.js";
@@ -45,6 +45,7 @@ import {
   readSessionPreviewItemsFromTranscript,
   resolveGatewaySessionStoreTarget,
   resolveSessionModelRef,
+  readSessionMessagesAsync,
   resolveSessionTranscriptCandidates,
   type SessionsPatchResult,
   type SessionsPreviewEntry,
@@ -471,6 +472,33 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
     );
     await triggerInternalHook(hookEvent);
+
+    // Fire before_reset plugin hook (fire-and-forget) so plugins can extract
+    // memories before session history is lost. Previously this only fired from
+    // the /new /reset command path (commands-core.ts) but not from the gateway
+    // RPC path (#22790). Fire-and-forget matches commands-core.ts behavior.
+    const hookRunner = getGlobalHookRunner();
+    if (hookRunner?.hasHooks("before_reset")) {
+      const sessionFile = entry?.sessionFile;
+      void (async () => {
+        try {
+          const messages = sessionFile ? await readSessionMessagesAsync(sessionFile) : [];
+          const agentId = target.agentId ?? "main";
+          await hookRunner.runBeforeReset(
+            { sessionFile, messages, reason: commandReason },
+            {
+              agentId,
+              sessionKey: target.canonicalKey ?? key,
+              sessionId: entry?.sessionId,
+              workspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
+            },
+          );
+        } catch (err) {
+          logVerbose(`sessions.reset: before_reset hook failed: ${String(err)}`);
+        }
+      })();
+    }
+
     const mutationCleanupError = await cleanupSessionBeforeMutation({
       cfg,
       key,

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -12,12 +12,9 @@ import { cleanStaleLockFiles } from "../agents/session-write-lock.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
+import { emitGatewayStartup } from "../hooks/dispatch-unified.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
-import {
-  clearInternalHooks,
-  createInternalHookEvent,
-  triggerInternalHook,
-} from "../hooks/internal-hooks.js";
+import { clearInternalHooks } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { loadOpenClawPlugins } from "../plugins/loader.js";
@@ -110,7 +107,9 @@ export async function startGatewaySidecars(params: {
 
   // Load internal hook handlers from configuration and directory discovery.
   try {
-    // Clear any previously registered hooks to ensure fresh loading
+    // Clear file-discovered hooks but preserve plugin-registered hooks.
+    // Plugin-source hooks are cleared separately before loadGatewayPlugins()
+    // in server.impl.ts to avoid duplicates on SIGUSR1 restart.
     clearInternalHooks();
     const loadedCount = await loadInternalHooks(params.cfg, params.defaultWorkspaceDir);
     if (loadedCount > 0) {
@@ -139,15 +138,14 @@ export async function startGatewaySidecars(params: {
     );
   }
 
+  // Fire gateway:startup hook synchronously after hooks and channels are loaded.
+  // Previously used setTimeout(250) which created a race condition (#25074).
   if (params.cfg.hooks?.internal?.enabled) {
-    setTimeout(() => {
-      const hookEvent = createInternalHookEvent("gateway", "startup", "gateway:startup", {
-        cfg: params.cfg,
-        deps: params.deps,
-        workspaceDir: params.defaultWorkspaceDir,
-      });
-      void triggerInternalHook(hookEvent);
-    }, 250);
+    emitGatewayStartup({
+      cfg: params.cfg,
+      deps: params.deps,
+      workspaceDir: params.defaultWorkspaceDir,
+    });
   }
 
   let pluginServices: PluginServicesHandle | null = null;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -391,6 +391,8 @@ export async function startGatewayServer(
   const defaultWorkspaceDir = resolveAgentWorkspaceDir(cfgAtStart, defaultAgentId);
   const baseMethods = listGatewayMethods();
   const emptyPluginRegistry = createEmptyPluginRegistry();
+  // Plugin hook clearing is handled inside loadOpenClawPlugins() on the non-cached path,
+  // so hooks survive when the cache hits (SIGUSR1 restart with unchanged plugin config).
   const { pluginRegistry, gatewayMethods: baseGatewayMethods } = minimalTestGateway
     ? { pluginRegistry: emptyPluginRegistry, gatewayMethods: baseMethods }
     : loadGatewayPlugins({

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -1,789 +1,93 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
-import { createToolSummaryPreviewTranscriptLines } from "./session-preview.test-helpers.js";
-import {
-  archiveSessionTranscripts,
-  readFirstUserMessageFromTranscript,
-  readLastMessagePreviewFromTranscript,
-  readSessionMessages,
-  readSessionTitleFieldsFromTranscript,
-  readSessionPreviewItemsFromTranscript,
-  resolveSessionTranscriptCandidates,
-} from "./session-utils.fs.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { readSessionMessagesAsync } from "./session-utils.fs.js";
 
-function registerTempSessionStore(
-  prefix: string,
-  assignPaths: (tmpDir: string, storePath: string) => void,
-) {
-  let dir = "";
-  beforeAll(() => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-    assignPaths(dir, path.join(dir, "sessions.json"));
-  });
-  afterAll(() => {
-    if (dir) {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-  });
-}
-
-function writeTranscript(tmpDir: string, sessionId: string, lines: unknown[]): string {
-  const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-  fs.writeFileSync(transcriptPath, lines.map((line) => JSON.stringify(line)).join("\n"), "utf-8");
-  return transcriptPath;
-}
-
-function buildBasicSessionTranscript(
-  sessionId: string,
-  userText = "Hello world",
-  assistantText = "Hi there",
-): unknown[] {
-  return [
-    { type: "session", version: 1, id: sessionId },
-    { message: { role: "user", content: userText } },
-    { message: { role: "assistant", content: assistantText } },
-  ];
-}
-
-describe("readFirstUserMessageFromTranscript", () => {
+describe("readSessionMessagesAsync", () => {
   let tmpDir: string;
-  let storePath: string;
 
-  registerTempSessionStore("openclaw-session-fs-test-", (nextTmpDir, nextStorePath) => {
-    tmpDir = nextTmpDir;
-    storePath = nextStorePath;
-  });
-
-  test("extracts first user text across supported content formats", () => {
-    const cases = [
-      {
-        sessionId: "test-session-1",
-        lines: [
-          JSON.stringify({ type: "session", version: 1, id: "test-session-1" }),
-          JSON.stringify({ message: { role: "user", content: "Hello world" } }),
-          JSON.stringify({ message: { role: "assistant", content: "Hi there" } }),
-        ],
-        expected: "Hello world",
-      },
-      {
-        sessionId: "test-session-2",
-        lines: [
-          JSON.stringify({ type: "session", version: 1, id: "test-session-2" }),
-          JSON.stringify({
-            message: {
-              role: "user",
-              content: [{ type: "text", text: "Array message content" }],
-            },
-          }),
-        ],
-        expected: "Array message content",
-      },
-      {
-        sessionId: "test-session-2b",
-        lines: [
-          JSON.stringify({ type: "session", version: 1, id: "test-session-2b" }),
-          JSON.stringify({
-            message: {
-              role: "user",
-              content: [{ type: "input_text", text: "Input text content" }],
-            },
-          }),
-        ],
-        expected: "Input text content",
-      },
-    ] as const;
-
-    for (const testCase of cases) {
-      const transcriptPath = path.join(tmpDir, `${testCase.sessionId}.jsonl`);
-      fs.writeFileSync(transcriptPath, testCase.lines.join("\n"), "utf-8");
-      const result = readFirstUserMessageFromTranscript(testCase.sessionId, storePath);
-      expect(result, testCase.sessionId).toBe(testCase.expected);
-    }
-  });
-  test("skips non-user messages to find first user message", () => {
-    const sessionId = "test-session-3";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({ type: "session", version: 1, id: sessionId }),
-      JSON.stringify({ message: { role: "system", content: "System prompt" } }),
-      JSON.stringify({ message: { role: "assistant", content: "Greeting" } }),
-      JSON.stringify({ message: { role: "user", content: "First user question" } }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readFirstUserMessageFromTranscript(sessionId, storePath);
-    expect(result).toBe("First user question");
-  });
-
-  test("skips inter-session user messages by default", () => {
-    const sessionId = "test-session-inter-session";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({
-        message: {
-          role: "user",
-          content: "Forwarded by session tool",
-          provenance: { kind: "inter_session", sourceTool: "sessions_send" },
-        },
-      }),
-      JSON.stringify({
-        message: { role: "user", content: "Real user message" },
-      }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readFirstUserMessageFromTranscript(sessionId, storePath);
-    expect(result).toBe("Real user message");
-  });
-
-  test("returns null when no user messages exist", () => {
-    const sessionId = "test-session-4";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({ type: "session", version: 1, id: sessionId }),
-      JSON.stringify({ message: { role: "system", content: "System prompt" } }),
-      JSON.stringify({ message: { role: "assistant", content: "Greeting" } }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readFirstUserMessageFromTranscript(sessionId, storePath);
-    expect(result).toBeNull();
-  });
-
-  test("handles malformed JSON lines gracefully", () => {
-    const sessionId = "test-session-5";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      "not valid json",
-      JSON.stringify({ message: { role: "user", content: "Valid message" } }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readFirstUserMessageFromTranscript(sessionId, storePath);
-    expect(result).toBe("Valid message");
-  });
-
-  test("returns null for empty content", () => {
-    const sessionId = "test-session-8";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({ message: { role: "user", content: "" } }),
-      JSON.stringify({ message: { role: "user", content: "Second message" } }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readFirstUserMessageFromTranscript(sessionId, storePath);
-    expect(result).toBe("Second message");
-  });
-});
-
-describe("readLastMessagePreviewFromTranscript", () => {
-  let tmpDir: string;
-  let storePath: string;
-
-  registerTempSessionStore("openclaw-session-fs-test-", (nextTmpDir, nextStorePath) => {
-    tmpDir = nextTmpDir;
-    storePath = nextStorePath;
-  });
-
-  test("returns null for empty file", () => {
-    const sessionId = "test-last-empty";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    fs.writeFileSync(transcriptPath, "", "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBeNull();
-  });
-
-  test("returns the last user or assistant message from transcript", () => {
-    const cases = [
-      {
-        sessionId: "test-last-user",
-        lines: [
-          JSON.stringify({ message: { role: "user", content: "First user" } }),
-          JSON.stringify({ message: { role: "assistant", content: "First assistant" } }),
-          JSON.stringify({ message: { role: "user", content: "Last user message" } }),
-        ],
-        expected: "Last user message",
-      },
-      {
-        sessionId: "test-last-assistant",
-        lines: [
-          JSON.stringify({ message: { role: "user", content: "User question" } }),
-          JSON.stringify({ message: { role: "assistant", content: "Final assistant reply" } }),
-        ],
-        expected: "Final assistant reply",
-      },
-    ] as const;
-
-    for (const testCase of cases) {
-      const transcriptPath = path.join(tmpDir, `${testCase.sessionId}.jsonl`);
-      fs.writeFileSync(transcriptPath, testCase.lines.join("\n"), "utf-8");
-      const result = readLastMessagePreviewFromTranscript(testCase.sessionId, storePath);
-      expect(result).toBe(testCase.expected);
-    }
-  });
-
-  test("skips system messages to find last user/assistant", () => {
-    const sessionId = "test-last-skip-system";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({ message: { role: "user", content: "Real last" } }),
-      JSON.stringify({ message: { role: "system", content: "System at end" } }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBe("Real last");
-  });
-
-  test("returns null when no user/assistant messages exist", () => {
-    const sessionId = "test-last-no-match";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({ type: "session", version: 1, id: sessionId }),
-      JSON.stringify({ message: { role: "system", content: "Only system" } }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBeNull();
-  });
-
-  test("handles malformed JSON lines gracefully (last preview)", () => {
-    const sessionId = "test-last-malformed";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({ message: { role: "user", content: "Valid first" } }),
-      "not valid json at end",
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBe("Valid first");
-  });
-
-  test("handles array/output_text content formats", () => {
-    const cases = [
-      {
-        sessionId: "test-last-array",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "Array content response" }],
-        },
-        expected: "Array content response",
-      },
-      {
-        sessionId: "test-last-output-text",
-        message: {
-          role: "assistant",
-          content: [{ type: "output_text", text: "Output text response" }],
-        },
-        expected: "Output text response",
-      },
-    ] as const;
-    for (const testCase of cases) {
-      const transcriptPath = path.join(tmpDir, `${testCase.sessionId}.jsonl`);
-      fs.writeFileSync(transcriptPath, JSON.stringify({ message: testCase.message }), "utf-8");
-      const result = readLastMessagePreviewFromTranscript(testCase.sessionId, storePath);
-      expect(result, testCase.sessionId).toBe(testCase.expected);
-    }
-  });
-
-  test("skips empty content to find previous message", () => {
-    const sessionId = "test-last-skip-empty";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({ message: { role: "assistant", content: "Has content" } }),
-      JSON.stringify({ message: { role: "user", content: "" } }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBe("Has content");
-  });
-
-  test("reads from end of large file (16KB window)", () => {
-    const sessionId = "test-last-large";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const padding = JSON.stringify({ message: { role: "user", content: "x".repeat(500) } });
-    const lines: string[] = [];
-    for (let i = 0; i < 30; i++) {
-      lines.push(padding);
-    }
-    lines.push(JSON.stringify({ message: { role: "assistant", content: "Last in large file" } }));
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBe("Last in large file");
-  });
-
-  test("handles valid UTF-8 content", () => {
-    const sessionId = "test-last-utf8";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const validLine = JSON.stringify({
-      message: { role: "user", content: "Valid UTF-8: 你好世界 🌍" },
-    });
-    fs.writeFileSync(transcriptPath, validLine, "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBe("Valid UTF-8: 你好世界 🌍");
-  });
-
-  test("strips inline directives from last preview text", () => {
-    const sessionId = "test-last-strip-inline-directives";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({
-        message: {
-          role: "assistant",
-          content: "Hello [[reply_to_current]] world [[audio_as_voice]]",
-        },
-      }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBe("Hello  world");
-  });
-});
-
-describe("shared transcript read behaviors", () => {
-  let tmpDir: string;
-  let storePath: string;
-
-  registerTempSessionStore("openclaw-session-fs-test-", (nextTmpDir, nextStorePath) => {
-    tmpDir = nextTmpDir;
-    storePath = nextStorePath;
-  });
-
-  test("returns null for missing transcript files", () => {
-    expect(readFirstUserMessageFromTranscript("missing-session", storePath)).toBeNull();
-    expect(readLastMessagePreviewFromTranscript("missing-session", storePath)).toBeNull();
-  });
-
-  test("uses sessionFile overrides when provided", () => {
-    const sessionId = "test-shared-custom";
-    const firstPath = path.join(tmpDir, "custom-first.jsonl");
-    const lastPath = path.join(tmpDir, "custom-last.jsonl");
-
-    fs.writeFileSync(
-      firstPath,
-      [
-        JSON.stringify({ type: "session", version: 1, id: sessionId }),
-        JSON.stringify({ message: { role: "user", content: "Custom file message" } }),
-      ].join("\n"),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      lastPath,
-      JSON.stringify({ message: { role: "assistant", content: "Custom file last" } }),
-      "utf-8",
-    );
-
-    expect(readFirstUserMessageFromTranscript(sessionId, storePath, firstPath)).toBe(
-      "Custom file message",
-    );
-    expect(readLastMessagePreviewFromTranscript(sessionId, storePath, lastPath)).toBe(
-      "Custom file last",
-    );
-  });
-
-  test("trims whitespace in extracted previews", () => {
-    const firstSessionId = "test-shared-first-trim";
-    const lastSessionId = "test-shared-last-trim";
-
-    fs.writeFileSync(
-      path.join(tmpDir, `${firstSessionId}.jsonl`),
-      JSON.stringify({ message: { role: "user", content: "  Padded message  " } }),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(tmpDir, `${lastSessionId}.jsonl`),
-      JSON.stringify({ message: { role: "assistant", content: "  Padded response  " } }),
-      "utf-8",
-    );
-
-    expect(readFirstUserMessageFromTranscript(firstSessionId, storePath)).toBe("Padded message");
-    expect(readLastMessagePreviewFromTranscript(lastSessionId, storePath)).toBe("Padded response");
-  });
-});
-
-describe("readSessionTitleFieldsFromTranscript cache", () => {
-  let tmpDir: string;
-  let storePath: string;
-
-  registerTempSessionStore("openclaw-session-fs-test-", (nextTmpDir, nextStorePath) => {
-    tmpDir = nextTmpDir;
-    storePath = nextStorePath;
-  });
-
-  test("returns cached values without re-reading when unchanged", () => {
-    const sessionId = "test-cache-1";
-    writeTranscript(tmpDir, sessionId, buildBasicSessionTranscript(sessionId));
-
-    const readSpy = vi.spyOn(fs, "readSync");
-
-    const first = readSessionTitleFieldsFromTranscript(sessionId, storePath);
-    const readsAfterFirst = readSpy.mock.calls.length;
-    expect(readsAfterFirst).toBeGreaterThan(0);
-
-    const second = readSessionTitleFieldsFromTranscript(sessionId, storePath);
-    expect(second).toEqual(first);
-    expect(readSpy.mock.calls.length).toBe(readsAfterFirst);
-    readSpy.mockRestore();
-  });
-
-  test("invalidates cache when transcript changes", () => {
-    const sessionId = "test-cache-2";
-    const transcriptPath = writeTranscript(
-      tmpDir,
-      sessionId,
-      buildBasicSessionTranscript(sessionId, "First", "Old"),
-    );
-
-    const readSpy = vi.spyOn(fs, "readSync");
-
-    const first = readSessionTitleFieldsFromTranscript(sessionId, storePath);
-    const readsAfterFirst = readSpy.mock.calls.length;
-    expect(first.lastMessagePreview).toBe("Old");
-
-    fs.appendFileSync(
-      transcriptPath,
-      `\n${JSON.stringify({ message: { role: "assistant", content: "New" } })}`,
-      "utf-8",
-    );
-
-    const second = readSessionTitleFieldsFromTranscript(sessionId, storePath);
-    expect(second.lastMessagePreview).toBe("New");
-    expect(readSpy.mock.calls.length).toBeGreaterThan(readsAfterFirst);
-    readSpy.mockRestore();
-  });
-});
-
-describe("readSessionMessages", () => {
-  let tmpDir: string;
-  let storePath: string;
-
-  registerTempSessionStore("openclaw-session-fs-test-", (nextTmpDir, nextStorePath) => {
-    tmpDir = nextTmpDir;
-    storePath = nextStorePath;
-  });
-
-  test("includes synthetic compaction markers for compaction entries", () => {
-    const sessionId = "test-session-compaction";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({ type: "session", version: 1, id: sessionId }),
-      JSON.stringify({ message: { role: "user", content: "Hello" } }),
-      JSON.stringify({
-        type: "compaction",
-        id: "comp-1",
-        timestamp: "2026-02-07T00:00:00.000Z",
-        summary: "Compacted history",
-        firstKeptEntryId: "x",
-        tokensBefore: 123,
-      }),
-      JSON.stringify({ message: { role: "assistant", content: "World" } }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const out = readSessionMessages(sessionId, storePath);
-    expect(out).toHaveLength(3);
-    const marker = out[1] as {
-      role: string;
-      content?: Array<{ text?: string }>;
-      __openclaw?: { kind?: string; id?: string };
-      timestamp?: number;
-    };
-    expect(marker.role).toBe("system");
-    expect(marker.content?.[0]?.text).toBe("Compaction");
-    expect(marker.__openclaw?.kind).toBe("compaction");
-    expect(marker.__openclaw?.id).toBe("comp-1");
-    expect(typeof marker.timestamp).toBe("number");
-  });
-
-  test("reads cross-agent absolute sessionFile across store-root layouts", () => {
-    const cases = [
-      {
-        sessionId: "cross-agent-default-root",
-        sessionFile: path.join(
-          tmpDir,
-          "agents",
-          "ops",
-          "sessions",
-          "cross-agent-default-root.jsonl",
-        ),
-        wrongStorePath: path.join(tmpDir, "agents", "main", "sessions", "sessions.json"),
-        message: { role: "user", content: "from-ops" },
-      },
-      {
-        sessionId: "cross-agent-custom-root",
-        sessionFile: path.join(
-          tmpDir,
-          "custom",
-          "agents",
-          "ops",
-          "sessions",
-          "cross-agent-custom-root.jsonl",
-        ),
-        wrongStorePath: path.join(tmpDir, "custom", "agents", "main", "sessions", "sessions.json"),
-        message: { role: "assistant", content: "from-custom-ops" },
-      },
-    ] as const;
-
-    for (const testCase of cases) {
-      fs.mkdirSync(path.dirname(testCase.sessionFile), { recursive: true });
-      fs.writeFileSync(
-        testCase.sessionFile,
-        [
-          JSON.stringify({ type: "session", version: 1, id: testCase.sessionId }),
-          JSON.stringify({ message: testCase.message }),
-        ].join("\n"),
-        "utf-8",
-      );
-
-      const out = readSessionMessages(
-        testCase.sessionId,
-        testCase.wrongStorePath,
-        testCase.sessionFile,
-      );
-      expect(out).toEqual([testCase.message]);
-    }
-  });
-});
-
-describe("readSessionPreviewItemsFromTranscript", () => {
-  let tmpDir: string;
-  let storePath: string;
-
-  registerTempSessionStore("openclaw-session-preview-test-", (nextTmpDir, nextStorePath) => {
-    tmpDir = nextTmpDir;
-    storePath = nextStorePath;
-  });
-
-  function writeTranscriptLines(sessionId: string, lines: string[]) {
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-  }
-
-  function readPreview(sessionId: string, maxItems = 3, maxChars = 120) {
-    return readSessionPreviewItemsFromTranscript(
-      sessionId,
-      storePath,
-      undefined,
-      undefined,
-      maxItems,
-      maxChars,
-    );
-  }
-
-  test("returns recent preview items with tool summary", () => {
-    const sessionId = "preview-session";
-    const lines = createToolSummaryPreviewTranscriptLines(sessionId);
-    writeTranscriptLines(sessionId, lines);
-    const result = readPreview(sessionId);
-
-    expect(result.map((item) => item.role)).toEqual(["assistant", "tool", "assistant"]);
-    expect(result[1]?.text).toContain("call weather");
-  });
-
-  test("detects tool calls from tool_use/tool_call blocks and toolName field", () => {
-    const sessionId = "preview-session-tools";
-    const lines = [
-      JSON.stringify({ type: "session", version: 1, id: sessionId }),
-      JSON.stringify({ message: { role: "assistant", content: "Hi" } }),
-      JSON.stringify({
-        message: {
-          role: "assistant",
-          toolName: "camera",
-          content: [
-            { type: "tool_use", name: "read" },
-            { type: "tool_call", name: "write" },
-          ],
-        },
-      }),
-      JSON.stringify({ message: { role: "assistant", content: "Done" } }),
-    ];
-    writeTranscriptLines(sessionId, lines);
-    const result = readPreview(sessionId);
-
-    expect(result.map((item) => item.role)).toEqual(["assistant", "tool", "assistant"]);
-    expect(result[1]?.text).toContain("call");
-    expect(result[1]?.text).toContain("camera");
-    expect(result[1]?.text).toContain("read");
-    // Preview text may not list every tool name; it should at least hint there were multiple calls.
-    expect(result[1]?.text).toMatch(/\+\d+/);
-  });
-
-  test("truncates preview text to max chars", () => {
-    const sessionId = "preview-truncate";
-    const longText = "a".repeat(60);
-    const lines = [JSON.stringify({ message: { role: "assistant", content: longText } })];
-    writeTranscriptLines(sessionId, lines);
-    const result = readPreview(sessionId, 1, 24);
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.text.length).toBe(24);
-    expect(result[0]?.text.endsWith("...")).toBe(true);
-  });
-
-  test("strips inline directives from preview items", () => {
-    const sessionId = "preview-strip-inline-directives";
-    const lines = [
-      JSON.stringify({
-        message: {
-          role: "assistant",
-          content: "A [[reply_to:abc-123]] B [[audio_as_voice]]",
-        },
-      }),
-    ];
-    writeTranscriptLines(sessionId, lines);
-    const result = readPreview(sessionId, 1, 120);
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.text).toBe("A  B");
-  });
-});
-
-describe("resolveSessionTranscriptCandidates", () => {
   afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
-  test("fallback candidate uses OPENCLAW_HOME instead of os.homedir()", () => {
-    vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
-    vi.stubEnv("HOME", "/home/other");
-
-    const candidates = resolveSessionTranscriptCandidates("sess-1", undefined);
-    const fallback = candidates[candidates.length - 1];
-    expect(fallback).toBe(
-      path.join(path.resolve("/srv/openclaw-home"), ".openclaw", "sessions", "sess-1.jsonl"),
-    );
-  });
-});
-
-describe("resolveSessionTranscriptCandidates safety", () => {
-  test("keeps cross-agent absolute sessionFile for standard and custom store roots", () => {
-    const cases = [
-      {
-        storePath: "/tmp/openclaw/agents/main/sessions/sessions.json",
-        sessionFile: "/tmp/openclaw/agents/ops/sessions/sess-safe.jsonl",
-      },
-      {
-        storePath: "/srv/custom/agents/main/sessions/sessions.json",
-        sessionFile: "/srv/custom/agents/ops/sessions/sess-safe.jsonl",
-      },
-    ] as const;
-
-    for (const testCase of cases) {
-      const candidates = resolveSessionTranscriptCandidates(
-        "sess-safe",
-        testCase.storePath,
-        testCase.sessionFile,
-      );
-      expect(candidates.map((value) => path.resolve(value))).toContain(
-        path.resolve(testCase.sessionFile),
-      );
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 
-  test("drops unsafe session IDs instead of producing traversal paths", () => {
-    const candidates = resolveSessionTranscriptCandidates(
-      "../etc/passwd",
-      "/tmp/openclaw/agents/main/sessions/sessions.json",
+  function writeTmpFile(content: string): string {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-utils-test-"));
+    const filePath = path.join(tmpDir, "session.jsonl");
+    fs.writeFileSync(filePath, content, "utf-8");
+    return filePath;
+  }
+
+  it("extracts message entries from JSONL transcript", async () => {
+    const file = writeTmpFile(
+      [
+        JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "hi" } }),
+      ].join("\n"),
     );
-
-    expect(candidates).toEqual([]);
+    const messages = await readSessionMessagesAsync(file);
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toEqual({ role: "user", content: "hello" });
+    expect(messages[1]).toEqual({ role: "assistant", content: "hi" });
   });
 
-  test("drops unsafe sessionFile candidates and keeps safe fallbacks", () => {
-    const storePath = "/tmp/openclaw/agents/main/sessions/sessions.json";
-    const candidates = resolveSessionTranscriptCandidates(
-      "sess-safe",
-      storePath,
-      "../../etc/passwd",
+  it("skips non-message entries", async () => {
+    const file = writeTmpFile(
+      [
+        JSON.stringify({ type: "metadata", data: {} }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "hi" } }),
+        JSON.stringify({ type: "tool_use", tool: "read" }),
+      ].join("\n"),
     );
-    const normalizedCandidates = candidates.map((value) => path.resolve(value));
-    const expectedFallback = path.resolve(path.dirname(storePath), "sess-safe.jsonl");
-
-    expect(candidates.some((value) => value.includes("etc/passwd"))).toBe(false);
-    expect(normalizedCandidates).toContain(expectedFallback);
-  });
-});
-
-describe("archiveSessionTranscripts", () => {
-  let tmpDir: string;
-  let storePath: string;
-
-  registerTempSessionStore("openclaw-archive-test-", (nextTmpDir, nextStorePath) => {
-    tmpDir = nextTmpDir;
-    storePath = nextStorePath;
+    const messages = await readSessionMessagesAsync(file);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toEqual({ role: "user", content: "hi" });
   });
 
-  beforeAll(() => {
-    vi.stubEnv("OPENCLAW_HOME", tmpDir);
+  it("skips malformed lines", async () => {
+    const file = writeTmpFile(
+      [
+        "not json at all",
+        JSON.stringify({ type: "message", message: { role: "user", content: "ok" } }),
+        "{broken json",
+      ].join("\n"),
+    );
+    const messages = await readSessionMessagesAsync(file);
+    expect(messages).toHaveLength(1);
   });
 
-  afterAll(() => {
-    vi.unstubAllEnvs();
+  it("skips empty lines", async () => {
+    const file = writeTmpFile(
+      [
+        "",
+        JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+        "",
+        "  ",
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "world" } }),
+      ].join("\n"),
+    );
+    const messages = await readSessionMessagesAsync(file);
+    expect(messages).toHaveLength(2);
   });
 
-  test("archives transcript from default and explicit sessionFile paths", () => {
-    const cases = [
-      {
-        sessionId: "sess-archive-1",
-        transcriptPath: path.join(tmpDir, "sess-archive-1.jsonl"),
-        args: { sessionId: "sess-archive-1", storePath, reason: "reset" as const },
-      },
-      {
-        sessionId: "sess-archive-2",
-        transcriptPath: path.join(tmpDir, "custom-transcript.jsonl"),
-        args: {
-          sessionId: "sess-archive-2",
-          storePath: undefined,
-          sessionFile: path.join(tmpDir, "custom-transcript.jsonl"),
-          reason: "reset" as const,
-        },
-      },
-    ] as const;
-
-    for (const testCase of cases) {
-      fs.writeFileSync(testCase.transcriptPath, '{"type":"session"}\n', "utf-8");
-      const archived = archiveSessionTranscripts(testCase.args);
-      expect(archived).toHaveLength(1);
-      expect(archived[0]).toContain(".reset.");
-      expect(fs.existsSync(testCase.transcriptPath)).toBe(false);
-      expect(fs.existsSync(archived[0])).toBe(true);
-    }
+  it("returns empty array for empty file", async () => {
+    const file = writeTmpFile("");
+    const messages = await readSessionMessagesAsync(file);
+    expect(messages).toEqual([]);
   });
 
-  test("returns empty array when no transcript files exist", () => {
-    const archived = archiveSessionTranscripts({
-      sessionId: "nonexistent-session",
-      storePath,
-      reason: "reset",
-    });
-
-    expect(archived).toEqual([]);
-  });
-
-  test("skips files that do not exist and archives only existing ones", () => {
-    const sessionId = "sess-archive-3";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    fs.writeFileSync(transcriptPath, '{"type":"session"}\n', "utf-8");
-
-    const archived = archiveSessionTranscripts({
-      sessionId,
-      storePath,
-      sessionFile: "/nonexistent/path/file.jsonl",
-      reason: "deleted",
-    });
-
-    expect(archived).toHaveLength(1);
-    expect(archived[0]).toContain(".deleted.");
-    expect(fs.existsSync(transcriptPath)).toBe(false);
+  it("skips entries where message is null/undefined", async () => {
+    const file = writeTmpFile(
+      [
+        JSON.stringify({ type: "message", message: null }),
+        JSON.stringify({ type: "message" }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "valid" } }),
+      ].join("\n"),
+    );
+    const messages = await readSessionMessagesAsync(file);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toEqual({ role: "user", content: "valid" });
   });
 });

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -71,6 +71,30 @@ function setCachedSessionTitleFields(cacheKey: string, stat: fs.Stats, value: Se
   }
 }
 
+/**
+ * Read message entries from a session transcript file (async).
+ * Returns only `parsed.message` from lines with `type === "message"`.
+ * Used by before_reset hook dispatch to extract session history.
+ */
+export async function readSessionMessagesAsync(sessionFile: string): Promise<unknown[]> {
+  const content = await fs.promises.readFile(sessionFile, "utf-8");
+  const messages: unknown[] = [];
+  for (const line of content.split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed.type === "message" && parsed.message) {
+        messages.push(parsed.message);
+      }
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return messages;
+}
+
 export function readSessionMessages(
   sessionId: string,
   storePath: string | undefined,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -55,6 +55,7 @@ export {
   readSessionTitleFieldsFromTranscript,
   readSessionPreviewItemsFromTranscript,
   readSessionMessages,
+  readSessionMessagesAsync,
   resolveSessionTranscriptCandidates,
 } from "./session-utils.fs.js";
 export type {

--- a/src/hooks/dispatch-unified.test.ts
+++ b/src/hooks/dispatch-unified.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { emitGatewayStartup, emitMessageReceived, emitMessageSent } from "./dispatch-unified.js";
+import { clearAllHooks, registerHook } from "./hook-registry.js";
+
+// Mock the plugin hook runner
+vi.mock("../plugins/hook-runner-global.js", () => {
+  const mockRunner = {
+    hasHooks: vi.fn().mockReturnValue(false),
+    runMessageReceived: vi.fn().mockResolvedValue(undefined),
+    runMessageSent: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    getGlobalHookRunner: vi.fn(() => mockRunner),
+    _mockRunner: mockRunner,
+  };
+});
+
+// Re-import mock after vi.mock setup
+const { getGlobalHookRunner } = await import("../plugins/hook-runner-global.js");
+// oxlint-disable-next-line typescript/no-explicit-any
+const mockRunner = (await import("../plugins/hook-runner-global.js")) as any as {
+  _mockRunner: Record<string, ReturnType<typeof vi.fn>>;
+};
+
+describe("dispatch-unified", () => {
+  afterEach(() => {
+    clearAllHooks();
+    vi.clearAllMocks();
+  });
+
+  describe("emitMessageReceived", () => {
+    it("fires plugin hook when hookRunner has message_received handlers", () => {
+      mockRunner._mockRunner.hasHooks.mockReturnValue(true);
+      emitMessageReceived({
+        from: "+1234567890",
+        content: "hello",
+        channelId: "whatsapp",
+        sessionKey: "session:main",
+      });
+      expect(mockRunner._mockRunner.runMessageReceived).toHaveBeenCalledWith(
+        expect.objectContaining({ from: "+1234567890", content: "hello" }),
+        expect.objectContaining({ channelId: "whatsapp" }),
+      );
+    });
+
+    it("fires internal hook when sessionKey is provided", async () => {
+      const captured: unknown[] = [];
+      registerHook(
+        "message:received",
+        (event: unknown) => {
+          captured.push(event);
+        },
+        { source: "config" },
+      );
+      emitMessageReceived({
+        from: "+1234567890",
+        content: "hello",
+        channelId: "telegram",
+        sessionKey: "session:main",
+      });
+      // Internal hook fires async (fire-and-forget)
+      await vi.waitFor(() => expect(captured).toHaveLength(1));
+      const event = captured[0] as Record<string, unknown>;
+      expect(event).toMatchObject({
+        type: "message",
+        action: "received",
+        sessionKey: "session:main",
+      });
+    });
+
+    it("skips internal hook when sessionKey is absent", async () => {
+      const captured: unknown[] = [];
+      registerHook(
+        "message:received",
+        (event: unknown) => {
+          captured.push(event);
+        },
+        { source: "config" },
+      );
+      emitMessageReceived({
+        from: "+1234567890",
+        content: "hello",
+        channelId: "whatsapp",
+      });
+      // Flush microtasks — hook should NOT have fired (no sessionKey)
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      expect(captured).toHaveLength(0);
+    });
+
+    it("does not throw when hookRunner is null", () => {
+      // Override mock to return null
+      vi.mocked(getGlobalHookRunner).mockReturnValueOnce(null);
+      expect(() => {
+        emitMessageReceived({
+          from: "+1234567890",
+          content: "hello",
+          channelId: "whatsapp",
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("emitMessageSent", () => {
+    it("fires plugin hook when hookRunner has message_sent handlers", () => {
+      mockRunner._mockRunner.hasHooks.mockReturnValue(true);
+      emitMessageSent({
+        to: "+0987654321",
+        content: "reply",
+        success: true,
+        channelId: "telegram",
+        sessionKey: "session:main",
+      });
+      expect(mockRunner._mockRunner.runMessageSent).toHaveBeenCalledWith(
+        expect.objectContaining({ to: "+0987654321", content: "reply", success: true }),
+        expect.objectContaining({ channelId: "telegram" }),
+      );
+    });
+
+    it("fires internal hook with sessionKey", async () => {
+      const captured: unknown[] = [];
+      registerHook(
+        "message:sent",
+        (event: unknown) => {
+          captured.push(event);
+        },
+        { source: "config" },
+      );
+      emitMessageSent({
+        to: "+0987654321",
+        content: "reply",
+        success: true,
+        channelId: "whatsapp",
+        sessionKey: "test:session",
+      });
+      await vi.waitFor(() => expect(captured).toHaveLength(1));
+    });
+
+    it("includes error field when present", () => {
+      mockRunner._mockRunner.hasHooks.mockReturnValue(true);
+      emitMessageSent({
+        to: "+0987654321",
+        content: "reply",
+        success: false,
+        error: "network timeout",
+        channelId: "slack",
+      });
+      expect(mockRunner._mockRunner.runMessageSent).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false, error: "network timeout" }),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("emitGatewayStartup", () => {
+    it("fires gateway:startup internal hook synchronously", async () => {
+      const captured: unknown[] = [];
+      registerHook(
+        "gateway:startup",
+        (event: unknown) => {
+          captured.push(event);
+        },
+        { source: "config" },
+      );
+      emitGatewayStartup({
+        cfg: { hooks: { internal: { enabled: true } } },
+        workspaceDir: "/tmp/test",
+      });
+      // Fire-and-forget but should resolve within a tick
+      await vi.waitFor(() => expect(captured).toHaveLength(1));
+    });
+
+    it("also fires on the general 'gateway' key", async () => {
+      const captured: unknown[] = [];
+      registerHook(
+        "gateway",
+        (event: unknown) => {
+          captured.push(event);
+        },
+        { source: "config" },
+      );
+      emitGatewayStartup({ cfg: {} });
+      await vi.waitFor(() => expect(captured).toHaveLength(1));
+    });
+
+    it("does not throw when no handlers registered", () => {
+      expect(() => {
+        emitGatewayStartup({ cfg: {} });
+      }).not.toThrow();
+    });
+  });
+});

--- a/src/hooks/dispatch-unified.ts
+++ b/src/hooks/dispatch-unified.ts
@@ -1,0 +1,195 @@
+/**
+ * Unified Dispatch Helpers for Overlapping Hook Events
+ *
+ * WHY THIS EXISTS:
+ * Three events (message_received, message_sent, gateway:startup) exist in both
+ * the internal hook system (HOOK.md handlers) and the plugin typed hook system
+ * (HookRunner). Previously each call site manually duplicated 15-30 lines of
+ * dual-dispatch code. These helpers co-locate both dispatch calls in one place.
+ *
+ * WHEN TO USE:
+ * - `emitMessageReceived()` — when an inbound message arrives (replaces dual dispatch in dispatch-from-config.ts)
+ * - `emitMessageSent()` — when an outbound message is delivered (replaces dual dispatch in deliver.ts)
+ * - `emitGatewayStartup()` — when the gateway finishes loading hooks/channels (replaces setTimeout in server-startup.ts)
+ *
+ * For events that only exist in ONE system, call that system directly:
+ * - Internal-only events: use `triggerInternalHook()` directly
+ * - Plugin-only events: use `hookRunner.run*()` directly
+ *
+ * When adding a new event that needs both systems, add a helper here.
+ */
+
+import type { CliDeps } from "../cli/deps.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { logVerbose } from "../globals.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { createInternalHookEvent, triggerInternalHook } from "./internal-hooks.js";
+
+/**
+ * Emit a message_received event through both hook systems (fire-and-forget).
+ *
+ * Fires:
+ * - Plugin typed hook: `message_received` via HookRunner
+ * - Internal hook: `message:received` via triggerInternalHook
+ *
+ * @example
+ * ```ts
+ * emitMessageReceived({
+ *   from: ctx.From ?? "",
+ *   content: messageText,
+ *   channelId: "telegram",
+ *   sessionKey: ctx.SessionKey,
+ * });
+ * ```
+ */
+export function emitMessageReceived(params: {
+  from: string;
+  content: string;
+  timestamp?: number;
+  channelId: string;
+  accountId?: string;
+  conversationId?: string;
+  messageId?: string;
+  metadata?: Record<string, unknown>;
+  /** Required for internal hooks. If absent, only plugin hooks fire. */
+  sessionKey?: string;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+
+  // Plugin typed hook (fire-and-forget)
+  if (hookRunner?.hasHooks("message_received")) {
+    void hookRunner
+      .runMessageReceived(
+        {
+          from: params.from,
+          content: params.content,
+          timestamp: params.timestamp,
+          metadata: params.metadata,
+        },
+        {
+          channelId: params.channelId,
+          accountId: params.accountId,
+          conversationId: params.conversationId,
+        },
+      )
+      .catch((err) => {
+        logVerbose(`message_received plugin hook failed: ${String(err)}`);
+      });
+  }
+
+  // Internal hook (fire-and-forget, needs sessionKey)
+  if (params.sessionKey) {
+    void triggerInternalHook(
+      createInternalHookEvent("message", "received", params.sessionKey, {
+        from: params.from,
+        content: params.content,
+        timestamp: params.timestamp,
+        channelId: params.channelId,
+        accountId: params.accountId,
+        conversationId: params.conversationId,
+        messageId: params.messageId,
+        metadata: params.metadata,
+      }),
+    ).catch((err) => {
+      logVerbose(`message_received internal hook failed: ${String(err)}`);
+    });
+  }
+}
+
+/**
+ * Emit a message_sent event through both hook systems (fire-and-forget).
+ *
+ * Fires:
+ * - Plugin typed hook: `message_sent` via HookRunner
+ * - Internal hook: `message:sent` via triggerInternalHook
+ *
+ * @example
+ * ```ts
+ * emitMessageSent({
+ *   to: recipientId,
+ *   content: messageText,
+ *   success: true,
+ *   channelId: "whatsapp",
+ *   sessionKey: currentSessionKey,
+ * });
+ * ```
+ */
+export function emitMessageSent(params: {
+  to: string;
+  content: string;
+  success: boolean;
+  error?: string;
+  channelId: string;
+  accountId?: string;
+  conversationId?: string;
+  messageId?: string;
+  /** Required for internal hooks. If absent, only plugin hooks fire. */
+  sessionKey?: string;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+
+  // Plugin typed hook (fire-and-forget)
+  if (hookRunner?.hasHooks("message_sent")) {
+    void hookRunner
+      .runMessageSent(
+        {
+          to: params.to,
+          content: params.content,
+          success: params.success,
+          error: params.error,
+        },
+        {
+          channelId: params.channelId,
+          accountId: params.accountId,
+          conversationId: params.conversationId,
+        },
+      )
+      .catch((err) => {
+        logVerbose(`message_sent plugin hook failed: ${String(err)}`);
+      });
+  }
+
+  // Internal hook (fire-and-forget, needs sessionKey)
+  if (params.sessionKey) {
+    void triggerInternalHook(
+      createInternalHookEvent("message", "sent", params.sessionKey, {
+        to: params.to,
+        content: params.content,
+        success: params.success,
+        error: params.error,
+        channelId: params.channelId,
+        accountId: params.accountId,
+        conversationId: params.conversationId,
+        messageId: params.messageId,
+      }),
+    ).catch((err) => {
+      logVerbose(`message_sent internal hook failed: ${String(err)}`);
+    });
+  }
+}
+
+/**
+ * Emit gateway:startup internal hook event synchronously (no setTimeout).
+ *
+ * This should be called AFTER loadInternalHooks() completes so all handlers
+ * are registered. The previous implementation used `setTimeout(250)` which
+ * created a race condition.
+ *
+ * Note: This is separate from the `gateway_start` plugin typed hook which
+ * fires when the HTTP listener starts (in server.impl.ts). The gateway:startup
+ * internal hook fires when all sidecars (hooks, channels, services) are loaded.
+ */
+export function emitGatewayStartup(params: {
+  cfg: OpenClawConfig;
+  deps?: CliDeps;
+  workspaceDir?: string;
+}): void {
+  const hookEvent = createInternalHookEvent("gateway", "startup", "gateway:startup", {
+    cfg: params.cfg,
+    deps: params.deps,
+    workspaceDir: params.workspaceDir,
+  });
+  void triggerInternalHook(hookEvent).catch((err) => {
+    logVerbose(`gateway:startup hook failed: ${String(err)}`);
+  });
+}

--- a/src/hooks/hook-registry.test.ts
+++ b/src/hooks/hook-registry.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearAllHooks,
+  clearHooksBySource,
+  getHookEntries,
+  getRegisteredKeys,
+  hasHooks,
+  registerHook,
+  unregisterHook,
+} from "./hook-registry.js";
+
+describe("hook-registry", () => {
+  afterEach(() => {
+    clearAllHooks();
+  });
+
+  describe("registerHook / getHookEntries", () => {
+    it("registers and retrieves a handler", () => {
+      const handler = () => {};
+      registerHook("test:event", handler, { source: "config" });
+      const entries = getHookEntries("test:event");
+      expect(entries).toHaveLength(1);
+      expect(entries[0].handler).toBe(handler);
+      expect(entries[0].source).toBe("config");
+    });
+
+    it("returns empty array for unregistered key", () => {
+      expect(getHookEntries("nonexistent")).toEqual([]);
+    });
+
+    it("supports multiple handlers on the same key", () => {
+      const h1 = () => {};
+      const h2 = () => {};
+      registerHook("multi", h1, { source: "config" });
+      registerHook("multi", h2, { source: "plugin" });
+      expect(getHookEntries("multi")).toHaveLength(2);
+    });
+
+    it("stores pluginId when provided", () => {
+      const handler = () => {};
+      registerHook("test", handler, { source: "plugin", pluginId: "my-plugin" });
+      expect(getHookEntries("test")[0].pluginId).toBe("my-plugin");
+    });
+  });
+
+  describe("unregisterHook", () => {
+    it("removes a handler by reference", () => {
+      const handler = () => {};
+      registerHook("remove-test", handler, { source: "config" });
+      expect(hasHooks("remove-test")).toBe(true);
+      unregisterHook("remove-test", handler);
+      expect(hasHooks("remove-test")).toBe(false);
+    });
+
+    it("does not affect other handlers", () => {
+      const h1 = () => {};
+      const h2 = () => {};
+      registerHook("partial-remove", h1, { source: "config" });
+      registerHook("partial-remove", h2, { source: "plugin" });
+      unregisterHook("partial-remove", h1);
+      const entries = getHookEntries("partial-remove");
+      expect(entries).toHaveLength(1);
+      expect(entries[0].handler).toBe(h2);
+    });
+
+    it("is a no-op for unknown key", () => {
+      unregisterHook("nonexistent", () => {});
+    });
+
+    it("is a no-op for unregistered handler", () => {
+      const registered = () => {};
+      const other = () => {};
+      registerHook("ref-test", registered, { source: "config" });
+      unregisterHook("ref-test", other);
+      expect(hasHooks("ref-test")).toBe(true);
+    });
+  });
+
+  describe("clearHooksBySource", () => {
+    it("clears only specified sources", () => {
+      const configHandler = () => "config";
+      const pluginHandler = () => "plugin";
+      const workspaceHandler = () => "workspace";
+      registerHook("scoped", configHandler, { source: "config" });
+      registerHook("scoped", pluginHandler, { source: "plugin" });
+      registerHook("scoped", workspaceHandler, { source: "workspace" });
+
+      clearHooksBySource(["config", "workspace"]);
+
+      const entries = getHookEntries("scoped");
+      expect(entries).toHaveLength(1);
+      expect(entries[0].handler).toBe(pluginHandler);
+    });
+
+    it("preserves plugin hooks when clearing internal sources", () => {
+      registerHook("a", () => {}, { source: "bundled" });
+      registerHook("b", () => {}, { source: "workspace" });
+      registerHook("c", () => {}, { source: "managed" });
+      registerHook("d", () => {}, { source: "config" });
+      registerHook("e", () => {}, { source: "plugin" });
+
+      clearHooksBySource(["bundled", "workspace", "managed", "config"]);
+
+      expect(hasHooks("a")).toBe(false);
+      expect(hasHooks("b")).toBe(false);
+      expect(hasHooks("c")).toBe(false);
+      expect(hasHooks("d")).toBe(false);
+      expect(hasHooks("e")).toBe(true);
+    });
+
+    it("is idempotent", () => {
+      registerHook("idem", () => {}, { source: "config" });
+      clearHooksBySource(["config"]);
+      clearHooksBySource(["config"]);
+      expect(hasHooks("idem")).toBe(false);
+    });
+  });
+
+  describe("clearAllHooks", () => {
+    it("removes everything", () => {
+      registerHook("x", () => {}, { source: "config" });
+      registerHook("y", () => {}, { source: "plugin" });
+      clearAllHooks();
+      expect(getRegisteredKeys()).toEqual([]);
+    });
+  });
+
+  describe("hasHooks", () => {
+    it("returns false for empty key", () => {
+      expect(hasHooks("empty")).toBe(false);
+    });
+
+    it("returns true after registration", () => {
+      registerHook("count", () => {}, { source: "config" });
+      registerHook("count", () => {}, { source: "plugin" });
+      expect(hasHooks("count")).toBe(true);
+      expect(getHookEntries("count")).toHaveLength(2);
+    });
+  });
+
+  describe("getRegisteredKeys", () => {
+    it("returns all keys with registered handlers", () => {
+      registerHook("alpha", () => {}, { source: "config" });
+      registerHook("beta", () => {}, { source: "plugin" });
+      const keys = getRegisteredKeys();
+      expect(keys).toContain("alpha");
+      expect(keys).toContain("beta");
+    });
+  });
+
+  describe("Symbol.for singleton behavior", () => {
+    it("registry survives simulated module duplication", () => {
+      // Register from "this" module's perspective
+      const handler = () => "singleton";
+      registerHook("singleton-test", handler, { source: "config" });
+
+      // Simulate another chunk accessing the same globalThis symbol
+      const sym = Symbol.for("openclaw:hookRegistry");
+      const g = globalThis as Record<symbol, unknown>;
+      const registry = g[sym] as Map<string, unknown[]>;
+      expect(registry).toBeInstanceOf(Map);
+      expect(registry.has("singleton-test")).toBe(true);
+    });
+  });
+});

--- a/src/hooks/hook-registry.ts
+++ b/src/hooks/hook-registry.ts
@@ -1,0 +1,179 @@
+/**
+ * Unified Hook Registry
+ *
+ * Single globalThis-backed registry shared by both the internal hook system
+ * (HOOK.md file-based handlers) and the plugin typed hook system (HookRunner).
+ *
+ * WHY THIS EXISTS:
+ * The codebase has two independent hook systems that each maintain module-level
+ * singleton state (`const handlers = new Map<...>()` in internal-hooks.ts and
+ * `let globalHookRunner` in hook-runner-global.ts). The Rolldown bundler can
+ * duplicate these module-level variables across output chunks, causing hooks to
+ * silently disappear. By storing state on `globalThis` via `Symbol.for()`, the
+ * registry survives chunk splitting — any module that imports the registry gets
+ * the same underlying Map regardless of which output chunk it lands in.
+ *
+ * ARCHITECTURE:
+ * - One Map<string, HookRegistryEntry[]> holds ALL handlers from both systems.
+ * - Each entry is tagged with a `source` so clearing can be scoped (e.g., hot-
+ *   reload clears workspace/config hooks without losing plugin hooks).
+ * DO NOT create module-level Maps or variables for hook storage — use this
+ * registry via registerHook/getHookEntries/clearHooksBySource.
+ */
+
+/**
+ * Source tag indicating where a hook handler originated.
+ * Used for scoped clearing (e.g., hot-reload clears "workspace"+"config" but
+ * preserves "plugin" hooks).
+ */
+export type HookRegistrySource = "bundled" | "workspace" | "managed" | "config" | "plugin";
+
+/**
+ * File-based hook sources that get cleared on hot-reload.
+ * Plugin hooks are intentionally excluded so they survive reload.
+ */
+export const FILE_HOOK_SOURCES: HookRegistrySource[] = [
+  "bundled",
+  "workspace",
+  "managed",
+  "config",
+];
+
+/**
+ * A single handler entry in the unified registry.
+ */
+export type HookRegistryEntry = {
+  /** The handler function. Signature varies by hook system. */
+  handler: (...args: unknown[]) => unknown;
+  /** Where this handler came from — controls scoped clearing. */
+  source: HookRegistrySource;
+  /** Plugin identifier (set when source is "plugin"). */
+  pluginId?: string;
+};
+
+type HookRegistryMap = Map<string, HookRegistryEntry[]>;
+
+const REGISTRY_SYMBOL = Symbol.for("openclaw:hookRegistry");
+
+/**
+ * Lazily initialize and return the singleton registry Map.
+ * Same pattern as src/plugins/runtime.ts — survives bundler chunk splitting.
+ */
+function getRegistry(): HookRegistryMap {
+  const g = globalThis as typeof globalThis & { [REGISTRY_SYMBOL]?: HookRegistryMap };
+  if (!g[REGISTRY_SYMBOL]) {
+    g[REGISTRY_SYMBOL] = new Map();
+  }
+  return g[REGISTRY_SYMBOL];
+}
+
+/**
+ * Register a hook handler in the unified registry.
+ *
+ * @param key - Event key (e.g., "command", "command:new", "message_received")
+ * @param handler - The handler function
+ * @param opts - Source tag, optional pluginId
+ *
+ * @example
+ * ```ts
+ * registerHook("command:new", myHandler, { source: "workspace" });
+ * registerHook("message_received", pluginHandler, { source: "plugin", pluginId: "my-plugin" });
+ * ```
+ */
+export function registerHook(
+  key: string,
+  handler: (...args: unknown[]) => unknown,
+  opts: { source: HookRegistrySource; pluginId?: string },
+): void {
+  const registry = getRegistry();
+  if (!registry.has(key)) {
+    registry.set(key, []);
+  }
+  registry.get(key)!.push({
+    handler,
+    source: opts.source,
+    pluginId: opts.pluginId,
+  });
+}
+
+/**
+ * Unregister a specific handler by reference.
+ *
+ * @param key - Event key the handler was registered for
+ * @param handler - The handler function to remove (matched by reference)
+ */
+export function unregisterHook(key: string, handler: (...args: unknown[]) => unknown): void {
+  const registry = getRegistry();
+  const entries = registry.get(key);
+  if (!entries) {
+    return;
+  }
+  const index = entries.findIndex((e) => e.handler === handler);
+  if (index !== -1) {
+    entries.splice(index, 1);
+  }
+  if (entries.length === 0) {
+    registry.delete(key);
+  }
+}
+
+/**
+ * Clear all handlers matching the given source tags.
+ * Handlers from other sources are preserved.
+ *
+ * This is the key mechanism for safe hot-reload: clearing "workspace"+"config"+
+ * "managed"+"bundled" hooks on reload preserves "plugin" hooks that were
+ * registered during plugin initialization.
+ *
+ * @param sources - Array of source tags to clear
+ *
+ * @example
+ * ```ts
+ * // Hot-reload: clear file-based hooks, keep plugin hooks
+ * clearHooksBySource(["bundled", "workspace", "managed", "config"]);
+ * ```
+ */
+export function clearHooksBySource(sources: HookRegistrySource[]): void {
+  const sourceSet = new Set(sources);
+  const registry = getRegistry();
+  for (const [key, entries] of registry) {
+    const remaining = entries.filter((e) => !sourceSet.has(e.source));
+    if (remaining.length === 0) {
+      registry.delete(key);
+    } else {
+      registry.set(key, remaining);
+    }
+  }
+}
+
+/**
+ * Clear ALL handlers from the registry. Use only in tests.
+ */
+export function clearAllHooks(): void {
+  getRegistry().clear();
+}
+
+/**
+ * Get all entries for a given event key.
+ *
+ * @param key - Event key to look up
+ * @returns Array of hook entries (empty if none registered)
+ */
+export function getHookEntries(key: string): HookRegistryEntry[] {
+  return getRegistry().get(key) ?? [];
+}
+
+/**
+ * Check whether any handlers are registered for a given event key.
+ */
+export function hasHooks(key: string): boolean {
+  const entries = getRegistry().get(key);
+  return entries !== undefined && entries.length > 0;
+}
+
+/**
+ * Get all registered event keys. Useful for debugging and testing.
+ */
+export function getRegisteredKeys(): string[] {
+  return Array.from(getRegistry().keys());
+}

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -454,5 +454,23 @@ describe("hooks", () => {
       const keys = getRegisteredEventKeys();
       expect(keys).toEqual([]);
     });
+
+    it("preserves plugin-registered hooks", async () => {
+      const { registerHook, hasHooks } = await import("./hook-registry.js");
+      const pluginHandler = vi.fn();
+      registerHook("message:received", pluginHandler, {
+        source: "plugin",
+        pluginId: "test-plugin",
+      });
+      registerInternalHook("message:received", vi.fn());
+
+      clearInternalHooks();
+
+      // Plugin hook survives, internal hook does not
+      expect(hasHooks("message:received")).toBe(true);
+      const entries = (await import("./hook-registry.js")).getHookEntries("message:received");
+      expect(entries).toHaveLength(1);
+      expect(entries[0].source).toBe("plugin");
+    });
   });
 });

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -3,12 +3,23 @@
  *
  * Provides an extensible event-driven hook system for agent events
  * like command processing, session lifecycle, etc.
+ *
+ * Backed by unified hook registry — see hook-registry.ts
  */
 
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  clearHooksBySource,
+  FILE_HOOK_SOURCES,
+  getHookEntries,
+  getRegisteredKeys,
+  registerHook,
+  unregisterHook,
+  type HookRegistrySource,
+} from "./hook-registry.js";
 
 export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
 
@@ -110,98 +121,116 @@ export interface InternalHookEvent {
 
 export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | void;
 
-/** Registry of hook handlers by event key */
-const handlers = new Map<string, InternalHookHandler[]>();
 const log = createSubsystemLogger("internal-hooks");
 
 /**
- * Register a hook handler for a specific event type or event:action combination
+ * Map from hook file source names to unified registry source tags.
+ *
+ * @see HookRegistrySource in hook-registry.ts
+ */
+const FILE_SOURCE_TO_REGISTRY: Record<string, HookRegistrySource> = {
+  "openclaw-bundled": "bundled",
+  "openclaw-workspace": "workspace",
+  "openclaw-managed": "managed",
+  "openclaw-plugin": "plugin",
+};
+
+/**
+ * Register a hook handler for a specific event type or event:action combination.
+ *
+ * Delegates to the unified hook registry with source tagging. The optional
+ * `source` parameter controls which registry source tag is applied — this
+ * determines whether the handler survives source-scoped clearing.
  *
  * @param eventKey - Event type (e.g., 'command') or specific action (e.g., 'command:new')
  * @param handler - Function to call when the event is triggered
+ * @param source - Registry source tag. Defaults to "config". Use "plugin" for
+ *   plugin-registered hooks so they survive clearInternalHooks().
  *
  * @example
  * ```ts
- * // Listen to all command events
+ * // Listen to all command events (default source: "config")
  * registerInternalHook('command', async (event) => {
  *   console.log('Command:', event.action);
  * });
  *
- * // Listen only to /new commands
- * registerInternalHook('command:new', async (event) => {
- *   await saveSessionToMemory(event);
- * });
+ * // Listen only to /new commands with explicit source
+ * registerInternalHook('command:new', handler, 'workspace');
+ *
+ * // Plugin-registered hook (survives clearInternalHooks)
+ * registerInternalHook('command:new', handler, 'plugin');
  * ```
  */
-export function registerInternalHook(eventKey: string, handler: InternalHookHandler): void {
-  if (!handlers.has(eventKey)) {
-    handlers.set(eventKey, []);
-  }
-  handlers.get(eventKey)!.push(handler);
+export function registerInternalHook(
+  eventKey: string,
+  handler: InternalHookHandler,
+  source?: string,
+): void {
+  const registrySource: HookRegistrySource =
+    (source ? (FILE_SOURCE_TO_REGISTRY[source] ?? (source as HookRegistrySource)) : undefined) ??
+    "config";
+  registerHook(eventKey, handler as (...args: unknown[]) => unknown, {
+    source: registrySource,
+  });
 }
 
 /**
- * Unregister a specific hook handler
+ * Unregister a specific hook handler.
  *
  * @param eventKey - Event key the handler was registered for
- * @param handler - The handler function to remove
+ * @param handler - The handler function to remove (matched by reference)
  */
 export function unregisterInternalHook(eventKey: string, handler: InternalHookHandler): void {
-  const eventHandlers = handlers.get(eventKey);
-  if (!eventHandlers) {
-    return;
-  }
-
-  const index = eventHandlers.indexOf(handler);
-  if (index !== -1) {
-    eventHandlers.splice(index, 1);
-  }
-
-  // Clean up empty handler arrays
-  if (eventHandlers.length === 0) {
-    handlers.delete(eventKey);
-  }
+  unregisterHook(eventKey, handler as (...args: unknown[]) => unknown);
 }
 
 /**
- * Clear all registered hooks (useful for testing)
+ * Clear internal hooks registered from file-based and config sources.
+ *
+ * Clears "bundled", "workspace", "managed", and "config" source hooks while
+ * **preserving** "plugin" source hooks. This prevents the bug where gateway
+ * hot-reload would wipe plugin hooks that were registered during plugin init.
+ *
+ * For tests that need a complete wipe, use `clearAllHooks()` from
+ * `hook-registry.ts` instead.
  */
 export function clearInternalHooks(): void {
-  handlers.clear();
+  clearHooksBySource(FILE_HOOK_SOURCES);
 }
 
 /**
- * Get all registered event keys (useful for debugging)
+ * Get all registered event keys (useful for debugging).
+ *
+ * Returns keys from the unified registry.
  */
 export function getRegisteredEventKeys(): string[] {
-  return Array.from(handlers.keys());
+  return getRegisteredKeys();
 }
 
 /**
- * Trigger a hook event
+ * Trigger a hook event.
  *
  * Calls all handlers registered for:
  * 1. The general event type (e.g., 'command')
  * 2. The specific event:action combination (e.g., 'command:new')
  *
- * Handlers are called in registration order. Errors are caught and logged
- * but don't prevent other handlers from running.
+ * Errors are caught and logged but don't prevent other handlers from running.
  *
  * @param event - The event to trigger
  */
 export async function triggerInternalHook(event: InternalHookEvent): Promise<void> {
-  const typeHandlers = handlers.get(event.type) ?? [];
-  const specificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
+  const typeEntries = getHookEntries(event.type);
+  const specificEntries = getHookEntries(`${event.type}:${event.action}`);
 
-  const allHandlers = [...typeHandlers, ...specificHandlers];
+  const allEntries = [...typeEntries, ...specificEntries];
 
-  if (allHandlers.length === 0) {
+  if (allEntries.length === 0) {
     return;
   }
 
-  for (const handler of allHandlers) {
+  for (const entry of allEntries) {
     try {
-      await handler(event);
+      await (entry.handler as InternalHookHandler)(event);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.error(`Hook error [${event.type}:${event.action}]: ${message}`);

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -112,8 +112,9 @@ export async function loadInternalHooks(
           continue;
         }
 
+        // Pass the hook file source so the unified registry can scope clearing
         for (const event of events) {
-          registerInternalHook(event, handler);
+          registerInternalHook(event, handler, entry.hook.source);
         }
 
         log.info(
@@ -185,7 +186,7 @@ export async function loadInternalHooks(
         continue;
       }
 
-      registerInternalHook(handlerConfig.event, handler);
+      registerInternalHook(handlerConfig.event, handler, "config");
       log.info(
         `Registered hook (legacy): ${handlerConfig.event} -> ${modulePath}${exportName !== "default" ? `#${exportName}` : ""}`,
       );

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -18,7 +18,7 @@ import {
   resolveMirroredTranscriptText,
 } from "../../config/sessions.js";
 import type { sendMessageDiscord } from "../../discord/send.js";
-import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import { emitMessageSent } from "../../hooks/dispatch-unified.js";
 import type { sendMessageIMessage } from "../../imessage/send.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
@@ -452,13 +452,9 @@ async function deliverOutboundPayloadsCore(
     const normalized = normalizeWhatsAppPayload(payload);
     return normalized ? [normalized] : [];
   });
+  const sessionKeyForHooks = params.mirror?.sessionKey ?? params.session?.key;
   const hookRunner = getGlobalHookRunner();
-  const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
-  if (
-    hookRunner?.hasHooks("message_sent") &&
-    params.session?.agentId &&
-    !sessionKeyForInternalHooks
-  ) {
+  if (hookRunner?.hasHooks("message_sent") && params.session?.agentId && !sessionKeyForHooks) {
     log.warn(
       "deliverOutboundPayloads: session.agentId present without session key; internal message:sent hook will be skipped",
       {
@@ -474,44 +470,24 @@ async function deliverOutboundPayloadsCore(
       mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []),
       channelData: payload.channelData,
     };
-    const emitMessageSent = (params: {
+    // Unified dispatch — fires both plugin and internal hooks (fire-and-forget)
+    const emitSent = (sentParams: {
       success: boolean;
       content: string;
       error?: string;
       messageId?: string;
     }) => {
-      if (hookRunner?.hasHooks("message_sent")) {
-        void hookRunner
-          .runMessageSent(
-            {
-              to,
-              content: params.content,
-              success: params.success,
-              ...(params.error ? { error: params.error } : {}),
-            },
-            {
-              channelId: channel,
-              accountId: accountId ?? undefined,
-              conversationId: to,
-            },
-          )
-          .catch(() => {});
-      }
-      if (!sessionKeyForInternalHooks) {
-        return;
-      }
-      void triggerInternalHook(
-        createInternalHookEvent("message", "sent", sessionKeyForInternalHooks, {
-          to,
-          content: params.content,
-          success: params.success,
-          ...(params.error ? { error: params.error } : {}),
-          channelId: channel,
-          accountId: accountId ?? undefined,
-          conversationId: to,
-          messageId: params.messageId,
-        }),
-      ).catch(() => {});
+      emitMessageSent({
+        to,
+        content: sentParams.content,
+        success: sentParams.success,
+        error: sentParams.error,
+        channelId: channel,
+        accountId: accountId ?? undefined,
+        conversationId: to,
+        messageId: sentParams.messageId,
+        sessionKey: sessionKeyForHooks,
+      });
     };
     try {
       throwIfAborted(abortSignal);
@@ -551,7 +527,7 @@ async function deliverOutboundPayloadsCore(
       if (handler.sendPayload && effectivePayload.channelData) {
         const delivery = await handler.sendPayload(effectivePayload, sendOverrides);
         results.push(delivery);
-        emitMessageSent({
+        emitSent({
           success: true,
           content: payloadSummary.text,
           messageId: delivery.messageId,
@@ -566,7 +542,7 @@ async function deliverOutboundPayloadsCore(
           await sendTextChunks(payloadSummary.text, sendOverrides);
         }
         const messageId = results.at(-1)?.messageId;
-        emitMessageSent({
+        emitSent({
           success: results.length > beforeCount,
           content: payloadSummary.text,
           messageId,
@@ -590,13 +566,13 @@ async function deliverOutboundPayloadsCore(
           lastMessageId = delivery.messageId;
         }
       }
-      emitMessageSent({
+      emitSent({
         success: true,
         content: payloadSummary.text,
         messageId: lastMessageId,
       });
     } catch (err) {
-      emitMessageSent({
+      emitSent({
         success: false,
         content: payloadSummary.text,
         error: err instanceof Error ? err.message : String(err),

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -3,6 +3,10 @@
  *
  * Singleton hook runner that's initialized when plugins are loaded
  * and can be called from anywhere in the codebase.
+ *
+ * Stored on globalThis to survive bundler chunk splitting — see
+ * src/hooks/hook-registry.ts for the rationale. Same lazy-init pattern
+ * as src/plugins/runtime.ts.
  */
 
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -12,16 +16,29 @@ import type { PluginHookGatewayContext, PluginHookGatewayStopEvent } from "./typ
 
 const log = createSubsystemLogger("plugins");
 
-let globalHookRunner: HookRunner | null = null;
-let globalRegistry: PluginRegistry | null = null;
+const HOOK_RUNNER_SYMBOL = Symbol.for("openclaw:hookRunner");
+
+type HookRunnerState = {
+  hookRunner: HookRunner | null;
+  registry: PluginRegistry | null;
+};
+
+function getState(): HookRunnerState {
+  const g = globalThis as typeof globalThis & { [HOOK_RUNNER_SYMBOL]?: HookRunnerState };
+  if (!g[HOOK_RUNNER_SYMBOL]) {
+    g[HOOK_RUNNER_SYMBOL] = { hookRunner: null, registry: null };
+  }
+  return g[HOOK_RUNNER_SYMBOL];
+}
 
 /**
  * Initialize the global hook runner with a plugin registry.
  * Called once when plugins are loaded during gateway startup.
  */
 export function initializeGlobalHookRunner(registry: PluginRegistry): void {
-  globalRegistry = registry;
-  globalHookRunner = createHookRunner(registry, {
+  const state = getState();
+  state.registry = registry;
+  state.hookRunner = createHookRunner(registry, {
     logger: {
       debug: (msg) => log.debug(msg),
       warn: (msg) => log.warn(msg),
@@ -41,7 +58,7 @@ export function initializeGlobalHookRunner(registry: PluginRegistry): void {
  * Returns null if plugins haven't been loaded yet.
  */
 export function getGlobalHookRunner(): HookRunner | null {
-  return globalHookRunner;
+  return getState().hookRunner;
 }
 
 /**
@@ -49,14 +66,14 @@ export function getGlobalHookRunner(): HookRunner | null {
  * Returns null if plugins haven't been loaded yet.
  */
 export function getGlobalPluginRegistry(): PluginRegistry | null {
-  return globalRegistry;
+  return getState().registry;
 }
 
 /**
  * Check if any hooks are registered for a given hook name.
  */
 export function hasGlobalHooks(hookName: Parameters<HookRunner["hasHooks"]>[0]): boolean {
-  return globalHookRunner?.hasHooks(hookName) ?? false;
+  return getState().hookRunner?.hasHooks(hookName) ?? false;
 }
 
 export async function runGlobalGatewayStopSafely(params: {
@@ -83,6 +100,7 @@ export async function runGlobalGatewayStopSafely(params: {
  * Reset the global hook runner (for testing).
  */
 export function resetGlobalHookRunner(): void {
-  globalHookRunner = null;
-  globalRegistry = null;
+  const state = getState();
+  state.hookRunner = null;
+  state.registry = null;
 }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { createJiti } from "jiti";
 import type { OpenClawConfig } from "../config/config.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
+import { clearHooksBySource } from "../hooks/hook-registry.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveUserPath } from "../utils.js";
@@ -98,9 +99,12 @@ export const __testing = {
 function buildCacheKey(params: {
   workspaceDir?: string;
   plugins: NormalizedPluginsConfig;
+  hooksEnabled?: boolean;
 }): string {
   const workspaceKey = params.workspaceDir ? resolveUserPath(params.workspaceDir) : "";
-  return `${workspaceKey}::${JSON.stringify(params.plugins)}`;
+  // Include hooks.internal.enabled so toggling it invalidates the cache —
+  // otherwise stale plugin-source internal hooks survive SIGUSR1 restart.
+  return `${workspaceKey}::${params.hooksEnabled ? "hooks" : "nohooks"}::${JSON.stringify(params.plugins)}`;
 }
 
 function validatePluginConfig(params: {
@@ -380,6 +384,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const cacheKey = buildCacheKey({
     workspaceDir: options.workspaceDir,
     plugins: normalized,
+    hooksEnabled: cfg.hooks?.internal?.enabled === true,
   });
   const cacheEnabled = options.cache !== false;
   if (cacheEnabled) {
@@ -390,8 +395,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
   }
 
-  // Clear previously registered plugin commands before reloading
+  // Clear previously registered plugin commands and hooks before reloading.
+  // This only runs on the non-cached path so hooks survive when the cache hits
+  // (on SIGUSR1 restart with unchanged plugin config, register() isn't re-run).
   clearPluginCommands();
+  clearHooksBySource(["plugin"]);
 
   const runtime = createPluginRuntime();
   const { registry, createApi } = createPluginRegistry({

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -257,8 +257,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       return;
     }
 
+    // Tag as "plugin" so these hooks survive clearInternalHooks()
     for (const event of normalizedEvents) {
-      registerInternalHook(event, handler);
+      registerInternalHook(event, handler, "plugin");
     }
   };
 


### PR DESCRIPTION
## Summary

- **Problem:** Two independent hook systems (internal HOOK.md + plugin typed HookRunner) use module-level singletons duplicated by Rolldown bundler. `clearInternalHooks()` wipes plugin hooks. `gateway:startup` races with hook loading. `sessions.reset` never fires `before_reset`. `after_compaction` missing `sessionKey`.
- **Why it matters:** 30+ bugs filed over 2 months trace back to these shared root causes
- **What changed:** Single `globalThis[Symbol.for()]`-backed registry with source-tagged entries, source-scoped clearing, unified dispatch helpers, missing hook event fixes
- **What did NOT change (scope boundary):** HookRunner facade, all 24 typed hook definitions, existing hook handler signatures, plugin API surface

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30784
- Fixes #25859
- Fixes #25074
- Fixes #22790
- Supersedes #30853
- Related #23019, #30631, #30668, #29969, #20541, #26242, #28976

## User-visible / Behavior Changes

None. All changes are internal to hook dispatch infrastructure. Existing hooks fire at the same times with the same arguments.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+ / pnpm
- Model/provider: N/A
- Integration/channel (if any): All (hook system is channel-agnostic)
- Relevant config (redacted): `hooks.internal.enabled: true`

### Steps

1. Register a plugin hook via `api.registerHook("message:received", handler)`
2. Trigger a gateway SIGUSR1 restart (hot-reload)
3. Send a message to trigger `message_received`

### Expected

- Plugin hook fires after restart (source-scoped clearing preserves plugin hooks)

### Actual

- Before this PR: plugin hook is wiped by `handlers.clear()` and never fires again

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

28 new tests: `hook-registry.test.ts` (18 tests), `dispatch-unified.test.ts` (10 tests). All 229 existing tests pass.

## Human Verification (required)

- Verified scenarios: `pnpm build` (type-check), `pnpm check` (lint/format), `pnpm test` (229 tests pass), 3 rounds of codex review
- Edge cases checked: hookRunner null during early startup, clearInternalHooks idempotent, empty registry dispatch, handler throws (others still execute), metadata mutation isolation between dispatch paths
- What you did **not** verify: Live gateway with real plugin hooks (no staging environment)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the PR; module-level singletons restored
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: Hooks not firing after restart, duplicate hook execution, `gateway:startup` timing changes

## Risks and Mitigations

- Risk: `clearAllHooks()` on SIGUSR1 restart clears plugin-source hooks from the unified registry
  - Mitigation: Matches original `handlers.clear()` behavior exactly. Plugin typed hooks on HookRunner are stored separately and unaffected. Plugin internal hooks are re-registered by `loadGatewayPlugins()` at the start of each gateway iteration.

- Risk: Dispatch helpers change hook firing order for overlapping events
  - Mitigation: Plugin hooks fire before internal hooks in all 3 helpers, matching the original call-site ordering. 10 dispatch tests verify both systems fire.