### PR TITLE
fix(line): classify M4A voice messages as audio instead of video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- LINE/Voice: fix M4A voice messages misclassified as `video/mp4` by checking the ftyp major brand (`M4A `) instead of treating all MPEG-4 containers as video. (#29751)
 - Cron/Delivery: disable the agent messaging tool when `delivery.mode` is `"none"` so cron output is not sent to Telegram or other channels. (#21808)
 - Feishu/Reply media attachments: send Feishu reply `mediaUrl`/`mediaUrls` payloads as attachments alongside text/streamed replies in the reply dispatcher, including legacy fallback when `mediaUrls` is empty. (#28959)
 - Feishu/Reaction notifications: add `channels.feishu.reactionNotifications` (`off | own | all`, default `own`) so operators can disable reaction ingress or allow all verified reaction events (not only bot-authored message reactions). (#28529)

--- a/src/line/download.ts
+++ b/src/line/download.ts
@@ -80,15 +80,20 @@ function detectContentType(buffer: Buffer): string {
     ) {
       return "image/webp";
     }
-    // MP4
-    if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
-      return "video/mp4";
-    }
-    // M4A/AAC
-    if (buffer[0] === 0x00 && buffer[1] === 0x00 && buffer[2] === 0x00) {
-      if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
+    // MPEG-4 container (ftyp box) — distinguish audio (M4A) from video (MP4)
+    // by checking the major brand at bytes 8-11.
+    if (
+      buffer.length >= 12 &&
+      buffer[4] === 0x66 &&
+      buffer[5] === 0x74 &&
+      buffer[6] === 0x79 &&
+      buffer[7] === 0x70
+    ) {
+      const brand = String.fromCharCode(buffer[8], buffer[9], buffer[10], buffer[11]);
+      if (brand === "M4A " || brand === "M4B ") {
         return "audio/mp4";
       }
+      return "video/mp4";
     }
   }
 


### PR DESCRIPTION
## Summary

LINE voice messages (M4A) are never transcribed because `detectContentType()` classifies them as `video/mp4` instead of `audio/mp4`.

- The `ftyp` box check (bytes 4-7) matches **all** MPEG-4 containers and returns `"video/mp4"`
- The subsequent M4A check (bytes 0-2 + 4-7) is unreachable dead code — the generic ftyp branch fires first
- Fix: inspect the **ftyp major brand** at bytes 8-11 to distinguish `M4A ` / `M4B ` (audio) from `isom` / `mp42` (video)

## Impact

100% of LINE voice messages fail to transcribe. The full downstream chain:

`detectContentType()` → `"video/mp4"` → `mediaKindFromMime()` → `"video"` → `isAudioAttachment()` → `false` → `transcribeFirstAudio()` → skipped

## Test plan

- [x] Added test: M4A magic bytes (`ftyp` + `M4A ` brand) → `audio/mp4` with `.m4a` extension
- [x] Added test: MP4 video magic bytes (`ftyp` + `isom` brand) → `video/mp4` with `.mp4` extension
- [x] Existing path-safety and size-limit tests still pass
- [x] All 4 tests pass

Fixes #29751

🤖 Generated with [Claude Code](https://claude.com/claude-code)