### PR TITLE
fix(signal): filter group admin and expiration timer events

### DIFF
--- a/src/signal/monitor/event-handler.group-admin.test.ts
+++ b/src/signal/monitor/event-handler.group-admin.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSignalEventHandler } from "./event-handler.js";
+import {
+  createBaseSignalEventHandlerDeps,
+  createSignalReceiveEvent,
+} from "./event-handler.test-harness.js";
+
+const { dispatchInboundMessageMock } = vi.hoisted(() => ({
+  dispatchInboundMessageMock: vi.fn(async () => ({
+    queuedFinal: false,
+    counts: { tool: 0, block: 0, final: 0 },
+  })),
+}));
+
+vi.mock("../send.js", () => ({
+  sendMessageSignal: vi.fn(),
+  sendTypingSignal: vi.fn().mockResolvedValue(true),
+  sendReadReceiptSignal: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../../auto-reply/dispatch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../auto-reply/dispatch.js")>();
+  return {
+    ...actual,
+    dispatchInboundMessage: dispatchInboundMessageMock,
+    dispatchInboundMessageWithDispatcher: dispatchInboundMessageMock,
+    dispatchInboundMessageWithBufferedDispatcher: dispatchInboundMessageMock,
+  };
+});
+
+vi.mock("../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: vi.fn().mockResolvedValue([]),
+  upsertChannelPairingRequest: vi.fn(),
+}));
+
+describe("signal group admin / settings event filtering", () => {
+  beforeEach(() => {
+    dispatchInboundMessageMock.mockClear();
+  });
+
+  it("drops group UPDATE events (admin actions)", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "Group name changed",
+          groupInfo: { groupId: "g1", groupName: "New Name", type: "UPDATE" },
+        },
+      }),
+    );
+
+    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("drops expiration timer update events", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: null,
+          isExpirationUpdate: true,
+          expiresInSeconds: 3600,
+          groupInfo: { groupId: "g1", groupName: "Test Group" },
+        },
+      }),
+    );
+
+    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("allows normal DELIVER group messages through", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "Hello everyone",
+          groupInfo: { groupId: "g1", groupName: "Test Group", type: "DELIVER" },
+        },
+      }),
+    );
+
+    expect(dispatchInboundMessageMock).toHaveBeenCalled();
+  });
+});

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -447,6 +447,17 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     }
 
     const dataMessage = envelope.dataMessage ?? envelope.editMessage?.dataMessage;
+
+    // Skip group admin/settings messages (member additions, permission changes, etc.).
+    if (dataMessage?.groupInfo?.type === "UPDATE") {
+      return;
+    }
+
+    // Skip expiration timer update messages (disappearing messages setting changes).
+    if (dataMessage?.isExpirationUpdate) {
+      return;
+    }
+
     const reaction = deps.isSignalReactionMessage(envelope.reactionMessage)
       ? envelope.reactionMessage
       : deps.isSignalReactionMessage(dataMessage?.reaction)

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -34,7 +34,7 @@ export type SignalDataMessage = {
   groupInfo?: {
     groupId?: string | null;
     groupName?: string | null;
-    type?: "DELIVER" | "UPDATE" | (string & {}) | null;
+    type?: "UPDATE" | "DELIVER" | "QUIT" | "REQUEST_INFO" | (string & {}) | null;
   } | null;
   quote?: { text?: string | null } | null;
   reaction?: SignalReactionMessage | null;

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -34,7 +34,7 @@ export type SignalDataMessage = {
   groupInfo?: {
     groupId?: string | null;
     groupName?: string | null;
-    type?: string | null;
+    type?: "DELIVER" | "UPDATE" | (string & {}) | null;
   } | null;
   quote?: { text?: string | null } | null;
   reaction?: SignalReactionMessage | null;

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -27,11 +27,14 @@ export type SignalMention = {
 export type SignalDataMessage = {
   timestamp?: number;
   message?: string | null;
+  expiresInSeconds?: number;
+  isExpirationUpdate?: boolean | null;
   attachments?: Array<SignalAttachment>;
   mentions?: Array<SignalMention> | null;
   groupInfo?: {
     groupId?: string | null;
     groupName?: string | null;
+    type?: string | null;
   } | null;
   quote?: { text?: string | null } | null;
   reaction?: SignalReactionMessage | null;


### PR DESCRIPTION
## Summary
- Group admin actions (member additions, permission changes, group name changes) were forwarded to the agent as regular messages
- Expiration timer updates (disappearing messages setting) also reached the agent
- Root cause: `SignalDataMessage` didn't model `groupInfo.type` or `isExpirationUpdate`, so the event handler couldn't filter them
- Added the missing type fields and early-return guards before message processing

## Test plan
- [x] Added 3 tests: drops UPDATE events, drops expiration updates, allows DELIVER through
- [x] All 103 Signal tests pass
- [ ] In a Signal group, change the group name or add a member — agent should not respond

Closes #30981

🤖 Generated with [Claude Code](https://claude.com/claude-code)