### PR TITLE
feat(gateway): detect exec/sandbox config conflicts at startup

### DIFF
--- a/src/gateway/server-startup-log.test.ts
+++ b/src/gateway/server-startup-log.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { logGatewayStartup } from "./server-startup-log.js";
+import { collectConfigConflicts, logGatewayStartup } from "./server-startup-log.js";
 
 describe("gateway startup log", () => {
   it("warns when dangerous config flags are enabled", () => {
@@ -43,6 +43,32 @@ describe("gateway startup log", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("warns on exec/sandbox config conflicts", () => {
+    const info = vi.fn();
+    const warn = vi.fn();
+
+    logGatewayStartup({
+      cfg: {
+        tools: {
+          exec: { ask: "off" },
+        },
+        agents: {
+          defaults: {
+            sandbox: { mode: "non-main" },
+          },
+        },
+      },
+      bindHost: "127.0.0.1",
+      port: 18789,
+      log: { info, warn },
+      isNixMode: false,
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('tools.exec.ask is "off" but agents.defaults.sandbox.mode is'),
+    );
+  });
+
   it("logs all listen endpoints on a single line", () => {
     const info = vi.fn();
     const warn = vi.fn();
@@ -62,5 +88,48 @@ describe("gateway startup log", () => {
     expect(listenMessages).toEqual([
       `listening on ws://127.0.0.1:18789, ws://[::1]:18789 (PID ${process.pid})`,
     ]);
+  });
+});
+
+describe("collectConfigConflicts", () => {
+  it("detects exec.ask=off with sandbox.mode=non-main", () => {
+    const conflicts = collectConfigConflicts({
+      tools: { exec: { ask: "off" } },
+      agents: { defaults: { sandbox: { mode: "non-main" } } },
+    });
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toContain("tools.exec.ask");
+    expect(conflicts[0]).toContain("non-main");
+  });
+
+  it("detects exec.security=full with sandbox.mode=non-main", () => {
+    const conflicts = collectConfigConflicts({
+      tools: { exec: { security: "full" } },
+      agents: { defaults: { sandbox: { mode: "non-main" } } },
+    });
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toContain("tools.exec.security");
+  });
+
+  it("detects exec.host=gateway with sandbox.mode=non-main", () => {
+    const conflicts = collectConfigConflicts({
+      tools: { exec: { host: "gateway" } },
+      agents: { defaults: { sandbox: { mode: "non-main" } } },
+    });
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toContain("tools.exec.host");
+  });
+
+  it("returns no conflicts when sandbox.mode=off", () => {
+    const conflicts = collectConfigConflicts({
+      tools: { exec: { ask: "off", security: "full" } },
+      agents: { defaults: { sandbox: { mode: "off" } } },
+    });
+    expect(conflicts).toHaveLength(0);
+  });
+
+  it("returns no conflicts when exec config is default", () => {
+    const conflicts = collectConfigConflicts({});
+    expect(conflicts).toHaveLength(0);
   });
 });

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -1,7 +1,8 @@
 import chalk from "chalk";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveConfiguredModelRef } from "../agents/model-selection.js";
-import type { loadConfig } from "../config/config.js";
+import { resolveSandboxConfigForAgent } from "../agents/sandbox.js";
+import type { OpenClawConfig, loadConfig } from "../config/config.js";
 import { getResolvedLoggerSettings } from "../logging.js";
 import { collectEnabledInsecureOrDangerousFlags } from "../security/dangerous-config-flags.js";
 
@@ -41,4 +42,56 @@ export function logGatewayStartup(params: {
       "Run `openclaw security audit`.";
     params.log.warn(warning);
   }
+
+  for (const conflict of collectConfigConflicts(params.cfg)) {
+    params.log.warn(conflict);
+  }
+}
+
+/**
+ * Detect semantic conflicts between layered security/exec config options that
+ * would silently override each other at runtime.
+ */
+export function collectConfigConflicts(cfg: OpenClawConfig): string[] {
+  const conflicts: string[] = [];
+
+  const execAsk = cfg.tools?.exec?.ask;
+  const execSecurity = cfg.tools?.exec?.security;
+  const execHost = cfg.tools?.exec?.host;
+  const sandboxCfg = resolveSandboxConfigForAgent(cfg);
+  const sandboxMode = sandboxCfg.mode;
+
+  if (execAsk === "off" && sandboxMode === "non-main") {
+    conflicts.push(
+      'tools.exec.ask is "off" but agents.defaults.sandbox.mode is "non-main". ' +
+        "Exec commands from channel sessions (Telegram, Discord, etc.) will still require approval via sandbox. " +
+        'To allow exec without approval, set agents.defaults.sandbox.mode to "off".',
+    );
+  }
+
+  if (execAsk === "off" && sandboxMode === "all") {
+    conflicts.push(
+      'tools.exec.ask is "off" but agents.defaults.sandbox.mode is "all". ' +
+        "Sandbox overrides ask mode for all sessions, including main. " +
+        'To allow exec without approval, set agents.defaults.sandbox.mode to "off".',
+    );
+  }
+
+  if (execSecurity === "full" && sandboxMode !== "off") {
+    conflicts.push(
+      `tools.exec.security is "full" but agents.defaults.sandbox.mode is "${sandboxMode}". ` +
+        "Sandbox approval will override full-security exec for affected sessions. " +
+        'Set agents.defaults.sandbox.mode to "off" if you intend unrestricted exec.',
+    );
+  }
+
+  if (execHost === "gateway" && sandboxMode === "non-main") {
+    conflicts.push(
+      'tools.exec.host is "gateway" but agents.defaults.sandbox.mode is "non-main". ' +
+        "Non-main sessions will still route exec through sandbox despite the gateway host setting. " +
+        'Set sandbox.mode to "off" to bypass sandbox routing.',
+    );
+  }
+
+  return conflicts;
 }


### PR DESCRIPTION
## Summary

- Problem: OpenClaw has multiple layered security systems (sandbox, elevated, exec approvals, ask mode) that can silently override each other. Users configure `tools.exec.ask: "off"` expecting unrestricted exec, but `agents.defaults.sandbox.mode: "non-main"` (the default when sandbox is configured) silently blocks exec for channel sessions. The gateway starts with no warnings, and the conflict only surfaces at runtime as a generic "Approval required" timeout.
- Why it matters: Users spend hours debugging the wrong subsystem. One real-world case: 4-step debugging process over ~2 hours to discover that `sandbox.mode` was overriding `exec.ask`. A single startup warning would have saved the entire effort.
- What changed: Added a `collectConfigConflicts()` function that runs during `logGatewayStartup`. It detects 4 specific exec/sandbox conflicts and emits clear warnings with remediation guidance.
- What did NOT change (scope boundary): No changes to exec, sandbox, or approval logic. No changes to config schema or validation. This is purely additive diagnostic output. The `security audit` command's existing findings are not affected.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31036
- Related #26666, #2083

## User-visible / Behavior Changes

1. **New startup warnings**: When exec and sandbox configurations conflict, the gateway logs clear warnings at startup:
   - `tools.exec.ask is "off" but agents.defaults.sandbox.mode is "non-main"` — exec approval bypass won't apply to channel sessions
   - `tools.exec.security is "full" but sandbox.mode is not "off"` — sandbox overrides unrestricted exec
   - `tools.exec.host is "gateway" but sandbox.mode is "non-main"` — non-main sessions still route through sandbox
2. Each warning includes remediation guidance (what to change).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Apple M4)
- Runtime/container: Node.js 22+
- Model/provider: Any
- Integration/channel (if any): Telegram/Discord
- Relevant config (redacted): `{ "tools": { "exec": { "ask": "off" } }, "agents": { "defaults": { "sandbox": { "mode": "non-main" } } } }`

### Steps

1. Configure `tools.exec.ask: "off"` and `agents.defaults.sandbox.mode: "non-main"`
2. Start the gateway
3. Observe startup logs

### Expected

- Warning: `tools.exec.ask is "off" but agents.defaults.sandbox.mode is "non-main". Exec commands from channel sessions will still require approval via sandbox.`

### Actual

- Before this PR: No warning. Exec silently fails at runtime with "Approval required" timeout.
- After this PR: Clear warning at startup with remediation guidance.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test suite includes 6 test cases: exec.ask+sandbox, exec.security+sandbox, exec.host+sandbox, sandbox.mode=off (no conflict), default config (no conflict), and integration test via `logGatewayStartup`.

## Human Verification (required)

- Verified scenarios: Each of the 4 conflict patterns triggers the correct warning; no conflicts when sandbox.mode="off"; no conflicts with default config; warnings appear alongside dangerous flag warnings when both are present.
- Edge cases checked: Empty config object; config with only exec settings; config with only sandbox settings; multiple simultaneous conflicts.
- What you did **not** verify: Full end-to-end gateway startup in Docker with sandbox enabled (requires Docker runtime).

## Compatibility / Migration

- Backward compatible? `Yes` — additive warnings only. No behavior changes.
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the `collectConfigConflicts` call from `logGatewayStartup`. The function is isolated and has no side effects.
- Files/config to restore: `src/gateway/server-startup-log.ts`
- Known bad symptoms reviewers should watch for: False positives if `resolveSandboxConfigForAgent` default changes. The conflict checks use the resolved default, not hardcoded values.

## Risks and Mitigations

- Risk: False positives for intentional configurations where users want sandbox to override exec.
  - Mitigation: Warnings are informational, not errors. The gateway starts normally. Users who intentionally layer sandbox on top of exec can ignore the warning.
- Risk: `resolveSandboxConfigForAgent` import adds a dependency to the startup path.
  - Mitigation: The function is lightweight (pure config resolution, no I/O). Already used in security audit path.

