### PR TITLE
fix(gateway): support wildcard in controlUi.allowedOrigins for remote access

### DIFF
--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -22,17 +22,17 @@ enum HostEnvSecurityPolicy {
         "PS4",
         "GCONV_PATH",
         "IFS",
-        "SSLKEYLOGFILE",
+        "SSLKEYLOGFILE"
     ]
 
     static let blockedOverrideKeys: Set<String> = [
         "HOME",
-        "ZDOTDIR",
+        "ZDOTDIR"
     ]
 
     static let blockedPrefixes: [String] = [
         "DYLD_",
         "LD_",
-        "BASH_FUNC_",
+        "BASH_FUNC_"
     ]
 }

--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -36,6 +36,15 @@ describe("checkBrowserOrigin", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("accepts wildcard allowedOrigins", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.example.com:18789",
+      origin: "https://any-origin.example.com",
+      allowedOrigins: ["*"],
+    });
+    expect(result.ok).toBe(true);
+  });
+
   it("rejects missing origin", () => {
     const result = checkBrowserOrigin({
       requestHost: "gateway.example.com:18789",

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -32,10 +32,10 @@ export function checkBrowserOrigin(params: {
     return { ok: false, reason: "origin missing or invalid" };
   }
 
-  const allowlist = (params.allowedOrigins ?? [])
-    .map((value) => value.trim().toLowerCase())
-    .filter(Boolean);
-  if (allowlist.includes(parsedOrigin.origin)) {
+  const allowlist = new Set(
+    (params.allowedOrigins ?? []).map((value) => value.trim().toLowerCase()).filter(Boolean),
+  );
+  if (allowlist.has("*") || allowlist.has(parsedOrigin.origin)) {
     return { ok: true };
   }
 


### PR DESCRIPTION
Fixes #30990

## Summary

The `checkBrowserOrigin` function in `origin-check.ts` did not handle the `"*"` wildcard in `allowedOrigins`. When users configured `gateway.controlUi.allowedOrigins: ["*"]`, the Control UI was still inaccessible from remote networks (Tailscale, LAN).

## Changes

- Add wildcard `"*"` check in `checkBrowserOrigin` before individual origin matching
- Add test case covering the wildcard scenario

## Testing

- All 7 origin-check tests pass
- No changes to existing behavior when specific origins are listed