### PR TITLE
feat(feishu): add upload action to feishu_drive tool

### DIFF
--- a/extensions/feishu/skills/feishu-drive/SKILL.md
+++ b/extensions/feishu/skills/feishu-drive/SKILL.md
@@ -56,6 +56,31 @@ In parent folder:
 { "action": "move", "file_token": "ABC123", "type": "docx", "folder_token": "fldcnXXX" }
 ```
 
+### Upload File
+
+```json
+{ "action": "upload", "file_path": "/path/to/local/file.pdf" }
+```
+
+To a specific folder:
+
+```json
+{ "action": "upload", "file_path": "/path/to/local/file.pdf", "folder_token": "fldcnXXX" }
+```
+
+With a custom name:
+
+```json
+{
+  "action": "upload",
+  "file_path": "/path/to/local/file.pdf",
+  "folder_token": "fldcnXXX",
+  "file_name": "report-2026.pdf"
+}
+```
+
+Direct upload limit: 20MB per file.
+
 ### Delete File
 
 ```json
@@ -86,7 +111,7 @@ channels:
 
 ## Permissions
 
-- `drive:drive` - Full access (create, move, delete)
+- `drive:drive` - Full access (create, upload, move, delete)
 - `drive:drive:readonly` - Read only (list, info)
 
 ## Known Limitations

--- a/extensions/feishu/src/drive-schema.ts
+++ b/extensions/feishu/src/drive-schema.ts
@@ -41,6 +41,16 @@ export const FeishuDriveSchema = Type.Union([
     file_token: Type.String({ description: "File token to delete" }),
     type: FileType,
   }),
+  Type.Object({
+    action: Type.Literal("upload"),
+    file_path: Type.String({ description: "Local file path to upload" }),
+    folder_token: Type.Optional(
+      Type.String({ description: "Target folder token (optional, omit for root)" }),
+    ),
+    file_name: Type.Optional(
+      Type.String({ description: "Override file name in Drive (defaults to local file name)" }),
+    ),
+  }),
 ]);
 
 export type FeishuDriveParams = Static<typeof FeishuDriveSchema>;

