### PR TITLE
Auto-reply: strip NO_REPLY markers in mixed text replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/NO_REPLY cleanup: strip leading/trailing `NO_REPLY` sentinel tokens from mixed-content replies (for example `NO_REPLY ✅` or `Done NO_REPLY`) while still suppressing silent-only payloads, so sentinel text no longer leaks into delivered user messages. Fixes #30955 and #30916.
 - Security/Node metadata policy: harden node platform classification against Unicode confusables and switch unknown platform defaults to a conservative allowlist that excludes `system.run`/`system.which` unless explicitly allowlisted, preventing metadata canonicalization drift from broadening node command permissions. Thanks @tdjackey for reporting.
 - Plugins/Discovery precedence: load bundled plugins before auto-discovered global extensions so bundled channel plugins win duplicate-ID resolution by default (explicit `plugins.load.paths` overrides remain highest precedence), with loader regression coverage. Landed from contributor PR #29710 by @Sid-Qin. Thanks @Sid-Qin.
 - Discord/Reconnect integrity: release Discord message listener lane immediately while preserving serialized handler execution, add HELLO-stall resume-first recovery with bounded fresh-identify fallback after repeated stalls, and extend lifecycle/listener regression coverage for forced reconnect scenarios. Landed from contributor PR #29508 by @cgdusek. Thanks @cgdusek.

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -1,4 +1,5 @@
 import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers.js";
+import { escapeRegExp } from "../../utils.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import { HEARTBEAT_TOKEN, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { ReplyPayload } from "../types.js";
@@ -19,6 +20,20 @@ export type NormalizeReplyOptions = {
   silentToken?: string;
   onSkip?: (reason: NormalizeReplySkipReason) => void;
 };
+
+function stripSilentTokenEdges(text: string, token: string): string {
+  const escaped = escapeRegExp(token);
+  const leading = new RegExp(`^\\s*${escaped}(?=\\s|$)\\s*`);
+  const trailing = new RegExp(`\\s*${escaped}(?=\\s*$)\\s*$`);
+  let cleaned = text;
+  while (leading.test(cleaned)) {
+    cleaned = cleaned.replace(leading, "");
+  }
+  while (trailing.test(cleaned)) {
+    cleaned = cleaned.replace(trailing, "");
+  }
+  return cleaned.trim();
+}
 
 export function normalizeReplyPayload(
   payload: ReplyPayload,
@@ -42,6 +57,15 @@ export function normalizeReplyPayload(
       return null;
     }
     text = "";
+  } else if (text && text.includes(silentToken)) {
+    const stripped = stripSilentTokenEdges(text, silentToken);
+    if (stripped !== text.trim()) {
+      text = stripped;
+      if (!text && !hasMedia && !hasChannelData) {
+        opts.onSkip?.("silent");
+        return null;
+      }
+    }
   }
   if (text && !trimmed) {
     // Keep empty text when media exists so media-only replies still send.

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -108,6 +108,30 @@ describe("normalizeReplyPayload", () => {
       expect(reasons, testCase.name).toEqual([testCase.reason]);
     }
   });
+
+  it("strips NO_REPLY from mixed-content prefixes and suffixes", () => {
+    const suffix = normalizeReplyPayload({ text: "Looks good NO_REPLY" });
+    expect(suffix).not.toBeNull();
+    expect(suffix?.text).toBe("Looks good");
+
+    const prefix = normalizeReplyPayload({ text: "NO_REPLY ✅ shipped" });
+    expect(prefix).not.toBeNull();
+    expect(prefix?.text).toBe("✅ shipped");
+  });
+
+  it("suppresses payloads when mixed content becomes silent-only after stripping", () => {
+    const reasons: string[] = [];
+    const normalized = normalizeReplyPayload(
+      {
+        text: " NO_REPLY  \n  NO_REPLY ",
+      },
+      {
+        onSkip: (reason) => reasons.push(reason),
+      },
+    );
+    expect(normalized).toBeNull();
+    expect(reasons).toEqual(["silent"]);
+  });
 });
 
 describe("typing controller", () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `normalizeReplyPayload` only treated exact `NO_REPLY` as silent; mixed replies like `Done NO_REPLY` or `NO_REPLY ✅` leaked the sentinel to users.
- Why it matters: end users see internal control tokens in normal channel messages, which looks broken and confuses automation flows.
- What changed: added edge-token stripping for leading/trailing `NO_REPLY` markers in mixed text, while preserving existing exact-silent behavior.
- What did NOT change (scope boundary): no changes to streaming directive parsing, no changes to in-text middle-token semantics, no channel-specific send-path rewrites.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30955
- Related #30916

## User-visible / Behavior Changes

- Replies that accidentally include leading/trailing `NO_REPLY` now deliver cleaned user text instead of leaking the sentinel token.
- Silent-only payloads still suppress delivery.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Auto-reply normalization path (channel-agnostic)
- Relevant config (redacted): default silent token `NO_REPLY`

### Steps

1. Call `normalizeReplyPayload({ text: "Looks good NO_REPLY" })`.
2. Call `normalizeReplyPayload({ text: "NO_REPLY ✅ shipped" })`.
3. Call `normalizeReplyPayload({ text: " NO_REPLY\nNO_REPLY " }, { onSkip })`.

### Expected

- Mixed text keeps substantive content and strips edge sentinel token.
- Sentinel-only content is suppressed as silent.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test src/auto-reply/reply/reply-utils.test.ts`
`pnpm test src/auto-reply/tokens.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: prefix/suffix mixed-content cleanup and silent-only suppression via new/updated unit tests.
- Edge cases checked: repeated sentinel tokens with whitespace/newlines still suppress when no substantive content remains.
- What you did **not** verify: live end-to-end delivery on external channels.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `79944a04e`.
- Files/config to restore: `src/auto-reply/reply/normalize-reply.ts`, `src/auto-reply/reply/reply-utils.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: over-stripping valid text when it starts/ends with `NO_REPLY` as literal content.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Legitimate user text intentionally ending/starting with the sentinel literal could be cleaned.
  - Mitigation: stripping is limited to edge markers; middle-content mentions are not altered.
