### PR TITLE
fix: drain Telegram polling session after runner stop to prevent 409 conflicts (#31107)

### DIFF
--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -258,6 +258,14 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       }
     };
 
+    const drainPollingSession = async (bot: TelegramBot) => {
+      try {
+        await bot.api.getUpdates({ offset: -1, limit: 1, timeout: 0 });
+      } catch {
+        // Best-effort: connection may already be closed.
+      }
+    };
+
     const runPollingCycle = async (bot: TelegramBot): Promise<"continue" | "exit"> => {
       const runner = run(bot, runnerOptions);
       activeRunner = runner;
@@ -309,6 +317,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       } finally {
         opts.abortSignal?.removeEventListener("abort", stopOnAbort);
         await stopRunner();
+        await drainPollingSession(bot);
       }
     };
 


### PR DESCRIPTION
## Summary
- **Problem:** After SIGUSR1 restart (e.g., via `config.patch`), the old Telegram `getUpdates` long-poll connection lingers on Telegram's server. When the new polling loop starts, Telegram returns 409 Conflict errors, causing messages to be randomly routed to the contextless old loop.
- **Why it matters:** Users experience complete context loss — the bot gives bizarre responses that forget conversation history. 1,361 conflicts logged over 2 weeks.
- **What changed:** After `runner.stop()` completes, a short `getUpdates(offset: -1, limit: 1, timeout: 0)` call is made to explicitly terminate the server-side polling session before a new loop can start.
- **What did NOT change:** No changes to the runner lifecycle, abort handling, or retry logic.

## Change Type
- [x] Bug fix

## Scope
- [x] Integrations

## Linked Issue/PR
- Closes #31107

## User-visible / Behavior Changes
SIGUSR1 restarts and `config.patch` no longer cause Telegram 409 conflicts or message routing to stale contexts.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — one additional `getUpdates` call with `timeout: 0` on each polling cycle stop
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk: The additional `getUpdates` call is a standard Telegram Bot API call with minimal payload. It's best-effort and errors are silently ignored.

## Repro + Verification
### Environment
- OS: macOS (Darwin 25.3.0), Linux (Docker)
- Runtime: Node.js v22.22.0
- Model/provider: Any
- Integration/channel: Telegram
- Config: Single bot instance with `KeepAlive: true`

### Steps
1. Run gateway with Telegram channel
2. Apply config change via `config.patch` (triggers SIGUSR1)
3. Check gateway error log for 409 conflicts

### Expected
- No 409 conflicts after restart

### Actual (before fix)
- 409 conflicts appear within seconds of restart

## Evidence
- [x] Trace/log snippets
- Issue reporter documented 1,361 conflicts over 2 weeks
- Only workaround was `gateway stop && sleep 5 && gateway start` (5-second delay for server-side cleanup)

## Human Verification
- Verified scenarios: Code review of the polling lifecycle, abort flow, and runner stop path
- Edge cases checked: Bot already disconnected (drain silently fails), multiple rapid restarts (each drain is independent)
- What was not verified: Live Telegram environment with SIGUSR1

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: Revert this commit
- Files to restore: `src/telegram/monitor.ts`
- Known bad symptoms: If `drainPollingSession` hangs (unlikely with `timeout: 0`), it could delay restart

## Risks and Mitigations
- Risk: The drain `getUpdates` call with `offset: -1` could theoretically consume an update
  - Mitigation: `offset: -1` with `limit: 1` only confirms the latest update; the runner has already processed all updates before stopping
- Risk: The drain call might fail on network error
  - Mitigation: Errors are caught and silently ignored (best-effort)

Made with [Cursor](https://cursor.com)