### PR TITLE
docs: agent scaffolding — AGENTS.md map, ADRs, extracted reference docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,253 +4,105 @@
 - In chat replies, file references must be repo-root relative only (example: `extensions/bluebubbles/src/channel.ts:80`); never absolute paths or `~/...`.
 - GitHub issues/comments/PR comments: use literal multiline strings or `-F - <<'EOF'` (or $'...') for real newlines; never embed "\\n".
 - GitHub comment footgun: never use `gh issue/pr comment -b "..."` when body contains backticks or shell chars. Always use single-quoted heredoc (`-F - <<'EOF'`) so no command substitution/escaping corruption.
-- GitHub linking footgun: don’t wrap issue/PR refs like `#24643` in backticks when you want auto-linking. Use plain `#24643` (optionally add full URL).
 - Security advisory analysis: before triage/severity decisions, read `SECURITY.md` to align with OpenClaw's trust model and design boundaries.
 
-## Project Structure & Module Organization
+## Project Structure
 
-- Source code: `src/` (CLI wiring in `src/cli`, commands in `src/commands`, web provider in `src/provider-web.ts`, infra in `src/infra`, media pipeline in `src/media`).
-- Tests: colocated `*.test.ts`.
-- Docs: `docs/` (images, queue, Pi config). Built output lives in `dist/`.
-- Plugins/extensions: live under `extensions/*` (workspace packages). Keep plugin-only deps in the extension `package.json`; do not add them to the root `package.json` unless core uses them.
-- Plugins: install runs `npm install --omit=dev` in plugin dir; runtime deps must live in `dependencies`. Avoid `workspace:*` in `dependencies` (npm install breaks); put `openclaw` in `devDependencies` or `peerDependencies` instead (runtime resolves `openclaw/plugin-sdk` via jiti alias).
-- Installers served from `https://openclaw.ai/*`: live in the sibling repo `../openclaw.ai` (`public/install.sh`, `public/install-cli.sh`, `public/install.ps1`).
-- Messaging channels: always consider **all** built-in + extension channels when refactoring shared logic (routing, allowlists, pairing, command gating, onboarding, docs).
-  - Core channel docs: `docs/channels/`
-  - Core channel code: `src/telegram`, `src/discord`, `src/slack`, `src/signal`, `src/imessage`, `src/web` (WhatsApp web), `src/channels`, `src/routing`
-  - Extensions (channel plugins): `extensions/*` (e.g. `extensions/msteams`, `extensions/matrix`, `extensions/zalo`, `extensions/zalouser`, `extensions/voice-call`)
-- When adding channels/extensions/apps/docs, update `.github/labeler.yml` and create matching GitHub labels (use existing channel/extension label colors).
+- Source: `src/` (CLI wiring in `src/cli`, commands in `src/commands`, infra in `src/infra`, media pipeline in `src/media`)
+- Tests: colocated `*.test.ts`
+- Docs: `docs/` — built output in `dist/`
+- Plugins/extensions: `extensions/*` (workspace packages). Plugin-only deps stay in the extension `package.json`; avoid `workspace:*` in `dependencies`.
+- Messaging channels: always consider **all** built-in + extension channels when refactoring shared logic.
+  - Core channel code: `src/telegram`, `src/discord`, `src/slack`, `src/signal`, `src/imessage`, `src/web`, `src/channels`, `src/routing`
+  - Extension channels: `extensions/*` (e.g. `extensions/msteams`, `extensions/matrix`, `extensions/zalo`)
+- When adding channels/extensions/apps/docs, update `.github/labeler.yml` and create matching GitHub labels.
 
-## Docs Linking (Mintlify)
+## Key Docs
 
-- Docs are hosted on Mintlify (docs.openclaw.ai).
-- Internal doc links in `docs/**/*.md`: root-relative, no `.md`/`.mdx` (example: `[Config](/configuration)`).
-- When working with documentation, read the mintlify skill.
-- Section cross-references: use anchors on root-relative paths (example: `[Hooks](/configuration#hooks)`).
-- Doc headings and anchors: avoid em dashes and apostrophes in headings because they break Mintlify anchor links.
-- When Peter asks for links, reply with full `https://docs.openclaw.ai/...` URLs (not root-relative).
-- When you touch docs, end the reply with the `https://docs.openclaw.ai/...` URLs you referenced.
-- README (GitHub): keep absolute docs URLs (`https://docs.openclaw.ai/...`) so links work on GitHub.
-- Docs content must be generic: no personal device names/hostnames/paths; use placeholders like `user@gateway-host` and “gateway host”.
+| Path                            | Purpose                                    |
+| ------------------------------- | ------------------------------------------ |
+| `docs/decisions/`               | ADRs — read before changing covered areas  |
+| `docs/conventions.md`           | Coding style, naming, TypeScript rules     |
+| `docs/testing.md`               | Testing setup, commands, live tests        |
+| `docs/releases.md`              | Release channels, versioning, publish flow |
+| `docs/ops/vm.md`                | exe.dev VM ops and SSH access              |
+| `docs/reference/RELEASING.md`   | Full release checklist                     |
+| `.agents/skills/PR_WORKFLOW.md` | Maintainer PR workflow                     |
 
-## Docs i18n (zh-CN)
+## Architecture Decisions
 
-- `docs/zh-CN/**` is generated; do not edit unless the user explicitly asks.
-- Pipeline: update English docs → adjust glossary (`docs/.i18n/glossary.zh-CN.json`) → run `scripts/docs-i18n` → apply targeted fixes only if instructed.
-- Translation memory: `docs/.i18n/zh-CN.tm.jsonl` (generated).
-- See `docs/.i18n/README.md`.
-- The pipeline can be slow/inefficient; if it’s dragging, ping @jospalmbier on Discord instead of hacking around it.
+See `docs/decisions/` for ADRs. Read the relevant ADR before changing an area it covers.
 
