### PR TITLE
fix(auto-reply): allow message tool for media/file sends in group chats

### DIFF
--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -99,7 +99,7 @@ export function buildGroupChatContext(params: { sessionCtx: TemplateContext }): 
     lines.push(`Participants: ${members}.`);
   }
   lines.push(
-    "Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group — just reply normally.",
+    "Your replies are automatically sent to this group chat. For plain text responses, reply directly — do not use the message tool for text to this same group. To send files, images, or other media to this group, use the message tool (action=send with media or filePath).",
   );
   return lines.join(" ");
 }


### PR DESCRIPTION
## Summary

- **Problem:** In all group-chat sessions (Telegram forum topics, regular groups, Discord channels, etc.), the persistent system-prompt context block contained: `"Do not use the message tool to send to this same group — just reply normally."` — intended to suppress duplicate text echoes, but the model read it as a blanket prohibition on the message tool, including for file and media attachments.
- **Why it matters:** Users in Telegram forum topics (and other group chats) who ask the bot to send a file, image, or document receive a refusal like "message tool disabled in this chat" despite having `tools.allow: ["*"]` and `actions.sendMessage: true`. The exec-tool workaround is the only option today.
- **What changed:** Updated the one instruction line in `buildGroupChatContext()` (`src/auto-reply/reply/groups.ts`) to clarify the distinction: plain-text replies go through the normal reply pipeline (no message tool), while file/media sends still need the message tool (`action=send` with `media`/`filePath`).
- **What did NOT change:** The auto-threading helper `resolveTelegramAutoThreadId()` already injects the correct `message_thread_id` when the message tool targets the originating forum topic — no changes needed there.

Fixes #31368

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Testing

- All 879 tests in `src/auto-reply/` continue to pass.
- The change is a one-line prompt text update; no new test infrastructure is needed, but a unit test for `buildGroupChatContext` covering both the text-only and media cases can be added in follow-up.

---
🤖 Generated with Claude Code