### PR TITLE
fix: emit message:sent hook for agent replies on all channels (#31293)

### DIFF
--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
+import { emitMessageSentHookForReply } from "./reply/emit-message-sent-hook.js";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
 import {
   createReplyDispatcher,
@@ -10,7 +11,18 @@ import {
   type ReplyDispatcherWithTypingOptions,
 } from "./reply/reply-dispatcher.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
-import type { GetReplyOptions } from "./types.js";
+import type { GetReplyOptions, ReplyPayload } from "./types.js";
+
+/** Build an onDelivered callback that emits message_sent hooks from ctx. */
+function buildOnDeliveredHook(ctx: MsgContext | FinalizedMsgContext) {
+  const sessionKey = ctx.SessionKey;
+  const channelId = String(ctx.Surface ?? ctx.Provider ?? "unknown").toLowerCase();
+  const accountId = ctx.AccountId;
+  const to = ctx.To ?? ctx.From ?? "";
+  return (payload: ReplyPayload) => {
+    emitMessageSentHookForReply(payload, { sessionKey, channelId, accountId, to });
+  };
+}
 
 export type DispatchInboundResult = DispatchFromConfigResult;
 
@@ -60,9 +72,14 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping(
-    params.dispatcherOptions,
-  );
+  const onDeliveredHook = buildOnDeliveredHook(params.ctx);
+  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
+    ...params.dispatcherOptions,
+    onDelivered: (payload, info) => {
+      params.dispatcherOptions.onDelivered?.(payload, info);
+      onDeliveredHook(payload);
+    },
+  });
   try {
     return await dispatchInboundMessage({
       ctx: params.ctx,
@@ -86,7 +103,14 @@ export async function dispatchInboundMessageWithDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const dispatcher = createReplyDispatcher(params.dispatcherOptions);
+  const onDeliveredHook = buildOnDeliveredHook(params.ctx);
+  const dispatcher = createReplyDispatcher({
+    ...params.dispatcherOptions,
+    onDelivered: (payload, info) => {
+      params.dispatcherOptions.onDelivered?.(payload, info);
+      onDeliveredHook(payload);
+    },
+  });
   return await dispatchInboundMessage({
     ctx: params.ctx,
     cfg: params.cfg,

--- a/src/auto-reply/reply/emit-message-sent-hook.test.ts
+++ b/src/auto-reply/reply/emit-message-sent-hook.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the dependencies before importing the module under test
+vi.mock("../../hooks/internal-hooks.js", () => ({
+  createInternalHookEvent: vi.fn(
+    (type: string, action: string, sessionKey: string, context: Record<string, unknown>) => ({
+      type,
+      action,
+      sessionKey,
+      context,
+      timestamp: new Date(),
+      messages: [],
+    }),
+  ),
+  triggerInternalHook: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => null),
+}));
+
+import { triggerInternalHook, createInternalHookEvent } from "../../hooks/internal-hooks.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { emitMessageSentHookForReply } from "./emit-message-sent-hook.js";
+
+describe("emitMessageSentHookForReply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits internal hook with correct context when sessionKey is provided", () => {
+    emitMessageSentHookForReply(
+      { text: "Hello world" },
+      {
+        sessionKey: "test-session-key",
+        channelId: "discord",
+        accountId: "acc-123",
+        to: "channel-456",
+      },
+    );
+
+    expect(createInternalHookEvent).toHaveBeenCalledWith("message", "sent", "test-session-key", {
+      to: "channel-456",
+      content: "Hello world",
+      success: true,
+      channelId: "discord",
+      accountId: "acc-123",
+      conversationId: "channel-456",
+    });
+    expect(triggerInternalHook).toHaveBeenCalled();
+  });
+
+  it("does not emit internal hook when sessionKey is missing", () => {
+    emitMessageSentHookForReply(
+      { text: "Hello" },
+      {
+        channelId: "discord",
+        to: "channel-456",
+      },
+    );
+
+    expect(triggerInternalHook).not.toHaveBeenCalled();
+  });
+
+  it("uses empty string for content when payload has no text", () => {
+    emitMessageSentHookForReply(
+      {},
+      {
+        sessionKey: "test-key",
+        channelId: "slack",
+        to: "C123",
+      },
+    );
+
+    expect(createInternalHookEvent).toHaveBeenCalledWith(
+      "message",
+      "sent",
+      "test-key",
+      expect.objectContaining({ content: "" }),
+    );
+  });
+
+  it("emits plugin hook when hookRunner has message_sent hooks", () => {
+    const mockRunner = {
+      hasHooks: vi.fn((name: string) => name === "message_sent"),
+      runMessageSent: vi.fn(() => Promise.resolve()),
+    };
+    vi.mocked(getGlobalHookRunner).mockReturnValue(mockRunner as unknown);
+
+    emitMessageSentHookForReply(
+      { text: "test" },
+      {
+        sessionKey: "sk",
+        channelId: "telegram",
+        accountId: "bot-1",
+        to: "chat-789",
+      },
+    );
+
+    expect(mockRunner.runMessageSent).toHaveBeenCalledWith(
+      { to: "chat-789", content: "test", success: true },
+      { channelId: "telegram", accountId: "bot-1", conversationId: "chat-789" },
+    );
+  });
+
+  it("does not throw when hookRunner throws", () => {
+    const mockRunner = {
+      hasHooks: () => {
+        throw new Error("hook error");
+      },
+    };
+    vi.mocked(getGlobalHookRunner).mockReturnValue(mockRunner as unknown);
+
+    // Should not throw
+    expect(() =>
+      emitMessageSentHookForReply(
+        { text: "test" },
+        { sessionKey: "sk", channelId: "discord", to: "ch" },
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/auto-reply/reply/emit-message-sent-hook.test.ts
+++ b/src/auto-reply/reply/emit-message-sent-hook.test.ts
@@ -62,7 +62,7 @@ describe("emitMessageSentHookForReply", () => {
     expect(triggerInternalHook).not.toHaveBeenCalled();
   });
 
-  it("uses empty string for content when payload has no text", () => {
+  it("skips hooks for empty payloads (no text, no media)", () => {
     emitMessageSentHookForReply(
       {},
       {
@@ -72,12 +72,20 @@ describe("emitMessageSentHookForReply", () => {
       },
     );
 
-    expect(createInternalHookEvent).toHaveBeenCalledWith(
-      "message",
-      "sent",
-      "test-key",
-      expect.objectContaining({ content: "" }),
+    expect(createInternalHookEvent).not.toHaveBeenCalled();
+  });
+
+  it("skips hooks for reasoning payloads", () => {
+    emitMessageSentHookForReply(
+      { text: "thinking...", isReasoning: true },
+      {
+        sessionKey: "test-key",
+        channelId: "discord",
+        to: "user123",
+      },
     );
+
+    expect(createInternalHookEvent).not.toHaveBeenCalled();
   });
 
   it("emits plugin hook when hookRunner has message_sent hooks", () => {

--- a/src/auto-reply/reply/emit-message-sent-hook.ts
+++ b/src/auto-reply/reply/emit-message-sent-hook.ts
@@ -1,0 +1,69 @@
+/**
+ * Emit the `message:sent` internal hook and plugin hook for agent replies
+ * delivered through channel-specific dispatcher paths (Discord, Telegram, Slack, etc.)
+ * that bypass `deliverOutboundPayloads`.
+ *
+ * Refs #31293.
+ */
+
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import type { ReplyPayload } from "../types.js";
+
+export interface MessageSentHookContext {
+  sessionKey?: string;
+  channelId: string;
+  accountId?: string;
+  to: string;
+}
+
+/**
+ * Emit `message_sent` hooks (both internal and plugin) after a reply payload
+ * has been successfully delivered through the dispatcher path.
+ *
+ * Wraps in try/catch so hook failures never break the reply flow.
+ */
+export function emitMessageSentHookForReply(
+  payload: ReplyPayload,
+  hookCtx: MessageSentHookContext,
+): void {
+  const content = payload.text ?? "";
+  const { sessionKey, channelId, accountId, to } = hookCtx;
+
+  try {
+    // Plugin hook (fire-and-forget)
+    const hookRunner = getGlobalHookRunner();
+    if (hookRunner?.hasHooks("message_sent")) {
+      void hookRunner
+        .runMessageSent(
+          {
+            to,
+            content,
+            success: true,
+          },
+          {
+            channelId,
+            accountId,
+            conversationId: to,
+          },
+        )
+        .catch(() => {});
+    }
+
+    // Internal hook (fire-and-forget)
+    if (sessionKey) {
+      void triggerInternalHook(
+        createInternalHookEvent("message", "sent", sessionKey, {
+          to,
+          content,
+          success: true,
+          channelId,
+          accountId,
+          conversationId: to,
+        }),
+      ).catch(() => {});
+    }
+  } catch {
+    // Never break the reply flow due to hook failures
+  }
+}

--- a/src/auto-reply/reply/emit-message-sent-hook.ts
+++ b/src/auto-reply/reply/emit-message-sent-hook.ts
@@ -27,7 +27,15 @@ export function emitMessageSentHookForReply(
   payload: ReplyPayload,
   hookCtx: MessageSentHookContext,
 ): void {
+  // Skip hook for reasoning payloads and empty payloads that were likely
+  // suppressed by the channel deliverer (e.g. Discord drops reasoning blocks).
+  if (payload.isReasoning) {
+    return;
+  }
   const content = payload.text ?? "";
+  if (!content && !payload.mediaUrl && !payload.mediaUrls?.length) {
+    return;
+  }
   const { sessionKey, channelId, accountId, to } = hookCtx;
 
   try {

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -51,6 +51,8 @@ export type ReplyDispatcherOptions = {
   onHeartbeatStrip?: () => void;
   onIdle?: () => void;
   onError?: ReplyDispatchErrorHandler;
+  /** Called after a payload is successfully delivered. */
+  onDelivered?: (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => void;
   // AIDEV-NOTE: onSkip lets channels detect silent/empty drops (e.g. Telegram empty-response fallback).
   onSkip?: ReplyDispatchSkipHandler;
   /** Human-like delay between block replies for natural rhythm. */
@@ -156,6 +158,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         // Safe: deliver is called inside an async .then() callback, so even a synchronous
         // throw becomes a rejection that flows through .catch()/.finally(), ensuring cleanup.
         await options.deliver(normalized, { kind });
+        options.onDelivered?.(normalized, { kind });
       })
       .catch((err) => {
         options.onError?.(err, { kind });

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -4,6 +4,7 @@ import { EmbeddedBlockChunker } from "../../agents/pi-embedded-block-chunker.js"
 import { resolveChunkMode } from "../../auto-reply/chunk.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import { formatInboundEnvelope, resolveEnvelopeFormatOptions } from "../../auto-reply/envelope.js";
+import { emitMessageSentHookForReply } from "../../auto-reply/reply/emit-message-sent-hook.js";
 import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
@@ -674,6 +675,14 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     onReplyStart: async () => {
       await typingCallbacks.onReplyStart();
       await statusReactions.setThinking();
+    },
+    onDelivered: (payload) => {
+      emitMessageSentHookForReply(payload, {
+        sessionKey: ctxPayload.SessionKey,
+        channelId: "discord",
+        accountId: accountId,
+        to: deliverTarget,
+      });
     },
   });
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -5,6 +5,7 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveThinkingDefault } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
+import { emitMessageSentHookForReply } from "../../auto-reply/reply/emit-message-sent-hook.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
@@ -842,6 +843,13 @@ export const chatHandlers: GatewayRequestHandlers = {
             return;
           }
           finalReplyParts.push(text);
+        },
+        onDelivered: (payload) => {
+          emitMessageSentHookForReply(payload, {
+            sessionKey: ctx.SessionKey,
+            channelId: "webchat",
+            to: ctx.To ?? ctx.From ?? "",
+          });
         },
       });
 

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -7,6 +7,7 @@ import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
 } from "../../auto-reply/inbound-debounce.js";
+import { emitMessageSentHookForReply } from "../../auto-reply/reply/emit-message-sent-hook.js";
 import {
   clearHistoryEntriesIfEnabled,
   DEFAULT_GROUP_HISTORY_LIMIT,
@@ -376,6 +377,14 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       },
       onError: (err, info) => {
         runtime.error?.(danger(`imessage ${info.kind} reply failed: ${String(err)}`));
+      },
+      onDelivered: (payload) => {
+        emitMessageSentHookForReply(payload, {
+          sessionKey: ctxPayload.SessionKey,
+          channelId: "imessage",
+          accountId: accountInfo.accountId,
+          to: ctxPayload.To ?? "",
+        });
       },
     });
 

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -10,6 +10,7 @@ import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
 } from "../../auto-reply/inbound-debounce.js";
+import { emitMessageSentHookForReply } from "../../auto-reply/reply/emit-message-sent-hook.js";
 import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
@@ -242,6 +243,14 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       },
       onError: (err, info) => {
         deps.runtime.error?.(danger(`signal ${info.kind} reply failed: ${String(err)}`));
+      },
+      onDelivered: (payload) => {
+        emitMessageSentHookForReply(payload, {
+          sessionKey: ctxPayload.SessionKey,
+          channelId: "signal",
+          accountId: deps.accountId,
+          to: ctxPayload.To ?? "",
+        });
       },
     });
 

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -1,5 +1,6 @@
 import { resolveHumanDelayConfig } from "../../../agents/identity.js";
 import { dispatchInboundMessage } from "../../../auto-reply/dispatch.js";
+import { emitMessageSentHookForReply } from "../../../auto-reply/reply/emit-message-sent-hook.js";
 import { clearHistoryEntriesIfEnabled } from "../../../auto-reply/reply/history.js";
 import { createReplyDispatcherWithTyping } from "../../../auto-reply/reply/reply-dispatcher.js";
 import type { ReplyPayload } from "../../../auto-reply/types.js";
@@ -323,6 +324,14 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     onError: (err, info) => {
       runtime.error?.(danger(`slack ${info.kind} reply failed: ${String(err)}`));
       typingCallbacks.onIdle?.();
+    },
+    onDelivered: (payload) => {
+      emitMessageSentHookForReply(payload, {
+        sessionKey: prepared.ctxPayload.SessionKey,
+        channelId: "slack",
+        accountId: route.accountId,
+        to: prepared.replyTarget,
+      });
     },
   });
 


### PR DESCRIPTION
## Summary
Fixes #31293 — The `message:sent` internal hook and plugin hook never fire for normal agent replies because they only fire from the `message` tool's explicit send path, not from channel dispatchers.

## Root Cause
Agent replies go through channel-specific dispatch paths (Discord, Telegram, Signal, Slack, iMessage, etc.) that bypass `deliverOutboundPayloads`, which is the only place that emitted `message_sent` hooks.

## Fix
- Added `emit-message-sent-hook.ts`: utility to emit both plugin and internal `message_sent` hooks after successful delivery, wrapped in try/catch so failures never break the reply flow
- Added `onDelivered` callback to `dispatch.ts` that emits the hook
- Added hook emission in 5 channel-specific dispatchers: Discord, Signal, Slack, iMessage, and the gateway chat handler
- Hooks fire AFTER successful delivery (not before)

## Tests
- Added `emit-message-sent-hook.test.ts` with 4 tests covering plugin hook, internal hook, error resilience, and missing session key handling
- All tests pass