### PR TITLE
fix(sandbox): allow mkdirp for directories within workspace boundary

### DIFF
--- a/src/agents/sandbox/fs-bridge.test.ts
+++ b/src/agents/sandbox/fs-bridge.test.ts
@@ -211,6 +211,44 @@ describe("sandbox fs bridge shell compatibility", () => {
     });
   });
 
+  it("allows mkdirp for missing in-boundary subdirectories", async () => {
+    await withTempDir("openclaw-fs-bridge-mkdirp-missing-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      await expect(bridge.mkdirp({ filePath: "memory/kemik" })).resolves.toBeUndefined();
+
+      const mkdirCall = findCallByScriptFragment('mkdir -p -- "$1"');
+      expect(mkdirCall).toBeDefined();
+      const mkdirPath = mkdirCall ? getDockerPathArg(mkdirCall[0]) : "";
+      expect(mkdirPath).toBe("/workspace/memory/kemik");
+    });
+  });
+
+  it("rejects mkdirp outside workspace boundary", async () => {
+    await withTempDir("openclaw-fs-bridge-mkdirp-outside-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      await expect(bridge.mkdirp({ filePath: "/outside/path" })).rejects.toThrow(
+        /escapes allowed mounts|escapes sandbox root/i,
+      );
+      expect(mockedExecDockerRaw).not.toHaveBeenCalled();
+    });
+  });
+
   it("rejects mkdirp when target exists as a file", async () => {
     await withTempDir("openclaw-fs-bridge-mkdirp-file-", async (stateDir) => {
       const workspaceDir = path.join(stateDir, "workspace");

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
+import { resolveBoundaryPath } from "../../infra/boundary-path.js";
 import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../../infra/path-alias-guards.js";
 import type { SafeOpenSyncAllowedType } from "../../infra/safe-open-sync.js";
 import { execDockerRaw, type ExecDockerRawResult } from "./docker.js";
@@ -258,23 +259,47 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       );
     }
 
-    const guarded = await openBoundaryFile({
-      absolutePath: target.hostPath,
-      rootPath: lexicalMount.hostRoot,
-      boundaryLabel: "sandbox mount root",
-      aliasPolicy: options.aliasPolicy,
-      allowedType: options.allowedType,
-    });
-    if (!guarded.ok) {
-      if (guarded.reason !== "path") {
-        throw guarded.error instanceof Error
-          ? guarded.error
+    if (options.allowedType === "directory") {
+      let resolvedTarget;
+      try {
+        resolvedTarget = await resolveBoundaryPath({
+          absolutePath: target.hostPath,
+          rootPath: lexicalMount.hostRoot,
+          boundaryLabel: "sandbox mount root",
+          policy: options.aliasPolicy,
+        });
+      } catch (error) {
+        throw error instanceof Error
+          ? error
           : new Error(
               `Sandbox boundary checks failed; cannot ${options.action}: ${target.containerPath}`,
             );
       }
+
+      if (resolvedTarget.exists && resolvedTarget.kind !== "directory") {
+        throw new Error(
+          `Sandbox boundary checks failed; cannot ${options.action}: ${target.containerPath}`,
+        );
+      }
     } else {
-      fs.closeSync(guarded.fd);
+      const guarded = await openBoundaryFile({
+        absolutePath: target.hostPath,
+        rootPath: lexicalMount.hostRoot,
+        boundaryLabel: "sandbox mount root",
+        aliasPolicy: options.aliasPolicy,
+        allowedType: options.allowedType,
+      });
+      if (!guarded.ok) {
+        if (guarded.reason !== "path") {
+          throw guarded.error instanceof Error
+            ? guarded.error
+            : new Error(
+                `Sandbox boundary checks failed; cannot ${options.action}: ${target.containerPath}`,
+              );
+        }
+      } else {
+        fs.closeSync(guarded.fd);
+      }
     }
 
     const canonicalContainerPath = await this.resolveCanonicalContainerPath({


### PR DESCRIPTION
## Summary
Fix sandbox boundary checks failing on `mkdirp` operations within the workspace.

## Root Cause
`assertPathSafety` used file-open validation (`openBoundaryFile`) for all operations including directory creation. This treated directories as files and failed with "cannot create directories: /workspace".

## Fix
- Directory operations (`allowedType === "directory"`) now use `resolveBoundaryPath()` for boundary validation instead of `openBoundaryFile()`
- Still enforces sandbox mount/workspace boundaries
- Added guard: fails if target exists but is not a directory

## Tests
- Added: mkdirp in-boundary succeeds
- Added: mkdirp out-of-boundary fails
- 13/13 tests pass

Closes #31438