### PR TITLE
fix(discord): add autoHardBreaks config to fix newline rendering

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1354,6 +1354,8 @@ export const FIELD_HELP: Record<string, string> = {
   "channels.discord.commands.native": 'Override native commands for Discord (bool or "auto").',
   "channels.discord.commands.nativeSkills":
     'Override native skill commands for Discord (bool or "auto").',
+  "channels.discord.autoHardBreaks":
+    'Convert single newlines to Discord markdown hard breaks ("  \\n"). Preserves paragraph breaks and fenced code blocks. Default: false.',
   "channels.telegram.commands.native": 'Override native commands for Telegram (bool or "auto").',
   "channels.telegram.commands.nativeSkills":
     'Override native skill commands for Telegram (bool or "auto").',

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -699,6 +699,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.discord.proxy": "Discord Proxy URL",
   "channels.discord.commands.native": "Discord Native Commands",
   "channels.discord.commands.nativeSkills": "Discord Native Skill Commands",
+  "channels.discord.autoHardBreaks": "Discord Auto Hard Breaks",
   "channels.discord.streaming": "Discord Streaming Mode",
   "channels.discord.streamMode": "Discord Stream Mode (Legacy)",
   "channels.discord.draftChunk.minChars": "Discord Draft Chunk Min Chars",

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -214,6 +214,8 @@ export type DiscordAccountConfig = {
   textChunkLimit?: number;
   /** Chunking mode: "length" (default) splits by size; "newline" splits on every newline. */
   chunkMode?: "length" | "newline";
+  /** Convert single newlines to hard breaks (`"  \n"`) for Discord markdown rendering. */
+  autoHardBreaks?: boolean;
   /** Disable block streaming for this account. */
   blockStreaming?: boolean;
   /**

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -437,6 +437,7 @@ export const DiscordAccountSchema = z
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
+    autoHardBreaks: z.boolean().optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     // Canonical streaming mode. Legacy aliases (`streamMode`, boolean `streaming`) are auto-mapped.

--- a/src/discord/hard-breaks.test.ts
+++ b/src/discord/hard-breaks.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { applyDiscordAutoHardBreaks } from "./hard-breaks.js";
+
+describe("applyDiscordAutoHardBreaks", () => {
+  it("converts single newlines to markdown hard breaks", () => {
+    expect(applyDiscordAutoHardBreaks("alpha\nbeta\ngamma")).toBe("alpha  \nbeta  \ngamma");
+  });
+
+  it("preserves paragraph breaks", () => {
+    expect(applyDiscordAutoHardBreaks("alpha\n\nbeta")).toBe("alpha\n\nbeta");
+    expect(applyDiscordAutoHardBreaks("alpha\n \nbeta")).toBe("alpha\n \nbeta");
+  });
+
+  it("does not convert newlines inside fenced code blocks", () => {
+    const input = [
+      "alpha",
+      "beta",
+      "```ts",
+      "const a = 1;",
+      "const b = 2;",
+      "```",
+      "gamma",
+      "delta",
+    ].join("\n");
+    const expected = [
+      "alpha  ",
+      "beta",
+      "```ts",
+      "const a = 1;",
+      "const b = 2;",
+      "```",
+      "gamma  ",
+      "delta",
+    ].join("\n");
+    expect(applyDiscordAutoHardBreaks(input)).toBe(expected);
+  });
+});

--- a/src/discord/hard-breaks.ts
+++ b/src/discord/hard-breaks.ts
@@ -1,0 +1,88 @@
+type FenceState = {
+  inFence: boolean;
+  marker?: "`" | "~";
+  length?: number;
+};
+
+function parseFenceDelimiter(line: string): { marker: "`" | "~"; length: number } | undefined {
+  const trimmed = line.trimStart();
+  if (trimmed.length < 3) {
+    return undefined;
+  }
+  const first = trimmed[0];
+  if (first !== "`" && first !== "~") {
+    return undefined;
+  }
+  let length = 0;
+  while (trimmed[length] === first) {
+    length += 1;
+  }
+  if (length < 3) {
+    return undefined;
+  }
+  return {
+    marker: first,
+    length,
+  };
+}
+
+function nextFenceState(state: FenceState, line: string): FenceState {
+  const delimiter = parseFenceDelimiter(line);
+  if (!delimiter) {
+    return state;
+  }
+  if (!state.inFence) {
+    return {
+      inFence: true,
+      marker: delimiter.marker,
+      length: delimiter.length,
+    };
+  }
+  if (state.marker === delimiter.marker && delimiter.length >= (state.length ?? 3)) {
+    return { inFence: false };
+  }
+  return state;
+}
+
+function shouldConvertSingleNewline(
+  currentLine: string,
+  nextLine: string,
+  fenceStateAfterCurrentLine: FenceState,
+): boolean {
+  if (fenceStateAfterCurrentLine.inFence) {
+    return false;
+  }
+  if (!currentLine.trim() || !nextLine.trim()) {
+    return false;
+  }
+  if (parseFenceDelimiter(currentLine) || parseFenceDelimiter(nextLine)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Convert single newlines into hard breaks (`"  \n"`) for Discord markdown,
+ * while preserving paragraph breaks and fenced code blocks.
+ */
+export function applyDiscordAutoHardBreaks(text: string): string {
+  if (!text.includes("\n")) {
+    return text;
+  }
+  const lines = text.split("\n");
+  const output: string[] = [];
+  let fenceState: FenceState = { inFence: false };
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const currentLine = lines[index] ?? "";
+    output.push(currentLine);
+    if (index === lines.length - 1) {
+      continue;
+    }
+    const nextLine = lines[index + 1] ?? "";
+    fenceState = nextFenceState(fenceState, currentLine);
+    output.push(shouldConvertSingleNewline(currentLine, nextLine, fenceState) ? "  \n" : "\n");
+  }
+
+  return output.join("");
+}

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -15,6 +15,7 @@ import { extensionForMime } from "../media/mime.js";
 import type { PollInput } from "../polls.js";
 import { loadWebMediaRaw } from "../web/media.js";
 import { resolveDiscordAccount } from "./accounts.js";
+import { applyDiscordAutoHardBreaks } from "./hard-breaks.js";
 import {
   buildDiscordMessagePayload,
   buildDiscordSendError,
@@ -143,6 +144,9 @@ export async function sendMessageDiscord(
   });
   const chunkMode = resolveChunkMode(cfg, "discord", accountInfo.accountId);
   const textWithTables = convertMarkdownTables(text ?? "", tableMode);
+  const textWithDiscordLineBreaks = accountInfo.config.autoHardBreaks
+    ? applyDiscordAutoHardBreaks(textWithTables)
+    : textWithTables;
   const { token, rest, request } = createDiscordClient(opts, cfg);
   const recipient = await parseAndResolveRecipient(to, opts.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
@@ -152,7 +156,7 @@ export async function sendMessageDiscord(
 
   if (isForumLikeType(channelType)) {
     const threadName = deriveForumThreadName(textWithTables);
-    const chunks = buildDiscordTextChunks(textWithTables, {
+    const chunks = buildDiscordTextChunks(textWithDiscordLineBreaks, {
       maxLinesPerMessage: accountInfo.config.maxLinesPerMessage,
       chunkMode,
     });
@@ -262,7 +266,7 @@ export async function sendMessageDiscord(
       result = await sendDiscordMedia(
         rest,
         channelId,
-        textWithTables,
+        textWithDiscordLineBreaks,
         opts.mediaUrl,
         opts.mediaLocalRoots,
         opts.replyTo,
@@ -277,7 +281,7 @@ export async function sendMessageDiscord(
       result = await sendDiscordText(
         rest,
         channelId,
-        textWithTables,
+        textWithDiscordLineBreaks,
         opts.replyTo,
         request,
         accountInfo.config.maxLinesPerMessage,


### PR DESCRIPTION
Closes #30962

Discord renders single `\n` as spaces in bot messages, making multi-line agent output unreadable.

## Solution

Add `channels.discord.autoHardBreaks` config option (default: `false`) that converts single newlines to hard breaks (two spaces + newline) before sending to Discord.

### How it works
- Single `\n` → `  \n` (hard break)
- `\n\n` paragraph breaks preserved
- Newlines inside fenced code blocks preserved

### Config
```json
{"channels": {"discord": {"autoHardBreaks": true}}}
```

### Files changed
| File | Change |
|------|--------|
| `src/discord/hard-breaks.ts` | New — conversion logic |
| `src/discord/hard-breaks.test.ts` | New — 3 unit tests |
| `src/discord/send.outbound.ts` | Apply conversion in send pipeline |
| `src/config/types.discord.ts` | Add type |
| `src/config/zod-schema.providers-core.ts` | Zod validation |
| `src/config/schema.labels.ts` | UI label |
| `src/config/schema.help.ts` | Help text |