### PR TITLE
fix(ui): add Array.prototype.toSorted polyfill for older browsers

### DIFF
--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,2 +1,3 @@
+import "./polyfills.ts";
 import "./styles.css";
 import "./ui/app.ts";

--- a/ui/src/polyfills.ts
+++ b/ui/src/polyfills.ts
@@ -1,0 +1,8 @@
+// Polyfill Array.prototype.toSorted for browsers that lack it (e.g. Chrome < 110).
+if (!Array.prototype.toSorted) {
+  // eslint-disable-next-line no-extend-native
+  Array.prototype.toSorted = function <T>(this: T[], compareFn?: (a: T, b: T) => number): T[] {
+    // oxlint-disable-next-line unicorn/no-array-sort -- polyfill must use sort()
+    return [...this].sort(compareFn);
+  };
+}


### PR DESCRIPTION
## Summary
- **Problem:** Control UI crashes with a blank page on browsers without native `Array.prototype.toSorted` support (e.g. Chrome < 110 on Windows 7), showing `TypeError: Array.from(...).toSorted is not a function`.
- **Why it matters:** Users on older systems cannot access the Control UI at all — the page is completely blank with no graceful degradation.
- **What changed:** Added a lightweight `toSorted` polyfill (`ui/src/polyfills.ts`) imported before any UI code in `ui/src/main.ts`. The polyfill creates a sorted copy via `[...this].sort()`, matching the spec behavior.
- **What did NOT change:** No existing `toSorted` call sites were modified. All 22+ usages across the UI continue to work as before on modern browsers.

## Change Type
- [x] Bug fix

## Scope
- [x] UI/DX

## Linked Issue/PR
- Closes #30467

## User-visible / Behavior Changes
Control UI now loads correctly on older browsers that lack `Array.prototype.toSorted` (Chrome < 110, Firefox < 115).

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: Windows 7 (client) / Linux Docker (gateway) / Runtime: Node 22+

### Steps
1. Start gateway with `gateway.controlUi.enabled: true`
2. Access Control UI from a browser without `toSorted` support
3. Page should load normally instead of showing blank

### Expected / Actual
- Expected: Control UI renders normally
- Actual (before fix): Blank page with `TypeError` in console

## Evidence
- [x] Passing lint/format checks (`pnpm oxlint`, `pnpm oxfmt --check`)
- Polyfill covers all 22+ `toSorted` call sites across `ui/src/`

## Human Verification [AI-assisted]
- Verified scenarios: lint/format pass, polyfill logic matches TC39 spec (non-mutating sorted copy)
- Edge cases checked: polyfill only installs when `toSorted` is absent; no-op on modern browsers
- What you did NOT verify: live testing on Windows 7 / Chrome < 110

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert quickly: revert this commit (2 files)
- Files/config to restore: `ui/src/main.ts`, remove `ui/src/polyfills.ts`
- Known bad symptoms: N/A (polyfill is additive only)

## Risks and Mitigations
None — the polyfill is a standard spec-compliant shim that only activates on browsers missing the method.