### PR TITLE
fix(test): fix flaky Windows CI failure in subagent-announce.format.test

### DIFF
--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -145,8 +145,13 @@ describe("subagent announce formatting", () => {
   let runSubagentAnnounceFlow: (typeof import("./subagent-announce.js"))["runSubagentAnnounceFlow"];
 
   beforeAll(async () => {
-    ({ runSubagentAnnounceFlow } = await import("./subagent-announce.js"));
+    // Capture and set OPENCLAW_TEST_FAST *before* the dynamic import so the
+    // module-level FAST_TEST_MODE const picks it up. Without this, Windows CI
+    // (where the env var may not be pre-set) uses production retry intervals
+    // that are too slow for the tight timeoutMs values in these tests.
     previousFastTestEnv = process.env.OPENCLAW_TEST_FAST;
+    process.env.OPENCLAW_TEST_FAST = "1";
+    ({ runSubagentAnnounceFlow } = await import("./subagent-announce.js"));
   });
 
   afterAll(() => {


### PR DESCRIPTION
## Summary

- **Problem:** `subagent-announce.format.test.ts` — "waits for updated synthesized output before announcing nested subagent completion" fails intermittently on Windows CI.
- **Why it matters:** This flaky test has been causing spurious failures on merged PRs for weeks (#29716, #29576, #29456, #29440, #29421, #29299, #29279).
- **What changed:** Moved `process.env.OPENCLAW_TEST_FAST = "1"` from `beforeEach` into `beforeAll` **before** the dynamic `import("./subagent-announce.js")`, so the module-level `FAST_TEST_MODE` const captures the correct value.
- **What did NOT change:** Production code, other tests, retry intervals.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #31298

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows (CI runner)
- Runtime/container: Node 22+

### Steps

1. Run `pnpm test src/agents/subagent-announce.format.test.ts` on a Windows environment without `OPENCLAW_TEST_FAST` pre-set

### Expected

All 51 tests pass.

### Actual (before fix)

"waits for updated synthesized output..." test fails because `FAST_TEST_MODE` is `false`, retry interval is 100ms (not 8ms), and the 100ms timeout expires before the 3rd mock call.

## Evidence

- [x] Failing test/log before + passing after
- All 51 tests pass locally after the fix

## Human Verification (required)

- Verified scenarios: `pnpm test src/agents/subagent-announce.format.test.ts` — 51 tests pass
- Edge cases checked: `afterAll` correctly restores the previous env value
- What I did **not** verify: Cannot run on actual Windows CI locally, but the root cause analysis (module-level const evaluated before env stub) is deterministic

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files to restore: `src/agents/subagent-announce.format.test.ts`
- Known bad symptoms: N/A — test-only change

## Risks and Mitigations

None — this is a one-line reorder in test setup.