### PR TITLE
Version: prefer module metadata over OPENCLAW_BUNDLED_VERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Version/CLI label resolution: prefer runtime module metadata (`package.json` / `build-info.json`) before `OPENCLAW_BUNDLED_VERSION` so stale env overrides no longer pin `openclaw --version` labels after updates. Fixes #30934.
 - Security/Node metadata policy: harden node platform classification against Unicode confusables and switch unknown platform defaults to a conservative allowlist that excludes `system.run`/`system.which` unless explicitly allowlisted, preventing metadata canonicalization drift from broadening node command permissions. Thanks @tdjackey for reporting.
 - Plugins/Discovery precedence: load bundled plugins before auto-discovered global extensions so bundled channel plugins win duplicate-ID resolution by default (explicit `plugins.load.paths` overrides remain highest precedence), with loader regression coverage. Landed from contributor PR #29710 by @Sid-Qin. Thanks @Sid-Qin.
 - Discord/Reconnect integrity: release Discord message listener lane immediately while preserving serialized handler execution, add HELLO-stall resume-first recovery with bounded fresh-identify fallback after repeated stalls, and extend lifecycle/listener regression coverage for forced reconnect scenarios. Landed from contributor PR #29508 by @cgdusek. Thanks @cgdusek.

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   readVersionFromBuildInfoForModuleUrl,
   readVersionFromPackageJsonForModuleUrl,
+  resolveBundledCliVersion,
   resolveRuntimeServiceVersion,
   resolveVersionFromModuleUrl,
 } from "./version.js";
@@ -131,5 +132,32 @@ describe("version resolution", () => {
         "fallback",
       ),
     ).toBe("fallback");
+  });
+
+  it("prefers module metadata over OPENCLAW_BUNDLED_VERSION", async () => {
+    await withTempDir(async (root) => {
+      await writeJsonFixture(root, "package.json", { name: "openclaw", version: "1.2.3" });
+      const moduleUrl = await ensureModuleFixture(root);
+      expect(
+        resolveBundledCliVersion({
+          moduleUrl,
+          env: { OPENCLAW_BUNDLED_VERSION: "0.0.0-stale" },
+          fallback: "fallback",
+        }),
+      ).toBe("1.2.3");
+    });
+  });
+
+  it("falls back to OPENCLAW_BUNDLED_VERSION when module metadata is missing", async () => {
+    await withTempDir(async (root) => {
+      const moduleUrl = await ensureModuleFixture(root);
+      expect(
+        resolveBundledCliVersion({
+          moduleUrl,
+          env: { OPENCLAW_BUNDLED_VERSION: "9.9.9-bundled" },
+          fallback: "fallback",
+        }),
+      ).toBe("9.9.9-bundled");
+    });
   });
 });

--- a/src/version.ts
+++ b/src/version.ts
@@ -88,11 +88,29 @@ export function resolveRuntimeServiceVersion(
   );
 }
 
+export function resolveBundledCliVersion(
+  params: {
+    moduleUrl?: string;
+    env?: RuntimeVersionEnv;
+    injectedVersion?: string;
+    fallback?: string;
+  } = {},
+): string {
+  const moduleUrl = params.moduleUrl ?? import.meta.url;
+  const env = params.env ?? (process.env as RuntimeVersionEnv);
+  const fallback = params.fallback ?? "0.0.0";
+  return (
+    firstNonEmpty(
+      params.injectedVersion,
+      resolveVersionFromModuleUrl(moduleUrl) ?? undefined,
+      env["OPENCLAW_BUNDLED_VERSION"],
+    ) ?? fallback
+  );
+}
+
 // Single source of truth for the current OpenClaw version.
 // - Embedded/bundled builds: injected define or env var.
 // - Dev/npm builds: package.json.
-export const VERSION =
-  (typeof __OPENCLAW_VERSION__ === "string" && __OPENCLAW_VERSION__) ||
-  process.env.OPENCLAW_BUNDLED_VERSION ||
-  resolveVersionFromModuleUrl(import.meta.url) ||
-  "0.0.0";
+export const VERSION = resolveBundledCliVersion({
+  injectedVersion: typeof __OPENCLAW_VERSION__ === "string" ? __OPENCLAW_VERSION__ : undefined,
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `VERSION` prioritized `OPENCLAW_BUNDLED_VERSION` before module metadata, so stale env values could pin displayed version labels.
- Why it matters: after upgrades, CLI/service version output could appear outdated and mislead operators.
- What changed: introduced `resolveBundledCliVersion()` and changed precedence to injected define -> module metadata -> bundled env fallback.
- What did NOT change (scope boundary): no runtime service version (`OPENCLAW_VERSION` / `OPENCLAW_SERVICE_VERSION`) behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30934
- Related #30934

## User-visible / Behavior Changes

- `openclaw --version` / bundled CLI version labels now prefer package/build metadata when available, and only fall back to `OPENCLAW_BUNDLED_VERSION` when metadata is unavailable.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): CLI version resolution
- Relevant config (redacted): `OPENCLAW_BUNDLED_VERSION` set to stale value in test env

### Steps

1. Prepare module fixture with valid `package.json` version and set `OPENCLAW_BUNDLED_VERSION` to stale text.
2. Resolve bundled CLI version.
3. Repeat with missing metadata fixture.

### Expected

- Metadata wins when present.
- Bundled env value is used only as fallback.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test src/version.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: metadata-over-env precedence and env fallback when metadata missing via new unit tests.
- Edge cases checked: explicit fallback value path and existing runtime service version tests remain green.
- What you did **not** verify: full built-distribution runtime in a packaged binary.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `707c1be7f`.
- Files/config to restore: `src/version.ts`, `src/version.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: incorrect fallback to `0.0.0` in metadata-missing contexts.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: edge build layouts with non-standard metadata paths could rely on env fallback timing.
  - Mitigation: env fallback is still preserved when metadata cannot be resolved.
