### PR TITLE
fix(session): treat types omitted from resetByType as persistent

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -641,7 +641,7 @@ describe("initSessionState reset policy", () => {
     expect(result.sessionId).toBe(existingSessionId);
   });
 
-  it("defaults to daily resets when only resetByType is configured", async () => {
+  it("keeps types omitted from resetByType persistent (no silent daily reset)", async () => {
     vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
     const root = await makeCaseDir("openclaw-reset-type-default-");
     const storePath = path.join(root, "sessions.json");
@@ -667,8 +667,8 @@ describe("initSessionState reset policy", () => {
       commandAuthorized: true,
     });
 
-    expect(result.isNewSession).toBe(true);
-    expect(result.sessionId).not.toBe(existingSessionId);
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe(existingSessionId);
   });
 
   it("keeps legacy idleMinutes behavior without reset config", async () => {

--- a/src/config/sessions/reset.ts
+++ b/src/config/sessions/reset.ts
@@ -2,7 +2,7 @@ import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import type { SessionConfig, SessionResetConfig } from "../types.base.js";
 import { DEFAULT_IDLE_MINUTES } from "./types.js";
 
-export type SessionResetMode = "daily" | "idle";
+export type SessionResetMode = "daily" | "idle" | "persistent";
 export type SessionResetType = "direct" | "group" | "thread";
 
 export type SessionResetPolicy = {
@@ -97,10 +97,18 @@ export function resolveSessionResetPolicy(params: {
         : undefined));
   const hasExplicitReset = Boolean(baseReset || sessionCfg?.resetByType);
   const legacyIdleMinutes = params.resetOverride ? undefined : sessionCfg?.idleMinutes;
+  // When resetByType is defined but omits this type, treat the type as
+  // persistent (no automatic reset) rather than falling back to "daily".
+  // This prevents silent data loss when upgrading with a partial resetByType.
+  const typeOmittedFromResetByType = !typeReset && sessionCfg?.resetByType != null && !baseReset;
   const mode =
     typeReset?.mode ??
     baseReset?.mode ??
-    (!hasExplicitReset && legacyIdleMinutes != null ? "idle" : DEFAULT_RESET_MODE);
+    (typeOmittedFromResetByType
+      ? "persistent"
+      : !hasExplicitReset && legacyIdleMinutes != null
+        ? "idle"
+        : DEFAULT_RESET_MODE);
   const atHour = normalizeResetAtHour(
     typeReset?.atHour ?? baseReset?.atHour ?? DEFAULT_RESET_AT_HOUR,
   );
@@ -141,6 +149,9 @@ export function evaluateSessionFreshness(params: {
   now: number;
   policy: SessionResetPolicy;
 }): SessionFreshness {
+  if (params.policy.mode === "persistent") {
+    return { fresh: true };
+  }
   const dailyResetAt =
     params.policy.mode === "daily"
       ? resolveDailyResetAtMs(params.now, params.policy.atHour)

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -17,7 +17,7 @@ import {
   resolveSessionTranscriptPathInDir,
   validateSessionId,
 } from "./paths.js";
-import { resolveSessionResetPolicy } from "./reset.js";
+import { evaluateSessionFreshness, resolveSessionResetPolicy } from "./reset.js";
 import { appendAssistantMessageToSessionTranscript } from "./transcript.js";
 import type { SessionEntry } from "./types.js";
 
@@ -140,7 +140,61 @@ describe("resolveSessionResetPolicy", () => {
         resetType: "group",
       });
 
-      expect(groupPolicy.mode).toBe("daily");
+      expect(groupPolicy.mode).toBe("persistent");
+    });
+  });
+
+  describe("types omitted from resetByType stay persistent", () => {
+    it("group not listed in resetByType → persistent", () => {
+      const sessionCfg = {
+        resetByType: {
+          direct: { mode: "idle" as const, idleMinutes: 43200 },
+          thread: { mode: "idle" as const, idleMinutes: 43200 },
+        },
+      } as unknown as SessionConfig;
+
+      const policy = resolveSessionResetPolicy({ sessionCfg, resetType: "group" });
+      expect(policy.mode).toBe("persistent");
+    });
+
+    it("listed types still use their configured mode", () => {
+      const sessionCfg = {
+        resetByType: {
+          direct: { mode: "idle" as const, idleMinutes: 100 },
+          group: { mode: "daily" as const, atHour: 6 },
+        },
+      } as unknown as SessionConfig;
+
+      expect(resolveSessionResetPolicy({ sessionCfg, resetType: "group" }).mode).toBe("daily");
+      expect(resolveSessionResetPolicy({ sessionCfg, resetType: "direct" }).mode).toBe("idle");
+      expect(resolveSessionResetPolicy({ sessionCfg, resetType: "thread" }).mode).toBe(
+        "persistent",
+      );
+    });
+
+    it("persistent sessions always evaluate as fresh", () => {
+      const policy = { mode: "persistent" as const, atHour: 4 };
+      const result = evaluateSessionFreshness({
+        updatedAt: 0,
+        now: Date.now(),
+        policy,
+      });
+      expect(result.fresh).toBe(true);
+      expect(result.dailyResetAt).toBeUndefined();
+      expect(result.idleExpiresAt).toBeUndefined();
+    });
+
+    it("falls back to base session.reset when resetByType omits the type", () => {
+      const sessionCfg = {
+        reset: { mode: "idle" as const, idleMinutes: 60 },
+        resetByType: {
+          direct: { mode: "daily" as const },
+        },
+      } as unknown as SessionConfig;
+
+      const groupPolicy = resolveSessionResetPolicy({ sessionCfg, resetType: "group" });
+      expect(groupPolicy.mode).toBe("idle");
+      expect(groupPolicy.idleMinutes).toBe(60);
     });
   });
 });

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -68,7 +68,7 @@ export type SessionSendPolicyConfig = {
   rules?: SessionSendPolicyRule[];
 };
 
