### PR TITLE
fix(webchat): allow image-only sends via opts.images

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -208,6 +208,29 @@ describe("runPreparedReply media-only handling", () => {
     expect(vi.mocked(runReplyAgent)).not.toHaveBeenCalled();
   });
 
+  it("allows webchat image-only sends via opts.images", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "webchat",
+        },
+        opts: {
+          images: [{ type: "image", mimeType: "image/png", data: "iVBORw0KGgo=" }],
+        },
+      }),
+    );
+
+    expect(result).toEqual({ text: "ok" });
+    expect(vi.mocked(runReplyAgent)).toHaveBeenCalled();
+  });
+
   it("omits auth key labels from /new and /reset confirmation messages", async () => {
     await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -306,7 +306,9 @@ export async function runPreparedReply(
     : [inboundUserContext, baseBodyFinal].filter(Boolean).join("\n\n");
   const baseBodyTrimmed = baseBodyForPrompt.trim();
   const hasMediaAttachment = Boolean(
-    sessionCtx.MediaPath || (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0),
+    sessionCtx.MediaPath ||
+    (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0) ||
+    (opts?.images && opts.images.length > 0),
   );
   if (!baseBodyTrimmed && !hasMediaAttachment) {
     await typing.onReplyStart();


### PR DESCRIPTION
## Summary
- Fixes pasted images (Cmd+V / Ctrl+V) in webchat being silently dropped when sent without text
- Root cause: `hasMediaAttachment` only checked `sessionCtx.MediaPath` / `sessionCtx.MediaPaths` (disk-based channels like Feishu/DingTalk), but webchat sends inline images through `opts.images`
- Added `opts?.images` to the `hasMediaAttachment` guard so image-only webchat messages proceed to the agent runner

## Test plan
- [x] Added test: `allows webchat image-only sends via opts.images`
- [x] All 8 media-only tests pass
- [ ] Paste an image in webchat without text — should reach the agent instead of returning "I didn't receive any text"

Closes #30818

🤖 Generated with [Claude Code](https://claude.com/claude-code)