### PR TITLE
fix(tts): use ogg-opus for Edge TTS on voice-bubble channels (Feishu)

### DIFF
--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -55,6 +55,7 @@ const DEFAULT_OPENAI_VOICE = "alloy";
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
 const DEFAULT_EDGE_LANG = "en-US";
 const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+const VOICE_BUBBLE_EDGE_OUTPUT_FORMAT = "ogg-24khz-16bit-mono-opus";
 
 const DEFAULT_ELEVENLABS_VOICE_SETTINGS = {
   stability: 0.5,
@@ -571,6 +572,9 @@ export async function textToSpeech(params: {
         mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
         const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
         let edgeOutputFormat = resolveEdgeOutputFormat(config);
+        if (output.voiceCompatible && !config.edge.outputFormatConfigured) {
+          edgeOutputFormat = VOICE_BUBBLE_EDGE_OUTPUT_FORMAT;
+        }
         const fallbackEdgeOutputFormat =
           edgeOutputFormat !== DEFAULT_EDGE_OUTPUT_FORMAT ? DEFAULT_EDGE_OUTPUT_FORMAT : undefined;
 


### PR DESCRIPTION
## Summary

- Problem: Feishu receives TTS audio as mp3 file instead of voice bubble because Edge TTS defaults to mp3 output regardless of channel.
- Why it matters: Users cannot play voice messages directly in Feishu chat — they appear as file attachments.
- What changed: When the target channel requires voice-compatible audio (Feishu, Telegram, WhatsApp) and the user hasn't explicitly configured an Edge output format, override to `ogg-24khz-16bit-mono-opus`. The `.ogg` extension is already recognized by Feishu's `detectFileType` as `"opus"` → `msgType: "audio"` → voice bubble.
- What did NOT change: Channels not in `VOICE_BUBBLE_CHANNELS` still get mp3. Explicitly configured `edge.outputFormat` is still respected. OpenAI/ElevenLabs providers already use opus for these channels.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #31100

## User-visible / Behavior Changes

Feishu (and other voice-bubble channels) now receive opus audio from Edge TTS, rendered as playable voice bubbles instead of file attachments.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node
- Integration/channel: Feishu
- Relevant config: TTS enabled, provider: edge (default)

### Steps

1. Configure OpenClaw with Feishu channel
2. Enable TTS (default Edge provider)
3. Trigger a message that produces TTS output
4. Observe Feishu chat

### Expected

Voice bubble (playable audio) in Feishu chat.

### Actual

Mp3 file attachment in Feishu chat.

## Evidence

- [x] `npx vitest run src/tts/` — 24/24 passed
- [x] `npx oxfmt --check` — clean
- [x] Code trace: `ogg-24khz-16bit-mono-opus` → `inferEdgeExtension` returns `.ogg` → `isVoiceCompatibleAudio` returns true (`.ogg` ∈ `TELEGRAM_VOICE_AUDIO_EXTENSIONS`) → Feishu `detectFileType(".ogg")` returns `"opus"` → `msgType: "audio"`

## Human Verification (required)

- Verified scenarios: Voice-bubble channel + Edge TTS gets opus; non-voice channel still gets mp3; explicit `edge.outputFormat` overrides this behavior
- Edge cases checked: `config.edge.outputFormatConfigured === true` bypasses override; fallback to mp3 still works when opus format fails
- What you did **not** verify: Live Feishu voice bubble rendering

## Compatibility / Migration

- Backward compatible? Yes — only changes default behavior for Edge TTS on voice-bubble channels
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Set `edge.outputFormat` explicitly to `"audio-24khz-48kbitrate-mono-mp3"` in config to restore mp3 behavior
- Or revert commit

## Risks and Mitigations

- Risk: Edge TTS server may not support `ogg-24khz-16bit-mono-opus` in all regions
  - Mitigation: Existing fallback logic retries with `DEFAULT_EDGE_OUTPUT_FORMAT` (mp3) if the opus format fails