### PR TITLE
feat(hooks): support session:end events in session-memory hook

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -27,6 +27,7 @@ import {
 } from "../../config/sessions.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { archiveSessionTranscripts } from "../../gateway/session-utils.fs.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -625,6 +626,15 @@ export async function initSessionState(params: {
           )
           .catch(() => {});
       }
+
+      // Also fire internal session:end hook so bundled hooks (e.g. session-memory)
+      // can save context for sessions that end without an explicit /new or /reset.
+      void triggerInternalHook(
+        createInternalHookEvent("session", "end", sessionKey, {
+          sessionEntry: previousSessionEntry,
+          cfg,
+        }),
+      ).catch(() => {});
     }
 
     // Fire session_start for the new session

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -1,13 +1,13 @@
 ---
 name: session-memory
-description: "Save session context to memory when /new or /reset command is issued"
+description: "Save session context to memory when /new or /reset command is issued, or when a session ends naturally"
 homepage: https://docs.openclaw.ai/automation/hooks#session-memory
 metadata:
   {
     "openclaw":
       {
         "emoji": "💾",
-        "events": ["command:new", "command:reset"],
+        "events": ["command:new", "command:reset", "session:end"],
         "requires": { "config": ["workspace.dir"] },
         "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
       },
@@ -16,7 +16,7 @@ metadata:
 
 # Session Memory Hook
 
-Automatically saves session context to your workspace memory when you issue `/new` or `/reset`.
+Automatically saves session context to your workspace memory when you issue `/new` or `/reset`, or when a session ends naturally (timeout, replacement, etc.).
 
 ## What It Does
 

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -506,4 +506,47 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("user: Only message 1");
     expect(memoryContent).toContain("assistant: Only message 2");
   });
