### PR TITLE
fix(infra): resolve argv1 symlink in update-runner for npm global installs

### DIFF
--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -491,6 +491,67 @@ describe("runGatewayUpdate", () => {
     });
   });
 
+  it("resolves global npm install root via argv1 bin symlink", async () => {
+    // Simulate npm global install layout:
+    //   ~/.npm-global/bin/openclaw  (symlink → ../lib/node_modules/openclaw/openclaw.mjs)
+    //   ~/.npm-global/lib/node_modules/openclaw/  (actual package)
+    // The process cwd is a different git-tracked workspace (e.g. ~/clawd).
+    const binDir = path.join(tempDir, "bin");
+    const nodeModulesDir = path.join(tempDir, "lib", "node_modules");
+    const pkgRoot = path.join(nodeModulesDir, "openclaw");
+    const binScript = path.join(pkgRoot, "openclaw.mjs");
+    const binLink = path.join(binDir, "openclaw");
+
+    await fs.mkdir(binDir, { recursive: true });
+    await seedGlobalPackageRoot(pkgRoot);
+    await fs.writeFile(binScript, "export {};\n", "utf-8");
+    // bin/openclaw → ../lib/node_modules/openclaw/openclaw.mjs
+    await fs.symlink(binScript, binLink);
+
+    const workspaceDir = path.join(tempDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+
+    const calls: string[] = [];
+    const installCommand = "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error";
+    const runCommand = async (argv: string[]) => {
+      const key = argv.join(" ");
+      calls.push(key);
+      // Workspace looks like a git repo (different project, not openclaw)
+      if (key === `git -C ${workspaceDir} rev-parse --show-toplevel`) {
+        return { stdout: workspaceDir, stderr: "", code: 0 as const };
+      }
+      // npm global root detection
+      if (key === "npm root -g") {
+        return { stdout: nodeModulesDir, stderr: "", code: 0 as const };
+      }
+      if (key === "pnpm root -g") {
+        return { stdout: "", stderr: "", code: 1 as const };
+      }
+      if (key === installCommand) {
+        await fs.writeFile(
+          path.join(pkgRoot, "package.json"),
+          JSON.stringify({ name: "openclaw", version: "2.0.0" }),
+          "utf-8",
+        );
+        return { stdout: "ok", stderr: "", code: 0 as const };
+      }
+      return { stdout: "", stderr: "", code: 0 as const };
+    };
+
+    const result = await runGatewayUpdate({
+      cwd: workspaceDir,
+      argv1: binLink,
+      runCommand: async (argv) => runCommand(argv),
+      timeoutMs: 5000,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.mode).toBe("npm");
+    expect(result.before?.version).toBe("1.0.0");
+    expect(result.after?.version).toBe("2.0.0");
+    expect(calls.some((call) => call === installCommand)).toBe(true);
+  });
+
   it("rejects git roots that are not a openclaw checkout", async () => {
     await fs.mkdir(path.join(tempDir, ".git"));
     const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(tempDir);

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -121,6 +122,17 @@ function buildStartDirs(opts: UpdateRunnerOptions): string[] {
   const argv1 = normalizeDir(opts.argv1);
   if (argv1) {
     dirs.push(path.dirname(argv1));
+    // Resolve symlinks so npm/yarn/pnpm global bin/ symlinks (e.g.
+    // ~/.npm-global/bin/openclaw → ../lib/node_modules/openclaw/openclaw.mjs)
+    // are followed to the actual package directory.
+    try {
+      const resolved = fsSync.realpathSync(argv1);
+      if (path.resolve(resolved) !== path.resolve(argv1)) {
+        dirs.push(path.dirname(resolved));
+      }
+    } catch {
+      // realpathSync throws if the path doesn't exist — keep original candidates
+    }
     const packageRoot = resolveNodeModulesBinPackageRoot(argv1);
     if (packageRoot) {
       dirs.push(packageRoot);


### PR DESCRIPTION
## Summary

- **Problem:** `update.run` (and `openclaw update` CLI) returns `not-openclaw-root` when openclaw is installed via `npm install -g`. The bin entry point (`~/.npm-global/bin/openclaw`) is a symlink to the actual script inside the package (`lib/node_modules/openclaw/openclaw.mjs`). `buildStartDirs()` was not following symlinks, so it searched `~/.npm-global/bin/` for a package root — missing the real package at `~/.npm-global/lib/node_modules/openclaw/`. Meanwhile the workspace dir (`~/clawd`) IS a git repo, causing `resolveGitRoot()` to set `gitRoot = workspace` while `pkgRoot = null`, which triggers the `not-openclaw-root` guard.
- **Why it matters:** Users on npm global installs cannot use the built-in updater. They must stop the gateway, `rm -rf` the package, and reinstall manually to avoid ENOTEMPTY race conditions.
- **What changed:** After adding `path.dirname(argv1)` to candidates, also call `fsSync.realpathSync(argv1)` and push the resolved directory. Mirrors the same pattern already in `src/infra/openclaw-root.ts`.
- **What did NOT change:** All existing update paths (git, npm/pnpm/bun global) are unaffected. New test covers the symlink scenario.

Fixes #31382

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Chore/infra

## Testing

- Added `it("resolves global npm install root via argv1 bin symlink")` which creates a realistic `bin/ → lib/node_modules/openclaw/` symlink layout, passes the symlink as `argv1`, and a separate workspace dir as `cwd`, and asserts the npm global update succeeds (`mode: "npm"`, before: 1.0.0, after: 2.0.0).
- All 17 existing tests in `update-runner.test.ts` continue to pass.

---
🤖 Generated with Claude Code