### PR TITLE
fix: auto-convert newlines to hard breaks for Discord bot messages (#30962)

### DIFF
--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -16,6 +16,7 @@ import type { PollInput } from "../polls.js";
 import { loadWebMediaRaw } from "../web/media.js";
 import { resolveDiscordAccount } from "./accounts.js";
 import {
+  applyDiscordHardBreaks,
   buildDiscordMessagePayload,
   buildDiscordSendError,
   buildDiscordTextChunks,
@@ -357,7 +358,7 @@ export async function sendWebhookMessageDiscord(
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        content: text,
+        content: applyDiscordHardBreaks(text),
         username: opts.username?.trim() || undefined,
         avatar_url: opts.avatarUrl?.trim() || undefined,
         ...(messageReference ? { message_reference: messageReference } : {}),

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -28,6 +28,69 @@ const DISCORD_POLL_MAX_DURATION_HOURS = 32 * 24;
 const DISCORD_MISSING_PERMISSIONS = 50013;
 const DISCORD_CANNOT_DM = 50007;
 
+/**
+ * Convert bare newlines to Markdown hard breaks for Discord rendering.
+ *
+ * Discord's message renderer treats a single `\n` as a soft break, which
+ * collapses to a space.  Two trailing spaces before `\n` produce a hard
+ * break (`<br>`).  This function adds those trailing spaces where needed
+ * while preserving:
+ *  - fenced code blocks (``` or ~~~)
+ *  - lines that are already followed by a blank line (paragraph break)
+ *  - lines that already end with two trailing spaces
+ */
+export function applyDiscordHardBreaks(text: string): string {
+  if (!text) {
+    return text;
+  }
+
+  const lines = text.split("\n");
+  const result: string[] = [];
+  let insideCodeFence = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Toggle code-fence state on opening/closing fences.
+    if (/^\s*(`{3,}|~{3,})/.test(line)) {
+      insideCodeFence = !insideCodeFence;
+      result.push(line);
+      continue;
+    }
+
+    // Never touch lines inside fenced code blocks.
+    if (insideCodeFence) {
+      result.push(line);
+      continue;
+    }
+
+    // Last line — nothing follows, no hard break needed.
+    if (i === lines.length - 1) {
+      result.push(line);
+      continue;
+    }
+
+    const nextLine = lines[i + 1];
+
+    // If the next line is blank this is already a paragraph break.
+    if (nextLine.trim() === "") {
+      result.push(line);
+      continue;
+    }
+
+    // If the line already ends with two+ trailing spaces, leave it alone.
+    if (line.endsWith("  ")) {
+      result.push(line);
+      continue;
+    }
+
+    // Append two trailing spaces to force a hard break.
+    result.push(line + "  ");
+  }
+
+  return result.join("\n");
+}
+
 type DiscordRequest = RetryRunner;
 
 export type DiscordSendComponentFactory = (text: string) => TopLevelComponents[];
@@ -320,7 +383,7 @@ export function buildDiscordMessagePayload(params: {
   const hasV2 = hasV2Components(params.components);
   const trimmed = params.text.trim();
   if (!hasV2 && trimmed) {
-    payload.content = params.text;
+    payload.content = applyDiscordHardBreaks(params.text);
   }
   if (params.components?.length) {
     payload.components = params.components;


### PR DESCRIPTION
## Summary
- **Problem:** Discord renders single newlines (`\n`) as soft breaks, which collapse to spaces in bot messages. This makes multi-line agent replies unreadable — everything appears as one long line.
- **Why it matters:** All Discord bot messages (status updates, lists, structured output) are unreadable.
- **What changed:** Added `applyDiscordHardBreaks()` that converts bare `\n` to `  \n` (Markdown hard break). Fenced code blocks, paragraph breaks, and already-correct lines are preserved.
- **What did NOT change:** No changes to chunking logic, markdown table conversion, or message structure.

## Change Type
- [x] Bug fix

## Scope
- [x] Integrations

## Linked Issue/PR
- Closes #30962

## User-visible / Behavior Changes
Discord bot messages now preserve line breaks as intended. Multi-line content (lists, status updates, step-by-step instructions) renders with proper line separation.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: Any
- Runtime: Node.js v22.22.0
- Model/provider: Any
- Integration/channel: Discord
- Config: Default Discord channel config

### Steps
1. Have agent send a multi-line message via Discord
2. Observe the message rendering

### Expected
- Lines render separately (stacked)

### Actual (before fix)
- All lines collapsed into one long line

## Evidence
- [x] Trace/log snippets
- Discord chunk tests pass (10 tests)
- `applyDiscordHardBreaks` correctly handles: plain text, code blocks (preserved), paragraph breaks (preserved), already-hard-broken lines (preserved)

## Human Verification
- Verified scenarios: Multi-line text, code blocks, paragraph breaks, mixed content
- Edge cases checked: Empty lines (preserved as paragraph breaks), trailing spaces (not doubled), code fence nesting
- What was not verified: Live Discord rendering

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert: Revert this commit
- Files to restore: `src/discord/send.shared.ts`, `src/discord/send.outbound.ts`
- Known bad symptoms: If hard breaks cause visual issues in some Discord clients, users may see extra spaces

## Risks and Mitigations
- Risk: Two trailing spaces might be visible in some Discord clients or copy-paste scenarios
  - Mitigation: This is the standard Markdown hard break syntax and is well-supported by Discord's renderer
- Risk: Code blocks might be incorrectly detected (e.g., inline code with backticks)
  - Mitigation: Detection uses fence-style matching (3+ backticks/tildes at start of line), which avoids false positives from inline code
