### PR TITLE
feat(feishu): add urgent (buzz) message tool

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -7,6 +7,7 @@ import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
 import { setFeishuRuntime } from "./src/runtime.js";
+import { registerFeishuUrgentTools } from "./src/urgent-tool.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
 export { monitorFeishuProvider } from "./src/monitor.js";
@@ -31,6 +32,7 @@ export {
   listReactionsFeishu,
   FeishuEmoji,
 } from "./src/reactions.js";
+export { urgentMessageFeishu, type FeishuUrgentType } from "./src/urgent.js";
 export {
   extractMentionTargets,
   extractMessageBody,
@@ -59,6 +61,7 @@ const plugin = {
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
     registerFeishuBitableTools(api);
+    registerFeishuUrgentTools(api);
   },
 };
 

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -56,6 +56,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     drive: false,
     perm: false,
     scopes: false,
+    urgent: false,
   };
   for (const account of accounts) {
     const cfg = resolveToolsConfig(account.config.tools);
@@ -65,6 +66,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     merged.drive = merged.drive || cfg.drive;
     merged.perm = merged.perm || cfg.perm;
     merged.scopes = merged.scopes || cfg.scopes;
+    merged.urgent = merged.urgent || cfg.urgent;
   }
   return merged;
 }

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -12,6 +12,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   drive: true,
   perm: false,
   scopes: true,
+  urgent: true,
 };
 
 /**

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -72,6 +72,8 @@ export type FeishuToolsConfig = {
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  /** Enable the feishu_urgent tool (buzz/urgent notifications). Enabled by default. */
+  urgent?: boolean;
 };
 
 export type DynamicAgentCreationConfig = {

--- a/extensions/feishu/src/urgent-schema.ts
+++ b/extensions/feishu/src/urgent-schema.ts
@@ -1,0 +1,28 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+const URGENT_TYPE_VALUES = ["app", "sms", "phone"] as const;
+
+export const FeishuUrgentSchema = Type.Object({
+  message_id: Type.String({
+    description: "Message ID to send urgent notification for (e.g. om_xxx)",
+  }),
+  user_ids: Type.Array(Type.String(), {
+    description:
+      "List of open_id values to buzz. The recipients must be members of the chat where the message was sent.",
+    minItems: 1,
+  }),
+  urgent_type: Type.Optional(
+    Type.Unsafe<(typeof URGENT_TYPE_VALUES)[number]>({
+      type: "string",
+      enum: [...URGENT_TYPE_VALUES],
+      description:
+        "Urgency delivery method: app (in-app buzz, default), sms (SMS), phone (voice call). Note: sms and phone may incur cost on the tenant.",
+      default: "app",
+    }),
+  ),
+  account_id: Type.Optional(
+    Type.String({ description: "Feishu account ID (uses default account if omitted)" }),
+  ),
+});
+
+export type FeishuUrgentParams = Static<typeof FeishuUrgentSchema>;

--- a/extensions/feishu/src/urgent-tool.ts
+++ b/extensions/feishu/src/urgent-tool.ts
@@ -1,0 +1,74 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
+import { FeishuUrgentSchema, type FeishuUrgentParams } from "./urgent-schema.js";
+import { urgentMessageFeishu } from "./urgent.js";
+
+function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    details: data,
+  };
+}
+
+export function registerFeishuUrgentTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_urgent: No config available, skipping");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_urgent: No Feishu accounts configured, skipping");
+    return;
+  }
+
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  if (!toolsCfg.urgent) {
+    api.logger.debug?.("feishu_urgent: urgent tool disabled in config");
+    return;
+  }
+
+  api.registerTool(
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_urgent",
+        label: "Feishu Urgent",
+        description:
+          "Send an urgent (buzz) notification for an existing Feishu message. " +
+          "Supported urgent_type values: app (in-app buzz, default), sms (SMS push), phone (voice call). " +
+          "Requires the message_id of an already-sent message and the open_id list of recipients to buzz. " +
+          "Use this to escalate important messages that require immediate attention.",
+        parameters: FeishuUrgentSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuUrgentParams;
+          try {
+            const client = createFeishuToolClient({
+              api,
+              executeParams: { accountId: p.account_id },
+              defaultAccountId,
+            });
+            const result = await urgentMessageFeishu({
+              client,
+              messageId: p.message_id,
+              userIds: p.user_ids,
+              urgentType: p.urgent_type ?? "app",
+            });
+            return json({
+              ok: true,
+              message_id: p.message_id,
+              urgent_type: p.urgent_type ?? "app",
+              invalid_user_list: result.invalidUserList,
+            });
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
+          }
+        },
+      };
+    },
+    { name: "feishu_urgent" },
+  );
+
+  api.logger.info?.("feishu_urgent: Registered feishu_urgent tool");
+}

