### PR TITLE
fix(ui): stabilize chat item keys to prevent disappearing long messages

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -620,10 +620,16 @@ function messageKey(message: unknown): string {
   const timestamp = typeof m.timestamp === "number" ? m.timestamp : 0;
 
   let sig = "";
-  try {
-    sig = JSON.stringify(m).slice(0, 160);
-  } catch {
-    sig = typeof m.content === "string" ? m.content : JSON.stringify(m.content ?? "");
+  const content = m.content;
+
+  if (typeof content === "string") {
+    sig = content;
+  } else {
+    try {
+      sig = JSON.stringify(content ?? "");
+    } catch {
+      sig = Object.prototype.toString.call(content);
+    }
   }
 
   return `msg:${role}:${timestamp}:${sig.slice(0, 160)}`;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -529,6 +529,14 @@ function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
 
 function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   const items: ChatItem[] = [];
+
+  const keyCounts = new Map<string, number>();
+  const dedupeKey = (base: string): string => {
+    const next = (keyCounts.get(base) ?? 0) + 1;
+    keyCounts.set(base, next);
+    return next === 1 ? base : `${base}#${next}`;
+  };
+
   const history = Array.isArray(props.messages) ? props.messages : [];
   const tools = Array.isArray(props.toolMessages) ? props.toolMessages : [];
   const historyStart = Math.max(0, history.length - CHAT_HISTORY_RENDER_LIMIT);
@@ -567,7 +575,7 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
 
     items.push({
       kind: "message",
-      key: messageKey(msg),
+      key: dedupeKey(messageKey(msg)),
       message: msg,
     });
   }
@@ -575,7 +583,7 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
     for (let i = 0; i < tools.length; i++) {
       items.push({
         kind: "message",
-        key: messageKey(tools[i]),
+        key: dedupeKey(messageKey(tools[i])),
         message: tools[i],
       });
     }


### PR DESCRIPTION
## Summary

- **Problem:** In Webchat, long messages could disappear when a subsequent message was rendered, then reappear after page refresh.
- **Why it matters:** This breaks reading flow and creates user-visible instability in chat history.
- **What changed:** Stabilized chat item key generation in `ui/src/ui/views/chat.ts` by removing index-based key fallback and using deterministic message-derived fallback keys.
- **What did NOT change (scope boundary):** No gateway/protocol/backend logic changed; this PR only adjusts UI list keying behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31144

## User-visible / Behavior Changes

- Long assistant messages are less likely to disappear from the visible chat thread when a new message is appended immediately after.
- Chat history rendering is more stable across append/re-render cycles.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any Yes, explain risk + mitigation:
- N/A

## Repro + Verification

### Environment

- OS: Ubuntu (VM) + browser via tunnel
- Runtime/container: local dev
- Model/provider: N/A (UI rendering fix)
- Integration/channel (if any): Webchat UI
- Relevant config (redacted): default local gateway config

### Steps

1. Render a long assistant message in webchat.
2. Send/render a short follow-up immediately after.
3. Observe message list before and after refresh.

### Expected

- Previously rendered long message should remain visible when the next message appears.

### Actual

- Long message remains visible after follow-up append; no disappearance observed in manual check.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios:**
- Ran UI test: `pnpm --dir ui test src/ui/views/chat.test.ts`
- Result: `Test Files 1 passed (1), Tests 8 passed (8)`
- Manual webchat flow with long message + immediate short follow-up; long message stayed visible.
- **Edge cases checked:**
- Follow-up render append behavior
- Refresh behavior preserved transcript visibility
- **What you did not verify:**
- Full cross-browser matrix (single local browser path only)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
- N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Revert this PR commit.
- Files/config to restore:
- `ui/src/ui/views/chat.ts`
- Known bad symptoms reviewers should watch for:
- Message flicker/disappearance during append
- Regressions in grouping/render order

## Risks and Mitigations

- Risk: Deterministic fallback keys derived from message content could collide in rare cases with identical role/timestamp/content prefix.
- Mitigation: Primary key path still prefers explicit IDs (`toolCallId`, `id`, `messageId`); fallback only applies when IDs are absent.