### PR TITLE
feat(agents): add per-model contextTokens override

### DIFF
--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -82,6 +82,48 @@ describe("createSessionManagerRuntimeRegistry", () => {
 });
 
 describe("resolveContextTokensForModel", () => {
+  it("prefers per-model contextTokens over defaults.contextTokens", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        agents: {
+          defaults: {
+            contextTokens: 97_000,
+            models: {
+              "openai/gpt-4.1": {
+                contextTokens: 128_000,
+              },
+            },
+          },
+        },
+      },
+      provider: "openai",
+      model: "gpt-4.1",
+      fallbackContextTokens: 201_000,
+    });
+
+    expect(result).toBe(128_000);
+  });
+
+  it("uses defaults.contextTokens when no per-model override exists", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        agents: {
+          defaults: {
+            contextTokens: 96_000,
+            models: {
+              "openai/gpt-4.1": {},
+            },
+          },
+        },
+      },
+      provider: "openai",
+      model: "gpt-4.1",
+      fallbackContextTokens: 202_000,
+    });
+
+    expect(result).toBe(96_000);
+  });
+
   it("returns 1M context when anthropic context1m is enabled for opus/sonnet", () => {
     const result = resolveContextTokensForModel({
       cfg: {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -14,7 +14,7 @@ type ModelRegistryLike = {
 type ConfigModelEntry = { id?: string; contextWindow?: number };
 type ProviderConfigEntry = { models?: ConfigModelEntry[] };
 type ModelsConfig = { providers?: Record<string, ProviderConfigEntry | undefined> };
-type AgentModelEntry = { params?: Record<string, unknown> };
+type AgentModelEntry = { params?: Record<string, unknown>; contextTokens?: number };
 
 const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as const;
 export const ANTHROPIC_CONTEXT_1M_TOKENS = 1_048_576;
@@ -134,6 +134,29 @@ function resolveConfiguredModelParams(
   return undefined;
 }
 
+function resolveConfiguredModelContextTokens(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+  model: string,
+): number | undefined {
+  const models = cfg?.agents?.defaults?.models;
+  if (!models) {
+    return undefined;
+  }
+  const key = `${provider}/${model}`.trim().toLowerCase();
+  for (const [rawKey, entry] of Object.entries(models)) {
+    if (rawKey.trim().toLowerCase() !== key) {
+      continue;
+    }
+    const tokens = (entry as AgentModelEntry | undefined)?.contextTokens;
+    if (typeof tokens === "number" && tokens > 0) {
+      return Math.trunc(tokens);
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
 function resolveProviderModelRef(params: {
   provider?: string;
   model?: string;
@@ -179,16 +202,34 @@ export function resolveContextTokensForModel(params: {
   if (typeof params.contextTokensOverride === "number" && params.contextTokensOverride > 0) {
     return params.contextTokensOverride;
   }
+  const defaultsContextTokens =
+    typeof params.cfg?.agents?.defaults?.contextTokens === "number" &&
+    params.cfg.agents.defaults.contextTokens > 0
+      ? Math.trunc(params.cfg.agents.defaults.contextTokens)
+      : undefined;
 
   const ref = resolveProviderModelRef({
     provider: params.provider,
     model: params.model,
   });
   if (ref) {
+    const perModelTokens = resolveConfiguredModelContextTokens(params.cfg, ref.provider, ref.model);
+    if (typeof perModelTokens === "number" && perModelTokens > 0) {
+      return perModelTokens;
+    }
+
+    if (typeof defaultsContextTokens === "number") {
+      return defaultsContextTokens;
+    }
+
     const modelParams = resolveConfiguredModelParams(params.cfg, ref.provider, ref.model);
     if (modelParams?.context1m === true && isAnthropic1MModel(ref.provider, ref.model)) {
       return ANTHROPIC_CONTEXT_1M_TOKENS;
     }
+  }
+
+  if (typeof defaultsContextTokens === "number") {
+    return defaultsContextTokens;
   }
 
   return lookupContextTokens(params.model) ?? params.fallbackContextTokens;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
@@ -273,7 +273,6 @@ export async function runReplyAgent(params: {
     sessionKey,
     storePath,
     defaultModel,
-    agentCfgContextTokens,
   });
 
   let responseUsageLine: string | undefined;
@@ -480,10 +479,12 @@ export async function runReplyAgent(params: {
       ? runResult.meta?.agentMeta?.sessionId?.trim()
       : undefined;
     const contextTokensUsed =
-      agentCfgContextTokens ??
-      lookupContextTokens(modelUsed) ??
-      activeSessionEntry?.contextTokens ??
-      DEFAULT_CONTEXT_TOKENS;
+      resolveContextTokensForModel({
+        cfg,
+        provider: providerUsed,
+        model: modelUsed,
+        fallbackContextTokens: activeSessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
+      }) ?? DEFAULT_CONTEXT_TOKENS;
 
     await persistRunSessionUsage({
       storePath,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { resolveRunModelFallbacksOverride } from "../../agents/agent-scope.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
@@ -41,7 +41,6 @@ export function createFollowupRunner(params: {
   sessionKey?: string;
   storePath?: string;
   defaultModel: string;
-  agentCfgContextTokens?: number;
 }): (queued: FollowupRun) => Promise<void> {
   const {
     opts,
@@ -52,7 +51,6 @@ export function createFollowupRunner(params: {
     sessionKey,
     storePath,
     defaultModel,
-    agentCfgContextTokens,
   } = params;
   const typingSignals = createTypingSignaler({
     typing,
@@ -214,11 +212,14 @@ export function createFollowupRunner(params: {
       const usage = runResult.meta?.agentMeta?.usage;
       const promptTokens = runResult.meta?.agentMeta?.promptTokens;
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
+      const providerUsed = runResult.meta?.agentMeta?.provider ?? fallbackProvider;
       const contextTokensUsed =
-        agentCfgContextTokens ??
-        lookupContextTokens(modelUsed) ??
-        sessionEntry?.contextTokens ??
-        DEFAULT_CONTEXT_TOKENS;
+        resolveContextTokensForModel({
+          cfg: queued.run.config,
+          provider: providerUsed,
+          model: modelUsed,
+          fallbackContextTokens: sessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
+        }) ?? DEFAULT_CONTEXT_TOKENS;
 
       if (storePath && sessionKey) {
         await persistRunSessionUsage({
@@ -228,7 +229,7 @@ export function createFollowupRunner(params: {
           lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
           promptTokens,
           modelUsed,
-          providerUsed: fallbackProvider,
+          providerUsed,
           contextTokensUsed,
           logLabel: "followup",
         });

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -406,7 +406,9 @@ export async function resolveReplyDirectives(params: {
   }
 
   let contextTokens = resolveContextTokens({
+    cfg,
     agentCfg,
+    provider,
     model,
   });
 

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -1,5 +1,5 @@
 import { clearSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import {
@@ -599,10 +599,27 @@ export function resolveModelDirectiveSelection(params: {
 }
 
 export function resolveContextTokens(params: {
+  cfg: OpenClawConfig;
   agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
+  provider: string;
   model: string;
 }): number {
+  const contextConfig: OpenClawConfig = {
+    ...params.cfg,
+    agents: {
+      ...params.cfg.agents,
+      defaults: {
+        ...params.cfg.agents?.defaults,
+        ...params.agentCfg,
+      },
+    },
+  };
   return (
-    params.agentCfg?.contextTokens ?? lookupContextTokens(params.model) ?? DEFAULT_CONTEXT_TOKENS
+    resolveContextTokensForModel({
+      cfg: contextConfig,
+      provider: params.provider,
+      model: params.model,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    }) ?? DEFAULT_CONTEXT_TOKENS
   );
 }

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -451,7 +451,7 @@ export function buildStatusMessage(args: StatusArgs): string {
       cfg: contextConfig,
       provider: activeProvider,
       model: activeModel,
-      contextTokensOverride: entry?.contextTokens ?? args.agent?.contextTokens,
+      contextTokensOverride: entry?.contextTokens,
       fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
     }) ?? DEFAULT_CONTEXT_TOKENS;
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -911,9 +911,18 @@ export async function agentCommand(
 
     // Update token+model fields in the session store.
     if (sessionStore && sessionKey) {
+      const cfgWithAgentDefaults: OpenClawConfig = {
+        ...cfg,
+        agents: {
+          ...cfg.agents,
+          defaults: {
+            ...cfg.agents?.defaults,
+            ...agentCfg,
+          },
+        },
+      };
       await updateSessionStoreAfterAgentRun({
-        cfg,
-        contextTokensOverride: agentCfg?.contextTokens,
+        cfg: cfgWithAgentDefaults,
         sessionId,
         sessionKey,
         storePath,

--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -17,7 +17,6 @@ type RunResult = Awaited<
 
 export async function updateSessionStoreAfterAgentRun(params: {
   cfg: OpenClawConfig;
-  contextTokensOverride?: number;
   sessionId: string;
   sessionKey: string;
   storePath: string;
@@ -51,7 +50,6 @@ export async function updateSessionStoreAfterAgentRun(params: {
       cfg,
       provider: providerUsed,
       model: modelUsed,
-      contextTokensOverride: params.contextTokensOverride,
       fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
     }) ?? DEFAULT_CONTEXT_TOKENS;
 

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -109,7 +109,6 @@ export async function getStatusSummary(
       cfg,
       provider: resolved.provider ?? DEFAULT_PROVIDER,
       model: configModel,
-      contextTokensOverride: cfg.agents?.defaults?.contextTokens,
       fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
     }) ?? DEFAULT_CONTEXT_TOKENS;
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -720,6 +720,8 @@ export const FIELD_HELP: Record<string, string> = {
     'Include absolute timestamps in message envelopes ("on" or "off").',
   "agents.defaults.envelopeElapsed": 'Include elapsed time in message envelopes ("on" or "off").',
   "agents.defaults.models": "Configured model catalog (keys are full provider/model IDs).",
+  "agents.defaults.models.*.contextTokens":
+    "Optional per-model context window override in tokens. Resolution order: per-model override, then agents.defaults.contextTokens, then catalog lookup, then built-in default.",
   "agents.defaults.memorySearch":
     "Vector search over MEMORY.md and memory/*.md (per-agent overrides supported).",
   "agents.defaults.memorySearch.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -401,6 +401,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "auth.cooldowns.billingMaxHours": "Billing Backoff Cap (hours)",
   "auth.cooldowns.failureWindowHours": "Failover Window (hours)",
   "agents.defaults.models": "Models",
+  "agents.defaults.models.*.contextTokens": "Model Context Tokens",
   "agents.defaults.model.primary": "Primary Model",
   "agents.defaults.model.fallbacks": "Model Fallbacks",
   "agents.defaults.imageModel.primary": "Image Model",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -14,6 +14,8 @@ export type AgentModelEntryConfig = {
   params?: Record<string, unknown>;
   /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
   streaming?: boolean;
+  /** Optional per-model context window override (tokens). */
+  contextTokens?: number;
 };
 
 export type AgentModelListConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -28,6 +28,8 @@ export const AgentDefaultsSchema = z
             params: z.record(z.string(), z.unknown()).optional(),
             /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
             streaming: z.boolean().optional(),
+            /** Optional per-model context window override (tokens). */
+            contextTokens: z.number().int().positive().optional(),
           })
           .strict(),
       )

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -60,9 +60,17 @@ vi.mock("../../agents/pi-embedded.js", () => ({
   runEmbeddedPiAgent: vi.fn(),
 }));
 
-vi.mock("../../agents/context.js", () => ({
-  lookupContextTokens: vi.fn().mockReturnValue(128000),
-}));
+vi.mock("../../agents/context.js", () => {
+  const lookupContextTokens = vi.fn().mockReturnValue(128000);
+  const resolveContextTokensForModel = vi.fn(
+    (params: { cfg?: { agents?: { defaults?: { contextTokens?: number } } }; model?: string }) =>
+      params.cfg?.agents?.defaults?.contextTokens ?? lookupContextTokens(params.model) ?? undefined,
+  );
+  return {
+    lookupContextTokens,
+    resolveContextTokensForModel,
+  };
+});
 
 vi.mock("../../agents/date-time.js", () => ({
   formatUserTime: vi.fn().mockReturnValue("2026-02-10 12:00"),

--- a/src/cron/isolated-agent/run.payload-fallbacks.test.ts
+++ b/src/cron/isolated-agent/run.payload-fallbacks.test.ts
@@ -69,9 +69,17 @@ vi.mock("../../agents/pi-embedded.js", () => ({
   }),
 }));
 
-vi.mock("../../agents/context.js", () => ({
-  lookupContextTokens: vi.fn().mockReturnValue(128000),
-}));
+vi.mock("../../agents/context.js", () => {
+  const lookupContextTokens = vi.fn().mockReturnValue(128000);
+  const resolveContextTokensForModel = vi.fn(
+    (params: { cfg?: { agents?: { defaults?: { contextTokens?: number } } }; model?: string }) =>
+      params.cfg?.agents?.defaults?.contextTokens ?? lookupContextTokens(params.model) ?? undefined,
+  );
+  return {
+    lookupContextTokens,
+    resolveContextTokensForModel,
+  };
+});
 
 vi.mock("../../agents/date-time.js", () => ({
   formatUserTime: vi.fn().mockReturnValue("2026-02-10 12:00"),

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -72,9 +72,17 @@ vi.mock("../../agents/pi-embedded.js", () => ({
   }),
 }));
 
-vi.mock("../../agents/context.js", () => ({
-  lookupContextTokens: vi.fn().mockReturnValue(128000),
-}));
+vi.mock("../../agents/context.js", () => {
+  const lookupContextTokens = vi.fn().mockReturnValue(128000);
+  const resolveContextTokensForModel = vi.fn(
+    (params: { cfg?: { agents?: { defaults?: { contextTokens?: number } } }; model?: string }) =>
+      params.cfg?.agents?.defaults?.contextTokens ?? lookupContextTokens(params.model) ?? undefined,
+  );
+  return {
+    lookupContextTokens,
+    resolveContextTokensForModel,
+  };
+});
 
 vi.mock("../../agents/date-time.js", () => ({
   formatUserTime: vi.fn().mockReturnValue("2026-02-10 12:00"),

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -8,7 +8,7 @@ import {
 import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId, setCliSessionId } from "../../agents/cli-session.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
@@ -542,7 +542,12 @@ export async function runCronIsolatedAgentTurn(params: {
     const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? model;
     const providerUsed = runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? provider;
     const contextTokens =
-      agentCfg?.contextTokens ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+      resolveContextTokensForModel({
+        cfg: cfgWithAgentDefaults,
+        provider: providerUsed,
+        model: modelUsed,
+        fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+      }) ?? DEFAULT_CONTEXT_TOKENS;
 
     setSessionRuntimeModel(cronSession.sessionEntry, {
       provider: providerUsed,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { lookupContextTokens } from "../agents/context.js";
+import { resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import {
   inferUniqueProviderFromConfiguredModels,
@@ -624,9 +624,12 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
     defaultModel: DEFAULT_MODEL,
   });
   const contextTokens =
-    cfg.agents?.defaults?.contextTokens ??
-    lookupContextTokens(resolved.model) ??
-    DEFAULT_CONTEXT_TOKENS;
+    resolveContextTokensForModel({
+      cfg,
+      provider: resolved.provider ?? DEFAULT_PROVIDER,
+      model: resolved.model ?? DEFAULT_MODEL,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    }) ?? DEFAULT_CONTEXT_TOKENS;
   return {
     modelProvider: resolved.provider ?? null,
     model: resolved.model ?? null,


### PR DESCRIPTION
## Summary

- Problem: `agents.defaults.models["provider/model"]` had no `contextTokens` field, so users could only rely on catalog lookup or `agents.defaults.contextTokens`.
- Why it matters: custom/proxied/self-hosted models can have incorrect or missing catalog context windows, leading to bad budgeting/compaction behavior.
- What changed: added per-model `contextTokens` in config type+schema and applied precedence in runtime resolution: `session override > per-model > agents.defaults.contextTokens > catalog > default`.
- What did NOT change (scope boundary): no migration format changes and no behavior change when per-model `contextTokens` is unset.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31278
- Related #31418

## User-visible / Behavior Changes

- Users can now set `agents.defaults.models["provider/model"].contextTokens`.
- Per-model context window now takes precedence over `agents.defaults.contextTokens`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node + Vitest
- Model/provider: mocked in unit tests
- Integration/channel (if any): auto-reply, cron, gateway session defaults
- Relevant config (redacted): `agents.defaults.models.*.contextTokens`, `agents.defaults.contextTokens`

### Steps

1. Configure `agents.defaults.models["openai/gpt-4.1"].contextTokens`.
2. Keep a different `agents.defaults.contextTokens`.
3. Run resolution paths (status/reply/cron/gateway session defaults) and verify precedence.

### Expected

- Per-model value is used when present.
- Global `agents.defaults.contextTokens` is used when per-model value is absent.

### Actual

- Matches expected in updated unit tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `src/agents/context.test.ts`
  - `src/auto-reply/status.test.ts`
  - `src/auto-reply/reply/model-selection.test.ts`
  - `src/auto-reply/reply/followup-runner.test.ts`
  - `src/auto-reply/reply/agent-runner.runreplyagent.test.ts`
  - `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
  - `src/cron/isolated-agent/run.cron-model-override.test.ts`
  - `src/cron/isolated-agent/run.payload-fallbacks.test.ts`
  - `src/cron/isolated-agent/run.skill-filter.test.ts`
- Edge cases checked:
  - per-model vs defaults precedence
  - config merge paths for reply/status
  - cron test mocks updated for new resolver usage
- What you did **not** verify:
  - full repository test suite in this run

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Remove `agents.defaults.models.*.contextTokens` entries to restore prior behavior.
  - Revert this commit.
- Files/config to restore:
  - `src/agents/context.ts` and call sites listed in commit.
- Known bad symptoms reviewers should watch for:
  - unexpected context window values in status/session accounting.

## Risks and Mitigations

- Risk: precedence mismatch across code paths.
  - Mitigation: centralized resolver use + targeted test updates on affected paths.
