### PR TITLE
fix(cron): always use direct delivery for announce, bypass subagent summarization

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -390,16 +390,14 @@ export async function dispatchCronDelivery(
       };
     }
 
-    // Route text-only cron announce output back through the main session so it
-    // follows the same system-message injection path as subagent completions.
-    // Keep direct outbound delivery only for structured payloads (media/channel
-    // data), which cannot be represented by the shared announce flow.
+    // Always use direct outbound delivery for cron announce.
     //
-    // Forum/topic targets should also use direct delivery. Announce flow can
-    // be swallowed by ANNOUNCE_SKIP/NO_REPLY in the target agent turn, which
-    // silently drops cron output for topic-bound sessions.
-    const useDirectDelivery =
-      params.deliveryPayloadHasStructuredContent || params.resolvedDelivery.threadId != null;
+    // The announce flow routes output through a subagent turn that may
+    // summarize, truncate, or silently drop the content via ANNOUNCE_SKIP
+    // or NO_REPLY. This affects all channel types, not just forum topics.
+    //
+    // Fixes: openclaw#13812 (announce sends summary instead of full output)
+    const useDirectDelivery = true;
     if (useDirectDelivery) {
       const directResult = await deliverViaDirect(params.resolvedDelivery);
       if (directResult) {


### PR DESCRIPTION
## Problem

Cron jobs with `delivery.mode: "announce"` targeting regular Discord channels (and other non-threaded channel types) deliver only a summarized/truncated version of the output instead of the full cron result.

### Root Cause

PR #23841 partially fixed this for forum topics by checking `resolvedDelivery.threadId != null`, but regular channel targets (which don't have a `threadId`) still go through the announce flow. The announce flow triggers a subagent turn in the target session, where the receiving agent may:
- Summarize/truncate the content
- Respond with `ANNOUNCE_SKIP` or `NO_REPLY`, silently dropping the output

This affects Discord channels, Telegram chats, and any non-threaded delivery target.

### Evidence

- Agent produces 3108-character detailed report with Markdown tables
- `summary` in cron runs is truncated to 2000 characters
- User receives a short summary (a few paragraphs, no tables) instead of the full report
- Same behavior reported by multiple users across Discord, Telegram, Feishu, MS Teams

## Fix

Always use the direct outbound delivery path (`deliverViaDirect`) for all cron announce deliveries, bypassing the subagent announce flow entirely.
