### PR TITLE
fix(discord): prevent wildcard component registration collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/Components wildcard handlers: use distinct internal registration sentinel IDs and parse those sentinels as wildcard keys so select/user/role/channel/mentionable/modal interactions are not dropped by raw customId dedupe paths. Landed from contributor PR #29459 by @Sid-Qin. Thanks @Sid-Qin.
 - Model directives/Auth profiles: split `/model` profile suffixes at the first `@` after the last slash so email-based auth profile IDs (for example OAuth profile IDs) resolve correctly. Landed from contributor PR #30932 by @haosenwang1018. Thanks @haosenwang1018.
 - Windows/Plugin install: avoid `spawn EINVAL` on Windows npm/npx invocations by resolving to `node` + npm CLI scripts instead of spawning `.cmd` directly. Landed from contributor PR #31147 by @codertony. Thanks @codertony.
 - LINE/Voice transcription: classify M4A voice media as `audio/mp4` (not `video/mp4`) by checking the MPEG-4 `ftyp` major brand (`M4A ` / `M4B `), restoring voice transcription for LINE voice messages. Landed from contributor PR #31151 by @scoootscooob. Thanks @scoootscooob.

--- a/src/discord/components.ts
+++ b/src/discord/components.ts
@@ -662,7 +662,7 @@ export function parseDiscordComponentCustomIdForCarbon(id: string): ComponentPar
 }
 
 export function parseDiscordModalCustomIdForCarbon(id: string): ComponentParserResult {
-  if (id === "*" || id === "__openclaw_discord_component_modal_wildcard__") {
+  if (id === "*" || isDiscordComponentWildcardRegistrationId(id)) {
     return { key: "*", data: {} };
   }
   const parsed = parseCustomId(id);

--- a/src/discord/components.ts
+++ b/src/discord/components.ts
@@ -646,8 +646,12 @@ export function parseDiscordModalCustomId(id: string): string | null {
   return modalId;
 }
 
+function isDiscordComponentWildcardRegistrationId(id: string): boolean {
+  return /^__openclaw_discord_component_[a-z_]+_wildcard__$/.test(id);
+}
+
 export function parseDiscordComponentCustomIdForCarbon(id: string): ComponentParserResult {
-  if (id === "*") {
+  if (id === "*" || isDiscordComponentWildcardRegistrationId(id)) {
     return { key: "*", data: {} };
   }
   const parsed = parseCustomId(id);
@@ -658,7 +662,7 @@ export function parseDiscordComponentCustomIdForCarbon(id: string): ComponentPar
 }
 
 export function parseDiscordModalCustomIdForCarbon(id: string): ComponentParserResult {
-  if (id === "*") {
+  if (id === "*" || id === "__openclaw_discord_component_modal_wildcard__") {
     return { key: "*", data: {} };
   }
   const parsed = parseCustomId(id);

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -1456,7 +1456,7 @@ export class AgentSelectMenu extends StringSelectMenu {
 
 class DiscordComponentButton extends Button {
   label = "component";
-  customId = "*";
+  customId = "__openclaw_discord_component_button_wildcard__";
   style = ButtonStyle.Primary;
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
@@ -1488,7 +1488,7 @@ class DiscordComponentButton extends Button {
 }
 
 class DiscordComponentStringSelect extends StringSelectMenu {
-  customId = "*";
+  customId = "__openclaw_discord_component_string_select_wildcard__";
   options: APIStringSelectComponent["options"] = [];
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
@@ -1511,7 +1511,7 @@ class DiscordComponentStringSelect extends StringSelectMenu {
 }
 
 class DiscordComponentUserSelect extends UserSelectMenu {
-  customId = "*";
+  customId = "__openclaw_discord_component_user_select_wildcard__";
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
 
@@ -1533,7 +1533,7 @@ class DiscordComponentUserSelect extends UserSelectMenu {
 }
 
 class DiscordComponentRoleSelect extends RoleSelectMenu {
-  customId = "*";
+  customId = "__openclaw_discord_component_role_select_wildcard__";
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
 
@@ -1555,7 +1555,7 @@ class DiscordComponentRoleSelect extends RoleSelectMenu {
 }
 
 class DiscordComponentMentionableSelect extends MentionableSelectMenu {
-  customId = "*";
+  customId = "__openclaw_discord_component_mentionable_select_wildcard__";
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
 
@@ -1577,7 +1577,7 @@ class DiscordComponentMentionableSelect extends MentionableSelectMenu {
 }
 
 class DiscordComponentChannelSelect extends ChannelSelectMenu {
-  customId = "*";
+  customId = "__openclaw_discord_component_channel_select_wildcard__";
   customIdParser = parseDiscordComponentCustomIdForCarbon;
   private ctx: AgentComponentContext;
 
@@ -1600,7 +1600,7 @@ class DiscordComponentChannelSelect extends ChannelSelectMenu {
 
 class DiscordComponentModal extends Modal {
   title = "OpenClaw form";
-  customId = "*";
+  customId = "__openclaw_discord_component_modal_wildcard__";
   components = [];
   customIdParser = parseDiscordModalCustomIdForCarbon;
   private ctx: AgentComponentContext;

--- a/src/discord/monitor/agent-components.wildcard.test.ts
+++ b/src/discord/monitor/agent-components.wildcard.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { buildDiscordComponentCustomId, buildDiscordModalCustomId } from "../components.js";
+import {
+  createDiscordComponentButton,
+  createDiscordComponentChannelSelect,
+  createDiscordComponentMentionableSelect,
+  createDiscordComponentModal,
+  createDiscordComponentRoleSelect,
+  createDiscordComponentStringSelect,
+  createDiscordComponentUserSelect,
+} from "./agent-components.js";
+
+type WildcardComponent = {
+  customId: string;
+  customIdParser: (id: string) => { key: string; data: unknown };
+};
+
+function asWildcardComponent(value: unknown): WildcardComponent {
+  return value as WildcardComponent;
+}
+
+function createWildcardComponents() {
+  const context = {} as Parameters<typeof createDiscordComponentButton>[0];
+  return [
+    asWildcardComponent(createDiscordComponentButton(context)),
+    asWildcardComponent(createDiscordComponentStringSelect(context)),
+    asWildcardComponent(createDiscordComponentUserSelect(context)),
+    asWildcardComponent(createDiscordComponentRoleSelect(context)),
+    asWildcardComponent(createDiscordComponentMentionableSelect(context)),
+    asWildcardComponent(createDiscordComponentChannelSelect(context)),
+    asWildcardComponent(createDiscordComponentModal(context)),
+  ];
+}
+
+describe("discord wildcard component registration ids", () => {
+  it("uses distinct sentinel customIds instead of a shared literal wildcard", () => {
+    const components = createWildcardComponents();
+    const customIds = components.map((component) => component.customId);
+
+    expect(customIds.every((id) => id !== "*")).toBe(true);
+    expect(new Set(customIds).size).toBe(customIds.length);
+  });
+
+  it("still resolves sentinel ids and runtime ids through wildcard parser key", () => {
+    const components = createWildcardComponents();
+    const interactionCustomId = buildDiscordComponentCustomId({ componentId: "sel_test" });
+    const interactionModalId = buildDiscordModalCustomId("mdl_test");
+
+    for (const component of components) {
+      expect(component.customIdParser(component.customId).key).toBe("*");
+      if (component.customId.includes("_modal_")) {
+        expect(component.customIdParser(interactionModalId).key).toBe("*");
+      } else {
+        expect(component.customIdParser(interactionCustomId).key).toBe("*");
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Recreate #29459 from a clean branch (previous fork PR was auto-closed as dirty by barnacle).
- Keep original fix scope: distinct internal Discord wildcard registration sentinel IDs for all wildcard handlers.
- Keep parser compatibility: sentinel IDs and legacy `*` both resolve to wildcard key.
- Apply parser consistency follow-up: modal wildcard path now uses shared sentinel helper.

## Why

Discord wildcard handlers that shared raw `customId="*"` could be dropped in dedupe-by-customId runtimes, causing select/user/role/channel/mentionable/modal interactions to fail with Unknown component.

## Validation (limited gate)

- `pnpm vitest run src/discord/monitor/agent-components.wildcard.test.ts src/discord/components.test.ts src/discord/monitor/provider.test.ts`

## Links

- Supersedes #29459
- Closes #29229
