### PR TITLE
feat(slack): Add slackApiUrl config option for custom Slack API endpoint

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -749,6 +749,7 @@ export const SlackAccountSchema = z
     botToken: z.string().optional().register(sensitive),
     appToken: z.string().optional().register(sensitive),
     userToken: z.string().optional().register(sensitive),
+    slackApiUrl: z.string().url().optional(),
     userTokenReadOnly: z.boolean().optional().default(true),
     allowBots: z.boolean().optional(),
     dangerouslyAllowNameMatching: z.boolean().optional(),

--- a/src/slack/client.test.ts
+++ b/src/slack/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@slack/web-api", () => {
   const WebClient = vi.fn(function WebClientMock(
@@ -40,6 +40,56 @@ describe("slack web client config", () => {
       expect.objectContaining({
         timeout: 1234,
         retryConfig: SLACK_DEFAULT_RETRY_OPTIONS,
+      }),
+    );
+  });
+});
+
+describe("slack api url override", () => {
+  const originalEnv = process.env.SLACK_API_URL;
+
+  beforeEach(() => {
+    delete process.env.SLACK_API_URL;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.SLACK_API_URL = originalEnv;
+    } else {
+      delete process.env.SLACK_API_URL;
+    }
+  });
+
+  it("does not include slackApiUrl when not set", () => {
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.slackApiUrl).toBeUndefined();
+  });
+
+  it("reads slackApiUrl from SLACK_API_URL env var", () => {
+    process.env.SLACK_API_URL = "https://proxy.example.com/slack/";
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.slackApiUrl).toBe("https://proxy.example.com/slack/");
+  });
+
+  it("prefers explicit slackApiUrl option over env var", () => {
+    process.env.SLACK_API_URL = "https://env.example.com/";
+    const options = resolveSlackWebClientOptions({
+      slackApiUrl: "https://explicit.example.com/",
+    });
+
+    expect(options.slackApiUrl).toBe("https://explicit.example.com/");
+  });
+
+  it("passes slackApiUrl to WebClient", () => {
+    process.env.SLACK_API_URL = "https://proxy.example.com/api/";
+    createSlackWebClient("xoxb-test");
+
+    expect(WebClient).toHaveBeenCalledWith(
+      "xoxb-test",
+      expect.objectContaining({
+        slackApiUrl: "https://proxy.example.com/api/",
       }),
     );
   });

--- a/src/slack/client.ts
+++ b/src/slack/client.ts
@@ -8,9 +8,23 @@ export const SLACK_DEFAULT_RETRY_OPTIONS: RetryOptions = {
   randomize: true,
 };
 
+/**
+ * Resolve the Slack API URL to use.
+ * Priority: 1) explicit option, 2) SLACK_API_URL env var, 3) undefined (uses default)
+ */
+function resolveSlackApiUrl(explicit?: string): string | undefined {
+  if (explicit) {
+    return explicit;
+  }
+  const envUrl = process.env.SLACK_API_URL?.trim();
+  return envUrl || undefined;
+}
+
 export function resolveSlackWebClientOptions(options: WebClientOptions = {}): WebClientOptions {
+  const slackApiUrl = resolveSlackApiUrl(options.slackApiUrl);
   return {
     ...options,
+    ...(slackApiUrl ? { slackApiUrl } : {}),
     retryConfig: options.retryConfig ?? SLACK_DEFAULT_RETRY_OPTIONS,
   };
 }

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -1,5 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import SlackBolt from "@slack/bolt";
+import type { SessionScope } from "../../config/sessions.js";
+import type { MonitorSlackOpts } from "./types.js";
 import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "../../auto-reply/reply/history.js";
 import {
@@ -16,7 +18,6 @@ import {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../../config/runtime-group-policy.js";
-import type { SessionScope } from "../../config/sessions.js";
 import { warn } from "../../globals.js";
 import { computeBackoff, sleepWithAbort } from "../../infra/backoff.js";
 import { installRequestBodyLimitGuard } from "../../infra/http-body.js";
@@ -34,7 +35,6 @@ import { createSlackMonitorContext } from "./context.js";
 import { registerSlackMonitorEvents } from "./events.js";
 import { createSlackMessageHandler } from "./message-handler.js";
 import { registerSlackMonitorSlashCommands } from "./slash.js";
-import type { MonitorSlackOpts } from "./types.js";
 
 const slackBoltModule = SlackBolt as typeof import("@slack/bolt") & {
   default?: typeof import("@slack/bolt");
@@ -245,7 +245,9 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           endpoints: slackWebhookPath,
         })
       : null;
-  const clientOptions = resolveSlackWebClientOptions();
+  const clientOptions = resolveSlackWebClientOptions({
+    slackApiUrl: slackCfg.slackApiUrl,
+  });
   const app = new App(
     slackMode === "socket"
       ? {


### PR DESCRIPTION
## Summary

Adds `slackApiUrl` support for routing Slack API calls through a custom proxy/gateway.

## Use Cases

- **Credential injection** - Router holds real tokens, sandbox uses placeholder
- **Usage tracking** - Centralized logging/billing of Slack API calls  
- **Multi-tenant isolation** - Each sandbox routes through shared router

## Implementation

**Two-level support addressing reviewer feedback:**

### 1. Environment Variable (`SLACK_API_URL`)
Global default for ALL WebClient instances, including standalone calls like `slackSend()`, directory lookups, etc.

```bash
export SLACK_API_URL=https://my-proxy.example.com/slack-api/
```

### 2. Config Option (`channels.slack.slackApiUrl`)
Per-account configuration for the Bolt App, takes precedence over env var.

```yaml
channels:
  slack:
    botToken: 'proxy-internal'
    slackApiUrl: 'https://my-proxy.example.com/slack-api/'
```

### Priority
1. Explicit `slackApiUrl` option (highest)
2. `SLACK_API_URL` environment variable
3. Default Slack API URL

## Changes

- `src/slack/client.ts`: Add `resolveSlackApiUrl()` helper, check env var for ALL WebClient instances
- `src/slack/client.test.ts`: Add tests for env var, explicit option, and precedence
- `src/config/zod-schema.providers-core.ts`: Add `slackApiUrl` to schema
- `src/slack/monitor/provider.ts`: Pass config value to Bolt App clientOptions

## Testing

- ✅ Unit tests for env var, explicit option, and precedence
- ✅ Tested with local proxy (all API calls correctly routed)
- ✅ `pnpm build && pnpm check` passes

---
🤖 AI-assisted (Claude) - fully tested