### PR TITLE
fix(cron): send explicit delivery:{mode:"none"} when user selects None in editor

### DIFF
--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -624,7 +624,9 @@ export async function addCronJob(state: CronState) {
             to: form.deliveryTo.trim() || undefined,
             bestEffort: form.deliveryBestEffort,
           }
-        : undefined;
+        : selectedDeliveryMode === "none"
+          ? ({ mode: "none" } as const)
+          : undefined;
     const failureAlert = buildFailureAlert(form);
     const agentId = form.clearAgent ? null : form.agentId.trim();
     const job = {


### PR DESCRIPTION
Fixes #31075

## Root cause

In `ui/src/ui/controllers/cron.ts`, the ternary for building the delivery object returned `undefined` whenever `selectedDeliveryMode === "none"`:

```ts
const delivery =
  selectedDeliveryMode && selectedDeliveryMode !== "none"
    ? { mode: selectedDeliveryMode, ... }
    : undefined;  // ← BUG: sends undefined when user picked "none"
```

Because the backend update handler only applies the delivery patch when `patch.delivery` is truthy:

```ts
if (patch.delivery) {
  job.delivery = mergeCronDelivery(job.delivery, patch.delivery);
}
```

…an `undefined` delivery left the existing `delivery.mode` (e.g. `"announce"`) unchanged, so the job kept sending announcements even after the user explicitly selected **None (internal)**.

## Fix

Add a third branch so that `selectedDeliveryMode === "none"` yields `{ mode: "none" }` rather than `undefined`:

```ts
const delivery =
  selectedDeliveryMode && selectedDeliveryMode !== "none"
    ? { mode: selectedDeliveryMode, ... }
    : selectedDeliveryMode === "none"
      ? ({ mode: "none" } as const)
      : undefined;
```

This applies to both `cron.add` (new jobs) and `cron.update` (edits). It also aligns with the backend's `normalizeCronJobCreate` behavior, which defaults isolated agentTurn jobs to `mode: "announce"` when no delivery is supplied — so new jobs explicitly selecting "none" also benefit from the fix.

## Tests

- Added `sends delivery: { mode: "none" } explicitly in cron.add payload`
- Added `sends delivery: { mode: "none" } explicitly in cron.update patch`
- Fixed a pre-existing incorrect assertion in `does not submit stale announce delivery when unsupported`: after a successful `cron.add` the form resets to `DEFAULT_CRON_FORM`, so `state.cronForm.deliveryMode` is `"announce"` (the default), not `"none"` — that check was already failing on `main` before this PR.