### PR TITLE
fix(telegram): apply replyToMessageId only to first chunk in "first" mode

### DIFF
--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -132,9 +132,14 @@ export async function deliverReplies(params: {
         }
         // Only attach buttons to the first chunk.
         const shouldAttachButtons = i === 0 && replyMarkup;
+        // In "first" mode, only the first chunk should carry replyToMessageId.
+        const chunkReplyTo =
+          replyToId && (replyToMode === "all" || !hasReplied)
+            ? replyToId
+            : undefined;
         await sendTelegramText(bot, chatId, chunk.html, runtime, {
-          replyToMessageId: replyToMessageIdForPayload,
-          replyQuoteText,
+          replyToMessageId: chunkReplyTo,
+          replyQuoteText: !hasReplied ? replyQuoteText : undefined,
           thread,
           textMode: "html",
           plainText: chunk.text,
@@ -142,10 +147,10 @@ export async function deliverReplies(params: {
           replyMarkup: shouldAttachButtons ? replyMarkup : undefined,
         });
         sentTextChunk = true;
+        if (chunkReplyTo && !hasReplied) {
+          hasReplied = true;
+        }
         markDelivered();
-      }
-      if (replyToMessageIdForPayload && !hasReplied && sentTextChunk) {
-        hasReplied = true;
       }
       continue;
     }
@@ -287,14 +292,22 @@ export async function deliverReplies(params: {
         const chunks = chunkText(pendingFollowUpText);
         for (let i = 0; i < chunks.length; i += 1) {
           const chunk = chunks[i];
+          // In "first" mode, only reply-quote the first unseen chunk.
+          const followUpReplyTo =
+            replyToId && (replyToMode === "all" || !hasReplied)
+              ? replyToId
+              : undefined;
           await sendTelegramText(bot, chatId, chunk.html, runtime, {
-            replyToMessageId: replyToMessageIdForPayload,
+            replyToMessageId: followUpReplyTo,
             thread,
             textMode: "html",
             plainText: chunk.text,
             linkPreview,
             replyMarkup: i === 0 ? replyMarkup : undefined,
           });
+          if (followUpReplyTo && !hasReplied) {
+            hasReplied = true;
+          }
           markDelivered();
         }
         pendingFollowUpText = undefined;


### PR DESCRIPTION
## Summary

Fixes #31039

When `replyToMode` is `"first"`, all text chunks within a reply incorrectly carried `replyToMessageId` because it was computed once outside the chunk loop as a constant.

## Changes

- Compute the reply-to ID **per chunk** inside the loop, checking `hasReplied` each iteration
- Update `hasReplied` immediately after the first chunk is sent
- Apply the same fix to media follow-up text chunks (~line 292)
- Also gate `replyQuoteText` so only the first chunk carries the quote

## Before

All chunks show as replies to the original message in Telegram UI.

## After

Only the first chunk quotes the original message; subsequent chunks send without `reply_to_message_id`.

## Testing

1. Set `channels.telegram.replyToMode: "first"`
2. Trigger a reply >4096 chars (causes chunking)
3. Verify only the first chunk has reply-to markup