### PR TITLE
fix: bypass root Control UI for exact webhook routes

### DIFF
--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -243,7 +243,14 @@ export function registerBlueBubblesWebhookTarget(target: WebhookTarget): () => v
         path,
         pluginId: WEBHOOK_ROUTE_PLUGIN_ID,
         source: "bluebubbles-webhook",
-        handler: handleBlueBubblesWebhookRequest,
+        handler: async (req, res) => {
+          const handled = await handleBlueBubblesWebhookRequest(req, res);
+          if (!handled && !res.headersSent) {
+            res.statusCode = 404;
+            res.setHeader("Content-Type", "text/plain; charset=utf-8");
+            res.end("Not Found");
+          }
+        },
       }),
   });
   return () => {

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import {
   isRequestBodyLimitError,
   readRequestBodyWithLimit,
+  registerPluginHttpRoute,
   registerWebhookTarget,
   rejectNonPostWebhookRequest,
   requestBodyErrorToText,
@@ -46,6 +47,7 @@ type BlueBubblesDebounceEntry = {
  * sends as separate webhook events when no explicit inbound debounce config exists.
  */
 const DEFAULT_INBOUND_DEBOUNCE_MS = 500;
+const WEBHOOK_ROUTE_PLUGIN_ID = "bluebubbles";
 
 /**
  * Combines multiple debounced messages into a single message for processing.
@@ -235,7 +237,15 @@ function removeDebouncer(target: WebhookTarget): void {
 }
 
 export function registerBlueBubblesWebhookTarget(target: WebhookTarget): () => void {
-  const registered = registerWebhookTarget(webhookTargets, target);
+  const registered = registerWebhookTarget(webhookTargets, target, {
+    onFirstTargetForPath: (path) =>
+      registerPluginHttpRoute({
+        path,
+        pluginId: WEBHOOK_ROUTE_PLUGIN_ID,
+        source: "bluebubbles-webhook",
+        handler: handleBlueBubblesWebhookRequest,
+      }),
+  });
   return () => {
     registered.unregister();
     // Clean up debouncer when target is unregistered

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -242,6 +242,7 @@ export function registerBlueBubblesWebhookTarget(target: WebhookTarget): () => v
       registerPluginHttpRoute({
         path,
         pluginId: WEBHOOK_ROUTE_PLUGIN_ID,
+        requireGatewayAuth: false,
         source: "bluebubbles-webhook",
         handler: async (req, res) => {
           const handled = await handleBlueBubblesWebhookRequest(req, res);

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -5,6 +5,7 @@ import {
   createScopedPairingAccess,
   createReplyPrefixOptions,
   readJsonBodyWithLimit,
+  registerPluginHttpRoute,
   registerWebhookTarget,
   rejectNonPostWebhookRequest,
   isDangerousNameMatchingEnabled,
@@ -66,6 +67,7 @@ type WebhookTarget = {
 };
 
 const webhookTargets = new Map<string, WebhookTarget[]>();
+const WEBHOOK_ROUTE_PLUGIN_ID = "googlechat";
 
 function logVerbose(core: GoogleChatCoreRuntime, runtime: GoogleChatRuntimeEnv, message: string) {
   if (core.logging.shouldLogVerbose()) {
@@ -99,7 +101,23 @@ function warnDeprecatedUsersEmailEntries(
 }
 
 export function registerGoogleChatWebhookTarget(target: WebhookTarget): () => void {
-  return registerWebhookTarget(webhookTargets, target).unregister;
+  const registered = registerWebhookTarget(webhookTargets, target, {
+    onFirstTargetForPath: (path) =>
+      registerPluginHttpRoute({
+        path,
+        pluginId: WEBHOOK_ROUTE_PLUGIN_ID,
+        source: "googlechat-webhook",
+        handler: async (req, res) => {
+          const handled = await handleGoogleChatWebhookRequest(req, res);
+          if (!handled && !res.headersSent) {
+            res.statusCode = 404;
+            res.setHeader("Content-Type", "text/plain; charset=utf-8");
+            res.end("Not Found");
+          }
+        },
+      }),
+  });
+  return registered.unregister;
 }
 
 function normalizeAudienceType(value?: string | null): GoogleChatAudienceType | undefined {

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -106,6 +106,7 @@ export function registerGoogleChatWebhookTarget(target: WebhookTarget): () => vo
       registerPluginHttpRoute({
         path,
         pluginId: WEBHOOK_ROUTE_PLUGIN_ID,
+        requireGatewayAuth: false,
         source: "googlechat-webhook",
         handler: async (req, res) => {
           const handled = await handleGoogleChatWebhookRequest(req, res);

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -1,7 +1,9 @@
 import { EventEmitter } from "node:events";
 import type { IncomingMessage } from "node:http";
 import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../../../src/plugins/registry.js";
+import { setActivePluginRegistry } from "../../../src/plugins/runtime.js";
 import { createMockServerResponse } from "../../../src/test-utils/mock-http-response.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import { verifyGoogleChatRequest } from "./auth.js";
@@ -86,6 +88,10 @@ function registerTwoTargets() {
 }
 
 describe("Google Chat webhook routing", () => {
+  afterEach(() => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
   it("rejects ambiguous routing when multiple targets on the same path verify successfully", async () => {
     vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
 
@@ -133,6 +139,33 @@ describe("Google Chat webhook routing", () => {
       expect(sinkB).toHaveBeenCalledTimes(1);
     } finally {
       unregister();
+    }
+  });
+
+  it("registers an exact webhook route while a target is active", () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+
+    const unregister = registerGoogleChatWebhookTarget({
+      account: baseAccount("A"),
+      config: {} as OpenClawConfig,
+      runtime: {},
+      core: {} as PluginRuntime,
+      path: "/googlechat",
+      statusSink: vi.fn(),
+      mediaMaxMb: 5,
+    });
+
+    try {
+      expect(registry.httpRoutes).toContainEqual(
+        expect.objectContaining({
+          pluginId: "googlechat",
+          path: "/googlechat",
+        }),
+      );
+    } finally {
+      unregister();
+      expect(registry.httpRoutes).toHaveLength(0);
     }
   });
 });

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -161,6 +161,7 @@ describe("Google Chat webhook routing", () => {
         expect.objectContaining({
           pluginId: "googlechat",
           path: "/googlechat",
+          requireGatewayAuth: false,
         }),
       );
     } finally {

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -3,6 +3,7 @@ import type { MarkdownTableMode, OpenClawConfig, OutboundReplyPayload } from "op
 import {
   createScopedPairingAccess,
   createReplyPrefixOptions,
+  registerPluginHttpRoute,
   resolveSenderCommandAuthorization,
   resolveOutboundMediaUrls,
   resolveDefaultGroupPolicy,
@@ -73,7 +74,24 @@ function logVerbose(core: ZaloCoreRuntime, runtime: ZaloRuntimeEnv, message: str
 }
 
 export function registerZaloWebhookTarget(target: ZaloWebhookTarget): () => void {
-  return registerZaloWebhookTargetInternal(target);
+  const unregisterHttpRoute = registerPluginHttpRoute({
+    path: target.path,
+    pluginId: "zalo",
+    source: "zalo-webhook",
+    handler: async (req, res) => {
+      const handled = await handleZaloWebhookRequest(req, res);
+      if (!handled && !res.headersSent) {
+        res.statusCode = 404;
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        res.end("Not Found");
+      }
+    },
+  });
+  const unregisterWebhookTarget = registerZaloWebhookTargetInternal(target);
+  return () => {
+    unregisterHttpRoute();
+    unregisterWebhookTarget();
+  };
 }
 
 export {

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -74,24 +74,22 @@ function logVerbose(core: ZaloCoreRuntime, runtime: ZaloRuntimeEnv, message: str
 }
 
 export function registerZaloWebhookTarget(target: ZaloWebhookTarget): () => void {
-  const unregisterHttpRoute = registerPluginHttpRoute({
-    path: target.path,
-    pluginId: "zalo",
-    source: "zalo-webhook",
-    handler: async (req, res) => {
-      const handled = await handleZaloWebhookRequest(req, res);
-      if (!handled && !res.headersSent) {
-        res.statusCode = 404;
-        res.setHeader("Content-Type", "text/plain; charset=utf-8");
-        res.end("Not Found");
-      }
-    },
+  return registerZaloWebhookTargetInternal(target, {
+    onFirstTargetForPath: (path) =>
+      registerPluginHttpRoute({
+        path,
+        pluginId: "zalo",
+        source: "zalo-webhook",
+        handler: async (req, res) => {
+          const handled = await handleZaloWebhookRequest(req, res);
+          if (!handled && !res.headersSent) {
+            res.statusCode = 404;
+            res.setHeader("Content-Type", "text/plain; charset=utf-8");
+            res.end("Not Found");
+          }
+        },
+      }),
   });
-  const unregisterWebhookTarget = registerZaloWebhookTargetInternal(target);
-  return () => {
-    unregisterHttpRoute();
-    unregisterWebhookTarget();
-  };
 }
 
 export {

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -79,6 +79,7 @@ export function registerZaloWebhookTarget(target: ZaloWebhookTarget): () => void
       registerPluginHttpRoute({
         path,
         pluginId: "zalo",
+        requireGatewayAuth: false,
         source: "zalo-webhook",
         handler: async (req, res) => {
           const handled = await handleZaloWebhookRequest(req, res);

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -2,6 +2,8 @@ import { createServer, type RequestListener } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../../../src/plugins/registry.js";
+import { setActivePluginRegistry } from "../../../src/plugins/runtime.js";
 import {
   clearZaloWebhookSecurityStateForTest,
   getZaloWebhookRateLimitStateSizeForTest,
@@ -64,6 +66,25 @@ function registerTarget(params: {
 describe("handleZaloWebhookRequest", () => {
   afterEach(() => {
     clearZaloWebhookSecurityStateForTest();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("registers an exact webhook route while a target is active", () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+    const unregister = registerTarget({ path: "/hook" });
+
+    try {
+      expect(registry.httpRoutes).toContainEqual(
+        expect.objectContaining({
+          pluginId: "zalo",
+          path: "/hook",
+        }),
+      );
+    } finally {
+      unregister();
+      expect(registry.httpRoutes).toHaveLength(0);
+    }
   });
 
   it("returns 400 for non-object payloads", async () => {

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -79,6 +79,7 @@ describe("handleZaloWebhookRequest", () => {
         expect.objectContaining({
           pluginId: "zalo",
           path: "/hook",
+          requireGatewayAuth: false,
         }),
       );
     } finally {

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -87,6 +87,27 @@ describe("handleZaloWebhookRequest", () => {
     }
   });
 
+  it("keeps the exact webhook route until the last target unregisters", () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+    const unregisterA = registerTarget({ path: "/hook" });
+    const unregisterB = registerTarget({ path: "/hook" });
+
+    try {
+      expect(registry.httpRoutes).toHaveLength(1);
+
+      unregisterB();
+      expect(registry.httpRoutes).toHaveLength(1);
+      expect(registry.httpRoutes[0]?.path).toBe("/hook");
+
+      unregisterA();
+      expect(registry.httpRoutes).toHaveLength(0);
+    } finally {
+      unregisterA();
+      unregisterB();
+    }
+  });
+
   it("returns 400 for non-object payloads", async () => {
     const unregister = registerTarget({ path: "/hook" });
 

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -1,6 +1,6 @@
 import { timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig, RegisterWebhookTargetOptions } from "openclaw/plugin-sdk";
 import {
   createDedupeCache,
   createFixedWindowRateLimiter,
@@ -106,8 +106,11 @@ function recordWebhookStatus(
   });
 }
 
-export function registerZaloWebhookTarget(target: ZaloWebhookTarget): () => void {
-  return registerWebhookTarget(webhookTargets, target).unregister;
+export function registerZaloWebhookTarget(
+  target: ZaloWebhookTarget,
+  opts?: RegisterWebhookTargetOptions,
+): () => void {
+  return registerWebhookTarget(webhookTargets, target, opts).unregister;
 }
 
 export async function handleZaloWebhookRequest(

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -45,6 +45,7 @@ describe("handleControlUiHttpRequest", () => {
     method: "GET" | "HEAD" | "POST";
     rootPath: string;
     basePath?: string;
+    shouldBypassPath?: (pathname: string) => boolean;
   }) {
     const { res, end } = makeMockHttpResponse();
     const handled = handleControlUiHttpRequest(
@@ -52,6 +53,7 @@ describe("handleControlUiHttpRequest", () => {
       res,
       {
         ...(params.basePath ? { basePath: params.basePath } : {}),
+        ...(params.shouldBypassPath ? { shouldBypassPath: params.shouldBypassPath } : {}),
         root: { kind: "resolved", path: params.rootPath },
       },
     );
@@ -356,16 +358,32 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
-  it("falls through POST requests when basePath is empty", async () => {
+  it("falls through POST requests for explicit bypass paths when basePath is empty", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
         const { handled, end } = runControlUiRequest({
           url: "/webhook/bluebubbles",
           method: "POST",
           rootPath: tmp,
+          shouldBypassPath: (pathname) => pathname === "/webhook/bluebubbles",
         });
         expect(handled).toBe(false);
         expect(end).not.toHaveBeenCalled();
+      },
+    });
+  });
+
+  it("returns 405 for POST requests to root-mounted paths without an explicit bypass", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { handled, res, end } = runControlUiRequest({
+          url: "/webhook/bluebubbles",
+          method: "POST",
+          rootPath: tmp,
+        });
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(405);
+        expect(end).toHaveBeenCalledWith("Method Not Allowed");
       },
     });
   });
@@ -382,6 +400,21 @@ describe("handleControlUiHttpRequest", () => {
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(405);
         expect(end).toHaveBeenCalledWith("Method Not Allowed");
+      },
+    });
+  });
+
+  it("falls through POST requests outside configured basePath", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { handled, end } = runControlUiRequest({
+          url: "/bluebubbles-webhook",
+          method: "POST",
+          rootPath: tmp,
+          basePath: "/openclaw",
+        });
+        expect(handled).toBe(false);
+        expect(end).not.toHaveBeenCalled();
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -27,6 +27,7 @@ export type ControlUiRequestOptions = {
   config?: OpenClawConfig;
   agentId?: string;
   root?: ControlUiRootState;
+  shouldBypassPath?: (pathname: string) => boolean;
 };
 
 export type ControlUiRootState =
@@ -275,6 +276,7 @@ export function handleControlUiHttpRequest(
   if (!urlRaw) {
     return false;
   }
+  const isReadMethod = req.method === "GET" || req.method === "HEAD";
   const url = new URL(urlRaw, "http://localhost");
   const basePath = normalizeControlUiBasePath(opts?.basePath);
   const pathname = url.pathname;
@@ -293,6 +295,16 @@ export function handleControlUiHttpRequest(
     if (pathname === "/api" || pathname.startsWith("/api/")) {
       return false;
     }
+    if (!isReadMethod && opts?.shouldBypassPath?.(pathname)) {
+      return false;
+    }
+  }
+
+  if (!isReadMethod) {
+    res.statusCode = 405;
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.end("Method Not Allowed");
+    return true;
   }
 
   if (basePath) {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -193,6 +193,12 @@ function respondNotFound(res: ServerResponse) {
   res.end("Not Found");
 }
 
+function respondMethodNotAllowed(res: ServerResponse) {
+  res.statusCode = 405;
+  res.setHeader("Content-Type", "text/plain; charset=utf-8");
+  res.end("Method Not Allowed");
+}
+
 function setStaticFileHeaders(res: ServerResponse, filePath: string) {
   const ext = path.extname(filePath).toLowerCase();
   res.setHeader("Content-Type", contentTypeForExt(ext));
@@ -298,13 +304,10 @@ export function handleControlUiHttpRequest(
     if (!isReadMethod && opts?.shouldBypassPath?.(pathname)) {
       return false;
     }
-  }
-
-  if (!isReadMethod) {
-    res.statusCode = 405;
-    res.setHeader("Content-Type", "text/plain; charset=utf-8");
-    res.end("Method Not Allowed");
-    return true;
+    if (!isReadMethod) {
+      respondMethodNotAllowed(res);
+      return true;
+    }
   }
 
   if (basePath) {
@@ -318,19 +321,10 @@ export function handleControlUiHttpRequest(
     if (!pathname.startsWith(`${basePath}/`)) {
       return false;
     }
-  }
-
-  // Method guard must run AFTER path checks so that POST requests to non-UI
-  // paths (channel webhooks etc.) fall through to later handlers.  When no
-  // basePath is configured the SPA catch-all would otherwise 405 every POST.
-  if (req.method !== "GET" && req.method !== "HEAD") {
-    if (!basePath) {
-      return false;
+    if (!isReadMethod) {
+      respondMethodNotAllowed(res);
+      return true;
     }
-    res.statusCode = 405;
-    res.setHeader("Content-Type", "text/plain; charset=utf-8");
-    res.end("Method Not Allowed");
-    return true;
   }
 
   applyControlUiSecurityHeaders(res);

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -371,6 +371,7 @@ export function createGatewayHttpServer(opts: {
   strictTransportSecurityHeader?: string;
   handleHooksRequest: HooksRequestHandler;
   handlePluginRequest?: HooksRequestHandler;
+  shouldBypassControlUiForPath?: (requestPath: string) => boolean;
   shouldEnforcePluginGatewayAuth?: (requestPath: string) => boolean;
   resolvedAuth: ResolvedGatewayAuth;
   /** Optional rate limiter for auth brute-force protection. */
@@ -389,6 +390,7 @@ export function createGatewayHttpServer(opts: {
     strictTransportSecurityHeader,
     handleHooksRequest,
     handlePluginRequest,
+    shouldBypassControlUiForPath,
     shouldEnforcePluginGatewayAuth,
     resolvedAuth,
     rateLimiter,
@@ -503,6 +505,7 @@ export function createGatewayHttpServer(opts: {
             basePath: controlUiBasePath,
             config: configSnapshot,
             root: controlUiRoot,
+            shouldBypassPath: shouldBypassControlUiForPath,
           })
         ) {
           return;

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -29,6 +29,7 @@ import { createGatewayHooksRequestHandler } from "./server/hooks.js";
 import { listenGatewayHttpServer } from "./server/http-listen.js";
 import {
   createGatewayPluginRequestHandler,
+  isRegisteredPluginHttpRoutePath,
   shouldEnforceGatewayAuthForPluginPath,
 } from "./server/plugins-http.js";
 import type { GatewayTlsRuntime } from "./server/tls.js";
@@ -121,6 +122,9 @@ export async function createGatewayRuntimeState(params: {
   const shouldEnforcePluginGatewayAuth = (requestPath: string): boolean => {
     return shouldEnforceGatewayAuthForPluginPath(params.pluginRegistry, requestPath);
   };
+  const shouldBypassControlUiForPath = (requestPath: string): boolean => {
+    return isRegisteredPluginHttpRoutePath(params.pluginRegistry, requestPath);
+  };
 
   const bindHosts = await resolveGatewayListenHosts(params.bindHost);
   if (!isLoopbackHost(params.bindHost)) {
@@ -144,6 +148,7 @@ export async function createGatewayRuntimeState(params: {
       strictTransportSecurityHeader: params.strictTransportSecurityHeader,
       handleHooksRequest,
       handlePluginRequest,
+      shouldBypassControlUiForPath,
       shouldEnforcePluginGatewayAuth,
       resolvedAuth: params.resolvedAuth,
       rateLimiter: params.rateLimiter,

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -559,6 +559,57 @@ describe("gateway plugin HTTP auth boundary", () => {
     });
   });
 
+  test("serves root-level plugin webhook routes before control ui method guard", async () => {
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "none",
+      token: undefined,
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    await withTempConfig({
+      cfg: { gateway: { trustedProxies: [] } },
+      prefix: "openclaw-plugin-http-control-ui-webhook-test-",
+      run: async () => {
+        const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+          const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+          if (pathname === "/bluebubbles-webhook" && req.method === "POST") {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "text/plain; charset=utf-8");
+            res.end("webhook-ok");
+            return true;
+          }
+          return false;
+        });
+
+        const server = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
+          controlUiEnabled: true,
+          controlUiBasePath: "",
+          controlUiRoot: { kind: "missing" },
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest: async () => false,
+          handlePluginRequest,
+          shouldBypassControlUiForPath: (requestPath) => requestPath === "/bluebubbles-webhook",
+          resolvedAuth,
+        });
+
+        const response = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({ path: "/bluebubbles-webhook", method: "POST" }),
+          response.res,
+        );
+
+        expect(response.res.statusCode).toBe(200);
+        expect(response.getBody()).toContain("webhook-ok");
+        expect(handlePluginRequest).toHaveBeenCalledTimes(1);
+      },
+    });
+  });
+
   test("does not let plugin handlers shadow control ui routes", async () => {
     const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
       const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
@@ -582,6 +633,53 @@ describe("gateway plugin HTTP auth boundary", () => {
       },
       run: async (server) => {
         const response = await sendRequest(server, { path: "/chat" });
+
+        expect(response.res.statusCode).toBe(503);
+        expect(response.getBody()).toContain("Control UI assets not found");
+        expect(handlePluginRequest).not.toHaveBeenCalled();
+      },
+    });
+  });
+
+  test("does not let registered plugin routes shadow control ui read routes", async () => {
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "none",
+      token: undefined,
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    await withTempConfig({
+      cfg: { gateway: { trustedProxies: [] } },
+      prefix: "openclaw-plugin-http-control-ui-route-shadow-test-",
+      run: async () => {
+        const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+          const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+          if (pathname === "/chat") {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "text/plain; charset=utf-8");
+            res.end("plugin-route-shadow");
+            return true;
+          }
+          return false;
+        });
+
+        const server = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
+          controlUiEnabled: true,
+          controlUiBasePath: "",
+          controlUiRoot: { kind: "missing" },
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest: async () => false,
+          handlePluginRequest,
+          shouldBypassControlUiForPath: (requestPath) => requestPath === "/chat",
+          resolvedAuth,
+        });
+
+        const response = createResponse();
+        await dispatchRequest(server, createRequest({ path: "/chat" }), response.res);
 
         expect(response.res.statusCode).toBe(503);
         expect(response.getBody()).toContain("Control UI assets not found");

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -1,10 +1,16 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, test, vi } from "vitest";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
+import { registerPluginHttpRoute } from "../plugins/http-registry.js";
+import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import type { HooksConfigResolved } from "./hooks.js";
 import { canonicalizePathVariant, isProtectedPluginRoutePath } from "./security-path.js";
 import { createGatewayHttpServer, createHooksRequestHandler } from "./server-http.js";
