### PR TITLE
fix(agents): unblock gpt-5.3-codex API-key routing and replay

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -174,7 +174,7 @@ async function expectSkippedUnavailableProvider(params: {
 }
 
 describe("runWithModelFallback", () => {
-  it("normalizes openai gpt-5.3 codex to openai-codex before running", async () => {
+  it("keeps openai gpt-5.3 codex on the openai provider before running", async () => {
     const cfg = makeCfg();
     const run = vi.fn().mockResolvedValueOnce("ok");
 
@@ -187,7 +187,7 @@ describe("runWithModelFallback", () => {
 
     expect(result.result).toBe("ok");
     expect(run).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledWith("openai-codex", "gpt-5.3-codex");
+    expect(run).toHaveBeenCalledWith("openai", "gpt-5.3-codex");
   });
 
   it("falls back on unrecognized errors when candidates remain", async () => {

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -70,17 +70,17 @@ describe("model-selection", () => {
       });
     });
 
-    it("normalizes openai gpt-5.3 codex refs to openai-codex provider", () => {
+    it("keeps openai gpt-5.3 codex refs on the openai provider", () => {
       expect(parseModelRef("openai/gpt-5.3-codex", "anthropic")).toEqual({
-        provider: "openai-codex",
+        provider: "openai",
         model: "gpt-5.3-codex",
       });
       expect(parseModelRef("gpt-5.3-codex", "openai")).toEqual({
-        provider: "openai-codex",
+        provider: "openai",
         model: "gpt-5.3-codex",
       });
       expect(parseModelRef("openai/gpt-5.3-codex-codex", "anthropic")).toEqual({
-        provider: "openai-codex",
+        provider: "openai",
         model: "gpt-5.3-codex-codex",
       });
     });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -27,7 +27,6 @@ const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
   "sonnet-4.6": "claude-sonnet-4-6",
   "sonnet-4.5": "claude-sonnet-4-5",
 };
-const OPENAI_CODEX_OAUTH_MODEL_PREFIXES = ["gpt-5.3-codex"] as const;
 
 function normalizeAliasKey(value: string): string {
   return value.trim().toLowerCase();
@@ -133,25 +132,9 @@ function normalizeProviderModelId(provider: string, model: string): string {
   return model;
 }
 
-function shouldUseOpenAICodexProvider(provider: string, model: string): boolean {
-  if (provider !== "openai") {
-    return false;
-  }
-  const normalized = model.trim().toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  return OPENAI_CODEX_OAUTH_MODEL_PREFIXES.some(
-    (prefix) => normalized === prefix || normalized.startsWith(`${prefix}-`),
-  );
-}
-
 export function normalizeModelRef(provider: string, model: string): ModelRef {
   const normalizedProvider = normalizeProviderId(provider);
   const normalizedModel = normalizeProviderModelId(normalizedProvider, model.trim());
-  if (shouldUseOpenAICodexProvider(normalizedProvider, normalizedModel)) {
-    return { provider: "openai-codex", model: normalizedModel };
-  }
   return { provider: normalizedProvider, model: normalizedModel };
 }
 

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
   isMessagingToolDuplicate,
   normalizeTextForComparison,
@@ -315,6 +316,62 @@ describe("downgradeOpenAIReasoningBlocks", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     const twice = downgradeOpenAIReasoningBlocks(once as any);
     expect(twice).toEqual(once);
+  });
+});
+
+describe("downgradeOpenAIFunctionCallReasoningPairs", () => {
+  it("strips fc ids when reasoning cannot be replayed", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_123|fc_123", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_123|fc_123",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+      },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect(downgradeOpenAIFunctionCallReasoningPairs(input as any)).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_123", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_123",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+      },
+    ]);
+  });
+
+  it("keeps fc ids when replayable reasoning is present", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "internal",
+            thinkingSignature: JSON.stringify({ id: "rs_123", type: "reasoning" }),
+          },
+          { type: "toolCall", id: "call_123|fc_123", name: "read", arguments: {} },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_123|fc_123",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+      },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect(downgradeOpenAIFunctionCallReasoningPairs(input as any)).toEqual(input);
   });
 });
 

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -373,6 +373,69 @@ describe("downgradeOpenAIFunctionCallReasoningPairs", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     expect(downgradeOpenAIFunctionCallReasoningPairs(input as any)).toEqual(input);
   });
