### PR TITLE
Fix exec notifyOnExit wake path for immediate turn trigger

### DIFF
--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -19,6 +19,7 @@ Key parameters:
 - `background` (bool): background immediately
 - `timeout` (seconds, default 1800): kill the process after this timeout
 - `elevated` (bool): run on host if elevated mode is enabled/allowed
+- `wakeOnExit` (bool, default false): trigger an immediate session event run after enqueueing a background exec completion event
 - Need a real TTY? Set `pty: true`.
 - `workdir`, `env`
 
@@ -45,7 +46,7 @@ Config (preferred):
 - `tools.exec.backgroundMs` (default 10000)
 - `tools.exec.timeoutSec` (default 1800)
 - `tools.exec.cleanupMs` (default 1800000)
-- `tools.exec.notifyOnExit` (default true): enqueue a system event + request heartbeat when a backgrounded exec exits.
+- `tools.exec.notifyOnExit` (default true): enqueue a system event when a backgrounded exec exits.
 - `tools.exec.notifyOnExitEmptySuccess` (default false): when true, also enqueue completion events for successful backgrounded runs that produced no output.
 
 ## process tool

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -26,6 +26,7 @@ Background sessions are scoped per agent; `process` only sees sessions from the 
 - `ask` (`off | on-miss | always`): approval prompts for `gateway`/`node`
 - `node` (string): node id/name for `host=node`
 - `elevated` (bool): request elevated mode (gateway host); `security=full` is only forced when elevated resolves to `full`
+- `wakeOnExit` (bool, default `false`): when background completion is enqueued as a system event, trigger an immediate session event run
 
 Notes:
 
@@ -49,7 +50,7 @@ Notes:
 
 ## Config
 
-- `tools.exec.notifyOnExit` (default: true): when true, backgrounded exec sessions enqueue a system event and request a heartbeat on exit.
+- `tools.exec.notifyOnExit` (default: true): when true, backgrounded exec sessions enqueue a system event on exit.
 - `tools.exec.approvalRunningNoticeMs` (default: 10000): emit a single “running” notice when an approval-gated exec runs longer than this (0 disables).
 - `tools.exec.host` (default: `sandbox`)
 - `tools.exec.security` (default: `deny` for sandbox, `allowlist` for gateway + node when unset)

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -28,6 +28,7 @@ export type SessionStdin = {
 export interface ProcessSession {
   id: string;
   command: string;
+  agentId?: string;
   scopeKey?: string;
   sessionKey?: string;
   notifyOnExit?: boolean;

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -32,6 +32,7 @@ export interface ProcessSession {
   scopeKey?: string;
   sessionKey?: string;
   notifyOnExit?: boolean;
+  wakeOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   exitNotified?: boolean;
   child?: ChildProcessWithoutNullStreams;

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -188,6 +188,7 @@ export async function processGatewayAllowlist(
           {
             sessionKey: params.notifySessionKey,
             contextKey,
+            agentId: params.agentId,
           },
         );
         return;
@@ -241,6 +242,7 @@ export async function processGatewayAllowlist(
           {
             sessionKey: params.notifySessionKey,
             contextKey,
+            agentId: params.agentId,
           },
         );
         return;
@@ -263,6 +265,7 @@ export async function processGatewayAllowlist(
           pendingMaxOutput: params.pendingMaxOutput,
           notifyOnExit: false,
           notifyOnExitEmptySuccess: false,
+          agentId: params.agentId,
           scopeKey: params.scopeKey,
           sessionKey: params.notifySessionKey,
           timeoutSec: effectiveTimeout,
@@ -273,6 +276,7 @@ export async function processGatewayAllowlist(
           {
             sessionKey: params.notifySessionKey,
             contextKey,
+            agentId: params.agentId,
           },
         );
         return;
@@ -285,7 +289,7 @@ export async function processGatewayAllowlist(
         runningTimer = setTimeout(() => {
           emitExecSystemEvent(
             `Exec running (gateway id=${approvalId}, session=${run?.session.id}, >${noticeSeconds}s): ${params.command}`,
-            { sessionKey: params.notifySessionKey, contextKey },
+            { sessionKey: params.notifySessionKey, contextKey, agentId: params.agentId },
           );
         }, params.approvalRunningNoticeMs);
       }
@@ -301,7 +305,11 @@ export async function processGatewayAllowlist(
       const summary = output
         ? `Exec finished (gateway id=${approvalId}, session=${run.session.id}, ${exitLabel})\n${output}`
         : `Exec finished (gateway id=${approvalId}, session=${run.session.id}, ${exitLabel})`;
-      emitExecSystemEvent(summary, { sessionKey: params.notifySessionKey, contextKey });
+      emitExecSystemEvent(summary, {
+        sessionKey: params.notifySessionKey,
+        contextKey,
+        agentId: params.agentId,
+      });
     })();
 
     return {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -51,6 +51,7 @@ export type ProcessGatewayAllowlistParams = {
   scopeKey?: string;
   warnings: string[];
   notifySessionKey?: string;
+  wakeOnExit?: boolean;
   approvalRunningNoticeMs: number;
   maxOutput: number;
   pendingMaxOutput: number;
@@ -189,6 +190,7 @@ export async function processGatewayAllowlist(
             sessionKey: params.notifySessionKey,
             contextKey,
             agentId: params.agentId,
+            wakeOnExit: params.wakeOnExit === true,
           },
         );
         return;
@@ -243,6 +245,7 @@ export async function processGatewayAllowlist(
             sessionKey: params.notifySessionKey,
             contextKey,
             agentId: params.agentId,
+            wakeOnExit: params.wakeOnExit === true,
           },
         );
         return;
@@ -277,6 +280,7 @@ export async function processGatewayAllowlist(
             sessionKey: params.notifySessionKey,
             contextKey,
             agentId: params.agentId,
+            wakeOnExit: params.wakeOnExit === true,
           },
         );
         return;
@@ -289,7 +293,12 @@ export async function processGatewayAllowlist(
         runningTimer = setTimeout(() => {
           emitExecSystemEvent(
             `Exec running (gateway id=${approvalId}, session=${run?.session.id}, >${noticeSeconds}s): ${params.command}`,
-            { sessionKey: params.notifySessionKey, contextKey, agentId: params.agentId },
+            {
+              sessionKey: params.notifySessionKey,
+              contextKey,
+              agentId: params.agentId,
+              wakeOnExit: params.wakeOnExit === true,
+            },
           );
         }, params.approvalRunningNoticeMs);
       }
@@ -309,6 +318,7 @@ export async function processGatewayAllowlist(
         sessionKey: params.notifySessionKey,
         contextKey,
         agentId: params.agentId,
+        wakeOnExit: params.wakeOnExit === true,
       });
     })();
 

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -229,7 +229,7 @@ export async function executeNodeHostCommand(
       } catch {
         emitExecSystemEvent(
           `Exec denied (node=${nodeId} id=${approvalId}, approval-request-failed): ${params.command}`,
-          { sessionKey: params.notifySessionKey, contextKey },
+          { sessionKey: params.notifySessionKey, contextKey, agentId: params.agentId },
         );
         return;
       }
@@ -265,6 +265,7 @@ export async function executeNodeHostCommand(
           {
             sessionKey: params.notifySessionKey,
             contextKey,
+            agentId: params.agentId,
           },
         );
         return;
@@ -275,7 +276,7 @@ export async function executeNodeHostCommand(
         runningTimer = setTimeout(() => {
           emitExecSystemEvent(
             `Exec running (node=${nodeId} id=${approvalId}, >${noticeSeconds}s): ${params.command}`,
-            { sessionKey: params.notifySessionKey, contextKey },
+            { sessionKey: params.notifySessionKey, contextKey, agentId: params.agentId },
           );
         }, params.approvalRunningNoticeMs);
       }