-## exe.dev VM ops (general)
+## Build & Test Commands
 
-- Access: stable path is `ssh exe.dev` then `ssh vm-name` (assume SSH key already set).
-- SSH flaky: use exe.dev web terminal or Shelley (web agent); keep a tmux session for long ops.
-- Update: `sudo npm i -g openclaw@latest` (global install needs root on `/usr/lib/node_modules`).
-- Config: use `openclaw config set ...`; ensure `gateway.mode=local` is set.
-- Discord: store raw token only (no `DISCORD_BOT_TOKEN=` prefix).
-- Restart: stop old gateway and run:
-  `pkill -9 -f openclaw-gateway || true; nohup openclaw gateway run --bind loopback --port 18789 --force > /tmp/openclaw-gateway.log 2>&1 &`
-- Verify: `openclaw channels status --probe`, `ss -ltnp | rg 18789`, `tail -n 120 /tmp/openclaw-gateway.log`.
+```bash
+pnpm install       # Install deps
+pnpm build         # Type-check/build
+pnpm tsgo          # TypeScript checks
+pnpm check         # Lint/format (Oxlint + Oxfmt)
+pnpm format:fix    # Format fix
+pnpm test          # Run tests (Vitest)
+pnpm test:coverage # With V8 coverage
+```
 
-## Build, Test, and Development Commands
+- Runtime baseline: Node **22+**
+- Prefer Bun for TypeScript execution: `bun <file.ts>` / `bunx <tool>`
+- Low-memory test run: `OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test`
+- Pre-commit hooks: `prek install`
+- See `docs/testing.md` for full test suite details.
 
-- Runtime baseline: Node **22+** (keep Node + Bun paths working).
-- Install deps: `pnpm install`
-- If deps are missing (for example `node_modules` missing, `vitest not found`, or `command not found`), run the repo’s package-manager install command (prefer lockfile/README-defined PM), then rerun the exact requested command once. Apply this to test/build/lint/typecheck/dev commands; if retry still fails, report the command and first actionable error.
-- Pre-commit hooks: `prek install` (runs same checks as CI)
-- Also supported: `bun install` (keep `pnpm-lock.yaml` + Bun patching in sync when touching deps/patches).
-- Prefer Bun for TypeScript execution (scripts, dev, tests): `bun <file.ts>` / `bunx <tool>`.
-- Run CLI in dev: `pnpm openclaw ...` (bun) or `pnpm dev`.
-- Node remains supported for running built output (`dist/*`) and production installs.
-- Mac packaging (dev): `scripts/package-mac-app.sh` defaults to current arch. Release checklist: `docs/platforms/mac/release.md`.
-- Type-check/build: `pnpm build`
-- TypeScript checks: `pnpm tsgo`
-- Lint/format: `pnpm check`
-- Format check: `pnpm format` (oxfmt --check)
-- Format fix: `pnpm format:fix` (oxfmt --write)
-- Tests: `pnpm test` (vitest); coverage: `pnpm test:coverage`
+## Commit & PR Guidelines
 
-## Coding Style & Naming Conventions
+- Create commits with `scripts/committer "<msg>" <file...>`
+- Follow Conventional Commit style (e.g. `CLI: add verbose flag to send`)
+- PR template: `.github/pull_request_template.md`
+- Full maintainer workflow: `.agents/skills/PR_WORKFLOW.md`
 
-- Language: TypeScript (ESM). Prefer strict typing; avoid `any`.
-- Formatting/linting via Oxlint and Oxfmt; run `pnpm check` before commits.
-- Never add `@ts-nocheck` and do not disable `no-explicit-any`; fix root causes and update Oxlint/Oxfmt config only when required.
-- Never share class behavior via prototype mutation (`applyPrototypeMixins`, `Object.defineProperty` on `.prototype`, or exporting `Class.prototype` for merges). Use explicit inheritance/composition (`A extends B extends C`) or helper composition so TypeScript can typecheck.
-- If this pattern is needed, stop and get explicit approval before shipping; default behavior is to split/refactor into an explicit class hierarchy and keep members strongly typed.
-- In tests, prefer per-instance stubs over prototype mutation (`SomeClass.prototype.method = ...`) unless a test explicitly documents why prototype-level patching is required.
-- Add brief code comments for tricky or non-obvious logic.
-- Keep files concise; extract helpers instead of “V2” copies. Use existing patterns for CLI options and dependency injection via `createDefaultDeps`.
-- Aim to keep files under ~700 LOC; guideline only (not a hard guardrail). Split/refactor when it improves clarity or testability.
-- Naming: use **OpenClaw** for product/app/docs headings; use `openclaw` for CLI command, package/binary, paths, and config keys.
+## Docs (Mintlify)
 
-## Release Channels (Naming)
+- Internal links: root-relative, no `.md`/`.mdx` extension (e.g. `[Config](/configuration)`)
+- Docs content must be generic: no personal device names/hostnames/paths
+- `docs/zh-CN/**` is generated; do not edit unless explicitly asked
+- See `docs/.i18n/README.md` for i18n pipeline
 
-- stable: tagged releases only (e.g. `vYYYY.M.D`), npm dist-tag `latest`.
-- beta: prerelease tags `vYYYY.M.D-beta.N`, npm dist-tag `beta` (may ship without macOS app).
-- beta naming: prefer `-beta.N`; do not mint new `-1/-2` betas. Legacy `vYYYY.M.D-<patch>` and `vYYYY.M.D.beta.N` remain recognized.
-- dev: moving head on `main` (no tag; git checkout main).
+## Security & Configuration
 
