### PR TITLE
fix(config): reject non-loopback bind patches when tailscale serve/funnel is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Docs: https://docs.openclaw.ai
 - Web UI/Cron jobs: add schedule-kind and last-run-status filters to the Jobs list, with reset control and client-side filtering over loaded results. (#9510) Thanks @guxu11.
 - Cron/One-shot reliability: retry transient one-shot failures with bounded backoff and configurable retry policy before disabling. (#24435) Thanks .
 - Gateway/Cron auditability: add gateway info logs for successful cron create, update, and remove operations. (#25090) Thanks .
+- Gateway/Config patch guard: reject `config.patch` updates that set non-loopback `gateway.bind` while `gateway.tailscale.mode` is `serve`/`funnel`, preventing restart crash loops from invalid bind/tailscale combinations. (#30893)
 - Cron/Schedule errors: notify users when a job is auto-disabled after repeated schedule computation failures. (#29098) Thanks .
 - Cron/Schedule errors: notify users when a job is auto-disabled after repeated schedule computation failures. (#29098) Thanks .
 - File tools/tilde paths: expand `~/...` against the user home directory before workspace-root checks in host file read/write/edit paths, while preserving root-boundary enforcement so outside-root targets remain blocked. (#29779) Thanks @Glucksberg.

--- a/src/config/config.gateway-tailscale-bind.test.ts
+++ b/src/config/config.gateway-tailscale-bind.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+describe("gateway tailscale bind validation", () => {
+  it("accepts loopback bind when tailscale serve/funnel is enabled", () => {
+    const serveRes = validateConfigObject({
+      gateway: {
+        bind: "loopback",
+        tailscale: { mode: "serve" },
+      },
+    });
+    expect(serveRes.ok).toBe(true);
+
+    const funnelRes = validateConfigObject({
+      gateway: {
+        bind: "loopback",
+        tailscale: { mode: "funnel" },
+      },
+    });
+    expect(funnelRes.ok).toBe(true);
+  });
+
+  it("accepts custom loopback bind host with tailscale serve/funnel", () => {
+    const res = validateConfigObject({
+      gateway: {
+        bind: "custom",
+        customBindHost: "127.0.0.1",
+        tailscale: { mode: "serve" },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects non-loopback bind when tailscale serve/funnel is enabled", () => {
+    const lanRes = validateConfigObject({
+      gateway: {
+        bind: "lan",
+        tailscale: { mode: "serve" },
+      },
+    });
+    expect(lanRes.ok).toBe(false);
+    if (!lanRes.ok) {
+      expect(lanRes.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: "gateway.bind",
+            message: expect.stringContaining("gateway.bind must resolve to loopback"),
+          }),
+        ]),
+      );
+    }
+
+    const customRes = validateConfigObject({
+      gateway: {
+        bind: "custom",
+        customBindHost: "10.0.0.5",
+        tailscale: { mode: "funnel" },
+      },
+    });
+    expect(customRes.ok).toBe(false);
+    if (!customRes.ok) {
+      expect(customRes.issues.some((issue) => issue.path === "gateway.bind")).toBe(true);
+    }
+  });
+});

--- a/src/config/config.gateway-tailscale-bind.test.ts
+++ b/src/config/config.gateway-tailscale-bind.test.ts
@@ -31,6 +31,20 @@ describe("gateway tailscale bind validation", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("rejects IPv6 custom bind host for tailscale serve/funnel", () => {
+    const res = validateConfigObject({
+      gateway: {
+        bind: "custom",
+        customBindHost: "::1",
+        tailscale: { mode: "serve" },
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((issue) => issue.path === "gateway.bind")).toBe(true);
+    }
+  });
+
   it("rejects non-loopback bind when tailscale serve/funnel is enabled", () => {
     const lanRes = validateConfigObject({
       gateway: {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -15,6 +15,7 @@ import {
   isPathWithinRoot,
   isWindowsAbsolutePath,
 } from "../shared/avatar-policy.js";
+import { isLoopbackIpAddress } from "../shared/net/ip.js";
 import { isRecord } from "../utils.js";
 import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-dirs.js";
 import { applyAgentDefaults, applyModelDefaults, applySessionDefaults } from "./defaults.js";
@@ -80,6 +81,29 @@ function validateIdentityAvatar(config: OpenClawConfig): ConfigValidationIssue[]
   return issues;
 }
 
+function validateGatewayTailscaleBind(config: OpenClawConfig): ConfigValidationIssue[] {
+  const tailscaleMode = config.gateway?.tailscale?.mode ?? "off";
+  if (tailscaleMode !== "serve" && tailscaleMode !== "funnel") {
+    return [];
+  }
+  const bindMode = config.gateway?.bind ?? "loopback";
+  if (bindMode === "loopback") {
+    return [];
+  }
+  const customBindHost = config.gateway?.customBindHost;
+  if (bindMode === "custom" && isLoopbackIpAddress(customBindHost)) {
+    return [];
+  }
+  return [
+    {
+      path: "gateway.bind",
+      message:
+        `gateway.bind must resolve to loopback when gateway.tailscale.mode=${tailscaleMode} ` +
+        '(use gateway.bind="loopback" or gateway.bind="custom" with gateway.customBindHost="127.0.0.1")',
+    },
+  ];
+}
+
 /**
  * Validates config without applying runtime defaults.
  * Use this when you need the raw validated config (e.g., for writing back to file).
@@ -122,6 +146,10 @@ export function validateConfigObjectRaw(
   const avatarIssues = validateIdentityAvatar(validated.data as OpenClawConfig);
   if (avatarIssues.length > 0) {
     return { ok: false, issues: avatarIssues };
+  }
+  const gatewayTailscaleBindIssues = validateGatewayTailscaleBind(validated.data as OpenClawConfig);
+  if (gatewayTailscaleBindIssues.length > 0) {
+    return { ok: false, issues: gatewayTailscaleBindIssues };
   }
   return {
     ok: true,

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -15,7 +15,7 @@ import {
   isPathWithinRoot,
   isWindowsAbsolutePath,
 } from "../shared/avatar-policy.js";
-import { isLoopbackIpAddress } from "../shared/net/ip.js";
+import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "../shared/net/ip.js";
 import { isRecord } from "../utils.js";
 import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-dirs.js";
 import { applyAgentDefaults, applyModelDefaults, applySessionDefaults } from "./defaults.js";
@@ -91,7 +91,11 @@ function validateGatewayTailscaleBind(config: OpenClawConfig): ConfigValidationI
     return [];
   }
   const customBindHost = config.gateway?.customBindHost;
-  if (bindMode === "custom" && isLoopbackIpAddress(customBindHost)) {
+  if (
+    bindMode === "custom" &&
+    isCanonicalDottedDecimalIPv4(customBindHost) &&
+    isLoopbackIpAddress(customBindHost)
+  ) {
     return [];
   }
   return [


### PR DESCRIPTION
## Summary
- add a config validation guard for `gateway.tailscale.mode=serve|funnel` so `gateway.bind` must stay loopback-compatible
- surface the guard through `config.patch` before config is written, preventing restart crash loops from invalid bind/tailscale combinations
- add regression tests for config validation and gateway `config.patch`, and document the fix in `CHANGELOG.md`

Closes #30893.

## Security Impact
- no new privilege surface; this is a defensive config validation hardening change
- reduces accidental self-denial by rejecting known-invalid network exposure states earlier

## Repro + Verification
1. configure tailscale serve/funnel mode
2. run `config.patch` with `gateway.bind="lan"`
3. before this change: patch accepted then gateway fails on restart
4. after this change: patch is rejected with `invalid config` and `gateway.bind` issue details

## Human Verification
- `pnpm exec vitest run src/config/config.gateway-tailscale-bind.test.ts src/gateway/server.config-patch.test.ts`
- `pnpm build`
- `pnpm check` *(fails in this environment due missing optional extension deps, unrelated to this change: `@opentelemetry/*`, `@vector-im/matrix-bot-sdk`, etc.)*
