### PR TITLE
chore(format): swiftformat host env and exec approvals

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -535,7 +535,9 @@ enum ExecApprovalsStore {
                 [.posixPermissions: self.secureStateDirPermissions],
                 ofItemAtPath: url.path)
         } catch {
-            self.logger.warning("exec approvals state dir permission hardening failed: \(error.localizedDescription, privacy: .public)")
+            self.logger
+                .warning(
+                    "exec approvals state dir permission hardening failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -686,7 +686,8 @@ private final class ExecApprovalsSocketServer: @unchecked Sendable {
             do {
                 try ExecApprovalsSocketPathGuard.removeExistingSocket(at: self.socketPath)
             } catch {
-                self.logger.warning("exec approvals socket cleanup failed: \(error.localizedDescription, privacy: .public)")
+                self.logger
+                    .warning("exec approvals socket cleanup failed: \(error.localizedDescription, privacy: .public)")
             }
         }
     }
@@ -726,7 +727,8 @@ private final class ExecApprovalsSocketServer: @unchecked Sendable {
             try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: self.socketPath)
             try ExecApprovalsSocketPathGuard.removeExistingSocket(at: self.socketPath)
         } catch {
-            self.logger.error("exec approvals socket path hardening failed: \(error.localizedDescription, privacy: .public)")
+            self.logger
+                .error("exec approvals socket path hardening failed: \(error.localizedDescription, privacy: .public)")
             close(fd)
             return -1
         }

--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -22,17 +22,17 @@ enum HostEnvSecurityPolicy {
         "PS4",
         "GCONV_PATH",
         "IFS",
-        "SSLKEYLOGFILE"
+        "SSLKEYLOGFILE",
     ]
 
     static let blockedOverrideKeys: Set<String> = [
         "HOME",
-        "ZDOTDIR"
+        "ZDOTDIR",
     ]
 
     static let blockedPrefixes: [String] = [
         "DYLD_",
         "LD_",
-        "BASH_FUNC_"
+        "BASH_FUNC_",
     ]
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
