### PR TITLE
feat(discord): support per-guild and per-account blockStreamingBreak

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -364,7 +364,9 @@ export async function resolveReplyDirectives(params: {
           ? "on"
           : "off";
   const resolvedBlockStreamingBreak: "text_end" | "message_end" =
-    agentCfg?.blockStreamingBreak === "message_end" ? "message_end" : "text_end";
+    (opts?.blockStreamingBreak ?? agentCfg?.blockStreamingBreak) === "message_end"
+      ? "message_end"
+      : "text_end";
   const blockStreamingEnabled =
     resolvedBlockStreaming === "on" && opts?.disableBlockStreaming !== true;
   const blockReplyChunking = blockStreamingEnabled

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -58,6 +58,8 @@ export type GetReplyOptions = {
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;
   disableBlockStreaming?: boolean;
+  /** Per-channel/account override for block streaming break mode. */
+  blockStreamingBreak?: "text_end" | "message_end";
   /** Timeout for block reply delivery (ms). */
   blockReplyTimeoutMs?: number;
   /** If provided, only load these skills for this session (empty = no skills). */

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -46,6 +46,10 @@ export type DiscordGuildChannelConfig = {
   systemPrompt?: string;
   /** If false, omit thread starter context for this channel (default: true). */
   includeThreadStarter?: boolean;
+  /** Override block streaming for this channel. */
+  blockStreaming?: boolean;
+  /** Override block streaming break mode for this channel. */
+  blockStreamingBreak?: "text_end" | "message_end";
 };
 
 export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist";
@@ -63,6 +67,10 @@ export type DiscordGuildEntry = {
   /** Optional allowlist for guild senders by role ID. */
   roles?: string[];
   channels?: Record<string, DiscordGuildChannelConfig>;
+  /** Override block streaming for this guild. */
+  blockStreaming?: boolean;
+  /** Override block streaming break mode for this guild. */
+  blockStreamingBreak?: "text_end" | "message_end";
 };
 
 export type DiscordActionConfig = {
@@ -216,6 +224,8 @@ export type DiscordAccountConfig = {
   chunkMode?: "length" | "newline";
   /** Disable block streaming for this account. */
   blockStreaming?: boolean;
+  /** Override block streaming break mode for this account. */
+  blockStreamingBreak?: "text_end" | "message_end";
   /**
    * Live stream preview mode:
    * - "off": disable preview updates

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -373,6 +373,8 @@ export const DiscordGuildChannelSchema = z
     systemPrompt: z.string().optional(),
     includeThreadStarter: z.boolean().optional(),
     autoThread: z.boolean().optional(),
+    blockStreaming: z.boolean().optional(),
+    blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
   })
   .strict();
 
@@ -386,6 +388,8 @@ export const DiscordGuildSchema = z
     users: DiscordIdListSchema.optional(),
     roles: DiscordIdListSchema.optional(),
     channels: z.record(z.string(), DiscordGuildChannelSchema.optional()).optional(),
+    blockStreaming: z.boolean().optional(),
+    blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
   })
   .strict();
 
@@ -438,6 +442,7 @@ export const DiscordAccountSchema = z
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
+    blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     // Canonical streaming mode. Legacy aliases (`streamMode`, boolean `streaming`) are auto-mapped.
     streaming: z.union([z.boolean(), z.enum(["off", "partial", "block", "progress"])]).optional(),

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -35,8 +35,12 @@ export type DiscordGuildEntryResolved = {
       systemPrompt?: string;
       includeThreadStarter?: boolean;
       autoThread?: boolean;
+      blockStreaming?: boolean;
+      blockStreamingBreak?: "text_end" | "message_end";
     }
   >;
+  blockStreaming?: boolean;
+  blockStreamingBreak?: "text_end" | "message_end";
 };
 
 export type DiscordChannelConfigResolved = {
@@ -49,6 +53,8 @@ export type DiscordChannelConfigResolved = {
   systemPrompt?: string;
   includeThreadStarter?: boolean;
   autoThread?: boolean;
+  blockStreaming?: boolean;
+  blockStreamingBreak?: "text_end" | "message_end";
   matchKey?: string;
   matchSource?: ChannelMatchSource;
 };
@@ -368,6 +374,8 @@ function resolveDiscordChannelConfigEntry(
     systemPrompt: entry.systemPrompt,
     includeThreadStarter: entry.includeThreadStarter,
     autoThread: entry.autoThread,
+    blockStreaming: entry.blockStreaming,
+    blockStreamingBreak: entry.blockStreamingBreak,
   };
   return resolved;
 }

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -431,9 +431,16 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   // --- Discord draft stream (edit-based preview streaming) ---
   const discordStreamMode = resolveDiscordPreviewStreamMode(discordConfig);
   const draftMaxChars = Math.min(textLimit, 2000);
+  // Resolve blockStreaming with priority: channel > guild > account > global default.
+  const resolvedBlockStreaming: boolean | undefined =
+    channelConfig?.blockStreaming ?? guildInfo?.blockStreaming ?? discordConfig?.blockStreaming;
+  const resolvedBlockStreamingBreak: "text_end" | "message_end" | undefined =
+    channelConfig?.blockStreamingBreak ??
+    guildInfo?.blockStreamingBreak ??
+    discordConfig?.blockStreamingBreak;
   const accountBlockStreamingEnabled =
-    typeof discordConfig?.blockStreaming === "boolean"
-      ? discordConfig.blockStreaming
+    typeof resolvedBlockStreaming === "boolean"
+      ? resolvedBlockStreaming
       : cfg.agents?.defaults?.blockStreamingDefault === "on";
   const canStreamDraft = discordStreamMode !== "off" && !accountBlockStreamingEnabled;
   const draftReplyToMessageId = () => replyReference.use();
@@ -689,9 +696,8 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         skillFilter: channelConfig?.skills,
         disableBlockStreaming:
           disableBlockStreamingForDraft ??
-          (typeof discordConfig?.blockStreaming === "boolean"
-            ? !discordConfig.blockStreaming
-            : undefined),
+          (typeof resolvedBlockStreaming === "boolean" ? !resolvedBlockStreaming : undefined),
+        blockStreamingBreak: resolvedBlockStreamingBreak,
         onPartialReply: draftStream ? (payload) => updateDraftFromPartial(payload.text) : undefined,
         onAssistantMessageStart: draftStream
           ? () => {

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -1616,10 +1616,17 @@ async function dispatchDiscordCommandInteraction(params: {
     },
     replyOptions: {
       skillFilter: channelConfig?.skills,
-      disableBlockStreaming:
-        typeof discordConfig?.blockStreaming === "boolean"
-          ? !discordConfig.blockStreaming
-          : undefined,
+      disableBlockStreaming: (() => {
+        const bs =
+          channelConfig?.blockStreaming ??
+          guildInfo?.blockStreaming ??
+          discordConfig?.blockStreaming;
+        return typeof bs === "boolean" ? !bs : undefined;
+      })(),
+      blockStreamingBreak:
+        channelConfig?.blockStreamingBreak ??
+        guildInfo?.blockStreamingBreak ??
+        discordConfig?.blockStreamingBreak,
       onModelSelected,
     },
   });


### PR DESCRIPTION
Fixes #31281

## Problem

`blockStreamingBreak` (`text_end` / `message_end`) was only configurable globally at `agents.defaults.blockStreamingBreak`. Similarly, `blockStreaming` (on/off) was only per-account, not per-guild or per-guild-channel.

This caused problems in multi-agent Discord setups: when DMs need block streaming for progressive updates, but group channels need `message_end` so each agent sends one complete message (preventing other bots from being triggered by intermediate blocks).

## Changes

### Config types (`src/config/types.discord.ts`)
- Added `blockStreamingBreak?: "text_end" | "message_end"` to `DiscordAccountConfig`
- Added `blockStreaming?` and `blockStreamingBreak?` to `DiscordGuildEntry`
- Added `blockStreaming?` and `blockStreamingBreak?` to `DiscordGuildChannelConfig`

### Zod schema (`src/config/zod-schema.providers-core.ts`)
- Added corresponding schema fields for `DiscordGuildChannelSchema` and `DiscordGuildSchema`

### Runtime resolution (`src/discord/monitor/message-handler.process.ts`)
- `blockStreaming` now resolves with priority: **channel > guild > account > global default**
- `blockStreamingBreak` resolved with the same priority chain and passed as `replyOptions.blockStreamingBreak`

### Reply directives (`src/auto-reply/reply/get-reply-directives.ts`)
- Added `blockStreamingBreak` to `GetReplyOptions`
- `resolvedBlockStreamingBreak` now checks `opts.blockStreamingBreak` before falling back to `agentCfg.blockStreamingBreak`

## Example config

```json5
{
  channels: {
    discord: {
      blockStreamingBreak: "text_end",    // default for DMs
      guilds: {
        "1475876068597436586": {
          blockStreamingBreak: "message_end", // group channels: one message per turn
          blockStreaming: false,              // or disable entirely
        }
      }
    }
  }
}
```

## Testing

- Build passes: `pnpm build`
- Existing block-streaming tests pass: `pnpm vitest run src/auto-reply/reply/block-streaming.test.ts`