### PR TITLE
fix(cli): exit with correct code in `cron run` based on job result

### DIFF
--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -100,6 +100,8 @@ export function registerCronSimpleCommands(cron: Command) {
             mode: opts.due ? "due" : "force",
           });
           defaultRuntime.log(JSON.stringify(res, null, 2));
+          const result = res as { ok?: boolean; ran?: boolean } | undefined;
+          defaultRuntime.exit(result?.ok && result?.ran ? 0 : 1);
         } catch (err) {
           defaultRuntime.error(danger(String(err)));
           defaultRuntime.exit(1);


### PR DESCRIPTION
## Summary

- Problem: `openclaw cron run <job-id>` exits with code 1 even when the cron job completes successfully.
- Why it matters: Exit code 1 suggests failure when debugging or scripting manual cron triggers, even though `cron runs` confirms the job succeeded.
- What changed: Explicitly exit with code 0 when the gateway responds with `{ ok: true, ran: true }`, exit 1 for all other outcomes (not-due, already-running, error).
- What did NOT change: The `cron.run` server-side RPC handler and job execution logic are untouched.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #31094

## User-visible / Behavior Changes

`openclaw cron run <job-id>` now exits 0 on success, 1 on failure/skip.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node v25.4.0
- Model/provider: N/A
- Integration/channel: CLI
- Relevant config: Any working cron job

### Steps

1. Have a working cron job
2. Run: `openclaw cron run <job-id>`
3. Check exit code: `echo $?`

### Expected

Exit code 0 when job succeeds.

### Actual

Exit code 1 regardless of job outcome.

## Evidence

- [x] `npx vitest run src/cli/cron-cli` — 38/38 passed
- [x] `npx oxfmt --check` — clean

## Human Verification (required)

- Verified scenarios: Handler now calls `defaultRuntime.exit(0)` when `res.ok && res.ran`, `exit(1)` when not-due/already-running/error
- Edge cases checked: `res` is undefined or missing `ok`/`ran` fields → falls through to exit 1
- What you did **not** verify: Live gateway `cron run` execution (requires running gateway)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; exit code returns to implicit (1) behavior
- No config/files to restore

## Risks and Mitigations

- Risk: Scripts relying on exit code 1 as "success" (unlikely but possible)
  - Mitigation: This aligns with POSIX convention (0 = success) and the documented expected behavior