### PR TITLE
fix(discord): add reconnect watchdog for silent WebSocket drops

### DIFF
--- a/src/discord/monitor.gateway.test.ts
+++ b/src/discord/monitor.gateway.test.ts
@@ -81,4 +81,76 @@ describe("waitForDiscordGatewayStop", () => {
 
     await expect(promise).resolves.toBeUndefined();
   });
+
+  it("rejects via registerForceStop and disconnects gateway", async () => {
+    const emitter = new EventEmitter();
+    const disconnect = vi.fn();
+    const abort = new AbortController();
+    let forceStop: ((err: unknown) => void) | undefined;
+
+    const promise = waitForDiscordGatewayStop({
+      gateway: { emitter, disconnect },
+      abortSignal: abort.signal,
+      registerForceStop: (fn) => {
+        forceStop = fn;
+      },
+    });
+
+    expect(forceStop).toBeDefined();
+
+    const err = new Error("reconnect watchdog timeout");
+    forceStop!(err);
+
+    await expect(promise).rejects.toThrow("reconnect watchdog timeout");
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(emitter.listenerCount("error")).toBe(0);
+
+    // Subsequent abort is a no-op (already settled).
+    abort.abort();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("forceStop is idempotent — second call has no effect", async () => {
+    const emitter = new EventEmitter();
+    const disconnect = vi.fn();
+    const abort = new AbortController();
+    let forceStop: ((err: unknown) => void) | undefined;
+
+    const promise = waitForDiscordGatewayStop({
+      gateway: { emitter, disconnect },
+      abortSignal: abort.signal,
+      registerForceStop: (fn) => {
+        forceStop = fn;
+      },
+    });
+
+    const err = new Error("watchdog");
+    forceStop!(err);
+    forceStop!(new Error("second call — should be ignored"));
+
+    await expect(promise).rejects.toThrow("watchdog");
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("abort wins over registerForceStop when abort fires first", async () => {
+    const emitter = new EventEmitter();
+    const disconnect = vi.fn();
+    const abort = new AbortController();
+    let forceStop: ((err: unknown) => void) | undefined;
+
+    const promise = waitForDiscordGatewayStop({
+      gateway: { emitter, disconnect },
+      abortSignal: abort.signal,
+      registerForceStop: (fn) => {
+        forceStop = fn;
+      },
+    });
+
+    abort.abort();
+    await expect(promise).resolves.toBeUndefined();
+
+    // forceStop called after settlement is a no-op.
+    forceStop!(new Error("too late"));
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/discord/monitor.gateway.ts
+++ b/src/discord/monitor.gateway.ts
@@ -14,6 +14,13 @@ export async function waitForDiscordGatewayStop(params: {
   abortSignal?: AbortSignal;
   onGatewayError?: (err: unknown) => void;
   shouldStopOnError?: (err: unknown) => boolean;
+  /**
+   * Optional callback that receives a `forceStop(err)` function. Callers can
+   * invoke it to force-reject the waiting promise (e.g. from a reconnect
+   * watchdog timer) without having to emit a synthetic error event on the
+   * gateway emitter.
+   */
+  registerForceStop?: (forceStop: (err: unknown) => void) => void;
 }): Promise<void> {
   const { gateway, abortSignal, onGatewayError, shouldStopOnError } = params;
   const emitter = gateway?.emitter;
@@ -65,5 +72,9 @@ export async function waitForDiscordGatewayStop(params: {
 
     abortSignal?.addEventListener("abort", onAbort, { once: true });
     emitter?.on("error", onGatewayErrorEvent);
+
+    // Expose finishReject so external watchdog timers can force-stop without
+    // needing to emit a synthetic error event on the gateway emitter.
+    params.registerForceStop?.(finishReject);
   });
 }

--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -1,5 +1,6 @@
+import { EventEmitter } from "node:events";
 import type { Client } from "@buape/carbon";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../../runtime.js";
 
 const {
@@ -116,5 +117,152 @@ describe("runDiscordGatewayLifecycle", () => {
     await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
 
     expectLifecycleCleanup({ start, stop, threadStop, waitCalls: 1 });
+  });
+});
+
+describe("reconnect watchdog", () => {
+  // Each test uses fake timers so we can advance the 5-minute watchdog without
+  // waiting for real wall-clock time.
+  afterEach(() => {
+    vi.useRealTimers();
+    attachDiscordGatewayLoggingMock.mockReset();
+    getDiscordGatewayEmitterMock.mockReset();
+    waitForDiscordGatewayStopMock.mockReset();
+    registerGatewayMock.mockReset();
+    unregisterGatewayMock.mockReset();
+    stopGatewayLoggingMock.mockReset();
+    attachDiscordGatewayLoggingMock.mockImplementation(() => stopGatewayLoggingMock);
+    getDiscordGatewayEmitterMock.mockReturnValue(undefined);
+    waitForDiscordGatewayStopMock.mockResolvedValue(undefined);
+  });
+
+  /**
+   * Build a test harness where:
+   * - The gateway has a real EventEmitter so debug events can be simulated.
+   * - `waitForDiscordGatewayStop` is mocked to capture the `registerForceStop`
+   *   callback and expose it to the test, allowing the test to both trigger the
+   *   watchdog (by emitting "WebSocket connection closed" and advancing timers)
+   *   and to resolve the wait normally when needed.
+   */
+  function createWatchdogHarness() {
+    const emitter = new EventEmitter();
+    getDiscordGatewayEmitterMock.mockReturnValue(emitter);
+
+    let resolveWait: (() => void) | undefined;
+    let rejectWait: ((err: unknown) => void) | undefined;
+
+    waitForDiscordGatewayStopMock.mockImplementation(
+      (params: {
+        registerForceStop?: (fn: (err: unknown) => void) => void;
+        [key: string]: unknown;
+      }) => {
+        const p = new Promise<void>((resolve, reject) => {
+          resolveWait = resolve;
+          rejectWait = reject;
+        });
+        // Simulate what the real waitForDiscordGatewayStop does: hand out
+        // finishReject to the caller via registerForceStop.
+        params.registerForceStop?.(rejectWait!);
+        return p;
+      },
+    );
+
+    const runtimeError = vi.fn();
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: runtimeError,
+      exit: vi.fn(),
+    };
+    const threadStop = vi.fn();
+
+    const lifecycleParams = {
+      accountId: "default",
+      client: { getPlugin: vi.fn(() => undefined) } as unknown as Client,
+      runtime,
+      isDisallowedIntentsError: () => false,
+      voiceManager: null,
+      voiceManagerRef: { current: null },
+      execApprovalsHandler: null,
+      threadBindings: { stop: threadStop },
+    };
+
+    return {
+      emitter,
+      runtimeError,
+      threadStop,
+      lifecycleParams,
+      resolveWait: () => resolveWait?.(),
+    };
+  }
+
+  it("force-stops the lifecycle when WebSocket stays closed beyond the watchdog timeout", async () => {
+    vi.useFakeTimers();
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+
+    const { emitter, runtimeError, threadStop, lifecycleParams } = createWatchdogHarness();
+
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+    // Attach an early catch so Node.js does not report an "unhandledRejection"
+    // during the gap between the timer firing and the assertion below.
+    lifecyclePromise.catch(() => {});
+
+    // Simulate the gateway WebSocket closing (the carbon library emits this
+    // debug message when the connection drops).
+    emitter.emit("debug", "WebSocket connection closed");
+
+    // Advance past the 5-minute reconnect watchdog timeout.
+    await vi.advanceTimersByTimeAsync(5 * 60_000 + 1000);
+
+    // The watchdog should have called forceStop, causing the lifecycle to
+    // reject with the watchdog error.
+    await expect(lifecyclePromise).rejects.toThrow("reconnect watchdog timeout");
+
+    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("reconnect watchdog"));
+    expect(threadStop).toHaveBeenCalledTimes(1);
+    expect(unregisterGatewayMock).toHaveBeenCalledWith("default");
+  });
+
+  it("clears the watchdog when the WebSocket reconnects before the timeout", async () => {
+    vi.useFakeTimers();
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+
+    const { emitter, runtimeError, resolveWait, lifecycleParams } = createWatchdogHarness();
+
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+    // Connection drops.
+    emitter.emit("debug", "WebSocket connection closed");
+
+    // Advance only 2 minutes (less than the 5-minute watchdog).
+    await vi.advanceTimersByTimeAsync(2 * 60_000);
+
+    // Connection re-established — watchdog should be cleared.
+    emitter.emit("debug", "WebSocket connection opened");
+
+    // Advance past where the original watchdog would have fired (still safe).
+    await vi.advanceTimersByTimeAsync(3 * 60_000 + 1000);
+
+    // Lifecycle resolves normally (no watchdog rejection).
+    resolveWait();
+    await expect(lifecyclePromise).resolves.toBeUndefined();
+
+    expect(runtimeError).not.toHaveBeenCalledWith(expect.stringContaining("reconnect watchdog"));
+  });
+
+  it("does not fire the watchdog if no 'WebSocket connection closed' event is emitted", async () => {
+    vi.useFakeTimers();
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+
+    const { runtimeError, resolveWait, lifecycleParams } = createWatchdogHarness();
+
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+    // No connection-closed event — advance well past the watchdog window.
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+    resolveWait();
+    await expect(lifecyclePromise).resolves.toBeUndefined();
+
+    expect(runtimeError).not.toHaveBeenCalledWith(expect.stringContaining("reconnect watchdog"));
   });
 });

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -50,26 +50,73 @@ export async function runDiscordGatewayLifecycle(params: {
 
   const HELLO_TIMEOUT_MS = 30000;
   let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  // Reconnect watchdog: if the WebSocket closes and does not re-open within
+  // this window we force-stop the lifecycle so the outer channel manager can
+  // restart the whole provider with exponential backoff. 5 minutes gives the
+  // carbon library's built-in reconnect logic (up to 50 attempts) enough time
+  // to succeed before we escalate to a full provider restart.
+  const RECONNECT_WATCHDOG_MS = 5 * 60_000;
+  let reconnectWatchdogId: ReturnType<typeof setTimeout> | undefined;
+  // Populated once waitForDiscordGatewayStop registers the forceStop callback.
+  let forceStopLifecycle: ((err: unknown) => void) | null = null;
+
+  const clearReconnectWatchdog = () => {
+    if (reconnectWatchdogId !== undefined) {
+      clearTimeout(reconnectWatchdogId);
+      reconnectWatchdogId = undefined;
+    }
+  };
+
+  const startReconnectWatchdog = () => {
+    clearReconnectWatchdog();
+    reconnectWatchdogId = setTimeout(() => {
+      reconnectWatchdogId = undefined;
+      params.runtime.error?.(
+        danger(
+          `[${params.accountId}] discord reconnect watchdog: WebSocket has been closed for ${Math.round(RECONNECT_WATCHDOG_MS / 1000)}s without recovery — forcing provider restart`,
+        ),
+      );
+      forceStopLifecycle?.(
+        new Error(
+          `discord: reconnect watchdog timeout — WebSocket connection not re-established within ${RECONNECT_WATCHDOG_MS}ms`,
+        ),
+      );
+    }, RECONNECT_WATCHDOG_MS);
+  };
+
   const onGatewayDebug = (msg: unknown) => {
     const message = String(msg);
-    if (!message.includes("WebSocket connection opened")) {
+    if (message.includes("WebSocket connection opened")) {
+      // Connection (re-)established — clear any pending watchdog and start the
+      // HELLO timeout to guard against a stalled handshake.
+      clearReconnectWatchdog();
+      if (helloTimeoutId) {
+        clearTimeout(helloTimeoutId);
+      }
+      helloTimeoutId = setTimeout(() => {
+        if (!gateway?.isConnected) {
+          params.runtime.log?.(
+            danger(
+              `connection stalled: no HELLO received within ${HELLO_TIMEOUT_MS}ms, forcing reconnect`,
+            ),
+          );
+          gateway?.disconnect();
+          gateway?.connect(false);
+        }
+        helloTimeoutId = undefined;
+      }, HELLO_TIMEOUT_MS);
       return;
     }
-    if (helloTimeoutId) {
-      clearTimeout(helloTimeoutId);
+
+    // Connection dropped — start the watchdog. The carbon library will attempt
+    // its own reconnects (up to maxAttempts); if it succeeds the "WebSocket
+    // connection opened" branch above will clear the watchdog. If it silently
+    // exhausts retries without emitting an error event the watchdog fires and
+    // forces a clean provider restart.
+    if (message.includes("WebSocket connection closed")) {
+      startReconnectWatchdog();
     }
-    helloTimeoutId = setTimeout(() => {
-      if (!gateway?.isConnected) {
-        params.runtime.log?.(
-          danger(
-            `connection stalled: no HELLO received within ${HELLO_TIMEOUT_MS}ms, forcing reconnect`,
-          ),
-        );
-        gateway?.disconnect();
-        gateway?.connect(false);
-      }
-      helloTimeoutId = undefined;
-    }, HELLO_TIMEOUT_MS);
   };
   gatewayEmitter?.on("debug", onGatewayDebug);
 
@@ -107,12 +154,17 @@ export async function runDiscordGatewayLifecycle(params: {
           params.isDisallowedIntentsError(err)
         );
       },
+      registerForceStop: (fn) => {
+        forceStopLifecycle = fn;
+      },
     });
   } catch (err) {
     if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
       throw err;
     }
   } finally {
+    clearReconnectWatchdog();
+    forceStopLifecycle = null;
     unregisterGateway(params.accountId);
     stopGatewayLogging();
     if (helloTimeoutId) {


### PR DESCRIPTION
## Summary

Fixes #30514 — Discord bot enters zombie state (appears online but receives no messages) after WebSocket connection drops silently.

## Root Cause

`waitForDiscordGatewayStop` only listened for gateway `error` events. When the WebSocket closed without the `@buape/carbon` library emitting an error event (e.g. silent network drop, exhausted reconnects without an observable error), the lifecycle promise never settled. The outer channel manager never knew to restart the provider, so the bot appeared healthy but was effectively dead.

## Fix

**1. `src/discord/monitor.gateway.ts` — add `registerForceStop` callback**

Exposes the internal `finishReject` handle to callers so an external watchdog can force-reject the waiting promise without needing to synthesize an error event on the gateway emitter.

**2. `src/discord/monitor/provider.lifecycle.ts` — reconnect watchdog**

The `onGatewayDebug` handler now also listens for `"WebSocket connection closed"` messages emitted by the carbon library. When the connection drops:
- A 5-minute watchdog timer starts.
- If `"WebSocket connection opened"` is received before the timeout (carbon reconnected successfully), the watchdog is cleared — no action taken.
- If the timeout fires without recovery, `forceStop` is called, rejecting the lifecycle promise. The outer channel manager (`server-channels.ts`) then retries the full provider with exponential backoff, exactly as it does for other fatal errors.

The 5-minute window gives carbon's built-in reconnect logic (up to 50 attempts, `reconnect: { maxAttempts: 50 }`) ample time to succeed before escalating.

## Tests Added

- **`monitor.gateway.test.ts`** (3 new tests)
  - `registerForceStop` rejects the promise and disconnects correctly
  - `forceStop` is idempotent — second call is a no-op
  - Abort wins when it fires before `forceStop`

- **`monitor/provider.lifecycle.test.ts`** (3 new tests)
  - Watchdog fires and force-stops the lifecycle when WebSocket stays closed > 5 min
  - Watchdog is cleared when WebSocket reconnects before the timeout
  - Watchdog does not fire when no connection-closed event is emitted

All 416 existing Discord tests continue to pass.