### PR TITLE
Discord: guard message:received hook session keys

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1504,6 +1504,37 @@ describe("dispatchReplyFromConfig", () => {
     expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
   });
 
+  it("uses CommandTargetSessionKey for internal message:received hooks when SessionKey is missing", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: undefined,
+      CommandSource: "native",
+      CommandTargetSessionKey: "agent:main:discord:channel:c1",
+      CommandBody: "hello",
+      MessageSid: "msg-99",
+    });
+
+    const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledWith(
+      "message",
+      "received",
+      "agent:main:discord:channel:c1",
+      expect.objectContaining({
+        from: ctx.From,
+        content: "hello",
+        channelId: "discord",
+        messageId: "msg-99",
+      }),
+    );
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
+  });
+
   it("skips internal message:received hook when session key is unavailable", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -177,6 +177,7 @@ export async function dispatchReplyFromConfig(params: {
           : "";
   const channelId = (ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "").toLowerCase();
   const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
+  const hookSessionKey = ctx.SessionKey?.trim() || ctx.CommandTargetSessionKey?.trim() || undefined;
 
   // Trigger plugin hooks (fire-and-forget)
   if (hookRunner?.hasHooks("message_received")) {
@@ -214,9 +215,9 @@ export async function dispatchReplyFromConfig(params: {
   }
 
   // Bridge to internal hooks (HOOK.md discovery system) - refs #8807
-  if (sessionKey) {
+  if (hookSessionKey) {
     void triggerInternalHook(
-      createInternalHookEvent("message", "received", sessionKey, {
+      createInternalHookEvent("message", "received", hookSessionKey, {
         from: ctx.From ?? "",
         content,
         timestamp,

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -358,6 +358,32 @@ describe("processDiscordMessage session routing", () => {
     });
   });
 
+  it("falls back to route session key when derived session key is empty", async () => {
+    const ctx = await createBaseContext({
+      baseSessionKey: "",
+      route: {
+        agentId: "main",
+        channel: "discord",
+        accountId: "default",
+        sessionKey: "agent:main:discord:channel:c1",
+        mainSessionKey: "agent:main:main",
+      },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(getLastDispatchCtx()).toMatchObject({
+      SessionKey: "agent:main:discord:channel:c1",
+    });
+    expect(getLastRouteUpdate()).toEqual({
+      sessionKey: "agent:main:discord:channel:c1",
+      channel: "discord",
+      to: "channel:c1",
+      accountId: "default",
+    });
+  });
+
   it("prefers bound session keys and sets MessageThreadId for bound thread messages", async () => {
     const threadBindings = createThreadBindingManager({
       accountId: "default",

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -333,6 +333,12 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           timestamp: entry.timestamp,
         }))
       : undefined;
+  const inboundSessionKey = [
+    boundSessionKey,
+    autoThreadContext?.SessionKey,
+    threadKeys.sessionKey,
+    route.sessionKey,
+  ].find((value): value is string => typeof value === "string" && value.trim().length > 0);
 
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
@@ -342,7 +348,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     CommandBody: baseText,
     From: effectiveFrom,
     To: effectiveTo,
-    SessionKey: boundSessionKey ?? autoThreadContext?.SessionKey ?? threadKeys.sessionKey,
+    SessionKey: inboundSessionKey,
     AccountId: route.accountId,
     ChatType: isDirectMessage ? "direct" : "channel",
     ConversationLabel: fromLabel,
@@ -375,7 +381,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     OriginatingChannel: "discord" as const,
     OriginatingTo: autoThreadContext?.OriginatingTo ?? replyTarget,
   });
-  const persistedSessionKey = ctxPayload.SessionKey ?? route.sessionKey;
+  const persistedSessionKey = inboundSessionKey ?? route.sessionKey;
 
   await recordInboundSession({
     storePath,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `message:received` internal hooks rely on `SessionKey`; when inbound context ends up with an empty/missing session key, hook dispatch is skipped.
- Why it matters: Discord guild traffic can still process normally while hook automations miss events.
- What changed: added a session-key guard in Discord inbound processing and a fallback in hook dispatch (`SessionKey` -> `CommandTargetSessionKey`).
- What did NOT change (scope boundary): no changes to routing policy, mention gating, or reply delivery behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31212
- Related #

## User-visible / Behavior Changes

- Internal `message:received` hooks now still emit when inbound context has no `SessionKey` but has `CommandTargetSessionKey`.
- Discord inbound processing now guarantees a non-empty session key reaches dispatch by falling back to route session key.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: n/a
- Integration/channel (if any): Discord + internal hooks
- Relevant config (redacted): n/a

### Steps

1. Build inbound context where `SessionKey` is empty/missing.
2. Dispatch inbound message through `dispatchReplyFromConfig`.
3. Observe internal hook dispatch behavior.

### Expected

- `message:received` internal hooks emit when a fallback session key exists.

### Actual

- Before: skipped when `SessionKey` absent.
- After: emits using fallback `CommandTargetSessionKey`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run src/auto-reply/reply/dispatch-from-config.test.ts src/discord/monitor/message-handler.process.test.ts`
  - `pnpm exec oxlint src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts src/discord/monitor/message-handler.process.ts src/discord/monitor/message-handler.process.test.ts`
- Edge cases checked:
  - Missing `SessionKey` + present `CommandTargetSessionKey`.
  - Discord derived session key empty fallback to route session key.
- What you did **not** verify:
  - Live Discord runtime against real gateway credentials.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `0d76f9fbb`.
- Files/config to restore:
  - `src/auto-reply/reply/dispatch-from-config.ts`
  - `src/discord/monitor/message-handler.process.ts`
- Known bad symptoms reviewers should watch for:
  - duplicate/missing `message:received` internal hook events.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: fallback session-key resolution could emit a hook in cases that previously skipped.
  - Mitigation: added focused regression tests for both fallback paths and left default behavior unchanged when no key is available.
