### PR TITLE
Docs: expand sandbox guide for common image and Docker bootstrap

### DIFF
--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -129,6 +129,16 @@ other runtimes), either bake a custom image or install via
 `sandbox.docker.setupCommand` (requires network egress + writable root +
 root user).
 
+If you want a more functional sandbox image with common tooling (for example
+`curl`, `jq`, `nodejs`, `python3`, `git`), build:
+
+```bash
+scripts/sandbox-common-setup.sh
+```
+
+Then set `agents.defaults.sandbox.docker.image` to
+`openclaw-sandbox-common:bookworm-slim`.
+
 Sandboxed browser image:
 
 ```bash
@@ -146,6 +156,11 @@ Security defaults:
 
 Docker installs and the containerized gateway live here:
 [Docker](/install/docker)
+
+For Docker gateway deployments, `docker-setup.sh` can bootstrap sandbox config.
+Set `OPENCLAW_SANDBOX=1` (or `true`/`yes`/`on`) to enable that path. You can
+override socket location with `OPENCLAW_DOCKER_SOCKET`. Full setup and env
+reference: [Docker](/install/docker#enable-agent-sandbox-for-docker-gateway-opt-in).
 
 ## setupCommand (one-time container setup)
 


### PR DESCRIPTION
## Summary

- Add sandbox docs note for the `openclaw-sandbox-common:bookworm-slim` workflow (`scripts/sandbox-common-setup.sh`)
- Document Docker gateway sandbox bootstrap env behavior in the sandbox guide (`OPENCLAW_SANDBOX` truthy values + `OPENCLAW_DOCKER_SOCKET`)
- Link from sandbox guide to Docker setup anchor for the containerized gateway sandbox bootstrap path

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Related #10361
- Related #29974

## User-visible / Behavior Changes

- Docs only

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

- `pnpm exec oxfmt --check docs/gateway/sandboxing.md`

## Human Verification

- Verified updated docs section content and link target for Docker opt-in sandbox bootstrap path.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
