### PR TITLE
fix(hooks): fire message:sent from inline channel delivery paths

### DIFF
--- a/src/hooks/emit-message-sent.test.ts
+++ b/src/hooks/emit-message-sent.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRunMessageSent = vi.fn().mockResolvedValue(undefined);
+const mockHasHooks = vi.fn().mockReturnValue(false);
+const mockGetGlobalHookRunner = vi.fn().mockReturnValue(null);
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => mockGetGlobalHookRunner(),
+}));
+
+const mockTriggerInternalHook = vi.fn().mockResolvedValue(undefined);
+const mockCreateInternalHookEvent = vi.fn().mockReturnValue({ type: "message", action: "sent" });
+
+vi.mock("./internal-hooks.js", () => ({
+  triggerInternalHook: (...args: unknown[]) => mockTriggerInternalHook(...args),
+  createInternalHookEvent: (...args: unknown[]) => mockCreateInternalHookEvent(...args),
+}));
+
+import { emitMessageSentHook } from "./emit-message-sent.js";
+
+describe("emitMessageSentHook", () => {
+  const baseParams = {
+    to: "chat-123",
+    content: "Hello world",
+    success: true,
+    channelId: "telegram",
+    accountId: "acct-1",
+    sessionKey: "session-abc",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGlobalHookRunner.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("plugin hook", () => {
+    it("fires with correct args when hookRunner has hooks", () => {
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: mockHasHooks.mockReturnValue(true),
+        runMessageSent: mockRunMessageSent,
+      });
+
+      emitMessageSentHook(baseParams);
+
+      expect(mockRunMessageSent).toHaveBeenCalledWith(
+        { to: "chat-123", content: "Hello world", success: true },
+        { channelId: "telegram", accountId: "acct-1", conversationId: "chat-123" },
+      );
+    });
+
+    it("includes error field when success is false", () => {
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: mockHasHooks.mockReturnValue(true),
+        runMessageSent: mockRunMessageSent,
+      });
+
+      emitMessageSentHook({ ...baseParams, success: false, error: "send failed" });
+
+      expect(mockRunMessageSent).toHaveBeenCalledWith(
+        { to: "chat-123", content: "Hello world", success: false, error: "send failed" },
+        { channelId: "telegram", accountId: "acct-1", conversationId: "chat-123" },
+      );
+    });
+
+    it("does not fire when hookRunner is null (plugins not loaded)", () => {
+      mockGetGlobalHookRunner.mockReturnValue(null);
+
+      emitMessageSentHook(baseParams);
+
+      expect(mockRunMessageSent).not.toHaveBeenCalled();
+    });
+
+    it("does not fire when hookRunner.hasHooks returns false", () => {
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: mockHasHooks.mockReturnValue(false),
+        runMessageSent: mockRunMessageSent,
+      });
+
+      emitMessageSentHook(baseParams);
+
+      expect(mockRunMessageSent).not.toHaveBeenCalled();
+    });
+
+    it("swallows errors from plugin hook (fire-and-forget)", () => {
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: mockHasHooks.mockReturnValue(true),
+        runMessageSent: mockRunMessageSent.mockRejectedValue(new Error("plugin crash")),
+      });
+
+      // Should not throw
+      expect(() => emitMessageSentHook(baseParams)).not.toThrow();
+    });
+  });
+
+  describe("internal hook", () => {
+    it("fires with correct event shape when sessionKey is provided", () => {
+      emitMessageSentHook(baseParams);
+
+      expect(mockCreateInternalHookEvent).toHaveBeenCalledWith("message", "sent", "session-abc", {
+        to: "chat-123",
+        content: "Hello world",
+        success: true,
+        channelId: "telegram",
+        accountId: "acct-1",
+        conversationId: "chat-123",
+        messageId: undefined,
+      });
+      expect(mockTriggerInternalHook).toHaveBeenCalled();
+    });
+
+    it("does not fire when sessionKey is undefined", () => {
+      emitMessageSentHook({ ...baseParams, sessionKey: undefined });
+
+      expect(mockCreateInternalHookEvent).not.toHaveBeenCalled();
+      expect(mockTriggerInternalHook).not.toHaveBeenCalled();
+    });
+
+    it("includes messageId when provided", () => {
+      emitMessageSentHook({ ...baseParams, messageId: "msg-42" });
+
+      expect(mockCreateInternalHookEvent).toHaveBeenCalledWith(
+        "message",
+        "sent",
+        "session-abc",
+        expect.objectContaining({ messageId: "msg-42" }),
+      );
+    });
+
+    it("includes error in context when success is false", () => {
+      emitMessageSentHook({ ...baseParams, success: false, error: "timeout" });
+
+      expect(mockCreateInternalHookEvent).toHaveBeenCalledWith(
+        "message",
+        "sent",
+        "session-abc",
+        expect.objectContaining({ success: false, error: "timeout" }),
+      );
+    });
+
+    it("swallows errors from internal hook (fire-and-forget)", () => {
+      mockTriggerInternalHook.mockRejectedValue(new Error("internal hook crash"));
+
+      expect(() => emitMessageSentHook(baseParams)).not.toThrow();
+    });
+  });
+
+  describe("independence", () => {
+    it("fires internal hook even when plugin hook is not available", () => {
+      mockGetGlobalHookRunner.mockReturnValue(null);
+
+      emitMessageSentHook(baseParams);
+
+      expect(mockRunMessageSent).not.toHaveBeenCalled();
+      expect(mockTriggerInternalHook).toHaveBeenCalled();
+    });
+
+    it("fires plugin hook even when sessionKey is missing (internal hook skipped)", () => {
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: mockHasHooks.mockReturnValue(true),
+        runMessageSent: mockRunMessageSent,
+      });
+
+      emitMessageSentHook({ ...baseParams, sessionKey: undefined });
+
+      expect(mockRunMessageSent).toHaveBeenCalled();
+      expect(mockTriggerInternalHook).not.toHaveBeenCalled();
+    });
+
+    it("passes accountId as undefined when not provided", () => {
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: mockHasHooks.mockReturnValue(true),
+        runMessageSent: mockRunMessageSent,
+      });
+
+      emitMessageSentHook({ ...baseParams, accountId: undefined });
+
+      expect(mockRunMessageSent).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ accountId: undefined }),
+      );
+    });
+  });
+});

