### PR TITLE
fix(discord): send online presence on ready when no custom presence is configured

### DIFF
--- a/src/discord/monitor/presence.test.ts
+++ b/src/discord/monitor/presence.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { resolveDiscordPresenceUpdate } from "./presence.js";
+
+describe("resolveDiscordPresenceUpdate", () => {
+  it("returns online presence when no config is provided", () => {
+    const result = resolveDiscordPresenceUpdate({});
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("online");
+    expect(result!.activities).toEqual([]);
+  });
+
+  it("uses configured status", () => {
+    const result = resolveDiscordPresenceUpdate({ status: "dnd" });
+    expect(result!.status).toBe("dnd");
+  });
+
+  it("includes activity when configured", () => {
+    const result = resolveDiscordPresenceUpdate({ activity: "Helping humans" });
+    expect(result!.status).toBe("online");
+    expect(result!.activities).toHaveLength(1);
+    expect(result!.activities[0].state).toBe("Helping humans");
+  });
+
+  it("uses custom activity type by default", () => {
+    const result = resolveDiscordPresenceUpdate({ activity: "test" });
+    expect(result!.activities[0].type).toBe(4);
+    expect(result!.activities[0].name).toBe("Custom Status");
+  });
+
+  it("respects explicit activityType", () => {
+    const result = resolveDiscordPresenceUpdate({ activity: "test", activityType: 3 });
+    expect(result!.activities[0].type).toBe(3);
+    expect(result!.activities[0].name).toBe("test");
+  });
+
+  it("sets streaming URL for type 1", () => {
+    const result = resolveDiscordPresenceUpdate({
+      activity: "Live",
+      activityType: 1,
+      activityUrl: "https://twitch.tv/test",
+    });
+    expect(result!.activities[0].url).toBe("https://twitch.tv/test");
+  });
+});

--- a/src/discord/monitor/presence.ts
+++ b/src/discord/monitor/presence.ts
@@ -21,7 +21,7 @@ export function resolveDiscordPresenceUpdate(
   const hasStatus = Boolean(status);
 
   if (!hasActivity && !hasStatus) {
-    return null;
+    return { since: null, activities: [], status: "online", afk: false };
   }
 
   const activities: Activity[] = [];


### PR DESCRIPTION
## Summary

- Problem: Discord bot appears offline (gray status dot) despite functioning correctly. Messages send and receive fine, but the bot never shows as "online" in the Discord user list.
- Why it matters: Users see the bot as offline and may think it's broken, even though it's fully operational.
- What changed: `resolveDiscordPresenceUpdate` now returns a minimal `{ status: "online" }` presence object when neither `activity` nor `status` is configured, instead of returning `null`. This ensures `DiscordStatusReadyListener` always calls `gateway.updatePresence()` on connect.
- What did NOT change: Custom presence configuration (activity text, status, activity type, streaming URL) works exactly the same. Only the "no config" default changed from "no presence update" to "online".

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31260

## User-visible / Behavior Changes

1. Discord bots now appear "online" (green status dot) by default when connected, even without explicit presence configuration.
2. No config changes required — this is a sensible default change.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (presence update was already sent when configured; now it also fires when unconfigured)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+
- Integration: Discord (any bot token)

### Steps

1. Configure a Discord bot without `activity` or `status` fields
2. Start gateway
3. Check bot status in Discord

### Expected

- Bot shows as "online" (green)

### Actual

- Before: Bot shows as "offline" (gray)
- After: Bot shows as "online" (green)

## Evidence

- [x] Failing test/log before + passing after

New test file `presence.test.ts` with 6 test cases:
- Returns online presence when no config provided
- Uses configured status
- Includes activity when configured
- Uses custom activity type by default
- Respects explicit activityType
- Sets streaming URL for type 1

## Human Verification (required)

- Verified scenarios: no config (default online); custom status (dnd, idle); activity text with custom type; streaming URL
- Edge cases checked: empty strings for activity/status (treated as unconfigured); whitespace-only values
- What you did **not** verify: Live Discord bot with actual gateway connection

## Compatibility / Migration

- Backward compatible? `Yes` — bots with explicit presence config are unaffected. Bots without config will now appear online instead of offline.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Change the return value back to `null` in `resolveDiscordPresenceUpdate` when no config is set
- Files to restore: `src/discord/monitor/presence.ts`

## Risks and Mitigations

- Risk: Users who intentionally want the bot to appear offline would now see it as online
  - Mitigation: They can set `status: "invisible"` explicitly to hide the bot. The previous behavior was undocumented and almost certainly unintentional.

