### PR TITLE
fix(agents): default api to openai-completions for inline provider models

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -379,4 +379,43 @@ describe("resolveModel", () => {
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: google-antigravity/some-model");
   });
+
+  it("defaults api to openai-completions for inline models without api", () => {
+    const cfg = {
+      models: {
+        providers: {
+          nvidia: {
+            baseUrl: "https://integrate.api.nvidia.com/v1/chat/completions",
+            models: [makeModel("moonshotai/kimi-k2.5")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("nvidia", "moonshotai/kimi-k2.5", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toBeDefined();
+    expect(result.model!.api).toBe("openai-completions");
+    expect(result.model!.id).toBe("moonshotai/kimi-k2.5");
+  });
+
+  it("preserves explicit api from inline provider config", () => {
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://custom.api.example.com",
+            api: "anthropic-messages",
+            models: [makeModel("custom-model")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("custom", "custom-model", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model!.api).toBe("anthropic-messages");
+  });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -63,7 +63,10 @@ export function resolveModel(
       (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
     );
     if (inlineMatch) {
-      const normalized = normalizeModelCompat(inlineMatch as Model<Api>);
+      const withApi = inlineMatch.api
+        ? inlineMatch
+        : { ...inlineMatch, api: providers[provider]?.api ?? ("openai-completions" as Api) };
+      const normalized = normalizeModelCompat(withApi as Model<Api>);
       return {
         model: normalized,
         authStorage,


### PR DESCRIPTION
## Summary

- Problem: Subagents crash with "No API provider registered for api: undefined" when using custom providers (e.g. NVIDIA/kimi-k2.5) that don't have an explicit `api` field in their config. The main agent works because it resolves through ModelRegistry (models.json) which always has `api` set, but subagents can resolve through the inline provider path which returns `api: undefined`.
- Root cause: In `resolveModel`, the inline match path (lines 65-71) returns the model from `buildInlineProviderModels` as-is. When neither the model config nor the provider config specifies `api`, the model has `api: undefined`. The Pi SDK's `streamSimple` then fails because it cannot find a registered API provider.
- What changed: When an inline match has no explicit `api`, default to `"openai-completions"` (the transport used by most third-party providers like NVIDIA, vLLM, Ollama that expose OpenAI-compatible endpoints). Falls back to the provider-level `api` first if available.
- What did NOT change: The `buildInlineProviderModels` function itself is unchanged. Models with explicit `api` fields (at model or provider level) are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30988

## User-visible / Behavior Changes

1. Custom providers configured without an `api` field now work correctly for subagents. Previously they crashed with "No API provider registered for api: undefined".
2. The default `api` for inline providers without explicit config is `"openai-completions"`, matching the behavior of most third-party endpoints.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Debian 12)
- Runtime: Node.js 22
- Model/provider: nvidia/moonshotai/kimi-k2.5

### Steps

1. Configure NVIDIA provider without explicit `api`:
   ```json
   {
     "models": {
       "providers": {
         "nvidia": {
           "baseUrl": "https://integrate.api.nvidia.com/v1/chat/completions",
           "models": [{ "id": "moonshotai/kimi-k2.5", "name": "kimi-k2.5" }]
         }
       }
     }
   }
   ```
2. Trigger a subagent invocation
3. Before fix: crash with "No API provider registered for api: undefined"
4. After fix: subagent runs successfully with `api: "openai-completions"`

### Expected

- Subagent resolves model with a valid `api` and runs successfully

### Actual

- Before: `api: undefined` -> crash
- After: `api: "openai-completions"` -> success

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test cases in `model.test.ts`:
- `defaults api to openai-completions for inline models without api` - verifies the fix
- `preserves explicit api from inline provider config` - verifies no regression for explicit api

## Human Verification (required)

- Verified scenarios: NVIDIA provider without api; custom provider with explicit api; provider config fallback path unchanged.
- Edge cases checked: Model with `api` set (preserved); provider with `api` but model without (inherited); neither has `api` (defaulted to openai-completions).
- What you did **not** verify: Live NVIDIA API call with kimi-k2.5.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the `api` defaulting in the inline match path. Users can work around by adding `"api": "openai-completions"` to their provider config.
- Files/config to restore: `src/agents/pi-embedded-runner/model.ts`

## Risks and Mitigations

- Risk: Some exotic providers might need a different default api (e.g. `"openai-responses"`).
  - Mitigation: The fix falls back to the provider-level `api` first. Only when both model and provider lack `api` does it use `"openai-completions"`. Users can always set `api` explicitly in their config.