### PR TITLE
fix(heartbeat): Fix timer re-arm logic and add robust watchdog

### DIFF
--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -61,6 +61,62 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("re-arms timer after successful batch and fires again", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startDefaultRunner(runSpy);
+
+    // First heartbeat fires at 30 min
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    // Second heartbeat fires at 60 min
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).toHaveBeenCalledTimes(2);
+
+    // Third heartbeat fires at 90 min
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).toHaveBeenCalledTimes(3);
+
+    runner.stop();
+  });
+
+  it("watchdog recovers heartbeat when primary timer is lost", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startDefaultRunner(runSpy);
+
+    // First heartbeat fires normally at 30 min
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    // Advance well past the next due time -- the watchdog should eventually
+    // detect the overdue agent and trigger a heartbeat wake even if the
+    // primary setTimeout somehow failed to fire.
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 30_000);
+    expect(runSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    runner.stop();
+  });
+
+  it("does not fire heartbeat before agent is due", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startDefaultRunner(runSpy);
+
+    // Advance only 15 minutes -- less than the 30-minute interval
+    await vi.advanceTimersByTimeAsync(15 * 60_000);
+    expect(runSpy).not.toHaveBeenCalled();
+
+    runner.stop();
+  });
+
   it("continues scheduling after runOnce throws an unhandled error", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -88,16 +88,52 @@ describe("startHeartbeatRunner", () => {
     vi.setSystemTime(new Date(0));
 
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+
+    // Spy on global setTimeout so we can sabotage the re-armed primary timer
+    // after the first heartbeat fires, simulating the .unref() loss scenario.
+    const originalSetTimeout = globalThis.setTimeout;
+    let killNextPrimaryTimer = false;
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      fn: Function,
+      delay?: number,
+      ...args: unknown[]
+    ) => {
+      const id = originalSetTimeout(fn as Parameters<typeof originalSetTimeout>[0], delay, ...args);
+      // After the first heartbeat, the runner calls scheduleNext() which
+      // creates a new setTimeout.  We intercept it and immediately clear it
+      // to simulate the timer being lost.
+      if (killNextPrimaryTimer && typeof delay === "number" && delay > 0) {
+        clearTimeout(id);
+        killNextPrimaryTimer = false;
+      }
+      return id;
+    }) as typeof globalThis.setTimeout);
+
     const runner = startDefaultRunner(runSpy);
 
     // First heartbeat fires normally at 30 min
     await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
     expect(runSpy).toHaveBeenCalledTimes(1);
 
