### PR TITLE
Docker: add OCI base-image labels and document base-image metadata

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -69,6 +69,27 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Resolve OCI labels (amd64)
+        id: labels
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_SHA}"
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            version="main"
+          fi
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            version="${GITHUB_REF#refs/tags/v}"
+          fi
+          created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          {
+            echo "value<<EOF"
+            echo "org.opencontainers.image.revision=${GITHUB_SHA}"
+            echo "org.opencontainers.image.version=${version}"
+            echo "org.opencontainers.image.created=${created}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push amd64 image
         id: build
         uses: docker/build-push-action@v6
@@ -76,6 +97,7 @@ jobs:
           context: .
           platforms: linux/amd64
           tags: ${{ steps.tags.outputs.value }}
+          labels: ${{ steps.labels.outputs.value }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache:amd64
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache:amd64,mode=max
           provenance: false
@@ -128,6 +150,27 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Resolve OCI labels (arm64)
+        id: labels
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_SHA}"
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            version="main"
+          fi
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            version="${GITHUB_REF#refs/tags/v}"
+          fi
+          created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          {
+            echo "value<<EOF"
+            echo "org.opencontainers.image.revision=${GITHUB_SHA}"
+            echo "org.opencontainers.image.version=${version}"
+            echo "org.opencontainers.image.created=${created}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push arm64 image
         id: build
         uses: docker/build-push-action@v6
@@ -135,6 +178,7 @@ jobs:
           context: .
           platforms: linux/arm64
           tags: ${{ steps.tags.outputs.value }}
+          labels: ${{ steps.labels.outputs.value }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache:arm64
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache:arm64,mode=max
           provenance: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Docs/Docker images: clarify the official GHCR image source and tag guidance (`main`, `latest`, `<version>`), and document that `OPENCLAW_IMAGE` skips local image builds but still uses the repo-local compose/setup flow. (#27214, #31180) Fixes #15655. Thanks @ipl31.
+- Docker/Image base annotations: add OCI base-image labels (`org.opencontainers.image.base.name` and `org.opencontainers.image.base.digest`) and document Docker base-image metadata/release context in install docs. Fixes #27945.
 - Agents/Model fallback: classify additional network transport errors (`ECONNREFUSED`, `ENETUNREACH`, `EHOSTUNREACH`, `ENETRESET`, `EAI_AGAIN`) as failover-worthy so fallback chains advance when primary providers are unreachable. Landed from contributor PR #19077 by @ayanesakura. Thanks @ayanesakura.
 - Agents/Copilot token refresh: refresh GitHub Copilot runtime API tokens after auth-expiry failures and re-run with the renewed token so long-running embedded/subagent turns do not fail on mid-session 401 expiry. Landed from contributor PR #8805 by @Arthur742Ramos. Thanks @Arthur742Ramos.
 - Agents/Subagents delivery params: reject unsupported `sessions_spawn` channel-delivery params (`target`, `channel`, `to`, `threadId`, `replyTo`, `transport`) with explicit input errors so delivery intent does not silently leak output to the parent conversation. (#31000)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Docs/Docker images: clarify the official GHCR image source and tag guidance (`main`, `latest`, `<version>`), and document that `OPENCLAW_IMAGE` skips local image builds but still uses the repo-local compose/setup flow. (#27214, #31180) Fixes #15655. Thanks @ipl31.
-- Docker/Image base annotations: add OCI base-image labels (`org.opencontainers.image.base.name` and `org.opencontainers.image.base.digest`) and document Docker base-image metadata/release context in install docs. Fixes #27945.
+- Docker/Image base annotations: add OCI base-image labels (`org.opencontainers.image.base.name` and `org.opencontainers.image.base.digest`) and document Docker base-image metadata/release context in install docs. Fixes #27945. Thanks @vincentkoc.
 - Agents/Model fallback: classify additional network transport errors (`ECONNREFUSED`, `ENETUNREACH`, `EHOSTUNREACH`, `ENETRESET`, `EAI_AGAIN`) as failover-worthy so fallback chains advance when primary providers are unreachable. Landed from contributor PR #19077 by @ayanesakura. Thanks @ayanesakura.
 - Agents/Copilot token refresh: refresh GitHub Copilot runtime API tokens after auth-expiry failures and re-run with the renewed token so long-running embedded/subagent turns do not fail on mid-session 401 expiry. Landed from contributor PR #8805 by @Arthur742Ramos. Thanks @Arthur742Ramos.
 - Agents/Subagents delivery params: reject unsupported `sessions_spawn` channel-delivery params (`target`, `channel`, `to`, `threadId`, `replyTo`, `transport`) with explicit input errors so delivery intent does not silently leak output to the parent conversation. (#31000)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Docs/Docker images: clarify the official GHCR image source and tag guidance (`main`, `latest`, `<version>`), and document that `OPENCLAW_IMAGE` skips local image builds but still uses the repo-local compose/setup flow. (#27214, #31180) Fixes #15655. Thanks @ipl31.
-- Docker/Image base annotations: add OCI base-image labels (`org.opencontainers.image.base.name` and `org.opencontainers.image.base.digest`) and document Docker base-image metadata/release context in install docs. Fixes #27945. Thanks @vincentkoc.
+- Docker/Image base annotations: add OCI labels for base image plus source/documentation/license metadata, include revision/version/created labels in Docker release builds, and document annotation keys/release context in install docs. Fixes #27945. Thanks @vincentkoc.
 - Agents/Model fallback: classify additional network transport errors (`ECONNREFUSED`, `ENETUNREACH`, `EHOSTUNREACH`, `ENETRESET`, `EAI_AGAIN`) as failover-worthy so fallback chains advance when primary providers are unreachable. Landed from contributor PR #19077 by @ayanesakura. Thanks @ayanesakura.
 - Agents/Copilot token refresh: refresh GitHub Copilot runtime API tokens after auth-expiry failures and re-run with the renewed token so long-running embedded/subagent turns do not fail on mid-session 401 expiry. Landed from contributor PR #8805 by @Arthur742Ramos. Thanks @Arthur742Ramos.
 - Agents/Subagents delivery params: reject unsupported `sessions_spawn` channel-delivery params (`target`, `channel`, `to`, `threadId`, `replyTo`, `transport`) with explicit input errors so delivery intent does not silently leak output to the parent conversation. (#31000)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.base.name="docker.io/library/node:22-bookworm" \
       org.opencontainers.image.source="https://github.com/openclaw/openclaw" \
       org.opencontainers.image.url="https://openclaw.ai" \
       org.opencontainers.image.documentation="https://docs.openclaw.ai/install/docker" \
-      org.opencontainers.image.licenses="AGPL-3.0-only" \
+      org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.title="OpenClaw" \
       org.opencontainers.image.description="OpenClaw gateway and CLI runtime container image"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,13 @@ FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1
 
 # OCI base-image metadata for downstream image consumers.
 LABEL org.opencontainers.image.base.name="docker.io/library/node:22-bookworm" \
-      org.opencontainers.image.base.digest="sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935"
+      org.opencontainers.image.base.digest="sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935" \
+      org.opencontainers.image.source="https://github.com/openclaw/openclaw" \
+      org.opencontainers.image.url="https://openclaw.ai" \
+      org.opencontainers.image.documentation="https://docs.openclaw.ai/install/docker" \
+      org.opencontainers.image.licenses="AGPL-3.0-only" \
+      org.opencontainers.image.title="OpenClaw" \
+      org.opencontainers.image.description="OpenClaw gateway and CLI runtime container image"
 
 # Install Bun (required for build scripts)
 RUN curl -fsSL https://bun.sh/install | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935
 
+# OCI base-image metadata for downstream image consumers.
+LABEL org.opencontainers.image.base.name="docker.io/library/node:22-bookworm" \
+      org.opencontainers.image.base.digest="sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935"
+
 # Install Bun (required for build scripts)
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@ FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1
 # - docs/install/docker.md ("Base image metadata" section)
 # - https://docs.openclaw.ai/install/docker
 LABEL org.opencontainers.image.base.name="docker.io/library/node:22-bookworm" \
-      org.opencontainers.image.base.digest="sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935" \
-      org.opencontainers.image.source="https://github.com/openclaw/openclaw" \
-      org.opencontainers.image.url="https://openclaw.ai" \
-      org.opencontainers.image.documentation="https://docs.openclaw.ai/install/docker" \
-      org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.title="OpenClaw" \
-      org.opencontainers.image.description="OpenClaw gateway and CLI runtime container image"
+  org.opencontainers.image.base.digest="sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935" \
+  org.opencontainers.image.source="https://github.com/openclaw/openclaw" \
+  org.opencontainers.image.url="https://openclaw.ai" \
+  org.opencontainers.image.documentation="https://docs.openclaw.ai/install/docker" \
+  org.opencontainers.image.licenses="MIT" \
+  org.opencontainers.image.title="OpenClaw" \
+  org.opencontainers.image.description="OpenClaw gateway and CLI runtime container image"
 
 # Install Bun (required for build scripts)
 RUN curl -fsSL https://bun.sh/install | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935
 
 # OCI base-image metadata for downstream image consumers.
+# If you change these annotations, also update:
+# - docs/install/docker.md ("Base image metadata" section)
+# - https://docs.openclaw.ai/install/docker
 LABEL org.opencontainers.image.base.name="docker.io/library/node:22-bookworm" \
       org.opencontainers.image.base.digest="sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935" \
       org.opencontainers.image.source="https://github.com/openclaw/openclaw" \

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -120,7 +120,7 @@ The docker image now publishes OCI base-image annotations (sha256 is an example)
 - `org.opencontainers.image.source=https://github.com/openclaw/openclaw`
 - `org.opencontainers.image.url=https://openclaw.ai`
 - `org.opencontainers.image.documentation=https://docs.openclaw.ai/install/docker`
-- `org.opencontainers.image.licenses=AGPL-3.0-only`
+- `org.opencontainers.image.licenses=MIT`
 - `org.opencontainers.image.title=OpenClaw`
 - `org.opencontainers.image.description=OpenClaw gateway and CLI runtime container image`
 - `org.opencontainers.image.revision=<git-sha>`

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -117,6 +117,15 @@ The docker image now publishes OCI base-image annotations (sha256 is an example)
 
 - `org.opencontainers.image.base.name=docker.io/library/node:22-bookworm`
 - `org.opencontainers.image.base.digest=sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935`
+- `org.opencontainers.image.source=https://github.com/openclaw/openclaw`
+- `org.opencontainers.image.url=https://openclaw.ai`
+- `org.opencontainers.image.documentation=https://docs.openclaw.ai/install/docker`
+- `org.opencontainers.image.licenses=AGPL-3.0-only`
+- `org.opencontainers.image.title=OpenClaw`
+- `org.opencontainers.image.description=OpenClaw gateway and CLI runtime container image`
+- `org.opencontainers.image.revision=<git-sha>`
+- `org.opencontainers.image.version=<tag-or-main>`
+- `org.opencontainers.image.created=<rfc3339 timestamp>`
 
 Reference: [OCI image annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -111,9 +111,9 @@ Common tags:
 
 The main Docker image currently uses:
 
-- `node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935`
+- `node:22-bookworm`
 
-The image now publishes OCI base-image annotations:
+The docker image now publishes OCI base-image annotations (sha256 is an example):
 
 - `org.opencontainers.image.base.name=docker.io/library/node:22-bookworm`
 - `org.opencontainers.image.base.digest=sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935`

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -107,6 +107,22 @@ Common tags:
 - `<version>` — release tag builds (for example `2026.2.26`)
 - `latest` — latest stable release tag
 
+### Base image metadata
+
+The main Docker image currently uses:
+
+- `node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935`
+
+The image now publishes OCI base-image annotations:
+
+- `org.opencontainers.image.base.name=docker.io/library/node:22-bookworm`
+- `org.opencontainers.image.base.digest=sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935`
+
+Reference: [OCI image annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
+
+Release context: this repository's tagged history already uses Bookworm in
+`v2026.2.22` and earlier 2026 tags (for example `v2026.2.21`, `v2026.2.9`).
+
 By default the setup script builds the image from source. To pull a pre-built
 image instead, set `OPENCLAW_IMAGE` before running the script:
 


### PR DESCRIPTION
## Summary

- add OCI base-image annotations to the main Docker image:
  - `org.opencontainers.image.base.name`
  - `org.opencontainers.image.base.digest`
- document the current Docker base image and OCI annotation keys in Docker install docs
- clarify release context around reported base-image transition concerns
- add changelog entry under `Unreleased -> Fixes`

Fixes #27945

## Notes

- Verified against tagged releases in this repo: `v2026.2.22` and earlier 2026 tags already use Bookworm for this Dockerfile lineage.
- Annotation keys follow the OCI image-spec annotations guidance.

## Validation

- `pnpm check:docs`
