### PR TITLE
fix(voice-call): accept externally-initiated Twilio outbound-api calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Voice-call/Twilio external outbound: auto-register webhook-first `outbound-api` calls (initiated outside OpenClaw) so media streams are accepted and call direction metadata stays accurate. (#31181) Thanks @scoootscooob.
 - Voice-call/Twilio inbound greeting: run answered-call initial notify greeting for Twilio instead of skipping the manager speak path, with regression coverage for both Twilio and Plivo notify flows. (#29121) Thanks @xinhuagu.
 - Feishu/topic session routing: use `thread_id` as topic session scope fallback when `root_id` is absent, keep first-turn topic keys stable across thread creation, and force thread replies when inbound events already carry topic/thread context. (#29788) Thanks @songyaolun.
 - Feishu/topic root replies: prefer `root_id` as outbound `replyTargetMessageId` when present, and parse millisecond `message_create_time` values correctly so topic replies anchor to the root message in grouped thread flows. (#29968) Thanks @bmendonca3.

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -235,6 +235,50 @@ describe("processEvent (functional)", () => {
     expect(ctx.activeCalls.size).toBe(0);
   });
 
+  it("auto-registers externally-initiated outbound-api calls", () => {
+    const ctx = createContext();
+    const event: NormalizedEvent = {
+      id: "evt-external-1",
+      type: "call.initiated",
+      callId: "CA-external-123",
+      providerCallId: "CA-external-123",
+      timestamp: Date.now(),
+      direction: "outbound",
+      from: "+15550000000",
+      to: "+15559876543",
+    };
+
+    processEvent(ctx, event);
+
+    // Call should be registered in activeCalls and providerCallIdMap
+    expect(ctx.activeCalls.size).toBe(1);
+    expect(ctx.providerCallIdMap.get("CA-external-123")).toBeDefined();
+    const call = [...ctx.activeCalls.values()][0];
+    expect(call?.providerCallId).toBe("CA-external-123");
+    expect(call?.from).toBe("+15550000000");
+    expect(call?.to).toBe("+15559876543");
+  });
+
+  it("does not reject externally-initiated outbound calls even with disabled inbound policy", () => {
+    const { ctx, hangupCalls } = createRejectingInboundContext();
+    const event: NormalizedEvent = {
+      id: "evt-external-2",
+      type: "call.initiated",
+      callId: "CA-external-456",
+      providerCallId: "CA-external-456",
+      timestamp: Date.now(),
+      direction: "outbound",
+      from: "+15550000000",
+      to: "+15559876543",
+    };
+
+    processEvent(ctx, event);
+
+    // External outbound calls bypass inbound policy — they should be accepted
+    expect(ctx.activeCalls.size).toBe(1);
+    expect(hangupCalls).toHaveLength(0);
+  });
+
   it("deduplicates by dedupeKey even when event IDs differ", () => {
     const now = Date.now();
     const ctx = createContext();

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -235,7 +235,7 @@ describe("processEvent (functional)", () => {
     expect(ctx.activeCalls.size).toBe(0);
   });
 
-  it("auto-registers externally-initiated outbound-api calls", () => {
+  it("auto-registers externally-initiated outbound-api calls with correct direction", () => {
     const ctx = createContext();
     const event: NormalizedEvent = {
       id: "evt-external-1",
@@ -255,6 +255,7 @@ describe("processEvent (functional)", () => {
     expect(ctx.providerCallIdMap.get("CA-external-123")).toBeDefined();
     const call = [...ctx.activeCalls.values()][0];
     expect(call?.providerCallId).toBe("CA-external-123");
+    expect(call?.direction).toBe("outbound");
     expect(call?.from).toBe("+15550000000");
     expect(call?.to).toBe("+15559876543");
   });
@@ -277,6 +278,35 @@ describe("processEvent (functional)", () => {
     // External outbound calls bypass inbound policy — they should be accepted
     expect(ctx.activeCalls.size).toBe(1);
     expect(hangupCalls).toHaveLength(0);
+    const call = [...ctx.activeCalls.values()][0];
+    expect(call?.direction).toBe("outbound");
+  });
+
+  it("preserves inbound direction for auto-registered inbound calls", () => {
+    const ctx = createContext({
+      config: VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "plivo",
+        fromNumber: "+15550000000",
+        inboundPolicy: "open",
+      }),
+    });
+    const event: NormalizedEvent = {
+      id: "evt-inbound-dir",
+      type: "call.initiated",
+      callId: "CA-inbound-789",
+      providerCallId: "CA-inbound-789",
+      timestamp: Date.now(),
+      direction: "inbound",
+      from: "+15554444444",
+      to: "+15550000000",
+    };
+
+    processEvent(ctx, event);
+
+    expect(ctx.activeCalls.size).toBe(1);
+    const call = [...ctx.activeCalls.values()][0];
+    expect(call?.direction).toBe("inbound");
   });
 
   it("deduplicates by dedupeKey even when event IDs differ", () => {

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -59,9 +59,10 @@ function shouldAcceptInbound(config: EventContext["config"], from: string | unde
   }
 }
 
-function createInboundCall(params: {
+function createWebhookCall(params: {
   ctx: EventContext;
   providerCallId: string;
+  direction: "inbound" | "outbound";
   from: string;
   to: string;
 }): CallRecord {
@@ -71,7 +72,7 @@ function createInboundCall(params: {
     callId,
     providerCallId: params.providerCallId,
     provider: params.ctx.provider?.name || "twilio",
-    direction: "inbound",
+    direction: params.direction,
     state: "ringing",
     from: params.from,
     to: params.to,
@@ -79,7 +80,10 @@ function createInboundCall(params: {
     transcript: [],
     processedEventIds: [],
     metadata: {
-      initialMessage: params.ctx.config.inboundGreeting || "Hello! How can I help you today?",
+      initialMessage:
+        params.direction === "inbound"
+          ? params.ctx.config.inboundGreeting || "Hello! How can I help you today?"
+          : undefined,
     },
   };
 
@@ -87,7 +91,9 @@ function createInboundCall(params: {
   params.ctx.providerCallIdMap.set(params.providerCallId, callId);
   persistCallRecord(params.ctx.storePath, callRecord);
 
-  console.log(`[voice-call] Created inbound call record: ${callId} from ${params.from}`);
+  console.log(
+    `[voice-call] Created ${params.direction} call record: ${callId} from ${params.from}`,
+  );
   return callRecord;
 }
 
@@ -142,9 +148,10 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
       return;
     }
 
-    call = createInboundCall({
+    call = createWebhookCall({
       ctx,
       providerCallId: event.providerCallId,
+      direction: event.direction === "outbound" ? "outbound" : "inbound",
       from: event.from || "unknown",
       to: event.to || ctx.config.fromNumber || "unknown",
     });

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -104,8 +104,18 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
     callIdOrProviderCallId: event.callId,
   });
 
-  if (!call && event.direction === "inbound" && event.providerCallId) {
-    if (!shouldAcceptInbound(ctx.config, event.from)) {
+  // Auto-register untracked calls arriving via webhook. This covers both
+  // true inbound calls and externally-initiated outbound-api calls (e.g. calls
+  // placed directly via the Twilio REST API pointing at our webhook URL).
+  const isUnregisteredWebhookCall =
+    !call &&
+    event.providerCallId &&
+    (event.direction === "inbound" || event.direction === "outbound");
+
+  if (isUnregisteredWebhookCall) {
+    // Apply inbound policy for true inbound calls; external outbound-api calls
+    // are implicitly trusted because the caller controls the webhook URL.
+    if (event.direction === "inbound" && !shouldAcceptInbound(ctx.config, event.from)) {
       const pid = event.providerCallId;
       if (!ctx.provider) {
         console.warn(


### PR DESCRIPTION
## Problem

When calls are initiated directly via the Twilio REST API (e.g. `curl -X POST .../Calls.json -d "Url=https://example.com/voice/webhook"`), the voice-call plugin rejects the MediaStream connection with:

```
[MediaStream] Rejecting stream for unknown call: CAxxxxxxx
```

The call is immediately terminated after the recipient answers — no audio is played.

Fixes #30900

## Root Cause

`processEvent()` in `manager/events.ts` only auto-registers untracked calls when `event.direction === "inbound"`. Calls initiated via Twilio REST API arrive with `Direction=outbound-api`, which `parseDirection()` normalizes to `"outbound"`. Since `"outbound" !== "inbound"`, the call is never registered in `CallManager`, and `shouldAcceptStream()` rejects the media stream.

## Fix

Expand the auto-registration condition to also cover `direction === "outbound"` — these are externally-initiated outbound-api calls arriving at our webhook without a pre-existing tracked call. Inbound policy checks (disabled/allowlist/pairing) still only apply to true inbound calls; external outbound-api calls are implicitly trusted because the caller controls the webhook URL.

## Test

- 2 new tests in `events.test.ts`:
  - Verifies externally-initiated outbound-api calls are auto-registered in `activeCalls` and `providerCallIdMap`
  - Verifies outbound calls bypass disabled inbound policy (no hangup)
- All 80 existing voice-call tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)