-## Testing Guidelines
-
-- Framework: Vitest with V8 coverage thresholds (70% lines/branches/functions/statements).
-- Naming: match source names with `*.test.ts`; e2e in `*.e2e.test.ts`.
-- Run `pnpm test` (or `pnpm test:coverage`) before pushing when you touch logic.
-- Do not set test workers above 16; tried already.
-- If local Vitest runs cause memory pressure (common on non-Mac-Studio hosts), use `OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test` for land/gate runs.
-- Live tests (real keys): `CLAWDBOT_LIVE_TEST=1 pnpm test:live` (OpenClaw-only) or `LIVE=1 pnpm test:live` (includes provider live tests). Docker: `pnpm test:docker:live-models`, `pnpm test:docker:live-gateway`. Onboarding Docker E2E: `pnpm test:docker:onboard`.
-- Full kit + what’s covered: `docs/testing.md`.
-- Changelog: user-facing changes only; no internal/meta notes (version alignment, appcast reminders, release process).
-- Pure test additions/fixes generally do **not** need a changelog entry unless they alter user-facing behavior or the user asks for one.
-- Mobile: before using a simulator, check for connected real devices (iOS + Android) and prefer them when available.
-
-## Commit & Pull Request Guidelines
-
-**Full maintainer PR workflow (optional):** If you want the repo's end-to-end maintainer workflow (triage order, quality bar, rebase rules, commit/changelog conventions, co-contributor policy, and the `review-pr` > `prepare-pr` > `merge-pr` pipeline), see `.agents/skills/PR_WORKFLOW.md`. Maintainers may use other workflows; when a maintainer specifies a workflow, follow that. If no workflow is specified, default to PR_WORKFLOW.
-
-- Create commits with `scripts/committer "<msg>" <file...>`; avoid manual `git add`/`git commit` so staging stays scoped.
-- Follow concise, action-oriented commit messages (e.g., `CLI: add verbose flag to send`).
-- Group related changes; avoid bundling unrelated refactors.
-- PR submission template (canonical): `.github/pull_request_template.md`
-- Issue submission templates (canonical): `.github/ISSUE_TEMPLATE/`
-
-## Shorthand Commands
-
-- `sync`: if working tree is dirty, commit all changes (pick a sensible Conventional Commit message), then `git pull --rebase`; if rebase conflicts and cannot resolve, stop; otherwise `git push`.
-
-## Git Notes
-
-- If `git branch -d/-D <branch>` is policy-blocked, delete the local ref directly: `git update-ref -d refs/heads/<branch>`.
-- Bulk PR close/reopen safety: if a close action would affect more than 5 PRs, first ask for explicit user confirmation with the exact PR count and target scope/query.
-
-## GitHub Search (`gh`)
-
-- Prefer targeted keyword search before proposing new work or duplicating fixes.
-- Use `--repo openclaw/openclaw` + `--match title,body` first; add `--match comments` when triaging follow-up threads.
-- PRs: `gh search prs --repo openclaw/openclaw --match title,body --limit 50 -- "auto-update"`
-- Issues: `gh search issues --repo openclaw/openclaw --match title,body --limit 50 -- "auto-update"`
-- Structured output example:
-  `gh search issues --repo openclaw/openclaw --match title,body --limit 50 --json number,title,state,url,updatedAt -- "auto update" --jq '.[] | "\(.number) | \(.state) | \(.title) | \(.url)"'`
-
-## Security & Configuration Tips
-
-- Web provider stores creds at `~/.openclaw/credentials/`; rerun `openclaw login` if logged out.
-- Pi sessions live under `~/.openclaw/sessions/` by default; the base directory is not configurable.
-- Environment variables: see `~/.profile`.
-- Never commit or publish real phone numbers, videos, or live configuration values. Use obviously fake placeholders in docs, tests, and examples.
-- Release flow: always read `docs/reference/RELEASING.md` and `docs/platforms/mac/release.md` before any release work; do not ask routine questions once those docs answer them.
-
-## GHSA (Repo Advisory) Patch/Publish
-
-- Before reviewing security advisories, read `SECURITY.md`.
-- Fetch: `gh api /repos/openclaw/openclaw/security-advisories/<GHSA>`
-- Latest npm: `npm view openclaw version --userconfig "$(mktemp)"`
-- Private fork PRs must be closed:
-  `fork=$(gh api /repos/openclaw/openclaw/security-advisories/<GHSA> | jq -r .private_fork.full_name)`
-  `gh pr list -R "$fork" --state open` (must be empty)
-- Description newline footgun: write Markdown via heredoc to `/tmp/ghsa.desc.md` (no `"\\n"` strings)
-- Build patch JSON via jq: `jq -n --rawfile desc /tmp/ghsa.desc.md '{summary,severity,description:$desc,vulnerabilities:[...]}' > /tmp/ghsa.patch.json`
-- GHSA API footgun: cannot set `severity` and `cvss_vector_string` in the same PATCH; do separate calls.
-- Patch + publish: `gh api -X PATCH /repos/openclaw/openclaw/security-advisories/<GHSA> --input /tmp/ghsa.patch.json` (publish = include `"state":"published"`; no `/publish` endpoint)
-- If publish fails (HTTP 422): missing `severity`/`description`/`vulnerabilities[]`, or private fork has open PRs
-- Verify: re-fetch; ensure `state=published`, `published_at` set; `jq -r .description | rg '\\\\n'` returns nothing
-
-## Troubleshooting
-
-- Rebrand/migration issues or legacy config/service warnings: run `openclaw doctor` (see `docs/gateway/doctor.md`).
+- Never commit real phone numbers, videos, or live config values — use obvious placeholders
+- Release flow: read `docs/reference/RELEASING.md` and `docs/platforms/mac/release.md` before any release work
+- See `docs/releases.md` for version locations and release channel conventions
 
 ## Agent-Specific Notes
 
