### PR TITLE
fix(slack): use session lookup for announce target in multi-account setups

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -67,6 +67,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
   id: "slack",
   meta: {
     ...meta,
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: slackOnboardingAdapter,
   pairing: {

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -78,6 +78,26 @@ const installRegistry = async () => {
           },
         },
       },
+      {
+        pluginId: "slack",
+        source: "test",
+        plugin: {
+          id: "slack",
+          meta: {
+            id: "slack",
+            label: "Slack",
+            selectionLabel: "Slack",
+            docsPath: "/channels/slack",
+            blurb: "Slack test stub.",
+            preferSessionLookupForAnnounceTarget: true,
+          },
+          capabilities: { chatTypes: ["direct", "channel", "thread"] },
+          config: {
+            listAccountIds: () => ["default"],
+            resolveAccount: () => ({}),
+          },
+        },
+      },
     ]),
   );
 };
@@ -188,6 +208,35 @@ describe("resolveAnnounceTarget", () => {
       channel: "whatsapp",
       to: "123@g.us",
       accountId: "work",
+    });
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const first = callGatewayMock.mock.calls[0]?.[0] as { method?: string } | undefined;
+    expect(first).toBeDefined();
+    expect(first?.method).toBe("sessions.list");
+  });
+
+  it("hydrates Slack accountId from sessions.list when available", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:slack:channel:C123",
+          deliveryContext: {
+            channel: "slack",
+            to: "channel:C123",
+            accountId: "forge",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:slack:channel:C123",
+      displayKey: "agent:main:slack:channel:C123",
+    });
+    expect(target).toEqual({
+      channel: "slack",
+      to: "channel:C123",
+      accountId: "forge",
     });
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
     const first = callGatewayMock.mock.calls[0]?.[0] as { method?: string } | undefined;


### PR DESCRIPTION
## Summary
- enable `preferSessionLookupForAnnounceTarget` in the Slack channel plugin meta
- ensure `resolveAnnounceTarget()` hydrates Slack `accountId` from `sessions.list` delivery context
- add a regression test for Slack announce target hydration

## Why
In multi-account Slack setups, `sessions_send` announce replies could be sent with the default bot token because announce target resolution skipped session-store lookup and lost `accountId`.

Fixes #30956

## Testing
- `pnpm vitest run src/agents/tools/sessions.test.ts`
