### PR TITLE
fix: trigger session-memory hook for Feishu /new native reset path

### DIFF
--- a/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
@@ -194,6 +194,67 @@ describe("getReplyFromConfig reset-hook fallback", () => {
     );
   });
 
+  it("emits fallback hooks for /new when commandBodyNormalized is empty", async () => {
+    mocks.handleInlineActions.mockResolvedValue({ kind: "reply", reply: undefined });
+    mocks.resolveReplyDirectives.mockResolvedValue({
+      kind: "continue",
+      result: {
+        commandSource: "/new",
+        command: {
+          surface: "telegram",
+          channel: "telegram",
+          channelId: "telegram",
+          ownerList: [],
+          senderIsOwner: true,
+          isAuthorizedSender: true,
+          senderId: "123",
+          abortKey: "telegram:slash:123",
+          rawBodyNormalized: "",
+          commandBodyNormalized: "",
+          from: "telegram:123",
+          to: "slash:123",
+          resetHookTriggered: false,
+        },
+        allowTextCommands: true,
+        skillCommands: [],
+        directives: {},
+        cleanedBody: "/new",
+        elevatedEnabled: false,
+        elevatedAllowed: false,
+        elevatedFailures: [],
+        defaultActivation: "always",
+        resolvedThinkLevel: undefined,
+        resolvedVerboseLevel: "off",
+        resolvedReasoningLevel: "off",
+        resolvedElevatedLevel: "off",
+        execOverrides: undefined,
+        blockStreamingEnabled: false,
+        blockReplyChunking: undefined,
+        resolvedBlockStreamingBreak: undefined,
+        provider: "openai",
+        model: "gpt-4o-mini",
+        modelState: {
+          resolveDefaultThinkingLevel: async () => undefined,
+        },
+        contextTokens: 0,
+        inlineStatusRequested: false,
+        directiveAck: undefined,
+        perMessageQueueMode: undefined,
+        perMessageQueueOptions: undefined,
+      },
+    });
+
+    await getReplyFromConfig(buildNativeResetContext(), undefined, {});
+
+    expect(mocks.emitResetCommandHooks).toHaveBeenCalledTimes(1);
+    expect(mocks.emitResetCommandHooks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "new",
+        sessionKey: "agent:main:telegram:direct:123",
+      }),
+    );
+  });
+
   it("does not emit fallback hooks when resetHookTriggered is already set", async () => {
     mocks.handleInlineActions.mockResolvedValue({ kind: "reply", reply: undefined });
     mocks.resolveReplyDirectives.mockResolvedValue({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -277,11 +277,28 @@ export async function getReplyFromConfig(
     if (!resetTriggered || !command.isAuthorizedSender || command.resetHookTriggered) {
       return;
     }
-    const resetMatch = command.commandBodyNormalized.match(/^\/(new|reset)(?:\s|$)/);
-    if (!resetMatch) {
-      return;
-    }
-    const action: ResetCommandAction = resetMatch[1] === "reset" ? "reset" : "new";
+
+    const resolveAction = (): ResetCommandAction | null => {
+      const candidates = [
+        command.commandBodyNormalized,
+        command.rawBodyNormalized,
+        triggerBodyNormalized,
+        sessionCtx.CommandBody,
+        sessionCtx.RawBody,
+        ctx.CommandBody,
+        ctx.RawBody,
+      ];
+      for (const candidate of candidates) {
+        const match = candidate?.trim().match(/^\/(new|reset)(?:\s|$)/i);
+        if (!match) {
+          continue;
+        }
+        return match[1].toLowerCase() === "reset" ? "reset" : "new";
+      }
+      return null;
+    };
+
+    const action = resolveAction() ?? "new";
     await emitResetCommandHooks({
       action,
       ctx,


### PR DESCRIPTION
## Summary
- fix reset-hook fallback so it still emits hooks when normalized command text is empty
- infer reset action from multiple raw command sources (case-insensitive) instead of only `commandBodyNormalized`
- default fallback action to `new` when session reset is already confirmed but command text has been stripped
- add regression test covering empty `commandBodyNormalized` on native `/new`

## Root cause
For native slash-command flows (like Feishu), `resetTriggered` can be true while `command.commandBodyNormalized` is empty after normalization.
The fallback in `get-reply.ts` only checked `commandBodyNormalized`, so it returned early and never called `emitResetCommandHooks`, which prevented the `before_reset`/session-memory hook from running.

## Testing
- `pnpm vitest run src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts`
- `pnpm vitest run src/auto-reply/reply/commands.test.ts -t "triggers hooks for native /new routed to target sessions"`

Closes #31275
