### PR TITLE
fix(line): resolve relative tokenFile/secretFile paths against config dir (#10428)

### DIFF
--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -578,19 +578,25 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       for (const account of accounts) {
         const accountId = account.accountId ?? DEFAULT_ACCOUNT_ID;
         if (!account.channelAccessToken?.trim()) {
+          const tokenFile = account.config?.tokenFile;
           issues.push({
             channel: "line",
             accountId,
             kind: "config",
-            message: "LINE channel access token not configured",
+            message: tokenFile
+              ? `LINE tokenFile not readable: ${tokenFile}`
+              : "LINE channel access token not configured",
           });
         }
         if (!account.channelSecret?.trim()) {
+          const secretFile = account.config?.secretFile;
           issues.push({
             channel: "line",
             accountId,
             kind: "config",
-            message: "LINE channel secret not configured",
+            message: secretFile
+              ? `LINE secretFile not readable: ${secretFile}`
+              : "LINE channel secret not configured",
           });
         }
       }

--- a/src/line/accounts.test.ts
+++ b/src/line/accounts.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
@@ -95,6 +98,77 @@ describe("LINE accounts", () => {
 
       expect(account.channelAccessToken).toBe("");
       expect(account.channelSecret).toBe("");
+      expect(account.tokenSource).toBe("none");
+    });
+
+    it("resolves token from tokenFile with absolute path", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "line-test-"));
+      try {
+        const tokenPath = path.join(tmpDir, "token.txt");
+        const secretPath = path.join(tmpDir, "secret.txt");
+        fs.writeFileSync(tokenPath, "  absolute-token  ");
+        fs.writeFileSync(secretPath, "  absolute-secret  ");
+
+        const cfg: OpenClawConfig = {
+          channels: {
+            line: {
+              enabled: true,
+              tokenFile: tokenPath,
+              secretFile: secretPath,
+            },
+          },
+        };
+
+        const account = resolveLineAccount({ cfg });
+
+        expect(account.channelAccessToken).toBe("absolute-token");
+        expect(account.channelSecret).toBe("absolute-secret");
+        expect(account.tokenSource).toBe("file");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true });
+      }
+    });
+
+    it("resolves token from tokenFile with relative path when configDir is provided", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "line-test-"));
+      try {
+        fs.writeFileSync(path.join(tmpDir, "token.txt"), "  relative-token  ");
+        fs.writeFileSync(path.join(tmpDir, "secret.txt"), "  relative-secret  ");
+
+        const cfg: OpenClawConfig = {
+          channels: {
+            line: {
+              enabled: true,
+              tokenFile: "./token.txt",
+              secretFile: "./secret.txt",
+            },
+          },
+        };
+
+        const account = resolveLineAccount({ cfg, configDir: tmpDir });
+
+        expect(account.channelAccessToken).toBe("relative-token");
+        expect(account.channelSecret).toBe("relative-secret");
+        expect(account.tokenSource).toBe("file");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true });
+      }
+    });
+
+    it("returns empty token when relative tokenFile cannot be read without configDir", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          line: {
+            enabled: true,
+            tokenFile: "./no-such-file.txt",
+          },
+        },
+      };
+
+      // Without a valid configDir the file will not be found and token is empty.
+      const account = resolveLineAccount({ cfg, configDir: "/nonexistent-dir" });
+
+      expect(account.channelAccessToken).toBe("");
       expect(account.tokenSource).toBe("none");
     });
   });

