### PR TITLE
fix(sandbox): handle directories correctly in boundary checks

### DIFF
--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -274,7 +274,11 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
             );
       }
     } else {
-      fs.closeSync(guarded.fd);
+      // Only close valid file descriptors (fd >= 0)
+      // Directories return fd=-1 and don't need closing
+      if (guarded.fd >= 0) {
+        fs.closeSync(guarded.fd);
+      }
     }
 
     const canonicalContainerPath = await this.resolveCanonicalContainerPath({

--- a/src/infra/safe-open-sync.test.ts
+++ b/src/infra/safe-open-sync.test.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/src/infra/safe-open-sync.test.ts
+++ b/src/infra/safe-open-sync.test.ts
@@ -43,7 +43,8 @@ describe("openVerifiedFileSync", () => {
         return;
       }
       expect(opened.stat.isDirectory()).toBe(true);
-      fs.closeSync(opened.fd);
+      // Directories return fd=-1 and should not be closed
+      expect(opened.fd).toBe(-1);
     });
   });
 });

--- a/src/infra/safe-open-sync.ts
+++ b/src/infra/safe-open-sync.ts
@@ -63,6 +63,13 @@ export function openVerifiedFileSync(params: {
       return { ok: false, reason: "validation" };
     }
 
+    // For directories, we don't need to open with openSync - lstat is sufficient
+    // and avoids issues with directory file descriptors
+    if (allowedType === "directory") {
+      const opened = { ok: true as const, path: realPath, fd: -1, stat: preOpenStat };
+      return opened;
+    }
+
     fd = ioFs.openSync(realPath, openReadFlags);
     const openedStat = ioFs.fstatSync(fd);
     if (!isAllowedType(openedStat, allowedType)) {


### PR DESCRIPTION
## Summary

Fixes #31438 - Sandbox boundary checks fail on mkdirp when creating directories within mounted workspace (e.g., `/workspace/memory`).

## Problem

When using sandbox with `workspaceAccess: "rw"`, the `mkdirp` command failed with:
```
Sandbox boundary checks failed; cannot create directories: /workspace
```

The root cause was that `openVerifiedFileSync()` in `safe-open-sync.ts` tried to use `openSync()` on directories, which is incorrect. Directories don't need to be "opened" with `openSync()` - `lstat()` verification is sufficient for security checks.

## Solution

- **safe-open-sync.ts**: When `allowedType === "directory"`, skip the `openSync()` call and return early with `fd=-1` and the `lstat` results
- **fs-bridge.ts**: Only call `closeSync()` for valid file descriptors (`fd >= 0`)
- **safe-open-sync.test.ts**: Updated test to expect `fd=-1` for directories

## Testing

- Updated existing test `safe-open-sync.test.ts` to expect `fd=-1` for directories
- Manual verification: The fix allows `mkdirp` to work correctly on existing mount points while maintaining security boundaries

## Impact

This fix enables users to create directories within mounted workspaces (e.g., `/workspace/memory`, `/workspace/data`) when using sandbox mode, which is essential for agent workflows that need to organize data in subdirectories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)