### PR TITLE
fix: fail fast on unknown sessions_spawn agentId

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -155,6 +155,25 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     });
   });
 
+  it("rejects unknown agent ids before attempting spawn", async () => {
+    setAllowAgents(["*"]);
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "main",
+      agentChannel: "whatsapp",
+    });
+
+    const result = await tool.execute("call10b", {
+      task: "do thing",
+      agentId: "does-not-exist",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "forbidden",
+      error: 'agentId "does-not-exist" not found',
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
   it("forbids sandboxed cross-agent spawns that would unsandbox the child", async () => {
     setSessionsSpawnConfigOverride({
       session: {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -12,7 +12,7 @@ import {
   parseAgentSessionKey,
 } from "../routing/session-key.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
-import { resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
+import { listAgentIds, resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
@@ -331,6 +331,15 @@ export async function spawnSubagentDirect(
     ctx.requesterAgentIdOverride ?? parseAgentSessionKey(requesterInternalKey)?.agentId,
   );
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
+  if (requestedAgentId) {
+    const configuredAgents = new Set(listAgentIds(cfg).map((value) => value.toLowerCase()));
+    if (!configuredAgents.has(targetAgentId.toLowerCase())) {
+      return {
+        status: "forbidden",
+        error: `agentId \"${targetAgentId}\" not found`,
+      };
+    }
+  }
   if (targetAgentId !== requesterAgentId) {
     const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
     const allowAny = allowAgents.some((value) => value.trim() === "*");


### PR DESCRIPTION
## Summary
Prevent `sessions_spawn` from proceeding when an explicit `agentId` does not exist in configured agents.

## Problem
When callers passed an invalid `agentId`, spawn flow could continue into provisioning paths instead of failing fast. Issue #31311 reports filesystem artifacts from failed paths.

## Changes
- Added explicit configured-agent existence guard in `spawnSubagentDirect`:
  - If `agentId` is explicitly provided and not present in `listAgentIds(cfg)`, return:
    - `status: "forbidden"`
    - `error: agentId "<id>" not found`
- Added regression test:
  - `rejects unknown agent ids before attempting spawn`
  - verifies no gateway spawn calls are made.

## Why this is safe
- Only affects explicit `agentId` requests.
- Backward compatible for default same-agent spawns.
- Fails earlier and cleaner, reducing chance of side effects on invalid input.

Fixes openclaw/openclaw#31311