--- a/src/line/accounts.ts
+++ b/src/line/accounts.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs";
+import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveConfigPath } from "../config/paths.js";
 import {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId as normalizeSharedAccountId,
@@ -15,12 +17,19 @@ import type {
 
 export { DEFAULT_ACCOUNT_ID } from "../routing/account-id.js";
 
-function readFileIfExists(filePath: string | undefined): string | undefined {
+function readFileIfExists(
+  filePath: string | undefined,
+  configDir: string | undefined,
+): string | undefined {
   if (!filePath) {
     return undefined;
   }
+  // Resolve relative paths against the config file directory so that
+  // `tokenFile: ./token.txt` works regardless of the process working directory.
+  const resolvedPath =
+    configDir && !path.isAbsolute(filePath) ? path.resolve(configDir, filePath) : filePath;
   try {
-    return fs.readFileSync(filePath, "utf-8").trim();
+    return fs.readFileSync(resolvedPath, "utf-8").trim();
   } catch {
     return undefined;
   }
@@ -30,8 +39,9 @@ function resolveToken(params: {
   accountId: string;
   baseConfig?: LineConfig;
   accountConfig?: LineAccountConfig;
+  configDir: string | undefined;
 }): { token: string; tokenSource: LineTokenSource } {
-  const { accountId, baseConfig, accountConfig } = params;
+  const { accountId, baseConfig, accountConfig, configDir } = params;
 
   // Check account-level config first
   if (accountConfig?.channelAccessToken?.trim()) {
@@ -39,7 +49,7 @@ function resolveToken(params: {
   }
 
   // Check account-level token file
-  const accountFileToken = readFileIfExists(accountConfig?.tokenFile);
+  const accountFileToken = readFileIfExists(accountConfig?.tokenFile, configDir);
   if (accountFileToken) {
     return { token: accountFileToken, tokenSource: "file" };
   }
@@ -50,7 +60,7 @@ function resolveToken(params: {
       return { token: baseConfig.channelAccessToken.trim(), tokenSource: "config" };
     }
 
-    const baseFileToken = readFileIfExists(baseConfig?.tokenFile);
+    const baseFileToken = readFileIfExists(baseConfig?.tokenFile, configDir);
     if (baseFileToken) {
       return { token: baseFileToken, tokenSource: "file" };
     }
@@ -68,8 +78,9 @@ function resolveSecret(params: {
   accountId: string;
   baseConfig?: LineConfig;
   accountConfig?: LineAccountConfig;
+  configDir: string | undefined;
 }): string {
-  const { accountId, baseConfig, accountConfig } = params;
+  const { accountId, baseConfig, accountConfig, configDir } = params;
 
   // Check account-level config first
   if (accountConfig?.channelSecret?.trim()) {
@@ -77,7 +88,7 @@ function resolveSecret(params: {
   }
 
   // Check account-level secret file
-  const accountFileSecret = readFileIfExists(accountConfig?.secretFile);
+  const accountFileSecret = readFileIfExists(accountConfig?.secretFile, configDir);
   if (accountFileSecret) {
     return accountFileSecret;
   }
@@ -88,7 +99,7 @@ function resolveSecret(params: {
       return baseConfig.channelSecret.trim();
     }
 
-    const baseFileSecret = readFileIfExists(baseConfig?.secretFile);
+    const baseFileSecret = readFileIfExists(baseConfig?.secretFile, configDir);
     if (baseFileSecret) {
       return baseFileSecret;
     }
@@ -105,6 +116,8 @@ function resolveSecret(params: {
 export function resolveLineAccount(params: {
   cfg: OpenClawConfig;
   accountId?: string;
+  /** Directory of the OpenClaw config file; used to resolve relative tokenFile/secretFile paths. */
+  configDir?: string;
 }): ResolvedLineAccount {
   const cfg = params.cfg;
   const accountId = normalizeSharedAccountId(params.accountId);
@@ -113,16 +126,21 @@ export function resolveLineAccount(params: {
   const accountConfig =
     accountId !== DEFAULT_ACCOUNT_ID ? resolveAccountEntry(accounts, accountId) : undefined;
 
+  // Resolve the config directory so relative tokenFile/secretFile paths work correctly.
+  const configDir = params.configDir ?? path.dirname(resolveConfigPath());
+
   const { token, tokenSource } = resolveToken({
     accountId,
     baseConfig: lineConfig,
     accountConfig,
+    configDir,
   });
 
   const secret = resolveSecret({
     accountId,
     baseConfig: lineConfig,
     accountConfig,
+    configDir,
   });
 
   const {


### PR DESCRIPTION
## Problem

When users configure `tokenFile` or `secretFile` with a **relative path** in their LINE channel config (e.g. `tokenFile: ./my-token.txt`), the `readFileIfExists` function in `src/line/accounts.ts` reads the path relative to the **process working directory** rather than the **config file's directory**. This causes the read to fail silently (returning `undefined`), so the resolved `channelAccessToken` is empty, and `openclaw channels status` / the doctor always reports "LINE channel access token not configured" even though the token *is* configured.

The secondary symptom: the doctor message is identical whether the user never configured a token, or configured a tokenFile that can't be read — making diagnosis harder.

## Root Cause

`readFileIfExists(filePath)` in `src/line/accounts.ts` calls `fs.readFileSync(filePath)` with the raw path string. For relative paths, Node.js resolves these against `process.cwd()`, which is typically not where the config file lives.

## Fix

**`src/line/accounts.ts`**
- Added `configDir` parameter (optional, threaded from `resolveLineAccount` → `resolveToken` / `resolveSecret` → `readFileIfExists`).
- `readFileIfExists` now resolves relative paths via `path.resolve(configDir, filePath)` so they are relative to the config file directory.
- `resolveLineAccount` defaults `configDir` to `path.dirname(resolveConfigPath())` when not supplied, covering all runtime call sites automatically. Callers may also pass an explicit `configDir` (useful for tests).

**`extensions/line/src/channel.ts`**
- `collectStatusIssues` now emits a distinct message when `tokenFile`/`secretFile` is set but the file cannot be read (`LINE tokenFile not readable: <path>`) vs. when no token is configured at all (`LINE channel access token not configured`). This makes it immediately clear to users that the *path* is the problem.

**`src/line/accounts.test.ts`**
- Added tests covering absolute tokenFile paths, relative tokenFile paths with a valid `configDir`, and the unreadable-path case.

## Step 6 Re-verify (code-level — matches step 3 method)

Step 3 was code-level analysis only (no Docker reproduction); step 6 mirrors this.

```
grep "readFileIfExists(" src/line/accounts.ts
# Before fix: readFileIfExists(accountConfig?.tokenFile)  ← no configDir
# After fix:  readFileIfExists(accountConfig?.tokenFile, configDir)  ← configDir threaded through

grep "configDir" src/line/accounts.ts
# resolveLineAccount defaults: path.dirname(resolveConfigPath())
# readFileIfExists: path.resolve(configDir, filePath) for relative paths
```

oxfmt check on all 3 changed `.ts` files → **passed** (`All matched files use the correct format`).
