### PR TITLE
fix(ui): add toSorted/toReversed polyfills for older browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/Compat: add `Array.prototype.toSorted` and `toReversed` polyfills so the UI no longer crashes on older browsers (Chrome < 110, Firefox < 115). (#30467)
 - Cron/Delivery: disable the agent messaging tool when `delivery.mode` is `"none"` so cron output is not sent to Telegram or other channels. (#21808)
 - Feishu/Reply media attachments: send Feishu reply `mediaUrl`/`mediaUrls` payloads as attachments alongside text/streamed replies in the reply dispatcher, including legacy fallback when `mediaUrls` is empty. (#28959)
 - Feishu/Reaction notifications: add `channels.feishu.reactionNotifications` (`off | own | all`, default `own`) so operators can disable reaction ingress or allow all verified reaction events (not only bot-authored message reactions). (#28529)

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,2 +1,3 @@
+import "./polyfills.ts";
 import "./styles.css";
 import "./ui/app.ts";

--- a/ui/src/polyfills.test.ts
+++ b/ui/src/polyfills.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+describe("toSorted polyfill", () => {
+  it("sorts a copy without mutating the original", () => {
+    const arr = [3, 1, 2];
+    const sorted = arr.toSorted((a, b) => a - b);
+    expect(sorted).toEqual([1, 2, 3]);
+    expect(arr).toEqual([3, 1, 2]); // original unchanged
+  });
+
+  it("works with string comparator", () => {
+    const arr = ["banana", "apple", "cherry"];
+    const sorted = arr.toSorted((a, b) => a.localeCompare(b));
+    expect(sorted).toEqual(["apple", "banana", "cherry"]);
+  });
+
+  it("uses default lexicographic sort when no comparator is given", () => {
+    const arr = [10, 1, 2];
+    // eslint-disable-next-line @typescript-eslint/require-array-sort-compare
+    const sorted = arr.toSorted();
+    // Default sort is lexicographic
+    expect(sorted).toEqual([1, 10, 2]);
+  });
+});
+
+describe("toReversed polyfill", () => {
+  it("reverses a copy without mutating the original", () => {
+    const arr = [1, 2, 3];
+    const reversed = arr.toReversed();
+    expect(reversed).toEqual([3, 2, 1]);
+    expect(arr).toEqual([1, 2, 3]); // original unchanged
+  });
+});

--- a/ui/src/polyfills.ts
+++ b/ui/src/polyfills.ts
@@ -1,0 +1,23 @@
+/**
+ * Polyfills for browsers that lack ES2023+ Array methods.
+ * Fixes blank-page crash on older Chromium builds (e.g. Chrome < 110).
+ * See: https://github.com/openclaw/openclaw/issues/30467
+ */
+
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+
+if (!Array.prototype.toSorted) {
+  const nativeSort = Array.prototype.sort;
+  // eslint-disable-next-line no-extend-native
+  Array.prototype.toSorted = function <T>(this: T[], compareFn?: (a: T, b: T) => number): T[] {
+    return nativeSort.call([...this], compareFn);
+  };
+}
+
+if (!Array.prototype.toReversed) {
+  const nativeReverse = Array.prototype.reverse;
+  // eslint-disable-next-line no-extend-native
+  Array.prototype.toReversed = function <T>(this: T[]): T[] {
+    return nativeReverse.call([...this]);
+  };
+}


### PR DESCRIPTION
## Problem

The Control UI crashes with a blank page on browsers that lack ES2023 Array methods (e.g. Chrome < 110, older Chromium-based WebViews). `Array.prototype.toSorted` is used in ~18 places across the UI codebase but has no fallback for older runtimes.

Fixes #30467

## Fix

Add lightweight polyfills for `Array.prototype.toSorted` and `Array.prototype.toReversed` in a new `ui/src/polyfills.ts` module, imported before the app entry point in `main.ts`. The polyfills only install when the native methods are missing, using captured references to `Array.prototype.sort` / `Array.prototype.reverse` to avoid conflicts with the repo's lint auto-fixer (which rewrites `.sort()` → `.toSorted()`).

## Test

- 4 unit tests covering:
  - `toSorted` with comparator (sorts copy, original unchanged)
  - `toSorted` with string comparator
  - `toSorted` without comparator (lexicographic default)
  - `toReversed` (reverses copy, original unchanged)
- All existing UI tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)