### PR TITLE
feat(slack): Add SLACK_API_URL env var and slackApiUrl config for custom API endpoints

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -749,6 +749,7 @@ export const SlackAccountSchema = z
     botToken: z.string().optional().register(sensitive),
     appToken: z.string().optional().register(sensitive),
     userToken: z.string().optional().register(sensitive),
+    slackApiUrl: z.string().url().optional(),
     userTokenReadOnly: z.boolean().optional().default(true),
     allowBots: z.boolean().optional(),
     dangerouslyAllowNameMatching: z.boolean().optional(),

--- a/src/slack/client.test.ts
+++ b/src/slack/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@slack/web-api", () => {
   const WebClient = vi.fn(function WebClientMock(
@@ -40,6 +40,56 @@ describe("slack web client config", () => {
       expect.objectContaining({
         timeout: 1234,
         retryConfig: SLACK_DEFAULT_RETRY_OPTIONS,
+      }),
+    );
+  });
+});
+
+describe("slack api url override", () => {
+  const originalEnv = process.env.SLACK_API_URL;
+
+  beforeEach(() => {
+    delete process.env.SLACK_API_URL;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.SLACK_API_URL = originalEnv;
+    } else {
+      delete process.env.SLACK_API_URL;
+    }
+  });
+
+  it("does not include slackApiUrl when not set", () => {
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.slackApiUrl).toBeUndefined();
+  });
+
+  it("reads slackApiUrl from SLACK_API_URL env var", () => {
+    process.env.SLACK_API_URL = "https://proxy.example.com/slack/";
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.slackApiUrl).toBe("https://proxy.example.com/slack/");
+  });
+
+  it("prefers explicit slackApiUrl option over env var", () => {
+    process.env.SLACK_API_URL = "https://env.example.com/";
+    const options = resolveSlackWebClientOptions({
+      slackApiUrl: "https://explicit.example.com/",
+    });
+
+    expect(options.slackApiUrl).toBe("https://explicit.example.com/");
+  });
+
+  it("passes slackApiUrl to WebClient", () => {
+    process.env.SLACK_API_URL = "https://proxy.example.com/api/";
+    createSlackWebClient("xoxb-test");
+
+    expect(WebClient).toHaveBeenCalledWith(
+      "xoxb-test",
+      expect.objectContaining({
+        slackApiUrl: "https://proxy.example.com/api/",
       }),
     );
   });

--- a/src/slack/client.ts
+++ b/src/slack/client.ts
@@ -8,9 +8,23 @@ export const SLACK_DEFAULT_RETRY_OPTIONS: RetryOptions = {
   randomize: true,
 };
 
