### PR TITLE
fix: fall back to thinking "off" when provider rejects unsupported level

### DIFF
--- a/src/agents/pi-embedded-helpers/thinking.test.ts
+++ b/src/agents/pi-embedded-helpers/thinking.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { pickFallbackThinkingLevel } from "./thinking.js";
+
+describe("pickFallbackThinkingLevel", () => {
+  it("returns undefined for empty message", () => {
+    expect(pickFallbackThinkingLevel({ message: "", attempted: new Set() })).toBeUndefined();
+  });
+
+  it("returns undefined for undefined message", () => {
+    expect(pickFallbackThinkingLevel({ message: undefined, attempted: new Set() })).toBeUndefined();
+  });
+
+  it("extracts supported values from error message", () => {
+    const result = pickFallbackThinkingLevel({
+      message: 'Supported values are: "high", "medium"',
+      attempted: new Set(),
+    });
+    expect(result).toBe("high");
+  });
+
+  it("skips already attempted values", () => {
+    const result = pickFallbackThinkingLevel({
+      message: 'Supported values are: "high", "medium"',
+      attempted: new Set(["high"]),
+    });
+    expect(result).toBe("medium");
+  });
+
+  it('falls back to "off" when error says "not supported" without listing values', () => {
+    const result = pickFallbackThinkingLevel({
+      message: '400 think value "low" is not supported for this model',
+      attempted: new Set(),
+    });
+    expect(result).toBe("off");
+  });
+
+  it('falls back to "off" for generic not-supported messages', () => {
+    const result = pickFallbackThinkingLevel({
+      message: "thinking level not supported by this provider",
+      attempted: new Set(),
+    });
+    expect(result).toBe("off");
+  });
+
+  it('returns undefined if "off" was already attempted', () => {
+    const result = pickFallbackThinkingLevel({
+      message: '400 think value "low" is not supported for this model',
+      attempted: new Set(["off"]),
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for unrelated error messages", () => {
+    const result = pickFallbackThinkingLevel({
+      message: "rate limit exceeded, please retry after 30 seconds",
+      attempted: new Set(),
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/agents/pi-embedded-helpers/thinking.ts
+++ b/src/agents/pi-embedded-helpers/thinking.ts
@@ -29,6 +29,14 @@ export function pickFallbackThinkingLevel(params: {
   }
   const supported = extractSupportedValues(raw);
   if (supported.length === 0) {
+    // When the error clearly indicates the thinking level is unsupported but doesn't
+    // list supported values (e.g. OpenAI's "think value \"low\" is not supported for
+    // this model"), fall back to "off" to allow the request to succeed.
+    // This commonly happens during model fallback when switching from Anthropic
+    // (which supports thinking levels) to providers that don't.
+    if (/not supported/i.test(raw) && !params.attempted.has("off")) {
+      return "off";
+    }
     return undefined;
   }
   for (const entry of supported) {


### PR DESCRIPTION
## Problem

When model fallback switches from Anthropic (which supports thinking levels like `"low"`, `"medium"`, `"high"`) to providers like OpenAI, the thinking parameter is passed through unchanged. If the target provider rejects it with a "not supported" error:

```
400 think value "low" is not supported for this model
```

The error message does not include "supported values are: ..." so `pickFallbackThinkingLevel` returns `undefined`, causing the request to fail entirely instead of retrying without thinking.

## Fix

When the error message contains "not supported" but does not list supported values, fall back to `"off"` — the universal safe default that all providers support.

This commonly happens during model fallback: `opus → sonnet → openai/gpt-5.2 (thinking=low → 400 error → stuck)`.

## Changes

- `src/agents/pi-embedded-helpers/thinking.ts`: Added "not supported" fallback to `"off"` when no supported values are listed
- `src/agents/pi-embedded-helpers/thinking.test.ts`: Added 8 unit tests for `pickFallbackThinkingLevel` including the new behavior

## Testing

All 8 tests pass:
```
✓ src/agents/pi-embedded-helpers/thinking.test.ts (8 tests) 2ms
```