### PR TITLE
AI-assisted: fix test typing regressions in routing/session and mock harnesses

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -44,12 +44,12 @@ function createMergeConfigProvider() {
   return {
     baseUrl: "https://config.example/v1",
     apiKey: "CONFIG_KEY",
-    api: "openai-responses",
+    api: "openai-responses" as const,
     models: [
       {
         id: "config-model",
         name: "Config model",
-        input: ["text"],
+        input: ["text"] as Array<"text" | "image">,
         reasoning: false,
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 8192,

--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -56,7 +56,7 @@ function createMergeConfigProvider() {
         maxTokens: 2048,
       },
     ],
-  } as const;
+  };
 }
 
 async function runCustomProviderMergeTest(seedProvider: {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
@@ -11,7 +11,6 @@ function applyThinkingDefault(thinking: ThinkingLevel) {
   harness.setSessionsSpawnConfigOverride({
     session: { mainKey: "main", scope: "per-sender" },
     agents: { defaults: { subagents: { thinking } } },
-    routing: { sessions: { mainKey: MAIN_SESSION_KEY } },
   });
 }
 

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout-absent.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout-absent.test.ts
@@ -15,7 +15,6 @@ function configureDefaultsWithoutTimeout() {
   setSessionsSpawnConfigOverride({
     session: { mainKey: "main", scope: "per-sender" },
     agents: { defaults: { subagents: { maxConcurrent: 8 } } },
-    routing: { sessions: { mainKey: MAIN_SESSION_KEY } },
   });
 }
 

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
@@ -9,7 +9,6 @@ function applySubagentTimeoutDefault(seconds: number) {
   sessionsHarness.setSessionsSpawnConfigOverride({
     session: { mainKey: "main", scope: "per-sender" },
     agents: { defaults: { subagents: { runTimeoutSeconds: seconds } } },
-    routing: { sessions: { mainKey: MAIN_SESSION_KEY } },
   });
 }
 

--- a/src/agents/tools/sessions-resolution.test.ts
+++ b/src/agents/tools/sessions-resolution.test.ts
@@ -31,6 +31,19 @@ describe("resolveMainSessionAlias", () => {
       scope: "per-sender",
     });
   });