--- a/extensions/feishu/src/urgent.ts
+++ b/extensions/feishu/src/urgent.ts
@@ -1,0 +1,113 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
+
+/**
+ * Urgency type for Feishu urgent messages.
+ * - "app": In-app buzz notification (default, no extra cost)
+ * - "sms": SMS push to the recipient's phone
+ * - "phone": Voice call to the recipient's phone
+ */
+export type FeishuUrgentType = "app" | "sms" | "phone";
+
+type UrgentPayload = {
+  data: { user_id_list: string[] };
+  params: { user_id_type: "open_id" | "user_id" | "union_id" };
+  path: { message_id: string };
+};
+
+type UrgentResponse = {
+  code?: number;
+  msg?: string;
+  data?: { invalid_user_id_list?: string[] };
+};
+
+type LarkMessageWithUrgent = Lark.Client["im"]["message"] & {
+  urgentApp?: (payload: UrgentPayload) => Promise<UrgentResponse>;
+  urgentSms?: (payload: UrgentPayload) => Promise<UrgentResponse>;
+  urgentPhone?: (payload: UrgentPayload) => Promise<UrgentResponse>;
+};
+
+/**
+ * Extract a human-readable error message from a Feishu API error.
+ * The Feishu SDK throws HTTP errors as AxiosError; their response.data
+ * contains the actual Feishu error payload.
+ */
+function extractFeishuErrorMessage(err: unknown, fallback: string): string {
+  if (err && typeof err === "object") {
+    // AxiosError shape: err.response.data.msg
+    const axiosErr = err as {
+      response?: { data?: { msg?: string; code?: number } };
+      message?: string;
+    };
+    const apiMsg = axiosErr.response?.data?.msg;
+    if (apiMsg) return apiMsg;
+    if (axiosErr.message) return axiosErr.message;
+  }
+  return fallback;
+}
+
+/**
+ * Send an urgent (buzz) notification for an existing Feishu message.
+ *
+ * Calls the Feishu "urgent" API which sends a strong push notification
+ * (buzz) to the specified recipients. The message must already be sent.
+ *
+ * Requires `im:message:send_urgent_app` scope (or sms/phone variants).
+ *
+ * Note: Invalid user IDs cause a HTTP 400 error from the Feishu API rather
+ * than being silently returned in `invalid_user_id_list`. This function
+ * wraps such errors with a descriptive message.
+ *
+ * @see https://open.feishu.cn/document/server-docs/im-v1/message/urgent_app
+ * @see https://open.feishu.cn/document/server-docs/im-v1/message/urgent_sms
+ * @see https://open.feishu.cn/document/server-docs/im-v1/message/urgent_phone
+ */
+export async function urgentMessageFeishu(params: {
+  client: Lark.Client;
+  messageId: string;
+  userIds: string[];
+  urgentType?: FeishuUrgentType;
+}): Promise<{ invalidUserList: string[] }> {
+  const { client, messageId, userIds, urgentType = "app" } = params;
+
+  const larkMessage = client.im.message as LarkMessageWithUrgent;
+
+  const payload: UrgentPayload = {
+    path: { message_id: messageId },
+    params: { user_id_type: "open_id" },
+    data: { user_id_list: userIds },
+  };
+
+  const methodMap = {
+    app: larkMessage.urgentApp?.bind(larkMessage),
+    sms: larkMessage.urgentSms?.bind(larkMessage),
+    phone: larkMessage.urgentPhone?.bind(larkMessage),
+  } as const;
+
+  const method = methodMap[urgentType];
+  if (typeof method !== "function") {
+    throw new Error(
+      `Feishu urgent: SDK method not available for urgentType="${urgentType}". ` +
+        `Check that @larksuiteoapi/node-sdk is up to date.`,
+    );
+  }
+
+  let response: UrgentResponse;
+  try {
+    response = await method(payload);
+  } catch (err) {
+    // Feishu API returns HTTP 400 for invalid user IDs or other request errors.
+    // Wrap the error with a clear message instead of surfacing a raw AxiosError.
+    const msg = extractFeishuErrorMessage(err, `Feishu urgent (${urgentType}) request failed`);
+    throw new Error(`Feishu urgent message (${urgentType}) failed: ${msg}`);
+  }
+
+  if (response.code !== 0) {
+    throw new Error(
+      `Feishu urgent message (${urgentType}) failed: ${response.msg || `code ${response.code}`}`,
+    );
+  }
+
+  return {
+    invalidUserList: response.data?.invalid_user_id_list ?? [],
+  };
+}


### PR DESCRIPTION
## Summary

Adds a `feishu_urgent` tool to the Feishu plugin that lets OpenClaw send **urgent (buzz) notifications** for existing Feishu messages. Uses the Feishu urgent API to deliver strong push notifications to specified recipients.

## Changes

### New files
- `extensions/feishu/src/urgent.ts` — Core `urgentMessageFeishu()` function
- `extensions/feishu/src/urgent-schema.ts` — TypeBox parameter schema
- `extensions/feishu/src/urgent-tool.ts` — Tool registration via `registerFeishuUrgentTools()`

### Modified files
- `extensions/feishu/src/types.ts` — Add `urgent?: boolean` to `FeishuToolsConfig`
- `extensions/feishu/src/tools-config.ts` — Default `urgent: true`
- `extensions/feishu/src/tool-account.ts` — Include `urgent` in `resolveAnyEnabledFeishuToolsConfig`
- `extensions/feishu/index.ts` — Register tool + export `urgentMessageFeishu`

## Usage

```json
{
  "name": "feishu_urgent",
  "parameters": {
    "message_id": "om_xxxxxxxxxxxxxxxx",
    "user_ids": ["ou_xxxxxxxxxxxxxxxx"],
    "urgent_type": "app"
  }
}
```

## Required Feishu Scopes

| `urgent_type` | Required scope |
|---|---|
| `app` | `im:message:send_urgent_app` |
| `sms` | `im:message:send_urgent_sms` |
| `phone` | `im:message:send_urgent_phone` |

## Verification (end-to-end tested)

All scenarios verified against a live Feishu tenant:

| Scenario | Result |
|---|---|
| `urgentApp` with valid `open_id` | ✅ `code: 0`, buzz delivered |
| `urgentSms` with valid `open_id` | ✅ `code: 0` |
| `urgentPhone` with valid `open_id` | ✅ `code: 0` |
| Invalid `open_id` (HTTP 400) | ✅ throws clear error message |

Key finding during verification: Feishu returns HTTP 400 (not `code != 0`) for invalid user IDs. Added try/catch with `extractFeishuErrorMessage()` to surface a clean error instead of a raw AxiosError.

Refs: https://open.feishu.cn/document/server-docs/im-v1/message/urgent_app