### PR TITLE
feat(agents): include resolvedModel in agent:bootstrap hook context

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -67,6 +67,8 @@ export async function resolveBootstrapFilesForRun(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  provider?: string;
+  modelId?: string;
   warn?: (message: string) => void;
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;
@@ -91,6 +93,8 @@ export async function resolveBootstrapFilesForRun(params: {
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
     agentId: params.agentId,
+    provider: params.provider,
+    modelId: params.modelId,
   });
   return sanitizeBootstrapFiles(updated, params.warn);
 }
@@ -101,6 +105,8 @@ export async function resolveBootstrapContextForRun(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  provider?: string;
+  modelId?: string;
   warn?: (message: string) => void;
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;

--- a/src/agents/bootstrap-hooks.test.ts
+++ b/src/agents/bootstrap-hooks.test.ts
@@ -44,4 +44,54 @@ describe("applyBootstrapHookOverrides", () => {
     expect(updated).toHaveLength(2);
     expect(updated[1]?.path).toBe("/tmp/EXTRA.md");
   });
+
+  it("passes provider and modelId to hook context", async () => {
+    let capturedContext: AgentBootstrapHookContext | undefined;
+    registerInternalHook("agent:bootstrap", (event) => {
+      capturedContext = event.context as AgentBootstrapHookContext;
+    });
+
+    await applyBootstrapHookOverrides({
+      files: [makeFile()],
+      workspaceDir: "/tmp",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+    });
+
+    expect(capturedContext?.provider).toBe("anthropic");
+    expect(capturedContext?.modelId).toBe("claude-opus-4-6");
+  });
+
+  it("leaves provider and modelId undefined when not supplied", async () => {
+    let capturedContext: AgentBootstrapHookContext | undefined;
+    registerInternalHook("agent:bootstrap", (event) => {
+      capturedContext = event.context as AgentBootstrapHookContext;
+    });
+
+    await applyBootstrapHookOverrides({
+      files: [makeFile()],
+      workspaceDir: "/tmp",
+    });
+
+    expect(capturedContext?.provider).toBeUndefined();
+    expect(capturedContext?.modelId).toBeUndefined();
+  });
+
+  it("allows hook to filter files based on provider", async () => {
+    registerInternalHook("agent:bootstrap", (event) => {
+      const ctx = event.context as AgentBootstrapHookContext;
+      if (ctx.provider === "anthropic" && ctx.modelId?.includes("haiku")) {
+        ctx.bootstrapFiles = ctx.bootstrapFiles.filter((f) => f.name !== DEFAULT_SOUL_FILENAME);
+      }
+    });
+
+    const result = await applyBootstrapHookOverrides({
+      files: [makeFile()],
+      workspaceDir: "/tmp",
+      provider: "anthropic",
+      modelId: "claude-3-5-haiku",
+    });
+
+    expect(result).toHaveLength(0);
+  });
 });

--- a/src/agents/bootstrap-hooks.ts
+++ b/src/agents/bootstrap-hooks.ts
@@ -11,6 +11,8 @@ export async function applyBootstrapHookOverrides(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  provider?: string;
+  modelId?: string;
 }): Promise<WorkspaceBootstrapFile[]> {
   const sessionKey = params.sessionKey ?? params.sessionId ?? "unknown";
   const agentId =
@@ -23,6 +25,8 @@ export async function applyBootstrapHookOverrides(params: {
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
     agentId,
+    provider: params.provider,
+    modelId: params.modelId,
   };
   const event = createInternalHookEvent("agent", "bootstrap", sessionKey, context);
   await triggerInternalHook(event);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -538,6 +538,8 @@ export async function runEmbeddedAttempt(
         config: params.config,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
+        provider: params.provider,
+        modelId: params.modelId,
         warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
         contextMode: params.bootstrapContextMode,
         runKind: params.bootstrapContextRunKind,

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -19,6 +19,10 @@ export type AgentBootstrapHookContext = {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  /** Resolved provider id for this run (e.g. "anthropic", "openai"). */
+  provider?: string;
+  /** Resolved model id for this run (e.g. "claude-opus-4-6"). */
+  modelId?: string;
 };
 
 export type AgentBootstrapHookEvent = InternalHookEvent & {


### PR DESCRIPTION
## Summary

- Problem: The `agent:bootstrap` hook event provides `cfg`, `sessionKey`, `sessionId`, and `agentId`, but NOT the resolved model for the current run. This makes it impossible to conditionally filter bootstrap files based on which model is actually being used.
- Use case: Multi-model setups where Haiku handles heartbeats (lightweight scan) and Sonnet/Opus handles conversation. Heartbeat runs should strip heavy bootstrap files (SOUL.md, TOOLS.md, MEMORY.md) to save tokens.
- What changed: Added `provider` and `modelId` fields to `AgentBootstrapHookContext`. Threaded these values from the run attempt (`attempt.ts`) through `resolveBootstrapContextForRun` -> `resolveBootstrapFilesForRun` -> `applyBootstrapHookOverrides` into the hook event context.
- What did NOT change: The hook event structure is backward-compatible. Both fields are optional and default to `undefined` when not supplied.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31070

## User-visible / Behavior Changes

1. The `agent:bootstrap` hook now receives `provider` (e.g. `"anthropic"`) and `modelId` (e.g. `"claude-opus-4-6"`) in its context, enabling model-conditional bootstrap file filtering.
2. Fully backward-compatible: hooks that don't use these fields are unaffected.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node.js 22+

### Steps

1. Register an `agent:bootstrap` hook that reads `context.provider` and `context.modelId`
2. Configure multiple models (e.g. Haiku for heartbeats, Sonnet for conversation)
3. Trigger runs with different models
4. Observe that the hook correctly receives the resolved provider and model ID

### Expected

- Hook context contains the correct `provider` and `modelId` for each run

### Actual

- Before: `provider` and `modelId` were not available in the hook context
- After: Both fields are present and match the resolved model for the run

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test cases added to `bootstrap-hooks.test.ts`:
- `passes provider and modelId to hook context` - verifies fields are present
- `leaves provider and modelId undefined when not supplied` - verifies backward compat
- `allows hook to filter files based on provider` - end-to-end filtering scenario

## Human Verification (required)

- Verified scenarios: Hook receives provider/modelId; hook can filter files based on model; backward compatibility with hooks that don't use the new fields.
- Edge cases checked: Fields are `undefined` when not supplied (old call sites); hook that doesn't read the fields works unchanged.
- What you did **not** verify: Live multi-model session with Haiku heartbeats.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the 5 files changed. The new fields are additive and don't affect existing behavior.
- Files/config to restore: `src/hooks/internal-hooks.ts`, `src/agents/bootstrap-hooks.ts`, `src/agents/bootstrap-files.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms: None expected; all changes are additive optional fields.

## Risks and Mitigations

- Risk: None. All new fields are optional and backward-compatible.