### PR TITLE
fix(telegram): add elevated allowFrom fallback in channel dock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Docs: https://docs.openclaw.ai
 
 - Docs/Slack manifest scopes: add missing DM/group-DM bot scopes (`im:read`, `im:write`, `mpim:read`, `mpim:write`) to the Slack app manifest example so DM setup guidance is complete. (#29999) Thanks @JcMinarro.
 - Slack/Onboarding token help: update setup text to include the “From manifest” app-creation path and current install wording for obtaining the `xoxb-` bot token. (#30846) Thanks @yzhong52.
+- Telegram/Elevated allowFrom fallback: add Telegram channel dock `elevated.allowFromFallback` based on resolved account config so explicit Telegram allowlists are honored for elevated tool permission checks. (#30609)
 - Slack/Bot attachment-only messages: when `allowBots: true`, bot messages with empty `text` now include non-forwarded attachment `text`/`fallback` content so webhook alerts are not silently dropped. (#27616)
 - Slack/Inbound media auth + HTML guard: keep Slack auth headers on forwarded shared attachment image downloads, and reject login/error HTML payloads (while allowing expected `.html` uploads) when resolving Slack media so auth failures do not silently pass as files. (#18642)
 - Slack/Security ingress mismatch guard: drop slash-command and interaction payloads when app/team identifiers do not match the active Slack account context (including nested `team.id` interaction payloads), preventing cross-app or cross-workspace payload injection into system-event handling. (#29091) Thanks @Solvely-Colin.

--- a/src/channels/dock.test.ts
+++ b/src/channels/dock.test.ts
@@ -99,4 +99,29 @@ describe("channels dock", () => {
 
     expect(formatted).toEqual(["user", "foo", "plain"]);
   });
+
+  it("telegram elevated allowFrom fallback resolves per-account allowlists", () => {
+    const telegramDock = getChannelDock("telegram");
+    const cfg = {
+      channels: {
+        telegram: {
+          allowFrom: ["root-user"],
+          accounts: {
+            work: {
+              allowFrom: ["work-user"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const workAllowFrom = telegramDock?.elevated?.allowFromFallback?.({ cfg, accountId: "work" });
+    const defaultAllowFrom = telegramDock?.elevated?.allowFromFallback?.({
+      cfg,
+      accountId: "missing",
+    });
+
+    expect(workAllowFrom).toEqual(["work-user"]);
+    expect(defaultAllowFrom).toEqual(["root-user"]);
+  });
 });

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -239,6 +239,10 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
       blockStreaming: true,
     },
     outbound: DEFAULT_OUTBOUND_TEXT_CHUNK_LIMIT_4000,
+    elevated: {
+      allowFromFallback: ({ cfg, accountId }) =>
+        resolveTelegramAccount({ cfg, accountId }).config.allowFrom,
+    },
     config: {
       resolveAllowFrom: ({ cfg, accountId }) =>
         stringifyAllowFrom(resolveTelegramAccount({ cfg, accountId }).config.allowFrom ?? []),


### PR DESCRIPTION
## Summary

- Problem: Telegram channel dock lacked `elevated.allowFromFallback`, so explicit Telegram allowlists were not available to elevated permission checks in some command paths.
- Why it matters: allowlisted Telegram users could hit false `permission denied` for elevated/browser-style tool flows despite valid `channels.telegram.allowFrom` config (#30609).
- What changed: added Telegram `elevated.allowFromFallback` wired through `resolveTelegramAccount({ cfg, accountId }).config.allowFrom`.
- What changed in tests: added regression coverage proving elevated fallback resolves per-account and root Telegram allowlists.
- What did NOT change (scope boundary): no Telegram transport/monitor logic, no command parser changes, no auth model changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30609
- Related #30625

## User-visible / Behavior Changes

- Telegram allowlists now participate in elevated fallback checks through dock metadata, including account-scoped Telegram configs.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): channel dock metadata (Telegram)
- Relevant config (redacted): Telegram root + account `allowFrom` entries

### Steps

1. Run `pnpm exec vitest run src/channels/dock.test.ts`
2. Run `pnpm build`
3. Verify new test case for Telegram elevated allowFrom fallback

### Expected

- Telegram dock exposes elevated allowFrom fallback with account-aware resolution.

### Actual

- Verified by unit test and passing build.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:
- `pnpm exec vitest run src/channels/dock.test.ts`
- `pnpm build`
- `pnpm check` (fails in this environment due optional extension dependency gaps; unchanged baseline)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Telegram elevated fallback returns account-level allowFrom for explicit account ID.
  - Telegram elevated fallback returns root allowFrom when account is not explicitly configured.
- Edge cases checked:
  - Existing Telegram allowFrom formatter tests remain passing.
- What you did **not** verify:
  - Live Telegram runtime execution against a real bot session.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/channels/dock.ts`, `src/channels/dock.test.ts`.
- Known bad symptoms reviewers should watch for: Telegram elevated checks ignoring account-level allowFrom entries.

## Risks and Mitigations

- Risk: account resolution mismatch could return unexpected fallback list.
  - Mitigation: implementation reuses `resolveTelegramAccount` (same account resolution path used elsewhere) and adds regression coverage for account/root cases.
