### PR TITLE
fix(memory): change QMD searchMode default from 'search' to 'query'

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -155,8 +155,8 @@ out to QMD for retrieval. Key points:
 - Boot refresh now runs in the background by default so chat startup is not
   blocked; set `memory.qmd.update.waitForBootSync = true` to keep the previous
   blocking behavior.
-- Searches run via `memory.qmd.searchMode` (default `qmd search --json`; also
-  supports `vsearch` and `query`). If the selected mode rejects flags on your
+- Searches run via `memory.qmd.searchMode` (default `qmd query --json`; also
+  supports `search` and `vsearch`). If the selected mode rejects flags on your
   QMD build, OpenClaw retries with `qmd query`. If QMD fails or the binary is
   missing, OpenClaw automatically falls back to the builtin SQLite manager so
   memory tools keep working.
@@ -190,8 +190,11 @@ out to QMD for retrieval. Key points:
 **Config surface (`memory.qmd.*`)**
 
 - `command` (default `qmd`): override the executable path.
-- `searchMode` (default `search`): pick which QMD command backs
-  `memory_search` (`search`, `vsearch`, `query`).
+- `searchMode` (default `query`): pick which QMD command backs
+  `memory_search` (`query`, `search`, `vsearch`). The `query` mode uses hybrid
+  retrieval (BM25 + vector expansion + reranking) which handles the natural-language
+  queries that LLMs generate. Use `search` for faster pure-BM25 lookups on
+  CPU-only systems.
 - `includeDefaultMemory` (default `true`): auto-index `MEMORY.md` + `memory/**/*.md`.
 - `paths[]`: add extra directories/files (`path`, optional `pattern`, optional
   stable `name`).

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -802,7 +802,7 @@ export const FIELD_HELP: Record<string, string> = {
   "memory.qmd.mcporter.startDaemon":
     "Automatically starts the mcporter daemon when mcporter-backed QMD mode is enabled (default: true). Keep enabled unless process lifecycle is managed externally by your service supervisor.",
   "memory.qmd.searchMode":
-    'Selects the QMD retrieval path: "query" uses standard query flow, "search" uses search-oriented retrieval, and "vsearch" emphasizes vector retrieval. Keep default unless tuning relevance quality.',
+    'Selects the QMD retrieval path: "query" (default) uses hybrid retrieval (BM25 + vector expansion + reranking) for best recall with natural-language queries, "search" uses pure BM25 keyword matching (faster on CPU-only systems but may miss multi-word queries), and "vsearch" emphasizes vector retrieval. Switch to "search" if query latency is too high on systems without GPU acceleration.',
   "memory.qmd.includeDefaultMemory":
     "Automatically indexes default memory files (MEMORY.md and memory/**/*.md) into QMD collections. Keep enabled unless you want indexing controlled only through explicit custom paths.",
   "memory.qmd.paths":

--- a/src/memory/backend-config.test.ts
+++ b/src/memory/backend-config.test.ts
@@ -25,7 +25,7 @@ describe("resolveMemoryBackendConfig", () => {
     expect(resolved.backend).toBe("qmd");
     expect(resolved.qmd?.collections.length).toBeGreaterThanOrEqual(3);
     expect(resolved.qmd?.command).toBe("qmd");
-    expect(resolved.qmd?.searchMode).toBe("search");
+    expect(resolved.qmd?.searchMode).toBe("query");
     expect(resolved.qmd?.update.intervalMs).toBeGreaterThan(0);
     expect(resolved.qmd?.update.waitForBootSync).toBe(false);
     expect(resolved.qmd?.update.commandTimeoutMs).toBe(30_000);

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -74,9 +74,11 @@ const DEFAULT_CITATIONS: MemoryCitationsMode = "auto";
 const DEFAULT_QMD_INTERVAL = "5m";
 const DEFAULT_QMD_DEBOUNCE_MS = 15_000;
 const DEFAULT_QMD_TIMEOUT_MS = 4_000;
-// Defaulting to `query` can be extremely slow on CPU-only systems (query expansion + rerank).
-// Prefer a faster mode for interactive use; users can opt into `query` for best recall.
-const DEFAULT_QMD_SEARCH_MODE: MemoryQmdSearchMode = "search";
+// `query` (hybrid: BM25 + vector expansion + reranking) is far more accurate for the
+// natural-language queries that LLM-driven memory_search generates. Pure BM25 (`search`)
+// silently returns empty results for most multi-word queries because it ANDs all terms.
+// Users on CPU-only systems who experience slow searches can opt into `search` or `vsearch`.
+const DEFAULT_QMD_SEARCH_MODE: MemoryQmdSearchMode = "query";
 const DEFAULT_QMD_EMBED_INTERVAL = "60m";
 const DEFAULT_QMD_COMMAND_TIMEOUT_MS = 30_000;
 const DEFAULT_QMD_UPDATE_TIMEOUT_MS = 120_000;


### PR DESCRIPTION
## Summary

- **Problem:** The default `memory.qmd.searchMode` of `"search"` (pure BM25) silently returns empty results for most `memory_search` queries. LLMs generate natural-language queries (e.g. "kitchen renovation discussion last week") that BM25 cannot match because it ANDs all terms and requires exact token hits.
- **Why it matters:** Users set up QMD expecting memory to work, but get empty results with no error. Switching to `"query"` in their config fixes it immediately, but the default should work out of the box.
- **What changed:** Default `searchMode` flipped from `"search"` to `"query"` (hybrid: BM25 + vector expansion + reranking). Updated tests, schema help text, and docs.
- **What did NOT change:** All existing behavior for users who explicitly set `searchMode`. The `"search"` and `"vsearch"` modes remain fully supported.

## Trade-off

The previous default comment noted that `"query"` can be slower on CPU-only systems. This is a real concern, but the current default silently breaks the primary use case. Users who need faster lookups can opt into `"search"` — that is a better UX than the current situation where the default mode fails silently for most queries.

With `"query"` as default, `shouldRunEmbed()` will now run embedding updates on fresh installs. This is the correct behavior for hybrid retrieval mode.

## Testing

- Updated `backend-config.test.ts` default assertion from `"search"` to `"query"`
- Existing explicit `searchMode` tests unchanged (all pass)
- Verified against production OpenClaw instance running v2026.2.26

## Files Changed

| File | Change |
|------|--------|
| `src/memory/backend-config.ts` | Default + comment updated |
| `src/memory/backend-config.test.ts` | Default assertion updated |
| `src/config/schema.help.ts` | Help text clarified with mode descriptions |
| `docs/concepts/memory.md` | Docs updated to reflect new default |

Fixes #30942

Signed-off-by: Marco Figueroa <marcofigm@gmail.com>