### PR TITLE
Feishu: encode non-ASCII upload filenames

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -171,6 +171,42 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
+  it("keeps ASCII file names unchanged for upload payload", async () => {
+    await sendMediaFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      mediaBuffer: Buffer.from("doc"),
+      fileName: "report.pdf",
+    });
+
+    expect(fileCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ file_name: "report.pdf" }),
+      }),
+    );
+  });
+
+  it("URL-encodes non-ASCII file names for upload payload", async () => {
+    const originalName = "测试文件—特殊字符（2026-03-02）.md";
+    const expectedEncodedName = encodeURIComponent(originalName).replace(
+      /[!'()*]/g,
+      (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+    );
+
+    await sendMediaFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      mediaBuffer: Buffer.from("doc"),
+      fileName: originalName,
+    });
+
+    expect(fileCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ file_name: expectedEncodedName }),
+      }),
+    );
+  });
+
   it("uses msg_type=file when replying with mp4", async () => {
     await sendMediaFeishu({
       cfg: {} as any,

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -160,6 +160,18 @@ export type SendMediaResult = {
   chatId: string;
 };
 
+function encodeFeishuUploadFileName(fileName: string): string {
+  // Keep ASCII filenames unchanged so existing behavior and display remain stable.
+  // Non-ASCII names can break multipart headers in Feishu upload requests.
+  if (/^[\x20-\x7E]+$/.test(fileName)) {
+    return fileName;
+  }
+  return encodeURIComponent(fileName).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
 /**
  * Upload an image to Feishu and get an image_key for sending.
  * Supports: JPEG, PNG, WEBP, GIF, TIFF, BMP, ICO
@@ -235,7 +247,7 @@ export async function uploadFileFeishu(params: {
   const response = await client.im.file.create({
     data: {
       file_type: fileType,
-      file_name: fileName,
+      file_name: encodeFeishuUploadFileName(fileName),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
       file: fileData as any,
       ...(duration !== undefined && { duration }),


### PR DESCRIPTION
## Summary
- encode non-ASCII Feishu upload file names before `im.file.create` multipart upload
- keep ASCII file names unchanged to preserve existing behavior
- add regression tests for both ASCII passthrough and non-ASCII encoding in `sendMediaFeishu`

## Why
Feishu uploads can fail for names containing non-ASCII characters (for example Chinese characters and em dash), resulting in broken file delivery behavior. Encoding the filename in the upload payload makes this path robust.

Fixes #31179

## AI assistance
- [x] AI-assisted (Codex)

## Testing level
- [x] Fully tested for touched area

### Local validation
- `pnpm exec vitest run extensions/feishu/src/media.test.ts`
