### PR TITLE
fix(node-install): persist OPENCLAW_GATEWAY_TOKEN in service environment

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -413,6 +413,48 @@ describe("buildNodeServiceEnvironment", () => {
     });
     expect(env.NODE_EXTRA_CA_CERTS).toBe("/custom/certs/ca.pem");
   });
+
+  it("persists OPENCLAW_GATEWAY_TOKEN so the node service survives reboots (regression: #31041)", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user", OPENCLAW_GATEWAY_TOKEN: "tok_abc123" },
+    });
+    expect(env.OPENCLAW_GATEWAY_TOKEN).toBe("tok_abc123");
+  });
+
+  it("trims OPENCLAW_GATEWAY_TOKEN whitespace", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user", OPENCLAW_GATEWAY_TOKEN: "  tok_abc123  " },
+    });
+    expect(env.OPENCLAW_GATEWAY_TOKEN).toBe("tok_abc123");
+  });
+
+  it("omits OPENCLAW_GATEWAY_TOKEN when not set", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user" },
+    });
+    expect(env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+  });
+
+  it("persists OPENCLAW_GATEWAY_PASSWORD so the node service survives reboots", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user", OPENCLAW_GATEWAY_PASSWORD: "s3cret" },
+    });
+    expect(env.OPENCLAW_GATEWAY_PASSWORD).toBe("s3cret");
+  });
+
+  it("omits OPENCLAW_GATEWAY_PASSWORD when not set", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user" },
+    });
+    expect(env.OPENCLAW_GATEWAY_PASSWORD).toBeUndefined();
+  });
+
+  it("forwards OPENCLAW_PROFILE for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user", OPENCLAW_PROFILE: "work" },
+    });
+    expect(env.OPENCLAW_PROFILE).toBe("work");
+  });
 });
 
 describe("resolveGatewayStateDir", () => {

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -279,6 +279,7 @@ export function buildNodeServiceEnvironment(params: {
 }): Record<string, string | undefined> {
   const { env } = params;
   const platform = params.platform ?? process.platform;
+  const profile = env.OPENCLAW_PROFILE;
   const stateDir = env.OPENCLAW_STATE_DIR;
   const configPath = env.OPENCLAW_CONFIG_PATH;
   const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
@@ -288,14 +289,23 @@ export function buildNodeServiceEnvironment(params: {
   // works correctly when running as a LaunchAgent without extra user configuration.
   const nodeCaCerts =
     env.NODE_EXTRA_CA_CERTS ?? (platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
+  // Persist gateway auth credentials so the node service can reconnect after
+  // a reboot without needing the user to re-run `openclaw node install`.
+  // These are only written to the plist/systemd unit when present at install
+  // time; if absent, the node runner falls back to the config file values.
+  const gatewayToken = env.OPENCLAW_GATEWAY_TOKEN?.trim() || undefined;
+  const gatewayPassword = env.OPENCLAW_GATEWAY_PASSWORD?.trim() || undefined;
   return {
     HOME: env.HOME,
     TMPDIR: tmpDir,
     PATH: buildMinimalServicePath({ env }),
     ...proxyEnv,
     NODE_EXTRA_CA_CERTS: nodeCaCerts,
+    OPENCLAW_PROFILE: profile,
     OPENCLAW_STATE_DIR: stateDir,
     OPENCLAW_CONFIG_PATH: configPath,
+    OPENCLAW_GATEWAY_TOKEN: gatewayToken,
+    OPENCLAW_GATEWAY_PASSWORD: gatewayPassword,
     OPENCLAW_LAUNCHD_LABEL: resolveNodeLaunchAgentLabel(),
     OPENCLAW_SYSTEMD_UNIT: resolveNodeSystemdServiceName(),
     OPENCLAW_WINDOWS_TASK_NAME: resolveNodeWindowsTaskName(),


### PR DESCRIPTION
Fixes #31041

## Summary

`openclaw node install` generates a LaunchAgent plist (macOS) / systemd unit (Linux) / Windows Task without `OPENCLAW_GATEWAY_TOKEN` in the `EnvironmentVariables` section, even when the env var is set at install time. On reboot, the node service starts without the token, falls back to reading `gateway.auth.token` from the local config file, and fails with `gateway token mismatch` when connecting to a remote gateway that uses a different token.

## Root Cause

`buildNodeServiceEnvironment()` in `src/daemon/service-env.ts` does not forward `OPENCLAW_GATEWAY_TOKEN`, `OPENCLAW_GATEWAY_PASSWORD`, or `OPENCLAW_PROFILE` from the install-time environment. `buildServiceEnvironment()` (for the gateway service) already handles all three correctly:

```typescript
// buildServiceEnvironment (gateway) — correct ✅
OPENCLAW_GATEWAY_TOKEN: token,

// buildNodeServiceEnvironment (node) — missing ❌
// OPENCLAW_GATEWAY_TOKEN: ??? (omitted)
```

## Fix

Forward the three missing variables in `buildNodeServiceEnvironment()`:
- `OPENCLAW_GATEWAY_TOKEN` — bearer token for the remote gateway (trimmed; omitted when empty so the plist does not include a blank entry)
- `OPENCLAW_GATEWAY_PASSWORD` — password-based auth (same treatment)
- `OPENCLAW_PROFILE` — preserves the active config profile across reboots

## Changes

- **`src/daemon/service-env.ts`**: Add `OPENCLAW_GATEWAY_TOKEN`, `OPENCLAW_GATEWAY_PASSWORD`, and `OPENCLAW_PROFILE` to the `buildNodeServiceEnvironment()` return value.
- **`src/daemon/service-env.test.ts`**: Add regression tests verifying the token is forwarded, trimmed, and omitted when absent; same for password and profile.

## Testing

```
pnpm vitest run src/daemon/service-env.test.ts
✓ src/daemon/service-env.test.ts (43 tests)
```