### PR TITLE
fix(test): correct mock parameter type in plugin-context test

### DIFF
--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-const resolvePluginToolsMock = vi.fn(() => []);
+const resolvePluginToolsMock = vi.fn((_params: unknown) => []);
 
 vi.mock("../plugins/tools.js", () => ({
   resolvePluginTools: (params: unknown) => resolvePluginToolsMock(params),


### PR DESCRIPTION
## Summary

- Fixes TS2554 in `src/agents/openclaw-tools.plugin-context.test.ts` caused by `vi.fn(() => [])` being inferred as a 0-argument function, while the mock is invoked with 1 argument on line 6.
- Changes the mock to `vi.fn((_params: unknown) => [])` so TypeScript knows it accepts one parameter.

This was introduced by commit bbab94c1f and is currently breaking `pnpm check` / `pnpm tsgo` on main.

## Test plan

- [x] `pnpm tsgo` reports 0 errors
- [x] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)