### PR TITLE
fix(hooks): fire message:received internal hook unconditionally

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1435,7 +1435,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
   });
 
-  it("skips internal message:received hook when session key is unavailable", async () => {
+  it("still emits internal message:received hook when session key is unavailable", async () => {
     setNoAbort();
     const cfg = emptyConfig;
     const dispatcher = createDispatcher();
@@ -1449,8 +1449,17 @@ describe("dispatchReplyFromConfig", () => {
     const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
-    expect(internalHookMocks.createInternalHookEvent).not.toHaveBeenCalled();
-    expect(internalHookMocks.triggerInternalHook).not.toHaveBeenCalled();
+    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledWith(
+      "message",
+      "received",
+      "",
+      expect.objectContaining({
+        from: ctx.From,
+        content: "/help",
+        channelId: "telegram",
+      }),
+    );
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
   });
 
   it("emits diagnostics when enabled", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -214,33 +214,33 @@ export async function dispatchReplyFromConfig(params: {
   }
 
   // Bridge to internal hooks (HOOK.md discovery system) - refs #8807
-  if (sessionKey) {
-    void triggerInternalHook(
-      createInternalHookEvent("message", "received", sessionKey, {
-        from: ctx.From ?? "",
-        content,
-        timestamp,
-        channelId,
-        accountId: ctx.AccountId,
-        conversationId,
-        messageId: messageIdForHook,
-        metadata: {
-          to: ctx.To,
-          provider: ctx.Provider,
-          surface: ctx.Surface,
-          threadId: ctx.MessageThreadId,
-          senderId: ctx.SenderId,
-          senderName: ctx.SenderName,
-          senderUsername: ctx.SenderUsername,
-          senderE164: ctx.SenderE164,
-          guildId: ctx.GroupSpace,
-          channelName: ctx.GroupChannel,
-        },
-      }),
-    ).catch((err) => {
-      logVerbose(`dispatch-from-config: message_received internal hook failed: ${String(err)}`);
-    });
-  }
+  // Fire unconditionally so guild/channel messages always reach hook handlers
+  // even when sessionKey is not yet resolved (e.g. Discord guild channels).
+  void triggerInternalHook(
+    createInternalHookEvent("message", "received", sessionKey ?? "", {
+      from: ctx.From ?? "",
+      content,
+      timestamp,
+      channelId,
+      accountId: ctx.AccountId,
+      conversationId,
+      messageId: messageIdForHook,
+      metadata: {
+        to: ctx.To,
+        provider: ctx.Provider,
+        surface: ctx.Surface,
+        threadId: ctx.MessageThreadId,
+        senderId: ctx.SenderId,
+        senderName: ctx.SenderName,
+        senderUsername: ctx.SenderUsername,
+        senderE164: ctx.SenderE164,
+        guildId: ctx.GroupSpace,
+        channelName: ctx.GroupChannel,
+      },
+    }),
+  ).catch((err) => {
+    logVerbose(`dispatch-from-config: message_received internal hook failed: ${String(err)}`);
+  });
 
   // Check if we should route replies to originating channel instead of dispatcher.
   // Only route when the originating channel is DIFFERENT from the current surface.


### PR DESCRIPTION
## Summary

- Problem: The `message:received` internal hook was guarded by `if (sessionKey)`, which silently skipped the hook when `sessionKey` was falsy. Discord guild channel messages in certain configurations could have a missing or empty session key at hook emission time, causing the hook to never fire.
- Why it matters: Users rely on `message:received` hooks to intercept messages for routing, logging, or spawning lightweight agents. The silent skip left no diagnostic trace, making the issue difficult to debug.
- What changed: Removed the `if (sessionKey)` guard around the internal hook emission in `dispatch-from-config.ts`. Now passes `sessionKey ?? ""` to `createInternalHookEvent`, so the hook fires unconditionally for all non-duplicate inbound messages. Updated the corresponding test to verify the hook fires even without a session key.
- What did NOT change: Plugin hooks (`message_received`) were already unconditional and remain unchanged. The dedupe check still prevents hooks from firing for duplicate messages.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31212

## User-visible / Behavior Changes

- `message:received` internal hooks now fire for ALL non-duplicate inbound messages, regardless of whether a session key is available
- Hook handlers receive `sessionKey: ""` when no session key is resolved (handlers can check for this)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js 22+

### Steps

1. Register an internal hook handler for `message:received`
2. Send a message in a Discord guild channel
3. Observe: the hook handler is now called

### Expected

- Hook fires for all channels including Discord guild channels

### Actual

- Before: hook silently skipped when `sessionKey` was falsy
- After: hook fires unconditionally

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: existing test suite passes (34/34 tests), including updated test for missing session key
- Edge cases checked: empty session key passed as `""`, duplicate message dedupe still prevents double-firing
- What you did **not** verify: live Discord guild channel testing

## Compatibility / Migration

- Backward compatible? `Yes — handlers already receive the full event object`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/auto-reply/reply/dispatch-from-config.ts`

## Risks and Mitigations

- Risk: Hook handlers that relied on `sessionKey` being non-empty will now receive `""` for messages without a session key
  - Mitigation: Handlers should already check `event.sessionKey` for their filtering logic; the empty string is a valid signal for "no session"