--- a/extensions/feishu/src/drive.test.ts
+++ b/extensions/feishu/src/drive.test.ts
@@ -1,0 +1,182 @@
+import fsSync from "fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./accounts.js", () => ({
+  listEnabledFeishuAccounts: vi.fn().mockReturnValue([{ id: "main", configured: true }]),
+}));
+
+vi.mock("./tool-account.js", () => ({
+  resolveAnyEnabledFeishuToolsConfig: vi.fn().mockReturnValue({ drive: true }),
+  createFeishuToolClient: vi.fn(),
+}));
+
+import { registerFeishuDriveTools } from "./drive.js";
+import { createFeishuToolClient } from "./tool-account.js";
+
+function buildMockClient(overrides: Record<string, unknown> = {}) {
+  return {
+    domain: "https://open.feishu.cn",
+    httpInstance: {
+      get: vi.fn().mockResolvedValue({ code: 0, data: { token: "root_token" } }),
+    },
+    drive: {
+      file: {
+        list: vi.fn().mockResolvedValue({ code: 0, data: { files: [] } }),
+        createFolder: vi.fn().mockResolvedValue({ code: 0, data: { token: "new_folder" } }),
+        move: vi.fn().mockResolvedValue({ code: 0, data: { task_id: "t1" } }),
+        delete: vi.fn().mockResolvedValue({ code: 0, data: { task_id: "t2" } }),
+      },
+      media: {
+        uploadAll: vi.fn().mockResolvedValue({ file_token: "uploaded_token_123" }),
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("feishu_drive upload action", () => {
+  let executeTool: (params: Record<string, unknown>) => Promise<unknown>;
+  let mockClient: ReturnType<typeof buildMockClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = buildMockClient();
+    vi.mocked(createFeishuToolClient).mockReturnValue(mockClient as any);
+
+    const tools: { execute: typeof executeTool }[] = [];
+    const mockApi = {
+      config: { channels: { feishu: {} } },
+      logger: { debug: vi.fn(), info: vi.fn() },
+      registerTool: (factory: (ctx: any) => any, _opts: any) => {
+        const tool = factory({ agentAccountId: "main" });
+        tools.push(tool);
+      },
+    };
+
+    registerFeishuDriveTools(mockApi as any);
+    executeTool = (params) => tools[0].execute("call_1", params);
+  });
+
+  async function createTmpFile(
+    name = "test.pdf",
+    content = "file-content",
+  ): Promise<{ dir: string; file: string }> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-drive-test-"));
+    const file = path.join(dir, name);
+    await fs.writeFile(file, content);
+    return { dir, file };
+  }
+
+  it("uploads a local file to root folder", async () => {
+    const { dir, file } = await createTmpFile();
+    try {
+      const result = (await executeTool({ action: "upload", file_path: file })) as any;
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.file_token).toBe("uploaded_token_123");
+      expect(parsed.name).toBe("test.pdf");
+      expect(parsed.size).toBe(Buffer.from("file-content").length);
+
+      expect(mockClient.drive.media.uploadAll).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          file_name: "test.pdf",
+          parent_type: "explorer",
+          parent_node: "root_token",
+          size: Buffer.from("file-content").length,
+        }),
+      });
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uploads to a specific folder_token", async () => {
+    const { dir, file } = await createTmpFile();
+    try {
+      await executeTool({
+        action: "upload",
+        file_path: file,
+        folder_token: "fldcnTarget",
+      });
+
+      expect(mockClient.drive.media.uploadAll).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          parent_node: "fldcnTarget",
+        }),
+      });
+      // Should not call root folder API when explicit folder_token given
+      expect(mockClient.httpInstance.get).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses custom file_name override", async () => {
+    const { dir, file } = await createTmpFile();
+    try {
+      const result = (await executeTool({
+        action: "upload",
+        file_path: file,
+        file_name: "report-2026.pdf",
+      })) as any;
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.name).toBe("report-2026.pdf");
+      expect(mockClient.drive.media.uploadAll).toHaveBeenCalledWith({
+        data: expect.objectContaining({ file_name: "report-2026.pdf" }),
+      });
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns error for non-existent file", async () => {
+    const result = (await executeTool({
+      action: "upload",
+      file_path: "/tmp/does-not-exist-abc123.txt",
+    })) as any;
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.error).toMatch(/File not found/);
+    expect(mockClient.drive.media.uploadAll).not.toHaveBeenCalled();
+  });
+
+  it("returns error for directory path", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-drive-dir-"));
+    try {
+      const result = (await executeTool({
+        action: "upload",
+        file_path: dir,
+      })) as any;
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.error).toMatch(/Not a file/);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns error when file exceeds 20MB", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-drive-big-"));
+    const file = path.join(dir, "big.bin");
+    // Create a sparse file that reports > 20MB
+    const fd = fsSync.openSync(file, "w");
+    fsSync.ftruncateSync(fd, 21 * 1024 * 1024);
+    fsSync.closeSync(fd);
+    try {
+      const result = (await executeTool({
+        action: "upload",
+        file_path: file,
+      })) as any;
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.error).toMatch(/File too large/);
+      expect(parsed.error).toMatch(/20MB/);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -1,3 +1,5 @@
+import fs from "fs";
+import path from "path";
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { listEnabledFeishuAccounts } from "./accounts.js";
@@ -139,6 +141,60 @@ async function moveFile(client: Lark.Client, fileToken: string, type: string, fo
   };
 }
 
