### PR TITLE
feat(session-memory): support session:end event for saving session context (#31266)

### DIFF
--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -161,7 +161,7 @@ function expectMemoryConversation(params: {
 }
 
 describe("session-memory hook", () => {
-  it("skips non-command events", async () => {
+  it("skips non-command and non-session events", async () => {
     const tempDir = await makeTempWorkspace("openclaw-session-memory-");
 
     const event = createHookEvent("agent", "bootstrap", "agent:main:main", {
@@ -170,12 +170,12 @@ describe("session-memory hook", () => {
 
     await handler(event);
 
-    // Memory directory should not be created for non-command events
+    // Memory directory should not be created for non-command/non-session events
     const memoryDir = path.join(tempDir, "memory");
     await expect(fs.access(memoryDir)).rejects.toThrow();
   });
 
-  it("skips commands other than new", async () => {
+  it("skips commands other than new/reset", async () => {
     const tempDir = await makeTempWorkspace("openclaw-session-memory-");
 
     const event = createHookEvent("command", "help", "agent:main:main", {
@@ -185,6 +185,20 @@ describe("session-memory hook", () => {
     await handler(event);
 
     // Memory directory should not be created for other commands
+    const memoryDir = path.join(tempDir, "memory");
+    await expect(fs.access(memoryDir)).rejects.toThrow();
+  });
+
+  it("skips session events other than end", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-session-memory-");
+
+    const event = createHookEvent("session", "start", "agent:main:main", {
+      workspaceDir: tempDir,
+    });
+
+    await handler(event);
+
+    // Memory directory should not be created for session:start events
     const memoryDir = path.join(tempDir, "memory");
     await expect(fs.access(memoryDir)).rejects.toThrow();
   });
@@ -220,6 +234,44 @@ describe("session-memory hook", () => {
     expect(files.length).toBe(1);
     expect(memoryContent).toContain("user: Please reset and keep notes");
     expect(memoryContent).toContain("assistant: Captured before reset");
+  });
+
+  it("creates memory file with session content on session:end event", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-session-memory-");
+    const sessionsDir = path.join(tempDir, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Session ending message" },
+      { role: "assistant", content: "Captured on session end" },
+    ]);
+
+    const sessionFile = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "test-session.jsonl",
+      content: sessionContent,
+    });
+
+    // Use session:end event instead of command:new
+    const event = createHookEvent("session", "end", "agent:main:main", {
+      cfg: {
+        agents: { defaults: { workspace: tempDir } },
+      } satisfies OpenClawConfig,
+      sessionEntry: {
+        sessionId: "test-123",
+        sessionFile,
+      },
+    });
+
+    await handler(event);
+
+    const memoryDir = path.join(tempDir, "memory");
+    const files = await fs.readdir(memoryDir);
+    expect(files.length).toBe(1);
+
+    const memoryContent = await fs.readFile(path.join(memoryDir, files[0]), "utf-8");
+    expect(memoryContent).toContain("user: Session ending message");
+    expect(memoryContent).toContain("assistant: Captured on session end");
   });
 
   it("filters out non-message entries (tool calls, system)", async () => {

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -167,17 +167,19 @@ async function findPreviousSessionFile(params: {
 }
 
 /**
- * Save session context to memory when /new or /reset command is triggered
+ * Save session context to memory when /new or /reset command is triggered,
+ * or when a session ends (session:end event).
  */
 const saveSessionToMemory: HookHandler = async (event) => {
-  // Only trigger on reset/new commands
-  const isResetCommand = event.action === "new" || event.action === "reset";
-  if (event.type !== "command" || !isResetCommand) {
+  // Trigger on command:new, command:reset, or session:end
+  const isResetCommand = event.type === "command" && (event.action === "new" || event.action === "reset");
+  const isSessionEnd = event.type === "session" && event.action === "end";
+  if (!isResetCommand && !isSessionEnd) {
     return;
   }
 
   try {
-    log.debug("Hook triggered for reset/new command", { action: event.action });
+    log.debug("Hook triggered for session save", { type: event.type, action: event.action });
 
     const context = event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;


### PR DESCRIPTION
## Summary

Extends the session-memory hook to also trigger on `session:end` events, ensuring session context is saved when sessions timeout or end naturally.

## Problem

The session-memory hook currently only triggers on `command:new` and `command:reset` events. However, sessions can also end due to:
- Session timeout/expiration
- Natural session lifecycle completion
- External session termination

In these cases, the session context was not being saved to memory, resulting in lost conversation history.

## Solution

Add support for the `session:end` event in the session-memory hook handler:

- Modified the event type check to also accept `session:end` events
- Updated the guard condition to handle both command events (new/reset) and session events (end)
- Updated log messages to reflect the new event types

## Changes

- `src/hooks/bundled/session-memory/handler.ts`:
  - Extended event trigger condition to include `session:end`
  - Updated log message to show both event type and action
  - Updated JSDoc comments

- `src/hooks/bundled/session-memory/handler.test.ts`:
  - Updated existing test descriptions to reflect new behavior
  - Added test for skipping non-end session events (e.g., `session:start`)
  - Added test for `session:end` event handling

## Testing

All 18 tests in the session-memory handler test suite pass:
- Existing tests for `command:new` and `command:reset` continue to work
- New test verifies `session:end` triggers memory save
- New test verifies other session events (like `session:start`) are correctly skipped

Fixes #31266