-- Vocabulary: "makeup" = "mac app".
-- Never edit `node_modules` (global/Homebrew/npm/git installs too). Updates overwrite. Skill notes go in `tools.md` or `AGENTS.md`.
-- When adding a new `AGENTS.md` anywhere in the repo, also add a `CLAUDE.md` symlink pointing to it (example: `ln -s AGENTS.md CLAUDE.md`).
-- Signal: "update fly" => `fly ssh console -a flawd-bot -C "bash -lc 'cd /data/clawd/openclaw && git pull --rebase origin main'"` then `fly machines restart e825232f34d058 -a flawd-bot`.
-- When working on a GitHub Issue or PR, print the full URL at the end of the task.
-- When answering questions, respond with high-confidence answers only: verify in code; do not guess.
-- Never update the Carbon dependency.
-- Any dependency with `pnpm.patchedDependencies` must use an exact version (no `^`/`~`).
-- Patching dependencies (pnpm patches, overrides, or vendored changes) requires explicit approval; do not do this by default.
-- CLI progress: use `src/cli/progress.ts` (`osc-progress` + `@clack/prompts` spinner); don’t hand-roll spinners/bars.
-- Status output: keep tables + ANSI-safe wrapping (`src/terminal/table.ts`); `status --all` = read-only/pasteable, `status --deep` = probes.
-- Gateway currently runs only as the menubar app; there is no separate LaunchAgent/helper label installed. Restart via the OpenClaw Mac app or `scripts/restart-mac.sh`; to verify/kill use `launchctl print gui/$UID | grep openclaw` rather than assuming a fixed label. **When debugging on macOS, start/stop the gateway via the app, not ad-hoc tmux sessions; kill any temporary tunnels before handoff.**
-- macOS logs: use `./scripts/clawlog.sh` to query unified logs for the OpenClaw subsystem; it supports follow/tail/category filters and expects passwordless sudo for `/usr/bin/log`.
-- If shared guardrails are available locally, review them; otherwise follow this repo's guidance.
-- SwiftUI state management (iOS/macOS): prefer the `Observation` framework (`@Observable`, `@Bindable`) over `ObservableObject`/`@StateObject`; don’t introduce new `ObservableObject` unless required for compatibility, and migrate existing usages when touching related code.
-- Connection providers: when adding a new connection, update every UI surface and docs (macOS app, web UI, mobile if applicable, onboarding/overview docs) and add matching status + configuration forms so provider lists and settings stay in sync.
-- Version locations: `package.json` (CLI), `apps/android/app/build.gradle.kts` (versionName/versionCode), `apps/ios/Sources/Info.plist` + `apps/ios/Tests/Info.plist` (CFBundleShortVersionString/CFBundleVersion), `apps/macos/Sources/OpenClaw/Resources/Info.plist` (CFBundleShortVersionString/CFBundleVersion), `docs/install/updating.md` (pinned npm version), `docs/platforms/mac/release.md` (APP_VERSION/APP_BUILD examples), Peekaboo Xcode projects/Info.plists (MARKETING_VERSION/CURRENT_PROJECT_VERSION).
-- "Bump version everywhere" means all version locations above **except** `appcast.xml` (only touch appcast when cutting a new macOS Sparkle release).
-- **Restart apps:** “restart iOS/Android apps” means rebuild (recompile/install) and relaunch, not just kill/launch.
-- **Device checks:** before testing, verify connected real devices (iOS/Android) before reaching for simulators/emulators.
-- iOS Team ID lookup: `security find-identity -p codesigning -v` → use Apple Development (…) TEAMID. Fallback: `defaults read com.apple.dt.Xcode IDEProvisioningTeamIdentifiers`.
-- A2UI bundle hash: `src/canvas-host/a2ui/.bundle.hash` is auto-generated; ignore unexpected changes, and only regenerate via `pnpm canvas:a2ui:bundle` (or `scripts/bundle-a2ui.sh`) when needed. Commit the hash as a separate commit.
-- Release signing/notary keys are managed outside the repo; follow internal release docs.
-- Notary auth env vars (`APP_STORE_CONNECT_ISSUER_ID`, `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_API_KEY_P8`) are expected in your environment (per internal release docs).
-- **Multi-agent safety:** do **not** create/apply/drop `git stash` entries unless explicitly requested (this includes `git pull --rebase --autostash`). Assume other agents may be working; keep unrelated WIP untouched and avoid cross-cutting state changes.
-- **Multi-agent safety:** when the user says "push", you may `git pull --rebase` to integrate latest changes (never discard other agents' work). When the user says "commit", scope to your changes only. When the user says "commit all", commit everything in grouped chunks.
-- **Multi-agent safety:** do **not** create/remove/modify `git worktree` checkouts (or edit `.worktrees/*`) unless explicitly requested.
-- **Multi-agent safety:** do **not** switch branches / check out a different branch unless explicitly requested.
-- **Multi-agent safety:** running multiple agents is OK as long as each agent has its own session.
-- **Multi-agent safety:** when you see unrecognized files, keep going; focus on your changes and commit only those.
-- Lint/format churn:
-  - If staged+unstaged diffs are formatting-only, auto-resolve without asking.
-  - If commit/push already requested, auto-stage and include formatting-only follow-ups in the same commit (or a tiny follow-up commit if needed), no extra confirmation.
-  - Only ask when changes are semantic (logic/data/behavior).
-- Lobster seam: use the shared CLI palette in `src/terminal/palette.ts` (no hardcoded colors); apply palette to onboarding/config prompts and other TTY UI output as needed.
-- **Multi-agent safety:** focus reports on your edits; avoid guard-rail disclaimers unless truly blocked; when multiple agents touch the same file, continue if safe; end with a brief “other files present” note only if relevant.
-- Bug investigations: read source code of relevant npm dependencies and all related local code before concluding; aim for high-confidence root cause.
-- Code style: add brief comments for tricky logic; keep files under ~500 LOC when feasible (split/refactor as needed).
-- Tool schema guardrails (google-antigravity): avoid `Type.Union` in tool input schemas; no `anyOf`/`oneOf`/`allOf`. Use `stringEnum`/`optionalStringEnum` (Type.Unsafe enum) for string lists, and `Type.Optional(...)` instead of `... | null`. Keep top-level tool schema as `type: "object"` with `properties`.
-- Tool schema guardrails: avoid raw `format` property names in tool schemas; some validators treat `format` as a reserved keyword and reject the schema.
-- When asked to open a “session” file, open the Pi session logs under `~/.openclaw/agents/<agentId>/sessions/*.jsonl` (use the `agent=<id>` value in the Runtime line of the system prompt; newest unless a specific ID is given), not the default `sessions.json`. If logs are needed from another machine, SSH via Tailscale and read the same path there.
-- Do not rebuild the macOS app over SSH; rebuilds must be run directly on the Mac.
-- Never send streaming/partial replies to external messaging surfaces (WhatsApp, Telegram); only final replies should be delivered there. Streaming/tool events may still go to internal UIs/control channel.
-- Voice wake forwarding tips:
-  - Command template should stay `openclaw-mac agent --message "${text}" --thinking low`; `VoiceWakeForwarder` already shell-escapes `${text}`. Don’t add extra quotes.
-  - launchd PATH is minimal; ensure the app’s launch agent PATH includes standard system paths plus your pnpm bin (typically `$HOME/Library/pnpm`) so `pnpm`/`openclaw` binaries resolve when invoked via `openclaw-mac`.
-- For manual `openclaw message send` messages that include `!`, use the heredoc pattern noted below to avoid the Bash tool’s escaping.
-- Release guardrails: do not change version numbers without operator’s explicit consent; always ask permission before running any npm publish/release step.
-- Beta release guardrail: when using a beta Git tag (for example `vYYYY.M.D-beta.N`), publish npm with a matching beta version suffix (for example `YYYY.M.D-beta.N`) rather than a plain version on `--tag beta`; otherwise the plain version name gets consumed/blocked.
+- When adding a new `AGENTS.md` anywhere, also add a `CLAUDE.md` symlink: `ln -s AGENTS.md CLAUDE.md`
+- Vocabulary: "makeup" = "mac app"
+- Never edit `node_modules`. Never update Carbon dependency.
+- Any dep with `pnpm.patchedDependencies` must use exact version (no `^`/`~`)
+- CLI progress: use `src/terminal/palette.ts` and `src/cli/progress.ts`
+- SwiftUI: prefer `Observation` framework (`@Observable`, `@Bindable`) over `ObservableObject`
+- Version locations: `package.json`, `apps/android/app/build.gradle.kts`, `apps/ios/Sources/Info.plist`, `apps/macos/Sources/OpenClaw/Resources/Info.plist` — "bump version everywhere" means all of these
+- Bug investigations: read source + relevant npm deps before concluding; aim for high-confidence root cause
+- When asked to open a "session" file: `~/.openclaw/agents/<agentId>/sessions/*.jsonl`
+- Do not rebuild the macOS app over SSH
 
-## NPM + 1Password (publish/verify)
+## Multi-Agent Safety
 
-- Use the 1password skill; all `op` commands must run inside a fresh tmux session.
-- Sign in: `eval "$(op signin --account my.1password.com)"` (app unlocked + integration on).
-- OTP: `op read 'op://Private/Npmjs/one-time password?attribute=otp'`.
-- Publish: `npm publish --access public --otp="<otp>"` (run from the package dir).
-- Verify without local npmrc side effects: `npm view <pkg> version --userconfig "$(mktemp)"`.
-- Kill the tmux session after publish.
+- Do **not** create/apply/drop `git stash` entries unless explicitly requested
+- Do **not** create/remove/modify `git worktree` checkouts unless explicitly requested
+- Do **not** switch branches unless explicitly requested
+- When "push" is requested: `git pull --rebase` first to integrate latest changes
+- When "commit" is requested: scope to your changes only; "commit all" = commit in grouped chunks
+- When you see unrecognized files, keep going; focus on your changes
 
-## Plugin Release Fast Path (no core `openclaw` publish)
+## Shorthand Commands
 
-- Release only already-on-npm plugins. Source list is in `docs/reference/RELEASING.md` under "Current npm plugin list".
-- Run all CLI `op` calls and `npm publish` inside tmux to avoid hangs/interruption:
-  - `tmux new -d -s release-plugins-$(date +%Y%m%d-%H%M%S)`
-  - `eval "$(op signin --account my.1password.com)"`
-- 1Password helpers:
-  - password used by `npm login`:
-    `op item get Npmjs --format=json | jq -r '.fields[] | select(.id=="password").value'`
-  - OTP:
-    `op read 'op://Private/Npmjs/one-time password?attribute=otp'`
-- Fast publish loop (local helper script in `/tmp` is fine; keep repo clean):
-  - compare local plugin `version` to `npm view <name> version`
-  - only run `npm publish --access public --otp="<otp>"` when versions differ
-  - skip if package is missing on npm or version already matches.
-- Keep `openclaw` untouched: never run publish from repo root unless explicitly requested.
-- Post-check for each release:
-  - per-plugin: `npm view @openclaw/<name> version --userconfig "$(mktemp)"` should be `2026.2.17`
-  - core guard: `npm view openclaw version --userconfig "$(mktemp)"` should stay at previous version unless explicitly requested.
+- `sync`: commit all dirty changes (sensible Conventional Commit message), `git pull --rebase`, `git push`
 
-## Changelog Release Notes
+## Knowledge Capture
 
-- When cutting a mac release with beta GitHub prerelease:
-  - Tag `vYYYY.M.D-beta.N` from the release commit (example: `v2026.2.15-beta.1`).
-  - Create prerelease with title `openclaw YYYY.M.D-beta.N`.
-  - Use release notes from `CHANGELOG.md` version section (`Changes` + `Fixes`, no title duplicate).
-  - Attach at least `OpenClaw-YYYY.M.D.zip` and `OpenClaw-YYYY.M.D.dSYM.zip`; include `.dmg` if available.
+After completing any non-trivial work (took multiple attempts, non-obvious solution, future sessions would benefit), capture the solution in `docs/solutions/`.
 
-- Keep top version entries in `CHANGELOG.md` sorted by impact:
-  - `### Changes` first.
-  - `### Fixes` deduped and ranked with user-facing fixes first.
-- Before tagging/publishing, run:
-  - `node --import tsx scripts/release-check.ts`
-  - `pnpm release:check`
-  - `pnpm test:install:smoke` or `OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke` for non-root smoke path.
+Note: `/ce:compound` integration is pending skill access setup — see `docs/decisions/` for tracking note. In the meantime, write solutions manually to `docs/solutions/[category]/filename.md`.
+
+## Doc Gardening
+
+A doc-gardening agent runs periodically to check for drift between docs and code and opens fix PRs. Do not try to do this manually.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,45 @@
+# Coding Conventions
+
+## Language & Types
+
+- TypeScript (ESM). Prefer strict typing; avoid `any`.
+- Never add `@ts-nocheck` and do not disable `no-explicit-any`; fix root causes.
+- Never share class behavior via prototype mutation (`applyPrototypeMixins`, `Object.defineProperty` on `.prototype`). Use explicit inheritance/composition.
+- In tests, prefer per-instance stubs over prototype mutation unless explicitly documented.
+
+## Formatting & Linting
+
+- Oxlint + Oxfmt. Run `pnpm check` before commits.
+- Format fix: `pnpm format:fix`
+
+## Naming
+
+- Use **OpenClaw** for product/app/docs headings; use `openclaw` for CLI command, package/binary, paths, config keys.
+- Add brief code comments for tricky or non-obvious logic.
+
+## File Size
+
+- Aim to keep files under ~700 LOC (guideline, not hard guardrail). Split/refactor when it improves clarity or testability.
+
+## Dependency Management
+
+- Any dep with `pnpm.patchedDependencies` must use exact version (no `^`/`~`).
+- Patching dependencies requires explicit approval; do not do this by default.
+- Never update the Carbon dependency.
+
+## Tool Schema (google-antigravity guardrails)
+
+- Avoid `Type.Union` in tool input schemas; no `anyOf`/`oneOf`/`allOf`.
+- Use `stringEnum`/`optionalStringEnum` for string lists, `Type.Optional(...)` instead of `... | null`.
+- Avoid raw `format` property names in tool schemas.
+
+## Plugin/Extension Structure
+
+- Plugin-only deps stay in the extension `package.json`; do not add to root `package.json` unless core uses them.
+- Runtime deps must live in `dependencies` (not `devDependencies`). Avoid `workspace:*` in `dependencies`.
+- Put `openclaw` in `devDependencies` or `peerDependencies` (runtime resolves `openclaw/plugin-sdk` via jiti alias).
+
+## GitHub Footguns
+
+- Never use `gh issue/pr comment -b "..."` when body contains backticks or shell chars. Use single-quoted heredoc (`-F - <<'EOF'`).
+- Don't wrap issue/PR refs like `#24643` in backticks when you want auto-linking. Use plain `#24643`.

--- a/docs/decisions/2025-01-01-channel-routing-model.md
+++ b/docs/decisions/2025-01-01-channel-routing-model.md
@@ -1,0 +1,19 @@
+# ADR: Channel Routing Model
+
+**Date:** 2025-01-01 (reconstructed)
+
+## Context
+
+Messages arrive from many surfaces (Telegram, Discord, Signal, etc.) and need to be routed to the right session/agent. The routing logic must be consistent regardless of source channel.
+
+## Decision
+
+Routing lives in `src/routing/` as a shared layer. Individual channel monitors (`src/telegram`, `src/discord`, etc.) normalise inbound messages into a common format before handing off to the router. The router resolves the target session based on channel config, allowlists, and group vs DM context.
+
+When refactoring routing, allowlists, pairing, command gating, onboarding, or docs — always consider all built-in + extension channels, not just the one being changed.
+
+## Consequences
+
+- Adding a new channel means implementing the normalisation layer; routing logic is inherited for free
+- Bugs in routing affect all channels simultaneously — test broadly
+- Channel-specific behaviour (e.g. thread-bound sessions on Discord) is handled in the channel layer before routing

--- a/docs/decisions/2025-01-01-node-bun-runtime-strategy.md
+++ b/docs/decisions/2025-01-01-node-bun-runtime-strategy.md
@@ -1,0 +1,21 @@
+# ADR: Node 22+ / Bun Runtime Strategy
+
+**Date:** 2025-01-01 (reconstructed)
+
+## Context
+
+OpenClaw needs to support both Node.js (production installs, `dist/*`) and Bun (faster dev/test execution). These have different module resolution and ESM behaviours.
+
+## Decision
+
+- Runtime baseline: Node **22+**
+- Prefer Bun for TypeScript execution (scripts, dev, tests): `bun <file.ts>` / `bunx <tool>`
+- Node remains supported for running built output and production installs
+- Keep `pnpm-lock.yaml` + Bun patching in sync when touching deps/patches
+- Tests: Vitest auto-disables `vmForks` on Node 24+ to avoid `ERR_VM_MODULE_LINK_FAILURE`
+
+## Consequences
+
+- Both runtimes must be tested; CI runs on Node
+- Bun-specific APIs must not leak into code that ships in `dist/`
+- `bun install` is a supported alternative to `pnpm install` but lockfile sync is the developer's responsibility

--- a/docs/decisions/2025-01-01-plugin-extension-architecture.md
+++ b/docs/decisions/2025-01-01-plugin-extension-architecture.md
@@ -1,0 +1,23 @@
+# ADR: Plugin/Extension Architecture
+
+**Date:** 2025-01-01 (reconstructed)
+
+## Context
+
+OpenClaw needed to support many messaging channels (Telegram, Discord, Slack, Signal, iMessage, WhatsApp, Teams, Matrix, etc.) without bloating the core package. Each channel has different dependencies, auth flows, and message formats.
+
+## Decision
+
+Channels and integrations live as workspace packages under `extensions/*`. Each extension has its own `package.json` and dependency tree. Core (`src/`) contains only the routing, session, and agent infrastructure. Extensions are loaded at runtime via the plugin system.
+
+Key rules:
+
+- Plugin-only deps stay in the extension `package.json`; never added to root unless core uses them
+- Runtime deps must be in `dependencies` (not `devDependencies`) — `npm install --omit=dev` is run in plugin dirs
+- `workspace:*` is forbidden in `dependencies` (npm install breaks); put `openclaw` in `devDependencies` or `peerDependencies`
+
+## Consequences
+
+- Core stays lean; channels can be installed independently
+- Each extension can version independently
+- Adding a new channel requires updating `extensions/*`, `.github/labeler.yml`, and all relevant UI surfaces (macOS app, web UI, mobile, onboarding docs)

--- a/docs/decisions/2025-01-01-workspace-only-agent-isolation.md
+++ b/docs/decisions/2025-01-01-workspace-only-agent-isolation.md
@@ -1,0 +1,17 @@
+# ADR: Workspace-Only Agent Isolation
+
+**Date:** 2025-01-01 (reconstructed)
+
+## Context
+
+Coding agents (Codex, Claude Code, opencode) spawned by OpenClaw need to be isolated from the OpenClaw codebase itself — an agent working on a user's project should not be able to read or modify OpenClaw's own config, session data, or source.
+
+## Decision
+
+Agents run with `workdir` scoped to the user's workspace. The `~/.openclaw/` directory is never exposed to spawned agents. Sub-agents working in `~/openclaw/` (the Nova/PR pipeline repo) operate under the same isolation: never spawn agents inside `~/.openclaw/workspace/` itself.
+
+## Consequences
+
+- Agents can't accidentally exfiltrate session data or modify OpenClaw config
+- Prompts must be explicit about workdir; agents "wake up" in a focused directory
+- Never start a coding agent in `~/.openclaw/` — it will read soul docs and get confused about the org chart

--- a/docs/decisions/2026-03-02-learnings-capture-future.md
+++ b/docs/decisions/2026-03-02-learnings-capture-future.md
@@ -1,0 +1,26 @@
+# ADR: Learnings Capture — Future Work
+
+**Date:** 2026-03-02
+
+## Context
+
+We want agents to capture non-trivial solutions after completing work, building a searchable knowledge base that compounds over time. The `/ce:compound` skill (from the compound-docs skill) implements this well — structured YAML frontmatter, category-based organisation, promotion path to critical patterns.
+
+## Decision
+
+Defer `/ce:compound` integration for Nova until skill access is figured out. Coding agents (Claude Code, opencode) spawned by Nova don't have the compound-docs skill in scope by default.
+
+In the interim, agents should manually write solutions to `docs/solutions/[category]/filename.md` when they encounter non-trivial problems worth capturing.
+
+## Future State
+
+When `/ce:compound` is available to Nova agents:
+
+1. Add AGENTS.md instruction: "run `/ce:compound` after completing non-trivial work"
+2. Point `critical-patterns.md` as required reading before starting work
+3. Remove this ADR's "defer" note
+
+## Consequences
+
+- Learnings accumulate slowly until skill access is resolved
+- Manual capture is better than nothing — document it in AGENTS.md

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,13 @@
+# Architecture Decision Records
+
+Significant decisions are captured here as ADRs. Read the relevant ADR before changing an area it covers.
+
+Add new decisions as `YYYY-MM-DD-title.md`.
+
+## Index
+
+- [Plugin/Extension Architecture](2025-01-01-plugin-extension-architecture.md)
+- [Channel Routing Model](2025-01-01-channel-routing-model.md)
+- [Workspace-Only Agent Isolation](2025-01-01-workspace-only-agent-isolation.md)
+- [Node 22+ / Bun Runtime Strategy](2025-01-01-node-bun-runtime-strategy.md)
+- [Learnings Capture — Future Work](2026-03-02-learnings-capture-future.md)

--- a/docs/ops/vm.md
+++ b/docs/ops/vm.md
@@ -1,0 +1,63 @@
+# exe.dev VM Ops
+
+## Access
+
+```bash
+ssh exe.dev
+ssh vm-name   # from exe.dev
+```
+
+SSH is flaky: use exe.dev web terminal or Shelley (web agent) as fallback. Keep a tmux session for long ops.
+
+## Update OpenClaw
+
+```bash
+sudo npm i -g openclaw@latest   # global install needs root
+```
+
+## Config
+
+```bash
+openclaw config set ...
+# Ensure gateway.mode=local is set
+# Discord: store raw token only (no DISCORD_BOT_TOKEN= prefix)
+```
+
+## Restart Gateway
+
+```bash
+pkill -9 -f openclaw-gateway || true
+nohup openclaw gateway run --bind loopback --port 18789 --force > /tmp/openclaw-gateway.log 2>&1 &
+```
+
+## Verify
+
+```bash
+openclaw channels status --probe
+ss -ltnp | rg 18789
+tail -n 120 /tmp/openclaw-gateway.log
+```
+
+## macOS Gateway
+
+Gateway runs only as the menubar app — no separate LaunchAgent. Start/stop via the OpenClaw Mac app or `scripts/restart-mac.sh`.
+
+To verify/kill: `launchctl print gui/$UID | grep openclaw` (do not assume a fixed label).
+
+**Do not rebuild the macOS app over SSH.** Rebuilds must run directly on the Mac.
+
+## macOS Logs
+
+```bash
+./scripts/clawlog.sh   # Unified logs for OpenClaw subsystem; supports follow/tail/category filters
+# Expects passwordless sudo for /usr/bin/log
+```
+
+## Signal (Flawd Bot)
+
+Update:
+
+```bash
+fly ssh console -a flawd-bot -C "bash -lc 'cd /data/clawd/openclaw && git pull --rebase origin main'"
+fly machines restart e825232f34d058 -a flawd-bot
+```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,66 @@
+# Release Channels & Versioning
+
+## Release Channels
+
+| Channel  | Description                                                                          |
+| -------- | ------------------------------------------------------------------------------------ |
+| `stable` | Tagged releases only (e.g. `vYYYY.M.D`), npm dist-tag `latest`                       |
+| `beta`   | Prerelease tags `vYYYY.M.D-beta.N`, npm dist-tag `beta` (may ship without macOS app) |
+| `dev`    | Moving head on `main` (no tag)                                                       |
+
+Beta naming: prefer `-beta.N`; do not mint new `-1/-2` betas.
+
+## Version Locations
+
+Bump all of these when cutting a release:
+
+- `package.json` (CLI)
+- `apps/android/app/build.gradle.kts` (versionName/versionCode)
+- `apps/ios/Sources/Info.plist` + `apps/ios/Tests/Info.plist` (CFBundleShortVersionString/CFBundleVersion)
+- `apps/macos/Sources/OpenClaw/Resources/Info.plist` (CFBundleShortVersionString/CFBundleVersion)
+- `docs/install/updating.md` (pinned npm version)
+- `docs/platforms/mac/release.md` (APP_VERSION/APP_BUILD examples)
+
+Do **not** touch `appcast.xml` unless cutting a new macOS Sparkle release.
+
+## Pre-release Checks
+
+```bash
+node --import tsx scripts/release-check.ts
+pnpm release:check
+OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
+```
+
+## npm Publish (via 1Password)
+
+All `op` commands must run inside a fresh tmux session:
+
+```bash
+eval "$(op signin --account my.1password.com)"
+OTP=$(op read 'op://Private/Npmjs/one-time password?attribute=otp')
+npm publish --access public --otp="$OTP"
+```
+
+Verify: `npm view <pkg> version --userconfig "$(mktemp)"`
+
+## GitHub Release (macOS beta)
+
+- Tag: `vYYYY.M.D-beta.N` from the release commit
+- Title: `openclaw YYYY.M.D-beta.N`
+- Body: release notes from `CHANGELOG.md` (Changes + Fixes sections only)
+- Attach: `OpenClaw-YYYY.M.D.zip`, `OpenClaw-YYYY.M.D.dSYM.zip`, `.dmg` if available
+
+## CHANGELOG
+
+- User-facing changes only; no internal/meta notes
+- Keep top version entries sorted: `### Changes` first, then `### Fixes` (user-facing first)
+
+## Full Release Checklist
+
+See `docs/reference/RELEASING.md` and `docs/platforms/mac/release.md`.
+
+## Release Guardrails
+
+- Do not change version numbers without explicit consent
+- Always ask permission before running any npm publish/release step
+- When using a beta tag, publish npm with matching beta suffix (e.g. `2026.2.15-beta.1` not plain version on `--tag beta`)

--- a/docs/solutions/patterns/critical-patterns.md
+++ b/docs/solutions/patterns/critical-patterns.md
@@ -1,0 +1,5 @@
+# Critical Patterns
+
+Patterns that must be followed every time — non-obvious solutions that have burned us before.
+
+No critical patterns yet. Add here via `/ce:compound` → Option 2 (Add to Required Reading), or manually when the pattern is clear.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,54 @@
+# Testing
+
+## Framework
+
+Vitest with V8 coverage thresholds (70% lines/branches/functions/statements).
+
+- Test files: colocated `*.test.ts`; e2e in `*.e2e.test.ts`
+- Run before pushing when you touch logic
+
+## Commands
+
+```bash
+pnpm test                    # Full suite
+pnpm test:coverage           # With V8 coverage
+pnpm test:force              # Kills lingering gateway, runs suite (use when port 18789 is occupied)
+pnpm test:e2e                # Gateway end-to-end smoke tests
+pnpm test:docker:live-models # Docker live model tests
+pnpm test:docker:live-gateway
+pnpm test:docker:onboard     # Onboarding Docker E2E
+```
+
+## Live Tests (real keys)
+
+```bash
+CLAWDBOT_LIVE_TEST=1 pnpm test:live   # OpenClaw-only live tests
+LIVE=1 pnpm test:live                  # Includes provider live tests
+```
+
+## Memory Pressure (Pi / non-Mac-Studio)
+
+```bash
+OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test
+```
+
+## Workers
+
+- Do not set test workers above 16.
+- E2E workers: `OPENCLAW_E2E_WORKERS=<n>`, verbose: `OPENCLAW_E2E_VERBOSE=1`
+
+## Node 24+
+
+OpenClaw auto-disables Vitest `vmForks` and uses `forks` to avoid `ERR_VM_MODULE_LINK_FAILURE`. Force behavior with `OPENCLAW_TEST_VM_FORKS=0|1`.
+
+## Mobile
+
+Before using a simulator, check for connected real devices (iOS + Android) and prefer them when available.
+
+## Changelog
+
+- Pure test additions/fixes generally do **not** need a changelog entry unless they alter user-facing behavior.
+
+## Full Kit Docs
+
+See `docs/reference/test.md` and [Testing](/help/testing) for the complete guide.


### PR DESCRIPTION
Restructures agent documentation following map-not-manual pattern:

- AGENTS.md trimmed from 256 to 108 lines as a map with pointers
- Extracted to dedicated files: `docs/ops/vm.md`, `docs/conventions.md`, `docs/testing.md`, `docs/releases.md`
- `docs/decisions/` created with 5 seeded ADRs (plugin architecture, channel routing, agent isolation, runtime strategy, learnings future work)
- `docs/solutions/patterns/` structure created
- Knowledge capture and doc-gardening notes added to AGENTS.md

Part of agent scaffolding improvements based on compound engineering research.