### PR TITLE
fix(mattermost): pass mediaLocalRoots to loadWebMedia for workspace paths

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -279,10 +279,11 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
       });
       return { channel: "mattermost", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, replyToId }) => {
+    sendMedia: async ({ to, text, mediaUrl, accountId, replyToId, mediaLocalRoots }) => {
       const result = await sendMessageMattermost(to, text, {
         accountId: accountId ?? undefined,
         mediaUrl,
+        mediaLocalRoots,
         replyToId: replyToId ?? undefined,
       });
       return { channel: "mattermost", ...result };

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -16,6 +16,7 @@ export type MattermostSendOpts = {
   baseUrl?: string;
   accountId?: string;
   mediaUrl?: string;
+  mediaLocalRoots?: string[];
   replyToId?: string;
 };
 
@@ -174,9 +175,12 @@ export async function sendMessageMattermost(
   let fileIds: string[] | undefined;
   let uploadError: Error | undefined;
   const mediaUrl = opts.mediaUrl?.trim();
+  const mediaLocalRoots = opts.mediaLocalRoots;
   if (mediaUrl) {
     try {
-      const media = await core.media.loadWebMedia(mediaUrl);
+      const media = await core.media.loadWebMedia(mediaUrl, {
+        localRoots: mediaLocalRoots?.length ? mediaLocalRoots : undefined,
+      });
       const fileInfo = await uploadMattermostFile(client, {
         channelId,
         buffer: media.buffer,


### PR DESCRIPTION
Fixes #30830

When sending media files via the message tool on the Mattermost channel, file attachments are silently dropped because loadWebMedia is called without passing localRoots. This causes it to fall back to getDefaultMediaLocalRoots(), which explicitly excludes workspace-* directories.

This fix passes mediaLocalRoots through the sendMedia call chain and into loadWebMedia, consistent with how other channels (Discord, Feishu) handle media sends.