### PR TITLE
Exec approvals: support unique short-id resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Exec approvals/ID resolution: allow unique prefix IDs (for example 8-char slugs from chat surfaces) in `exec.approval.resolve` and `exec.approval.waitDecision`, while rejecting ambiguous prefixes explicitly, so `/approve <short-id>` flows can succeed without requiring full UUID copy/paste. Fixes #31043.
 - Security/Node metadata policy: harden node platform classification against Unicode confusables and switch unknown platform defaults to a conservative allowlist that excludes `system.run`/`system.which` unless explicitly allowlisted, preventing metadata canonicalization drift from broadening node command permissions. Thanks @tdjackey for reporting.
 - Plugins/Discovery precedence: load bundled plugins before auto-discovered global extensions so bundled channel plugins win duplicate-ID resolution by default (explicit `plugins.load.paths` overrides remain highest precedence), with loader regression coverage. Landed from contributor PR #29710 by @Sid-Qin. Thanks @Sid-Qin.
 - Discord/Reconnect integrity: release Discord message listener lane immediately while preserving serialized handler execution, add HELLO-stall resume-first recovery with bounded fresh-identify fallback after repeated stalls, and extend lifecycle/listener regression coverage for forced reconnect scenarios. Landed from contributor PR #29508 by @cgdusek. Thanks @cgdusek.

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -170,4 +170,35 @@ export class ExecApprovalManager {
     const entry = this.pending.get(recordId);
     return entry?.promise ?? null;
   }
+
+  resolvePendingId(inputId: string): { id: string | null; ambiguous: boolean } {
+    const normalized = inputId.trim();
+    if (!normalized) {
+      return { id: null, ambiguous: false };
+    }
+
+    const normalizedLower = normalized.toLowerCase();
+    for (const id of this.pending.keys()) {
+      if (id.toLowerCase() === normalizedLower) {
+        return { id, ambiguous: false };
+      }
+    }
+
+    // Keep short IDs strict to reduce accidental collisions/noisy matches.
+    if (normalized.length < 8) {
+      return { id: null, ambiguous: false };
+    }
+
+    let matched: string | null = null;
+    for (const id of this.pending.keys()) {
+      if (!id.toLowerCase().startsWith(normalizedLower)) {
+        continue;
+      }
+      if (matched && matched !== id) {
+        return { id: null, ambiguous: true };
+      }
+      matched = id;
+    }
+    return { id: matched, ambiguous: false };
+  }
 }

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -223,7 +223,24 @@ export function createExecApprovalHandlers(
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "id is required"));
         return;
       }
-      const decisionPromise = manager.awaitDecision(id);
+      const resolvedId = manager.resolvePendingId(id);
+      if (resolvedId.ambiguous) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "approval id is ambiguous"),
+        );
+        return;
+      }
+      if (!resolvedId.id) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "approval expired or not found"),
+        );
+        return;
+      }
+      const decisionPromise = manager.awaitDecision(resolvedId.id);
       if (!decisionPromise) {
         respond(
           false,
@@ -233,13 +250,13 @@ export function createExecApprovalHandlers(
         return;
       }
       // Capture snapshot before await (entry may be deleted after grace period)
-      const snapshot = manager.getSnapshot(id);
+      const snapshot = manager.getSnapshot(resolvedId.id);
       const decision = await decisionPromise;
       // Return decision (can be null on timeout) - let clients handle via askFallback
       respond(
         true,
         {
-          id,
+          id: resolvedId.id,
           decision,
           createdAtMs: snapshot?.createdAtMs,
           expiresAtMs: snapshot?.expiresAtMs,
@@ -267,21 +284,34 @@ export function createExecApprovalHandlers(
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "invalid decision"));
         return;
       }
-      const snapshot = manager.getSnapshot(p.id);
+      const resolvedId = manager.resolvePendingId(p.id);
+      if (resolvedId.ambiguous) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "approval id is ambiguous"),
+        );
+        return;
+      }
+      if (!resolvedId.id) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown approval id"));
+        return;
+      }
+      const snapshot = manager.getSnapshot(resolvedId.id);
       const resolvedBy = client?.connect?.client?.displayName ?? client?.connect?.client?.id;
