### PR TITLE
fix(routing): treat peer.kind group and channel as equivalent in bindings

### DIFF
--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -262,12 +262,24 @@ function hasRolesConstraint(match: NormalizedBindingMatch): boolean {
   return Boolean(match.roles);
 }
 
+function peerKindMatches(bindingKind: ChatType, scopeKind: ChatType): boolean {
+  if (bindingKind === scopeKind) {
+    return true;
+  }
+  const both = new Set([bindingKind, scopeKind]);
+  return both.has("group") && both.has("channel");
+}
+
 function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope): boolean {
   if (match.peer.state === "invalid") {
     return false;
   }
   if (match.peer.state === "valid") {
-    if (!scope.peer || scope.peer.kind !== match.peer.kind || scope.peer.id !== match.peer.id) {
+    if (
+      !scope.peer ||
+      !peerKindMatches(match.peer.kind, scope.peer.kind) ||
+      scope.peer.id !== match.peer.id
+    ) {
       return false;
     }
   }


### PR DESCRIPTION
## Summary

- Problem: Slack channel bindings configured with `peer.kind: "group"` silently fail to route public channels (`C` prefix IDs). Messages fall through to the default agent.
- Why it matters: Users naturally configure `"group"` for Slack channels since they are group conversations, but the routing uses `"channel"` internally for both public and private Slack channels.
- What changed: Added `peerKindMatches()` that treats `"group"` and `"channel"` as interchangeable in binding scope matching. `"direct"` remains distinct.
- What did NOT change: The Slack `peer.kind` assignment in `prepare.ts` is untouched. Existing bindings with `peer.kind: "channel"` continue to work.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #31099

## User-visible / Behavior Changes

`peer.kind: "group"` bindings now match Slack public/private channels. `peer.kind: "channel"` bindings also match `"group"` scope (symmetric).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node
- Integration/channel: Slack
- Relevant config: `bindings: [{ match: { channel: "slack", peer: { kind: "group", id: "C..." } } }]`

### Steps

1. Configure a binding with `peer.kind: "group"` and a Slack public channel ID
2. Post a message in that channel
3. Observe agent routing

### Expected

Message routed to the bound agent.

### Actual

Message falls through to the default agent.

## Evidence

- [x] `npx vitest run src/routing/` — 61/61 passed
- [x] `npx oxfmt --check` — clean
- [x] Code trace: `peerKindMatches("group", "channel")` returns true; `peerKindMatches("direct", "group")` returns false

## Human Verification (required)

- Verified scenarios: "group" matches "channel" (both directions); "direct" still distinct from both
- Edge cases checked: Same-kind match still works; binding with no peer constraint unaffected; `peer.state === "invalid"` still fails
- What you did **not** verify: Live Slack routing with a real channel

## Compatibility / Migration

- Backward compatible? Yes — existing "channel" bindings gain broader matching but the ID constraint ensures only the intended channel matches
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; "group"/"channel" matching becomes strict again
- No config/files to restore

## Risks and Mitigations

- Risk: Unintended match if user has both a "group" and "channel" binding for the same ID
  - Mitigation: This is unlikely (same ID), and the broader matching is the documented expected behavior per issue discussion

Made with [Cursor](https://cursor.com)