### PR TITLE
fix: strip trailing NO_REPLY token from substantive replies

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -1,6 +1,11 @@
 import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
-import { HEARTBEAT_TOKEN, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+import {
+  HEARTBEAT_TOKEN,
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+  stripTrailingSilentReplyToken,
+} from "../tokens.js";
 import type { ReplyPayload } from "../types.js";
 import { hasLineDirectives, parseLineDirectives } from "./line-directives.js";
 import {
@@ -36,6 +41,14 @@ export function normalizeReplyPayload(
 
   const silentToken = opts.silentToken ?? SILENT_REPLY_TOKEN;
   let text = payload.text ?? undefined;
+
+  if (text && !isSilentReplyText(text, silentToken)) {
+    const stripped = stripTrailingSilentReplyToken(text, silentToken);
+    if (stripped.didStrip) {
+      text = stripped.text;
+    }
+  }
+
   if (text && isSilentReplyText(text, silentToken)) {
     if (!hasMedia && !hasChannelData) {
       opts.onSkip?.("silent");
@@ -62,7 +75,9 @@ export function normalizeReplyPayload(
   }
 
   if (text) {
-    text = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
+    text = sanitizeUserFacingText(text, {
+      errorContext: Boolean(payload.isError),
+    });
   }
   if (!text?.trim() && !hasMedia && !hasChannelData) {
     opts.onSkip?.("empty");

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { isSilentReplyPrefixText, isSilentReplyText } from "./tokens.js";
+import {
+  isSilentReplyPrefixText,
+  isSilentReplyText,
+  stripTrailingSilentReplyToken,
+} from "./tokens.js";
 
 describe("isSilentReplyText", () => {
   it("returns true for exact token", () => {
@@ -54,5 +58,31 @@ describe("isSilentReplyPrefixText", () => {
     expect(isSilentReplyPrefixText("NO_X")).toBe(false);
     expect(isSilentReplyPrefixText("NO_REPLY more")).toBe(false);
     expect(isSilentReplyPrefixText("NO-")).toBe(false);
+  });
+});
+
+describe("stripTrailingSilentReplyToken", () => {
+  it("strips trailing NO_REPLY after newline", () => {
+    const { text, didStrip } = stripTrailingSilentReplyToken("File's there.\n\nNO_REPLY");
+    expect(didStrip).toBe(true);
+    expect(text).toBe("File's there.");
+  });
+
+  it("strips trailing NO_REPLY with whitespace", () => {
+    const { text, didStrip } = stripTrailingSilentReplyToken("Done.\n NO_REPLY ");
+    expect(didStrip).toBe(true);
+    expect(text).toBe("Done.");
+  });
+
+  it("does not strip exact NO_REPLY", () => {
+    const { text, didStrip } = stripTrailingSilentReplyToken("NO_REPLY");
+    expect(didStrip).toBe(false);
+    expect(text).toBe("NO_REPLY");
+  });
+
+  it("does not strip mid-sentence NO_REPLY", () => {
+    const { text, didStrip } = stripTrailingSilentReplyToken("Please NO_REPLY to this");
+    expect(didStrip).toBe(false);
+    expect(text).toBe("Please NO_REPLY to this");
   });
 });

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -17,6 +17,21 @@ export function isSilentReplyText(
   return new RegExp(`^\\s*${escaped}\\s*$`).test(text);
 }
 
+export function stripTrailingSilentReplyToken(
+  text: string,
+  token: string = SILENT_REPLY_TOKEN,
+): { text: string; didStrip: boolean } {
+  const escaped = escapeRegExp(token);
+  const trailingPattern = new RegExp(`\\s*\\n\\s*${escaped}\\s*$`);
+  if (trailingPattern.test(text)) {
+    return {
+      text: text.replace(trailingPattern, "").trimEnd(),
+      didStrip: true,
+    };
+  }
+  return { text, didStrip: false };
+}
+
 export function isSilentReplyPrefixText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** When models append `NO_REPLY` to substantive content (for example: `Done.\n\nNO_REPLY`), the token can leak to users.
- **Why it matters:** User-facing replies look broken/noisy even though the intent was to suppress only the token marker.
- **What changed:** Added `stripTrailingSilentReplyToken()` in `src/auto-reply/tokens.ts`, and applied it in `normalizeReplyPayload()` before exact silent-token suppression.
- **What did NOT change (scope boundary):** Exact `NO_REPLY` behavior is unchanged (still suppresses). Mid-sentence token text is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30916 

## User-visible / Behavior Changes

- Replies that accidentally end with trailing `NO_REPLY` are now delivered cleanly without the trailing token.
- Exact `NO_REPLY`-only messages remain suppressed as before.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu Linux
- Runtime/container: local dev env
- Model/provider: N/A (logic-level fix, model-agnostic)
- Integration/channel (if any): N/A
- Relevant config (redacted): default

### Steps

1. Create text with trailing token, e.g. `File's there.\n\nNO_REPLY`.
2. Run normalization path.
3. Observe normalized output.
4. Verify exact `NO_REPLY` still follows silent behavior.

### Expected

- Trailing token is removed from substantive messages.
- Exact `NO_REPLY` remains treated as silent.

### Actual

- Matches expected after fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios:**
- Trailing token strip: `"File's there.\n\nNO_REPLY"` -> `"File's there."`
- Trailing token strip with whitespace: `"Done.\n NO_REPLY "` -> `"Done."`
- Exact token unchanged by strip helper: `"NO_REPLY"`
- Mid-sentence token unchanged: `"Please NO_REPLY to this"`

- **Edge cases checked:**
- Existing `isSilentReplyText` behavior remains intact.
- Full reply test suite still passes.

- **What you did not verify:**
- Live end-to-end on every channel integration (covered by existing suite + targeted unit tests).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Revert this commit.

- Files/config to restore:
- `src/auto-reply/tokens.ts`
- `src/auto-reply/reply/normalize-reply.ts`
- `src/auto-reply/tokens.test.ts`

- Known bad symptoms reviewers should watch for:
- Trailing `NO_REPLY` token reappearing in user-facing messages.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Over-stripping in cases where literal trailing token text is intentional.
- Mitigation: Strip is narrowly scoped to trailing newline + token pattern; mid-sentence and exact-token behavior remain explicit and tested.
