### PR TITLE
fix: use VERSION constant for dashboard version instead of stale env vars (#31119)

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -23,7 +23,7 @@ import { rawDataToString } from "../../../infra/ws.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import { isGatewayCliClient, isWebchatClient } from "../../../utils/message-channel.js";
-import { resolveRuntimeServiceVersion } from "../../../version.js";
+import { VERSION, resolveRuntimeServiceVersion } from "../../../version.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
 import { isLocalDirectRequest } from "../../auth.js";
@@ -988,7 +988,8 @@ export function attachGatewayWsMessageHandler(params: {
           type: "hello-ok",
           protocol: PROTOCOL_VERSION,
           server: {
-            version: resolveRuntimeServiceVersion(process.env, "dev"),
+            version:
+              VERSION !== "0.0.0" ? VERSION : resolveRuntimeServiceVersion(process.env, "dev"),
             connId,
           },
           features: { methods: gatewayMethods, events },

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import os from "node:os";
 import { pickPrimaryLanIPv4 } from "../gateway/net.js";
-import { resolveRuntimeServiceVersion } from "../version.js";
+import { VERSION, resolveRuntimeServiceVersion } from "../version.js";
 
 export type SystemPresence = {
   host?: string;
@@ -51,7 +51,8 @@ function resolvePrimaryIPv4(): string | undefined {
 function initSelfPresence() {
   const host = os.hostname();
   const ip = resolvePrimaryIPv4() ?? undefined;
-  const version = resolveRuntimeServiceVersion(process.env, "unknown");
+  const version =
+    VERSION !== "0.0.0" ? VERSION : resolveRuntimeServiceVersion(process.env, "unknown");
   const modelIdentifier = (() => {
     const p = os.platform();
     if (p === "darwin") {


### PR DESCRIPTION
## Summary
- **Problem:** After `npm update -g openclaw`, the Dashboard continues to display the old version because `resolveRuntimeServiceVersion()` reads stale environment variables (`OPENCLAW_SERVICE_VERSION`) inherited from the daemon's LaunchAgent/systemd plist, which was generated during the old installation.
- **Why it matters:** Users cannot confirm their upgrade succeeded by looking at the Dashboard.
- **What changed:** The WebSocket `hello-ok` handler and system presence now prefer the `VERSION` constant (resolved from the actual package.json) over environment variables. Env vars are only used as fallback when `VERSION` is `"0.0.0"`.
- **What did NOT change:** `resolveRuntimeServiceVersion()` itself is unchanged; the fix is at the call sites.

## Change Type
- [x] Bug fix

## Scope
- [x] UI / DX
- [x] Gateway / orchestration

## Linked Issue/PR
- Closes #31119

## User-visible / Behavior Changes
Dashboard now displays the correct running version after `npm update` + restart, without requiring `openclaw node install` to regenerate the daemon plist.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: WSL2 (Ubuntu), macOS
- Runtime: Node.js v22.22.0
- Model/provider: Any
- Integration/channel: Dashboard/Control UI

### Steps
1. Run OpenClaw with version A
2. Upgrade via `npm update -g openclaw` to version B
3. Restart: `openclaw gateway restart`
4. Open Dashboard

### Expected
- Dashboard shows version B

### Actual (before fix)
- Dashboard shows version A

## Evidence
- [x] Trace/log snippets
- All 8 version tests pass
- `VERSION` correctly resolves from package.json in all build modes

## Human Verification
- Verified scenarios: `VERSION` resolves correctly, fallback to env vars when `VERSION` is `"0.0.0"`, system presence uses correct version
- Edge cases checked: Dev builds where `VERSION` is `"0.0.0"` (falls back to env vars as before)
- What was not verified: Actual daemon plist upgrade flow on macOS

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: Revert this commit
- Files to restore: `src/gateway/server/ws-connection/message-handler.ts`, `src/infra/system-presence.ts`
- Known bad symptoms: If `VERSION` resolves incorrectly (e.g., in a broken build), the dashboard would show "0.0.0" and fall back to env vars

## Risks and Mitigations
- Risk: `VERSION` might resolve incorrectly in some edge-case build configurations
  - Mitigation: Fallback to `resolveRuntimeServiceVersion` when `VERSION === "0.0.0"`
