### PR TITLE
fix(logging): use local timezone for subsystem logger timestamps

### DIFF
--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -4,7 +4,11 @@ import { CHAT_CHANNEL_ORDER } from "../channels/registry.js";
 import { isVerbose } from "../globals.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { clearActiveProgressLine } from "../terminal/progress-line.js";
-import { getConsoleSettings, shouldLogSubsystemToConsole } from "./console.js";
+import {
+  formatConsoleTimestamp,
+  getConsoleSettings,
+  shouldLogSubsystemToConsole,
+} from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
 import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
@@ -209,10 +213,10 @@ function formatConsoleLine(opts: {
   const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
   const time = (() => {
     if (opts.style === "pretty") {
-      return color.gray(new Date().toISOString().slice(11, 19));
+      return color.gray(formatConsoleTimestamp("pretty"));
     }
     if (loggingState.consoleTimestampPrefix) {
-      return color.gray(new Date().toISOString());
+      return color.gray(formatConsoleTimestamp("compact"));
     }
     return "";
   })();


### PR DESCRIPTION
## Summary

- Problem: Gateway startup logs show inconsistent timezones — subsystem loggers use UTC, console-captured logs use local time
- Why it matters: Operators in non-UTC timezones see interleaved UTC and local timestamps, making log correlation difficult
- What changed: `formatConsoleLine` in `subsystem.ts` now uses `formatConsoleTimestamp()` (local time) instead of `toISOString()` (UTC)
- What did NOT change: File logging, structured JSON logging, console capture layer — only the subsystem console formatter

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31427

## User-visible / Behavior Changes

All console log timestamps now use the local timezone consistently. Previously, subsystem logs (e.g. `hooks:loader`) showed UTC while other logs showed local time.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows_NT (China Standard Time, UTC+8)
- Runtime/container: Node v24.14.0
- Model/provider: Any
- Integration/channel: N/A
- Relevant config: Default logging

### Steps

1. Start OpenClaw Gateway in UTC+8 timezone
2. Observe log output during startup
3. Compare timestamps between `Config warnings:` line and `[hooks:loader]` lines

### Expected

- All timestamps show local time (e.g. `14:41:35`)

### Actual

- `hooks:loader` shows UTC (`06:41:35`) while `Config warnings` shows local time (`14:41:34`)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

All 5 `subsystem.test.ts` tests pass.

## Human Verification (required)

- Verified scenarios: Pretty mode uses local `HH:mm:ss`, compact mode uses `formatLocalIsoWithOffset`
- Edge cases checked: `consoleTimestampPrefix` flag path also uses local time; no-timestamp case still returns empty
- What you did **not** verify: Live gateway startup on Windows with UTC+8

## Compatibility / Migration

- Backward compatible? `Yes` (timestamps are for human consumption, not machine parsing)
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; timestamps will revert to UTC for subsystem loggers
- Files/config to restore: `src/logging/subsystem.ts`
- Known bad symptoms: If reverted, timezone inconsistency returns

## Risks and Mitigations

- Risk: Log parsers that expect UTC timestamps from subsystem loggers may break
  - Mitigation: Structured/file logs use separate formatters and are unaffected. Console output is for human readability; UTC was never intentional for subsystem logs.