### PR TITLE
[Bug Fix] plugins CLI: preserve non-plugin config keys on write

### DIFF
--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { Command } from "commander";
 import type { OpenClawConfig } from "../config/config.js";
-import { loadConfig, writeConfigFile } from "../config/config.js";
+import { loadConfig, readConfigFileSnapshotForWrite, writeConfigFile } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { type BundledPluginSource, findBundledPluginSource } from "../plugins/bundled-sources.js";
@@ -144,6 +144,24 @@ function createPluginInstallLogger(): { info: (msg: string) => void; warn: (msg:
   };
 }
 
+async function loadPluginsConfigForWriteOrExit(): Promise<{
+  config: OpenClawConfig;
+  writeOptions: Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>["writeOptions"];
+}> {
+  const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+  if (!snapshot.valid) {
+    defaultRuntime.error(`Config invalid at ${shortenHomePath(snapshot.path)}.`);
+    for (const issue of snapshot.issues) {
+      defaultRuntime.error(`- ${issue.path || "<root>"}: ${issue.message}`);
+    }
+    defaultRuntime.error("Run `openclaw doctor` to repair, then retry.");
+    process.exit(1);
+  }
+  return {
+    config: structuredClone(snapshot.resolved),
+    writeOptions,
+  };
+}
 function logSlotWarnings(warnings: string[]) {
   if (warnings.length === 0) {
     return;
@@ -552,12 +570,12 @@ export function registerPluginsCli(program: Command) {
     .description("Enable a plugin in config")
     .argument("<id>", "Plugin id")
     .action(async (id: string) => {
-      const cfg = loadConfig();
+      const { config: cfg, writeOptions } = await loadPluginsConfigForWriteOrExit();
       const enableResult = enablePluginInConfig(cfg, id);
       let next: OpenClawConfig = enableResult.config;
       const slotResult = applySlotSelectionForPlugin(next, id);
       next = slotResult.config;
-      await writeConfigFile(next);
+      await writeConfigFile(next, writeOptions);
       logSlotWarnings(slotResult.warnings);
       if (enableResult.enabled) {
         defaultRuntime.log(`Enabled plugin "${id}". Restart the gateway to apply.`);
@@ -575,9 +593,9 @@ export function registerPluginsCli(program: Command) {
     .description("Disable a plugin in config")
     .argument("<id>", "Plugin id")
     .action(async (id: string) => {
-      const cfg = loadConfig();
+      const { config: cfg, writeOptions } = await loadPluginsConfigForWriteOrExit();
       const next = setPluginEnabledInConfig(cfg, id, false);
-      await writeConfigFile(next);
+      await writeConfigFile(next, writeOptions);
       defaultRuntime.log(`Disabled plugin "${id}". Restart the gateway to apply.`);
     });
 
@@ -590,7 +608,7 @@ export function registerPluginsCli(program: Command) {
     .option("--force", "Skip confirmation prompt", false)
     .option("--dry-run", "Show what would be removed without making changes", false)
     .action(async (id: string, opts: PluginUninstallOptions) => {
-      const cfg = loadConfig();
+      const { config: cfg, writeOptions } = await loadPluginsConfigForWriteOrExit();
       const report = buildPluginStatusReport({ config: cfg });
       const extensionsDir = path.join(resolveStateDir(process.env, os.homedir), "extensions");
       const keepFiles = Boolean(opts.keepFiles || opts.keepConfig);
@@ -688,7 +706,7 @@ export function registerPluginsCli(program: Command) {
         defaultRuntime.log(theme.warn(warning));
       }
 
-      await writeConfigFile(result.config);
+      await writeConfigFile(result.config, writeOptions);
 
       const removed: string[] = [];
       if (result.actions.entry) {
@@ -733,7 +751,7 @@ export function registerPluginsCli(program: Command) {
     .option("--all", "Update all tracked plugins", false)
     .option("--dry-run", "Show what would change without writing", false)
     .action(async (id: string | undefined, opts: PluginUpdateOptions) => {
-      const cfg = loadConfig();
+      const { config: cfg, writeOptions } = await loadPluginsConfigForWriteOrExit();
       const installs = cfg.plugins?.installs ?? {};
       const targets = opts.all ? Object.keys(installs) : id ? [id] : [];
 
@@ -783,7 +801,7 @@ export function registerPluginsCli(program: Command) {
       }
 
       if (!opts.dryRun && result.changed) {
-        await writeConfigFile(result.config);
+        await writeConfigFile(result.config, writeOptions);
         defaultRuntime.log("Restart the gateway to load plugins.");
       }
     });

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -162,6 +162,11 @@ async function loadPluginsConfigForWriteOrExit(): Promise<{
     writeOptions,
   };
 }
+
+type PluginsConfigWriteOptions = Awaited<
+  ReturnType<typeof readConfigFileSnapshotForWrite>
+>["writeOptions"];
+
 function logSlotWarnings(warnings: string[]) {
   if (warnings.length === 0) {
     return;
@@ -173,6 +178,7 @@ function logSlotWarnings(warnings: string[]) {
 
 async function installBundledPluginSource(params: {
   config: OpenClawConfig;
+  writeOptions: PluginsConfigWriteOptions;
   rawSpec: string;
   bundledSource: BundledPluginSource;
   warning: string;
@@ -207,7 +213,7 @@ async function installBundledPluginSource(params: {
   });
   const slotResult = applySlotSelectionForPlugin(next, params.bundledSource.pluginId);
   next = slotResult.config;
-  await writeConfigFile(next);
+  await writeConfigFile(next, params.writeOptions);
   logSlotWarnings(slotResult.warnings);
   defaultRuntime.log(theme.warn(params.warning));
   defaultRuntime.log(`Installed plugin: ${params.bundledSource.pluginId}`);
@@ -226,7 +232,7 @@ async function runPluginInstallCommand(params: {
   }
   const normalized = fileSpec && fileSpec.ok ? fileSpec.path : raw;
   const resolved = resolveUserPath(normalized);
-  const cfg = loadConfig();
+  const { config: cfg, writeOptions } = await loadPluginsConfigForWriteOrExit();
 
   if (fs.existsSync(resolved)) {
     if (opts.link) {
@@ -260,7 +266,7 @@ async function runPluginInstallCommand(params: {
       });
       const slotResult = applySlotSelectionForPlugin(next, probe.pluginId);
       next = slotResult.config;
-      await writeConfigFile(next);
+      await writeConfigFile(next, writeOptions);
       logSlotWarnings(slotResult.warnings);
       defaultRuntime.log(`Linked plugin path: ${shortenHomePath(resolved)}`);
       defaultRuntime.log(`Restart the gateway to load plugins.`);
@@ -290,7 +296,7 @@ async function runPluginInstallCommand(params: {
     });
     const slotResult = applySlotSelectionForPlugin(next, result.pluginId);
     next = slotResult.config;
-    await writeConfigFile(next);
+    await writeConfigFile(next, writeOptions);
     logSlotWarnings(slotResult.warnings);
     defaultRuntime.log(`Installed plugin: ${result.pluginId}`);
     defaultRuntime.log(`Restart the gateway to load plugins.`);
@@ -325,6 +331,7 @@ async function runPluginInstallCommand(params: {
   if (bundledPreNpmPlan) {
     await installBundledPluginSource({
       config: cfg,
+      writeOptions,
       rawSpec: raw,
       bundledSource: bundledPreNpmPlan.bundledSource,
       warning: bundledPreNpmPlan.warning,
@@ -349,6 +356,7 @@ async function runPluginInstallCommand(params: {
 
     await installBundledPluginSource({
       config: cfg,
+      writeOptions,
       rawSpec: raw,
       bundledSource: bundledFallbackPlan.bundledSource,
       warning: bundledFallbackPlan.warning,
@@ -374,7 +382,7 @@ async function runPluginInstallCommand(params: {
   });
   const slotResult = applySlotSelectionForPlugin(next, result.pluginId);
   next = slotResult.config;
-  await writeConfigFile(next);
+  await writeConfigFile(next, writeOptions);
   logSlotWarnings(slotResult.warnings);
   defaultRuntime.log(`Installed plugin: ${result.pluginId}`);
   defaultRuntime.log(`Restart the gateway to load plugins.`);

--- a/src/cli/plugins-cli.write-snapshot.test.ts
+++ b/src/cli/plugins-cli.write-snapshot.test.ts
@@ -1,0 +1,157 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const writeOptions = {
+    expectedConfigPath: "/tmp/openclaw.json",
+    envSnapshotForRestore: { TEST_ENV: "1" },
+  };
+  return {
+    writeOptions,
+    loadConfig: vi.fn(() => ({})),
+    readConfigFileSnapshotForWrite: vi.fn(async () => ({
+      snapshot: {
+        valid: true,
+        path: "/tmp/openclaw.json",
+        resolved: { channels: { telegram: { dmPolicy: "open" } }, plugins: {} },
+        issues: [],
+      },
+      writeOptions,
+    })),
+    writeConfigFile: vi.fn(async () => {}),
+    setPluginEnabledInConfig: vi.fn(
+      (cfg: Record<string, unknown>, id: string, enabled: boolean) => ({
+        ...cfg,
+        plugins: { entries: { [id]: { enabled } } },
+      }),
+    ),
+    resolveStateDir: vi.fn(() => "/tmp/state"),
+    buildPluginStatusReport: vi.fn(() => ({ plugins: [], diagnostics: [], workspaceDir: "/tmp" })),
+    theme: {
+      muted: (s: string) => s,
+      heading: (s: string) => s,
+      success: (s: string) => s,
+      warn: (s: string) => s,
+      error: (s: string) => s,
+      command: (s: string) => s,
+    },
+    runtime: {
+      log: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+  readConfigFileSnapshotForWrite: mocks.readConfigFileSnapshotForWrite,
+  writeConfigFile: mocks.writeConfigFile,
+}));
+
+vi.mock("../config/paths.js", () => ({
+  resolveStateDir: mocks.resolveStateDir,
+}));
+
+vi.mock("./plugins-config.js", () => ({
+  setPluginEnabledInConfig: mocks.setPluginEnabledInConfig,
+}));
+
+vi.mock("../plugins/status.js", () => ({
+  buildPluginStatusReport: mocks.buildPluginStatusReport,
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+vi.mock("../terminal/theme.js", () => ({
+  theme: mocks.theme,
+}));
+
+vi.mock("../terminal/links.js", () => ({
+  formatDocsLink: () => "docs",
+}));
+
+vi.mock("../terminal/table.js", () => ({
+  renderTable: () => "",
+}));
+
+vi.mock("../plugins/enable.js", () => ({
+  enablePluginInConfig: (cfg: Record<string, unknown>) => ({ config: cfg, enabled: true }),
+}));
+
+vi.mock("../plugins/install.js", () => ({
+  installPluginFromNpmSpec: vi.fn(),
+  installPluginFromPath: vi.fn(),
+}));
+
+vi.mock("../plugins/installs.js", () => ({
+  recordPluginInstall: (cfg: Record<string, unknown>) => cfg,
+}));
+
+vi.mock("../plugins/manifest-registry.js", () => ({
+  clearPluginManifestRegistryCache: vi.fn(),
+}));
+
+vi.mock("../plugins/slots.js", () => ({
+  applyExclusiveSlotSelection: ({ config }: { config: Record<string, unknown> }) => ({
+    config,
+    warnings: [],
+  }),
+}));
+
+vi.mock("../plugins/source-display.js", () => ({
+  resolvePluginSourceRoots: vi.fn(() => ({})),
+  formatPluginSourceForTable: vi.fn(() => ({ value: "", rootKey: null })),
+}));
+
+vi.mock("../plugins/uninstall.js", () => ({
+  resolveUninstallDirectoryTarget: vi.fn(() => null),
+  uninstallPlugin: vi.fn(),
+}));
+
+vi.mock("../plugins/update.js", () => ({
+  updateNpmInstalledPlugins: vi.fn(),
+}));
+
+vi.mock("../utils.js", () => ({
+  resolveUserPath: (s: string) => s,
+  shortenHomeInString: (s: string) => s,
+  shortenHomePath: (s: string) => s,
+}));
+
+vi.mock("./npm-resolution.js", () => ({
+  resolvePinnedNpmInstallRecordForCli: vi.fn(() => ({})),
+}));
+
+vi.mock("./prompt.js", () => ({
+  promptYesNo: vi.fn(async () => true),
+}));
+
+import { registerPluginsCli } from "./plugins-cli.js";
+
+describe("plugins-cli config writes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses readConfigFileSnapshotForWrite + write options for disable", async () => {
+    const program = new Command();
+    registerPluginsCli(program);
+
+    await program.parseAsync(["plugins", "disable", "demo"], {
+      from: "user",
+    });
+
+    expect(mocks.readConfigFileSnapshotForWrite).toHaveBeenCalledTimes(1);
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+    expect(mocks.writeConfigFile).toHaveBeenCalledTimes(1);
+    expect(mocks.writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channels: { telegram: { dmPolicy: "open" } },
+        plugins: { entries: { demo: { enabled: false } } },
+      }),
+      mocks.writeOptions,
+    );
+  });
+});

--- a/src/cli/plugins-cli.write-snapshot.test.ts
+++ b/src/cli/plugins-cli.write-snapshot.test.ts
@@ -19,6 +19,14 @@ const mocks = vi.hoisted(() => {
       writeOptions,
     })),
     writeConfigFile: vi.fn(async () => {}),
+    enablePluginInConfig: vi.fn(
+      (
+        cfg: Record<string, unknown>,
+      ): { config: Record<string, unknown>; enabled: boolean; reason?: string } => ({
+        config: cfg,
+        enabled: true,
+      }),
+    ),
     setPluginEnabledInConfig: vi.fn(
       (cfg: Record<string, unknown>, id: string, enabled: boolean) => ({
         ...cfg,
@@ -77,7 +85,7 @@ vi.mock("../terminal/table.js", () => ({
 }));
 
 vi.mock("../plugins/enable.js", () => ({
-  enablePluginInConfig: (cfg: Record<string, unknown>) => ({ config: cfg, enabled: true }),
+  enablePluginInConfig: mocks.enablePluginInConfig,
 }));
 
 vi.mock("../plugins/install.js", () => ({
@@ -152,6 +160,37 @@ describe("plugins-cli config writes", () => {
         plugins: { entries: { demo: { enabled: false } } },
       }),
       mocks.writeOptions,
+    );
+  });
+
+  it("preserves enable guard behavior and logs warning when enable is denied", async () => {
+    mocks.enablePluginInConfig.mockReturnValueOnce({
+      config: { channels: { telegram: { dmPolicy: "open" } }, plugins: {} },
+      enabled: false,
+      reason: "blocked by denylist",
+    });
+    const program = new Command();
+    registerPluginsCli(program);
+
+    await program.parseAsync(["plugins", "enable", "demo"], {
+      from: "user",
+    });
+
+    expect(mocks.readConfigFileSnapshotForWrite).toHaveBeenCalledTimes(1);
+    expect(mocks.enablePluginInConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channels: { telegram: { dmPolicy: "open" } },
+      }),
+      "demo",
+    );
+    expect(mocks.writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channels: { telegram: { dmPolicy: "open" } },
+      }),
+      mocks.writeOptions,
+    );
+    expect(mocks.runtime.log).toHaveBeenCalledWith(
+      'Plugin "demo" could not be enabled (blocked by denylist).',
     );
   });
 });

--- a/src/cli/plugins-cli.write-snapshot.test.ts
+++ b/src/cli/plugins-cli.write-snapshot.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -35,6 +36,8 @@ const mocks = vi.hoisted(() => {
     ),
     resolveStateDir: vi.fn(() => "/tmp/state"),
     buildPluginStatusReport: vi.fn(() => ({ plugins: [], diagnostics: [], workspaceDir: "/tmp" })),
+    installPluginFromNpmSpec: vi.fn(),
+    installPluginFromPath: vi.fn(),
     theme: {
       muted: (s: string) => s,
       heading: (s: string) => s,
@@ -89,8 +92,8 @@ vi.mock("../plugins/enable.js", () => ({
 }));
 
 vi.mock("../plugins/install.js", () => ({
-  installPluginFromNpmSpec: vi.fn(),
-  installPluginFromPath: vi.fn(),
+  installPluginFromNpmSpec: mocks.installPluginFromNpmSpec,
+  installPluginFromPath: mocks.installPluginFromPath,
 }));
 
 vi.mock("../plugins/installs.js", () => ({
@@ -192,5 +195,43 @@ describe("plugins-cli config writes", () => {
     expect(mocks.runtime.log).toHaveBeenCalledWith(
       'Plugin "demo" could not be enabled (blocked by denylist).',
     );
+  });
+
+  it("uses readConfigFileSnapshotForWrite + write options for install --link", async () => {
+    const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    try {
+      mocks.installPluginFromPath.mockResolvedValueOnce({
+        ok: true,
+        pluginId: "demo",
+        version: "1.2.3",
+      });
+
+      const program = new Command();
+      registerPluginsCli(program);
+
+      await program.parseAsync(["plugins", "install", "--link", "/some/path"], {
+        from: "user",
+      });
+
+      expect(mocks.readConfigFileSnapshotForWrite).toHaveBeenCalledTimes(1);
+      expect(mocks.loadConfig).not.toHaveBeenCalled();
+      expect(mocks.installPluginFromPath).toHaveBeenCalledWith({
+        path: "/some/path",
+        dryRun: true,
+      });
+      expect(mocks.writeConfigFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channels: { telegram: { dmPolicy: "open" } },
+          plugins: expect.objectContaining({
+            load: {
+              paths: ["/some/path"],
+            },
+          }),
+        }),
+        mocks.writeOptions,
+      );
+    } finally {
+      existsSpy.mockRestore();
+    }
   });
 });

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -193,6 +193,39 @@ describe("removePluginFromConfig", () => {
     expect(actions.loadPath).toBe(true);
   });
 
+  it("removes linked path from load.paths when sourcePath uses a different spelling", () => {
+    const homeDir = path.join(os.tmpdir(), "openclaw-uninstall-home");
+    const config: OpenClawConfig = {
+      plugins: {
+        installs: {
+          "my-plugin": {
+            source: "path",
+            sourcePath: "~/plugins/my-plugin",
+            installPath: "~/plugins/my-plugin",
+          },
+        },
+        load: {
+          paths: [path.join(homeDir, "plugins", "my-plugin"), "/other/path"],
+        },
+      },
+    };
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = homeDir;
+    try {
+      const { config: result, actions } = removePluginFromConfig(config, "my-plugin");
+
+      expect(result.plugins?.load?.paths).toEqual(["/other/path"]);
+      expect(actions.loadPath).toBe(true);
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+    }
+  });
+
   it("clears memory slot when uninstalling active memory plugin", () => {
     const config: OpenClawConfig = {
       plugins: {

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { resolveUserPath } from "../utils.js";
 import { resolvePluginInstallDir } from "./install.js";
 import { defaultSlotIdForKey } from "./slots.js";
 
@@ -66,6 +67,13 @@ export function removePluginFromConfig(
   cfg: OpenClawConfig,
   pluginId: string,
 ): { config: OpenClawConfig; actions: Omit<UninstallActions, "directory"> } {
+  const pathsEqual = (left: string | undefined, right: string | undefined): boolean => {
+    if (!left || !right) {
+      return false;
+    }
+    return resolveUserPath(left) === resolveUserPath(right);
+  };
+
   const actions: Omit<UninstallActions, "directory"> = {
     entry: false,
     install: false,
@@ -108,8 +116,8 @@ export function removePluginFromConfig(
   if (installRecord?.source === "path" && installRecord.sourcePath) {
     const sourcePath = installRecord.sourcePath;
     const loadPaths = load?.paths;
-    if (Array.isArray(loadPaths) && loadPaths.includes(sourcePath)) {
-      const nextLoadPaths = loadPaths.filter((p) => p !== sourcePath);
+    if (Array.isArray(loadPaths) && loadPaths.some((entry) => pathsEqual(entry, sourcePath))) {
+      const nextLoadPaths = loadPaths.filter((entry) => !pathsEqual(entry, sourcePath));
       load = nextLoadPaths.length > 0 ? { ...load, paths: nextLoadPaths } : undefined;
       actions.loadPath = true;
     }

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const installPluginFromNpmSpecMock = vi.fn();
@@ -155,6 +158,60 @@ describe("updateNpmInstalledPlugins", () => {
         message: "Failed to check bad: unsupported npm spec: github:evil/evil",
       },
     ]);
+  });
+
+  it("normalizes tilde install paths before reading the installed version", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-home-"));
+    const installDir = path.join(homeDir, "plugins", "demo");
+    await fs.mkdir(installDir, { recursive: true });
+    await fs.writeFile(
+      path.join(installDir, "package.json"),
+      JSON.stringify({ version: "1.2.3" }),
+      "utf-8",
+    );
+
+    installPluginFromNpmSpecMock.mockResolvedValue({
+      ok: true,
+      pluginId: "demo",
+      targetDir: installDir,
+      version: "1.2.3",
+      extensions: ["index.js"],
+    });
+
+    try {
+      const { updateNpmInstalledPlugins } = await import("./update.js");
+      const result = await updateNpmInstalledPlugins({
+        config: {
+          plugins: {
+            installs: {
+              demo: {
+                source: "npm",
+                spec: "demo@1.2.3",
+                installPath: "~/plugins/demo",
+              },
+            },
+          },
+        },
+        pluginIds: ["demo"],
+        dryRun: true,
+        env: {
+          ...process.env,
+          HOME: homeDir,
+        },
+      });
+
+      expect(result.outcomes).toEqual([
+        {
+          pluginId: "demo",
+          status: "unchanged",
+          currentVersion: "1.2.3",
+          nextVersion: "1.2.3",
+          message: "demo is up to date (1.2.3).",
+        },
+      ]);
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -204,9 +204,11 @@ export async function updateNpmInstalledPlugins(params: {
   pluginIds?: string[];
   skipIds?: Set<string>;
   dryRun?: boolean;
+  env?: NodeJS.ProcessEnv;
   onIntegrityDrift?: (params: PluginUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
 }): Promise<PluginUpdateSummary> {
   const logger = params.logger ?? {};
+  const env = params.env ?? process.env;
   const installs = params.config.plugins?.installs ?? {};
   const targets = params.pluginIds?.length ? params.pluginIds : Object.keys(installs);
   const outcomes: PluginUpdateOutcome[] = [];
@@ -253,7 +255,7 @@ export async function updateNpmInstalledPlugins(params: {
 
     let installPath: string;
     try {
-      installPath = record.installPath ?? resolvePluginInstallDir(pluginId);
+      installPath = resolveUserPath(record.installPath ?? resolvePluginInstallDir(pluginId), env);
     } catch (err) {
       outcomes.push({
         pluginId,


### PR DESCRIPTION
## Summary
Fix plugin CLI config writes so `plugins` operations preserve unrelated config keys.

This changes `openclaw plugins` commands that mutate config (`enable`, `disable`, `install`, `uninstall`, `update`) to:
- load from `readConfigFileSnapshotForWrite()`
- mutate `snapshot.resolved`
- pass returned `writeOptions` into `writeConfigFile`

This avoids writing from runtime-normalized config objects and reduces risk of non-plugin key clobbering during plugin operations.

Closes #31251.

## AI-Assisted Disclosure
This PR is AI-assisted. I reviewed and tested the resulting code before submitting.

## Testing
Degree: fully tested

- `pnpm check`
- `pnpm -s vitest src/cli/plugins-cli.write-snapshot.test.ts src/plugins/uninstall.test.ts src/plugins/install.test.ts`
- Manual repro in isolated temp config:
  - `plugins install --link` + `plugins uninstall --force --keep-files`
  - verified `channels.telegram.dmPolicy` remained `open` across operations

## Notes
A full-suite `pnpm test` run in this environment hit an unrelated timeout/OOM path in `src/commands/sandbox-explain.test.ts` under parallel load; isolated rerun of that test passes.
