### PR TITLE
fix(image): handle trimmed custom provider keys for image model lookup

### DIFF
--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { normalizeProviders } from "./models-config.providers.js";
+
+describe("normalizeProviders", () => {
+  it("trims provider keys so image models remain discoverable for custom providers", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    try {
+      const providers: NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]> = {
+        " dashscope-vision ": {
+          baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+          api: "openai-completions",
+          apiKey: "DASHSCOPE_API_KEY",
+          models: [
+            {
+              id: "qwen-vl-max",
+              name: "Qwen VL Max",
+              input: ["text", "image"],
+              reasoning: false,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 32000,
+              maxTokens: 4096,
+            },
+          ],
+        },
+      };
+
+      const normalized = normalizeProviders({ providers, agentDir });
+      expect(Object.keys(normalized ?? {})).toEqual(["dashscope-vision"]);
+      expect(normalized?.["dashscope-vision"]?.models?.[0]?.id).toBe("qwen-vl-max");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- normalize `models.providers` keys by trimming surrounding whitespace before writing `models.json`
- prevent image model resolution mismatch when a custom provider key contains accidental leading/trailing spaces
- add regression test covering `dashscope-vision` provider key normalization

## Root cause
`normalizeProviders()` computed a trimmed provider key but stored the normalized provider entry back under the original raw key.

When users configured a provider key like `" dashscope-vision "`, image model fallback resolved `dashscope-vision/qwen-vl-max` (trimmed), but `ModelRegistry` only had the raw key from `models.json`, causing:

`Unknown model: dashscope-vision/qwen-vl-max`

## Validation
- `pnpm vitest run src/agents/models-config.providers.normalize-keys.test.ts`

Closes #31187
