### PR TITLE
fix(sessions-send): prevent 'message is too long' delivery failures and fix Telegram HTML chunking

### DIFF
--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -40,7 +40,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: markdownToTelegramHtmlChunks,
   chunkerMode: "markdown",
-  textChunkLimit: 4000,
+  textChunkLimit: 3000,
   sendText: async ({ to, text, accountId, deps, replyToId, threadId }) => {
     const { send, baseOpts } = resolveTelegramSendContext({
       deps,

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -320,6 +320,8 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /chat_id is empty/i,
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
+  // Message content errors — retrying will always fail with the same payload.
+  /message is too long/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -263,13 +263,76 @@ export function markdownToTelegramChunks(
 // Telegram Bot API hard limit for message text (HTML mode).
 const TELEGRAM_HTML_MAX_CHARS = 4096;
 
+/**
+ * Re-chunks a single source text whose rendered HTML exceeded the hard limit.
+ * Splits the source text at a safe whitespace/newline boundary near the midpoint,
+ * renders each half, and recurses until all pieces fit within the limit.
+ */
+function rechunkOverflow(sourceText: string): string[] {
+  const rendered = wrapFileReferencesInHtml(
+    renderTelegramHtml(
+      markdownToIR(sourceText, {
+        linkify: true,
+        enableSpoilers: true,
+        headingStyle: "none",
+        blockquotePrefix: "",
+      }),
+    ),
+  );
+
+  if (rendered.length <= TELEGRAM_HTML_MAX_CHARS) {
+    return [rendered];
+  }
+
+  // Find a safe split point near the midpoint — prefer newline, then whitespace
+  const mid = Math.floor(sourceText.length / 2);
+  let splitAt = -1;
+
+  // Search backwards from mid for a newline
+  for (let i = mid; i >= 0; i--) {
+    if (sourceText[i] === "\n") {
+      splitAt = i + 1;
+      break;
+    }
+  }
+  // Fall back to whitespace
+  if (splitAt < 0) {
+    for (let i = mid; i >= 0; i--) {
+      if (/\s/.test(sourceText[i])) {
+        splitAt = i + 1;
+        break;
+      }
+    }
+  }
+  // Last resort: hard split at midpoint
+  if (splitAt <= 0) {
+    splitAt = mid;
+  }
+
+  const left = sourceText.slice(0, splitAt);
+  const right = sourceText.slice(splitAt);
+
+  // Avoid infinite loop if we cannot split further
+  if (!left || !right) {
+    return [rendered.slice(0, TELEGRAM_HTML_MAX_CHARS - 1) + "\u2026"];
+  }
+
+  return [...rechunkOverflow(left), ...rechunkOverflow(right)];
+}
+
 export function markdownToTelegramHtmlChunks(markdown: string, limit: number): string[] {
-  const chunks = markdownToTelegramChunks(markdown, limit).map((chunk) => chunk.html);
+  const chunks = markdownToTelegramChunks(markdown, limit);
   // Safety guard: chunkMarkdownIR splits by plain-text length, but HTML rendering can
   // expand the output (entity escaping, tag overhead). If any rendered chunk still
-  // exceeds Telegram's hard limit, truncate it with an ellipsis rather than letting
-  // the API reject the whole message.
-  return chunks.map((html) =>
-    html.length > TELEGRAM_HTML_MAX_CHARS ? html.slice(0, TELEGRAM_HTML_MAX_CHARS - 1) + "…" : html,
-  );
+  // exceeds Telegram's hard limit, re-chunk the overflow rather than truncating it —
+  // silent data loss is worse than sending an extra message.
+  const result: string[] = [];
+  for (const chunk of chunks) {
+    if (chunk.html.length > TELEGRAM_HTML_MAX_CHARS) {
+      result.push(...rechunkOverflow(chunk.text));
+    } else {
+      result.push(chunk.html);
+    }
+  }
+  return result;
 }

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -314,8 +314,24 @@ function rechunkOverflow(ir: MarkdownIR, renderedHtml?: string): string[] {
 
   const text = ir.text;
   if (text.length <= 1) {
-    // Cannot split further — truncate as a last resort.
-    return [rendered.slice(0, TELEGRAM_HTML_MAX_CHARS - 1) + "\u2026"];
+    // Cannot split further — strip links and re-render as plain text to avoid
+    // slicing inside an <a> tag or HTML entity, then truncate the plain-text
+    // source (not the rendered HTML) if it still exceeds the limit.
+    const plainIR: MarkdownIR = { ...ir, links: [] };
+    const plainRendered = wrapFileReferencesInHtml(renderTelegramHtml(plainIR));
+    if (plainRendered.length <= TELEGRAM_HTML_MAX_CHARS) {
+      return [plainRendered];
+    }
+    const truncatedText = plainIR.text.slice(0, TELEGRAM_HTML_MAX_CHARS - 1) + "\u2026";
+    return [
+      wrapFileReferencesInHtml(
+        renderTelegramHtml({
+          ...plainIR,
+          text: truncatedText,
+          styles: sliceStyleSpans(plainIR.styles, 0, TELEGRAM_HTML_MAX_CHARS - 1),
+        }),
+      ),
+    ];
   }
 
   // Find a safe split point near the midpoint — prefer newline, then whitespace
@@ -357,7 +373,22 @@ function rechunkOverflow(ir: MarkdownIR, renderedHtml?: string): string[] {
 
   // Avoid infinite loop if we cannot split further
   if (!leftIR.text || !rightIR.text) {
-    return [rendered.slice(0, TELEGRAM_HTML_MAX_CHARS - 1) + "\u2026"];
+    // Strip links and truncate plain-text source to avoid slicing inside HTML tags.
+    const plainIR: MarkdownIR = { ...ir, links: [] };
+    const plainRendered = wrapFileReferencesInHtml(renderTelegramHtml(plainIR));
+    if (plainRendered.length <= TELEGRAM_HTML_MAX_CHARS) {
+      return [plainRendered];
+    }
+    const truncatedText = plainIR.text.slice(0, TELEGRAM_HTML_MAX_CHARS - 1) + "\u2026";
+    return [
+      wrapFileReferencesInHtml(
+        renderTelegramHtml({
+          ...plainIR,
+          text: truncatedText,
+          styles: sliceStyleSpans(plainIR.styles, 0, TELEGRAM_HTML_MAX_CHARS - 1),
+        }),
+      ),
+    ];
   }
 
   // Guard: if the left half's rendered HTML is not smaller than the parent's, the

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -360,6 +360,18 @@ function rechunkOverflow(ir: MarkdownIR, renderedHtml?: string): string[] {
     return [rendered.slice(0, TELEGRAM_HTML_MAX_CHARS - 1) + "\u2026"];
   }
 
+  // Guard: if the left half's rendered HTML is not smaller than the parent's, the
+  // overflow is dominated by link href length (not text length) — splitting will never
+  // converge.  Fall back to stripping links for both halves and recursing without them
+  // so that subsequent splits converge on text length alone.
+  const leftFull = wrapFileReferencesInHtml(renderTelegramHtml(leftIR));
+  if (leftFull.length >= rendered.length) {
+    return [
+      ...rechunkOverflow({ ...leftIR, links: [] }),
+      ...rechunkOverflow({ ...rightIR, links: [] }),
+    ];
+  }
+
   return [...rechunkOverflow(leftIR), ...rechunkOverflow(rightIR)];
 }
 

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -260,6 +260,16 @@ export function markdownToTelegramChunks(
   }));
 }
 
+// Telegram Bot API hard limit for message text (HTML mode).
+const TELEGRAM_HTML_MAX_CHARS = 4096;
+
 export function markdownToTelegramHtmlChunks(markdown: string, limit: number): string[] {
-  return markdownToTelegramChunks(markdown, limit).map((chunk) => chunk.html);
+  const chunks = markdownToTelegramChunks(markdown, limit).map((chunk) => chunk.html);
+  // Safety guard: chunkMarkdownIR splits by plain-text length, but HTML rendering can
+  // expand the output (entity escaping, tag overhead). If any rendered chunk still
+  // exceeds Telegram's hard limit, truncate it with an ellipsis rather than letting
+  // the API reject the whole message.
+  return chunks.map((html) =>
+    html.length > TELEGRAM_HTML_MAX_CHARS ? html.slice(0, TELEGRAM_HTML_MAX_CHARS - 1) + "…" : html,
+  );
 }

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -3,6 +3,7 @@ import {
   chunkMarkdownIR,
   markdownToIR,
   type MarkdownLinkSpan,
+  type MarkdownStyleSpan,
   type MarkdownIR,
 } from "../markdown/ir.js";
 import { renderMarkdownWithMarkers } from "../markdown/render.js";
@@ -263,34 +264,67 @@ export function markdownToTelegramChunks(
 // Telegram Bot API hard limit for message text (HTML mode).
 const TELEGRAM_HTML_MAX_CHARS = 4096;
 
+function sliceStyleSpans(
+  styles: MarkdownStyleSpan[],
+  start: number,
+  end: number,
+): MarkdownStyleSpan[] {
+  return styles.flatMap((span) => {
+    if (span.end <= start || span.start >= end) {
+      return [];
+    }
+    const nextStart = Math.max(span.start, start) - start;
+    const nextEnd = Math.min(span.end, end) - start;
+    if (nextEnd <= nextStart) {
+      return [];
+    }
+    return [{ ...span, start: nextStart, end: nextEnd }];
+  });
+}
+
+function sliceLinkSpans(links: MarkdownLinkSpan[], start: number, end: number): MarkdownLinkSpan[] {
+  return links.flatMap((link) => {
+    if (link.end <= start || link.start >= end) {
+      return [];
+    }
+    const nextStart = Math.max(link.start, start) - start;
+    const nextEnd = Math.min(link.end, end) - start;
+    if (nextEnd <= nextStart) {
+      return [];
+    }
+    return [{ ...link, start: nextStart, end: nextEnd }];
+  });
+}
+
 /**
- * Re-chunks a single source text whose rendered HTML exceeded the hard limit.
- * Splits the source text at a safe whitespace/newline boundary near the midpoint,
- * renders each half, and recurses until all pieces fit within the limit.
+ * Re-chunks a single MarkdownIR whose rendered HTML exceeded the hard limit.
+ * Splits the IR node array at a safe whitespace/newline boundary near the
+ * midpoint — preserving original span metadata (styles, link hrefs) — and
+ * recurses on each half until all pieces fit within the limit.
+ *
+ * Accepts a pre-rendered HTML string to avoid a redundant re-render on the
+ * first call.
  */
-function rechunkOverflow(sourceText: string): string[] {
-  const rendered = wrapFileReferencesInHtml(
-    renderTelegramHtml(
-      markdownToIR(sourceText, {
-        linkify: true,
-        enableSpoilers: true,
-        headingStyle: "none",
-        blockquotePrefix: "",
-      }),
-    ),
-  );
+function rechunkOverflow(ir: MarkdownIR, renderedHtml?: string): string[] {
+  const rendered = renderedHtml ?? wrapFileReferencesInHtml(renderTelegramHtml(ir));
 
   if (rendered.length <= TELEGRAM_HTML_MAX_CHARS) {
     return [rendered];
   }
 
+  const text = ir.text;
+  if (text.length <= 1) {
+    // Cannot split further — truncate as a last resort.
+    return [rendered.slice(0, TELEGRAM_HTML_MAX_CHARS - 1) + "\u2026"];
+  }
+
   // Find a safe split point near the midpoint — prefer newline, then whitespace
-  const mid = Math.floor(sourceText.length / 2);
+  const mid = Math.floor(text.length / 2);
   let splitAt = -1;
 
   // Search backwards from mid for a newline
   for (let i = mid; i >= 0; i--) {
-    if (sourceText[i] === "\n") {
+    if (text[i] === "\n") {
       splitAt = i + 1;
       break;
     }
@@ -298,7 +332,7 @@ function rechunkOverflow(sourceText: string): string[] {
   // Fall back to whitespace
   if (splitAt < 0) {
     for (let i = mid; i >= 0; i--) {
-      if (/\s/.test(sourceText[i])) {
+      if (/\s/.test(text[i])) {
         splitAt = i + 1;
         break;
       }
@@ -309,29 +343,47 @@ function rechunkOverflow(sourceText: string): string[] {
     splitAt = mid;
   }
 
-  const left = sourceText.slice(0, splitAt);
-  const right = sourceText.slice(splitAt);
+  // Slice the IR (text + span metadata) rather than re-parsing plain text.
+  const leftIR: MarkdownIR = {
+    text: text.slice(0, splitAt),
+    styles: sliceStyleSpans(ir.styles, 0, splitAt),
+    links: sliceLinkSpans(ir.links, 0, splitAt),
+  };
+  const rightIR: MarkdownIR = {
+    text: text.slice(splitAt),
+    styles: sliceStyleSpans(ir.styles, splitAt, text.length),
+    links: sliceLinkSpans(ir.links, splitAt, text.length),
+  };
 
   // Avoid infinite loop if we cannot split further
-  if (!left || !right) {
+  if (!leftIR.text || !rightIR.text) {
     return [rendered.slice(0, TELEGRAM_HTML_MAX_CHARS - 1) + "\u2026"];
   }
 
-  return [...rechunkOverflow(left), ...rechunkOverflow(right)];
+  return [...rechunkOverflow(leftIR), ...rechunkOverflow(rightIR)];
 }
 
 export function markdownToTelegramHtmlChunks(markdown: string, limit: number): string[] {
-  const chunks = markdownToTelegramChunks(markdown, limit);
+  // Work directly with MarkdownIR chunks so we can pass the original IR (with span
+  // metadata) into rechunkOverflow — avoiding a lossy round-trip through plain text.
+  const ir = markdownToIR(markdown ?? "", {
+    linkify: true,
+    enableSpoilers: true,
+    headingStyle: "none",
+    blockquotePrefix: "",
+  });
+  const irChunks = chunkMarkdownIR(ir, limit);
   // Safety guard: chunkMarkdownIR splits by plain-text length, but HTML rendering can
   // expand the output (entity escaping, tag overhead). If any rendered chunk still
   // exceeds Telegram's hard limit, re-chunk the overflow rather than truncating it —
   // silent data loss is worse than sending an extra message.
   const result: string[] = [];
-  for (const chunk of chunks) {
-    if (chunk.html.length > TELEGRAM_HTML_MAX_CHARS) {
-      result.push(...rechunkOverflow(chunk.text));
+  for (const irChunk of irChunks) {
+    const html = wrapFileReferencesInHtml(renderTelegramHtml(irChunk));
+    if (html.length > TELEGRAM_HTML_MAX_CHARS) {
+      result.push(...rechunkOverflow(irChunk, html));
     } else {
-      result.push(chunk.html);
+      result.push(html);
     }
   }
   return result;


### PR DESCRIPTION
## Problem

Failed delivery entries in `~/.openclaw/delivery-queue/failed/` showed two error patterns from `sessions_send` mirrors:

1. `"Network request for 'sendMessage' failed!"` — transient (1012 service restart) ✅ expected
2. `"Bad Request: message is too long"` — permanent, but queue kept retrying forever ❌

The second error occurs when a subagent reply (e.g. a long integration proposal) is mirrored to the user's Telegram session. The mirror text is stored verbatim in the delivery queue payload and can be 5000+ characters.

## Root Cause

`chunkMarkdownIR` splits by **plain-text** character count (`ir.text.length`), but `renderTelegramHtml` produces HTML that can be significantly longer due to:
- Entity escaping: `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`
- HTML tag overhead: `<b>`, `<i>`, `<code>`, `<pre>` wrapping
- Markdown table reformatting into code blocks

With `textChunkLimit: 4000`, a 4000-char plain-text chunk can easily exceed Telegram's **4096-char HTML limit**, causing the Bot API to reject the entire message.

Additionally, `"message is too long"` was not in `PERMANENT_ERROR_PATTERNS`, so the queue retried the same unchanged payload up to `MAX_RETRIES` times — all guaranteed to fail.

## Fix

Three-part fix:

### 1. Add `message is too long` to `PERMANENT_ERROR_PATTERNS` ()
A message Telegram rejects as too long will always fail with the same payload. Move it to `failed/` immediately instead of burning retry budget.

### 2. Reduce Telegram `textChunkLimit` from 4000 → 3000 ()
Gives 1000 chars of headroom for HTML expansion. The Telegram API limit is 4096 HTML chars; plain-text inputs of 3000 chars should reliably stay under it.

### 3. Post-render safety truncation in `markdownToTelegramHtmlChunks` ()
Even with the lower limit, edge cases (dense code blocks, many HTML entities) can still produce HTML > 4096. Added a hard-cap guard: any chunk exceeding `TELEGRAM_HTML_MAX_CHARS` (4096) is truncated with an ellipsis before sending. Prevents the API error regardless of input.

## Failed entries examined

- `36c0fe21`: 5179-char subagent reply (integration proposal with markdown tables) → `Bad Request: message is too long`
- `505f99ce`: Another 5179-char message → same error  
- `301d1efa`: Short "Connection error." message → `Network request for 'sendMessage' failed!` (1012, transient, fine)

Fixes #24353