### PR TITLE
fix(ui): simplify mixed primitive+complex unions in config form schem…

### DIFF
--- a/ui/src/ui/config-form.browser.test.ts
+++ b/ui/src/ui/config-form.browser.test.ts
@@ -317,6 +317,58 @@ describe("config form renderer", () => {
     expect(analysis.unsupportedPaths).toContain("mixed");
   });
 
+  it("propagates unsupported children in additionalProperties without blocking parent", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        providers: {
+          type: "object",
+          additionalProperties: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              apiKey: {
+                anyOf: [
+                  { type: "string" },
+                  { type: "object", properties: { source: { type: "string" } } },
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+    const analysis = analyzeConfigSchema(schema);
+    expect(analysis.unsupportedPaths).not.toContain("providers");
+    expect(analysis.unsupportedPaths).toContain("providers.*.apiKey");
+  });
+
+  it("propagates unsupported children in array items without blocking parent", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        items: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              compat: {
+                anyOf: [
+                  { type: "object", properties: { a: { type: "string" } } },
+                  { type: "object", properties: { b: { type: "number" } } },
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+    const analysis = analyzeConfigSchema(schema);
+    expect(analysis.unsupportedPaths).not.toContain("items");
+    expect(analysis.unsupportedPaths).toContain("items.*.compat");
+  });
+
   it("supports nullable types", () => {
     const schema = {
       type: "object",

--- a/ui/src/ui/views/config-form.analyze.ts
+++ b/ui/src/ui/views/config-form.analyze.ts
@@ -86,8 +86,8 @@ function normalizeSchemaNode(
       if (!isAnySchema(schema.additionalProperties)) {
         const res = normalizeSchemaNode(schema.additionalProperties, [...path, "*"]);
         normalized.additionalProperties = res.schema ?? schema.additionalProperties;
-        if (res.unsupportedPaths.length > 0) {
-          unsupported.add(pathLabel);
+        for (const entry of res.unsupportedPaths) {
+          unsupported.add(entry);
         }
       }
     }
@@ -98,8 +98,8 @@ function normalizeSchemaNode(
     } else {
       const res = normalizeSchemaNode(itemsSchema, [...path, "*"]);
       normalized.items = res.schema ?? itemsSchema;
-      if (res.unsupportedPaths.length > 0) {
-        unsupported.add(pathLabel);
+      for (const entry of res.unsupportedPaths) {
+        unsupported.add(entry);
       }
     }
   } else if (
@@ -202,23 +202,6 @@ function normalizeUnion(
       },
       unsupportedPaths: [],
     };
-  }
-
-  // When a union mixes a single primitive with complex types (e.g. SecretInputSchema:
-  // string | { source: "env"|"file"|"exec", ... }), simplify to the primitive so the
-  // form can render a text input instead of marking the field unsupported.
-  if (remaining.length > 0 && literals.length === 0) {
-    const primitives = remaining.filter(
-      (entry) => entry.type && primitiveTypes.has(String(entry.type)),
-    );
-    if (primitives.length >= 1) {
-      const chosen = primitives[0];
-      const res = normalizeSchemaNode(chosen, path);
-      if (res.schema) {
-        res.schema.nullable = nullable || res.schema.nullable;
-      }
-      return res;
-    }
   }
 
   return null;

--- a/ui/src/ui/views/config-form.analyze.ts
+++ b/ui/src/ui/views/config-form.analyze.ts
@@ -204,5 +204,22 @@ function normalizeUnion(
     };
   }
 
+  // When a union mixes a single primitive with complex types (e.g. SecretInputSchema:
+  // string | { source: "env"|"file"|"exec", ... }), simplify to the primitive so the
+  // form can render a text input instead of marking the field unsupported.
+  if (remaining.length > 0 && literals.length === 0) {
+    const primitives = remaining.filter(
+      (entry) => entry.type && primitiveTypes.has(String(entry.type)),
+    );
+    if (primitives.length >= 1) {
+      const chosen = primitives[0];
+      const res = normalizeSchemaNode(chosen, path);
+      if (res.schema) {
+        res.schema.nullable = nullable || res.schema.nullable;
+      }
+      return res;
+    }
+  }
+
   return null;
 }

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -4,6 +4,7 @@ import {
   defaultValue,
   hintForPath,
   humanize,
+  isPathUnsupported,
   pathKey,
   schemaType,
   type JsonSchema,
@@ -340,7 +341,7 @@ export function renderNode(params: {
   const key = pathKey(path);
   const criteria = params.searchCriteria;
 
-  if (unsupported.has(key)) {
+  if (isPathUnsupported(key, unsupported)) {
     return html`<div class="cfg-field cfg-field--error">
       <div class="cfg-field__label">${label}</div>
       <div class="cfg-field__error">Unsupported schema node. Use Raw mode.</div>

--- a/ui/src/ui/views/config-form.shared.ts
+++ b/ui/src/ui/views/config-form.shared.ts
@@ -87,6 +87,33 @@ export function hintForPath(path: Array<string | number>, hints: ConfigUiHints) 
   return undefined;
 }
 
+export function isPathUnsupported(key: string, unsupported: Set<string>): boolean {
+  if (unsupported.has(key)) {
+    return true;
+  }
+  const segments = key.split(".");
+  for (const pattern of unsupported) {
+    if (!pattern.includes("*")) {
+      continue;
+    }
+    const patternSegments = pattern.split(".");
+    if (patternSegments.length !== segments.length) {
+      continue;
+    }
+    let match = true;
+    for (let i = 0; i < segments.length; i += 1) {
+      if (patternSegments[i] !== "*" && patternSegments[i] !== segments[i]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function humanize(raw: string) {
   return raw
     .replace(/_/g, " ")


### PR DESCRIPTION
## Summary

- **Problem:** When `additionalProperties` or `array.items` contained a child field with an unsupported schema (e.g. `apiKey` using `SecretInputSchema` with `anyOf: [string, object]`), the analyzer marked the entire parent as unsupported. That hid entire config sections (`models.providers`, `agents.list`, etc.) from the Form view.
- **Why it matters:** Users saw "Unsupported schema node. Use Raw mode." for whole sections and could not edit provider configurations through the UI, even though most fields were editable.
- **What changed:** `additionalProperties` and `array.items` now propagate child unsupported paths individually (same as `properties`), instead of marking the parent. Added `isPathUnsupported()` with wildcard matching so paths like `providers.*.apiKey` match concrete paths like `providers.zte-qwen.apiKey` during rendering.
- **What did NOT change (scope boundary):** No changes to the Zod schemas, JSON Schema generation, config validation, or Raw mode behavior. Only the UI-side schema analysis and propagation logic are affected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
Closed   #31490 

## User-visible / Behavior Changes

- `models.providers` and other config sections that contain `SecretInputSchema` fields (e.g. `apiKey`) now render correctly in the config Form view instead of showing "Unsupported schema node. Use Raw mode." for the whole section.
- Only the unsupported fields (e.g. `apiKey`) show "Unsupported schema node. Use Raw mode." inline; other fields remain editable.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+ / pnpm
- Model/provider: Any custom provider via `models.providers`
- Relevant config (redacted):

models:
  providers:
    my-provider:
      baseUrl: "https://example.com/v1"
      apiKey: "sk-***"
      api: "openai-completions"
      models:
        - id: "my-model"
          name: "My Model"
          contextWindow: 200000
          maxTokens: 8192
<img width="2527" height="1088" alt="2026-03⁄02⁄26_3" src="https://github.com/user-attachments/assets/6ddfa9b2-99df-4bfa-9b13-e86479265efb" />
