### PR TITLE
fix(infra): retry session-event runs on failure and pass sessionKey for exec wakes

### DIFF
--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -94,6 +94,19 @@ describe("heartbeat-wake", () => {
     expect(handler.mock.calls[1]?.[0]).toEqual({ reason: "hook:wake" });
   });
 
+  it("retries failed handler results after the default retry delay", async () => {
+    vi.useFakeTimers();
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "failed", reason: "dispatch error" })
+      .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
+    await expectRetryAfterDefaultDelay({
+      handler,
+      initialReason: "exec-event",
+      expectedRetryReason: "exec-event",
+    });
+  });
+
   it("retries thrown handler errors after the default retry delay", async () => {
     vi.useFakeTimers();
     const handler = vi

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -153,8 +153,10 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
           ...(pendingWake.sessionKey ? { sessionKey: pendingWake.sessionKey } : {}),
         };
         const res = await active(wakeOpts);
-        if (res.status === "skipped" && res.reason === "requests-in-flight") {
-          // The main lane is busy; retry this wake target soon.
+        if (
+          (res.status === "skipped" && res.reason === "requests-in-flight") ||
+          res.status === "failed"
+        ) {
           queuePendingWakeReason({
             reason: pendingWake.reason ?? "retry",
             agentId: pendingWake.agentId,


### PR DESCRIPTION
## Summary

- Problem: `requestHeartbeatNow` calls from exec completion and node exec events were missing the `sessionKey` parameter, causing the heartbeat runner to potentially target the wrong session. Additionally, when a heartbeat handler returned `{ status: "failed" }`, the wake was silently dropped instead of being retried.
- Why it matters: Exec completion events are intended to produce an immediate follow-up turn. A transient dispatch/model failure should not silently lose that immediate-run attempt, and the wake must target the correct session to drain the right event queue.
- What changed:
  1. Pass `sessionKey` to `requestHeartbeatNow` in `bash-tools.exec-runtime.ts` (both `notifyExecExit` and `emitExecSystemEvent`) and `server-node-events.ts` (exec event handler)
  2. Treat `{ status: "failed" }` handler results the same as `requests-in-flight` — requeue the wake and schedule a retry after `DEFAULT_RETRY_MS` (1s)
  3. Added a new test case verifying failed-status retry behavior
- What did NOT change (scope boundary): No changes to the heartbeat runner itself, system event queue semantics, retry count limits, or cron event handling (which already passes `sessionKey` correctly)

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31354

## User-visible / Behavior Changes

- Exec completion events now reliably trigger a follow-up agent turn for the correct session, even after transient failures
- Previously silent failures now retry with 1s backoff instead of being dropped

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22+

### Steps

1. Configure an agent with exec tools enabled
2. Run a long-running exec command in a session
3. When exec completes, observe that the follow-up turn targets the correct session
4. Simulate a transient heartbeat failure — observe the wake is retried after 1s

### Expected

- Follow-up turn fires for the correct session after exec completion
- Transient failures are retried, not silently dropped

### Actual

- Before: `requestHeartbeatNow` without `sessionKey` could target wrong session; `failed` status was silently dropped
- After: `sessionKey` is always forwarded; `failed` results trigger retry with 1s backoff

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: exec exit notification with sessionKey forwarding; failed handler result triggers retry; all 14 heartbeat-wake tests pass
- Edge cases checked: multiple concurrent exec completions for different sessions; retry after requests-in-flight still works unchanged
- What you did **not** verify: production multi-agent setup with real model failures; cron timer integration (already passes sessionKey correctly)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; the previous behavior (no retry on failed, no sessionKey on exec wakes) is restored
- Files/config to restore: `src/infra/heartbeat-wake.ts`, `src/agents/bash-tools.exec-runtime.ts`, `src/gateway/server-node-events.ts`

## Risks and Mitigations

- Risk: Failed wakes could retry indefinitely if the underlying cause is permanent
  - Mitigation: The retry mechanism reuses the existing coalescing/dedup logic — duplicate wakes for the same target are merged, and the heartbeat runner itself has timeout and schedule-advance logic that prevents infinite loops

