### PR TITLE
fix(cron): persist lightContext in mergeCronPayload and buildPayloadFromPatch

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -579,6 +579,9 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   if (typeof patch.bestEffortDeliver === "boolean") {
     next.bestEffortDeliver = patch.bestEffortDeliver;
   }
+  if (typeof patch.lightContext === "boolean") {
+    next.lightContext = patch.lightContext;
+  }
   return next;
 }
 
@@ -646,6 +649,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     channel: patch.channel,
     to: patch.to,
     bestEffortDeliver: patch.bestEffortDeliver,
+    lightContext: patch.lightContext,
   };
 }
 


### PR DESCRIPTION
## Summary

- Problem: `cron edit --light-context` is accepted by the CLI but the flag is silently dropped in the cron service merge layer
- Why it matters: Users cannot toggle `lightContext` on existing cron jobs without recreating them or editing JSON directly
- What changed: Added `lightContext` handling in both `mergeCronPayload` (same-kind merge) and `buildPayloadFromPatch` (kind-change rebuild)
- What did NOT change: CLI argument parsing, cron runtime behavior, other agentTurn fields — only the two merge/build functions

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31425

## User-visible / Behavior Changes

`openclaw cron edit <id> --light-context` now correctly persists `lightContext: true` in the job payload. `--no-light-context` correctly clears it.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux x64
- Runtime/container: Node v22.22.0
- Model/provider: Any
- Integration/channel: N/A
- Relevant config: Any cron job configuration

### Steps

1. Create a cron job without `--light-context`: `openclaw cron add --name test --at "1h" --message "test"`
2. Edit to add flag: `openclaw cron edit <id> --light-context`
3. Check: `openclaw cron list --json`
4. Observe `lightContext` is missing from payload

### Expected

- `lightContext: true` appears in the job payload after edit

### Actual

- `lightContext` is absent; flag was silently dropped

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

All 33 `cron-cli.test.ts` tests pass, including existing tests for `--light-context` and `--no-light-context` on cron edit.

## Human Verification (required)

- Verified scenarios: Setting `lightContext` via edit, clearing via `--no-light-context`, kind-change rebuild path
- Edge cases checked: `buildPayloadFromPatch` (kind change) also includes `lightContext`; all other agentTurn fields unaffected
- What you did **not** verify: Live cron job execution with `lightContext` toggled

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; `lightContext` will be silently dropped again on edit
- Files/config to restore: `src/cron/service/jobs.ts`
- Known bad symptoms: If reverted, cron edit `--light-context` appears to succeed but has no effect

## Risks and Mitigations

`None` — This is a straightforward field addition consistent with all other agentTurn fields in the same functions.