### PR TITLE
fix(signal): filter syncMessage by property existence, not truthiness

### DIFF
--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -438,9 +438,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       return;
     }
 
-    // For non-own sync messages (e.g., messages synced from other devices),
-    // we could process them but for now we skip to be conservative
-    if (envelope.syncMessage) {
+    // Filter all sync messages (sentTranscript, readReceipts, etc.).
+    // signal-cli may set syncMessage to null instead of omitting it, so
+    // check property existence rather than truthiness to avoid replaying
+    // the bot's own sent messages on daemon restart.
+    if ("syncMessage" in envelope) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- Problem: On daemon restart, signal-cli replays recently sent messages as `sentTranscript` (sync) envelopes. These bypass loop protection because `envelope.syncMessage` may be `null` (falsy), and the source number is the recipient (not the bot), so both checks fail. The agent processes its own sent messages as inbound and replies to them.
- Why it matters: Creates an infinite self-reply loop after every gateway restart.
- What changed: Replaced `if (envelope.syncMessage)` (truthiness check) with `if ("syncMessage" in envelope)` (property existence check). This catches sync messages regardless of whether the property is `null`, `{}`, or a populated object.
- What did NOT change: The `isOwnMessage` check, sender resolution, and all downstream message processing are untouched.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #31084

## User-visible / Behavior Changes

Signal sync messages (sentTranscript) are now reliably filtered on daemon restart, preventing self-reply loops.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node
- Integration/channel: Signal (signal-cli 0.14.0)
- Relevant config: `dmPolicy: "pairing"` or `"allowlist"` with `allowFrom` entries

### Steps

1. Send messages through Signal
2. Restart the gateway
3. signal-cli daemon replays recent sent messages

### Expected

Sync messages are silently dropped.

### Actual

Agent processes its own sent messages as inbound, creating self-reply loops.

## Evidence

- [x] `npx vitest run src/signal/` — 99/99 passed (13 test files)
- [x] `npx oxfmt --check` — clean
- [x] Code trace: `"syncMessage" in envelope` returns `true` for `{syncMessage: null}`, `{syncMessage: {}}`, and `{syncMessage: {sentMessage: ...}}`; returns `false` only when the property is absent

## Human Verification (required)

- Verified scenarios: `syncMessage: null` → filtered; `syncMessage: { sentMessage: ... }` → filtered; no `syncMessage` property → passed through
- Edge cases checked: Regular incoming messages without `syncMessage` property are unaffected; `isOwnMessage` check still runs first as defense-in-depth
- What you did **not** verify: Live signal-cli daemon restart replay

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; sync message filtering returns to truthiness check
- No config/files to restore

## Risks and Mitigations

- Risk: Legitimate sync messages (if any exist that should be processed) would be filtered
  - Mitigation: The existing comment says "we skip to be conservative" — no sync messages are intended for processing