### PR TITLE
Telegram: recover when sendVoice caption exceeds limit

### DIFF
--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -380,6 +380,47 @@ describe("deliverReplies", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("retries voice without caption and sends text when caption is too long", async () => {
+    const runtime = createRuntime();
+    const sendVoice = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          "GrammyError: Call to 'sendVoice' failed! (400: Bad Request: message caption is too long)",
+        ),
+      )
+      .mockResolvedValueOnce({
+        message_id: 8,
+        chat: { id: "123" },
+      });
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 9,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendVoice, sendMessage });
+
+    mockMediaLoad("note.ogg", "audio/ogg", "voice");
+
+    await deliverWith({
+      replies: [
+        { mediaUrl: "https://example.com/note.ogg", text: "<".repeat(300), audioAsVoice: true },
+      ],
+      runtime,
+      bot,
+    });
+
+    expect(sendVoice).toHaveBeenCalledTimes(2);
+    const firstOptions = sendVoice.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(firstOptions).toMatchObject({
+      caption: expect.any(String),
+      parse_mode: "HTML",
+    });
+    const retryOptions = sendVoice.mock.calls[1]?.[2] as Record<string, unknown>;
+    expect(retryOptions).not.toHaveProperty("caption");
+    expect(retryOptions).not.toHaveProperty("parse_mode");
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("rethrows VOICE_MESSAGES_FORBIDDEN when no text fallback is available", async () => {
     const { runtime, sendVoice, sendMessage, bot } = createVoiceFailureHarness({
       voiceError: createVoiceMessagesForbiddenError(),

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -35,6 +35,7 @@ import type { StickerMetadata, TelegramContext } from "./types.js";
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const EMPTY_TEXT_ERR_RE = /message text is empty/i;
 const VOICE_FORBIDDEN_RE = /VOICE_MESSAGES_FORBIDDEN/;
+const VOICE_CAPTION_TOO_LONG_RE = /caption is too long/i;
 const FILE_TOO_BIG_RE = /file is too big/i;
 const TELEGRAM_MEDIA_SSRF_POLICY = {
   // Telegram file downloads should trust api.telegram.org even when DNS/proxy
@@ -259,6 +260,48 @@ export async function deliverReplies(params: {
               // Skip this media item; continue with next.
               continue;
             }
+            // If Telegram rejects the voice caption, retry voice without caption
+            // and deliver the full text as a separate message.
+            if (isVoiceCaptionTooLong(voiceErr)) {
+              const fallbackText = reply.text;
+              logVerbose(
+                "telegram sendVoice caption exceeded Telegram limit; retrying without caption and sending text separately",
+              );
+              await withTelegramApiErrorLogging({
+                operation: "sendVoice",
+                runtime,
+                fn: () =>
+                  bot.api.sendVoice(
+                    chatId,
+                    file,
+                    buildTelegramSendParams({
+                      replyToMessageId: replyToMessageIdForPayload,
+                      thread,
+                    }),
+                  ),
+              });
+              markDelivered();
+              if (fallbackText && fallbackText.trim()) {
+                await sendTelegramVoiceFallbackText({
+                  bot,
+                  chatId,
+                  runtime,
+                  text: fallbackText,
+                  chunkText,
+                  replyToId: replyToMessageIdForPayload,
+                  thread,
+                  linkPreview,
+                  replyMarkup,
+                  replyQuoteText,
+                });
+                if (replyToMessageIdForPayload && !hasReplied) {
+                  hasReplied = true;
+                }
+                markDelivered();
+              }
+              // Skip this media item; continue with next.
+              continue;
+            }
             throw voiceErr;
           }
         } else {
@@ -461,6 +504,13 @@ function isVoiceMessagesForbidden(err: unknown): boolean {
     return VOICE_FORBIDDEN_RE.test(err.description);
   }
   return VOICE_FORBIDDEN_RE.test(formatErrorMessage(err));
+}
+
+function isVoiceCaptionTooLong(err: unknown): boolean {
+  if (err instanceof GrammyError) {
+    return VOICE_CAPTION_TOO_LONG_RE.test(err.description);
+  }
+  return VOICE_CAPTION_TOO_LONG_RE.test(formatErrorMessage(err));
 }
 
 /**


### PR DESCRIPTION
## Summary
- handle Telegram `sendVoice` failures caused by `message caption is too long`
- retry the voice send without caption
- send the full reply text separately so users still receive content
- add a regression test for this flow in `src/telegram/bot/delivery.test.ts`

## Why
Telegram enforces caption limits for voice messages. When this error occurs, the previous behavior could fail the entire reply path. This keeps delivery resilient by preserving both voice and text output.

Fixes #30980

## AI assistance
- [x] AI-assisted (Codex)

## Testing level
- [x] Fully tested for touched area

### Local validation
- `pnpm exec vitest run src/telegram/bot/delivery.test.ts`
- `pnpm exec oxlint --type-aware src/telegram/bot/delivery.ts src/telegram/bot/delivery.test.ts`
