### PR TITLE
feat(feishu): add streamingThrottleMs config parameter

### DIFF
--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -40,6 +40,10 @@ const RenderModeSchema = z.enum(["auto", "raw", "card"]).optional();
 // for incremental text display with a "Thinking..." placeholder
 const StreamingModeSchema = z.boolean().optional();
 
+// Streaming throttle: controls the minimum interval between card updates (in milliseconds)
+// Higher values reduce API call consumption but decrease real-time responsiveness
+const StreamingThrottleMsSchema = z.number().int().positive().optional();
+
 const BlockStreamingCoalesceSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -160,6 +164,7 @@ const FeishuSharedConfigShape = {
   heartbeat: ChannelHeartbeatVisibilitySchema,
   renderMode: RenderModeSchema,
   streaming: StreamingModeSchema,
+  streamingThrottleMs: StreamingThrottleMsSchema.default(1000).optional(),
   tools: FeishuToolsConfigSchema,
   replyInThread: ReplyInThreadSchema,
   reactionNotifications: ReactionNotificationModeSchema,

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -164,7 +164,7 @@ const FeishuSharedConfigShape = {
   heartbeat: ChannelHeartbeatVisibilitySchema,
   renderMode: RenderModeSchema,
   streaming: StreamingModeSchema,
-  streamingThrottleMs: StreamingThrottleMsSchema.default(1000).optional(),
+  streamingThrottleMs: StreamingThrottleMsSchema.default(100).optional(),
   tools: FeishuToolsConfigSchema,
   replyInThread: ReplyInThreadSchema,
   reactionNotifications: ReactionNotificationModeSchema,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -120,7 +120,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         return;
       }
 
-      const throttleMs = account.config?.streamingThrottleMs ?? 1000;
+      const throttleMs = account.config?.streamingThrottleMs ?? 100;
 
       streaming = new FeishuStreamingSession(createFeishuClient(account), creds, (message) =>
         params.runtime.log?.(`feishu[${account.accountId}] ${message}`),

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -120,8 +120,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         return;
       }
 
+      const throttleMs = account.config?.streamingThrottleMs ?? 1000;
+
       streaming = new FeishuStreamingSession(createFeishuClient(account), creds, (message) =>
         params.runtime.log?.(`feishu[${account.accountId}] ${message}`),
+        throttleMs,
       );
       try {
         await streaming.start(chatId, resolveReceiveIdType(chatId), {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -97,7 +97,7 @@ export class FeishuStreamingSession {
   private pendingText: string | null = null;
   private updateThrottleMs: number; // Throttle updates (ms between updates)
 
-  constructor(client: Client, creds: Credentials, log?: (msg: string) => void, throttleMs: number = 1000) {
+  constructor(client: Client, creds: Credentials, log?: (msg: string) => void, throttleMs: number = 100) {
     this.client = client;
     this.creds = creds;
     this.log = log;

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -95,12 +95,13 @@ export class FeishuStreamingSession {
   private log?: (msg: string) => void;
   private lastUpdateTime = 0;
   private pendingText: string | null = null;
-  private updateThrottleMs = 100; // Throttle updates to max 10/sec
+  private updateThrottleMs: number; // Throttle updates (ms between updates)
 
-  constructor(client: Client, creds: Credentials, log?: (msg: string) => void) {
+  constructor(client: Client, creds: Credentials, log?: (msg: string) => void, throttleMs: number = 1000) {
     this.client = client;
     this.creds = creds;
     this.log = log;
+    this.updateThrottleMs = throttleMs;
   }
 
   async start(


### PR DESCRIPTION
## Problem

The streaming card update frequency `updateThrottleMs` was originally hardcoded at 100ms in the source code. When adding the `streamingThrottleMs` configuration parameter, the default value was mistakenly set to 1000ms, which changes the original behavior.

## Solution

Correct the default value to maintain backward compatibility with the original 100ms behavior.

## Configuration Example

```yaml
channels:
  feishu:
    streamingThrottleMs: 100  # Default 100ms, maintains original behavior
```

## Changes

1. **config-schema.ts**: Changed `.default(1000)` to `.default(100)`
2. **streaming-card.ts**: Changed `throttleMs: number = 1000` to `throttleMs: number = 100`
3. **reply-dispatcher.ts**: Changed `?? 1000` to `?? 100`

## Impact

- **Backward compatible**: Default value 100ms matches the original hardcoded behavior
- Users can still adjust based on actual needs to balance real-time output and API consumption

## Testing

- Configure different `streamingThrottleMs` values to verify update frequency
- Verify default behavior matches original 100ms
- Verify streaming output functionality works correctly

Closes #31136