### PR TITLE
fix: sandbox mkdirp boundary check for /workspace root path (#31438)

### DIFF
--- a/src/agents/sandbox/fs-bridge.test.ts
+++ b/src/agents/sandbox/fs-bridge.test.ts
@@ -211,6 +211,48 @@ describe("sandbox fs bridge shell compatibility", () => {
     });
   });
 
+  it("allows mkdirp for the workspace root path /workspace", async () => {
+    await withTempDir("openclaw-fs-bridge-mkdirp-root-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      await expect(bridge.mkdirp({ filePath: "/workspace" })).resolves.toBeUndefined();
+
+      const mkdirCall = findCallByScriptFragment('mkdir -p -- "$1"');
+      expect(mkdirCall).toBeDefined();
+      const mkdirPath = mkdirCall ? getDockerPathArg(mkdirCall[0]) : "";
+      expect(mkdirPath).toBe("/workspace");
+    });
+  });
+
+  it("allows mkdirp for /workspace when containerWorkdir has trailing slash", async () => {
+    await withTempDir("openclaw-fs-bridge-mkdirp-trailing-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+          containerWorkdir: "/workspace/",
+        }),
+      });
+
+      await expect(bridge.mkdirp({ filePath: "/workspace" })).resolves.toBeUndefined();
+
+      const mkdirCall = findCallByScriptFragment('mkdir -p -- "$1"');
+      expect(mkdirCall).toBeDefined();
+      const mkdirPath = mkdirCall ? getDockerPathArg(mkdirCall[0]) : "";
+      expect(mkdirPath).toBe("/workspace");
+    });
+  });
   it("rejects mkdirp when target exists as a file", async () => {
     await withTempDir("openclaw-fs-bridge-mkdirp-file-", async (stateDir) => {
       const workspaceDir = path.join(stateDir, "workspace");

--- a/src/agents/sandbox/path-utils.ts
+++ b/src/agents/sandbox/path-utils.ts
@@ -2,7 +2,14 @@ import path from "node:path";
 
 export function normalizeContainerPath(value: string): string {
   const normalized = path.posix.normalize(value);
-  return normalized === "." ? "/" : normalized;
+  if (normalized === "." || normalized === "/") {
+    return "/";
+  }
+  // Strip trailing slash to ensure consistent boundary comparisons.
+  // Without this, a workdir configured as "/workspace/" would fail
+  // isPathInsideContainerRoot checks against paths normalized without
+  // the trailing slash (e.g. mkdirp for "/workspace").
+  return normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
 }
 
 export function isPathInsideContainerRoot(root: string, target: string): boolean {


### PR DESCRIPTION
## Summary
Fixes #31438 — Sandbox boundary checks fail on `mkdirp` for `/workspace` when the container workdir has a trailing slash.

## Root Cause
`normalizeContainerPath()` in `path-utils.ts` did not strip trailing slashes, so `/workspace/` and `/workspace` were treated as different paths during `isPathInsideContainerRoot()` boundary comparisons.

## Fix
- Strip trailing slashes in `normalizeContainerPath()` for consistent boundary comparisons
- Handle edge cases: `.` and `/` normalize to `/`

## Tests
- Added 2 regression tests: mkdirp for `/workspace` root path (with and without trailing slash in containerWorkdir)
- All 13 fs-bridge tests pass