### PR TITLE
fix(telegram): replyToMode 'first' should only quote the first chunk

### DIFF
--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1742,10 +1742,20 @@ describe("createTelegramBot", () => {
       });
 
       expect(sendMessageSpy.mock.calls.length).toBeGreaterThan(1);
-      for (const call of sendMessageSpy.mock.calls) {
-        expect((call[2] as { reply_to_message_id?: number } | undefined)?.reply_to_message_id).toBe(
-          messageId,
-        );
+      for (let i = 0; i < sendMessageSpy.mock.calls.length; i++) {
+        const call = sendMessageSpy.mock.calls[i];
+        const opts = call[2] as { reply_to_message_id?: number } | undefined;
+        if (mode === "all") {
+          // Every chunk carries the reply reference.
+          expect(opts?.reply_to_message_id).toBe(messageId);
+        } else {
+          // "first" mode: only the first chunk carries reply_to_message_id.
+          if (i === 0) {
+            expect(opts?.reply_to_message_id).toBe(messageId);
+          } else {
+            expect(opts?.reply_to_message_id).toBeUndefined();
+          }
+        }
       }
     }
   });

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -124,7 +124,6 @@ export async function deliverReplies(params: {
     const replyMarkup = buildInlineKeyboard(telegramData?.buttons);
     if (mediaList.length === 0) {
       const chunks = chunkText(reply.text || "");
-      let sentTextChunk = false;
       for (let i = 0; i < chunks.length; i += 1) {
         const chunk = chunks[i];
         if (!chunk) {
@@ -132,20 +131,22 @@ export async function deliverReplies(params: {
         }
         // Only attach buttons to the first chunk.
         const shouldAttachButtons = i === 0 && replyMarkup;
+        // In "first" mode, only the first chunk should carry the reply reference.
+        const chunkReplyToId =
+          replyToMode === "all" || !hasReplied ? replyToMessageIdForPayload : undefined;
         await sendTelegramText(bot, chatId, chunk.html, runtime, {
-          replyToMessageId: replyToMessageIdForPayload,
-          replyQuoteText,
+          replyToMessageId: chunkReplyToId,
+          replyQuoteText: !hasReplied ? replyQuoteText : undefined,
           thread,
           textMode: "html",
           plainText: chunk.text,
           linkPreview,
           replyMarkup: shouldAttachButtons ? replyMarkup : undefined,
         });
-        sentTextChunk = true;
+        if (chunkReplyToId && !hasReplied) {
+          hasReplied = true;
+        }
         markDelivered();
-      }
-      if (replyToMessageIdForPayload && !hasReplied && sentTextChunk) {
-        hasReplied = true;
       }
       continue;
     }
@@ -287,20 +288,22 @@ export async function deliverReplies(params: {
         const chunks = chunkText(pendingFollowUpText);
         for (let i = 0; i < chunks.length; i += 1) {
           const chunk = chunks[i];
+          const chunkReplyToId =
+            replyToMode === "all" || !hasReplied ? replyToMessageIdForPayload : undefined;
           await sendTelegramText(bot, chatId, chunk.html, runtime, {
-            replyToMessageId: replyToMessageIdForPayload,
+            replyToMessageId: chunkReplyToId,
             thread,
             textMode: "html",
             plainText: chunk.text,
             linkPreview,
             replyMarkup: i === 0 ? replyMarkup : undefined,
           });
+          if (chunkReplyToId && !hasReplied) {
+            hasReplied = true;
+          }
           markDelivered();
         }
         pendingFollowUpText = undefined;
-      }
-      if (replyToMessageIdForPayload && !hasReplied) {
-        hasReplied = true;
       }
     }
   }


### PR DESCRIPTION
When a reply is split into multiple Telegram messages (chunks), `replyToMode: "first"` was applying `reply_to_message_id` to **all chunks** instead of only the first one.

## Root Cause

`replyToMessageIdForPayload` was computed once outside the chunk loop and reused for every chunk. `hasReplied` was only updated after the entire loop completed.

## Fix

Evaluate `hasReplied` inside the chunk loop so that after the first chunk is sent with a reply reference, subsequent chunks are sent without one. Applied to both:

- Text-only chunk loops
- Media follow-up text chunk loops

Also gates `replyQuoteText` to only the first chunk (consistent with reply reference behavior).

## Edge Cases Verified

| Scenario | Behavior |
|---|---|
| Empty chunks | Skipped, no state change ✅ |
| Single chunk | Gets reply ref normally ✅ |
| `replyToMode: "all"` | All chunks still get reply ref (unchanged) ✅ |
| `replyToMode: "off"` | No reply ref (unchanged) ✅ |
| `replyToMode: "first"`, multi-chunk | **Only first chunk quotes** ✅ |

Fixes #31039