### PR TITLE
fix(mattermost): pass mediaLocalRoots to loadWebMedia for workspace paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Mattermost/Media upload: pass `mediaLocalRoots` through the Mattermost send chain into `loadWebMedia` so agent workspace media files (e.g. `workspace-server/`) upload correctly instead of being silently dropped. (#30830)
 - Cron/Delivery: disable the agent messaging tool when `delivery.mode` is `"none"` so cron output is not sent to Telegram or other channels. (#21808)
 - Feishu/Reply media attachments: send Feishu reply `mediaUrl`/`mediaUrls` payloads as attachments alongside text/streamed replies in the reply dispatcher, including legacy fallback when `mediaUrls` is empty. (#28959)
 - Feishu/Reaction notifications: add `channels.feishu.reactionNotifications` (`off | own | all`, default `own`) so operators can disable reaction ingress or allow all verified reaction events (not only bot-authored message reactions). (#28529)

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -279,10 +279,11 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
       });
       return { channel: "mattermost", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, replyToId }) => {
+    sendMedia: async ({ to, text, mediaUrl, accountId, replyToId, mediaLocalRoots }) => {
       const result = await sendMessageMattermost(to, text, {
         accountId: accountId ?? undefined,
         mediaUrl,
+        mediaLocalRoots,
         replyToId: replyToId ?? undefined,
       });
       return { channel: "mattermost", ...result };

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setMattermostRuntime } from "../runtime.js";
+import type { MattermostSendOpts } from "./send.js";
+
+const uploadMattermostFile = vi.fn();
+const createMattermostPost = vi.fn();
+const createMattermostClient = vi.fn(() => "mock-client");
+const normalizeMattermostBaseUrl = vi.fn((url: string) => url);
+const loadWebMedia = vi.fn();
+
+vi.mock("./client.js", () => ({
+  createMattermostClient: (...args: unknown[]) => createMattermostClient(...args),
+  normalizeMattermostBaseUrl: (url: string) => normalizeMattermostBaseUrl(url),
+  uploadMattermostFile: (...args: unknown[]) => uploadMattermostFile(...args),
+  fetchMattermostMe: vi.fn(),
+  fetchMattermostUserByUsername: vi.fn(),
+  createMattermostDirectChannel: vi.fn(),
+  createMattermostPost: (...args: unknown[]) => createMattermostPost(...args),
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveMattermostAccount: () => ({
+    accountId: "default",
+    botToken: "test-bot-token",
+    baseUrl: "https://chat.example.com",
+    enabled: true,
+    config: {},
+  }),
+}));
+
+describe("sendMessageMattermost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    setMattermostRuntime({
+      media: {
+        loadWebMedia: (...args: unknown[]) => loadWebMedia(...args),
+      },
+      config: {
+        loadConfig: () => ({
+          channels: {
+            mattermost: {
+              enabled: true,
+              botToken: "test-bot-token",
+              baseUrl: "https://chat.example.com",
+            },
+          },
+        }),
+      },
+      logging: {
+        getChildLogger: () => ({ debug: vi.fn() }),
+        shouldLogVerbose: () => false,
+      },
+      channel: {
+        text: {
+          resolveMarkdownTableMode: () => "text",
+          convertMarkdownTables: (text: string) => text,
+        },
+        activity: {
+          record: vi.fn(),
+        },
+      },
+    } as any);
+  });
+
+  it("passes mediaLocalRoots to loadWebMedia", async () => {
+    const mediaLocalRoots = ["/home/user/.openclaw/workspace-server"];
+    loadWebMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+      fileName: "screenshot.png",
+    });
+    uploadMattermostFile.mockResolvedValueOnce({ id: "file-1" });
+    createMattermostPost.mockResolvedValueOnce({ id: "post-1" });
+
+    const { sendMessageMattermost } = await import("./send.js");
+    await sendMessageMattermost("channel:general", "check this", {
+      mediaUrl: "/home/user/.openclaw/workspace-server/screenshot.png",
+      mediaLocalRoots,
+    } satisfies MattermostSendOpts);
+
+    expect(loadWebMedia).toHaveBeenCalledWith(
+      "/home/user/.openclaw/workspace-server/screenshot.png",
+      { localRoots: mediaLocalRoots },
+    );
+  });
+
+  it("calls loadWebMedia without localRoots when mediaLocalRoots is omitted", async () => {
+    loadWebMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("img"),
+      contentType: "image/jpeg",
+      fileName: "photo.jpg",
+    });
+    uploadMattermostFile.mockResolvedValueOnce({ id: "file-2" });
+    createMattermostPost.mockResolvedValueOnce({ id: "post-2" });
+
+    const { sendMessageMattermost } = await import("./send.js");
+    await sendMessageMattermost("channel:general", "photo", {
+      mediaUrl: "https://example.com/photo.jpg",
+    });
+
+    expect(loadWebMedia).toHaveBeenCalledWith("https://example.com/photo.jpg", {
+      localRoots: undefined,
+    });
+  });
+});

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -16,6 +16,7 @@ export type MattermostSendOpts = {
   baseUrl?: string;
   accountId?: string;
   mediaUrl?: string;
+  mediaLocalRoots?: readonly string[];
   replyToId?: string;
 };
 
@@ -176,7 +177,9 @@ export async function sendMessageMattermost(
   const mediaUrl = opts.mediaUrl?.trim();
   if (mediaUrl) {
     try {
-      const media = await core.media.loadWebMedia(mediaUrl);
+      const media = await core.media.loadWebMedia(mediaUrl, {
+        localRoots: opts.mediaLocalRoots,
+      });
       const fileInfo = await uploadMattermostFile(client, {
         channelId,
         buffer: media.buffer,


### PR DESCRIPTION
## Problem

When sending media files from agent workspace directories (e.g. `~/.openclaw/workspace-server/image.png`) via the Mattermost channel, file attachments are silently dropped. Only the text caption is posted.

`loadWebMedia` in `send.ts` was called without `localRoots`, causing it to fall back to `getDefaultMediaLocalRoots()` which explicitly excludes `workspace-*` directories. The error is caught silently and the send degrades to text-only without any indication of failure.

Fixes #30830

## Fix

Thread `mediaLocalRoots` through the Mattermost send chain:

1. Add `mediaLocalRoots` to `MattermostSendOpts` type
2. Destructure `mediaLocalRoots` in `channel.ts` `sendMedia` handler and pass it to `sendMessageMattermost`
3. Forward `opts.mediaLocalRoots` as `localRoots` to `core.media.loadWebMedia()`

This is consistent with how Discord, Telegram, and Feishu handle media local roots.

## Test

- 2 new tests in `send.test.ts`:
  - Verifies `mediaLocalRoots` is forwarded to `loadWebMedia`
  - Verifies `localRoots: undefined` when `mediaLocalRoots` is omitted
- All 42 existing Mattermost tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)