### PR TITLE
fix(whatsapp): strip thumbnailDirectPath from voice notes to prevent truncated download

### DIFF
--- a/src/web/inbound/media.node.test.ts
+++ b/src/web/inbound/media.node.test.ts
@@ -64,4 +64,41 @@ describe("downloadInboundMedia", () => {
     expect(result?.mimetype).toBe("application/pdf");
     expect(result?.fileName).toBe("report.pdf");
   });
+
+  it("strips thumbnailDirectPath from audioMessage to prevent waveform download", async () => {
+    downloadMediaMessage.mockClear();
+    const msg = {
+      message: {
+        audioMessage: {
+          ptt: true,
+          mimetype: "audio/ogg; codecs=opus",
+          directPath: "/full-audio-path",
+          thumbnailDirectPath: "/waveform-thumbnail",
+          mediaKey: Buffer.from("key"),
+        },
+      },
+    } as never;
+    await downloadInboundMedia(msg, mockSock);
+    expect(downloadMediaMessage).toHaveBeenCalledOnce();
+    const passedMsg = downloadMediaMessage.mock.calls[0][0];
+    expect(passedMsg.message.audioMessage.directPath).toBe("/full-audio-path");
+    expect(passedMsg.message.audioMessage.thumbnailDirectPath).toBeUndefined();
+  });
+
+  it("does not strip thumbnailDirectPath from non-audio messages", async () => {
+    downloadMediaMessage.mockClear();
+    const msg = {
+      message: {
+        imageMessage: {
+          mimetype: "image/jpeg",
+          directPath: "/image-path",
+          thumbnailDirectPath: "/thumb-path",
+        },
+      },
+    } as never;
+    await downloadInboundMedia(msg, mockSock);
+    expect(downloadMediaMessage).toHaveBeenCalledOnce();
+    const passedMsg = downloadMediaMessage.mock.calls[0][0];
+    expect(passedMsg.message.imageMessage.thumbnailDirectPath).toBe("/thumb-path");
+  });
 });

--- a/src/web/inbound/media.ts
+++ b/src/web/inbound/media.ts
@@ -59,8 +59,20 @@ export async function downloadInboundMedia(
     return undefined;
   }
   try {
+    // Baileys picks thumbnailDirectPath (waveform ~1 KB) over directPath (full
+    // audio) when `url` is absent.  Strip it for audio/ptt messages so the
+    // library falls back to the full-content directPath.
+    let downloadMsg = msg;
+    if (message.audioMessage && "thumbnailDirectPath" in message.audioMessage) {
+      const { thumbnailDirectPath: _stripped, ...audioRest } = message.audioMessage;
+      downloadMsg = {
+        ...msg,
+        message: { ...msg.message, audioMessage: audioRest },
+      } as WAMessage;
+    }
+
     const buffer = await downloadMediaMessage(
-      msg as WAMessage,
+      downloadMsg as WAMessage,
       "buffer",
       {},
       {


### PR DESCRIPTION
## Summary

- Problem: WhatsApp voice notes (.ogg, Opus) are saved as truncated/corrupt files (~1KB instead of 15-30KB). Baileys' `downloadMediaMessage` selects `thumbnailDirectPath` (waveform preview image, ~1KB) over `directPath` (full audio) when the message's `url` field is absent. This results in silent audio (max amplitude 1) when decoded with ffmpeg, and empty/hallucinated Whisper transcriptions.
- Why it matters: Voice note transcription is completely broken — the core STT pipeline receives garbage input. Users see either empty transcriptions or AI hallucinations with no error indication.
- What changed: Before calling `downloadMediaMessage`, strip `thumbnailDirectPath` from `audioMessage` objects. This forces Baileys to use `directPath` for the full audio content instead of the waveform thumbnail.
- What did NOT change (scope boundary): Non-audio media (images, video, documents, stickers) are untouched — `thumbnailDirectPath` is preserved for their download paths. The `reuploadRequest` retry mechanism is preserved. No Baileys source code was patched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31222

## User-visible / Behavior Changes

- WhatsApp voice notes are now downloaded in full (~15-30KB for 15s audio) instead of truncated waveform previews (~1KB).
- Whisper transcription and TTS pipeline receive correct audio input.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same Baileys download path, just different source URL within the message)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Receive a WhatsApp voice note (group or DM)
2. Check saved `.ogg` file in `~/.openclaw/media/inbound/`
3. Verify file size and audio content

### Expected

- `.ogg` file is 15-30KB for a 15-second voice note
- ffmpeg decodes to audible audio

### Actual

- Before: File is ~1KB (waveform thumbnail), ffmpeg decodes to silence
- After: File is full-size audio, ffmpeg decodes correctly

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Two new test cases:
1. `strips thumbnailDirectPath from audioMessage to prevent waveform download` — verifies `thumbnailDirectPath` is removed from the message passed to `downloadMediaMessage` while `directPath` is preserved
2. `does not strip thumbnailDirectPath from non-audio messages` — verifies image messages retain their `thumbnailDirectPath`

## Human Verification (required)

- Verified scenarios: Audio messages with thumbnailDirectPath are cleaned; non-audio messages are untouched; all 11 media tests pass
- Edge cases checked: audioMessage without thumbnailDirectPath (no-op); audioMessage with both url and thumbnailDirectPath (strip still applied, harmless)
- What you did **not** verify: End-to-end with a live WhatsApp voice note (tested via mocked unit tests)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert `src/web/inbound/media.ts` (remove the `thumbnailDirectPath` stripping block)
- Files/config to restore: `src/web/inbound/media.ts`

## Risks and Mitigations

- Risk: If Baileys needs `thumbnailDirectPath` for audio re-upload or retry logic
  - Mitigation: The original message `msg` with `thumbnailDirectPath` is still passed to `reuploadRequest` via the sock context. Only the download-specific copy has it stripped. Baileys' re-upload logic uses the original message reference.