### PR TITLE
test(web_search): lock Brave endpoint to /res/v1 and close #31142

### DIFF
--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -177,6 +177,12 @@ describe("web_search country and language parameters", () => {
     return new URL(mockFetch.mock.calls[0][0] as string);
   }
 
+  it("uses the current Brave Search endpoint path", async () => {
+    const url = await runBraveSearchAndGetUrl({});
+    expect(url.origin).toBe("https://api.search.brave.com");
+    expect(url.pathname).toBe("/res/v1/web/search");
+  });
+
   it.each([
     { key: "country", value: "DE" },
     { key: "search_lang", value: "de" },


### PR DESCRIPTION
## Summary\n- investigated issue #31142 and verified current code already uses Brave's new endpoint path ()\n- confirmed no remaining  references in source\n- added a regression test that asserts web_search calls \n\n## Why\nIssue #31142 reports Brave Search API path changes breaking calls. The runtime implementation is already on the new path, so this PR adds a guardrail test to prevent accidental regressions to old paths.\n\n## Validation\n- 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/tmp/tmp.f25AjhzUmi/openclaw[39m

 [32m✓[39m src/agents/tools/web-tools.enabled-defaults.test.ts [2m([22m[2m30 tests[22m[2m | [22m[33m29 skipped[39m[2m)[22m[32m 31[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m1 passed[39m[22m[2m | [22m[33m29 skipped[39m[90m (30)[39m
[2m   Start at [22m 11:09:42
[2m   Duration [22m 1.07s[2m (transform 551ms, setup 362ms, import 510ms, tests 31ms, environment 0ms)[22m\n\nCloses #31142.