### PR TITLE
fix(tools): expand ~ in Edit and Write tool paths when workspaceOnly is false

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { createEditTool, createReadTool, createWriteTool } from "@mariozechner/pi-coding-agent";
 import { SafeOpenError, openFileWithinRoot, writeFileWithinRoot } from "../infra/fs-safe.js";
+import { expandHomePrefix } from "../infra/home-dir.js";
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
@@ -764,11 +765,11 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
     // When workspaceOnly is false, allow writes anywhere on the host
     return {
       mkdir: async (dir: string) => {
-        const resolved = path.resolve(dir);
+        const resolved = path.resolve(expandHomePrefix(dir));
         await fs.mkdir(resolved, { recursive: true });
       },
       writeFile: async (absolutePath: string, content: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = path.resolve(expandHomePrefix(absolutePath));
         const dir = path.dirname(resolved);
         await fs.mkdir(dir, { recursive: true });
         await fs.writeFile(resolved, content, "utf-8");
@@ -803,17 +804,17 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
     // When workspaceOnly is false, allow edits anywhere on the host
     return {
       readFile: async (absolutePath: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = path.resolve(expandHomePrefix(absolutePath));
         return await fs.readFile(resolved);
       },
       writeFile: async (absolutePath: string, content: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = path.resolve(expandHomePrefix(absolutePath));
         const dir = path.dirname(resolved);
         await fs.mkdir(dir, { recursive: true });
         await fs.writeFile(resolved, content, "utf-8");
       },
       access: async (absolutePath: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = path.resolve(expandHomePrefix(absolutePath));
         await fs.access(resolved);
       },
     } as const;


### PR DESCRIPTION
## Summary
- **Problem:** Edit and Write tools treat `~` as a literal character in file paths, causing "File not found" errors for paths like `~/.codex/config.toml`.
- **Why it matters:** LLMs naturally generate `~` paths (standard Unix convention), and every failed attempt wastes a tool call and forces a retry with an absolute path.
- **What changed:** Applied `expandHomePrefix()` to all `path.resolve()` calls in the `workspaceOnly=false` branches of `createHostEditOperations` and `createHostWriteOperations`, matching Read tool behavior.
- **What did NOT change:** The `workspaceOnly=true` (default) branches already handle this correctly via `openFileWithinRoot` / `writeFileWithinRoot`. No behavioral change for sandboxed operations.

## Change Type
- [x] Bug fix

## Scope
- [x] Skills/tool execution

## Linked Issue/PR
- Closes #30669
- Related: #29779 (original tilde expansion PR that missed Edit/Write)

## User-visible / Behavior Changes
`Edit(file_path="~/.codex/config.toml", ...)` and `Write(file_path="~/some/file", ...)` now correctly resolve `~` to the home directory instead of returning "File not found".

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No — paths were already allowed in the workspaceOnly=false branch; this only fixes the resolution.

## Repro + Verification
### Environment
- OS: Ubuntu 24.04 (WSL2) / macOS / Runtime: Node 22+

### Steps
1. Set up an agent with `workspaceOnly: false`
2. Call `Edit(file_path="~/.codex/config.toml", old_string="foo", new_string="bar")`
3. Observe: file resolves correctly instead of "File not found"

### Expected / Actual
- Expected: File resolves to `/home/user/.codex/config.toml`
- Actual (before fix): Error "File not found: ~/.codex/config.toml"

## Evidence
- [x] Lint/format pass (`pnpm oxlint`, `pnpm oxfmt --check`)
- [x] TypeScript type check passes (`pnpm tsc --noEmit`)
- [x] `expandHomePrefix` unit tests pass (8/8 in `home-dir.test.ts`)

## Human Verification [AI-assisted]
- Verified: `expandHomePrefix` correctly handles `~`, `~/path`, `~\path`, and non-tilde paths
- Edge cases: empty strings, paths without tilde (no-op), unresolvable home dir (returns input unchanged)
- What you did NOT verify: live gateway testing with actual agent tool calls

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert quickly: revert this single commit
- Files/config to restore: `src/agents/pi-tools.read.ts`
- Known bad symptoms: N/A

## Risks and Mitigations
None — uses the same `expandHomePrefix` already trusted by the Read tool path.