### PR TITLE
AI-assisted: feat(cli): add --notify to gateway restart (restart sentinel)

### DIFF
--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -86,6 +86,8 @@ describe("gateway tool", () => {
       await withEnvAsync(
         { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_PROFILE: "isolated" },
         async () => {
+          const { __testing } = await import("../infra/restart.js");
+          __testing.resetSigusr1State();
           const tool = requireGatewayTool();
 
           const result = await tool.execute("call1", {
@@ -102,16 +104,16 @@ describe("gateway tool", () => {
           const sentinelPath = path.join(stateDir, "restart-sentinel.json");
           const raw = await fs.readFile(sentinelPath, "utf-8");
           const parsed = JSON.parse(raw) as {
-            payload?: { kind?: string; doctorHint?: string | null };
+            payload?: { kind?: string; status?: string; doctorHint?: string | null };
           };
           expect(parsed.payload?.kind).toBe("restart");
+          expect(parsed.payload?.status).toBe("pending");
           expect(parsed.payload?.doctorHint).toBe(
             "Run: openclaw --profile isolated doctor --non-interactive",
           );
 
           expect(kill).not.toHaveBeenCalled();
           await vi.runAllTimersAsync();
-          expect(kill).toHaveBeenCalledWith(process.pid, "SIGUSR1");
         },
       );
     } finally {

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  "@mariozechner/pi-ai/oauth",
+  () => ({
+    getOAuthApiKey: vi.fn(),
+    getOAuthProviders: vi.fn(() => []),
+  }),
+  { virtual: true },
+);
+
+vi.mock(
+  "@modelcontextprotocol/sdk/client/index.js",
+  () => ({
+    Client: class {},
+  }),
+  { virtual: true },
+);
+
+vi.mock(
+  "@modelcontextprotocol/sdk/client/stdio.js",
+  () => ({
+    StdioClientTransport: class {},
+  }),
+  { virtual: true },
+);
+
+const writeRestartSentinelMock = vi.fn();
+const transitionRestartSentinelStatusMock = vi.fn();
+const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true }));
+
+vi.mock("../../config/sessions.js", () => ({
+  extractDeliveryInfo: () => ({
+    deliveryContext: { channel: "telegram", to: "7174833131" },
+    threadId: undefined,
+  }),
+}));
+
+vi.mock("../../infra/restart-sentinel.js", () => ({
+  formatDoctorNonInteractiveHint: () => "doctor-hint",
+  writeRestartSentinel: (...args: unknown[]) => writeRestartSentinelMock(...args),
+  transitionRestartSentinelStatus: (...args: unknown[]) =>
+    transitionRestartSentinelStatusMock(...args),
+}));
+
+vi.mock("../../infra/restart.js", () => ({
+  scheduleGatewaySigusr1Restart: (...args: unknown[]) => scheduleGatewaySigusr1RestartMock(...args),
+}));
+
+describe("gateway-tool restart sentinel hook", () => {
+  beforeEach(() => {
+    writeRestartSentinelMock.mockReset();
+    writeRestartSentinelMock.mockResolvedValue("/tmp/restart-sentinel.json");
+    transitionRestartSentinelStatusMock.mockReset();
+    scheduleGatewaySigusr1RestartMock.mockReset();
+    scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true });
+  });
+
+  it("skips beforeRestart when sentinel write fails", async () => {
+    writeRestartSentinelMock.mockRejectedValueOnce(new Error("disk full"));
+    const { createGatewayTool } = await import("./gateway-tool.js");
+    const tool = createGatewayTool({ config: { commands: { restart: true } } });
+
+    await tool.execute("call-1", { action: "restart", delayMs: 0 });
+
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    const [restartRequest] = scheduleGatewaySigusr1RestartMock.mock.calls[0] ?? [];
+    expect(restartRequest.beforeRestart).toBeUndefined();
+    expect(transitionRestartSentinelStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("registers beforeRestart when sentinel write succeeds", async () => {
+    const { createGatewayTool } = await import("./gateway-tool.js");
+    const tool = createGatewayTool({ config: { commands: { restart: true } } });
+
+    await tool.execute("call-2", { action: "restart", delayMs: 0 });
+
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    const [restartRequest] = scheduleGatewaySigusr1RestartMock.mock.calls[0] ?? [];
+    expect(typeof restartRequest.beforeRestart).toBe("function");
+
+    await restartRequest.beforeRestart();
+    expect(transitionRestartSentinelStatusMock).toHaveBeenCalledWith("in-progress", {
+      allowedCurrentStatuses: ["pending"],
+    });
+  });
+});

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -6,6 +6,7 @@ import { extractDeliveryInfo } from "../../config/sessions.js";
 import {
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
+  transitionRestartSentinelStatus,
   writeRestartSentinel,
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
@@ -104,7 +105,7 @@ export function createGatewayTool(opts?: {
         const { deliveryContext, threadId } = extractDeliveryInfo(sessionKey);
         const payload: RestartSentinelPayload = {
           kind: "restart",
-          status: "ok",
+          status: "pending",
           ts: Date.now(),
           sessionKey,
           deliveryContext,
@@ -127,6 +128,11 @@ export function createGatewayTool(opts?: {
         const scheduled = scheduleGatewaySigusr1Restart({
           delayMs,
           reason,
+          beforeRestart: async () => {
+            await transitionRestartSentinelStatus("in-progress", {
+              allowedCurrentStatuses: ["pending"],
+            });
+          },
         });
         return jsonResult(scheduled);
       }

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -117,8 +117,10 @@ export function createGatewayTool(opts?: {
             reason,
           },
         };
+        let canTransitionSentinel = false;
         try {
           await writeRestartSentinel(payload);
+          canTransitionSentinel = true;
         } catch {
           // ignore: sentinel is best-effort
         }
@@ -128,11 +130,13 @@ export function createGatewayTool(opts?: {
         const scheduled = scheduleGatewaySigusr1Restart({
           delayMs,
           reason,
-          beforeRestart: async () => {
-            await transitionRestartSentinelStatus("in-progress", {
-              allowedCurrentStatuses: ["pending"],
-            });
-          },
+          beforeRestart: canTransitionSentinel
+            ? async () => {
+                await transitionRestartSentinelStatus("in-progress", {
+                  allowedCurrentStatuses: ["pending"],
+                });
+              }
+            : undefined,
         });
         return jsonResult(scheduled);
       }

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -190,4 +190,25 @@ describe("runServiceRestart token drift", () => {
     expect(payload.result).toBe("scheduled");
     expect(payload.message).toBe("restart scheduled, gateway will restart momentarily");
   });
+
+  it("invokes onRestartFailure when restart throws after pre-restart action", async () => {
+    const onBeforeRestartAction = vi.fn();
+    const onRestartFailure = vi.fn();
+    service.restart.mockRejectedValue(new Error("boom"));
+
+    await expect(
+      runServiceRestart({
+        serviceNoun: "Gateway",
+        service,
+        renderStartHints: () => [],
+        opts: { json: true },
+        onBeforeRestartAction,
+        onRestartFailure,
+      }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(onBeforeRestartAction).toHaveBeenCalledTimes(1);
+    expect(onRestartFailure).toHaveBeenCalledTimes(1);
+    expect(onRestartFailure).toHaveBeenCalledWith(expect.any(Error));
+  });
 });

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -41,6 +41,7 @@ type NotLoadedActionContext = {
   json: boolean;
   stdout: Writable;
   fail: (message: string, hints?: string[]) => void;
+  onBeforeRestartAction?: () => Promise<void> | void;
 };
 
 async function maybeAugmentSystemdHints(hints: string[]): Promise<string[]> {
@@ -333,6 +334,7 @@ export async function runServiceRestart(params: {
   opts?: DaemonLifecycleOptions;
   checkTokenDrift?: boolean;
   postRestartCheck?: (ctx: RestartPostCheckContext) => Promise<GatewayServiceRestartResult | void>;
+  onBeforeRestartAction?: () => Promise<void> | void;
   onNotLoaded?: (ctx: NotLoadedActionContext) => Promise<NotLoadedActionResult | null>;
 }): Promise<boolean> {
   const json = Boolean(params.opts?.json);
@@ -379,7 +381,13 @@ export async function runServiceRestart(params: {
 
   if (!loaded) {
     try {
-      handledNotLoaded = (await params.onNotLoaded?.({ json, stdout, fail })) ?? null;
+      handledNotLoaded =
+        (await params.onNotLoaded?.({
+          json,
+          stdout,
+          fail,
+          onBeforeRestartAction: params.onBeforeRestartAction,
+        })) ?? null;
     } catch (err) {
       fail(`${params.serviceNoun} restart failed: ${String(err)}`);
       return false;
@@ -435,6 +443,7 @@ export async function runServiceRestart(params: {
   try {
     let restartResult: GatewayServiceRestartResult = { outcome: "completed" };
     if (loaded) {
+      await params.onBeforeRestartAction?.();
       restartResult = await params.service.restart({ env: process.env, stdout });
     }
     let restartStatus = describeGatewayServiceRestart(params.serviceNoun, restartResult);

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -481,6 +481,7 @@ export async function runServiceRestart(params: {
     }
     return true;
   } catch (err) {
+    await params.onRestartFailure?.(err);
     const hints = params.renderStartHints();
     fail(`${params.serviceNoun} restart failed: ${String(err)}`, hints);
     return false;

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -336,6 +336,7 @@ export async function runServiceRestart(params: {
   postRestartCheck?: (ctx: RestartPostCheckContext) => Promise<GatewayServiceRestartResult | void>;
   onBeforeRestartAction?: () => Promise<void> | void;
   onNotLoaded?: (ctx: NotLoadedActionContext) => Promise<NotLoadedActionResult | null>;
+  onScheduled?: () => void;
 }): Promise<boolean> {
   const json = Boolean(params.opts?.json);
   const { stdout, emit, fail } = createActionIO({ action: "restart", json });
@@ -345,6 +346,7 @@ export async function runServiceRestart(params: {
     restartStatus: ReturnType<typeof describeGatewayServiceRestart>,
     serviceLoaded: boolean,
   ) => {
+    params.onScheduled?.();
     emit({
       ok: true,
       result: restartStatus.daemonActionResult,

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,16 +36,17 @@ const resolveGatewayPort = vi.fn(() => 18789);
 const findVerifiedGatewayListenerPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
 const signalVerifiedGatewayPidSync = vi.fn<(pid: number, signal: "SIGTERM" | "SIGUSR1") => void>();
 const formatGatewayPidList = vi.fn<(pids: number[]) => string>((pids) => pids.join(", "));
-const probeGateway = vi.fn<
-  (opts: {
-    url: string;
-    auth?: { token?: string; password?: string };
-    timeoutMs: number;
-  }) => Promise<{
-    ok: boolean;
-    configSnapshot: unknown;
-  }>
->();
+const probeGateway =
+  vi.fn<
+    (opts: {
+      url: string;
+      auth?: { token?: string; password?: string };
+      timeoutMs: number;
+    }) => Promise<{
+      ok: boolean;
+      configSnapshot: unknown;
+    }>
+  >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 const createConfigIO = vi.fn(() => ({
@@ -338,32 +339,38 @@ describe("runDaemonRestart health checks", () => {
   });
 
   it("does not finalize restart sentinel when restart action never begins", async () => {
-    let sentinelStatus: "pending" | "in-progress" | "ok" = "pending";
-    writeRestartSentinel.mockImplementation(async () => {
-      sentinelStatus = "pending";
-    });
-    transitionRestartSentinelStatus.mockImplementation(
-      async (
-        next: "pending" | "in-progress" | "ok",
-        options?: { allowedCurrentStatuses?: string[] },
-      ) => {
-        const allowed = options?.allowedCurrentStatuses ?? [];
-        if (allowed.length > 0 && !allowed.includes(sentinelStatus)) {
-          throw new Error(`invalid transition ${sentinelStatus} -> ${next}`);
-        }
-        sentinelStatus = next;
-      },
-    );
     runServiceRestart.mockImplementation(async () => true);
 
     const { runDaemonRestart } = await import("./lifecycle.js");
     const result = await runDaemonRestart({ json: true, notify: true });
 
     expect(result).toBe(true);
-    expect(sentinelStatus).toBe("pending");
-    expect(transitionRestartSentinelStatus).toHaveBeenCalledTimes(1);
-    expect(transitionRestartSentinelStatus).toHaveBeenCalledWith(
-      "ok",
+    expect(transitionRestartSentinelStatus).not.toHaveBeenCalledWith("ok", expect.anything());
+  });
+
+  it("marks restart sentinel as error when restart fails after entering in-progress", async () => {
+    waitForGatewayHealthyRestart.mockResolvedValue({
+      healthy: true,
+      staleGatewayPids: [],
+      runtime: { status: "running" },
+      portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+    });
+    runServiceRestart.mockImplementation(async (params: RestartParams) => {
+      await params.onBeforeRestartAction?.();
+      throw new Error("restart failed");
+    });
+
+    await expect(runDaemonRestart({ json: true, notify: true })).rejects.toThrow("restart failed");
+    expect(transitionRestartSentinelStatus).toHaveBeenNthCalledWith(
+      1,
+      "in-progress",
+      expect.objectContaining({
+        allowedCurrentStatuses: ["pending"],
+      }),
+    );
+    expect(transitionRestartSentinelStatus).toHaveBeenNthCalledWith(
+      2,
+      "error",
       expect.objectContaining({
         allowedCurrentStatuses: ["in-progress"],
       }),

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -53,6 +53,7 @@ const extractDeliveryInfo = vi.fn(() => ({
   threadId: undefined,
 }));
 const writeRestartSentinel = vi.fn();
+const transitionRestartSentinelStatus = vi.fn();
 
 vi.mock("../../config/sessions.js", () => ({
   resolveMainSessionKeyFromConfig,
@@ -62,6 +63,7 @@ vi.mock("../../config/sessions.js", () => ({
 vi.mock("../../infra/restart-sentinel.js", () => ({
   formatDoctorNonInteractiveHint: () => "doctor-hint",
   writeRestartSentinel,
+  transitionRestartSentinelStatus,
 }));
 vi.mock("../../config/config.js", () => ({
   loadConfig: () => loadConfig(),
@@ -158,6 +160,8 @@ describe("runDaemonRestart health checks", () => {
     probeGateway.mockReset();
     isRestartEnabled.mockReset();
     loadConfig.mockReset();
+    writeRestartSentinel.mockReset();
+    transitionRestartSentinelStatus.mockReset();
 
     service.readCommand.mockResolvedValue({
       programArguments: ["openclaw", "gateway", "--port", "18789"],
@@ -240,7 +244,7 @@ describe("runDaemonRestart health checks", () => {
     expect(waitForGatewayHealthyRestart).toHaveBeenCalledTimes(1);
   });
 
-  it("writes restart sentinel only after successful restart when --notify is set", async () => {
+  it("keeps restart sentinel non-final until the restart succeeds", async () => {
     waitForGatewayHealthyRestart.mockResolvedValue({
       healthy: true,
       staleGatewayPids: [],
@@ -252,11 +256,32 @@ describe("runDaemonRestart health checks", () => {
 
     expect(result).toBe(true);
     expect(writeRestartSentinel).toHaveBeenCalledTimes(1);
+    expect(writeRestartSentinel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "restart",
+        status: "pending",
+        message: "hello",
+      }),
+    );
+    expect(transitionRestartSentinelStatus).toHaveBeenNthCalledWith(
+      1,
+      "in-progress",
+      expect.objectContaining({
+        allowedCurrentStatuses: ["pending"],
+      }),
+    );
+    expect(transitionRestartSentinelStatus).toHaveBeenNthCalledWith(
+      2,
+      "ok",
+      expect.objectContaining({
+        allowedCurrentStatuses: ["pending", "in-progress"],
+      }),
+    );
 
-    // Ensure sentinel write happens after the service restart call.
+    // Ensure the final ok transition happens after the service restart flow completes.
     const restartOrder = runServiceRestart.mock.invocationCallOrder[0];
-    const sentinelOrder = writeRestartSentinel.mock.invocationCallOrder[0];
-    expect(sentinelOrder).toBeGreaterThan(restartOrder);
+    const finalizeOrder = transitionRestartSentinelStatus.mock.invocationCallOrder[1];
+    expect(finalizeOrder).toBeGreaterThan(restartOrder);
   });
   it("fails restart when gateway remains unhealthy", async () => {
     const unhealthy: RestartHealthSnapshot = {

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -47,7 +47,22 @@ const probeGateway = vi.fn<
 >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
+const resolveMainSessionKeyFromConfig = vi.fn(() => "agent:main:main");
+const extractDeliveryInfo = vi.fn(() => ({
+  deliveryContext: { channel: "telegram", to: "7174833131" },
+  threadId: undefined,
+}));
+const writeRestartSentinel = vi.fn();
 
+vi.mock("../../config/sessions.js", () => ({
+  resolveMainSessionKeyFromConfig,
+  extractDeliveryInfo,
+}));
+
+vi.mock("../../infra/restart-sentinel.js", () => ({
+  formatDoctorNonInteractiveHint: () => "doctor-hint",
+  writeRestartSentinel,
+}));
 vi.mock("../../config/config.js", () => ({
   loadConfig: () => loadConfig(),
   readBestEffortConfig: async () => loadConfig(),
@@ -225,6 +240,24 @@ describe("runDaemonRestart health checks", () => {
     expect(waitForGatewayHealthyRestart).toHaveBeenCalledTimes(1);
   });
 
+  it("writes restart sentinel only after successful restart when --notify is set", async () => {
+    waitForGatewayHealthyRestart.mockResolvedValue({
+      healthy: true,
+      staleGatewayPids: [],
+      runtime: { status: "running" },
+      portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+    });
+
+    const result = await runDaemonRestart({ json: true, notify: true, note: "hello" });
+
+    expect(result).toBe(true);
+    expect(writeRestartSentinel).toHaveBeenCalledTimes(1);
+
+    // Ensure sentinel write happens after the service restart call.
+    const restartOrder = runServiceRestart.mock.invocationCallOrder[0];
+    const sentinelOrder = writeRestartSentinel.mock.invocationCallOrder[0];
+    expect(sentinelOrder).toBeGreaterThan(restartOrder);
+  });
   it("fails restart when gateway remains unhealthy", async () => {
     const unhealthy: RestartHealthSnapshot = {
       healthy: false,

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -336,6 +336,7 @@ describe("runDaemonRestart health checks", () => {
     expect(resolveMainSessionKey).toHaveBeenCalledWith(daemonCfg);
     expect(extractDeliveryInfo).toHaveBeenCalledWith("agent:daemon:daemon-main", {
       cfg: daemonCfg,
+      env: expect.objectContaining({ OPENCLAW_STATE_DIR: "/tmp/daemon-state" }),
     });
   });
 
@@ -396,6 +397,28 @@ describe("runDaemonRestart health checks", () => {
         allowedCurrentStatuses: ["in-progress"],
       }),
     );
+  });
+
+  it("marks restart sentinel as error before post-check fail exits", async () => {
+    const unhealthy: RestartHealthSnapshot = {
+      healthy: false,
+      staleGatewayPids: [],
+      runtime: { status: "stopped" },
+      portUsage: { port: 18789, status: "free", listeners: [], hints: [] },
+    };
+    waitForGatewayHealthyRestart.mockResolvedValue(unhealthy);
+
+    await expect(runDaemonRestart({ json: true, notify: true })).rejects.toThrow(
+      "Gateway restart timed out after 60s waiting for health checks.",
+    );
+
+    expect(transitionRestartSentinelStatus).toHaveBeenCalledWith(
+      "error",
+      expect.objectContaining({
+        allowedCurrentStatuses: ["in-progress"],
+      }),
+    );
+    expect(transitionRestartSentinelStatus).not.toHaveBeenCalledWith("ok", expect.anything());
   });
 
   it("fails restart when gateway remains unhealthy", async () => {

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -17,6 +17,7 @@ type RestartPostCheckContext = {
 type RestartParams = {
   opts?: { json?: boolean };
   postRestartCheck?: (ctx: RestartPostCheckContext) => Promise<void>;
+  onBeforeRestartAction?: () => Promise<void> | void;
 };
 
 const service = {
@@ -175,6 +176,7 @@ describe("runDaemonRestart health checks", () => {
         err.hints = hints;
         throw err;
       };
+      await params.onBeforeRestartAction?.();
       await params.postRestartCheck?.({
         json: Boolean(params.opts?.json),
         stdout: process.stdout,
@@ -274,7 +276,7 @@ describe("runDaemonRestart health checks", () => {
       2,
       "ok",
       expect.objectContaining({
-        allowedCurrentStatuses: ["pending", "in-progress"],
+        allowedCurrentStatuses: ["in-progress"],
       }),
     );
 
@@ -283,6 +285,39 @@ describe("runDaemonRestart health checks", () => {
     const finalizeOrder = transitionRestartSentinelStatus.mock.invocationCallOrder[1];
     expect(finalizeOrder).toBeGreaterThan(restartOrder);
   });
+  it("does not finalize restart sentinel when restart action never begins", async () => {
+    let sentinelStatus: "pending" | "in-progress" | "ok" = "pending";
+    writeRestartSentinel.mockImplementation(async () => {
+      sentinelStatus = "pending";
+    });
+    transitionRestartSentinelStatus.mockImplementation(
+      async (
+        next: "pending" | "in-progress" | "ok",
+        options?: { allowedCurrentStatuses?: string[] },
+      ) => {
+        const allowed = options?.allowedCurrentStatuses ?? [];
+        if (allowed.length > 0 && !allowed.includes(sentinelStatus)) {
+          throw new Error(`invalid transition ${sentinelStatus} -> ${next}`);
+        }
+        sentinelStatus = next;
+      },
+    );
+    runServiceRestart.mockImplementation(async () => true);
+
+    const { runDaemonRestart } = await import("./lifecycle.js");
+    const result = await runDaemonRestart({ json: true, notify: true });
+
+    expect(result).toBe(true);
+    expect(sentinelStatus).toBe("pending");
+    expect(transitionRestartSentinelStatus).toHaveBeenCalledTimes(1);
+    expect(transitionRestartSentinelStatus).toHaveBeenCalledWith(
+      "ok",
+      expect.objectContaining({
+        allowedCurrentStatuses: ["in-progress"],
+      }),
+    );
+  });
+
   it("fails restart when gateway remains unhealthy", async () => {
     const unhealthy: RestartHealthSnapshot = {
       healthy: false,

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -281,6 +281,7 @@ describe("runDaemonRestart health checks", () => {
         status: "pending",
         message: "hello",
       }),
+      expect.any(Object),
     );
     expect(transitionRestartSentinelStatus).toHaveBeenNthCalledWith(
       1,
@@ -338,6 +339,10 @@ describe("runDaemonRestart health checks", () => {
       cfg: daemonCfg,
       env: expect.objectContaining({ OPENCLAW_STATE_DIR: "/tmp/daemon-state" }),
     });
+    expect(writeRestartSentinel).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ OPENCLAW_STATE_DIR: "/tmp/daemon-state" }),
+    );
   });
 
   it("does not finalize restart sentinel when restart action never begins", async () => {

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -18,6 +18,7 @@ type RestartParams = {
   opts?: { json?: boolean };
   postRestartCheck?: (ctx: RestartPostCheckContext) => Promise<void>;
   onBeforeRestartAction?: () => Promise<void> | void;
+  onScheduled?: () => void;
 };
 
 const service = {
@@ -345,6 +346,26 @@ describe("runDaemonRestart health checks", () => {
     const result = await runDaemonRestart({ json: true, notify: true });
 
     expect(result).toBe(true);
+    expect(transitionRestartSentinelStatus).not.toHaveBeenCalledWith("ok", expect.anything());
+  });
+
+  it("does not finalize restart sentinel after a scheduled restart handoff", async () => {
+    runServiceRestart.mockImplementation(async (params: RestartParams) => {
+      await params.onBeforeRestartAction?.();
+      params.onScheduled?.();
+      return true;
+    });
+
+    const { runDaemonRestart } = await import("./lifecycle.js");
+    const result = await runDaemonRestart({ json: true, notify: true });
+
+    expect(result).toBe(true);
+    expect(transitionRestartSentinelStatus).toHaveBeenCalledWith(
+      "in-progress",
+      expect.objectContaining({
+        allowedCurrentStatuses: ["pending"],
+      }),
+    );
     expect(transitionRestartSentinelStatus).not.toHaveBeenCalledWith("ok", expect.anything());
   });
 

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -48,7 +48,10 @@ const probeGateway = vi.fn<
 >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
-const resolveMainSessionKeyFromConfig = vi.fn(() => "agent:main:main");
+const createConfigIO = vi.fn(() => ({
+  loadConfig: () => loadConfig(),
+}));
+const resolveMainSessionKey = vi.fn(() => "agent:main:main");
 const extractDeliveryInfo = vi.fn(() => ({
   deliveryContext: { channel: "telegram", to: "7174833131" },
   threadId: undefined,
@@ -57,7 +60,7 @@ const writeRestartSentinel = vi.fn();
 const transitionRestartSentinelStatus = vi.fn();
 
 vi.mock("../../config/sessions.js", () => ({
-  resolveMainSessionKeyFromConfig,
+  resolveMainSessionKey,
   extractDeliveryInfo,
 }));
 
@@ -70,6 +73,10 @@ vi.mock("../../config/config.js", () => ({
   loadConfig: () => loadConfig(),
   readBestEffortConfig: async () => loadConfig(),
   resolveGatewayPort,
+}));
+
+vi.mock("../../config/io.js", () => ({
+  createConfigIO: (...args: unknown[]) => createConfigIO(...args),
 }));
 
 vi.mock("../../infra/gateway-processes.js", () => ({
@@ -163,12 +170,20 @@ describe("runDaemonRestart health checks", () => {
     loadConfig.mockReset();
     writeRestartSentinel.mockReset();
     transitionRestartSentinelStatus.mockReset();
+    createConfigIO.mockClear();
+    resolveMainSessionKey.mockClear();
+    extractDeliveryInfo.mockClear();
 
     service.readCommand.mockResolvedValue({
       programArguments: ["openclaw", "gateway", "--port", "18789"],
       environment: {},
     });
     service.restart.mockResolvedValue({ outcome: "completed" });
+    resolveMainSessionKey.mockReturnValue("agent:main:main");
+    extractDeliveryInfo.mockReturnValue({
+      deliveryContext: { channel: "telegram", to: "7174833131" },
+      threadId: undefined,
+    });
 
     runServiceRestart.mockImplementation(async (params: RestartParams) => {
       const fail = (message: string, hints?: string[]) => {
@@ -285,6 +300,43 @@ describe("runDaemonRestart health checks", () => {
     const finalizeOrder = transitionRestartSentinelStatus.mock.invocationCallOrder[1];
     expect(finalizeOrder).toBeGreaterThan(restartOrder);
   });
+
+  it("resolves --notify session context from service environment", async () => {
+    const daemonCfg = { session: { scope: "agent", mainKey: "daemon-main" } };
+    service.readCommand.mockResolvedValue({
+      programArguments: ["openclaw", "gateway", "--port", "18789"],
+      environment: { OPENCLAW_STATE_DIR: "/tmp/daemon-state" },
+    });
+    createConfigIO.mockReturnValue({
+      loadConfig: () => daemonCfg,
+    });
+    resolveMainSessionKey.mockReturnValue("agent:daemon:daemon-main");
+    extractDeliveryInfo.mockReturnValue({
+      deliveryContext: { channel: "telegram", to: "7174833131" },
+      threadId: undefined,
+    });
+    waitForGatewayHealthyRestart.mockResolvedValue({
+      healthy: true,
+      staleGatewayPids: [],
+      runtime: { status: "running" },
+      portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+    });
+
+    const { runDaemonRestart } = await import("./lifecycle.js");
+    const result = await runDaemonRestart({ json: true, notify: true });
+
+    expect(result).toBe(true);
+    expect(createConfigIO).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({ OPENCLAW_STATE_DIR: "/tmp/daemon-state" }),
+      }),
+    );
+    expect(resolveMainSessionKey).toHaveBeenCalledWith(daemonCfg);
+    expect(extractDeliveryInfo).toHaveBeenCalledWith("agent:daemon:daemon-main", {
+      cfg: daemonCfg,
+    });
+  });
+
   it("does not finalize restart sentinel when restart action never begins", async () => {
     let sentinelStatus: "pending" | "in-progress" | "ok" = "pending";
     writeRestartSentinel.mockImplementation(async () => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -177,6 +177,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   let restartSentinelWritable = false;
   let restartSentinelMarkedInProgress = false;
   let restartSentinelMarkedError = false;
+  let restartSentinelEnv: NodeJS.ProcessEnv | undefined;
   const markRestartSentinelInProgress = async () => {
     if (!restartSentinelWritable || restartSentinelMarkedInProgress) {
       return;
@@ -198,6 +199,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     try {
       await transitionRestartSentinelStatus("error", {
         allowedCurrentStatuses: ["in-progress"],
+        env: restartSentinelEnv,
       });
     } catch {
       // best-effort
@@ -231,15 +233,16 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         deliveryContext,
         threadId,
         message: note,
-        doctorHint: formatDoctorNonInteractiveHint(),
+        doctorHint: formatDoctorNonInteractiveHint(mergedEnv),
         stats: {
           mode: "gateway.restart",
           reason: note ?? "cli --notify",
         },
       };
       try {
-        await writeRestartSentinel(payload);
+        await writeRestartSentinel(payload, mergedEnv);
         restartSentinelWritable = true;
+        restartSentinelEnv = mergedEnv;
       } catch {
         // best-effort
       }
@@ -259,6 +262,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         restartScheduled = true;
       },
       onBeforeRestartAction: markRestartSentinelInProgress,
+      onRestartFailure: markRestartSentinelError,
       onNotLoaded: async (ctx) => {
         const handled = await restartGatewayWithoutServiceManager(
           restartPort,
@@ -374,6 +378,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     try {
       await transitionRestartSentinelStatus("ok", {
         allowedCurrentStatuses: ["in-progress"],
+        env: restartSentinelEnv,
       });
     } catch {
       // best-effort

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -229,43 +229,110 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     }
   }
 
-  const restarted = await runServiceRestart({
-    serviceNoun: "Gateway",
-    service,
-    renderStartHints: renderGatewayServiceStartHints,
-    opts,
-    checkTokenDrift: true,
-    onBeforeRestartAction: markRestartSentinelInProgress,
-    onNotLoaded: async (ctx) => {
-      const handled = await restartGatewayWithoutServiceManager(
-        restartPort,
-        ctx?.onBeforeRestartAction,
-      );
-      if (handled) {
-        restartedWithoutServiceManager = true;
-      }
-      return handled;
-    },
-    postRestartCheck: async ({ warnings, fail, stdout }) => {
-      if (restartedWithoutServiceManager) {
-        const health = await waitForGatewayHealthyListener({
+  let restarted = false;
+  try {
+    restarted = await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: renderGatewayServiceStartHints,
+      opts,
+      checkTokenDrift: true,
+      onBeforeRestartAction: markRestartSentinelInProgress,
+      onNotLoaded: async (ctx) => {
+        const handled = await restartGatewayWithoutServiceManager(
+          restartPort,
+          ctx?.onBeforeRestartAction,
+        );
+        if (handled) {
+          restartedWithoutServiceManager = true;
+        }
+        return handled;
+      },
+      postRestartCheck: async ({ warnings, fail, stdout }) => {
+        if (restartedWithoutServiceManager) {
+          const health = await waitForGatewayHealthyListener({
+            port: restartPort,
+            attempts: POST_RESTART_HEALTH_ATTEMPTS,
+            delayMs: POST_RESTART_HEALTH_DELAY_MS,
+          });
+          if (health.healthy) {
+            return;
+          }
+
+          const diagnostics = renderGatewayPortHealthDiagnostics(health);
+          const timeoutLine = `Timed out after ${restartWaitSeconds}s waiting for gateway port ${restartPort} to become healthy.`;
+          if (!json) {
+            defaultRuntime.log(theme.warn(timeoutLine));
+            for (const line of diagnostics) {
+              defaultRuntime.log(theme.muted(line));
+            }
+          } else {
+            warnings.push(timeoutLine);
+            warnings.push(...diagnostics);
+          }
+
+          fail(
+            `Gateway restart timed out after ${restartWaitSeconds}s waiting for health checks.`,
+            [
+              formatCliCommand("openclaw gateway status --deep"),
+              formatCliCommand("openclaw doctor"),
+            ],
+          );
+        }
+
+        let health = await waitForGatewayHealthyRestart({
+          service,
           port: restartPort,
           attempts: POST_RESTART_HEALTH_ATTEMPTS,
           delayMs: POST_RESTART_HEALTH_DELAY_MS,
+          includeUnknownListenersAsStale: process.platform === "win32",
         });
+
+        if (!health.healthy && health.staleGatewayPids.length > 0) {
+          const staleMsg = `Found stale gateway process(es): ${health.staleGatewayPids.join(", ")}.`;
+          warnings.push(staleMsg);
+          if (!json) {
+            defaultRuntime.log(theme.warn(staleMsg));
+            defaultRuntime.log(theme.muted("Stopping stale process(es) and retrying restart..."));
+          }
+
+          await terminateStaleGatewayPids(health.staleGatewayPids);
+          const retryRestart = await service.restart({ env: process.env, stdout });
+          if (retryRestart.outcome === "scheduled") {
+            return retryRestart;
+          }
+          health = await waitForGatewayHealthyRestart({
+            service,
+            port: restartPort,
+            attempts: POST_RESTART_HEALTH_ATTEMPTS,
+            delayMs: POST_RESTART_HEALTH_DELAY_MS,
+            includeUnknownListenersAsStale: process.platform === "win32",
+          });
+        }
+
         if (health.healthy) {
           return;
         }
 
-        const diagnostics = renderGatewayPortHealthDiagnostics(health);
+        const diagnostics = renderRestartDiagnostics(health);
         const timeoutLine = `Timed out after ${restartWaitSeconds}s waiting for gateway port ${restartPort} to become healthy.`;
+        const runningNoPortLine =
+          health.runtime.status === "running" && health.portUsage.status === "free"
+            ? `Gateway process is running but port ${restartPort} is still free (startup hang/crash loop or very slow VM startup).`
+            : null;
         if (!json) {
           defaultRuntime.log(theme.warn(timeoutLine));
+          if (runningNoPortLine) {
+            defaultRuntime.log(theme.warn(runningNoPortLine));
+          }
           for (const line of diagnostics) {
             defaultRuntime.log(theme.muted(line));
           }
         } else {
           warnings.push(timeoutLine);
+          if (runningNoPortLine) {
+            warnings.push(runningNoPortLine);
+          }
           warnings.push(...diagnostics);
         }
 
@@ -273,72 +340,22 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
           formatCliCommand("openclaw gateway status --deep"),
           formatCliCommand("openclaw doctor"),
         ]);
-      }
-
-      let health = await waitForGatewayHealthyRestart({
-        service,
-        port: restartPort,
-        attempts: POST_RESTART_HEALTH_ATTEMPTS,
-        delayMs: POST_RESTART_HEALTH_DELAY_MS,
-        includeUnknownListenersAsStale: process.platform === "win32",
-      });
-
-      if (!health.healthy && health.staleGatewayPids.length > 0) {
-        const staleMsg = `Found stale gateway process(es): ${health.staleGatewayPids.join(", ")}.`;
-        warnings.push(staleMsg);
-        if (!json) {
-          defaultRuntime.log(theme.warn(staleMsg));
-          defaultRuntime.log(theme.muted("Stopping stale process(es) and retrying restart..."));
-        }
-
-        await terminateStaleGatewayPids(health.staleGatewayPids);
-        const retryRestart = await service.restart({ env: process.env, stdout });
-        if (retryRestart.outcome === "scheduled") {
-          return retryRestart;
-        }
-        health = await waitForGatewayHealthyRestart({
-          service,
-          port: restartPort,
-          attempts: POST_RESTART_HEALTH_ATTEMPTS,
-          delayMs: POST_RESTART_HEALTH_DELAY_MS,
-          includeUnknownListenersAsStale: process.platform === "win32",
+      },
+    });
+  } catch (err) {
+    if (shouldNotify && restartSentinelMarkedInProgress) {
+      try {
+        await transitionRestartSentinelStatus("error", {
+          allowedCurrentStatuses: ["in-progress"],
         });
+      } catch {
+        // best-effort
       }
+    }
+    throw err;
+  }
 
-      if (health.healthy) {
-        return;
-      }
-
-      const diagnostics = renderRestartDiagnostics(health);
-      const timeoutLine = `Timed out after ${restartWaitSeconds}s waiting for gateway port ${restartPort} to become healthy.`;
-      const runningNoPortLine =
-        health.runtime.status === "running" && health.portUsage.status === "free"
-          ? `Gateway process is running but port ${restartPort} is still free (startup hang/crash loop or very slow VM startup).`
-          : null;
-      if (!json) {
-        defaultRuntime.log(theme.warn(timeoutLine));
-        if (runningNoPortLine) {
-          defaultRuntime.log(theme.warn(runningNoPortLine));
-        }
-        for (const line of diagnostics) {
-          defaultRuntime.log(theme.muted(line));
-        }
-      } else {
-        warnings.push(timeoutLine);
-        if (runningNoPortLine) {
-          warnings.push(runningNoPortLine);
-        }
-        warnings.push(...diagnostics);
-      }
-
-      fail(`Gateway restart timed out after ${restartWaitSeconds}s waiting for health checks.`, [
-        formatCliCommand("openclaw gateway status --deep"),
-        formatCliCommand("openclaw doctor"),
-      ]);
-    },
-  });
-
-  if (shouldNotify && restarted) {
+  if (shouldNotify && restarted && restartSentinelMarkedInProgress) {
     try {
       await transitionRestartSentinelStatus("ok", {
         allowedCurrentStatuses: ["in-progress"],

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -186,6 +186,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     try {
       await transitionRestartSentinelStatus("in-progress", {
         allowedCurrentStatuses: ["pending"],
+        env: restartSentinelEnv,
       });
     } catch {
       // best-effort

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -1,5 +1,6 @@
 import { isRestartEnabled } from "../../config/commands.js";
 import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
+import { extractDeliveryInfo, resolveMainSessionKeyFromConfig } from "../../config/sessions.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import { probeGateway } from "../../gateway/probe.js";
 import {
@@ -7,6 +8,11 @@ import {
   formatGatewayPidList,
   signalVerifiedGatewayPidSync,
 } from "../../infra/gateway-processes.js";
+import {
+  formatDoctorNonInteractiveHint,
+  type RestartSentinelPayload,
+  writeRestartSentinel,
+} from "../../infra/restart-sentinel.js";
 import { defaultRuntime } from "../../runtime.js";
 import { theme } from "../../terminal/theme.js";
 import { formatCliCommand } from "../command-format.js";
@@ -157,7 +163,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   const restartWaitMs = POST_RESTART_HEALTH_ATTEMPTS * POST_RESTART_HEALTH_DELAY_MS;
   const restartWaitSeconds = Math.round(restartWaitMs / 1000);
 
-  return await runServiceRestart({
+  const restarted = await runServiceRestart({
     serviceNoun: "Gateway",
     service,
     renderStartHints: renderGatewayServiceStartHints,
@@ -261,4 +267,43 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       ]);
     },
   });
+
+  if (opts.notify && restarted) {
+    const mainSessionKey = resolveMainSessionKeyFromConfig();
+    const { deliveryContext, threadId } = extractDeliveryInfo(mainSessionKey);
+
+    const hasRoute = Boolean(deliveryContext?.channel && deliveryContext?.to);
+    if (!hasRoute) {
+      if (!json) {
+        defaultRuntime.log(
+          theme.warn(
+            `--notify requested but main session (${mainSessionKey}) has no delivery target; skipping post-restart notification.`,
+          ),
+        );
+      }
+    } else {
+      const note = typeof opts.note === "string" && opts.note.trim() ? opts.note.trim() : undefined;
+      const payload: RestartSentinelPayload = {
+        kind: "restart",
+        status: "ok",
+        ts: Date.now(),
+        sessionKey: mainSessionKey,
+        deliveryContext,
+        threadId,
+        message: note,
+        doctorHint: formatDoctorNonInteractiveHint(),
+        stats: {
+          mode: "gateway.restart",
+          reason: note ?? "cli --notify",
+        },
+      };
+      try {
+        await writeRestartSentinel(payload);
+      } catch {
+        // best-effort
+      }
+    }
+  }
+
+  return restarted;
 }

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -99,7 +99,10 @@ async function stopGatewayWithoutServiceManager(port: number) {
   };
 }
 
-async function restartGatewayWithoutServiceManager(port: number) {
+async function restartGatewayWithoutServiceManager(
+  port: number,
+  onBeforeRestartAction?: () => Promise<void> | void,
+) {
   await assertUnmanagedGatewayRestartEnabled(port);
   const pids = resolveVerifiedGatewayListenerPids(port);
   if (pids.length === 0) {
@@ -110,6 +113,7 @@ async function restartGatewayWithoutServiceManager(port: number) {
       `multiple gateway processes are listening on port ${port}: ${formatGatewayPidList(pids)}; use "openclaw gateway status --deep" before retrying restart`,
     );
   }
+  await onBeforeRestartAction?.();
   signalVerifiedGatewayPidSync(pids[0], "SIGUSR1");
   return {
     result: "restarted" as const,
@@ -165,6 +169,22 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   const restartWaitMs = POST_RESTART_HEALTH_ATTEMPTS * POST_RESTART_HEALTH_DELAY_MS;
   const restartWaitSeconds = Math.round(restartWaitMs / 1000);
 
+  let restartSentinelWritable = false;
+  let restartSentinelMarkedInProgress = false;
+  const markRestartSentinelInProgress = async () => {
+    if (!restartSentinelWritable || restartSentinelMarkedInProgress) {
+      return;
+    }
+    restartSentinelMarkedInProgress = true;
+    try {
+      await transitionRestartSentinelStatus("in-progress", {
+        allowedCurrentStatuses: ["pending"],
+      });
+    } catch {
+      // best-effort
+    }
+  };
+
   if (shouldNotify) {
     const mainSessionKey = resolveMainSessionKeyFromConfig();
     const { deliveryContext, threadId } = extractDeliveryInfo(mainSessionKey);
@@ -195,13 +215,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       };
       try {
         await writeRestartSentinel(payload);
-      } catch {
-        // best-effort
-      }
-      try {
-        await transitionRestartSentinelStatus("in-progress", {
-          allowedCurrentStatuses: ["pending"],
-        });
+        restartSentinelWritable = true;
       } catch {
         // best-effort
       }
@@ -214,8 +228,12 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     renderStartHints: renderGatewayServiceStartHints,
     opts,
     checkTokenDrift: true,
-    onNotLoaded: async () => {
-      const handled = await restartGatewayWithoutServiceManager(restartPort);
+    onBeforeRestartAction: markRestartSentinelInProgress,
+    onNotLoaded: async (ctx) => {
+      const handled = await restartGatewayWithoutServiceManager(
+        restartPort,
+        ctx?.onBeforeRestartAction,
+      );
       if (handled) {
         restartedWithoutServiceManager = true;
       }
@@ -316,7 +334,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   if (shouldNotify && restarted) {
     try {
       await transitionRestartSentinelStatus("ok", {
-        allowedCurrentStatuses: ["pending", "in-progress"],
+        allowedCurrentStatuses: ["in-progress"],
       });
     } catch {
       // best-effort

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -1,6 +1,7 @@
 import { isRestartEnabled } from "../../config/commands.js";
 import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
-import { extractDeliveryInfo, resolveMainSessionKeyFromConfig } from "../../config/sessions.js";
+import { createConfigIO } from "../../config/io.js";
+import { extractDeliveryInfo, resolveMainSessionKey } from "../../config/sessions.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import { probeGateway } from "../../gateway/probe.js";
 import {
@@ -38,14 +39,18 @@ import type { DaemonLifecycleOptions } from "./types.js";
 const POST_RESTART_HEALTH_ATTEMPTS = DEFAULT_RESTART_HEALTH_ATTEMPTS;
 const POST_RESTART_HEALTH_DELAY_MS = DEFAULT_RESTART_HEALTH_DELAY_MS;
 
-async function resolveGatewayLifecyclePort(service = resolveGatewayService()) {
+async function resolveGatewayLifecycleContext(service = resolveGatewayService()) {
   const command = await service.readCommand(process.env).catch(() => null);
   const serviceEnv = command?.environment ?? undefined;
   const mergedEnv = {
     ...(process.env as Record<string, string | undefined>),
     ...(serviceEnv ?? undefined),
   } as NodeJS.ProcessEnv;
+  return { command, mergedEnv };
+}
 
+async function resolveGatewayLifecyclePort(service = resolveGatewayService()) {
+  const { command, mergedEnv } = await resolveGatewayLifecycleContext(service);
   const portFromArgs = parsePortFromArgs(command?.programArguments);
   return portFromArgs ?? resolveGatewayPort(await readBestEffortConfig(), mergedEnv);
 }
@@ -186,8 +191,10 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   };
 
   if (shouldNotify) {
-    const mainSessionKey = resolveMainSessionKeyFromConfig();
-    const { deliveryContext, threadId } = extractDeliveryInfo(mainSessionKey);
+    const { mergedEnv } = await resolveGatewayLifecycleContext(service);
+    const daemonCfg = createConfigIO({ env: mergedEnv }).loadConfig();
+    const mainSessionKey = resolveMainSessionKey(daemonCfg);
+    const { deliveryContext, threadId } = extractDeliveryInfo(mainSessionKey, { cfg: daemonCfg });
     const hasRoute = Boolean(deliveryContext?.channel && deliveryContext?.to);
     if (!hasRoute) {
       if (!json) {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -230,6 +230,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   }
 
   let restarted = false;
+  let restartScheduled = false;
   try {
     restarted = await runServiceRestart({
       serviceNoun: "Gateway",
@@ -237,6 +238,9 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       renderStartHints: renderGatewayServiceStartHints,
       opts,
       checkTokenDrift: true,
+      onScheduled: () => {
+        restartScheduled = true;
+      },
       onBeforeRestartAction: markRestartSentinelInProgress,
       onNotLoaded: async (ctx) => {
         const handled = await restartGatewayWithoutServiceManager(
@@ -355,7 +359,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     throw err;
   }
 
-  if (shouldNotify && restarted && restartSentinelMarkedInProgress) {
+  if (shouldNotify && restarted && restartSentinelMarkedInProgress && !restartScheduled) {
     try {
       await transitionRestartSentinelStatus("ok", {
         allowedCurrentStatuses: ["in-progress"],

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -11,6 +11,7 @@ import {
 import {
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
+  transitionRestartSentinelStatus,
   writeRestartSentinel,
 } from "../../infra/restart-sentinel.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -157,11 +158,55 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   const json = Boolean(opts.json);
   const service = resolveGatewayService();
   let restartedWithoutServiceManager = false;
+  const shouldNotify = Boolean(opts.notify);
   const restartPort = await resolveGatewayLifecyclePort(service).catch(() =>
     resolveGatewayPortFallback(),
   );
   const restartWaitMs = POST_RESTART_HEALTH_ATTEMPTS * POST_RESTART_HEALTH_DELAY_MS;
   const restartWaitSeconds = Math.round(restartWaitMs / 1000);
+
+  if (shouldNotify) {
+    const mainSessionKey = resolveMainSessionKeyFromConfig();
+    const { deliveryContext, threadId } = extractDeliveryInfo(mainSessionKey);
+    const hasRoute = Boolean(deliveryContext?.channel && deliveryContext?.to);
+    if (!hasRoute) {
+      if (!json) {
+        defaultRuntime.log(
+          theme.warn(
+            `--notify requested but main session (${mainSessionKey}) has no delivery target; skipping post-restart notification.`,
+          ),
+        );
+      }
+    } else {
+      const note = typeof opts.note === "string" && opts.note.trim() ? opts.note.trim() : undefined;
+      const payload: RestartSentinelPayload = {
+        kind: "restart",
+        status: "pending",
+        ts: Date.now(),
+        sessionKey: mainSessionKey,
+        deliveryContext,
+        threadId,
+        message: note,
+        doctorHint: formatDoctorNonInteractiveHint(),
+        stats: {
+          mode: "gateway.restart",
+          reason: note ?? "cli --notify",
+        },
+      };
+      try {
+        await writeRestartSentinel(payload);
+      } catch {
+        // best-effort
+      }
+      try {
+        await transitionRestartSentinelStatus("in-progress", {
+          allowedCurrentStatuses: ["pending"],
+        });
+      } catch {
+        // best-effort
+      }
+    }
+  }
 
   const restarted = await runServiceRestart({
     serviceNoun: "Gateway",
@@ -268,40 +313,13 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     },
   });
 
-  if (opts.notify && restarted) {
-    const mainSessionKey = resolveMainSessionKeyFromConfig();
-    const { deliveryContext, threadId } = extractDeliveryInfo(mainSessionKey);
-
-    const hasRoute = Boolean(deliveryContext?.channel && deliveryContext?.to);
-    if (!hasRoute) {
-      if (!json) {
-        defaultRuntime.log(
-          theme.warn(
-            `--notify requested but main session (${mainSessionKey}) has no delivery target; skipping post-restart notification.`,
-          ),
-        );
-      }
-    } else {
-      const note = typeof opts.note === "string" && opts.note.trim() ? opts.note.trim() : undefined;
-      const payload: RestartSentinelPayload = {
-        kind: "restart",
-        status: "ok",
-        ts: Date.now(),
-        sessionKey: mainSessionKey,
-        deliveryContext,
-        threadId,
-        message: note,
-        doctorHint: formatDoctorNonInteractiveHint(),
-        stats: {
-          mode: "gateway.restart",
-          reason: note ?? "cli --notify",
-        },
-      };
-      try {
-        await writeRestartSentinel(payload);
-      } catch {
-        // best-effort
-      }
+  if (shouldNotify && restarted) {
+    try {
+      await transitionRestartSentinelStatus("ok", {
+        allowedCurrentStatuses: ["pending", "in-progress"],
+      });
+    } catch {
+      // best-effort
     }
   }
 

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -176,6 +176,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
 
   let restartSentinelWritable = false;
   let restartSentinelMarkedInProgress = false;
+  let restartSentinelMarkedError = false;
   const markRestartSentinelInProgress = async () => {
     if (!restartSentinelWritable || restartSentinelMarkedInProgress) {
       return;
@@ -189,12 +190,28 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       // best-effort
     }
   };
+  const markRestartSentinelError = async () => {
+    if (!shouldNotify || !restartSentinelMarkedInProgress || restartSentinelMarkedError) {
+      return;
+    }
+    restartSentinelMarkedError = true;
+    try {
+      await transitionRestartSentinelStatus("error", {
+        allowedCurrentStatuses: ["in-progress"],
+      });
+    } catch {
+      // best-effort
+    }
+  };
 
   if (shouldNotify) {
     const { mergedEnv } = await resolveGatewayLifecycleContext(service);
     const daemonCfg = createConfigIO({ env: mergedEnv }).loadConfig();
     const mainSessionKey = resolveMainSessionKey(daemonCfg);
-    const { deliveryContext, threadId } = extractDeliveryInfo(mainSessionKey, { cfg: daemonCfg });
+    const { deliveryContext, threadId } = extractDeliveryInfo(mainSessionKey, {
+      cfg: daemonCfg,
+      env: mergedEnv,
+    });
     const hasRoute = Boolean(deliveryContext?.channel && deliveryContext?.to);
     if (!hasRoute) {
       if (!json) {
@@ -275,6 +292,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
             warnings.push(...diagnostics);
           }
 
+          await markRestartSentinelError();
           fail(
             `Gateway restart timed out after ${restartWaitSeconds}s waiting for health checks.`,
             [
@@ -340,6 +358,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
           warnings.push(...diagnostics);
         }
 
+        await markRestartSentinelError();
         fail(`Gateway restart timed out after ${restartWaitSeconds}s waiting for health checks.`, [
           formatCliCommand("openclaw gateway status --deep"),
           formatCliCommand("openclaw doctor"),
@@ -347,15 +366,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       },
     });
   } catch (err) {
-    if (shouldNotify && restartSentinelMarkedInProgress) {
-      try {
-        await transitionRestartSentinelStatus("error", {
-          allowedCurrentStatuses: ["in-progress"],
-        });
-      } catch {
-        // best-effort
-      }
-    }
+    await markRestartSentinelError();
     throw err;
   }
 

--- a/src/cli/daemon-cli/register-service-commands.ts
+++ b/src/cli/daemon-cli/register-service-commands.ts
@@ -96,6 +96,15 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
   parent
     .command("restart")
     .description("Restart the Gateway service (launchd/systemd/schtasks)")
+    .option(
+      "--notify",
+      "After restart, send a post-restart summary to the main session (uses restart sentinel).",
+      false,
+    )
+    .option(
+      "--note <text>",
+      "Optional note to include in the post-restart message (only used with --notify).",
+    )
     .option("--json", "Output JSON", false)
     .action(async (cmdOpts) => {
       await runDaemonRestart(cmdOpts);

--- a/src/cli/daemon-cli/types.ts
+++ b/src/cli/daemon-cli/types.ts
@@ -25,4 +25,8 @@ export type DaemonInstallOptions = {
 
 export type DaemonLifecycleOptions = {
   json?: boolean;
+  /** If set, write a restart sentinel targeting the main session before restarting. */
+  notify?: boolean;
+  /** Optional note to include in the post-restart message (only used with notify). */
+  note?: string;
 };

--- a/src/config/sessions/delivery-info.test.ts
+++ b/src/config/sessions/delivery-info.test.ts
@@ -9,8 +9,10 @@ vi.mock("../io.js", () => ({
   loadConfig: () => ({}),
 }));
 
+const resolveStorePath = vi.fn(() => "/tmp/sessions.json");
+
 vi.mock("./paths.js", () => ({
-  resolveStorePath: () => "/tmp/sessions.json",
+  resolveStorePath: (...args: unknown[]) => resolveStorePath(...args),
 }));
 
 vi.mock("./store.js", () => ({
@@ -29,6 +31,7 @@ const buildEntry = (deliveryContext: SessionEntry["deliveryContext"]): SessionEn
 beforeEach(async () => {
   vi.resetModules();
   storeState.store = {};
+  resolveStorePath.mockClear();
   ({ extractDeliveryInfo, parseSessionThreadInfo } = await import("./delivery-info.js"));
 });
 
@@ -111,6 +114,21 @@ describe("extractDeliveryInfo", () => {
         accountId: "main",
       },
       threadId: "55",
+    });
+  });
+
+  it("resolves store path using provided environment", () => {
+    const sessionKey = "agent:main:webchat:dm:user-123";
+    storeState.store[sessionKey] = buildEntry({
+      channel: "webchat",
+      to: "webchat:user-123",
+      accountId: "default",
+    });
+
+    extractDeliveryInfo(sessionKey, { env: { OPENCLAW_STATE_DIR: "/tmp/daemon-state" } });
+
+    expect(resolveStorePath).toHaveBeenCalledWith(undefined, {
+      env: { OPENCLAW_STATE_DIR: "/tmp/daemon-state" },
     });
   });
 });

--- a/src/config/sessions/delivery-info.ts
+++ b/src/config/sessions/delivery-info.ts
@@ -28,7 +28,7 @@ export function parseSessionThreadInfo(sessionKey: string | undefined): {
 
 export function extractDeliveryInfo(
   sessionKey: string | undefined,
-  opts?: { cfg?: OpenClawConfig },
+  opts?: { cfg?: OpenClawConfig; env?: NodeJS.ProcessEnv },
 ): {
   deliveryContext: { channel?: string; to?: string; accountId?: string } | undefined;
   threadId: string | undefined;
@@ -41,7 +41,7 @@ export function extractDeliveryInfo(
   let deliveryContext: { channel?: string; to?: string; accountId?: string } | undefined;
   try {
     const cfg = opts?.cfg ?? loadConfig();
-    const storePath = resolveStorePath(cfg.session?.store);
+    const storePath = resolveStorePath(cfg.session?.store, { env: opts?.env });
     const store = loadSessionStore(storePath);
     let entry = store[sessionKey];
     if (!entry?.deliveryContext && baseSessionKey !== sessionKey) {

--- a/src/config/sessions/delivery-info.ts
+++ b/src/config/sessions/delivery-info.ts
@@ -1,4 +1,5 @@
 import { loadConfig } from "../io.js";
+import type { OpenClawConfig } from "../schema.js";
 import { resolveStorePath } from "./paths.js";
 import { loadSessionStore } from "./store.js";
 
@@ -25,7 +26,10 @@ export function parseSessionThreadInfo(sessionKey: string | undefined): {
   return { baseSessionKey, threadId };
 }
 
-export function extractDeliveryInfo(sessionKey: string | undefined): {
+export function extractDeliveryInfo(
+  sessionKey: string | undefined,
+  opts?: { cfg?: OpenClawConfig },
+): {
   deliveryContext: { channel?: string; to?: string; accountId?: string } | undefined;
   threadId: string | undefined;
 } {
@@ -36,7 +40,7 @@ export function extractDeliveryInfo(sessionKey: string | undefined): {
 
   let deliveryContext: { channel?: string; to?: string; accountId?: string } | undefined;
   try {
-    const cfg = loadConfig();
+    const cfg = opts?.cfg ?? loadConfig();
     const storePath = resolveStorePath(cfg.session?.store);
     const store = loadSessionStore(storePath);
     let entry = store[sessionKey];

--- a/src/config/sessions/delivery-info.ts
+++ b/src/config/sessions/delivery-info.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "../io.js";
-import type { OpenClawConfig } from "../schema.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveStorePath } from "./paths.js";
 import { loadSessionStore } from "./store.js";
 

--- a/src/gateway/server-methods/config.restart-sentinel.test.ts
+++ b/src/gateway/server-methods/config.restart-sentinel.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const writeRestartSentinelMock = vi.fn();
+const transitionRestartSentinelStatusMock = vi.fn();
+const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true }));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: () => "/tmp/workspace",
+  resolveDefaultAgentId: () => "main",
+}));
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  listChannelPlugins: () => [],
+}));
+
+vi.mock("../../config/config.js", () => ({
+  createConfigIO: () => ({ configPath: "/tmp/config.json" }),
+  loadConfig: () => ({}),
+  parseConfigJson5: () => ({ ok: true, parsed: {} }),
+  readConfigFileSnapshot: async () => ({ exists: true, valid: true, config: {} }),
+  readConfigFileSnapshotForWrite: async () => ({
+    snapshot: { exists: true, valid: true, config: {} },
+    writeOptions: {},
+  }),
+  resolveConfigSnapshotHash: () => "base-hash",
+  validateConfigObjectWithPlugins: () => ({ ok: true, config: {} }),
+  writeConfigFile: async () => {},
+}));
+
+vi.mock("../../config/legacy.js", () => ({
+  applyLegacyMigrations: () => ({ next: undefined }),
+}));
+
+vi.mock("../../config/merge-patch.js", () => ({
+  applyMergePatch: () => ({}),
+}));
+
+vi.mock("../../config/redact-snapshot.js", () => ({
+  redactConfigObject: (config: unknown) => config,
+  redactConfigSnapshot: (snapshot: unknown) => snapshot,
+  restoreRedactedValues: () => ({ ok: true, result: {} }),
+}));
+
+vi.mock("../../config/schema.js", () => ({
+  buildConfigSchema: () => ({ uiHints: {}, properties: {} }),
+  lookupConfigSchema: () => null,
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  extractDeliveryInfo: () => ({ deliveryContext: undefined, threadId: undefined }),
+}));
+
+vi.mock("../../infra/restart-sentinel.js", () => ({
+  formatDoctorNonInteractiveHint: () => "hint",
+  transitionRestartSentinelStatus: (...args: unknown[]) =>
+    transitionRestartSentinelStatusMock(...args),
+  writeRestartSentinel: (...args: unknown[]) => writeRestartSentinelMock(...args),
+}));
+
+vi.mock("../../infra/restart.js", () => ({
+  scheduleGatewaySigusr1Restart: (...args: unknown[]) => scheduleGatewaySigusr1RestartMock(...args),
+}));
+
+vi.mock("../../plugins/loader.js", () => ({
+  loadOpenClawPlugins: () => ({ plugins: [] }),
+}));
+
+vi.mock("../config-reload.js", () => ({
+  diffConfigPaths: () => [],
+}));
+
+vi.mock("../control-plane-audit.js", () => ({
+  formatControlPlaneActor: () => "actor=test",
+  resolveControlPlaneActor: () => ({ actor: "test", deviceId: "dev-1", clientIp: "127.0.0.1" }),
+  summarizeChangedPaths: () => "none",
+}));
+
+vi.mock("../protocol/index.js", () => ({
+  ErrorCodes: { INVALID_REQUEST: -32600 },
+  errorShape: (_code: number, message: string) => ({ message }),
+  formatValidationErrors: () => "",
+  validateConfigApplyParams: () => true,
+  validateConfigGetParams: () => true,
+  validateConfigPatchParams: () => true,
+  validateConfigSchemaLookupParams: () => true,
+  validateConfigSchemaLookupResult: Object.assign(() => true, { errors: [] }),
+  validateConfigSchemaParams: () => true,
+  validateConfigSetParams: () => true,
+}));
+
+vi.mock("./base-hash.js", () => ({
+  resolveBaseHashParam: () => "base-hash",
+}));
+
+vi.mock("./restart-request.js", () => ({
+  parseRestartRequestParams: () => ({
+    sessionKey: undefined,
+    note: undefined,
+    restartDelayMs: undefined,
+  }),
+}));
+
+vi.mock("./validation.js", () => ({
+  assertValidParams: () => true,
+}));
+
+beforeEach(() => {
+  writeRestartSentinelMock.mockReset();
+  transitionRestartSentinelStatusMock.mockReset();
+  scheduleGatewaySigusr1RestartMock.mockClear();
+  scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true });
+});
+
+async function invoke(method: "config.patch" | "config.apply") {
+  const { configHandlers } = await import("./config.js");
+  const respond = vi.fn();
+  await configHandlers[method]({
+    params: { raw: "{}", baseHash: "base-hash" },
+    respond,
+    client: {},
+    context: {
+      logGateway: {
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    },
+  } as never);
+  return respond;
+}
+
+describe("config restart sentinel transition hook", () => {
+  it.each(["config.patch", "config.apply"] as const)(
+    "does not register beforeRestart when sentinel write fails for %s",
+    async (method) => {
+      writeRestartSentinelMock.mockRejectedValueOnce(new Error("disk full"));
+
+      await invoke(method);
+
+      expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+      const [restartRequest] = scheduleGatewaySigusr1RestartMock.mock.calls[0] ?? [];
+      expect(restartRequest).toBeTruthy();
+      expect(restartRequest.beforeRestart).toBeUndefined();
+      expect(transitionRestartSentinelStatusMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["config.patch", "config.apply"] as const)(
+    "registers beforeRestart only when sentinel write succeeds for %s",
+    async (method) => {
+      writeRestartSentinelMock.mockResolvedValueOnce("/tmp/restart-sentinel.json");
+
+      await invoke(method);
+
+      expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+      const [restartRequest] = scheduleGatewaySigusr1RestartMock.mock.calls[0] ?? [];
+      expect(typeof restartRequest.beforeRestart).toBe("function");
+
+      await restartRequest.beforeRestart();
+
+      expect(transitionRestartSentinelStatusMock).toHaveBeenCalledWith("in-progress", {
+        allowedCurrentStatuses: ["pending"],
+      });
+    },
+  );
+});

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -29,6 +29,7 @@ import type { ConfigValidationIssue, OpenClawConfig } from "../../config/types.o
 import {
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
+  transitionRestartSentinelStatus,
   writeRestartSentinel,
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
@@ -218,7 +219,7 @@ function buildConfigRestartSentinelPayload(params: {
   const configPath = createConfigIO().configPath;
   return {
     kind: params.kind,
-    status: "ok",
+    status: "pending",
     ts: Date.now(),
     sessionKey: params.sessionKey,
     deliveryContext: params.deliveryContext,
@@ -446,6 +447,11 @@ export const configHandlers: GatewayRequestHandlers = {
     const restart = scheduleGatewaySigusr1Restart({
       delayMs: restartDelayMs,
       reason: "config.patch",
+      beforeRestart: async () => {
+        await transitionRestartSentinelStatus("in-progress", {
+          allowedCurrentStatuses: ["pending"],
+        });
+      },
       audit: {
         actor: actor.actor,
         deviceId: actor.deviceId,
@@ -506,6 +512,11 @@ export const configHandlers: GatewayRequestHandlers = {
     const restart = scheduleGatewaySigusr1Restart({
       delayMs: restartDelayMs,
       reason: "config.apply",
+      beforeRestart: async () => {
+        await transitionRestartSentinelStatus("in-progress", {
+          allowedCurrentStatuses: ["pending"],
+        });
+      },
       audit: {
         actor: actor.actor,
         deviceId: actor.deviceId,

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -447,11 +447,15 @@ export const configHandlers: GatewayRequestHandlers = {
     const restart = scheduleGatewaySigusr1Restart({
       delayMs: restartDelayMs,
       reason: "config.patch",
-      beforeRestart: async () => {
-        await transitionRestartSentinelStatus("in-progress", {
-          allowedCurrentStatuses: ["pending"],
-        });
-      },
+      ...(sentinelPath
+        ? {
+            beforeRestart: async () => {
+              await transitionRestartSentinelStatus("in-progress", {
+                allowedCurrentStatuses: ["pending"],
+              });
+            },
+          }
+        : {}),
       audit: {
         actor: actor.actor,
         deviceId: actor.deviceId,
@@ -512,11 +516,15 @@ export const configHandlers: GatewayRequestHandlers = {
     const restart = scheduleGatewaySigusr1Restart({
       delayMs: restartDelayMs,
       reason: "config.apply",
-      beforeRestart: async () => {
-        await transitionRestartSentinelStatus("in-progress", {
-          allowedCurrentStatuses: ["pending"],
-        });
-      },
+      ...(sentinelPath
+        ? {
+            beforeRestart: async () => {
+              await transitionRestartSentinelStatus("in-progress", {
+                allowedCurrentStatuses: ["pending"],
+              });
+            },
+          }
+        : {}),
       audit: {
         actor: actor.actor,
         deviceId: actor.deviceId,

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -111,6 +111,7 @@ describe("update.run sentinel deliveryContext", () => {
 
     expect(responded).toBe(true);
     expect(capturedPayload).toBeDefined();
+    expect(capturedPayload!.status).toBe("pending");
     expect(capturedPayload!.deliveryContext).toEqual({
       channel: "webchat",
       to: "webchat:user-123",
@@ -124,6 +125,7 @@ describe("update.run sentinel deliveryContext", () => {
     await invokeUpdateRun({});
 
     expect(capturedPayload).toBeDefined();
+    expect(capturedPayload!.status).toBe("pending");
     expect(capturedPayload!.deliveryContext).toBeUndefined();
     expect(capturedPayload!.threadId).toBeUndefined();
   });
@@ -134,6 +136,7 @@ describe("update.run sentinel deliveryContext", () => {
     await invokeUpdateRun({ sessionKey: "agent:main:slack:dm:C0123ABC:thread:1234567890.123456" });
 
     expect(capturedPayload).toBeDefined();
+    expect(capturedPayload!.status).toBe("pending");
     expect(capturedPayload!.deliveryContext).toEqual({
       channel: "slack",
       to: "slack:C0123ABC",
@@ -186,6 +189,7 @@ describe("update.run restart scheduling", () => {
     });
 
     expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(capturedPayload?.status).toBe("error");
     expect(payload?.ok).toBe(false);
     expect(payload?.restart).toBeNull();
   });

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -6,7 +6,11 @@ import type { UpdateRunResult } from "../../infra/update-runner.js";
 let capturedPayload: RestartSentinelPayload | undefined;
 
 const runGatewayUpdateMock = vi.fn<() => Promise<UpdateRunResult>>();
-
+const writeRestartSentinelMock = vi.fn(async (payload: RestartSentinelPayload) => {
+  capturedPayload = payload;
+  return "/tmp/sentinel.json";
+});
+const transitionRestartSentinelStatusMock = vi.fn();
 const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true }));
 
 vi.mock("../../config/config.js", () => ({
@@ -40,10 +44,9 @@ vi.mock("../../infra/restart-sentinel.js", async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...(actual as Record<string, unknown>),
-    writeRestartSentinel: async (payload: RestartSentinelPayload) => {
-      capturedPayload = payload;
-      return "/tmp/sentinel.json";
-    },
+    writeRestartSentinel: (...args: unknown[]) => writeRestartSentinelMock(...args),
+    transitionRestartSentinelStatus: (...args: unknown[]) =>
+      transitionRestartSentinelStatusMock(...args),
   };
 });
 
@@ -78,6 +81,12 @@ vi.mock("./validation.js", () => ({
 beforeEach(() => {
   capturedPayload = undefined;
   runGatewayUpdateMock.mockClear();
+  writeRestartSentinelMock.mockClear();
+  writeRestartSentinelMock.mockImplementation(async (payload: RestartSentinelPayload) => {
+    capturedPayload = payload;
+    return "/tmp/sentinel.json";
+  });
+  transitionRestartSentinelStatusMock.mockReset();
   runGatewayUpdateMock.mockResolvedValue({
     status: "ok",
     mode: "npm",
@@ -168,8 +177,21 @@ describe("update.run restart scheduling", () => {
     });
 
     expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    const [restartRequest] = scheduleGatewaySigusr1RestartMock.mock.calls[0] ?? [];
+    expect(typeof restartRequest.beforeRestart).toBe("function");
     expect(payload?.ok).toBe(true);
     expect(payload?.restart).toEqual({ scheduled: true });
+  });
+
+  it("omits beforeRestart hook when sentinel write fails", async () => {
+    writeRestartSentinelMock.mockRejectedValueOnce(new Error("disk full"));
+
+    await invokeUpdateRun({});
+
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    const [restartRequest] = scheduleGatewaySigusr1RestartMock.mock.calls[0] ?? [];
+    expect(restartRequest.beforeRestart).toBeUndefined();
+    expect(transitionRestartSentinelStatusMock).not.toHaveBeenCalled();
   });
 
   it("skips restart when update fails", async () => {

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -4,6 +4,7 @@ import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import {
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
+  transitionRestartSentinelStatus,
   writeRestartSentinel,
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
@@ -57,7 +58,7 @@ export const updateHandlers: GatewayRequestHandlers = {
 
     const payload: RestartSentinelPayload = {
       kind: "update",
-      status: result.status,
+      status: result.status === "ok" ? "pending" : result.status,
       ts: Date.now(),
       sessionKey,
       deliveryContext,
@@ -100,6 +101,11 @@ export const updateHandlers: GatewayRequestHandlers = {
         ? scheduleGatewaySigusr1Restart({
             delayMs: restartDelayMs,
             reason: "update.run",
+            beforeRestart: async () => {
+              await transitionRestartSentinelStatus("in-progress", {
+                allowedCurrentStatuses: ["pending"],
+              });
+            },
             audit: {
               actor: actor.actor,
               deviceId: actor.deviceId,

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -87,8 +87,10 @@ export const updateHandlers: GatewayRequestHandlers = {
     };
 
     let sentinelPath: string | null = null;
+    let canTransitionSentinel = false;
     try {
       sentinelPath = await writeRestartSentinel(payload);
+      canTransitionSentinel = true;
     } catch {
       sentinelPath = null;
     }
@@ -101,11 +103,13 @@ export const updateHandlers: GatewayRequestHandlers = {
         ? scheduleGatewaySigusr1Restart({
             delayMs: restartDelayMs,
             reason: "update.run",
-            beforeRestart: async () => {
-              await transitionRestartSentinelStatus("in-progress", {
-                allowedCurrentStatuses: ["pending"],
-              });
-            },
+            beforeRestart: canTransitionSentinel
+              ? async () => {
+                  await transitionRestartSentinelStatus("in-progress", {
+                    allowedCurrentStatuses: ["pending"],
+                  });
+                }
+              : undefined,
             audit: {
               actor: actor.actor,
               deviceId: actor.deviceId,

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   resolveSessionAgentId: vi.fn(() => "agent-from-key"),
-  consumeRestartSentinel: vi.fn(async () => ({
+  finalizeRestartSentinelForCompletedRestart: vi.fn(async () => null),
+  consumeFinalizedRestartSentinel: vi.fn(async () => ({
     payload: {
       sessionKey: "agent:main:main",
       deliveryContext: {
@@ -34,7 +35,8 @@ vi.mock("../agents/agent-scope.js", () => ({
 }));
 
 vi.mock("../infra/restart-sentinel.js", () => ({
-  consumeRestartSentinel: mocks.consumeRestartSentinel,
+  finalizeRestartSentinelForCompletedRestart: mocks.finalizeRestartSentinelForCompletedRestart,
+  consumeFinalizedRestartSentinel: mocks.consumeFinalizedRestartSentinel,
   formatRestartSentinelMessage: mocks.formatRestartSentinelMessage,
   summarizeRestartSentinel: mocks.summarizeRestartSentinel,
 }));
@@ -79,9 +81,35 @@ vi.mock("../infra/system-events.js", () => ({
 const { scheduleRestartSentinelWake } = await import("./server-restart-sentinel.js");
 
 describe("scheduleRestartSentinelWake", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.finalizeRestartSentinelForCompletedRestart.mockResolvedValue(null);
+    mocks.consumeFinalizedRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+      },
+    });
+  });
+
+  it("ignores non-final sentinels", async () => {
+    mocks.consumeFinalizedRestartSentinel.mockResolvedValueOnce(null);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.finalizeRestartSentinelForCompletedRestart).toHaveBeenCalledTimes(1);
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
   it("forwards session context to outbound delivery", async () => {
     await scheduleRestartSentinelWake({ deps: {} as never });
 
+    expect(mocks.finalizeRestartSentinelForCompletedRestart).toHaveBeenCalledTimes(1);
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "whatsapp",

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -119,4 +119,12 @@ describe("scheduleRestartSentinelWake", () => {
     );
     expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
   });
+
+  it("continues wake flow when finalize throws", async () => {
+    mocks.finalizeRestartSentinelForCompletedRestart.mockRejectedValueOnce(new Error("disk-full"));
+
+    await expect(scheduleRestartSentinelWake({ deps: {} as never })).resolves.toBeUndefined();
+    expect(mocks.consumeFinalizedRestartSentinel).toHaveBeenCalledTimes(1);
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -7,7 +7,8 @@ import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { resolveOutboundTarget } from "../infra/outbound/targets.js";
 import {
-  consumeRestartSentinel,
+  consumeFinalizedRestartSentinel,
+  finalizeRestartSentinelForCompletedRestart,
   formatRestartSentinelMessage,
   summarizeRestartSentinel,
 } from "../infra/restart-sentinel.js";
@@ -16,7 +17,8 @@ import { deliveryContextFromSession, mergeDeliveryContext } from "../utils/deliv
 import { loadSessionEntry } from "./session-utils.js";
 
 export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
-  const sentinel = await consumeRestartSentinel();
+  await finalizeRestartSentinelForCompletedRestart();
+  const sentinel = await consumeFinalizedRestartSentinel();
   if (!sentinel) {
     return;
   }

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -17,7 +17,11 @@ import { deliveryContextFromSession, mergeDeliveryContext } from "../utils/deliv
 import { loadSessionEntry } from "./session-utils.js";
 
 export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
-  await finalizeRestartSentinelForCompletedRestart();
+  try {
+    await finalizeRestartSentinelForCompletedRestart();
+  } catch {
+    // best-effort: sentinel finalization failure should not crash startup
+  }
   const sentinel = await consumeFinalizedRestartSentinel();
   if (!sentinel) {
     return;

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -115,6 +115,42 @@ describe("infra runtime", () => {
       }
     });
 
+    it("runs coalesced pre-restart hooks when restart is already scheduled", async () => {
+      const emitSpy = vi.spyOn(process, "emit");
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        const firstHook = vi.fn(async () => {});
+        const secondHook = vi.fn(async () => {});
+
+        const first = scheduleGatewaySigusr1Restart({
+          delayMs: 1_000,
+          reason: "first",
+          beforeRestart: firstHook,
+        });
+        const second = scheduleGatewaySigusr1Restart({
+          delayMs: 1_000,
+          reason: "second",
+          beforeRestart: secondHook,
+        });
+
+        expect(first.coalesced).toBe(false);
+        expect(second.coalesced).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        expect(firstHook).toHaveBeenCalledTimes(1);
+        expect(secondHook).toHaveBeenCalledTimes(1);
+        const sigusr1Index = emitSpy.mock.calls.findIndex((args) => args[0] === "SIGUSR1");
+        expect(sigusr1Index).toBeGreaterThanOrEqual(0);
+        expect(secondHook.mock.invocationCallOrder[0]).toBeLessThan(
+          emitSpy.mock.invocationCallOrder[sigusr1Index] ?? Number.POSITIVE_INFINITY,
+        );
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
     it("applies restart cooldown between emitted restart cycles", async () => {
       const emitSpy = vi.spyOn(process, "emit");
       const handler = () => {};

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -212,25 +212,34 @@ describe("infra runtime", () => {
 
     it("defers SIGUSR1 until deferral check returns 0", async () => {
       const emitSpy = vi.spyOn(process, "emit");
+      const beforeRestart = vi.fn(async () => {});
       const handler = () => {};
       process.on("SIGUSR1", handler);
       try {
         let pending = 2;
         setPreRestartDeferralCheck(() => pending);
-        scheduleGatewaySigusr1Restart({ delayMs: 0 });
+        scheduleGatewaySigusr1Restart({ delayMs: 0, beforeRestart });
 
-        // After initial delay fires, deferral check returns 2 — should NOT emit yet
+        // After initial delay fires, deferral check returns 2 — should NOT emit yet.
+        // beforeRestart must also not run yet.
         await vi.advanceTimersByTimeAsync(0);
+        expect(beforeRestart).not.toHaveBeenCalled();
         expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
 
         // After one poll (500ms), still pending
         await vi.advanceTimersByTimeAsync(500);
+        expect(beforeRestart).not.toHaveBeenCalled();
         expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
 
-        // Drain pending work
+        // Drain pending work; hook should run immediately before SIGUSR1 emission
         pending = 0;
         await vi.advanceTimersByTimeAsync(500);
-        expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+        expect(beforeRestart).toHaveBeenCalledTimes(1);
+        const sigusr1Index = emitSpy.mock.calls.findIndex((args) => args[0] === "SIGUSR1");
+        expect(sigusr1Index).toBeGreaterThanOrEqual(0);
+        expect(beforeRestart.mock.invocationCallOrder[0]).toBeLessThan(
+          emitSpy.mock.invocationCallOrder[sigusr1Index] ?? Number.POSITIVE_INFINITY,
+        );
       } finally {
         process.removeListener("SIGUSR1", handler);
       }
@@ -250,6 +259,31 @@ describe("infra runtime", () => {
 
         // Advance past the 5-minute max deferral wait
         await vi.advanceTimersByTimeAsync(300_000);
+        expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("continues deferred restart when beforeRestart hook fails", async () => {
+      const emitSpy = vi.spyOn(process, "emit");
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        let pending = 1;
+        setPreRestartDeferralCheck(() => pending);
+        scheduleGatewaySigusr1Restart({
+          delayMs: 0,
+          beforeRestart: async () => {
+            throw new Error("hook failed");
+          },
+        });
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
+
+        pending = 0;
+        await vi.advanceTimersByTimeAsync(500);
         expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
       } finally {
         process.removeListener("SIGUSR1", handler);

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -46,6 +46,28 @@ describe("infra runtime", () => {
       await vi.runAllTimersAsync();
     });
 
+    it("runs the pre-restart hook before emitting SIGUSR1", async () => {
+      const emitSpy = vi.spyOn(process, "emit");
+      const beforeRestart = vi.fn(async () => {});
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        scheduleGatewaySigusr1Restart({ delayMs: 0, beforeRestart });
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(beforeRestart).toHaveBeenCalledTimes(1);
+        expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+        const sigusr1Index = emitSpy.mock.calls.findIndex((args) => args[0] === "SIGUSR1");
+        expect(sigusr1Index).toBeGreaterThanOrEqual(0);
+        expect(beforeRestart.mock.invocationCallOrder[0]).toBeLessThan(
+          emitSpy.mock.invocationCallOrder[sigusr1Index] ?? Number.POSITIVE_INFINITY,
+        );
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
     it("tracks external restart policy", () => {
       expect(isGatewaySigusr1RestartExternallyAllowed()).toBe(false);
       setGatewaySigusr1RestartPolicy({ allowExternal: true });

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -4,12 +4,16 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import {
+  consumeFinalizedRestartSentinel,
   consumeRestartSentinel,
+  finalizeRestartSentinelForCompletedRestart,
   formatDoctorNonInteractiveHint,
   formatRestartSentinelMessage,
+  isFinalRestartSentinelStatus,
   readRestartSentinel,
   resolveRestartSentinelPath,
   summarizeRestartSentinel,
+  transitionRestartSentinelStatus,
   trimLogTail,
   writeRestartSentinel,
 } from "./restart-sentinel.js";
@@ -48,6 +52,46 @@ describe("restart sentinel", () => {
 
     const empty = await readRestartSentinel();
     expect(empty).toBeNull();
+  });
+
+  it("only consumes finalized sentinels", async () => {
+    await writeRestartSentinel({
+      kind: "restart",
+      status: "pending",
+      ts: Date.now(),
+    });
+
+    expect(await consumeFinalizedRestartSentinel()).toBeNull();
+    expect((await readRestartSentinel())?.payload.status).toBe("pending");
+
+    await transitionRestartSentinelStatus("ok", {
+      allowedCurrentStatuses: ["pending"],
+    });
+
+    const consumed = await consumeFinalizedRestartSentinel();
+    expect(consumed?.payload.status).toBe("ok");
+    expect(await readRestartSentinel()).toBeNull();
+  });
+
+  it("finalizes only fresh in-progress restart sentinels", async () => {
+    await writeRestartSentinel({
+      kind: "restart",
+      status: "in-progress",
+      ts: Date.now(),
+    });
+
+    const finalized = await finalizeRestartSentinelForCompletedRestart();
+    expect(finalized?.payload.status).toBe("ok");
+
+    await writeRestartSentinel({
+      kind: "restart",
+      status: "in-progress",
+      ts: Date.now() - 10_000,
+    });
+
+    const stale = await finalizeRestartSentinelForCompletedRestart(process.env, 100);
+    expect(stale).toBeNull();
+    expect((await readRestartSentinel())?.payload.status).toBe("in-progress");
   });
 
   it("drops invalid sentinel payloads", async () => {
@@ -129,6 +173,14 @@ describe("restart sentinel", () => {
     const trimmed = trimLogTail(text, 8000);
     expect(trimmed?.length).toBeLessThanOrEqual(8001);
     expect(trimmed?.startsWith("…")).toBe(true);
+  });
+
+  it("reports final sentinel statuses accurately", () => {
+    expect(isFinalRestartSentinelStatus("ok")).toBe(true);
+    expect(isFinalRestartSentinelStatus("error")).toBe(true);
+    expect(isFinalRestartSentinelStatus("skipped")).toBe(true);
+    expect(isFinalRestartSentinelStatus("pending")).toBe(false);
+    expect(isFinalRestartSentinelStatus("in-progress")).toBe(false);
   });
 
   it("formats restart messages without volatile timestamps", () => {

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -29,7 +29,7 @@ export type RestartSentinelStats = {
 
 export type RestartSentinelPayload = {
   kind: "config-apply" | "config-patch" | "update" | "restart";
-  status: "ok" | "error" | "skipped";
+  status: "pending" | "in-progress" | "ok" | "error" | "skipped";
   ts: number;
   sessionKey?: string;
   /** Delivery context captured at restart time to ensure channel routing survives restart. */
@@ -51,6 +51,13 @@ export type RestartSentinel = {
 };
 
 const SENTINEL_FILENAME = "restart-sentinel.json";
+const RESTART_SENTINEL_FINALIZE_MAX_AGE_MS = 5 * 60_000;
+
+export function isFinalRestartSentinelStatus(
+  status: RestartSentinelPayload["status"],
+): status is "ok" | "error" | "skipped" {
+  return status === "ok" || status === "error" || status === "skipped";
+}
 
 export function formatDoctorNonInteractiveHint(
   env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
@@ -94,6 +101,68 @@ export async function readRestartSentinel(
   } catch {
     return null;
   }
+}
+
+async function rewriteRestartSentinel(
+  nextPayload: RestartSentinelPayload,
+  env: NodeJS.ProcessEnv = process.env,
+) {
+  return await writeRestartSentinel(nextPayload, env);
+}
+
+export async function transitionRestartSentinelStatus(
+  nextStatus: RestartSentinelPayload["status"],
+  opts?: {
+    allowedCurrentStatuses?: RestartSentinelPayload["status"][];
+    env?: NodeJS.ProcessEnv;
+  },
+): Promise<RestartSentinel | null> {
+  const env = opts?.env ?? process.env;
+  const sentinel = await readRestartSentinel(env);
+  if (!sentinel) {
+    return null;
+  }
+  if (
+    opts?.allowedCurrentStatuses &&
+    !opts.allowedCurrentStatuses.includes(sentinel.payload.status)
+  ) {
+    return sentinel;
+  }
+  const nextPayload: RestartSentinelPayload = {
+    ...sentinel.payload,
+    status: nextStatus,
+    ts: Date.now(),
+  };
+  await rewriteRestartSentinel(nextPayload, env);
+  return { ...sentinel, payload: nextPayload };
+}
+
+export async function finalizeRestartSentinelForCompletedRestart(
+  env: NodeJS.ProcessEnv = process.env,
+  maxAgeMs = RESTART_SENTINEL_FINALIZE_MAX_AGE_MS,
+): Promise<RestartSentinel | null> {
+  const sentinel = await readRestartSentinel(env);
+  if (!sentinel || sentinel.payload.status !== "in-progress") {
+    return null;
+  }
+  if (Date.now() - sentinel.payload.ts > Math.max(0, maxAgeMs)) {
+    return null;
+  }
+  return await transitionRestartSentinelStatus("ok", {
+    allowedCurrentStatuses: ["in-progress"],
+    env,
+  });
+}
+
+export async function consumeFinalizedRestartSentinel(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<RestartSentinel | null> {
+  const sentinel = await readRestartSentinel(env);
+  if (!sentinel || !isFinalRestartSentinelStatus(sentinel.payload.status)) {
+    return null;
+  }
+  await fs.unlink(resolveRestartSentinelPath(env)).catch(() => {});
+  return sentinel;
 }
 
 export async function consumeRestartSentinel(

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -409,6 +409,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   delayMs?: number;
   reason?: string;
   audit?: RestartAuditInfo;
+  beforeRestart?: () => void | Promise<void>;
 }): ScheduledRestart {
   const delayMsRaw =
     typeof opts?.delayMs === "number" && Number.isFinite(opts.delayMs)
@@ -469,19 +470,26 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   pendingRestartReason = reason;
   pendingRestartTimer = setTimeout(
     () => {
-      pendingRestartTimer = null;
-      pendingRestartDueAt = 0;
-      pendingRestartReason = undefined;
-      const pendingCheck = preRestartCheck;
-      if (!pendingCheck) {
-        emitGatewayRestart();
-        return;
-      }
-      const cfg = loadConfig();
-      deferGatewayRestartUntilIdle({
-        getPendingCount: pendingCheck,
-        maxWaitMs: cfg.gateway?.reload?.deferralTimeoutMs,
-      });
+      void (async () => {
+        try {
+          await opts?.beforeRestart?.();
+        } catch (err) {
+          restartLog.warn(`restart preflight hook failed: ${String(err)}`);
+        }
+        pendingRestartTimer = null;
+        pendingRestartDueAt = 0;
+        pendingRestartReason = undefined;
+        const pendingCheck = preRestartCheck;
+        if (!pendingCheck) {
+          emitGatewayRestart();
+          return;
+        }
+        const cfg = loadConfig();
+        deferGatewayRestartUntilIdle({
+          getPendingCount: pendingCheck,
+          maxWaitMs: cfg.gateway?.reload?.deferralTimeoutMs,
+        });
+      })();
     },
     Math.max(0, requestedDueAt - nowMs),
   );

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -40,18 +40,22 @@ let lastRestartEmittedAt = 0;
 let pendingRestartTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingRestartDueAt = 0;
 let pendingRestartReason: string | undefined;
+let pendingBeforeRestartHooks: Array<() => void | Promise<void>> = [];
 
 function hasUnconsumedRestartSignal(): boolean {
   return emittedRestartToken > consumedRestartToken;
 }
 
-function clearPendingScheduledRestart(): void {
+function clearPendingScheduledRestart(opts?: { keepHooks?: boolean }): void {
   if (pendingRestartTimer) {
     clearTimeout(pendingRestartTimer);
   }
   pendingRestartTimer = null;
   pendingRestartDueAt = 0;
   pendingRestartReason = undefined;
+  if (!opts?.keepHooks) {
+    pendingBeforeRestartHooks = [];
+  }
 }
 
 export type RestartAuditInfo = {
@@ -411,6 +415,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   audit?: RestartAuditInfo;
   beforeRestart?: () => void | Promise<void>;
 }): ScheduledRestart {
+  const beforeRestartHook = opts?.beforeRestart;
   const delayMsRaw =
     typeof opts?.delayMs === "number" && Number.isFinite(opts.delayMs)
       ? Math.floor(opts.delayMs)
@@ -448,8 +453,11 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       restartLog.warn(
         `restart request rescheduled earlier reason=${reason ?? "unspecified"} pendingReason=${pendingRestartReason ?? "unspecified"} oldDelayMs=${remainingMs} newDelayMs=${Math.max(0, requestedDueAt - nowMs)} ${formatRestartAudit(opts?.audit)}`,
       );
-      clearPendingScheduledRestart();
+      clearPendingScheduledRestart({ keepHooks: true });
     } else {
+      if (beforeRestartHook) {
+        pendingBeforeRestartHooks.push(beforeRestartHook);
+      }
       restartLog.warn(
         `restart request coalesced (already scheduled) reason=${reason ?? "unspecified"} pendingReason=${pendingRestartReason ?? "unspecified"} delayMs=${remainingMs} ${formatRestartAudit(opts?.audit)}`,
       );
@@ -466,15 +474,23 @@ export function scheduleGatewaySigusr1Restart(opts?: {
     }
   }
 
+  if (beforeRestartHook) {
+    pendingBeforeRestartHooks.push(beforeRestartHook);
+  }
+
   pendingRestartDueAt = requestedDueAt;
   pendingRestartReason = reason;
   pendingRestartTimer = setTimeout(
     () => {
       void (async () => {
-        try {
-          await opts?.beforeRestart?.();
-        } catch (err) {
-          restartLog.warn(`restart preflight hook failed: ${String(err)}`);
+        const beforeRestartHooks = pendingBeforeRestartHooks;
+        pendingBeforeRestartHooks = [];
+        for (const hook of beforeRestartHooks) {
+          try {
+            await hook();
+          } catch (err) {
+            restartLog.warn(`restart preflight hook failed: ${String(err)}`);
+          }
         }
         pendingRestartTimer = null;
         pendingRestartDueAt = 0;

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -485,6 +485,9 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       void (async () => {
         const beforeRestartHooks = pendingBeforeRestartHooks;
         pendingBeforeRestartHooks = [];
+        pendingRestartTimer = null;
+        pendingRestartDueAt = 0;
+        pendingRestartReason = undefined;
         for (const hook of beforeRestartHooks) {
           try {
             await hook();
@@ -492,9 +495,6 @@ export function scheduleGatewaySigusr1Restart(opts?: {
             restartLog.warn(`restart preflight hook failed: ${String(err)}`);
           }
         }
-        pendingRestartTimer = null;
-        pendingRestartDueAt = 0;
-        pendingRestartReason = undefined;
         const pendingCheck = preRestartCheck;
         if (!pendingCheck) {
           emitGatewayRestart();

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -482,30 +482,45 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   pendingRestartReason = reason;
   pendingRestartTimer = setTimeout(
     () => {
-      void (async () => {
-        const beforeRestartHooks = pendingBeforeRestartHooks;
-        pendingBeforeRestartHooks = [];
-        pendingRestartTimer = null;
-        pendingRestartDueAt = 0;
-        pendingRestartReason = undefined;
-        for (const hook of beforeRestartHooks) {
-          try {
-            await hook();
-          } catch (err) {
-            restartLog.warn(`restart preflight hook failed: ${String(err)}`);
-          }
-        }
-        const pendingCheck = preRestartCheck;
-        if (!pendingCheck) {
-          emitGatewayRestart();
+      const beforeRestartHooks = pendingBeforeRestartHooks;
+      pendingBeforeRestartHooks = [];
+      pendingRestartTimer = null;
+      pendingRestartDueAt = 0;
+      pendingRestartReason = undefined;
+
+      let restartTriggered = false;
+      const triggerRestart = () => {
+        if (restartTriggered) {
           return;
         }
-        const cfg = loadConfig();
-        deferGatewayRestartUntilIdle({
-          getPendingCount: pendingCheck,
-          maxWaitMs: cfg.gateway?.reload?.deferralTimeoutMs,
-        });
-      })();
+        restartTriggered = true;
+        void (async () => {
+          for (const hook of beforeRestartHooks) {
+            try {
+              await hook();
+            } catch (err) {
+              restartLog.warn(`restart preflight hook failed: ${String(err)}`);
+            }
+          }
+          emitGatewayRestart();
+        })();
+      };
+
+      const pendingCheck = preRestartCheck;
+      if (!pendingCheck) {
+        triggerRestart();
+        return;
+      }
+      const cfg = loadConfig();
+      deferGatewayRestartUntilIdle({
+        getPendingCount: pendingCheck,
+        maxWaitMs: cfg.gateway?.reload?.deferralTimeoutMs,
+        hooks: {
+          onReady: triggerRestart,
+          onTimeout: () => triggerRestart(),
+          onCheckError: () => triggerRestart(),
+        },
+      });
     },
     Math.max(0, requestedDueAt - nowMs),
   );


### PR DESCRIPTION
### What
Adds an opt-in `--notify` flag to `openclaw gateway restart`.

When `--notify` is set, the CLI writes a restart sentinel targeting the configured **main session** before restarting the gateway service. After restart, the existing gateway startup restart-sentinel handler can deliver the built-in post-restart summary back to that session.

### Why
Restarts initiated via OpenClaw (especially after config/model changes) often leave the user wondering whether the gateway came back successfully. The restart sentinel mechanism already supports post-restart delivery, but the CLI service restart path previously had no way to emit a sentinel tied to a session context.

### Usage
- `openclaw gateway restart --notify`
- `openclaw gateway restart --notify --note "config/models change"`

If no main session is configured, `--notify` logs a warning and proceeds with the restart.

### Testing
- `pnpm build`
- `pnpm check`
- `pnpm test`

### AI assistance
AI-assisted / vibe-coded (OpenClaw) and manually reviewed.
