### PR TITLE
fix(feishu): prevent phantom System DM previews leaking into prompt

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1043,10 +1043,11 @@ export async function handleFeishuMessage(params: {
       ? `Feishu[${account.accountId}] message in group ${ctx.chatId}`
       : `Feishu[${account.accountId}] DM from ${ctx.senderOpenId}`;
 
-    core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
-      sessionKey: route.sessionKey,
-      contextKey: `feishu:message:${ctx.chatId}:${ctx.messageId}`,
-    });
+    // Do not enqueue inbound user previews as system events.
+    // These lines are prepended to future model prompts as `System: [...] ...`,
+    // which can be misinterpreted as authoritative transcript turns and leak
+    // into chat as phantom user-like messages (issue #31165).
+    log(`feishu[${account.accountId}]: ${inboundLabel}: ${preview}`);
 
     // Resolve media from message
     const mediaMaxBytes = (feishuCfg?.mediaMaxMb ?? 30) * 1024 * 1024; // 30MB default


### PR DESCRIPTION
## Summary
Fixes a regression where Feishu inbound DM/group preview lines were enqueued as **system events** and then prepended to future turns as `System: [timestamp] ...`.

Those synthetic lines can be interpreted by the model as authoritative transcript context, which can leak as phantom user-like messages and user-intent simulation.

## Root cause
`extensions/feishu/src/bot.ts` was calling:

- `core.system.enqueueSystemEvent(...)`

for every inbound message.

System events are intended for operational/runtime notices, but these lines contain user-message previews (`DM from <id>: <content>`), so they were injected into the model prompt under a `System:` prefix in subsequent turns.

## Fix
- Stop enqueuing inbound Feishu message previews as system events.
- Keep observability by logging the same preview via `log(...)` only.

## Validation
- Ran Feishu bot unit tests:
  - `pnpm exec vitest run extensions/feishu/src/bot.test.ts`
  - Result: **pass** (26/26 tests)

Fixes #31165
