### PR TITLE
fix(plugins): initialize global hook runner when loading from cache

### DIFF
--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -30,7 +30,7 @@ export function initializeGlobalHookRunner(registry: PluginRegistry): void {
     catchErrors: true,
   });
 
-  const hookCount = registry.hooks.length;
+  const hookCount = registry.typedHooks.length;
   if (hookCount > 0) {
     log.info(`hook runner initialized with ${hookCount} registered hooks`);
   }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -381,6 +381,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     const cached = registryCache.get(cacheKey);
     if (cached) {
       setActivePluginRegistry(cached, cacheKey);
+      initializeGlobalHookRunner(cached);
       return cached;
     }
   }


### PR DESCRIPTION
## Summary

Fixes a regression where plugin hooks registered via `api.on()` would never fire when plugins were loaded from cache.

## Root Cause

In `loadOpenClawPlugins()`, when a cached registry was found, the function would return early without calling `initializeGlobalHookRunner()`. This meant:

1. **First load (no cache)**: Hooks work correctly
2. **Subsequent loads (from cache)**: Hooks silently fail because the global hook runner is never initialized

## Changes

1. **loader.ts**: Added `initializeGlobalHookRunner(cached)` call in the cache hit path
2. **hook-runner-global.ts**: Fixed logging to use `registry.typedHooks.length` instead of `registry.hooks.length` (the legacy array that `api.on()` hooks are never added to)

## Testing

All existing plugin tests pass (172 tests), including the hook-related tests.

Fixes #31038