### PR TITLE
fix(ui): make cron edit form scroll within viewport

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -608,6 +608,8 @@
 .cron-workspace-form {
   position: sticky;
   top: 74px;
+  max-height: calc(100vh - 74px);
+  overflow: auto;
 }
 
 .cron-form {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -926,6 +926,8 @@
   .cron-workspace-form {
     position: static;
     order: -1;
+    max-height: none;
+    overflow: visible;
   }
 
   .cron-form-grid {


### PR DESCRIPTION
Fixes #31120.

The cron edit form panel is sticky; when it is taller than the viewport it could overflow and become unreachable unless the left list created enough page scroll. This makes the form container itself scrollable within the viewport.

Change:
- ui/src/styles/components.css: add max-height + overflow:auto to .cron-workspace-form