### PR TITLE
fix(sandbox): remap Docker bind sources via gateway mounts (#31331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(sandbox): remap sandbox bind sources to host paths when OpenClaw runs in Docker (#31457) (credits: @AaronWander, @frankekn)
 - Feishu/Multi-account + reply reliability: add `channels.feishu.defaultAccount` outbound routing support with schema validation, prevent inbound preview text from leaking into prompt system events, keep quoted-message extraction text-first (post/interactive/file placeholders instead of raw JSON), route Feishu video sends as `msg_type: "file"`, and avoid websocket event blocking by using non-blocking event handling in monitor dispatch. Landed from contributor PRs #31209, #29610, #30432, #30331, and #29501. Thanks @stakeswky, @hclsys, @bmendonca3, @patrick-yingxi-pan, and @zwffff.
 - Feishu/Target routing + replies + dedupe: normalize provider-prefixed targets (`feishu:`/`lark:`), prefer configured `channels.feishu.defaultAccount` for tool execution, honor Feishu outbound `renderMode` in adapter text/caption sends, fall back to normal send when reply targets are withdrawn/deleted, and add synchronous in-memory dedupe guard for concurrent duplicate inbound events. Landed from contributor PRs #30428, #30438, #29958, #30444, and #29463. Thanks @bmendonca3 and @Yaxuan42.
 - Channels/Multi-account default routing: add optional `channels.<channel>.defaultAccount` default-selection support across message channels so omitted `accountId` routes to an explicit configured account instead of relying on implicit first-entry ordering (fallback behavior unchanged when unset).

--- a/src/agents/sandbox/docker-bind-source-map.test.ts
+++ b/src/agents/sandbox/docker-bind-source-map.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapContainerPathToDockerHostPath,
+  resolveAllowedBindSourceRoots,
+} from "./docker-bind-source-map.js";
+
+describe("sandbox docker bind source mapping", () => {
+  it("maps a container path under a bind mount to its host source", () => {
+    const mapped = mapContainerPathToDockerHostPath({
+      containerPath: "/home/node/.openclaw/workspace/project-a",
+      mounts: [
+        {
+          Source: "/DATA/openclaw/workspace",
+          Destination: "/home/node/.openclaw/workspace",
+        },
+      ],
+    });
+    expect(mapped).toBe("/DATA/openclaw/workspace/project-a");
+  });
+
+  it("prefers the most specific mount destination", () => {
+    const mapped = mapContainerPathToDockerHostPath({
+      containerPath: "/home/node/.openclaw/sandboxes/shared",
+      mounts: [
+        { Source: "/var/lib/docker/volumes/openclaw_home/_data", Destination: "/home/node" },
+        {
+          Source: "/var/lib/docker/volumes/openclaw_state/_data",
+          Destination: "/home/node/.openclaw",
+        },
+      ],
+    });
+    expect(mapped).toBe("/var/lib/docker/volumes/openclaw_state/_data/sandboxes/shared");
+  });
+
+  it("returns the original path when no mount matches", () => {
+    const mapped = mapContainerPathToDockerHostPath({
+      containerPath: "/opt/openclaw/sandboxes",
+      mounts: [
+        { Source: "/DATA/openclaw/workspace", Destination: "/home/node/.openclaw/workspace" },
+      ],
+    });
+    expect(mapped).toBe("/opt/openclaw/sandboxes");
+  });
+
+  it("returns both container and mapped roots for validation", () => {
+    const roots = resolveAllowedBindSourceRoots({
+      containerRoots: ["/home/node/.openclaw/sandboxes"],
+      mounts: [
+        { Source: "/var/lib/docker/volumes/openclaw_home/_data", Destination: "/home/node" },
+      ],
+    });
+    expect(roots).toContain("/home/node/.openclaw/sandboxes");
+    expect(roots).toContain("/var/lib/docker/volumes/openclaw_home/_data/.openclaw/sandboxes");
+  });
+});

--- a/src/agents/sandbox/docker-bind-source-map.test.ts
+++ b/src/agents/sandbox/docker-bind-source-map.test.ts
@@ -42,6 +42,14 @@ describe("sandbox docker bind source mapping", () => {
     expect(mapped).toBe("/opt/openclaw/sandboxes");
   });
 
