### PR TITLE
fix(ui): persist delivery mode "none" in cron editor

### DIFF
--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -614,17 +614,19 @@ export async function addCronJob(state: CronState) {
     const payload = buildCronPayload(form);
     const selectedDeliveryMode = form.deliveryMode;
     const delivery =
-      selectedDeliveryMode && selectedDeliveryMode !== "none"
-        ? {
-            mode: selectedDeliveryMode,
-            channel:
-              selectedDeliveryMode === "announce"
-                ? form.deliveryChannel.trim() || "last"
-                : undefined,
-            to: form.deliveryTo.trim() || undefined,
-            bestEffort: form.deliveryBestEffort,
-          }
-        : undefined;
+      selectedDeliveryMode === "none"
+        ? { mode: "none" as const }
+        : selectedDeliveryMode
+          ? {
+              mode: selectedDeliveryMode,
+              channel:
+                selectedDeliveryMode === "announce"
+                  ? form.deliveryChannel.trim() || "last"
+                  : undefined,
+              to: form.deliveryTo.trim() || undefined,
+              bestEffort: form.deliveryBestEffort,
+            }
+          : undefined;
     const failureAlert = buildFailureAlert(form);
     const agentId = form.clearAgent ? null : form.agentId.trim();
     const job = {


### PR DESCRIPTION
## Summary

- Problem: Cron editor does not persist "Result delivery = None (internal)" on save — `delivery.mode` remains `"announce"`.
- Why it matters: Users cannot disable delivery for existing cron jobs through the UI.
- What changed: When `deliveryMode === "none"`, the UI now sends `delivery: { mode: "none" }` instead of `delivery: undefined`.
- What did NOT change: Backend cron patch logic, schema validation, and normalization are all untouched — they already support `mode: "none"`.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #31075

## User-visible / Behavior Changes

Selecting "Result delivery = None (internal)" in the cron editor now correctly saves and persists across reloads.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 11 (host) + Docker Linux containers
- Runtime/container: openclaw-gateway/openclaw-node
- Integration/channel: Control UI
- Relevant config: Any existing cron job with `delivery.mode: "announce"`

### Steps

1. Open cron job editor for an existing job with delivery mode "announce"
2. Change Result delivery to "None (internal)"
3. Click "Save changes"
4. Re-open the job or check via API/CLI

### Expected

`delivery.mode` saved as `"none"`.

### Actual

`delivery.mode` remains `"announce"`.

## Evidence

- [x] `npx oxfmt --check` — clean
- [x] Code trace: UI now sends `{ mode: "none" }` → backend `if (patch.delivery)` is truthy → `mergeCronDelivery` updates `job.delivery` → persisted
- [x] Backend schema (`CronDeliveryPatchSchema`) already accepts `mode: "none"` — no backend change needed

## Human Verification (required)

- Verified scenarios: `deliveryMode === "none"` produces `{ mode: "none" }`; `deliveryMode === "announce"` still includes channel/to/bestEffort; `deliveryMode` falsy still produces undefined
- Edge cases checked: Empty/unset delivery mode; switching between announce → none → announce
- What you did **not** verify: Live UI save + reload cycle

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; delivery "none" selection silently ignored again
- No config/files to restore

## Risks and Mitigations

None — this aligns the UI with the already-supported backend schema.