-export type SessionResetMode = "daily" | "idle";
+export type SessionResetMode = "daily" | "idle" | "persistent";
 export type SessionResetConfig = {
   mode?: SessionResetMode;
   /** Local hour (0-23) for the daily reset boundary. */

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -15,7 +15,7 @@ import { sensitive } from "./zod-schema.sensitive.js";
 
 const SessionResetConfigSchema = z
   .object({
-    mode: z.union([z.literal("daily"), z.literal("idle")]).optional(),
+    mode: z.union([z.literal("daily"), z.literal("idle"), z.literal("persistent")]).optional(),
     atHour: z.number().int().min(0).max(23).optional(),
     idleMinutes: z.number().int().positive().optional(),
   })


### PR DESCRIPTION
## Summary

- Problem: When `session.resetByType` is defined but omits a chat type (e.g. `group`), the omitted type silently falls back to `DEFAULT_RESET_MODE` (`"daily"`, 4 AM UTC). Users upgrading from pre-v2026.2.26 with partial `resetByType` configs experience silent daily session resets and conversation history loss for unconfigured types.
- Why it matters: This is a data-loss regression. Users who configured `resetByType` for `dm` and `thread` but intentionally left `group` unconfigured (expecting it to remain persistent) lose all group chat sessions every day at 4 AM UTC with zero warnings.
- What changed: Added `"persistent"` as a valid `SessionResetMode`. When `resetByType` is defined but does NOT include the current chat type, AND no base `session.reset` is set, the type now resolves to `mode: "persistent"` instead of `mode: "daily"`. `evaluateSessionFreshness` returns `fresh: true` immediately for persistent sessions.
- What did NOT change (scope boundary): Explicitly configured types in `resetByType` still use their configured mode. The `session.reset` base config still applies as fallback when set. Legacy `session.idleMinutes` behavior is preserved. The `"daily"` default for configs without ANY reset configuration remains unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31322

## User-visible / Behavior Changes

- Chat types not listed in `resetByType` are now persistent (never auto-reset) instead of defaulting to daily reset at 4 AM.
- New `"persistent"` mode available in `session.resetByType.<type>.mode` and `session.reset.mode` config.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js 22+

### Steps

1. Configure `session.resetByType` with only `dm` and `thread`, leaving `group` unconfigured
2. Create a group chat session before 4 AM UTC
3. Wait until after 4 AM UTC
4. Send a message to the same group chat

### Expected

- Group session remains intact (persistent)

### Actual

- Before: Group session resets, history lost, new session created
- After: Group session persists, history preserved

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Updated and new test cases:
1. `does not use dm fallback for group/thread types` — updated to expect `persistent` instead of `daily`
2. `group not listed in resetByType → persistent` — verifies omitted group stays persistent
3. `listed types still use their configured mode` — verifies explicitly configured types are unaffected
4. `persistent sessions always evaluate as fresh` — verifies `evaluateSessionFreshness` returns `fresh: true`
5. `falls back to base session.reset when resetByType omits the type` — verifies `session.reset` base config still applies as fallback
6. `keeps types omitted from resetByType persistent (no silent daily reset)` — integration test verifying no session reset occurs

## Human Verification (required)

- Verified scenarios: Omitted types stay persistent; listed types use configured mode; base `session.reset` still applies as fallback; legacy `idleMinutes` behavior preserved; persistent mode always evaluates fresh
- Edge cases checked: `resetByType` defined with only one type; `session.reset` + `resetByType` combination; explicit `mode: "persistent"` in config
- What you did **not** verify: Production upgrade path from v2026.2.26 to verify existing sessions are preserved

## Compatibility / Migration

- Backward compatible? Yes (new `persistent` mode is additive; existing configs with all types defined are unaffected)
- Config/env changes? No (new `"persistent"` mode value is optional; omission from `resetByType` now implies persistent)
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert `src/config/sessions/reset.ts`, `src/config/types.base.ts`, `src/config/zod-schema.session.ts`
- Files/config to restore: Users can explicitly set `group: { mode: "daily" }` in `resetByType` to restore old behavior

## Risks and Mitigations

- Risk: Users who relied on the implicit daily default for omitted types will see changed behavior (sessions persist instead of resetting)
  - Mitigation: This is the intended fix — users should explicitly configure `mode: "daily"` for types they want to reset. Silent data loss is worse than explicit persistence.

