### PR TITLE
docs(secrets): add 1Password Environments exec resolver example

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -184,6 +184,48 @@ Optional per-id errors:
 }
 ```
 
+### 1Password Environments
+
+This example uses a small wrapper script that implements the exec provider protocol and calls `op environment read` once per batch.
+
+- Script: `scripts/secrets/openclaw-op-environments-resolver`
+- `op` is resolved from `PATH` by default (set `OP_BIN` for an absolute override)
+- Requires 1Password CLI `2.33-beta.02` or newer (`op environment read`)
+- Required: `OP_ENVIRONMENT_ID`
+- Auth: prefers `OP_SERVICE_ACCOUNT_TOKEN`; falls back to desktop auth via `OP_ACCOUNT_NAME`
+
+```json5
+{
+  secrets: {
+    providers: {
+      onepassword_environment: {
+        source: "exec",
+        // Point this at wherever you install the resolver.
+        command: "/usr/local/bin/openclaw-op-environments-resolver",
+        args: [],
+        passEnv: [
+          "OP_ENVIRONMENT_ID",
+          "OP_SERVICE_ACCOUNT_TOKEN",
+          "OP_ACCOUNT_NAME",
+          "PATH",
+          "OP_BIN",
+        ],
+        jsonOnly: true,
+      },
+    },
+  },
+  models: {
+    providers: {
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+        models: [{ id: "gpt-5", name: "gpt-5" }],
+        apiKey: { source: "exec", provider: "onepassword_environment", id: "OPENAI_API_KEY" },
+      },
+    },
+  },
+}
+```
+
 ### HashiCorp Vault CLI
 
 ```json5

--- a/scripts/secrets/openclaw-op-environments-resolver
+++ b/scripts/secrets/openclaw-op-environments-resolver
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+//
+// OpenClaw SecretRef exec resolver for 1Password Environments.
+// Protocol v1: reads JSON from stdin, returns JSON on stdout.
+//
+
+import { execFileSync } from "node:child_process";
+
+const OP = process.env.OP_BIN?.trim() || "op";
+
+function parseEnvironmentOutput(raw) {
+  const values = {};
+  const lines = raw.split(/\r?\n/);
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+    const separator = line.indexOf("=");
+    if (separator <= 0) {
+      throw new Error(`invalid output line: ${line}`);
+    }
+    const key = line.slice(0, separator).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      throw new Error(`invalid environment key: ${key}`);
+    }
+    values[key] = line.slice(separator + 1);
+  }
+  return values;
+}
+
+async function main() {
+  let input = "";
+  for await (const chunk of process.stdin) input += chunk;
+
+  const req = JSON.parse(input);
+  if (req.protocolVersion !== 1) {
+    process.stderr.write(`unsupported protocol version: ${req.protocolVersion}\n`);
+    process.exit(1);
+  }
+
+  const ids = req.ids || [];
+  if (ids.length === 0) {
+    process.stdout.write(JSON.stringify({ protocolVersion: 1, values: {} }));
+    return;
+  }
+
+  const environmentId = process.env.OP_ENVIRONMENT_ID?.trim();
+  if (!environmentId) {
+    process.stderr.write("OP_ENVIRONMENT_ID is required\n");
+    process.exit(1);
+  }
+
+  const hasServiceAccountToken = Boolean(process.env.OP_SERVICE_ACCOUNT_TOKEN?.trim());
+  const hasDesktopAccountName = Boolean(process.env.OP_ACCOUNT_NAME?.trim());
+  if (!hasServiceAccountToken && !hasDesktopAccountName) {
+    process.stderr.write(
+      "Either OP_SERVICE_ACCOUNT_TOKEN or OP_ACCOUNT_NAME is required (service account preferred)\n",
+    );
+    process.exit(1);
+  }
+
+  let keyMap;
+  try {
+    const raw = execFileSync(OP, ["environment", "read", environmentId], {
+      env: {
+        OP_SERVICE_ACCOUNT_TOKEN: process.env.OP_SERVICE_ACCOUNT_TOKEN,
+        OP_ACCOUNT_NAME: process.env.OP_ACCOUNT_NAME,
+        PATH: process.env.PATH || "",
+      },
+      timeout: 15000,
+      maxBuffer: 1024 * 1024,
+      encoding: "utf8",
+    });
+    keyMap = parseEnvironmentOutput(raw);
+  } catch (err) {
+    process.stderr.write(`op environment read failed: ${err.message}\n`);
+    process.exit(1);
+  }
+
+  const values = {};
+  const errors = {};
+  for (const id of ids) {
+    if (id in keyMap) values[id] = keyMap[id];
+    else errors[id] = { message: `environment variable "${id}" not found in 1Password environment` };
+  }
+
+  process.stdout.write(JSON.stringify({ protocolVersion: 1, values, errors }));
+}
+
+main().catch((err) => {
+  process.stderr.write(`resolver error: ${err.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Add a new 1Password Environments exec resolver example for OpenClaw Secrets Management.

- Add `scripts/secrets/openclaw-op-environments-resolver`
  - Implements OpenClaw exec provider protocol v1 (`stdin` request, `stdout` `{ protocolVersion, values, errors }`)
  - Calls `op environment read $OP_ENVIRONMENT_ID` once per batch
  - Maps requested ids to env values
  - Supports auth via:
    - `OP_SERVICE_ACCOUNT_TOKEN` (preferred)
    - `OP_ACCOUNT_NAME` fallback (1Password Desktop)
  - Supports optional `OP_BIN` override (defaults to `op` from `PATH`)
- Add docs example in `docs/gateway/secrets.md` for `secrets.providers.onepassword_environment`
- Add docs note: requires 1Password CLI `2.33-beta.02+` for `op environment read`

## Inspiration

This follows the same integration pattern as #29110 (standalone exec resolver script + docs integration example), adapted for 1Password Environments.

## Why

Current 1Password docs/examples for OpenClaw focus on single-secret reads (for example `op read op://...`).
This adds a batch-friendly resolver for 1Password Environments so SecretRef ids can be resolved in one provider call, which minimizes per-secret config overhead and reduces operational configuration bloat.

## Testing

Manual validation completed:

- Service Account auth path:
  - `OP_SERVICE_ACCOUNT_TOKEN` + `OP_ENVIRONMENT_ID` set
  - Resolver returns expected `values` and per-id `errors`
- Desktop auth fallback path:
  - `OP_ACCOUNT_NAME` + `OP_ENVIRONMENT_ID` set (without service token)
  - Resolver works as expected
- Missing id behavior:
  - Returns per-id error in `errors`
- Local checks:
  - `pnpm check` passes

## Notes

- 1Password Environments currently requires 1Password CLI `2.33-beta.02` or newer for `op environment read`:
  https://releases.1password.com/developers/cli-beta/
