### PR TITLE
docs: brew official formula/cask

### DIFF
--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -13,7 +13,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
-              "formula": "steipete/tap/gogcli",
+              "formula": "gogcli",
               "bins": ["gog"],
               "label": "Install gog (brew)",
             },

--- a/skills/model-usage/SKILL.md
+++ b/skills/model-usage/SKILL.md
@@ -13,7 +13,7 @@ metadata:
             {
               "id": "brew-cask",
               "kind": "brew",
-              "formula": "steipete/tap/codexbar",
+              "formula": "codexbar",
               "bins": ["codexbar"],
               "label": "Install CodexBar (brew cask)",
             },


### PR DESCRIPTION
## Summary
- **Problem:** Brew formula/cask references used custom tap prefixes (`steipete/tap/gogcli`, `steipete/tap/codexbar`) instead of the official formula names
- **Why it matters:** Incorrect formula names would cause `brew install` to fail or resolve to the wrong package for users following the skill installation steps
- **What changed:** Updated `formula` field in `skills/gog/SKILL.md` to `gogcli` and in `skills/model-usage/SKILL.md` to `codexbar` (official Homebrew names)
- **What did NOT change:** No logic, behavior, skill functionality, or any other config was touched

## Change Type (select all)
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #
- Related #

## User-visible / Behavior Changes
Users following brew install instructions in skill docs will now get the correct official formula name, fixing potential install failures.

## Security Impact (required)
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification
### Environment
- OS: macOS
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel: Homebrew
- Relevant config: N/A

### Steps
1. Run `brew install gogcli` (gog skill)
2. Run `brew install codexbar` (model-usage skill)

### Expected
- Package installs successfully from official Homebrew formula

### Actual
- ✅ Installs correctly with updated formula names

## Evidence
- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

> Verified `brew install gogcli` and `brew install codexbar` resolve correctly with official names.

## Human Verification (required)
- **Verified scenarios:** Both formula names resolve via Homebrew without the tap prefix
- **Edge cases checked:** N/A — pure doc string change
- **What you did not verify:** Full skill execution end-to-end after install

## Compatibility / Migration
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)
- How to revert: Restore `steipete/tap/gogcli` and `steipete/tap/codexbar` in the two SKILL.md files
- Files to restore: `skills/gog/SKILL.md`, `skills/model-usage/SKILL.md`
- Known bad symptoms: None expected — doc-only change

## Risks and Mitigations
None — two-line doc correction with no behavioral impact.