### PR TITLE
fix(mattermost): map private channel type "P" to group to fix policy routing (#29830)

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -114,11 +114,18 @@ function channelKind(channelType?: string | null): ChatType {
   if (!channelType) {
     return "channel";
   }
+  // Mattermost channel types: D=direct, G=group DM, O=public channel, P=private channel.
   const normalized = channelType.trim().toUpperCase();
   if (normalized === "D") {
     return "direct";
   }
   if (normalized === "G") {
+    return "group";
+  }
+  if (normalized === "P") {
+    // Private channels are invitation-restricted spaces; route as "group" so
+    // groupPolicy / groupAllowFrom can gate access separately from open public
+    // channels (type "O"), and the From prefix becomes mattermost:group:<id>.
     return "group";
   }
   return "channel";


### PR DESCRIPTION
## Problem

Mattermost private channels (`type="P"`) were silently misclassified as public channels. In `channelKind()`, only `"D"` (direct) and `"G"` (group DM) had explicit cases; the Mattermost private channel type `"P"` fell through to the default `"channel"` return — the same as open public channels (`"O"`).

This meant:
- Private channel messages were routed via `mattermost:channel:<id>` instead of a distinct prefix
- `groupPolicy` / `groupAllowFrom` could not be used to control private-channel access separately from public channels
- No way to configure different `requireMention` behaviour for private vs public channels

## Root Cause

`extensions/mattermost/src/mattermost/monitor.ts` — `channelKind()` only handled `"D"` and `"G"`. Mattermost channel type `"P"` (private channel) fell through to the default `"channel"` case, treating it identically to open public channels (`"O"`).

## Fix

Added an explicit `if (normalized === "P")` branch in `channelKind()` that returns `"group"`. Private channels in Mattermost are invitation-restricted persistent spaces — semantically closer to restricted groups than open public channels. Routing them as `"group"` lets operators use `groupPolicy` + `groupAllowFrom` to gate private-channel access, and the `From` address becomes `mattermost:group:<channelId>` rather than `mattermost:channel:<channelId>`, making it distinguishable in allowlists.

## Step 6 Re-verify (code-level)

Bug pattern confirmed GONE in fix branch:
- `channelKind("P")` now explicitly returns `"group"` instead of falling through to `"channel"`
- Grep of fixed file confirms `if (normalized === "P")` branch is present
- `oxfmt --check` passes on changed file (exit 0)
- All `if` statements use braces (curly rule satisfied)