### PR TITLE
fix(voice-call): accept externally-initiated outbound Twilio calls

### DIFF
--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -150,6 +150,59 @@ describe("processEvent (functional)", () => {
     expect(hangupCalls[0]?.providerCallId).toBe("prov-dup");
   });
 
+  it("creates a call record for unknown outbound provider events", () => {
+    const now = Date.now();
+    const ctx = createContext();
+    const event: NormalizedEvent = {
+      id: "evt-outbound-answered",
+      type: "call.answered",
+      callId: "CA-external-1",
+      providerCallId: "CA-external-1",
+      timestamp: now,
+      direction: "outbound",
+      from: "+15550000000",
+      to: "+15550009999",
+    };
+
+    processEvent(ctx, event);
+
+    const mappedCallId = ctx.providerCallIdMap.get("CA-external-1");
+    expect(mappedCallId).toBeTruthy();
+    const call = mappedCallId ? ctx.activeCalls.get(mappedCallId) : undefined;
+    expect(call).toMatchObject({
+      callId: "CA-external-1",
+      providerCallId: "CA-external-1",
+      direction: "outbound",
+      state: "answered",
+      from: "+15550000000",
+      to: "+15550009999",
+      metadata: {
+        mode: ctx.config.outbound.defaultMode,
+      },
+    });
+    expect(call?.answeredAt).toBe(now);
+  });
+
+  it("does not create unknown outbound calls from terminal events only", () => {
+    const ctx = createContext();
+    const event: NormalizedEvent = {
+      id: "evt-outbound-ended",
+      type: "call.ended",
+      callId: "CA-external-ended",
+      providerCallId: "CA-external-ended",
+      timestamp: Date.now(),
+      direction: "outbound",
+      reason: "completed",
+      from: "+15550000000",
+      to: "+15550009999",
+    };
+
+    processEvent(ctx, event);
+
+    expect(ctx.activeCalls.size).toBe(0);
+    expect(ctx.providerCallIdMap.size).toBe(0);
+  });
+
   it("updates providerCallId map when provider ID changes", () => {
     const now = Date.now();
     const ctx = createContext();

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -91,6 +91,48 @@ function createInboundCall(params: {
   return callRecord;
 }
 
+function createOutboundCallFromProviderEvent(params: {
+  ctx: EventContext;
+  event: Extract<
+    NormalizedEvent,
+    { type: "call.initiated" | "call.ringing" | "call.answered" | "call.active" }
+  >;
+  providerCallId: string;
+}): CallRecord {
+  const { ctx, event, providerCallId } = params;
+  const callId = event.callId?.trim() || providerCallId;
+  const stateByEvent: Record<typeof event.type, CallState> = {
+    "call.initiated": "initiated",
+    "call.ringing": "ringing",
+    "call.answered": "answered",
+    "call.active": "active",
+  };
+  const callRecord: CallRecord = {
+    callId,
+    providerCallId,
+    provider: ctx.provider?.name || "twilio",
+    direction: "outbound",
+    state: stateByEvent[event.type],
+    from: event.from || ctx.config.fromNumber || "unknown",
+    to: event.to || "unknown",
+    startedAt: event.timestamp || Date.now(),
+    ...(event.type === "call.answered" ? { answeredAt: event.timestamp } : undefined),
+    transcript: [],
+    processedEventIds: [],
+    metadata: ctx.config.outbound?.defaultMode
+      ? { mode: ctx.config.outbound.defaultMode }
+      : undefined,
+  };
+
+  ctx.activeCalls.set(callId, callRecord);
+  ctx.providerCallIdMap.set(providerCallId, callId);
+  persistCallRecord(ctx.storePath, callRecord);
+  console.log(
+    `[voice-call] Created outbound call record from provider event: ${callId} (${providerCallId})`,
+  );
+  return callRecord;
+}
+
 export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
   const dedupeKey = event.dedupeKey || event.id;
   if (ctx.processedEventIds.has(dedupeKey)) {
@@ -140,6 +182,23 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
     });
 
     // Normalize event to internal ID for downstream consumers.
+    event.callId = call.callId;
+  }
+
+  if (
+    !call &&
+    event.direction === "outbound" &&
+    event.providerCallId &&
+    (event.type === "call.initiated" ||
+      event.type === "call.ringing" ||
+      event.type === "call.answered" ||
+      event.type === "call.active")
+  ) {
+    call = createOutboundCallFromProviderEvent({
+      ctx,
+      event,
+      providerCallId: event.providerCallId,
+    });
     event.callId = call.callId;
   }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: externally-initiated outbound Twilio calls (created outside `openclaw voicecall call`) were not tracked by `CallManager`, so MediaStream startup was rejected as an unknown call.
- Why it matters: accepted phone calls were terminated immediately after stream connect, breaking external Twilio API call flows.
- What changed: when webhook events arrive for an unknown outbound call (`initiated/ringing/answered/active`), we now create and track a call record from provider event data.
- What changed: added tests for outbound auto-tracking and boundary behavior (do not create from terminal-only unknown outbound events).
- What did NOT change (scope boundary): inbound policy behavior, stream token validation, and existing internally-initiated outbound call path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30900
- Related #

## User-visible / Behavior Changes

- Outbound calls initiated directly via Twilio API are now recognized and tracked when webhook events arrive, so MediaStream connections are accepted instead of being rejected as unknown.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm (repo local)
- Model/provider: N/A
- Integration/channel (if any): voice-call / Twilio path (unit tests)
- Relevant config (redacted): voice-call plugin enabled with outbound mode defaults

### Steps

1. Process an outbound provider webhook event (`call.answered`) for an unknown provider call id.
2. Verify manager creates a tracked call record + provider call map entry.
3. Verify terminal-only unknown outbound event does not create orphan calls.

### Expected

- Unknown outbound early lifecycle events materialize a tracked call record.

### Actual

- Before fix: event was ignored and no call record existed, causing downstream stream rejection.
- After fix: call is tracked and can be resolved by provider call id.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run extensions/voice-call/src/manager/events.test.ts extensions/voice-call/src/media-stream.test.ts`
  - New test confirms unknown outbound event now creates tracked call entry with outbound defaults.
- Edge cases checked:
  - Terminal-only unknown outbound events are ignored (no orphan records).
  - Existing inbound reject behavior remains unchanged.
- What you did **not** verify:
  - Live end-to-end Twilio call against real account credentials.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `extensions/voice-call/src/manager/events.ts`
  - `extensions/voice-call/src/manager/events.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected auto-created outbound calls from malformed provider webhooks.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Could create outbound call records for provider callbacks that should have been ignored.
  - Mitigation:
    - Creation is limited to unknown outbound early lifecycle events with a provider call id; terminal-only unknown events are explicitly ignored.
