### PR TITLE
fix(sandbox): map DOOD workspace binds to host source paths

### DIFF
--- a/src/agents/sandbox/docker.host-bind-source.test.ts
+++ b/src/agents/sandbox/docker.host-bind-source.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { resolveSandboxHostBindSourcePath } from "./docker.js";
+
+describe("resolveSandboxHostBindSourcePath", () => {
+  it("maps exact workspace destination to host source", async () => {
+    const resolved = await resolveSandboxHostBindSourcePath("/home/node/.openclaw/workspace", {
+      mounts: [
+        {
+          Source: "/DATA/openclaw/workspace",
+          Destination: "/home/node/.openclaw/workspace",
+        },
+      ],
+    });
+    expect(resolved).toBe("/DATA/openclaw/workspace");
+  });
+
+  it("maps nested sandbox paths using parent destination", async () => {
+    const resolved = await resolveSandboxHostBindSourcePath(
+      "/home/node/.openclaw/sandboxes/main/workdir",
+      {
+        mounts: [
+          {
+            Source: "/DATA/openclaw/config",
+            Destination: "/home/node/.openclaw",
+          },
+        ],
+      },
+    );
+    expect(resolved).toBe("/DATA/openclaw/config/sandboxes/main/workdir");
+  });
+
+  it("prefers the longest matching destination mount", async () => {
+    const resolved = await resolveSandboxHostBindSourcePath(
+      "/home/node/.openclaw/workspace/subdir/project",
+      {
+        mounts: [
+          {
+            Source: "/DATA/openclaw/config",
+            Destination: "/home/node/.openclaw",
+          },
+          {
+            Source: "/DATA/openclaw/workspace",
+            Destination: "/home/node/.openclaw/workspace",
+          },
+        ],
+      },
+    );
+    expect(resolved).toBe("/DATA/openclaw/workspace/subdir/project");
+  });
+
+  it("keeps the original path when no destination mount matches", async () => {
+    const original = "/home/node/.openclaw/workspace";
+    const resolved = await resolveSandboxHostBindSourcePath(original, {
+      mounts: [
+        {
+          Source: "/DATA/openclaw/other",
+          Destination: "/opt/other",
+        },
+      ],
+    });
+    expect(resolved).toBe(original);
+  });
+});

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -121,10 +121,12 @@ export function execDockerRaw(
   });
 }
 
