### PR TITLE
feat(hooks): include resolvedModel in agent:bootstrap hook context (#31070)

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -67,6 +67,7 @@ export async function resolveBootstrapFilesForRun(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  resolvedModel?: { provider: string; model: string };
   warn?: (message: string) => void;
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;
@@ -91,6 +92,7 @@ export async function resolveBootstrapFilesForRun(params: {
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
     agentId: params.agentId,
+    resolvedModel: params.resolvedModel,
   });
   return sanitizeBootstrapFiles(updated, params.warn);
 }
@@ -101,6 +103,7 @@ export async function resolveBootstrapContextForRun(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  resolvedModel?: { provider: string; model: string };
   warn?: (message: string) => void;
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;

--- a/src/agents/bootstrap-hooks.ts
+++ b/src/agents/bootstrap-hooks.ts
@@ -11,6 +11,7 @@ export async function applyBootstrapHookOverrides(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  resolvedModel?: { provider: string; model: string };
 }): Promise<WorkspaceBootstrapFile[]> {
   const sessionKey = params.sessionKey ?? params.sessionId ?? "unknown";
   const agentId =
@@ -23,6 +24,7 @@ export async function applyBootstrapHookOverrides(params: {
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
     agentId,
+    resolvedModel: params.resolvedModel,
   };
   const event = createInternalHookEvent("agent", "bootstrap", sessionKey, context);
   await triggerInternalHook(event);

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -91,6 +91,7 @@ export async function runCliAgent(params: {
     config: params.config,
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
+    resolvedModel: params.model ? { provider: params.provider, model: params.model } : undefined,
     warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
   });
   const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -359,6 +359,7 @@ export async function compactEmbeddedPiSessionDirect(
       config: params.config,
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
+      resolvedModel: { provider, model: modelId },
       warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
     });
     const runAbortController = new AbortController();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -539,6 +539,7 @@ export async function runEmbeddedAttempt(
         config: params.config,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
+        resolvedModel: { provider: params.provider, model: params.modelId },
         warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
         contextMode: params.bootstrapContextMode,
         runKind: params.bootstrapContextRunKind,

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -33,6 +33,7 @@ export async function resolveCommandsSystemPromptBundle(
     config: params.cfg,
     sessionKey: params.sessionKey,
     sessionId: params.sessionEntry?.sessionId,
+    resolvedModel: { provider: params.provider, model: params.model },
   });
   const skillsSnapshot = (() => {
     try {

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -19,6 +19,8 @@ export type AgentBootstrapHookContext = {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  /** Resolved model (provider and model name) for this session */
+  resolvedModel?: { provider: string; model: string };
 };
 
 export type AgentBootstrapHookEvent = InternalHookEvent & {


### PR DESCRIPTION
Add resolvedModel to the AgentBootstrapHookContext to provide hook handlers with information about the resolved model (provider and model name) being used for the current session.

## Changes

- Added `resolvedModel?: { provider: string; model: string }` to `AgentBootstrapHookContext` in `src/hooks/internal-hooks.ts`
- Updated `applyBootstrapHookOverrides` to accept and pass through `resolvedModel`
- Updated `resolveBootstrapFilesForRun` and `resolveBootstrapContextForRun` to accept and pass through `resolvedModel`
- Updated all callers to pass the resolved model:
  - `src/agents/cli-runner.ts`
  - `src/agents/pi-embedded-runner/run/attempt.ts`
  - `src/agents/pi-embedded-runner/compact.ts`
  - `src/auto-reply/reply/commands-system-prompt.ts`

This allows bootstrap hooks to make decisions based on the model being used for the session.
