### PR TITLE
fix(feishu): encode filename for Chinese/special characters in file upload

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -232,10 +232,17 @@ export async function uploadFileFeishu(params: {
   // See: https://github.com/larksuite/node-sdk/issues/121
   const fileData = typeof file === "string" ? fs.createReadStream(file) : file;
 
+  // URL encode filename to handle Chinese characters and special characters
+  // HTTP multipart/form-data requires 7bit ASCII for Content-Disposition header
+  const safeFileName = encodeURIComponent(fileName)
+    .replace(/'/g, "%27")
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29");
+
   const response = await client.im.file.create({
     data: {
       file_type: fileType,
-      file_name: fileName,
+      file_name: safeFileName,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
       file: fileData as any,
       ...(duration !== undefined && { duration }),


### PR DESCRIPTION
## Summary

Fixes #31179 - Feishu file upload fails when filename contains Chinese characters or special characters (e.g., em dash, spaces, brackets).

## Problem

When sending files via Feishu channel with Chinese characters or special characters in the filename, the file appears as a text link instead of a downloadable attachment. Users cannot download or preview the file.

**Root Cause**: HTTP multipart/form-data requires 7bit ASCII encoding for the Content-Disposition header. Chinese characters and special characters (e.g., `—` U+2014 em dash) exceed this range, causing Feishu API to treat the filename as plain text.

## Solution

URL encode the filename before sending to Feishu API:

```typescript
const safeFileName = encodeURIComponent(fileName)
  .replace(/'/g, "%27")
  .replace(/\(/g, "%28")
  .replace(/\)/g, "%29");
```

## Changes

- Modified `extensions/feishu/src/media.ts` in the `uploadFileFeishu()` function
- Added filename URL encoding to handle non-ASCII characters
- Added explanatory comments about RFC2388 multipart/form-data requirements

## Testing

- [x] Unit tests pass (`pnpm test -- extensions/feishu/src/media.test.ts` - 14 tests)
- [x] Code format check passes

## AI-Assisted Disclosure

- [x] This PR is AI-assisted (Claude Code)
- [x] Testing status: Fully tested
- [x] I understand what the code does

## Related

- Fixes #31179