### PR TITLE
fix: parse localized IDENTITY avatars and unblock heartbeat retries

### DIFF
--- a/src/agents/identity-file.test.ts
+++ b/src/agents/identity-file.test.ts
@@ -33,4 +33,15 @@ describe("parseIdentityMarkdown", () => {
       avatar: "avatars/openclaw.png",
     });
   });
+
+  it("parses avatar with full-width separators and localized labels", () => {
+    const content = `
+- **Avatar：** avatars/openclaw-en.png
+- **头像：**avatars/openclaw-zh.webp
+`;
+    const parsed = parseIdentityMarkdown(content);
+    expect(parsed).toEqual({
+      avatar: "avatars/openclaw-zh.webp",
+    });
+  });
 });

--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -19,6 +19,30 @@ const IDENTITY_PLACEHOLDER_VALUES = new Set([
   "workspace-relative path, http(s) url, or data uri",
 ]);
 
+function resolveIdentityLabel(raw: string): keyof AgentIdentityFile | null {
+  const normalized = raw.replace(/[*_]/g, "").trim().toLowerCase();
+  switch (normalized) {
+    case "name":
+    case "名字":
+    case "名称":
+      return "name";
+    case "emoji":
+    case "表情":
+      return "emoji";
+    case "creature":
+      return "creature";
+    case "vibe":
+      return "vibe";
+    case "theme":
+      return "theme";
+    case "avatar":
+    case "头像":
+      return "avatar";
+    default:
+      return null;
+  }
+}
+
 function normalizeIdentityValue(value: string): string {
   let normalized = value.trim();
   normalized = normalized.replace(/^[*_]+|[*_]+$/g, "").trim();
@@ -40,39 +64,22 @@ export function parseIdentityMarkdown(content: string): AgentIdentityFile {
   const lines = content.split(/\r?\n/);
   for (const line of lines) {
     const cleaned = line.trim().replace(/^\s*-\s*/, "");
-    const colonIndex = cleaned.indexOf(":");
-    if (colonIndex === -1) {
+    const match = cleaned.match(/^([^:：]+)\s*[:：]\s*(.+)$/);
+    if (!match) {
       continue;
     }
-    const label = cleaned.slice(0, colonIndex).replace(/[*_]/g, "").trim().toLowerCase();
-    const value = cleaned
-      .slice(colonIndex + 1)
-      .replace(/^[*_]+|[*_]+$/g, "")
-      .trim();
+    const label = resolveIdentityLabel(match[1] ?? "");
+    if (!label) {
+      continue;
+    }
+    const value = (match[2] ?? "").replace(/^[*_]+|[*_]+$/g, "").trim();
     if (!value) {
       continue;
     }
     if (isIdentityPlaceholder(value)) {
       continue;
     }
-    if (label === "name") {
-      identity.name = value;
-    }
-    if (label === "emoji") {
-      identity.emoji = value;
-    }
-    if (label === "creature") {
-      identity.creature = value;
-    }
-    if (label === "vibe") {
-      identity.vibe = value;
-    }
-    if (label === "theme") {
-      identity.theme = value;
-    }
-    if (label === "avatar") {
-      identity.avatar = value;
-    }
+    identity[label] = value;
   }
   return identity;
 }

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -157,10 +157,16 @@ describe("startHeartbeatRunner", () => {
     // First heartbeat returns requests-in-flight
     await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
     expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(runSpy.mock.calls[0]?.[0]).toEqual(expect.objectContaining({ reason: "interval" }));
 
-    // Timer should be rescheduled; next heartbeat should still fire
-    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    // Retry wake should run quickly and bypass interval due-time checks.
+    await vi.advanceTimersByTimeAsync(1_000);
     expect(runSpy).toHaveBeenCalledTimes(2);
+    expect(runSpy.mock.calls[1]?.[0]).toEqual(expect.objectContaining({ reason: "retry" }));
+
+    // Regular interval schedule still fires after the original cadence.
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+    expect(runSpy).toHaveBeenCalledTimes(3);
 
     runner.stop();
   });

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -59,7 +59,7 @@ describe("heartbeat-wake", () => {
     expect(hasPendingHeartbeatWake()).toBe(false);
   });
 
-  it("retries requests-in-flight after the default retry delay", async () => {
+  it("retries interval requests-in-flight after the default retry delay with reason=retry", async () => {
     vi.useFakeTimers();
     const handler = vi
       .fn()
@@ -68,7 +68,7 @@ describe("heartbeat-wake", () => {
     await expectRetryAfterDefaultDelay({
       handler,
       initialReason: "interval",
-      expectedRetryReason: "interval",
+      expectedRetryReason: "retry",
     });
   });
 

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -106,6 +106,11 @@ function queuePendingWakeReason(params?: {
   }
 }
 
+function resolveRetryWakeReason(reason?: string): string {
+  const normalized = normalizeWakeReason(reason);
+  return resolveHeartbeatReasonKind(normalized) === "interval" ? "retry" : normalized;
+}
+
 function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
   const delay = Number.isFinite(coalesceMs) ? Math.max(0, coalesceMs) : DEFAULT_COALESCE_MS;
   const dueAt = Date.now() + delay;
@@ -156,7 +161,9 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
         if (res.status === "skipped" && res.reason === "requests-in-flight") {
           // The main lane is busy; retry this wake target soon.
           queuePendingWakeReason({
-            reason: pendingWake.reason ?? "retry",
+            // Interval retries must downgrade to `retry`; keeping `interval`
+            // can be filtered as "not due" by the scheduler.
+            reason: resolveRetryWakeReason(pendingWake.reason),
             agentId: pendingWake.agentId,
             sessionKey: pendingWake.sessionKey,
           });
@@ -167,7 +174,7 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
       // Error is already logged by the heartbeat runner; schedule a retry.
       for (const pendingWake of pendingBatch) {
         queuePendingWakeReason({
-          reason: pendingWake.reason ?? "retry",
+          reason: resolveRetryWakeReason(pendingWake.reason),
           agentId: pendingWake.agentId,
           sessionKey: pendingWake.sessionKey,
         });


### PR DESCRIPTION
## Summary
- fix `parseIdentityMarkdown` to recognize full-width separators (`：`) and localized avatar labels (`头像`) so avatar paths in `IDENTITY.md` are parsed correctly
- add parser regression coverage for localized/full-width avatar lines
- fix heartbeat wake retry behavior: when an `interval` wake is skipped as `requests-in-flight`, retry with `reason=retry` instead of `reason=interval`
- add wake/runner tests to verify retry reason downgrade and that retries still execute promptly after busy-lane skips

## Why
- Addresses avatar parsing failure reported in #31216 (example: `- **头像：**avatars/...` was ignored)
- Prevents interval retries from being filtered as "not due" after a busy-lane skip, which can leave heartbeat runs stalled (symptom described in #31237)

## Testing
- `pnpm test src/agents/identity-file.test.ts src/agents/identity-avatar.test.ts src/gateway/assistant-identity.test.ts src/gateway/session-utils.test.ts src/infra/heartbeat-wake.test.ts src/infra/heartbeat-runner.scheduler.test.ts`

## Notes
- Includes two focused commits:
  - `Agent identity: parse localized avatar labels in IDENTITY.md`
  - `Heartbeat: downgrade interval retries to reason=retry`
