### PR TITLE
fix(plugins): suppress false duplicate plugin id warning when bundled copy is superseded

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -272,6 +272,47 @@ describe("loadOpenClawPlugins", () => {
     expect(memory?.name).toBe("Memory (Core)");
     expect(memory?.version).toBe("1.2.3");
   });
+  it("no duplicate plugin id warning when globally-installed plugin also exists in bundled dir (#30908)", () => {
+    // Regression test: when a user installs feishu globally (~/.openclaw/extensions/feishu/)
+    // and the npm package also bundles feishu (extensions/feishu/), the plugin should
+    // load cleanly from the global copy without emitting a spurious duplicate warning.
+    const globalStateDir = makeTempDir();
+    const globalExtDir = path.join(globalStateDir, "extensions", "feishu");
+    fs.mkdirSync(globalExtDir, { recursive: true });
+
+    const bundledDir = makeTempDir();
+    const bundledFeishuDir = path.join(bundledDir, "feishu");
+    fs.mkdirSync(bundledFeishuDir, { recursive: true });
+
+    const pluginBody = `export default { id: "feishu", register() {} };`;
+
+    writePlugin({ id: "feishu", body: pluginBody, dir: globalExtDir, filename: "index.js" });
+    writePlugin({ id: "feishu", body: pluginBody, dir: bundledFeishuDir, filename: "index.js" });
+
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+
+    const registry = withEnv({ OPENCLAW_STATE_DIR: globalStateDir }, () =>
+      loadOpenClawPlugins({
+        cache: false,
+        config: {
+          plugins: {
+            entries: { feishu: { enabled: true } },
+          },
+        },
+      }),
+    );
+
+    const duplicateWarnings = registry.diagnostics.filter(
+      (d) => d.level === "warn" && d.message?.includes("duplicate plugin id"),
+    );
+    expect(duplicateWarnings).toHaveLength(0);
+
+    const feishuEntries = registry.plugins.filter((p) => p.id === "feishu");
+    const loadedFeishu = feishuEntries.filter((p) => p.status === "loaded");
+    expect(loadedFeishu).toHaveLength(1);
+    expect(loadedFeishu[0]?.origin).toBe("global");
+  });
+
   it("loads plugins from config paths", () => {
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
     const plugin = writePlugin({

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -62,7 +62,7 @@ afterEach(() => {
 });
 
 describe("loadPluginManifestRegistry", () => {
-  it("emits duplicate warning for truly distinct plugins with same id", () => {
+  it("emits duplicate warning when two plugins from the same origin share an id", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "test-plugin", configSchema: { type: "object" } };
@@ -73,7 +73,7 @@ describe("loadPluginManifestRegistry", () => {
       createPluginCandidate({
         idHint: "test-plugin",
         rootDir: dirA,
-        origin: "bundled",
+        origin: "global",
       }),
       createPluginCandidate({
         idHint: "test-plugin",
@@ -83,6 +83,57 @@ describe("loadPluginManifestRegistry", () => {
     ];
 
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
+  });
+
+  it("suppresses duplicate warning when a globally-installed plugin supersedes the bundled copy (feishu scenario)", () => {
+    // This is the regression scenario from #30908: a user installs feishu
+    // globally (~/.openclaw/extensions/feishu/) and the bundled copy also
+    // exists in the package (extensions/feishu/). Discovery processes global
+    // before bundled, so global is seen first. The bundled copy showing up
+    // second should not produce a spurious warning.
+    const globalDir = makeTempDir();
+    const bundledDir = makeTempDir();
+    const manifest = { id: "feishu", configSchema: { type: "object" } };
+    writeManifest(globalDir, manifest);
+    writeManifest(bundledDir, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: globalDir,
+        origin: "global",
+      }),
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: bundledDir,
+        origin: "bundled",
+      }),
+    ];
+
+    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
+  });
+
+  it("suppresses duplicate warning when a config-path plugin supersedes the bundled copy", () => {
+    const configDir = makeTempDir();
+    const bundledDir = makeTempDir();
+    const manifest = { id: "feishu", configSchema: { type: "object" } };
+    writeManifest(configDir, manifest);
+    writeManifest(bundledDir, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: configDir,
+        origin: "config",
+      }),
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: bundledDir,
+        origin: "bundled",
+      }),
+    ];
+
+    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -216,12 +216,20 @@ export function loadPluginManifestRegistry(params: {
         }
         continue;
       }
-      diagnostics.push({
-        level: "warn",
-        pluginId: manifest.id,
-        source: candidate.source,
-        message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
-      });
+      // Suppress the warning when the incoming candidate has strictly lower
+      // precedence than the already-registered entry. A bundled plugin being
+      // superseded by an explicitly-installed (global/workspace/config) copy
+      // is expected behavior and should not surface a confusing warning.
+      const incomingHasLowerPrecedence =
+        PLUGIN_ORIGIN_RANK[candidate.origin] > PLUGIN_ORIGIN_RANK[existing.candidate.origin];
+      if (!incomingHasLowerPrecedence) {
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: candidate.source,
+          message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
+        });
+      }
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     }


### PR DESCRIPTION
## Summary

Fixes #30908 — users running `openclaw gateway restart` on v2026.2.26 immediately see a spurious warning at startup:

```
plugin feishu: duplicate plugin id detected; later plugin may be overridden
(/root/.nvm/.../openclaw/extensions/feishu/index.ts)
```

**Root cause:** When a user has feishu (or any bundled plugin) installed both globally (`~/.openclaw/extensions/feishu/`) and bundled inside the npm package (`extensions/feishu/`), the manifest registry emits a duplicate-id warning on every startup. The discovery order is `config > workspace > global > bundled`, so the global copy is always seen first and correctly wins. However, `manifest-registry.ts` emitted the warning unconditionally for any two candidates with the same plugin id from different physical directories — regardless of whether the second candidate had lower precedence than the first.

**Fix:** In `src/plugins/manifest-registry.ts`, the duplicate warning is now suppressed when the incoming (second) candidate has strictly **lower** precedence than the already-registered entry. A bundled plugin being superseded by an explicitly-installed global/workspace/config copy is expected behavior and does not need a warning. The warning is still emitted when the incoming candidate has equal or higher precedence (e.g. two `global`-origin copies of the same plugin id — a genuine conflict).

**Tests added:**
- `manifest-registry.test.ts`: new cases asserting that `global → bundled` and `config → bundled` duplicate pairs produce zero warnings, and that `global → global` (same-origin, different dirs) still produces one warning.
- `loader.test.ts`: regression test (#30908) that simulates global + bundled feishu directories, runs the full `loadOpenClawPlugins` pipeline, and asserts zero duplicate warnings and exactly one loaded feishu plugin from the `global` origin.

## Test plan

- [x] `pnpm test -- src/plugins/` — all 160 tests pass
- [x] `pnpm lint -- src/plugins/manifest-registry.ts src/plugins/loader.test.ts src/plugins/manifest-registry.test.ts` — 0 warnings, 0 errors

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
