### PR TITLE
fix(matrix): preserve room ID casing in group directory lookup

### DIFF
--- a/extensions/matrix/src/directory-live.test.ts
+++ b/extensions/matrix/src/directory-live.test.ts
@@ -71,4 +71,15 @@ describe("matrix directory live", () => {
     expect(result).toEqual([]);
     expect(resolveMatrixAuth).not.toHaveBeenCalled();
   });
+
+  it("preserves original casing for room IDs without :server suffix", async () => {
+    const mixedCaseId = "!EonMPPbOuhntHEHgZ2dnBO-c_EglMaXlIh2kdo8cgiA";
+    const result = await listMatrixDirectoryGroupsLive({
+      cfg,
+      query: mixedCaseId,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(mixedCaseId);
+  });
 });

--- a/extensions/matrix/src/directory-live.ts
+++ b/extensions/matrix/src/directory-live.ts
@@ -174,7 +174,8 @@ export async function listMatrixDirectoryGroupsLive(
   }
 
   if (query.startsWith("!")) {
-    return [createGroupDirectoryEntry({ id: query, name: query })];
+    const originalId = params.query?.trim() ?? query;
+    return [createGroupDirectoryEntry({ id: originalId, name: originalId })];
   }
 
   const joined = await fetchMatrixJson<MatrixJoinedRoomsResponse>({


### PR DESCRIPTION
## Summary

- Fixes room IDs starting with `!` (without `:server` suffix) being lowercased during group directory resolution, causing case-sensitive allowlist lookups to fail silently at message delivery time
- Uses original `params.query` casing instead of the `normalizeQuery()`-lowercased `query` in the `!` branch of `listMatrixDirectoryGroupsLive`
- Adds test to verify mixed-case room IDs preserve their original casing

Fixes #31190

## Test plan

- [x] Configured 5 Matrix bot accounts with `groups` entries using a room ID without `:server` suffix
- [x] Sent a message mentioning a bot in the group room
- [x] Verified bots receive and respond to messages (grawg and vaws both replied)
- [x] Before fix: `rooms resolved: ...→!eonmppb...` (lowercased). After fix: `rooms resolved: ...→!EonMPPb...` (original casing preserved)
- [x] Room IDs with standard `:server` format unaffected (fast path in `monitor/index.ts:156` — not touched by this change)
- [x] Existing + new matrix extension tests pass: `npx vitest run extensions/matrix/src/directory-live.test.ts` (5/5)