### PR TITLE
fix(tts): use opus format for Feishu voice messages

### DIFF
--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -154,10 +154,19 @@ describe("tts", () => {
   });
 
   describe("resolveOutputFormat", () => {
-    it("selects opus for Telegram and mp3 for other channels", () => {
+    it("selects opus for Telegram/Feishu and mp3 for other channels", () => {
       const cases = [
         {
           channel: "telegram",
+          expected: {
+            openai: "opus",
+            elevenlabs: "opus_48000_64",
+            extension: ".opus",
+            voiceCompatible: true,
+          },
+        },
+        {
+          channel: "feishu",
           expected: {
             openai: "opus",
             elevenlabs: "opus_48000_64",

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -481,7 +481,7 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 }
 
 function resolveOutputFormat(channelId?: string | null) {
-  if (channelId === "telegram") {
+  if (channelId === "telegram" || channelId === "feishu") {
     return TELEGRAM_OUTPUT;
   }
   return DEFAULT_OUTPUT;


### PR DESCRIPTION
## Summary
\`resolveOutputFormat\` only checked for \`"telegram"\` when selecting opus audio output, causing Feishu TTS voice messages to use mp3 instead. Feishu supports opus and renders it as native voice bubbles, but mp3 files appear as regular file attachments.

Added \`"feishu"\` to the opus channel check alongside Telegram.

## Change type
Bug fix

## Scope
- \`src/tts/tts.ts\` — \`resolveOutputFormat\`
- \`src/tts/tts.test.ts\` — added feishu test case

## Linked issue
Closes #31100

## How was this change tested?
- Updated existing \`resolveOutputFormat\` test to include feishu channel
- Verified Feishu extension's \`sendMediaFeishu\` already supports opus format

## Security impact
None

Made with [Cursor](https://cursor.com)