### PR TITLE
fix(slack): auto-reconnect on streaming API degradation (channel events silently dropped)

### DIFF
--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -98,6 +98,8 @@ export type SlackMonitorContext = {
     channelId?: string | null;
     channelType?: string | null;
   }) => string;
+  /** Callback to notify when streaming API fails (for degraded state detection). */
+  onStreamingError?: () => void;
   isChannelAllowed: (params: {
     channelId?: string;
     channelName?: string;
@@ -152,6 +154,8 @@ export function createSlackMonitorContext(params: {
   ackReactionScope: string;
   mediaMaxBytes: number;
   removeAckAfterReply: boolean;
+  /** Callback to notify when streaming API fails (for degraded state detection). */
+  onStreamingError?: () => void;
 }): SlackMonitorContext {
   const channelHistories = new Map<string, HistoryEntry[]>();
   const logger = getChildLogger({ module: "slack-auto-reply" });
@@ -432,5 +436,6 @@ export function createSlackMonitorContext(params: {
     resolveChannelName,
     resolveUserName,
     setSlackThreadStatus,
+    onStreamingError: params.onStreamingError,
   };
 }

--- a/src/slack/monitor/events.ts
+++ b/src/slack/monitor/events.ts
@@ -14,14 +14,32 @@ export function registerSlackMonitorEvents(params: {
   handleSlackMessage: SlackMessageHandler;
   /** Called on each inbound event to update liveness tracking. */
   trackEvent?: () => void;
+  /** Called on each inbound channel event (not DM) to track channel event liveness. */
+  trackChannelEvent?: (isChannel: boolean) => void;
 }) {
   registerSlackMessageEvents({
     ctx: params.ctx,
     handleSlackMessage: params.handleSlackMessage,
   });
-  registerSlackReactionEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
-  registerSlackMemberEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
-  registerSlackChannelEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
-  registerSlackPinEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
+  registerSlackReactionEvents({
+    ctx: params.ctx,
+    trackEvent: params.trackEvent,
+    trackChannelEvent: params.trackChannelEvent,
+  });
+  registerSlackMemberEvents({
+    ctx: params.ctx,
+    trackEvent: params.trackEvent,
+    trackChannelEvent: params.trackChannelEvent,
+  });
+  registerSlackChannelEvents({
+    ctx: params.ctx,
+    trackEvent: params.trackEvent,
+    trackChannelEvent: params.trackChannelEvent,
+  });
+  registerSlackPinEvents({
+    ctx: params.ctx,
+    trackEvent: params.trackEvent,
+    trackChannelEvent: params.trackChannelEvent,
+  });
   registerSlackInteractionEvents({ ctx: params.ctx });
 }

--- a/src/slack/monitor/events/channels.ts
+++ b/src/slack/monitor/events/channels.ts
@@ -15,8 +15,9 @@ import type {
 export function registerSlackChannelEvents(params: {
   ctx: SlackMonitorContext;
   trackEvent?: () => void;
+  trackChannelEvent?: (isChannel: boolean) => void;
 }) {
-  const { ctx, trackEvent } = params;
+  const { ctx, trackEvent, trackChannelEvent } = params;
 
   const enqueueChannelSystemEvent = (params: {
     kind: "created" | "renamed";
@@ -55,6 +56,8 @@ export function registerSlackChannelEvents(params: {
           return;
         }
         trackEvent?.();
+        // Channel events are always channel events (not DM)
+        trackChannelEvent?.(true);
 
         const payload = event as SlackChannelCreatedEvent;
         const channelId = payload.channel?.id;
@@ -74,6 +77,8 @@ export function registerSlackChannelEvents(params: {
           return;
         }
         trackEvent?.();
+        // Channel events are always channel events (not DM)
+        trackChannelEvent?.(true);
 
         const payload = event as SlackChannelRenamedEvent;
         const channelId = payload.channel?.id;
@@ -93,6 +98,8 @@ export function registerSlackChannelEvents(params: {
           return;
         }
         trackEvent?.();
+        // Channel events are always channel events (not DM)
+        trackChannelEvent?.(true);
 
         const payload = event as SlackChannelIdChangedEvent;
         const oldChannelId = payload.old_channel_id;

--- a/src/slack/monitor/events/members.ts
+++ b/src/slack/monitor/events/members.ts
@@ -8,8 +8,9 @@ import { authorizeAndResolveSlackSystemEventContext } from "./system-event-conte
 export function registerSlackMemberEvents(params: {
   ctx: SlackMonitorContext;
   trackEvent?: () => void;
+  trackChannelEvent?: (isChannel: boolean) => void;
 }) {
-  const { ctx, trackEvent } = params;
+  const { ctx, trackEvent, trackChannelEvent } = params;
 
   const handleMemberChannelEvent = async (params: {
     verb: "joined" | "left";
@@ -25,6 +26,9 @@ export function registerSlackMemberEvents(params: {
       const channelId = payload.channel;
       const channelInfo = channelId ? await ctx.resolveChannelName(channelId) : {};
       const channelType = payload.channel_type ?? channelInfo?.type;
+      // Track channel events (not DM) for degraded state detection
+      const isChannel = channelType !== "im" && channelType !== "mpim";
+      trackChannelEvent?.(isChannel);
       const ingressContext = await authorizeAndResolveSlackSystemEventContext({
         ctx,
         senderId: payload.user,

--- a/src/slack/monitor/events/pins.ts
+++ b/src/slack/monitor/events/pins.ts
@@ -8,13 +8,15 @@ import { authorizeAndResolveSlackSystemEventContext } from "./system-event-conte
 async function handleSlackPinEvent(params: {
   ctx: SlackMonitorContext;
   trackEvent?: () => void;
+  trackChannelEvent?: (isChannel: boolean) => void;
   body: unknown;
   event: unknown;
   action: "pinned" | "unpinned";
   contextKeySuffix: "added" | "removed";
   errorLabel: string;
 }): Promise<void> {
-  const { ctx, trackEvent, body, event, action, contextKeySuffix, errorLabel } = params;
+  const { ctx, trackEvent, trackChannelEvent, body, event, action, contextKeySuffix, errorLabel } =
+    params;
 
   try {
     if (ctx.shouldDropMismatchedSlackEvent(body)) {
@@ -24,6 +26,8 @@ async function handleSlackPinEvent(params: {
 
     const payload = event as SlackPinEvent;
     const channelId = payload.channel_id;
+    // Pins are typically channel events (not DM)
+    trackChannelEvent?.(true);
     const ingressContext = await authorizeAndResolveSlackSystemEventContext({
       ctx,
       senderId: payload.user,
@@ -52,13 +56,15 @@ async function handleSlackPinEvent(params: {
 export function registerSlackPinEvents(params: {
   ctx: SlackMonitorContext;
   trackEvent?: () => void;
+  trackChannelEvent?: (isChannel: boolean) => void;
 }) {
-  const { ctx, trackEvent } = params;
+  const { ctx, trackEvent, trackChannelEvent } = params;
 
   ctx.app.event("pin_added", async ({ event, body }: SlackEventMiddlewareArgs<"pin_added">) => {
     await handleSlackPinEvent({
       ctx,
       trackEvent,
+      trackChannelEvent,
       body,
       event,
       action: "pinned",
@@ -71,6 +77,7 @@ export function registerSlackPinEvents(params: {
     await handleSlackPinEvent({
       ctx,
       trackEvent,
+      trackChannelEvent,
       body,
       event,
       action: "unpinned",

--- a/src/slack/monitor/events/reactions.ts
+++ b/src/slack/monitor/events/reactions.ts
@@ -8,8 +8,9 @@ import { authorizeAndResolveSlackSystemEventContext } from "./system-event-conte
 export function registerSlackReactionEvents(params: {
   ctx: SlackMonitorContext;
   trackEvent?: () => void;
+  trackChannelEvent?: (isChannel: boolean) => void;
 }) {
-  const { ctx, trackEvent } = params;
+  const { ctx, trackEvent, trackChannelEvent } = params;
 
   const handleReactionEvent = async (event: SlackReactionEvent, action: string) => {
     try {
@@ -18,6 +19,8 @@ export function registerSlackReactionEvents(params: {
         return;
       }
       trackEvent?.();
+      // Reactions are always channel events (not DM)
+      trackChannelEvent?.(true);
 
       const ingressContext = await authorizeAndResolveSlackSystemEventContext({
         ctx,

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -21,8 +21,10 @@ export function createSlackMessageHandler(params: {
   account: ResolvedSlackAccount;
   /** Called on each inbound event to update liveness tracking. */
   trackEvent?: () => void;
+  /** Called on each inbound channel event (not DM) to track channel event liveness. */
+  trackChannelEvent?: (isChannel: boolean) => void;
 }): SlackMessageHandler {
-  const { ctx, account, trackEvent } = params;
+  const { ctx, account, trackEvent, trackChannelEvent } = params;
   const debounceMs = resolveInboundDebounceMs({ cfg: ctx.cfg, channel: "slack" });
   const threadTsResolver = createSlackThreadTsResolver({ client: ctx.app.client });
 
@@ -116,6 +118,10 @@ export function createSlackMessageHandler(params: {
       return;
     }
     trackEvent?.();
+    // Track channel events separately for degraded state detection
+    const channelType = message.channel_type;
+    const isChannel = channelType !== "im" && channelType !== "mpim";
+    trackChannelEvent?.(isChannel);
     const resolvedMessage = await threadTsResolver.resolve({ message, source: opts.source });
     await debouncer.enqueue({ message: resolvedMessage, opts });
   };

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -255,6 +255,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         danger(`slack-stream: streaming API call failed: ${String(err)}, falling back`),
       );
       streamFailed = true;
+      // Notify provider about streaming error for degraded state detection
+      ctx.onStreamingError?.();
       await deliverNormally(payload, streamSession?.threadTs ?? plannedThreadTs);
     }
   };
@@ -429,11 +431,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   // -----------------------------------------------------------------------
   const finalStream = streamSession as SlackStreamSession | null;
   if (finalStream && !finalStream.stopped) {
-    try {
-      await stopSlackStream({ session: finalStream });
-    } catch (err) {
-      runtime.error?.(danger(`slack-stream: failed to stop stream: ${String(err)}`));
-    }
+      try {
+        await stopSlackStream({ session: finalStream });
+      } catch (err) {
+        runtime.error?.(danger(`slack-stream: failed to stop stream: ${String(err)}`));
+        // Notify provider about streaming error for degraded state detection
+        ctx.onStreamingError?.();
+      }
   }
 
   const anyReplyDelivered = queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -335,20 +335,96 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     ackReactionScope,
     mediaMaxBytes,
     removeAckAfterReply,
+    onStreamingError,
   });
 
   // Wire up event liveness tracking: update lastEventAt on every inbound event
   // so the health monitor can detect "half-dead" sockets that pass health checks
   // but silently stop delivering events.
+  // Also track channel events separately for streaming API degraded state detection.
+  let lastChannelEventAt: number | undefined;
+  let lastStreamingErrorAt: number | undefined;
+  let degradedStateCheckTimer: ReturnType<typeof setTimeout> | undefined;
+  const STREAMING_DEGRADED_CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+  const STREAMING_DEGRADED_THRESHOLD_MS = 3 * 60 * 1000; // 3 minutes without channel events
+
   const trackEvent = opts.setStatus
     ? () => {
         opts.setStatus!({ lastEventAt: Date.now(), lastInboundAt: Date.now() });
       }
     : undefined;
 
-  const handleSlackMessage = createSlackMessageHandler({ ctx, account, trackEvent });
+  const trackChannelEvent = (isChannel: boolean) => {
+    if (isChannel) {
+      lastChannelEventAt = Date.now();
+      // Reset degraded state if we receive a channel event after streaming error
+      if (lastStreamingErrorAt !== undefined) {
+        lastStreamingErrorAt = undefined;
+        if (degradedStateCheckTimer) {
+          clearTimeout(degradedStateCheckTimer);
+          degradedStateCheckTimer = undefined;
+        }
+      }
+    }
+    trackEvent?.();
+  };
 
-  registerSlackMonitorEvents({ ctx, account, handleSlackMessage, trackEvent });
+  // AbortController to trigger reconnect when degraded state is detected
+  let degradedStateAbortController: AbortController | undefined;
+
+  const onStreamingError = () => {
+    if (slackMode !== "socket") {
+      return;
+    }
+    lastStreamingErrorAt = Date.now();
+    // Clear any existing timer
+    if (degradedStateCheckTimer) {
+      clearTimeout(degradedStateCheckTimer);
+    }
+    // Schedule a check for degraded state
+    degradedStateCheckTimer = setTimeout(() => {
+      const now = Date.now();
+      const timeSinceError = now - (lastStreamingErrorAt ?? 0);
+      const timeSinceLastChannelEvent = lastChannelEventAt
+        ? now - lastChannelEventAt
+        : Infinity;
+
+      // If we haven't received channel events for threshold duration after streaming error,
+      // trigger a reconnect
+      if (
+        timeSinceError >= STREAMING_DEGRADED_THRESHOLD_MS &&
+        timeSinceLastChannelEvent >= STREAMING_DEGRADED_THRESHOLD_MS
+      ) {
+        runtime.error?.(
+          `slack socket mode: detected degraded state (no channel events for ${Math.round(timeSinceLastChannelEvent / 1000)}s after streaming API error), triggering reconnect`,
+        );
+        // Trigger reconnect by stopping the app and aborting the waitForSlackSocketDisconnect promise
+        // This will cause the reconnect loop to restart
+        void app.stop().catch(() => undefined);
+        // Also abort the waitForSlackSocketDisconnect to immediately trigger reconnect
+        if (!degradedStateAbortController) {
+          degradedStateAbortController = new AbortController();
+        }
+        degradedStateAbortController.abort();
+      }
+      degradedStateCheckTimer = undefined;
+    }, STREAMING_DEGRADED_CHECK_INTERVAL_MS);
+  };
+
+  const handleSlackMessage = createSlackMessageHandler({
+    ctx,
+    account,
+    trackEvent,
+    trackChannelEvent,
+  });
+
+  registerSlackMonitorEvents({
+    ctx,
+    account,
+    handleSlackMessage,
+    trackEvent,
+    trackChannelEvent,
+  });
   await registerSlackMonitorSlashCommands({ ctx, account });
   if (slackMode === "http" && slackHttpHandler) {
     unregisterHttpHandler = registerSlackHttpHandler({


### PR DESCRIPTION
## Summary

Fixes #31287

When Slack streaming API returns \internal_error\, the gateway falls back but enters a degraded state where:
- DM events still arrive normally
- Channel events are silently dropped 鈥?no error logged, no retry, no reconnect

This PR implements automatic reconnection detection for this degraded state.

## Changes

1. **Streaming API error tracking**: Track when streaming API calls fail (start/append/stop)
2. **Channel event tracking**: Track channel events separately from DM events
3. **Degraded state detection**: If no channel events are received for 3 minutes after a streaming API error, trigger a reconnect
4. **Automatic reconnection**: When degraded state is detected, stop the socket connection to trigger the existing reconnect loop

## Implementation Details

- Added \onStreamingError\ callback to \SlackMonitorContext\ to notify provider of streaming API failures
- Modified event tracking to distinguish channel events from DM events
- Added degraded state detection timer that checks for channel event liveness after streaming errors
- When degraded state is detected, calls \pp.stop()\ which triggers the existing socket disconnect/reconnect logic

## Testing

- [ ] Manual testing with Slack socket mode
- [ ] Verify reconnection happens when degraded state is detected
- [ ] Verify normal operation is not affected

## Related Issues

Closes #31287