### PR TITLE
docs(acp): add permission configuration section and troubleshooting entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - ACP/Harness thread spawn routing: force ACP harness thread creation through `sessions_spawn` (`runtime: "acp"`, `thread: true`) and explicitly forbid `message action=thread-create` for ACP harness requests, avoiding misrouted `Unknown channel` errors. (#30957) Thanks @dutifulbob.
+- Docs/ACP permissions: document the correct `permissionMode` default (`approve-reads`) and clarify non-interactive permission failure behavior/troubleshooting guidance. (#31044) Thanks @barronlroth.
 - Security/Inbound metadata stripping: tighten sentinel matching and JSON-fence validation for inbound metadata stripping so user-authored lookalike lines no longer trigger unintended metadata removal.
 - Channels/Command parsing parity: align command-body parsing fields with channel command-gating text for Slack, Signal, Microsoft Teams, Mattermost, and BlueBubbles to avoid mention-strip mismatches and inconsistent command detection.
 - CLI/Startup (Raspberry Pi + small hosts): speed up startup by avoiding unnecessary plugin preload on fast routes, adding root `--version` fast-path bootstrap bypass, parallelizing status JSON/non-JSON scans where safe, and enabling Node compile cache at startup with env override compatibility (`NODE_COMPILE_CACHE`, `NODE_DISABLE_COMPILE_CACHE`). (#5871) Thanks @BookCatKid and @vincentkoc for raising startup reports, and @lupuletic for related startup work in #27973.

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -353,16 +353,57 @@ Notes:
 
 See [Plugins](/tools/plugin).
 
+## Permission configuration
+
+ACP sessions run non-interactively — there is no TTY to approve or deny file-write and shell-exec permission prompts. The acpx plugin provides two config keys that control how permissions are handled:
+
+### `permissionMode`
+
+Controls which operations the harness agent can perform without prompting.
+
+| Value           | Behavior                                                       |
+| --------------- | -------------------------------------------------------------- |
+| `approve-all`   | Auto-approve all file writes and shell commands. **(default)** |
+| `approve-reads` | Auto-approve reads only; writes and exec require prompts.      |
+| `deny-all`      | Deny all permission prompts.                                   |
+
+### `nonInteractivePermissions`
+
+Controls what happens when a permission prompt would be shown but no interactive TTY is available (which is always the case for ACP sessions).
+
+| Value  | Behavior                                                          |
+| ------ | ----------------------------------------------------------------- |
+| `fail` | Abort the session with `AcpRuntimeError`. **(default)**           |
+| `deny` | Silently deny the permission and continue (graceful degradation). |
+
+### Configuration
+
+Set via plugin config:
+
+```bash
+openclaw config set plugins.entries.acpx.config.permissionMode approve-all
+openclaw config set plugins.entries.acpx.config.nonInteractivePermissions fail
+```
+
+Restart the gateway after changing these values.
+
+> **Important:** If you are on an older OpenClaw version where `permissionMode` defaults to `approve-reads` and `nonInteractivePermissions` defaults to `fail`, ACP sessions will abort immediately on any write or exec operation. The error (`AcpRuntimeError: Permission prompt unavailable in non-interactive mode`) is logged to the gateway but **not surfaced to the spawning agent** — the session appears to silently fail.
+>
+> If you need to restrict permissions, set `nonInteractivePermissions` to `deny` so sessions degrade gracefully instead of crashing.
+
 ## Troubleshooting
 
-| Symptom                                                                 | Likely cause                                   | Fix                                                        |
-| ----------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------- |
-| `ACP runtime backend is not configured`                                 | Backend plugin missing or disabled.            | Install and enable backend plugin, then run `/acp doctor`. |
-| `ACP is disabled by policy (acp.enabled=false)`                         | ACP globally disabled.                         | Set `acp.enabled=true`.                                    |
-| `ACP dispatch is disabled by policy (acp.dispatch.enabled=false)`       | Dispatch from normal thread messages disabled. | Set `acp.dispatch.enabled=true`.                           |
-| `ACP agent "<id>" is not allowed by policy`                             | Agent not in allowlist.                        | Use allowed `agentId` or update `acp.allowedAgents`.       |
-| `Unable to resolve session target: ...`                                 | Bad key/id/label token.                        | Run `/acp sessions`, copy exact key/label, retry.          |
-| `--thread here requires running /acp spawn inside an active ... thread` | `--thread here` used outside a thread context. | Move to target thread or use `--thread auto`/`off`.        |
-| `Only <user-id> can rebind this thread.`                                | Another user owns thread binding.              | Rebind as owner or use a different thread.                 |
-| `Thread bindings are unavailable for <channel>.`                        | Adapter lacks thread binding capability.       | Use `--thread off` or move to supported adapter/channel.   |
-| Missing ACP metadata for bound session                                  | Stale/deleted ACP session metadata.            | Recreate with `/acp spawn`, then rebind/focus thread.      |
+| Symptom                                                                  | Likely cause                                                        | Fix                                                                                                                                               |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ACP runtime backend is not configured`                                  | Backend plugin missing or disabled.                                 | Install and enable backend plugin, then run `/acp doctor`.                                                                                        |
+| `ACP is disabled by policy (acp.enabled=false)`                          | ACP globally disabled.                                              | Set `acp.enabled=true`.                                                                                                                           |
+| `ACP dispatch is disabled by policy (acp.dispatch.enabled=false)`        | Dispatch from normal thread messages disabled.                      | Set `acp.dispatch.enabled=true`.                                                                                                                  |
+| `ACP agent "<id>" is not allowed by policy`                              | Agent not in allowlist.                                             | Use allowed `agentId` or update `acp.allowedAgents`.                                                                                              |
+| `Unable to resolve session target: ...`                                  | Bad key/id/label token.                                             | Run `/acp sessions`, copy exact key/label, retry.                                                                                                 |
+| `--thread here requires running /acp spawn inside an active ... thread`  | `--thread here` used outside a thread context.                      | Move to target thread or use `--thread auto`/`off`.                                                                                               |
+| `Only <user-id> can rebind this thread.`                                 | Another user owns thread binding.                                   | Rebind as owner or use a different thread.                                                                                                        |
+| `Thread bindings are unavailable for <channel>.`                         | Adapter lacks thread binding capability.                            | Use `--thread off` or move to supported adapter/channel.                                                                                          |
+| Missing ACP metadata for bound session                                   | Stale/deleted ACP session metadata.                                 | Recreate with `/acp spawn`, then rebind/focus thread.                                                                                             |
+| `AcpRuntimeError: Permission prompt unavailable in non-interactive mode` | `permissionMode` blocks writes/exec in non-interactive ACP session. | Set `plugins.entries.acpx.config.permissionMode` to `approve-all` and restart gateway. See [Permission configuration](#permission-configuration). |
+| ACP session silently fails (no error, no output)                         | Permission error swallowed; not surfaced to spawning agent.         | Check gateway logs for `AcpRuntimeError`. Ensure `permissionMode` is `approve-all`.                                                               |
+| ACP session stalls indefinitely after completing work                    | Harness process finished but ACP session did not report completion. | Monitor with `ps aux \| grep acpx`; kill stale processes manually.                                                                                |

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -361,11 +361,11 @@ ACP sessions run non-interactively — there is no TTY to approve or deny file-w
 
 Controls which operations the harness agent can perform without prompting.
 
-| Value           | Behavior                                                       |
-| --------------- | -------------------------------------------------------------- |
-| `approve-all`   | Auto-approve all file writes and shell commands. **(default)** |
-| `approve-reads` | Auto-approve reads only; writes and exec require prompts.      |
-| `deny-all`      | Deny all permission prompts.                                   |
+| Value           | Behavior                                                  |
+| --------------- | --------------------------------------------------------- |
+| `approve-all`   | Auto-approve all file writes and shell commands.          |
+| `approve-reads` | Auto-approve reads only; writes and exec require prompts. |
+| `deny-all`      | Deny all permission prompts.                              |
 
 ### `nonInteractivePermissions`
 
@@ -387,23 +387,23 @@ openclaw config set plugins.entries.acpx.config.nonInteractivePermissions fail
 
 Restart the gateway after changing these values.
 
-> **Important:** If you are on an older OpenClaw version where `permissionMode` defaults to `approve-reads` and `nonInteractivePermissions` defaults to `fail`, ACP sessions will abort immediately on any write or exec operation. The error (`AcpRuntimeError: Permission prompt unavailable in non-interactive mode`) is logged to the gateway but **not surfaced to the spawning agent** — the session appears to silently fail.
+> **Important:** OpenClaw currently defaults to `permissionMode=approve-reads` and `nonInteractivePermissions=fail`. In non-interactive ACP sessions, any write or exec that triggers a permission prompt can fail with `AcpRuntimeError: Permission prompt unavailable in non-interactive mode`.
 >
 > If you need to restrict permissions, set `nonInteractivePermissions` to `deny` so sessions degrade gracefully instead of crashing.
 
 ## Troubleshooting
 
-| Symptom                                                                  | Likely cause                                                        | Fix                                                                                                                                               |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ACP runtime backend is not configured`                                  | Backend plugin missing or disabled.                                 | Install and enable backend plugin, then run `/acp doctor`.                                                                                        |
-| `ACP is disabled by policy (acp.enabled=false)`                          | ACP globally disabled.                                              | Set `acp.enabled=true`.                                                                                                                           |
-| `ACP dispatch is disabled by policy (acp.dispatch.enabled=false)`        | Dispatch from normal thread messages disabled.                      | Set `acp.dispatch.enabled=true`.                                                                                                                  |
-| `ACP agent "<id>" is not allowed by policy`                              | Agent not in allowlist.                                             | Use allowed `agentId` or update `acp.allowedAgents`.                                                                                              |
-| `Unable to resolve session target: ...`                                  | Bad key/id/label token.                                             | Run `/acp sessions`, copy exact key/label, retry.                                                                                                 |
-| `--thread here requires running /acp spawn inside an active ... thread`  | `--thread here` used outside a thread context.                      | Move to target thread or use `--thread auto`/`off`.                                                                                               |
-| `Only <user-id> can rebind this thread.`                                 | Another user owns thread binding.                                   | Rebind as owner or use a different thread.                                                                                                        |
-| `Thread bindings are unavailable for <channel>.`                         | Adapter lacks thread binding capability.                            | Use `--thread off` or move to supported adapter/channel.                                                                                          |
-| Missing ACP metadata for bound session                                   | Stale/deleted ACP session metadata.                                 | Recreate with `/acp spawn`, then rebind/focus thread.                                                                                             |
-| `AcpRuntimeError: Permission prompt unavailable in non-interactive mode` | `permissionMode` blocks writes/exec in non-interactive ACP session. | Set `plugins.entries.acpx.config.permissionMode` to `approve-all` and restart gateway. See [Permission configuration](#permission-configuration). |
-| ACP session silently fails (no error, no output)                         | Permission error swallowed; not surfaced to spawning agent.         | Check gateway logs for `AcpRuntimeError`. Ensure `permissionMode` is `approve-all`.                                                               |
-| ACP session stalls indefinitely after completing work                    | Harness process finished but ACP session did not report completion. | Monitor with `ps aux \| grep acpx`; kill stale processes manually.                                                                                |
+| Symptom                                                                  | Likely cause                                                                    | Fix                                                                                                                                                               |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ACP runtime backend is not configured`                                  | Backend plugin missing or disabled.                                             | Install and enable backend plugin, then run `/acp doctor`.                                                                                                        |
+| `ACP is disabled by policy (acp.enabled=false)`                          | ACP globally disabled.                                                          | Set `acp.enabled=true`.                                                                                                                                           |
+| `ACP dispatch is disabled by policy (acp.dispatch.enabled=false)`        | Dispatch from normal thread messages disabled.                                  | Set `acp.dispatch.enabled=true`.                                                                                                                                  |
+| `ACP agent "<id>" is not allowed by policy`                              | Agent not in allowlist.                                                         | Use allowed `agentId` or update `acp.allowedAgents`.                                                                                                              |
+| `Unable to resolve session target: ...`                                  | Bad key/id/label token.                                                         | Run `/acp sessions`, copy exact key/label, retry.                                                                                                                 |
+| `--thread here requires running /acp spawn inside an active ... thread`  | `--thread here` used outside a thread context.                                  | Move to target thread or use `--thread auto`/`off`.                                                                                                               |
+| `Only <user-id> can rebind this thread.`                                 | Another user owns thread binding.                                               | Rebind as owner or use a different thread.                                                                                                                        |
+| `Thread bindings are unavailable for <channel>.`                         | Adapter lacks thread binding capability.                                        | Use `--thread off` or move to supported adapter/channel.                                                                                                          |
+| Missing ACP metadata for bound session                                   | Stale/deleted ACP session metadata.                                             | Recreate with `/acp spawn`, then rebind/focus thread.                                                                                                             |
+| `AcpRuntimeError: Permission prompt unavailable in non-interactive mode` | `permissionMode` blocks writes/exec in non-interactive ACP session.             | Set `plugins.entries.acpx.config.permissionMode` to `approve-all` and restart gateway. See [Permission configuration](#permission-configuration).                 |
+| ACP session fails early with little output                               | Permission prompts are blocked by `permissionMode`/`nonInteractivePermissions`. | Check gateway logs for `AcpRuntimeError`. For full permissions, set `permissionMode=approve-all`; for graceful degradation, set `nonInteractivePermissions=deny`. |
+| ACP session stalls indefinitely after completing work                    | Harness process finished but ACP session did not report completion.             | Monitor with `ps aux \| grep acpx`; kill stale processes manually.                                                                                                |


### PR DESCRIPTION
## What

Adds a **Permission configuration** section to the ACP agents docs page and three new troubleshooting table entries.

## Why

The `permissionMode` and `nonInteractivePermissions` plugin config keys are critical for ACP sessions to function, but were undocumented. On older versions where `permissionMode` defaulted to `approve-reads`, ACP sessions would silently abort on any write operation — the error was logged to the gateway but never surfaced to the spawning agent. This led to confusing "session accepted but nothing happened" behavior.

The default has since been fixed to `approve-all` on main, but the config keys and their interactions still need documentation for users who:
- Are on older versions
- Want to restrict permissions and need to understand the tradeoffs
- Hit the error and need to diagnose it

## Changes

- New **Permission configuration** section documenting `permissionMode` (3 values) and `nonInteractivePermissions` (2 values) with tables, config commands, and a callout about the silent failure footgun
- Three new troubleshooting entries:
  - `AcpRuntimeError: Permission prompt unavailable in non-interactive mode`
  - Silent session failures (no error, no output)
  - Stalled ACP sessions that never report completion

Relates to #29195

- [x] AI-assisted
- [x] Lightly tested (verified docs render correctly in markdown)