### PR TITLE
fix(sandbox): skip openSync for directory boundary checks in mkdirp

### DIFF
--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -273,7 +273,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
               `Sandbox boundary checks failed; cannot ${options.action}: ${target.containerPath}`,
             );
       }
-    } else {
+    } else if (guarded.fd >= 0) {
       fs.closeSync(guarded.fd);
     }
 

--- a/src/infra/safe-open-sync.test.ts
+++ b/src/infra/safe-open-sync.test.ts
@@ -43,7 +43,39 @@ describe("openVerifiedFileSync", () => {
         return;
       }
       expect(opened.stat.isDirectory()).toBe(true);
-      fs.closeSync(opened.fd);
+      expect(opened.fd).toBe(-1);
+    });
+  });
+
+  it("returns fd=-1 for directory without calling openSync", async () => {
+    await withTempDir("openclaw-safe-open-", async (root) => {
+      const targetDir = path.join(root, "subdir");
+      await fsp.mkdir(targetDir, { recursive: true });
+
+      const openSyncCalls: string[] = [];
+      const mockFs: Parameters<typeof openVerifiedFileSync>[0]["ioFs"] = {
+        constants: fs.constants,
+        lstatSync: fs.lstatSync.bind(fs),
+        realpathSync: fs.realpathSync.bind(fs),
+        openSync: (...args: Parameters<typeof fs.openSync>) => {
+          openSyncCalls.push(String(args[0]));
+          return fs.openSync(...args);
+        },
+        fstatSync: fs.fstatSync.bind(fs),
+        closeSync: fs.closeSync.bind(fs),
+      };
+
+      const opened = openVerifiedFileSync({
+        filePath: targetDir,
+        allowedType: "directory",
+        ioFs: mockFs,
+      });
+      expect(opened.ok).toBe(true);
+      if (!opened.ok) {
+        return;
+      }
+      expect(opened.fd).toBe(-1);
+      expect(openSyncCalls).toHaveLength(0);
     });
   });
 });

--- a/src/infra/safe-open-sync.ts
+++ b/src/infra/safe-open-sync.ts
@@ -63,6 +63,10 @@ export function openVerifiedFileSync(params: {
       return { ok: false, reason: "validation" };
     }
 
+    if (allowedType === "directory" && preOpenStat.isDirectory()) {
+      return { ok: true, path: realPath, fd: -1, stat: preOpenStat };
+    }
+
     fd = ioFs.openSync(realPath, openReadFlags);
     const openedStat = ioFs.fstatSync(fd);
     if (!isAllowedType(openedStat, allowedType)) {


### PR DESCRIPTION
## Summary

- Problem: `openVerifiedFileSync` calls `openSync(dir, O_RDONLY|O_NOFOLLOW)` on directories, which fails with `EISDIR` on certain Linux kernel configs and Docker host environments
- Why it matters: Sandbox agents cannot create directories via `mkdirp` inside mounted workspaces, breaking workspace initialization
- What changed: When `allowedType === "directory"`, skip `openSync`/`fstatSync` TOCTOU check and return early after `lstatSync` confirmation; guard `closeSync` for sentinel `fd=-1`
- What did NOT change: File boundary checks, symlink traversal, mount resolution — only the directory-specific verification path

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31438

## User-visible / Behavior Changes

Sandbox agents can now create directories inside mounted workspaces without boundary check failures.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (TencentOS 5.4.241, x86_64)
- Runtime/container: Docker sandbox with workspace mount
- Model/provider: Any
- Integration/channel: N/A
- Relevant config: `sandbox.mode: "all"`, `sandbox.workspaceAccess: "rw"`

### Steps

1. Configure agent sandbox with `sandbox.mode: "all"`, `sandbox.scope: "agent"`, `sandbox.workspaceAccess: "rw"`
2. Agent attempts to create directory (e.g. `/workspace/memory`)
3. Observe error: `Sandbox boundary checks failed; cannot create directories: /workspace`

### Expected

- Directory creation succeeds inside mounted workspace

### Actual

- Boundary check fails with `EISDIR` from `openSync` on directory path

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

3 unit tests pass in `safe-open-sync.test.ts`, including new test verifying `openSync` is never called for directory validation.

## Human Verification (required)

- Verified scenarios: Directory exists, directory doesn't exist, file validation unchanged
- Edge cases checked: `fd=-1` sentinel handled correctly in `assertPathSafety`, existing file boundary checks unaffected
- What you did **not** verify: Full Docker sandbox end-to-end on TencentOS

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; directory boundary checks will use `openSync` again
- Files/config to restore: `src/infra/safe-open-sync.ts`, `src/agents/sandbox/fs-bridge.ts`
- Known bad symptoms: If reverted, mkdirp failures in sandbox on affected platforms

## Risks and Mitigations

- Risk: Skipping `openSync` TOCTOU check for directories reduces verification depth
  - Mitigation: Directories cannot be atomically swapped like files; `lstatSync` confirmation is sufficient for directory identity. `resolveBoundaryPath` already handles symlink traversal.