@@ -292,6 +293,7 @@ export async function executeNodeHostCommand(
           {
             sessionKey: params.notifySessionKey,
             contextKey,
+            agentId: params.agentId,
           },
         );
       } finally {

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -47,6 +47,7 @@ export type ExecuteNodeHostCommandParams = {
   approvalRunningNoticeMs: number;
   warnings: string[];
   notifySessionKey?: string;
+  wakeOnExit?: boolean;
   trustedSafeBinDirs?: ReadonlySet<string>;
 };
 
@@ -177,6 +178,7 @@ export async function executeNodeHostCommand(
         timeoutMs: typeof params.timeoutSec === "number" ? params.timeoutSec * 1000 : undefined,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
+        wakeOnExit: params.wakeOnExit === true ? true : undefined,
         approved: approvedByAsk,
         approvalDecision: approvalDecision ?? undefined,
         runId: runId ?? undefined,
@@ -229,7 +231,12 @@ export async function executeNodeHostCommand(
       } catch {
         emitExecSystemEvent(
           `Exec denied (node=${nodeId} id=${approvalId}, approval-request-failed): ${params.command}`,
-          { sessionKey: params.notifySessionKey, contextKey, agentId: params.agentId },
+          {
+            sessionKey: params.notifySessionKey,
+            contextKey,
+            agentId: params.agentId,
+            wakeOnExit: params.wakeOnExit === true,
+          },
         );
         return;
       }
@@ -266,6 +273,7 @@ export async function executeNodeHostCommand(
             sessionKey: params.notifySessionKey,
             contextKey,
             agentId: params.agentId,
+            wakeOnExit: params.wakeOnExit === true,
           },
         );
         return;
@@ -276,7 +284,12 @@ export async function executeNodeHostCommand(
         runningTimer = setTimeout(() => {
           emitExecSystemEvent(
             `Exec running (node=${nodeId} id=${approvalId}, >${noticeSeconds}s): ${params.command}`,
-            { sessionKey: params.notifySessionKey, contextKey, agentId: params.agentId },
+            {
+              sessionKey: params.notifySessionKey,
+              contextKey,
+              agentId: params.agentId,
+              wakeOnExit: params.wakeOnExit === true,
+            },
           );
         }, params.approvalRunningNoticeMs);
       }
@@ -294,6 +307,7 @@ export async function executeNodeHostCommand(
             sessionKey: params.notifySessionKey,
             contextKey,
             agentId: params.agentId,
+            wakeOnExit: params.wakeOnExit === true,
           },
         );
       } finally {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -2,10 +2,9 @@ import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import type { ExecAsk, ExecHost, ExecSecurity } from "../infra/exec-approvals.js";
-import { shouldUseSessionScopedHeartbeatWake } from "../infra/heartbeat-reason.js";
-import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
 import { mergePathPrepend } from "../infra/path-prepend.js";
+import { requestSessionEventRun } from "../infra/session-event-run.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
@@ -201,12 +200,8 @@ function compactNotifyOutput(value: string, maxChars = DEFAULT_NOTIFY_SNIPPET_CH
 }
 
 function requestExecEventWake(opts: { sessionKey: string; agentId?: string }) {
-  if (!shouldUseSessionScopedHeartbeatWake(opts.sessionKey)) {
-    requestHeartbeatNow({ reason: "exec-event" });
-    return;
-  }
-  requestHeartbeatNow({
-    reason: "exec-event",
+  requestSessionEventRun({
+    source: "exec-event",
     sessionKey: opts.sessionKey,
     agentId: opts.agentId,
   });

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -237,8 +237,11 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
   const summary = output
     ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
-  enqueueSystemEvent(summary, { sessionKey });
-  requestHeartbeatNow({ reason: `exec:${session.id}:exit` });
+  const queued = enqueueSystemEvent(summary, { sessionKey });
+  if (!queued) {
+    return;
+  }
+  requestHeartbeatNow({ reason: "exec-event", sessionKey });
 }
 
 export function createApprovalSlug(id: string) {
@@ -263,8 +266,11 @@ export function emitExecSystemEvent(
   if (!sessionKey) {
     return;
   }
-  enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
-  requestHeartbeatNow({ reason: "exec-event" });
+  const queued = enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
+  if (!queued) {
+    return;
+  }
+  requestHeartbeatNow({ reason: "exec-event", sessionKey });
 }
 
 export async function runExecProcess(opts: {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import type { ExecAsk, ExecHost, ExecSecurity } from "../infra/exec-approvals.js";
+import { shouldUseSessionScopedHeartbeatWake } from "../infra/heartbeat-reason.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
 import { mergePathPrepend } from "../infra/path-prepend.js";
@@ -199,12 +200,8 @@ function compactNotifyOutput(value: string, maxChars = DEFAULT_NOTIFY_SNIPPET_CH
   return `${normalized.slice(0, safe)}…`;
 }
 
-function shouldUseSessionScopedExecWake(sessionKey: string) {
-  return sessionKey.trim().toLowerCase().startsWith("agent:");
-}
-
 function requestExecEventWake(opts: { sessionKey: string; agentId?: string }) {
-  if (!shouldUseSessionScopedExecWake(opts.sessionKey)) {
+  if (!shouldUseSessionScopedHeartbeatWake(opts.sessionKey)) {
     requestHeartbeatNow({ reason: "exec-event" });
     return;
   }

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -241,7 +241,11 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
   if (!queued) {
     return;
   }
-  requestHeartbeatNow({ reason: "exec-event", sessionKey });
+  requestHeartbeatNow({
+    reason: "exec-event",
+    sessionKey,
+    agentId: session.agentId,
+  });
 }
 
 export function createApprovalSlug(id: string) {
@@ -260,7 +264,7 @@ export function resolveApprovalRunningNoticeMs(value?: number) {
 
 export function emitExecSystemEvent(
   text: string,
-  opts: { sessionKey?: string; contextKey?: string },
+  opts: { sessionKey?: string; contextKey?: string; agentId?: string },
 ) {
   const sessionKey = opts.sessionKey?.trim();
   if (!sessionKey) {
@@ -270,7 +274,11 @@ export function emitExecSystemEvent(
   if (!queued) {
     return;
   }
-  requestHeartbeatNow({ reason: "exec-event", sessionKey });
+  requestHeartbeatNow({
+    reason: "exec-event",
+    sessionKey,
+    agentId: opts.agentId,
+  });
 }
 
 export async function runExecProcess(opts: {
@@ -288,6 +296,7 @@ export async function runExecProcess(opts: {
   pendingMaxOutput: number;
   notifyOnExit: boolean;
   notifyOnExitEmptySuccess?: boolean;
+  agentId?: string;
   scopeKey?: string;
   sessionKey?: string;
   timeoutSec: number | null;
@@ -301,6 +310,7 @@ export async function runExecProcess(opts: {
   const session: ProcessSession = {
     id: sessionId,
     command: opts.command,
+    agentId: opts.agentId,
     scopeKey: opts.scopeKey,
     sessionKey: opts.sessionKey,
     notifyOnExit: opts.notifyOnExit,

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -199,6 +199,22 @@ function compactNotifyOutput(value: string, maxChars = DEFAULT_NOTIFY_SNIPPET_CH
   return `${normalized.slice(0, safe)}…`;
 }
 
+function shouldUseSessionScopedExecWake(sessionKey: string) {
+  return sessionKey.trim().toLowerCase().startsWith("agent:");
+}
+
+function requestExecEventWake(opts: { sessionKey: string; agentId?: string }) {
+  if (!shouldUseSessionScopedExecWake(opts.sessionKey)) {
+    requestHeartbeatNow({ reason: "exec-event" });
+    return;
+  }
+  requestHeartbeatNow({
+    reason: "exec-event",
+    sessionKey: opts.sessionKey,
+    agentId: opts.agentId,
+  });
+}
+
 export function applyShellPath(env: Record<string, string>, shellPath?: string | null) {
   if (!shellPath) {
     return;
@@ -241,11 +257,7 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
   if (!queued) {
     return;
   }
-  requestHeartbeatNow({
-    reason: "exec-event",
-    sessionKey,
-    agentId: session.agentId,
-  });
+  requestExecEventWake({ sessionKey, agentId: session.agentId });
 }
 
 export function createApprovalSlug(id: string) {
@@ -274,11 +286,7 @@ export function emitExecSystemEvent(
   if (!queued) {
     return;
   }
-  requestHeartbeatNow({
-    reason: "exec-event",
-    sessionKey,
-    agentId: opts.agentId,
-  });
+  requestExecEventWake({ sessionKey, agentId: opts.agentId });
 }
 
 export async function runExecProcess(opts: {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -135,6 +135,12 @@ export const execSchema = Type.Object({
       description: "Node id/name for host=node.",
     }),
   ),
+  wakeOnExit: Type.Optional(
+    Type.Boolean({
+      description:
+        "When true, trigger an immediate session event run after enqueueing a background exec completion event (default false). Implies notifyOnExit=true.",
+    }),
+  ),
 });
 
 export type ExecProcessOutcome = {
@@ -249,7 +255,9 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
   if (!queued) {
     return;
   }
-  requestExecEventWake({ sessionKey, agentId: session.agentId });
+  if (session.wakeOnExit === true) {
+    requestExecEventWake({ sessionKey, agentId: session.agentId });
+  }
 }
 
 export function createApprovalSlug(id: string) {
@@ -268,7 +276,7 @@ export function resolveApprovalRunningNoticeMs(value?: number) {
 
 export function emitExecSystemEvent(
   text: string,
-  opts: { sessionKey?: string; contextKey?: string; agentId?: string },
+  opts: { sessionKey?: string; contextKey?: string; agentId?: string; wakeOnExit?: boolean },
 ) {
   const sessionKey = opts.sessionKey?.trim();
   if (!sessionKey) {
@@ -278,7 +286,9 @@ export function emitExecSystemEvent(
   if (!queued) {
     return;
   }
-  requestExecEventWake({ sessionKey, agentId: opts.agentId });
+  if (opts.wakeOnExit === true) {
+    requestExecEventWake({ sessionKey, agentId: opts.agentId });
+  }
 }
 
 export async function runExecProcess(opts: {
@@ -295,6 +305,7 @@ export async function runExecProcess(opts: {
   maxOutput: number;
   pendingMaxOutput: number;
   notifyOnExit: boolean;
+  wakeOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   agentId?: string;
   scopeKey?: string;
@@ -314,6 +325,7 @@ export async function runExecProcess(opts: {
     scopeKey: opts.scopeKey,
     sessionKey: opts.sessionKey,
     notifyOnExit: opts.notifyOnExit,
+    wakeOnExit: opts.wakeOnExit === true,
     notifyOnExitEmptySuccess: opts.notifyOnExitEmptySuccess === true,
     exitNotified: false,
     child: undefined,

--- a/src/agents/bash-tools.exec-runtime.wake-on-exit.test.ts
+++ b/src/agents/bash-tools.exec-runtime.wake-on-exit.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { enqueueSystemEventMock, requestSessionEventRunMock } = vi.hoisted(() => ({
+  enqueueSystemEventMock: vi.fn(() => true),
+  requestSessionEventRunMock: vi.fn(),
+}));
+
+vi.mock("../infra/system-events.js", () => ({
+  enqueueSystemEvent: enqueueSystemEventMock,
+}));
+vi.mock("../infra/session-event-run.js", () => ({
+  requestSessionEventRun: requestSessionEventRunMock,
+}));
+
+import { markBackgrounded, resetProcessRegistryForTests } from "./bash-process-registry.js";
+import { emitExecSystemEvent, runExecProcess } from "./bash-tools.exec-runtime.js";
+
+const isWin = process.platform === "win32";
+const delayedCommand = isWin
+  ? "Start-Sleep -Milliseconds 20; Write-Output wake-test"
+  : "sleep 0.02; echo wake-test";
+
+function stringifyEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value === "string") {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+async function runBackgroundExec(wakeOnExit: boolean) {
+  const run = await runExecProcess({
+    command: delayedCommand,
+    workdir: process.cwd(),
+    env: stringifyEnv(process.env),
+    usePty: false,
+    warnings: [],
+    maxOutput: 20_000,
+    pendingMaxOutput: 20_000,
+    notifyOnExit: true,
+    wakeOnExit,
+    notifyOnExitEmptySuccess: true,
+    sessionKey: "agent:main:main",
+    timeoutSec: 5,
+  });
+  markBackgrounded(run.session);
+  await run.promise;
+}
+
+describe("exec wakeOnExit", () => {
+  beforeEach(() => {
+    enqueueSystemEventMock.mockReset();
+    enqueueSystemEventMock.mockReturnValue(true);
+    requestSessionEventRunMock.mockReset();
+    resetProcessRegistryForTests();
+  });
+
+  it("does not trigger a session event run for background exits when wakeOnExit is false", async () => {
+    await runBackgroundExec(false);
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+  });
+
+  it("triggers a session event run for background exits when wakeOnExit is true", async () => {
+    await runBackgroundExec(true);
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "agent:main:main",
+      agentId: undefined,
+    });
+  });
+
+  it("does not trigger wake when enqueueing an exec event fails", () => {
+    enqueueSystemEventMock.mockReturnValue(false);
+
+    emitExecSystemEvent("Exec finished", {
+      sessionKey: "agent:main:main",
+      wakeOnExit: true,
+    });
+
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+  });
+
+  it("triggers wake only when emitExecSystemEvent receives wakeOnExit=true", () => {
+    emitExecSystemEvent("Exec finished", {
+      sessionKey: "agent:main:main",
+      wakeOnExit: false,
+    });
+    emitExecSystemEvent("Exec finished", {
+      sessionKey: "agent:main:main",
+      wakeOnExit: true,
+    });
+
+    expect(requestSessionEventRunMock).toHaveBeenCalledTimes(1);
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "agent:main:main",
+      agentId: undefined,
+    });
+  });
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -481,6 +481,7 @@ export function createExecTool(
         pendingMaxOutput,
         notifyOnExit,
         notifyOnExitEmptySuccess,
+        agentId,
         scopeKey: defaults?.scopeKey,
         sessionKey: notifySessionKey,
         timeoutSec: effectiveTimeout,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -190,7 +190,7 @@ export function createExecTool(
       `exec: interpreter/runtime binaries in safeBins (${unprofiledInterpreterSafeBins.join(", ")}) are unsafe without explicit hardened profiles; prefer allowlist entries`,
     );
   }
-  const notifyOnExit = defaults?.notifyOnExit !== false;
+  const defaultNotifyOnExit = defaults?.notifyOnExit !== false;
   const notifyOnExitEmptySuccess = defaults?.notifyOnExitEmptySuccess === true;
   const notifySessionKey = defaults?.sessionKey?.trim() || undefined;
   const approvalRunningNoticeMs = resolveApprovalRunningNoticeMs(defaults?.approvalRunningNoticeMs);
@@ -220,6 +220,7 @@ export function createExecTool(
         security?: string;
         ask?: string;
         node?: string;
+        wakeOnExit?: boolean;
       };
 
       if (!params.command) {
@@ -229,6 +230,15 @@ export function createExecTool(
       const maxOutput = DEFAULT_MAX_OUTPUT;
       const pendingMaxOutput = DEFAULT_PENDING_MAX_OUTPUT;
       const warnings: string[] = [];
+      const wakeOnExit = params.wakeOnExit === true;
+      let notifyOnExit = defaultNotifyOnExit;
+      if (wakeOnExit && !notifyOnExit) {
+        notifyOnExit = true;
+        const warning =
+          "Warning: wakeOnExit=true requires notifyOnExit=true; forcing notifyOnExit for this exec run.";
+        warnings.push(warning);
+        logInfo(`exec: wakeOnExit requested while notifyOnExit disabled; forcing notifyOnExit.`);
+      }
       let execCommandOverride: string | undefined;
       const backgroundRequested = params.background === true;
       const yieldRequested = typeof params.yieldMs === "number";
@@ -419,6 +429,7 @@ export function createExecTool(
           approvalRunningNoticeMs,
           warnings,
           notifySessionKey,
+          wakeOnExit,
           trustedSafeBinDirs,
         });
       }
@@ -444,6 +455,7 @@ export function createExecTool(
           scopeKey: defaults?.scopeKey,
           warnings,
           notifySessionKey,
+          wakeOnExit,
           approvalRunningNoticeMs,
           maxOutput,
           pendingMaxOutput,
@@ -480,6 +492,7 @@ export function createExecTool(
         maxOutput,
         pendingMaxOutput,
         notifyOnExit,
+        wakeOnExit,
         notifyOnExitEmptySuccess,
         agentId,
         scopeKey: defaults?.scopeKey,

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -522,7 +522,7 @@ describe("exec notifyOnExit", () => {
     expect(hasEvent).toBe(true);
   });
 
-  it("wakes heartbeat with explicit agentId for non-agent session keys", async () => {
+  it("falls back to unscoped wake for non-agent session keys", async () => {
     const wakeCalls: Array<{ reason?: string; agentId?: string; sessionKey?: string }> = [];
     const disposeWakeHandler = setHeartbeatWakeHandler(async (opts) => {
       wakeCalls.push(opts);
@@ -537,6 +537,43 @@ describe("exec notifyOnExit", () => {
       });
 
       const sessionId = await startBackgroundCommand(tool, echoAfterDelay("notify-agent"));
+      const status = await waitForCompletion(sessionId);
+      expect(status).toBe(PROCESS_STATUS_COMPLETED);
+      await waitForNotifyEvent(sessionId, notifySessionKey);
+
+      await expect
+        .poll(
+          () =>
+            wakeCalls.some(
+              (call) =>
+                call.reason === "exec-event" &&
+                call.sessionKey === undefined &&
+                call.agentId === undefined,
+            ),
+          NOTIFY_POLL_OPTIONS,
+        )
+        .toBe(true);
+    } finally {
+      disposeWakeHandler();
+      resetHeartbeatWakeStateForTests();
+    }
+  });
+
+  it("keeps session-scoped wake for agent session keys", async () => {
+    const wakeCalls: Array<{ reason?: string; agentId?: string; sessionKey?: string }> = [];
+    const disposeWakeHandler = setHeartbeatWakeHandler(async (opts) => {
+      wakeCalls.push(opts);
+      return { status: "skipped", reason: "disabled" };
+    });
+
+    try {
+      const notifySessionKey = "agent:ops:main";
+      const tool = createNotifyOnExitExecTool({
+        sessionKey: notifySessionKey,
+        agentId: "ops",
+      });
+
+      const sessionId = await startBackgroundCommand(tool, echoAfterDelay("notify-agent-scoped"));
       const status = await waitForCompletion(sessionId);
       expect(status).toBe(PROCESS_STATUS_COMPLETED);
       await waitForNotifyEvent(sessionId, notifySessionKey);

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -1,9 +1,5 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  resetHeartbeatWakeStateForTests,
-  setHeartbeatWakeHandler,
-} from "../infra/heartbeat-wake.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
 import { captureEnv } from "../test-utils/env.js";
 import { getFinishedSession, resetProcessRegistryForTests } from "./bash-process-registry.js";
@@ -410,7 +406,6 @@ beforeEach(() => {
   callIdCounter = 0;
   resetProcessRegistryForTests();
   resetSystemEventsForTest();
-  resetHeartbeatWakeStateForTests();
 });
 
 describe("exec tool backgrounding", () => {
@@ -520,80 +515,6 @@ describe("exec notifyOnExit", () => {
 
     expect(finished).toBeTruthy();
     expect(hasEvent).toBe(true);
-  });
-
-  it("falls back to unscoped wake for non-agent session keys", async () => {
-    const wakeCalls: Array<{ reason?: string; agentId?: string; sessionKey?: string }> = [];
-    const disposeWakeHandler = setHeartbeatWakeHandler(async (opts) => {
-      wakeCalls.push(opts);
-      return { status: "skipped", reason: "disabled" };
-    });
-
-    try {
-      const notifySessionKey = "global";
-      const tool = createNotifyOnExitExecTool({
-        sessionKey: notifySessionKey,
-        agentId: "ops",
-      });
-
-      const sessionId = await startBackgroundCommand(tool, echoAfterDelay("notify-agent"));
-      const status = await waitForCompletion(sessionId);
-      expect(status).toBe(PROCESS_STATUS_COMPLETED);
-      await waitForNotifyEvent(sessionId, notifySessionKey);
-
-      await expect
-        .poll(
-          () =>
-            wakeCalls.some(
-              (call) =>
-                call.reason === "exec-event" &&
-                call.sessionKey === undefined &&
-                call.agentId === undefined,
-            ),
-          NOTIFY_POLL_OPTIONS,
-        )
-        .toBe(true);
-    } finally {
-      disposeWakeHandler();
-      resetHeartbeatWakeStateForTests();
-    }
-  });
-
-  it("keeps session-scoped wake for agent session keys", async () => {
-    const wakeCalls: Array<{ reason?: string; agentId?: string; sessionKey?: string }> = [];
-    const disposeWakeHandler = setHeartbeatWakeHandler(async (opts) => {
-      wakeCalls.push(opts);
-      return { status: "skipped", reason: "disabled" };
-    });
-
-    try {
-      const notifySessionKey = "agent:ops:main";
-      const tool = createNotifyOnExitExecTool({
-        sessionKey: notifySessionKey,
-        agentId: "ops",
-      });
-
-      const sessionId = await startBackgroundCommand(tool, echoAfterDelay("notify-agent-scoped"));
-      const status = await waitForCompletion(sessionId);
-      expect(status).toBe(PROCESS_STATUS_COMPLETED);
-      await waitForNotifyEvent(sessionId, notifySessionKey);
-
-      await expect
-        .poll(
-          () =>
-            wakeCalls.some(
-              (call) =>
-                call.reason === "exec-event" &&
-                call.sessionKey === notifySessionKey &&
-                call.agentId === "ops",
-            ),
-          NOTIFY_POLL_OPTIONS,
-        )
-        .toBe(true);
-    } finally {
-      disposeWakeHandler();
-      resetHeartbeatWakeStateForTests();
-    }
   });
 
   it.each<NotifyNoopCase>(NOOP_NOTIFY_CASES)("$label", runNotifyNoopCase);

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -1,5 +1,9 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  resetHeartbeatWakeStateForTests,
+  setHeartbeatWakeHandler,
+} from "../infra/heartbeat-wake.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
 import { captureEnv } from "../test-utils/env.js";
 import { getFinishedSession, resetProcessRegistryForTests } from "./bash-process-registry.js";
@@ -191,24 +195,24 @@ const requireRunningSessionId = (result: { details: unknown }) => {
   return requireSessionId(result.details as { sessionId?: string });
 };
 
-function hasNotifyEventForPrefix(prefix: string): boolean {
-  return peekSystemEvents(DEFAULT_NOTIFY_SESSION_KEY).some((event) => event.includes(prefix));
+function hasNotifyEventForPrefix(prefix: string, sessionKey = DEFAULT_NOTIFY_SESSION_KEY): boolean {
+  return peekSystemEvents(sessionKey).some((event) => event.includes(prefix));
 }
 
-async function waitForNotifyEvent(sessionId: string) {
+async function waitForNotifyEvent(sessionId: string, sessionKey = DEFAULT_NOTIFY_SESSION_KEY) {
   const prefix = sessionId.slice(0, 8);
   let finished = getFinishedSession(sessionId);
-  let hasEvent = hasNotifyEventForPrefix(prefix);
+  let hasEvent = hasNotifyEventForPrefix(prefix, sessionKey);
   await expect
     .poll(() => {
       finished = getFinishedSession(sessionId);
-      hasEvent = hasNotifyEventForPrefix(prefix);
+      hasEvent = hasNotifyEventForPrefix(prefix, sessionKey);
       return Boolean(finished && hasEvent);
     }, NOTIFY_POLL_OPTIONS)
     .toBe(true);
   return {
     finished: finished ?? getFinishedSession(sessionId),
-    hasEvent: hasEvent || hasNotifyEventForPrefix(prefix),
+    hasEvent: hasEvent || hasNotifyEventForPrefix(prefix, sessionKey),
   };
 }
 
@@ -406,6 +410,7 @@ beforeEach(() => {
   callIdCounter = 0;
   resetProcessRegistryForTests();
   resetSystemEventsForTest();
+  resetHeartbeatWakeStateForTests();
 });
 
 describe("exec tool backgrounding", () => {
@@ -515,6 +520,43 @@ describe("exec notifyOnExit", () => {
 
     expect(finished).toBeTruthy();
     expect(hasEvent).toBe(true);
+  });
+
+  it("wakes heartbeat with explicit agentId for non-agent session keys", async () => {
+    const wakeCalls: Array<{ reason?: string; agentId?: string; sessionKey?: string }> = [];
+    const disposeWakeHandler = setHeartbeatWakeHandler(async (opts) => {
+      wakeCalls.push(opts);
+      return { status: "skipped", reason: "disabled" };
+    });
+
+    try {
+      const notifySessionKey = "global";
+      const tool = createNotifyOnExitExecTool({
+        sessionKey: notifySessionKey,
+        agentId: "ops",
+      });
+
+      const sessionId = await startBackgroundCommand(tool, echoAfterDelay("notify-agent"));
+      const status = await waitForCompletion(sessionId);
+      expect(status).toBe(PROCESS_STATUS_COMPLETED);
+      await waitForNotifyEvent(sessionId, notifySessionKey);
+
+      await expect
+        .poll(
+          () =>
+            wakeCalls.some(
+              (call) =>
+                call.reason === "exec-event" &&
+                call.sessionKey === notifySessionKey &&
+                call.agentId === "ops",
+            ),
+          NOTIFY_POLL_OPTIONS,
+        )
+        .toBe(true);
+    } finally {
+      disposeWakeHandler();
+      resetHeartbeatWakeStateForTests();
+    }
   });
 
   it.each<NotifyNoopCase>(NOOP_NOTIFY_CASES)("$label", runNotifyNoopCase);

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -517,6 +517,22 @@ describe("exec notifyOnExit", () => {
     expect(hasEvent).toBe(true);
   });
 
+  it("coerces notifyOnExit to true when wakeOnExit is requested", async () => {
+    const tool = createNotifyOnExitExecTool({ notifyOnExit: false });
+    const result = await executeExecCommand(tool, echoAfterDelay("notify"), {
+      background: true,
+      wakeOnExit: true,
+    });
+    expect(readTextContent(result.content) ?? "").toContain(
+      "wakeOnExit=true requires notifyOnExit=true",
+    );
+
+    const sessionId = requireRunningSessionId(result);
+    const { finished, hasEvent } = await waitForNotifyEvent(sessionId);
+    expect(finished).toBeTruthy();
+    expect(hasEvent).toBe(true);
+  });
+
   it.each<NotifyNoopCase>(NOOP_NOTIFY_CASES)("$label", runNotifyNoopCase);
 });
 

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -207,6 +207,31 @@ describe("runPreparedReply media-only handling", () => {
     expect(vi.mocked(runReplyAgent)).not.toHaveBeenCalled();
   });
 
+  it("allows system-event-only runs when empty-body override is enabled", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "slack",
+        },
+        opts: {
+          allowEmptyBodyForSystemEvent: true,
+        },
+      }),
+    );
+
+    expect(result).toEqual({ text: "ok" });
+    expect(vi.mocked(runReplyAgent)).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call?.followupRun.prompt).toContain("[System event update]");
+  });
+
   it("omits auth key labels from /new and /reset confirmation messages", async () => {
     await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -305,7 +305,8 @@ export async function runPreparedReply(
   const hasMediaAttachment = Boolean(
     sessionCtx.MediaPath || (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0),
   );
-  if (!baseBodyTrimmed && !hasMediaAttachment) {
+  const allowEmptyBodyForSystemEvent = opts?.allowEmptyBodyForSystemEvent === true;
+  if (!baseBodyTrimmed && !hasMediaAttachment && !allowEmptyBodyForSystemEvent) {
     await typing.onReplyStart();
     logVerbose("Inbound body empty after normalization; skipping agent run");
     typing.cleanup();
@@ -317,7 +318,9 @@ export async function runPreparedReply(
   // run proceeds and the image/document is injected by the embedded runner.
   const effectiveBaseBody = baseBodyTrimmed
     ? baseBodyForPrompt
-    : "[User sent media without caption]";
+    : hasMediaAttachment
+      ? "[User sent media without caption]"
+      : "[System event update]";
   let prefixedBodyBase = await applySessionHints({
     baseBody: effectiveBaseBody,
     abortedLastRun,

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -42,6 +42,8 @@ export type GetReplyOptions = {
   heartbeatModelOverride?: string;
   /** If true, suppress tool error warning payloads for this run. */
   suppressToolErrorWarnings?: boolean;
+  /** Allow runs with an empty inbound body when system events are queued for this session. */
+  allowEmptyBodyForSystemEvent?: boolean;
   onPartialReply?: (payload: ReplyPayload) => Promise<void> | void;
   onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when a thinking/reasoning block ends. */

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -140,6 +140,33 @@ describe("node exec events", () => {
     });
   });
 
+  it("canonicalizes exec event session key before enqueue and wake", async () => {
+    loadSessionEntryMock.mockReturnValueOnce({
+      ...buildSessionLookup("node-node-2"),
+      canonicalKey: "agent:main:node-node-2",
+    });
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-2", {
+      event: "exec.finished",
+      payloadJSON: JSON.stringify({
+        runId: "run-2",
+        exitCode: 0,
+        timedOut: false,
+        output: "done",
+      }),
+    });
+
+    expect(loadSessionEntryMock).toHaveBeenCalledWith("node-node-2");
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Exec finished (node=node-2 id=run-2, code 0)\ndone",
+      { sessionKey: "agent:main:node-node-2", contextKey: "exec:run-2" },
+    );
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:main:node-node-2",
+    });
+  });
+
   it("suppresses noisy exec.finished success events with empty output", async () => {
     const ctx = buildCtx();
     await handleNodeEvent(ctx, "node-2", {

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -30,6 +30,9 @@ vi.mock("../infra/system-events.js", () => ({
 vi.mock("../infra/heartbeat-wake.js", () => ({
   requestHeartbeatNow: vi.fn(),
 }));
+vi.mock("../infra/session-event-run.js", () => ({
+  requestSessionEventRun: vi.fn(),
+}));
 vi.mock("../commands/agent.js", () => ({
   agentCommand: vi.fn(),
 }));
@@ -55,6 +58,7 @@ import type { HealthSummary } from "../commands/health.js";
 import { loadConfig } from "../config/config.js";
 import { updateSessionStore } from "../config/sessions.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
+import { requestSessionEventRun } from "../infra/session-event-run.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import type { NodeEventContext } from "./server-node-events-types.js";
 import { handleNodeEvent } from "./server-node-events.js";
@@ -62,6 +66,7 @@ import { loadSessionEntry } from "./session-utils.js";
 
 const enqueueSystemEventMock = vi.mocked(enqueueSystemEvent);
 const requestHeartbeatNowMock = vi.mocked(requestHeartbeatNow);
+const requestSessionEventRunMock = vi.mocked(requestSessionEventRun);
 const loadConfigMock = vi.mocked(loadConfig);
 const agentCommandMock = vi.mocked(agentCommand);
 const updateSessionStoreMock = vi.mocked(updateSessionStore);
@@ -95,6 +100,7 @@ describe("node exec events", () => {
     enqueueSystemEventMock.mockClear();
     enqueueSystemEventMock.mockReturnValue(true);
     requestHeartbeatNowMock.mockClear();
+    requestSessionEventRunMock.mockClear();
   });
 
   it("enqueues exec.started events", async () => {
@@ -112,10 +118,11 @@ describe("node exec events", () => {
       "Exec started (node=node-1 id=run-1): ls -la",
       { sessionKey: "agent:main:main", contextKey: "exec:run-1" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
-      reason: "exec-event",
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
       sessionKey: "agent:main:main",
     });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
   });
 
   it("enqueues exec.finished events with output", async () => {
@@ -134,12 +141,14 @@ describe("node exec events", () => {
       "Exec finished (node=node-2 id=run-2, code 0)\ndone",
       { sessionKey: "node-node-2", contextKey: "exec:run-2" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
-      reason: "exec-event",
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "node-node-2",
     });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
   });
 
-  it("keeps fallback exec wakes unscoped when canonical key is agent-scoped", async () => {
+  it("uses canonical agent session keys for exec event runs", async () => {
     loadSessionEntryMock.mockReturnValueOnce({
       ...buildSessionLookup("node-node-2"),
       canonicalKey: "agent:main:node-node-2",
@@ -160,12 +169,14 @@ describe("node exec events", () => {
       "Exec finished (node=node-2 id=run-2, code 0)\ndone",
       { sessionKey: "agent:main:node-node-2", contextKey: "exec:run-2" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
-      reason: "exec-event",
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "agent:main:node-node-2",
     });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
   });
 
-  it("falls back to unscoped wake for non-agent canonical exec session keys", async () => {
+  it("passes non-agent canonical keys to exec event run helper", async () => {
     loadSessionEntryMock.mockReturnValueOnce({
       ...buildSessionLookup("global"),
       canonicalKey: "global",
@@ -187,9 +198,11 @@ describe("node exec events", () => {
       "Exec finished (node=node-2 id=run-global, code 0)\ndone",
       { sessionKey: "global", contextKey: "exec:run-global" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
-      reason: "exec-event",
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "global",
     });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
   });
 
   it("suppresses noisy exec.finished success events with empty output", async () => {
@@ -206,6 +219,7 @@ describe("node exec events", () => {
 
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
   });
 
   it("truncates long exec.finished output in system events", async () => {
@@ -225,9 +239,11 @@ describe("node exec events", () => {
     expect(text.startsWith("Exec finished (node=node-2 id=run-long, code 0)\n")).toBe(true);
     expect(text.endsWith("…")).toBe(true);
     expect(text.length).toBeLessThan(280);
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
-      reason: "exec-event",
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "node-node-2",
     });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
   });
 
   it("enqueues exec.denied events with reason", async () => {
@@ -246,10 +262,11 @@ describe("node exec events", () => {
       "Exec denied (node=node-3 id=run-3, allowlist-miss): rm -rf /",
       { sessionKey: "agent:demo:main", contextKey: "exec:run-3" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
-      reason: "exec-event",
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
       sessionKey: "agent:demo:main",
     });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
   });
 
   it("suppresses exec.started when notifyOnExit is false", async () => {
@@ -269,6 +286,7 @@ describe("node exec events", () => {
 
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
   });
 
   it("suppresses exec.finished when notifyOnExit is false", async () => {
@@ -289,6 +307,7 @@ describe("node exec events", () => {
 
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
   });
 
   it("suppresses exec.denied when notifyOnExit is false", async () => {
@@ -309,6 +328,7 @@ describe("node exec events", () => {
 
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -93,6 +93,7 @@ function buildCtx(): NodeEventContext {
 describe("node exec events", () => {
   beforeEach(() => {
     enqueueSystemEventMock.mockClear();
+    enqueueSystemEventMock.mockReturnValue(true);
     requestHeartbeatNowMock.mockClear();
   });
 
@@ -111,7 +112,10 @@ describe("node exec events", () => {
       "Exec started (node=node-1 id=run-1): ls -la",
       { sessionKey: "agent:main:main", contextKey: "exec:run-1" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:main:main",
+    });
   });
 
   it("enqueues exec.finished events with output", async () => {
@@ -130,7 +134,10 @@ describe("node exec events", () => {
       "Exec finished (node=node-2 id=run-2, code 0)\ndone",
       { sessionKey: "node-node-2", contextKey: "exec:run-2" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "node-node-2",
+    });
   });
 
   it("suppresses noisy exec.finished success events with empty output", async () => {
@@ -166,7 +173,10 @@ describe("node exec events", () => {
     expect(text.startsWith("Exec finished (node=node-2 id=run-long, code 0)\n")).toBe(true);
     expect(text.endsWith("…")).toBe(true);
     expect(text.length).toBeLessThan(280);
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "node-node-2",
+    });
   });
 
   it("enqueues exec.denied events with reason", async () => {
@@ -185,7 +195,10 @@ describe("node exec events", () => {
       "Exec denied (node=node-3 id=run-3, allowlist-miss): rm -rf /",
       { sessionKey: "agent:demo:main", contextKey: "exec:run-3" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:demo:main",
+    });
   });
 
   it("suppresses exec.started when notifyOnExit is false", async () => {

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -139,7 +139,7 @@ describe("node exec events", () => {
     });
   });
 
-  it("canonicalizes exec event session key before enqueue and wake", async () => {
+  it("keeps fallback exec wakes unscoped when canonical key is agent-scoped", async () => {
     loadSessionEntryMock.mockReturnValueOnce({
       ...buildSessionLookup("node-node-2"),
       canonicalKey: "agent:main:node-node-2",
@@ -162,7 +162,6 @@ describe("node exec events", () => {
     );
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "exec-event",
-      sessionKey: "agent:main:node-node-2",
     });
   });
 

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -136,7 +136,6 @@ describe("node exec events", () => {
     );
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "exec-event",
-      sessionKey: "node-node-2",
     });
   });
 
@@ -164,6 +163,33 @@ describe("node exec events", () => {
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "exec-event",
       sessionKey: "agent:main:node-node-2",
+    });
+  });
+
+  it("falls back to unscoped wake for non-agent canonical exec session keys", async () => {
+    loadSessionEntryMock.mockReturnValueOnce({
+      ...buildSessionLookup("global"),
+      canonicalKey: "global",
+    });
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-2", {
+      event: "exec.finished",
+      payloadJSON: JSON.stringify({
+        runId: "run-global",
+        exitCode: 0,
+        timedOut: false,
+        output: "done",
+        sessionKey: "global",
+      }),
+    });
+
+    expect(loadSessionEntryMock).toHaveBeenCalledWith("global");
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Exec finished (node=node-2 id=run-global, code 0)\ndone",
+      { sessionKey: "global", contextKey: "exec:run-global" },
+    );
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
     });
   });
 
@@ -202,7 +228,6 @@ describe("node exec events", () => {
     expect(text.length).toBeLessThan(280);
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "exec-event",
-      sessionKey: "node-node-2",
     });
   });
 

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -111,6 +111,7 @@ describe("node exec events", () => {
         sessionKey: "agent:main:main",
         runId: "run-1",
         command: "ls -la",
+        wakeOnExit: true,
       }),
     });
 
@@ -134,6 +135,7 @@ describe("node exec events", () => {
         exitCode: 0,
         timedOut: false,
         output: "done",
+        wakeOnExit: true,
       }),
     });
 
@@ -161,6 +163,7 @@ describe("node exec events", () => {
         exitCode: 0,
         timedOut: false,
         output: "done",
+        wakeOnExit: true,
       }),
     });
 
@@ -190,6 +193,7 @@ describe("node exec events", () => {
         timedOut: false,
         output: "done",
         sessionKey: "global",
+        wakeOnExit: true,
       }),
     });
 
@@ -222,6 +226,26 @@ describe("node exec events", () => {
     expect(requestSessionEventRunMock).not.toHaveBeenCalled();
   });
 
+  it("enqueues exec events without waking when wakeOnExit is false", async () => {
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-2", {
+      event: "exec.finished",
+      payloadJSON: JSON.stringify({
+        runId: "run-no-wake",
+        exitCode: 0,
+        timedOut: false,
+        output: "done",
+      }),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Exec finished (node=node-2 id=run-no-wake, code 0)\ndone",
+      { sessionKey: "node-node-2", contextKey: "exec:run-no-wake" },
+    );
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+
   it("truncates long exec.finished output in system events", async () => {
     const ctx = buildCtx();
     await handleNodeEvent(ctx, "node-2", {
@@ -231,6 +255,7 @@ describe("node exec events", () => {
         exitCode: 0,
         timedOut: false,
         output: "x".repeat(600),
+        wakeOnExit: true,
       }),
     });
 
@@ -255,6 +280,7 @@ describe("node exec events", () => {
         runId: "run-3",
         command: "rm -rf /",
         reason: "allowlist-miss",
+        wakeOnExit: true,
       }),
     });
 
@@ -308,6 +334,34 @@ describe("node exec events", () => {
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
     expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+  });
+
+  it("allows exec.finished notifications when wakeOnExit is true even if notifyOnExit is false", async () => {
+    loadConfigMock.mockReturnValueOnce({
+      session: { mainKey: "agent:main:main" },
+      tools: { exec: { notifyOnExit: false } },
+    } as ReturnType<typeof loadConfig>);
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-2", {
+      event: "exec.finished",
+      payloadJSON: JSON.stringify({
+        runId: "run-force-notify",
+        exitCode: 0,
+        timedOut: false,
+        output: "done",
+        wakeOnExit: true,
+      }),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Exec finished (node=node-2 id=run-force-notify, code 0)\ndone",
+      { sessionKey: "node-node-2", contextKey: "exec:run-force-notify" },
+    );
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "node-node-2",
+    });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
   });
 
   it("suppresses exec.denied when notifyOnExit is false", async () => {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -4,6 +4,7 @@ import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 import { agentCommand } from "../commands/agent.js";
 import { loadConfig } from "../config/config.js";
 import { updateSessionStore } from "../config/sessions.js";
+import { shouldUseSessionScopedHeartbeatWake } from "../infra/heartbeat-reason.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
@@ -121,10 +122,6 @@ function compactExecEventOutput(raw: string) {
   }
   const safe = Math.max(1, MAX_EXEC_EVENT_OUTPUT_CHARS - 1);
   return `${normalized.slice(0, safe)}…`;
-}
-
-function shouldUseSessionScopedExecWake(sessionKey: string) {
-  return sessionKey.trim().toLowerCase().startsWith("agent:");
 }
 
 function compactNotificationEventText(raw: string) {
@@ -532,7 +529,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       if (!sessionKeyRaw) {
         return;
       }
-      const shouldUseScopedWake = shouldUseSessionScopedExecWake(sessionKeyRaw);
+      const shouldUseScopedWake = shouldUseSessionScopedHeartbeatWake(sessionKeyRaw);
       const { canonicalKey: sessionKey } = loadSessionEntry(sessionKeyRaw);
 
       // Respect tools.exec.notifyOnExit setting (default: true)

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -123,6 +123,10 @@ function compactExecEventOutput(raw: string) {
   return `${normalized.slice(0, safe)}…`;
 }
 
+function shouldUseSessionScopedExecWake(sessionKey: string) {
+  return sessionKey.trim().toLowerCase().startsWith("agent:");
+}
+
 function compactNotificationEventText(raw: string) {
   const normalized = raw.replace(/\s+/g, " ").trim();
   if (!normalized) {
@@ -577,7 +581,11 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         contextKey: runId ? `exec:${runId}` : "exec",
       });
       if (queued) {
-        requestHeartbeatNow({ reason: "exec-event", sessionKey });
+        if (shouldUseSessionScopedExecWake(sessionKey)) {
+          requestHeartbeatNow({ reason: "exec-event", sessionKey });
+        } else {
+          requestHeartbeatNow({ reason: "exec-event" });
+        }
       }
       return;
     }

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -571,8 +571,13 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         }
       }
 
-      enqueueSystemEvent(text, { sessionKey, contextKey: runId ? `exec:${runId}` : "exec" });
-      requestHeartbeatNow({ reason: "exec-event" });
+      const queued = enqueueSystemEvent(text, {
+        sessionKey,
+        contextKey: runId ? `exec:${runId}` : "exec",
+      });
+      if (queued) {
+        requestHeartbeatNow({ reason: "exec-event", sessionKey });
+      }
       return;
     }
     case "push.apns.register": {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -532,6 +532,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       if (!sessionKeyRaw) {
         return;
       }
+      const shouldUseScopedWake = shouldUseSessionScopedExecWake(sessionKeyRaw);
       const { canonicalKey: sessionKey } = loadSessionEntry(sessionKeyRaw);
 
       // Respect tools.exec.notifyOnExit setting (default: true)
@@ -581,7 +582,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         contextKey: runId ? `exec:${runId}` : "exec",
       });
       if (queued) {
-        if (shouldUseSessionScopedExecWake(sessionKey)) {
+        if (shouldUseScopedWake) {
           requestHeartbeatNow({ reason: "exec-event", sessionKey });
         } else {
           requestHeartbeatNow({ reason: "exec-event" });

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -4,12 +4,12 @@ import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 import { agentCommand } from "../commands/agent.js";
 import { loadConfig } from "../config/config.js";
 import { updateSessionStore } from "../config/sessions.js";
-import { shouldUseSessionScopedHeartbeatWake } from "../infra/heartbeat-reason.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { resolveOutboundTarget } from "../infra/outbound/targets.js";
 import { registerApnsToken } from "../infra/push-apns.js";
+import { requestSessionEventRun } from "../infra/session-event-run.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { normalizeMainKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
@@ -529,7 +529,6 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       if (!sessionKeyRaw) {
         return;
       }
-      const shouldUseScopedWake = shouldUseSessionScopedHeartbeatWake(sessionKeyRaw);
       const { canonicalKey: sessionKey } = loadSessionEntry(sessionKeyRaw);
 
       // Respect tools.exec.notifyOnExit setting (default: true)
@@ -579,11 +578,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         contextKey: runId ? `exec:${runId}` : "exec",
       });
       if (queued) {
-        if (shouldUseScopedWake) {
-          requestHeartbeatNow({ reason: "exec-event", sessionKey });
-        } else {
-          requestHeartbeatNow({ reason: "exec-event" });
-        }
+        requestSessionEventRun({ source: "exec-event", sessionKey });
       }
       return;
     }

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -523,11 +523,12 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       if (!obj) {
         return;
       }
-      const sessionKey =
+      const sessionKeyRaw =
         typeof obj.sessionKey === "string" ? obj.sessionKey.trim() : `node-${nodeId}`;
-      if (!sessionKey) {
+      if (!sessionKeyRaw) {
         return;
       }
+      const { canonicalKey: sessionKey } = loadSessionEntry(sessionKeyRaw);
 
       // Respect tools.exec.notifyOnExit setting (default: true)
       // When false, skip system event notifications for node exec events.

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -530,11 +530,13 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         return;
       }
       const { canonicalKey: sessionKey } = loadSessionEntry(sessionKeyRaw);
+      const wakeOnExit = obj.wakeOnExit === true;
 
       // Respect tools.exec.notifyOnExit setting (default: true)
-      // When false, skip system event notifications for node exec events.
+      // When false, skip system event notifications for node exec events unless
+      // this run explicitly requested wakeOnExit (which implies notifyOnExit).
       const cfg = loadConfig();
-      const notifyOnExit = cfg.tools?.exec?.notifyOnExit !== false;
+      const notifyOnExit = cfg.tools?.exec?.notifyOnExit !== false || wakeOnExit;
       if (!notifyOnExit) {
         return;
       }
@@ -577,7 +579,9 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         sessionKey,
         contextKey: runId ? `exec:${runId}` : "exec",
       });
-      if (queued) {
+      if (queued && wakeOnExit) {
+        // Known limitation: runs originating from internal webchat sessions may not emit
+        // routable outbound replies because webchat is not supported by route-reply.
         requestSessionEventRun({ source: "exec-event", sessionKey });
       }
       return;

--- a/src/infra/heartbeat-reason.test.ts
+++ b/src/infra/heartbeat-reason.test.ts
@@ -18,6 +18,7 @@ describe("heartbeat-reason", () => {
     expect(resolveHeartbeatReasonKind("interval")).toBe("interval");
     expect(resolveHeartbeatReasonKind("manual")).toBe("manual");
     expect(resolveHeartbeatReasonKind("exec-event")).toBe("exec-event");
+    expect(resolveHeartbeatReasonKind("exec:abc:exit")).toBe("exec-event");
     expect(resolveHeartbeatReasonKind("wake")).toBe("wake");
     expect(resolveHeartbeatReasonKind("cron:job-1")).toBe("cron");
     expect(resolveHeartbeatReasonKind("hook:wake")).toBe("hook");

--- a/src/infra/heartbeat-reason.test.ts
+++ b/src/infra/heartbeat-reason.test.ts
@@ -4,6 +4,7 @@ import {
   isHeartbeatEventDrivenReason,
   normalizeHeartbeatWakeReason,
   resolveHeartbeatReasonKind,
+  shouldUseSessionScopedHeartbeatWake,
 } from "./heartbeat-reason.js";
 
 describe("heartbeat-reason", () => {
@@ -51,5 +52,13 @@ describe("heartbeat-reason", () => {
     expect(isHeartbeatActionWakeReason("interval")).toBe(false);
     expect(isHeartbeatActionWakeReason("cron:job-1")).toBe(false);
     expect(isHeartbeatActionWakeReason("retry")).toBe(false);
+  });
+
+  it("uses session-scoped wake only for agent-prefixed session keys", () => {
+    expect(shouldUseSessionScopedHeartbeatWake("agent:main:main")).toBe(true);
+    expect(shouldUseSessionScopedHeartbeatWake(" agent:ops:work ")).toBe(true);
+    expect(shouldUseSessionScopedHeartbeatWake("global")).toBe(false);
+    expect(shouldUseSessionScopedHeartbeatWake("node-123")).toBe(false);
+    expect(shouldUseSessionScopedHeartbeatWake(undefined)).toBe(false);
   });
 });

--- a/src/infra/heartbeat-reason.test.ts
+++ b/src/infra/heartbeat-reason.test.ts
@@ -34,6 +34,7 @@ describe("heartbeat-reason", () => {
 
   it("matches event-driven behavior used by heartbeat preflight", () => {
     expect(isHeartbeatEventDrivenReason("exec-event")).toBe(true);
+    expect(isHeartbeatEventDrivenReason("exec:abc:exit")).toBe(true);
     expect(isHeartbeatEventDrivenReason("cron:job-1")).toBe(true);
     expect(isHeartbeatEventDrivenReason("wake")).toBe(true);
     expect(isHeartbeatEventDrivenReason("hook:gmail:sync")).toBe(true);
@@ -45,6 +46,7 @@ describe("heartbeat-reason", () => {
   it("matches action-priority wake behavior", () => {
     expect(isHeartbeatActionWakeReason("manual")).toBe(true);
     expect(isHeartbeatActionWakeReason("exec-event")).toBe(true);
+    expect(isHeartbeatActionWakeReason("exec:abc:exit")).toBe(true);
     expect(isHeartbeatActionWakeReason("hook:wake")).toBe(true);
     expect(isHeartbeatActionWakeReason("interval")).toBe(false);
     expect(isHeartbeatActionWakeReason("cron:job-1")).toBe(false);

--- a/src/infra/heartbeat-reason.ts
+++ b/src/infra/heartbeat-reason.ts
@@ -28,7 +28,7 @@ export function resolveHeartbeatReasonKind(reason?: string): HeartbeatReasonKind
   if (trimmed === "manual") {
     return "manual";
   }
-  if (trimmed === "exec-event") {
+  if (trimmed === "exec-event" || trimmed.startsWith("exec:")) {
     return "exec-event";
   }
   if (trimmed === "wake") {

--- a/src/infra/heartbeat-reason.ts
+++ b/src/infra/heartbeat-reason.ts
@@ -12,6 +12,11 @@ function trimReason(reason?: string): string {
   return typeof reason === "string" ? reason.trim() : "";
 }
 
+export function shouldUseSessionScopedHeartbeatWake(sessionKey?: string): boolean {
+  const trimmed = trimReason(sessionKey);
+  return trimmed.toLowerCase().startsWith("agent:");
+}
+
 export function normalizeHeartbeatWakeReason(reason?: string): string {
   const trimmed = trimReason(reason);
   return trimmed.length > 0 ? trimmed : "requested";

--- a/src/infra/session-event-run.test.ts
+++ b/src/infra/session-event-run.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { loadSessionEntry as loadSessionEntryType } from "../gateway/session-utils.js";
+
+const {
+  dispatchInboundMessageWithDispatcherMock,
+  createReplyPrefixOptionsMock,
+  loadSessionEntryMock,
+} = vi.hoisted(() => ({
+  dispatchInboundMessageWithDispatcherMock: vi.fn(async () => ({
+    queuedFinal: false,
+    counts: { tool: 0, block: 0, final: 0 },
+  })),
+  createReplyPrefixOptionsMock: vi.fn(() => ({
+    responsePrefix: undefined,
+    responsePrefixContextProvider: () => ({ identityName: "OpenClaw" }),
+    onModelSelected: vi.fn(),
+  })),
+  loadSessionEntryMock: vi.fn(
+    (sessionKey: string): ReturnType<typeof loadSessionEntryType> => ({
+      cfg: { session: { mainKey: "agent:main:main" } } as OpenClawConfig,
+      storePath: "/tmp/sessions.json",
+      store: {},
+      entry: {
+        sessionId: `sid-${sessionKey}`,
+        lastChannel: "telegram",
+        lastTo: "123",
+        lastAccountId: "acct-1",
+        lastThreadId: "topic-1",
+      },
+      canonicalKey: sessionKey,
+      legacyKey: undefined,
+    }),
+  ),
+}));
+
+vi.mock("../auto-reply/dispatch.js", () => ({
+  dispatchInboundMessageWithDispatcher: dispatchInboundMessageWithDispatcherMock,
+}));
+vi.mock("../channels/reply-prefix.js", () => ({
+  createReplyPrefixOptions: createReplyPrefixOptionsMock,
+}));
+vi.mock("../gateway/session-utils.js", () => ({
+  loadSessionEntry: loadSessionEntryMock,
+}));
+vi.mock("../logger.js", () => ({
+  logWarn: vi.fn(),
+}));
+
+import { triggerSessionEventRun } from "./session-event-run.js";
+
+describe("triggerSessionEventRun", () => {
+  beforeEach(() => {
+    dispatchInboundMessageWithDispatcherMock.mockClear();
+    createReplyPrefixOptionsMock.mockClear();
+    loadSessionEntryMock.mockClear();
+    loadSessionEntryMock.mockImplementation(
+      (sessionKey: string): ReturnType<typeof loadSessionEntryType> => ({
+        cfg: { session: { mainKey: "agent:main:main" } } as OpenClawConfig,
+        storePath: "/tmp/sessions.json",
+        store: {},
+        entry: {
+          sessionId: `sid-${sessionKey}`,
+          lastChannel: "telegram",
+          lastTo: "123",
+          lastAccountId: "acct-1",
+          lastThreadId: "topic-1",
+        },
+        canonicalKey: sessionKey,
+        legacyKey: undefined,
+      }),
+    );
+  });
+
+  it("dispatches a normal inbound run for agent sessions", async () => {
+    const triggered = await triggerSessionEventRun({
+      sessionKey: "agent:ops:main",
+      source: "exec-event",
+      agentId: "ops",
+    });
+
+    expect(triggered).toBe(true);
+    expect(dispatchInboundMessageWithDispatcherMock).toHaveBeenCalledTimes(1);
+    const [call] = dispatchInboundMessageWithDispatcherMock.mock.calls;
+    const params = call?.[0] as
+      | {
+          ctx?: Record<string, unknown>;
+          replyOptions?: Record<string, unknown>;
+        }
+      | undefined;
+    expect(params?.ctx?.SessionKey).toBe("agent:ops:main");
+    expect(params?.ctx?.Surface).toBe("webchat");
+    expect(params?.ctx?.OriginatingChannel).toBe("telegram");
+    expect(params?.ctx?.OriginatingTo).toBe("123");
+    expect(typeof params?.ctx?.MessageSid).toBe("string");
+    expect(params?.ctx?.MessageSid).toMatch(/^exec-event:/);
+    expect(params?.replyOptions).toMatchObject({
+      suppressTyping: true,
+      allowEmptyBodyForSystemEvent: true,
+    });
+  });
+
+  it("uses canonical agent keys from session lookup", async () => {
+    loadSessionEntryMock.mockImplementationOnce(
+      (_sessionKey: string): ReturnType<typeof loadSessionEntryType> => ({
+        cfg: { session: { mainKey: "agent:ops:work" } } as OpenClawConfig,
+        storePath: "/tmp/sessions.json",
+        store: {},
+        entry: {
+          sessionId: "sid-main",
+          lastChannel: "discord",
+          lastTo: "C123",
+        },
+        canonicalKey: "agent:ops:work",
+        legacyKey: "main",
+      }),
+    );
+
+    const triggered = await triggerSessionEventRun({
+      sessionKey: "main",
+      source: "exec-event",
+    });
+
+    expect(triggered).toBe(true);
+    const [call] = dispatchInboundMessageWithDispatcherMock.mock.calls;
+    const params = call?.[0] as { ctx?: Record<string, unknown> } | undefined;
+    expect(params?.ctx?.SessionKey).toBe("agent:ops:work");
+    expect(params?.ctx?.OriginatingChannel).toBe("discord");
+    expect(params?.ctx?.OriginatingTo).toBe("C123");
+  });
+
+  it("skips non-agent canonical session keys", async () => {
+    loadSessionEntryMock.mockImplementationOnce(
+      (_sessionKey: string): ReturnType<typeof loadSessionEntryType> => ({
+        cfg: { session: { mainKey: "agent:main:main" } } as OpenClawConfig,
+        storePath: "/tmp/sessions.json",
+        store: {},
+        entry: {
+          sessionId: "sid-global",
+        },
+        canonicalKey: "global",
+        legacyKey: undefined,
+      }),
+    );
+
+    const triggered = await triggerSessionEventRun({
+      sessionKey: "global",
+      source: "exec-event",
+    });
+
+    expect(triggered).toBe(false);
+    expect(dispatchInboundMessageWithDispatcherMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/infra/session-event-run.test.ts
+++ b/src/infra/session-event-run.test.ts
@@ -6,8 +6,9 @@ const {
   dispatchInboundMessageWithDispatcherMock,
   createReplyPrefixOptionsMock,
   loadSessionEntryMock,
+  hasSystemEventsMock,
 } = vi.hoisted(() => ({
-  dispatchInboundMessageWithDispatcherMock: vi.fn(async () => ({
+  dispatchInboundMessageWithDispatcherMock: vi.fn(async (_params: unknown) => ({
     queuedFinal: false,
     counts: { tool: 0, block: 0, final: 0 },
   })),
@@ -16,6 +17,7 @@ const {
     responsePrefixContextProvider: () => ({ identityName: "OpenClaw" }),
     onModelSelected: vi.fn(),
   })),
+  hasSystemEventsMock: vi.fn(() => true),
   loadSessionEntryMock: vi.fn(
     (sessionKey: string): ReturnType<typeof loadSessionEntryType> => ({
       cfg: { session: { mainKey: "agent:main:main" } } as OpenClawConfig,
@@ -23,6 +25,7 @@ const {
       store: {},
       entry: {
         sessionId: `sid-${sessionKey}`,
+        updatedAt: Date.now(),
         lastChannel: "telegram",
         lastTo: "123",
         lastAccountId: "acct-1",
@@ -43,6 +46,9 @@ vi.mock("../channels/reply-prefix.js", () => ({
 vi.mock("../gateway/session-utils.js", () => ({
   loadSessionEntry: loadSessionEntryMock,
 }));
+vi.mock("./system-events.js", () => ({
+  hasSystemEvents: hasSystemEventsMock,
+}));
 vi.mock("../logger.js", () => ({
   logWarn: vi.fn(),
 }));
@@ -54,6 +60,8 @@ describe("triggerSessionEventRun", () => {
     dispatchInboundMessageWithDispatcherMock.mockClear();
     createReplyPrefixOptionsMock.mockClear();
     loadSessionEntryMock.mockClear();
+    hasSystemEventsMock.mockReset();
+    hasSystemEventsMock.mockReturnValue(true);
     loadSessionEntryMock.mockImplementation(
       (sessionKey: string): ReturnType<typeof loadSessionEntryType> => ({
         cfg: { session: { mainKey: "agent:main:main" } } as OpenClawConfig,
@@ -61,6 +69,7 @@ describe("triggerSessionEventRun", () => {
         store: {},
         entry: {
           sessionId: `sid-${sessionKey}`,
+          updatedAt: Date.now(),
           lastChannel: "telegram",
           lastTo: "123",
           lastAccountId: "acct-1",
@@ -108,6 +117,7 @@ describe("triggerSessionEventRun", () => {
         store: {},
         entry: {
           sessionId: "sid-main",
+          updatedAt: Date.now(),
           lastChannel: "discord",
           lastTo: "C123",
         },
@@ -137,6 +147,7 @@ describe("triggerSessionEventRun", () => {
         store: {},
         entry: {
           sessionId: "sid-global",
+          updatedAt: Date.now(),
         },
         canonicalKey: "global",
         legacyKey: undefined,
@@ -145,6 +156,18 @@ describe("triggerSessionEventRun", () => {
 
     const triggered = await triggerSessionEventRun({
       sessionKey: "global",
+      source: "exec-event",
+    });
+
+    expect(triggered).toBe(false);
+    expect(dispatchInboundMessageWithDispatcherMock).not.toHaveBeenCalled();
+  });
+
+  it("skips dispatch when there are no queued system events", async () => {
+    hasSystemEventsMock.mockReturnValue(false);
+
+    const triggered = await triggerSessionEventRun({
+      sessionKey: "agent:ops:main",
       source: "exec-event",
     });
 

--- a/src/infra/session-event-run.ts
+++ b/src/infra/session-event-run.ts
@@ -8,6 +8,7 @@ import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { deliveryContextFromSession } from "../utils/delivery-context.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import { shouldUseSessionScopedHeartbeatWake } from "./heartbeat-reason.js";
+import { hasSystemEvents } from "./system-events.js";
 
 export async function triggerSessionEventRun(params: {
   sessionKey: string;
@@ -21,6 +22,9 @@ export async function triggerSessionEventRun(params: {
 
   const { cfg, canonicalKey, entry } = loadSessionEntry(sessionKey);
   if (!shouldUseSessionScopedHeartbeatWake(canonicalKey)) {
+    return false;
+  }
+  if (!hasSystemEvents(canonicalKey)) {
     return false;
   }
 

--- a/src/infra/session-event-run.ts
+++ b/src/infra/session-event-run.ts
@@ -1,0 +1,86 @@
+import { randomUUID } from "node:crypto";
+import { dispatchInboundMessageWithDispatcher } from "../auto-reply/dispatch.js";
+import { normalizeChannelId } from "../channels/plugins/index.js";
+import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
+import { loadSessionEntry } from "../gateway/session-utils.js";
+import { logWarn } from "../logger.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { deliveryContextFromSession } from "../utils/delivery-context.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
+import { shouldUseSessionScopedHeartbeatWake } from "./heartbeat-reason.js";
+
+export async function triggerSessionEventRun(params: {
+  sessionKey: string;
+  source: string;
+  agentId?: string;
+}): Promise<boolean> {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    return false;
+  }
+
+  const { cfg, canonicalKey, entry } = loadSessionEntry(sessionKey);
+  if (!shouldUseSessionScopedHeartbeatWake(canonicalKey)) {
+    return false;
+  }
+
+  const delivery = deliveryContextFromSession(entry);
+  const originatingChannel = delivery?.channel
+    ? (normalizeChannelId(delivery.channel) ?? delivery.channel)
+    : undefined;
+  const originatingTo = delivery?.to?.trim() || undefined;
+  const resolvedAgentId = params.agentId ?? resolveAgentIdFromSessionKey(canonicalKey);
+  const source = params.source.trim() || "system-event";
+  const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+    cfg,
+    agentId: resolvedAgentId,
+    channel: originatingChannel,
+    accountId: delivery?.accountId,
+  });
+
+  await dispatchInboundMessageWithDispatcher({
+    cfg,
+    ctx: {
+      Body: "",
+      RawBody: "",
+      CommandBody: "",
+      BodyForAgent: "",
+      BodyForCommands: "",
+      SessionKey: canonicalKey,
+      Provider: INTERNAL_MESSAGE_CHANNEL,
+      Surface: INTERNAL_MESSAGE_CHANNEL,
+      OriginatingChannel: originatingChannel,
+      OriginatingTo: originatingTo,
+      AccountId: delivery?.accountId,
+      MessageThreadId: delivery?.threadId,
+      MessageSid: `${source}:${randomUUID()}`,
+      CommandAuthorized: true,
+    },
+    dispatcherOptions: {
+      ...prefixOptions,
+      deliver: async () => {},
+      onError: (err, info) => {
+        logWarn(`session event dispatch ${info.kind} failed: ${String(err)}`);
+      },
+    },
+    replyOptions: {
+      suppressTyping: true,
+      allowEmptyBodyForSystemEvent: true,
+      onModelSelected,
+    },
+  });
+
+  return true;
+}
+
+export function requestSessionEventRun(params: {
+  sessionKey: string;
+  source: string;
+  agentId?: string;
+}) {
+  void triggerSessionEventRun(params).catch((err) => {
+    logWarn(
+      `session event run failed: source=${params.source} session=${params.sessionKey} error=${String(err)}`,
+    );
+  });
+}

--- a/src/infra/session-event-run.ts
+++ b/src/infra/session-event-run.ts
@@ -29,6 +29,8 @@ export async function triggerSessionEventRun(params: {
   }
 
   const delivery = deliveryContextFromSession(entry);
+  // Follow-up: internal webchat sessions are currently non-routable in route-reply,
+  // so event-driven runs may not produce outbound replies on webchat-bound sessions.
   const originatingChannel = delivery?.channel
     ? (normalizeChannelId(delivery.channel) ?? delivery.channel)
     : undefined;

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -49,6 +49,7 @@ type SystemRunExecutionContext = {
   sessionKey: string;
   runId: string;
   cmdText: string;
+  wakeOnExit: boolean;
 };
 
 type ResolvedExecApprovals = ReturnType<typeof resolveExecApprovals>;
@@ -133,6 +134,7 @@ export type HandleSystemRunInvokeOptions = {
     sessionKey: string;
     runId: string;
     cmdText: string;
+    wakeOnExit: boolean;
     result: {
       stdout?: string;
       stderr?: string;
@@ -164,6 +166,7 @@ async function sendSystemRunDenied(
       runId: execution.runId,
       host: "node",
       command: execution.cmdText,
+      ...(execution.wakeOnExit ? { wakeOnExit: true } : {}),
       reason: params.reason,
     }),
   );
@@ -203,6 +206,7 @@ async function parseSystemRunPhase(
   const agentId = opts.params.agentId?.trim() || undefined;
   const sessionKey = opts.params.sessionKey?.trim() || "node";
   const runId = opts.params.runId?.trim() || crypto.randomUUID();
+  const wakeOnExit = opts.params.wakeOnExit === true;
   const envOverrides = sanitizeSystemRunEnvOverrides({
     overrides: opts.params.env ?? undefined,
     shellWrapper: shellCommand !== null,
@@ -214,7 +218,7 @@ async function parseSystemRunPhase(
     agentId,
     sessionKey,
     runId,
-    execution: { sessionKey, runId, cmdText },
+    execution: { sessionKey, runId, cmdText, wakeOnExit },
     approvalDecision: resolveExecApprovalDecision(opts.params.approvalDecision),
     envOverrides,
     env: opts.sanitizeEnv(envOverrides),
@@ -383,6 +387,7 @@ async function executeSystemRunPhase(
         sessionKey: phase.sessionKey,
         runId: phase.runId,
         cmdText: phase.cmdText,
+        wakeOnExit: phase.execution.wakeOnExit,
         result,
       });
       await opts.sendInvokeResult({
@@ -450,6 +455,7 @@ async function executeSystemRunPhase(
     sessionKey: phase.sessionKey,
     runId: phase.runId,
     cmdText: phase.cmdText,
+    wakeOnExit: phase.execution.wakeOnExit,
     result,
   });
 

--- a/src/node-host/invoke-types.ts
+++ b/src/node-host/invoke-types.ts
@@ -9,6 +9,7 @@ export type SystemRunParams = {
   needsScreenRecording?: boolean | null;
   agentId?: string | null;
   sessionKey?: string | null;
+  wakeOnExit?: boolean | null;
   approved?: boolean | null;
   approvalDecision?: string | null;
   runId?: string | null;
@@ -29,6 +30,7 @@ export type ExecEventPayload = {
   runId: string;
   host: string;
   command?: string;
+  wakeOnExit?: boolean;
   exitCode?: number;
   timedOut?: boolean;
   success?: boolean;

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -262,6 +262,7 @@ async function sendExecFinishedEvent(params: {
   sessionKey: string;
   runId: string;
   cmdText: string;
+  wakeOnExit: boolean;
   result: {
     stdout?: string;
     stderr?: string;
@@ -282,6 +283,7 @@ async function sendExecFinishedEvent(params: {
       runId: params.runId,
       host: "node",
       command: params.cmdText,
+      ...(params.wakeOnExit ? { wakeOnExit: true } : {}),
       exitCode: params.result.exitCode ?? undefined,
       timedOut: params.result.timedOut,
       success: params.result.success,
@@ -479,8 +481,8 @@ export async function handleInvoke(
     sendInvokeResult: async (result) => {
       await sendInvokeResult(client, frame, result);
     },
-    sendExecFinishedEvent: async ({ sessionKey, runId, cmdText, result }) => {
-      await sendExecFinishedEvent({ client, sessionKey, runId, cmdText, result });
+    sendExecFinishedEvent: async ({ sessionKey, runId, cmdText, wakeOnExit, result }) => {
+      await sendExecFinishedEvent({ client, sessionKey, runId, cmdText, wakeOnExit, result });
     },
     preferMacAppExecHost,
   });


### PR DESCRIPTION
## Purpose

When a background exec process finishes (e.g. a coding agent like Claude Code or Codex), the agent that spawned it should be woken up immediately to act on the result. Previously, the completion notification was queued but never triggered a new turn — it only appeared when the user sent their next message.

## Summary
- Thread `sessionKey` and `agentId` through all exec wake paths so the heartbeat dispatcher targets the correct session
- Only trigger wake when system event enqueue succeeds (skip deduped/empty events)
- Add `shouldUseSessionScopedHeartbeatWake` guard: agent-scoped keys get targeted wake, non-agent keys (global, aliases, node-scoped) fall back to unscoped wake to avoid regressions
- Classify legacy `exec:*` wake reasons as `exec-event` for backward compatibility

## Testing
- `bun x vitest run src/agents/bash-tools.test.ts src/gateway/server-node-events.test.ts src/infra/heartbeat-reason.test.ts`

Fixes #18237