### PR TITLE
fix(feishu): pass mediaLocalRoots in sendText local-image auto-convert

### DIFF
--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -70,6 +70,31 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
     }
   });
 
+  it("forwards mediaLocalRoots to sendMediaFeishu for local image auto-convert", async () => {
+    const { dir, file } = await createTmpImage();
+    const roots = ["/tmp", "/home/user/workspace"] as const;
+    try {
+      await sendText({
+        cfg: {} as any,
+        to: "chat_1",
+        text: file,
+        accountId: "main",
+        mediaLocalRoots: roots,
+      });
+
+      expect(sendMediaFeishuMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: "chat_1",
+          mediaUrl: file,
+          accountId: "main",
+          mediaLocalRoots: roots,
+        }),
+      );
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps non-path text on the text-send path", async () => {
     await sendText({
       cfg: {} as any,

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -65,7 +65,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   chunker: (text, limit) => getFeishuRuntime().channel.text.chunkMarkdownText(text, limit),
   chunkerMode: "markdown",
   textChunkLimit: 4000,
-  sendText: async ({ cfg, to, text, accountId }) => {
+  sendText: async ({ cfg, to, text, accountId, mediaLocalRoots }) => {
     // Scheme A compatibility shim:
     // when upstream accidentally returns a local image path as plain text,
     // auto-upload and send as Feishu image message instead of leaking path text.
@@ -77,6 +77,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           mediaUrl: localImagePath,
           accountId: accountId ?? undefined,
+          mediaLocalRoots,
         });
         return { channel: "feishu", ...result };
       } catch (err) {


### PR DESCRIPTION
## Summary

- **Problem**: When a Feishu outbound message contains a bare local image path (e.g. `/Users/name/Desktop/screenshot.png`), the `sendText` handler detects it and attempts auto-upload via `sendMediaFeishu`. However, it was not forwarding `mediaLocalRoots` from the `ChannelOutboundContext`, causing `loadWebMedia` to reject paths outside the default state directories (added in CVE-2026-26321 security patch). The upload silently fails and the raw path string is sent as text.
- **Fix**: Destructure `mediaLocalRoots` from the outbound context in `sendText` and pass it through to `sendMediaFeishu`, matching the existing behavior in `sendMedia`.
- **Scope**: One-line change in `outbound.ts`, one new test case in `outbound.test.ts`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31378

## User-visible / Behavior Changes

1. Local image paths sent as text through Feishu outbound are now correctly uploaded and displayed as images (when the path is within allowed `mediaLocalRoots`).
2. No change to `sendMedia` path — it already passed `mediaLocalRoots` correctly.
3. Fallback to plain text still applies if upload fails for other reasons.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — same `sendMediaFeishu` call, just with correct allowed-roots context
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — `mediaLocalRoots` already existed in the context; it was simply not being forwarded

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22+
- Channel: Feishu

### Steps

1. Configure Feishu channel with `im:resource` permission
2. Have an agent take a screenshot with `screencapture ~/Desktop/shot.png`
3. Agent outputs the path as text → `sendText` fires

### Expected

- Image is uploaded to Feishu and displayed as an image message

### Actual (before fix)

- Raw path string `/Users/.../shot.png` sent as text message

## Evidence

- [x] Failing test/log before + passing after

New test: `forwards mediaLocalRoots to sendMediaFeishu for local image auto-convert`

## Human Verification (required)

- Verified scenarios: sendText with local image path + mediaLocalRoots; sendText with local image path without mediaLocalRoots (falls back to default roots); sendText with non-image text (unchanged behavior); sendMedia path (unchanged, already correct)

## Failure Recovery

- Revert commit `fix(feishu): pass mediaLocalRoots in sendText local-image auto-convert`
- Impact: local image auto-convert returns to pre-fix behavior (path sent as text)

## Risks and Mitigations

- **Risk**: None — this adds a previously-missing parameter that was already available in the context. The `sendMedia` path already uses the same pattern successfully.