+  it("preserves the leading slash when mapping from a root mount", () => {
+    const mapped = mapContainerPathToDockerHostPath({
+      containerPath: "/workspace",
+      mounts: [{ Source: "/host", Destination: "/" }],
+    });
+    expect(mapped).toBe("/host/workspace");
+  });
+
   it("returns both container and mapped roots for validation", () => {
     const roots = resolveAllowedBindSourceRoots({
       containerRoots: ["/home/node/.openclaw/sandboxes"],

--- a/src/agents/sandbox/docker-bind-source-map.ts
+++ b/src/agents/sandbox/docker-bind-source-map.ts
@@ -1,0 +1,68 @@
+import { posix as pathPosix } from "node:path";
+
+export type DockerMountLike = {
+  Source?: string;
+  Destination?: string;
+};
+
+function normalizeAbsolutePosixPath(value: string): string {
+  const normalized = pathPosix.normalize(value);
+  if (normalized.length > 1 && normalized.endsWith("/")) {
+    return normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+export function mapContainerPathToDockerHostPath(params: {
+  containerPath: string;
+  mounts: readonly DockerMountLike[];
+}): string {
+  const rawContainerPath = params.containerPath.trim();
+  if (!rawContainerPath.startsWith("/")) {
+    return params.containerPath;
+  }
+
+  const containerPath = normalizeAbsolutePosixPath(rawContainerPath);
+  const mounts = [...params.mounts]
+    .filter((mount): mount is Required<DockerMountLike> =>
+      Boolean(mount.Source && mount.Destination),
+    )
+    .map((mount) => ({
+      Source: normalizeAbsolutePosixPath(mount.Source),
+      Destination: normalizeAbsolutePosixPath(mount.Destination),
+    }))
+    .toSorted((a, b) => b.Destination.length - a.Destination.length);
+
+  for (const mount of mounts) {
+    if (containerPath === mount.Destination) {
+      return mount.Source;
+    }
+    const prefix = mount.Destination === "/" ? "/" : `${mount.Destination}/`;
+    if (containerPath.startsWith(prefix)) {
+      const remainder = containerPath.slice(mount.Destination.length);
+      return `${mount.Source}${remainder}`;
+    }
+  }
+
+  return params.containerPath;
+}
+
+export function resolveAllowedBindSourceRoots(params: {
+  containerRoots: readonly string[];
+  mounts: readonly DockerMountLike[];
+}): string[] {
+  const roots = new Set<string>();
+  for (const root of params.containerRoots) {
+    if (!root.trim()) {
+      continue;
+    }
+    roots.add(root);
+    roots.add(
+      mapContainerPathToDockerHostPath({
+        containerPath: root,
+        mounts: params.mounts,
+      }),
+    );
+  }
+  return [...roots];
+}

--- a/src/agents/sandbox/docker-bind-source-map.ts
+++ b/src/agents/sandbox/docker-bind-source-map.ts
@@ -39,8 +39,9 @@ export function mapContainerPathToDockerHostPath(params: {
     }
     const prefix = mount.Destination === "/" ? "/" : `${mount.Destination}/`;
     if (containerPath.startsWith(prefix)) {
-      const remainder = containerPath.slice(mount.Destination.length);
-      return `${mount.Source}${remainder}`;
+      const remainder =
+        mount.Destination === "/" ? containerPath : containerPath.slice(mount.Destination.length);
+      return normalizeAbsolutePosixPath(`${mount.Source}${remainder}`);
     }
   }
 

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -1,5 +1,11 @@
 import { spawn } from "node:child_process";
+import fs from "node:fs";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { DockerMountLike } from "./docker-bind-source-map.js";
+import {
+  mapContainerPathToDockerHostPath,
+  resolveAllowedBindSourceRoots,
+} from "./docker-bind-source-map.js";
 import { sanitizeEnvVars } from "./sanitize-env-vars.js";
 
 type ExecDockerRawOptions = {
@@ -391,6 +397,35 @@ function appendCustomBinds(args: string[], cfg: SandboxDockerConfig): void {
   }
 }
 
+async function readDockerSelfMounts(): Promise<DockerMountLike[] | null> {
+  if (!fs.existsSync("/.dockerenv")) {
+    return null;
+  }
+  const containerRef = process.env.HOSTNAME?.trim();
+  if (!containerRef) {
+    return null;
+  }
+  const result = await execDocker(["inspect", "-f", "{{json .Mounts}}", containerRef], {
+    allowFailure: true,
+  });
+  if (result.code !== 0) {
+    return null;
+  }
+  const raw = result.stdout.trim();
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as DockerMountLike[];
+  } catch {
+    return null;
+  }
+}
+
 async function createSandboxContainer(params: {
   name: string;
   cfg: SandboxDockerConfig;
@@ -403,24 +438,41 @@ async function createSandboxContainer(params: {
   const { name, cfg, workspaceDir, scopeKey } = params;
   await ensureDockerImage(cfg.image);
 
+  const selfMounts = await readDockerSelfMounts();
+  const bindWorkspaceDir =
+    selfMounts?.length && workspaceDir.startsWith("/")
+      ? mapContainerPathToDockerHostPath({ containerPath: workspaceDir, mounts: selfMounts })
+      : workspaceDir;
+  const bindAgentWorkspaceDir =
+    selfMounts?.length && params.agentWorkspaceDir.startsWith("/")
+      ? mapContainerPathToDockerHostPath({
+          containerPath: params.agentWorkspaceDir,
+          mounts: selfMounts,
+        })
+      : params.agentWorkspaceDir;
+
+  const bindSourceRoots = selfMounts?.length
+    ? resolveAllowedBindSourceRoots({
+        containerRoots: [workspaceDir, params.agentWorkspaceDir],
+        mounts: selfMounts,
+      })
+    : [workspaceDir, params.agentWorkspaceDir];
+
   const args = buildSandboxCreateArgs({
     name,
     cfg,
     scopeKey,
     configHash: params.configHash,
     includeBinds: false,
-    bindSourceRoots: [workspaceDir, params.agentWorkspaceDir],
+    bindSourceRoots,
   });
   args.push("--workdir", cfg.workdir);
   const mainMountSuffix =
     params.workspaceAccess === "ro" && workspaceDir === params.agentWorkspaceDir ? ":ro" : "";
-  args.push("-v", `${workspaceDir}:${cfg.workdir}${mainMountSuffix}`);
+  args.push("-v", `${bindWorkspaceDir}:${cfg.workdir}${mainMountSuffix}`);
   if (params.workspaceAccess !== "none" && workspaceDir !== params.agentWorkspaceDir) {
     const agentMountSuffix = params.workspaceAccess === "ro" ? ":ro" : "";
-    args.push(
-      "-v",
-      `${params.agentWorkspaceDir}:${SANDBOX_AGENT_WORKSPACE_MOUNT}${agentMountSuffix}`,
-    );
+    args.push("-v", `${bindAgentWorkspaceDir}:${SANDBOX_AGENT_WORKSPACE_MOUNT}${agentMountSuffix}`);
   }
   appendCustomBinds(args, cfg);
   args.push(cfg.image, "sleep", "infinity");


### PR DESCRIPTION
## **Summary**

- **Problem:** When the gateway runs inside Docker (Docker‑outside‑of‑Docker sandboxing), sandbox containers are created with bind sources that use the gateway container’s internal paths (for example /home/node/.openclaw/...). The host Docker engine can’t resolve those paths correctly, so it may create empty host directories and the sandbox can’t access the intended workspace.
- **Why it matters:** This breaks sandboxing for the Docker install path and can make /workspace mounts incorrect or unusable.
- **What changed:** When creating sandbox containers, OpenClaw now remaps the automatic bind sources (workspaceDir and agentWorkspaceDir) from container paths to host paths by inspecting the gateway container mounts (docker inspect $HOSTNAME). The security validator also receives both container roots and their mapped host equivalents as allowed bind-source roots.
- **What did NOT change (scope boundary):** No behavior changes when OpenClaw is not running inside Docker; no runtime logic changes outside sandbox container creation; custom binds are still passed through as configured.

## **Change Type (select all)**

- [x]  Bug fix
- [ ]  Feature
- [ ]  Refactor
- [ ]  Docs
- [ ]  Security hardening
- [ ]  Chore/infra

## **Scope (select all touched areas)**

- [ ]  Gateway / orchestration
- [x]  Skills / tool execution
- [ ]  Auth / tokens
- [ ]  Memory / storage
- [ ]  Integrations
- [ ]  API / contracts
- [ ]  UI / DX
- [ ]  CI/CD / infra

## **Linked Issue/PR**

- Closes [Bug]: Docker Install + Sandbox can't workspaceAccess at all #31331

## **User-visible / Behavior Changes**

Sandbox containers created from a Docker‑hosted gateway use host‑resolvable bind sources for workspace mounts (instead of container‑internal paths).

## **Security Impact (required)**

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation:

## **Repro + Verification**

### **Environment**

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### **Steps**

1. Run pnpm check.
2. Run pnpm test src/agents/sandbox/docker-bind-source-map.test.ts.
3. Install smoke tests (root + non‑root) with scripts/docker/install-sh-common mounted to /usr/local/install-sh-common.
4. CLI install smoke (non‑root image) via [install-cli.sh](http://install-cli.sh/) --set-npm-prefix --no-onboard.

### **Expected**

- Checks pass; bind-source mapping yields host paths for container-mounted directories; install smoke passes.

### **Actual**

- Before this change, Docker‑hosted gateways could create sandbox binds using container‑internal paths that don’t exist on the host.

## **Evidence**

- [x]  pnpm check passed
- [x]  docker-bind-source-map.test.ts passed
- [x]  Install smoke (root + non‑root + CLI) passed

## **Human Verification (required)**

- Verified scenarios: pnpm check; docker-bind-source-map.test.ts; install smoke (root + non‑root + CLI)
- Edge cases checked: most-specific mount destination wins; non‑matching paths unchanged
- What you did **not** verify: full end‑to‑end Docker Compose sandbox run on a Linux host

## **Compatibility / Migration**

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## **Failure Recovery (if this breaks)**

- Revert this commit.

## **Risks and Mitigations**

None.