### PR TITLE
fix(tui): preserve long credential-like tokens in rendered output

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -249,6 +249,20 @@ describe("sanitizeRenderableText", () => {
     expect(sanitized).toBe(input);
   });
 
+  it("preserves long credential-like base64 tokens for copy safety", () => {
+    const input = "hPc5j+rBJs5Vh0LLEKnd9qdanH0TD3VjLRlYCTKImuw=";
+    const sanitized = sanitizeRenderableText(input);
+
+    expect(sanitized).toBe(input);
+  });
+
+  it("preserves long hexadecimal digest tokens for copy safety", () => {
+    const input = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const sanitized = sanitizeRenderableText(input);
+
+    expect(sanitized).toBe(input);
+  });
+
   it("wraps rtl lines with directional isolation marks", () => {
     const input = "مرحبا بالعالم";
     const sanitized = sanitizeRenderableText(input);

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -11,6 +11,7 @@ const BINARY_LINE_REPLACEMENT_THRESHOLD = 12;
 const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
+const CREDENTIAL_TOKEN_RE = /^[A-Za-z0-9+/=_-]+$/;
 const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
 const BIDI_CONTROL_RE = /[\u202a-\u202e\u2066-\u2069]/;
 const RTL_ISOLATE_START = "\u2067";
@@ -55,7 +56,22 @@ function chunkToken(token: string, maxChars: number): string[] {
   return chunks;
 }
 
+function looksLikeCredentialToken(token: string): boolean {
+  if (token.length <= MAX_TOKEN_CHARS) {
+    return false;
+  }
+  if (!CREDENTIAL_TOKEN_RE.test(token)) {
+    return false;
+  }
+  const hasDigit = /\d/.test(token);
+  const hasSecretPunctuation = /[+/=_-]/.test(token);
+  return hasDigit || hasSecretPunctuation;
+}
+
 function isCopySensitiveToken(token: string): boolean {
+  if (looksLikeCredentialToken(token)) {
+    return true;
+  }
   if (URL_PREFIX_RE.test(token)) {
     return true;
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: TUI sanitization inserted spaces into long contiguous tokens (>32 chars), which altered copy-pasted credentials/keys.
- Why it matters: user-visible output was mutated (`...TD3Vj LRlY...`), breaking direct copy/paste workflows for secrets and key material.
- What changed: `sanitizeRenderableText` now treats credential-like long tokens (base64/hex/api-key style character sets with digits/punctuation) as copy-sensitive and preserves them verbatim.
- What did NOT change (scope boundary): long plain prose tokens are still wrapped for terminal safety; URL/path/file-name preservation behavior is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30370
- Related #

## User-visible / Behavior Changes

Long credential-like tokens (e.g. RustDesk keys, long hex digests) are no longer space-split in TUI output.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: TUI formatter path (model-agnostic)
- Integration/channel (if any): TUI output rendering
- Relevant config (redacted): default

### Steps

1. Pass `hPc5j+rBJs5Vh0LLEKnd9qdanH0TD3VjLRlYCTKImuw=` through `sanitizeRenderableText`.
2. Observe rendered token output.

### Expected

- Token is preserved exactly with no inserted spaces.

### Actual

- Before fix, output inserted a space after 32 chars.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: RustDesk-like base64 token and long hex digest both remain unchanged; existing long plain-token wrapping tests still pass.
- Edge cases checked: URL/path/underscore-file token preservation remains intact.
- What you did **not** verify: manual interactive terminal rendering across all terminal emulators.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/tui/tui-formatters.ts`.
- Known bad symptoms reviewers should watch for: credential-like tokens split with inserted spaces.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: preserving more long tokens may reduce wrapping in narrow terminals for some machine-like strings.
  - Mitigation: preservation is constrained to credential-like character sets with digits/punctuation; long plain words still wrap.
