### PR TITLE
fix(agents): forward disableMessageTool and requireExplicitMessageTarget to runEmbeddedAttempt

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -730,6 +730,8 @@ export async function runEmbeddedPiAgent(
             currentMessageId: params.currentMessageId,
             replyToMode: params.replyToMode,
             hasRepliedRef: params.hasRepliedRef,
+            requireExplicitMessageTarget: params.requireExplicitMessageTarget,
+            disableMessageTool: params.disableMessageTool,
             sessionFile: params.sessionFile,
             workspaceDir: resolvedWorkspace,
             agentDir,


### PR DESCRIPTION
## Summary

- Problem: `runEmbeddedPiAgent` (run.ts) explicitly lists every parameter for `runEmbeddedAttempt` but omits `disableMessageTool` and `requireExplicitMessageTarget`. Both fields exist in `RunEmbeddedPiAgentParams` and are consumed by `attempt.ts`, but the intermediate dispatcher silently drops them.
- Why it matters: Cron delivery runs set `disableMessageTool: true` to suppress the message tool during output delivery, but the flag never reaches the tool creation layer. Similarly, `requireExplicitMessageTarget` (used to prevent implicit last-route sends) is dropped, potentially allowing unintended message routing in Telegram forum topics and subagent contexts.
- What changed: Added two lines to forward `requireExplicitMessageTarget` and `disableMessageTool` from `params` to the `runEmbeddedAttempt` call object.
- What did NOT change: No changes to tool creation logic, policy resolution, message routing, or any other parameter forwarding.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31368

## User-visible / Behavior Changes

- Cron delivery runs now correctly suppress the message tool when `disableMessageTool` is set
- `requireExplicitMessageTarget` now propagates, preventing unintended implicit message sends in subagent and forum-topic contexts

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No — existing flags now correctly propagate`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js 22+

### Steps

1. Set up a cron job with delivery mode that sets `disableMessageTool: true`
2. Trigger the cron run
3. Observe that the message tool is now correctly absent from the agent's tool list

### Expected

- `disableMessageTool` flag reaches `attempt.ts` and suppresses the message tool

### Actual

- Before: flag is silently dropped by `run.ts`; message tool remains available
- After: flag is forwarded; message tool is correctly suppressed

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: parameter forwarding in `run.ts` matches `RunEmbeddedPiAgentParams` definition and `attempt.ts` consumption
- Edge cases checked: undefined values (no change in behavior — `undefined` is falsy, so `disableMessageTool: undefined` still creates the tool)
- What you did **not** verify: end-to-end Telegram forum topic test with actual bot

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/pi-embedded-runner/run.ts`

## Risks and Mitigations

- Risk: Cron runs that previously had the message tool available (due to the dropped flag) will now correctly suppress it
  - Mitigation: This is the intended behavior; the flag was always meant to be forwarded

