### PR TITLE
fix: treat OAuth 403 permission_error as auth_permanent for fallback

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -87,6 +87,15 @@ describe("failover-error", () => {
     );
   });
 
+  it("403 permission_error OAuth org restriction returns auth_permanent", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 403,
+        message: "HTTP 403 permission_error: OAuth authentication is currently not allowed for this organization.",
+      }),
+    ).toBe("auth_permanent");
+  });
+
   it("resolveFailoverStatus maps auth_permanent to 403", () => {
     expect(resolveFailoverStatus("auth_permanent")).toBe(403);
   });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -30,6 +30,7 @@ describe("isAuthPermanentErrorMessage", () => {
       "could not validate credentials",
       "API_KEY_REVOKED",
       "api_key_deleted",
+      "HTTP 403 permission_error: OAuth authentication is currently not allowed for this organization.",
     ];
     for (const sample of samples) {
       expect(isAuthPermanentErrorMessage(sample)).toBe(true);

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -659,6 +659,8 @@ const ERROR_PATTERNS = {
     "key has been disabled",
     "key has been revoked",
     "account has been deactivated",
+    "permission_error",
+    "oauth authentication is currently not allowed for this organization",
     /could not (?:authenticate|validate).*(?:api[_ ]?key|credentials)/i,
   ],
   auth: [


### PR DESCRIPTION
## Summary
Classify OAuth 403 `permission_error` org-restriction failures as `auth_permanent` so profile fallback rotates away from unusable OAuth profiles.

## Problem
Issue #31306 reports repeated retries against the same expired/unauthorized OAuth profile (`permission_error`) instead of falling back to healthy profiles.

## Changes
- Extended permanent-auth classification patterns to include:
  - `permission_error`
  - `OAuth authentication is currently not allowed for this organization`
- Added regression coverage in:
  - `pi-embedded-helpers.isbillingerrormessage.test.ts`
  - `failover-error.test.ts`

## Expected behavior after fix
A 403 with this OAuth `permission_error` is treated as `auth_permanent`, enabling profile health transitions/fallback instead of infinite retries on the same profile.

Fixes openclaw/openclaw#31306