### PR TITLE
fix(cli): prompt for custom provider context window and max tokens

### DIFF
--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -100,6 +100,8 @@ export function registerOnboardCommand(program: Command) {
       "--custom-compatibility <mode>",
       "Custom provider API compatibility: openai|anthropic (default: openai)",
     )
+    .option("--custom-context-window <size>", "Custom provider context window size")
+    .option("--custom-max-tokens <tokens>", "Custom provider max output tokens")
     .option("--gateway-port <port>", "Gateway port")
     .option("--gateway-bind <mode>", "Gateway bind: loopback|tailnet|lan|auto|custom")
     .option("--gateway-auth <mode>", "Gateway auth: token|password")
@@ -170,6 +172,8 @@ export function registerOnboardCommand(program: Command) {
           customModelId: opts.customModelId as string | undefined,
           customProviderId: opts.customProviderId as string | undefined,
           customCompatibility: opts.customCompatibility as "openai" | "anthropic" | undefined,
+          customContextWindow: opts.customContextWindow as number | undefined,
+          customMaxTokens: opts.customMaxTokens as number | undefined,
           gatewayPort:
             typeof gatewayPort === "number" && Number.isFinite(gatewayPort)
               ? gatewayPort

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -85,42 +85,67 @@ describe("promptCustomApiConfig", () => {
 
   it("handles openai flow and saves alias", async () => {
     const prompter = createTestPrompter({
-      text: ["http://localhost:11434/v1", "", "llama3", "custom", "local"],
+      text: ["http://localhost:11434/v1", "", "llama3", "custom", "local", "128000", "4096"],
       select: ["plaintext", "openai"],
     });
     stubFetchSequence([{ ok: true }]);
     const result = await runPromptCustomApi(prompter);
 
-    expectOpenAiCompatResult({ prompter, textCalls: 5, selectCalls: 2, result });
+    expectOpenAiCompatResult({ prompter, textCalls: 7, selectCalls: 2, result });
     expect(result.config.agents?.defaults?.models?.["custom/llama3"]?.alias).toBe("local");
   });
 
   it("retries when verification fails", async () => {
     const prompter = createTestPrompter({
-      text: ["http://localhost:11434/v1", "", "bad-model", "good-model", "custom", ""],
+      text: [
+        "http://localhost:11434/v1",
+        "",
+        "bad-model",
+        "good-model",
+        "custom",
+        "",
+        "128000",
+        "4096",
+      ],
       select: ["plaintext", "openai", "model"],
     });
     stubFetchSequence([{ ok: false, status: 400 }, { ok: true }]);
     await runPromptCustomApi(prompter);
 
-    expect(prompter.text).toHaveBeenCalledTimes(6);
+    expect(prompter.text).toHaveBeenCalledTimes(8);
     expect(prompter.select).toHaveBeenCalledTimes(3);
   });
 
   it("detects openai compatibility when unknown", async () => {
     const prompter = createTestPrompter({
-      text: ["https://example.com/v1", "test-key", "detected-model", "custom", "alias"],
+      text: [
+        "https://example.com/v1",
+        "test-key",
+        "detected-model",
+        "custom",
+        "alias",
+        "128000",
+        "4096",
+      ],
       select: ["plaintext", "unknown"],
     });
     stubFetchSequence([{ ok: true }]);
     const result = await runPromptCustomApi(prompter);
 
-    expectOpenAiCompatResult({ prompter, textCalls: 5, selectCalls: 2, result });
+    expectOpenAiCompatResult({ prompter, textCalls: 7, selectCalls: 2, result });
   });
 
   it("uses expanded max_tokens for openai verification probes", async () => {
     const prompter = createTestPrompter({
-      text: ["https://example.com/v1", "test-key", "detected-model", "custom", "alias"],
+      text: [
+        "https://example.com/v1",
+        "test-key",
+        "detected-model",
+        "custom",
+        "alias",
+        "128000",
+        "4096",
+      ],
       select: ["plaintext", "openai"],
     });
     const fetchMock = stubFetchSequence([{ ok: true }]);
@@ -140,6 +165,8 @@ describe("promptCustomApiConfig", () => {
         "gpt-4.1",
         "custom",
         "alias",
+        "128000",
+        "4096",
       ],
       select: ["plaintext", "openai"],
     });
@@ -173,7 +200,15 @@ describe("promptCustomApiConfig", () => {
 
   it("uses expanded max_tokens for anthropic verification probes", async () => {
     const prompter = createTestPrompter({
-      text: ["https://example.com", "test-key", "detected-model", "custom", "alias"],
+      text: [
+        "https://example.com",
+        "test-key",
+        "detected-model",
+        "custom",
+        "alias",
+        "128000",
+        "4096",
+      ],
       select: ["plaintext", "unknown"],
     });
     const fetchMock = stubFetchSequence([{ ok: false, status: 404 }, { ok: true }]);
@@ -196,6 +231,8 @@ describe("promptCustomApiConfig", () => {
         "ok-key",
         "custom",
         "",
+        "128000",
+        "4096",
       ],
       select: ["plaintext", "unknown", "baseUrl", "plaintext"],
     });
@@ -210,7 +247,7 @@ describe("promptCustomApiConfig", () => {
 
   it("renames provider id when baseUrl differs", async () => {
     const prompter = createTestPrompter({
-      text: ["http://localhost:11434/v1", "", "llama3", "custom", ""],
+      text: ["http://localhost:11434/v1", "", "llama3", "custom", "", "128000", "4096"],
       select: ["plaintext", "openai"],
     });
     stubFetchSequence([{ ok: true }]);
@@ -244,7 +281,16 @@ describe("promptCustomApiConfig", () => {
   it("aborts verification after timeout", async () => {
     vi.useFakeTimers();
     const prompter = createTestPrompter({
-      text: ["http://localhost:11434/v1", "", "slow-model", "fast-model", "custom", ""],
+      text: [
+        "http://localhost:11434/v1",
+        "",
+        "slow-model",
+        "fast-model",
+        "custom",
+        "",
+        "128000",
+        "4096",
+      ],
       select: ["plaintext", "openai", "model"],
     });
 
@@ -263,13 +309,21 @@ describe("promptCustomApiConfig", () => {
     await vi.advanceTimersByTimeAsync(30_000);
     await promise;
 
-    expect(prompter.text).toHaveBeenCalledTimes(6);
+    expect(prompter.text).toHaveBeenCalledTimes(8);
   });
 
   it("stores env SecretRef for custom provider when selected", async () => {
     vi.stubEnv("CUSTOM_PROVIDER_API_KEY", "test-env-key");
     const prompter = createTestPrompter({
-      text: ["https://example.com/v1", "CUSTOM_PROVIDER_API_KEY", "detected-model", "custom", ""],
+      text: [
+        "https://example.com/v1",
+        "CUSTOM_PROVIDER_API_KEY",
+        "detected-model",
+        "custom",
+        "",
+        "128000",
+        "4096",
+      ],
       select: ["ref", "env", "openai"],
     });
     const fetchMock = stubFetchSequence([{ ok: true }]);
@@ -297,6 +351,8 @@ describe("promptCustomApiConfig", () => {
         "detected-model",
         "custom",
         "",
+        "128000",
+        "4096",
       ],
       select: ["ref", "provider", "filemain", "env", "openai"],
     });

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -17,7 +17,6 @@ import { normalizeAlias } from "./models/shared.js";
 import type { SecretInputMode } from "./onboard-types.js";
 
 const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
-const DEFAULT_CONTEXT_WINDOW = CONTEXT_WINDOW_HARD_MIN_TOKENS;
 const DEFAULT_MAX_TOKENS = 4096;
 const VERIFY_TIMEOUT_MS = 30_000;
 
@@ -78,6 +77,8 @@ export type ApplyCustomApiConfigParams = {
   apiKey?: SecretInput;
   providerId?: string;
   alias?: string;
+  contextWindow?: number;
+  maxTokens?: number;
 };
 
 export type ParseNonInteractiveCustomApiFlagsParams = {
@@ -86,6 +87,8 @@ export type ParseNonInteractiveCustomApiFlagsParams = {
   compatibility?: string;
   apiKey?: string;
   providerId?: string;
+  contextWindow?: number;
+  maxTokens?: number;
 };
 
 export type ParsedNonInteractiveCustomApiFlags = {
@@ -94,6 +97,8 @@ export type ParsedNonInteractiveCustomApiFlags = {
   compatibility: CustomApiCompatibility;
   apiKey?: string;
   providerId?: string;
+  contextWindow?: number;
+  maxTokens?: number;
 };
 
 export type CustomApiErrorCode =
@@ -102,7 +107,8 @@ export type CustomApiErrorCode =
   | "invalid_base_url"
   | "invalid_model_id"
   | "invalid_provider_id"
-  | "invalid_alias";
+  | "invalid_alias"
+  | "invalid_context_window";
 
 export class CustomApiError extends Error {
   readonly code: CustomApiErrorCode;
@@ -549,6 +555,8 @@ export function parseNonInteractiveCustomApiFlags(
     compatibility: parseCustomApiCompatibility(params.compatibility),
     ...(apiKey ? { apiKey } : {}),
     ...(providerId ? { providerId } : {}),
+    ...(params.contextWindow !== undefined ? { contextWindow: params.contextWindow } : {}),
+    ...(params.maxTokens !== undefined ? { maxTokens: params.maxTokens } : {}),
   };
 }
 
@@ -571,6 +579,12 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
   if (!modelId) {
     throw new CustomApiError("invalid_model_id", "Custom provider model ID is required.");
   }
+
+  const contextWindow = params.contextWindow !== undefined ? params.contextWindow : 128000;
+  if (contextWindow < 16000) {
+    throw new CustomApiError("invalid_context_window", "Context window must be at least 16000.");
+  }
+  const maxTokens = params.maxTokens !== undefined ? params.maxTokens : DEFAULT_MAX_TOKENS;
 
   // Transform Azure URLs to include the deployment path for API calls
   const resolvedBaseUrl = isAzureUrl(baseUrl) ? transformAzureUrl(baseUrl, modelId) : baseUrl;
@@ -600,8 +614,8 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
   const nextModel = {
     id: modelId,
     name: `${modelId} (Custom Provider)`,
-    contextWindow: DEFAULT_CONTEXT_WINDOW,
-    maxTokens: DEFAULT_MAX_TOKENS,
+    contextWindow,
+    maxTokens,
     input: ["text"] as ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     reasoning: false,
@@ -802,6 +816,37 @@ export async function promptCustomApiConfig(params: {
       return resolveAliasError({ raw: value, cfg: config, modelRef });
     },
   });
+  const contextWindowInput = await prompter.text({
+    message: "Context window size",
+    initialValue: "128000",
+    placeholder: "e.g. 128000",
+    validate: (value) => {
+      const num = parseInt(value, 10);
+      if (isNaN(num)) {
+        return "Must be a valid number.";
+      }
+      if (num < 16000) {
+        return "Context window must be at least 16000.";
+      }
+      return undefined;
+    },
+  });
+  const contextWindow = parseInt(contextWindowInput, 10);
+
+  const maxTokensInput = await prompter.text({
+    message: "Max output tokens",
+    initialValue: "4096",
+    placeholder: "e.g. 4096",
+    validate: (value) => {
+      const num = parseInt(value, 10);
+      if (isNaN(num) || num <= 0) {
+        return "Must be a positive number.";
+      }
+      return undefined;
+    },
+  });
+  const maxTokens = parseInt(maxTokensInput, 10);
+
   const resolvedCompatibility = compatibility ?? "openai";
   const result = applyCustomApiConfig({
     config,
@@ -811,6 +856,8 @@ export async function promptCustomApiConfig(params: {
     apiKey,
     providerId: providerIdInput,
     alias: aliasInput,
+    contextWindow,
+    maxTokens,
   });
 
   if (result.providerIdRenamedFrom && result.providerId) {

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -930,6 +930,8 @@ export async function applyNonInteractiveAuthChoice(params: {
         compatibility: opts.customCompatibility,
         apiKey: opts.customApiKey,
         providerId: opts.customProviderId,
+        contextWindow: opts.customContextWindow ? Number(opts.customContextWindow) : undefined,
+        maxTokens: opts.customMaxTokens ? Number(opts.customMaxTokens) : undefined,
       });
       const resolvedProviderId = resolveCustomProviderId({
         config: nextConfig,

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -140,6 +140,8 @@ export type OnboardOptions = {
   customModelId?: string;
   customProviderId?: string;
   customCompatibility?: "openai" | "anthropic";
+  customContextWindow?: number;
+  customMaxTokens?: number;
   gatewayPort?: number;
   gatewayBind?: GatewayBind;
   gatewayAuth?: GatewayAuthChoice;


### PR DESCRIPTION
Fixes an issue where configuring a Custom Provider defaults contextWindow to 4096, which fails the minimum 16000 requirement. This PR adds CLI flags and interactive prompts for customContextWindow and customMaxTokens.