### PR TITLE
fix(identity): support fullwidth colon and CJK labels in IDENTITY.md

### DIFF
--- a/src/agents/identity-file.test.ts
+++ b/src/agents/identity-file.test.ts
@@ -33,4 +33,16 @@ describe("parseIdentityMarkdown", () => {
       avatar: "avatars/openclaw.png",
     });
   });
+
+  it("parses fullwidth colon labels used in CJK locales", () => {
+    const content = `
+- **名称：** 小助手
+- **头像：**avatars/C-3PO.webp
+`;
+    const parsed = parseIdentityMarkdown(content);
+    expect(parsed).toEqual({
+      name: "小助手",
+      avatar: "avatars/C-3PO.webp",
+    });
+  });
 });

--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -11,6 +11,16 @@ export type AgentIdentityFile = {
   avatar?: string;
 };
 
+const LABEL_ALIASES: Record<string, string> = {
+  名称: "name",
+  名字: "name",
+  头像: "avatar",
+  表情: "emoji",
+  生物: "creature",
+  氛围: "vibe",
+  主题: "theme",
+};
+
 const IDENTITY_PLACEHOLDER_VALUES = new Set([
   "pick something you like",
   "ai? robot? familiar? ghost in the machine? something weirder?",
@@ -40,11 +50,13 @@ export function parseIdentityMarkdown(content: string): AgentIdentityFile {
   const lines = content.split(/\r?\n/);
   for (const line of lines) {
     const cleaned = line.trim().replace(/^\s*-\s*/, "");
-    const colonIndex = cleaned.indexOf(":");
-    if (colonIndex === -1) {
+    const colonMatch = cleaned.match(/[:：]/);
+    if (!colonMatch || colonMatch.index === undefined) {
       continue;
     }
-    const label = cleaned.slice(0, colonIndex).replace(/[*_]/g, "").trim().toLowerCase();
+    const colonIndex = colonMatch.index;
+    const rawLabel = cleaned.slice(0, colonIndex).replace(/[*_]/g, "").trim().toLowerCase();
+    const label = LABEL_ALIASES[rawLabel] ?? rawLabel;
     const value = cleaned
       .slice(colonIndex + 1)
       .replace(/^[*_]+|[*_]+$/g, "")


### PR DESCRIPTION
## Summary

- Problem: `parseIdentityMarkdown` only matched ASCII colon (`:`) when splitting label/value pairs. Users writing IDENTITY.md in Chinese commonly use the fullwidth colon (`：`, U+FF1A), causing avatar, name, and other fields to be silently ignored. Additionally, CJK label names (e.g. `头像` for avatar, `名称` for name) were not recognized.
- Why it matters: CJK-locale users cannot set their agent's avatar or other identity fields using their native language, despite IDENTITY.md being a user-facing file.
- What changed:
  1. Updated the colon-matching regex from `cleaned.indexOf(":")` to `cleaned.match(/[:：]/)` to support both ASCII and fullwidth colons
  2. Added a `LABEL_ALIASES` map that maps common CJK labels to their English equivalents: `头像`→`avatar`, `名称`/`名字`→`name`, `表情`→`emoji`, `生物`→`creature`, `氛围`→`vibe`, `主题`→`theme`
- What did NOT change: No changes to avatar file resolution, serving, or the webchat frontend

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31216

## User-visible / Behavior Changes

- IDENTITY.md now supports fullwidth colons (`：`) in addition to ASCII colons (`:`)
- CJK label names like `头像`, `名称`, `表情`, `生物`, `氛围`, `主题` are now recognized as aliases for their English counterparts

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js 22+

### Steps

1. Create IDENTITY.md with CJK labels: `- **头像：**avatars/agent.webp`
2. Start gateway and access webchat
3. Avatar now loads correctly

### Expected

- CJK labels and fullwidth colons are parsed correctly

### Actual

- Before: avatar (and other fields) silently ignored when using CJK labels or fullwidth colons
- After: parsed correctly

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: all 3 tests pass, including new CJK locale test
- Edge cases checked: mixed ASCII/fullwidth colons, labels with markdown bold formatting
- What you did **not** verify: end-to-end webchat avatar display

## Compatibility / Migration

- Backward compatible? `Yes — existing ASCII colon format continues to work`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/identity-file.ts`