--- a/src/hooks/emit-message-sent.ts
+++ b/src/hooks/emit-message-sent.ts
@@ -1,0 +1,61 @@
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { createInternalHookEvent, triggerInternalHook } from "./internal-hooks.js";
+
+/**
+ * Fire message:sent hooks (plugin + internal) for inline delivery paths.
+ *
+ * Mirrors the hook emission in src/infra/outbound/deliver.ts (emitMessageSent),
+ * extracted as a shared utility so channel-specific deliverReplies functions
+ * can fire hooks without routing through the centralized outbound path.
+ *
+ * Both hooks are fire-and-forget — errors are caught and swallowed.
+ */
+export function emitMessageSentHook(params: {
+  to: string;
+  content: string;
+  success: boolean;
+  error?: string;
+  messageId?: string;
+  channelId: string;
+  accountId?: string;
+  sessionKey?: string;
+}): void {
+  const { to, content, success, error, messageId, channelId, accountId, sessionKey } = params;
+
+  // Plugin hook
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("message_sent")) {
+    void hookRunner
+      .runMessageSent(
+        {
+          to,
+          content,
+          success,
+          ...(error ? { error } : {}),
+        },
+        {
+          channelId,
+          accountId,
+          conversationId: to,
+        },
+      )
+      .catch(() => {});
+  }
+
+  // Internal hook (requires sessionKey)
+  if (!sessionKey) {
+    return;
+  }
+  void triggerInternalHook(
+    createInternalHookEvent("message", "sent", sessionKey, {
+      to,
+      content,
+      success,
+      ...(error ? { error } : {}),
+      channelId,
+      accountId,
+      conversationId: to,
+      messageId,
+    }),
+  ).catch(() => {});
+}

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -372,6 +372,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           maxBytes: mediaMaxBytes,
           textLimit,
           sentMessageCache,
