### PR TITLE
fix(telegram): expose account_id in inbound meta system prompt

### DIFF
--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -60,6 +60,7 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   const payload = {
     schema: "openclaw.inbound_meta.v1",
     chat_id: safeTrim(ctx.OriginatingTo),
+    account_id: safeTrim(ctx.AccountId),
     channel: channelValue,
     provider: safeTrim(ctx.Provider),
     surface: safeTrim(ctx.Surface),


### PR DESCRIPTION
## Problem

When multiple Telegram accounts are connected to OpenClaw, the `account_id` field is missing from the inbound meta system prompt. This makes it impossible for agents to distinguish *which* account a message arrived on — routing logic, multi-account setups, and per-account personas all break silently.

## Fix

Add `account_id: safeTrim(ctx.AccountId)` to the `payload` object in `buildInboundMetaSystemPrompt`, immediately after `chat_id`.

```diff
 const payload = {
   schema: "openclaw.inbound_meta.v1",
   chat_id: safeTrim(ctx.OriginatingTo),
+  account_id: safeTrim(ctx.AccountId),
   channel: channelValue,
```

`ctx.AccountId` is already available on `TemplateContext` and populated by the gateway — this is a one-line omission in the serialization step.

## Impact

- Multi-account Telegram setups can now correctly identify the receiving account
- No breaking changes — `account_id` is an additive field
- Consistent with how `chat_id` and `channel` are already exposed

## Testing

Verified in production across a 4-agent setup with multiple Telegram accounts. The field appears correctly in the system prompt JSON block after the fix.