### PR TITLE
Auto-reply: strip inline NO_REPLY token from mixed replies

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -1,4 +1,5 @@
 import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers.js";
+import { escapeRegExp } from "../../utils.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import { HEARTBEAT_TOKEN, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { ReplyPayload } from "../types.js";
@@ -42,6 +43,15 @@ export function normalizeReplyPayload(
       return null;
     }
     text = "";
+  }
+  if (text && text.includes(silentToken)) {
+    const inlineSilentToken = new RegExp(`(^|\\s+)${escapeRegExp(silentToken)}(?=\\s+|$)`, "g");
+    const stripped = text.replace(inlineSilentToken, "$1").trim();
+    if (!stripped && !hasMedia && !hasChannelData) {
+      opts.onSkip?.("silent");
+      return null;
+    }
+    text = stripped;
   }
   if (text && !trimmed) {
     // Keep empty text when media exists so media-only replies still send.

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -108,6 +108,24 @@ describe("normalizeReplyPayload", () => {
       expect(reasons, testCase.name).toEqual([testCase.reason]);
     }
   });
+
+  it("strips inline silent token suffix from mixed content", () => {
+    const normalized = normalizeReplyPayload({ text: "😄 NO_REPLY" });
+    expect(normalized).not.toBeNull();
+    expect(normalized?.text).toBe("😄");
+  });
+
+  it("strips inline silent token prefix from mixed content", () => {
+    const normalized = normalizeReplyPayload({ text: "NO_REPLY 👍" });
+    expect(normalized).not.toBeNull();
+    expect(normalized?.text).toBe("👍");
+  });
+
+  it("does not strip token-like substrings inside words", () => {
+    const normalized = normalizeReplyPayload({ text: "open_NO_REPLY_token" });
+    expect(normalized).not.toBeNull();
+    expect(normalized?.text).toBe("open_NO_REPLY_token");
+  });
 });
 
 describe("typing controller", () => {


### PR DESCRIPTION
## Summary
- strip standalone `NO_REPLY` tokens when they appear inline with actual content in `normalizeReplyPayload`
- preserve existing behavior where pure `NO_REPLY` suppresses the reply
- add tests for suffix/prefix stripping and a guardrail test that token-like substrings inside words are not stripped

## Why
`NO_REPLY` is a control token. When models return mixed text like `😄 NO_REPLY`, the token currently leaks to end users. This keeps the visible content and removes the control token.

Fixes #30955

## AI assistance
- [x] AI-assisted (Codex)

## Testing level
- [x] Fully tested for touched area

### Local validation
- `pnpm exec vitest run src/auto-reply/reply/reply-utils.test.ts`
- `pnpm exec vitest run src/auto-reply/tokens.test.ts`
- `pnpm exec oxlint --type-aware src/auto-reply/reply/normalize-reply.ts src/auto-reply/reply/reply-utils.test.ts`