-      const ok = manager.resolve(p.id, decision, resolvedBy ?? null);
+      const ok = manager.resolve(resolvedId.id, decision, resolvedBy ?? null);
       if (!ok) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown approval id"));
         return;
       }
       context.broadcast(
         "exec.approval.resolved",
-        { id: p.id, decision, resolvedBy, ts: Date.now(), request: snapshot?.request },
+        { id: resolvedId.id, decision, resolvedBy, ts: Date.now(), request: snapshot?.request },
         { dropIfSlow: true },
       );
       void opts?.forwarder
         ?.handleResolved({
-          id: p.id,
+          id: resolvedId.id,
           decision,
           resolvedBy,
           ts: Date.now(),

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -318,7 +318,7 @@ describe("exec approval handlers", () => {
       },
       hasExecApprovalClients: () => true,
     };
-    return { handlers, broadcasts, respond, context };
+    return { manager, handlers, broadcasts, respond, context };
   }
 
   describe("ExecApprovalRequestParams validation", () => {
@@ -577,6 +577,85 @@ describe("exec approval handlers", () => {
       undefined,
     );
     expect(resolveRespond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+  });
+
+  it("accepts unique approval-id prefixes when resolving", async () => {
+    const { manager, handlers, context } = createExecApprovalFixture();
+    const respond = vi.fn();
+    const decisionPromise = manager.register(
+      manager.create(
+        {
+          command: "echo ok",
+          commandArgv: ["echo", "ok"],
+          cwd: "/tmp",
+          host: "node",
+          nodeId: "node-1",
+        },
+        2_000,
+        "a17b4920-1111-4000-8000-123456789abc",
+      ),
+      2_000,
+    );
+
+    await resolveExecApproval({
+      handlers,
+      id: "a17b4920",
+      respond,
+      context,
+    });
+
+    await expect(decisionPromise).resolves.toBe("allow-once");
+    expect(respond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+  });
+
+  it("rejects ambiguous approval-id prefixes", async () => {
+    const { manager, handlers, context } = createExecApprovalFixture();
+    const respond = vi.fn();
+    const firstDecision = manager.register(
+      manager.create(
+        {
+          command: "echo first",
+          commandArgv: ["echo", "first"],
+          cwd: "/tmp",
+          host: "node",
+          nodeId: "node-1",
+        },
+        2_000,
+        "deadbeef-1111-4000-8000-123456789abc",
+      ),
+      2_000,
+    );
+    const secondDecision = manager.register(
+      manager.create(
+        {
+          command: "echo second",
+          commandArgv: ["echo", "second"],
+          cwd: "/tmp",
+          host: "node",
+          nodeId: "node-1",
+        },
+        2_000,
+        "deadbeef-2222-4000-8000-abcdef123456",
+      ),
+      2_000,
+    );
+
+    await resolveExecApproval({
+      handlers,
+      id: "deadbeef",
+      respond,
+      context,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "approval id is ambiguous" }),
+    );
+
+    manager.resolve("deadbeef-1111-4000-8000-123456789abc", "deny", "test");
+    manager.resolve("deadbeef-2222-4000-8000-abcdef123456", "deny", "test");
+    await Promise.all([firstDecision, secondDecision]);
   });
 
   it("forwards turn-source metadata to exec approval forwarding", async () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `exec.approval.resolve` and `exec.approval.waitDecision` required exact full IDs, while some channels show/enter short approval slugs (for example 8-char prefixes).
- Why it matters: `/approve <short-id> ...` fails with `unknown approval id`, breaking approval workflows on Signal and similar surfaces.
- What changed: added manager-side pending-ID resolver that supports case-insensitive exact IDs and unique prefix IDs (length >= 8), with explicit ambiguous-prefix rejection.
- What did NOT change (scope boundary): no change to approval security model, decision semantics, or persisted approval records.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31043
- Related #30924

## User-visible / Behavior Changes

- Approval commands can now use a unique short approval ID prefix (for example the first 8 chars) for `exec.approval.resolve` and `exec.approval.waitDecision`.
- If a prefix matches multiple pending approvals, the API now returns a clear `approval id is ambiguous` error.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Gateway exec approval APIs used by chat channels
- Relevant config (redacted): exec approvals enabled

### Steps

1. Register pending approval with full UUID-like ID.
2. Resolve via `exec.approval.resolve` using unique 8-char prefix.
3. Register two approvals sharing same 8-char prefix and resolve by that prefix.

### Expected

- Unique prefix resolves successfully.
- Ambiguous prefix fails with explicit ambiguity message.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test src/gateway/server-methods/server-methods.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: unique short-prefix resolve + ambiguous-prefix rejection via new handler tests.
- Edge cases checked: case-insensitive exact ID matching and short (<8) IDs remain strict.
- What you did **not** verify: live Signal end-to-end interaction against a running gateway.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `9bb12258a`.
- Files/config to restore: `src/gateway/exec-approval-manager.ts`, `src/gateway/server-methods/exec-approval.ts`, `src/gateway/server-methods/server-methods.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: unexpected ambiguous-ID errors when multiple approvals share prefixes.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: prefix matching can pick unintended entries if prefixes are too short.
  - Mitigation: exact match first, prefix matching requires length >= 8, and ambiguous matches are rejected.
