### PR TITLE
fix(googlechat): handle thread replies and Add-on event types

### DIFF
--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -128,7 +128,11 @@ export async function sendGoogleChatMessage(params: {
       ...(item.contentName ? { contentName: item.contentName } : {}),
     }));
   }
-  const url = `${CHAT_API_BASE}/${space}/messages`;
+  const urlObj = new URL(`${CHAT_API_BASE}/${space}/messages`);
+  if (thread) {
+    urlObj.searchParams.set("messageReplyOption", "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD");
+  }
+  const url = urlObj.toString();
   const result = await fetchJson<{ name?: string }>(account, url, {
     method: "POST",
     body: JSON.stringify(body),


### PR DESCRIPTION
## Problems Fixed

### 1. Thread replies not routed correctly
When replying to an existing thread in Google Chat, messages were not correctly threaded. The `thread.name` was sent in the request body, but the Google Chat API also requires a `messageReplyOption` query parameter.

**Fix:** Added `messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD` as a query parameter when a `thread` is specified.

### 2. Add-on non-MESSAGE events causing 400 errors
When the Chat app is configured as a Google Workspace Add-on, Google Chat sends events in the Add-on format (`commonEventObject.hostApp=CHAT`). Previously, only MESSAGE events (`chat.messagePayload`) were handled. Other event types like `ADDED_TO_SPACE` and `REMOVED_FROM_SPACE` were not transformed, causing 400 'invalid payload' responses — which then caused Google Chat to stop sending events entirely.

**Fix:**
- Handle `ADDED_TO_SPACE` events (`chat.addedToSpacePayload`)
- Handle `REMOVED_FROM_SPACE` events (`chat.removedFromSpacePayload`)
- For unknown Add-on event types, respond 200 to avoid error logs
- Move `systemIdToken` extraction before event-type branching

## References
- Google Chat API: https://developers.google.com/workspace/chat/create-messages
- Google Workspace Add-ons Chat format: https://developers.google.com/workspace/add-ons/chat/build