### PR TITLE
fix(daemon): include OPENCLAW_GATEWAY_TOKEN in node service environment

### DIFF
--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -288,6 +288,7 @@ export function buildNodeServiceEnvironment(params: {
   // works correctly when running as a LaunchAgent without extra user configuration.
   const nodeCaCerts =
     env.NODE_EXTRA_CA_CERTS ?? (platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
+  const gatewayToken = env.OPENCLAW_GATEWAY_TOKEN;
   return {
     HOME: env.HOME,
     TMPDIR: tmpDir,
@@ -296,6 +297,7 @@ export function buildNodeServiceEnvironment(params: {
     NODE_EXTRA_CA_CERTS: nodeCaCerts,
     OPENCLAW_STATE_DIR: stateDir,
     OPENCLAW_CONFIG_PATH: configPath,
+    OPENCLAW_GATEWAY_TOKEN: gatewayToken,
     OPENCLAW_LAUNCHD_LABEL: resolveNodeLaunchAgentLabel(),
     OPENCLAW_SYSTEMD_UNIT: resolveNodeSystemdServiceName(),
     OPENCLAW_WINDOWS_TASK_NAME: resolveNodeWindowsTaskName(),


### PR DESCRIPTION
## Summary

- Problem: `openclaw node install` generates a LaunchAgent/systemd plist that does NOT include `OPENCLAW_GATEWAY_TOKEN` in `EnvironmentVariables`, causing the node service to fail with "gateway token mismatch" on restart.
- Why it matters: Multi-machine setups (remote gateway + headless node) rely on this env var for authentication. `openclaw node run` works manually but `node install` produces a broken service.
- What changed: Added `OPENCLAW_GATEWAY_TOKEN` to the object returned by `buildNodeServiceEnvironment`, reading it from `env.OPENCLAW_GATEWAY_TOKEN`.
- What did NOT change: `buildServiceEnvironment` (gateway) already includes the token. `renderEnvDict` and plist generation are untouched. If the env var is not set, `undefined` is passed and the plist entry is omitted (existing behavior for optional vars).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] CI/CD / infra

## Linked Issue/PR

- Closes #31041

## User-visible / Behavior Changes

`openclaw node install` now includes `OPENCLAW_GATEWAY_TOKEN` in the LaunchAgent/systemd plist when the env var is set during installation.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — the gateway token is now persisted in the LaunchAgent plist `EnvironmentVariables`, mirroring the gateway service behavior
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: The token is already stored in the gateway plist with the same mechanism. LaunchAgent plists are user-scoped files under `~/Library/LaunchAgents/` with standard permissions.

## Repro + Verification

### Environment

- OS: macOS (arm64) or Linux (systemd)
- Runtime/container: Node
- Integration/channel: N/A
- Relevant config: Multi-machine setup with `OPENCLAW_GATEWAY_TOKEN` env var

### Steps

1. Set `OPENCLAW_GATEWAY_TOKEN=<token>` in shell
2. Run: `openclaw node install`
3. Inspect generated plist: `cat ~/Library/LaunchAgents/com.openclaw.node.plist`

### Expected

`EnvironmentVariables` contains `OPENCLAW_GATEWAY_TOKEN`.

### Actual

`OPENCLAW_GATEWAY_TOKEN` is missing.

## Evidence

- [x] `npx vitest run src/daemon/` — 150/150 passed (14 test files)
- [x] `npx oxfmt --check` — clean
- [x] Code comparison: `buildServiceEnvironment` (gateway) includes `OPENCLAW_GATEWAY_TOKEN: token` — same pattern applied to `buildNodeServiceEnvironment`

## Human Verification (required)

- Verified scenarios: `OPENCLAW_GATEWAY_TOKEN` set → included in output; not set → omitted (undefined filtered by `renderEnvDict`)
- Edge cases checked: Empty string token (`""`) → filtered by `renderEnvDict` trim check; whitespace-only → filtered
- What you did **not** verify: Live `openclaw node install` on macOS

## Compatibility / Migration

- Backward compatible? Yes — previously installed services without the token are unaffected; re-running `openclaw node install` with the env var set will regenerate the plist with the token
- Config/env changes? No
- Migration needed? No — just re-run `openclaw node install` with `OPENCLAW_GATEWAY_TOKEN` set

## Failure Recovery (if this breaks)

- Revert commit; token excluded from node plist again
- Users can manually add `OPENCLAW_GATEWAY_TOKEN` to the plist

## Risks and Mitigations

None — this mirrors the established pattern used by the gateway service.