### PR TITLE
fix(delivery-queue): increment retryCount on entries deferred when time budget exceeded

### DIFF
--- a/scripts/generate-bundled-plugin-metadata.mjs
+++ b/scripts/generate-bundled-plugin-metadata.mjs
@@ -8,12 +8,7 @@ const GENERATED_BY = "scripts/generate-bundled-plugin-metadata.mjs";
 const DEFAULT_OUTPUT_PATH = "src/plugins/bundled-plugin-metadata.generated.ts";
 const MANIFEST_KEY = "openclaw";
 const FORMATTER_CWD = path.resolve(import.meta.dirname, "..");
-const OXFMT_BIN = path.join(
-  FORMATTER_CWD,
-  "node_modules",
-  ".bin",
-  process.platform === "win32" ? "oxfmt.cmd" : "oxfmt",
-);
+const OXFMT_BIN = path.join(FORMATTER_CWD, "node_modules", ".bin", "oxfmt");
 const CANONICAL_PACKAGE_ID_ALIASES = {
   "elevenlabs-speech": "elevenlabs",
   "microsoft-speech": "microsoft",
@@ -134,18 +129,17 @@ function normalizePluginManifest(raw) {
 
 function formatTypeScriptModule(source, { outputPath }) {
   const formatterPath = path.relative(FORMATTER_CWD, outputPath) || outputPath;
-  const command = fs.existsSync(OXFMT_BIN)
-    ? OXFMT_BIN
-    : process.platform === "win32"
-      ? "pnpm.cmd"
-      : "pnpm";
-  const args = fs.existsSync(OXFMT_BIN)
+  const useDirectFormatter = process.platform !== "win32" && fs.existsSync(OXFMT_BIN);
+  const command = useDirectFormatter ? OXFMT_BIN : "pnpm";
+  const args = useDirectFormatter
     ? ["--stdin-filepath", formatterPath]
     : ["exec", "oxfmt", "--stdin-filepath", formatterPath];
   const formatter = spawnSync(command, args, {
     cwd: FORMATTER_CWD,
     input: source,
     encoding: "utf8",
+    // Windows requires a shell to launch package-manager shim scripts reliably.
+    ...(process.platform === "win32" ? { shell: true } : {}),
   });
   if (formatter.status !== 0) {
     const details =

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -324,7 +324,7 @@ export async function launchOpenClawChrome(
       userDataDir,
     });
     return spawn(exe.path, args, {
-      stdio: "pipe",
+      stdio: ["ignore", "ignore", "ignore"],
       env: {
         ...process.env,
         // Reduce accidental sharing with the user's env.

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -1,4 +1,4 @@
-import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { type ChildProcess, type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -70,7 +70,7 @@ export type RunningChrome = {
   userDataDir: string;
   cdpPort: number;
   startedAt: number;
-  proc: ChildProcessWithoutNullStreams;
+  proc: ChildProcess;
 };
 
 function resolveBrowserExecutable(resolved: ResolvedBrowserConfig): BrowserExecutable | null {
@@ -323,14 +323,18 @@ export async function launchOpenClawChrome(
       profile,
       userDataDir,
     });
+    // stdio tuple: discard stdout to prevent buffer saturation in constrained
+    // environments (e.g. Docker), while keeping stderr piped for diagnostics.
+    // Cast to ChildProcessWithoutNullStreams so callers can use .stderr safely;
+    // the tuple overload resolution varies across @types/node versions.
     return spawn(exe.path, args, {
-      stdio: ["ignore", "ignore", "ignore"],
+      stdio: ["ignore", "ignore", "pipe"],
       env: {
         ...process.env,
         // Reduce accidental sharing with the user's env.
         HOME: os.homedir(),
       },
-    });
+    }) as unknown as ChildProcessWithoutNullStreams;
   };
 
   const startedAt = Date.now();

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -769,22 +769,22 @@ export const usageHandlers: GatewayRequestHandlers = {
           .toSorted((a, b) => b.count - a.count),
       },
       byModel: Array.from(byModelMap.values()).toSorted((a, b) => {
-        const costDiff = b.totals.totalCost - a.totals.totalCost;
+        const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
         if (costDiff !== 0) {
           return costDiff;
         }
-        return b.totals.totalTokens - a.totals.totalTokens;
+        return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
       }),
       byProvider: Array.from(byProviderMap.values()).toSorted((a, b) => {
-        const costDiff = b.totals.totalCost - a.totals.totalCost;
+        const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
         if (costDiff !== 0) {
           return costDiff;
         }
-        return b.totals.totalTokens - a.totals.totalTokens;
+        return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
       }),
       byAgent: Array.from(byAgentMap.entries())
         .map(([id, totals]) => ({ agentId: id, totals }))
-        .toSorted((a, b) => b.totals.totalCost - a.totals.totalCost),
+        .toSorted((a, b) => (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0)),
       ...tail,
     };
 

--- a/src/infra/outbound/delivery-queue.test.ts
+++ b/src/infra/outbound/delivery-queue.test.ts
@@ -463,7 +463,7 @@ describe("delivery-queue", () => {
       const remaining = await loadPendingDeliveries(tmpDir);
       expect(remaining).toHaveLength(3);
 
-      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("deferred to next restart"));
+      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("deferred to next startup"));
     });
 
     it("defers entries until backoff becomes eligible", async () => {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -344,19 +344,7 @@ export async function recoverPendingDeliveries(opts: {
   for (const entry of pending) {
     const now = Date.now();
     if (now >= deadline) {
-      // Increment retryCount on remaining entries so they eventually hit MAX_RETRIES
-      const remaining = pending.slice(pending.indexOf(entry));
-      for (const r of remaining) {
-        try {
-          await failDelivery(r.id, "Recovery time budget exceeded — deferred", opts.stateDir);
-        } catch {
-          /* best-effort */
-        }
-      }
-      const deferred = remaining.length;
-      opts.log.warn(
-        `Recovery time budget exceeded — ${deferred} entries deferred (retryCount incremented)`,
-      );
+      opts.log.warn(`Recovery time budget exceeded — remaining entries deferred to next startup`);
       break;
     }
     if (entry.retryCount >= MAX_RETRIES) {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -321,7 +321,7 @@ export async function recoverPendingDeliveries(opts: {
   log: RecoveryLogger;
   cfg: OpenClawConfig;
   stateDir?: string;
-  /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next restart. Default: 60 000. */
+  /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next startup. Default: 60 000. */
   maxRecoveryMs?: number;
 }): Promise<RecoverySummary> {
   const pending = await loadPendingDeliveries(opts.stateDir);

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -341,10 +341,19 @@ export async function recoverPendingDeliveries(opts: {
   let skippedMaxRetries = 0;
   let deferredBackoff = 0;
 
-  for (const entry of pending) {
+  for (let i = 0; i < pending.length; i++) {
+    const entry = pending[i];
     const now = Date.now();
     if (now >= deadline) {
       opts.log.warn(`Recovery time budget exceeded — remaining entries deferred to next startup`);
+      // Increment retryCount for all remaining entries so that entries which
+      // are consistently deferred by the time budget eventually reach
+      // MAX_RETRIES and are pruned rather than looping forever.
+      await Promise.allSettled(
+        pending
+          .slice(i)
+          .map((e) => failDelivery(e.id, "recovery time budget exceeded", opts.stateDir)),
+      );
       break;
     }
     if (entry.retryCount >= MAX_RETRIES) {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -344,8 +344,19 @@ export async function recoverPendingDeliveries(opts: {
   for (const entry of pending) {
     const now = Date.now();
     if (now >= deadline) {
-      const deferred = pending.length - recovered - failed - skippedMaxRetries - deferredBackoff;
-      opts.log.warn(`Recovery time budget exceeded — ${deferred} entries deferred to next restart`);
+      // Increment retryCount on remaining entries so they eventually hit MAX_RETRIES
+      const remaining = pending.slice(pending.indexOf(entry));
+      for (const r of remaining) {
+        try {
+          await failDelivery(r.id, "Recovery time budget exceeded — deferred", opts.stateDir);
+        } catch {
+          /* best-effort */
+        }
+      }
+      const deferred = remaining.length;
+      opts.log.warn(
+        `Recovery time budget exceeded — ${deferred} entries deferred (retryCount incremented)`,
+      );
       break;
     }
     if (entry.retryCount >= MAX_RETRIES) {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -504,9 +504,13 @@ describe("delivery-queue", () => {
       expect(result.skippedMaxRetries).toBe(0);
       expect(result.deferredBackoff).toBe(0);
 
-      // All entries should still be in the queue.
+      // All entries should still be in the queue (retryCount < MAX_RETRIES).
       const remaining = await loadPendingDeliveries(tmpDir);
       expect(remaining).toHaveLength(3);
+
+      // retryCount should be incremented on all deferred entries so they
+      // eventually reach MAX_RETRIES and are pruned rather than looping forever.
+      expect(remaining.every((e) => e.retryCount === 1)).toBe(true);
 
       // Should have logged a warning about deferred entries.
       expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("deferred to next startup"));

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -509,7 +509,7 @@ describe("delivery-queue", () => {
       expect(remaining).toHaveLength(3);
 
       // Should have logged a warning about deferred entries.
-      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("deferred to next restart"));
+      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("deferred to next startup"));
     });
 
     it("defers entries until backoff becomes eligible", async () => {

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -707,11 +707,11 @@ export async function loadSessionCostSummary(params: {
 
   const modelUsage = modelUsageMap.size
     ? Array.from(modelUsageMap.values()).toSorted((a, b) => {
-        const costDiff = b.totals.totalCost - a.totals.totalCost;
+        const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
         if (costDiff !== 0) {
           return costDiff;
         }
-        return b.totals.totalTokens - a.totals.totalTokens;
+        return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
       })
     : undefined;
 


### PR DESCRIPTION
## Problem

When delivery recovery exceeded the 60s time budget, remaining pending entries were silently skipped with a log warning but no `retryCount` increment. This caused them to loop forever across restarts — they'd always defer, never hit `MAX_RETRIES`, and never move to `failed/`.

Two code paths were affected:
1. The deadline check (`now >= deadline`)
2. The backoff-exceeds-deadline check (`now + backoff >= deadline`)

## Fix

Call `failDelivery()` on each remaining entry before breaking out of the loop. This increments `retryCount` so that entries eventually exhaust `MAX_RETRIES` and are permanently skipped instead of spinning forever.

The existing `failDelivery` helper already handles the retryCount increment and stateDir write — no new logic needed.

Fixes #24353