### PR TITLE
test: set OPENCLAW_TEST_FAST before subagent-announce import

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -145,8 +145,9 @@ describe("subagent announce formatting", () => {
   let runSubagentAnnounceFlow: (typeof import("./subagent-announce.js"))["runSubagentAnnounceFlow"];
 
   beforeAll(async () => {
-    ({ runSubagentAnnounceFlow } = await import("./subagent-announce.js"));
     previousFastTestEnv = process.env.OPENCLAW_TEST_FAST;
+    process.env.OPENCLAW_TEST_FAST = "1";
+    ({ runSubagentAnnounceFlow } = await import("./subagent-announce.js"));
   });
 
   afterAll(() => {


### PR DESCRIPTION
## Summary
Fix Windows flakiness in subagent announce formatting tests by setting `OPENCLAW_TEST_FAST=1` before importing `subagent-announce`.

## Root cause
`OPENCLAW_TEST_FAST` is read at module load time in `subagent-announce.ts`. The test previously set it in `beforeEach`, which is too late when module import already happened in `beforeAll`.

## Change
- In `subagent-announce.format.e2e.test.ts`:
  - save previous env value
  - set `process.env.OPENCLAW_TEST_FAST = "1"` before dynamic import
  - keep existing env restore in `afterAll`

This aligns test setup with module-level env evaluation and removes timing-dependent behavior on Windows.

Fixes openclaw/openclaw#31298