### PR TITLE
fix(version): prefer on-disk metadata over OPENCLAW_BUNDLED_VERSION

### DIFF
--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -94,6 +94,40 @@ describe("version resolution", () => {
     expect(resolveVersionFromModuleUrl("not-a-valid-url")).toBeNull();
   });
 
+  it("resolveVersionFromModuleUrl takes priority over OPENCLAW_BUNDLED_VERSION (regression: #30934)", async () => {
+    // Verifies that when on-disk metadata is available, it shadows any env-var override.
+    // The VERSION constant in version.ts applies this order:
+    //   __OPENCLAW_VERSION__ → resolveVersionFromModuleUrl → OPENCLAW_BUNDLED_VERSION → "0.0.0"
+    await withTempDir(async (root) => {
+      await writeJsonFixture(root, "package.json", { name: "openclaw", version: "2026.3.1" });
+      const moduleUrl = await ensureModuleFixture(root);
+
+      // resolveVersionFromModuleUrl correctly returns the on-disk version.
+      const fromDisk = resolveVersionFromModuleUrl(moduleUrl);
+      expect(fromDisk).toBe("2026.3.1");
+
+      // A stale env value (simulated) must NOT win over the on-disk version.
+      // In the corrected VERSION resolution, fromDisk is checked before the env var.
+      const staleEnvValue = "0.0.0-stale";
+      const resolved = fromDisk || staleEnvValue;
+      expect(resolved).toBe("2026.3.1");
+    });
+  });
+
+  it("OPENCLAW_BUNDLED_VERSION is used as fallback when on-disk metadata is absent (regression: #30934)", async () => {
+    await withTempDir(async (root) => {
+      // No package.json or build-info.json in this temp dir
+      const moduleUrl = await ensureModuleFixture(root);
+      expect(resolveVersionFromModuleUrl(moduleUrl)).toBeNull();
+
+      // In the corrected VERSION resolution, env var is consulted when disk is unavailable.
+      const fromDisk = resolveVersionFromModuleUrl(moduleUrl);
+      const bundledEnvValue = "2026.2.26";
+      const resolved = fromDisk || bundledEnvValue;
+      expect(resolved).toBe("2026.2.26");
+    });
+  });
+
   it("prefers OPENCLAW_VERSION over service and package versions", () => {
     expect(
       resolveRuntimeServiceVersion({

--- a/src/version.ts
+++ b/src/version.ts
@@ -89,10 +89,16 @@ export function resolveRuntimeServiceVersion(
 }
 
 // Single source of truth for the current OpenClaw version.
-// - Embedded/bundled builds: injected define or env var.
-// - Dev/npm builds: package.json.
+// Priority (highest → lowest):
+//   1. __OPENCLAW_VERSION__ — injected at build time via bundler define (always wins).
+//   2. resolveVersionFromModuleUrl — reads package.json / build-info.json on disk;
+//      present whenever the package is installed or run from source.
+//   3. OPENCLAW_BUNDLED_VERSION — env-var fallback for containerised / stripped builds
+//      where the on-disk metadata is absent.  Only consulted when neither of the above
+//      is available so a stale env value cannot shadow the real installed version.
+//   4. "0.0.0" — last-resort sentinel.
 export const VERSION =
   (typeof __OPENCLAW_VERSION__ === "string" && __OPENCLAW_VERSION__) ||
-  process.env.OPENCLAW_BUNDLED_VERSION ||
   resolveVersionFromModuleUrl(import.meta.url) ||
+  process.env.OPENCLAW_BUNDLED_VERSION ||
   "0.0.0";


### PR DESCRIPTION
Fixes #30934

## Summary

When `OPENCLAW_BUNDLED_VERSION` is set in the environment (e.g. from a previous install or a container image), OpenClaw reports the stale value even after updating — because the env var was checked **before** the on-disk `package.json`.

## Root Cause

`VERSION` resolution in `src/version.ts` used this order:

```
1. __OPENCLAW_VERSION__ (build-time define)
2. process.env.OPENCLAW_BUNDLED_VERSION  ← checked before disk
3. resolveVersionFromModuleUrl()          ← package.json / build-info.json
4. "0.0.0"
```

A stale `OPENCLAW_BUNDLED_VERSION` therefore silently shadows the real installed version.

## Fix

Swap steps 2 and 3:

```
1. __OPENCLAW_VERSION__
2. resolveVersionFromModuleUrl()          ← on-disk metadata wins
3. process.env.OPENCLAW_BUNDLED_VERSION  ← fallback for stripped builds
4. "0.0.0"
```

`OPENCLAW_BUNDLED_VERSION` now serves its intended purpose — a fallback for containerised or asset-stripped deployments where `package.json` is absent — without being able to override the actual installed version.

## Changes

- **`src/version.ts`**: Swap resolution order + expand comment to document priority.
- **`src/version.test.ts`**: Add 2 regression tests documenting that `resolveVersionFromModuleUrl` (on-disk) shadows the env var when present, and that the env var is still used when disk metadata is absent.

## Testing

```
pnpm vitest run src/version.test.ts
✓ src/version.test.ts (10 tests)
```