### PR TITLE
fix(gateway): honor x-openclaw-message-channel in /v1/chat/completions

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -166,6 +166,21 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
+        mockAgentOnce([{ text: "hello" }]);
+        const res = await postChatCompletions(
+          port,
+          { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
+          { "x-openclaw-message-channel": "custom-client-channel" },
+        );
+        expect(res.status).toBe(200);
+        const opts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0];
+        expect((opts as { messageChannel?: string } | undefined)?.messageChannel).toBe(
+          "custom-client-channel",
+        );
+        await res.text();
+      }
+
+      {
         await expectAgentSessionKeyMatch({
           body: {
             model: "openclaw:beta",

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -5,6 +5,7 @@ import { agentCommand } from "../commands/agent.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
 import { defaultRuntime } from "../runtime.js";
+import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
 import {
   buildAgentMessageFromConversationEntries,
@@ -14,7 +15,7 @@ import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
-import { resolveAgentIdForRequest, resolveSessionKey } from "./http-utils.js";
+import { getHeader, resolveAgentIdForRequest, resolveSessionKey } from "./http-utils.js";
 
 type OpenAiHttpOptions = {
   auth: ResolvedGatewayAuth;
@@ -45,6 +46,7 @@ function buildAgentCommandInput(params: {
   prompt: { message: string; extraSystemPrompt?: string };
   sessionKey: string;
   runId: string;
+  messageChannel?: string;
 }) {
   return {
     message: params.prompt.message,
@@ -52,7 +54,7 @@ function buildAgentCommandInput(params: {
     sessionKey: params.sessionKey,
     runId: params.runId,
     deliver: false as const,
-    messageChannel: "webchat" as const,
+    messageChannel: params.messageChannel ?? "webchat",
     bestEffortDeliver: false as const,
   };
 }
@@ -238,11 +240,15 @@ export async function handleOpenAiHttpRequest(
   }
 
   const runId = `chatcmpl_${randomUUID()}`;
+  const messageChannel = normalizeMessageChannel(
+    getHeader(req, "x-openclaw-message-channel") ?? "",
+  );
   const deps = createDefaultDeps();
   const commandInput = buildAgentCommandInput({
     prompt,
     sessionKey,
     runId,
+    messageChannel,
   });
 
   if (!stream) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `POST /v1/chat/completions` always set `messageChannel` to `webchat`, ignoring `x-openclaw-message-channel`.
- Why it matters: custom HTTP clients cannot identify their channel, and behavior was inconsistent with `/v1/tools/*`.
- What changed: the endpoint now reads `x-openclaw-message-channel`, normalizes it through `normalizeMessageChannel`, and falls back to `webchat` when missing/empty.
- What did NOT change (scope boundary): no changes to auth/session routing, streaming format, delivery behavior, or other HTTP endpoints.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29449
- Related #

## User-visible / Behavior Changes

`/v1/chat/completions` now honors `x-openclaw-message-channel` (normalized), instead of hardcoding `webchat`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: gateway OpenAI-compatible HTTP shim
- Integration/channel (if any): Gateway HTTP `/v1/chat/completions`
- Relevant config (redacted): `openAiChatCompletionsEnabled=true`, token auth enabled

### Steps

1. Start gateway with OpenAI chat completions enabled.
2. Send `POST /v1/chat/completions` with header `x-openclaw-message-channel: custom-client-channel`.
3. Inspect `agentCommand` input.

### Expected

- `agentCommand(...).messageChannel === "custom-client-channel"`.

### Actual

- `agentCommand(...).messageChannel === "webchat"`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: header value is passed through normalized and forwarded into `agentCommand`; existing session/validation/streaming tests remain green.
- Edge cases checked: no header still defaults to `webchat`.
- What you did **not** verify: live external channel integrations beyond the gateway unit/e2e test surface.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/gateway/openai-http.ts`.
- Known bad symptoms reviewers should watch for: custom channel headers being ignored again.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: accepting arbitrary channel labels could alter downstream channel labeling for callers that set custom headers.
  - Mitigation: `normalizeMessageChannel` is already used in gateway HTTP surfaces and keeps built-in/plugin normalization consistent.
