### PR TITLE
fix(control-ui): restore full-width layout for Debug Event Log payloads

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1191,6 +1191,21 @@
   width: 100%;
 }
 
+/* Debug event log payloads should use full width like other debug sections. */
+.debug-event-log__item {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.debug-event-log__meta {
+  min-width: 0;
+  text-align: left;
+}
+
+.debug-event-log__payload {
+  margin: 0;
+  max-width: 100%;
+}
+
 /* Cron jobs: allow long payload/state text and keep action buttons inside the card. */
 .cron-job-payload,
 .cron-job-agent,

--- a/ui/src/ui/views/debug.ts
+++ b/ui/src/ui/views/debug.ts
@@ -131,7 +131,7 @@ export function renderDebug(props: DebugProps) {
               ${props.eventLog.map(
                 (evt) => html`
                   <div class="list-item debug-event-log__item">
-                    <div class="list-main debug-event-log__main">
+                    <div class="list-main">
                       <div class="list-title">${evt.event}</div>
                       <div class="list-sub">${new Date(evt.ts).toLocaleTimeString()}</div>
                     </div>

--- a/ui/src/ui/views/debug.ts
+++ b/ui/src/ui/views/debug.ts
@@ -127,16 +127,18 @@ export function renderDebug(props: DebugProps) {
               <div class="muted" style="margin-top: 12px">No events yet.</div>
             `
           : html`
-            <div class="list" style="margin-top: 12px;">
+            <div class="list debug-event-log" style="margin-top: 12px;">
               ${props.eventLog.map(
                 (evt) => html`
-                  <div class="list-item">
-                    <div class="list-main">
+                  <div class="list-item debug-event-log__item">
+                    <div class="list-main debug-event-log__main">
                       <div class="list-title">${evt.event}</div>
                       <div class="list-sub">${new Date(evt.ts).toLocaleTimeString()}</div>
                     </div>
-                    <div class="list-meta">
-                      <pre class="code-block">${formatEventPayload(evt.payload)}</pre>
+                    <div class="list-meta debug-event-log__meta">
+                      <pre class="code-block debug-event-log__payload">${formatEventPayload(
+                        evt.payload,
+                      )}</pre>
                     </div>
                   </div>
                 `,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: In `Settings → Debug → Event Log`, event payloads were rendered in the generic two-column list layout, causing payload content to appear squished into a constrained right-side column.
- Why it matters: Event payloads are high-signal debugging data; compressed rendering hurts readability and slows troubleshooting.
- What changed: Added Event Log-specific classes in `ui/src/ui/views/debug.ts` and scoped CSS overrides in `ui/src/styles/components.css` so Event Log entries render as single-column cards with full-width payload blocks.
- What did NOT change (scope boundary): No gateway logic, event data shape, RPC behavior, model/status rendering, or APIs were changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `Settings → Debug → Event Log` now displays each event entry in a full-width layout (no squished right column), matching readability expectations from nearby debug sections (e.g., Models).

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: OpenClaw local install
- Model/provider: N/A (UI-only change)
- Integration/channel (if any): N/A
- Relevant config (redacted): default control UI

### Steps

1. Open Control UI and navigate to `Settings → Debug`.
2. Inspect `Event Log` with one or more events containing JSON payloads.
3. Compare payload readability before vs after this patch.

### Expected

- Event payloads render full width and are easy to read.

### Actual

- Before fix: payload content appeared compressed in a narrow right-side column.
- After fix: payload content renders full width.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before: 

<img width="946" height="314" alt="Screenshot 2026-03-01 113847" src="https://github.com/user-attachments/assets/ea672152-8f45-423f-ad16-a9a47e8834e6" />


After:
[
<img width="1878" height="830" alt="after" src="https://github.com/user-attachments/assets/42ec049b-3220-4344-add5-12e829a41fe5" />
](url)


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Event Log with real incoming events in Debug view; hard refresh + gateway restart; confirmed corrected layout.
- Edge cases checked: Empty state (`No events yet`) remains unchanged.
- What you did **not** verify: Full visual regression sweep across all list-based views.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `8c342ab95`.
- Files/config to restore:
- `ui/src/ui/views/debug.ts`
- `ui/src/styles/components.css`
- Known bad symptoms reviewers should watch for: Event Log entries unexpectedly reverting to two-column compressed layout.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Scoped CSS class names could diverge from template if Event Log markup changes in future refactors.
- Mitigation: Classes are co-located in `debug.ts` and intentionally narrow in scope; easy to update together.