### PR TITLE
Dashboard: fix Channels schema errors, auto-load Usage, align Telegram health

### DIFF
--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -26,6 +26,7 @@ import { loadNodes } from "./controllers/nodes.ts";
 import { loadPresence } from "./controllers/presence.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { loadSkills } from "./controllers/skills.ts";
+import { loadUsage } from "./controllers/usage.ts";
 import {
   inferBasePathFromPathname,
   normalizeBasePath,
@@ -245,6 +246,9 @@ export async function refreshActiveTab(host: SettingsHost) {
   if (host.tab === "debug") {
     await loadDebug(host as unknown as OpenClawApp);
     host.eventLog = host.eventLogBuffer;
+  }
+  if (host.tab === "usage") {
+    await loadUsage(host as unknown as OpenClawApp);
   }
   if (host.tab === "logs") {
     host.logsAtBottom = true;

--- a/ui/src/ui/config-form.browser.test.ts
+++ b/ui/src/ui/config-form.browser.test.ts
@@ -350,6 +350,28 @@ describe("config form renderer", () => {
     expect(analysis.unsupportedPaths).not.toContain("channels");
   });
 
+  it("tracks unsupported additionalProperties paths precisely", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        channels: {
+          type: "object",
+          additionalProperties: {
+            type: "object",
+            properties: {
+              capabilities: {
+                anyOf: [{ type: "string" }, { type: "object", properties: {} }],
+              },
+            },
+          },
+        },
+      },
+    };
+    const analysis = analyzeConfigSchema(schema);
+    expect(analysis.unsupportedPaths).toContain("channels.*.capabilities");
+    expect(analysis.unsupportedPaths).not.toContain("channels");
+  });
+
   it("flags additionalProperties true", () => {
     const schema = {
       type: "object",

--- a/ui/src/ui/controllers/debug.ts
+++ b/ui/src/ui/controllers/debug.ts
@@ -24,14 +24,33 @@ export async function loadDebug(state: DebugState) {
   }
   state.debugLoading = true;
   try {
-    const [status, health, models, heartbeat] = await Promise.all([
+    const [status, health, channels, models, heartbeat] = await Promise.all([
       state.client.request("status", {}),
       state.client.request("health", {}),
+      state.client.request("channels.status", { probe: false, timeoutMs: 8000 }),
       state.client.request("models.list", {}),
       state.client.request("last-heartbeat", {}),
     ]);
     state.debugStatus = status as StatusSummary;
-    state.debugHealth = health as HealthSnapshot;
+
+    const debugHealth = health as HealthSnapshot;
+    const channelsSnapshot = channels as
+      | { channels?: Record<string, { running?: boolean; lastStartAt?: number | null }> }
+      | null
+      | undefined;
+    const telegramRuntime = channelsSnapshot?.channels?.telegram;
+    const telegramHealth = (debugHealth?.channels as Record<string, unknown> | undefined)
+      ?.telegram as Record<string, unknown> | undefined;
+    if (telegramHealth && telegramRuntime) {
+      if (typeof telegramRuntime.running === "boolean") {
+        telegramHealth.running = telegramRuntime.running;
+      }
+      if (telegramRuntime.lastStartAt != null) {
+        telegramHealth.lastStartAt = telegramRuntime.lastStartAt;
+      }
+    }
+
+    state.debugHealth = debugHealth;
     const modelPayload = models as { models?: unknown[] } | undefined;
     state.debugModels = Array.isArray(modelPayload?.models) ? modelPayload?.models : [];
     state.debugHeartbeat = heartbeat;

--- a/ui/src/ui/views/config-form.analyze.ts
+++ b/ui/src/ui/views/config-form.analyze.ts
@@ -86,8 +86,8 @@ function normalizeSchemaNode(
       if (!isAnySchema(schema.additionalProperties)) {
         const res = normalizeSchemaNode(schema.additionalProperties, [...path, "*"]);
         normalized.additionalProperties = res.schema ?? schema.additionalProperties;
-        if (res.unsupportedPaths.length > 0) {
-          unsupported.add(pathLabel);
+        for (const entry of res.unsupportedPaths) {
+          unsupported.add(entry);
         }
       }
     }

--- a/ui/src/ui/views/config-form.render.ts
+++ b/ui/src/ui/views/config-form.render.ts
@@ -290,20 +290,24 @@ function matchesSearch(params: {
   }
   const criteria = parseConfigSearchQuery(params.query);
   const q = criteria.text;
+  const hasTagFilter = criteria.tags.length > 0;
   const meta = SECTION_META[params.key];
 
-  // Check key name
-  if (q && params.key.toLowerCase().includes(q)) {
-    return true;
-  }
-
-  // Check label and description
-  if (q && meta) {
-    if (meta.label.toLowerCase().includes(q)) {
+  // Fast-path matches only apply when no tag filters are present.
+  if (!hasTagFilter) {
+    // Check key name
+    if (q && params.key.toLowerCase().includes(q)) {
       return true;
     }
-    if (meta.description.toLowerCase().includes(q)) {
-      return true;
+
+    // Check label and description
+    if (q && meta) {
+      if (meta.label.toLowerCase().includes(q)) {
+        return true;
+      }
+      if (meta.description.toLowerCase().includes(q)) {
+        return true;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #31247\n\n### Summary\n- Dashboard Usage tab now loads data on first open (previously only loaded after manual refresh).\n- Config schema analysis now reports unsupported paths precisely for additionalProperties schemas (avoids marking whole parent objects as unsupported).\n- Config search respects tag filters when matching section names/labels (prevents false positives that hide the empty-results UI).\n- Debug health: align Telegram running/lastStartAt with Channels snapshot to avoid misleading mismatch in the dashboard.\n\n### Notes\n- The schema fix targets the form renderer's unsupported-path tracking so Telegram channel fields like accounts/capabilities no longer force Raw mode for the entire Channels section.\n\n