+import {
+  createGatewayPluginRequestHandler,
+  shouldEnforceGatewayAuthForPluginPath,
+} from "./server/plugins-http.js";
 import { withTempConfig } from "./test-temp-config.js";
 
 type GatewayHttpServer = ReturnType<typeof createGatewayHttpServer>;
@@ -607,6 +613,62 @@ describe("gateway plugin HTTP auth boundary", () => {
         expect(response.getBody()).toContain("webhook-ok");
         expect(handlePluginRequest).toHaveBeenCalledTimes(1);
       },
+    });
+  });
+
+  test("keeps webhook exact routes ungated while default exact routes still require auth", async () => {
+    await withGatewayTempConfig("openclaw-plugin-http-auth-exact-route-test-", async () => {
+      const registry = createEmptyPluginRegistry();
+
+      registerPluginHttpRoute({
+        path: "/bluebubbles-webhook",
+        handler: async (_req, res) => {
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "text/plain; charset=utf-8");
+          res.end("webhook-ok");
+        },
+        requireGatewayAuth: false,
+        registry,
+      });
+      registerPluginHttpRoute({
+        path: "/plugins/private",
+        handler: async (_req, res) => {
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "text/plain; charset=utf-8");
+          res.end("private-ok");
+        },
+        registry,
+      });
+
+      const handlePluginRequest = createGatewayPluginRequestHandler({
+        registry,
+        log: { warn: vi.fn() } as unknown as ReturnType<typeof createSubsystemLogger>,
+      });
+
+      const server = createTestGatewayServer({
+        resolvedAuth: AUTH_TOKEN,
+        overrides: {
+          controlUiEnabled: true,
+          controlUiBasePath: "",
+          controlUiRoot: { kind: "missing" },
+          handlePluginRequest,
+          shouldBypassControlUiForPath: (requestPath) => requestPath === "/bluebubbles-webhook",
+          shouldEnforcePluginGatewayAuth: (requestPath) =>
+            shouldEnforceGatewayAuthForPluginPath(registry, requestPath),
+        },
+      });
+
+      const webhookResponse = await sendRequest(server, {
+        path: "/bluebubbles-webhook",
+        method: "POST",
+      });
+      expect(webhookResponse.res.statusCode).toBe(200);
+      expect(webhookResponse.getBody()).toBe("webhook-ok");
+
+      const privateResponse = await sendRequest(server, {
+        path: "/plugins/private",
+      });
+      expectUnauthorizedResponse(privateResponse);
     });
   });
 

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -17,12 +17,14 @@ function createPluginLog(): PluginHandlerLog {
 function createRoute(params: {
   path: string;
   pluginId?: string;
+  requireGatewayAuth?: boolean;
   handler?: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>;
 }) {
   return {
     pluginId: params.pluginId ?? "route",
     path: params.path,
     handler: params.handler ?? (() => {}),
+    requireGatewayAuth: params.requireGatewayAuth ?? true,
     source: params.pluginId ?? "route",
   };
 }
@@ -151,5 +153,14 @@ describe("plugin HTTP registry helpers", () => {
     expect(shouldEnforceGatewayAuthForPluginPath(registry, "/api//demo")).toBe(true);
     expect(shouldEnforceGatewayAuthForPluginPath(registry, "/api/channels/status")).toBe(true);
     expect(shouldEnforceGatewayAuthForPluginPath(registry, "/not-plugin")).toBe(false);
+  });
+
+  it("skips gateway auth for routes that opt out explicitly", () => {
+    const registry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/googlechat", requireGatewayAuth: false })],
+    });
+
+    expect(shouldEnforceGatewayAuthForPluginPath(registry, "/googlechat")).toBe(false);
+    expect(shouldEnforceGatewayAuthForPluginPath(registry, "/api/channels/status")).toBe(true);
   });
 });

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -36,9 +36,11 @@ export function shouldEnforceGatewayAuthForPluginPath(
   registry: PluginRegistry,
   pathname: string,
 ): boolean {
-  return (
-    isProtectedPluginRoutePath(pathname) || isRegisteredPluginHttpRoutePath(registry, pathname)
-  );
+  if (isProtectedPluginRoutePath(pathname)) {
+    return true;
+  }
+  const route = findRegisteredPluginHttpRoute(registry, pathname);
+  return route ? route.requireGatewayAuth !== false : false;
 }
 
 export function createGatewayPluginRequestHandler(params: {

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -128,7 +128,7 @@ export {
   resolveSingleWebhookTargetAsync,
   resolveWebhookTargets,
 } from "./webhook-targets.js";
-export type { WebhookTargetMatchResult } from "./webhook-targets.js";
+export type { RegisterWebhookTargetOptions, WebhookTargetMatchResult } from "./webhook-targets.js";
 export {
   applyBasicWebhookRequestGuards,
   isJsonContentType,

--- a/src/plugin-sdk/webhook-targets.test.ts
+++ b/src/plugin-sdk/webhook-targets.test.ts
@@ -31,6 +31,32 @@ describe("registerWebhookTarget", () => {
     registered.unregister();
     expect(targets.has("/hook")).toBe(false);
   });
+
+  it("runs path activation once and cleans up after the last unregister", () => {
+    const targets = new Map<string, Array<{ path: string; id: string }>>();
+    const cleanup = vi.fn();
+    const onFirstTargetForPath = vi.fn(() => cleanup);
+
+    const first = registerWebhookTarget(
+      targets,
+      { path: "hook", id: "A" },
+      { onFirstTargetForPath },
+    );
+    const second = registerWebhookTarget(
+      targets,
+      { path: "/hook/", id: "B" },
+      { onFirstTargetForPath },
+    );
+
+    expect(onFirstTargetForPath).toHaveBeenCalledTimes(1);
+    expect(onFirstTargetForPath).toHaveBeenCalledWith("/hook");
+
+    first.unregister();
+    expect(cleanup).not.toHaveBeenCalled();
+
+    second.unregister();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("resolveWebhookTargets", () => {

--- a/src/plugin-sdk/webhook-targets.ts
+++ b/src/plugin-sdk/webhook-targets.ts
@@ -6,13 +6,28 @@ export type RegisteredWebhookTarget<T> = {
   unregister: () => void;
 };
 
+export type RegisterWebhookTargetOptions = {
+  onFirstTargetForPath?: (normalizedPath: string) => void | (() => void);
+};
+
+const cleanupByTargetsMap = new WeakMap<object, Map<string, () => void>>();
+
 export function registerWebhookTarget<T extends { path: string }>(
   targetsByPath: Map<string, T[]>,
   target: T,
+  opts?: RegisterWebhookTargetOptions,
 ): RegisteredWebhookTarget<T> {
   const key = normalizeWebhookPath(target.path);
   const normalizedTarget = { ...target, path: key };
   const existing = targetsByPath.get(key) ?? [];
+  if (existing.length === 0) {
+    const cleanup = opts?.onFirstTargetForPath?.(key);
+    if (cleanup) {
+      const pathCleanups = cleanupByTargetsMap.get(targetsByPath) ?? new Map<string, () => void>();
+      pathCleanups.set(key, cleanup);
+      cleanupByTargetsMap.set(targetsByPath, pathCleanups);
+    }
+  }
   targetsByPath.set(key, [...existing, normalizedTarget]);
   const unregister = () => {
     const updated = (targetsByPath.get(key) ?? []).filter((entry) => entry !== normalizedTarget);
@@ -21,6 +36,10 @@ export function registerWebhookTarget<T extends { path: string }>(
       return;
     }
     targetsByPath.delete(key);
+    const pathCleanups = cleanupByTargetsMap.get(targetsByPath);
+    const cleanup = pathCleanups?.get(key);
+    pathCleanups?.delete(key);
+    cleanup?.();
   };
   return { target: normalizedTarget, unregister };
 }

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -16,9 +16,23 @@ describe("registerPluginHttpRoute", () => {
     expect(registry.httpRoutes).toHaveLength(1);
     expect(registry.httpRoutes[0]?.path).toBe("/plugins/demo");
     expect(registry.httpRoutes[0]?.handler).toBe(handler);
+    expect(registry.httpRoutes[0]?.requireGatewayAuth).toBe(true);
 
     unregister();
     expect(registry.httpRoutes).toHaveLength(0);
+  });
+
+  it("allows routes to opt out of gateway auth", () => {
+    const registry = createEmptyPluginRegistry();
+
+    registerPluginHttpRoute({
+      path: "/plugins/webhook",
+      handler: vi.fn(),
+      requireGatewayAuth: false,
+      registry,
+    });
+
+    expect(registry.httpRoutes[0]?.requireGatewayAuth).toBe(false);
   });
 
   it("returns noop unregister when path is missing", () => {

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -12,6 +12,7 @@ export function registerPluginHttpRoute(params: {
   path?: string | null;
   fallbackPath?: string | null;
   handler: PluginHttpRouteHandler;
+  requireGatewayAuth?: boolean;
   pluginId?: string;
   source?: string;
   accountId?: string;
@@ -39,6 +40,7 @@ export function registerPluginHttpRoute(params: {
   const entry: PluginHttpRouteRegistration = {
     path: normalizedPath,
     handler: params.handler,
+    requireGatewayAuth: params.requireGatewayAuth ?? true,
     pluginId: params.pluginId,
     source: params.source,
   };

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -59,6 +59,7 @@ export type PluginHttpRouteRegistration = {
   pluginId?: string;
   path: string;
   handler: OpenClawPluginHttpRouteHandler;
+  requireGatewayAuth?: boolean;
   source?: string;
 };
 


### PR DESCRIPTION
## Summary

_Wanted to provide a couple of proposed solutions - this one is the smaller more BlueBubbles scoped approach compared to https://github.com/openclaw/openclaw/pull/31423_

I noticed that https://github.com/openclaw/openclaw/pull/31349 was opened as well but I think it reverses what broke BlueBubbles, which also reverts the intent of the changes in `2026.3.1` around hardening the allowed gateway routes.

- Problem: root-mounted Control UI intercepted root webhook paths before plugin handlers could receive them, which broke BlueBubbles webhook delivery after `2026.3.1`.
- Why it matters: BlueBubbles inbound webhooks on paths like `/bluebubbles-webhook` returned Control UI responses instead of reaching the channel integration.
- What changed: added an exact-route bypass for non-read requests in the root-mounted Control UI path, threaded that predicate through gateway HTTP setup, and registered the BlueBubbles webhook path as an exact plugin route.
- What did NOT change (scope boundary): read routes like `/chat` still belong to the Control UI, generic plugin handler precedence was not restored, and no broader plugin route kind model was introduced.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes https://github.com/openclaw/openclaw/issues/31344
- Related #31349, #31423

## User-visible / Behavior Changes

- BlueBubbles root webhook endpoints can again receive POST requests when the Control UI is mounted at `/`.
- Root Control UI read routes like `/chat` remain Control UI-owned and are not shadowed by exact plugin routes.
- No config or CLI behavior changed.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm test run
- Model/provider: N/A
- Integration/channel (if any): BlueBubbles
- Relevant config (redacted): gateway Control UI enabled at root path

### Steps

1. Configure gateway with Control UI enabled at `/` and a BlueBubbles webhook path like `/bluebubbles-webhook`.
2. Send a POST request to the webhook path.
3. Send a GET request to `/chat`.

### Expected

- POST `/bluebubbles-webhook` reaches the plugin webhook handler.
- GET `/chat` remains owned by the Control UI.

### Actual

- Before this change, the root-mounted Control UI intercepted the webhook path before plugin handling.
- After this change, the webhook path falls through correctly while `/chat` still resolves to Control UI.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- src/gateway/server.plugin-http-auth.test.ts src/plugin-sdk/webhook-targets.test.ts extensions/bluebubbles/src/monitor.test.ts` and confirmed the new webhook passthrough and route-shadow regression coverage pass.
- Edge cases checked: exact registered route should not shadow `/chat`; shared webhook target lifecycle registers/unregisters the plugin route once per path.
- What you did **not** verify: live BlueBubbles traffic against a running gateway instance.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `1cdcdd831` or disable the BlueBubbles webhook route change by rolling back this PR.
- Files/config to restore: `src/gateway/control-ui.ts`, `src/gateway/server-http.ts`, `src/gateway/server-runtime-state.ts`, `extensions/bluebubbles/src/monitor.ts`, and the related tests.
- Known bad symptoms reviewers should watch for: `POST /bluebubbles-webhook` returning `405 Method Not Allowed`, or exact plugin routes unexpectedly shadowing root Control UI read paths.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: exact registered plugin routes could bypass the root-mounted Control UI too broadly.
  - Mitigation: bypass is limited to non-`GET`/`HEAD` requests and covered by a regression test that keeps `/chat` under Control UI ownership.
- Risk: route registration lifecycle could leak or unregister too aggressively when multiple webhook targets share a path.
  - Mitigation: shared webhook target lifecycle is covered by `src/plugin-sdk/webhook-targets.test.ts` and BlueBubbles multi-target monitor tests still pass.
