### PR TITLE
refactor(memory): consolidate QMD subprocess spawning via runSubprocess

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@
 - In tests, prefer per-instance stubs over prototype mutation (`SomeClass.prototype.method = ...`) unless a test explicitly documents why prototype-level patching is required.
 - Add brief code comments for tricky or non-obvious logic.
 - Keep files concise; extract helpers instead of “V2” copies. Use existing patterns for CLI options and dependency injection via `createDefaultDeps`.
+- QMD subprocess spawning: use `QmdMemoryManager.runSubprocess()` for all subprocess invocations in `src/memory/qmd-manager.ts`. Do not add inline `spawn()` calls; add thin wrappers that delegate to `runSubprocess()` instead.
 - Aim to keep files under ~700 LOC; guideline only (not a hard guardrail). Split/refactor when it improves clarity or testability.
 - Naming: use **OpenClaw** for product/app/docs headings; use `openclaw` for CLI command, package/binary, paths, and config keys.
 

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -2339,6 +2339,128 @@ describe("QmdMemoryManager", () => {
       }
     });
   });
+
+  describe("runQmd delegates to runSubprocess", () => {
+    it("passes the configured qmd command and 'qmd' label to spawn", async () => {
+      spawnMock.mockImplementation(() => createMockChild());
+      const { manager } = await createManager();
+
+      // Trigger a runQmd call via the public sync() method.
+      await manager.sync();
+
+      // Verify it uses the configured command (default: "qmd").
+      const updateCall = spawnMock.mock.calls.find((call: string[][]) => call[1]?.[0] === "update");
+      expect(updateCall).toBeDefined();
+      expect(updateCall![0]).toBe("qmd");
+      await manager.close();
+    });
+
+    it("propagates timeout errors with the 'qmd' label", async () => {
+      spawnMock.mockImplementation(() => createMockChild({ autoClose: false }));
+      const shortTimeoutCfg: OpenClawConfig = {
+        ...cfg,
+        memory: {
+          ...cfg.memory,
+          qmd: {
+            ...cfg.memory!.qmd!,
+            limits: { timeoutMs: 1 },
+          },
+        },
+      };
+      const { manager } = await createManager({ cfg: shortTimeoutCfg });
+
+      await expect(
+        manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" }),
+      ).rejects.toThrow(/^qmd .* timed out/);
+      await manager.close();
+    });
+
+    it("propagates failure errors with the 'qmd' label", async () => {
+      spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+        if (args[0] === "search") {
+          const child = createMockChild({ autoClose: false });
+          emitAndClose(child, "stderr", "something broke", 1);
+          return child;
+        }
+        return createMockChild();
+      });
+      const { manager } = await createManager();
+
+      await expect(
+        manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" }),
+      ).rejects.toThrow(/^qmd .* failed/);
+      await manager.close();
+    });
+
+    it("propagates spawn errors (e.g. ENOENT) through runSubprocess", async () => {
+      spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+        if (args[0] === "search") {
+          const child = createMockChild({ autoClose: false });
+          queueMicrotask(() => {
+            child.emit("error", new Error("spawn ENOENT"));
+          });
+          return child;
+        }
+        return createMockChild();
+      });
+      const { manager } = await createManager();
+
+      await expect(
+        manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" }),
+      ).rejects.toThrow(/spawn ENOENT/);
+      await manager.close();
+    });
+
+    it("rejects with output-cap error when stderr exceeds limit", async () => {
+      const noisyPayload = "e".repeat(240_000);
+      spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+        if (args[0] === "search") {
+          const child = createMockChild({ autoClose: false });
+          emitAndClose(child, "stderr", noisyPayload);
+          return child;
+        }
+        return createMockChild();
+      });
+      const { manager } = await createManager();
+
+      await expect(
+        manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" }),
+      ).rejects.toThrow(/too much output/);
+      await manager.close();
+    });
+
+    it("includes stderr in failure message when stdout is empty", async () => {
+      spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+        if (args[0] === "search") {
+          const child = createMockChild({ autoClose: false });
+          emitAndClose(child, "stderr", "detailed error info", 2);
+          return child;
+        }
+        return createMockChild();
+      });
+      const { manager } = await createManager();
+
+      await expect(
+        manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" }),
+      ).rejects.toThrow(/detailed error info/);
+      await manager.close();
+    });
+
+    it("passes env and cwd to the spawned subprocess", async () => {
+      spawnMock.mockImplementation(() => createMockChild());
+      const { manager } = await createManager();
+
+      await manager.sync();
+
+      const updateCall = spawnMock.mock.calls.find((call: string[][]) => call[1]?.[0] === "update");
+      expect(updateCall).toBeDefined();
+      // Third arg is spawn options with env and cwd.
+      const spawnOpts = updateCall![2] as { env: Record<string, string>; cwd: string };
+      expect(spawnOpts.cwd).toBe(workspaceDir);
+      expect(spawnOpts.env).toBeDefined();
+      await manager.close();
+    });
+  });
 });
 
 function createDeferred<T>() {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1061,12 +1061,25 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
   }
 
