### PR TITLE
Feishu: encode upload file names for special chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/File upload filenames: percent-encode non-ASCII/special-character `file_name` values in Feishu multipart uploads so Chinese/symbol-heavy filenames are sent as proper attachments instead of plain text links. (#31179)
 - Docs/Docker images: clarify the official GHCR image source and tag guidance (`main`, `latest`, `<version>`), and document that `OPENCLAW_IMAGE` skips local image builds but still uses the repo-local compose/setup flow. (#27214, #31180) Fixes #15655. Thanks @ipl31.
 - Agents/Model fallback: classify additional network transport errors (`ECONNREFUSED`, `ENETUNREACH`, `EHOSTUNREACH`, `ENETRESET`, `EAI_AGAIN`) as failover-worthy so fallback chains advance when primary providers are unreachable. Landed from contributor PR #19077 by @ayanesakura. Thanks @ayanesakura.
 - Agents/Copilot token refresh: refresh GitHub Copilot runtime API tokens after auth-expiry failures and re-run with the renewed token so long-running embedded/subagent turns do not fail on mid-session 401 expiry. Landed from contributor PR #8805 by @Arthur742Ramos. Thanks @Arthur742Ramos.

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -36,7 +36,12 @@ vi.mock("./runtime.js", () => ({
   }),
 }));
 
-import { downloadImageFeishu, downloadMessageResourceFeishu, sendMediaFeishu } from "./media.js";
+import {
+  downloadImageFeishu,
+  downloadMessageResourceFeishu,
+  sendMediaFeishu,
+  uploadFileFeishu,
+} from "./media.js";
 
 function expectPathIsolatedToTmpRoot(pathValue: string, key: string): void {
   expect(pathValue).not.toContain(key);
@@ -265,6 +270,24 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(fileCreateMock).not.toHaveBeenCalled();
     expect(messageCreateMock).not.toHaveBeenCalled();
     expect(messageReplyMock).not.toHaveBeenCalled();
+  });
+
+  it("encodes non-ASCII/special upload file names before calling feishu sdk", async () => {
+    await uploadFileFeishu({
+      cfg: {} as any,
+      file: Buffer.from("doc"),
+      fileName: "测试文件—特殊字符（2026-03-02）.md",
+      fileType: "pdf",
+    });
+
+    expect(fileCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          file_name:
+            "%E6%B5%8B%E8%AF%95%E6%96%87%E4%BB%B6%E2%80%94%E7%89%B9%E6%AE%8A%E5%AD%97%E7%AC%A6%EF%BC%882026-03-02%EF%BC%89.md",
+        }),
+      }),
+    );
   });
 
   it("uses isolated temp paths for image downloads", async () => {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -20,6 +20,20 @@ export type DownloadMessageResourceResult = {
   fileName?: string;
 };
 
+const FEISHU_SAFE_FILE_NAME_RE = /^[A-Za-z0-9._-]+$/;
+const RFC5987_EXTRA_ESCAPE_RE = /[!'()*]/g;
+
+function encodeFeishuUploadFileName(fileName: string): string {
+  // Keep common ASCII names readable; encode names with spaces/non-ASCII/special chars.
+  if (FEISHU_SAFE_FILE_NAME_RE.test(fileName)) {
+    return fileName;
+  }
+  return encodeURIComponent(fileName).replace(
+    RFC5987_EXTRA_ESCAPE_RE,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
 async function readFeishuResponseBuffer(params: {
   response: unknown;
   tmpDirPrefix: string;
@@ -226,6 +240,7 @@ export async function uploadFileFeishu(params: {
   }
 
   const client = createFeishuClient(account);
+  const encodedFileName = encodeFeishuUploadFileName(fileName);
 
   // SDK accepts Buffer directly or fs.ReadStream for file paths
   // Using Readable.from(buffer) causes issues with form-data library
@@ -235,7 +250,7 @@ export async function uploadFileFeishu(params: {
   const response = await client.im.file.create({
     data: {
       file_type: fileType,
-      file_name: fileName,
+      file_name: encodedFileName,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
       file: fileData as any,
       ...(duration !== undefined && { duration }),


### PR DESCRIPTION
## Summary
- percent-encode non-ASCII/special-character Feishu upload `file_name` values before calling `client.im.file.create`
- keep plain safe ASCII names unchanged to minimize behavioral drift for common file names
- add regression coverage for Chinese + symbol-heavy file names
- add Unreleased changelog note

Fixes #31179.

## Testing
- `pnpm test extensions/feishu/src/media.test.ts`
- `pnpm exec oxlint extensions/feishu/src/media.ts extensions/feishu/src/media.test.ts`