+const UPLOAD_MAX_BYTES = 20 * 1024 * 1024; // Feishu direct upload limit
+
+async function uploadFile(
+  client: Lark.Client,
+  filePath: string,
+  folderToken?: string,
+  fileName?: string,
+) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+  const stat = fs.statSync(filePath);
+  if (!stat.isFile()) {
+    throw new Error(`Not a file: ${filePath}`);
+  }
+  if (stat.size > UPLOAD_MAX_BYTES) {
+    throw new Error(
+      `File too large (${(stat.size / 1024 / 1024).toFixed(1)}MB). ` +
+        `Direct upload limit is 20MB.`,
+    );
+  }
+
+  let effectiveFolder = folderToken && folderToken !== "0" ? folderToken : undefined;
+  if (!effectiveFolder) {
+    effectiveFolder = await getRootFolderToken(client);
+  }
+
+  const name = fileName ?? path.basename(filePath);
+  const buffer = fs.readFileSync(filePath);
+
+  const res = await client.drive.media.uploadAll({
+    data: {
+      file_name: name,
+      parent_type: "explorer",
+      parent_node: effectiveFolder,
+      size: buffer.length,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK file type
+      file: buffer as any,
+    },
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK response shape
+  const resAny = res as any;
+  if (resAny.code !== undefined && resAny.code !== 0) {
+    throw new Error(resAny.msg ?? `Upload failed with code ${resAny.code}`);
+  }
+
+  return {
+    file_token: res?.file_token ?? resAny?.data?.file_token,
+    name,
+    size: buffer.length,
+  };
+}
+
 async function deleteFile(client: Lark.Client, fileToken: string, type: string) {
   const res = await client.drive.file.delete({
     path: { file_token: fileToken },
@@ -194,7 +250,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
         name: "feishu_drive",
         label: "Feishu Drive",
         description:
-          "Feishu cloud storage operations. Actions: list, info, create_folder, move, delete",
+          "Feishu cloud storage operations. Actions: list, info, create_folder, upload, move, delete",
         parameters: FeishuDriveSchema,
         async execute(_toolCallId, params) {
           const p = params as FeishuDriveExecuteParams;
@@ -215,6 +271,8 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
                 return json(await moveFile(client, p.file_token, p.type, p.folder_token));
               case "delete":
                 return json(await deleteFile(client, p.file_token, p.type));
+              case "upload":
+                return json(await uploadFile(client, p.file_path, p.folder_token, p.file_name));
               default:
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
                 return json({ error: `Unknown action: ${(p as any).action}` });


### PR DESCRIPTION
## Summary

- **Problem**: The `feishu_drive` tool only supported `list`, `info`, `create_folder`, `move`, and `delete` actions. Users who wanted to automate file backups to Feishu Drive had no way to upload files programmatically.
- **Solution**: Added a new `upload` action that reads a local file and uploads it to Feishu Drive via `drive.media.uploadAll` with `parent_type: "explorer"`. Supports optional `folder_token` (defaults to root) and `file_name` override.
- **Scope**: `drive.ts`, `drive-schema.ts`, `drive.test.ts` (new), `SKILL.md`

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31372

## User-visible / Behavior Changes

1. `feishu_drive` tool now supports `action: "upload"` with parameters:
   - `file_path` (required): local file path to upload
   - `folder_token` (optional): target Drive folder (defaults to root)
   - `file_name` (optional): override the file name in Drive
2. Direct upload limit: 20MB per file (Feishu API constraint)
3. Returns `file_token`, `name`, and `size` on success
4. All existing actions unchanged

## Security Impact (required)

- New permissions/capabilities? `Yes` — the tool can now read local files for upload. File access is bounded by the agent's execution context. The `drive:drive` permission is required (same as create/move/delete).
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — adds `drive.media.uploadAll` call to Feishu Open API
- Command/tool execution surface changed? `No`
- Data access scope changed? `Yes` — reads local files specified by `file_path`. Validated with `existsSync`/`statSync` before read.

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+
- Channel: Feishu with `drive:drive` permission

### Steps

1. Configure Feishu with drive tool enabled
2. Call `feishu_drive` with:
   ```json
   { "action": "upload", "file_path": "/path/to/file.pdf", "folder_token": "fldcnXXX" }
   ```

### Expected

- File uploaded to Feishu Drive, returns `file_token`

### Actual (before)

- `Unknown action: upload` error

## Evidence

- [x] Failing test/log before + passing after

Six new test cases in `drive.test.ts`:
- uploads a local file to root folder
- uploads to a specific folder_token
- uses custom file_name override
- returns error for non-existent file
- returns error for directory path
- returns error when file exceeds 20MB

## Human Verification (required)

- Verified scenarios: upload to root folder; upload to specific folder; custom file name; non-existent file path; directory path; oversized file; existing actions (list/info/create_folder/move/delete) unchanged

## Failure Recovery

- Revert commit `feat(feishu): add upload action to feishu_drive tool`
- Impact: `upload` action returns `Unknown action` error; all other actions unaffected

## Risks and Mitigations

- **Risk**: Large file uploads may timeout. **Mitigation**: Enforced 20MB limit with clear error message; Feishu's chunked upload API can be added later for larger files.
- **Risk**: Reading arbitrary local files. **Mitigation**: The tool runs within the agent's sandbox context; file access is validated with existence and type checks before read.