### PR TITLE
feat(telegram): add pin/unpin message actions

### DIFF
--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -13,6 +13,8 @@ const sendStickerTelegram = vi.fn(async () => ({
   chatId: "123",
 }));
 const deleteMessageTelegram = vi.fn(async () => ({ ok: true }));
+const pinMessageTelegram = vi.fn(async () => ({ ok: true }));
+const unpinMessageTelegram = vi.fn(async () => ({ ok: true }));
 let envSnapshot: ReturnType<typeof captureEnv>;
 
 vi.mock("../../telegram/send.js", () => ({
@@ -24,6 +26,10 @@ vi.mock("../../telegram/send.js", () => ({
     sendStickerTelegram(...args),
   deleteMessageTelegram: (...args: Parameters<typeof deleteMessageTelegram>) =>
     deleteMessageTelegram(...args),
+  pinMessageTelegram: (...args: Parameters<typeof pinMessageTelegram>) =>
+    pinMessageTelegram(...args),
+  unpinMessageTelegram: (...args: Parameters<typeof unpinMessageTelegram>) =>
+    unpinMessageTelegram(...args),
 }));
 
 describe("handleTelegramAction", () => {
@@ -67,6 +73,8 @@ describe("handleTelegramAction", () => {
     sendMessageTelegram.mockClear();
     sendStickerTelegram.mockClear();
     deleteMessageTelegram.mockClear();
+    pinMessageTelegram.mockClear();
+    unpinMessageTelegram.mockClear();
     process.env.TELEGRAM_BOT_TOKEN = "tok";
   });
 
@@ -415,6 +423,45 @@ describe("handleTelegramAction", () => {
         cfg,
       ),
     ).rejects.toThrow(/Telegram deleteMessage is disabled/);
+  });
+
+  it("pins a message", async () => {
+    const cfg = {
+      channels: { telegram: { botToken: "tok" } },
+    } as OpenClawConfig;
+    await handleTelegramAction(
+      {
+        action: "pinMessage",
+        chatId: "123",
+        messageId: 456,
+        disable_notification: true,
+      },
+      cfg,
+    );
+    expect(pinMessageTelegram).toHaveBeenCalledWith(
+      "123",
+      456,
+      expect.objectContaining({ token: "tok", disableNotification: true }),
+    );
+  });
+
+  it("unpins a message", async () => {
+    const cfg = {
+      channels: { telegram: { botToken: "tok" } },
+    } as OpenClawConfig;
+    await handleTelegramAction(
+      {
+        action: "unpinMessage",
+        chatId: "123",
+        messageId: 456,
+      },
+      cfg,
+    );
+    expect(unpinMessageTelegram).toHaveBeenCalledWith(
+      "123",
+      456,
+      expect.objectContaining({ token: "tok" }),
+    );
   });
 
   it("throws on missing bot token for sendMessage", async () => {

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -11,9 +11,11 @@ import {
   createForumTopicTelegram,
   deleteMessageTelegram,
   editMessageTelegram,
+  pinMessageTelegram,
   reactMessageTelegram,
   sendMessageTelegram,
   sendStickerTelegram,
+  unpinMessageTelegram,
 } from "../../telegram/send.js";
 import { getCacheStats, searchStickers } from "../../telegram/sticker-cache.js";
 import { resolveTelegramToken } from "../../telegram/token.js";
@@ -265,6 +267,57 @@ export async function handleTelegramAction(
       accountId: accountId ?? undefined,
     });
     return jsonResult({ ok: true, deleted: true });
+  }
+
+  if (action === "pinMessage") {
+    const chatId = readStringOrNumberParam(params, "chatId", {
+      required: true,
+    });
+    const messageId = readNumberParam(params, "messageId", {
+      required: true,
+      integer: true,
+    });
+    const disableNotification =
+      typeof params.disableNotification === "boolean"
+        ? params.disableNotification
+        : typeof params.disable_notification === "boolean"
+          ? params.disable_notification
+          : typeof params.silent === "boolean"
+            ? params.silent
+            : undefined;
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    await pinMessageTelegram(chatId ?? "", messageId ?? 0, {
+      token,
+      accountId: accountId ?? undefined,
+      disableNotification,
+    });
+    return jsonResult({ ok: true, pinned: true });
+  }
+
+  if (action === "unpinMessage") {
+    const chatId = readStringOrNumberParam(params, "chatId", {
+      required: true,
+    });
+    const messageId = readNumberParam(params, "messageId", {
+      required: true,
+      integer: true,
+    });
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    await unpinMessageTelegram(chatId ?? "", messageId ?? 0, {
+      token,
+      accountId: accountId ?? undefined,
+    });
+    return jsonResult({ ok: true, unpinned: true });
   }
 
   if (action === "editMessage") {

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -492,6 +492,8 @@ describe("telegramMessageActions", () => {
 
     for (const testCase of cases) {
       const actions = telegramMessageActions.listActions?.({ cfg: testCase.cfg }) ?? [];
+      expect(actions, testCase.name).toContain("pin");
+      expect(actions, testCase.name).toContain("unpin");
       if (testCase.expectSticker) {
         expect(actions, testCase.name).toContain("sticker");
         expect(actions, testCase.name).toContain("sticker-search");
@@ -550,6 +552,36 @@ describe("telegramMessageActions", () => {
           messageId: 42,
           content: "Updated",
           buttons: [],
+          accountId: undefined,
+        },
+      },
+      {
+        name: "pin maps to pinMessage",
+        action: "pin" as const,
+        params: {
+          chatId: "123",
+          messageId: 42,
+          silent: true,
+        },
+        expectedPayload: {
+          action: "pinMessage",
+          chatId: "123",
+          messageId: 42,
+          disableNotification: true,
+          accountId: undefined,
+        },
+      },
+      {
+        name: "unpin maps to unpinMessage",
+        action: "unpin" as const,
+        params: {
+          channelId: "123",
+          messageId: 42,
+        },
+        expectedPayload: {
+          action: "unpinMessage",
+          chatId: "123",
+          messageId: 42,
           accountId: undefined,
         },
       },

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -61,6 +61,19 @@ function readTelegramMessageIdParam(params: Record<string, unknown>): number {
   return messageId;
 }
 
+function readTelegramPinDisableNotification(params: Record<string, unknown>): boolean | undefined {
+  if (typeof params.disableNotification === "boolean") {
+    return params.disableNotification;
+  }
+  if (typeof params.disable_notification === "boolean") {
+    return params.disable_notification;
+  }
+  if (typeof params.silent === "boolean") {
+    return params.silent;
+  }
+  return undefined;
+}
+
 export const telegramMessageActions: ChannelMessageActionAdapter = {
   listActions: ({ cfg }) => {
     const accounts = listTokenSourcedAccounts(listEnabledTelegramAccounts(cfg));
@@ -76,7 +89,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     );
     const isEnabled = (key: keyof TelegramActionConfig, defaultValue = true) =>
       gate(key, defaultValue);
-    const actions = new Set<ChannelMessageActionName>(["send"]);
+    const actions = new Set<ChannelMessageActionName>(["send", "pin", "unpin"]);
     if (isEnabled("reactions")) {
       actions.add("react");
     }
@@ -146,6 +159,38 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
       return await handleTelegramAction(
         {
           action: "deleteMessage",
+          chatId,
+          messageId,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "pin") {
+      const chatId = readTelegramChatIdParam(params);
+      const messageId = readTelegramMessageIdParam(params);
+      const disableNotification = readTelegramPinDisableNotification(params);
+      return await handleTelegramAction(
+        {
+          action: "pinMessage",
+          chatId,
+          messageId,
+          disableNotification,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "unpin") {
+      const chatId = readTelegramChatIdParam(params);
+      const messageId = readTelegramMessageIdParam(params);
+      return await handleTelegramAction(
+        {
+          action: "unpinMessage",
           chatId,
           messageId,
           accountId: accountId ?? undefined,

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -806,6 +806,10 @@ type TelegramDeleteOpts = {
   retry?: RetryConfig;
 };
 
+type TelegramPinOpts = TelegramDeleteOpts & {
+  disableNotification?: boolean;
+};
+
 export async function deleteMessageTelegram(
   chatIdInput: string | number,
   messageIdInput: string | number,
@@ -830,6 +834,66 @@ export async function deleteMessageTelegram(
   });
   await requestWithDiag(() => api.deleteMessage(chatId, messageId), "deleteMessage");
   logVerbose(`[telegram] Deleted message ${messageId} from chat ${chatId}`);
+  return { ok: true };
+}
+
+export async function pinMessageTelegram(
+  chatIdInput: string | number,
+  messageIdInput: string | number,
+  opts: TelegramPinOpts = {},
+): Promise<{ ok: true }> {
+  const { cfg, account, api } = resolveTelegramApiContext(opts);
+  const rawTarget = String(chatIdInput);
+  const chatId = await resolveAndPersistChatId({
+    cfg,
+    api,
+    lookupTarget: rawTarget,
+    persistTarget: rawTarget,
+    verbose: opts.verbose,
+  });
+  const messageId = normalizeMessageId(messageIdInput);
+  const requestWithDiag = createTelegramRequestWithDiag({
+    cfg,
+    account,
+    retry: opts.retry,
+    verbose: opts.verbose,
+    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
+  });
+  await requestWithDiag(
+    () =>
+      api.pinChatMessage(chatId, messageId, {
+        disable_notification: opts.disableNotification === true,
+      }),
+    "pinChatMessage",
+  );
+  logVerbose(`[telegram] Pinned message ${messageId} in chat ${chatId}`);
+  return { ok: true };
+}
+
+export async function unpinMessageTelegram(
+  chatIdInput: string | number,
+  messageIdInput: string | number,
+  opts: TelegramDeleteOpts = {},
+): Promise<{ ok: true }> {
+  const { cfg, account, api } = resolveTelegramApiContext(opts);
+  const rawTarget = String(chatIdInput);
+  const chatId = await resolveAndPersistChatId({
+    cfg,
+    api,
+    lookupTarget: rawTarget,
+    persistTarget: rawTarget,
+    verbose: opts.verbose,
+  });
+  const messageId = normalizeMessageId(messageIdInput);
+  const requestWithDiag = createTelegramRequestWithDiag({
+    cfg,
+    account,
+    retry: opts.retry,
+    verbose: opts.verbose,
+    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
+  });
+  await requestWithDiag(() => api.unpinChatMessage(chatId, messageId), "unpinChatMessage");
+  logVerbose(`[telegram] Unpinned message ${messageId} in chat ${chatId}`);
   return { ok: true };
 }
 


### PR DESCRIPTION
Closes #30518

Add `pin` and `unpin` actions to the Telegram message tool.

## What it does

Agents can now programmatically pin/unpin messages in Telegram chats:

```json
{"action": "pin", "channel": "telegram", "messageId": "123", "target": "-100xxx"}
{"action": "unpin", "channel": "telegram", "messageId": "123", "target": "-100xxx"}
```

Pin supports `silent: true` to disable notification.

## Implementation

- `pinMessageTelegram()` / `unpinMessageTelegram()` in `src/telegram/send.ts`
- Wired into direct tool (`src/agents/tools/telegram-actions.ts`)
- Wired into plugin channel actions (`src/channels/plugins/actions/telegram.ts`)
- Full test coverage: 73 tests pass

## Files changed
| File | Change |
|------|--------|
| `src/telegram/send.ts` | New pin/unpin functions |
| `src/agents/tools/telegram-actions.ts` | Wire pin/unpin actions |
| `src/agents/tools/telegram-actions.test.ts` | Tests |
| `src/channels/plugins/actions/telegram.ts` | Plugin channel wiring |
| `src/channels/plugins/actions/actions.test.ts` | Tests |