### PR TITLE
fix(slack): bind download-file to channel/thread scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/download-file scope binding: require channel-targeted `download-file` actions and enforce channel/thread share checks before resolving Slack private download URLs, reducing cross-channel/thread attachment fetch surface.
 - Agents/Model fallback: classify additional network transport errors (`ECONNREFUSED`, `ENETUNREACH`, `EHOSTUNREACH`, `ENETRESET`, `EAI_AGAIN`) as failover-worthy so fallback chains advance when primary providers are unreachable. Landed from contributor PR #19077 by @ayanesakura. Thanks @ayanesakura.
 - Agents/Copilot token refresh: refresh GitHub Copilot runtime API tokens after auth-expiry failures and re-run with the renewed token so long-running embedded/subagent turns do not fail on mid-session 401 expiry. Landed from contributor PR #8805 by @Arthur742Ramos. Thanks @Arthur742Ramos.
 - Discord/Allowlist diagnostics: add debug logs for guild/channel allowlist drops so operators can quickly identify ignored inbound messages and required allowlist entries. Landed from contributor PR #30966 by @haosenwang1018. Thanks @haosenwang1018.

--- a/src/agents/tools/slack-actions.test.ts
+++ b/src/agents/tools/slack-actions.test.ts
@@ -202,12 +202,13 @@ describe("handleSlackAction", () => {
       {
         action: "downloadFile",
         fileId: "F123",
+        channelId: "C1",
       },
       slackConfig(),
     );
     expect(downloadSlackFile).toHaveBeenCalledWith(
       "F123",
-      expect.objectContaining({ maxBytes: 20 * 1024 * 1024 }),
+      expect.objectContaining({ channelId: "C1", maxBytes: 20 * 1024 * 1024 }),
     );
     expect(result).toEqual(
       expect.objectContaining({
@@ -241,6 +242,18 @@ describe("handleSlackAction", () => {
         details: expect.objectContaining({ ok: false }),
       }),
     );
+  });
+
+  it("requires a channel target for downloadFile", async () => {
+    await expect(
+      handleSlackAction(
+        {
+          action: "downloadFile",
+          fileId: "F123",
+        },
+        slackConfig(),
+      ),
+    ).rejects.toThrow(/to/i);
   });
 
   it.each([

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -290,8 +290,9 @@ export async function handleSlackAction(
       }
       case "downloadFile": {
         const fileId = readStringParam(params, "fileId", { required: true });
-        const channelTarget = readStringParam(params, "channelId") ?? readStringParam(params, "to");
-        const channelId = channelTarget ? resolveSlackChannelId(channelTarget) : undefined;
+        const channelTarget =
+          readStringParam(params, "channelId") ?? readStringParam(params, "to", { required: true });
+        const channelId = resolveSlackChannelId(channelTarget);
         const threadId = readStringParam(params, "threadId") ?? readStringParam(params, "replyTo");
         const maxBytes = account.config?.mediaMaxMb
           ? account.config.mediaMaxMb * 1024 * 1024

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -55,7 +55,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     kick: "none",
     ban: "none",
     "set-presence": "none",
-    "download-file": "none",
+    "download-file": "to",
   };
 
 const ACTION_TARGET_ALIASES: Partial<Record<ChannelMessageActionName, string[]>> = {

--- a/src/plugin-sdk/slack-message-actions.test.ts
+++ b/src/plugin-sdk/slack-message-actions.test.ts
@@ -63,4 +63,26 @@ describe("handleSlackMessageAction", () => {
       expect.any(Object),
     );
   });
+
+  it("requires a target channel for download-file", async () => {
+    const invoke = vi.fn(async (action: Record<string, unknown>) => ({
+      ok: true,
+      content: action,
+    }));
+
+    await expect(
+      handleSlackMessageAction({
+        providerId: "slack",
+        ctx: {
+          action: "download-file",
+          cfg: {},
+          params: {
+            fileId: "F-no-target",
+          },
+        } as never,
+        invoke: invoke as never,
+      }),
+    ).rejects.toThrow(/to/i);
+    expect(invoke).not.toHaveBeenCalled();
+  });
 });

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -178,15 +178,14 @@ export async function handleSlackMessageAction(params: {
 
   if (action === "download-file") {
     const fileId = readStringParam(actionParams, "fileId", { required: true });
-    const channelId =
-      readStringParam(actionParams, "channelId") ?? readStringParam(actionParams, "to");
+    const channelId = resolveChannelId();
     const threadId =
       readStringParam(actionParams, "threadId") ?? readStringParam(actionParams, "replyTo");
     return await invoke(
       {
         action: "downloadFile",
         fileId,
-        channelId: channelId ?? undefined,
+        channelId,
         threadId: threadId ?? undefined,
         accountId,
       },

--- a/src/slack/actions.download-file.test.ts
+++ b/src/slack/actions.download-file.test.ts
@@ -39,6 +39,7 @@ describe("downloadSlackFile", () => {
       client,
       token: "xoxb-test",
       maxBytes: 1024,
+      channelId: "C123",
     });
 
     expect(result).toBeNull();
@@ -67,6 +68,7 @@ describe("downloadSlackFile", () => {
       client,
       token: "xoxb-test",
       maxBytes: 1024,
+      channelId: "C123",
     });
 
     expect(client.files.info).toHaveBeenCalledWith({ file: "F123" });

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -372,12 +372,12 @@ function collectSlackThreadShares(
 
 function hasSlackScopeMismatch(params: {
   file: SlackFileInfoSummary;
-  channelId?: string;
+  channelId: string;
   threadId?: string;
 }): boolean {
   const channelId = normalizeSlackScopeValue(params.channelId);
   if (!channelId) {
-    return false;
+    return true;
   }
   const threadId = normalizeSlackScopeValue(params.threadId);
 
@@ -410,7 +410,7 @@ function hasSlackScopeMismatch(params: {
  */
 export async function downloadSlackFile(
   fileId: string,
-  opts: SlackActionClientOpts & { maxBytes: number; channelId?: string; threadId?: string },
+  opts: SlackActionClientOpts & { maxBytes: number; channelId: string; threadId?: string },
 ): Promise<SlackMediaResult | null> {
   const token = resolveToken(opts.token, opts.accountId);
   const client = await getClient(opts);


### PR DESCRIPTION
## Summary

- Problem: Slack `download-file` could execute with only `fileId`, so action scope was not consistently bound to the active channel/thread context.
- Why it matters: if a valid `fileId` is known and token access permits, attachment fetches could cross channel/thread context.
- What changed: require target context for `download-file` in action spec + SDK/tool plumbing, and enforce channel/thread share checks before resolving private download URLs.
- What did NOT change (scope boundary): this does not change Slack token permissions/scopes, media size limits, or non-download Slack actions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #24723

## User-visible / Behavior Changes

- `download-file` now requires a channel target (`to`/`channelId`) and will reject calls without it.
- `download-file` returns the same friendly failure response when scope checks indicate channel/thread mismatch.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - Risk addressed: cross-channel/thread file fetch surface with known `fileId`.
  - Mitigation: require channel-targeted invocation and verify file share metadata against requested channel/thread before download.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev runtime
- Model/provider: N/A
- Integration/channel (if any): Slack actions pipeline
- Relevant config (redacted): default Slack action config in tests

### Steps

1. Invoke Slack `download-file` without `to`/`channelId`.
2. Invoke Slack `download-file` with channel/thread that does not match file share metadata.
3. Invoke Slack `download-file` with matching channel/thread (or with no share evidence in metadata).

### Expected

- Calls without a target are rejected.
- Mismatched channel/thread returns safe failure (no download).
- Valid/in-scope download behavior remains intact.

### Actual

- Matches expected in updated tests and tool behavior.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm vitest run src/slack/actions.download-file.test.ts src/plugin-sdk/slack-message-actions.test.ts src/agents/tools/slack-actions.test.ts`
  - `pnpm build`
- Edge cases checked:
  - missing target channel rejection
  - channel share mismatch deny
  - thread share mismatch deny
  - metadata without share evidence keeps prior behavior
- What you did **not** verify:
  - live Slack workspace end-to-end run

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit to restore prior `download-file` behavior.
- Files/config to restore:
  - `src/infra/outbound/message-action-spec.ts`
  - `src/plugin-sdk/slack-message-actions.ts`
  - `src/agents/tools/slack-actions.ts`
  - `src/slack/actions.ts`
- Known bad symptoms reviewers should watch for:
  - legacy callers invoking `download-file` without `to`/`channelId` now error as expected

## Risks and Mitigations

- Risk: Slack `files.info` metadata shape can vary by workspace/app scopes.
  - Mitigation: fail closed only when there is positive mismatch evidence; preserve legacy behavior when no channel/thread share evidence exists.
