### PR TITLE
fix(slack): add preferSessionLookupForAnnounceTarget to Slack channel meta

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -67,6 +67,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
   id: "slack",
   meta: {
     ...meta,
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: slackOnboardingAdapter,
   pairing: {


### PR DESCRIPTION
## Problem

In multi-account Slack setups, `sessions_send` announce replies use the default bot token instead of the target agent's bot token. This happens because `resolveAnnounceTarget()` in `src/agents/tools/sessions-announce-target.ts` checks `plugin.meta.preferSessionLookupForAnnounceTarget` at line 18 — without this flag, it returns the key-parsed fallback which never carries `accountId`, so the delivery layer falls back to the default Slack account.

WhatsApp already sets this flag (`extensions/whatsapp/src/channel.ts:46`). Slack does not.

## Fix

One-line change: add `preferSessionLookupForAnnounceTarget: true` to Slack channel plugin meta, matching WhatsApp's existing pattern.

## Testing

- Multi-account Slack setup: Agent A (default account) sends to Agent B (forge account) via `sessions_send` → announce reply now uses Agent B's bot token
- Single-account setups: no behavior change (session lookup finds the same default account)

Fixes #30956
Re-opens fix from stale-closed PR #14912