### PR TITLE
fix: /model directive splits on first non-path @ for profile IDs

### DIFF
--- a/src/auto-reply/model.test.ts
+++ b/src/auto-reply/model.test.ts
@@ -50,6 +50,13 @@ describe("extractModelDirective", () => {
       expect(result.rawProfile).toBe("work");
     });
 
+    it("handles OAuth profile IDs containing @ (email-based)", () => {
+      const result = extractModelDirective("/model flash@google-gemini-cli:test@gmail.com");
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("flash");
+      expect(result.rawProfile).toBe("google-gemini-cli:test@gmail.com");
+    });
+
     it("returns no directive for plain text", () => {
       const result = extractModelDirective("hello world");
       expect(result.hasDirective).toBe(false);

--- a/src/auto-reply/model.ts
+++ b/src/auto-reply/model.ts
@@ -34,7 +34,15 @@ export function extractModelDirective(
   let rawModel = raw;
   let rawProfile: string | undefined;
   if (raw) {
-    const atIndex = raw.lastIndexOf("@");
+    // Find the first '@' that is not part of an OpenRouter preset path
+    // (preset paths use '/@' like 'openrouter/@preset/...').
+    let atIndex = -1;
+    for (let i = 1; i < raw.length; i++) {
+      if (raw[i] === "@" && raw[i - 1] !== "/") {
+        atIndex = i;
+        break;
+      }
+    }
     if (atIndex > 0) {
       const candidateModel = raw.slice(0, atIndex).trim();
       const candidateProfile = raw.slice(atIndex + 1).trim();


### PR DESCRIPTION
## Summary
The \`/model\` directive parser used \`lastIndexOf("@")\` to split model from auth profile, which broke OAuth profile IDs containing \`@\` (e.g. \`google-gemini-cli:test@gmail.com\`).

**Before:** \`/model flash@google-gemini-cli:test@gmail.com\` → model=\`flash@google-gemini-cli:test\`, profile=\`gmail.com\` (wrong)
**After:** \`/model flash@google-gemini-cli:test@gmail.com\` → model=\`flash\`, profile=\`google-gemini-cli:test@gmail.com\` (correct)

Now finds the first \`@\` not preceded by \`/\` (OpenRouter preset paths use \`/@\`), preserving the full email-based profile ID.

## Change type
Bug fix

## Scope
- \`src/auto-reply/model.ts\` — \`extractModelDirective\`
- \`src/auto-reply/model.test.ts\` — added email-profile test

## Linked issue
Closes #30912

## How was this change tested?
- Added test: \`/model flash@google-gemini-cli:test@gmail.com\`
- Existing tests pass: OpenRouter \`/@preset/\` paths, simple \`model@profile\`, and \`/@preset/model@profile\`

## Security impact
None

Made with [Cursor](https://cursor.com)