### PR TITLE
fix: fire internal message:sent hook for dispatcher-based agent replies

### DIFF
--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -60,12 +60,20 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping(
-    params.dispatcherOptions,
-  );
+  const finalized = finalizeInboundContext(params.ctx);
+  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
+    ...params.dispatcherOptions,
+    messageSentHook: {
+      sessionKey: finalized.SessionKey,
+      channelId: finalized.OriginatingChannel ?? finalized.Surface ?? finalized.Provider,
+      accountId: finalized.AccountId,
+      conversationId: finalized.OriginatingTo ?? finalized.From ?? finalized.To,
+      to: finalized.To ?? finalized.OriginatingTo ?? finalized.From,
+    },
+  });
   try {
     return await dispatchInboundMessage({
-      ctx: params.ctx,
+      ctx: finalized,
       cfg: params.cfg,
       dispatcher,
       replyResolver: params.replyResolver,
@@ -86,9 +94,19 @@ export async function dispatchInboundMessageWithDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const dispatcher = createReplyDispatcher(params.dispatcherOptions);
+  const finalized = finalizeInboundContext(params.ctx);
+  const dispatcher = createReplyDispatcher({
+    ...params.dispatcherOptions,
+    messageSentHook: {
+      sessionKey: finalized.SessionKey,
+      channelId: finalized.OriginatingChannel ?? finalized.Surface ?? finalized.Provider,
+      accountId: finalized.AccountId,
+      conversationId: finalized.OriginatingTo ?? finalized.From ?? finalized.To,
+      to: finalized.To ?? finalized.OriginatingTo ?? finalized.From,
+    },
+  });
   return await dispatchInboundMessage({
-    ctx: params.ctx,
+    ctx: finalized,
     cfg: params.cfg,
     dispatcher,
     replyResolver: params.replyResolver,

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,11 +1,20 @@
 import type { TypingCallbacks } from "../../channels/typing.js";
 import type { HumanDelayConfig } from "../../config/types.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { sleep } from "../../utils.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { registerDispatcher } from "./dispatcher-registry.js";
 import { normalizeReplyPayload, type NormalizeReplySkipReason } from "./normalize-reply.js";
 import type { ResponsePrefixContext } from "./response-prefix-template.js";
 import type { TypingController } from "./typing.js";
+
+type ReplyMessageSentHookContext = {
+  sessionKey?: string;
+  channelId?: string;
+  accountId?: string;
+  conversationId?: string;
+  to?: string;
+};
 
 export type ReplyDispatchKind = "tool" | "block" | "final";
 
@@ -55,6 +64,8 @@ export type ReplyDispatcherOptions = {
   onSkip?: ReplyDispatchSkipHandler;
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
+  /** Emits internal message:sent hook for dispatcher-driven agent replies. */
+  messageSentHook?: ReplyMessageSentHookContext;
 };
 
 export type ReplyDispatcherWithTypingOptions = Omit<ReplyDispatcherOptions, "onIdle"> & {
@@ -100,6 +111,30 @@ function normalizeReplyPayloadInternal(
     onHeartbeatStrip: opts.onHeartbeatStrip,
     onSkip: opts.onSkip,
   });
+}
+
+function emitInternalMessageSentHook(params: {
+  hook?: ReplyMessageSentHookContext;
+  payload: ReplyPayload;
+  success: boolean;
+  error?: string;
+}): void {
+  const sessionKey = params.hook?.sessionKey;
+  if (!sessionKey) {
+    return;
+  }
+  const content = params.payload.text ?? "";
+  void triggerInternalHook(
+    createInternalHookEvent("message", "sent", sessionKey, {
+      to: params.hook?.to ?? params.hook?.conversationId,
+      content,
+      success: params.success,
+      ...(params.error ? { error: params.error } : {}),
+      channelId: params.hook?.channelId,
+      accountId: params.hook?.accountId,
+      conversationId: params.hook?.conversationId,
+    }),
+  ).catch(() => {});
 }
 
 export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDispatcher {
@@ -156,8 +191,19 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         // Safe: deliver is called inside an async .then() callback, so even a synchronous
         // throw becomes a rejection that flows through .catch()/.finally(), ensuring cleanup.
         await options.deliver(normalized, { kind });
+        emitInternalMessageSentHook({
+          hook: options.messageSentHook,
+          payload: normalized,
+          success: true,
+        });
       })
       .catch((err) => {
+        emitInternalMessageSentHook({
+          hook: options.messageSentHook,
+          payload: normalized,
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
         options.onError?.(err, { kind });
       })
       .finally(() => {


### PR DESCRIPTION
## Summary
Fixes #31293.

Agent replies delivered through the reply dispatcher path (Discord/Slack/Signal/iMessage/Webchat) were not emitting the internal `message:sent` hook, even though outbound delivery via `deliverOutboundPayloads` did. This made `message:sent` appear broken across channels for normal auto-replies.

## Root cause
`message:sent` internal hook emission existed in `src/infra/outbound/deliver.ts`, but most channel reply flows send through `createReplyDispatcher` directly and bypass `deliverOutboundPayloads`. As a result, no internal hook was triggered for those replies.

## Changes
- `src/auto-reply/reply/reply-dispatcher.ts`
  - Added optional `messageSentHook` context to `ReplyDispatcherOptions`
  - Emit internal `message:sent` hook after successful `deliver(...)`
  - Emit internal `message:sent` hook with `success: false` and `error` when delivery throws
- `src/auto-reply/dispatch.ts`
  - When constructing buffered and non-buffered dispatchers, derive hook context from finalized inbound context and pass it into dispatcher options.

## Notes
Could not run tests in this environment because dependencies are not installed (`vitest` missing / `node_modules` absent). The change is scoped and type-safe within existing dispatcher flow.