+import path from "node:path";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { defaultRuntime } from "../../runtime.js";
 import { computeSandboxConfigHash } from "./config-hash.js";
 import { DEFAULT_SANDBOX_IMAGE, SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
+import { resolveSandboxHostPathViaExistingAncestor } from "./host-paths.js";
 import { readRegistry, updateRegistry } from "./registry.js";
 import { resolveSandboxAgentId, resolveSandboxScopeKey, slugifySessionKey } from "./shared.js";
 import type { SandboxConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
@@ -196,6 +198,118 @@ export async function readDockerPort(containerName: string, port: number) {
   }
   const mapped = Number.parseInt(match[1] ?? "", 10);
   return Number.isFinite(mapped) ? mapped : null;
+}
+
+type DockerMount = {
+  Source?: string;
+  Destination?: string;
+};
+
+let selfContainerMountsPromise: Promise<DockerMount[] | null> | null = null;
+
+function normalizeContainerMountPath(raw: string): string {
+  const normalized = path.posix.normalize(raw.trim().replaceAll("\\", "/"));
+  if (!normalized) {
+    return "/";
+  }
+  return normalized.replace(/\/+$/, "") || "/";
+}
+
+function isPathInsideMountRoot(root: string, target: string): boolean {
+  if (root === "/") {
+    return target.startsWith("/");
+  }
+  return target === root || target.startsWith(`${root}/`);
+}
+
+function parseDockerMounts(raw: string): DockerMount[] | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed.filter((entry) => entry && typeof entry === "object") as DockerMount[];
+  } catch {
+    return null;
+  }
+}
+
+async function loadSelfContainerMounts(): Promise<DockerMount[] | null> {
+  const containerRef =
+    process.env.OPENCLAW_SANDBOX_SELF_CONTAINER?.trim() || process.env.HOSTNAME?.trim() || "";
+  if (!containerRef) {
+    return null;
+  }
+  const result = await execDocker(
+    ["inspect", "--type", "container", "--format", "{{json .Mounts}}", containerRef],
+    { allowFailure: true },
+  );
+  if (result.code !== 0) {
+    return null;
+  }
+  return parseDockerMounts(result.stdout);
+}
+
+function getSelfContainerMounts(): Promise<DockerMount[] | null> {
+  if (!selfContainerMountsPromise) {
+    selfContainerMountsPromise = loadSelfContainerMounts();
+  }
+  return selfContainerMountsPromise;
+}
+
+function resolveHostPathFromMounts(
+  containerPath: string,
+  mounts: readonly DockerMount[],
+): string | null {
+  if (!containerPath.startsWith("/")) {
+    return null;
+  }
+  const normalizedTarget = normalizeContainerMountPath(containerPath);
+  let bestMatch: { source: string; destination: string } | null = null;
+  for (const mount of mounts) {
+    const source = mount.Source?.trim();
+    const destinationRaw = mount.Destination?.trim();
+    if (!source || !destinationRaw || !destinationRaw.startsWith("/")) {
+      continue;
+    }
+    const destination = normalizeContainerMountPath(destinationRaw);
+    if (!isPathInsideMountRoot(destination, normalizedTarget)) {
+      continue;
+    }
+    if (!bestMatch || destination.length > bestMatch.destination.length) {
+      bestMatch = { source, destination };
+    }
+  }
+  if (!bestMatch) {
+    return null;
+  }
+  const relative = path.posix.relative(bestMatch.destination, normalizedTarget);
+  const segments = relative.split("/").filter(Boolean);
+  const hostPath =
+    segments.length > 0
+      ? path.resolve(bestMatch.source, ...segments)
+      : path.resolve(bestMatch.source);
+  try {
+    return resolveSandboxHostPathViaExistingAncestor(hostPath);
+  } catch {
+    return hostPath;
+  }
+}
+
+export function resetSandboxHostBindSourcePathCacheForTests(): void {
+  selfContainerMountsPromise = null;
+}
+
+export async function resolveSandboxHostBindSourcePath(
+  containerPath: string,
+  options?: { mounts?: readonly DockerMount[] | null },
+): Promise<string> {
+  if (!containerPath.startsWith("/")) {
+    return containerPath;
+  }
+  const mounts = options?.mounts ?? (await getSelfContainerMounts());
+  const resolved = mounts ? resolveHostPathFromMounts(containerPath, mounts) : null;
+  return resolved ?? containerPath;
 }
 
 async function dockerImageExists(image: string) {
@@ -402,6 +516,8 @@ async function createSandboxContainer(params: {
 }) {
   const { name, cfg, workspaceDir, scopeKey } = params;
   await ensureDockerImage(cfg.image);
+  const hostWorkspaceDir = await resolveSandboxHostBindSourcePath(workspaceDir);
+  const hostAgentWorkspaceDir = await resolveSandboxHostBindSourcePath(params.agentWorkspaceDir);
 
   const args = buildSandboxCreateArgs({
     name,
@@ -409,18 +525,15 @@ async function createSandboxContainer(params: {
     scopeKey,
     configHash: params.configHash,
     includeBinds: false,
-    bindSourceRoots: [workspaceDir, params.agentWorkspaceDir],
+    bindSourceRoots: [hostWorkspaceDir, hostAgentWorkspaceDir],
   });
   args.push("--workdir", cfg.workdir);
   const mainMountSuffix =
     params.workspaceAccess === "ro" && workspaceDir === params.agentWorkspaceDir ? ":ro" : "";
-  args.push("-v", `${workspaceDir}:${cfg.workdir}${mainMountSuffix}`);
+  args.push("-v", `${hostWorkspaceDir}:${cfg.workdir}${mainMountSuffix}`);
   if (params.workspaceAccess !== "none" && workspaceDir !== params.agentWorkspaceDir) {
     const agentMountSuffix = params.workspaceAccess === "ro" ? ":ro" : "";
-    args.push(
-      "-v",
-      `${params.agentWorkspaceDir}:${SANDBOX_AGENT_WORKSPACE_MOUNT}${agentMountSuffix}`,
-    );
+    args.push("-v", `${hostAgentWorkspaceDir}:${SANDBOX_AGENT_WORKSPACE_MOUNT}${agentMountSuffix}`);
   }
   appendCustomBinds(args, cfg);
   args.push(cfg.image, "sleep", "infinity");


### PR DESCRIPTION
## Summary
- resolve sandbox workspace bind sources against the current gateway container mount table before creating sandbox containers
- ensure DOOD setups mount host paths (not in-container paths) for `/workspace` and `/agent`
- keep behavior backward-compatible by falling back to original paths when no mount mapping is available
- add regression tests for exact-match, nested-path, longest-match, and no-match fallback mapping

## Testing
- pnpm test src/agents/sandbox/docker.host-bind-source.test.ts
- pnpm test src/agents/sandbox-create-args.test.ts

Fixes #31331
