### PR TITLE
fix(discord): raise event queue listener timeout for long handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Docs: https://docs.openclaw.ai
 
 - Docs/Slack manifest scopes: add missing DM/group-DM bot scopes (`im:read`, `im:write`, `mpim:read`, `mpim:write`) to the Slack app manifest example so DM setup guidance is complete. (#29999) Thanks @JcMinarro.
 - Slack/Onboarding token help: update setup text to include the “From manifest” app-creation path and current install wording for obtaining the `xoxb-` bot token. (#30846) Thanks @yzhong52.
+- Discord/Event queue timeout: configure Discord monitor client `eventQueue.listenerTimeout` to 120 seconds so long-running handlers do not hit the Carbon 30-second listener timeout and trigger duplicate delivery retries. (#30816)
 - Slack/Bot attachment-only messages: when `allowBots: true`, bot messages with empty `text` now include non-forwarded attachment `text`/`fallback` content so webhook alerts are not silently dropped. (#27616)
 - Slack/Inbound media auth + HTML guard: keep Slack auth headers on forwarded shared attachment image downloads, and reject login/error HTML payloads (while allowing expected `.html` uploads) when resolving Slack media so auth failures do not silently pass as files. (#18642)
 - Slack/Security ingress mismatch guard: drop slash-command and interaction payloads when app/team identifiers do not match the active Slack account context (including nested `team.id` interaction payloads), preventing cross-app or cross-workspace payload injection into system-event handling. (#29091) Thanks @Solvely-Colin.

--- a/src/discord/monitor/provider.test.ts
+++ b/src/discord/monitor/provider.test.ts
@@ -6,6 +6,7 @@ import type { RuntimeEnv } from "../../runtime.js";
 const {
   clientFetchUserMock,
   clientGetPluginMock,
+  capturedClientOptions,
   createDiscordNativeCommandMock,
   createNoopThreadBindingManagerMock,
   createThreadBindingManagerMock,
@@ -20,9 +21,11 @@ const {
   resolveNativeSkillsEnabledMock,
 } = vi.hoisted(() => {
   const createdBindingManagers: Array<{ stop: ReturnType<typeof vi.fn> }> = [];
+  const capturedClientOptions: unknown[] = [];
   return {
     clientFetchUserMock: vi.fn(async (_target: string) => ({ id: "bot-1" })),
     clientGetPluginMock: vi.fn<(_name: string) => unknown>(() => undefined),
+    capturedClientOptions,
     createDiscordNativeCommandMock: vi.fn(() => ({ name: "mock-command" })),
     createNoopThreadBindingManagerMock: vi.fn(() => {
       const manager = { stop: vi.fn() };
@@ -69,7 +72,8 @@ vi.mock("@buape/carbon", () => {
   class Client {
     listeners: unknown[];
     rest: { put: ReturnType<typeof vi.fn> };
-    constructor(_options: unknown, handlers: { listeners?: unknown[] }) {
+    constructor(options: unknown, handlers: { listeners?: unknown[] }) {
+      capturedClientOptions.push(options);
       this.listeners = handlers.listeners ?? [];
       this.rest = { put: vi.fn(async () => undefined) };
     }
@@ -256,6 +260,7 @@ describe("monitorDiscordProvider", () => {
   beforeEach(() => {
     clientFetchUserMock.mockClear().mockResolvedValue({ id: "bot-1" });
     clientGetPluginMock.mockClear().mockReturnValue(undefined);
+    capturedClientOptions.length = 0;
     createDiscordNativeCommandMock.mockClear().mockReturnValue({ name: "mock-command" });
     createNoopThreadBindingManagerMock.mockClear();
     createThreadBindingManagerMock.mockClear();
@@ -333,5 +338,19 @@ describe("monitorDiscordProvider", () => {
     };
     expect(lifecycleArgs.pendingGatewayErrors).toHaveLength(1);
     expect(String(lifecycleArgs.pendingGatewayErrors?.[0])).toContain("4014");
+  });
+
+  it("configures event queue listener timeout for long-running discord handlers", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    const clientOptions = capturedClientOptions[0] as {
+      eventQueue?: { listenerTimeout?: number };
+    };
+    expect(clientOptions.eventQueue?.listenerTimeout).toBe(120_000);
   });
 });

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -110,6 +110,7 @@ function summarizeGuilds(entries?: Record<string, unknown>) {
 
 const DEFAULT_THREAD_BINDING_IDLE_HOURS = 24;
 const DEFAULT_THREAD_BINDING_MAX_AGE_HOURS = 0;
+const DISCORD_EVENT_QUEUE_LISTENER_TIMEOUT_MS = 120_000;
 
 function normalizeThreadBindingHours(raw: unknown): number | undefined {
   if (typeof raw !== "number" || !Number.isFinite(raw)) {
@@ -523,6 +524,9 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         publicKey: "a",
         token,
         autoDeploy: false,
+        eventQueue: {
+          listenerTimeout: DISCORD_EVENT_QUEUE_LISTENER_TIMEOUT_MS,
+        },
       },
       {
         commands,


### PR DESCRIPTION
## Summary

- Problem: Discord `MESSAGE_CREATE` listeners can exceed Carbon's default 30s event-queue listener timeout during long-running agent turns.
- Why it matters: timeout/retry paths can produce duplicate Discord deliveries (reported for cron announce flows in #30816).
- What changed: configured Discord monitor `Client` with `eventQueue.listenerTimeout = 120_000` and added a regression test asserting the timeout is wired at client construction.
- What did NOT change (scope boundary): no routing logic, dedupe algorithm, or retry policy changes outside Discord provider client initialization.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30816
- Related #30826

## User-visible / Behavior Changes

- Discord listener timeout budget increases from 30s (Carbon default) to 120s for this provider, reducing false listener timeouts during long-running handlers.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15 (local dev)
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Discord provider unit tests
- Relevant config (redacted): default discord account fixture in test

### Steps

1. Run `pnpm exec vitest run src/discord/monitor/provider.test.ts src/discord/monitor/provider.proxy.test.ts`
2. Run `pnpm build`
3. Confirm new test checks `eventQueue.listenerTimeout` for created Discord client

### Expected

- Discord provider client is initialized with `eventQueue.listenerTimeout: 120_000`.

### Actual

- Verified by new unit test and passing build.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: provider initialization now includes event queue timeout configuration; regression test passes.
- Edge cases checked: existing provider proxy tests still pass; no behavior changes in unrelated provider lifecycle tests.
- What you did **not** verify: end-to-end Discord cron delivery in a live guild environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit to restore Carbon defaults.
- Files/config to restore: `src/discord/monitor/provider.ts`.
- Known bad symptoms reviewers should watch for: longer wait before timeout logs for genuinely hung Discord listeners.

## Risks and Mitigations

- Risk: higher timeout can delay surfacing truly stuck listener failures.
  - Mitigation: existing slow-listener warning remains at 30s (`discord/event-queue` warning path), preserving early signal while avoiding premature hard timeout.