+
+  it("uses session.mainKey over any legacy routing sessions key", () => {
+    const cfg = {
+      session: { mainKey: "  work ", scope: "per-sender" },
+      routing: { sessions: { mainKey: "legacy-main" } },
+    } as OpenClawConfig;
+
+    expect(resolveMainSessionAlias(cfg)).toEqual({
+      mainKey: "work",
+      alias: "work",
+      scope: "per-sender",
+    });
+  });
 });
 
 describe("session key display/internal mapping", () => {

--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import type { MockInstance } from "vitest";
 import { createTypingCallbacks } from "./typing.js";
+
+type TypingCallbackOverrides = Partial<Parameters<typeof createTypingCallbacks>[0]>;
+type TypingHarnessStart = ReturnType<typeof vi.fn<() => Promise<void>>>;
+type TypingHarnessError = ReturnType<typeof vi.fn<(err: unknown) => void>>;
 
 const flushMicrotasks = async () => {
   await Promise.resolve();
@@ -16,17 +19,25 @@ async function withFakeTimers(run: () => Promise<void>) {
   }
 }
 
-function createTypingHarness(overrides: Partial<Parameters<typeof createTypingCallbacks>[0]> = {}) {
-  const start = (overrides.start ?? vi.fn().mockResolvedValue(undefined)) as MockInstance<
-    [],
-    Promise<void>
-  >;
-  const stop = (overrides.stop ?? vi.fn().mockResolvedValue(undefined)) as MockInstance<
-    [],
-    Promise<void>
-  >;
-  const onStartError = (overrides.onStartError ?? vi.fn()) as MockInstance<[unknown], void>;
-  const onStopError = (overrides.onStopError ?? vi.fn()) as MockInstance<[unknown], void>;
+function createTypingHarness(overrides: TypingCallbackOverrides = {}) {
+  const start: TypingHarnessStart = vi.fn<() => Promise<void>>(async () => {});
+  const stop: TypingHarnessStart = vi.fn<() => Promise<void>>(async () => {});
+  const onStartError: TypingHarnessError = vi.fn<(err: unknown) => void>();
+  const onStopError: TypingHarnessError = vi.fn<(err: unknown) => void>();
+
+  if (overrides.start) {
+    start.mockImplementation(overrides.start);
+  }
+  if (overrides.stop) {
+    stop.mockImplementation(overrides.stop);
+  }
+  if (overrides.onStartError) {
+    onStartError.mockImplementation(overrides.onStartError);
+  }
+  if (overrides.onStopError) {
+    onStopError.mockImplementation(overrides.onStopError);
+  }
+
   const callbacks = createTypingCallbacks({
     start,
     stop,

--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
 import { createTypingCallbacks } from "./typing.js";
 
 const flushMicrotasks = async () => {
@@ -16,15 +17,21 @@ async function withFakeTimers(run: () => Promise<void>) {
 }
 
 function createTypingHarness(overrides: Partial<Parameters<typeof createTypingCallbacks>[0]> = {}) {
-  const start = overrides.start ?? vi.fn().mockResolvedValue(undefined);
-  const stop = overrides.stop ?? vi.fn().mockResolvedValue(undefined);
-  const onStartError = overrides.onStartError ?? vi.fn();
-  const onStopError = overrides.onStopError ?? vi.fn();
+  const start = (overrides.start ?? vi.fn().mockResolvedValue(undefined)) as MockInstance<
+    [],
+    Promise<void>
+  >;
+  const stop = (overrides.stop ?? vi.fn().mockResolvedValue(undefined)) as MockInstance<
+    [],
+    Promise<void>
+  >;
+  const onStartError = (overrides.onStartError ?? vi.fn()) as MockInstance<[unknown], void>;
+  const onStopError = (overrides.onStopError ?? vi.fn()) as MockInstance<[unknown], void>;
   const callbacks = createTypingCallbacks({
     start,
     stop,
     onStartError,
-    ...(onStopError ? { onStopError } : {}),
+    onStopError,
     ...(overrides.maxConsecutiveFailures !== undefined
       ? { maxConsecutiveFailures: overrides.maxConsecutiveFailures }
       : {}),

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -227,7 +227,7 @@ function createTelegramOutboundPlugin() {
       };
       to: string;
       text: string;
-      accountId?: string;
+      accountId?: string | null;
       mediaUrl?: string;
     },
     mediaUrl?: string,

--- a/src/commands/channel-test-helpers.ts
+++ b/src/commands/channel-test-helpers.ts
@@ -10,6 +10,20 @@ import type { ChannelChoice } from "./onboard-types.js";
 import { getChannelOnboardingAdapter } from "./onboarding/registry.js";
 import type { ChannelOnboardingAdapter } from "./onboarding/types.js";
 
+type ChannelOnboardingAdapterPatch = Partial<
+  Pick<
+    ChannelOnboardingAdapter,
+    "configure" | "configureInteractive" | "configureWhenConfigured" | "getStatus"
+  >
+>;
+
+type PatchedOnboardingAdapterFields = {
+  configure?: ChannelOnboardingAdapter["configure"];
+  configureInteractive?: ChannelOnboardingAdapter["configureInteractive"];
+  configureWhenConfigured?: ChannelOnboardingAdapter["configureWhenConfigured"];
+  getStatus?: ChannelOnboardingAdapter["getStatus"];
+};
+
 export function setDefaultChannelPluginRegistryForTests(): void {
   const channels = [
     { pluginId: "discord", plugin: discordPlugin, source: "test" },
@@ -24,21 +38,44 @@ export function setDefaultChannelPluginRegistryForTests(): void {
 
 export function patchChannelOnboardingAdapter(
   channel: ChannelChoice,
-  patch: Partial<ChannelOnboardingAdapter>,
+  patch: ChannelOnboardingAdapterPatch,
 ): () => void {
   const adapter = getChannelOnboardingAdapter(channel);
   if (!adapter) {
     throw new Error(`missing onboarding adapter for ${channel}`);
   }
-  const keys = Object.keys(patch) as Array<keyof ChannelOnboardingAdapter>;
-  const previous: Partial<ChannelOnboardingAdapter> = {};
-  for (const key of keys) {
-    previous[key] = adapter[key];
-    adapter[key] = patch[key] as ChannelOnboardingAdapter[typeof key];
+
+  const previous: PatchedOnboardingAdapterFields = {};
+
+  if (Object.prototype.hasOwnProperty.call(patch, "getStatus")) {
+    previous.getStatus = adapter.getStatus;
+    adapter.getStatus = patch.getStatus ?? adapter.getStatus;
   }
+  if (Object.prototype.hasOwnProperty.call(patch, "configure")) {
+    previous.configure = adapter.configure;
+    adapter.configure = patch.configure ?? adapter.configure;
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, "configureInteractive")) {
+    previous.configureInteractive = adapter.configureInteractive;
+    adapter.configureInteractive = patch.configureInteractive;
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, "configureWhenConfigured")) {
+    previous.configureWhenConfigured = adapter.configureWhenConfigured;
+    adapter.configureWhenConfigured = patch.configureWhenConfigured;
+  }
+
   return () => {
-    for (const key of keys) {
-      adapter[key] = previous[key] as ChannelOnboardingAdapter[typeof key];
+    if (Object.prototype.hasOwnProperty.call(patch, "getStatus")) {
+      adapter.getStatus = previous.getStatus!;
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, "configure")) {
+      adapter.configure = previous.configure!;
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, "configureInteractive")) {
+      adapter.configureInteractive = previous.configureInteractive;
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, "configureWhenConfigured")) {
+      adapter.configureWhenConfigured = previous.configureWhenConfigured;
     }
   };
 }

--- a/src/commands/channel-test-helpers.ts
+++ b/src/commands/channel-test-helpers.ts
@@ -22,23 +22,23 @@ export function setDefaultChannelPluginRegistryForTests(): void {
   setActivePluginRegistry(createTestRegistry(channels));
 }
 
-export function patchChannelOnboardingAdapter<K extends keyof ChannelOnboardingAdapter>(
+export function patchChannelOnboardingAdapter(
   channel: ChannelChoice,
-  patch: Pick<ChannelOnboardingAdapter, K>,
+  patch: Partial<ChannelOnboardingAdapter>,
 ): () => void {
   const adapter = getChannelOnboardingAdapter(channel);
   if (!adapter) {
     throw new Error(`missing onboarding adapter for ${channel}`);
   }
-  const keys = Object.keys(patch) as K[];
-  const previous = {} as Pick<ChannelOnboardingAdapter, K>;
+  const keys = Object.keys(patch) as Array<keyof ChannelOnboardingAdapter>;
+  const previous: Partial<ChannelOnboardingAdapter> = {};
   for (const key of keys) {
     previous[key] = adapter[key];
-    adapter[key] = patch[key];
+    adapter[key] = patch[key] as ChannelOnboardingAdapter[typeof key];
   }
   return () => {
     for (const key of keys) {
-      adapter[key] = previous[key];
+      adapter[key] = previous[key] as ChannelOnboardingAdapter[typeof key];
     }
   };
 }

--- a/src/commands/onboard-channels.e2e.test.ts
+++ b/src/commands/onboard-channels.e2e.test.ts
@@ -84,12 +84,14 @@ function createTelegramCfg(botToken: string, enabled?: boolean): OpenClawConfig 
 
 function patchTelegramAdapter(overrides: Parameters<typeof patchChannelOnboardingAdapter>[1]) {
   return patchChannelOnboardingAdapter("telegram", {
-    getStatus: vi.fn(async ({ cfg }: { cfg: OpenClawConfig }) => ({
-      channel: "telegram",
-      configured: Boolean(cfg.channels?.telegram?.botToken),
-      statusLines: [],
-    })),
     ...overrides,
+    getStatus:
+      overrides.getStatus ??
+      vi.fn(async ({ cfg }: { cfg: OpenClawConfig }) => ({
+        channel: "telegram",
+        configured: Boolean(cfg.channels?.telegram?.botToken),
+        statusLines: [],
+      })),
   });
 }
 

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
 import {
   applyCustomApiConfig,

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -78,13 +78,13 @@ function expectOpenAiCompatResult(params: {
 
 function buildCustomProviderConfig(contextWindow?: number) {
   if (contextWindow === undefined) {
-    return {};
+    return {} as OpenClawConfig;
   }
   return {
     models: {
       providers: {
         custom: {
-          api: "openai-completions",
+          api: "openai-completions" as const,
           baseUrl: "https://llm.example.com/v1",
           models: [
             {
@@ -100,7 +100,7 @@ function buildCustomProviderConfig(contextWindow?: number) {
         },
       },
     },
-  };
+  } as OpenClawConfig;
 }
 
 function applyCustomModelConfigWithContextWindow(contextWindow?: number) {

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -81,7 +81,7 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
   // Hold onto the cron session *object* — the code may reassign its
   // `sessionEntry` property (e.g. during skills snapshot refresh), so
   // checking a stale reference would give a false negative.
-  let cronSession: { sessionEntry: ReturnType<typeof makeFreshSessionEntry>; [k: string]: unknown };
+  let cronSession: ReturnType<typeof makeCronSession>;
 
   beforeEach(() => {
     previousFastTestEnv = clearFastTestEnv();
@@ -103,7 +103,7 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
 
     cronSession = makeCronSession({
       sessionEntry: makeFreshSessionEntry(),
-    }) as { sessionEntry: ReturnType<typeof makeFreshSessionEntry>; [k: string]: unknown };
+    });
     resolveCronSessionMock.mockReturnValue(cronSession);
   });
 

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { type Mock, vi } from "vitest";
 
 type CronSessionEntry = {
   sessionId: string;
@@ -17,23 +17,23 @@ type CronSession = {
   [key: string]: unknown;
 };
 
-export const buildWorkspaceSkillSnapshotMock = vi.fn();
-export const resolveAgentConfigMock = vi.fn();
-export const resolveAgentModelFallbacksOverrideMock = vi.fn();
-export const resolveAgentSkillsFilterMock = vi.fn();
-export const getModelRefStatusMock = vi.fn();
-export const isCliProviderMock = vi.fn();
-export const resolveAllowedModelRefMock = vi.fn();
-export const resolveConfiguredModelRefMock = vi.fn();
-export const resolveHooksGmailModelMock = vi.fn();
-export const resolveThinkingDefaultMock = vi.fn();
-export const runWithModelFallbackMock = vi.fn();
-export const runEmbeddedPiAgentMock = vi.fn();
-export const runCliAgentMock = vi.fn();
-export const getCliSessionIdMock = vi.fn();
-export const updateSessionStoreMock = vi.fn();
-export const resolveCronSessionMock = vi.fn();
-export const logWarnMock = vi.fn();
+export const buildWorkspaceSkillSnapshotMock: Mock = vi.fn();
+export const resolveAgentConfigMock: Mock = vi.fn();
+export const resolveAgentModelFallbacksOverrideMock: Mock = vi.fn();
+export const resolveAgentSkillsFilterMock: Mock = vi.fn();
+export const getModelRefStatusMock: Mock = vi.fn();
+export const isCliProviderMock: Mock = vi.fn();
+export const resolveAllowedModelRefMock: Mock = vi.fn();
+export const resolveConfiguredModelRefMock: Mock = vi.fn();
+export const resolveHooksGmailModelMock: Mock = vi.fn();
+export const resolveThinkingDefaultMock: Mock = vi.fn();
+export const runWithModelFallbackMock: Mock = vi.fn();
+export const runEmbeddedPiAgentMock: Mock = vi.fn();
+export const runCliAgentMock: Mock = vi.fn();
+export const getCliSessionIdMock: Mock = vi.fn();
+export const updateSessionStoreMock: Mock = vi.fn();
+export const resolveCronSessionMock: Mock = vi.fn();
+export const logWarnMock: Mock = vi.fn();
 
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentConfig: resolveAgentConfigMock,

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -1,11 +1,17 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, type Mock, vi } from "vitest";
 import { saveExecApprovals } from "../infra/exec-approvals.js";
 import type { ExecHostResponse } from "../infra/exec-host.js";
 import { handleSystemRunInvoke, formatSystemRunAllowlistMissMessage } from "./invoke-system-run.js";
 import type { HandleSystemRunInvokeOptions } from "./invoke-system-run.js";
+
+type MockedRunCommand = Mock<HandleSystemRunInvokeOptions["runCommand"]>;
+type MockedRunViaMacAppExecHost = Mock<HandleSystemRunInvokeOptions["runViaMacAppExecHost"]>;
+type MockedSendInvokeResult = Mock<HandleSystemRunInvokeOptions["sendInvokeResult"]>;
+type MockedSendExecFinishedEvent = Mock<HandleSystemRunInvokeOptions["sendExecFinishedEvent"]>;
+type MockedSendNodeEvent = Mock<HandleSystemRunInvokeOptions["sendNodeEvent"]>;
 
 describe("formatSystemRunAllowlistMissMessage", () => {
   it("returns legacy allowlist miss message by default", () => {
@@ -35,7 +41,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   }
 
   function expectInvokeOk(
-    sendInvokeResult: ReturnType<typeof vi.fn>,
+    sendInvokeResult: MockedSendInvokeResult,
     params?: { payloadContains?: string },
   ) {
     expect(sendInvokeResult).toHaveBeenCalledWith(
@@ -49,7 +55,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   }
 
   function expectInvokeErrorMessage(
-    sendInvokeResult: ReturnType<typeof vi.fn>,
+    sendInvokeResult: MockedSendInvokeResult,
     params: { message: string; exact?: boolean },
   ) {
     expect(sendInvokeResult).toHaveBeenCalledWith(
@@ -63,8 +69,8 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   }
 
   function expectApprovalRequiredDenied(params: {
-    sendNodeEvent: ReturnType<typeof vi.fn>;
-    sendInvokeResult: ReturnType<typeof vi.fn>;
+    sendNodeEvent: MockedSendNodeEvent;
+    sendInvokeResult: MockedSendInvokeResult;
   }) {
     expect(params.sendNodeEvent).toHaveBeenCalledWith(
       expect.anything(),
@@ -126,7 +132,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   }
 
   function expectCommandPinnedToCanonicalPath(params: {
-    runCommand: ReturnType<typeof vi.fn>;
+    runCommand: MockedRunCommand;
     expected: string;
     commandTail: string[];
     cwd?: string;
@@ -153,24 +159,44 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     sendExecFinishedEvent?: HandleSystemRunInvokeOptions["sendExecFinishedEvent"];
     sendNodeEvent?: HandleSystemRunInvokeOptions["sendNodeEvent"];
     skillBinsCurrent?: () => Promise<Array<{ name: string; resolvedPath: string }>>;
-  }) {
-    const runCommand =
-      params.runCommand ??
-      (vi.fn(async (_command: string[], _cwd?: string, _env?: Record<string, string>) =>
-        createLocalRunResult(),
-      ) as HandleSystemRunInvokeOptions["runCommand"]);
-    const runViaMacAppExecHost =
-      params.runViaMacAppExecHost ??
-      (vi.fn(async () => params.runViaResponse ?? null) as HandleSystemRunInvokeOptions["runViaMacAppExecHost"]);
-    const sendInvokeResult =
-      params.sendInvokeResult ??
-      (vi.fn(async () => {}) as HandleSystemRunInvokeOptions["sendInvokeResult"]);
-    const sendExecFinishedEvent =
-      params.sendExecFinishedEvent ??
-      (vi.fn(async () => {}) as HandleSystemRunInvokeOptions["sendExecFinishedEvent"]);
-    const sendNodeEvent =
-      params.sendNodeEvent ??
-      (vi.fn(async () => {}) as HandleSystemRunInvokeOptions["sendNodeEvent"]);
+  }): Promise<{
+    runCommand: MockedRunCommand;
+    runViaMacAppExecHost: MockedRunViaMacAppExecHost;
+    sendInvokeResult: MockedSendInvokeResult;
+    sendNodeEvent: MockedSendNodeEvent;
+    sendExecFinishedEvent: MockedSendExecFinishedEvent;
+  }> {
+    const runCommand: MockedRunCommand = vi.fn<HandleSystemRunInvokeOptions["runCommand"]>(
+      async () => createLocalRunResult(),
+    );
+    const runViaMacAppExecHost: MockedRunViaMacAppExecHost = vi.fn<
+      HandleSystemRunInvokeOptions["runViaMacAppExecHost"]
+    >(async () => params.runViaResponse ?? null);
+    const sendInvokeResult: MockedSendInvokeResult = vi.fn<
+      HandleSystemRunInvokeOptions["sendInvokeResult"]
+    >(async () => {});
+    const sendNodeEvent: MockedSendNodeEvent = vi.fn<HandleSystemRunInvokeOptions["sendNodeEvent"]>(
+      async () => {},
+    );
+    const sendExecFinishedEvent: MockedSendExecFinishedEvent = vi.fn<
+      HandleSystemRunInvokeOptions["sendExecFinishedEvent"]
+    >(async () => {});
+
+    if (params.runCommand !== undefined) {
+      runCommand.mockImplementation(params.runCommand);
+    }
+    if (params.runViaMacAppExecHost !== undefined) {
+      runViaMacAppExecHost.mockImplementation(params.runViaMacAppExecHost);
+    }
+    if (params.sendInvokeResult !== undefined) {
+      sendInvokeResult.mockImplementation(params.sendInvokeResult);
+    }
+    if (params.sendNodeEvent !== undefined) {
+      sendNodeEvent.mockImplementation(params.sendNodeEvent);
+    }
+    if (params.sendExecFinishedEvent !== undefined) {
+      sendExecFinishedEvent.mockImplementation(params.sendExecFinishedEvent);
+    }
 
     await handleSystemRunInvoke({
       client: {} as never,
@@ -198,7 +224,13 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       preferMacAppExecHost: params.preferMacAppExecHost,
     });
 
-    return { runCommand, runViaMacAppExecHost, sendInvokeResult, sendExecFinishedEvent };
+    return {
+      runCommand,
+      runViaMacAppExecHost,
+      sendInvokeResult,
+      sendNodeEvent,
+      sendExecFinishedEvent,
+    };
   }
 
   it("uses local execution by default when mac app exec host preference is disabled", async () => {

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { saveExecApprovals } from "../infra/exec-approvals.js";
 import type { ExecHostResponse } from "../infra/exec-host.js";
 import { handleSystemRunInvoke, formatSystemRunAllowlistMissMessage } from "./invoke-system-run.js";
+import type { HandleSystemRunInvokeOptions } from "./invoke-system-run.js";
 
 describe("formatSystemRunAllowlistMissMessage", () => {
   it("returns legacy allowlist miss message by default", () => {
@@ -146,23 +147,30 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     security?: "full" | "allowlist";
     ask?: "off" | "on-miss" | "always";
     approved?: boolean;
-    runCommand?: ReturnType<typeof vi.fn>;
-    runViaMacAppExecHost?: ReturnType<typeof vi.fn>;
-    sendInvokeResult?: ReturnType<typeof vi.fn>;
-    sendExecFinishedEvent?: ReturnType<typeof vi.fn>;
-    sendNodeEvent?: ReturnType<typeof vi.fn>;
+    runCommand?: HandleSystemRunInvokeOptions["runCommand"];
+    runViaMacAppExecHost?: HandleSystemRunInvokeOptions["runViaMacAppExecHost"];
+    sendInvokeResult?: HandleSystemRunInvokeOptions["sendInvokeResult"];
+    sendExecFinishedEvent?: HandleSystemRunInvokeOptions["sendExecFinishedEvent"];
+    sendNodeEvent?: HandleSystemRunInvokeOptions["sendNodeEvent"];
     skillBinsCurrent?: () => Promise<Array<{ name: string; resolvedPath: string }>>;
   }) {
     const runCommand =
       params.runCommand ??
-      vi.fn(async (_command: string[], _cwd?: string, _env?: Record<string, string>) =>
+      (vi.fn(async (_command: string[], _cwd?: string, _env?: Record<string, string>) =>
         createLocalRunResult(),
-      );
+      ) as HandleSystemRunInvokeOptions["runCommand"]);
     const runViaMacAppExecHost =
-      params.runViaMacAppExecHost ?? vi.fn(async () => params.runViaResponse ?? null);
-    const sendInvokeResult = params.sendInvokeResult ?? vi.fn(async () => {});
-    const sendExecFinishedEvent = params.sendExecFinishedEvent ?? vi.fn(async () => {});
-    const sendNodeEvent = params.sendNodeEvent ?? vi.fn(async () => {});
+      params.runViaMacAppExecHost ??
+      (vi.fn(async () => params.runViaResponse ?? null) as HandleSystemRunInvokeOptions["runViaMacAppExecHost"]);
+    const sendInvokeResult =
+      params.sendInvokeResult ??
+      (vi.fn(async () => {}) as HandleSystemRunInvokeOptions["sendInvokeResult"]);
+    const sendExecFinishedEvent =
+      params.sendExecFinishedEvent ??
+      (vi.fn(async () => {}) as HandleSystemRunInvokeOptions["sendExecFinishedEvent"]);
+    const sendNodeEvent =
+      params.sendNodeEvent ??
+      (vi.fn(async () => {}) as HandleSystemRunInvokeOptions["sendNodeEvent"]);
 
     await handleSystemRunInvoke({
       client: {} as never,

--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import type { SecretProviderConfig } from "../config/types.secrets.js";
 import { resolveSecretRefString, resolveSecretRefValue } from "./resolve.js";
 
 async function writeSecureFile(filePath: string, content: string, mode = 0o600): Promise<void> {
@@ -28,7 +29,7 @@ describe("secret ref resolver", () => {
 
   function createProviderConfig(
     providerId: string,
-    provider: Record<string, unknown>,
+    provider: SecretProviderConfig,
   ): OpenClawConfig {
     return {
       secrets: {
@@ -42,7 +43,7 @@ describe("secret ref resolver", () => {
   async function resolveWithProvider(params: {
     ref: Parameters<typeof resolveSecretRefString>[0];
     providerId: string;
-    provider: Record<string, unknown>;
+    provider: SecretProviderConfig;
   }) {
     return await resolveSecretRefString(params.ref, {
       config: createProviderConfig(params.providerId, params.provider),
@@ -52,17 +53,17 @@ describe("secret ref resolver", () => {
   function createExecProvider(
     command: string,
     overrides?: Record<string, unknown>,
-  ): Record<string, unknown> {
+  ): SecretProviderConfig {
     return {
       source: "exec",
       command,
       passEnv: ["PATH"],
       ...overrides,
-    };
+    } as SecretProviderConfig;
   }
 
   async function expectExecResolveRejects(
-    provider: Record<string, unknown>,
+    provider: SecretProviderConfig,
     message: string,
   ): Promise<void> {
     await expect(

--- a/src/slack/monitor/events/members.test.ts
+++ b/src/slack/monitor/events/members.test.ts
@@ -72,7 +72,7 @@ async function runMemberCase(args: MemberCaseArgs = {}): Promise<void> {
 }
 
 describe("registerSlackMemberEvents", () => {
-  it.each([
+  const cases: Array<{ name: string; args: MemberCaseArgs; calls: number }> = [
     {
       name: "enqueues DM member events when dmPolicy is open",
       args: { overrides: { dmPolicy: "open" } },
@@ -112,7 +112,8 @@ describe("registerSlackMemberEvents", () => {
       },
       calls: 0,
     },
-  ])("$name", async ({ args, calls }) => {
+  ];
+  it.each(cases)("$name", async ({ args, calls }) => {
     await runMemberCase(args);
     expect(memberMocks.enqueue).toHaveBeenCalledTimes(calls);
   });

--- a/src/slack/monitor/events/messages.test.ts
+++ b/src/slack/monitor/events/messages.test.ts
@@ -87,7 +87,7 @@ async function runMessageCase(input: MessageCase = {}): Promise<void> {
 }
 
 describe("registerSlackMessageEvents", () => {
-  it.each([
+  const cases: Array<{ name: string; input: MessageCase; calls: number }> = [
     {
       name: "enqueues message_changed system events when dmPolicy is open",
       input: { overrides: { dmPolicy: "open" }, event: makeChangedEvent() },
@@ -130,7 +130,8 @@ describe("registerSlackMessageEvents", () => {
       },
       calls: 0,
     },
-  ])("$name", async ({ input, calls }) => {
+  ];
+  it.each(cases)("$name", async ({ input, calls }) => {
     await runMessageCase(input);
     expect(messageQueueMock).toHaveBeenCalledTimes(calls);
   });

--- a/src/slack/monitor/events/pins.test.ts
+++ b/src/slack/monitor/events/pins.test.ts
@@ -76,16 +76,30 @@ async function runPinCase(input: PinCase = {}): Promise<void> {
 
 describe("registerSlackPinEvents", () => {
   const cases: Array<{ name: string; args: PinCase; expectedCalls: number }> = [
-    { name: "enqueues DM pin system events when dmPolicy is open", args: { overrides: { dmPolicy: "open" } }, expectedCalls: 1 },
-    { name: "blocks DM pin system events when dmPolicy is disabled", args: { overrides: { dmPolicy: "disabled" } }, expectedCalls: 0 },
+    {
+      name: "enqueues DM pin system events when dmPolicy is open",
+      args: { overrides: { dmPolicy: "open" } },
+      expectedCalls: 1,
+    },
+    {
+      name: "blocks DM pin system events when dmPolicy is disabled",
+      args: { overrides: { dmPolicy: "disabled" } },
+      expectedCalls: 0,
+    },
     {
       name: "blocks DM pin system events for unauthorized senders in allowlist mode",
-      args: { overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] }, event: makePinEvent({ user: "U1" }) },
+      args: {
+        overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] },
+        event: makePinEvent({ user: "U1" }),
+      },
       expectedCalls: 0,
     },
     {
       name: "allows DM pin system events for authorized senders in allowlist mode",
-      args: { overrides: { dmPolicy: "allowlist", allowFrom: ["U1"] }, event: makePinEvent({ user: "U1" }) },
+      args: {
+        overrides: { dmPolicy: "allowlist", allowFrom: ["U1"] },
+        event: makePinEvent({ user: "U1" }),
+      },
       expectedCalls: 1,
     },
     {

--- a/src/slack/monitor/events/pins.test.ts
+++ b/src/slack/monitor/events/pins.test.ts
@@ -75,32 +75,22 @@ async function runPinCase(input: PinCase = {}): Promise<void> {
 }
 
 describe("registerSlackPinEvents", () => {
-  it.each([
-    ["enqueues DM pin system events when dmPolicy is open", { overrides: { dmPolicy: "open" } }, 1],
-    [
-      "blocks DM pin system events when dmPolicy is disabled",
-      { overrides: { dmPolicy: "disabled" } },
-      0,
-    ],
-    [
-      "blocks DM pin system events for unauthorized senders in allowlist mode",
-      {
-        overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] },
-        event: makePinEvent({ user: "U1" }),
-      },
-      0,
-    ],
-    [
-      "allows DM pin system events for authorized senders in allowlist mode",
-      {
-        overrides: { dmPolicy: "allowlist", allowFrom: ["U1"] },
-        event: makePinEvent({ user: "U1" }),
-      },
-      1,
-    ],
-    [
-      "blocks channel pin events for users outside channel users allowlist",
-      {
+  const cases: Array<{ name: string; args: PinCase; expectedCalls: number }> = [
+    { name: "enqueues DM pin system events when dmPolicy is open", args: { overrides: { dmPolicy: "open" } }, expectedCalls: 1 },
+    { name: "blocks DM pin system events when dmPolicy is disabled", args: { overrides: { dmPolicy: "disabled" } }, expectedCalls: 0 },
+    {
+      name: "blocks DM pin system events for unauthorized senders in allowlist mode",
+      args: { overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] }, event: makePinEvent({ user: "U1" }) },
+      expectedCalls: 0,
+    },
+    {
+      name: "allows DM pin system events for authorized senders in allowlist mode",
+      args: { overrides: { dmPolicy: "allowlist", allowFrom: ["U1"] }, event: makePinEvent({ user: "U1" }) },
+      expectedCalls: 1,
+    },
+    {
+      name: "blocks channel pin events for users outside channel users allowlist",
+      args: {
         overrides: {
           dmPolicy: "open",
           channelType: "channel",
@@ -108,9 +98,10 @@ describe("registerSlackPinEvents", () => {
         },
         event: makePinEvent({ channel: "C1", user: "U_ATTACKER" }),
       },
-      0,
-    ],
-  ])("%s", async (_name, args: PinCase, expectedCalls: number) => {
+      expectedCalls: 0,
+    },
+  ];
+  it.each(cases)("$name", async ({ args, expectedCalls }) => {
     await runPinCase(args);
     expect(pinEnqueueMock).toHaveBeenCalledTimes(expectedCalls);
   });

--- a/src/slack/monitor/events/reactions.test.ts
+++ b/src/slack/monitor/events/reactions.test.ts
@@ -78,20 +78,20 @@ async function executeReactionCase(input: ReactionRunInput = {}) {
 }
 
 describe("registerSlackReactionEvents", () => {
-  it.each([
+  const cases: Array<{ name: string; input: ReactionRunInput; expectedCalls: number }> = [
     {
       name: "enqueues DM reaction system events when dmPolicy is open",
-      args: { overrides: { dmPolicy: "open" } },
+      input: { overrides: { dmPolicy: "open" } },
       expectedCalls: 1,
     },
     {
       name: "blocks DM reaction system events when dmPolicy is disabled",
-      args: { overrides: { dmPolicy: "disabled" } },
+      input: { overrides: { dmPolicy: "disabled" } },
       expectedCalls: 0,
     },
     {
       name: "blocks DM reaction system events for unauthorized senders in allowlist mode",
-      args: {
+      input: {
         overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] },
         event: buildReactionEvent({ user: "U1" }),
       },
@@ -99,7 +99,7 @@ describe("registerSlackReactionEvents", () => {
     },
     {
       name: "allows DM reaction system events for authorized senders in allowlist mode",
-      args: {
+      input: {
         overrides: { dmPolicy: "allowlist", allowFrom: ["U1"] },
         event: buildReactionEvent({ user: "U1" }),
       },
@@ -107,8 +107,8 @@ describe("registerSlackReactionEvents", () => {
     },
     {
       name: "enqueues channel reaction events regardless of dmPolicy",
-      args: {
-        handler: "removed" as const,
+      input: {
+        handler: "removed",
         overrides: { dmPolicy: "disabled", channelType: "channel" },
         event: {
           ...buildReactionEvent({ channel: "C1" }),
@@ -119,7 +119,7 @@ describe("registerSlackReactionEvents", () => {
     },
     {
       name: "blocks channel reaction events for users outside channel users allowlist",
-      args: {
+      input: {
         overrides: {
           dmPolicy: "open",
           channelType: "channel",
@@ -129,8 +129,10 @@ describe("registerSlackReactionEvents", () => {
       },
       expectedCalls: 0,
     },
-  ])("$name", async ({ args, expectedCalls }) => {
-    await executeReactionCase(args);
+  ];
+
+  it.each(cases)("$name", async ({ input, expectedCalls }) => {
+    await executeReactionCase(input);
     expect(reactionQueueMock).toHaveBeenCalledTimes(expectedCalls);
   });
 


### PR DESCRIPTION
## Summary
- `src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts`: fixed model provider input typing and kept `api` as literal `"openai-responses"` so the merge config provider satisfies `ModelProviderConfig` typing.
- `src/channels/typing.test.ts`: replaced cast-heavy `MockInstance` usage with explicitly typed callback mocks and stable defaults in `createTypingHarness`.
- `src/commands/channel-test-helpers.ts`: narrowed adapter patch surface to required onboarding adapter keys and made patch/restore logic explicit per field.
- `src/node-host/invoke-system-run.test.ts`: replaced loosely-typed callback mocks with explicit `Mock<...>` aliases for better type compatibility.
- `src/cron/isolated-agent/run.test-harness.ts`: typed shared mock exports as `Mock` to avoid TS portable inference (`TS2742`) issues.
- `src/commands/onboard-custom.test.ts` / `src/slack/monitor/events/pins.test.ts`: adjusted fixture typing/formatting tied to stricter type checks.

## Validation
- `pnpm check`

## Notes
- Primary route for the `routing` concern is still represented via `session` in subagent spawn test config objects; no top-level `OpenClawConfig.routing` usage is required in these updated typings.
- AI-assisted changes included in this PR.
