### PR TITLE
fix(plugins): expose ephemeral sessionId in tool contexts for per-conversation isolation

### DIFF
--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -25,4 +25,21 @@ describe("createOpenClawTools plugin context", () => {
       }),
     );
   });
+
+  it("forwards ephemeral sessionId to plugin tool context", () => {
+    createOpenClawTools({
+      config: {} as never,
+      agentSessionKey: "agent:main:telegram:direct:12345",
+      sessionId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    });
+
+    expect(resolvePluginToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          sessionKey: "agent:main:telegram:direct:12345",
+          sessionId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        }),
+      }),
+    );
+  });
 });

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -69,6 +69,8 @@ export function createOpenClawTools(options?: {
   requesterSenderId?: string | null;
   /** Whether the requesting sender is an owner. */
   senderIsOwner?: boolean;
+  /** Ephemeral session UUID — regenerated on /new and /reset. */
+  sessionId?: string;
 }): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);
   const imageTool = options?.agentDir?.trim()
@@ -185,6 +187,7 @@ export function createOpenClawTools(options?: {
         config: options?.config,
       }),
       sessionKey: options?.agentSessionKey,
+      sessionId: options?.sessionId,
       messageChannel: options?.agentChannel,
       agentAccountId: options?.agentAccountId,
       requesterSenderId: options?.requesterSenderId ?? undefined,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -584,6 +584,7 @@ export async function runEmbeddedAttempt(
           senderE164: params.senderE164,
           senderIsOwner: params.senderIsOwner,
           sessionKey: params.sessionKey ?? params.sessionId,
+          sessionId: params.sessionId,
           agentDir,
           workspaceDir: effectiveWorkspace,
           config: params.config,

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -9,6 +9,8 @@ import type { AnyAgentTool } from "./tools/common.js";
 export type HookContext = {
   agentId?: string;
   sessionKey?: string;
+  /** Ephemeral session UUID — regenerated on /new and /reset. */
+  sessionId?: string;
   loopDetection?: ToolLoopDetectionConfig;
 };
 
@@ -148,6 +150,7 @@ export async function runBeforeToolCallHook(args: {
         toolName,
         agentId: args.ctx?.agentId,
         sessionKey: args.ctx?.sessionKey,
+        sessionId: args.ctx?.sessionId,
       },
     );
 

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -188,6 +188,8 @@ export function createOpenClawCodingTools(options?: {
   messageThreadId?: string | number;
   sandbox?: SandboxContext | null;
   sessionKey?: string;
+  /** Ephemeral session UUID — regenerated on /new and /reset. */
+  sessionId?: string;
   agentDir?: string;
   workspaceDir?: string;
   config?: OpenClawConfig;
@@ -493,6 +495,7 @@ export function createOpenClawCodingTools(options?: {
       requesterAgentIdOverride: agentId,
       requesterSenderId: options?.senderId,
       senderIsOwner: options?.senderIsOwner,
+      sessionId: options?.sessionId,
     }),
   ];
   const toolsForMessageProvider = applyMessageProviderToolPolicy(tools, options?.messageProvider);
@@ -530,6 +533,7 @@ export function createOpenClawCodingTools(options?: {
     wrapToolWithBeforeToolCallHook(tool, {
       agentId,
       sessionKey: options?.sessionKey,
+      sessionId: options?.sessionId,
       loopDetection: resolveToolLoopDetectionConfig({ cfg: options?.config, agentId }),
     }),
   );

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -61,6 +61,8 @@ export type OpenClawPluginToolContext = {
   agentDir?: string;
   agentId?: string;
   sessionKey?: string;
+  /** Ephemeral session UUID — regenerated on /new and /reset. Use for per-conversation isolation. */
+  sessionId?: string;
   messageChannel?: string;
   agentAccountId?: string;
   /** Trusted sender id from inbound context (runtime-provided, not tool args). */
@@ -477,6 +479,8 @@ export type PluginHookMessageSentEvent = {
 export type PluginHookToolContext = {
   agentId?: string;
   sessionKey?: string;
+  /** Ephemeral session UUID — regenerated on /new and /reset. */
+  sessionId?: string;
   toolName: string;
 };
 


### PR DESCRIPTION
## Summary

- Problem: Plugin tool contexts (`OpenClawPluginToolContext` and `PluginHookToolContext`) only provide `sessionKey`, which is a durable channel identifier (e.g. `agent:main:telegram:direct:5263871946`) that survives `/new` and `/reset`. Plugins like mem0 that need per-conversation isolation have no way to distinguish between conversations, causing session-scoped memories to grow unbounded.
- Root cause: `sessionId` (the ephemeral UUID regenerated on `/new` and `/reset`) was available in the agent context (`PluginHookAgentContext`) but missing from tool contexts. Plugins registering tools via `registerTool` factories could only access `sessionKey`.
- What changed: Added `sessionId` to `OpenClawPluginToolContext`, `PluginHookToolContext`, and the internal `HookContext` for tool call wrappers. Threaded the value from the run attempt through `createOpenClawCodingTools` -> `createOpenClawTools` -> `resolvePluginTools` and through the `wrapToolWithBeforeToolCallHook` wrapper.
- What did NOT change: `sessionKey` remains available for durable channel identification. All new fields are optional and backward-compatible.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31253

## User-visible / Behavior Changes

1. Plugin tool factories (`registerTool`) now receive `ctx.sessionId` (ephemeral UUID) in addition to `ctx.sessionKey` (durable channel ID).
2. `before_tool_call` and `after_tool_call` hook contexts now include `sessionId`.
3. Plugins like mem0 can use `sessionId` as `run_id` to properly isolate session-scoped memories per conversation.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` (sessionId is already available in agent contexts)

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime: Node.js 22+
- Plugin: openclaw-mem0 or any plugin using `registerTool`

### Steps

1. Register a plugin tool that reads `ctx.sessionId` from its factory context
2. Send a message to trigger the tool
3. Run `/new` to start a new conversation
4. Send another message to trigger the tool
5. Verify `ctx.sessionId` changed between conversations

### Expected

- `sessionId` changes on `/new` and `/reset`, enabling per-conversation isolation
- `sessionKey` remains the same (durable channel ID)

### Actual

- Before: `sessionId` was not available in tool contexts; plugins could only use `sessionKey`
- After: `sessionId` is available and changes per conversation

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test case in `openclaw-tools.plugin-context.test.ts`:
- `forwards ephemeral sessionId to plugin tool context` - verifies sessionId is passed through

## Human Verification (required)

- Verified scenarios: sessionId flows from attempt -> pi-tools -> openclaw-tools -> plugin context; sessionId flows through tool hook context; backward compat with plugins that don't read sessionId.
- Edge cases: sessionId is undefined when not supplied (old call sites); plugins that only read sessionKey are unaffected.
- What you did **not** verify: Live mem0 plugin with Qdrant using sessionId as run_id.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to revert: Remove `sessionId` fields from the 3 context types and 3 call sites. All additive changes.
- Files to restore: `src/plugins/types.ts`, `src/agents/pi-tools.before-tool-call.ts`, `src/agents/pi-tools.ts`, `src/agents/openclaw-tools.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`

## Risks and Mitigations

- Risk: None. All changes are additive optional fields with full backward compatibility.