### PR TITLE
fix(slack): reference ctx instead of params in isChannelAllowed closure

### DIFF
--- a/src/slack/monitor/context.test.ts
+++ b/src/slack/monitor/context.test.ts
@@ -47,6 +47,49 @@ function createTestContext() {
   });
 }
 
+describe("createSlackMonitorContext isChannelAllowed closure correctness", () => {
+  it("picks up channelsConfig mutations made after context creation", () => {
+    const ctx = createTestContext();
+    // Initially no channelsConfig — channel should be allowed under allowlist policy
+    // only if groupPolicy is "open" (default is "allowlist", so blocked).
+    ctx.groupPolicy = "open";
+    expect(ctx.isChannelAllowed({ channelId: "C_ROOM", channelType: "channel" })).toBe(true);
+
+    // Mutate ctx.channelsConfig to explicitly deny the channel.
+    ctx.channelsConfig = { C_ROOM: { allow: false } };
+    expect(ctx.isChannelAllowed({ channelId: "C_ROOM", channelType: "channel" })).toBe(false);
+  });
+
+  it("reflects channelsConfig set from undefined to a value", () => {
+    const ctx = createTestContext();
+    ctx.groupPolicy = "allowlist";
+    // No channelsConfig — allowlist policy blocks all channels by default.
+    expect(ctx.isChannelAllowed({ channelId: "C_NEW", channelType: "channel" })).toBe(false);
+
+    // Set channelsConfig to allow the channel — closure must see the update.
+    ctx.channelsConfig = { C_NEW: { allow: true } };
+    expect(ctx.isChannelAllowed({ channelId: "C_NEW", channelType: "channel" })).toBe(true);
+  });
+
+  it("reflects dmEnabled mutations", () => {
+    const ctx = createTestContext();
+    // Default: dmEnabled is true
+    expect(ctx.isChannelAllowed({ channelId: "D_DM", channelType: "im" })).toBe(true);
+
+    ctx.dmEnabled = false;
+    expect(ctx.isChannelAllowed({ channelId: "D_DM", channelType: "im" })).toBe(false);
+  });
+
+  it("reflects groupDmEnabled mutations", () => {
+    const ctx = createTestContext();
+    // Default: groupDmEnabled is false
+    expect(ctx.isChannelAllowed({ channelId: "G_GDM", channelType: "mpim" })).toBe(false);
+
+    ctx.groupDmEnabled = true;
+    expect(ctx.isChannelAllowed({ channelId: "G_GDM", channelType: "mpim" })).toBe(true);
+  });
+});
+
 describe("createSlackMonitorContext shouldDropMismatchedSlackEvent", () => {
   it("drops mismatched top-level app/team identifiers", () => {
     const ctx = createTestContext();

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -290,77 +290,6 @@ export function createSlackMonitorContext(params: {
     }
   };
 
-  const isChannelAllowed = (p: {
-    channelId?: string;
-    channelName?: string;
-    channelType?: SlackMessageEvent["channel_type"];
-  }) => {
-    const channelType = normalizeSlackChannelType(p.channelType, p.channelId);
-    const isDirectMessage = channelType === "im";
-    const isGroupDm = channelType === "mpim";
-    const isRoom = channelType === "channel" || channelType === "group";
-
-    if (isDirectMessage && !params.dmEnabled) {
-      return false;
-    }
-    if (isGroupDm && !params.groupDmEnabled) {
-      return false;
-    }
-
-    if (isGroupDm && groupDmChannels.length > 0) {
-      const allowList = normalizeAllowListLower(groupDmChannels);
-      const candidates = [
-        p.channelId,
-        p.channelName ? `#${p.channelName}` : undefined,
-        p.channelName,
-        p.channelName ? normalizeSlackSlug(p.channelName) : undefined,
-      ]
-        .filter((value): value is string => Boolean(value))
-        .map((value) => value.toLowerCase());
-      const permitted =
-        allowList.includes("*") || candidates.some((candidate) => allowList.includes(candidate));
-      if (!permitted) {
-        return false;
-      }
-    }
-
-    if (isRoom && p.channelId) {
-      const channelConfig = resolveSlackChannelConfig({
-        channelId: p.channelId,
-        channelName: p.channelName,
-        channels: params.channelsConfig,
-        defaultRequireMention,
-      });
-      const channelMatchMeta = formatAllowlistMatchMeta(channelConfig);
-      const channelAllowed = channelConfig?.allowed !== false;
-      const channelAllowlistConfigured =
-        Boolean(params.channelsConfig) && Object.keys(params.channelsConfig ?? {}).length > 0;
-      if (
-        !isSlackChannelAllowedByPolicy({
-          groupPolicy: params.groupPolicy,
-          channelAllowlistConfigured,
-          channelAllowed,
-        })
-      ) {
-        logVerbose(
-          `slack: drop channel ${p.channelId} (groupPolicy=${params.groupPolicy}, ${channelMatchMeta})`,
-        );
-        return false;
-      }
-      // When groupPolicy is "open", only block channels that are EXPLICITLY denied
-      // (i.e., have a matching config entry with allow:false). Channels not in the
-      // config (matchSource undefined) should be allowed under open policy.
-      const hasExplicitConfig = Boolean(channelConfig?.matchSource);
-      if (!channelAllowed && (params.groupPolicy !== "open" || hasExplicitConfig)) {
-        logVerbose(`slack: drop channel ${p.channelId} (${channelMatchMeta})`);
-        return false;
-      }
-      logVerbose(`slack: allow channel ${p.channelId} (${channelMatchMeta})`);
-    }
-
-    return true;
-  };
-
   const shouldDropMismatchedSlackEvent = (body: unknown) => {
     if (!body || typeof body !== "object") {
       return false;
@@ -391,7 +320,11 @@ export function createSlackMonitorContext(params: {
     return false;
   };
 
-  return {
+  // Build ctx first so isChannelAllowed can read mutable ctx properties.
+  // provider.ts mutates ctx.channelsConfig after async allowlist resolution;
+  // referencing ctx.* (not params.*) ensures the closure sees updates
+  // (same class of fix as b3a1024f6).
+  const ctx = {
     cfg: params.cfg,
     accountId: params.accountId,
     botToken: params.botToken,
@@ -428,9 +361,81 @@ export function createSlackMonitorContext(params: {
     markMessageSeen,
     shouldDropMismatchedSlackEvent,
     resolveSlackSystemEventSessionKey,
-    isChannelAllowed,
     resolveChannelName,
     resolveUserName,
     setSlackThreadStatus,
+  } as SlackMonitorContext;
+
+  ctx.isChannelAllowed = (p: {
+    channelId?: string;
+    channelName?: string;
+    channelType?: SlackMessageEvent["channel_type"];
+  }) => {
+    const channelType = normalizeSlackChannelType(p.channelType, p.channelId);
+    const isDirectMessage = channelType === "im";
+    const isGroupDm = channelType === "mpim";
+    const isRoom = channelType === "channel" || channelType === "group";
+
+    if (isDirectMessage && !ctx.dmEnabled) {
+      return false;
+    }
+    if (isGroupDm && !ctx.groupDmEnabled) {
+      return false;
+    }
+
+    if (isGroupDm && groupDmChannels.length > 0) {
+      const allowList = normalizeAllowListLower(groupDmChannels);
+      const candidates = [
+        p.channelId,
+        p.channelName ? `#${p.channelName}` : undefined,
+        p.channelName,
+        p.channelName ? normalizeSlackSlug(p.channelName) : undefined,
+      ]
+        .filter((value): value is string => Boolean(value))
+        .map((value) => value.toLowerCase());
+      const permitted =
+        allowList.includes("*") || candidates.some((candidate) => allowList.includes(candidate));
+      if (!permitted) {
+        return false;
+      }
+    }
+
+    if (isRoom && p.channelId) {
+      const channelConfig = resolveSlackChannelConfig({
+        channelId: p.channelId,
+        channelName: p.channelName,
+        channels: ctx.channelsConfig,
+        defaultRequireMention,
+      });
+      const channelMatchMeta = formatAllowlistMatchMeta(channelConfig);
+      const channelAllowed = channelConfig?.allowed !== false;
+      const channelAllowlistConfigured =
+        Boolean(ctx.channelsConfig) && Object.keys(ctx.channelsConfig ?? {}).length > 0;
+      if (
+        !isSlackChannelAllowedByPolicy({
+          groupPolicy: ctx.groupPolicy,
+          channelAllowlistConfigured,
+          channelAllowed,
+        })
+      ) {
+        logVerbose(
+          `slack: drop channel ${p.channelId} (groupPolicy=${ctx.groupPolicy}, ${channelMatchMeta})`,
+        );
+        return false;
+      }
+      // When groupPolicy is "open", only block channels that are EXPLICITLY denied
+      // (i.e., have a matching config entry with allow:false). Channels not in the
+      // config (matchSource undefined) should be allowed under open policy.
+      const hasExplicitConfig = Boolean(channelConfig?.matchSource);
+      if (!channelAllowed && (ctx.groupPolicy !== "open" || hasExplicitConfig)) {
+        logVerbose(`slack: drop channel ${p.channelId} (${channelMatchMeta})`);
+        return false;
+      }
+      logVerbose(`slack: allow channel ${p.channelId} (${channelMatchMeta})`);
+    }
+
+    return true;
   };
+
+  return ctx;
 }


### PR DESCRIPTION
## Summary

- `isChannelAllowed` closure captured `params.channelsConfig` (and `params.dmEnabled`, `params.groupDmEnabled`, `params.groupPolicy`) at creation time, so `provider.ts` mutations via `ctx.channelsConfig = nextChannels` after async allowlist resolution never reached the closure
- Build the return object as `ctx` first, then define `isChannelAllowed` referencing `ctx.*` so it picks up post-creation mutations — same class of fix as b3a1024f6

## Root Cause

Commit `05f49d284` (`fix(slack): resolve allowlists async`) changed allowlist resolution from `await` to `void` to avoid blocking Slack Socket Mode startup. However, `isChannelAllowed` still referenced `params.channelsConfig` (2 locations), which is a snapshot from context creation time. When `provider.ts` later set `ctx.channelsConfig = nextChannels`, the closure never saw the update.

## Changes

- **`src/slack/monitor/context.ts`** — Build return object as `ctx` variable first, then assign `isChannelAllowed` as a method that reads `ctx.*` instead of `params.*`
- **`src/slack/monitor/context.test.ts`** — Tests verifying `isChannelAllowed` reflects `ctx.channelsConfig`, `ctx.dmEnabled`, `ctx.groupDmEnabled` mutations after creation

## Test plan

- [x] `pnpm build` — type-check passes
- [x] `pnpm test -- src/slack` — all 43 test files (331 tests) pass
- [x] New test: `isChannelAllowed` picks up `channelsConfig` mutations made after context creation
- [x] New test: `isChannelAllowed` handles `channelsConfig` set from `undefined` to a value
- [x] New test: `isChannelAllowed` reflects `dmEnabled` mutations
- [x] New test: `isChannelAllowed` reflects `groupDmEnabled` mutations

Fixes #25968
Supersedes #29300

🤖 Generated with [Claude Code](https://claude.com/claude-code)