### PR TITLE
fix: preserve core route precedence for plugin webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/Plugins: allow explicit webhook plugin routes to bypass the root Control UI SPA fallback without restoring generic plugin handler precedence, fixing BlueBubbles, Google Chat, and Zalo root-path webhooks after `2026.3.1`.
 - CLI/Config validation: add `openclaw config validate` (with `--json`) to validate config files before gateway startup, and include detailed invalid-key paths in startup invalid-config errors. (#31220) thanks @Sid-Qin.
 - Sessions/Attachments: add inline file attachment support for `sessions_spawn` (subagent runtime only) with base64/utf8 encoding, transcript content redaction, lifecycle cleanup, and configurable limits via `tools.sessions_spawn.attachments`. (#16761) Thanks @napetrov.
 - Agents/Thinking defaults: set `adaptive` as the default thinking level for Anthropic Claude 4.6 models (including Bedrock Claude 4.6 refs) while keeping other reasoning-capable models at `low` unless explicitly configured.

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -417,6 +417,34 @@ describe("BlueBubbles webhook monitor", () => {
     );
   });
 
+  it("does not activate a webhook target when the path conflicts with a core route", async () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+
+    unregister = registerBlueBubblesWebhookTarget({
+      account: createMockAccount(),
+      config: {} as OpenClawConfig,
+      runtime: {},
+      core: createMockRuntime(),
+      path: "/chat",
+    });
+
+    expect(registry.httpRoutes).toHaveLength(0);
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        pluginId: "bluebubbles",
+        message: "http webhook route conflicts with core path: /chat",
+      }),
+    );
+
+    const req = createMockRequest("POST", "/chat", {});
+    const res = createMockResponse();
+    const handled = await handleBlueBubblesWebhookRequest(req, res);
+
+    expect(handled).toBe(false);
+  });
+
   describe("webhook parsing + auth handling", () => {
     it("rejects non-POST requests", async () => {
       const account = createMockAccount();

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -417,18 +417,19 @@ describe("BlueBubbles webhook monitor", () => {
     );
   });
 
-  it("does not activate a webhook target when the path conflicts with a core route", async () => {
+  it("rejects a webhook target when the path conflicts with a core route", () => {
     const registry = createEmptyPluginRegistry();
     setActivePluginRegistry(registry);
 
-    unregister = registerBlueBubblesWebhookTarget({
-      account: createMockAccount(),
-      config: {} as OpenClawConfig,
-      runtime: {},
-      core: createMockRuntime(),
-      path: "/chat",
-    });
-
+    expect(() => {
+      unregister = registerBlueBubblesWebhookTarget({
+        account: createMockAccount(),
+        config: {} as OpenClawConfig,
+        runtime: {},
+        core: createMockRuntime(),
+        path: "/chat",
+      });
+    }).toThrow("Failed to register HTTP route: /chat");
     expect(registry.httpRoutes).toHaveLength(0);
     expect(registry.diagnostics).toContainEqual(
       expect.objectContaining({
@@ -437,12 +438,6 @@ describe("BlueBubbles webhook monitor", () => {
         message: "http webhook route conflicts with core path: /chat",
       }),
     );
-
-    const req = createMockRequest("POST", "/chat", {});
-    const res = createMockResponse();
-    const handled = await handleBlueBubblesWebhookRequest(req, res);
-
-    expect(handled).toBe(false);
   });
 
   describe("webhook parsing + auth handling", () => {

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -3,6 +3,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk";
 import { removeAckReactionAfterReply, shouldAckReaction } from "openclaw/plugin-sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../../../src/plugins/registry.js";
+import { setActivePluginRegistry } from "../../../src/plugins/runtime.js";
 import type { ResolvedBlueBubblesAccount } from "./accounts.js";
 import { fetchBlueBubblesHistory } from "./history.js";
 import {
@@ -392,6 +394,27 @@ describe("BlueBubbles webhook monitor", () => {
 
   afterEach(() => {
     unregister?.();
+  });
+
+  it("registers an exact webhook route while the target is active", () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+
+    unregister = registerBlueBubblesWebhookTarget({
+      account: createMockAccount(),
+      config: {} as OpenClawConfig,
+      runtime: {},
+      core: createMockRuntime(),
+      path: "/bluebubbles-webhook",
+    });
+
+    expect(registry.httpRoutes).toContainEqual(
+      expect.objectContaining({
+        pluginId: "bluebubbles",
+        path: "/bluebubbles-webhook",
+        kind: "webhook",
+      }),
+    );
   });
 
   describe("webhook parsing + auth handling", () => {

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import {
   isRequestBodyLimitError,
   readRequestBodyWithLimit,
-  registerPluginHttpRoute,
+  registerPluginWebhookRoute,
   registerWebhookTarget,
   rejectNonPostWebhookRequest,
   requestBodyErrorToText,
@@ -236,7 +236,7 @@ function removeDebouncer(target: WebhookTarget): void {
 }
 
 export function registerBlueBubblesWebhookTarget(target: WebhookTarget): () => void {
-  const unregisterHttpRoute = registerPluginHttpRoute({
+  const registration = registerPluginWebhookRoute({
     path: target.path,
     handler: async (req, res) => {
       const handled = await handleBlueBubblesWebhookRequest(req, res);
@@ -247,13 +247,15 @@ export function registerBlueBubblesWebhookTarget(target: WebhookTarget): () => v
       }
     },
     pluginId: "bluebubbles",
-    kind: "webhook",
     accountId: target.account.accountId,
     log: target.runtime.log,
   });
+  if (!registration.ok) {
+    return registration.unregister;
+  }
   const registered = registerWebhookTarget(webhookTargets, target);
   return () => {
-    unregisterHttpRoute();
+    registration.unregister();
     registered.unregister();
     // Clean up debouncer when target is unregistered
     removeDebouncer(registered.target);

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -251,7 +251,7 @@ export function registerBlueBubblesWebhookTarget(target: WebhookTarget): () => v
     log: target.runtime.log,
   });
   if (!registration.ok) {
-    return registration.unregister;
+    throw new Error(`Failed to register HTTP route: ${target.path}`);
   }
   const registered = registerWebhookTarget(webhookTargets, target);
   return () => {

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import {
   isRequestBodyLimitError,
   readRequestBodyWithLimit,
+  registerPluginHttpRoute,
   registerWebhookTarget,
   rejectNonPostWebhookRequest,
   requestBodyErrorToText,
@@ -235,8 +236,24 @@ function removeDebouncer(target: WebhookTarget): void {
 }
 
 export function registerBlueBubblesWebhookTarget(target: WebhookTarget): () => void {
+  const unregisterHttpRoute = registerPluginHttpRoute({
+    path: target.path,
+    handler: async (req, res) => {
+      const handled = await handleBlueBubblesWebhookRequest(req, res);
+      if (!handled && !res.headersSent) {
+        res.statusCode = 404;
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        res.end("Not Found");
+      }
+    },
+    pluginId: "bluebubbles",
+    kind: "webhook",
+    accountId: target.account.accountId,
+    log: target.runtime.log,
+  });
   const registered = registerWebhookTarget(webhookTargets, target);
   return () => {
+    unregisterHttpRoute();
     registered.unregister();
     // Clean up debouncer when target is unregistered
     removeDebouncer(registered.target);

--- a/extensions/googlechat/src/channel.startup.test.ts
+++ b/extensions/googlechat/src/channel.startup.test.ts
@@ -99,4 +99,29 @@ describe("googlechatPlugin gateway.startAccount", () => {
     expect(patches.some((entry) => entry.running === true)).toBe(true);
     expect(patches.some((entry) => entry.running === false)).toBe(true);
   });
+
+  it("propagates monitor startup failures", async () => {
+    hoisted.startGoogleChatMonitor.mockRejectedValue(
+      new Error("Failed to register HTTP route: /chat"),
+    );
+
+    const account: ResolvedGoogleChatAccount = {
+      accountId: "default",
+      enabled: true,
+      credentialSource: "inline",
+      credentials: {},
+      config: {
+        webhookPath: "/chat",
+      },
+    };
+
+    await expect(
+      googlechatPlugin.gateway!.startAccount!(
+        createStartAccountCtx({
+          account,
+          abortSignal: new AbortController().signal,
+        }),
+      ),
+    ).rejects.toThrow("Failed to register HTTP route: /chat");
+  });
 });

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -5,7 +5,7 @@ import {
   createScopedPairingAccess,
   createReplyPrefixOptions,
   readJsonBodyWithLimit,
-  registerPluginHttpRoute,
+  registerPluginWebhookRoute,
   registerWebhookTarget,
   rejectNonPostWebhookRequest,
   isDangerousNameMatchingEnabled,
@@ -100,7 +100,7 @@ function warnDeprecatedUsersEmailEntries(
 }
 
 export function registerGoogleChatWebhookTarget(target: WebhookTarget): () => void {
-  const unregisterHttpRoute = registerPluginHttpRoute({
+  const registration = registerPluginWebhookRoute({
     path: target.path,
     handler: async (req, res) => {
       const handled = await handleGoogleChatWebhookRequest(req, res);
@@ -111,13 +111,15 @@ export function registerGoogleChatWebhookTarget(target: WebhookTarget): () => vo
       }
     },
     pluginId: "googlechat",
-    kind: "webhook",
     accountId: target.account.accountId,
     log: target.runtime.log,
   });
+  if (!registration.ok) {
+    return registration.unregister;
+  }
   const registered = registerWebhookTarget(webhookTargets, target);
   return () => {
-    unregisterHttpRoute();
+    registration.unregister();
     registered.unregister();
   };
 }

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -115,7 +115,7 @@ export function registerGoogleChatWebhookTarget(target: WebhookTarget): () => vo
     log: target.runtime.log,
   });
   if (!registration.ok) {
-    return registration.unregister;
+    throw new Error(`Failed to register HTTP route: ${target.path}`);
   }
   const registered = registerWebhookTarget(webhookTargets, target);
   return () => {

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -5,6 +5,7 @@ import {
   createScopedPairingAccess,
   createReplyPrefixOptions,
   readJsonBodyWithLimit,
+  registerPluginHttpRoute,
   registerWebhookTarget,
   rejectNonPostWebhookRequest,
   isDangerousNameMatchingEnabled,
@@ -99,7 +100,26 @@ function warnDeprecatedUsersEmailEntries(
 }
 
 export function registerGoogleChatWebhookTarget(target: WebhookTarget): () => void {
-  return registerWebhookTarget(webhookTargets, target).unregister;
+  const unregisterHttpRoute = registerPluginHttpRoute({
+    path: target.path,
+    handler: async (req, res) => {
+      const handled = await handleGoogleChatWebhookRequest(req, res);
+      if (!handled && !res.headersSent) {
+        res.statusCode = 404;
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        res.end("Not Found");
+      }
+    },
+    pluginId: "googlechat",
+    kind: "webhook",
+    accountId: target.account.accountId,
+    log: target.runtime.log,
+  });
+  const registered = registerWebhookTarget(webhookTargets, target);
+  return () => {
+    unregisterHttpRoute();
+    registered.unregister();
+  };
 }
 
 function normalizeAudienceType(value?: string | null): GoogleChatAudienceType | undefined {

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -166,43 +166,29 @@ describe("Google Chat webhook routing", () => {
     }
   });
 
-  it("does not activate a webhook target when the path conflicts with a core route", async () => {
+  it("rejects a webhook target when the path conflicts with a core route", () => {
     const registry = createEmptyPluginRegistry();
     setActivePluginRegistry(registry);
 
-    const unregister = registerGoogleChatWebhookTarget({
-      account: baseAccount("A"),
-      config: {} as OpenClawConfig,
-      runtime: {},
-      core: {} as PluginRuntime,
-      path: "/chat",
-      statusSink: vi.fn(),
-      mediaMaxMb: 5,
-    });
+    expect(() =>
+      registerGoogleChatWebhookTarget({
+        account: baseAccount("A"),
+        config: {} as OpenClawConfig,
+        runtime: {},
+        core: {} as PluginRuntime,
+        path: "/chat",
+        statusSink: vi.fn(),
+        mediaMaxMb: 5,
+      }),
+    ).toThrow("Failed to register HTTP route: /chat");
 
-    try {
-      expect(registry.httpRoutes).toHaveLength(0);
-      expect(registry.diagnostics).toContainEqual(
-        expect.objectContaining({
-          level: "error",
-          pluginId: "googlechat",
-          message: "http webhook route conflicts with core path: /chat",
-        }),
-      );
-
-      const res = createMockServerResponse();
-      const handled = await handleGoogleChatWebhookRequest(
-        createWebhookRequest({
-          authorization: "Bearer test-token",
-          path: "/chat",
-          payload: { type: "ADDED_TO_SPACE", space: { name: "spaces/AAA" } },
-        }),
-        res,
-      );
-
-      expect(handled).toBe(false);
-    } finally {
-      unregister();
-    }
+    expect(registry.httpRoutes).toHaveLength(0);
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        pluginId: "googlechat",
+        message: "http webhook route conflicts with core path: /chat",
+      }),
+    );
   });
 });

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -165,4 +165,44 @@ describe("Google Chat webhook routing", () => {
       expect(registry.httpRoutes).toHaveLength(0);
     }
   });
+
+  it("does not activate a webhook target when the path conflicts with a core route", async () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+
+    const unregister = registerGoogleChatWebhookTarget({
+      account: baseAccount("A"),
+      config: {} as OpenClawConfig,
+      runtime: {},
+      core: {} as PluginRuntime,
+      path: "/chat",
+      statusSink: vi.fn(),
+      mediaMaxMb: 5,
+    });
+
+    try {
+      expect(registry.httpRoutes).toHaveLength(0);
+      expect(registry.diagnostics).toContainEqual(
+        expect.objectContaining({
+          level: "error",
+          pluginId: "googlechat",
+          message: "http webhook route conflicts with core path: /chat",
+        }),
+      );
+
+      const res = createMockServerResponse();
+      const handled = await handleGoogleChatWebhookRequest(
+        createWebhookRequest({
+          authorization: "Bearer test-token",
+          path: "/chat",
+          payload: { type: "ADDED_TO_SPACE", space: { name: "spaces/AAA" } },
+        }),
+        res,
+      );
+
+      expect(handled).toBe(false);
+    } finally {
+      unregister();
+    }
+  });
 });

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -2,6 +2,8 @@ import { EventEmitter } from "node:events";
 import type { IncomingMessage } from "node:http";
 import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk";
 import { describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../../../src/plugins/registry.js";
+import { setActivePluginRegistry } from "../../../src/plugins/runtime.js";
 import { createMockServerResponse } from "../../../src/test-utils/mock-http-response.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import { verifyGoogleChatRequest } from "./auth.js";
@@ -133,6 +135,34 @@ describe("Google Chat webhook routing", () => {
       expect(sinkB).toHaveBeenCalledTimes(1);
     } finally {
       unregister();
+    }
+  });
+
+  it("registers an exact webhook route while the target is active", () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+
+    const unregister = registerGoogleChatWebhookTarget({
+      account: baseAccount("A"),
+      config: {} as OpenClawConfig,
+      runtime: {},
+      core: {} as PluginRuntime,
+      path: "/googlechat",
+      statusSink: vi.fn(),
+      mediaMaxMb: 5,
+    });
+
+    try {
+      expect(registry.httpRoutes).toContainEqual(
+        expect.objectContaining({
+          pluginId: "googlechat",
+          path: "/googlechat",
+          kind: "webhook",
+        }),
+      );
+    } finally {
+      unregister();
+      expect(registry.httpRoutes).toHaveLength(0);
     }
   });
 });

--- a/extensions/synology-chat/src/channel.integration.test.ts
+++ b/extensions/synology-chat/src/channel.integration.test.ts
@@ -8,13 +8,15 @@ type RegisteredRoute = {
   handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>;
 };
 
-const registerPluginHttpRouteMock = vi.fn<(params: RegisteredRoute) => () => void>(() => vi.fn());
+const tryRegisterPluginHttpRouteMock = vi.fn<
+  (params: RegisteredRoute) => { ok: boolean; unregister: () => void }
+>(() => ({ ok: true, unregister: vi.fn() }));
 const dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockResolvedValue({ counts: {} });
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
   setAccountEnabledInConfigSection: vi.fn((_opts: any) => ({})),
-  registerPluginHttpRoute: registerPluginHttpRouteMock,
+  tryRegisterPluginHttpRoute: tryRegisterPluginHttpRouteMock,
   buildChannelConfigSchema: vi.fn((schema: any) => ({ schema })),
   createFixedWindowRateLimiter: vi.fn(() => ({
     isRateLimited: vi.fn(() => false),
@@ -74,7 +76,7 @@ function makeFormBody(fields: Record<string, string>): string {
 
 describe("Synology channel wiring integration", () => {
   beforeEach(() => {
-    registerPluginHttpRouteMock.mockClear();
+    tryRegisterPluginHttpRouteMock.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
   });
 
@@ -103,11 +105,11 @@ describe("Synology channel wiring integration", () => {
     };
 
     const started = await plugin.gateway.startAccount(ctx);
-    expect(registerPluginHttpRouteMock).toHaveBeenCalledTimes(1);
+    expect(tryRegisterPluginHttpRouteMock).toHaveBeenCalledTimes(1);
 
-    const firstCall = registerPluginHttpRouteMock.mock.calls[0];
+    const firstCall = tryRegisterPluginHttpRouteMock.mock.calls[0];
     expect(firstCall).toBeTruthy();
-    if (!firstCall) throw new Error("Expected registerPluginHttpRoute to be called");
+    if (!firstCall) throw new Error("Expected tryRegisterPluginHttpRoute to be called");
     const registered = firstCall[0];
     expect(registered.path).toBe("/webhook/synology-alerts");
     expect(registered.accountId).toBe("alerts");
@@ -130,5 +132,36 @@ describe("Synology channel wiring integration", () => {
     expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
 
     started.stop();
+  });
+
+  it("fails closed when route registration is rejected", async () => {
+    tryRegisterPluginHttpRouteMock.mockReturnValueOnce({ ok: false, unregister: vi.fn() });
+
+    const plugin = createSynologyChatPlugin();
+    const ctx = {
+      cfg: {
+        channels: {
+          "synology-chat": {
+            enabled: true,
+            accounts: {
+              alerts: {
+                enabled: true,
+                token: "valid-token",
+                incomingUrl: "https://nas.example.com/incoming",
+                webhookPath: "/webhook/synology-alerts",
+                dmPolicy: "allowlist",
+                allowedUserIds: ["456"],
+              },
+            },
+          },
+        },
+      },
+      accountId: "alerts",
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    };
+
+    await expect(plugin.gateway.startAccount(ctx)).rejects.toThrow(
+      "Failed to register HTTP route: /webhook/synology-alerts",
+    );
   });
 });

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
   setAccountEnabledInConfigSection: vi.fn((_opts: any) => ({})),
-  registerPluginHttpRoute: vi.fn(() => vi.fn()),
+  tryRegisterPluginHttpRoute: vi.fn(() => ({ ok: true, unregister: vi.fn() })),
   buildChannelConfigSchema: vi.fn((schema: any) => ({ schema })),
   createFixedWindowRateLimiter: vi.fn(() => ({
     isRateLimited: vi.fn(() => false),
@@ -44,7 +44,7 @@ vi.mock("zod", () => ({
 }));
 
 const { createSynologyChatPlugin } = await import("./channel.js");
-const { registerPluginHttpRoute } = await import("openclaw/plugin-sdk");
+const { tryRegisterPluginHttpRoute } = await import("openclaw/plugin-sdk");
 
 describe("createSynologyChatPlugin", () => {
   it("returns a plugin object with all required sections", () => {
@@ -363,7 +363,7 @@ describe("createSynologyChatPlugin", () => {
     });
 
     it("startAccount refuses allowlist accounts with empty allowedUserIds", async () => {
-      const registerMock = vi.mocked(registerPluginHttpRoute);
+      const registerMock = vi.mocked(tryRegisterPluginHttpRoute);
       registerMock.mockClear();
 
       const plugin = createSynologyChatPlugin();
@@ -392,8 +392,10 @@ describe("createSynologyChatPlugin", () => {
     it("deregisters stale route before re-registering same account/path", async () => {
       const unregisterFirst = vi.fn();
       const unregisterSecond = vi.fn();
-      const registerMock = vi.mocked(registerPluginHttpRoute);
-      registerMock.mockReturnValueOnce(unregisterFirst).mockReturnValueOnce(unregisterSecond);
+      const registerMock = vi.mocked(tryRegisterPluginHttpRoute);
+      registerMock
+        .mockReturnValueOnce({ ok: true, unregister: unregisterFirst })
+        .mockReturnValueOnce({ ok: true, unregister: unregisterSecond });
 
       const plugin = createSynologyChatPlugin();
       const ctx = {

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -7,7 +7,7 @@
 import {
   DEFAULT_ACCOUNT_ID,
   setAccountEnabledInConfigSection,
-  registerPluginHttpRoute,
+  tryRegisterPluginHttpRoute,
   buildChannelConfigSchema,
 } from "openclaw/plugin-sdk";
 import { z } from "zod";
@@ -293,13 +293,17 @@ export function createSynologyChatPlugin() {
           activeRouteUnregisters.delete(routeKey);
         }
 
-        const unregister = registerPluginHttpRoute({
+        const routeRegistration = tryRegisterPluginHttpRoute({
           path: account.webhookPath,
           pluginId: CHANNEL_ID,
           accountId: account.accountId,
           log: (msg: string) => log?.info?.(msg),
           handler,
         });
+        if (!routeRegistration.ok) {
+          throw new Error(`Failed to register HTTP route: ${account.webhookPath}`);
+        }
+        const unregister = routeRegistration.unregister;
         activeRouteUnregisters.set(routeKey, unregister);
 
         log?.info?.(`Registered HTTP route: ${account.webhookPath} for Synology Chat`);

--- a/extensions/zalo/src/monitor.provider.test.ts
+++ b/extensions/zalo/src/monitor.provider.test.ts
@@ -1,0 +1,108 @@
+import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedZaloAccount } from "./accounts.js";
+
+const hoisted = vi.hoisted(() => ({
+  deleteWebhook: vi.fn(),
+  registerPluginWebhookRoute: vi.fn(),
+  setWebhook: vi.fn(),
+  unregister: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk")>("openclaw/plugin-sdk");
+  return {
+    ...actual,
+    registerPluginWebhookRoute: hoisted.registerPluginWebhookRoute,
+  };
+});
+
+vi.mock("./api.js", async () => {
+  const actual = await vi.importActual<typeof import("./api.js")>("./api.js");
+  return {
+    ...actual,
+    deleteWebhook: hoisted.deleteWebhook,
+    setWebhook: hoisted.setWebhook,
+  };
+});
+
+import { monitorZaloProvider } from "./monitor.js";
+import { setZaloRuntime } from "./runtime.js";
+
+const DEFAULT_ACCOUNT: ResolvedZaloAccount = {
+  accountId: "default",
+  enabled: true,
+  token: "tok",
+  tokenSource: "config",
+  config: {
+    webhookUrl: "https://example.com/zalo",
+    webhookSecret: "supersecret",
+    webhookPath: "/zalo-hook",
+  },
+};
+
+describe("monitorZaloProvider webhook startup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setZaloRuntime({
+      logging: { shouldLogVerbose: () => false },
+    } as PluginRuntime);
+    hoisted.unregister.mockReset();
+    hoisted.registerPluginWebhookRoute.mockReturnValue({
+      ok: true,
+      unregister: hoisted.unregister,
+    });
+    hoisted.setWebhook.mockResolvedValue({ ok: true });
+    hoisted.deleteWebhook.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fails before setting the remote webhook when local route registration is rejected", async () => {
+    hoisted.registerPluginWebhookRoute.mockReturnValueOnce({
+      ok: false,
+      unregister: hoisted.unregister,
+    });
+
+    await expect(
+      monitorZaloProvider({
+        token: DEFAULT_ACCOUNT.token,
+        account: DEFAULT_ACCOUNT,
+        config: {} as OpenClawConfig,
+        runtime: {},
+        abortSignal: new AbortController().signal,
+        useWebhook: true,
+        webhookUrl: DEFAULT_ACCOUNT.config.webhookUrl,
+        webhookSecret: DEFAULT_ACCOUNT.config.webhookSecret,
+        webhookPath: DEFAULT_ACCOUNT.config.webhookPath,
+        fetcher: vi.fn(),
+      }),
+    ).rejects.toThrow("Failed to register HTTP route: /zalo-hook");
+
+    expect(hoisted.setWebhook).not.toHaveBeenCalled();
+    expect(hoisted.unregister).not.toHaveBeenCalled();
+  });
+
+  it("unregisters the local route when remote webhook setup fails", async () => {
+    hoisted.setWebhook.mockRejectedValueOnce(new Error("setWebhook failed"));
+
+    await expect(
+      monitorZaloProvider({
+        token: DEFAULT_ACCOUNT.token,
+        account: DEFAULT_ACCOUNT,
+        config: {} as OpenClawConfig,
+        runtime: {},
+        abortSignal: new AbortController().signal,
+        useWebhook: true,
+        webhookUrl: DEFAULT_ACCOUNT.config.webhookUrl,
+        webhookSecret: DEFAULT_ACCOUNT.config.webhookSecret,
+        webhookPath: DEFAULT_ACCOUNT.config.webhookPath,
+        fetcher: vi.fn(),
+      }),
+    ).rejects.toThrow("setWebhook failed");
+
+    expect(hoisted.unregister).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -89,7 +89,7 @@ export function registerZaloWebhookTarget(target: ZaloWebhookTarget): () => void
     log: target.runtime.log,
   });
   if (!registration.ok) {
-    return registration.unregister;
+    throw new Error(`Failed to register HTTP route: ${target.path}`);
   }
   const unregisterWebhookTarget = registerZaloWebhookTargetInternal(target);
   return () => {
@@ -657,8 +657,6 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
       throw new Error("Zalo webhookPath could not be derived");
     }
 
-    await setWebhook(token, { url: webhookUrl, secret_token: webhookSecret }, fetcher);
-
     const unregister = registerZaloWebhookTarget({
       token,
       account,
@@ -671,6 +669,12 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
       mediaMaxMb: effectiveMediaMaxMb,
       fetcher,
     });
+    try {
+      await setWebhook(token, { url: webhookUrl, secret_token: webhookSecret }, fetcher);
+    } catch (error) {
+      unregister();
+      throw error;
+    }
     stopHandlers.push(unregister);
     abortSignal.addEventListener(
       "abort",

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -3,7 +3,7 @@ import type { MarkdownTableMode, OpenClawConfig, OutboundReplyPayload } from "op
 import {
   createScopedPairingAccess,
   createReplyPrefixOptions,
-  registerPluginHttpRoute,
+  registerPluginWebhookRoute,
   resolveSenderCommandAuthorization,
   resolveOutboundMediaUrls,
   resolveDefaultGroupPolicy,
@@ -74,7 +74,7 @@ function logVerbose(core: ZaloCoreRuntime, runtime: ZaloRuntimeEnv, message: str
 }
 
 export function registerZaloWebhookTarget(target: ZaloWebhookTarget): () => void {
-  const unregisterHttpRoute = registerPluginHttpRoute({
+  const registration = registerPluginWebhookRoute({
     path: target.path,
     handler: async (req, res) => {
       const handled = await handleZaloWebhookRequest(req, res);
@@ -85,13 +85,15 @@ export function registerZaloWebhookTarget(target: ZaloWebhookTarget): () => void
       }
     },
     pluginId: "zalo",
-    kind: "webhook",
     accountId: target.account.accountId,
     log: target.runtime.log,
   });
+  if (!registration.ok) {
+    return registration.unregister;
+  }
   const unregisterWebhookTarget = registerZaloWebhookTargetInternal(target);
   return () => {
-    unregisterHttpRoute();
+    registration.unregister();
     unregisterWebhookTarget();
   };
 }

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -3,6 +3,7 @@ import type { MarkdownTableMode, OpenClawConfig, OutboundReplyPayload } from "op
 import {
   createScopedPairingAccess,
   createReplyPrefixOptions,
+  registerPluginHttpRoute,
   resolveSenderCommandAuthorization,
   resolveOutboundMediaUrls,
   resolveDefaultGroupPolicy,
@@ -73,7 +74,26 @@ function logVerbose(core: ZaloCoreRuntime, runtime: ZaloRuntimeEnv, message: str
 }
 
 export function registerZaloWebhookTarget(target: ZaloWebhookTarget): () => void {
-  return registerZaloWebhookTargetInternal(target);
+  const unregisterHttpRoute = registerPluginHttpRoute({
+    path: target.path,
+    handler: async (req, res) => {
+      const handled = await handleZaloWebhookRequest(req, res);
+      if (!handled && !res.headersSent) {
+        res.statusCode = 404;
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        res.end("Not Found");
+      }
+    },
+    pluginId: "zalo",
+    kind: "webhook",
+    accountId: target.account.accountId,
+    log: target.runtime.log,
+  });
+  const unregisterWebhookTarget = registerZaloWebhookTargetInternal(target);
+  return () => {
+    unregisterHttpRoute();
+    unregisterWebhookTarget();
+  };
 }
 
 export {

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -87,37 +87,19 @@ describe("handleZaloWebhookRequest", () => {
     }
   });
 
-  it("does not activate a webhook target when the path conflicts with a core route", async () => {
+  it("rejects a webhook target when the path conflicts with a core route", () => {
     const registry = createEmptyPluginRegistry();
     setActivePluginRegistry(registry);
-    const unregister = registerTarget({ path: "/chat" });
 
-    try {
-      expect(registry.httpRoutes).toHaveLength(0);
-      expect(registry.diagnostics).toContainEqual(
-        expect.objectContaining({
-          level: "error",
-          pluginId: "zalo",
-          message: "http webhook route conflicts with core path: /chat",
-        }),
-      );
-
-      await withServer(webhookRequestHandler, async (baseUrl) => {
-        const response = await fetch(`${baseUrl}/chat`, {
-          method: "POST",
-          headers: {
-            "x-bot-api-secret-token": "secret",
-            "content-type": "application/json",
-          },
-          body: "{}",
-        });
-
-        expect(response.status).toBe(404);
-        expect(await response.text()).toBe("not found");
-      });
-    } finally {
-      unregister();
-    }
+    expect(() => registerTarget({ path: "/chat" })).toThrow("Failed to register HTTP route: /chat");
+    expect(registry.httpRoutes).toHaveLength(0);
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        pluginId: "zalo",
+        message: "http webhook route conflicts with core path: /chat",
+      }),
+    );
   });
 
   it("returns 400 for non-object payloads", async () => {

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -87,6 +87,39 @@ describe("handleZaloWebhookRequest", () => {
     }
   });
 
+  it("does not activate a webhook target when the path conflicts with a core route", async () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+    const unregister = registerTarget({ path: "/chat" });
+
+    try {
+      expect(registry.httpRoutes).toHaveLength(0);
+      expect(registry.diagnostics).toContainEqual(
+        expect.objectContaining({
+          level: "error",
+          pluginId: "zalo",
+          message: "http webhook route conflicts with core path: /chat",
+        }),
+      );
+
+      await withServer(webhookRequestHandler, async (baseUrl) => {
+        const response = await fetch(`${baseUrl}/chat`, {
+          method: "POST",
+          headers: {
+            "x-bot-api-secret-token": "secret",
+            "content-type": "application/json",
+          },
+          body: "{}",
+        });
+
+        expect(response.status).toBe(404);
+        expect(await response.text()).toBe("not found");
+      });
+    } finally {
+      unregister();
+    }
+  });
+
   it("returns 400 for non-object payloads", async () => {
     const unregister = registerTarget({ path: "/hook" });
 

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -2,6 +2,8 @@ import { createServer, type RequestListener } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../../../src/plugins/registry.js";
+import { setActivePluginRegistry } from "../../../src/plugins/runtime.js";
 import {
   clearZaloWebhookSecurityStateForTest,
   getZaloWebhookRateLimitStateSizeForTest,
@@ -64,6 +66,25 @@ function registerTarget(params: {
 describe("handleZaloWebhookRequest", () => {
   afterEach(() => {
     clearZaloWebhookSecurityStateForTest();
+  });
+
+  it("registers an exact webhook route while the target is active", () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+    const unregister = registerTarget({ path: "/hook" });
+
+    try {
+      expect(registry.httpRoutes).toContainEqual(
+        expect.objectContaining({
+          pluginId: "zalo",
+          path: "/hook",
+          kind: "webhook",
+        }),
+      );
+    } finally {
+      unregister();
+      expect(registry.httpRoutes).toHaveLength(0);
+    }
   });
 
   it("returns 400 for non-object payloads", async () => {

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -45,6 +45,7 @@ describe("handleControlUiHttpRequest", () => {
     method: "GET" | "HEAD" | "POST";
     rootPath: string;
     basePath?: string;
+    shouldBypassSpaForPath?: (requestPath: string) => boolean;
   }) {
     const { res, end } = makeMockHttpResponse();
     const handled = handleControlUiHttpRequest(
@@ -52,6 +53,9 @@ describe("handleControlUiHttpRequest", () => {
       res,
       {
         ...(params.basePath ? { basePath: params.basePath } : {}),
+        ...(params.shouldBypassSpaForPath
+          ? { shouldBypassSpaForPath: params.shouldBypassSpaForPath }
+          : {}),
         root: { kind: "resolved", path: params.rootPath },
       },
     );
@@ -352,6 +356,35 @@ describe("handleControlUiHttpRequest", () => {
           });
           expect(handled, `expected ${pluginPath} to not be handled`).toBe(false);
         }
+      },
+    });
+  });
+
+  it("falls through exact webhook routes that explicitly bypass the root spa", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { handled } = runControlUiRequest({
+          url: "/bluebubbles-webhook",
+          method: "GET",
+          rootPath: tmp,
+          shouldBypassSpaForPath: (requestPath) => requestPath === "/bluebubbles-webhook",
+        });
+        expect(handled).toBe(false);
+      },
+    });
+  });
+
+  it("still handles control ui routes when only webhook paths are bypassed", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { handled, res } = runControlUiRequest({
+          url: "/chat",
+          method: "GET",
+          rootPath: tmp,
+          shouldBypassSpaForPath: (requestPath) => requestPath === "/bluebubbles-webhook",
+        });
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -27,6 +27,7 @@ export type ControlUiRequestOptions = {
   config?: OpenClawConfig;
   agentId?: string;
   root?: ControlUiRootState;
+  shouldBypassSpaForPath?: (requestPath: string) => boolean;
 };
 
 export type ControlUiRootState =
@@ -291,6 +292,9 @@ export function handleControlUiHttpRequest(
       return false;
     }
     if (pathname === "/api" || pathname.startsWith("/api/")) {
+      return false;
+    }
+    if (opts?.shouldBypassSpaForPath?.(pathname)) {
       return false;
     }
   }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -371,6 +371,7 @@ export function createGatewayHttpServer(opts: {
   strictTransportSecurityHeader?: string;
   handleHooksRequest: HooksRequestHandler;
   handlePluginRequest?: HooksRequestHandler;
+  shouldBypassControlUiSpaForPath?: (requestPath: string) => boolean;
   shouldEnforcePluginGatewayAuth?: (requestPath: string) => boolean;
   resolvedAuth: ResolvedGatewayAuth;
   /** Optional rate limiter for auth brute-force protection. */
@@ -389,6 +390,7 @@ export function createGatewayHttpServer(opts: {
     strictTransportSecurityHeader,
     handleHooksRequest,
     handlePluginRequest,
+    shouldBypassControlUiSpaForPath,
     shouldEnforcePluginGatewayAuth,
     resolvedAuth,
     rateLimiter,
@@ -503,6 +505,7 @@ export function createGatewayHttpServer(opts: {
             basePath: controlUiBasePath,
             config: configSnapshot,
             root: controlUiRoot,
+            shouldBypassSpaForPath: shouldBypassControlUiSpaForPath,
           })
         ) {
           return;

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -29,6 +29,7 @@ import { createGatewayHooksRequestHandler } from "./server/hooks.js";
 import { listenGatewayHttpServer } from "./server/http-listen.js";
 import {
   createGatewayPluginRequestHandler,
+  shouldBypassControlUiSpaForPluginPath,
   shouldEnforceGatewayAuthForPluginPath,
 } from "./server/plugins-http.js";
 import type { GatewayTlsRuntime } from "./server/tls.js";
@@ -121,6 +122,9 @@ export async function createGatewayRuntimeState(params: {
   const shouldEnforcePluginGatewayAuth = (requestPath: string): boolean => {
     return shouldEnforceGatewayAuthForPluginPath(params.pluginRegistry, requestPath);
   };
+  const shouldBypassControlUiSpaForPath = (requestPath: string): boolean => {
+    return shouldBypassControlUiSpaForPluginPath(params.pluginRegistry, requestPath);
+  };
 
   const bindHosts = await resolveGatewayListenHosts(params.bindHost);
   if (!isLoopbackHost(params.bindHost)) {
@@ -144,6 +148,7 @@ export async function createGatewayRuntimeState(params: {
       strictTransportSecurityHeader: params.strictTransportSecurityHeader,
       handleHooksRequest,
       handlePluginRequest,
+      shouldBypassControlUiSpaForPath,
       shouldEnforcePluginGatewayAuth,
       resolvedAuth: params.resolvedAuth,
       rateLimiter: params.rateLimiter,

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -5,6 +5,11 @@ import type { ResolvedGatewayAuth } from "./auth.js";
 import type { HooksConfigResolved } from "./hooks.js";
 import { canonicalizePathVariant, isProtectedPluginRoutePath } from "./security-path.js";
 import { createGatewayHttpServer, createHooksRequestHandler } from "./server-http.js";
+import { createTestRegistry } from "./server/__tests__/test-utils.js";
+import {
+  createGatewayPluginRequestHandler,
+  shouldEnforceGatewayAuthForPluginPath,
+} from "./server/plugins-http.js";
 import { withTempConfig } from "./test-temp-config.js";
 
 type GatewayHttpServer = ReturnType<typeof createGatewayHttpServer>;
@@ -522,6 +527,69 @@ describe("gateway plugin HTTP auth boundary", () => {
         });
         expect(authenticatedChannel.res.statusCode).toBe(200);
         expect(authenticatedChannel.getBody()).toContain('"route":"channel-default"');
+      },
+    });
+  });
+
+  test("keeps exact webhook routes ungated while still enforcing auth on default exact routes", async () => {
+    const registry = createTestRegistry({
+      httpRoutes: [
+        {
+          pluginId: "bluebubbles",
+          path: "/bluebubbles-webhook",
+          handler: (_req: IncomingMessage, res: ServerResponse) => {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "text/plain; charset=utf-8");
+            res.end("webhook-ok");
+          },
+          kind: "webhook",
+          source: "bluebubbles",
+        },
+        {
+          pluginId: "route",
+          path: "/plugin/default",
+          handler: (_req: IncomingMessage, res: ServerResponse) => {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "text/plain; charset=utf-8");
+            res.end("default-ok");
+          },
+          kind: "default",
+          source: "route",
+        },
+      ],
+    });
+    const handlePluginRequest = createGatewayPluginRequestHandler({
+      registry,
+      log: {
+        warn: vi.fn(),
+      } as unknown as ReturnType<typeof createSubsystemLogger>,
+    });
+
+    await withGatewayServer({
+      prefix: "openclaw-plugin-http-auth-webhook-exact-test-",
+      resolvedAuth: AUTH_TOKEN,
+      overrides: {
+        handlePluginRequest,
+        shouldEnforcePluginGatewayAuth: (requestPath) =>
+          shouldEnforceGatewayAuthForPluginPath(registry, requestPath),
+      },
+      run: async (server) => {
+        const webhookResponse = await sendRequest(server, {
+          path: "/bluebubbles-webhook",
+          method: "POST",
+        });
+        expect(webhookResponse.res.statusCode).toBe(200);
+        expect(webhookResponse.getBody()).toBe("webhook-ok");
+
+        const defaultResponse = await sendRequest(server, { path: "/plugin/default" });
+        expectUnauthorizedResponse(defaultResponse);
+
+        const authenticatedDefaultResponse = await sendRequest(server, {
+          path: "/plugin/default",
+          authorization: "Bearer test-token",
+        });
+        expect(authenticatedDefaultResponse.res.statusCode).toBe(200);
+        expect(authenticatedDefaultResponse.getBody()).toBe("default-ok");
       },
     });
   });

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -590,6 +590,67 @@ describe("gateway plugin HTTP auth boundary", () => {
     });
   });
 
+  test("lets exact webhook routes bypass the root control ui spa without restoring generic precedence", async () => {
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "none",
+      token: undefined,
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    await withTempConfig({
+      cfg: { gateway: { trustedProxies: [] } },
+      prefix: "openclaw-plugin-http-webhook-bypass-test-",
+      run: async () => {
+        const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+          const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+          if (pathname === "/bluebubbles-webhook") {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "text/plain; charset=utf-8");
+            res.end("plugin-webhook");
+            return true;
+          }
+          if (pathname === "/chat") {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "text/plain; charset=utf-8");
+            res.end("plugin-shadow");
+            return true;
+          }
+          return false;
+        });
+
+        const server = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
+          controlUiEnabled: true,
+          controlUiBasePath: "",
+          controlUiRoot: { kind: "missing" },
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest: async () => false,
+          handlePluginRequest,
+          shouldBypassControlUiSpaForPath: (requestPath) => requestPath === "/bluebubbles-webhook",
+          resolvedAuth,
+        });
+
+        const webhookResponse = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({ path: "/bluebubbles-webhook", method: "POST" }),
+          webhookResponse.res,
+        );
+        expect(webhookResponse.res.statusCode).toBe(200);
+        expect(webhookResponse.getBody()).toBe("plugin-webhook");
+
+        const chatResponse = createResponse();
+        await dispatchRequest(server, createRequest({ path: "/chat" }), chatResponse.res);
+        expect(chatResponse.res.statusCode).toBe(503);
+        expect(chatResponse.getBody()).toContain("Control UI assets not found");
+        expect(handlePluginRequest).toHaveBeenCalledTimes(1);
+      },
+    });
+  });
+
   test("requires gateway auth for canonicalized /api/channels variants", async () => {
     const handlePluginRequest = createCanonicalizedChannelPluginHandler();
 

--- a/src/gateway/server/core-http-paths.ts
+++ b/src/gateway/server/core-http-paths.ts
@@ -1,0 +1,54 @@
+import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH } from "../../canvas-host/a2ui.js";
+import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "../control-ui-contract.js";
+import { canonicalizePathVariant, isPathProtectedByPrefixes } from "../security-path.js";
+
+const CORE_EXACT_PATHS = new Set(
+  [
+    "/",
+    "/agents",
+    "/channels",
+    "/chat",
+    "/config",
+    "/cron",
+    "/debug",
+    "/health",
+    "/healthz",
+    "/instances",
+    "/logs",
+    "/nodes",
+    "/overview",
+    "/ready",
+    "/readyz",
+    "/sessions",
+    "/skills",
+    "/tools/invoke",
+    "/usage",
+    "/v1/chat/completions",
+    "/v1/responses",
+    A2UI_PATH,
+    CANVAS_HOST_PATH,
+    CANVAS_WS_PATH,
+    CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
+  ].map((path) => canonicalizePathVariant(path)),
+);
+
+const CORE_PREFIXES = [
+  "/api",
+  "/assets",
+  "/avatar",
+  "/plugins",
+  "/ui",
+  A2UI_PATH,
+  CANVAS_HOST_PATH,
+] as const;
+
+export function isCoreOwnedHttpPath(pathname: string): boolean {
+  const canonicalPath = canonicalizePathVariant(pathname);
+  return (
+    CORE_EXACT_PATHS.has(canonicalPath) || isPathProtectedByPrefixes(canonicalPath, CORE_PREFIXES)
+  );
+}
+
+export function canPluginWebhookRouteBypassControlUi(pathname: string): boolean {
+  return !isCoreOwnedHttpPath(pathname);
+}

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -147,11 +147,15 @@ describe("plugin HTTP registry helpers", () => {
     expect(isRegisteredPluginHttpRoutePath(registry, "/api/%2564emo")).toBe(true);
   });
 
-  it("enforces auth for protected and registered plugin routes", () => {
+  it("enforces auth for protected and default exact plugin routes, but not webhook exact routes", () => {
     const registry = createTestRegistry({
-      httpRoutes: [createRoute({ path: "/api/demo" })],
+      httpRoutes: [
+        createRoute({ path: "/demo" }),
+        createRoute({ path: "/bluebubbles-webhook", kind: "webhook" }),
+      ],
     });
-    expect(shouldEnforceGatewayAuthForPluginPath(registry, "/api//demo")).toBe(true);
+    expect(shouldEnforceGatewayAuthForPluginPath(registry, "/demo")).toBe(true);
+    expect(shouldEnforceGatewayAuthForPluginPath(registry, "/bluebubbles-webhook")).toBe(false);
     expect(shouldEnforceGatewayAuthForPluginPath(registry, "/api/channels/status")).toBe(true);
     expect(shouldEnforceGatewayAuthForPluginPath(registry, "/not-plugin")).toBe(false);
   });

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -5,6 +5,7 @@ import { createTestRegistry } from "./__tests__/test-utils.js";
 import {
   createGatewayPluginRequestHandler,
   isRegisteredPluginHttpRoutePath,
+  shouldBypassControlUiSpaForPluginPath,
   shouldEnforceGatewayAuthForPluginPath,
 } from "./plugins-http.js";
 
@@ -17,12 +18,14 @@ function createPluginLog(): PluginHandlerLog {
 function createRoute(params: {
   path: string;
   pluginId?: string;
+  kind?: "default" | "webhook";
   handler?: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>;
 }) {
   return {
     pluginId: params.pluginId ?? "route",
     path: params.path,
     handler: params.handler ?? (() => {}),
+    kind: params.kind ?? "default",
     source: params.pluginId ?? "route",
   };
 }
@@ -151,5 +154,57 @@ describe("plugin HTTP registry helpers", () => {
     expect(shouldEnforceGatewayAuthForPluginPath(registry, "/api//demo")).toBe(true);
     expect(shouldEnforceGatewayAuthForPluginPath(registry, "/api/channels/status")).toBe(true);
     expect(shouldEnforceGatewayAuthForPluginPath(registry, "/not-plugin")).toBe(false);
+  });
+
+  it("only bypasses control ui for exact webhook-kind routes on non-core paths", () => {
+    const registry = createTestRegistry({
+      httpRoutes: [
+        {
+          pluginId: "bluebubbles",
+          path: "/bluebubbles-webhook",
+          handler: () => {},
+          kind: "webhook",
+          source: "bluebubbles",
+        },
+        {
+          pluginId: "route",
+          path: "/chat",
+          handler: () => {},
+          kind: "default",
+          source: "route",
+        },
+        {
+          pluginId: "route",
+          path: "/plugins/demo",
+          handler: () => {},
+          kind: "webhook",
+          source: "route",
+        },
+      ],
+    });
+
+    expect(shouldBypassControlUiSpaForPluginPath(registry, "/bluebubbles-webhook")).toBe(true);
+    expect(shouldBypassControlUiSpaForPluginPath(registry, "/chat")).toBe(false);
+    expect(shouldBypassControlUiSpaForPluginPath(registry, "/plugins/demo")).toBe(false);
+    expect(shouldBypassControlUiSpaForPluginPath(registry, "/missing")).toBe(false);
+  });
+
+  it("does not canonicalize webhook-kind route matching", () => {
+    const registry = createTestRegistry({
+      httpRoutes: [
+        {
+          pluginId: "bluebubbles",
+          path: "/bluebubbles-webhook",
+          handler: () => {},
+          kind: "webhook",
+          source: "bluebubbles",
+        },
+      ],
+    });
+
+    expect(isRegisteredPluginHttpRoutePath(registry, "/bluebubbles-webhook")).toBe(true);
+    expect(isRegisteredPluginHttpRoutePath(registry, "/BLUEBUBBLES-WEBHOOK")).toBe(false);
+    expect(isRegisteredPluginHttpRoutePath(registry, "/bluebubbles-webhook/")).toBe(true);
+    expect(isRegisteredPluginHttpRoutePath(registry, "/bluebubbles%2Dwebhook")).toBe(false);
   });
 });

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -31,8 +31,8 @@ export function findRegisteredPluginHttpRoute(
 }
 
 // Only checks specific routes registered via registerHttpRoute, not wildcard handlers
-// registered via registerHttpHandler. Wildcard handlers (e.g., webhooks) implement
-// their own signature-based auth and are handled separately in the auth enforcement logic.
+// registered via registerHttpHandler. Exact webhook routes are intentionally excluded
+// from gateway auth enforcement because they keep their plugin-level auth model.
 export function isRegisteredPluginHttpRoutePath(
   registry: PluginRegistry,
   pathname: string,
@@ -44,9 +44,11 @@ export function shouldEnforceGatewayAuthForPluginPath(
   registry: PluginRegistry,
   pathname: string,
 ): boolean {
-  return (
-    isProtectedPluginRoutePath(pathname) || isRegisteredPluginHttpRoutePath(registry, pathname)
-  );
+  if (isProtectedPluginRoutePath(pathname)) {
+    return true;
+  }
+  const route = findRegisteredPluginHttpRoute(registry, pathname);
+  return route !== undefined && route.kind !== "webhook";
 }
 
 export function shouldBypassControlUiSpaForPluginPath(

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -1,8 +1,10 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
+import { normalizeWebhookPath } from "../../plugin-sdk/webhook-path.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
 import { canonicalizePathVariant } from "../security-path.js";
 import { isProtectedPluginRoutePath } from "../security-path.js";
+import { canPluginWebhookRouteBypassControlUi } from "./core-http-paths.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
@@ -13,13 +15,19 @@ export type PluginHttpRequestHandler = (
 
 type PluginHttpRouteEntry = NonNullable<PluginRegistry["httpRoutes"]>[number];
 
+function matchesRegisteredPluginHttpRoute(entry: PluginHttpRouteEntry, pathname: string): boolean {
+  if (entry.kind === "webhook") {
+    return normalizeWebhookPath(entry.path) === normalizeWebhookPath(pathname);
+  }
+  return canonicalizePathVariant(entry.path) === canonicalizePathVariant(pathname);
+}
+
 export function findRegisteredPluginHttpRoute(
   registry: PluginRegistry,
   pathname: string,
 ): PluginHttpRouteEntry | undefined {
-  const canonicalPath = canonicalizePathVariant(pathname);
   const routes = registry.httpRoutes ?? [];
-  return routes.find((entry) => canonicalizePathVariant(entry.path) === canonicalPath);
+  return routes.find((entry) => matchesRegisteredPluginHttpRoute(entry, pathname));
 }
 
 // Only checks specific routes registered via registerHttpRoute, not wildcard handlers
@@ -39,6 +47,14 @@ export function shouldEnforceGatewayAuthForPluginPath(
   return (
     isProtectedPluginRoutePath(pathname) || isRegisteredPluginHttpRoutePath(registry, pathname)
   );
+}
+
+export function shouldBypassControlUiSpaForPluginPath(
+  registry: PluginRegistry,
+  pathname: string,
+): boolean {
+  const route = findRegisteredPluginHttpRoute(registry, pathname);
+  return route?.kind === "webhook" && canPluginWebhookRouteBypassControlUi(pathname);
 }
 
 export function createGatewayPluginRequestHandler(params: {

--- a/src/line/monitor.lifecycle.test.ts
+++ b/src/line/monitor.lifecycle.test.ts
@@ -2,14 +2,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
 
-const { createLineBotMock, registerPluginHttpRouteMock, unregisterHttpMock } = vi.hoisted(() => ({
-  createLineBotMock: vi.fn(() => ({
-    account: { accountId: "default" },
-    handleWebhook: vi.fn(),
-  })),
-  registerPluginHttpRouteMock: vi.fn(),
-  unregisterHttpMock: vi.fn(),
-}));
+const { createLineBotMock, tryRegisterPluginHttpRouteMock, unregisterHttpMock } = vi.hoisted(
+  () => ({
+    createLineBotMock: vi.fn(() => ({
+      account: { accountId: "default" },
+      handleWebhook: vi.fn(),
+    })),
+    tryRegisterPluginHttpRouteMock: vi.fn(),
+    unregisterHttpMock: vi.fn(),
+  }),
+);
 
 vi.mock("./bot.js", () => ({
   createLineBot: createLineBotMock,
@@ -37,7 +39,7 @@ vi.mock("../plugins/http-path.js", () => ({
 }));
 
 vi.mock("../plugins/http-registry.js", () => ({
-  registerPluginHttpRoute: registerPluginHttpRouteMock,
+  tryRegisterPluginHttpRoute: tryRegisterPluginHttpRouteMock,
 }));
 
 vi.mock("./webhook-node.js", () => ({
@@ -78,7 +80,9 @@ describe("monitorLineProvider lifecycle", () => {
   beforeEach(() => {
     createLineBotMock.mockClear();
     unregisterHttpMock.mockClear();
-    registerPluginHttpRouteMock.mockClear().mockReturnValue(unregisterHttpMock);
+    tryRegisterPluginHttpRouteMock
+      .mockClear()
+      .mockReturnValue({ ok: true, unregister: unregisterHttpMock });
   });
 
   it("waits for abort before resolving", async () => {
@@ -97,7 +101,7 @@ describe("monitorLineProvider lifecycle", () => {
       return monitor;
     });
 
-    await vi.waitFor(() => expect(registerPluginHttpRouteMock).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(tryRegisterPluginHttpRouteMock).toHaveBeenCalledTimes(1));
     expect(resolved).toBe(false);
 
     abort.abort();
@@ -135,5 +139,23 @@ describe("monitorLineProvider lifecycle", () => {
     monitor.stop();
     monitor.stop();
     expect(unregisterHttpMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when route registration is rejected", async () => {
+    const { monitorLineProvider } = await import("./monitor.js");
+    tryRegisterPluginHttpRouteMock.mockReturnValueOnce({ ok: false, unregister: vi.fn() });
+
+    await expect(
+      monitorLineProvider({
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        config: {} as OpenClawConfig,
+        runtime: {
+          log: vi.fn(),
+          error: vi.fn(),
+          exit: vi.fn(),
+        } as RuntimeEnv,
+      }),
+    ).rejects.toThrow("line: failed to register webhook handler at /line/webhook");
   });
 });

--- a/src/line/monitor.ts
+++ b/src/line/monitor.ts
@@ -6,7 +6,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { danger, logVerbose } from "../globals.js";
 import { waitForAbortSignal } from "../infra/abort-signal.js";
 import { normalizePluginHttpPath } from "../plugins/http-path.js";
-import { registerPluginHttpRoute } from "../plugins/http-registry.js";
+import { tryRegisterPluginHttpRoute } from "../plugins/http-registry.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { deliverLineAutoReply } from "./auto-reply-delivery.js";
 import { createLineBot } from "./bot.js";
@@ -286,13 +286,19 @@ export async function monitorLineProvider(
 
   // Register HTTP webhook handler
   const normalizedPath = normalizePluginHttpPath(webhookPath, "/line/webhook") ?? "/line/webhook";
-  const unregisterHttp = registerPluginHttpRoute({
+  const routeRegistration = tryRegisterPluginHttpRoute({
     path: normalizedPath,
     pluginId: "line",
     accountId: resolvedAccountId,
     log: (msg) => logVerbose(msg),
     handler: createLineNodeWebhookHandler({ channelSecret: secret, bot, runtime }),
   });
+  if (!routeRegistration.ok) {
+    const message = `line: failed to register webhook handler at ${normalizedPath}`;
+    runtime.error?.(danger(message));
+    throw new Error(message);
+  }
+  const unregisterHttp = routeRegistration.unregister;
 
   logVerbose(`line: registered webhook handler at ${normalizedPath}`);
 

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -112,7 +112,7 @@ export type {
 } from "../gateway/server-methods/types.js";
 export type { PluginRuntime, RuntimeLogger } from "../plugins/runtime/types.js";
 export { normalizePluginHttpPath } from "../plugins/http-path.js";
-export { registerPluginHttpRoute } from "../plugins/http-registry.js";
+export { registerPluginHttpRoute, registerPluginWebhookRoute } from "../plugins/http-registry.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { OpenClawConfig } from "../config/config.js";
 /** @deprecated Use OpenClawConfig instead */

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -112,7 +112,11 @@ export type {
 } from "../gateway/server-methods/types.js";
 export type { PluginRuntime, RuntimeLogger } from "../plugins/runtime/types.js";
 export { normalizePluginHttpPath } from "../plugins/http-path.js";
-export { registerPluginHttpRoute, registerPluginWebhookRoute } from "../plugins/http-registry.js";
+export {
+  registerPluginHttpRoute,
+  registerPluginWebhookRoute,
+  tryRegisterPluginHttpRoute,
+} from "../plugins/http-registry.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { OpenClawConfig } from "../config/config.js";
 /** @deprecated Use OpenClawConfig instead */

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -98,6 +98,7 @@ export type {
   AnyAgentTool,
   OpenClawPluginConfigSchema,
   OpenClawPluginApi,
+  OpenClawPluginHttpRouteKind,
   OpenClawPluginService,
   OpenClawPluginServiceContext,
   PluginLogger,

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { registerPluginHttpRoute } from "./http-registry.js";
+import { registerPluginHttpRoute, registerPluginWebhookRoute } from "./http-registry.js";
 import { createEmptyPluginRegistry } from "./registry.js";
 
 describe("registerPluginHttpRoute", () => {
@@ -98,16 +98,16 @@ describe("registerPluginHttpRoute", () => {
   it("rejects webhook routes on core-owned paths", () => {
     const registry = createEmptyPluginRegistry();
     const logs: string[] = [];
-    const unregister = registerPluginHttpRoute({
+    const registration = registerPluginWebhookRoute({
       path: "/chat",
       handler: vi.fn(),
       registry,
       pluginId: "bluebubbles",
-      kind: "webhook",
       log: (msg) => logs.push(msg),
     });
 
     expect(registry.httpRoutes).toHaveLength(0);
+    expect(registration.ok).toBe(false);
     expect(registry.diagnostics).toContainEqual(
       expect.objectContaining({
         level: "error",
@@ -118,7 +118,30 @@ describe("registerPluginHttpRoute", () => {
     expect(logs).toContain(
       "plugin: refusing webhook path /chat because it conflicts with a core route",
     );
-    expect(() => unregister()).not.toThrow();
+    expect(() => registration.unregister()).not.toThrow();
+  });
+
+  it("returns success for accepted webhook routes", () => {
+    const registry = createEmptyPluginRegistry();
+
+    const registration = registerPluginWebhookRoute({
+      path: "/accepted-hook",
+      handler: vi.fn(),
+      registry,
+      pluginId: "bluebubbles",
+    });
+
+    expect(registration.ok).toBe(true);
+    expect(registry.httpRoutes).toContainEqual(
+      expect.objectContaining({
+        path: "/accepted-hook",
+        pluginId: "bluebubbles",
+        kind: "webhook",
+      }),
+    );
+
+    registration.unregister();
+    expect(registry.httpRoutes).toHaveLength(0);
   });
 
   it("refuses to replace a route registered by a different plugin", () => {

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { registerPluginHttpRoute, registerPluginWebhookRoute } from "./http-registry.js";
+import {
+  registerPluginHttpRoute,
+  registerPluginWebhookRoute,
+  tryRegisterPluginHttpRoute,
+} from "./http-registry.js";
 import { createEmptyPluginRegistry } from "./registry.js";
 
 describe("registerPluginHttpRoute", () => {
@@ -206,5 +210,36 @@ describe("registerPluginHttpRoute", () => {
     );
     expect(logs).toContain("plugin: refusing duplicate route /shared-hook");
     expect(() => unregister()).not.toThrow();
+  });
+
+  it("returns failure for duplicate default routes via the explicit helper", () => {
+    const registry = createEmptyPluginRegistry();
+    registerPluginHttpRoute({
+      path: "/line/webhook",
+      handler: vi.fn(),
+      registry,
+      pluginId: "line",
+    });
+
+    const logs: string[] = [];
+    const registration = tryRegisterPluginHttpRoute({
+      path: "/line/webhook",
+      handler: vi.fn(),
+      registry,
+      pluginId: "line",
+      log: (msg) => logs.push(msg),
+    });
+
+    expect(registration.ok).toBe(false);
+    expect(registry.httpRoutes).toHaveLength(1);
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        pluginId: "line",
+        message: "http route already registered: /line/webhook",
+      }),
+    );
+    expect(logs).toContain("plugin: refusing duplicate route /line/webhook");
+    expect(() => registration.unregister()).not.toThrow();
   });
 });

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -95,6 +95,37 @@ describe("registerPluginHttpRoute", () => {
     expect(registry.httpRoutes).toHaveLength(0);
   });
 
+  it("keeps shared webhook routes when one unregister callback is called twice", () => {
+    const registry = createEmptyPluginRegistry();
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn();
+
+    const unregisterFirst = registerPluginHttpRoute({
+      path: "/synology-webhook",
+      handler: firstHandler,
+      registry,
+      pluginId: "synology-chat",
+      kind: "webhook",
+    });
+
+    const unregisterSecond = registerPluginHttpRoute({
+      path: "/synology-webhook",
+      handler: secondHandler,
+      registry,
+      pluginId: "synology-chat",
+      kind: "webhook",
+    });
+
+    unregisterSecond();
+    unregisterSecond();
+
+    expect(registry.httpRoutes).toHaveLength(1);
+    expect(registry.httpRoutes[0]?.handler).toBe(firstHandler);
+
+    unregisterFirst();
+    expect(registry.httpRoutes).toHaveLength(0);
+  });
+
   it("rejects webhook routes on core-owned paths", () => {
     const registry = createEmptyPluginRegistry();
     const logs: string[] = [];

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -54,7 +54,7 @@ describe("registerPluginHttpRoute", () => {
     expect(() => unregister()).not.toThrow();
   });
 
-  it("replaces stale route on same path and keeps latest registration", () => {
+  it("reuses shared same-plugin webhook routes until the last unregister", () => {
     const registry = createEmptyPluginRegistry();
     const logs: string[] = [];
     const firstHandler = vi.fn();
@@ -81,16 +81,15 @@ describe("registerPluginHttpRoute", () => {
     });
 
     expect(registry.httpRoutes).toHaveLength(1);
-    expect(registry.httpRoutes[0]?.handler).toBe(secondHandler);
+    expect(registry.httpRoutes[0]?.handler).toBe(firstHandler);
     expect(registry.httpRoutes[0]?.kind).toBe("webhook");
     expect(logs).toContain(
-      'plugin: replacing stale webhook path /synology-webhook for account "default" (synology-chat)',
+      'plugin: reusing shared webhook path /synology-webhook for account "default" (synology-chat)',
     );
 
-    // Old unregister must not remove the replacement route.
     unregisterFirst();
     expect(registry.httpRoutes).toHaveLength(1);
-    expect(registry.httpRoutes[0]?.handler).toBe(secondHandler);
+    expect(registry.httpRoutes[0]?.handler).toBe(firstHandler);
 
     unregisterSecond();
     expect(registry.httpRoutes).toHaveLength(0);

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -8,14 +8,31 @@ describe("registerPluginHttpRoute", () => {
     const handler = vi.fn();
 
     const unregister = registerPluginHttpRoute({
-      path: "/plugins/demo",
+      path: "/demo",
       handler,
       registry,
     });
 
     expect(registry.httpRoutes).toHaveLength(1);
-    expect(registry.httpRoutes[0]?.path).toBe("/plugins/demo");
+    expect(registry.httpRoutes[0]?.path).toBe("/demo");
     expect(registry.httpRoutes[0]?.handler).toBe(handler);
+    expect(registry.httpRoutes[0]?.kind).toBe("default");
+
+    unregister();
+    expect(registry.httpRoutes).toHaveLength(0);
+  });
+
+  it("allows explicit webhook-kind routes", () => {
+    const registry = createEmptyPluginRegistry();
+    const unregister = registerPluginHttpRoute({
+      path: "/demo-hook",
+      handler: vi.fn(),
+      kind: "webhook",
+      registry,
+    });
+
+    expect(registry.httpRoutes).toHaveLength(1);
+    expect(registry.httpRoutes[0]?.kind).toBe("webhook");
 
     unregister();
     expect(registry.httpRoutes).toHaveLength(0);
@@ -44,27 +61,30 @@ describe("registerPluginHttpRoute", () => {
     const secondHandler = vi.fn();
 
     const unregisterFirst = registerPluginHttpRoute({
-      path: "/plugins/synology",
+      path: "/synology-webhook",
       handler: firstHandler,
       registry,
       accountId: "default",
       pluginId: "synology-chat",
+      kind: "webhook",
       log: (msg) => logs.push(msg),
     });
 
     const unregisterSecond = registerPluginHttpRoute({
-      path: "/plugins/synology",
+      path: "/synology-webhook",
       handler: secondHandler,
       registry,
       accountId: "default",
       pluginId: "synology-chat",
+      kind: "webhook",
       log: (msg) => logs.push(msg),
     });
 
     expect(registry.httpRoutes).toHaveLength(1);
     expect(registry.httpRoutes[0]?.handler).toBe(secondHandler);
+    expect(registry.httpRoutes[0]?.kind).toBe("webhook");
     expect(logs).toContain(
-      'plugin: replacing stale webhook path /plugins/synology for account "default" (synology-chat)',
+      'plugin: replacing stale webhook path /synology-webhook for account "default" (synology-chat)',
     );
 
     // Old unregister must not remove the replacement route.
@@ -74,5 +94,64 @@ describe("registerPluginHttpRoute", () => {
 
     unregisterSecond();
     expect(registry.httpRoutes).toHaveLength(0);
+  });
+
+  it("rejects webhook routes on core-owned paths", () => {
+    const registry = createEmptyPluginRegistry();
+    const logs: string[] = [];
+    const unregister = registerPluginHttpRoute({
+      path: "/chat",
+      handler: vi.fn(),
+      registry,
+      pluginId: "bluebubbles",
+      kind: "webhook",
+      log: (msg) => logs.push(msg),
+    });
+
+    expect(registry.httpRoutes).toHaveLength(0);
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        pluginId: "bluebubbles",
+        message: "http webhook route conflicts with core path: /chat",
+      }),
+    );
+    expect(logs).toContain(
+      "plugin: refusing webhook path /chat because it conflicts with a core route",
+    );
+    expect(() => unregister()).not.toThrow();
+  });
+
+  it("refuses to replace a route registered by a different plugin", () => {
+    const registry = createEmptyPluginRegistry();
+    registerPluginHttpRoute({
+      path: "/shared-hook",
+      handler: vi.fn(),
+      registry,
+      pluginId: "first",
+      kind: "webhook",
+    });
+
+    const logs: string[] = [];
+    const unregister = registerPluginHttpRoute({
+      path: "/shared-hook",
+      handler: vi.fn(),
+      registry,
+      pluginId: "second",
+      kind: "webhook",
+      log: (msg) => logs.push(msg),
+    });
+
+    expect(registry.httpRoutes).toHaveLength(1);
+    expect(registry.httpRoutes[0]?.pluginId).toBe("first");
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        pluginId: "second",
+        message: "http route already registered: /shared-hook",
+      }),
+    );
+    expect(logs).toContain("plugin: refusing duplicate route /shared-hook");
+    expect(() => unregister()).not.toThrow();
   });
 });

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -10,6 +10,22 @@ export type PluginHttpRouteHandler = (
   res: ServerResponse,
 ) => Promise<void> | void;
 
+const sharedWebhookRouteRefCounts = new WeakMap<
+  PluginRegistry,
+  Map<PluginHttpRouteRegistration, number>
+>();
+
+function getSharedWebhookRouteRefCounts(
+  registry: PluginRegistry,
+): Map<PluginHttpRouteRegistration, number> {
+  let counts = sharedWebhookRouteRefCounts.get(registry);
+  if (!counts) {
+    counts = new Map<PluginHttpRouteRegistration, number>();
+    sharedWebhookRouteRefCounts.set(registry, counts);
+  }
+  return counts;
+}
+
 export function registerPluginHttpRoute(params: {
   path?: string | null;
   fallbackPath?: string | null;
@@ -55,8 +71,21 @@ export function registerPluginHttpRoute(params: {
       existing.pluginId === params.pluginId
     ) {
       const pluginHint = params.pluginId ? ` (${params.pluginId})` : "";
-      params.log?.(`plugin: replacing stale webhook path ${normalizedPath}${suffix}${pluginHint}`);
-      routes.splice(existingIndex, 1);
+      const counts = getSharedWebhookRouteRefCounts(registry);
+      counts.set(existing, (counts.get(existing) ?? 1) + 1);
+      params.log?.(`plugin: reusing shared webhook path ${normalizedPath}${suffix}${pluginHint}`);
+      return () => {
+        const current = counts.get(existing) ?? 1;
+        if (current > 1) {
+          counts.set(existing, current - 1);
+          return;
+        }
+        counts.delete(existing);
+        const index = routes.indexOf(existing);
+        if (index >= 0) {
+          routes.splice(index, 1);
+        }
+      };
     } else {
       registry.diagnostics.push({
         level: "error",
@@ -77,8 +106,20 @@ export function registerPluginHttpRoute(params: {
     source: params.source,
   };
   routes.push(entry);
+  if (kind === "webhook") {
+    getSharedWebhookRouteRefCounts(registry).set(entry, 1);
+  }
 
   return () => {
+    if (kind === "webhook") {
+      const counts = getSharedWebhookRouteRefCounts(registry);
+      const current = counts.get(entry) ?? 1;
+      if (current > 1) {
+        counts.set(entry, current - 1);
+        return;
+      }
+      counts.delete(entry);
+    }
     const index = routes.indexOf(entry);
     if (index >= 0) {
       routes.splice(index, 1);

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -10,6 +10,11 @@ export type PluginHttpRouteHandler = (
   res: ServerResponse,
 ) => Promise<void> | void;
 
+export type RegisterPluginWebhookRouteResult = {
+  ok: boolean;
+  unregister: () => void;
+};
+
 const sharedWebhookRouteRefCounts = new WeakMap<
   PluginRegistry,
   Map<PluginHttpRouteRegistration, number>
@@ -26,7 +31,7 @@ function getSharedWebhookRouteRefCounts(
   return counts;
 }
 
-export function registerPluginHttpRoute(params: {
+type RegisterPluginHttpRouteParams = {
   path?: string | null;
   fallbackPath?: string | null;
   handler: PluginHttpRouteHandler;
@@ -36,7 +41,11 @@ export function registerPluginHttpRoute(params: {
   accountId?: string;
   log?: (message: string) => void;
   registry?: PluginRegistry;
-}): () => void {
+};
+
+function registerPluginHttpRouteInternal(
+  params: RegisterPluginHttpRouteParams,
+): RegisterPluginWebhookRouteResult {
   const registry = params.registry ?? requireActivePluginRegistry();
   const routes = registry.httpRoutes ?? [];
   registry.httpRoutes = routes;
@@ -46,7 +55,7 @@ export function registerPluginHttpRoute(params: {
   const suffix = params.accountId ? ` for account "${params.accountId}"` : "";
   if (!normalizedPath) {
     params.log?.(`plugin: webhook path missing${suffix}`);
-    return () => {};
+    return { ok: false, unregister: () => {} };
   }
 
   if (kind === "webhook" && isCoreOwnedHttpPath(normalizedPath)) {
@@ -59,7 +68,7 @@ export function registerPluginHttpRoute(params: {
     params.log?.(
       `plugin: refusing webhook path ${normalizedPath}${suffix} because it conflicts with a core route`,
     );
-    return () => {};
+    return { ok: false, unregister: () => {} };
   }
 
   const existingIndex = routes.findIndex((entry) => entry.path === normalizedPath);
@@ -74,17 +83,20 @@ export function registerPluginHttpRoute(params: {
       const counts = getSharedWebhookRouteRefCounts(registry);
       counts.set(existing, (counts.get(existing) ?? 1) + 1);
       params.log?.(`plugin: reusing shared webhook path ${normalizedPath}${suffix}${pluginHint}`);
-      return () => {
-        const current = counts.get(existing) ?? 1;
-        if (current > 1) {
-          counts.set(existing, current - 1);
-          return;
-        }
-        counts.delete(existing);
-        const index = routes.indexOf(existing);
-        if (index >= 0) {
-          routes.splice(index, 1);
-        }
+      return {
+        ok: true,
+        unregister: () => {
+          const current = counts.get(existing) ?? 1;
+          if (current > 1) {
+            counts.set(existing, current - 1);
+            return;
+          }
+          counts.delete(existing);
+          const index = routes.indexOf(existing);
+          if (index >= 0) {
+            routes.splice(index, 1);
+          }
+        },
       };
     } else {
       registry.diagnostics.push({
@@ -94,7 +106,7 @@ export function registerPluginHttpRoute(params: {
         message: `http route already registered: ${normalizedPath}`,
       });
       params.log?.(`plugin: refusing duplicate route ${normalizedPath}${suffix}`);
-      return () => {};
+      return { ok: false, unregister: () => {} };
     }
   }
 
@@ -110,19 +122,32 @@ export function registerPluginHttpRoute(params: {
     getSharedWebhookRouteRefCounts(registry).set(entry, 1);
   }
 
-  return () => {
-    if (kind === "webhook") {
-      const counts = getSharedWebhookRouteRefCounts(registry);
-      const current = counts.get(entry) ?? 1;
-      if (current > 1) {
-        counts.set(entry, current - 1);
-        return;
+  return {
+    ok: true,
+    unregister: () => {
+      if (kind === "webhook") {
+        const counts = getSharedWebhookRouteRefCounts(registry);
+        const current = counts.get(entry) ?? 1;
+        if (current > 1) {
+          counts.set(entry, current - 1);
+          return;
+        }
+        counts.delete(entry);
       }
-      counts.delete(entry);
-    }
-    const index = routes.indexOf(entry);
-    if (index >= 0) {
-      routes.splice(index, 1);
-    }
+      const index = routes.indexOf(entry);
+      if (index >= 0) {
+        routes.splice(index, 1);
+      }
+    },
   };
+}
+
+export function registerPluginHttpRoute(params: RegisterPluginHttpRouteParams): () => void {
+  return registerPluginHttpRouteInternal(params).unregister;
+}
+
+export function registerPluginWebhookRoute(
+  params: Omit<RegisterPluginHttpRouteParams, "kind">,
+): RegisterPluginWebhookRouteResult {
+  return registerPluginHttpRouteInternal({ ...params, kind: "webhook" });
 }

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -31,6 +31,17 @@ function getSharedWebhookRouteRefCounts(
   return counts;
 }
 
+function createIdempotentUnregister(action: () => void): () => void {
+  let unregistered = false;
+  return () => {
+    if (unregistered) {
+      return;
+    }
+    unregistered = true;
+    action();
+  };
+}
+
 type RegisterPluginHttpRouteParams = {
   path?: string | null;
   fallbackPath?: string | null;
@@ -85,8 +96,11 @@ function registerPluginHttpRouteInternal(
       params.log?.(`plugin: reusing shared webhook path ${normalizedPath}${suffix}${pluginHint}`);
       return {
         ok: true,
-        unregister: () => {
-          const current = counts.get(existing) ?? 1;
+        unregister: createIdempotentUnregister(() => {
+          const current = counts.get(existing);
+          if (current === undefined) {
+            return;
+          }
           if (current > 1) {
             counts.set(existing, current - 1);
             return;
@@ -96,7 +110,7 @@ function registerPluginHttpRouteInternal(
           if (index >= 0) {
             routes.splice(index, 1);
           }
-        },
+        }),
       };
     } else {
       registry.diagnostics.push({
@@ -124,10 +138,13 @@ function registerPluginHttpRouteInternal(
 
   return {
     ok: true,
-    unregister: () => {
+    unregister: createIdempotentUnregister(() => {
       if (kind === "webhook") {
         const counts = getSharedWebhookRouteRefCounts(registry);
-        const current = counts.get(entry) ?? 1;
+        const current = counts.get(entry);
+        if (current === undefined) {
+          return;
+        }
         if (current > 1) {
           counts.set(entry, current - 1);
           return;
@@ -138,7 +155,7 @@ function registerPluginHttpRouteInternal(
       if (index >= 0) {
         routes.splice(index, 1);
       }
-    },
+    }),
   };
 }
 

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -10,7 +10,7 @@ export type PluginHttpRouteHandler = (
   res: ServerResponse,
 ) => Promise<void> | void;
 
-export type RegisterPluginWebhookRouteResult = {
+export type RegisterPluginHttpRouteResult = {
   ok: boolean;
   unregister: () => void;
 };
@@ -56,7 +56,7 @@ type RegisterPluginHttpRouteParams = {
 
 function registerPluginHttpRouteInternal(
   params: RegisterPluginHttpRouteParams,
-): RegisterPluginWebhookRouteResult {
+): RegisterPluginHttpRouteResult {
   const registry = params.registry ?? requireActivePluginRegistry();
   const routes = registry.httpRoutes ?? [];
   registry.httpRoutes = routes;
@@ -163,8 +163,14 @@ export function registerPluginHttpRoute(params: RegisterPluginHttpRouteParams): 
   return registerPluginHttpRouteInternal(params).unregister;
 }
 
+export function tryRegisterPluginHttpRoute(
+  params: RegisterPluginHttpRouteParams,
+): RegisterPluginHttpRouteResult {
+  return registerPluginHttpRouteInternal(params);
+}
+
 export function registerPluginWebhookRoute(
   params: Omit<RegisterPluginHttpRouteParams, "kind">,
-): RegisterPluginWebhookRouteResult {
-  return registerPluginHttpRouteInternal({ ...params, kind: "webhook" });
+): RegisterPluginHttpRouteResult {
+  return tryRegisterPluginHttpRoute({ ...params, kind: "webhook" });
 }

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -1,7 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { isCoreOwnedHttpPath } from "../gateway/server/core-http-paths.js";
 import { normalizePluginHttpPath } from "./http-path.js";
 import type { PluginHttpRouteRegistration, PluginRegistry } from "./registry.js";
 import { requireActivePluginRegistry } from "./runtime.js";
+import type { OpenClawPluginHttpRouteKind } from "./types.js";
 
 export type PluginHttpRouteHandler = (
   req: IncomingMessage,
@@ -12,6 +14,7 @@ export function registerPluginHttpRoute(params: {
   path?: string | null;
   fallbackPath?: string | null;
   handler: PluginHttpRouteHandler;
+  kind?: OpenClawPluginHttpRouteKind;
   pluginId?: string;
   source?: string;
   accountId?: string;
@@ -23,22 +26,53 @@ export function registerPluginHttpRoute(params: {
   registry.httpRoutes = routes;
 
   const normalizedPath = normalizePluginHttpPath(params.path, params.fallbackPath);
+  const kind = params.kind ?? "default";
   const suffix = params.accountId ? ` for account "${params.accountId}"` : "";
   if (!normalizedPath) {
     params.log?.(`plugin: webhook path missing${suffix}`);
     return () => {};
   }
 
+  if (kind === "webhook" && isCoreOwnedHttpPath(normalizedPath)) {
+    registry.diagnostics.push({
+      level: "error",
+      pluginId: params.pluginId,
+      source: params.source,
+      message: `http webhook route conflicts with core path: ${normalizedPath}`,
+    });
+    params.log?.(
+      `plugin: refusing webhook path ${normalizedPath}${suffix} because it conflicts with a core route`,
+    );
+    return () => {};
+  }
+
   const existingIndex = routes.findIndex((entry) => entry.path === normalizedPath);
   if (existingIndex >= 0) {
-    const pluginHint = params.pluginId ? ` (${params.pluginId})` : "";
-    params.log?.(`plugin: replacing stale webhook path ${normalizedPath}${suffix}${pluginHint}`);
-    routes.splice(existingIndex, 1);
+    const existing = routes[existingIndex];
+    if (
+      existing?.kind === "webhook" &&
+      kind === "webhook" &&
+      existing.pluginId === params.pluginId
+    ) {
+      const pluginHint = params.pluginId ? ` (${params.pluginId})` : "";
+      params.log?.(`plugin: replacing stale webhook path ${normalizedPath}${suffix}${pluginHint}`);
+      routes.splice(existingIndex, 1);
+    } else {
+      registry.diagnostics.push({
+        level: "error",
+        pluginId: params.pluginId,
+        source: params.source,
+        message: `http route already registered: ${normalizedPath}`,
+      });
+      params.log?.(`plugin: refusing duplicate route ${normalizedPath}${suffix}`);
+      return () => {};
+    }
   }
 
   const entry: PluginHttpRouteRegistration = {
     path: normalizedPath,
     handler: params.handler,
+    kind,
     pluginId: params.pluginId,
     source: params.source,
   };

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -532,8 +532,41 @@ describe("loadOpenClawPlugins", () => {
     const route = registry.httpRoutes.find((entry) => entry.pluginId === "http-route-demo");
     expect(route).toBeDefined();
     expect(route?.path).toBe("/demo");
+    expect(route?.kind).toBe("default");
     const httpPlugin = registry.plugins.find((entry) => entry.id === "http-route-demo");
     expect(httpPlugin?.httpHandlers).toBe(1);
+  });
+
+  it("rejects webhook routes on core-owned paths", () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    const plugin = writePlugin({
+      id: "http-route-webhook-core-conflict",
+      body: `export default { id: "http-route-webhook-core-conflict", register(api) {
+  api.registerHttpRoute({ path: "/chat", kind: "webhook", handler: async (_req, res) => { res.statusCode = 200; res.end("ok"); } });
+} };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["http-route-webhook-core-conflict"],
+        },
+      },
+    });
+
+    expect(
+      registry.httpRoutes.find((entry) => entry.pluginId === "http-route-webhook-core-conflict"),
+    ).toBeUndefined();
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        pluginId: "http-route-webhook-core-conflict",
+        message: "http webhook route conflicts with core path: /chat",
+      }),
+    );
   });
 
   it("respects explicit disable in config", () => {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -6,6 +6,7 @@ import type {
   GatewayRequestHandler,
   GatewayRequestHandlers,
 } from "../gateway/server-methods/types.js";
+import { isCoreOwnedHttpPath } from "../gateway/server/core-http-paths.js";
 import { registerInternalHook } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
 import { resolveUserPath } from "../utils.js";
@@ -18,6 +19,7 @@ import type {
   OpenClawPluginCliRegistrar,
   OpenClawPluginCommandDefinition,
   OpenClawPluginHttpHandler,
+  OpenClawPluginHttpRouteKind,
   OpenClawPluginHttpRouteHandler,
   OpenClawPluginHookOptions,
   ProviderPlugin,
@@ -59,6 +61,7 @@ export type PluginHttpRouteRegistration = {
   pluginId?: string;
   path: string;
   handler: OpenClawPluginHttpRouteHandler;
+  kind: OpenClawPluginHttpRouteKind;
   source?: string;
 };
 
@@ -299,9 +302,14 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
 
   const registerHttpRoute = (
     record: PluginRecord,
-    params: { path: string; handler: OpenClawPluginHttpRouteHandler },
+    params: {
+      path: string;
+      handler: OpenClawPluginHttpRouteHandler;
+      kind?: OpenClawPluginHttpRouteKind;
+    },
   ) => {
     const normalizedPath = normalizePluginHttpPath(params.path);
+    const kind = params.kind ?? "default";
     if (!normalizedPath) {
       pushDiagnostic({
         level: "warn",
@@ -320,11 +328,21 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       });
       return;
     }
+    if (kind === "webhook" && isCoreOwnedHttpPath(normalizedPath)) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `http webhook route conflicts with core path: ${normalizedPath}`,
+      });
+      return;
+    }
     record.httpHandlers += 1;
     registry.httpRoutes.push({
       pluginId: record.id,
       path: normalizedPath,
       handler: params.handler,
+      kind,
       source: record.source,
     });
   };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -204,6 +204,8 @@ export type OpenClawPluginHttpRouteHandler = (
   res: ServerResponse,
 ) => Promise<void> | void;
 
+export type OpenClawPluginHttpRouteKind = "default" | "webhook";
+
 export type OpenClawPluginCliContext = {
   program: Command;
   config: OpenClawConfig;
@@ -266,7 +268,11 @@ export type OpenClawPluginApi = {
     opts?: OpenClawPluginHookOptions,
   ) => void;
   registerHttpHandler: (handler: OpenClawPluginHttpHandler) => void;
-  registerHttpRoute: (params: { path: string; handler: OpenClawPluginHttpRouteHandler }) => void;
+  registerHttpRoute: (params: {
+    path: string;
+    handler: OpenClawPluginHttpRouteHandler;
+    kind?: OpenClawPluginHttpRouteKind;
+  }) => void;
   registerChannel: (registration: OpenClawPluginChannelRegistration | ChannelPlugin) => void;
   registerGatewayMethod: (method: string, handler: GatewayRequestHandler) => void;
   registerCli: (registrar: OpenClawPluginCliRegistrar, opts?: { commands?: string[] }) => void;


### PR DESCRIPTION
## Summary

_Wanted to create a couple of proposals: This is larger future-proof fix compared to https://github.com/openclaw/openclaw/pull/31434_

I noticed that https://github.com/openclaw/openclaw/pull/31349 was opened as well but I think it reverses what broke BlueBubbles, which also reverts the intent of the changes in `2026.3.1` around hardening the allowed gateway routes.

- Problem: root-mounted Control UI could swallow explicit plugin webhook endpoints like `/bluebubbles-webhook` after the `2026.3.1` gateway precedence hardening.
- Why it matters: BlueBubbles webhook delivery broke, and other webhook-style plugins using root paths had the same regression class.
- What changed: add exact-route metadata for plugin HTTP routes, allow only exact `kind: "webhook"` routes to bypass the root Control UI SPA fallback, register runtime webhook routes for BlueBubbles, Google Chat, and Zalo, and fail closed when a webhook path conflicts with a core-owned route so the plugin target is not activated behind the wildcard handler.
- What did NOT change (scope boundary): generic plugin handlers still run after built-in gateway handlers; wildcard handlers still do not bypass Control UI; protected plugin-path auth behavior is preserved, and exact webhook routes keep their plugin-level auth model instead of inheriting gateway auth.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31344

## User-visible / Behavior Changes

- BlueBubbles, Google Chat, and Zalo root-path webhooks work again when `gateway.controlUi.basePath` is unset.
- Exact plugin HTTP routes can now declare `kind: "webhook"`.
- Only exact webhook routes may bypass the root Control UI SPA fallback; generic plugin handlers still cannot shadow Control UI/core routes.
- Misconfigured webhook paths that conflict with core routes such as `/chat` are rejected and do not become reachable through plugin wildcard handlers.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): BlueBubbles, Google Chat, Zalo
- Relevant config (redacted): `gateway.controlUi.basePath` unset, webhook plugins using root webhook paths

### Steps

1. Start gateway with Control UI mounted at root.
2. Configure BlueBubbles/Google Chat/Zalo webhook on a root path such as `/bluebubbles-webhook`.
3. Send webhook traffic to the gateway.

### Expected

- Explicit webhook endpoint reaches the plugin webhook handler.
- Core/UI routes such as `/chat` still stay owned by built-in handlers.
- Misconfigured core-owned webhook paths are rejected instead of remaining reachable via wildcard handlers.

### Actual

- Before this patch, Control UI intercepted the webhook path and returned SPA HTML for GET or `405` for POST.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - exact `kind: "webhook"` routes bypass root Control UI SPA fallback
  - `/chat` still resolves to Control UI, not plugin handlers
  - BlueBubbles, Google Chat, and Zalo register exact runtime webhook routes
  - webhook-kind routes do not match canonicalized uppercase/decoded variants
  - core-owned webhook path conflicts produce diagnostics and do not activate BlueBubbles/Google Chat/Zalo webhook targets
- Edge cases checked:
  - helper default remains `kind: "default"` for existing `registerPluginHttpRoute(...)` callers
  - core-owned webhook paths are rejected with plugin diagnostics
  - exact webhook routes do not inherit gateway auth
- What you did **not** verify:
  - full end-to-end live webhook delivery against external services

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the commits in this PR
- Files/config to restore: gateway/plugin route registration and Control UI routing files touched in this PR
- Known bad symptoms reviewers should watch for: root webhook paths returning `404`/`405` again, plugins unexpectedly intercepting `/chat` or other built-in routes, or misconfigured webhook paths still being reachable through wildcard handlers

## Risks and Mitigations

- Risk: future built-in HTTP routes may need to be added to the core-owned path list.
  - Mitigation: the new path policy is centralized in `src/gateway/server/core-http-paths.ts` and covered by routing tests.