+
+  it("saves memory on session:end event", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-session-memory-");
+    const sessionsDir = path.join(tempDir, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const sessionFile = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "timed-out-session.jsonl",
+      content: createMockSessionContent([
+        { role: "user", content: "Message before timeout" },
+        { role: "assistant", content: "Reply before timeout" },
+      ]),
+    });
+
+    const event = createHookEvent("session", "end", "agent:main:main", {
+      cfg: { agents: { defaults: { workspace: tempDir } } } satisfies OpenClawConfig,
+      sessionEntry: { sessionId: "timeout-123", sessionFile },
+    });
+
+    await handler(event);
+
+    const memoryDir = path.join(tempDir, "memory");
+    const files = await fs.readdir(memoryDir);
+    expect(files.length).toBe(1);
+
+    const memoryContent = await fs.readFile(path.join(memoryDir, files[0]), "utf-8");
+    expect(memoryContent).toContain("user: Message before timeout");
+    expect(memoryContent).toContain("assistant: Reply before timeout");
+  });
+
+  it("ignores unrelated session events", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-session-memory-");
+
+    const event = createHookEvent("session", "start", "agent:main:main", {
+      cfg: { agents: { defaults: { workspace: tempDir } } } satisfies OpenClawConfig,
+    });
+
+    await handler(event);
+
+    const memoryDir = path.join(tempDir, "memory");
+    await expect(fs.access(memoryDir)).rejects.toThrow();
+  });
 });

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -167,17 +167,19 @@ async function findPreviousSessionFile(params: {
 }
 
 /**
- * Save session context to memory when /new or /reset command is triggered
+ * Save session context to memory when /new or /reset command is triggered,
+ * or when a session ends naturally (timeout, reap, etc.).
  */
 const saveSessionToMemory: HookHandler = async (event) => {
-  // Only trigger on reset/new commands
-  const isResetCommand = event.action === "new" || event.action === "reset";
-  if (event.type !== "command" || !isResetCommand) {
+  const isResetCommand =
+    event.type === "command" && (event.action === "new" || event.action === "reset");
+  const isSessionEnd = event.type === "session" && event.action === "end";
+  if (!isResetCommand && !isSessionEnd) {
     return;
   }
 
   try {
-    log.debug("Hook triggered for reset/new command", { action: event.action });
+    log.debug("Hook triggered", { type: event.type, action: event.action });
 
     const context = event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;
@@ -192,12 +194,13 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const now = new Date(event.timestamp);
     const dateStr = now.toISOString().split("T")[0]; // YYYY-MM-DD
 
-    // Generate descriptive slug from session using LLM
-    // Prefer previousSessionEntry (old session before /new) over current (which may be empty)
-    const sessionEntry = (context.previousSessionEntry || context.sessionEntry || {}) as Record<
-      string,
-      unknown
-    >;
+    // For session:end, the ending session is the "current" one; for command:new/reset,
+    // prefer previousSessionEntry (old session before /new) over current (which may be empty).
+    const sessionEntry = (
+      isSessionEnd
+        ? context.sessionEntry || {}
+        : context.previousSessionEntry || context.sessionEntry || {}
+    ) as Record<string, unknown>;
     const currentSessionId = sessionEntry.sessionId as string;
     let currentSessionFile = (sessionEntry.sessionFile as string) || undefined;
 


### PR DESCRIPTION
## Summary

- Problem: The bundled session-memory hook only listened to `command:new` and `command:reset` events. Sessions that ended naturally (timeout, session replacement, reap, etc.) never had their conversation context saved to memory, causing memory gaps.
- Root cause: The internal hook system had no `session:end` event. Only the plugin system had `session_end`, which bundled hooks don't subscribe to.
- What changed:
  1. Emit a `session:end` internal hook event from `initSessionState` when an existing session is being replaced (alongside the existing plugin `session_end` event).
  2. Update the session-memory handler to accept `session:end` events, using `sessionEntry` (the ending session) for context extraction.
  3. Register `session:end` in `HOOK.md` event declarations.
- What did NOT change: `command:new` and `command:reset` handling is unchanged. The handler still uses `previousSessionEntry` for those events and `sessionEntry` for `session:end`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31266

## User-visible / Behavior Changes

1. Sessions that end naturally (timeout, replacement) now have their conversation context automatically saved to `<workspace>/memory/YYYY-MM-DD-slug.md`, just like `/new` and `/reset` sessions.
2. Memory files from `session:end` have the same format as those from `/new` and `/reset`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime: Node.js 22+

### Steps

1. Configure session-memory hook (enabled by default)
2. Start a conversation via any channel
3. Let the session time out or be replaced
4. Check `<workspace>/memory/` for a new memory file

### Expected

- Memory file is created with the conversation context from the ended session

### Actual

- Before: No memory file created when sessions end naturally
- After: Memory file is created with conversation context

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test cases in `handler.test.ts`:
- `saves memory on session:end event` - verifies memory is saved when session ends naturally
- `ignores unrelated session events` - verifies session:start is not processed

## Human Verification (required)

- Verified scenarios: session:end saves memory; command:new still works; command:reset still works; unrelated events are skipped.
- Edge cases: session:end with missing sessionEntry (handled gracefully); session:end with empty session file (falls through to timestamp slug).
- What you did **not** verify: Live session timeout scenario.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable: Remove `"session:end"` from `HOOK.md` events list. Alternatively, disable the hook via config.
- Files to restore: `src/hooks/bundled/session-memory/handler.ts`, `src/hooks/bundled/session-memory/HOOK.md`, `src/auto-reply/reply/session.ts`

## Risks and Mitigations

- Risk: Duplicate memory files when `/new` triggers both `command:new` and `session:end` for the same session.
  - Mitigation: The `session:end` event fires for the **old** session being replaced, while `command:new` fires for the reset action. The handler uses `previousSessionEntry` for command events and `sessionEntry` for session:end, but they point to the same session. In practice, both will attempt to create a memory file with the same slug/date, but `fs.writeFile` overwrites, so only one file exists. If the slug differs (LLM variance), both files contain equivalent content.