### PR TITLE
fix(test): use path.resolve in tilde expansion test for Windows compat

### DIFF
--- a/changelog/fragments/pr-30889.md
+++ b/changelog/fragments/pr-30889.md
@@ -1,0 +1,1 @@
+- Tests/Windows: normalize `fs-safe` tilde-expansion expectation with `path.resolve` for cross-platform path assertions (#30889) (thanks @jalehman)

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -182,7 +182,8 @@ describe("tilde expansion in file tools", () => {
     process.env.HOME = fakeHome;
     try {
       const result = expandHomePrefix("~/file.txt");
-      expect(result).toBe(`${fakeHome}/file.txt`);
+      // path.resolve produces platform-native paths (e.g. C:\tmp\... on Windows)
+      expect(result).toBe(`${path.resolve(fakeHome)}/file.txt`);
     } finally {
       process.env.HOME = originalHome;
     }


### PR DESCRIPTION
## Summary

`expandHomePrefix` resolves HOME through platform-native path normalization, producing drive-letter paths on Windows (e.g. `C:\tmp\...`). The tilde expansion test in `fs-safe.test.ts` compared against the raw POSIX string `/tmp/fake-home-test/file.txt`, causing a consistent CI failure on Windows shard 1/2:

```
expected 'C:\tmp\fake-home-test/file.txt' to be '/tmp/fake-home-test/file.txt'
```

Fix: use `path.resolve(fakeHome)` for the expected value so it matches on all platforms. No-op on POSIX where `resolve("/tmp/...") === "/tmp/..."`.

## Linked Issue

Fixes the `checks-windows (node, test, 1, 2)` CI failure on main.

## User-visible Behavior

Test-only change. No user-visible behavior change.

## Security Impact

- New permissions/capabilities: No
- Secrets/tokens handling changed: No
- New/changed network calls: No
- Command/tool execution surface changed: No
- Data access scope changed: No