+
+  it("only rewrites tool results paired to the downgraded assistant turn", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_123|fc_123", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_123|fc_123",
+        toolName: "read",
+        content: [{ type: "text", text: "turn1" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "internal",
+            thinkingSignature: JSON.stringify({ id: "rs_123", type: "reasoning" }),
+          },
+          { type: "toolCall", id: "call_123|fc_123", name: "read", arguments: {} },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_123|fc_123",
+        toolName: "read",
+        content: [{ type: "text", text: "turn2" }],
+      },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect(downgradeOpenAIFunctionCallReasoningPairs(input as any)).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_123", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_123",
+        toolName: "read",
+        content: [{ type: "text", text: "turn1" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "internal",
+            thinkingSignature: JSON.stringify({ id: "rs_123", type: "reasoning" }),
+          },
+          { type: "toolCall", id: "call_123|fc_123", name: "read", arguments: {} },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_123|fc_123",
+        toolName: "read",
+        content: [{ type: "text", text: "turn2" }],
+      },
+    ]);
+  });
 });
 
 describe("normalizeTextForComparison", () => {

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -42,7 +42,10 @@ export {
 } from "./pi-embedded-helpers/errors.js";
 export { isGoogleModelApi, sanitizeGoogleTurnOrdering } from "./pi-embedded-helpers/google.js";
 
-export { downgradeOpenAIReasoningBlocks } from "./pi-embedded-helpers/openai.js";
+export {
+  downgradeOpenAIFunctionCallReasoningPairs,
+  downgradeOpenAIReasoningBlocks,
+} from "./pi-embedded-helpers/openai.js";
 export {
   isEmptyAssistantMessageContent,
   sanitizeSessionMessagesImages,

--- a/src/agents/pi-embedded-helpers/openai.ts
+++ b/src/agents/pi-embedded-helpers/openai.ts
@@ -92,98 +92,109 @@ function isOpenAIToolCallType(type: unknown): boolean {
 export function downgradeOpenAIFunctionCallReasoningPairs(
   messages: AgentMessage[],
 ): AgentMessage[] {
-  const rewrittenIds = new Map<string, string>();
   let changed = false;
+  const rewrittenMessages: AgentMessage[] = [];
+  let pendingRewrittenIds: Map<string, string> | null = null;
 
-  const rewrittenAssistantMessages = messages.map((msg) => {
-    if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "assistant") {
-      return msg;
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      pendingRewrittenIds = null;
+      rewrittenMessages.push(msg);
+      continue;
     }
-    const assistantMsg = msg as Extract<AgentMessage, { role: "assistant" }>;
-    if (!Array.isArray(assistantMsg.content)) {
-      return msg;
+
+    const role = (msg as { role?: unknown }).role;
+    if (role === "assistant") {
+      const assistantMsg = msg as Extract<AgentMessage, { role: "assistant" }>;
+      if (!Array.isArray(assistantMsg.content)) {
+        pendingRewrittenIds = null;
+        rewrittenMessages.push(msg);
+        continue;
+      }
+
+      const localRewrittenIds = new Map<string, string>();
+      let seenReplayableReasoning = false;
+      let assistantChanged = false;
+      const nextContent = assistantMsg.content.map((block) => {
+        if (!block || typeof block !== "object") {
+          return block;
+        }
+
+        const thinkingBlock = block as OpenAIThinkingBlock;
+        if (
+          thinkingBlock.type === "thinking" &&
+          parseOpenAIReasoningSignature(thinkingBlock.thinkingSignature)
+        ) {
+          seenReplayableReasoning = true;
+          return block;
+        }
+
+        const toolCallBlock = block as OpenAIToolCallBlock;
+        if (!isOpenAIToolCallType(toolCallBlock.type) || typeof toolCallBlock.id !== "string") {
+          return block;
+        }
+
+        const pairing = splitOpenAIFunctionCallPairing(toolCallBlock.id);
+        if (seenReplayableReasoning || !pairing.itemId || !pairing.itemId.startsWith("fc_")) {
+          return block;
+        }
+
+        assistantChanged = true;
+        localRewrittenIds.set(toolCallBlock.id, pairing.callId);
+        return {
+          ...(block as unknown as Record<string, unknown>),
+          id: pairing.callId,
+        } as typeof block;
+      });
+
+      pendingRewrittenIds = localRewrittenIds.size > 0 ? localRewrittenIds : null;
+      if (!assistantChanged) {
+        rewrittenMessages.push(msg);
+        continue;
+      }
+      changed = true;
+      rewrittenMessages.push({ ...assistantMsg, content: nextContent } as AgentMessage);
+      continue;
     }
 
-    let seenReplayableReasoning = false;
-    let assistantChanged = false;
-    const nextContent = assistantMsg.content.map((block) => {
-      if (!block || typeof block !== "object") {
-        return block;
+    if (role === "toolResult" && pendingRewrittenIds && pendingRewrittenIds.size > 0) {
+      const toolResult = msg as Extract<AgentMessage, { role: "toolResult" }> & {
+        toolUseId?: unknown;
+      };
+      let toolResultChanged = false;
+      const updates: Record<string, string> = {};
+
+      if (typeof toolResult.toolCallId === "string") {
+        const nextToolCallId = pendingRewrittenIds.get(toolResult.toolCallId);
+        if (nextToolCallId && nextToolCallId !== toolResult.toolCallId) {
+          updates.toolCallId = nextToolCallId;
+          toolResultChanged = true;
+        }
       }
 
-      const thinkingBlock = block as OpenAIThinkingBlock;
-      if (
-        thinkingBlock.type === "thinking" &&
-        parseOpenAIReasoningSignature(thinkingBlock.thinkingSignature)
-      ) {
-        seenReplayableReasoning = true;
-        return block;
+      if (typeof toolResult.toolUseId === "string") {
+        const nextToolUseId = pendingRewrittenIds.get(toolResult.toolUseId);
+        if (nextToolUseId && nextToolUseId !== toolResult.toolUseId) {
+          updates.toolUseId = nextToolUseId;
+          toolResultChanged = true;
+        }
       }
 
-      const toolCallBlock = block as OpenAIToolCallBlock;
-      if (!isOpenAIToolCallType(toolCallBlock.type) || typeof toolCallBlock.id !== "string") {
-        return block;
+      if (!toolResultChanged) {
+        rewrittenMessages.push(msg);
+        continue;
       }
-
-      const pairing = splitOpenAIFunctionCallPairing(toolCallBlock.id);
-      if (seenReplayableReasoning || !pairing.itemId || !pairing.itemId.startsWith("fc_")) {
-        return block;
-      }
-
-      assistantChanged = true;
-      rewrittenIds.set(toolCallBlock.id, pairing.callId);
-      return {
-        ...(block as unknown as Record<string, unknown>),
-        id: pairing.callId,
-      } as typeof block;
-    });
-
-    if (!assistantChanged) {
-      return msg;
+      changed = true;
+      rewrittenMessages.push({
+        ...toolResult,
+        ...updates,
+      } as AgentMessage);
+      continue;
     }
-    changed = true;
-    return { ...assistantMsg, content: nextContent } as AgentMessage;
-  });
 
-  if (rewrittenIds.size === 0) {
-    return messages;
+    pendingRewrittenIds = null;
+    rewrittenMessages.push(msg);
   }
-
-  const rewrittenMessages = rewrittenAssistantMessages.map((msg) => {
-    if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "toolResult") {
-      return msg;
-    }
-    const toolResult = msg as Extract<AgentMessage, { role: "toolResult" }> & {
-      toolUseId?: unknown;
-    };
-    let toolResultChanged = false;
-    const updates: Record<string, string> = {};
-
-    if (typeof toolResult.toolCallId === "string") {
-      const nextToolCallId = rewrittenIds.get(toolResult.toolCallId);
-      if (nextToolCallId && nextToolCallId !== toolResult.toolCallId) {
-        updates.toolCallId = nextToolCallId;
-        toolResultChanged = true;
-      }
-    }
-
-    if (typeof toolResult.toolUseId === "string") {
-      const nextToolUseId = rewrittenIds.get(toolResult.toolUseId);
-      if (nextToolUseId && nextToolUseId !== toolResult.toolUseId) {
-        updates.toolUseId = nextToolUseId;
-        toolResultChanged = true;
-      }
-    }
-
-    if (!toolResultChanged) {
-      return msg;
-    }
-    changed = true;
-    return {
-      ...toolResult,
-      ...updates,
-    } as AgentMessage;
-  });
 
   return changed ? rewrittenMessages : messages;
 }

--- a/src/agents/pi-embedded-helpers/openai.ts
+++ b/src/agents/pi-embedded-helpers/openai.ts
@@ -6,6 +6,11 @@ type OpenAIThinkingBlock = {
   thinkingSignature?: unknown;
 };
 
+type OpenAIToolCallBlock = {
+  type?: unknown;
+  id?: unknown;
+};
+
 type OpenAIReasoningSignature = {
   id: string;
   type: string;
@@ -57,6 +62,130 @@ function hasFollowingNonThinkingBlock(
     }
   }
   return false;
+}
+
+function splitOpenAIFunctionCallPairing(id: string): {
+  callId: string;
+  itemId?: string;
+} {
+  const separator = id.indexOf("|");
+  if (separator <= 0 || separator >= id.length - 1) {
+    return { callId: id };
+  }
+  return {
+    callId: id.slice(0, separator),
+    itemId: id.slice(separator + 1),
+  };
+}
+
+function isOpenAIToolCallType(type: unknown): boolean {
+  return type === "toolCall" || type === "toolUse" || type === "functionCall";
+}
+
+/**
+ * OpenAI can reject replayed `function_call` items with an `fc_*` id if the
+ * matching `reasoning` item is absent in the same assistant turn.
+ *
+ * When that pairing is missing, strip the `|fc_*` suffix from tool call ids so
+ * pi-ai omits `function_call.id` on replay.
+ */
+export function downgradeOpenAIFunctionCallReasoningPairs(
+  messages: AgentMessage[],
+): AgentMessage[] {
+  const rewrittenIds = new Map<string, string>();
+  let changed = false;
+
+  const rewrittenAssistantMessages = messages.map((msg) => {
+    if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "assistant") {
+      return msg;
+    }
+    const assistantMsg = msg as Extract<AgentMessage, { role: "assistant" }>;
+    if (!Array.isArray(assistantMsg.content)) {
+      return msg;
+    }
+
+    let seenReplayableReasoning = false;
+    let assistantChanged = false;
+    const nextContent = assistantMsg.content.map((block) => {
+      if (!block || typeof block !== "object") {
+        return block;
+      }
+
+      const thinkingBlock = block as OpenAIThinkingBlock;
+      if (
+        thinkingBlock.type === "thinking" &&
+        parseOpenAIReasoningSignature(thinkingBlock.thinkingSignature)
+      ) {
+        seenReplayableReasoning = true;
+        return block;
+      }
+
+      const toolCallBlock = block as OpenAIToolCallBlock;
+      if (!isOpenAIToolCallType(toolCallBlock.type) || typeof toolCallBlock.id !== "string") {
+        return block;
+      }
+
+      const pairing = splitOpenAIFunctionCallPairing(toolCallBlock.id);
+      if (seenReplayableReasoning || !pairing.itemId || !pairing.itemId.startsWith("fc_")) {
+        return block;
+      }
+
+      assistantChanged = true;
+      rewrittenIds.set(toolCallBlock.id, pairing.callId);
+      return {
+        ...(block as unknown as Record<string, unknown>),
+        id: pairing.callId,
+      } as typeof block;
+    });
+
+    if (!assistantChanged) {
+      return msg;
+    }
+    changed = true;
+    return { ...assistantMsg, content: nextContent } as AgentMessage;
+  });
+
+  if (rewrittenIds.size === 0) {
+    return messages;
+  }
+
+  const rewrittenMessages = rewrittenAssistantMessages.map((msg) => {
+    if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "toolResult") {
+      return msg;
+    }
+    const toolResult = msg as Extract<AgentMessage, { role: "toolResult" }> & {
+      toolUseId?: unknown;
+    };
+    let toolResultChanged = false;
+    const updates: Record<string, string> = {};
+
+    if (typeof toolResult.toolCallId === "string") {
+      const nextToolCallId = rewrittenIds.get(toolResult.toolCallId);
+      if (nextToolCallId && nextToolCallId !== toolResult.toolCallId) {
+        updates.toolCallId = nextToolCallId;
+        toolResultChanged = true;
+      }
+    }
+
+    if (typeof toolResult.toolUseId === "string") {
+      const nextToolUseId = rewrittenIds.get(toolResult.toolUseId);
+      if (nextToolUseId && nextToolUseId !== toolResult.toolUseId) {
+        updates.toolUseId = nextToolUseId;
+        toolResultChanged = true;
+      }
+    }
+
+    if (!toolResultChanged) {
+      return msg;
+    }
+    changed = true;
+    return {
+      ...toolResult,
+      ...updates,
+    } as AgentMessage;
+  });
+
+  return changed ? rewrittenMessages : messages;
 }
 
 /**

--- a/src/agents/pi-embedded-runner.openai-tool-id-preservation.test.ts
+++ b/src/agents/pi-embedded-runner.openai-tool-id-preservation.test.ts
@@ -7,7 +7,7 @@ import {
 import { sanitizeSessionHistory } from "./pi-embedded-runner/google.js";
 
 describe("sanitizeSessionHistory openai tool id preservation", () => {
-  it("keeps canonical call_id|fc_id pairings for same-model openai replay", async () => {
+  it("strips fc ids when replayable reasoning metadata is missing", async () => {
     const sessionEntries = [
       makeModelSnapshotEntry({
         provider: "openai",
@@ -21,6 +21,54 @@ describe("sanitizeSessionHistory openai tool id preservation", () => {
       {
         role: "assistant",
         content: [{ type: "toolCall", id: "call_123|fc_123", name: "noop", arguments: {} }],
+      } as unknown as AgentMessage,
+      {
+        role: "toolResult",
+        toolCallId: "call_123|fc_123",
+        toolName: "noop",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      } as unknown as AgentMessage,
+    ];
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      modelId: "gpt-5.2-codex",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    const assistant = result[0] as { content?: Array<{ type?: string; id?: string }> };
+    const toolCall = assistant.content?.find((block) => block.type === "toolCall");
+    expect(toolCall?.id).toBe("call_123");
+
+    const toolResult = result[1] as { toolCallId?: string };
+    expect(toolResult.toolCallId).toBe("call_123");
+  });
+
+  it("keeps canonical call_id|fc_id pairings when replayable reasoning is present", async () => {
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "openai",
+        modelApi: "openai-responses",
+        modelId: "gpt-5.2-codex",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "internal reasoning",
+            thinkingSignature: JSON.stringify({ id: "rs_123", type: "reasoning" }),
+          },
+          { type: "toolCall", id: "call_123|fc_123", name: "noop", arguments: {} },
+        ],
       } as unknown as AgentMessage,
       {
         role: "toolResult",

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -10,6 +10,7 @@ import {
 } from "../../sessions/input-provenance.js";
 import { resolveImageSanitizationLimits } from "../image-sanitization.js";
 import {
+  downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
   isCompactionFailureError,
   isGoogleModelApi,
@@ -464,7 +465,9 @@ export async function sanitizeSessionHistory(params: {
       })
     : false;
   const sanitizedOpenAI = isOpenAIResponsesApi
-    ? downgradeOpenAIReasoningBlocks(sanitizedCompactionUsage)
+    ? downgradeOpenAIFunctionCallReasoningPairs(
+        downgradeOpenAIReasoningBlocks(sanitizedCompactionUsage),
+      )
     : sanitizedCompactionUsage;
 
   if (hasSnapshot && (!priorSnapshot || modelChanged)) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -45,6 +45,7 @@ import { createOllamaStreamFn, OLLAMA_NATIVE_BASE_URL } from "../../ollama-strea
 import { createOpenAIWebSocketStreamFn, releaseWsSession } from "../../openai-ws-stream.js";
 import { resolveOwnerDisplaySetting } from "../../owner-display.js";
 import {
+  downgradeOpenAIFunctionCallReasoningPairs,
   isCloudCodeAssistFormatError,
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
@@ -1003,6 +1004,29 @@ export async function runEmbeddedAttempt(
             return inner(model, context, options);
           }
           const sanitized = sanitizeToolCallIdsForCloudCodeAssist(messages as AgentMessage[], mode);
+          if (sanitized === messages) {
+            return inner(model, context, options);
+          }
+          const nextContext = {
+            ...(context as unknown as Record<string, unknown>),
+            messages: sanitized,
+          } as unknown;
+          return inner(model, nextContext as typeof context, options);
+        };
+      }
+
+      if (
+        params.model.api === "openai-responses" ||
+        params.model.api === "openai-codex-responses"
+      ) {
+        const inner = activeSession.agent.streamFn;
+        activeSession.agent.streamFn = (model, context, options) => {
+          const ctx = context as unknown as { messages?: unknown };
+          const messages = ctx?.messages;
+          if (!Array.isArray(messages)) {
+            return inner(model, context, options);
+          }
+          const sanitized = downgradeOpenAIFunctionCallReasoningPairs(messages as AgentMessage[]);
           if (sanitized === messages) {
             return inner(model, context, options);
           }

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -25,20 +25,20 @@ const screenMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./gateway.js", () => ({
-  callGatewayTool: (...args: unknown[]) => gatewayMocks.callGatewayTool(...args),
-  readGatewayCallOptions: (...args: unknown[]) => gatewayMocks.readGatewayCallOptions(...args),
+  callGatewayTool: gatewayMocks.callGatewayTool,
+  readGatewayCallOptions: gatewayMocks.readGatewayCallOptions,
 }));
 
 vi.mock("./nodes-utils.js", () => ({
-  resolveNodeId: (...args: unknown[]) => nodeUtilsMocks.resolveNodeId(...args),
-  listNodes: (...args: unknown[]) => nodeUtilsMocks.listNodes(...args),
-  resolveNodeIdFromList: (...args: unknown[]) => nodeUtilsMocks.resolveNodeIdFromList(...args),
+  resolveNodeId: nodeUtilsMocks.resolveNodeId,
+  listNodes: nodeUtilsMocks.listNodes,
+  resolveNodeIdFromList: nodeUtilsMocks.resolveNodeIdFromList,
 }));
 
 vi.mock("../../cli/nodes-screen.js", () => ({
-  parseScreenRecordPayload: (...args: unknown[]) => screenMocks.parseScreenRecordPayload(...args),
-  screenRecordTempPath: (...args: unknown[]) => screenMocks.screenRecordTempPath(...args),
-  writeScreenRecordToFile: (...args: unknown[]) => screenMocks.writeScreenRecordToFile(...args),
+  parseScreenRecordPayload: screenMocks.parseScreenRecordPayload,
+  screenRecordTempPath: screenMocks.screenRecordTempPath,
+  writeScreenRecordToFile: screenMocks.writeScreenRecordToFile,
 }));
 
 import { createNodesTool } from "./nodes-tool.js";

--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -84,8 +84,11 @@ function resolveAccountConfig(
 }
 
 function mergeTelegramAccountConfig(cfg: OpenClawConfig, accountId: string): TelegramAccountConfig {
-  const { accounts: _ignored, groups: channelGroups, ...base } = (cfg.channels?.telegram ??
-    {}) as TelegramAccountConfig & { accounts?: unknown };
+  const {
+    accounts: _ignored,
+    groups: channelGroups,
+    ...base
+  } = (cfg.channels?.telegram ?? {}) as TelegramAccountConfig & { accounts?: unknown };
   const account = resolveAccountConfig(cfg, accountId) ?? {};
 
   // In multi-account setups, channel-level `groups` must NOT be inherited by


### PR DESCRIPTION
## Summary
- stop auto-rerouting `openai/gpt-5.3-codex` to `openai-codex`, so API-key users stay on the `openai` provider path
- add OpenAI replay hardening that strips `|fc_*` tool-call IDs only when replayable reasoning metadata is missing, and rewrites matching toolResult IDs
- apply the replay hardening both when sanitizing persisted session history and on live outbound OpenAI Responses requests
- add/adjust regression tests for routing normalization and OpenAI replay ID handling

## Why
`#30923` reports two blockers for `gpt-5.3-codex` on API key:
1. forced routing to `openai-codex` (OAuth-only)
2. `400 Item 'function_call' ... was provided without its required 'reasoning' item` when replaying tool turns without replayable reasoning metadata

This patch addresses both blockers in one path.

## Validation
- `pnpm test -- src/agents/model-selection.test.ts src/agents/model-fallback.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/agents/pi-embedded-runner.openai-tool-id-preservation.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/openai-responses.reasoning-replay.test.ts`
- `pnpm check`

## Related
- #30923
- #30844
- #18282
