### PR TITLE
fix: respect tools.elevated.allowFrom using originating channel

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -17,6 +17,7 @@ import { clearExecInlineDirectives, clearInlineDirectives } from "./get-reply-di
 import { defaultGroupActivation, resolveGroupRequireMention } from "./groups.js";
 import { CURRENT_MESSAGE_MARKER, stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import { createModelSelectionState, resolveContextTokens } from "./model-selection.js";
+import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { formatElevatedUnavailableMessage, resolveElevatedPermissions } from "./reply-elevated.js";
 import { stripInlineStatus } from "./reply-inline.js";
 import type { TypingController } from "./typing.js";
@@ -304,7 +305,10 @@ export async function resolveReplyDirectives(params: {
   sessionCtx.BodyStripped = cleanedBody;
 
   const messageProviderKey =
-    sessionCtx.Provider?.trim().toLowerCase() ?? ctx.Provider?.trim().toLowerCase() ?? "";
+    resolveOriginMessageProvider({
+      originatingChannel: sessionCtx.OriginatingChannel ?? ctx.OriginatingChannel,
+      provider: sessionCtx.Provider ?? ctx.Provider,
+    }) ?? "";
   const elevated = resolveElevatedPermissions({
     cfg,
     agentId,


### PR DESCRIPTION
## Summary
- use `resolveOriginMessageProvider(...)` when computing the provider key for elevated permission checks
- prefer `OriginatingChannel` over internal `Provider` to match routing behavior in follow-up/relay flows
- prevents false negatives where trusted channels (e.g. telegram/webchat) were ignored and approvals were always required

## Root cause
`resolveReplyDirectives` used `sessionCtx.Provider`/`ctx.Provider` directly for `resolveElevatedPermissions`. In routed/relayed paths this value can be internal transport context instead of the user-facing origin channel, so `tools.elevated.allowFrom.<channel>` lookup missed and elevated remained disallowed.

## Validation
- `pnpm -s vitest run src/auto-reply/reply/origin-routing.test.ts src/auto-reply/reply/reply-elevated.test.ts`

Closes #30924
