### PR TITLE
fix(openrouter): respect cacheRetention setting for Anthropic models

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -279,10 +279,11 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
       });
       return { channel: "mattermost", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, replyToId }) => {
+    sendMedia: async ({ to, text, mediaUrl, accountId, replyToId, mediaLocalRoots }) => {
       const result = await sendMessageMattermost(to, text, {
         accountId: accountId ?? undefined,
         mediaUrl,
+        mediaLocalRoots,
         replyToId: replyToId ?? undefined,
       });
       return { channel: "mattermost", ...result };

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -16,6 +16,7 @@ export type MattermostSendOpts = {
   baseUrl?: string;
   accountId?: string;
   mediaUrl?: string;
+  mediaLocalRoots?: readonly string[];
   replyToId?: string;
 };
 
@@ -174,9 +175,12 @@ export async function sendMessageMattermost(
   let fileIds: string[] | undefined;
   let uploadError: Error | undefined;
   const mediaUrl = opts.mediaUrl?.trim();
+  const mediaLocalRoots = opts.mediaLocalRoots;
   if (mediaUrl) {
     try {
-      const media = await core.media.loadWebMedia(mediaUrl);
+      const media = await core.media.loadWebMedia(mediaUrl, {
+        localRoots: mediaLocalRoots?.length ? mediaLocalRoots : undefined,
+      });
       const fileInfo = await uploadMattermostFile(client, {
         channelId,
         buffer: media.buffer,

--- a/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
@@ -2,6 +2,7 @@ import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model } from "@mariozechner/pi-ai";
 import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import { applyExtraParamsToAgent } from "./extra-params.js";
 
 type StreamPayload = {
@@ -11,14 +12,14 @@ type StreamPayload = {
   }>;
 };
 
-function runOpenRouterPayload(payload: StreamPayload, modelId: string) {
+function runOpenRouterPayload(payload: StreamPayload, modelId: string, cfg?: OpenClawConfig) {
   const baseStreamFn: StreamFn = (_model, _context, options) => {
     options?.onPayload?.(payload);
     return createAssistantMessageEventStream();
   };
   const agent = { streamFn: baseStreamFn };
 
-  applyExtraParamsToAgent(agent, undefined, "openrouter", modelId);
+  applyExtraParamsToAgent(agent, cfg, "openrouter", modelId);
 
   const model = {
     api: "openai-completions",
@@ -89,5 +90,89 @@ describe("extra-params: OpenRouter Anthropic cache_control", () => {
     runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
 
     expect(payload.messages[0].content).toBe("Hello");
+  });
+
+  it("respects cacheRetention: none - does not inject cache_control", () => {
+    const payload = {
+      messages: [{ role: "system", content: "You are a helpful assistant." }],
+    };
+
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openrouter/anthropic/claude-opus-4-6": {
+              params: { cacheRetention: "none" },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6", cfg);
+
+    expect(payload.messages[0].content).toBe("You are a helpful assistant.");
+  });
+
+  it("respects cacheRetention: short - injects ephemeral cache_control", () => {
+    const payload = {
+      messages: [{ role: "system", content: "You are a helpful assistant." }],
+    };
+
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openrouter/anthropic/claude-opus-4-6": {
+              params: { cacheRetention: "short" },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6", cfg);
+
+    expect(payload.messages[0].content).toEqual([
+      { type: "text", text: "You are a helpful assistant.", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("respects cacheRetention: long - injects persistent cache_control", () => {
+    const payload = {
+      messages: [{ role: "system", content: "You are a helpful assistant." }],
+    };
+
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openrouter/anthropic/claude-opus-4-6": {
+              params: { cacheRetention: "long" },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6", cfg);
+
+    expect(payload.messages[0].content).toEqual([
+      { type: "text", text: "You are a helpful assistant.", cache_control: { type: "persistent" } },
+    ]);
+  });
+
+  it("defaults to ephemeral when cacheRetention is not configured", () => {
+    // This is the existing behavior - should default to ephemeral (short)
+    const payload = {
+      messages: [{ role: "system", content: "You are a helpful assistant." }],
+    };
+
+    // No cfg provided - should default to ephemeral
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
+
+    expect(payload.messages[0].content).toEqual([
+      { type: "text", text: "You are a helpful assistant.", cache_control: { type: "ephemeral" } },
+    ]);
   });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -57,6 +57,7 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
  * Applies to:
  * - direct Anthropic provider
  * - Anthropic Claude models on Bedrock when cache retention is explicitly configured
+ * - Anthropic models through OpenRouter
  *
  * OpenRouter uses openai-completions API with hardcoded cache_control instead
  * of the cacheRetention stream option.
@@ -66,13 +67,18 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
 function resolveCacheRetention(
   extraParams: Record<string, unknown> | undefined,
   provider: string,
+  modelId?: string,
 ): CacheRetention | undefined {
   const isAnthropicDirect = provider === "anthropic";
   const hasBedrockOverride =
     extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
   const isAnthropicBedrock = provider === "amazon-bedrock" && hasBedrockOverride;
+  const isOpenRouterAnthropic =
+    provider === "openrouter" &&
+    typeof modelId === "string" &&
+    modelId.toLowerCase().startsWith("anthropic/");
 
-  if (!isAnthropicDirect && !isAnthropicBedrock) {
+  if (!isAnthropicDirect && !isAnthropicBedrock && !isOpenRouterAnthropic) {
     return undefined;
   }
 
@@ -92,7 +98,7 @@ function resolveCacheRetention(
   }
 
   // Default to "short" only for direct Anthropic when not explicitly configured.
-  // Bedrock retains upstream provider defaults unless explicitly set.
+  // Bedrock and OpenRouter retain upstream provider defaults unless explicitly set.
   if (!isAnthropicDirect) {
     return undefined;
   }
@@ -443,12 +449,39 @@ type PayloadMessage = {
 };
 
 /**
+ * Map cacheRetention to OpenRouter's cache_control type.
+ * - "none" → no cache_control (disabled)
+ * - "short" → { type: "ephemeral" } (5 min)
+ * - "long" → { type: "persistent" } (1 hour)
+ */
+function mapCacheRetentionToOpenRouterCacheControl(
+  cacheRetention: CacheRetention,
+): { type: "ephemeral" } | { type: "persistent" } | undefined {
+  switch (cacheRetention) {
+    case "none":
+      return undefined;
+    case "short":
+      return { type: "ephemeral" };
+    case "long":
+      return { type: "persistent" };
+  }
+}
+
+/**
  * Inject cache_control into the system message for OpenRouter Anthropic models.
  * OpenRouter passes through Anthropic's cache_control field — caching the system
  * prompt avoids re-processing it on every request.
+ *
+ * @param cacheRetention - Controls cache duration: "none" (disabled), "short" (5min), "long" (1hr)
  */
-function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+function createOpenRouterSystemCacheWrapper(
+  baseStreamFn: StreamFn | undefined,
+  cacheRetention?: CacheRetention,
+): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
+  const cacheControl = cacheRetention
+    ? mapCacheRetentionToOpenRouterCacheControl(cacheRetention)
+    : { type: "ephemeral" }; // Default to "short" behavior for backwards compatibility
   return (model, context, options) => {
     if (
       typeof model.provider !== "string" ||
@@ -468,14 +501,16 @@ function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined):
             if (msg.role !== "system" && msg.role !== "developer") {
               continue;
             }
+            // Only inject cache_control if cacheRetention is not "none"
+            if (cacheControl === undefined) {
+              continue;
+            }
             if (typeof msg.content === "string") {
-              msg.content = [
-                { type: "text", text: msg.content, cache_control: { type: "ephemeral" } },
-              ];
+              msg.content = [{ type: "text", text: msg.content, cache_control: cacheControl }];
             } else if (Array.isArray(msg.content) && msg.content.length > 0) {
               const last = msg.content[msg.content.length - 1];
               if (last && typeof last === "object") {
-                (last as Record<string, unknown>).cache_control = { type: "ephemeral" };
+                (last as Record<string, unknown>).cache_control = cacheControl;
               }
             }
           }
@@ -780,7 +815,9 @@ export function applyExtraParamsToAgent(
     // See: openclaw/openclaw#24851
     const openRouterThinkingLevel = modelId === "auto" ? undefined : thinkingLevel;
     agent.streamFn = createOpenRouterWrapper(agent.streamFn, openRouterThinkingLevel);
-    agent.streamFn = createOpenRouterSystemCacheWrapper(agent.streamFn);
+    // Resolve cacheRetention for OpenRouter Anthropic models
+    const openRouterCacheRetention = resolveCacheRetention(merged, provider, modelId);
+    agent.streamFn = createOpenRouterSystemCacheWrapper(agent.streamFn, openRouterCacheRetention);
   }
 
   if (provider === "amazon-bedrock" && !isAnthropicBedrockModel(modelId)) {

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
@@ -413,6 +414,19 @@ function normalizeTextLikeParam(record: Record<string, unknown>, key: string) {
 // Normalize tool parameters from Claude Code conventions to pi-coding-agent conventions.
 // Claude Code uses file_path/old_string/new_string while pi-coding-agent uses path/oldText/newText.
 // This prevents models trained on Claude Code from getting stuck in tool-call loops.
+function expandHomeDir(filePath: unknown): unknown {
+  if (typeof filePath !== "string") {
+    return filePath;
+  }
+  if (filePath === "~") {
+    return os.homedir();
+  }
+  if (filePath.startsWith("~/")) {
+    return os.homedir() + filePath.slice(1);
+  }
+  return filePath;
+}
+
 export function normalizeToolParams(params: unknown): Record<string, unknown> | undefined {
   if (!params || typeof params !== "object") {
     return undefined;
@@ -421,8 +435,12 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
   const normalized = { ...record };
   // file_path → path (read, write, edit)
   if ("file_path" in normalized && !("path" in normalized)) {
-    normalized.path = normalized.file_path;
+    normalized.path = expandHomeDir(normalized.file_path);
     delete normalized.file_path;
+  }
+  // Expand ~ in path for read, write, and edit tools
+  if ("path" in normalized) {
+    normalized.path = expandHomeDir(normalized.path);
   }
   // old_string → oldText (edit)
   if ("old_string" in normalized && !("oldText" in normalized)) {

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -523,6 +523,14 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         publicKey: "a",
         token,
         autoDeploy: false,
+        // Increase listener timeout to 2 minutes to avoid timeout errors during
+        // long-running operations like LLM inference in cron jobs and message handlers.
+        // The default 30s timeout in Carbon's EventQueue was causing duplicate
+        // deliveries when listeners took too long to process.
+        // See: https://github.com/openclaw/openclaw/issues/30816
+        eventQueue: {
+          listenerTimeout: 120_000,
+        },
       },
       {
         commands,


### PR DESCRIPTION
Fixes #30850

Previously, Anthropic models used through OpenRouter always used ephemeral cache (5 min) regardless of the user's cacheRetention setting. This fix:

1. Updates resolveCacheRetention() to also handle OpenRouter with Anthropic models (provider=openrouter, model starts with anthropic/)
2. Passes the resolved cacheRetention to createOpenRouterSystemCacheWrapper()
3. Maps cacheRetention values to OpenRouter's cache_control types:
   - 'none' → no cache_control (disabled)
   - 'short' → { type: 'ephemeral' } (5 min)
   - 'long' → { type: 'persistent' } (1 hour)

Adds tests to verify all cacheRetention values work correctly.