### PR TITLE
fix(gateway): make OpenResponses runs abortable via chat.abort

### DIFF
--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -5,7 +5,13 @@ import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
-import { agentCommand, getFreePort, installGatewayTestHooks } from "./test-helpers.js";
+import {
+  agentCommand,
+  getFreePort,
+  installGatewayTestHooks,
+  rpcReq,
+  startConnectedServerWithClient,
+} from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
@@ -77,6 +83,46 @@ function parseSseEvents(text: string): Array<{ event?: string; data: string }> {
   }
 
   return events;
+}
+
+async function readFirstResponseId(res: Response): Promise<string> {
+  const reader = res.body?.getReader();
+  if (!reader) {
+    throw new Error("missing response body reader");
+  }
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    buffer += decoder.decode(value, { stream: true });
+    const blocks = buffer.split("\n\n");
+    for (const block of blocks) {
+      if (!block.includes("event: response.created")) {
+        continue;
+      }
+      const dataLine = block
+        .split("\n")
+        .map((line) => line.trim())
+        .find((line) => line.startsWith("data: "));
+      if (!dataLine) {
+        continue;
+      }
+      const payload = JSON.parse(dataLine.slice("data: ".length)) as {
+        response?: { id?: string };
+      };
+      const runId = payload.response?.id;
+      if (typeof runId === "string" && runId.trim()) {
+        await reader.cancel().catch(() => {});
+        return runId;
+      }
+    }
+  }
+  await reader.cancel().catch(() => {});
+  throw new Error(`failed to read response.created event:\n${buffer}`);
 }
 
 async function ensureResponseConsumed(res: Response) {
@@ -511,6 +557,69 @@ describe("OpenResponses HTTP API (e2e)", () => {
       }
     } finally {
       // shared server
+    }
+  });
+
+  it("allows chat.abort to cancel in-flight OpenResponses runs", async () => {
+    let resolveAgent: ((value: unknown) => void) | undefined;
+    agentCommand.mockImplementationOnce(
+      ((opts: unknown) =>
+        new Promise((resolve, reject) => {
+          resolveAgent = resolve;
+          const abortSignal = (opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+          const onAbort = () => {
+            const abortErr = Object.assign(new Error("aborted"), { name: "AbortError" });
+            reject(abortErr);
+          };
+          if (abortSignal?.aborted) {
+            onAbort();
+            return;
+          }
+          abortSignal?.addEventListener("abort", onAbort, { once: true });
+        })) as never,
+    );
+
+    const started = await startConnectedServerWithClient("secret", {
+      host: "127.0.0.1",
+      auth: { mode: "token", token: "secret" },
+      controlUiEnabled: false,
+      openResponsesEnabled: true,
+    });
+
+    const sessionKey = "agent:main:openresponses:abort-test";
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${started.port}/v1/responses`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json",
+          "x-openclaw-session-key": sessionKey,
+        },
+        body: JSON.stringify({ model: "openclaw", input: "wait", stream: true }),
+      });
+
+      expect(res.status).toBe(200);
+      const runId = await readFirstResponseId(res);
+      expect(runId.startsWith("resp_")).toBe(true);
+
+      const abortRes = await rpcReq<{ aborted?: boolean; runIds?: string[] }>(
+        started.ws,
+        "chat.abort",
+        { sessionKey, runId },
+      );
+      expect(abortRes.ok).toBe(true);
+      expect(abortRes.payload?.aborted).toBe(true);
+      expect(abortRes.payload?.runIds ?? []).toEqual([runId]);
+    } finally {
+      resolveAgent?.({ payloads: [{ text: "done" }] });
+      try {
+        started.ws.close();
+      } catch {
+        // ignore
+      }
+      await started.server.close({ reason: "openresponses abort test done" });
+      started.envSnapshot.restore();
     }
   });
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -32,6 +32,8 @@ import { defaultRuntime } from "../runtime.js";
 import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
+import type { ChatAbortControllerEntry } from "./chat-abort.js";
+import { resolveChatRunExpiresAtMs } from "./chat-abort.js";
 import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import { resolveAgentIdForRequest, resolveSessionKey } from "./http-utils.js";
@@ -52,6 +54,7 @@ type OpenResponsesHttpOptions = {
   trustedProxies?: string[];
   allowRealIpFallback?: boolean;
   rateLimiter?: AuthRateLimiter;
+  chatAbortControllers?: Map<string, ChatAbortControllerEntry>;
 };
 
 const DEFAULT_BODY_BYTES = 20 * 1024 * 1024;
@@ -242,6 +245,7 @@ async function runResponsesAgentCommand(params: {
   sessionKey: string;
   runId: string;
   deps: ReturnType<typeof createDefaultDeps>;
+  abortSignal?: AbortSignal;
 }) {
   return agentCommand(
     {
@@ -252,6 +256,7 @@ async function runResponsesAgentCommand(params: {
       streamParams: params.streamParams ?? undefined,
       sessionKey: params.sessionKey,
       runId: params.runId,
+      abortSignal: params.abortSignal,
       deliver: false,
       messageChannel: "webchat",
       bestEffortDeliver: false,
@@ -444,6 +449,18 @@ export async function handleOpenResponsesHttpRequest(
   const responseId = `resp_${randomUUID()}`;
   const outputItemId = `msg_${randomUUID()}`;
   const deps = createDefaultDeps();
+  const runAbortController = new AbortController();
+  const runStartedAtMs = Date.now();
+  opts.chatAbortControllers?.set(responseId, {
+    controller: runAbortController,
+    sessionId: responseId,
+    sessionKey,
+    startedAtMs: runStartedAtMs,
+    expiresAtMs: resolveChatRunExpiresAtMs({
+      now: runStartedAtMs,
+      timeoutMs: 30_000,
+    }),
+  });
   const streamParams =
     typeof payload.max_output_tokens === "number"
       ? { maxTokens: payload.max_output_tokens }
@@ -460,6 +477,7 @@ export async function handleOpenResponsesHttpRequest(
         sessionKey,
         runId: responseId,
         deps,
+        abortSignal: runAbortController.signal,
       });
 
       const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
@@ -525,6 +543,8 @@ export async function handleOpenResponsesHttpRequest(
         error: { code: "api_error", message: "internal error" },
       });
       sendJson(res, 500, response);
+    } finally {
+      opts.chatAbortControllers?.delete(responseId);
     }
     return true;
   }
@@ -692,6 +712,7 @@ export async function handleOpenResponsesHttpRequest(
         sessionKey,
         runId: responseId,
         deps,
+        abortSignal: runAbortController.signal,
       });
 
       finalUsage = extractUsageFromResult(result);
@@ -834,6 +855,7 @@ export async function handleOpenResponsesHttpRequest(
           data: { phase: "end" },
         });
       }
+      opts.chatAbortControllers?.delete(responseId);
     }
   })();
 

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -22,6 +22,7 @@ import {
 } from "./auth-rate-limit.js";
 import { type GatewayAuthResult, type ResolvedGatewayAuth } from "./auth.js";
 import { normalizeCanvasScopedUrl } from "./canvas-capability.js";
+import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import {
   handleControlUiAvatarRequest,
   handleControlUiHttpRequest,
@@ -331,6 +332,7 @@ export function createGatewayHttpServer(opts: {
   openAiChatCompletionsEnabled: boolean;
   openResponsesEnabled: boolean;
   openResponsesConfig?: import("../config/types.gateway.js").GatewayHttpResponsesConfig;
+  chatAbortControllers?: Map<string, ChatAbortControllerEntry>;
   strictTransportSecurityHeader?: string;
   handleHooksRequest: HooksRequestHandler;
   handlePluginRequest?: HooksRequestHandler;
@@ -349,6 +351,7 @@ export function createGatewayHttpServer(opts: {
     openAiChatCompletionsEnabled,
     openResponsesEnabled,
     openResponsesConfig,
+    chatAbortControllers,
     strictTransportSecurityHeader,
     handleHooksRequest,
     handlePluginRequest,
@@ -411,6 +414,7 @@ export function createGatewayHttpServer(opts: {
             trustedProxies,
             allowRealIpFallback,
             rateLimiter,
+            chatAbortControllers,
           })
         ) {
           return;

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -118,6 +118,7 @@ export async function createGatewayRuntimeState(params: {
     registry: params.pluginRegistry,
     log: params.logPlugins,
   });
+  const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
   const shouldEnforcePluginGatewayAuth = (requestPath: string): boolean => {
     return shouldEnforceGatewayAuthForPluginPath(params.pluginRegistry, requestPath);
   };
@@ -141,6 +142,7 @@ export async function createGatewayRuntimeState(params: {
       openAiChatCompletionsEnabled: params.openAiChatCompletionsEnabled,
       openResponsesEnabled: params.openResponsesEnabled,
       openResponsesConfig: params.openResponsesConfig,
+      chatAbortControllers,
       strictTransportSecurityHeader: params.strictTransportSecurityHeader,
       handleHooksRequest,
       handlePluginRequest,
@@ -194,7 +196,6 @@ export async function createGatewayRuntimeState(params: {
   const chatDeltaSentAt = chatRunState.deltaSentAt;
   const addChatRun = chatRunRegistry.add;
   const removeChatRun = chatRunRegistry.remove;
-  const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
   const toolEventRecipients = createToolEventRecipientRegistry();
 
   return {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `/v1/responses` runs (`resp_*`) were never registered in gateway abort state and were started without an `abortSignal`, so `chat.abort` could not cancel them.
- Why it matters: operators see `chat.abort` return `aborted: false` while work keeps running.
- What changed: OpenResponses now registers active runs in `chatAbortControllers`, passes `abortSignal` into `agentCommand`, and removes run registrations on completion/failure.
- What did NOT change (scope boundary): no changes to OpenResponses response schema, auth, routing, or non-abort chat behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30558
- Related #

## User-visible / Behavior Changes

`chat.abort` can now cancel active OpenResponses `/v1/responses` runs when called with matching `sessionKey` + `runId`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: gateway OpenResponses endpoint
- Integration/channel (if any): HTTP `/v1/responses` + WS `chat.abort`
- Relevant config (redacted): token auth enabled, `openResponsesEnabled=true`

### Steps

1. Start a streaming `POST /v1/responses` request and capture `response.created.response.id` (`resp_*`).
2. Call `chat.abort` with that `runId` and the same `sessionKey`.
3. Observe abort response and run termination behavior.

### Expected

- `chat.abort` returns `{ aborted: true, runIds: ["resp_..."] }` and the run is canceled.

### Actual

- Before fix: `chat.abort` returned `{ aborted: false, runIds: [] }` and run continued.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: in-flight OpenResponses run can be aborted over RPC; run registration is cleaned up after completion/error.
- Edge cases checked: non-stream + stream both register abort controller and clean it up via `finally`.
- What you did **not** verify: manual live-provider latency/behavior outside automated gateway tests.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/gateway/openresponses-http.ts`, `src/gateway/server-http.ts`, `src/gateway/server-runtime-state.ts`.
- Known bad symptoms reviewers should watch for: `chat.abort` for `resp_*` returning false while runs continue.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: stale abort-controller entries if a run path exits unexpectedly.
  - Mitigation: registration cleanup is in `finally` blocks for both stream and non-stream paths.
