### PR TITLE
fix(plugins): use globalThis for cross-chunk hook runner access

### DIFF
--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -12,6 +12,30 @@ import type { PluginHookGatewayContext, PluginHookGatewayStopEvent } from "./typ
 
 const log = createSubsystemLogger("plugins");
 
+/**
+ * Use globalThis to store the hook runner and registry.
+ * This ensures all bundled chunks share the same instance,
+ * even when code is split across multiple entry points.
+ */
+const GLOBAL_KEY = "openclaw:pluginHookRunner";
+const GLOBAL_REGISTRY_KEY = "openclaw:pluginRegistry";
+
+function getStoredHookRunner(): HookRunner | null {
+  return (globalThis as Record<string, unknown>)[GLOBAL_KEY] as HookRunner | null;
+}
+
+function setStoredHookRunner(runner: HookRunner | null): void {
+  (globalThis as Record<string, unknown>)[GLOBAL_KEY] = runner;
+}
+
+function getStoredRegistry(): PluginRegistry | null {
+  return (globalThis as Record<string, unknown>)[GLOBAL_REGISTRY_KEY] as PluginRegistry | null;
+}
+
+function setStoredRegistry(registry: PluginRegistry | null): void {
+  (globalThis as Record<string, unknown>)[GLOBAL_REGISTRY_KEY] = registry;
+}
+
 let globalHookRunner: HookRunner | null = null;
 let globalRegistry: PluginRegistry | null = null;
 
@@ -30,7 +54,11 @@ export function initializeGlobalHookRunner(registry: PluginRegistry): void {
     catchErrors: true,
   });
 
-  const hookCount = registry.hooks.length;
+  // Also store in globalThis for cross-chunk access in bundled builds
+  setStoredRegistry(registry);
+  setStoredHookRunner(globalHookRunner);
+
+  const hookCount = registry.typedHooks.length;
   if (hookCount > 0) {
     log.info(`hook runner initialized with ${hookCount} registered hooks`);
   }
@@ -41,7 +69,12 @@ export function initializeGlobalHookRunner(registry: PluginRegistry): void {
  * Returns null if plugins haven't been loaded yet.
  */
 export function getGlobalHookRunner(): HookRunner | null {
-  return globalHookRunner;
+  // First try the module-level variable (works in non-bundled builds)
+  if (globalHookRunner) {
+    return globalHookRunner;
+  }
+  // Fall back to globalThis (required for bundled builds with code splitting)
+  return getStoredHookRunner();
 }
 
 /**
@@ -49,7 +82,12 @@ export function getGlobalHookRunner(): HookRunner | null {
  * Returns null if plugins haven't been loaded yet.
  */
 export function getGlobalPluginRegistry(): PluginRegistry | null {
-  return globalRegistry;
+  // First try the module-level variable (works in non-bundled builds)
+  if (globalRegistry) {
+    return globalRegistry;
+  }
+  // Fall back to globalThis (required for bundled builds with code splitting)
+  return getStoredRegistry();
 }
 
 /**
@@ -85,4 +123,6 @@ export async function runGlobalGatewayStopSafely(params: {
 export function resetGlobalHookRunner(): void {
   globalHookRunner = null;
   globalRegistry = null;
+  setStoredHookRunner(null);
+  setStoredRegistry(null);
 }


### PR DESCRIPTION
## Summary

This PR fixes the issue where plugin `message_sending` hooks registered via `api.on()` never fire in bundled builds with code splitting.

## Root Cause

When tsdown bundles the code with code splitting, each chunk (e.g., `deliver-CH3Y5bRD.js`) has its own module-scoped `globalHookRunner` variable. When plugins are loaded, only one chunk's `globalHookRunner` gets initialized, while other chunks still have `null`.

This means:
1. Plugin hooks are correctly registered in `registry.typedHooks`
2. `initializeGlobalHookRunner()` is called and creates a hook runner
3. But delivery modules in other chunks have their own `globalHookRunner` which remains `null`
4. Result: `getGlobalHookRunner()` returns `null` in those chunks, hooks never fire

## Solution

Use `globalThis` to store the hook runner and registry, so all bundled chunks share the same instance:

1. Store the hook runner in `globalThis['openclaw:pluginHookRunner']`
2. Store the registry in `globalThis['openclaw:pluginRegistry']`
3. `getGlobalHookRunner()` first checks the module-level variable, then falls back to `globalThis`

This ensures all chunks can access the same hook runner instance, regardless of code splitting.

## Additional Fix

Also fixed hook count logging which was checking `registry.hooks` (legacy array) instead of `registry.typedHooks` (where `api.on()` hooks are stored).

## Testing

This fix allows plugins to intercept and modify outgoing messages using the `message_sending` hook, as documented in the plugin API.

Fixes #31038