### PR TITLE
fix(agents): parse first @ after last slash in splitTrailingAuthProfile

### DIFF
--- a/src/agents/model-ref-profile.test.ts
+++ b/src/agents/model-ref-profile.test.ts
@@ -46,4 +46,11 @@ describe("splitTrailingAuthProfile", () => {
       model: "provider/foo@bar/baz",
     });
   });
+
+  it("uses first @ after last slash for email-based auth profiles", () => {
+    expect(splitTrailingAuthProfile("flash@google-gemini-cli:test@gmail.com")).toEqual({
+      model: "flash",
+      profile: "google-gemini-cli:test@gmail.com",
+    });
+  });
 });

--- a/src/agents/model-ref-profile.ts
+++ b/src/agents/model-ref-profile.ts
@@ -7,9 +7,9 @@ export function splitTrailingAuthProfile(raw: string): {
     return { model: "" };
   }
 
-  const profileDelimiter = trimmed.lastIndexOf("@");
   const lastSlash = trimmed.lastIndexOf("/");
-  if (profileDelimiter <= 0 || profileDelimiter <= lastSlash) {
+  const profileDelimiter = trimmed.indexOf("@", lastSlash + 1);
+  if (profileDelimiter <= 0) {
     return { model: trimmed };
   }
 


### PR DESCRIPTION
## Summary
- **Problem:** `/model flash@google-gemini-cli:test@gmail.com` incorrectly splits at the `@` in the email, yielding profile `gmail.com` instead of the full auth profile ID.
- **Why it matters:** OAuth-based providers (e.g. Google Gemini CLI) generate email-based profile IDs containing `@`, making the `/model` directive unusable with these profiles.
- **What changed:** Replaced `lastIndexOf("@")` with `indexOf("@", lastSlash + 1)` so the parser finds the first `@` after the last `/`, correctly distinguishing the model/profile separator from `@` characters inside scoped paths (`@cf/...`) or email addresses.
- **What did NOT change:** All existing behaviors for non-email profiles, scoped model paths, and slash-containing suffixes remain identical (verified by existing + new test).

## Change Type
- [x] Bug fix

## Scope
- [x] Skills/tool execution

## Linked Issue/PR
- Closes #30912

## User-visible / Behavior Changes
`/model <model>@<email-based-profile>` now correctly resolves the full profile ID instead of truncating at the email's `@`.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: macOS / Runtime: Node 22+ / Channel: any

### Steps
1. Configure an OAuth provider that generates email-based profile IDs (e.g. `google-gemini-cli:test@gmail.com`)
2. Run `/model flash@google-gemini-cli:test@gmail.com`
3. Observe correct model=`flash`, profile=`google-gemini-cli:test@gmail.com`

### Expected / Actual
- Expected: profile resolves to `google-gemini-cli:test@gmail.com`
- Actual (before fix): profile resolves to `gmail.com`

## Evidence
- [x] Failing test + passing after: added `"uses first @ after last slash for email-based auth profiles"` test case
- All 8 existing + new tests pass

## Human Verification [AI-assisted]
- Verified scenarios: all 7 existing test cases + 1 new email-based profile case
- Edge cases checked: scoped paths (`@cf/...`), slash-containing suffixes, empty strings, whitespace
- What you did NOT verify: live gateway testing with actual OAuth provider

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert quickly: revert this single commit
- Files/config to restore: `src/agents/model-ref-profile.ts`
- Known bad symptoms: `/model` directive with `@` in profile ID would fail

## Risks and Mitigations
None — the change is a minimal, well-scoped parser fix that preserves all existing behavior.