### PR TITLE
fix(whatsapp): send 'unavailable' presence by default to prevent push notification suppression

### DIFF
--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -89,6 +89,8 @@ type WhatsAppConfigCore = {
   configWrites?: boolean;
   /** Send read receipts for incoming messages (default true). */
   sendReadReceipts?: boolean;
+  /** Mark the bot as "online" on connect (default false). When false, sends "unavailable" to avoid suppressing push notifications on the user's phone. */
+  markOnline?: boolean;
   /** Inbound message prefix override (WhatsApp only). */
   messagePrefix?: string;
   /** Outbound response prefix override. */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -37,6 +37,7 @@ const WhatsAppSharedSchema = z.object({
   markdown: MarkdownConfigSchema,
   configWrites: z.boolean().optional(),
   sendReadReceipts: z.boolean().optional(),
+  markOnline: z.boolean().optional(),
   messagePrefix: z.string().optional(),
   responsePrefix: z.string().optional(),
   dmPolicy: DmPolicySchema.optional().default("pairing"),

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -14,6 +14,7 @@ export type ResolvedWhatsAppAccount = {
   name?: string;
   enabled: boolean;
   sendReadReceipts: boolean;
+  markOnline: boolean;
   messagePrefix?: string;
   authDir: string;
   isLegacyAuthDir: boolean;
@@ -128,6 +129,7 @@ export function resolveWhatsAppAccount(params: {
     name: accountCfg?.name?.trim() || undefined,
     enabled,
     sendReadReceipts: accountCfg?.sendReadReceipts ?? rootCfg?.sendReadReceipts ?? true,
+    markOnline: accountCfg?.markOnline ?? rootCfg?.markOnline ?? false,
     messagePrefix:
       accountCfg?.messagePrefix ?? rootCfg?.messagePrefix ?? params.cfg.messages?.messagePrefix,
     authDir,

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -202,6 +202,7 @@ export async function monitorWebChannel(
       authDir: account.authDir,
       mediaMaxMb: account.mediaMaxMb,
       sendReadReceipts: account.sendReadReceipts,
+      markOnline: account.markOnline,
       debounceMs: inboundDebounceMs,
       shouldDebounce,
       onMessage: async (msg: WebInboundMsg) => {

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -30,6 +30,8 @@ export async function monitorWebInbox(options: {
   mediaMaxMb?: number;
   /** Send read receipts for incoming messages (default true). */
   sendReadReceipts?: boolean;
+  /** Mark the bot as "online" on connect (default false). */
+  markOnline?: boolean;
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */
   debounceMs?: number;
   /** Optional debounce gating predicate. */
@@ -56,13 +58,14 @@ export async function monitorWebInbox(options: {
     resolver(reason);
   };
 
+  const presenceStatus = options.markOnline ? "available" : "unavailable";
   try {
-    await sock.sendPresenceUpdate("available");
+    await sock.sendPresenceUpdate(presenceStatus);
     if (shouldLogVerbose()) {
-      logVerbose("Sent global 'available' presence on connect");
+      logVerbose(`Sent global '${presenceStatus}' presence on connect`);
     }
   } catch (err) {
-    logVerbose(`Failed to send 'available' presence on connect: ${String(err)}`);
+    logVerbose(`Failed to send '${presenceStatus}' presence on connect: ${String(err)}`);
   }
 
   const selfJid = sock.user?.id;

--- a/src/web/monitor-inbox.captures-media-path-image-messages.test.ts
+++ b/src/web/monitor-inbox.captures-media-path-image-messages.test.ts
@@ -74,7 +74,7 @@ describe("web monitor inbox", () => {
         fromMe: false,
       },
     ]);
-    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
+    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("unavailable");
     await listener.close();
   });
 

--- a/src/web/monitor-inbox.streams-inbound-messages.test.ts
+++ b/src/web/monitor-inbox.streams-inbound-messages.test.ts
@@ -105,7 +105,7 @@ describe("web monitor inbox", () => {
     });
 
     const { listener, sock } = await startInboxMonitor(onMessage);
-    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
+    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("unavailable");
     const upsert = buildMessageUpsert({
       id: "abc",
       remoteJid: "999@s.whatsapp.net",
@@ -128,7 +128,7 @@ describe("web monitor inbox", () => {
         fromMe: false,
       },
     ]);
-    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
+    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("unavailable");
     expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("composing", "999@s.whatsapp.net");
     expect(sock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
       text: "pong",


### PR DESCRIPTION
## Problem

When a WhatsApp Web session connects via Baileys, \sendPresenceUpdate('available')\ is called unconditionally. This marks the bot as online, which causes WhatsApp to suppress push notifications on the user's phone — the phone thinks someone is already reading messages on the web client.

## Fix

- Add \markOnline\ config option to \WhatsAppConfigCore\ (default: \alse\)
- When \markOnline\ is false (the default), send \'unavailable'\ presence on connect
- When \markOnline\ is true, preserve the current behavior of sending \'available'\
- Follows the existing \sendReadReceipts\ pattern for config plumbing

## Changes

- \src/config/types.whatsapp.ts\: Add \markOnline?: boolean\ to \WhatsAppConfigCore\
- \src/config/zod-schema.providers-whatsapp.ts\: Add zod schema entry
- \src/web/accounts.ts\: Add to \ResolvedWhatsAppAccount\ type and resolution
- \src/web/inbound/monitor.ts\: Use \markOnline\ to determine presence status
- \src/web/auto-reply/monitor.ts\: Pass \markOnline\ through from account config
- Tests updated to expect \'unavailable'\ as default presence

Fixes #30286