### PR TITLE
fix(thinking): add openai/gpt-5.2-pro to xhigh-capable model list

### DIFF
--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -23,6 +23,7 @@ export function isBinaryThinkingProvider(provider?: string | null): boolean {
 
 export const XHIGH_MODEL_REFS = [
   "openai/gpt-5.2",
+  "openai/gpt-5.2-pro",
   "openai-codex/gpt-5.3-codex",
   "openai-codex/gpt-5.3-codex-spark",
   "openai-codex/gpt-5.2-codex",


### PR DESCRIPTION
## Summary

- `openai/gpt-5.2-pro` was missing from `XHIGH_MODEL_REFS` in `src/auto-reply/thinking.ts`
- `supportsXHighThinking()` uses exact string matching against this list — no prefix or fuzzy matching
- `openai/gpt-5.2` was present, but `openai/gpt-5.2-pro` was not, causing the gateway to silently downgrade any xhigh request for gpt-5.2-pro to `high`
- GPT-5.2-pro supports medium, high, and xhigh per OpenAI's capability docs

## Change

Added `"openai/gpt-5.2-pro"` to `XHIGH_MODEL_REFS` alongside the existing `"openai/gpt-5.2"` entry.

## Test plan

- [ ] Confirm `supportsXHighThinking("openai", "gpt-5.2-pro")` returns `true`
- [ ] Confirm existing entries (`openai/gpt-5.2`, `openai-codex/*`, `github-copilot/*`) are unaffected
- [ ] Confirm a non-listed model (e.g. `openai/gpt-4o`) still returns `false`
- [ ] Confirm `listThinkingLevels("openai", "gpt-5.2-pro")` now includes `"xhigh"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)