### PR TITLE
fix: make global plugin hook runner singleton robust across module instances

### DIFF
--- a/src/plugins/hook-runner-global.shared-state.test.ts
+++ b/src/plugins/hook-runner-global.shared-state.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TypedPluginHookRegistration } from "./registry.js";
+
+describe("hook-runner-global shared state", () => {
+  afterEach(async () => {
+    const mod = await import("./hook-runner-global.js");
+    mod.resetGlobalHookRunner();
+    vi.resetModules();
+  });
+
+  it("preserves initialized hook runner across module reloads", async () => {
+    const mod1 = await import("./hook-runner-global.js");
+    const { createEmptyPluginRegistry } = await import("./registry.js");
+
+    const registry = createEmptyPluginRegistry();
+    const hook: TypedPluginHookRegistration = {
+      pluginId: "test.plugin",
+      hookName: "message_sending",
+      handler: async () => undefined,
+      source: "test",
+    };
+    registry.typedHooks.push(hook);
+
+    mod1.initializeGlobalHookRunner(registry);
+    expect(mod1.getGlobalHookRunner()?.hasHooks("message_sending")).toBe(true);
+
+    vi.resetModules();
+
+    const mod2 = await import("./hook-runner-global.js");
+    expect(mod2.getGlobalHookRunner()?.hasHooks("message_sending")).toBe(true);
+  });
+});

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -12,16 +12,33 @@ import type { PluginHookGatewayContext, PluginHookGatewayStopEvent } from "./typ
 
 const log = createSubsystemLogger("plugins");
 
-let globalHookRunner: HookRunner | null = null;
-let globalRegistry: PluginRegistry | null = null;
+const HOOK_RUNNER_STATE = Symbol.for("openclaw.pluginHookRunnerState");
+
+type HookRunnerState = {
+  hookRunner: HookRunner | null;
+  registry: PluginRegistry | null;
+};
+
+const state: HookRunnerState = (() => {
+  const globalState = globalThis as typeof globalThis & {
+    [HOOK_RUNNER_STATE]?: HookRunnerState;
+  };
+  if (!globalState[HOOK_RUNNER_STATE]) {
+    globalState[HOOK_RUNNER_STATE] = {
+      hookRunner: null,
+      registry: null,
+    };
+  }
+  return globalState[HOOK_RUNNER_STATE];
+})();
 
 /**
  * Initialize the global hook runner with a plugin registry.
  * Called once when plugins are loaded during gateway startup.
  */
 export function initializeGlobalHookRunner(registry: PluginRegistry): void {
-  globalRegistry = registry;
-  globalHookRunner = createHookRunner(registry, {
+  state.registry = registry;
+  state.hookRunner = createHookRunner(registry, {
     logger: {
       debug: (msg) => log.debug(msg),
       warn: (msg) => log.warn(msg),
@@ -41,7 +58,7 @@ export function initializeGlobalHookRunner(registry: PluginRegistry): void {
  * Returns null if plugins haven't been loaded yet.
  */
 export function getGlobalHookRunner(): HookRunner | null {
-  return globalHookRunner;
+  return state.hookRunner;
 }
 
 /**
@@ -49,14 +66,14 @@ export function getGlobalHookRunner(): HookRunner | null {
  * Returns null if plugins haven't been loaded yet.
  */
 export function getGlobalPluginRegistry(): PluginRegistry | null {
-  return globalRegistry;
+  return state.registry;
 }
 
 /**
  * Check if any hooks are registered for a given hook name.
  */
 export function hasGlobalHooks(hookName: Parameters<HookRunner["hasHooks"]>[0]): boolean {
-  return globalHookRunner?.hasHooks(hookName) ?? false;
+  return state.hookRunner?.hasHooks(hookName) ?? false;
 }
 
 export async function runGlobalGatewayStopSafely(params: {
@@ -83,6 +100,6 @@ export async function runGlobalGatewayStopSafely(params: {
  * Reset the global hook runner (for testing).
  */
 export function resetGlobalHookRunner(): void {
-  globalHookRunner = null;
-  globalRegistry = null;
+  state.hookRunner = null;
+  state.registry = null;
 }


### PR DESCRIPTION
## Summary
Fixes #31038 by making the global plugin hook runner state process-global (via `globalThis` symbol) instead of module-local.

## Root cause
`api.on()` registrations correctly populated `registry.typedHooks`, but in some runtime/bundle loading paths the outbound delivery code and plugin loader could end up with different module instances of `hook-runner-global`. That meant `initializeGlobalHookRunner()` wrote state in one instance while `getGlobalHookRunner()` in delivery read another instance (`null`), so `message_sending` hooks were never executed.

## Changes
- Store hook-runner state on `globalThis[Symbol.for("openclaw.pluginHookRunnerState")]`.
- Update `initializeGlobalHookRunner`, `getGlobalHookRunner`, `getGlobalPluginRegistry`, `hasGlobalHooks`, and `resetGlobalHookRunner` to use the shared state object.
- Add regression test `hook-runner-global.shared-state.test.ts` verifying hook runner state survives module reloads.

## Validation
- `pnpm vitest run src/plugins/hook-runner-global.shared-state.test.ts src/infra/outbound/deliver.test.ts`
