### PR TITLE
feat(feishu): 添加 streamingThrottleMs 配置参数以控制流式卡片更新频率

### DIFF
--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -49,6 +49,8 @@ const BlockStreamingCoalesceSchema = z
   .strict()
   .optional();
 
+const StreamingThrottleMsSchema = z.number().int().positive().optional();
+
 const ChannelHeartbeatVisibilitySchema = z
   .object({
     visibility: z.enum(["visible", "hidden"]).optional(),
@@ -160,6 +162,7 @@ const FeishuSharedConfigShape = {
   heartbeat: ChannelHeartbeatVisibilitySchema,
   renderMode: RenderModeSchema,
   streaming: StreamingModeSchema,
+  streamingThrottleMs: StreamingThrottleMsSchema.default(1000).optional(),
   tools: FeishuToolsConfigSchema,
   replyInThread: ReplyInThreadSchema,
   reactionNotifications: ReactionNotificationModeSchema,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -120,8 +120,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         return;
       }
 
-      streaming = new FeishuStreamingSession(createFeishuClient(account), creds, (message) =>
-        params.runtime.log?.(`feishu[${account.accountId}] ${message}`),
+      const throttleMs = account.config?.streamingThrottleMs ?? 1000;
+      streaming = new FeishuStreamingSession(
+        createFeishuClient(account),
+        creds,
+        (message) => params.runtime.log?.(`feishu[${account.accountId}] ${message}`),
+        throttleMs,
       );
       try {
         await streaming.start(chatId, resolveReceiveIdType(chatId), {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -95,12 +95,18 @@ export class FeishuStreamingSession {
   private log?: (msg: string) => void;
   private lastUpdateTime = 0;
   private pendingText: string | null = null;
-  private updateThrottleMs = 100; // Throttle updates to max 10/sec
+  private updateThrottleMs: number; // Throttle updates (default 1000ms = 1 sec)
 
-  constructor(client: Client, creds: Credentials, log?: (msg: string) => void) {
+  constructor(
+    client: Client,
+    creds: Credentials,
+    log?: (msg: string) => void,
+    throttleMs: number = 1000,
+  ) {
     this.client = client;
     this.creds = creds;
     this.log = log;
+    this.updateThrottleMs = throttleMs;
   }
 
   async start(


### PR DESCRIPTION
## 问题描述

当前飞书流式卡片的更新频率 `updateThrottleMs` 硬编码在源代码中（100ms），用户无法通过配置修改。这导致：

- API 调用消耗过高
- 无法根据实际需求调整更新频率

## 解决方案

添加 `streamingThrottleMs` 配置参数，允许用户自定义流式卡片的更新频率。

### 配置示例

```yaml
channels:
  feishu:
    streamingThrottleMs: 1000  # 默认 1000ms，即每秒最多更新一次
```

### 修改内容

1. **config-schema.ts**: 添加 `streamingThrottleMs` 配置字段
   - 类型：`z.number().int().positive().optional()`
   - 默认值：1000ms

2. **streaming-card.ts**: 修改 `FeishuStreamingSession` 类
   - 构造函数新增 `throttleMs: number = 1000` 参数
   - 使用传入的参数初始化 `updateThrottleMs`

3. **reply-dispatcher.ts**: 在创建 `FeishuStreamingSession` 时传入配置值
   - `const throttleMs = account.config?.streamingThrottleMs ?? 1000;`

## 影响

- 向后兼容：默认值 1000ms 比原来的 100ms 更保守，减少 API 调用
- 用户可根据实际需求调整，平衡实时性和 API 消耗

## 测试建议

- 配置不同 `streamingThrottleMs` 值验证更新频率
- 验证默认值行为
- 验证流式输出功能正常

---

Closes #31136