### PR TITLE
fix(config): align snapshot normalization chain to prevent config clobber on plugin writes

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -24,8 +24,8 @@ import {
   applyMessageDefaults,
   applyModelDefaults,
   applySessionDefaults,
-  applyTalkConfigNormalization,
   applyTalkApiKey,
+  applyTalkConfigNormalization,
 } from "./defaults.js";
 import { restoreEnvVarRefs } from "./env-preserve.js";
 import {
@@ -953,8 +953,14 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         applyTalkApiKey(
           applyTalkConfigNormalization(
             applyModelDefaults(
-              applyAgentDefaults(
-                applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+              applyCompactionDefaults(
+                applyContextPruningDefaults(
+                  applyAgentDefaults(
+                    applySessionDefaults(
+                      applyLoggingDefaults(applyMessageDefaults(validated.config)),
+                    ),
+                  ),
+                ),
               ),
             ),
           ),
@@ -1040,7 +1046,8 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     let envRefMap: Map<string, string> | null = null;
     let changedPaths: Set<string> | null = null;
     if (snapshot.valid && snapshot.exists) {
-      const patch = createMergePatch(snapshot.config, cfg);
+      const alignedCfg = applyTalkApiKey(cfg);
+      const patch = createMergePatch(snapshot.config, alignedCfg);
       persistCandidate = applyMergePatch(snapshot.resolved, patch);
       try {
         const resolvedIncludes = resolveConfigIncludes(snapshot.parsed, configPath, {


### PR DESCRIPTION
## Summary

- Problem: `writeConfigFile` computes a merge patch between `snapshot.config` and the caller's `cfg` (from `loadConfig`), but these used different post-Zod normalization chains, producing phantom diffs that silently overwrite unrelated config keys
- Why it matters: Plugin install/uninstall could revert user settings like `channels.telegram.dmPolicy` from `"open"` to `"pairing"` without any warning
- What changed: Added missing `applyCompactionDefaults` and `applyContextPruningDefaults` to the snapshot normalization chain; aligned the `cfg` side in `writeConfigFile` by applying `applyTalkApiKey` before comparison
- What did NOT change: Config loading behavior, snapshot display, config validation, env var handling — only the merge patch comparison baseline

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31251
- Related #30320, #13835, #6792

## User-visible / Behavior Changes

Plugin install/uninstall no longer silently overwrites unrelated config keys. All non-plugin settings (dmPolicy, allowFrom, botToken, etc.) are preserved exactly.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.2 (arm64)
- Runtime/container: Node v22.22.0
- Model/provider: Any
- Integration/channel: Telegram (dmPolicy affected)
- Relevant config: `channels.telegram.dmPolicy: "open"`

### Steps

1. Set `channels.telegram.dmPolicy` to `"open"` in `openclaw.json`
2. Run `openclaw plugins install /path/to/plugin`
3. Check `openclaw.json` — `dmPolicy` has reverted to `"pairing"`
4. Repeat with `openclaw plugins uninstall <plugin>`

### Expected

- `dmPolicy` stays `"open"` after plugin operations

### Actual

- `dmPolicy` reverts to `"pairing"` due to normalization-chain mismatch in merge patch

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

All 646 config tests and 176 plugin tests pass, including the `talk.normalize.test.ts` that validates snapshot normalization.

## Human Verification (required)

- Verified scenarios: Snapshot normalization chain now matches `loadConfig()` chain; merge patch produces no phantom diffs for unchanged keys
- Edge cases checked: `applyTalkApiKey` presence in snapshot preserved for display consumers; `applyCompactionDefaults`/`applyContextPruningDefaults` idempotent when defaults already set
- What you did **not** verify: Live plugin install/uninstall cycle with Telegram dmPolicy on macOS

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; normalization mismatch will return
- Files/config to restore: `src/config/io.ts`
- Known bad symptoms: If reverted, plugin operations may silently clobber unrelated config keys

## Risks and Mitigations

- Risk: Adding `applyCompactionDefaults`/`applyContextPruningDefaults` to the snapshot may change config hash values, triggering unnecessary config-change detection
  - Mitigation: Both functions are idempotent when defaults are already present; only affects first-time evaluation for configs without explicit compaction/pruning settings
- Risk: Applying `applyTalkApiKey` to `cfg` in `writeConfigFile` might inject env-derived API keys into the merge patch
  - Mitigation: `applyTalkApiKey` is a no-op when the config already has an API key set (from file); both sides of the comparison get the same env-derived key, so the diff cancels out