### PR TITLE
feat(matrix): hot-reload DM and group allowlists without restart

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -15,6 +15,9 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
       .mockImplementation((ctx: Record<string, unknown>) => ctx);
 
     const core = {
+      config: {
+        loadConfig: vi.fn().mockReturnValue({}),
+      },
       channel: {
         pairing: {
           readAllowFromStore: vi.fn().mockResolvedValue([]),

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -7,6 +7,7 @@ import {
   formatAllowlistMatchMeta,
   logInboundDrop,
   logTypingFailure,
+  mergeAllowlist,
   resolveControlCommandGate,
   type PluginRuntime,
   type RuntimeEnv,
@@ -233,14 +234,23 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         senderId,
         senderUsername,
       });
-      const groupAllowFrom = cfg.channels?.matrix?.groupAllowFrom ?? [];
+      // Hot-reload: re-read allowlists from the live config so new entries added
+      // after startup take effect without a restart.  Display-name entries are only
+      // resolved at startup; hot-reloaded entries must be full Matrix IDs (@user:server).
+      const liveConfig = core.config.loadConfig() as CoreConfig;
+      const liveDmAllowFrom = (liveConfig.channels?.matrix?.dm?.allowFrom ?? []).map(String);
+      const effectiveDmAllowFrom = mergeAllowlist({
+        existing: allowFrom,
+        additions: liveDmAllowFrom,
+      });
+      const groupAllowFrom = (liveConfig.channels?.matrix?.groupAllowFrom ?? []).map(String);
       const { access, effectiveAllowFrom, effectiveGroupAllowFrom, groupAllowConfigured } =
         await resolveMatrixAccessState({
           isDirectMessage,
           resolvedAccountId,
           dmPolicy,
           groupPolicy,
-          allowFrom,
+          allowFrom: effectiveDmAllowFrom,
           groupAllowFrom,
           senderId,
           readStoreForDmPolicy: pairing.readStoreForDmPolicy,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -14,6 +14,7 @@ import {
   type RuntimeLogger,
 } from "openclaw/plugin-sdk/matrix";
 import type { CoreConfig, MatrixRoomConfig, ReplyToMode } from "../../types.js";
+import { resolveMatrixAccountConfig } from "../accounts.js";
 import { fetchEventSummary } from "../actions/summary.js";
 import {
   formatPollAsText,
@@ -237,13 +238,23 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       // Hot-reload: re-read allowlists from the live config so new entries added
       // after startup take effect without a restart.  Display-name entries are only
       // resolved at startup; hot-reloaded entries must be full Matrix IDs (@user:server).
+      // We resolve the per-account config so multi-account deployments pick up
+      // account-specific allowlist edits (not just the top-level defaults).
       const liveConfig = core.config.loadConfig() as CoreConfig;
-      const liveDmAllowFrom = (liveConfig.channels?.matrix?.dm?.allowFrom ?? []).map(String);
+      const liveAccountConfig = resolveMatrixAccountConfig({
+        cfg: liveConfig,
+        accountId,
+      });
+      const liveDmAllowFrom = (liveAccountConfig.dm?.allowFrom ?? []).map(String);
       const effectiveDmAllowFrom = mergeAllowlist({
         existing: allowFrom,
         additions: liveDmAllowFrom,
       });
-      const groupAllowFrom = (liveConfig.channels?.matrix?.groupAllowFrom ?? []).map(String);
+      const liveGroupAllowFrom = (liveAccountConfig.groupAllowFrom ?? []).map(String);
+      const groupAllowFrom = mergeAllowlist({
+        existing: (cfg.channels?.matrix?.groupAllowFrom ?? []).map(String),
+        additions: liveGroupAllowFrom,
+      });
       const { access, effectiveAllowFrom, effectiveGroupAllowFrom, groupAllowConfigured } =
         await resolveMatrixAccessState({
           isDirectMessage,


### PR DESCRIPTION
## Summary
- Matrix DM/group allowlists (`dm.allowFrom`, `groupAllowFrom`) were resolved once at startup and captured in a closure — changes required a full gateway restart
- Now re-reads the live config via `core.config.loadConfig()` on each inbound message and merges with startup-resolved entries using `mergeAllowlist()`
- Hot-reloaded entries must be full Matrix IDs (`@user:server`) since display-name resolution only runs at startup — this is a known trade-off documented in the code comments

## Test plan
- [x] All 92 Matrix tests pass
- [x] Fixed existing test mock to include `core.config.loadConfig()`
- [ ] Add `@newuser:matrix.org` to `dm.allowFrom` in config while gateway is running — verify new user can DM the bot without restart

Closes #30665

🤖 Generated with [Claude Code](https://claude.com/claude-code)