+          sessionKey: ctxPayload.SessionKey ?? decision.route.sessionKey,
         });
       },
       onError: (err, info) => {

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -238,6 +238,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           runtime: deps.runtime,
           maxBytes: deps.mediaMaxBytes,
           textLimit: deps.textLimit,
+          sessionKey: route.sessionKey,
         });
       },
       onError: (err, info) => {

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -104,6 +104,7 @@ export type SignalEventHandlerDeps = {
     runtime: RuntimeEnv;
     maxBytes: number;
     textLimit: number;
+    sessionKey?: string;
   }) => Promise<void>;
   resolveSignalReactionTargets: (reaction: SignalReactionMessage) => SignalReactionTarget[];
   isSignalReactionMessage: (

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -203,6 +203,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       textLimit: ctx.textLimit,
       replyThreadTs,
       replyToMode: prepared.replyToMode,
+      sessionKey: prepared.ctxPayload.SessionKey ?? route.mainSessionKey,
       ...(slackIdentity ? { identity: slackIdentity } : {}),
     });
     // Record the thread ts only after confirmed delivery success.

--- a/src/slack/monitor/replies.test.ts
+++ b/src/slack/monitor/replies.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../../runtime.js";
 
-const sendMock = vi.fn();
+const emitMessageSentHookMock = vi.hoisted(() => vi.fn());
+vi.mock("../../hooks/emit-message-sent.js", () => ({
+  emitMessageSentHook: (...args: unknown[]) => emitMessageSentHookMock(...args),
+}));
+
+const sendMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 vi.mock("../send.js", () => ({
   sendMessageSlack: (...args: unknown[]) => sendMock(...args),
 }));
@@ -12,17 +18,92 @@ function baseParams(overrides?: Record<string, unknown>) {
     replies: [{ text: "hello" }],
     target: "C123",
     token: "xoxb-test",
-    runtime: { log: () => {}, error: () => {}, exit: () => {} },
+    runtime: { log: () => {}, error: () => {}, exit: () => {} } as unknown as RuntimeEnv,
     textLimit: 4000,
     replyToMode: "off" as const,
     ...overrides,
   };
 }
 
