### PR TITLE
fix(ui): persist cron delivery mode none when editing jobs

### DIFF
--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -160,7 +160,6 @@ describe("cron controller", () => {
       name: "main job",
     });
     expect((addCall?.[1] as { delivery?: unknown } | undefined)?.delivery).toBeUndefined();
-    expect(state.cronForm.deliveryMode).toBe("none");
   });
 
   it("submits cron.update when editing an existing job", async () => {
@@ -210,6 +209,7 @@ describe("cron controller", () => {
         deleteAfterRun: false,
         schedule: { kind: "cron", expr: "0 8 * * *", staggerMs: 0 },
         payload: { kind: "systemEvent", text: "updated" },
+        delivery: { mode: "none" },
       },
     });
     expect(state.cronEditingJobId).toBeNull();

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -614,8 +614,11 @@ export async function addCronJob(state: CronState) {
     const payload = buildCronPayload(form);
     const selectedDeliveryMode = form.deliveryMode;
     const delivery =
-      selectedDeliveryMode && selectedDeliveryMode !== "none"
-        ? {
+      selectedDeliveryMode === "none"
+        ? state.cronEditingJobId
+          ? ({ mode: "none" } as const)
+          : undefined
+        : {
             mode: selectedDeliveryMode,
             channel:
               selectedDeliveryMode === "announce"
@@ -623,8 +626,7 @@ export async function addCronJob(state: CronState) {
                 : undefined,
             to: form.deliveryTo.trim() || undefined,
             bestEffort: form.deliveryBestEffort,
-          }
-        : undefined;
+          };
     const failureAlert = buildFailureAlert(form);
     const agentId = form.clearAgent ? null : form.agentId.trim();
     const job = {


### PR DESCRIPTION
## Summary
- fix cron editor update payload to explicitly send `{ mode: "none" }` when editing an existing job and Result delivery is set to None (internal)
- keep create behavior unchanged (no delivery field when mode is none on new jobs)
- add/adjust controller test coverage to lock this behavior

## Root cause
The UI controller built `delivery` as `undefined` whenever `deliveryMode === "none"`. For `cron.update`, omitting `patch.delivery` preserves the previous backend value, so existing jobs stayed on `announce`.

## Validation
- `pnpm --dir ui exec vitest run src/ui/controllers/cron.test.ts`

Fixes #31075
