### PR TITLE
fix(telegram): stop typing indicator when agent returns empty reply

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -548,7 +548,7 @@ export const dispatchTelegramMessage = async ({
             reasoningStepState.resetForNextStep();
           }
           const canSendAsIs =
-            hasMedia || typeof payload.text !== "string" || payload.text.length > 0;
+            hasMedia || (typeof payload.text === "string" && payload.text.length > 0);
           if (!canSendAsIs) {
             if (info.kind === "final") {
               await flushBufferedFinalAnswer();


### PR DESCRIPTION
## Summary

- Fix null/undefined guard in the Telegram delivery pipeline that caused the typing indicator to stay active for 2 minutes when an agent returned no text reply
- The `canSendAsIs` condition in `bot-message-dispatch.ts` only handled empty strings (`""`), not `null`/`undefined` — when `payload.text` was nullish, `typeof payload.text !== "string"` short-circuited to `true`, calling `sendPayload` which hit the Telegram API 400 error (`text must be non-empty`), leaving the typing indicator stuck until TTL

## Changes

**`src/telegram/bot-message-dispatch.ts`**

Before (buggy):
```ts
const canSendAsIs =
  hasMedia || typeof payload.text !== "string" || payload.text.length > 0;
```

After (fixed):
```ts
const canSendAsIs =
  hasMedia || (typeof payload.text === "string" && payload.text.length > 0);
```

This ensures `null`/`undefined` text (without media) correctly skips sending and lets the typing indicator clean up immediately.

Closes #30731

## Test plan

- [ ] Trigger an agent run that produces no text output (e.g., tool-only run or early return with no assistant message) on a Telegram channel
- [ ] Verify the typing indicator stops immediately instead of persisting for 2 minutes
- [ ] Verify normal text replies and media-only replies still work correctly
- [ ] Verify empty string replies (`""`) continue to be skipped (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)