### PR TITLE
fix: classify OAuth permission_error as auth_permanent

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -87,6 +87,16 @@ describe("failover-error", () => {
     );
   });
 
+  it("403 OAuth permission_error message returns auth_permanent", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 403,
+        message:
+          "HTTP 403 permission_error: OAuth authentication is currently not allowed for this organization.",
+      }),
+    ).toBe("auth_permanent");
+  });
+
   it("resolveFailoverStatus maps auth_permanent to 403", () => {
     expect(resolveFailoverStatus("auth_permanent")).toBe(403);
   });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -26,6 +26,7 @@ describe("isAuthPermanentErrorMessage", () => {
       "key has been disabled",
       "key has been revoked",
       "account has been deactivated",
+      "HTTP 403 permission_error: OAuth authentication is currently not allowed for this organization.",
       "could not authenticate api key",
       "could not validate credentials",
       "API_KEY_REVOKED",
@@ -524,6 +525,11 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("Your api key has been revoked")).toBe("auth_permanent");
     expect(classifyFailoverReason("key has been disabled")).toBe("auth_permanent");
     expect(classifyFailoverReason("account has been deactivated")).toBe("auth_permanent");
+    expect(
+      classifyFailoverReason(
+        "HTTP 403 permission_error: OAuth authentication is currently not allowed for this organization.",
+      ),
+    ).toBe("auth_permanent");
   });
   it("classifies JSON api_error internal server failures as timeout", () => {
     expect(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -659,6 +659,7 @@ const ERROR_PATTERNS = {
     "key has been disabled",
     "key has been revoked",
     "account has been deactivated",
+    "oauth authentication is currently not allowed for this organization",
     /could not (?:authenticate|validate).*(?:api[_ ]?key|credentials)/i,
   ],
   auth: [


### PR DESCRIPTION
## Summary
- classify OAuth org-level 403 `permission_error` messages as `auth_permanent`
- ensure auth-profile fallback treats this failure as a persistent profile health issue instead of a short retry cooldown
- add regression coverage for both helper-level classification and failover error resolution

## Testing
- pnpm test src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/failover-error.test.ts

Fixes #31306
