### PR TITLE
fix(gateway): move plugin HTTP routes before Control UI SPA fallback

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -452,6 +452,25 @@ export function createGatewayHttpServer(opts: {
           return;
         }
       }
+      // Plugin routes run before Control UI so the SPA fallback doesn't swallow them.
+      if (handlePluginRequest) {
+        if ((shouldEnforcePluginGatewayAuth ?? isProtectedPluginRoutePath)(requestPath)) {
+          const pluginAuthOk = await enforcePluginRouteGatewayAuth({
+            req,
+            res,
+            auth: resolvedAuth,
+            trustedProxies,
+            allowRealIpFallback,
+            rateLimiter,
+          });
+          if (!pluginAuthOk) {
+            return;
+          }
+        }
+        if (await handlePluginRequest(req, res)) {
+          return;
+        }
+      }
       if (controlUiEnabled) {
         if (
           handleControlUiAvatarRequest(req, res, {
@@ -468,25 +487,6 @@ export function createGatewayHttpServer(opts: {
             root: controlUiRoot,
           })
         ) {
-          return;
-        }
-      }
-      // Plugins run last so built-in gateway routes keep precedence on overlapping paths.
-      if (handlePluginRequest) {
-        if ((shouldEnforcePluginGatewayAuth ?? isProtectedPluginRoutePath)(requestPath)) {
-          const pluginAuthOk = await enforcePluginRouteGatewayAuth({
-            req,
-            res,
-            auth: resolvedAuth,
-            trustedProxies,
-            allowRealIpFallback,
-            rateLimiter,
-          });
-          if (!pluginAuthOk) {
-            return;
-          }
-        }
-        if (await handlePluginRequest(req, res)) {
           return;
         }
       }


### PR DESCRIPTION
## Summary

The Control UI handler (`control-ui.ts`) has an SPA fallback that serves `index.html` for any unknown GET path, only exempting `/api/*` routes. Plugin HTTP routes were registered **after** the Control UI handler in the request chain (`server-http.ts`), so any plugin GET route (e.g. `/my-plugin/endpoint`) was swallowed by the SPA fallback before the plugin handler could process it.

This moves the plugin route handling block above the Control UI block so plugin routes are matched first. Built-in gateway routes (hooks, tools, Slack, OpenAI, canvas) still take precedence since they run before both.

## Changes

- `src/gateway/server-http.ts` — Swap ordering of plugin HTTP route handler and Control UI SPA handler in the request chain

## Test plan

- [ ] Verify plugin HTTP GET routes (e.g. registered via `registerHttpRoute`) are reachable when Control UI is enabled
- [ ] Verify Control UI still serves correctly for browser navigation (SPA fallback still works for non-plugin paths)
- [ ] Verify built-in gateway routes (hooks, tools, Slack, OpenAI, canvas) still take precedence over both
- [ ] Existing gateway tests pass (979 tests)