+describe("deliverReplies", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits message:sent hook on successful text delivery", async () => {
+    await deliverReplies({
+      ...baseParams(),
+      accountId: "acct-1",
+      sessionKey: "agent:main:main",
+      target: "C12345",
+    });
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(emitMessageSentHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "C12345",
+        content: "hello",
+        success: true,
+        channelId: "slack",
+        accountId: "acct-1",
+        sessionKey: "agent:main:main",
+      }),
+    );
+  });
+
+  it("emits message:sent failure hook when send throws", async () => {
+    sendMock.mockRejectedValueOnce(new Error("slack_api_error"));
+
+    await expect(
+      deliverReplies({
+        ...baseParams(),
+        target: "C99999",
+        sessionKey: "sess-fail",
+      }),
+    ).rejects.toThrow("slack_api_error");
+
+    expect(emitMessageSentHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "C99999",
+        success: false,
+        error: "slack_api_error",
+        channelId: "slack",
+      }),
+    );
+  });
+
+  it("emits hook per media item on successful delivery", async () => {
+    await deliverReplies({
+      ...baseParams({
+        replies: [
+          {
+            text: "caption",
+            mediaUrls: ["https://example.com/a.jpg", "https://example.com/b.jpg"],
+          },
+        ],
+      }),
+      target: "C12345",
+      sessionKey: "sess-media",
+    });
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(emitMessageSentHookMock).toHaveBeenCalledTimes(2);
+    expect(emitMessageSentHookMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ content: "caption", success: true }),
+    );
+    expect(emitMessageSentHookMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ content: "https://example.com/b.jpg", success: true }),
+    );
+  });
+});
+
 describe("deliverReplies identity passthrough", () => {
   beforeEach(() => {
     sendMock.mockReset();
   });
+
   it("passes identity to sendMessageSlack for text replies", async () => {
     sendMock.mockResolvedValue(undefined);
     const identity = { username: "Bot", iconEmoji: ":robot:" };

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -4,6 +4,7 @@ import { createReplyReferencePlanner } from "../../auto-reply/reply/reply-refere
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
+import { emitMessageSentHook } from "../../hooks/emit-message-sent.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
 import { sendMessageSlack, type SlackSendIdentity } from "../send.js";
@@ -17,6 +18,7 @@ export async function deliverReplies(params: {
   textLimit: number;
   replyThreadTs?: string;
   replyToMode: "off" | "first" | "all";
+  sessionKey?: string;
   identity?: SlackSendIdentity;
 }) {
   for (const payload of params.replies) {
@@ -30,30 +32,51 @@ export async function deliverReplies(params: {
       continue;
     }
 
-    if (mediaList.length === 0) {
-      const trimmed = text.trim();
-      if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
-        continue;
-      }
-      await sendMessageSlack(params.target, trimmed, {
-        token: params.token,
-        threadTs,
-        accountId: params.accountId,
-        ...(params.identity ? { identity: params.identity } : {}),
-      });
-    } else {
-      let first = true;
-      for (const mediaUrl of mediaList) {
-        const caption = first ? text : "";
-        first = false;
-        await sendMessageSlack(params.target, caption, {
+    const hookBase = {
+      to: params.target,
+      channelId: "slack" as const,
+      accountId: params.accountId,
+      sessionKey: params.sessionKey,
+    };
+    let lastContent = text;
+    try {
+      if (mediaList.length === 0) {
+        const trimmed = text.trim();
+        if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
+          continue;
+        }
+        lastContent = trimmed;
+        await sendMessageSlack(params.target, trimmed, {
           token: params.token,
-          mediaUrl,
           threadTs,
           accountId: params.accountId,
           ...(params.identity ? { identity: params.identity } : {}),
         });
+        emitMessageSentHook({ ...hookBase, content: trimmed, success: true });
+      } else {
+        let first = true;
+        for (const mediaUrl of mediaList) {
+          const caption = first ? text : "";
+          first = false;
+          lastContent = caption || mediaUrl;
+          await sendMessageSlack(params.target, caption, {
+            token: params.token,
+            mediaUrl,
+            threadTs,
+            accountId: params.accountId,
+            ...(params.identity ? { identity: params.identity } : {}),
+          });
+          emitMessageSentHook({ ...hookBase, content: caption || mediaUrl, success: true });
+        }
       }
+    } catch (err) {
+      emitMessageSentHook({
+        ...hookBase,
+        content: lastContent,
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
     }
     params.runtime.log?.(`delivered reply to ${params.target}`);
   }

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -393,6 +393,8 @@ export const dispatchTelegramMessage = async ({
     chunkMode,
     linkPreview: telegramCfg.linkPreview,
     replyQuoteText,
+    sessionKey: ctxPayload.SessionKey,
+    accountId: route.accountId,
   };
   const applyTextToPayload = (payload: ReplyPayload, text: string): ReplyPayload => {
     if (payload.text === text) {

--- a/src/telegram/bot/delivery-hook-integration.test.ts
+++ b/src/telegram/bot/delivery-hook-integration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Integration test: verifies the full hook chain from deliverReplies() through
+ * the real (unmocked) emitMessageSentHook helper down to the hook infrastructure.
+ *
+ * Unlike delivery.test.ts which mocks emitMessageSentHook to test channel
+ * delivery logic, this test leaves the helper unmocked and instead mocks the
+ * lowest-level sinks (getGlobalHookRunner, triggerInternalHook) to prove the
+ * end-to-end wiring works.
+ */
+import type { Bot } from "grammy";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../../runtime.js";
+import { deliverReplies } from "./delivery.js";
+
+// Mock the lowest-level hook sinks — NOT emitMessageSentHook itself.
+const mockRunMessageSent = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockHasHooks = vi.hoisted(() => vi.fn().mockReturnValue(true));
+const mockTriggerInternalHook = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockCreateInternalHookEvent = vi.hoisted(() =>
+  vi.fn((type: string, action: string, sessionKey: string, context: Record<string, unknown>) => ({
+    type,
+    action,
+    sessionKey,
+    context,
+  })),
+);
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => ({
+    hasHooks: mockHasHooks,
+    runMessageSent: mockRunMessageSent,
+  }),
+}));
+
+vi.mock("../../hooks/internal-hooks.js", () => ({
+  triggerInternalHook: (...args: unknown[]) => mockTriggerInternalHook(...args),
+  createInternalHookEvent: (
+    type: string,
+    action: string,
+    sessionKey: string,
+    context: Record<string, unknown>,
+  ) => mockCreateInternalHookEvent(type, action, sessionKey, context),
+}));
+
+// Mock grammy and media loader (same as delivery.test.ts — no real API calls).
+vi.mock("grammy", () => ({
+  InputFile: class {
+    constructor(
+      public buffer: Buffer,
+      public fileName?: string,
+    ) {}
+  },
+  GrammyError: class GrammyError extends Error {
+    description = "";
+  },
+}));
+
+const loadWebMedia = vi.fn();
+vi.mock("../../web/media.js", () => ({
+  loadWebMedia: (...args: unknown[]) => loadWebMedia(...args),
+}));
+
+function createRuntime(): Pick<RuntimeEnv, "error" | "log" | "exit"> {
+  return { error: vi.fn(), log: vi.fn(), exit: vi.fn() };
+}
+
+function createBot(api: Record<string, unknown> = {}): Bot {
+  return { api } as unknown as Bot;
+}
+
+describe("Telegram delivery → hook infrastructure (integration)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasHooks.mockReturnValue(true);
+  });
+
+  it("fires plugin hook runner end-to-end on successful text delivery", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 42, chat: { id: "100" } });
+
+    await deliverReplies({
+      replies: [{ text: "integration test" }],
+      chatId: "100",
+      token: "tok",
+      runtime: createRuntime() as RuntimeEnv,
+      bot: createBot({ sendMessage }),
+      replyToMode: "off",
+      textLimit: 4000,
+      sessionKey: "agent:main:e2e",
+      accountId: "acct-int",
+    });
+
+    expect(mockRunMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "100",
+        content: expect.stringContaining("integration test"),
+        success: true,
+      }),
+      expect.objectContaining({
+        channelId: "telegram",
+        accountId: "acct-int",
+        conversationId: "100",
+      }),
+    );
+  });
+
+  it("fires internal hook end-to-end with sessionKey on successful delivery", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 55, chat: { id: "200" } });
+
+    await deliverReplies({
+      replies: [{ text: "hook chain test" }],
+      chatId: "200",
+      token: "tok",
+      runtime: createRuntime() as RuntimeEnv,
+      bot: createBot({ sendMessage }),
+      replyToMode: "off",
+      textLimit: 4000,
+      sessionKey: "agent:main:sess",
+      accountId: "acct-2",
+    });
+
+    expect(mockCreateInternalHookEvent).toHaveBeenCalledWith(
+      "message",
+      "sent",
+      "agent:main:sess",
+      expect.objectContaining({
+        to: "200",
+        content: expect.stringContaining("hook chain test"),
+        success: true,
+        channelId: "telegram",
+        accountId: "acct-2",
+        messageId: "55",
+      }),
+    );
+    expect(mockTriggerInternalHook).toHaveBeenCalled();
+  });
+
+  it("fires both plugin and internal failure hooks end-to-end when send throws", async () => {
+    const sendMessage = vi.fn().mockRejectedValue(new Error("API down"));
+
+    await expect(
+      deliverReplies({
+        replies: [{ text: "will fail" }],
+        chatId: "300",
+        token: "tok",
+        runtime: createRuntime() as RuntimeEnv,
+        bot: createBot({ sendMessage }),
+        replyToMode: "off",
+        textLimit: 4000,
+        sessionKey: "agent:main:fail",
+        accountId: "acct-3",
+      }),
+    ).rejects.toThrow("API down");
+
+    expect(mockRunMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "300",
+        success: false,
+        error: "API down",
+      }),
+      expect.objectContaining({ channelId: "telegram" }),
+    );
+
+    expect(mockCreateInternalHookEvent).toHaveBeenCalledWith(
+      "message",
+      "sent",
+      "agent:main:fail",
+      expect.objectContaining({
+        success: false,
+        error: "API down",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** The `message:sent` hook (both plugin and internal) only fires from the centralized outbound delivery path (`src/infra/outbound/deliver.ts`). Conversational replies — the primary message flow — route through channel-specific inline `deliverReplies()` functions in Telegram, Signal, Slack, and iMessage that bypass this path entirely, so the hook never fires.
- **Why it matters:** Any integration relying on `message:sent` for conversation logging, analytics, or downstream processing silently misses all conversational replies. This was identified as a gap in #24968.
- **What changed:** A shared `emitMessageSentHook()` utility is added and wired into all four inline delivery paths. `sessionKey` is threaded from each channel's routing context to enable internal hook emission. `accountId` is included for multi-account attribution. All send paths (text and media) emit both success and failure hooks.
- **What did NOT change (scope boundary):** The centralized outbound delivery path is untouched. Hook semantics, payload shape, and fire-and-forget behavior are identical to the existing implementation. No new dependencies.

Supersedes #28076 (same fix, clean commit history, all reviewer feedback addressed).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24968
- Supersedes #28076

## User-visible / Behavior Changes

- `message:sent` plugin hooks now fire for conversational replies delivered via Telegram, Signal, Slack, and iMessage inline delivery paths (previously only fired for outbound messages routed through the centralized delivery path).
- Internal hooks (`message` / `sent` events) now fire for the same paths when a `sessionKey` is available.
- No config changes required. No new config options.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (hooks are existing internal event dispatch)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Node 22 slim container via Docker/Colima) and macOS (Darwin 25.3.0)
- Runtime/container: Node 22 (Docker container for E2E), pnpm/Bun (local for unit tests)
- Model/provider: Anthropic (Claude Opus 4.6, used for E2E Telegram test)
- Integration/channel: Telegram (E2E verified), Signal/Slack/iMessage (unit tested)
- Relevant config: Internal `message:sent` hook writing JSONL to `/tmp/message_sent.log`

### Steps

1. Register a `message:sent` internal hook that appends events to a log file
2. Start the gateway from this branch in a Docker container with only the test Telegram bot
3. Send a DM to the bot on Telegram and wait for a reply
4. Inspect the log file for `message:sent` events

### Expected

- `message:sent` hook fires for every outbound reply, with `to`, `content`, `success`, `channelId`, `accountId`, `messageId`, and `sessionKey` populated

### Actual (before fix)

- Hook only fires for messages routed through `src/infra/outbound/deliver.ts` (e.g., scheduled messages, broadcast). Conversational replies via inline `deliverReplies()` silently skip hook emission.

### Actual (after fix)

- Hook fires correctly. Example JSONL output from E2E test:

```json
{"timestamp":"2026-02-27T00:55:32.057Z","type":"message","action":"sent","to":"8323132901","content":"Hey. I just came online...","success":true,"channelId":"telegram","accountId":"e2etest","conversationId":"8323132901","messageId":"8","sessionKey":"agent:main:main"}
```

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

### Test coverage

**Unit tests (13)** for the shared `emitMessageSentHook()` utility covering:
- Plugin hook firing with correct args
- Error field inclusion on failure
- No-op when hookRunner is null or has no hooks
- Fire-and-forget error swallowing
- Internal hook firing with sessionKey
- Internal hook skipped when sessionKey is undefined
- messageId threading
- Independence of plugin and internal hooks

**Regression tests (8)** per channel:
- Telegram: text success, text failure, media success
- Slack: text success, text failure, media success
- iMessage: text success, text failure

**Integration test (3)** — does NOT mock `emitMessageSentHook`; instead mocks only the lowest-level hook sinks (`getGlobalHookRunner`, `triggerInternalHook`) to verify the full call chain from `deliverTelegramReplies` → `emitMessageSentHook` → hook sinks:
- Plugin hook e2e flow
- Internal hook e2e flow
- Both failure hooks e2e flow

**Full suite:** All tests pass (`pnpm test`). Build (`pnpm build`), type-check (`pnpm tsgo`), lint/format (`pnpm check`) all pass.

**Live E2E:** Telegram bot in Docker container (Node 22, Linux) confirmed hook fires on real conversational replies with all expected fields.

## Human Verification (required)

This PR was written by Claude Code. This is now me (Ahmed Kaddoura) editing this PR. I discovered the bug and confirmed the fix works by spinning up a Docker container and running a gateway with the fix. Messaged my agent via Telegram and confirmed the hook now fires. Note I only tested with Telegram and did not test with Signal, iMessage, or Slack.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit. The hook calls are additive and fire-and-forget, so removing them restores exact previous behavior.
- Files/config to restore: No config changes to revert.
- Known bad symptoms reviewers should watch for: Unexpected errors logged from hook execution (though errors are caught and swallowed). Performance degradation if hooks do expensive synchronous work (unlikely — hooks are async).

## Risks and Mitigations

- Risk: Hook handlers that assume they only receive centralized-path messages may see unexpected volume.
  - Mitigation: Hook payload shape is identical to the existing centralized path. The documentation describes `message:sent` as firing "when an outbound message is successfully sent" — this fix makes reality match the contract.

---

## AI Transparency

This PR was AI-assisted using Claude Code (Opus 4.6). The approach was validated by comparing independent implementations from three LLMs (Claude Opus 4.6, gemini-3.1-pro-preview, and gpt-5.3-codex) in isolated git worktrees — all three converged on the same core solution. The shared helper pattern was chosen as the cleanest (DRY, single maintenance point).

### Discovery Story

I'm building a product on top of OpenClaw and needed bidirectional conversation logging via the `message:sent` hook. I discovered the hook wasn't firing for conversational replies — the primary message flow. Investigation confirmed this affects all four built-in channels with inline delivery paths (Telegram, Signal, Slack, iMessage) and that it was identified as a known gap in #24968.

<details>
<summary>AI Prompt Used</summary>

```
Fix the message:sent hook gap in OpenClaw where conversational replies bypass hook emission.

Context: The message:sent hook (both plugin hooks via hookRunner.runMessageSent and internal hooks
via triggerInternalHook/createInternalHookEvent) only fires from the centralized outbound delivery
path in src/infra/outbound/deliver.ts. Four channels have inline deliverReplies() functions that
bypass this path: Telegram, Signal, Slack, and iMessage.

Reference implementation (src/infra/outbound/deliver.ts lines 448-510):
- Plugin hook: hookRunner.runMessageSent({to, content, success, error?}, {channelId, accountId, conversationId})
- Internal hook: triggerInternalHook(createInternalHookEvent("message", "sent", sessionKey, context))
- Both are fire-and-forget: void promise.catch(() => {})

Solution approach:
1. Create src/hooks/emit-message-sent.ts — shared utility that fires both hooks
2. Wire into all four inline delivery paths
3. Thread sessionKey from each channel's routing context

Key constraints:
- Hooks must never block message delivery (fire-and-forget)
- Use void promise.catch(() => {}) pattern
- sessionKey is required for internal hooks but optional (gracefully skip if missing)
- Plugin hooks check hookRunner?.hasHooks("message_sent") before calling
- All send paths (text + media) must emit both success and failure hooks
- Include accountId in hook context for multi-account setups
- Follow existing code style (TypeScript ESM, tabs, Oxfmt formatting)
```

</details>

### Testing Level

- 13 unit tests for the shared utility (all pass)
- 8 regression tests across Telegram, Slack, and iMessage (all pass)
- 3 integration tests verifying full call chain without mocking the shared utility (all pass)
- Full test suite passes (`pnpm test`)
- Build (`pnpm build`), type-check (`pnpm tsgo`), lint/format (`pnpm check`) all pass
- CI: all checks green
- **Live E2E: Telegram bot in Docker container (Node 22, Linux) confirmed hook fires on real conversational replies with all expected fields**

I confirm that I understand the contribution guidelines and that this submission complies with them.