### PR TITLE
fix: keep multiple openai-codex oauth accounts without overwrite

### DIFF
--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -2,7 +2,11 @@ import fs from "node:fs";
 import path from "node:path";
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import { resolveOpenClawAgentDir } from "../agents/agent-paths.js";
-import { upsertAuthProfile } from "../agents/auth-profiles.js";
+import {
+  loadAuthProfileStoreForSecretsRuntime,
+  upsertAuthProfile,
+  type AuthProfileCredential,
+} from "../agents/auth-profiles.js";
 import { resolveStateDir } from "../config/paths.js";
 import {
   coerceSecretRef,
@@ -150,16 +154,105 @@ function resolveSiblingAgentDirs(primaryAgentDir: string): string[] {
   return result;
 }
 
+function base64UrlDecode(input: string): string | null {
+  const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  try {
+    return Buffer.from(padded, "base64").toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
+function extractOpenAICodexProfileEmailFromAccessToken(access?: string): string | undefined {
+  const token = typeof access === "string" ? access.trim() : "";
+  if (!token) {
+    return undefined;
+  }
+  const parts = token.split(".");
+  if (parts.length < 2) {
+    return undefined;
+  }
+  const decodedPayload = base64UrlDecode(parts[1] ?? "");
+  if (!decodedPayload) {
+    return undefined;
+  }
+  try {
+    const payload = JSON.parse(decodedPayload) as Record<string, unknown>;
+    const emailClaim = payload["https://api.openai.com/profile.email"];
+    const plainEmail = payload.email;
+    const value = typeof emailClaim === "string" ? emailClaim : plainEmail;
+    const trimmed = typeof value === "string" ? value.trim().toLowerCase() : "";
+    return trimmed || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeProfileSuffix(raw: string): string {
+  const trimmed = raw.trim().toLowerCase();
+  const slug = trimmed
+    .replace(/[^a-z0-9._@-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "default";
+}
+
+function isSameOAuthIdentity(existing: AuthProfileCredential | undefined, creds: OAuthCredentials): boolean {
+  if (!existing) {
+    return false;
+  }
+  if (existing.type !== "oauth" && existing.type !== "token") {
+    return false;
+  }
+  if (existing.access && creds.access && existing.access === creds.access) {
+    return true;
+  }
+  if (existing.refresh && creds.refresh && existing.refresh === creds.refresh) {
+    return true;
+  }
+  return false;
+}
+
+function resolveUniqueOAuthProfileId(params: {
+  provider: string;
+  preferredSuffix: string;
+  creds: OAuthCredentials;
+  agentDir: string;
+}): string {
+  const store = loadAuthProfileStoreForSecretsRuntime(params.agentDir);
+  const baseId = `${params.provider}:${normalizeProfileSuffix(params.preferredSuffix)}`;
+  const existingBase = store.profiles[baseId];
+  if (!existingBase || isSameOAuthIdentity(existingBase, params.creds)) {
+    return baseId;
+  }
+
+  for (let n = 2; n < 1000; n++) {
+    const candidate = `${baseId}-${n}`;
+    const existing = store.profiles[candidate];
+    if (!existing || isSameOAuthIdentity(existing, params.creds)) {
+      return candidate;
+    }
+  }
+  return `${baseId}-${Date.now()}`;
+}
+
 export async function writeOAuthCredentials(
   provider: string,
   creds: OAuthCredentials,
   agentDir?: string,
   options?: WriteOAuthCredentialsOptions,
 ): Promise<string> {
-  const email =
-    typeof creds.email === "string" && creds.email.trim() ? creds.email.trim() : "default";
-  const profileId = `${provider}:${email}`;
   const resolvedAgentDir = path.resolve(resolveAuthAgentDir(agentDir));
+  const providedEmail = typeof creds.email === "string" ? creds.email.trim() : "";
+  const derivedCodexEmail =
+    provider === "openai-codex" ? extractOpenAICodexProfileEmailFromAccessToken(creds.access) : undefined;
+  const profileId = resolveUniqueOAuthProfileId({
+    provider,
+    preferredSuffix: providedEmail || derivedCodexEmail || "default",
+    creds,
+    agentDir: resolvedAgentDir,
+  });
   const targetAgentDirs = options?.syncSiblingAgents
     ? resolveSiblingAgentDirs(resolvedAgentDir)
     : [resolvedAgentDir];

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -226,6 +226,67 @@ describe("writeOAuthCredentials", () => {
     await expect(fs.readFile(authProfilePathFor(mainAgentDir), "utf8")).rejects.toThrow();
   });
 
+  it("uses OpenAI profile email claim to avoid default profile collisions", async () => {
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-oauth-codex-email-"));
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+
+    const agentDir = path.join(tempStateDir, "agents", "main", "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+
+    const payload = Buffer.from(
+      JSON.stringify({ "https://api.openai.com/profile.email": "user1@example.com" }),
+    ).toString("base64url");
+    const creds = {
+      refresh: "refresh-email",
+      access: `header.${payload}.sig`,
+      expires: Date.now() + 60_000,
+    } satisfies OAuthCredentials;
+
+    const profileId = await writeOAuthCredentials("openai-codex", creds, agentDir);
+
+    expect(profileId).toBe("openai-codex:user1@example.com");
+    const raw = await fs.readFile(authProfilePathFor(agentDir), "utf8");
+    const parsed = JSON.parse(raw) as {
+      profiles?: Record<string, OAuthCredentials & { type?: string }>;
+    };
+    expect(parsed.profiles?.["openai-codex:user1@example.com"]).toMatchObject({
+      access: creds.access,
+      type: "oauth",
+    });
+  });
+
+  it("allocates unique default-* profile when email is unavailable", async () => {
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-oauth-codex-default-"));
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+
+    const agentDir = path.join(tempStateDir, "agents", "main", "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+
+    const first = {
+      refresh: "refresh-1",
+      access: "opaque-access-1",
+      expires: Date.now() + 60_000,
+    } satisfies OAuthCredentials;
+    const second = {
+      refresh: "refresh-2",
+      access: "opaque-access-2",
+      expires: Date.now() + 60_000,
+    } satisfies OAuthCredentials;
+
+    const id1 = await writeOAuthCredentials("openai-codex", first, agentDir);
+    const id2 = await writeOAuthCredentials("openai-codex", second, agentDir);
+
+    expect(id1).toBe("openai-codex:default");
+    expect(id2).toBe("openai-codex:default-2");
+
+    const raw = await fs.readFile(authProfilePathFor(agentDir), "utf8");
+    const parsed = JSON.parse(raw) as {
+      profiles?: Record<string, OAuthCredentials & { type?: string }>;
+    };
+    expect(parsed.profiles?.["openai-codex:default"]?.access).toBe("opaque-access-1");
+    expect(parsed.profiles?.["openai-codex:default-2"]?.access).toBe("opaque-access-2");
+  });
+
   it("syncs siblings from explicit agentDir outside OPENCLAW_STATE_DIR", async () => {
     tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-oauth-external-"));
     process.env.OPENCLAW_STATE_DIR = tempStateDir;


### PR DESCRIPTION
## Summary
Prevent `openai-codex` OAuth onboarding from overwriting an existing profile when adding a second account.

## Root cause
`writeOAuthCredentials` used `${provider}:${email || "default"}`. For Codex OAuth flows where email is missing, this produced `openai-codex:default` every time, so the second login replaced the first.

## Changes
- Added OpenAI Codex JWT claim extraction for profile naming:
  - prefers `https://api.openai.com/profile.email`
  - falls back to `email`
- Added unique profile-id allocation logic:
  - keeps existing profile id if same OAuth identity
  - otherwise allocates suffixed id (`...:default-2`, `...:default-3`, etc.) to avoid overwrite
- Added regression tests:
  - uses profile.email claim to produce `openai-codex:<email>`
  - creates `openai-codex:default-2` when email is unavailable and default already exists

## Notes
I could not run the local test suite end-to-end in this environment because `pnpm` is not installed (`spawn pnpm ENOENT` from `scripts/test-parallel.mjs`).

Fixes openclaw/openclaw#24787