### PR TITLE
fix(matrix): add m.mentions field to outbound messages for notification highlights

### DIFF
--- a/extensions/matrix/src/matrix/send/formatting.mentions.test.ts
+++ b/extensions/matrix/src/matrix/send/formatting.mentions.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { extractMatrixUserMentions, applyMatrixMentions } from "./formatting.js";
+
+describe("extractMatrixUserMentions", () => {
+  it("extracts single user mention", () => {
+    expect(extractMatrixUserMentions("Hello @alice:example.com!")).toEqual(["@alice:example.com"]);
+  });
+
+  it("extracts multiple unique mentions", () => {
+    const result = extractMatrixUserMentions("cc @alice:example.com and @bob:matrix.org");
+    expect(result).toEqual(["@alice:example.com", "@bob:matrix.org"]);
+  });
+
+  it("deduplicates mentions", () => {
+    const result = extractMatrixUserMentions("@alice:example.com said hi to @alice:example.com");
+    expect(result).toEqual(["@alice:example.com"]);
+  });
+
+  it("returns empty array for no mentions", () => {
+    expect(extractMatrixUserMentions("just some text")).toEqual([]);
+  });
+
+  it("returns empty array for empty/null input", () => {
+    expect(extractMatrixUserMentions("")).toEqual([]);
+  });
+
+  it("handles complex localparts", () => {
+    expect(extractMatrixUserMentions("@user_name.test=foo/bar:server.example.org")).toEqual([
+      "@user_name.test=foo/bar:server.example.org",
+    ]);
+  });
+});
+
+describe("applyMatrixMentions", () => {
+  it("adds m.mentions to content with user mentions", () => {
+    const content: Record<string, unknown> = { msgtype: "m.text", body: "hi @alice:example.com" };
+    applyMatrixMentions(content, "hi @alice:example.com");
+    expect(content["m.mentions"]).toEqual({ user_ids: ["@alice:example.com"] });
+  });
+
+  it("does not add m.mentions when no mentions present", () => {
+    const content: Record<string, unknown> = { msgtype: "m.text", body: "hello" };
+    applyMatrixMentions(content, "hello");
+    expect(content["m.mentions"]).toBeUndefined();
+  });
+});

--- a/extensions/matrix/src/matrix/send/formatting.ts
+++ b/extensions/matrix/src/matrix/send/formatting.ts
@@ -13,6 +13,16 @@ import {
 
 const getCore = () => getMatrixRuntime();
 
+/**
+ * Extract Matrix user IDs (@user:server) from message text for m.mentions (MSC3952).
+ */
+export function extractMatrixUserMentions(body: string): string[] {
+  if (!body) return [];
+  // Matrix user IDs: @localpart:server.tld
+  const matches = body.match(/@[a-zA-Z0-9._=\-\/]+:[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g);
+  return matches ? [...new Set(matches)] : [];
+}
+
 export function buildTextContent(body: string, relation?: MatrixRelation): MatrixTextContent {
   const content: MatrixTextContent = relation
     ? {
@@ -25,6 +35,7 @@ export function buildTextContent(body: string, relation?: MatrixRelation): Matri
         body,
       };
   applyMatrixFormatting(content, body);
+  applyMatrixMentions(content, body);
   return content;
 }
 
@@ -37,6 +48,16 @@ export function applyMatrixFormatting(content: MatrixFormattedContent, body: str
   content.formatted_body = formatted;
 }
 
+/**
+ * Add m.mentions field to content based on Matrix user IDs found in the body.
+ * Per MSC3952/Matrix spec v1.9, clients use m.mentions.user_ids for highlight notifications.
+ */
+export function applyMatrixMentions(content: Record<string, unknown>, body: string): void {
+  const userIds = extractMatrixUserMentions(body);
+  if (userIds.length > 0) {
+    (content as Record<string, unknown>)["m.mentions"] = { user_ids: userIds };
+  }
+}
 export function buildReplyRelation(replyToId?: string): MatrixReplyRelation | undefined {
   const trimmed = replyToId?.trim();
   if (!trimmed) {

--- a/extensions/matrix/src/matrix/send/media.ts
+++ b/extensions/matrix/src/matrix/send/media.ts
@@ -7,7 +7,7 @@ import type {
   VideoFileInfo,
 } from "@vector-im/matrix-bot-sdk";
 import { getMatrixRuntime } from "../../runtime.js";
-import { applyMatrixFormatting } from "./formatting.js";
+import { applyMatrixFormatting, applyMatrixMentions } from "./formatting.js";
 import {
   type MatrixMediaContent,
   type MatrixMediaInfo,
@@ -104,6 +104,7 @@ export function buildMediaContent(params: {
     base["m.relates_to"] = params.relation;
   }
   applyMatrixFormatting(base, params.body);
+  applyMatrixMentions(base, params.body);
   return base;
 }
 


### PR DESCRIPTION
## Summary

Matrix clients (Element, FluffyChat, Cinny, etc.) use the `m.mentions.user_ids` field ([MSC3952](https://github.com/matrix-org/matrix-spec-proposals/pull/3952), [Matrix spec v1.9](https://spec.matrix.org/v1.9/client-server-api/#user-and-room-mentions)) to determine notification highlights. Without this field, @-mentions in OpenClaw messages do not trigger notifications for the mentioned users.

## Changes

- **`extensions/matrix/src/matrix/send/formatting.ts`**: Added `extractMatrixUserMentions()` to parse Matrix user IDs (`@user:server`) from message body, and `applyMatrixMentions()` to set the `m.mentions` field on outbound content. Applied in `buildTextContent()`.
- **`extensions/matrix/src/matrix/send/media.ts`**: Applied `applyMatrixMentions()` in `buildMediaContent()` so media messages with text also trigger mention notifications.
- **`extensions/matrix/src/matrix/send/formatting.mentions.test.ts`**: 8 tests covering extraction, deduplication, empty input, and content mutation.

## Testing

- All 8 new tests pass
- `oxlint` reports 0 warnings/errors
- `tsc --noEmit` clean (pre-existing unrelated errors only)

Fixes #30656