### PR TITLE
fix: route chat completions through dispatchInboundMessage for command/directive support

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2,10 +2,9 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
-import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
-  agentCommand,
   getFreePort,
+  getReplyFromConfig,
   installGatewayTestHooks,
   testState,
   withGatewayServer,
@@ -83,6 +82,14 @@ function parseSseDataLines(text: string): string[] {
     .map((line) => line.slice("data: ".length));
 }
 
+type ReplyCtx = {
+  Body?: string;
+  BodyForAgent?: string;
+  BodyForCommands?: string;
+  SessionKey?: string;
+  GroupSystemPrompt?: string;
+};
+
 describe("OpenAI-compatible HTTP API (e2e)", () => {
   it("rejects when disabled (default + config)", { timeout: 15_000 }, async () => {
     await expectChatCompletionsDisabled(startServerWithDefaultConfig);
@@ -95,23 +102,23 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
 
   it("handles request validation and routing", async () => {
     const port = enabledPort;
-    const mockAgentOnce = (payloads: Array<{ text: string }>) => {
-      agentCommand.mockClear();
-      agentCommand.mockResolvedValueOnce({ payloads } as never);
+    const mockReplyOnce = (text: string) => {
+      getReplyFromConfig.mockClear();
+      getReplyFromConfig.mockResolvedValueOnce({ text } as never);
     };
-    const expectAgentSessionKeyMatch = async (request: {
+    const expectSessionKeyMatch = async (request: {
       body: unknown;
       headers?: Record<string, string>;
       matcher: RegExp;
     }) => {
-      mockAgentOnce([{ text: "hello" }]);
+      mockReplyOnce("hello");
       const res = await postChatCompletions(port, request.body, request.headers);
       expect(res.status).toBe(200);
-      expect(agentCommand).toHaveBeenCalledTimes(1);
-      const opts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0];
-      expect((opts as { sessionKey?: string } | undefined)?.sessionKey ?? "").toMatch(
-        request.matcher,
-      );
+      expect(getReplyFromConfig).toHaveBeenCalledTimes(1);
+      const ctx = (getReplyFromConfig.mock.calls[0] as unknown[] | undefined)?.[0] as
+        | ReplyCtx
+        | undefined;
+      expect(ctx?.SessionKey ?? "").toMatch(request.matcher);
       await res.text();
     };
     const expectMessageContext = (
@@ -127,15 +134,9 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(message).toContain(line);
       }
     };
-    const getFirstAgentCall = () =>
-      (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0] as
-        | {
-            sessionKey?: string;
-            message?: string;
-            extraSystemPrompt?: string;
-          }
-        | undefined;
-    const getFirstAgentMessage = () => getFirstAgentCall()?.message ?? "";
+    const getFirstReplyCtx = () =>
+      (getReplyFromConfig.mock.calls[0] as unknown[] | undefined)?.[0] as ReplyCtx | undefined;
+    const getFirstAgentMessage = () => getFirstReplyCtx()?.Body ?? "";
 
     try {
       {
@@ -158,7 +159,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
-        await expectAgentSessionKeyMatch({
+        await expectSessionKeyMatch({
           body: { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
           headers: { "x-openclaw-agent-id": "beta" },
           matcher: /^agent:beta:/,
@@ -166,7 +167,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
-        await expectAgentSessionKeyMatch({
+        await expectSessionKeyMatch({
           body: {
             model: "openclaw:beta",
             messages: [{ role: "user", content: "hi" }],
@@ -176,7 +177,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
-        await expectAgentSessionKeyMatch({
+        await expectSessionKeyMatch({
           body: {
             model: "openclaw:beta",
             messages: [{ role: "user", content: "hi" }],
@@ -187,7 +188,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
-        mockAgentOnce([{ text: "hello" }]);
+        mockReplyOnce("hello");
         const res = await postChatCompletions(
           port,
           { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
@@ -198,15 +199,13 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         );
         expect(res.status).toBe(200);
 
-        const opts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0];
-        expect((opts as { sessionKey?: string } | undefined)?.sessionKey).toBe(
-          "agent:beta:openai:custom",
-        );
+        const ctx = getFirstReplyCtx();
+        expect(ctx?.SessionKey).toBe("agent:beta:openai:custom");
         await res.text();
       }
 
       {
-        mockAgentOnce([{ text: "hello" }]);
+        mockReplyOnce("hello");
         const res = await postChatCompletions(port, {
           user: "alice",
           model: "openclaw",
@@ -214,15 +213,13 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         });
         expect(res.status).toBe(200);
 
-        const opts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0];
-        expect((opts as { sessionKey?: string } | undefined)?.sessionKey ?? "").toContain(
-          "openai-user:alice",
-        );
+        const ctx = getFirstReplyCtx();
+        expect(ctx?.SessionKey ?? "").toContain("openai-user:alice");
         await res.text();
       }
 
       {
-        mockAgentOnce([{ text: "hello" }]);
+        mockReplyOnce("hello");
         const res = await postChatCompletions(port, {
           model: "openclaw",
           messages: [
@@ -237,13 +234,13 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         });
         expect(res.status).toBe(200);
 
-        const opts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0];
-        expect((opts as { message?: string } | undefined)?.message).toBe("hello\nworld");
+        const ctx = getFirstReplyCtx();
+        expect(ctx?.Body).toBe("hello\nworld");
         await res.text();
       }
 
       {
-        mockAgentOnce([{ text: "I am Claude" }]);
+        mockReplyOnce("I am Claude");
         const res = await postChatCompletions(port, {
           model: "openclaw",
           messages: [
@@ -264,7 +261,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
-        mockAgentOnce([{ text: "hello" }]);
+        mockReplyOnce("hello");
         const res = await postChatCompletions(port, {
           model: "openclaw",
           messages: [
@@ -282,7 +279,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
-        mockAgentOnce([{ text: "hello" }]);
+        mockReplyOnce("hello");
         const res = await postChatCompletions(port, {
           model: "openclaw",
           messages: [
@@ -292,13 +289,13 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         });
         expect(res.status).toBe(200);
 
-        const extraSystemPrompt = getFirstAgentCall()?.extraSystemPrompt ?? "";
-        expect(extraSystemPrompt).toBe("You are a helpful assistant.");
+        const ctx = getFirstReplyCtx();
+        expect(ctx?.GroupSystemPrompt ?? "").toBe("You are a helpful assistant.");
         await res.text();
       }
 
       {
-        mockAgentOnce([{ text: "ok" }]);
+        mockReplyOnce("ok");
         const res = await postChatCompletions(port, {
           model: "openclaw",
           messages: [
@@ -319,7 +316,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
-        mockAgentOnce([{ text: "hello" }]);
+        mockReplyOnce("hello");
         const res = await postChatCompletions(port, {
           stream: false,
           model: "openclaw",
@@ -336,8 +333,8 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
-        agentCommand.mockClear();
-        agentCommand.mockResolvedValueOnce({ payloads: [{ text: "" }] } as never);
+        getReplyFromConfig.mockClear();
+        getReplyFromConfig.mockResolvedValueOnce(undefined as never);
         const res = await postChatCompletions(port, {
           stream: false,
           model: "openclaw",
@@ -413,14 +410,14 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     const port = enabledPort;
     try {
       {
-        agentCommand.mockClear();
-        agentCommand.mockImplementationOnce((async (opts: unknown) =>
-          buildAssistantDeltaResult({
-            opts,
-            emit: emitAgentEvent,
-            deltas: ["he", "llo"],
-            text: "hello",
-          })) as never);
+        getReplyFromConfig.mockClear();
+        getReplyFromConfig.mockImplementationOnce((async (_ctx: unknown, opts: unknown) => {
+          const runId = (opts as { runId?: string })?.runId ?? "";
+          for (const delta of ["he", "llo"]) {
+            emitAgentEvent({ runId, stream: "assistant", data: { delta } });
+          }
+          return { text: "hello" };
+        }) as never);
 
         const res = await postChatCompletions(port, {
           stream: true,
@@ -447,14 +444,14 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
-        agentCommand.mockClear();
-        agentCommand.mockImplementationOnce((async (opts: unknown) =>
-          buildAssistantDeltaResult({
-            opts,
-            emit: emitAgentEvent,
-            deltas: ["hi", "hi"],
-            text: "hihi",
-          })) as never);
+        getReplyFromConfig.mockClear();
+        getReplyFromConfig.mockImplementationOnce((async (_ctx: unknown, opts: unknown) => {
+          const runId = (opts as { runId?: string })?.runId ?? "";
+          for (const delta of ["hi", "hi"]) {
+            emitAgentEvent({ runId, stream: "assistant", data: { delta } });
+          }
+          return { text: "hihi" };
+        }) as never);
 
         const repeatedRes = await postChatCompletions(port, {
           stream: true,
@@ -476,10 +473,8 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
-        agentCommand.mockClear();
-        agentCommand.mockResolvedValueOnce({
-          payloads: [{ text: "hello" }],
-        } as never);
+        getReplyFromConfig.mockClear();
+        getReplyFromConfig.mockResolvedValueOnce({ text: "hello" } as never);
 
         const fallbackRes = await postChatCompletions(port, {
           stream: true,
@@ -493,8 +488,8 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
-        agentCommand.mockClear();
-        agentCommand.mockRejectedValueOnce(new Error("boom"));
+        getReplyFromConfig.mockClear();
+        getReplyFromConfig.mockRejectedValueOnce(new Error("boom"));
 
         const errorRes = await postChatCompletions(port, {
           stream: true,

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -198,7 +198,7 @@ function buildMsgContext(params: {
     Body: prompt.message,
     BodyForAgent: stampedMessage,
     BodyForCommands: prompt.commandText,
-    RawBody: prompt.commandText,
+    RawBody: prompt.message,
     CommandBody: prompt.commandText,
     SessionKey: sessionKey,
     Provider: INTERNAL_MESSAGE_CHANNEL,

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1,10 +1,14 @@
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { createDefaultDeps } from "../cli/deps.js";
-import { agentCommand } from "../commands/agent.js";
+import { resolveSessionAgentId } from "../agents/agent-scope.js";
+import { dispatchInboundMessage } from "../auto-reply/dispatch.js";
+import { createReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
+import type { MsgContext } from "../auto-reply/templating.js";
+import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
+import { loadConfig } from "../config/config.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
-import { defaultRuntime } from "../runtime.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
 import {
   buildAgentMessageFromConversationEntries,
@@ -15,6 +19,7 @@ import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import { resolveAgentIdForRequest, resolveSessionKey } from "./http-utils.js";
+import { injectTimestamp, timestampOptsFromConfig } from "./server-methods/agent-timestamp.js";
 
 type OpenAiHttpOptions = {
   auth: ResolvedGatewayAuth;
@@ -39,22 +44,6 @@ type OpenAiChatCompletionRequest = {
 
 function writeSse(res: ServerResponse, data: unknown) {
   res.write(`data: ${JSON.stringify(data)}\n\n`);
-}
-
-function buildAgentCommandInput(params: {
-  prompt: { message: string; extraSystemPrompt?: string };
-  sessionKey: string;
-  runId: string;
-}) {
-  return {
-    message: params.prompt.message,
-    extraSystemPrompt: params.prompt.extraSystemPrompt,
-    sessionKey: params.sessionKey,
-    runId: params.runId,
-    deliver: false as const,
-    messageChannel: "webchat" as const,
-    bestEffortDeliver: false as const,
-  };
 }
 
 function writeAssistantRoleChunk(res: ServerResponse, params: { runId: string; model: string }) {
@@ -120,14 +109,19 @@ function extractTextContent(content: unknown): string {
   return "";
 }
 
-function buildAgentPrompt(messagesUnknown: unknown): {
+type AgentPromptResult = {
   message: string;
+  /** Raw text of the last user/tool message, used for command/directive parsing. */
+  commandText: string;
   extraSystemPrompt?: string;
-} {
+};
+
+function buildAgentPrompt(messagesUnknown: unknown): AgentPromptResult {
   const messages = asMessages(messagesUnknown);
 
   const systemParts: string[] = [];
   const conversationEntries: ConversationEntry[] = [];
+  let lastNonAssistantContent = "";
 
   for (const msg of messages) {
     if (!msg || typeof msg !== "object") {
@@ -146,6 +140,10 @@ function buildAgentPrompt(messagesUnknown: unknown): {
     const normalizedRole = role === "function" ? "tool" : role;
     if (normalizedRole !== "user" && normalizedRole !== "assistant" && normalizedRole !== "tool") {
       continue;
+    }
+
+    if (normalizedRole === "user" || normalizedRole === "tool") {
+      lastNonAssistantContent = content;
     }
 
     const name = typeof msg.name === "string" ? msg.name.trim() : "";
@@ -168,6 +166,7 @@ function buildAgentPrompt(messagesUnknown: unknown): {
 
   return {
     message,
+    commandText: lastNonAssistantContent || message,
     extraSystemPrompt: systemParts.length > 0 ? systemParts.join("\n\n") : undefined,
   };
 }
@@ -187,16 +186,31 @@ function coerceRequest(val: unknown): OpenAiChatCompletionRequest {
   return val as OpenAiChatCompletionRequest;
 }
 
-function resolveAgentResponseText(result: unknown): string {
-  const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
-  if (!Array.isArray(payloads) || payloads.length === 0) {
-    return "No response from OpenClaw.";
-  }
-  const content = payloads
-    .map((p) => (typeof p.text === "string" ? p.text : ""))
-    .filter(Boolean)
-    .join("\n\n");
-  return content || "No response from OpenClaw.";
+function buildMsgContext(params: {
+  prompt: AgentPromptResult;
+  sessionKey: string;
+  runId: string;
+  cfg: ReturnType<typeof loadConfig>;
+}): MsgContext {
+  const { prompt, sessionKey, runId, cfg } = params;
+  const stampedMessage = injectTimestamp(prompt.message, timestampOptsFromConfig(cfg));
+  return {
+    Body: prompt.message,
+    BodyForAgent: stampedMessage,
+    BodyForCommands: prompt.commandText,
+    RawBody: prompt.commandText,
+    CommandBody: prompt.commandText,
+    SessionKey: sessionKey,
+    Provider: INTERNAL_MESSAGE_CHANNEL,
+    Surface: INTERNAL_MESSAGE_CHANNEL,
+    OriginatingChannel: INTERNAL_MESSAGE_CHANNEL,
+    ChatType: "direct",
+    CommandAuthorized: true,
+    MessageSid: runId,
+    // Pass OpenAI system/developer messages as the group system prompt so they
+    // are included in the agent's extra system prompt by the reply pipeline.
+    GroupSystemPrompt: prompt.extraSystemPrompt,
+  };
 }
 
 export async function handleOpenAiHttpRequest(
@@ -238,18 +252,47 @@ export async function handleOpenAiHttpRequest(
   }
 
   const runId = `chatcmpl_${randomUUID()}`;
-  const deps = createDefaultDeps();
-  const commandInput = buildAgentCommandInput({
-    prompt,
-    sessionKey,
-    runId,
+  const cfg = loadConfig();
+  const resolvedAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
+  const ctx = buildMsgContext({ prompt, sessionKey, runId, cfg });
+  const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+    cfg,
+    agentId: resolvedAgentId,
+    channel: INTERNAL_MESSAGE_CHANNEL,
   });
 
   if (!stream) {
-    try {
-      const result = await agentCommand(commandInput, defaultRuntime, deps);
+    const finalReplyParts: string[] = [];
+    const dispatcher = createReplyDispatcher({
+      ...prefixOptions,
+      onError: (err) => {
+        logWarn(`openai-compat: chat completion dispatch failed: ${String(err)}`);
+      },
+      deliver: async (_payload, info) => {
+        if (info.kind !== "final") {
+          return;
+        }
+        const text = _payload.text?.trim() ?? "";
+        if (text) {
+          finalReplyParts.push(text);
+        }
+      },
+    });
 
-      const content = resolveAgentResponseText(result);
+    try {
+      await dispatchInboundMessage({
+        ctx,
+        cfg,
+        dispatcher,
+        replyOptions: { runId, onModelSelected },
+      });
+
+      const content =
+        finalReplyParts
+          .map((part) => part.trim())
+          .filter(Boolean)
+          .join("\n\n")
+          .trim() || "No response from OpenClaw.";
 
       sendJson(res, 200, {
         id: runId,
@@ -274,11 +317,13 @@ export async function handleOpenAiHttpRequest(
     return true;
   }
 
+  // --- Streaming path ---
   setSseHeaders(res);
 
   let wroteRole = false;
   let sawAssistantDelta = false;
   let closed = false;
+  const finalReplyParts: string[] = [];
 
   const unsubscribe = onAgentEvent((evt) => {
     if (evt.runId !== runId) {
@@ -325,21 +370,48 @@ export async function handleOpenAiHttpRequest(
     unsubscribe();
   });
 
+  const dispatcher = createReplyDispatcher({
+    ...prefixOptions,
+    onError: (err) => {
+      logWarn(`openai-compat: streaming dispatch failed: ${String(err)}`);
+    },
+    deliver: async (_payload, info) => {
+      if (info.kind !== "final") {
+        return;
+      }
+      const text = _payload.text?.trim() ?? "";
+      if (text) {
+        finalReplyParts.push(text);
+      }
+    },
+  });
+
   void (async () => {
     try {
-      const result = await agentCommand(commandInput, defaultRuntime, deps);
+      await dispatchInboundMessage({
+        ctx,
+        cfg,
+        dispatcher,
+        replyOptions: { runId, onModelSelected },
+      });
 
       if (closed) {
         return;
       }
 
+      // If no streaming deltas arrived, send the collected final reply parts.
       if (!sawAssistantDelta) {
         if (!wroteRole) {
           wroteRole = true;
           writeAssistantRoleChunk(res, { runId, model });
         }
 
-        const content = resolveAgentResponseText(result);
+        const content =
+          finalReplyParts
+            .map((part) => part.trim())
+            .filter(Boolean)
+            .join("\n\n")
+            .trim() || "No response from OpenClaw.";
 
         sawAssistantDelta = true;
         writeAssistantContentChunk(res, {


### PR DESCRIPTION
## Summary

The `POST /v1/chat/completions` endpoint bypasses the directive/command dispatch pipeline, sending slash commands like `/model`, `/status`, and `/reset` directly to the agent as plain chat messages instead of being intercepted by the gateway.

## Changes

Refactors `handleOpenAiHttpRequest` in `src/gateway/openai-http.ts` to route through `dispatchInboundMessage()` instead of calling `agentCommand()` directly, matching the WebSocket webchat handler pattern from `src/gateway/server-methods/chat.ts`:

- Builds a proper `MsgContext` with `CommandAuthorized: true`
- Uses `createReplyDispatcher` to collect final reply parts
- Passes system/developer messages via `GroupSystemPrompt`
- Extracts last user/tool message as `commandText` for directive parsing
- Injects timestamps via `injectTimestamp` for agent date/time awareness
- Both streaming and non-streaming paths now go through the dispatch pipeline

## Testing

Updated `openai-http.test.ts` to reflect the new dispatch-based architecture. Tested locally with custom iOS chat client (Conduit) — `/model`, `/status`, `/reset` all work correctly through the HTTP API.

## Motivation

Discovered while building a custom iOS chat client (Conduit) that connects via the chat completions API. Model switching via `/model gemini` was being sent to the agent as a chat message instead of being processed as a directive. This makes the HTTP API a second-class citizen compared to Discord/Telegram/WebSocket webchat.

Fixes #31422

## AI Disclosure

- [x] **AI-assisted**: Initial implementation by Claude Code (Anthropic Max), reviewed and directed by human
- [x] **Testing**: Fully tested — all existing tests updated, CI passes, manual testing with live OpenClaw instance
- [x] **Understanding**: We understand what the code does — it aligns the OpenAI HTTP endpoint with the existing WebSocket webchat dispatch pattern (`dispatchInboundMessage` + `createReplyDispatcher` + `MsgContext`)