### PR TITLE
fix(plugins): suppress duplicate warnings for same package identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 - Update/Global npm: fallback to `--omit=optional` when global `npm update` fails so optional dependency install failures no longer abort update flows. (#24896) Thanks @xinhuagu and @vincentkoc.
 - Plugins/NPM spec install: fix npm-spec plugin installs when `npm pack` output is empty by detecting newly created `.tgz` archives in the pack directory. (#21039) Thanks @graysurf and @vincentkoc.
 - Plugins/Install: clear stale install errors when an npm package is not found so follow-up install attempts report current state correctly. (#25073) Thanks @dalefrieswthat.
+- Plugins/Manifest registry: suppress duplicate-id warnings when bundled/global plugin candidates resolve to the same package identity/version, while still preferring origin precedence (`config > workspace > global > bundled`) for the retained record. (#30908)
 - OpenAI Responses/Compaction: rewrite and unify the OpenAI Responses store patches to treat empty `baseUrl` as non-direct, honor `compat.supportsStore=false`, and auto-inject server-side compaction `context_management` for compatible direct OpenAI models (with per-model opt-out/threshold overrides). Landed from contributor PRs #16930 (@OiPunk), #22441 (@EdwardWu7), and #25088 (@MoerAI). Thanks @OiPunk, @EdwardWu7, and @MoerAI.
 
 ## Unreleased

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -24,12 +24,16 @@ function createPluginCandidate(params: {
   rootDir: string;
   sourceName?: string;
   origin: "bundled" | "global" | "workspace" | "config";
+  packageName?: string;
+  packageVersion?: string;
 }): PluginCandidate {
   return {
     idHint: params.idHint,
     source: path.join(params.rootDir, params.sourceName ?? "index.ts"),
     rootDir: params.rootDir,
     origin: params.origin,
+    packageName: params.packageName,
+    packageVersion: params.packageVersion,
   };
 }
 
@@ -166,6 +170,35 @@ describe("loadPluginManifestRegistry", () => {
     expect(countDuplicateWarnings(registry)).toBe(0);
     expect(registry.plugins.length).toBe(1);
     expect(registry.plugins[0]?.origin).toBe("config");
+  });
+
+  it("suppresses duplicate warning for same package id/version across origins", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "feishu", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    const registry = loadRegistry([
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirA,
+        origin: "bundled",
+        packageName: "@openclaw/feishu",
+        packageVersion: "2026.2.26",
+      }),
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirB,
+        origin: "global",
+        packageName: "@openclaw/feishu",
+        packageVersion: "2026.2.26",
+      }),
+    ]);
+
+    expect(countDuplicateWarnings(registry)).toBe(0);
+    expect(registry.plugins).toHaveLength(1);
+    expect(registry.plugins[0]?.origin).toBe("global");
   });
 
   it("rejects manifest paths that escape plugin root via symlink", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -103,6 +103,25 @@ function normalizeManifestLabel(raw: string | undefined): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+function normalizePackageValue(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim().toLowerCase();
+  return trimmed ? trimmed : undefined;
+}
+
+function isSamePackageCandidate(a: PluginCandidate, b: PluginCandidate): boolean {
+  const aName = normalizePackageValue(a.packageName);
+  const bName = normalizePackageValue(b.packageName);
+  if (!aName || !bName || aName !== bName) {
+    return false;
+  }
+  const aVersion = normalizePackageValue(a.packageVersion);
+  const bVersion = normalizePackageValue(b.packageVersion);
+  if (aVersion && bVersion && aVersion !== bVersion) {
+    return false;
+  }
+  return true;
+}
+
 function buildRecord(params: {
   manifest: PluginManifest;
   candidate: PluginCandidate;
@@ -200,8 +219,11 @@ export function loadPluginManifestRegistry(params: {
       // is a false-positive duplicate and can be silently skipped.
       const existingReal = safeRealpathSync(existing.candidate.rootDir, realpathCache);
       const candidateReal = safeRealpathSync(candidate.rootDir, realpathCache);
-      const samePlugin = Boolean(existingReal && candidateReal && existingReal === candidateReal);
-      if (samePlugin) {
+      const sameRealPathPlugin = Boolean(
+        existingReal && candidateReal && existingReal === candidateReal,
+      );
+      const samePackagePlugin = isSamePackageCandidate(existing.candidate, candidate);
+      if (sameRealPathPlugin || samePackagePlugin) {
         // Prefer higher-precedence origins even if candidates are passed in
         // an unexpected order (config > workspace > global > bundled).
         if (PLUGIN_ORIGIN_RANK[candidate.origin] < PLUGIN_ORIGIN_RANK[existing.candidate.origin]) {


### PR DESCRIPTION
## Summary
- detect duplicate plugin candidates as the *same package* when `packageName` matches and versions are compatible
- suppress duplicate-id warnings for those same-package duplicates and keep only the highest-precedence origin record (`config > workspace > global > bundled`)
- add regression coverage for same-package cross-origin duplicates and document the fix in `CHANGELOG.md`

Closes #30908.

## Security Impact
- no new external surface; this refines plugin registry dedupe behavior
- reduces noisy false-positive warnings without weakening plugin path safety checks

## Repro + Verification
1. have duplicate plugin candidates for the same package id/version across bundled + global discovery roots
2. before this change: duplicate-id warning appears and both records may be retained
3. after this change: warning is suppressed and only the higher-precedence candidate is retained

## Human Verification
- `pnpm exec vitest run src/plugins/manifest-registry.test.ts src/config/config.plugin-validation.test.ts`
- `pnpm build`
- `pnpm check` *(fails in this environment due missing optional extension deps, unrelated to this change: `@opentelemetry/*`, `@vector-im/matrix-bot-sdk`, etc.)*
