### PR TITLE
fix(browser): bypass proxy for local CDP probes

### DIFF
--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -243,6 +243,32 @@ describe("browser chrome helpers", () => {
     await expect(isChromeReachable("http://127.0.0.1:12345", 50)).resolves.toBe(false);
   });
 
+  it("bypasses proxy dispatcher for loopback CDP probes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" }),
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(isChromeReachable("http://127.0.0.1:12345", 50)).resolves.toBe(true);
+
+    const init = fetchMock.mock.calls[0]?.[1] as { dispatcher?: unknown } | undefined;
+    expect(init?.dispatcher).toBeDefined();
+  });
+
+  it("does not force loopback dispatcher for remote CDP probes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ webSocketDebuggerUrl: "ws://example.com/devtools" }),
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(isChromeReachable("http://example.com:12345", 50)).resolves.toBe(true);
+
+    const init = fetchMock.mock.calls[0]?.[1] as { dispatcher?: unknown } | undefined;
+    expect(init?.dispatcher).toBeUndefined();
+  });
+
   it("stopOpenClawChrome no-ops when process is already killed", async () => {
     const proc = makeProc({ killed: true });
     await stopOpenClawChrome(

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -2,11 +2,12 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Agent } from "undici";
 import WebSocket from "ws";
 import { ensurePortAvailable } from "../infra/ports.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CONFIG_DIR } from "../utils.js";
-import { appendCdpPath } from "./cdp.helpers.js";
+import { appendCdpPath, isLoopbackHost } from "./cdp.helpers.js";
 import { getHeadersWithAuth, normalizeCdpWsUrl } from "./cdp.js";
 import {
   type BrowserExecutable,
@@ -67,6 +68,22 @@ function cdpUrlForPort(cdpPort: number) {
   return `http://127.0.0.1:${cdpPort}`;
 }
 
+function shouldBypassProxyForCdp(cdpUrl: string): boolean {
+  try {
+    const url = new URL(cdpUrl);
+    return isLoopbackHost(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function createLocalCdpDispatcher(cdpUrl: string): Agent | undefined {
+  if (!shouldBypassProxyForCdp(cdpUrl)) {
+    return undefined;
+  }
+  return new Agent({ connect: { proxy: undefined } });
+}
+
 export async function isChromeReachable(cdpUrl: string, timeoutMs = 500): Promise<boolean> {
   const version = await fetchChromeVersion(cdpUrl, timeoutMs);
   return Boolean(version);
@@ -83,10 +100,13 @@ async function fetchChromeVersion(cdpUrl: string, timeoutMs = 500): Promise<Chro
   const t = setTimeout(ctrl.abort.bind(ctrl), timeoutMs);
   try {
     const versionUrl = appendCdpPath(cdpUrl, "/json/version");
-    const res = await fetch(versionUrl, {
+    const dispatcher = createLocalCdpDispatcher(cdpUrl);
+    const init: RequestInit & { dispatcher?: Agent } = {
       signal: ctrl.signal,
       headers: getHeadersWithAuth(versionUrl),
-    });
+      ...(dispatcher ? { dispatcher } : {}),
+    };
+    const res = await fetch(versionUrl, init);
     if (!res.ok) {
       return null;
     }

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -2,7 +2,7 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { Agent } from "undici";
+import { Agent, type Dispatcher } from "undici";
 import WebSocket from "ws";
 import { ensurePortAvailable } from "../infra/ports.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -68,22 +68,6 @@ function cdpUrlForPort(cdpPort: number) {
   return `http://127.0.0.1:${cdpPort}`;
 }
 
-function shouldBypassProxyForCdp(cdpUrl: string): boolean {
-  try {
-    const url = new URL(cdpUrl);
-    return isLoopbackHost(url.hostname);
-  } catch {
-    return false;
-  }
-}
-
-function createLocalCdpDispatcher(cdpUrl: string): Agent | undefined {
-  if (!shouldBypassProxyForCdp(cdpUrl)) {
-    return undefined;
-  }
-  return new Agent({ connect: { proxy: undefined } });
-}
-
 export async function isChromeReachable(cdpUrl: string, timeoutMs = 500): Promise<boolean> {
   const version = await fetchChromeVersion(cdpUrl, timeoutMs);
   return Boolean(version);
@@ -95,18 +79,30 @@ type ChromeVersion = {
   "User-Agent"?: string;
 };
 
+// Use a shared direct dispatcher for loopback probes so local CDP checks
+// bypass process-wide proxy dispatch without recreating agents per request.
+const loopbackProbeDispatcher: Dispatcher = new Agent();
+
+function resolveCdpProbeDispatcher(cdpUrl: string): Dispatcher | undefined {
+  try {
+    const parsed = new URL(cdpUrl);
+    return isLoopbackHost(parsed.hostname) ? loopbackProbeDispatcher : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function fetchChromeVersion(cdpUrl: string, timeoutMs = 500): Promise<ChromeVersion | null> {
   const ctrl = new AbortController();
   const t = setTimeout(ctrl.abort.bind(ctrl), timeoutMs);
   try {
     const versionUrl = appendCdpPath(cdpUrl, "/json/version");
-    const dispatcher = createLocalCdpDispatcher(cdpUrl);
-    const init: RequestInit & { dispatcher?: Agent } = {
+    const dispatcher = resolveCdpProbeDispatcher(cdpUrl);
+    const res = await fetch(versionUrl, {
       signal: ctrl.signal,
       headers: getHeadersWithAuth(versionUrl),
       ...(dispatcher ? { dispatcher } : {}),
-    };
-    const res = await fetch(versionUrl, init);
+    });
     if (!res.ok) {
       return null;
     }


### PR DESCRIPTION
## Summary
Fixes browser startup failures when HTTP proxy env vars are set by ensuring loopback CDP health checks do not route through EnvHttpProxyAgent.

Closes #31219

## Root cause
`isChromeReachable()` probes `http://127.0.0.1:<port>/json/version` via global `fetch`. When `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` is configured, undici may route this loopback probe through proxy infrastructure, causing timeout/failure even though Chrome is healthy on localhost.

## Changes
- In `src/browser/chrome.ts`:
  - Detect loopback CDP URLs using `isLoopbackHost`.
  - For loopback CDP probes only, pass an explicit undici `Agent({ connect: { proxy: undefined } })` dispatcher to `fetch` so the request bypasses env proxy routing.
  - Preserve existing behavior for non-loopback/remote CDP URLs.
- In `src/browser/chrome.test.ts`:
  - Added tests that assert loopback probes receive a dispatcher (proxy bypass path).
  - Added tests that assert remote probes do not force this dispatcher.

## Validation
- `pnpm exec vitest run --config vitest.unit.config.ts src/browser/chrome.test.ts`
