### PR TITLE
fix(daemon): enable service before bootstrap in LaunchAgent restart

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -203,7 +203,7 @@ describe("launchd install", () => {
     expect(plist).toContain(`<integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>`);
   });
 
-  it("restarts LaunchAgent with bootout-bootstrap-kickstart order", async () => {
+  it("restarts LaunchAgent with bootout-enable-bootstrap-kickstart order", async () => {
     const env = createDefaultLaunchdEnv();
     await restartLaunchAgent({
       env,
@@ -213,21 +213,43 @@ describe("launchd install", () => {
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const label = "ai.openclaw.gateway";
     const plistPath = resolveLaunchAgentPlistPath(env);
+    const serviceId = `${domain}/${label}`;
     const bootoutIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
+      (c) => c[0] === "bootout" && c[1] === serviceId,
+    );
+    const enableIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "enable" && c[1] === serviceId,
     );
     const bootstrapIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
     );
     const kickstartIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
+      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
     );
 
     expect(bootoutIndex).toBeGreaterThanOrEqual(0);
+    expect(enableIndex).toBeGreaterThanOrEqual(0);
     expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
     expect(kickstartIndex).toBeGreaterThanOrEqual(0);
-    expect(bootoutIndex).toBeLessThan(bootstrapIndex);
+    expect(bootoutIndex).toBeLessThan(enableIndex);
+    expect(enableIndex).toBeLessThan(bootstrapIndex);
     expect(bootstrapIndex).toBeLessThan(kickstartIndex);
+  });
+
+  it("tolerates already-bootstrapped (code 5/125) after bootout race", async () => {
+    state.bootstrapError = "Bootstrap failed: 5: service already loaded";
+    const env = createDefaultLaunchdEnv();
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+    const kickstartIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
+    );
+    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
   });
 
   it("waits for previous launchd pid to exit before bootstrapping", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -323,6 +323,11 @@ function isLaunchctlNotLoaded(res: { stdout: string; stderr: string; code: numbe
   );
 }
 
+function isAlreadyBootstrapped(detail: string): boolean {
+  const normalized = detail.toLowerCase();
+  return normalized.includes("bootstrap failed: 5:") || normalized.includes("already loaded");
+}
+
 function isUnsupportedGuiDomain(detail: string): boolean {
   const normalized = detail.toLowerCase();
   return (
@@ -465,6 +470,10 @@ export async function restartLaunchAgent({
     await waitForPidExit(previousPid);
   }
 
+  // Clear any persistent "disabled" state left by bootout so the service is
+  // startable after bootstrap — mirrors what installLaunchAgent does.
+  await execLaunchctl(["enable", `${domain}/${label}`]);
+
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
     const detail = (boot.stderr || boot.stdout).trim();
@@ -479,7 +488,9 @@ export async function restartLaunchAgent({
         ].join("\n"),
       );
     }
-    throw new Error(`launchctl bootstrap failed: ${detail}`);
+    if (!isAlreadyBootstrapped(detail)) {
+      throw new Error(`launchctl bootstrap failed: ${detail}`);
+    }
   }
 
   const start = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);


### PR DESCRIPTION
## Summary

- Problem: `openclaw gateway restart` fails on macOS with `launchctl kickstart failed: Could not find service "ai.openclaw.gateway"`. After `bootout`, launchd persists a "disabled" state for the service. Without calling `launchctl enable` before `bootstrap`, the service remains disabled and `kickstart` cannot find it.
- Why it matters: The gateway process is killed by `bootout` but never properly restarted. Users rely on `KeepAlive` to eventually recover, which can take up to `ThrottleInterval` seconds (60s by default). This makes `openclaw gateway restart` unreliable.
- What changed: (1) Added `launchctl enable` call between `bootout` and `bootstrap` in `restartLaunchAgent`, mirroring the existing pattern in `installLaunchAgent`. (2) Added `isAlreadyBootstrapped` helper to tolerate "already loaded" bootstrap responses (launchd error codes 5/125) that can occur due to bootout/bootstrap race conditions.
- What did NOT change (scope boundary): `installLaunchAgent`, `stopLaunchAgent`, `triggerOpenClawRestart` (SIGUSR1 path), and systemd restart logic are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31280

## User-visible / Behavior Changes

- `openclaw gateway restart` on macOS now reliably restarts the LaunchAgent service instead of failing with "Could not find service".
- Tolerates race conditions where the service appears "already loaded" after a rapid bootout/bootstrap cycle.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0 (arm64)
- Runtime: Node.js 22+

### Steps

1. Install LaunchAgent: `openclaw gateway install`
2. Verify running: `openclaw gateway status`
3. Run: `openclaw gateway restart`

### Expected

- Gateway gracefully restarts without errors

### Actual

- Before: `launchctl kickstart failed: Could not find service "ai.openclaw.gateway"`
- After: Gateway restarts successfully with bootout → enable → bootstrap → kickstart sequence

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Two test changes:
1. `restarts LaunchAgent with bootout-enable-bootstrap-kickstart order` — verifies the `enable` call is present and ordered correctly between `bootout` and `bootstrap`
2. `tolerates already-bootstrapped (code 5/125) after bootout race` — verifies that bootstrap "already loaded" errors don't abort the restart; `kickstart` still runs

## Human Verification (required)

- Verified scenarios: Restart sequence includes `enable` in correct order; "already loaded" bootstrap errors are tolerated; all 17 tests pass
- Edge cases checked: Race condition where service is already loaded after bootout; `isUnsupportedGuiDomain` error still properly surfaces GUI session guidance
- What you did **not** verify: End-to-end on a live macOS LaunchAgent setup (tested via mocked unit tests)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert `src/daemon/launchd.ts`
- Files/config to restore: `src/daemon/launchd.ts`

## Risks and Mitigations

- Risk: Extra `launchctl enable` call on every restart adds ~10ms latency
  - Mitigation: `enable` is idempotent and essentially no-op when service is already enabled. `installLaunchAgent` already does this successfully.

