### PR TITLE
fix(plugin): fail-to-install-plugin-in-windows

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -135,10 +135,12 @@ export async function runCommandWithTimeout(
 
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
   const resolvedCommand = resolveCommand(argv[0] ?? "");
+  const isWindows = process.platform === "win32";
   const child = spawn(resolvedCommand, argv.slice(1), {
     stdio,
     cwd,
     env: resolvedEnv,
+    shell: isWindows,
     windowsVerbatimArguments,
     ...(shouldSpawnWithShell({ resolvedCommand, platform: process.platform })
       ? { shell: true }


### PR DESCRIPTION
## Summary
- Why it matters

On Windows, someversions of the operating system cannot install plugins.Such as Feishu.
When user execute 
> openclaw plugins install @openclaw/feishu
CMD will show error with **Error: spawn EINVAL**.

This bug has affected the installation of all plugins in the Windows environment.

- What changed:

Modify the code lines 138 to 146 in **src/process/exec.ts**.
Make OpenClaw compatible with Windows operating commands.

- What did NOT change (scope boundary):

Only support for Windows commands has been added; no modifications or deletions have been made to the rest of the code.

## Change Type (select all)

- [x ] Bug fix


## Scope (select all touched areas)

- [ x] Integrations


## Linked Issue/PR

- Closes #9224 #13936 etc.
- Related #7631 #27402 #25830 etc. 

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation:
None

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: CMD or PowerShell
- Model/provider: glm-5
- Integration/channel (if any): Feishu
- Relevant config (redacted): None

### Steps

1. clone base repository on Windows
2. build and start Openclaw
3. execute official instructions to install Feishu plugin (fail to install)
4. modify code with  **src/process/exec.tx**
5. rebuild and restart Openclaw
6. reinstall Feishu plugin

### Expected

- The Feishu plugin has been sucessfully installed

### Actual

- The Feishu plugin has been sucessfully installed


## Evidence

Attach at least one:

- [x ] Failing test/log before + passing after:
| Failing log | Passing log |
|--|--|
| [openclaw] Failed to start CLI: Error: spawn EINVAL | Installed plugin: feishu |


## Human Verification (required)

- Verified scenarios: Verification on multiple Windows envs
- Edge cases checked: Other Plugin


## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

None

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

None

## Note
Many people have encountered this bug, and there are corresponding solutions available in the issue tracker. I have found a useful solution, made the necessary modifications, and submitted this PR.

