### PR TITLE
fix: honor legacy heartbeat.model override in heartbeat runs

### DIFF
--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -111,6 +111,53 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
     );
   });
 
+  it("passes heartbeatModelOverride from legacy top-level heartbeat config", async () => {
+    await withHeartbeatFixture(async ({ tmpDir, storePath, seedSession }) => {
+      const cfg = {
+        heartbeat: {
+          every: "5m",
+          target: "whatsapp",
+          model: "ollama/llama3.2:1b",
+        },
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      } as OpenClawConfig & {
+        heartbeat?: {
+          every?: string;
+          target?: string;
+          model?: string;
+        };
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await seedSession(sessionKey, { lastChannel: "whatsapp", lastTo: "+1555" });
+
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          isHeartbeat: true,
+          heartbeatModelOverride: "ollama/llama3.2:1b",
+        }),
+        cfg,
+      );
+    });
+  });
+
   it("passes suppressToolErrorWarnings when configured", async () => {
     const replyOpts = await runDefaultsHeartbeat({ suppressToolErrorWarnings: true });
     expect(replyOpts).toEqual(

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -87,6 +87,14 @@ type HeartbeatAgent = {
   heartbeat?: HeartbeatConfig;
 };
 
+function resolveLegacyHeartbeatConfig(cfg: OpenClawConfig): HeartbeatConfig | undefined {
+  const legacy = (cfg as Record<string, unknown>).heartbeat;
+  if (!legacy || typeof legacy !== "object") {
+    return undefined;
+  }
+  return legacy as HeartbeatConfig;
+}
+
 export type HeartbeatSummary = {
   enabled: boolean;
   every: string;
@@ -135,21 +143,24 @@ function resolveHeartbeatConfig(
   agentId?: string,
 ): HeartbeatConfig | undefined {
   const defaults = cfg.agents?.defaults?.heartbeat;
+  const legacyDefaults = resolveLegacyHeartbeatConfig(cfg);
+  const mergedDefaults =
+    defaults || legacyDefaults ? { ...legacyDefaults, ...defaults } : undefined;
   if (!agentId) {
-    return defaults;
+    return mergedDefaults;
   }
   const overrides = resolveAgentConfig(cfg, agentId)?.heartbeat;
-  if (!defaults && !overrides) {
+  if (!mergedDefaults && !overrides) {
     return overrides;
   }
-  return { ...defaults, ...overrides };
+  return { ...mergedDefaults, ...overrides };
 }
 
 export function resolveHeartbeatSummaryForAgent(
   cfg: OpenClawConfig,
   agentId?: string,
 ): HeartbeatSummary {
-  const defaults = cfg.agents?.defaults?.heartbeat;
+  const defaults = resolveHeartbeatConfig(cfg);
   const overrides = agentId ? resolveAgentConfig(cfg, agentId)?.heartbeat : undefined;
   const enabled = isHeartbeatEnabledForAgent(cfg, agentId);
 
@@ -213,10 +224,12 @@ export function resolveHeartbeatIntervalMs(
   overrideEvery?: string,
   heartbeat?: HeartbeatConfig,
 ) {
+  const legacyDefaults = resolveLegacyHeartbeatConfig(cfg);
   const raw =
     overrideEvery ??
     heartbeat?.every ??
     cfg.agents?.defaults?.heartbeat?.every ??
+    legacyDefaults?.every ??
     DEFAULT_HEARTBEAT_EVERY;
   if (!raw) {
     return null;
@@ -238,7 +251,11 @@ export function resolveHeartbeatIntervalMs(
 }
 
 export function resolveHeartbeatPrompt(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig) {
-  return resolveHeartbeatPromptText(heartbeat?.prompt ?? cfg.agents?.defaults?.heartbeat?.prompt);
+  return resolveHeartbeatPromptText(
+    heartbeat?.prompt ??
+      cfg.agents?.defaults?.heartbeat?.prompt ??
+      resolveLegacyHeartbeatConfig(cfg)?.prompt,
+  );
 }
 
 function resolveHeartbeatAckMaxChars(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig) {
@@ -246,6 +263,7 @@ function resolveHeartbeatAckMaxChars(cfg: OpenClawConfig, heartbeat?: HeartbeatC
     0,
     heartbeat?.ackMaxChars ??
       cfg.agents?.defaults?.heartbeat?.ackMaxChars ??
+      resolveLegacyHeartbeatConfig(cfg)?.ackMaxChars ??
       DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   );
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: heartbeat runs ignored `heartbeat.model` when users had a legacy top-level `heartbeat` block instead of `agents.defaults.heartbeat`.
- Why it matters: heartbeats silently fell back to the default model, causing higher-cost model usage and configuration confusion.
- What changed: heartbeat config resolution now merges legacy top-level `heartbeat` as a fallback/default source (with `agents.defaults.heartbeat` still taking precedence), so `model` (and related heartbeat fields) are honored.
- What changed: added a regression test that verifies `heartbeatModelOverride` is passed through from legacy top-level `heartbeat.model`.
- What did NOT change (scope boundary): no schema changes, no CLI path aliasing changes, and no behavior changes for users already using `agents.defaults.heartbeat`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30894
- Related #

## User-visible / Behavior Changes

- Heartbeat runs now honor legacy top-level `heartbeat.model` (fallback compatibility path), instead of silently using the default model.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm (repo local)
- Model/provider: N/A (mocked in tests)
- Integration/channel (if any): WhatsApp (test harness)
- Relevant config (redacted): legacy top-level `heartbeat: { model: ..., every: ..., target: ... }`

### Steps

1. Configure legacy top-level `heartbeat.model` and run a heartbeat cycle.
2. Spy on `getReplyFromConfig` options passed by `runHeartbeatOnce`.
3. Confirm `heartbeatModelOverride` is present and equals configured model.

### Expected

- Heartbeat run forwards configured model override.

### Actual

- Before fix: default model was used in this legacy config shape.
- After fix: configured legacy heartbeat model is forwarded.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run src/infra/heartbeat-runner.model-override.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`
  - New regression test passes and confirms `heartbeatModelOverride` propagation from top-level legacy `heartbeat`.
- Edge cases checked:
  - Existing defaults path (`agents.defaults.heartbeat.model`) still passes (existing tests remain green).
  - Per-agent heartbeat behavior remains covered by existing tests.
- What you did **not** verify:
  - End-to-end live heartbeat on a running gateway with external provider credentials.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/infra/heartbeat-runner.ts`
  - `src/infra/heartbeat-runner.model-override.test.ts`
- Known bad symptoms reviewers should watch for:
  - Heartbeats unexpectedly selecting a model from legacy top-level config when both legacy and defaults are set (defaults should still win).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Legacy top-level heartbeat fallback could override expectations when mixed configs are malformed.
  - Mitigation:
    - Merge order keeps `agents.defaults.heartbeat` authoritative; legacy only fills missing defaults.
