### PR TITLE
test(subagent-announce): fix flaky Windows-only test failure (#31298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Tests/Subagent announce: set `OPENCLAW_TEST_FAST=1` before importing `subagent-announce` format suites so module-level fast-mode constants are captured deterministically on Windows CI, preventing timeout flakes in nested completion announce coverage. (#31370) Thanks @zwffff.
 - Gateway/Node dangerous-command parity: include `sms.send` in default onboarding node `denyCommands`, share onboarding deny defaults with the gateway dangerous-command source of truth, and include `sms.send` in phone-control `/phone arm writes` handling so SMS follows the same break-glass flow as other dangerous node commands. Thanks @zpbrent.
 - Zalo/Pairing auth tests: add webhook regression coverage asserting DM pairing-store reads/writes remain account-scoped, preventing cross-account authorization bleed in multi-account setups. (#26121) Thanks @bmendonca3.
 - Logging: use local time for logged timestamps instead of UTC, aligning log output with documented local timezone behavior and avoiding confusion during local diagnostics. (#28434) Thanks @liuy.

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -147,8 +147,13 @@ describe("subagent announce formatting", () => {
   let runSubagentAnnounceFlow: (typeof import("./subagent-announce.js"))["runSubagentAnnounceFlow"];
 
   beforeAll(async () => {
-    ({ runSubagentAnnounceFlow } = await import("./subagent-announce.js"));
+    // Set FAST_TEST_MODE before importing the module to ensure the module-level
+    // constant picks it up. This fixes flaky Windows CI failures where the test
+    // timeout budget is too tight without fast mode enabled.
+    // See: https://github.com/openclaw/openclaw/issues/31298
     previousFastTestEnv = process.env.OPENCLAW_TEST_FAST;
+    process.env.OPENCLAW_TEST_FAST = "1";
+    ({ runSubagentAnnounceFlow } = await import("./subagent-announce.js"));
   });
 
   afterAll(() => {
@@ -160,7 +165,8 @@ describe("subagent announce formatting", () => {
   });
 
   beforeEach(() => {
-    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    // OPENCLAW_TEST_FAST is set in beforeAll before module import
+    // to ensure the module-level constant picks it up.
     agentSpy
       .mockClear()
       .mockImplementation(async (_req: AgentCallRequest) => ({ runId: "run-main", status: "ok" }));


### PR DESCRIPTION
## Summary

Fixes flaky Windows-only test failure in `subagent-announce.format.e2e.test.ts`.

## Problem

The test \"waits for updated synthesized output before announcing nested subagent completion\" was failing intermittently on Windows CI because:

1. `FAST_TEST_MODE` is evaluated at **module load time** in `subagent-announce.ts`
2. The test was setting `vi.stubEnv(\"OPENCLAW_TEST_FAST\", \"1\")` in `beforeEach`, which runs **after** `beforeAll` where the module is imported
3. On Windows, `setTimeout(100)` routinely overshoots to 115-150ms due to default timer resolution (~15.6ms)
4. Without fast mode, the poll loop only had 1-2 iterations — not enough to reach the 3rd `chatHistory` mock call

## Solution

Move `process.env.OPENCLAW_TEST_FAST = \"1\"` to `beforeAll` **before** the dynamic module import, so the module-level constant captures the fast mode setting.

## Changes

- Set `OPENCLAW_TEST_FAST=1` in `beforeAll` before importing `subagent-announce.js`
- Remove redundant `vi.stubEnv` from `beforeEach`
- Add explanatory comments referencing issue #31298

## Testing

- All 52 tests in `subagent-announce.format.e2e.test.ts` pass
- This fix ensures consistent fast mode behavior across all platforms

Fixes #31298