### PR TITLE
fix(telegram): only apply reply-to on first chunk in replyToMode first

### DIFF
--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -123,11 +123,11 @@ export async function deliverReplies(params: {
         if (!chunk) {
           continue;
         }
-        // Only attach buttons to the first chunk.
-        const shouldAttachButtons = i === 0 && replyMarkup;
+        const isFirstChunk = i === 0;
+        const shouldAttachButtons = isFirstChunk && replyMarkup;
         await sendTelegramText(bot, chatId, chunk.html, runtime, {
-          replyToMessageId: replyToMessageIdForPayload,
-          replyQuoteText,
+          replyToMessageId: isFirstChunk ? replyToMessageIdForPayload : undefined,
+          replyQuoteText: isFirstChunk ? replyQuoteText : undefined,
           thread,
           textMode: "html",
           plainText: chunk.text,


### PR DESCRIPTION
## Summary
When \`replyToMode\` is \`"first"\` and a reply is split into multiple Telegram message chunks, **all chunks** carried \`reply_to_message_id\`, making every chunk quote the original message. Now only the first chunk gets the reply reference; subsequent chunks send without it.

## Change type
Bug fix

## Scope
\`src/telegram/bot/delivery.ts\` — text chunk dispatch loop

## Linked issue
Closes #31039

## How was this change tested?
- Verified the existing \`hasReplied\` flag logic still works for cross-reply deduplication
- The fix only scopes the per-chunk \`replyToMessageId\` to \`i === 0\`

## Security impact
None

Made with [Cursor](https://cursor.com)