### PR TITLE
fix(security): enforce immutable Discord user ID for owner authorization

### DIFF
--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -226,14 +226,16 @@ describe("discord allowlist helpers", () => {
     if (!allow) {
       throw new Error("Expected allow list to be normalized");
     }
-    expect(allowListMatches(allow, { id: "123" })).toBe(true);
-    expect(allowListMatches(allow, { name: "steipete" })).toBe(false);
-    expect(allowListMatches(allow, { name: "friends-of-openclaw" })).toBe(false);
+    expect(allowListMatches(allow, { id: "123" }, { allowNameMatching: false })).toBe(true);
+    expect(allowListMatches(allow, { name: "steipete" }, { allowNameMatching: false })).toBe(false);
+    expect(
+      allowListMatches(allow, { name: "friends-of-openclaw" }, { allowNameMatching: false }),
+    ).toBe(false);
     expect(allowListMatches(allow, { name: "steipete" }, { allowNameMatching: true })).toBe(true);
     expect(
       allowListMatches(allow, { name: "friends-of-openclaw" }, { allowNameMatching: true }),
     ).toBe(true);
-    expect(allowListMatches(allow, { name: "other" })).toBe(false);
+    expect(allowListMatches(allow, { name: "other" }, { allowNameMatching: false })).toBe(false);
   });
 
   it("matches pk-prefixed allowlist entries", () => {
@@ -242,8 +244,62 @@ describe("discord allowlist helpers", () => {
     if (!allow) {
       throw new Error("Expected allow list to be normalized");
     }
-    expect(allowListMatches(allow, { id: "member-123" })).toBe(true);
-    expect(allowListMatches(allow, { id: "member-999" })).toBe(false);
+    expect(allowListMatches(allow, { id: "member-123" }, { allowNameMatching: false })).toBe(true);
+    expect(allowListMatches(allow, { id: "member-999" }, { allowNameMatching: false })).toBe(false);
+  });
+
+  it("rejects user with matching display name but different snowflake ID (name spoofing)", () => {
+    // Owner "alice" has snowflake ID "111222333". An attacker changes their
+    // Discord display name to "alice" but has a different snowflake ID.
+    const allow = normalizeDiscordAllowList(["111222333", "alice"], ["discord:", "user:", "pk:"]);
+    expect(allow).not.toBeNull();
+    if (!allow) {
+      throw new Error("Expected allow list to be normalized");
+    }
+
+    // Real owner: ID match succeeds
+    expect(
+      allowListMatches(
+        allow,
+        { id: "111222333", name: "alice", tag: "alice" },
+        { allowNameMatching: false },
+      ),
+    ).toBe(true);
+
+    // Attacker: same display name, different ID — MUST be rejected
+    expect(
+      allowListMatches(
+        allow,
+        { id: "999888777", name: "alice", tag: "alice" },
+        { allowNameMatching: false },
+      ),
+    ).toBe(false);
+
+    // Attacker with name matching explicitly enabled (break-glass) — allowed
+    expect(
+      allowListMatches(
+        allow,
+        { id: "999888777", name: "alice", tag: "alice" },
+        { allowNameMatching: true },
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects user whose tag matches an allowlist entry when name matching is off", () => {
+    const allow = normalizeDiscordAllowList(["owner#1234"], ["discord:", "user:", "pk:"]);
+    expect(allow).not.toBeNull();
+    if (!allow) {
+      throw new Error("Expected allow list to be normalized");
+    }
+
+    // Attacker spoofs tag: different ID, matching tag — rejected
+    expect(
+      allowListMatches(
+        allow,
+        { id: "999", name: "owner", tag: "owner#1234" },
+        { allowNameMatching: false },
+      ),
+    ).toBe(false);
   });
 });
 
@@ -711,6 +767,7 @@ describe("discord reaction notification gating", () => {
           botId: "bot-1",
           messageAuthorId: "bot-1",
           userId: "user-1",
+          allowNameMatching: false,
         },
         expected: true,
       },
@@ -721,6 +778,7 @@ describe("discord reaction notification gating", () => {
           botId: "bot-1",
           messageAuthorId: "user-1",
           userId: "user-2",
+          allowNameMatching: false,
         },
         expected: false,
       },
@@ -731,6 +789,7 @@ describe("discord reaction notification gating", () => {
           botId: "bot-1",
           messageAuthorId: "bot-1",
           userId: "user-1",
+          allowNameMatching: false,
         },
         expected: false,
       },
@@ -741,6 +800,7 @@ describe("discord reaction notification gating", () => {
           botId: "bot-1",
           messageAuthorId: "user-1",
           userId: "user-2",
+          allowNameMatching: false,
         },
         expected: true,
       },
@@ -751,6 +811,7 @@ describe("discord reaction notification gating", () => {
           botId: "bot-1",
           messageAuthorId: "bot-1",
           userId: "user-2",
+          allowNameMatching: false,
         },
         expected: true,
       },
@@ -761,6 +822,7 @@ describe("discord reaction notification gating", () => {
           botId: "bot-1",
           messageAuthorId: "user-2",
           userId: "user-3",
+          allowNameMatching: false,
         },
         expected: false,
       },
@@ -772,6 +834,7 @@ describe("discord reaction notification gating", () => {
           messageAuthorId: "user-1",
           userId: "user-2",
           allowlist: [] as string[],
+          allowNameMatching: false,
         },
         expected: false,
       },
@@ -784,6 +847,7 @@ describe("discord reaction notification gating", () => {
           userId: "123",
           userName: "steipete",
           allowlist: ["123", "other"] as string[],
+          allowNameMatching: false,
         },
         expected: true,
       },
@@ -796,6 +860,7 @@ describe("discord reaction notification gating", () => {
           userId: "999",
           userName: "trusted-user",
           allowlist: ["trusted-user"] as string[],
+          allowNameMatching: false,
         },
         expected: false,
       },

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -95,10 +95,15 @@ export function normalizeDiscordSlug(value: string) {
     .replace(/^-+|-+$/g, "");
 }
 
+// Security: allowNameMatching is intentionally required (not optional) to force
+// every call site to explicitly decide whether mutable name/tag matching is
+// permitted. Omitting this parameter would silently default to a safe value,
+// but requiring it prevents accidental regressions — callers must consciously
+// pass the result of isDangerousNameMatchingEnabled().
 export function allowListMatches(
   list: DiscordAllowList,
   candidate: { id?: string; name?: string; tag?: string },
-  params?: { allowNameMatching?: boolean },
+  params: { allowNameMatching: boolean },
 ) {
   if (list.allowAll) {
     return true;
@@ -106,7 +111,7 @@ export function allowListMatches(
   if (candidate.id && list.ids.has(candidate.id)) {
     return true;
   }
-  if (params?.allowNameMatching === true) {
+  if (params.allowNameMatching) {
     const slug = candidate.name ? normalizeDiscordSlug(candidate.name) : "";
     if (slug && list.names.has(slug)) {
       return true;
@@ -121,7 +126,7 @@ export function allowListMatches(
 export function resolveDiscordAllowListMatch(params: {
   allowList: DiscordAllowList;
   candidate: { id?: string; name?: string; tag?: string };
-  allowNameMatching?: boolean;
+  allowNameMatching: boolean;
 }): DiscordAllowListMatch {
   const { allowList, candidate } = params;
   if (allowList.allowAll) {
@@ -130,7 +135,7 @@ export function resolveDiscordAllowListMatch(params: {
   if (candidate.id && allowList.ids.has(candidate.id)) {
     return { allowed: true, matchKey: candidate.id, matchSource: "id" };
   }
-  if (params.allowNameMatching === true) {
+  if (params.allowNameMatching) {
     const nameSlug = candidate.name ? normalizeDiscordSlug(candidate.name) : "";
     if (nameSlug && allowList.names.has(nameSlug)) {
       return { allowed: true, matchKey: nameSlug, matchSource: "name" };
@@ -148,7 +153,7 @@ export function resolveDiscordUserAllowed(params: {
   userId: string;
   userName?: string;
   userTag?: string;
-  allowNameMatching?: boolean;
+  allowNameMatching: boolean;
 }) {
   const allowList = normalizeDiscordAllowList(params.allowList, ["discord:", "user:", "pk:"]);
   if (!allowList) {
@@ -187,7 +192,7 @@ export function resolveDiscordMemberAllowed(params: {
   userId: string;
   userName?: string;
   userTag?: string;
-  allowNameMatching?: boolean;
+  allowNameMatching: boolean;
 }) {
   const hasUserRestriction = Array.isArray(params.userAllowList) && params.userAllowList.length > 0;
   const hasRoleRestriction = Array.isArray(params.roleAllowList) && params.roleAllowList.length > 0;
@@ -217,7 +222,7 @@ export function resolveDiscordMemberAccessState(params: {
   guildInfo?: DiscordGuildEntryResolved | null;
   memberRoleIds: string[];
   sender: { id: string; name?: string; tag?: string };
-  allowNameMatching?: boolean;
+  allowNameMatching: boolean;
 }) {
   const channelUsers = params.channelConfig?.users ?? params.guildInfo?.users;
   const channelRoles = params.channelConfig?.roles ?? params.guildInfo?.roles;
@@ -240,7 +245,7 @@ export function resolveDiscordOwnerAllowFrom(params: {
   channelConfig?: DiscordChannelConfigResolved | null;
   guildInfo?: DiscordGuildEntryResolved | null;
   sender: { id: string; name?: string; tag?: string };
-  allowNameMatching?: boolean;
+  allowNameMatching: boolean;
 }): string[] | undefined {
   const rawAllowList = params.channelConfig?.users ?? params.guildInfo?.users;
   if (!Array.isArray(rawAllowList) || rawAllowList.length === 0) {
@@ -270,7 +275,7 @@ export function resolveDiscordCommandAuthorized(params: {
   allowFrom?: string[];
   guildInfo?: DiscordGuildEntryResolved | null;
   author: User;
-  allowNameMatching?: boolean;
+  allowNameMatching: boolean;
 }) {
   if (!params.isDirectMessage) {
     return true;
@@ -523,7 +528,7 @@ export function shouldEmitDiscordReactionNotification(params: {
   userName?: string;
   userTag?: string;
   allowlist?: string[];
-  allowNameMatching?: boolean;
+  allowNameMatching: boolean;
 }) {
   const mode = params.mode ?? "own";
   if (mode === "off") {

--- a/src/discord/monitor/dm-command-auth.test.ts
+++ b/src/discord/monitor/dm-command-auth.test.ts
@@ -98,4 +98,59 @@ describe("resolveDiscordDmCommandAccess", () => {
     expect(result.decision).toBe("allow");
     expect(result.commandAuthorized).toBe(true);
   });
+
+  it("rejects sender whose display name matches owner but has different snowflake ID", async () => {
+    // Owner "alice" has snowflake ID "456". An attacker changes their Discord
+    // display name to "alice" but has snowflake ID "123" — must be rejected.
+    const attacker = { id: "123", name: "alice", tag: "alice" };
+    const result = await resolveDiscordDmCommandAccess({
+      accountId: "default",
+      dmPolicy: "pairing",
+      configuredAllowFrom: ["discord:456"],
+      sender: attacker,
+      allowNameMatching: false,
+      useAccessGroups: true,
+      readStoreAllowFrom: async () => [],
+    });
+
+    expect(result.decision).toBe("pairing");
+    expect(result.commandAuthorized).toBe(false);
+  });
+
+  it("rejects name-only allowlist entries when allowNameMatching is disabled", async () => {
+    // Config has a username "alice" in allowFrom (no numeric ID).
+    // A sender whose username is "alice" but has a different ID must be
+    // rejected when dangerouslyAllowNameMatching is false.
+    const spoofingSender = { id: "999", name: "alice", tag: "alice" };
+    const result = await resolveDiscordDmCommandAccess({
+      accountId: "default",
+      dmPolicy: "pairing",
+      configuredAllowFrom: ["alice"],
+      sender: spoofingSender,
+      allowNameMatching: false,
+      useAccessGroups: true,
+      readStoreAllowFrom: async () => [],
+    });
+
+    expect(result.decision).toBe("pairing");
+    expect(result.commandAuthorized).toBe(false);
+    expect(result.allowMatch.allowed).toBe(false);
+  });
+
+  it("allows name-matching only when dangerouslyAllowNameMatching is true", async () => {
+    const spoofingSender = { id: "999", name: "alice", tag: "alice" };
+    const result = await resolveDiscordDmCommandAccess({
+      accountId: "default",
+      dmPolicy: "pairing",
+      configuredAllowFrom: ["alice"],
+      sender: spoofingSender,
+      allowNameMatching: true,
+      useAccessGroups: true,
+      readStoreAllowFrom: async () => [],
+    });
+
+    expect(result.decision).toBe("allow");
+    expect(result.commandAuthorized).toBe(true);
+    expect(result.allowMatch.allowed).toBe(true);
+  });
 });

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -176,6 +176,11 @@ export async function preflightDiscordMessage(
   const useAccessGroups = params.cfg.commands?.useAccessGroups !== false;
   const resolvedAccountId = params.accountId ?? DEFAULT_ACCOUNT_ID;
   const allowNameMatching = isDangerousNameMatchingEnabled(params.discordConfig);
+  if (allowNameMatching) {
+    logVerbose(
+      "discord: dangerouslyAllowNameMatching is enabled — sender authorization will match mutable display names/tags in addition to immutable user IDs",
+    );
+  }
   let commandAuthorized = true;
   if (isDirectMessage) {
     if (dmPolicy === "disabled") {

--- a/src/discord/monitor/monitor.test.ts
+++ b/src/discord/monitor/monitor.test.ts
@@ -506,6 +506,7 @@ describe("resolveDiscordOwnerAllowFrom", () => {
     const result = resolveDiscordOwnerAllowFrom({
       channelConfig: { allowed: true } as DiscordChannelConfigResolved,
       sender: { id: "123" },
+      allowNameMatching: false,
     });
 
     expect(result).toBeUndefined();
@@ -515,6 +516,7 @@ describe("resolveDiscordOwnerAllowFrom", () => {
     const result = resolveDiscordOwnerAllowFrom({
       channelConfig: { allowed: true, users: ["*"] } as DiscordChannelConfigResolved,
       sender: { id: "123" },
+      allowNameMatching: false,
     });
 
     expect(result).toBeUndefined();
@@ -524,6 +526,7 @@ describe("resolveDiscordOwnerAllowFrom", () => {
     const result = resolveDiscordOwnerAllowFrom({
       channelConfig: { allowed: true, users: ["123"] } as DiscordChannelConfigResolved,
       sender: { id: "123" },
+      allowNameMatching: false,
     });
 
     expect(result).toEqual(["123"]);
@@ -533,6 +536,7 @@ describe("resolveDiscordOwnerAllowFrom", () => {
     const defaultResult = resolveDiscordOwnerAllowFrom({
       channelConfig: { allowed: true, users: ["Some User"] } as DiscordChannelConfigResolved,
       sender: { id: "999", name: "Some User" },
+      allowNameMatching: false,
     });
     expect(defaultResult).toBeUndefined();
 
@@ -591,6 +595,7 @@ describe("resolveDiscordMemberAllowed", () => {
       roleAllowList: undefined,
       memberRoleIds: [],
       userId: "u1",
+      allowNameMatching: false,
     });
 
     expect(allowed).toBe(true);
@@ -602,6 +607,7 @@ describe("resolveDiscordMemberAllowed", () => {
       roleAllowList: ["456"],
       memberRoleIds: ["999"],
       userId: "123",
+      allowNameMatching: false,
     });
 
     expect(allowed).toBe(true);
@@ -613,6 +619,7 @@ describe("resolveDiscordMemberAllowed", () => {
       roleAllowList: ["456"],
       memberRoleIds: ["456"],
       userId: "123",
+      allowNameMatching: false,
     });
 
     expect(allowed).toBe(true);
@@ -624,6 +631,7 @@ describe("resolveDiscordMemberAllowed", () => {
       roleAllowList: ["role-2"],
       memberRoleIds: ["role-1"],
       userId: "u1",
+      allowNameMatching: false,
     });
 
     expect(allowed).toBe(false);


### PR DESCRIPTION
## Summary
Fix Discord owner authorization vulnerability where mutable display names/nicknames could be used to impersonate the system owner.

## Changes
- Made `allowNameMatching` a **required boolean** parameter in all 8 Discord auth functions (`allowListMatches`, `resolveDiscordAllowListMatch`, etc.) — prevents accidental omission
- Added runtime warning when `dangerouslyAllowNameMatching` is active
- Added 5 security tests proving name-spoofing is rejected when `allowNameMatching=false`

## Root Cause
The `allowNameMatching` parameter was optional in Discord allowlist functions. While the default was safe (falsy = no name matching), this made it easy for future code to accidentally enable name-based auth.

## Testing
- 90 tests pass
- TypeScript type check clean
- Lint clean (oxfmt)

Closes #31233