### PR TITLE
feat(config): add `openclaw config validate` and improve startup error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- CLI/Config validation: add `openclaw config validate` (with `--json`) to validate config files before gateway startup, and include detailed invalid-key paths in startup invalid-config errors. (#31220) thanks @Sid-Qin.
 - ACP/ACPX streaming: pin ACPX plugin support to `0.1.15`, add configurable ACPX command/version probing, and streamline ACP stream delivery (`final_only` default + reduced tool-event noise) with matching runtime and test updates. (#30036) Thanks @osolmaz.
 - Cron/Heartbeat light bootstrap context: add opt-in lightweight bootstrap mode for automation runs (`--light-context` for cron agent turns and `agents.*.heartbeat.lightContext` for heartbeat), keeping only `HEARTBEAT.md` for heartbeat runs and skipping bootstrap-file injection for cron lightweight runs. (#26064) Thanks @jose-velez.
 - OpenAI/Streaming transport: make `openai` Responses WebSocket-first by default (`transport: "auto"` with SSE fallback), add shared OpenAI WS stream/connection runtime wiring with per-session cleanup, and preserve server-side compaction payload mutation (`store` + `context_management`) on the WS path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- CLI/Config validation: add `openclaw config validate` (with `--json`) to validate config files before gateway startup, and include detailed invalid-key paths in startup invalid-config errors. (#31220) thanks @Sid-Qin.
 - Sessions/Attachments: add inline file attachment support for `sessions_spawn` (subagent runtime only) with base64/utf8 encoding, transcript content redaction, lifecycle cleanup, and configurable limits via `tools.sessions_spawn.attachments`. (#16761) Thanks @napetrov.
 - Agents/Thinking defaults: set `adaptive` as the default thinking level for Anthropic Claude 4.6 models (including Bedrock Claude 4.6 refs) while keeping other reasoning-capable models at `low` unless explicitly configured.
 - Gateway/Container probes: add built-in HTTP liveness/readiness endpoints (`/health`, `/healthz`, `/ready`, `/readyz`) for Docker/Kubernetes health checks, with fallback routing so existing handlers on those paths are not shadowed. (#31272) Thanks @vincentkoc.
@@ -131,7 +132,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- CLI/Config validation: add `openclaw config validate` (with `--json`) to validate config files before gateway startup, and include detailed invalid-key paths in startup invalid-config errors. (#31220) thanks @Sid-Qin.
 - ACP/ACPX streaming: pin ACPX plugin support to `0.1.15`, add configurable ACPX command/version probing, and streamline ACP stream delivery (`final_only` default + reduced tool-event noise) with matching runtime and test updates. (#30036) Thanks @osolmaz.
 - Cron/Heartbeat light bootstrap context: add opt-in lightweight bootstrap mode for automation runs (`--light-context` for cron agent turns and `agents.*.heartbeat.lightContext` for heartbeat), keeping only `HEARTBEAT.md` for heartbeat runs and skipping bootstrap-file injection for cron lightweight runs. (#26064) Thanks @jose-velez.
 - OpenAI/Streaming transport: make `openai` Responses WebSocket-first by default (`transport: "auto"` with SSE fallback), add shared OpenAI WS stream/connection runtime wiring with per-session cleanup, and preserve server-side compaction payload mutation (`store` + `context_management`) on the WS path.

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -1,5 +1,5 @@
 ---
-summary: "CLI reference for `openclaw config` (get/set/unset values and config file path)"
+summary: "CLI reference for `openclaw config` (get/set/unset/file/validate)"
 read_when:
   - You want to read or edit config non-interactively
 title: "config"
@@ -7,8 +7,8 @@ title: "config"
 
 # `openclaw config`
 
-Config helpers: get/set/unset values by path and print the active config file.
-Run without a subcommand to open
+Config helpers: get/set/unset/validate values by path and print the active
+config file. Run without a subcommand to open
 the configure wizard (same as `openclaw configure`).
 
 ## Examples
@@ -20,6 +20,8 @@ openclaw config set browser.executablePath "/usr/bin/google-chrome"
 openclaw config set agents.defaults.heartbeat.every "2h"
 openclaw config set agents.list[0].tools.exec.node "node-id-or-name"
 openclaw config unset tools.web.search.apiKey
+openclaw config validate
+openclaw config validate --json
 ```
 
 ## Paths
@@ -54,3 +56,13 @@ openclaw config set channels.whatsapp.groups '["*"]' --strict-json
 - `config file`: Print the active config file path (resolved from `OPENCLAW_CONFIG_PATH` or default location).
 
 Restart the gateway after edits.
+
+## Validate
+
+Validate the current config against the active schema without starting the
+gateway.
+
+```bash
+openclaw config validate
+openclaw config validate --json
+```

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -380,7 +380,7 @@ Interactive configuration wizard (models, channels, skills, gateway).
 
 ### `config`
 
-Non-interactive config helpers (get/set/unset/file). Running `openclaw config` with no
+Non-interactive config helpers (get/set/unset/file/validate). Running `openclaw config` with no
 subcommand launches the wizard.
 
 Subcommands:
@@ -389,6 +389,8 @@ Subcommands:
 - `config set <path> <value>`: set a value (JSON5 or raw string).
 - `config unset <path>`: remove a value.
 - `config file`: print the active config file path.
+- `config validate`: validate the current config against the schema without starting the gateway.
+- `config validate --json`: emit machine-readable JSON output.
 
 ### `doctor`
 

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -198,7 +198,7 @@ describe("config cli", () => {
 
     it("prints issues and exits 1 when config is invalid", async () => {
       setSnapshotOnce({
-        path: "/tmp/openclaw.json",
+        path: "/tmp/custom-openclaw.json",
         exists: true,
         raw: "{}",
         parsed: {},
@@ -226,7 +226,7 @@ describe("config cli", () => {
 
     it("returns machine-readable JSON with --json for invalid config", async () => {
       setSnapshotOnce({
-        path: "/tmp/openclaw.json",
+        path: "/tmp/custom-openclaw.json",
         exists: true,
         raw: "{}",
         parsed: {},
@@ -250,7 +250,7 @@ describe("config cli", () => {
         issues: Array<{ path: string; message: string }>;
       };
       expect(payload.valid).toBe(false);
-      expect(payload.path).toContain("openclaw.json");
+      expect(payload.path).toBe("/tmp/custom-openclaw.json");
       expect(payload.issues).toEqual([{ path: "gateway.bind", message: "Invalid enum value" }]);
       expect(mockError).not.toHaveBeenCalled();
     });

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -56,6 +56,10 @@ function setSnapshot(resolved: OpenClawConfig, config: OpenClawConfig) {
   mockReadConfigFileSnapshot.mockResolvedValueOnce(buildSnapshot({ resolved, config }));
 }
 
+function setSnapshotOnce(snapshot: ConfigFileSnapshot) {
+  mockReadConfigFileSnapshot.mockResolvedValueOnce(snapshot);
+}
+
 let registerConfigCli: typeof import("./config-cli.js").registerConfigCli;
 
 async function runConfigCommand(args: string[]) {
@@ -175,6 +179,99 @@ describe("config cli", () => {
       await runConfigCommand(["config", "get", "gateway.auth.token"]);
 
       expect(mockLog).toHaveBeenCalledWith("__OPENCLAW_REDACTED__");
+    });
+  });
+
+  describe("config validate", () => {
+    it("prints success and exits 0 when config is valid", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "validate"]);
+
+      expect(mockExit).not.toHaveBeenCalled();
+      expect(mockError).not.toHaveBeenCalled();
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("Config valid:"));
+    });
+
+    it("prints issues and exits 1 when config is invalid", async () => {
+      setSnapshotOnce({
+        path: "/tmp/openclaw.json",
+        exists: true,
+        raw: "{}",
+        parsed: {},
+        resolved: {},
+        valid: false,
+        config: {},
+        issues: [
+          {
+            path: "agents.defaults.suppressToolErrorWarnings",
+            message: "Unrecognized key(s) in object",
+          },
+        ],
+        warnings: [],
+        legacyIssues: [],
+      });
+
+      await expect(runConfigCommand(["config", "validate"])).rejects.toThrow("__exit__:1");
+
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining("Config invalid at"));
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining("agents.defaults.suppressToolErrorWarnings"),
+      );
+      expect(mockLog).not.toHaveBeenCalled();
+    });
+
+    it("returns machine-readable JSON with --json for invalid config", async () => {
+      setSnapshotOnce({
+        path: "/tmp/openclaw.json",
+        exists: true,
+        raw: "{}",
+        parsed: {},
+        resolved: {},
+        valid: false,
+        config: {},
+        issues: [{ path: "gateway.bind", message: "Invalid enum value" }],
+        warnings: [],
+        legacyIssues: [],
+      });
+
+      await expect(runConfigCommand(["config", "validate", "--json"])).rejects.toThrow(
+        "__exit__:1",
+      );
+
+      const raw = mockLog.mock.calls.at(0)?.[0];
+      expect(typeof raw).toBe("string");
+      const payload = JSON.parse(String(raw)) as {
+        valid: boolean;
+        path: string;
+        issues: Array<{ path: string; message: string }>;
+      };
+      expect(payload.valid).toBe(false);
+      expect(payload.path).toContain("openclaw.json");
+      expect(payload.issues).toEqual([{ path: "gateway.bind", message: "Invalid enum value" }]);
+      expect(mockError).not.toHaveBeenCalled();
+    });
+
+    it("prints file-not-found and exits 1 when config file is missing", async () => {
+      setSnapshotOnce({
+        path: "/tmp/openclaw.json",
+        exists: false,
+        raw: null,
+        parsed: {},
+        resolved: {},
+        valid: true,
+        config: {},
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      });
+
+      await expect(runConfigCommand(["config", "validate"])).rejects.toThrow("__exit__:1");
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining("Config file not found:"));
+      expect(mockLog).not.toHaveBeenCalled();
     });
   });
 

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -16,6 +16,10 @@ type PathSegment = string;
 type ConfigSetParseOpts = {
   strictJson?: boolean;
 };
+type ConfigIssue = {
+  path: string;
+  message: string;
+};
 
 const OLLAMA_API_KEY_PATH: PathSegment[] = ["models", "providers", "ollama", "apiKey"];
 const OLLAMA_PROVIDER_PATH: PathSegment[] = ["models", "providers", "ollama"];
@@ -96,6 +100,21 @@ function parseValue(raw: string, opts: ConfigSetParseOpts): unknown {
 
 function hasOwnPathKey(value: Record<string, unknown>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function normalizeConfigIssues(issues: ReadonlyArray<ConfigIssue>): ConfigIssue[] {
+  return issues.map((issue) => ({
+    path: issue.path || "<root>",
+    message: issue.message,
+  }));
+}
+
+function formatConfigIssueLines(issues: ReadonlyArray<ConfigIssue>, marker: string): string[] {
+  return normalizeConfigIssues(issues).map((issue) => `${marker} ${issue.path}: ${issue.message}`);
+}
+
+function formatDoctorHint(message: string): string {
+  return `Run \`${formatCliCommand("openclaw doctor")}\` ${message}`;
 }
 
 function validatePathSegments(path: PathSegment[]): void {
@@ -230,10 +249,10 @@ async function loadValidConfig(runtime: RuntimeEnv = defaultRuntime) {
     return snapshot;
   }
   runtime.error(`Config invalid at ${shortenHomePath(snapshot.path)}.`);
-  for (const issue of snapshot.issues) {
-    runtime.error(`- ${issue.path || "<root>"}: ${issue.message}`);
+  for (const line of formatConfigIssueLines(snapshot.issues, "-")) {
+    runtime.error(line);
   }
-  runtime.error(`Run \`${formatCliCommand("openclaw doctor")}\` to repair, then retry.`);
+  runtime.error(formatDoctorHint("to repair, then retry."));
   runtime.exit(1);
   return snapshot;
 }
@@ -338,15 +357,16 @@ export async function runConfigFile(opts: { runtime?: RuntimeEnv }) {
 
 export async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } = {}) {
   const runtime = opts.runtime ?? defaultRuntime;
-  const configPath = CONFIG_PATH ?? "openclaw.json";
-  const shortPath = shortenHomePath(configPath);
+  let outputPath = CONFIG_PATH ?? "openclaw.json";
 
   try {
     const snapshot = await readConfigFileSnapshot();
+    outputPath = snapshot.path;
+    const shortPath = shortenHomePath(outputPath);
 
     if (!snapshot.exists) {
       if (opts.json) {
-        runtime.log(JSON.stringify({ valid: false, path: configPath, error: "file not found" }));
+        runtime.log(JSON.stringify({ valid: false, path: outputPath, error: "file not found" }));
       } else {
         runtime.error(danger(`Config file not found: ${shortPath}`));
       }
@@ -355,35 +375,30 @@ export async function runConfigValidate(opts: { json?: boolean; runtime?: Runtim
     }
 
     if (!snapshot.valid) {
-      const issues = snapshot.issues.map((iss) => ({
-        path: iss.path || "<root>",
-        message: iss.message,
-      }));
+      const issues = normalizeConfigIssues(snapshot.issues);
 
       if (opts.json) {
-        runtime.log(JSON.stringify({ valid: false, path: configPath, issues }, null, 2));
+        runtime.log(JSON.stringify({ valid: false, path: outputPath, issues }, null, 2));
       } else {
         runtime.error(danger(`Config invalid at ${shortPath}:`));
-        for (const issue of issues) {
-          runtime.error(`  ${danger("×")} ${issue.path}: ${issue.message}`);
+        for (const line of formatConfigIssueLines(issues, danger("×"))) {
+          runtime.error(`  ${line}`);
         }
         runtime.error("");
-        runtime.error(
-          `Run \`${formatCliCommand("openclaw doctor")}\` to repair, or fix the keys above manually.`,
-        );
+        runtime.error(formatDoctorHint("to repair, or fix the keys above manually."));
       }
       runtime.exit(1);
       return;
     }
 
     if (opts.json) {
-      runtime.log(JSON.stringify({ valid: true, path: configPath }));
+      runtime.log(JSON.stringify({ valid: true, path: outputPath }));
     } else {
       runtime.log(success(`Config valid: ${shortPath}`));
     }
   } catch (err) {
     if (opts.json) {
-      runtime.log(JSON.stringify({ valid: false, path: configPath, error: String(err) }));
+      runtime.log(JSON.stringify({ valid: false, path: outputPath, error: String(err) }));
     } else {
       runtime.error(danger(`Config validation error: ${String(err)}`));
     }

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1,9 +1,10 @@
 import type { Command } from "commander";
 import JSON5 from "json5";
 import { readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
+import { CONFIG_PATH } from "../config/paths.js";
 import { isBlockedObjectKey } from "../config/prototype-keys.js";
 import { redactConfigObject } from "../config/redact-snapshot.js";
-import { danger, info } from "../globals.js";
+import { danger, info, success } from "../globals.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
@@ -335,11 +336,66 @@ export async function runConfigFile(opts: { runtime?: RuntimeEnv }) {
   }
 }
 
+export async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } = {}) {
+  const runtime = opts.runtime ?? defaultRuntime;
+  const configPath = CONFIG_PATH ?? "openclaw.json";
+  const shortPath = shortenHomePath(configPath);
+
+  try {
+    const snapshot = await readConfigFileSnapshot();
+
+    if (!snapshot.exists) {
+      if (opts.json) {
+        runtime.log(JSON.stringify({ valid: false, path: configPath, error: "file not found" }));
+      } else {
+        runtime.error(danger(`Config file not found: ${shortPath}`));
+      }
+      runtime.exit(1);
+      return;
+    }
+
+    if (!snapshot.valid) {
+      const issues = snapshot.issues.map((iss) => ({
+        path: iss.path || "<root>",
+        message: iss.message,
+      }));
+
+      if (opts.json) {
+        runtime.log(JSON.stringify({ valid: false, path: configPath, issues }, null, 2));
+      } else {
+        runtime.error(danger(`Config invalid at ${shortPath}:`));
+        for (const issue of issues) {
+          runtime.error(`  ${danger("×")} ${issue.path}: ${issue.message}`);
+        }
+        runtime.error("");
+        runtime.error(
+          `Run \`${formatCliCommand("openclaw doctor")}\` to repair, or fix the keys above manually.`,
+        );
+      }
+      runtime.exit(1);
+      return;
+    }
+
+    if (opts.json) {
+      runtime.log(JSON.stringify({ valid: true, path: configPath }));
+    } else {
+      runtime.log(success(`Config valid: ${shortPath}`));
+    }
+  } catch (err) {
+    if (opts.json) {
+      runtime.log(JSON.stringify({ valid: false, path: configPath, error: String(err) }));
+    } else {
+      runtime.error(danger(`Config validation error: ${String(err)}`));
+    }
+    runtime.exit(1);
+  }
+}
+
 export function registerConfigCli(program: Command) {
   const cmd = program
     .command("config")
     .description(
-      "Non-interactive config helpers (get/set/unset/file). Run without subcommand for the setup wizard.",
+      "Non-interactive config helpers (get/set/unset/file/validate). Run without subcommand for the setup wizard.",
     )
     .addHelpText(
       "after",
@@ -407,5 +463,13 @@ export function registerConfigCli(program: Command) {
     .description("Print the active config file path")
     .action(async () => {
       await runConfigFile({});
+    });
+
+  cmd
+    .command("validate")
+    .description("Validate the current config against the schema without starting the gateway")
+    .option("--json", "Output validation result as JSON", false)
+    .action(async (opts) => {
+      await runConfigValidate({ json: Boolean(opts.json) });
     });
 }

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -83,7 +83,7 @@ const coreEntries: CoreCliEntry[] = [
       {
         name: "config",
         description:
-          "Non-interactive config helpers (get/set/unset/file). Default: starts setup wizard.",
+          "Non-interactive config helpers (get/set/unset/file/validate). Default: starts setup wizard.",
         hasSubcommands: true,
       },
     ],

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -720,7 +720,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           loggedInvalidConfigs.add(configPath);
           deps.logger.error(`Invalid config at ${configPath}:\\n${details}`);
         }
-        const error = new Error("Invalid config");
+        const error = new Error(`Invalid config at ${configPath}:\n${details}`);
         (error as { code?: string; details?: string }).code = "INVALID_CONFIG";
         (error as { code?: string; details?: string }).details = details;
         throw error;


### PR DESCRIPTION
## Summary

- Problem: OpenClaw does not validate config at write time for external edits. Invalid keys written to `openclaw.json` (by agents, `jq`, text editors) sit undetected until the next gateway restart, causing crash loops. The startup error says "Invalid config" without identifying which key is invalid.
- Why it matters: In agentic deployments, agents modify config programmatically and have no way to verify the write was valid. One user experienced 28 restart cycles over ~14 minutes from a single unrecognized key.
- What changed: (1) Added `openclaw config validate` CLI command for pre-flight config validation without starting the gateway. Supports `--json` for machine-readable output. (2) Improved the `loadConfig` error to include specific key paths in the Error message itself.
- What did NOT change (scope boundary): The existing `writeConfigFile` validation (which already works for `config set`/`config patch` paths) is untouched. No changes to Zod schema strictness — `.strict()` was already applied to all objects.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31148

## User-visible / Behavior Changes

1. **New CLI command**: `openclaw config validate` — validates the current config against the active Zod schema, reports all offending key paths, and exits with code 0 (valid) or 1 (invalid).
2. **`--json` flag**: `openclaw config validate --json` outputs `{ "valid": true/false, "path": "...", "issues": [...] }` for machine consumption. Agents can call this after writing config to detect errors before restart.
3. **Improved error message**: `loadConfig()` now throws with the full validation details in the Error message (e.g. `"Invalid config at ~/.openclaw/openclaw.json:\n- agents.defaults.suppressToolErrorWarnings: Unrecognized key(s)"`), making crash logs immediately actionable without searching separate log lines.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — read-only validation, no config modification
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Apple M4)
- Runtime/container: Node.js 22+
- Model/provider: Any
- Integration/channel (if any): Any
- Relevant config (redacted): Standard `openclaw.json`

### Steps

1. Add an unrecognized key to `openclaw.json`: `{ "agents": { "defaults": { "suppressToolErrorWarnings": true } } }`
2. Run `openclaw config validate`
3. Observe clear error identifying the exact key path

### Expected

- `openclaw config validate` exits with code 1 and prints: `× agents.defaults.suppressToolErrorWarnings: Unrecognized key(s) in object`

### Actual

- Before this PR: No `validate` subcommand exists. Startup error says "Invalid config" without the key path.
- After this PR: `config validate` catches the issue immediately. Startup error includes the key path.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verified `runConfigValidate` with valid config (exit 0, "Config valid") and with invalid keys (exit 1, per-key error output). Verified `--json` mode produces parseable JSON.

## Human Verification (required)

- Verified scenarios: Valid config → exit 0; invalid key → exit 1 with key path; missing config file → exit 1; `--json` flag produces correct JSON structure.
- Edge cases checked: Multiple validation issues reported; config file not found; `<root>` path fallback for top-level errors.
- What you did **not** verify: Integration test in a full systemd deployment with crash-loop recovery.

## Compatibility / Migration

- Backward compatible? `Yes` — additive CLI subcommand, no existing behavior changed.
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: The `validate` subcommand is entirely additive. Removing it has no effect on gateway startup or config handling.
- Files/config to restore: `src/cli/config-cli.ts` — remove `runConfigValidate` and the `validate` subcommand registration.
- Known bad symptoms reviewers should watch for: None — the command is read-only.

## Risks and Mitigations

- Risk: `CONFIG_PATH` could resolve to `undefined` if called before config initialization.
  - Mitigation: Falls back to `"openclaw.json"` literal. The `readConfigFileSnapshot()` call itself handles path resolution independently.