+/**
+ * Resolve the Slack API URL to use.
+ * Priority: 1) explicit option, 2) SLACK_API_URL env var, 3) undefined (uses default)
+ */
+function resolveSlackApiUrl(explicit?: string): string | undefined {
+  if (explicit) {
+    return explicit;
+  }
+  const envUrl = process.env.SLACK_API_URL?.trim();
+  return envUrl || undefined;
+}
+
 export function resolveSlackWebClientOptions(options: WebClientOptions = {}): WebClientOptions {
+  const slackApiUrl = resolveSlackApiUrl(options.slackApiUrl);
   return {
     ...options,
+    ...(slackApiUrl ? { slackApiUrl } : {}),
     retryConfig: options.retryConfig ?? SLACK_DEFAULT_RETRY_OPTIONS,
   };
 }

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -1,5 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import SlackBolt from "@slack/bolt";
+import type { SessionScope } from "../../config/sessions.js";
+import type { MonitorSlackOpts } from "./types.js";
 import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "../../auto-reply/reply/history.js";
 import {
@@ -16,7 +18,6 @@ import {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../../config/runtime-group-policy.js";
-import type { SessionScope } from "../../config/sessions.js";
 import { warn } from "../../globals.js";
 import { computeBackoff, sleepWithAbort } from "../../infra/backoff.js";
 import { installRequestBodyLimitGuard } from "../../infra/http-body.js";
@@ -34,7 +35,6 @@ import { createSlackMonitorContext } from "./context.js";
 import { registerSlackMonitorEvents } from "./events.js";
 import { createSlackMessageHandler } from "./message-handler.js";
 import { registerSlackMonitorSlashCommands } from "./slash.js";
-import type { MonitorSlackOpts } from "./types.js";
 
 const slackBoltModule = SlackBolt as typeof import("@slack/bolt") & {
   default?: typeof import("@slack/bolt");
@@ -245,7 +245,9 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           endpoints: slackWebhookPath,
         })
       : null;
-  const clientOptions = resolveSlackWebClientOptions();
+  const clientOptions = resolveSlackWebClientOptions({
+    slackApiUrl: slackCfg.slackApiUrl,
+  });
   const app = new App(
     slackMode === "socket"
       ? {


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw's Slack WebClient instances hardcode the Slack API URL, preventing routing through custom proxies for credential injection, usage tracking, or multi-tenant architectures.
- **Why it matters:** Multi-tenant deployments (e.g., sandboxed agents) need to route Slack API calls through a gateway that injects real tokens — the sandbox should never hold actual Slack credentials.
- **What changed:** Added `SLACK_API_URL` env var support for ALL WebClient instances, plus `channels.slack.slackApiUrl` config option for per-account configuration.
- **What did NOT change:** Default behavior unchanged — without env var or config, uses standard Slack API URLs.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #30909 (previous iteration, closed for template compliance)

## User-visible / Behavior Changes

- New optional env var: `SLACK_API_URL` - sets default Slack API endpoint for all WebClient instances
- New optional config: `channels.slack.slackApiUrl` - per-account Slack API endpoint (takes precedence over env var)
- No changes to default behavior

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` (this enables *better* token isolation via proxy)
- New/changed network calls? `Yes` - Slack API calls can be routed to custom endpoint
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- **Risk + mitigation:** Custom endpoint could theoretically intercept Slack traffic, but this is opt-in and the use case is specifically for trusted proxy architectures (e.g., credential injection gateways). The default behavior is unchanged.

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 22.04)
- Runtime/container: Node.js 22
- Model/provider: Anthropic Claude
- Integration/channel: Slack
- Relevant config: `SLACK_API_URL=https://proxy.example.com/slack-api/`

### Steps

1. Set `SLACK_API_URL=https://httpbin.org/anything/` env var
2. Start OpenClaw with Slack channel enabled
3. Trigger a Slack API call (e.g., send a message)

### Expected

- WebClient calls route to the custom URL instead of `https://slack.com/api/`

### Actual

- Confirmed: All WebClient instances (Bolt app, standalone `slackSend()`, directory lookups) use the custom URL

## Evidence

- [x] Unit tests added: `src/slack/client.test.ts` - tests env var, explicit option, and precedence
- [x] Local testing with proxy endpoint confirmed routing works

## Human Verification (required)

- **Verified scenarios:** 
  - Env var alone routes all WebClient calls
  - Config option overrides env var
  - No env var/config = default Slack API (unchanged behavior)
- **Edge cases checked:**
  - Multiple WebClient instances (Bolt app vs standalone)
  - Precedence: explicit option > env var > default
- **What I did NOT verify:** Production multi-tenant deployment (tested locally with mock proxy)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` - new optional config/env (additive only)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- **How to disable/revert:** Remove `SLACK_API_URL` env var and/or `slackApiUrl` config option
- **Files/config to restore:** None needed - removing config restores default behavior
- **Known bad symptoms:** Slack API calls failing with connection errors (would indicate misconfigured proxy URL)

## Risks and Mitigations

- **Risk:** Misconfigured proxy URL causes Slack API failures
  - **Mitigation:** Only affects users who explicitly set the env var/config; default behavior unchanged

---

🤖 AI-assisted (Claude via OpenClaw) - fully tested with `pnpm build && pnpm check`
