### PR TITLE
fix(auth): keep SecretRef-only profiles eligible in auth order

### DIFF
--- a/src/agents/auth-profiles.resolve-auth-profile-order.uses-stored-profiles-no-config-exists.test.ts
+++ b/src/agents/auth-profiles.resolve-auth-profile-order.uses-stored-profiles-no-config-exists.test.ts
@@ -193,6 +193,61 @@ describe("resolveAuthProfileOrder", () => {
     const order = resolveMinimaxOrderWithProfile(profile);
     expect(order).toEqual([]);
   });
+  it("keeps api_key profiles that only provide keyRef", () => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          order: {
+            minimax: ["minimax:default"],
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "minimax:default": {
+            type: "api_key",
+            provider: "minimax",
+            keyRef: {
+              source: "exec",
+              provider: "keychain",
+              id: "minimax-default",
+            },
+          },
+        },
+      },
+      provider: "minimax",
+    });
+    expect(order).toEqual(["minimax:default"]);
+  });
+  it("keeps token profiles that only provide tokenRef", () => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          order: {
+            minimax: ["minimax:default"],
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "minimax:default": {
+            type: "token",
+            provider: "minimax",
+            token: "",
+            tokenRef: {
+              source: "exec",
+              provider: "keychain",
+              id: "minimax-token",
+            },
+          },
+        },
+      },
+      provider: "minimax",
+    });
+    expect(order).toEqual(["minimax:default"]);
+  });
   it("keeps oauth profiles that can refresh", () => {
     const order = resolveAuthProfileOrder({
       cfg: {

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/config.js";
+import { coerceSecretRef } from "../../config/types.secrets.js";
 import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
 import { dedupeProfileIds, listProfilesForProvider } from "./profiles.js";
 import type { AuthProfileStore } from "./types.js";
@@ -58,9 +59,12 @@ export function resolveAuthProfileOrder(params: {
       }
     }
     if (cred.type === "api_key") {
-      return Boolean(cred.key?.trim());
+      return Boolean(cred.key?.trim() || coerceSecretRef(cred.keyRef));
     }
     if (cred.type === "token") {
+      if (coerceSecretRef(cred.tokenRef)) {
+        return true;
+      }
       if (!cred.token?.trim()) {
         return false;
       }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `resolveAuthProfileOrder` treated profiles as valid only when plaintext `key`/`token` existed, excluding SecretRef-only (`keyRef`/`tokenRef`) profiles.
- Why it matters: `models status --probe` surfaced false “missing or expired” for working exec/env/file SecretRef-backed auth profiles.
- What changed: auth-order validity now accepts `api_key` profiles with `keyRef` and `token` profiles with `tokenRef`; added regression tests for both cases.
- What did NOT change (scope boundary): no runtime credential resolution flow changes, no SecretRef provider execution changes, and no probe output formatting changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30311
- Related #

## User-visible / Behavior Changes

`models status --probe` no longer misclassifies SecretRef-only auth profiles as missing due to auth-order filtering.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: Auth-profile ordering / models status probe path
- Integration/channel (if any): `models status --probe`
- Relevant config (redacted): auth profiles with SecretRefs only (`keyRef`/`tokenRef`)

### Steps

1. Configure provider profiles with SecretRef-only credentials (no plaintext `key`/`token`).
2. Resolve auth profile order for that provider.
3. Run probe/status path that consumes that order.

### Expected

- SecretRef-backed profiles remain in auth order and are probe-eligible.

### Actual

- Before fix, they were filtered out as invalid/missing.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `api_key`+`keyRef` and `token`+`tokenRef` profiles are now returned by `resolveAuthProfileOrder`; existing invalid-empty-token case still fails as expected.
- Edge cases checked: existing oauth/token expiry behavior remains unchanged when no SecretRef is present.
- What you did **not** verify: live external secret-provider invocation during probe in an end-to-end runtime.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/auth-profiles/order.ts`.
- Known bad symptoms reviewers should watch for: SecretRef-only auth profiles disappearing from auth order again.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: SecretRef presence could mask expired inline token fields if both are set.
  - Mitigation: this is intentional for external-secret-backed profiles; inline token expiry checks remain unchanged when no `tokenRef` is present.
