### PR TITLE
fix(heartbeat ): retry session-event runs on transient failures

### DIFF
--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -107,6 +107,79 @@ describe("heartbeat-wake", () => {
     });
   });
 
+  it("retries failed handler results after the default retry delay", async () => {
+    vi.useFakeTimers();
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "failed", reason: "model timeout" })
+      .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
+    await expectRetryAfterDefaultDelay({
+      handler,
+      initialReason: "exec-event",
+      expectedRetryReason: "exec-event",
+    });
+  });
+
+  it("stops retrying failed results after MAX_FAIL_RETRIES attempts", async () => {
+    vi.useFakeTimers();
+    const handler = vi.fn().mockResolvedValue({ status: "failed", reason: "persistent error" });
+    setHeartbeatWakeHandler(handler as unknown as Parameters<typeof setHeartbeatWakeHandler>[0]);
+    requestHeartbeatNow({ reason: "exec-event", coalesceMs: 0 });
+
+    // Initial attempt
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Retry 1
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(handler).toHaveBeenCalledTimes(2);
+
+    // Retry 2
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(handler).toHaveBeenCalledTimes(3);
+
+    // Retry 3 (final)
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(handler).toHaveBeenCalledTimes(4);
+
+    // No more retries — exhausted
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(handler).toHaveBeenCalledTimes(4);
+    expect(hasPendingHeartbeatWake()).toBe(false);
+  });
+
+  it("preserves wake target fields across failed-result retries", async () => {
+    vi.useFakeTimers();
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "failed", reason: "dispatch error" })
+      .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handler);
+
+    requestHeartbeatNow({
+      reason: "exec-event",
+      agentId: "ops",
+      sessionKey: "agent:ops:discord:channel:alerts",
+      coalesceMs: 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0]?.[0]).toEqual({
+      reason: "exec-event",
+      agentId: "ops",
+      sessionKey: "agent:ops:discord:channel:alerts",
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[1]?.[0]).toEqual({
+      reason: "exec-event",
+      agentId: "ops",
+      sessionKey: "agent:ops:discord:channel:alerts",
+    });
+  });
+
   it("stale disposer does not clear a newer handler", async () => {
     vi.useFakeTimers();
     const handlerA = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -19,6 +19,7 @@ type WakeTimerKind = "normal" | "retry";
 type PendingWakeReason = {
   reason: string;
   priority: number;
+  failCount: number;
   requestedAt: number;
   agentId?: string;
   sessionKey?: string;
@@ -35,6 +36,7 @@ let timerKind: WakeTimerKind | null = null;
 
 const DEFAULT_COALESCE_MS = 250;
 const DEFAULT_RETRY_MS = 1_000;
+const MAX_FAIL_RETRIES = 3;
 const REASON_PRIORITY = {
   RETRY: 0,
   INTERVAL: 1,
@@ -76,11 +78,13 @@ function queuePendingWakeReason(params?: {
   requestedAt?: number;
   agentId?: string;
   sessionKey?: string;
+  failCount?: number;
 }) {
   const requestedAt = params?.requestedAt ?? Date.now();
   const normalizedReason = normalizeWakeReason(params?.reason);
   const normalizedAgentId = normalizeWakeTarget(params?.agentId);
   const normalizedSessionKey = normalizeWakeTarget(params?.sessionKey);
+  const failCount = params?.failCount ?? 0;
   const wakeTargetKey = getWakeTargetKey({
     agentId: normalizedAgentId,
     sessionKey: normalizedSessionKey,
@@ -88,6 +92,7 @@ function queuePendingWakeReason(params?: {
   const next: PendingWakeReason = {
     reason: normalizedReason,
     priority: resolveReasonPriority(normalizedReason),
+    failCount,
     requestedAt,
     agentId: normalizedAgentId,
     sessionKey: normalizedSessionKey,
@@ -159,8 +164,24 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
             reason: pendingWake.reason ?? "retry",
             agentId: pendingWake.agentId,
             sessionKey: pendingWake.sessionKey,
+            failCount: pendingWake.failCount,
           });
           schedule(DEFAULT_RETRY_MS, "retry");
+        }
+        if (res.status === "failed") {
+          // Transient dispatch/model failure — requeue with bounded retry so
+          // queued system events (e.g. exec-completion wake) are not silently
+          // dropped.  The fail counter prevents infinite retry loops.
+          const nextFailCount = (pendingWake.failCount ?? 0) + 1;
+          if (nextFailCount <= MAX_FAIL_RETRIES) {
+            queuePendingWakeReason({
+              reason: pendingWake.reason ?? "retry",
+              agentId: pendingWake.agentId,
+              sessionKey: pendingWake.sessionKey,
+              failCount: nextFailCount,
+            });
+            schedule(DEFAULT_RETRY_MS, "retry");
+          }
         }
       }
     } catch {
@@ -170,6 +191,7 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
           reason: pendingWake.reason ?? "retry",
           agentId: pendingWake.agentId,
           sessionKey: pendingWake.sessionKey,
+          failCount: pendingWake.failCount,
         });
       }
       schedule(DEFAULT_RETRY_MS, "retry");


### PR DESCRIPTION
Fixes #31354

## Summary

Session-event runs (e.g. `exec-event` wake) were silently dropped when the heartbeat runner
encountered transient failures. This PR adds bounded retry semantics so queued system events
are not permanently lost.

## Problem

`requestHeartbeatNow({ reason: "exec-event" })` triggers a wake through the `heartbeat-wake`
scheduler. When the heartbeat runner encounters a transient error (model timeout, dispatch
failure, etc.), it catches the error and returns `{ status: "failed", reason }` instead of
re-throwing. The scheduler's `catch` block — which handles retry — never fires. The
`requests-in-flight` retry path also doesn't match. Result: the wake is silently dropped and
the queued system events remain unprocessed until another unrelated event triggers a run.

## Fix

Add a `failed`-status retry path in the `heartbeat-wake` scheduler, parallel to the existing
`requests-in-flight` path:

- When the handler returns `{ status: "failed" }`, re-queue the wake with a `failCount`
  counter and schedule a retry after `DEFAULT_RETRY_MS` (1 s).
- Cap retries at `MAX_FAIL_RETRIES` (3) to prevent infinite loops on persistent errors.
- Preserve the original `reason`, `agentId`, and `sessionKey` across retries.

This is a minimal, targeted fix within `heartbeat-wake.ts` that does not alter the
error-handling semantics of `heartbeat-runner.ts` or `runHeartbeatOnce`.

## Changes

| File | What changed |
|---|---|
| `src/infra/heartbeat-wake.ts` | Add `failCount` to `PendingWakeReason`; add bounded retry on `failed` status |
| `src/infra/heartbeat-wake.test.ts` | 3 new tests: retry on failed, bounded exhaustion, target field preservation |

## Testing

- [x] New unit tests added and passing locally
- [x] Existing `heartbeat-wake` tests unaffected
- [x] AI-assisted (analysis and code generation)
