### PR TITLE
fix(sandbox): map workspace bind to host source under Docker gateway installs

### DIFF
--- a/src/agents/sandbox/docker.nested-mount-paths.test.ts
+++ b/src/agents/sandbox/docker.nested-mount-paths.test.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SandboxConfig } from "./types.js";
+
+const execDocker = vi.hoisted(() => vi.fn());
+const readRegistry = vi.hoisted(() => vi.fn(async () => ({ entries: [] })));
+const updateRegistry = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("./docker.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./docker.js")>();
+  return {
+    ...actual,
+    execDocker,
+  };
+});
+
+vi.mock("./registry.js", () => ({
+  readRegistry,
+  updateRegistry,
+}));
+
+describe("ensureSandboxContainer nested docker workspace bind source", () => {
+  const originalHostname = process.env.HOSTNAME;
+  const originalReadFile = fs.readFile;
+
+  beforeEach(() => {
+    vi.resetModules();
+    execDocker.mockReset();
+    readRegistry.mockReset();
+    updateRegistry.mockReset();
+    readRegistry.mockResolvedValue({ entries: [] });
+    updateRegistry.mockResolvedValue(undefined);
+    process.env.HOSTNAME = "gateway";
+  });
+
+  afterEach(() => {
+    process.env.HOSTNAME = originalHostname;
+    vi.restoreAllMocks();
+    (fs.readFile as unknown as typeof originalReadFile) = originalReadFile;
+  });
+
+  it("maps container workspace path to host bind source from mountinfo", async () => {
+    const mountLine =
+      "36 35 0:42 / /home/node/.openclaw/workspace rw,relatime - ext4 /DATA/openclaw/workspace rw";
+    vi.spyOn(fs, "readFile").mockImplementation(async (p: fs.PathLike, _enc?: BufferEncoding) => {
+      if (String(p) === "/proc/self/mountinfo") {
+        return mountLine;
+      }
+      throw new Error(`unexpected read: ${String(p)}`);
+    });
+
+    execDocker.mockImplementation(async (args: string[]) => {
+      if (args[0] === "image" && args[1] === "inspect") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "inspect" && args[1] === "-f") {
+        // readDockerContainerEnvVar for OPENCLAW_SANDBOX_HOST_WORKSPACE on current container
+        return { code: 1, stdout: "", stderr: "" };
+      }
+      if (args[0] === "inspect") {
+        return { code: 1, stdout: "", stderr: "" };
+      }
+      if (args[0] === "create") {
+        const mountArgIndex = args.indexOf("-v");
+        expect(mountArgIndex).toBeGreaterThan(0);
+        expect(args[mountArgIndex + 1]).toBe("/DATA/openclaw/workspace:/workspace");
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    const { ensureSandboxContainer } = await import("./docker.js");
+    const cfg: SandboxConfig = {
+      mode: "all",
+      scope: "shared",
+      workspaceAccess: "rw",
+      workspaceRoot: "/home/node/.openclaw/sandboxes",
+      docker: {
+        image: "openclaw-sandbox:bookworm-slim",
+        containerPrefix: "openclaw-sbx-",
+        workdir: "/workspace",
+        readOnlyRoot: true,
+        tmpfs: ["/tmp", "/var/tmp", "/run"],
+        network: "none",
+        capDrop: ["ALL"],
+        env: { LANG: "C.UTF-8" },
+      },
+      browser: {
+        enabled: false,
+        image: "openclaw-sandbox-browser:bookworm-slim",
+        containerPrefix: "openclaw-sbx-browser-",
+        network: "openclaw-sandbox-browser",
+        cdpPort: 9222,
+        vncPort: 5900,
+        noVncPort: 6080,
+        headless: false,
+        enableNoVnc: true,
+        allowHostControl: false,
+        autoStart: true,
+        autoStartTimeoutMs: 12_000,
+      },
+      tools: {},
+      prune: { idleHours: 24, maxAgeDays: 7 },
+    };
+
+    await ensureSandboxContainer({
+      sessionKey: "agent:main:main",
+      workspaceDir: "/home/node/.openclaw/workspace",
+      agentWorkspaceDir: "/home/node/.openclaw/workspace",
+      cfg,
+    });
+  });
+});

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { sanitizeEnvVars } from "./sanitize-env-vars.js";
 
@@ -391,6 +393,72 @@ function appendCustomBinds(args: string[], cfg: SandboxDockerConfig): void {
   }
 }
 
+function splitBindSpec(bind: string): { source: string; target: string } | null {
+  const trimmed = bind.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const first = trimmed.indexOf(":");
+  if (first <= 0) {
+    return null;
+  }
+  const second = trimmed.indexOf(":", first + 1);
+  const source = trimmed.slice(0, first).trim();
+  const target =
+    second === -1 ? trimmed.slice(first + 1).trim() : trimmed.slice(first + 1, second).trim();
+  if (!source || !target) {
+    return null;
+  }
+  return { source, target };
+}
+
+function isAbsoluteHostPath(input: string): boolean {
+  if (input.startsWith("/")) {
+    return true;
+  }
+  return /^[a-zA-Z]:[\\/]/.test(input);
+}
+
+async function resolveHostPathForNestedDockerMount(params: {
+  hostWorkspaceHint?: string;
+  containerWorkspacePath: string;
+  fallbackPath: string;
+}): Promise<string> {
+  const hint = params.hostWorkspaceHint?.trim();
+  if (hint && isAbsoluteHostPath(hint)) {
+    return path.resolve(hint);
+  }
+
+  try {
+    const mountJson = await fs.readFile("/proc/self/mountinfo", "utf8");
+    const containerPath = path.resolve(params.containerWorkspacePath);
+    for (const rawLine of mountJson.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line) {
+        continue;
+      }
+      const separator = line.indexOf(" - ");
+      if (separator === -1) {
+        continue;
+      }
+      const mountFields = line.slice(0, separator).split(" ");
+      const mountPoint = mountFields[4];
+      if (!mountPoint || path.resolve(mountPoint) !== containerPath) {
+        continue;
+      }
+      const sourceFields = line.slice(separator + 3).split(" ");
+      const source = sourceFields[1]?.trim();
+      if (source && isAbsoluteHostPath(source)) {
+        return path.resolve(source);
+      }
+    }
+  } catch {
+    // Best-effort fallback below.
+  }
+
+  return path.resolve(params.fallbackPath);
+}
+
 async function createSandboxContainer(params: {
   name: string;
   cfg: SandboxDockerConfig;
@@ -403,26 +471,56 @@ async function createSandboxContainer(params: {
   const { name, cfg, workspaceDir, scopeKey } = params;
   await ensureDockerImage(cfg.image);
 
+  const hostWorkspaceHint = await readDockerContainerEnvVar(
+    process.env.HOSTNAME ?? "",
+    "OPENCLAW_SANDBOX_HOST_WORKSPACE",
+  );
+  const workspaceMountSource = await resolveHostPathForNestedDockerMount({
+    hostWorkspaceHint,
+    containerWorkspacePath: workspaceDir,
+    fallbackPath: workspaceDir,
+  });
+  const hostAgentWorkspaceSource =
+    workspaceDir === params.agentWorkspaceDir
+      ? workspaceMountSource
+      : await resolveHostPathForNestedDockerMount({
+          hostWorkspaceHint: undefined,
+          containerWorkspacePath: params.agentWorkspaceDir,
+          fallbackPath: params.agentWorkspaceDir,
+        });
+
+  const bindSourceRoots = [workspaceMountSource, hostAgentWorkspaceSource];
   const args = buildSandboxCreateArgs({
     name,
     cfg,
     scopeKey,
     configHash: params.configHash,
     includeBinds: false,
-    bindSourceRoots: [workspaceDir, params.agentWorkspaceDir],
+    bindSourceRoots,
   });
   args.push("--workdir", cfg.workdir);
   const mainMountSuffix =
     params.workspaceAccess === "ro" && workspaceDir === params.agentWorkspaceDir ? ":ro" : "";
-  args.push("-v", `${workspaceDir}:${cfg.workdir}${mainMountSuffix}`);
+  args.push("-v", `${workspaceMountSource}:${cfg.workdir}${mainMountSuffix}`);
   if (params.workspaceAccess !== "none" && workspaceDir !== params.agentWorkspaceDir) {
     const agentMountSuffix = params.workspaceAccess === "ro" ? ":ro" : "";
     args.push(
       "-v",
-      `${params.agentWorkspaceDir}:${SANDBOX_AGENT_WORKSPACE_MOUNT}${agentMountSuffix}`,
+      `${hostAgentWorkspaceSource}:${SANDBOX_AGENT_WORKSPACE_MOUNT}${agentMountSuffix}`,
     );
   }
-  appendCustomBinds(args, cfg);
+
+  const remappedCustomBinds = (cfg.binds ?? []).map((bind) => {
+    const parsed = splitBindSpec(bind);
+    if (!parsed) {
+      return bind;
+    }
+    if (path.resolve(parsed.source) !== path.resolve(workspaceDir)) {
+      return bind;
+    }
+    return bind.replace(parsed.source, workspaceMountSource);
+  });
+  appendCustomBinds(args, { ...cfg, binds: remappedCustomBinds });
   args.push(cfg.image, "sleep", "infinity");
 
   await execDocker(args);


### PR DESCRIPTION
## Summary\nFixes sandbox workspace mounting when Gateway itself runs inside Docker (Docker-outside-of-Docker).\n\nPreviously, sandbox container creation always used the Gateway container path (for example ) as the bind source for  mounts. When Docker CLI talks to the host daemon via , the host cannot resolve that in-container path, so  effectively fails.\n\nThis change resolves the actual host source path before creating sandbox containers:\n- Prefer explicit hint env () when provided.\n- Otherwise read  to map container workspace mountpoint to its host source path.\n- Fall back to the original path when no mapping is available.\n\nThe resolved host source is then used for:\n- Primary workspace mount ( mount to sandbox workdir)\n- Agent workspace mount ()\n- Allowed bind-source roots validation\n- Remapping any custom bind whose source equals the container workspace path\n\nFixes #31331\n\n## Tests\n- Added  to verify that when mountinfo maps , sandbox create uses .\n- Ran:\n  - undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "vitest" not found\n  - undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "vitest" not found\n