### PR TITLE
fix: include ttl in OpenRouter cache_control when cacheRetention is "long"

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
@@ -11,14 +11,18 @@ type StreamPayload = {
   }>;
 };
 
-function runOpenRouterPayload(payload: StreamPayload, modelId: string) {
+function runOpenRouterPayload(
+  payload: StreamPayload,
+  modelId: string,
+  extraParamsOverride?: Record<string, unknown>,
+) {
   const baseStreamFn: StreamFn = (_model, _context, options) => {
     options?.onPayload?.(payload);
     return createAssistantMessageEventStream();
   };
   const agent = { streamFn: baseStreamFn };
 
-  applyExtraParamsToAgent(agent, undefined, "openrouter", modelId);
+  applyExtraParamsToAgent(agent, undefined, "openrouter", modelId, extraParamsOverride);
 
   const model = {
     api: "openai-completions",
@@ -89,5 +93,81 @@ describe("extra-params: OpenRouter Anthropic cache_control", () => {
     runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
 
     expect(payload.messages[0].content).toBe("Hello");
+  });
+
+  it("includes ttl in cache_control when cacheRetention is 'long'", () => {
+    const payload = {
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hello" },
+      ],
+    };
+
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6", { cacheRetention: "long" });
+
+    expect(payload.messages[0].content).toEqual([
+      {
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      },
+    ]);
+    expect(payload.messages[1].content).toBe("Hello");
+  });
+
+  it("omits ttl from cache_control when cacheRetention is 'short'", () => {
+    const payload = {
+      messages: [{ role: "system", content: "You are a helpful assistant." }],
+    };
+
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6", { cacheRetention: "short" });
+
+    expect(payload.messages[0].content).toEqual([
+      {
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+  });
+
+  it("includes ttl in cache_control for array content when cacheRetention is 'long'", () => {
+    const payload = {
+      messages: [
+        {
+          role: "system",
+          content: [
+            { type: "text", text: "Part 1" },
+            { type: "text", text: "Part 2" },
+          ],
+        },
+      ],
+    };
+
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6", { cacheRetention: "long" });
+
+    const content = payload.messages[0].content as Array<Record<string, unknown>>;
+    expect(content[0]).toEqual({ type: "text", text: "Part 1" });
+    expect(content[1]).toEqual({
+      type: "text",
+      text: "Part 2",
+      cache_control: { type: "ephemeral", ttl: "1h" },
+    });
+  });
+
+  it("maps legacy cacheControlTtl '1h' to long cache retention with ttl", () => {
+    const payload = {
+      messages: [{ role: "system", content: "You are a helpful assistant." }],
+    };
+
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6", { cacheControlTtl: "1h" });
+
+    expect(payload.messages[0].content).toEqual([
+      {
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      },
+    ]);
   });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -443,12 +443,45 @@ type PayloadMessage = {
 };
 
 /**
+ * Resolve cacheRetention for OpenRouter from extraParams.
+ *
+ * Unlike direct Anthropic which defaults to "short", OpenRouter has no default —
+ * cache_control is only injected when explicitly configured. Supports both the
+ * new `cacheRetention` field and the legacy `cacheControlTtl` mapping.
+ */
+function resolveOpenRouterCacheRetention(
+  extraParams: Record<string, unknown> | undefined,
+): CacheRetention | undefined {
+  const newVal = extraParams?.cacheRetention;
+  if (newVal === "none" || newVal === "short" || newVal === "long") {
+    return newVal;
+  }
+  const legacy = extraParams?.cacheControlTtl;
+  if (legacy === "5m") {
+    return "short";
+  }
+  if (legacy === "1h") {
+    return "long";
+  }
+  return undefined;
+}
+
+/**
  * Inject cache_control into the system message for OpenRouter Anthropic models.
  * OpenRouter passes through Anthropic's cache_control field — caching the system
  * prompt avoids re-processing it on every request.
+ *
+ * When cacheRetention is "long", includes `ttl: "1h"` in the cache_control object
+ * so the cache persists for 1 hour instead of the default 5 minutes.
+ * @see https://openrouter.ai/docs/guides/best-practices/prompt-caching#anthropic-claude
  */
-function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+function createOpenRouterSystemCacheWrapper(
+  baseStreamFn: StreamFn | undefined,
+  cacheRetention?: CacheRetention,
+): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
+  const cacheControl: Record<string, string> =
+    cacheRetention === "long" ? { type: "ephemeral", ttl: "1h" } : { type: "ephemeral" };
   return (model, context, options) => {
     if (
       typeof model.provider !== "string" ||
@@ -469,13 +502,11 @@ function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined):
               continue;
             }
             if (typeof msg.content === "string") {
-              msg.content = [
-                { type: "text", text: msg.content, cache_control: { type: "ephemeral" } },
-              ];
+              msg.content = [{ type: "text", text: msg.content, cache_control: cacheControl }];
             } else if (Array.isArray(msg.content) && msg.content.length > 0) {
               const last = msg.content[msg.content.length - 1];
               if (last && typeof last === "object") {
-                (last as Record<string, unknown>).cache_control = { type: "ephemeral" };
+                (last as Record<string, unknown>).cache_control = cacheControl;
               }
             }
           }
@@ -780,7 +811,8 @@ export function applyExtraParamsToAgent(
     // See: openclaw/openclaw#24851
     const openRouterThinkingLevel = modelId === "auto" ? undefined : thinkingLevel;
     agent.streamFn = createOpenRouterWrapper(agent.streamFn, openRouterThinkingLevel);
-    agent.streamFn = createOpenRouterSystemCacheWrapper(agent.streamFn);
+    const openRouterCacheRetention = resolveOpenRouterCacheRetention(merged);
+    agent.streamFn = createOpenRouterSystemCacheWrapper(agent.streamFn, openRouterCacheRetention);
   }
 
   if (provider === "amazon-bedrock" && !isAnthropicBedrockModel(modelId)) {


### PR DESCRIPTION
## Summary

- Problem: `createOpenRouterSystemCacheWrapper` emits `cache_control: { type: "ephemeral" }` but omits `ttl` when `cacheRetention` is set to `"long"`, causing OpenRouter to use the default 5-minute cache instead of the intended 1-hour cache.
- Why it matters: Users paying for long cache retention on Anthropic models via OpenRouter get only 5 minutes of caching instead of 1 hour, leading to unnecessary extra cost.
- What changed: Added `resolveOpenRouterCacheRetention` to read `cacheRetention` (and legacy `cacheControlTtl`) from extraParams, and pass it to `createOpenRouterSystemCacheWrapper` which now conditionally includes `ttl: "1h"` in the `cache_control` object when retention is `"long"`.
- What did NOT change (scope boundary): Direct Anthropic and Bedrock cache retention logic is untouched. Default behavior (no `cacheRetention` configured) remains the same — `cache_control` is still `{ type: "ephemeral" }` without `ttl`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30850

## User-visible / Behavior Changes

- When `cacheRetention: "long"` is configured for an Anthropic model on OpenRouter, the `cache_control` object now includes `ttl: "1h"`, extending the cache lifetime from the default 5 minutes to 1 hour. This matches the documented OpenRouter behavior and reduces costs for users who configure long cache retention.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Model/provider: OpenRouter / Anthropic models (e.g. `anthropic/claude-opus-4-6`)
- Integration/channel (if any): N/A
- Relevant config (redacted): `cacheRetention: "long"` in model params

### Steps

1. Configure an agent with an Anthropic model on OpenRouter
2. Set `cacheRetention` to `"long"` in model configuration
3. Send a request and inspect the OpenRouter payload

### Expected

- `cache_control` object includes `{ type: "ephemeral", ttl: "1h" }`

### Actual (before fix)

- `cache_control` object is `{ type: "ephemeral" }` (no `ttl`, defaults to 5m)

## Evidence

- [x] Failing test/log before + passing after
  - Added 4 new test cases in `extra-params.openrouter-cache-control.test.ts` covering:
    - `cacheRetention: "long"` includes `ttl: "1h"` (string content)
    - `cacheRetention: "short"` omits `ttl` (unchanged behavior)
    - `cacheRetention: "long"` includes `ttl: "1h"` (array content)
    - Legacy `cacheControlTtl: "1h"` maps to long retention with `ttl`
  - All 8 tests pass (4 existing + 4 new)

## Human Verification (required)

- Verified scenarios: All 8 unit tests pass including the 4 new cache retention tests
- Edge cases checked: Legacy `cacheControlTtl` mapping, array vs string content, short vs long retention
- What you did **not** verify: Live OpenRouter API call (requires API key and billing)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; the `cacheRetention` param is simply ignored without this change
- Files/config to restore: `src/agents/pi-embedded-runner/extra-params.ts`
- Known bad symptoms reviewers should watch for: Unexpected `ttl` values in OpenRouter API payloads for non-Anthropic models (guarded by `isOpenRouterAnthropicModel`)

## Risks and Mitigations

- Risk: OpenRouter API rejects `ttl` field for certain Anthropic models
  - Mitigation: `ttl` is only included when explicitly configured via `cacheRetention: "long"`; default behavior is unchanged. The `ttl: "1h"` value is documented by OpenRouter.