### PR TITLE
docs: add compaction doc link to OpenAI site

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -768,6 +768,9 @@ the Server-side compaction accordion below.
 
     This applies to the built-in Pi harness path and to OpenAI provider hooks used by embedded runs. The native Codex app-server harness manages its own context through Codex and is configured separately with `agents.defaults.agentRuntime.id`.
 
+    Related OpenAI docs:
+    - [Compaction](https://developers.openai.com/api/docs/guides/compaction)
+
     <Tabs>
       <Tab title="Enable explicitly">
         Useful for compatible endpoints like Azure OpenAI Responses:

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -933,6 +933,9 @@ the Server-side compaction accordion below.
 
     This applies to the built-in Pi harness path and to OpenAI provider hooks used by embedded runs. The native Codex app-server harness manages its own context through Codex and is configured by OpenAI's default agent route or provider/model runtime policy.
 
+    Related OpenAI docs:
+    - [Compaction](https://developers.openai.com/api/docs/guides/compaction)
+
     <Tabs>
       <Tab title="Enable explicitly">
         Useful for compatible endpoints like Azure OpenAI Responses:


### PR DESCRIPTION
Added related OpenAI documentation link for compaction in the section that explains server-side compaction.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

N/A

### Environment

N/A

### Steps

N/A

## Evidence

N/A

## Compatibility / Migration

N/A

## Failure Recovery (if this breaks)

N/A

## Risks and Mitigations

N/A