### PR TITLE
Fix #30924: honor normalized provider keys in elevated allowFrom

### DIFF
--- a/src/auto-reply/reply/reply-elevated.test.ts
+++ b/src/auto-reply/reply/reply-elevated.test.ts
@@ -3,12 +3,12 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { MsgContext } from "../templating.js";
 import { resolveElevatedPermissions } from "./reply-elevated.js";
 
-function buildConfig(allowFrom: string[]): OpenClawConfig {
+function buildConfig(allowFrom: string[], provider: string = "whatsapp"): OpenClawConfig {
   return {
     tools: {
       elevated: {
         allowFrom: {
-          whatsapp: allowFrom,
+          [provider]: allowFrom,
         },
       },
     },
@@ -84,6 +84,25 @@ describe("resolveElevatedPermissions", () => {
       provider: "whatsapp",
       ctx: buildContext({
         SenderUsername: "owner_username",
+      }),
+    });
+
+    expect(result.enabled).toBe(true);
+    expect(result.allowed).toBe(true);
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("uses normalized provider key when allowFrom key casing differs", () => {
+    const result = resolveElevatedPermissions({
+      cfg: buildConfig(["*"], "telegram"),
+      agentId: "main",
+      provider: "Telegram",
+      ctx: buildContext({
+        Provider: "Telegram",
+        Surface: "Telegram",
+        SenderId: "12345",
+        From: "12345",
+        SenderE164: undefined,
       }),
     });
 

--- a/src/auto-reply/reply/reply-elevated.ts
+++ b/src/auto-reply/reply/reply-elevated.ts
@@ -23,8 +23,16 @@ function resolveElevatedAllowList(
   if (!allowFrom) {
     return fallbackAllowFrom;
   }
-  const value = allowFrom[provider];
-  return Array.isArray(value) ? value : fallbackAllowFrom;
+  const direct = allowFrom[provider];
+  if (Array.isArray(direct)) {
+    return direct;
+  }
+  const normalizedProvider = normalizeChannelId(provider);
+  if (!normalizedProvider || normalizedProvider === provider) {
+    return fallbackAllowFrom;
+  }
+  const normalized = allowFrom[normalizedProvider];
+  return Array.isArray(normalized) ? normalized : fallbackAllowFrom;
 }
 
 function resolveAllowFromFormatter(params: {


### PR DESCRIPTION
## Summary
- fix elevated allowFrom lookup to fall back to normalized provider keys
- keep direct key lookup first for backward compatibility
- add regression test for provider casing mismatch (Telegram request + telegram config key)

## Why
allowFrom could be ignored when runtime provider casing/alias differed from config keys, causing approvals to be requested unexpectedly.
