### PR TITLE
fix(feishu): strip group:/dm: prefix in normalizeFeishuTarget

### DIFF
--- a/extensions/feishu/src/targets.test.ts
+++ b/extensions/feishu/src/targets.test.ts
@@ -28,6 +28,16 @@ describe("normalizeFeishuTarget", () => {
   it("accepts provider-prefixed raw ids", () => {
     expect(normalizeFeishuTarget("feishu:ou_123")).toBe("ou_123");
   });
+
+  it("strips group: prefix to bare chat id", () => {
+    expect(normalizeFeishuTarget("group:oc_524f00307b58bc1da7bbd046afed326f")).toBe(
+      "oc_524f00307b58bc1da7bbd046afed326f",
+    );
+  });
+
+  it("strips dm: prefix to bare user id", () => {
+    expect(normalizeFeishuTarget("dm:ou_abc123")).toBe("ou_abc123");
+  });
 });
 
 describe("looksLikeFeishuId", () => {

--- a/extensions/feishu/src/targets.ts
+++ b/extensions/feishu/src/targets.ts
@@ -39,6 +39,12 @@ export function normalizeFeishuTarget(raw: string): string | null {
   if (lowered.startsWith("open_id:")) {
     return withoutProvider.slice("open_id:".length).trim() || null;
   }
+  if (lowered.startsWith("group:")) {
+    return withoutProvider.slice("group:".length).trim() || null;
+  }
+  if (lowered.startsWith("dm:")) {
+    return withoutProvider.slice("dm:".length).trim() || null;
+  }
 
   return withoutProvider;
 }


### PR DESCRIPTION
## Summary

- Problem: `normalizeFeishuTarget` does not strip `group:` or `dm:` prefixes, so `sessions_send` announce passes `group:oc_xxx` verbatim to Feishu API
- Why it matters: Feishu rejects the invalid `receive_id` with 400 error, and `resolveReceiveIdType` misclassifies it as `user_id` instead of `chat_id`
- What changed: Added `group:` and `dm:` prefix stripping in `normalizeFeishuTarget`, consistent with how `outbound-session.ts` already handles these prefixes
- What did NOT change: `resolveReceiveIdType`, `formatFeishuTarget`, `detectIdType` — only the normalization input path

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31426

## User-visible / Behavior Changes

`sessions_send` announce now works correctly in Feishu group chats. Previously it failed with 400 Bad Request.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same API, correct parameters now)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04.4 LTS
- Runtime/container: Node v22.22.0
- Model/provider: Any
- Integration/channel: Feishu (dual-bot group chat)
- Relevant config: Two Feishu bots in a group, bot A dispatching to bot B

### Steps

1. Set up dual-channel with two Feishu bots in a group chat
2. Bot A sends a message that triggers bot B via `sessions_send`
3. Bot B attempts to announce reply back to the group
4. Observe 400 error: `Invalid ids: [group:oc_524f00307b58bc1da7bbd046afed326f]`

### Expected

- Bot B successfully sends announce message to the Feishu group

### Actual

- Feishu API returns `code: 99992360` with invalid `receive_id`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

All 10 Feishu targets tests pass, including 2 new tests for `group:` and `dm:` normalization.

## Human Verification (required)

- Verified scenarios: `group:oc_xxx` → `oc_xxx`, `dm:ou_xxx` → `ou_xxx`, existing `chat:`/`user:`/`open_id:` paths unaffected
- Edge cases checked: Provider-prefixed group targets (`feishu:group:oc_xxx` → stripped via `stripProviderPrefix` then `group:`)
- What you did **not** verify: Live Feishu API call in dual-bot group setup

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; `group:` prefix will pass through again
- Files/config to restore: `extensions/feishu/src/targets.ts`
- Known bad symptoms: If reverted, Feishu group announce fails with 400 error

## Risks and Mitigations

- Risk: `dm:` prefix stripping might conflict with future DM-specific routing
  - Mitigation: `dm:` is already used in `outbound-session.ts` with the same stripping behavior; consistent handling across the codebase