-    // Advance well past the next due time -- the watchdog should eventually
-    // detect the overdue agent and trigger a heartbeat wake even if the
-    // primary setTimeout somehow failed to fire.
-    await vi.advanceTimersByTimeAsync(30 * 60_000 + 30_000);
+    // Now sabotage the next primary timer that scheduleNext() will create.
+    // The run callback triggers scheduleNext() internally, but since the run
+    // already completed above we need to arm the sabotage for the *next*
+    // config-driven reschedule.  Force a config update to trigger a new
+    // scheduleNext() whose timer we immediately kill.
+    killNextPrimaryTimer = true;
+    runner.updateConfig({
+      agents: { defaults: { heartbeat: { every: "30m" } } },
+    } as OpenClawConfig);
+
+    // Restore setTimeout so the watchdog's requestHeartbeatNow path works
+    // normally from here on.
+    setTimeoutSpy.mockRestore();
+
+    // Advance past the next due time.  The primary timer is dead, so only
+    // the watchdog (setInterval) can trigger the second heartbeat.
+    // Watchdog polls at minIntervalMs/4 = 30*60_000/4 = 450_000ms = 7.5 min
+    // We advance 35 min to be safe.
+    await vi.advanceTimersByTimeAsync(35 * 60_000);
     expect(runSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
 
     runner.stop();

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -107,7 +107,7 @@ describe("startHeartbeatRunner", () => {
         killNextPrimaryTimer = false;
       }
       return id;
-    }) as typeof globalThis.setTimeout);
+    }) as unknown as typeof globalThis.setTimeout);
 
     const runner = startDefaultRunner(runSpy);
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -996,9 +996,17 @@ export function startHeartbeatRunner(opts: {
     runtime,
     agents: new Map<string, HeartbeatAgentState>(),
     timer: null as NodeJS.Timeout | null,
+    watchdog: null as NodeJS.Timeout | null,
     stopped: false,
   };
   let initialized = false;
+  /**
+   * Minimum heartbeat interval across all configured agents (milliseconds).
+   * Updated on every config change and used by the watchdog to derive a
+   * reasonable polling cadence without hard-coding a fixed interval.
+   */
+  let minIntervalMs = Number.POSITIVE_INFINITY;
+  const WATCHDOG_POLL_DIVISOR = 4;
 
   const resolveNextDue = (now: number, intervalMs: number, prevState?: HeartbeatAgentState) => {
     if (typeof prevState?.lastRunMs === "number") {
@@ -1013,6 +1021,45 @@ export function startHeartbeatRunner(opts: {
   const advanceAgentSchedule = (agent: HeartbeatAgentState, now: number) => {
     agent.lastRunMs = now;
     agent.nextDueMs = now + agent.intervalMs;
+  };
+
+  /**
+   * Arm a periodic watchdog that acts as a safety net for the primary
+   * `setTimeout` in `scheduleNext()`.  In rare cases the primary timer
+   * fails to re-fire after a batch completes (see #31139).  The watchdog
+   * checks at `minIntervalMs / WATCHDOG_POLL_DIVISOR` (clamped to
+   * [15 s, 5 min]) whether any agent is overdue and, if so, re-triggers
+   * a heartbeat wake with a non-zero coalesce window so it cannot spin
+   * into a tight loop while a run is already in flight.
+   */
+  const armWatchdog = () => {
+    if (state.watchdog) {
+      clearInterval(state.watchdog);
+      state.watchdog = null;
+    }
+    if (state.stopped || state.agents.size === 0) {
+      return;
+    }
+    const pollMs = Math.max(
+      15_000,
+      Math.min(5 * 60_000, Math.floor(minIntervalMs / WATCHDOG_POLL_DIVISOR)),
+    );
+    state.watchdog = setInterval(() => {
+      if (state.stopped || state.agents.size === 0) {
+        return;
+      }
+      const now = Date.now();
+      for (const agent of state.agents.values()) {
+        if (now >= agent.nextDueMs) {
+          // Use a non-zero coalesce window (half the poll interval) so that
+          // the wake layer can de-duplicate with any in-flight run and avoid
+          // the tight-reschedule loop described in the Codex review of #31161.
+          requestHeartbeatNow({ reason: "interval", coalesceMs: Math.floor(pollMs / 2) });
+          return;
+        }
+      }
+    }, pollMs);
+    state.watchdog.unref?.();
   };
 
   const scheduleNext = () => {
@@ -1041,7 +1088,6 @@ export function startHeartbeatRunner(opts: {
       state.timer = null;
       requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });
     }, delay);
-    state.timer.unref?.();
   };
 
   const updateConfig = (cfg: OpenClawConfig) => {
@@ -1072,6 +1118,7 @@ export function startHeartbeatRunner(opts: {
 
     state.cfg = cfg;
     state.agents = nextAgents;
+    minIntervalMs = intervals.length > 0 ? Math.min(...intervals) : Number.POSITIVE_INFINITY;
     const nextEnabled = nextAgents.size > 0;
     if (!initialized) {
       if (!nextEnabled) {
@@ -1089,6 +1136,7 @@ export function startHeartbeatRunner(opts: {
     }
 
     scheduleNext();
+    armWatchdog();
   };
 
   const run: HeartbeatWakeHandler = async (params) => {
@@ -1212,6 +1260,10 @@ export function startHeartbeatRunner(opts: {
       clearTimeout(state.timer);
     }
     state.timer = null;
+    if (state.watchdog) {
+      clearInterval(state.watchdog);
+    }
+    state.watchdog = null;
   };
 
   opts.abortSignal?.addEventListener("abort", cleanup, { once: true });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1045,7 +1045,7 @@ export function startHeartbeatRunner(opts: {
       Math.min(5 * 60_000, Math.floor(minIntervalMs / WATCHDOG_POLL_DIVISOR)),
     );
     state.watchdog = setInterval(() => {
-      if (state.stopped || state.agents.size === 0) {
+      if (state.stopped || state.agents.size === 0 || !heartbeatsEnabled) {
         return;
       }
       const now = Date.now();


### PR DESCRIPTION
### Summary

**Problem:** After the first heartbeat batch fires, `scheduleNext()` sets a new `setTimeout` but immediately calls `.unref()` on it. In certain Node.js event-loop states this causes the timer to silently never fire again, so all subsequent heartbeats stop until the gateway is restarted (#31139).

**Fix (two parts):**

1. **Remove `.unref()` from the primary timer** — this is the root cause. The timer must keep the event loop alive to guarantee re-arming.
2. **Add a dynamic watchdog `setInterval`** — a safety-net that periodically checks whether any agent is overdue and re-triggers a heartbeat wake if the primary timer was somehow lost. This watchdog derives its cadence from the minimum configured heartbeat interval (`minIntervalMs / 4`, clamped to [15 s, 5 min]) and uses a **non-zero `coalesceMs`** to avoid tight-loop risks.

The watchdog itself uses `.unref()` so it won't keep the process alive on its own — only the primary timer does.

### Change Type

- [x] Bug fix

### Linked Issue/PR

- Fixes #31139

### Tests

Three new tests added to `heartbeat-runner.scheduler.test.ts`:

- `re-arms timer after successful batch and fires again` — verifies 3 consecutive fires
- `watchdog recovers heartbeat when primary timer is lost` — verifies watchdog recovery
- `does not fire heartbeat before agent is due` — verifies no premature firing

