### PR TITLE
fix: use VERSION constant for Web UI version display (#30922)

### DIFF
--- a/src/gateway/server/ws-connection/message-handler-version.test.ts
+++ b/src/gateway/server/ws-connection/message-handler-version.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { VERSION } from "../../../version.js";
+
+describe("message-handler version", () => {
+  it("VERSION constant is a proper semver string, not a fallback like 'dev'", () => {
+    expect(VERSION).toBeDefined();
+    expect(typeof VERSION).toBe("string");
+    expect(VERSION).not.toBe("dev");
+    expect(VERSION).not.toBe("");
+    // Should look like a semver (e.g. "1.2.3" or "1.2.3-beta.1")
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("message-handler imports VERSION for hello-ok frame", async () => {
+    const fs = await import("fs");
+    const source = fs.readFileSync(new URL("./message-handler.ts", import.meta.url), "utf-8");
+    // Verify VERSION is imported from version.js
+    expect(source).toContain('VERSION } from "../../../version.js"');
+    // Verify hello-ok server block uses VERSION, not resolveRuntimeServiceVersion
+    const helloOkMatch = source.match(/const helloOk[\s\S]*?server:\s*\{[^}]*version:\s*(\w+)/);
+    expect(helloOkMatch).not.toBeNull();
+    expect(helloOkMatch![1]).toBe("VERSION");
+  });
+});

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -23,7 +23,7 @@ import { rawDataToString } from "../../../infra/ws.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import { isGatewayCliClient, isWebchatClient } from "../../../utils/message-channel.js";
-import { resolveRuntimeServiceVersion } from "../../../version.js";
+import { VERSION } from "../../../version.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
 import { isLocalDirectRequest } from "../../auth.js";
@@ -1013,7 +1013,7 @@ export function attachGatewayWsMessageHandler(params: {
           type: "hello-ok",
           protocol: PROTOCOL_VERSION,
           server: {
-            version: resolveRuntimeServiceVersion(process.env, "dev"),
+            version: VERSION,
             connId,
           },
           features: { methods: gatewayMethods, events },


### PR DESCRIPTION
## Summary
Fixes #30922 — Web UI shows hardcoded/stale version `2026.2.13` instead of the actual installed version.

## Root Cause
The `hello-ok` WebSocket frame sent to the Web UI used `resolveRuntimeServiceVersion()`, which only checks environment variables (`OPENCLAW_VERSION`, `npm_package_version`, etc.) and falls back to `"dev"`. In most installations these env vars aren't set, so the UI gets a stale or wrong version.

## Fix
Replace `resolveRuntimeServiceVersion(process.env, "dev")` with the `VERSION` constant from `src/version.ts`, which has a proper resolution chain: injected define → package.json → build-info.json → `"0.0.0"`.

## Changes
- `src/gateway/server/ws-connection/message-handler.ts`: Import `VERSION` instead of `resolveRuntimeServiceVersion`, use it in the `hello-ok` server block
- Added `message-handler-version.test.ts`: Regression tests verifying VERSION is a proper semver and is used in the hello-ok frame

## Testing
- Existing tests pass
- New regression tests verify the fix