### PR TITLE
fix: allow RFC 2544 benchmark range in web tools SSRF guard

### DIFF
--- a/src/agents/tools/web-guarded-fetch.ts
+++ b/src/agents/tools/web-guarded-fetch.ts
@@ -7,6 +7,7 @@ import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 
 const WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {
   dangerouslyAllowPrivateNetwork: true,
+  allowRfc2544BenchmarkRange: true,
 };
 
 type WebToolGuardedFetchOptions = Omit<GuardedFetchOptions, "proxy"> & {


### PR DESCRIPTION
This fixes `web_fetch` being blocked when using Clash fake-ip mode, which returns addresses in the 198.18.0.0/15 range.

## Problem
When using Clash with fake-ip mode, DNS queries return addresses in the 198.18.0.0/15 range (RFC 2544 benchmark range). OpenClaw's SSRF guard was blocking these addresses as "private/internal/special-use IP", causing `web_fetch` to fail.

## Solution
1. Add `allowRfc2544BenchmarkRange: true` to `WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY`
2. Pass `policy` to `fetchWithSsrFGuard` in `fetchWithWebToolsNetworkGuard`

## Testing
Tested with Clash fake-ip mode enabled, `web_fetch` now works correctly with GitHub, Baidu, and other sites.