### PR TITLE
fix: resolve Mattermost thread root ID when reply_to_current targets a threaded reply (#30977)

### DIFF
--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -228,3 +228,10 @@ export async function uploadMattermostFile(
   }
   return info;
 }
+
+export async function fetchMattermostPost(
+  client: MattermostClient,
+  postId: string,
+): Promise<MattermostPost> {
+  return await client.request<MattermostPost>(`/posts/${postId}`);
+}

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -5,6 +5,7 @@ import {
   createMattermostDirectChannel,
   createMattermostPost,
   fetchMattermostMe,
+  fetchMattermostPost,
   fetchMattermostUserByUsername,
   normalizeMattermostBaseUrl,
   uploadMattermostFile,
@@ -137,6 +138,31 @@ async function resolveTargetChannelId(params: {
   return channel.id;
 }
 
+async function resolveThreadRootId(
+  client: ReturnType<typeof createMattermostClient>,
+  replyToId: string | undefined,
+  logger: { debug?: (...args: unknown[]) => void },
+): Promise<string | undefined> {
+  if (!replyToId) {
+    return undefined;
+  }
+  try {
+    const post = await fetchMattermostPost(client, replyToId);
+    if (post.root_id) {
+      logger.debug?.(
+        `mattermost send: replyToId ${replyToId} is a threaded reply, resolved root to ${post.root_id}`,
+      );
+      return post.root_id;
+    }
+    return replyToId;
+  } catch (err) {
+    logger.debug?.(
+      `mattermost send: failed to fetch post ${replyToId}, using as-is: ${String(err)}`,
+    );
+    return replyToId;
+  }
+}
+
 export async function sendMessageMattermost(
   to: string,
   text: string,
@@ -211,10 +237,11 @@ export async function sendMessageMattermost(
     throw new Error("Mattermost message is empty");
   }
 
+  const rootId = await resolveThreadRootId(client, opts.replyToId, logger);
   const post = await createMattermostPost(client, {
     channelId,
     message,
-    rootId: opts.replyToId,
+    rootId,
     fileIds,
   });
 


### PR DESCRIPTION
## Summary
- Problem: When `[[reply_to_current]]` resolves to a Mattermost post that is itself a threaded reply (has a non-empty `root_id`), this post ID is passed as `root_id` to the Mattermost API. Mattermost rejects it with "400 Bad Request: Invalid RootId" because `root_id` must reference the actual root post of a thread.
- Why it matters: Thread fork sessions with `[[reply_to_current]]` fail silently, and the bot's reply is lost.
- What changed: Before creating a post, `sendMessageMattermost()` now resolves the `replyToId` to the actual thread root by fetching the target post and using its `root_id` if it exists.
- What did NOT change: The direct inbound delivery path (monitor.ts) already correctly uses `threadRootId` from `post.root_id`.

## Change Type
- [x] Bug fix

## Scope
- [x] Integrations

## Linked Issue/PR
- Closes #30977

## User-visible / Behavior Changes
`[[reply_to_current]]` in Mattermost thread fork sessions now correctly replies in the thread instead of failing with 400 Bad Request.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — one additional `GET /posts/{id}` call per outbound message with `replyToId`
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk: The additional API call reads a post the bot already has access to. If it fails, the original `replyToId` is used as fallback.

## Repro + Verification
### Environment
- OS: Any (K8s reported)
- Runtime: Node.js
- Model/provider: Any
- Integration/channel: Mattermost Team Edition 10.11.10

### Steps
1. Send a top-level DM message (post A)
2. Bot replies in thread (post B, root_id=A)
3. User replies in thread (post C, root_id=A)
4. Thread fork session replies with `[[reply_to_current]]`
5. `replyToId` resolves to post C

### Expected
- Bot replies in the thread (root_id=A)

### Actual (before fix)
- 400 Bad Request: Invalid RootId (root_id set to C instead of A)

## Evidence
- [x] Trace/log snippets
- Code review confirms `resolveThreadRootId` correctly resolves to `post.root_id` when the target is a threaded reply

## Human Verification
- Verified scenarios: replyToId is a root post (no change), replyToId is a threaded reply (resolved to root), replyToId is undefined (no API call)
- Edge cases checked: Post fetch failure (fallback to original ID), post without root_id (returns original ID)
- What was not verified: Live Mattermost instance

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: Revert this commit
- Files to restore: `extensions/mattermost/src/mattermost/send.ts`, `extensions/mattermost/src/mattermost/client.ts`
- Known bad symptoms: Extra API call per reply might add latency (mitigated by being a single lightweight GET request)

## Risks and Mitigations
- Risk: Extra API call adds latency to each reply
  - Mitigation: The call is only made when `replyToId` is provided, and it's a lightweight GET request
- Risk: Post fetch returns unexpected data
  - Mitigation: Falls back to original `replyToId` on any error
