### PR TITLE
fix(mattermost): prefer threadRootId over payload.replyToId for correct threading

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -750,7 +750,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               }
               await sendMessageMattermost(to, chunk, {
                 accountId: account.accountId,
-                replyToId: threadRootId,
+                replyToId: threadRootId || payload.replyToId,
               });
             }
           } else {
@@ -761,7 +761,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               await sendMessageMattermost(to, caption, {
                 accountId: account.accountId,
                 mediaUrl,
-                replyToId: threadRootId,
+                replyToId: threadRootId || payload.replyToId,
               });
             }
           }


### PR DESCRIPTION
When replying in Mattermost threads, `threadRootId` should take priority over `payload.replyToId`. Mattermost's `root_id` must point to the actual thread root post; when `payload.replyToId` is a mid-thread message (e.g. the inbound message that triggered the reply), it breaks threading by creating a new thread instead of continuing the existing one.

This change flips the priority so `threadRootId` is used first, with `payload.replyToId` as a fallback for cases where no thread root exists.

**Before:** `replyToId: threadRootId`
**After:** `replyToId: threadRootId || payload.replyToId`

This builds on top of the fix in #27744 which added `payload.replyToId` support but used it as the primary value.