### PR TITLE
fix(gateway): resolve approval ID by prefix slug in ExecApprovalManager

### DIFF
--- a/src/gateway/exec-approval-manager.test.ts
+++ b/src/gateway/exec-approval-manager.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { ExecApprovalManager } from "./exec-approval-manager.js";
+import type { ExecApprovalRequestPayload } from "./exec-approval-manager.js";
+
+const TIMEOUT_MS = 60_000;
+
+function dummyRequest(): ExecApprovalRequestPayload {
+  return {
+    command: "echo hello",
+    sessionKey: "agent:main:main",
+    agentId: "main",
+  } as ExecApprovalRequestPayload;
+}
+
+describe("ExecApprovalManager", () => {
+  it("resolves by full UUID", () => {
+    const mgr = new ExecApprovalManager();
+    const record = mgr.create(dummyRequest(), TIMEOUT_MS);
+    void mgr.register(record, TIMEOUT_MS);
+
+    const ok = mgr.resolve(record.id, "allow-once");
+    expect(ok).toBe(true);
+  });
+
+  it("resolves by 8-char slug prefix", async () => {
+    vi.useFakeTimers();
+    const mgr = new ExecApprovalManager();
+    const record = mgr.create(dummyRequest(), TIMEOUT_MS);
+    const promise = mgr.register(record, TIMEOUT_MS);
+
+    const slug = record.id.slice(0, 8);
+    const ok = mgr.resolve(slug, "allow-once");
+    expect(ok).toBe(true);
+
+    const decision = await promise;
+    expect(decision).toBe("allow-once");
+    vi.useRealTimers();
+  });
+
+  it("getSnapshot works with slug prefix", () => {
+    const mgr = new ExecApprovalManager();
+    const record = mgr.create(dummyRequest(), TIMEOUT_MS);
+    void mgr.register(record, TIMEOUT_MS);
+
+    const slug = record.id.slice(0, 8);
+    const snapshot = mgr.getSnapshot(slug);
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.id).toBe(record.id);
+  });
+
+  it("returns false when slug matches multiple pending approvals", () => {
+    const mgr = new ExecApprovalManager();
+    const r1 = mgr.create(dummyRequest(), TIMEOUT_MS, "aabb1111-0000-0000-0000-000000000001");
+    const r2 = mgr.create(dummyRequest(), TIMEOUT_MS, "aabb1111-0000-0000-0000-000000000002");
+    void mgr.register(r1, TIMEOUT_MS);
+    void mgr.register(r2, TIMEOUT_MS);
+
+    const ok = mgr.resolve("aabb1111", "allow-once");
+    expect(ok).toBe(false);
+  });
+
+  it("returns null snapshot when slug is ambiguous", () => {
+    const mgr = new ExecApprovalManager();
+    const r1 = mgr.create(dummyRequest(), TIMEOUT_MS, "ccdd2222-0000-0000-0000-000000000001");
+    const r2 = mgr.create(dummyRequest(), TIMEOUT_MS, "ccdd2222-0000-0000-0000-000000000002");
+    void mgr.register(r1, TIMEOUT_MS);
+    void mgr.register(r2, TIMEOUT_MS);
+
+    expect(mgr.getSnapshot("ccdd2222")).toBeNull();
+  });
+
+  it("consumeAllowOnce works with slug prefix", async () => {
+    vi.useFakeTimers();
+    const mgr = new ExecApprovalManager();
+    const record = mgr.create(dummyRequest(), TIMEOUT_MS);
+    void mgr.register(record, TIMEOUT_MS);
+
+    const slug = record.id.slice(0, 8);
+    mgr.resolve(slug, "allow-once");
+
+    const consumed = mgr.consumeAllowOnce(slug);
+    expect(consumed).toBe(true);
+
+    const secondConsume = mgr.consumeAllowOnce(slug);
+    expect(secondConsume).toBe(false);
+    vi.useRealTimers();
+  });
+});

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -34,6 +34,26 @@ type PendingEntry = {
 export class ExecApprovalManager {
   private pending = new Map<string, PendingEntry>();
 
+  /**
+   * Resolve a potentially abbreviated slug to the full record ID.
+   * Exact match takes priority; falls back to unique prefix match.
+   */
+  private resolveRecordId(idOrSlug: string): string | null {
+    if (this.pending.has(idOrSlug)) {
+      return idOrSlug;
+    }
+    let matched: string | null = null;
+    for (const key of this.pending.keys()) {
+      if (key.startsWith(idOrSlug)) {
+        if (matched !== null) {
+          return null;
+        }
+        matched = key;
+      }
+    }
+    return matched;
+  }
+
   create(
     request: ExecApprovalRequestPayload,
     timeoutMs: number,
@@ -97,10 +117,12 @@ export class ExecApprovalManager {
   }
 
   resolve(recordId: string, decision: ExecApprovalDecision, resolvedBy?: string | null): boolean {
-    const pending = this.pending.get(recordId);
-    if (!pending) {
+    const fullId = this.resolveRecordId(recordId);
+    const pending = fullId ? this.pending.get(fullId) : undefined;
+    if (!pending || !fullId) {
       return false;
     }
+    recordId = fullId;
     // Prevent double-resolve (e.g., if called after timeout already resolved)
     if (pending.record.resolvedAtMs !== undefined) {
       return false;
@@ -143,12 +165,14 @@ export class ExecApprovalManager {
   }
 
   getSnapshot(recordId: string): ExecApprovalRecord | null {
-    const entry = this.pending.get(recordId);
+    const fullId = this.resolveRecordId(recordId);
+    const entry = fullId ? this.pending.get(fullId) : undefined;
     return entry?.record ?? null;
   }
 
   consumeAllowOnce(recordId: string): boolean {
-    const entry = this.pending.get(recordId);
+    const fullId = this.resolveRecordId(recordId);
+    const entry = fullId ? this.pending.get(fullId) : undefined;
     if (!entry) {
       return false;
     }
@@ -167,7 +191,8 @@ export class ExecApprovalManager {
    * Returns the decision promise if the ID is pending, null otherwise.
    */
   awaitDecision(recordId: string): Promise<ExecApprovalDecision | null> | null {
-    const entry = this.pending.get(recordId);
+    const fullId = this.resolveRecordId(recordId);
+    const entry = fullId ? this.pending.get(fullId) : undefined;
     return entry?.promise ?? null;
   }
 }


### PR DESCRIPTION
## Summary

- Problem: `/approve <id>` fails with "unknown approval id" because the user sees an 8-char slug but the gateway expects the full UUID.
- Why it matters: Exec approvals via Signal (and any channel using the tool-result slug) are completely broken — users can never approve commands.
- What changed: Added `resolveRecordId()` to `ExecApprovalManager` that first tries exact map lookup, then falls back to unique prefix matching across pending entries.
- What did NOT change: The slug generation in `bash-tools.exec-runtime.ts` and the `/approve` command parser are untouched. Full UUIDs still work as before.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Auth / tokens

## Linked Issue/PR

- Closes #31043

## User-visible / Behavior Changes

`/approve <8-char-slug> allow-once` now correctly resolves the pending approval. Full UUIDs remain supported.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Note: Prefix matching only resolves when exactly one pending entry matches, preventing ambiguous approvals.

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node
- Integration/channel: Signal (or any channel showing the tool-result slug)
- Relevant config: Exec approvals enabled (session mode)

### Steps

1. Trigger a command requiring exec approval from Signal
2. Observe prompt: `Approval required (id a17b4920)`
3. Reply: `/approve a17b4920 allow-once`

### Expected

Approval resolves successfully.

### Actual

Gateway rejects with "unknown approval id".

## Evidence

- [x] `npx vitest run src/gateway/server-methods/server-methods.test.ts` — 39/39 passed
- [x] `npx vitest run src/gateway/node-invoke-system-run-approval.test.ts` — 14/14 passed
- [x] `npx oxfmt --check` — clean
- [x] Code review: `resolveRecordId` returns null on ambiguous (multiple prefix matches), safe against collision

## Human Verification (required)

- Verified scenarios: Slug lookup resolves unique prefix; exact UUID still works; ambiguous slug returns null (no match)
- Edge cases checked: Empty pending map; slug that matches no entry; slug that matches 2+ entries (returns null); already-resolved entry (still found during grace period)
- What you did **not** verify: Live Signal `/approve` flow

## Compatibility / Migration

- Backward compatible? Yes — full UUIDs still work
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; slug-based approval stops working, full UUID still works
- No config/files to restore

## Risks and Mitigations

- Risk: Prefix collision if two pending approvals share the same 8-char prefix
  - Mitigation: `resolveRecordId` returns null when multiple entries match, preserving the existing "unknown approval id" error rather than approving the wrong request