### PR TITLE
fix(memory): change default QMD searchMode from 'search' to 'query'

### DIFF
--- a/src/memory/backend-config.test.ts
+++ b/src/memory/backend-config.test.ts
@@ -25,7 +25,7 @@ describe("resolveMemoryBackendConfig", () => {
     expect(resolved.backend).toBe("qmd");
     expect(resolved.qmd?.collections.length).toBeGreaterThanOrEqual(3);
     expect(resolved.qmd?.command).toBe("qmd");
-    expect(resolved.qmd?.searchMode).toBe("search");
+    expect(resolved.qmd?.searchMode).toBe("query");
     expect(resolved.qmd?.update.intervalMs).toBeGreaterThan(0);
     expect(resolved.qmd?.update.waitForBootSync).toBe(false);
     expect(resolved.qmd?.update.commandTimeoutMs).toBe(30_000);

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -74,8 +74,8 @@ const DEFAULT_CITATIONS: MemoryCitationsMode = "auto";
 const DEFAULT_QMD_INTERVAL = "5m";
 const DEFAULT_QMD_DEBOUNCE_MS = 15_000;
 const DEFAULT_QMD_TIMEOUT_MS = 4_000;
-// Defaulting to `query` can be extremely slow on CPU-only systems (query expansion + rerank).
-// Prefer a faster mode for interactive use; users can opt into `query` for best recall.
+// BM25-only `search` fails silently on multi-term natural language queries (requires all terms to match).
+// Default to `query` (hybrid pipeline) for better recall; users can opt into `search` for faster CPU-only performance.
 const DEFAULT_QMD_SEARCH_MODE: MemoryQmdSearchMode = "query";
 const DEFAULT_QMD_EMBED_INTERVAL = "60m";
 const DEFAULT_QMD_COMMAND_TIMEOUT_MS = 30_000;

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -76,7 +76,7 @@ const DEFAULT_QMD_DEBOUNCE_MS = 15_000;
 const DEFAULT_QMD_TIMEOUT_MS = 4_000;
 // Defaulting to `query` can be extremely slow on CPU-only systems (query expansion + rerank).
 // Prefer a faster mode for interactive use; users can opt into `query` for best recall.
-const DEFAULT_QMD_SEARCH_MODE: MemoryQmdSearchMode = "search";
+const DEFAULT_QMD_SEARCH_MODE: MemoryQmdSearchMode = "query";
 const DEFAULT_QMD_EMBED_INTERVAL = "60m";
 const DEFAULT_QMD_COMMAND_TIMEOUT_MS = 30_000;
 const DEFAULT_QMD_UPDATE_TIMEOUT_MS = 120_000;


### PR DESCRIPTION
## Problem

`memory.qmd.searchMode` defaults to `"search"` (BM25 keyword matching only). BM25 AND-matches all query terms, which fails silently for the natural language queries that `memory_search` generates ~100% of the time.

Example:
- `qmd search "TestYourWell" --json` → results (single keyword matches)
- `qmd search "TestYourWell Next.js pivot" --json` → **empty** (BM25 requires all terms to match)
- `qmd query "TestYourWell Next.js pivot" --json` → **93% match** (hybrid pipeline with query expansion + reranking)

No errors are logged. The search returns empty results silently, so agents conclude nothing was found. Very hard to debug.

## Fix

Change `DEFAULT_QMD_SEARCH_MODE` from `"search"` to `"query"` in `src/memory/backend-config.ts`. This enables the hybrid pipeline (BM25 + vectors + reranking) by default.

Users who specifically need BM25-only behavior can still set `searchMode: "search"` in their config.

## Changes

- `src/memory/backend-config.ts`: Default changed to `"query"`
- `src/memory/backend-config.test.ts`: Updated default assertion

Fixes #30942