-  private async runQmd(
-    args: string[],
-    opts?: { timeoutMs?: number; discardOutput?: boolean },
-  ): Promise<{ stdout: string; stderr: string }> {
+  /**
+   * Canonical method for spawning QMD-related subprocesses. All subprocess
+   * invocations in this class should go through this method so that timeout,
+   * output-cap, error-reporting, and spawn options are maintained in one place.
+   */
+  private async runSubprocess(params: {
+    command: string;
+    args: string[];
+    label: string;
+    timeoutMs?: number;
+    discardOutput?: boolean;
+  }): Promise<{ stdout: string; stderr: string }> {
+    const { command, args, label, timeoutMs } = params;
+    // When discardOutput is set, skip stdout accumulation entirely and keep
+    // only a small stderr tail for diagnostics -- never fail on truncation.
+    // This prevents large `qmd update` runs from hitting the output cap.
+    const discard = params.discardOutput === true;
     return await new Promise((resolve, reject) => {
-      const child = spawn(resolveWindowsCommandShim(this.qmd.command), args, {
+      const child = spawn(resolveWindowsCommandShim(command), args, {
         env: this.env,
         cwd: this.workspaceDir,
       });
@@ -1074,15 +1087,11 @@ export class QmdMemoryManager implements MemorySearchManager {
       let stderr = "";
       let stdoutTruncated = false;
       let stderrTruncated = false;
-      // When discardOutput is set, skip stdout accumulation entirely and keep
-      // only a small stderr tail for diagnostics -- never fail on truncation.
-      // This prevents large `qmd update` runs from hitting the output cap.
-      const discard = opts?.discardOutput === true;
-      const timer = opts?.timeoutMs
+      const timer = timeoutMs
         ? setTimeout(() => {
             child.kill("SIGKILL");
-            reject(new Error(`qmd ${args.join(" ")} timed out after ${opts.timeoutMs}ms`));
-          }, opts.timeoutMs)
+            reject(new Error(`${label} ${args.join(" ")} timed out after ${timeoutMs}ms`));
+          }, timeoutMs)
         : null;
       child.stdout.on("data", (data) => {
         if (discard) {
@@ -1110,7 +1119,7 @@ export class QmdMemoryManager implements MemorySearchManager {
         if (!discard && (stdoutTruncated || stderrTruncated)) {
           reject(
             new Error(
-              `qmd ${args.join(" ")} produced too much output (limit ${this.maxQmdOutputChars} chars)`,
+              `${label} ${args.join(" ")} produced too much output (limit ${this.maxQmdOutputChars} chars)`,
             ),
           );
           return;
@@ -1118,9 +1127,24 @@ export class QmdMemoryManager implements MemorySearchManager {
         if (code === 0) {
           resolve({ stdout, stderr });
         } else {
-          reject(new Error(`qmd ${args.join(" ")} failed (code ${code}): ${stderr || stdout}`));
+          reject(
+            new Error(`${label} ${args.join(" ")} failed (code ${code}): ${stderr || stdout}`),
+          );
         }
       });
+    });
+  }
+
+  private async runQmd(
+    args: string[],
+    opts?: { timeoutMs?: number; discardOutput?: boolean },
+  ): Promise<{ stdout: string; stderr: string }> {
+    return this.runSubprocess({
+      command: this.qmd.command,
+      args,
+      label: "qmd",
+      timeoutMs: opts?.timeoutMs,
+      discardOutput: opts?.discardOutput,
     });
   }
 
@@ -1163,58 +1187,11 @@ export class QmdMemoryManager implements MemorySearchManager {
     args: string[],
     opts?: { timeoutMs?: number },
   ): Promise<{ stdout: string; stderr: string }> {
-    return await new Promise((resolve, reject) => {
-      const child = spawn(resolveWindowsCommandShim("mcporter"), args, {
-        // Keep mcporter and direct qmd commands on the same agent-scoped XDG state.
-        env: this.env,
-        cwd: this.workspaceDir,
-      });
-      let stdout = "";
-      let stderr = "";
-      let stdoutTruncated = false;
-      let stderrTruncated = false;
-      const timer = opts?.timeoutMs
-        ? setTimeout(() => {
-            child.kill("SIGKILL");
-            reject(new Error(`mcporter ${args.join(" ")} timed out after ${opts.timeoutMs}ms`));
-          }, opts.timeoutMs)
-        : null;
-      child.stdout.on("data", (data) => {
-        const next = appendOutputWithCap(stdout, data.toString("utf8"), this.maxQmdOutputChars);
-        stdout = next.text;
-        stdoutTruncated = stdoutTruncated || next.truncated;
-      });
-      child.stderr.on("data", (data) => {
-        const next = appendOutputWithCap(stderr, data.toString("utf8"), this.maxQmdOutputChars);
-        stderr = next.text;
-        stderrTruncated = stderrTruncated || next.truncated;
-      });
-      child.on("error", (err) => {
-        if (timer) {
-          clearTimeout(timer);
-        }
-        reject(err);
-      });
-      child.on("close", (code) => {
-        if (timer) {
-          clearTimeout(timer);
-        }
-        if (stdoutTruncated || stderrTruncated) {
-          reject(
-            new Error(
-              `mcporter ${args.join(" ")} produced too much output (limit ${this.maxQmdOutputChars} chars)`,
-            ),
-          );
-          return;
-        }
-        if (code === 0) {
-          resolve({ stdout, stderr });
-        } else {
-          reject(
-            new Error(`mcporter ${args.join(" ")} failed (code ${code}): ${stderr || stdout}`),
-          );
-        }
-      });
+    return this.runSubprocess({
+      command: "mcporter",
+      args,
+      label: "mcporter",
+      timeoutMs: opts?.timeoutMs,
     });
   }
 


### PR DESCRIPTION
## Summary
- Extracted a single `runSubprocess()` method in `QmdMemoryManager` that centralizes all subprocess spawn/timeout/output-cap/error-reporting logic
- Reduced `runQmd()` to a thin wrapper (~6 lines) that delegates to `runSubprocess()` with the appropriate command and label
- Added JSDoc on `runSubprocess()` directing contributors to use it for future subprocess calls
- Added AGENTS.md guidance for the pattern
- Added tests covering delegation behavior, spawn errors (ENOENT), stderr output cap, error message propagation, and env/cwd forwarding

Closes #31014

## Test plan
- [x] All 44 existing + new tests pass (`pnpm test src/memory/qmd-manager.test.ts`)
- [x] TypeScript typecheck passes (`pnpm tsgo`)
- [x] Lint/format clean (`pnpm check`, `pnpm format`)
- [x] No behavior change for any caller — `runQmd` signature and semantics unchanged