### PR TITLE
fix: fallback WhatsApp reaction messageId to inbound MessageSid

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -261,9 +261,15 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       if (action !== "react") {
         throw new Error(`Action ${action} is not supported for provider ${meta.id}.`);
       }
-      const messageId = readStringParam(params, "messageId", {
-        required: true,
-      });
+      const messageId =
+        readStringParam(params, "messageId") ??
+        readStringParam(params, "MessageSidFull") ??
+        readStringParam(params, "MessageSid") ??
+        readStringParam(params, "MessageSidFirst") ??
+        readStringParam(params, "MessageSidLast") ??
+        readStringParam(params, "messageId", {
+          required: true,
+        });
       const emoji = readStringParam(params, "emoji", { allowEmpty: true });
       const remove = typeof params.remove === "boolean" ? params.remove : undefined;
       return await getWhatsAppRuntime().channel.whatsapp.handleWhatsAppAction(

--- a/extensions/whatsapp/src/resolve-target.test.ts
+++ b/extensions/whatsapp/src/resolve-target.test.ts
@@ -208,6 +208,7 @@ describe("whatsapp resolveTarget", () => {
 describe("whatsapp action dispatch", () => {
   it("falls back to inbound MessageSid when messageId is omitted", async () => {
     await whatsappPlugin.actions?.handleAction?.({
+      channel: "whatsapp",
       action: "react",
       params: {
         to: "123@s.whatsapp.net",
@@ -232,6 +233,7 @@ describe("whatsapp action dispatch", () => {
 
   it("prefers explicit messageId over MessageSid fallback", async () => {
     await whatsappPlugin.actions?.handleAction?.({
+      channel: "whatsapp",
       action: "react",
       params: {
         to: "123@s.whatsapp.net",

--- a/extensions/whatsapp/src/resolve-target.test.ts
+++ b/extensions/whatsapp/src/resolve-target.test.ts
@@ -1,5 +1,31 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { installCommonResolveTargetErrorCases } from "../../shared/resolve-target-test-helpers.js";
+
+const { handleWhatsAppActionMock, readStringParamMock } = vi.hoisted(() => ({
+  handleWhatsAppActionMock: vi.fn(async () => ({ ok: true })),
+  readStringParamMock: vi.fn(
+    (
+      params: Record<string, unknown>,
+      key: string,
+      options?: { required?: boolean; allowEmpty?: boolean },
+    ) => {
+      const raw = params[key];
+      if (typeof raw !== "string") {
+        if (options?.required) {
+          throw new Error(`${key} required`);
+        }
+        return undefined;
+      }
+      if (!options?.allowEmpty && raw.length === 0) {
+        if (options?.required) {
+          throw new Error(`${key} required`);
+        }
+        return undefined;
+      }
+      return raw;
+    },
+  ),
+}));
 
 vi.mock("openclaw/plugin-sdk", () => ({
   getChatChannelMeta: () => ({ id: "whatsapp", label: "WhatsApp" }),
@@ -68,7 +94,7 @@ vi.mock("openclaw/plugin-sdk", () => ({
   normalizeAccountId: vi.fn(),
   normalizeE164: vi.fn(),
   normalizeWhatsAppMessagingTarget: vi.fn(),
-  readStringParam: vi.fn(),
+  readStringParam: readStringParamMock,
   resolveDefaultWhatsAppAccountId: vi.fn(),
   resolveWhatsAppAccount: vi.fn(),
   resolveWhatsAppGroupIntroHint: vi.fn(),
@@ -85,6 +111,7 @@ vi.mock("./runtime.js", () => ({
       whatsapp: {
         sendMessageWhatsApp: vi.fn(),
         createLoginTool: vi.fn(),
+        handleWhatsAppAction: handleWhatsAppActionMock,
       },
     },
   })),
@@ -93,6 +120,13 @@ vi.mock("./runtime.js", () => ({
 import { whatsappPlugin } from "./channel.js";
 
 const resolveTarget = whatsappPlugin.outbound!.resolveTarget!;
+type WhatsAppHandleAction = NonNullable<NonNullable<typeof whatsappPlugin.actions>["handleAction"]>;
+type WhatsAppHandleActionParams = Parameters<WhatsAppHandleAction>[0];
+
+beforeEach(() => {
+  handleWhatsAppActionMock.mockClear();
+  readStringParamMock.mockClear();
+});
 
 describe("whatsapp resolveTarget", () => {
   it("should resolve valid target in explicit mode", () => {
@@ -168,5 +202,56 @@ describe("whatsapp resolveTarget", () => {
   installCommonResolveTargetErrorCases({
     resolveTarget,
     implicitAllowFrom: ["5511999999999"],
+  });
+});
+
+describe("whatsapp action dispatch", () => {
+  it("falls back to inbound MessageSid when messageId is omitted", async () => {
+    await whatsappPlugin.actions?.handleAction?.({
+      action: "react",
+      params: {
+        to: "123@s.whatsapp.net",
+        MessageSid: "ctx-msg-1",
+        emoji: "👍",
+      },
+      cfg: {},
+      accountId: "default",
+    } as WhatsAppHandleActionParams);
+
+    expect(handleWhatsAppActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "react",
+        chatJid: "123@s.whatsapp.net",
+        messageId: "ctx-msg-1",
+        emoji: "👍",
+        accountId: "default",
+      }),
+      {},
+    );
+  });
+
+  it("prefers explicit messageId over MessageSid fallback", async () => {
+    await whatsappPlugin.actions?.handleAction?.({
+      action: "react",
+      params: {
+        to: "123@s.whatsapp.net",
+        messageId: "explicit-msg",
+        MessageSid: "ctx-msg-2",
+        emoji: "🔥",
+      },
+      cfg: {},
+      accountId: "default",
+    } as WhatsAppHandleActionParams);
+
+    expect(handleWhatsAppActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "react",
+        chatJid: "123@s.whatsapp.net",
+        messageId: "explicit-msg",
+        emoji: "🔥",
+        accountId: "default",
+      }),
+      {},
+    );
   });
 });

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -242,14 +242,14 @@ function buildReactionSchema() {
     messageId: Type.Optional(
       Type.String({
         description:
-          "Target message id for reaction. For Telegram, if omitted, defaults to the current inbound message id when available.",
+          "Target message id for reaction. For Telegram, if omitted, defaults to the current inbound message id when available. For WhatsApp, MessageSid/MessageSidFull from inbound context can be used as fallback.",
       }),
     ),
     message_id: Type.Optional(
       Type.String({
         // Intentional duplicate alias for tool-schema discoverability in LLMs.
         description:
-          "snake_case alias of messageId. For Telegram, if omitted, defaults to the current inbound message id when available.",
+          "snake_case alias of messageId. For Telegram, if omitted, defaults to the current inbound message id when available. For WhatsApp, MessageSid/MessageSidFull from inbound context can be used as fallback.",
       }),
     ),
     emoji: Type.Optional(Type.String()),

--- a/src/agents/tools/whatsapp-actions.test.ts
+++ b/src/agents/tools/whatsapp-actions.test.ts
@@ -40,6 +40,43 @@ describe("handleWhatsAppAction", () => {
     });
   });
 
+  it("falls back to inbound MessageSid when messageId is omitted", async () => {
+    await handleWhatsAppAction(
+      {
+        action: "react",
+        chatJid: "123@s.whatsapp.net",
+        MessageSid: "ctx-msg-1",
+        emoji: "👍",
+      },
+      enabledConfig,
+    );
+    expect(sendReactionWhatsApp).toHaveBeenLastCalledWith("+123", "ctx-msg-1", "👍", {
+      verbose: false,
+      fromMe: undefined,
+      participant: undefined,
+      accountId: DEFAULT_ACCOUNT_ID,
+    });
+  });
+
+  it("prefers explicit messageId over inbound MessageSid fallback", async () => {
+    await handleWhatsAppAction(
+      {
+        action: "react",
+        chatJid: "123@s.whatsapp.net",
+        messageId: "explicit-msg",
+        MessageSid: "ctx-msg-2",
+        emoji: "🔥",
+      },
+      enabledConfig,
+    );
+    expect(sendReactionWhatsApp).toHaveBeenLastCalledWith("+123", "explicit-msg", "🔥", {
+      verbose: false,
+      fromMe: undefined,
+      participant: undefined,
+      accountId: DEFAULT_ACCOUNT_ID,
+    });
+  });
+
   it("removes reactions on empty emoji", async () => {
     await handleWhatsAppAction(
       {

--- a/src/agents/tools/whatsapp-actions.ts
+++ b/src/agents/tools/whatsapp-actions.ts
@@ -16,7 +16,13 @@ export async function handleWhatsAppAction(
       throw new Error("WhatsApp reactions are disabled.");
     }
     const chatJid = readStringParam(params, "chatJid", { required: true });
-    const messageId = readStringParam(params, "messageId", { required: true });
+    const messageId =
+      readStringParam(params, "messageId") ??
+      readStringParam(params, "MessageSidFull") ??
+      readStringParam(params, "MessageSid") ??
+      readStringParam(params, "MessageSidFirst") ??
+      readStringParam(params, "MessageSidLast") ??
+      readStringParam(params, "messageId", { required: true });
     const { emoji, remove, isEmpty } = readReactionParams(params, {
       removeErrorMessage: "Emoji is required to remove a WhatsApp reaction.",
     });


### PR DESCRIPTION
## Summary
- make WhatsApp `react` action resolve message id from inbound context fields (`MessageSidFull`, `MessageSid`, `MessageSidFirst`, `MessageSidLast`) when explicit `messageId` is missing
- keep explicit `messageId` precedence unchanged
- update reaction tool schema descriptions to mention WhatsApp context fallback so model guidance matches runtime behavior
- add regression tests for MessageSid fallback and explicit-id precedence

## Testing
- pnpm test src/agents/tools/whatsapp-actions.test.ts
- pnpm exec oxlint src/agents/tools/whatsapp-actions.ts src/agents/tools/whatsapp-actions.test.ts src/agents/tools/message-tool.ts
- pnpm exec oxfmt --check src/agents/tools/whatsapp-actions.ts src/agents/tools/whatsapp-actions.test.ts src/agents/tools/message-tool.ts

Closes #31303
