### PR TITLE
Mattermost: pass mediaLocalRoots to loadWebMedia for agent workspace paths (fix #30830)

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -279,10 +279,11 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
       });
       return { channel: "mattermost", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, replyToId }) => {
+    sendMedia: async ({ to, text, mediaUrl, mediaLocalRoots, accountId, replyToId }) => {
       const result = await sendMessageMattermost(to, text, {
         accountId: accountId ?? undefined,
         mediaUrl,
+        mediaLocalRoots,
         replyToId: replyToId ?? undefined,
       });
       return { channel: "mattermost", ...result };

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -26,6 +26,7 @@ import {
   resolveChannelMediaMaxBytes,
   warnMissingProviderGroupPolicyFallbackOnce,
   type HistoryEntry,
+  getAgentScopedMediaLocalRoots,
 } from "openclaw/plugin-sdk";
 import { getMattermostRuntime } from "../runtime.js";
 import { resolveMattermostAccount } from "./accounts.js";
@@ -747,6 +748,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         deliver: async (payload: ReplyPayload) => {
           const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
           const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
+          const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
           if (mediaUrls.length === 0) {
             const chunkMode = core.channel.text.resolveChunkMode(
               cfg,
@@ -771,6 +773,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               await sendMessageMattermost(to, caption, {
                 accountId: account.accountId,
                 mediaUrl,
+                mediaLocalRoots,
                 replyToId: threadRootId,
               });
             }

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -16,6 +16,7 @@ export type MattermostSendOpts = {
   baseUrl?: string;
   accountId?: string;
   mediaUrl?: string;
+  mediaLocalRoots?: readonly string[];
   replyToId?: string;
 };
 
@@ -176,7 +177,9 @@ export async function sendMessageMattermost(
   const mediaUrl = opts.mediaUrl?.trim();
   if (mediaUrl) {
     try {
-      const media = await core.media.loadWebMedia(mediaUrl);
+      const media = await core.media.loadWebMedia(mediaUrl, {
+        localRoots: opts.mediaLocalRoots,
+      });
       const fileInfo = await uploadMattermostFile(client, {
         channelId,
         buffer: media.buffer,

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -449,6 +449,7 @@ export type {
 } from "../infra/diagnostic-events.js";
 export { detectMime, extensionForMime, getFileExtension } from "../media/mime.js";
 export { extractOriginalFilename } from "../media/store.js";
+export { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
 
 // Channel: Discord
 export {


### PR DESCRIPTION
Fixes #30830