### PR TITLE
fix(usage): clamp negative input token counts to zero

### DIFF
--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -105,6 +105,20 @@ describe("normalizeUsage", () => {
     });
   });
 
+  it("clamps negative prompt_tokens alias to zero", () => {
+    const usage = normalizeUsage({
+      prompt_tokens: -12,
+      completion_tokens: 4,
+    });
+    expect(usage).toEqual({
+      input: 0,
+      output: 4,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      total: undefined,
+    });
+  });
+
   it("returns undefined when no valid fields are provided", () => {
     const usage = normalizeUsage(null);
     expect(usage).toBeUndefined();

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -88,6 +88,23 @@ describe("normalizeUsage", () => {
     });
   });
 
+  it("clamps negative input to zero (pre-subtracted cached_tokens > prompt_tokens)", () => {
+    // pi-ai OpenAI-format providers subtract cached_tokens from prompt_tokens
+    // upstream.  When cached_tokens exceeds prompt_tokens the result is negative.
+    const usage = normalizeUsage({
+      input: -4900,
+      output: 200,
+      cacheRead: 5000,
+    });
+    expect(usage).toEqual({
+      input: 0,
+      output: 200,
+      cacheRead: 5000,
+      cacheWrite: undefined,
+      total: undefined,
+    });
+  });
+
   it("returns undefined when no valid fields are provided", () => {
     const usage = normalizeUsage(null);
     expect(usage).toBeUndefined();

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -90,9 +90,13 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
     return undefined;
   }
 
-  const input = asFiniteNumber(
+  // Some providers (pi-ai OpenAI-format) pre-subtract cached_tokens from
+  // prompt_tokens upstream.  When cached_tokens > prompt_tokens the result is
+  // negative, which is nonsensical.  Clamp to 0.
+  const rawInput = asFiniteNumber(
     raw.input ?? raw.inputTokens ?? raw.input_tokens ?? raw.promptTokens ?? raw.prompt_tokens,
   );
+  const input = rawInput !== undefined && rawInput < 0 ? 0 : rawInput;
   const output = asFiniteNumber(
     raw.output ??
       raw.outputTokens ??


### PR DESCRIPTION
## Summary
- Fixes negative token counts displayed in the TUI status bar and `/usage` dashboard when using OpenAI-format providers with prompt caching
- Root cause: pi-ai pre-subtracts `cached_tokens` from `prompt_tokens`; when `cached_tokens > prompt_tokens` (provider inconsistency), `input` goes negative
- Clamps `rawInput` to `0` in `normalizeUsage()` — the single normalization entry point for all providers

## Test plan
- [x] Added test: `clamps negative input to zero (pre-subtracted cached_tokens > prompt_tokens)`
- [x] All 18 usage tests pass
- [ ] Verify negative token counts no longer appear on `/usage` dashboard with Kimi K2 or other OpenAI-format providers

Closes #30765

🤖 Generated with [Claude Code](https://claude.com/claude-code)