### PR TITLE
fix(ui): add toSorted compatibility for Control UI bootstrap

### DIFF
--- a/src/ui-tosorted-polyfill.test.ts
+++ b/src/ui-tosorted-polyfill.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { installUiPolyfills } from "../ui/src/ui/polyfills.ts";
+
+describe("control-ui toSorted polyfill", () => {
+  it("adds Array.prototype.toSorted when missing", () => {
+    const arrayPrototype = Array.prototype as unknown as { toSorted?: unknown };
+    const original = arrayPrototype.toSorted;
+    delete arrayPrototype.toSorted;
+
+    try {
+      installUiPolyfills();
+      const installed = arrayPrototype.toSorted as
+        | ((this: number[], compareFn?: (a: number, b: number) => number) => number[])
+        | undefined;
+      expect(typeof installed).toBe("function");
+      const originalValues = [3, 1, 2];
+      const sorted = installed?.call(originalValues, (a, b) => a - b);
+      expect(sorted).toEqual([1, 2, 3]);
+      expect(originalValues).toEqual([3, 1, 2]);
+    } finally {
+      if (original) {
+        arrayPrototype.toSorted = original;
+      } else {
+        delete arrayPrototype.toSorted;
+      }
+    }
+  });
+});

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,2 +1,3 @@
 import "./styles.css";
+import "./ui/polyfills.ts";
 import "./ui/app.ts";

--- a/ui/src/ui/polyfills.ts
+++ b/ui/src/ui/polyfills.ts
@@ -1,0 +1,50 @@
+type ToSortedFn = <T>(this: T[], compareFn?: (a: T, b: T) => number) => T[];
+
+function defaultCompare(a: unknown, b: unknown): number {
+  const left = String(a);
+  const right = String(b);
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+}
+
+function toSortedCopy<T>(values: T[], compareFn?: (a: T, b: T) => number): T[] {
+  const sorted = [...values];
+  const compare =
+    compareFn ??
+    ((left: T, right: T) => {
+      return defaultCompare(left, right);
+    });
+  for (let i = 1; i < sorted.length; i += 1) {
+    const value = sorted[i];
+    let j = i - 1;
+    while (j >= 0 && compare(sorted[j], value) > 0) {
+      sorted[j + 1] = sorted[j];
+      j -= 1;
+    }
+    sorted[j + 1] = value;
+  }
+  return sorted;
+}
+
+export function installUiPolyfills(): void {
+  const arrayPrototype = Array.prototype as Array<unknown> & {
+    toSorted?: ToSortedFn;
+  };
+  if (typeof arrayPrototype.toSorted === "function") {
+    return;
+  }
+  Object.defineProperty(arrayPrototype, "toSorted", {
+    value: function toSorted<T>(this: T[], compareFn?: (a: T, b: T) => number): T[] {
+      return toSortedCopy(this, compareFn);
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+installUiPolyfills();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Control UI relied on `Array.prototype.toSorted`, causing runtime crashes/blank UI on browsers that do not implement it.
- Why it matters: dashboard becomes unusable on older browser engines.
- What changed: added a Control UI bootstrap polyfill that defines `Array.prototype.toSorted` when missing, and load it before app initialization.
- What did NOT change (scope boundary): no UI behavior/layout logic changes; only compatibility shimming and its regression test were added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30467
- Related #

## User-visible / Behavior Changes

Control UI now boots on browsers/environments without native `Array.prototype.toSorted` support.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Control UI frontend bootstrap
- Relevant config (redacted): default

### Steps

1. Remove `Array.prototype.toSorted` from runtime.
2. Initialize Control UI bootstrap/polyfills.
3. Execute code paths that rely on `toSorted`.

### Expected

- `toSorted` is available and behavior remains non-mutating.

### Actual

- Before fix, missing `toSorted` produced runtime errors and prevented UI usage.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: polyfill installs when absent, supports compare function, and preserves non-mutating semantics.
- Edge cases checked: when native `toSorted` exists, installer exits without overriding.
- What you did **not** verify: manual cross-browser matrix beyond automated test/lint/typecheck.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `ui/src/main.ts`, `ui/src/ui/polyfills.ts`.
- Known bad symptoms reviewers should watch for: Control UI failing at startup with `toSorted is not a function`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: polyfill sort semantics could drift from native edge-case behavior.
  - Mitigation: only activates when native API is missing; implementation preserves non-mutating semantics and compare callback support.
