### PR TITLE
fix(plugins): load plugin registry for agent command so hooks fire

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -90,6 +90,7 @@ describe("registerPreActionHooks", () => {
       .argument("<value>")
       .option("--json")
       .action(async () => {});
+    program.command("agent").action(async () => {});
     program.command("channels").action(async () => {});
     program.command("directory").action(async () => {});
     program.command("agents").action(async () => {});
@@ -163,6 +164,15 @@ describe("registerPreActionHooks", () => {
     await runCommand({
       parseArgv: ["agents"],
       processArgv: ["node", "openclaw", "agents"],
+    });
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads plugin registry for agent command", async () => {
+    await runCommand({
+      parseArgv: ["agent"],
+      processArgv: ["node", "openclaw", "agent"],
     });
 
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -22,6 +22,7 @@ function setProcessTitleForCommand(actionCommand: Command) {
 
 // Commands that need channel plugins loaded
 const PLUGIN_REQUIRED_COMMANDS = new Set([
+  "agent",
   "message",
   "channels",
   "directory",


### PR DESCRIPTION
## Summary

- Problem: Plugin hooks registered via `api.on("message_sending", ...)` never fire when running `openclaw agent`. The `"agent"` command was missing from `PLUGIN_REQUIRED_COMMANDS` in `preaction.ts`, so `ensurePluginRegistryLoaded()` was never called, leaving `getGlobalHookRunner()` returning `null`. The hook invocation in `deliver.ts` uses optional chaining (`hookRunner?.hasHooks(...)`), so a null runner silently skips all hooks.
- Why it matters: Plugins that depend on `message_sending` hooks (e.g., content filtering, thread ownership, audit logging) are completely non-functional in standalone agent mode.
- What changed: Added `"agent"` to `PLUGIN_REQUIRED_COMMANDS` so the plugin registry loads before the agent command executes. Added a corresponding test.
- What did NOT change (scope boundary): No changes to hook runner logic, hook invocation in deliver.ts, or plugin registration API.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31038

## User-visible / Behavior Changes

- `message_sending` and `message_sent` plugin hooks now fire correctly in standalone `openclaw agent` mode
- Plugins with registered hooks are loaded before agent execution

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Create a plugin that registers a `message_sending` hook: `api.on("message_sending", (event) => { ... })`
2. Run `openclaw agent --deliver`
3. Send a message

### Expected

- `message_sending` hook fires before message delivery

### Actual

- Before: Hook never fires; `getGlobalHookRunner()` returns `null`
- After: Plugin registry loads, hook runner is initialized, hook fires

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `agent` command triggers plugin loading; all 11 preaction tests pass; existing plugin-required commands still work
- Edge cases checked: `agent` without `--deliver` (plugins still load, which is correct — other agent features may need plugins); gateway mode (already loads plugins via different path, unaffected)
- What you did **not** verify: end-to-end test with actual plugin hook in standalone agent mode

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; plugins will not load for agent command (original behavior)
- Files/config to restore: `src/cli/program/preaction.ts`

## Risks and Mitigations

- Risk: Loading plugins adds startup latency to the agent command
  - Mitigation: Plugin loading is already fast (disk scan + registration); all other delivery-capable commands already load plugins. The agent command needs them for correct hook behavior.

