### PR TITLE
feat(diagnostics-otel): OpenTelemetry diagnostics with GenAI semantic conventions (rebased)

### DIFF
--- a/docs/diagnostics/events.md
+++ b/docs/diagnostics/events.md
@@ -1,0 +1,128 @@
+---
+summary: "Diagnostic event lifecycle for tracing and metrics"
+---
+
+## Overview
+
+OpenClaw emits diagnostic events that exporters and plugins can subscribe to (for example the built-in OpenTelemetry exporters). The diagnostic stream is a structured, append-only sequence of events describing:
+
+- Webhook ingestion and processing (per channel)
+- Queueing, session state, and stuck-session detection
+- Agent runs (attempts, start/completion)
+- Model calls (start/completion, timings, usage)
+- Tool executions (duration, errors, optional input/output)
+
+Events are designed to be:
+
+- Cohesive: a single stream can reconstruct a run and its child operations.
+- Low-coupling: producers emit events; exporters consume events.
+- Safe-by-default: message content is opt-in (see Content Capture).
+
+## Common Fields
+
+All diagnostic events include:
+
+- `ts`: timestamp (milliseconds since epoch)
+- `seq`: monotonically increasing sequence number (process-local)
+
+Many events also include correlation fields when available:
+
+- `runId`: logical identifier for a single agent run
+- `sessionId`: provider/runtime session identifier
+- `sessionKey`: OpenClaw session key (when applicable)
+- `channel`: the channel name (for example `telegram`, `discord`, `slack`)
+
+## Core Events
+
+**`run.started`**
+Emitted once at the start of an agent run. This establishes the parent span for the entire turn.
+
+**`run.attempt`**
+Emitted when a run begins (or retries) an attempt. Runs may contain multiple attempts.
+
+**`model.inference.started`**
+Emitted at the start of each LLM call. When content capture is enabled, this event can include the per-call input messages, system instructions, and tool definitions that were passed to the model.
+
+**`model.inference`**
+Emitted once per LLM call, including follow-up calls after tool results. There can be zero or many `model.inference` events per run.
+
+**`tool.execution`**
+Emitted once per tool call. Tool events typically occur between inference calls and are children of the active inference span (the LLM call that requested them). If no active inference span is known, they fall back to being children of the run span or standalone spans.
+
+**`run.completed`**
+Emitted once at the end of the run. This closes the parent span and includes aggregate usage, cost, and any final error metadata.
+
+## Webhook Events
+
+These events describe inbound webhook traffic for message channels.
+
+**`webhook.received`**
+Emitted when a channel webhook update is received.
+
+**`webhook.processed`**
+Emitted when a webhook update has been fully processed (includes `durationMs` when available).
+
+**`webhook.error`**
+Emitted when webhook processing fails (includes an `error` string).
+
+## Messaging and Queue Events
+
+These events capture queueing and processing at the message level.
+
+**`message.queued`**
+Emitted when a message is queued for processing (includes optional `queueDepth`).
+
+**`message.processed`**
+Emitted when message processing completes (includes `outcome` and optional `durationMs` / `reason` / `error`).
+
+**`queue.lane.enqueue`**
+Emitted when work is enqueued into an internal lane (includes `queueSize`).
+
+**`queue.lane.dequeue`**
+Emitted when work is dequeued from an internal lane (includes `queueSize` and `waitMs`).
+
+## Session State Events
+
+These events describe high-level session state transitions and stuck-session detection.
+
+**`session.state`**
+Emitted when a session transitions between states (for example `idle` -> `processing` -> `waiting`).
+
+**`session.stuck`**
+Emitted when a session has remained in a non-idle state for longer than expected (includes `ageMs`).
+
+## Heartbeat
+
+**`diagnostic.heartbeat`**
+Periodic aggregate counters, intended for dashboards and quick health checks.
+
+## Flexible Ordering
+
+The event sequence is not fixed to a single inference pass. A run can include repeated loops:
+
+- `run.started`
+- `run.attempt`
+- `model.inference.started`
+- `model.inference`
+- `tool.execution`
+- `model.inference.started`
+- `model.inference`
+- `tool.execution`
+- `model.inference.started`
+- `model.inference`
+- `run.completed`
+
+## Content Capture
+
+Message and tool content is intentionally opt-in. When `diagnostics.otel.captureContent` is enabled, OpenClaw may include message content fields in diagnostic events so exporters can attach them to traces/logs.
+
+When capture is enabled:
+
+- `model.inference.started` may include `gen_ai.input.messages`, `gen_ai.system_instructions`, and `gen_ai.request.tools`.
+- `model.inference` may include `gen_ai.output.messages`.
+- `run.completed` may include the turn-level input/output messages and system instructions.
+- `tool.execution` may include tool input/output (depending on tool type and sanitization).
+
+When capture is disabled, these fields are omitted.
+
+Note: per-inference token usage is best-effort. `run.completed` includes aggregate usage; individual `model.inference` events may not always include token usage for every call depending on provider/SDK support.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -163,9 +163,13 @@ diagnostics + the exporter plugin are enabled.
 
 ### Diagnostic event catalog
 
-Model usage:
+Runs + inference:
 
-- `model.usage`: tokens, cost, duration, context, provider/model/channel, session ids.
+- `run.started`: start of an agent run (parent span for the whole turn).
+- `model.inference.started`: start of an LLM call (used to capture per-call input messages when content capture is enabled).
+- `model.inference`: end of an LLM call (duration, TTFT, usage when available).
+- `tool.execution`: tool call execution (duration, error, metadata).
+- `run.completed`: end of an agent run (aggregate usage, cost, duration, final error metadata).
 
 Message flow:
 
@@ -220,6 +224,7 @@ Notes:
 - Flag logs go to the standard log file (same as `logging.file`).
 - Output is still redacted according to `logging.redactSensitive`.
 - Full guide: [/diagnostics/flags](/diagnostics/flags).
+- Event lifecycle: [/diagnostics/events](/diagnostics/events).
 
 ### Export to OpenTelemetry
 

--- a/docs/specs/otel-genai-alignment.md
+++ b/docs/specs/otel-genai-alignment.md
@@ -1,0 +1,871 @@
+# Spec: OTel GenAI Semantic Convention Alignment
+
+**Status:** Draft
+**Branch:** `otel-diagnostics-fixes`
+**Scope:** Align OpenClaw diagnostics with OTel GenAI Semantic Conventions v1.38+
+
+---
+
+## 1. Goal
+
+Enrich the existing `diagnostics-otel` plugin to emit spans, metrics, and events
+that follow the [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+so that OpenClaw telemetry works out-of-the-box with GenAI-aware backends
+(Datadog, Grafana, Orq, LangWatch, Langfuse, Arize, etc.) while keeping the existing
+`openclaw.*` operational telemetry intact.
+
+---
+
+## 2. Key Decisions
+
+### D1: Dual-namespace (not migration)
+
+Emit **both** `gen_ai.*` and `openclaw.*` attributes on model-usage spans.
+The `openclaw.*` namespace stays for domain-specific operational data
+(channels, queues, sessions, webhooks). No existing attributes are removed.
+
+### D2: Content capture is opt-in
+
+Message content (`gen_ai.input.messages`, `gen_ai.output.messages`,
+`gen_ai.system_instructions`) is sensitive data. The spec says
+instrumentations SHOULD NOT capture it by default.
+
+New config key: `diagnostics.otel.captureContent` (default `false`).
+When `false`, content attributes are omitted entirely. When `true`,
+content is recorded as span attributes on inference spans using the
+standard JSON structure.
+
+### D3: Span naming follows the spec
+
+Current span names like `openclaw.model.usage` become
+`chat {model}` (e.g. `chat openai/gpt-5.2`) per the spec pattern
+`{gen_ai.operation.name} {gen_ai.request.model}`.
+
+The old `openclaw.model.usage` span name is dropped (breaking change
+for dashboards, but this is pre-stable / development-phase telemetry).
+
+### D4: New diagnostic event types for tool calls and finish reasons
+
+Add new fields to `DiagnosticUsageEvent` and new event types to carry
+the data needed for GenAI conventions. The diagnostic event system
+remains the boundary between core and the OTel plugin.
+
+### D5: Standard metrics alongside custom ones
+
+Add the two required GenAI metrics (`gen_ai.client.operation.duration`,
+`gen_ai.client.token.usage`) alongside existing `openclaw.*` metrics.
+Both continue to be emitted.
+
+### D6: No agent-level spans yet
+
+The `create_agent` / `invoke_agent` span types from the GenAI agent
+conventions are deferred. They require deeper instrumentation of the
+agent lifecycle. Model inference and tool execution spans come first.
+
+### D7: Target `gen_ai_latest_experimental` directly
+
+We build against the latest OTel GenAI semantic conventions
+(`gen_ai_latest_experimental`). Since we have no prior version of
+GenAI attributes shipped, there is no backward compatibility concern.
+
+We will read `OTEL_SEMCONV_STABILITY_OPT_IN` for spec compliance,
+but it is effectively a no-op today - all `gen_ai.*` attributes are
+always emitted. When the conventions stabilize, we can gate legacy
+vs. stable attributes behind this env var if needed.
+
+---
+
+## 3. Changes
+
+### 3.1 Config changes
+
+**File:** `src/config/schema.ts`
+
+Add to `FIELD_LABELS`:
+
+```
+"diagnostics.otel.captureContent": "OTel Capture Message Content"
+```
+
+Add to `FIELD_HELP`:
+
+```
+"diagnostics.otel.captureContent":
+  "Record gen_ai.input.messages and gen_ai.output.messages on inference spans (opt-in, contains sensitive data)."
+```
+
+**File:** `src/config/config.ts` (or wherever the config type lives)
+
+Add to the `otel` config block:
+
+```ts
+captureContent?: boolean;
+```
+
+### 3.2 Diagnostic event changes
+
+**File:** `src/infra/diagnostic-events.ts`
+
+#### 3.2.1 Extend `DiagnosticUsageEvent`
+
+Add new optional fields:
+
+```ts
+export type DiagnosticUsageEvent = DiagnosticBaseEvent & {
+  type: "model.usage";
+  // ... existing fields ...
+
+  // New fields for GenAI alignment:
+  operationName?: string; // "chat" | "text_completion" | "generate_content"
+  responseId?: string; // provider completion ID (e.g. "chatcmpl-xyz")
+  responseModel?: string; // actual model used (may differ from requested)
+  finishReasons?: string[]; // ["stop"] | ["tool_call"] | ["length"]
+  inputMessages?: GenAiMessage[]; // structured input (opt-in)
+  outputMessages?: GenAiMessage[]; // structured output (opt-in)
+  systemInstructions?: GenAiPart[]; // system prompt parts (opt-in)
+  toolDefinitions?: GenAiToolDef[]; // available tools (opt-in)
+};
+```
+
+#### 3.2.2 Add GenAI message types
+
+```ts
+export type GenAiPartText = { type: "text"; content: string };
+export type GenAiPartToolCall = {
+  type: "tool_call";
+  id: string;
+  name: string;
+  arguments?: Record<string, unknown>;
+};
+export type GenAiPartToolCallResponse = {
+  type: "tool_call_response";
+  id: string;
+  response: unknown;
+};
+export type GenAiPartReasoning = { type: "reasoning"; content: string };
+export type GenAiPartMedia = {
+  type: "uri" | "blob";
+  modality: "image" | "audio" | "video";
+  mime_type?: string;
+  uri?: string;
+  content?: string; // base64 for blob
+};
+
+export type GenAiPart =
+  | GenAiPartText
+  | GenAiPartToolCall
+  | GenAiPartToolCallResponse
+  | GenAiPartReasoning
+  | GenAiPartMedia;
+
+export type GenAiMessage = {
+  role: "system" | "user" | "assistant" | "tool";
+  parts: GenAiPart[];
+  finish_reason?: string;
+};
+
+export type GenAiToolDef = {
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+};
+```
+
+#### 3.2.3 Add tool execution event
+
+```ts
+export type DiagnosticToolExecutionEvent = DiagnosticBaseEvent & {
+  type: "tool.execution";
+  toolName: string;
+  toolType?: "function" | "extension" | "datastore";
+  toolCallId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  channel?: string;
+  durationMs?: number;
+  error?: string;
+  // Opt-in content:
+  arguments?: Record<string, unknown>;
+  result?: unknown;
+};
+```
+
+Add to `DiagnosticEventPayload` union.
+
+### 3.3 Emit-site changes
+
+**File:** `src/auto-reply/reply/agent-runner.ts`
+
+At the `emitDiagnosticEvent({ type: "model.usage", ... })` call site (~line 443):
+
+1. Add `operationName: "chat"` (always "chat" for the main reply path).
+2. Add `finishReasons` extracted from the provider response.
+3. Add `responseId` from the provider response if available.
+4. Add `responseModel` from the provider response if available.
+5. When `captureContent` is enabled AND `isDiagnosticsEnabled`:
+   - Convert the session messages to `GenAiMessage[]` format.
+   - Attach as `inputMessages`.
+   - Convert the model response to `GenAiMessage[]` format.
+   - Attach as `outputMessages`.
+   - Attach `systemInstructions` if a system prompt was used.
+
+**File:** `src/agents/tools/` (tool execution sites)
+
+Emit `DiagnosticToolExecutionEvent` when a tool is invoked, wrapping
+the execution with timing.
+
+### 3.4 OTel plugin changes
+
+**File:** `extensions/diagnostics-otel/src/service.ts`
+
+#### 3.4.1 New metrics
+
+```ts
+// Required by spec
+const genAiOperationDuration = meter.createHistogram("gen_ai.client.operation.duration", {
+  unit: "s",
+  description: "GenAI operation duration",
+});
+
+// Recommended by spec
+const genAiTokenUsage = meter.createHistogram("gen_ai.client.token.usage", {
+  unit: "{token}",
+  description: "GenAI token usage",
+});
+```
+
+#### 3.4.2 Updated `recordModelUsage`
+
+Rename the span from `openclaw.model.usage` to the spec pattern:
+
+```ts
+const spanName = `${evt.operationName ?? "chat"} ${evt.model ?? "unknown"}`;
+```
+
+Add `gen_ai.*` attributes alongside existing `openclaw.*` attributes:
+
+```ts
+const spanAttrs: Record<string, string | number | string[]> = {
+  // Existing openclaw.* attributes (keep all)
+  "openclaw.channel": evt.channel ?? "unknown",
+  "openclaw.provider": evt.provider ?? "unknown",
+  "openclaw.model": evt.model ?? "unknown",
+  "openclaw.sessionKey": evt.sessionKey ?? "",
+  "openclaw.sessionId": evt.sessionId ?? "",
+  "openclaw.tokens.input": usage.input ?? 0,
+  "openclaw.tokens.output": usage.output ?? 0,
+  "openclaw.tokens.cache_read": usage.cacheRead ?? 0,
+  "openclaw.tokens.cache_write": usage.cacheWrite ?? 0,
+  "openclaw.tokens.total": usage.total ?? 0,
+
+  // New gen_ai.* attributes (spec-aligned)
+  "gen_ai.operation.name": evt.operationName ?? "chat",
+  "gen_ai.provider.name": mapProviderName(evt.provider),
+  "gen_ai.request.model": evt.model ?? "unknown",
+  "gen_ai.usage.input_tokens": usage.input ?? 0,
+  "gen_ai.usage.output_tokens": usage.output ?? 0,
+};
+
+// Conditionally add optional gen_ai attributes
+if (evt.responseModel) {
+  spanAttrs["gen_ai.response.model"] = evt.responseModel;
+}
+if (evt.responseId) {
+  spanAttrs["gen_ai.response.id"] = evt.responseId;
+}
+if (evt.finishReasons?.length) {
+  spanAttrs["gen_ai.response.finish_reasons"] = evt.finishReasons;
+}
+if (evt.sessionKey) {
+  spanAttrs["gen_ai.conversation.id"] = evt.sessionKey;
+}
+```
+
+Add opt-in content attributes:
+
+```ts
+if (evt.inputMessages) {
+  spanAttrs["gen_ai.input.messages"] = JSON.stringify(evt.inputMessages);
+}
+if (evt.outputMessages) {
+  spanAttrs["gen_ai.output.messages"] = JSON.stringify(evt.outputMessages);
+}
+if (evt.systemInstructions) {
+  spanAttrs["gen_ai.system_instructions"] = JSON.stringify(evt.systemInstructions);
+}
+```
+
+Record standard metrics:
+
+```ts
+const metricAttrs = {
+  "gen_ai.operation.name": evt.operationName ?? "chat",
+  "gen_ai.provider.name": mapProviderName(evt.provider),
+  "gen_ai.request.model": evt.model ?? "unknown",
+};
+
+if (evt.durationMs) {
+  genAiOperationDuration.record(evt.durationMs / 1000, metricAttrs);
+}
+if (usage.input) {
+  genAiTokenUsage.record(usage.input, {
+    ...metricAttrs,
+    "gen_ai.token.type": "input",
+  });
+}
+if (usage.output) {
+  genAiTokenUsage.record(usage.output, {
+    ...metricAttrs,
+    "gen_ai.token.type": "output",
+  });
+}
+```
+
+#### 3.4.3 New `recordToolExecution` handler
+
+```ts
+const recordToolExecution = (evt: Extract<DiagnosticEventPayload, { type: "tool.execution" }>) => {
+  if (!tracesEnabled) return;
+
+  const spanAttrs: Record<string, string | number> = {
+    "gen_ai.operation.name": "execute_tool",
+    "gen_ai.tool.name": evt.toolName,
+    "gen_ai.tool.type": evt.toolType ?? "function",
+  };
+  if (evt.toolCallId) {
+    spanAttrs["gen_ai.tool.call.id"] = evt.toolCallId;
+  }
+  if (evt.channel) {
+    spanAttrs["openclaw.channel"] = evt.channel;
+  }
+
+  const span = spanWithDuration(`execute_tool ${evt.toolName}`, spanAttrs, evt.durationMs);
+  if (evt.error) {
+    span.setStatus({ code: SpanStatusCode.ERROR, message: evt.error });
+    spanAttrs["error.type"] = evt.error;
+  }
+  span.end();
+};
+```
+
+#### 3.4.4 Provider name mapping
+
+```ts
+function mapProviderName(provider?: string): string {
+  if (!provider) return "unknown";
+  const p = provider.toLowerCase();
+  if (p.includes("openai") || p === "orq") return "openai";
+  if (p.includes("anthropic") || p.includes("claude")) return "anthropic";
+  if (p.includes("google") || p.includes("gemini")) return "gcp.gemini";
+  if (p.includes("bedrock")) return "aws.bedrock";
+  if (p.includes("mistral")) return "mistral_ai";
+  if (p.includes("deepseek")) return "deepseek";
+  if (p.includes("groq")) return "groq";
+  if (p.includes("cohere")) return "cohere";
+  if (p.includes("perplexity")) return "perplexity";
+  return provider;
+}
+```
+
+### 3.5 Span kind
+
+Set span kind to `CLIENT` for inference spans (the spec requires this):
+
+```ts
+import { SpanKind } from "@opentelemetry/api";
+
+const span = tracer.startSpan(spanName, {
+  kind: SpanKind.CLIENT,
+  attributes: spanAttrs,
+  ...(startTime ? { startTime } : {}),
+});
+```
+
+Set span kind to `INTERNAL` for tool execution spans.
+
+---
+
+## 4. Output-Based Tests
+
+All tests go in `extensions/diagnostics-otel/src/service.test.ts`.
+
+### Test 1: GenAI span attributes on model.usage
+
+```ts
+test("model.usage emits gen_ai.* span attributes", async () => {
+  const service = createDiagnosticsOtelService();
+  await service.start(createTestCtx());
+
+  emitDiagnosticEvent({
+    type: "model.usage",
+    channel: "webchat",
+    provider: "openai",
+    model: "gpt-5.2",
+    operationName: "chat",
+    responseId: "chatcmpl-abc123",
+    responseModel: "gpt-5.2-2025-06-01",
+    finishReasons: ["stop"],
+    sessionKey: "agent:main:main",
+    sessionId: "sess-001",
+    usage: { input: 100, output: 50, cacheRead: 80, cacheWrite: 0, total: 230 },
+    durationMs: 1500,
+  });
+
+  // Span was created with the spec-mandated name pattern
+  const spanCall = telemetryState.tracer.startSpan.mock.calls[0];
+  expect(spanCall[0]).toBe("chat gpt-5.2");
+
+  // Span has gen_ai.* attributes
+  const attrs = spanCall[1]?.attributes;
+  expect(attrs["gen_ai.operation.name"]).toBe("chat");
+  expect(attrs["gen_ai.provider.name"]).toBe("openai");
+  expect(attrs["gen_ai.request.model"]).toBe("gpt-5.2");
+  expect(attrs["gen_ai.usage.input_tokens"]).toBe(100);
+  expect(attrs["gen_ai.usage.output_tokens"]).toBe(50);
+  expect(attrs["gen_ai.response.id"]).toBe("chatcmpl-abc123");
+  expect(attrs["gen_ai.response.model"]).toBe("gpt-5.2-2025-06-01");
+  expect(attrs["gen_ai.response.finish_reasons"]).toEqual(["stop"]);
+  expect(attrs["gen_ai.conversation.id"]).toBe("agent:main:main");
+
+  // Existing openclaw.* attributes are preserved
+  expect(attrs["openclaw.channel"]).toBe("webchat");
+  expect(attrs["openclaw.provider"]).toBe("openai");
+  expect(attrs["openclaw.model"]).toBe("gpt-5.2");
+  expect(attrs["openclaw.tokens.input"]).toBe(100);
+  expect(attrs["openclaw.tokens.output"]).toBe(50);
+  expect(attrs["openclaw.tokens.cache_read"]).toBe(80);
+
+  await service.stop?.();
+});
+```
+
+### Test 2: gen_ai.client.operation.duration metric
+
+```ts
+test("model.usage records gen_ai.client.operation.duration in seconds", async () => {
+  const service = createDiagnosticsOtelService();
+  await service.start(createTestCtx());
+
+  emitDiagnosticEvent({
+    type: "model.usage",
+    provider: "anthropic",
+    model: "claude-sonnet-4-5-20250929",
+    usage: { input: 200, output: 100, total: 300 },
+    durationMs: 3200,
+  });
+
+  const histogram = telemetryState.histograms.get("gen_ai.client.operation.duration");
+  expect(histogram?.record).toHaveBeenCalledWith(
+    3.2, // seconds, not ms
+    expect.objectContaining({
+      "gen_ai.operation.name": "chat",
+      "gen_ai.provider.name": "anthropic",
+      "gen_ai.request.model": "claude-sonnet-4-5-20250929",
+    }),
+  );
+
+  await service.stop?.();
+});
+```
+
+### Test 3: gen_ai.client.token.usage metric split by type
+
+```ts
+test("model.usage records gen_ai.client.token.usage histogram split by input/output", async () => {
+  const service = createDiagnosticsOtelService();
+  await service.start(createTestCtx());
+
+  emitDiagnosticEvent({
+    type: "model.usage",
+    provider: "openai",
+    model: "gpt-5.2",
+    usage: { input: 500, output: 120, total: 620 },
+  });
+
+  const histogram = telemetryState.histograms.get("gen_ai.client.token.usage");
+  expect(histogram?.record).toHaveBeenCalledWith(
+    500,
+    expect.objectContaining({ "gen_ai.token.type": "input" }),
+  );
+  expect(histogram?.record).toHaveBeenCalledWith(
+    120,
+    expect.objectContaining({ "gen_ai.token.type": "output" }),
+  );
+
+  await service.stop?.();
+});
+```
+
+### Test 4: Provider name mapping
+
+```ts
+test("maps provider names to gen_ai.provider.name enum values", async () => {
+  const service = createDiagnosticsOtelService();
+  await service.start(createTestCtx());
+
+  const cases = [
+    { input: "orq", expected: "openai" },
+    { input: "anthropic", expected: "anthropic" },
+    { input: "google-gemini", expected: "gcp.gemini" },
+    { input: "aws-bedrock", expected: "aws.bedrock" },
+    { input: "mistral", expected: "mistral_ai" },
+    { input: "some-custom-provider", expected: "some-custom-provider" },
+  ];
+
+  for (const { input, expected } of cases) {
+    telemetryState.tracer.startSpan.mockClear();
+    emitDiagnosticEvent({
+      type: "model.usage",
+      provider: input,
+      model: "test-model",
+      usage: { input: 10, output: 5, total: 15 },
+    });
+    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    expect(attrs?.["gen_ai.provider.name"]).toBe(expected);
+  }
+
+  await service.stop?.();
+});
+```
+
+### Test 5: Opt-in content capture
+
+```ts
+test("records gen_ai.input.messages when captureContent is enabled", async () => {
+  const service = createDiagnosticsOtelService();
+  await service.start(createTestCtx({ captureContent: true }));
+
+  const inputMessages = [
+    {
+      role: "user" as const,
+      parts: [{ type: "text" as const, content: "Hello" }],
+    },
+  ];
+  const outputMessages = [
+    {
+      role: "assistant" as const,
+      parts: [{ type: "text" as const, content: "Hi there!" }],
+      finish_reason: "stop",
+    },
+  ];
+
+  emitDiagnosticEvent({
+    type: "model.usage",
+    provider: "openai",
+    model: "gpt-5.2",
+    usage: { input: 10, output: 5, total: 15 },
+    inputMessages,
+    outputMessages,
+  });
+
+  const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+  expect(attrs["gen_ai.input.messages"]).toBe(JSON.stringify(inputMessages));
+  expect(attrs["gen_ai.output.messages"]).toBe(JSON.stringify(outputMessages));
+
+  await service.stop?.();
+});
+```
+
+### Test 6: Content NOT captured when captureContent is false/default
+
+```ts
+test("does NOT record gen_ai.input.messages when captureContent is disabled", async () => {
+  const service = createDiagnosticsOtelService();
+  await service.start(createTestCtx()); // captureContent defaults to false
+
+  emitDiagnosticEvent({
+    type: "model.usage",
+    provider: "openai",
+    model: "gpt-5.2",
+    usage: { input: 10, output: 5, total: 15 },
+    inputMessages: [{ role: "user", parts: [{ type: "text", content: "secret" }] }],
+  });
+
+  const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+  expect(attrs["gen_ai.input.messages"]).toBeUndefined();
+  expect(attrs["gen_ai.output.messages"]).toBeUndefined();
+
+  await service.stop?.();
+});
+```
+
+### Test 7: Multimodal message parts
+
+```ts
+test("input messages with media parts use correct modality and type", async () => {
+  const service = createDiagnosticsOtelService();
+  await service.start(createTestCtx({ captureContent: true }));
+
+  const inputMessages = [
+    {
+      role: "user" as const,
+      parts: [
+        { type: "text" as const, content: "What's in this image?" },
+        {
+          type: "uri" as const,
+          modality: "image" as const,
+          mime_type: "image/png",
+          uri: "https://example.com/photo.png",
+        },
+      ],
+    },
+  ];
+
+  emitDiagnosticEvent({
+    type: "model.usage",
+    provider: "openai",
+    model: "gpt-5.2",
+    usage: { input: 500, output: 50, total: 550 },
+    inputMessages,
+  });
+
+  const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+  const parsed = JSON.parse(attrs["gen_ai.input.messages"] as string);
+  expect(parsed[0].parts).toHaveLength(2);
+  expect(parsed[0].parts[0].type).toBe("text");
+  expect(parsed[0].parts[1].type).toBe("uri");
+  expect(parsed[0].parts[1].modality).toBe("image");
+  expect(parsed[0].parts[1].mime_type).toBe("image/png");
+
+  await service.stop?.();
+});
+```
+
+### Test 8: Tool call in output messages
+
+```ts
+test("output messages with tool_call parts are recorded correctly", async () => {
+  const service = createDiagnosticsOtelService();
+  await service.start(createTestCtx({ captureContent: true }));
+
+  const outputMessages = [
+    {
+      role: "assistant" as const,
+      parts: [
+        {
+          type: "tool_call" as const,
+          id: "call_abc",
+          name: "get_weather",
+          arguments: { location: "Paris" },
+        },
+      ],
+      finish_reason: "tool_call",
+    },
+  ];
+
+  emitDiagnosticEvent({
+    type: "model.usage",
+    provider: "openai",
+    model: "gpt-5.2",
+    finishReasons: ["tool_call"],
+    usage: { input: 100, output: 20, total: 120 },
+    outputMessages,
+  });
+
+  const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+  expect(attrs["gen_ai.response.finish_reasons"]).toEqual(["tool_call"]);
+  const parsed = JSON.parse(attrs["gen_ai.output.messages"] as string);
+  expect(parsed[0].parts[0].type).toBe("tool_call");
+  expect(parsed[0].parts[0].name).toBe("get_weather");
+  expect(parsed[0].finish_reason).toBe("tool_call");
+
+  await service.stop?.();
+});
+```
+
+### Test 9: Tool execution span
+
+```ts
+test("tool.execution emits execute_tool span with gen_ai.tool.* attributes", async () => {
+  const service = createDiagnosticsOtelService();
+  await service.start(createTestCtx());
+
+  emitDiagnosticEvent({
+    type: "tool.execution",
+    toolName: "web_search",
+    toolType: "function",
+    toolCallId: "call_xyz",
+    channel: "webchat",
+    durationMs: 850,
+  });
+
+  const spanCall = telemetryState.tracer.startSpan.mock.calls[0];
+  expect(spanCall[0]).toBe("execute_tool web_search");
+
+  const attrs = spanCall[1]?.attributes;
+  expect(attrs["gen_ai.operation.name"]).toBe("execute_tool");
+  expect(attrs["gen_ai.tool.name"]).toBe("web_search");
+  expect(attrs["gen_ai.tool.type"]).toBe("function");
+  expect(attrs["gen_ai.tool.call.id"]).toBe("call_xyz");
+  expect(attrs["openclaw.channel"]).toBe("webchat");
+
+  await service.stop?.();
+});
+```
+
+### Test 10: Tool execution error sets span status
+
+```ts
+test("tool.execution with error sets ERROR span status", async () => {
+  const service = createDiagnosticsOtelService();
+  await service.start(createTestCtx());
+
+  emitDiagnosticEvent({
+    type: "tool.execution",
+    toolName: "exec",
+    toolCallId: "call_err",
+    durationMs: 100,
+    error: "timeout",
+  });
+
+  const span = telemetryState.tracer.startSpan.mock.results[0]?.value;
+  expect(span.setStatus).toHaveBeenCalledWith(
+    expect.objectContaining({ code: 2, message: "timeout" }),
+  );
+
+  await service.stop?.();
+});
+```
+
+### Test 11: Span kind is CLIENT for inference, INTERNAL for tool execution
+
+```ts
+test("inference spans use SpanKind.CLIENT, tool spans use SpanKind.INTERNAL", async () => {
+  const service = createDiagnosticsOtelService();
+  await service.start(createTestCtx());
+
+  emitDiagnosticEvent({
+    type: "model.usage",
+    provider: "openai",
+    model: "gpt-5.2",
+    usage: { input: 10, output: 5, total: 15 },
+  });
+
+  emitDiagnosticEvent({
+    type: "tool.execution",
+    toolName: "web_search",
+    durationMs: 200,
+  });
+
+  const calls = telemetryState.tracer.startSpan.mock.calls;
+  // SpanKind.CLIENT = 2, SpanKind.INTERNAL = 0
+  expect(calls[0][1]?.kind).toBe(2); // CLIENT for inference
+  expect(calls[1][1]?.kind).toBe(0); // INTERNAL for tool execution
+
+  await service.stop?.();
+});
+```
+
+### Test 12: Existing openclaw.\* metrics are still emitted
+
+```ts
+test("existing openclaw.* metrics are still emitted alongside gen_ai.*", async () => {
+  const service = createDiagnosticsOtelService();
+  await service.start(createTestCtx());
+
+  emitDiagnosticEvent({
+    type: "model.usage",
+    provider: "openai",
+    model: "gpt-5.2",
+    usage: { input: 100, output: 50, total: 150 },
+    durationMs: 2000,
+    costUsd: 0.005,
+  });
+
+  // Existing openclaw metrics still work
+  expect(telemetryState.counters.get("openclaw.tokens")?.add).toHaveBeenCalled();
+  expect(telemetryState.counters.get("openclaw.cost.usd")?.add).toHaveBeenCalled();
+  expect(telemetryState.histograms.get("openclaw.run.duration_ms")?.record).toHaveBeenCalled();
+
+  // New gen_ai metrics also emitted
+  expect(
+    telemetryState.histograms.get("gen_ai.client.operation.duration")?.record,
+  ).toHaveBeenCalled();
+  expect(telemetryState.histograms.get("gen_ai.client.token.usage")?.record).toHaveBeenCalled();
+
+  await service.stop?.();
+});
+```
+
+### Test 13: finish_reason "length" indicates truncation
+
+```ts
+test("finish_reason length is recorded for truncated responses", async () => {
+  const service = createDiagnosticsOtelService();
+  await service.start(createTestCtx());
+
+  emitDiagnosticEvent({
+    type: "model.usage",
+    provider: "openai",
+    model: "gpt-5.2",
+    finishReasons: ["length"],
+    usage: { input: 10000, output: 4096, total: 14096 },
+  });
+
+  const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+  expect(attrs["gen_ai.response.finish_reasons"]).toEqual(["length"]);
+
+  await service.stop?.();
+});
+```
+
+### Test helper
+
+```ts
+function createTestCtx(otelOverrides?: { captureContent?: boolean }) {
+  return {
+    config: {
+      diagnostics: {
+        enabled: true,
+        otel: {
+          enabled: true,
+          endpoint: "http://otel-collector:4318",
+          protocol: "http/protobuf",
+          traces: true,
+          metrics: true,
+          logs: false,
+          ...otelOverrides,
+        },
+      },
+    },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  };
+}
+```
+
+---
+
+## 5. Implementation Order
+
+1. **Types first:** Add `GenAiMessage`, `GenAiPart`, etc. types and extend
+   `DiagnosticUsageEvent` in `diagnostic-events.ts`.
+2. **Add `DiagnosticToolExecutionEvent`** to the event union.
+3. **Config:** Add `captureContent` to the OTel config schema.
+4. **OTel plugin:** Update `recordModelUsage` to emit dual-namespace
+   attributes, standard metrics, and spec-compliant span names.
+5. **OTel plugin:** Add `recordToolExecution` handler.
+6. **Emit sites:** Enrich the `agent-runner.ts` emit call with
+   `finishReasons`, `responseId`, `responseModel`, `operationName`.
+7. **Emit sites:** Add content capture behind `captureContent` flag.
+8. **Emit sites:** Add `tool.execution` events at tool invocation points.
+9. **Tests:** Add all 13 tests.
+10. **Verify:** Run `pnpm build && pnpm check && pnpm test`.
+
+---
+
+## 6. What's Explicitly Out of Scope
+
+- **Agent-level spans** (`create_agent`, `invoke_agent`) - deferred to a
+  follow-up PR.
+- **MCP semantic conventions** - deferred.
+- **Embedding spans** - not applicable (OpenClaw doesn't expose embeddings
+  to the OTel pipeline today).
+- **Streaming metrics** (`time_to_first_token`, `time_per_output_token`) -
+  requires stream-level instrumentation, deferred.
+- **Removing `openclaw.*` attributes** - explicitly not happening.
+- **Cost in gen_ai namespace** - no standard exists; keep `openclaw.cost.usd`.

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -6,9 +6,10 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.212.0",
-    "@opentelemetry/exporter-logs-otlp-proto": "^0.212.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "^0.212.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.212.0",
+    "@opentelemetry/core": "^2.5.1",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.212.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.212.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.212.0",
     "@opentelemetry/resources": "^2.5.1",
     "@opentelemetry/sdk-logs": "^0.212.0",
     "@opentelemetry/sdk-metrics": "^2.5.1",

--- a/extensions/diagnostics-otel/src/otel-event-handlers.ts
+++ b/extensions/diagnostics-otel/src/otel-event-handlers.ts
@@ -1,0 +1,701 @@
+import type { DiagnosticEventPayload } from "openclaw/plugin-sdk";
+import {
+  context,
+  isSpanContextValid,
+  trace,
+  SpanKind,
+  SpanStatusCode,
+  type Span,
+  type Tracer,
+} from "@opentelemetry/api";
+import type { OtelMetricInstruments } from "./otel-metrics.js";
+import type { ActiveTrace, ResolvedCaptureContent, TraceHeaders } from "./otel-utils.js";
+import { formatTraceparent, mapProviderName } from "./otel-utils.js";
+
+export type AgentInfo = {
+  id: string;
+  name?: string;
+};
+
+export interface OtelHandlerCtx {
+  tracer: Tracer;
+  metrics: OtelMetricInstruments;
+  captureContent: ResolvedCaptureContent;
+  tracesEnabled: boolean;
+  debugExports: boolean;
+  logger: { info(msg: string): void };
+  activeTraces: Map<string, ActiveTrace>;
+  runSpans: Map<string, { span: Span; createdAt: number }>;
+  inferenceSpans: Map<string, { span: Span; createdAt: number }>;
+  activeInferenceSpanByRunId: Map<string, Span>;
+  runProviderByRunId: Map<string, string>;
+  resolveAgentInfo: (sessionKey?: string) => AgentInfo | null;
+  spanWithDuration: (
+    name: string,
+    attributes: Record<string, string | number | string[]>,
+    durationMs?: number,
+    kind?: SpanKind,
+    parentCtx?: ReturnType<typeof context.active>,
+  ) => Span;
+  safeJsonStringify: (v: unknown) => string;
+  createToolSpan: (
+    evt: Extract<DiagnosticEventPayload, { type: "tool.execution" }>,
+    parentCtx?: ReturnType<typeof context.active>,
+  ) => void;
+  ensureRunSpan: (params: {
+    runId?: string;
+    sessionKey?: string;
+    sessionId?: string;
+    channel?: string;
+    startTimeMs?: number;
+    attributes?: Record<string, string | number | string[]>;
+  }) => Span | null;
+  TRACE_ATTRS: {
+    SESSION_ID: string;
+  };
+  getTraceHeadersRegistry: () => Map<string, TraceHeaders>;
+}
+
+export function recordRunCompleted(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "run.completed" }>,
+): void {
+  const attrs = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.provider": evt.provider ?? "unknown",
+    "openclaw.model": evt.model ?? "unknown",
+  };
+
+  const usage = evt.usage;
+  if (usage.input) {
+    hctx.metrics.tokensCounter.add(usage.input, { ...attrs, "openclaw.token": "input" });
+  }
+  if (usage.output) {
+    hctx.metrics.tokensCounter.add(usage.output, { ...attrs, "openclaw.token": "output" });
+  }
+  if (usage.cacheRead) {
+    hctx.metrics.tokensCounter.add(usage.cacheRead, { ...attrs, "openclaw.token": "cache_read" });
+  }
+  if (usage.cacheWrite) {
+    hctx.metrics.tokensCounter.add(usage.cacheWrite, {
+      ...attrs,
+      "openclaw.token": "cache_write",
+    });
+  }
+  if (usage.promptTokens) {
+    hctx.metrics.tokensCounter.add(usage.promptTokens, { ...attrs, "openclaw.token": "prompt" });
+  }
+  if (usage.total) {
+    hctx.metrics.tokensCounter.add(usage.total, { ...attrs, "openclaw.token": "total" });
+  }
+
+  if (evt.costUsd) {
+    hctx.metrics.costCounter.add(evt.costUsd, attrs);
+  }
+  if (evt.durationMs) {
+    hctx.metrics.durationHistogram.record(evt.durationMs, attrs);
+  }
+  if (evt.context?.limit) {
+    hctx.metrics.contextHistogram.record(evt.context.limit, {
+      ...attrs,
+      "openclaw.context": "limit",
+    });
+  }
+  if (evt.context?.used) {
+    hctx.metrics.contextHistogram.record(evt.context.used, {
+      ...attrs,
+      "openclaw.context": "used",
+    });
+  }
+
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+
+  // Only put lightweight envelope attributes on the agent.turn span.
+  // gen_ai.* inference attributes (model, messages, tokens, etc.) belong
+  // exclusively on the child chat spans created by recordModelInference.
+  const turnAttrs: Record<string, string | number | string[]> = {
+    ...attrs,
+    "openclaw.runId": evt.runId,
+    "openclaw.sessionKey": evt.sessionKey ?? "",
+    "openclaw.sessionId": evt.sessionId ?? "",
+    "gen_ai.provider.name": mapProviderName(evt.provider),
+  };
+  if (typeof usage.input === "number") {
+    turnAttrs["openclaw.tokens.input"] = usage.input;
+  }
+  if (typeof usage.output === "number") {
+    turnAttrs["openclaw.tokens.output"] = usage.output;
+  }
+  if (typeof usage.cacheRead === "number") {
+    turnAttrs["openclaw.tokens.cache_read"] = usage.cacheRead;
+  }
+  if (typeof usage.cacheWrite === "number") {
+    turnAttrs["openclaw.tokens.cache_write"] = usage.cacheWrite;
+  }
+  if (typeof usage.total === "number") {
+    turnAttrs["openclaw.tokens.total"] = usage.total;
+  }
+  if (evt.sessionId) {
+    turnAttrs["gen_ai.conversation.id"] = evt.sessionId;
+  }
+  const runSpan = hctx.ensureRunSpan({
+    runId: evt.runId,
+    sessionKey: evt.sessionKey,
+    sessionId: evt.sessionId,
+    channel: evt.channel,
+    attributes: turnAttrs,
+    startTimeMs:
+      typeof evt.durationMs === "number" ? Date.now() - Math.max(0, evt.durationMs) : undefined,
+  });
+  if (!runSpan) {
+    // Fallback: add agent identity attrs for the standalone span
+    const agentInfo = hctx.resolveAgentInfo(evt.sessionKey);
+    if (agentInfo) {
+      turnAttrs["gen_ai.agent.id"] = agentInfo.id;
+      if (agentInfo.name) {
+        turnAttrs["gen_ai.agent.name"] = agentInfo.name;
+      }
+    }
+    turnAttrs["gen_ai.operation.name"] = "invoke_agent";
+  }
+  const fallbackSpanName = (() => {
+    const agentInfo = hctx.resolveAgentInfo(evt.sessionKey);
+    return agentInfo?.name ? `invoke_agent ${agentInfo.name}` : "invoke_agent";
+  })();
+  const finalRunSpan =
+    runSpan ??
+    hctx.spanWithDuration(fallbackSpanName, turnAttrs, evt.durationMs, SpanKind.INTERNAL);
+
+  if (evt.error) {
+    finalRunSpan.setStatus({ code: SpanStatusCode.ERROR, message: evt.error });
+    if (evt.errorType) {
+      finalRunSpan.setAttribute("error.type", evt.errorType);
+    }
+    finalRunSpan.setAttribute("openclaw.error", evt.error);
+  }
+
+  finalRunSpan.end();
+  hctx.runSpans.delete(evt.runId);
+  hctx.runProviderByRunId.delete(evt.runId);
+  if (evt.sessionKey) {
+    hctx.getTraceHeadersRegistry().delete(evt.sessionKey);
+  }
+}
+
+export function recordRunStarted(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "run.started" }>,
+): void {
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+  hctx.ensureRunSpan({
+    runId: evt.runId,
+    sessionKey: evt.sessionKey,
+    sessionId: evt.sessionId,
+    channel: evt.channel,
+    startTimeMs: evt.ts,
+  });
+}
+
+export function recordModelInferenceStarted(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "model.inference.started" }>,
+): void {
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+  const opName = evt.operationName ?? "chat";
+
+  const runSpan = hctx.ensureRunSpan({
+    runId: evt.runId,
+    sessionKey: evt.sessionKey,
+    sessionId: evt.sessionId,
+    channel: evt.channel,
+    startTimeMs: evt.ts,
+  });
+  const parentCtx = runSpan ? trace.setSpan(context.active(), runSpan) : context.active();
+
+  const spanAttrs: Record<string, string | number | string[]> = {
+    "gen_ai.operation.name": opName,
+    "gen_ai.provider.name": mapProviderName(evt.provider),
+    "gen_ai.request.model": evt.model ?? "unknown",
+  };
+  if (evt.sessionKey) {
+    spanAttrs["openclaw.sessionKey"] = evt.sessionKey;
+  }
+  if (evt.sessionId) {
+    spanAttrs["openclaw.sessionId"] = evt.sessionId;
+    spanAttrs["gen_ai.conversation.id"] = evt.sessionId;
+  }
+  if (typeof evt.callIndex === "number") {
+    spanAttrs["openclaw.callIndex"] = evt.callIndex;
+  }
+  if (typeof evt.temperature === "number") {
+    spanAttrs["gen_ai.request.temperature"] = evt.temperature;
+  }
+  if (typeof evt.maxOutputTokens === "number") {
+    spanAttrs["gen_ai.request.max_tokens"] = evt.maxOutputTokens;
+  }
+  if (hctx.captureContent.inputMessages && evt.inputMessages) {
+    spanAttrs["gen_ai.input.messages"] = JSON.stringify(evt.inputMessages);
+  }
+  if (hctx.captureContent.systemInstructions && evt.systemInstructions) {
+    spanAttrs["gen_ai.system_instructions"] = JSON.stringify(evt.systemInstructions);
+  }
+  if (hctx.captureContent.toolDefinitions && evt.toolDefinitions) {
+    spanAttrs["gen_ai.tool.definitions"] = JSON.stringify(evt.toolDefinitions);
+  }
+
+  const spanName = `${opName} ${evt.model ?? "unknown"}`;
+  const span = hctx.tracer.startSpan(
+    spanName,
+    { attributes: spanAttrs, startTime: evt.ts, kind: SpanKind.CLIENT },
+    parentCtx,
+  );
+  if (hctx.debugExports) {
+    hctx.logger.info(`diagnostics-otel: span created ${spanName}`);
+  }
+
+  if (evt.runId && typeof evt.callIndex === "number") {
+    hctx.inferenceSpans.set(`${evt.runId}:${evt.callIndex}`, { span, createdAt: Date.now() });
+  }
+  if (evt.runId) {
+    hctx.activeInferenceSpanByRunId.set(evt.runId, span);
+    if (evt.provider) {
+      hctx.runProviderByRunId.set(evt.runId, mapProviderName(evt.provider));
+    }
+  }
+}
+
+export function recordModelInference(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "model.inference" }>,
+): void {
+  const opName = evt.operationName ?? "chat";
+  const usage = evt.usage ?? {};
+
+  // GenAI standard metrics (gen_ai_latest_experimental)
+  const genAiMetricAttrs: Record<string, string> = {
+    "gen_ai.operation.name": opName,
+    "gen_ai.provider.name": mapProviderName(evt.provider),
+    "gen_ai.request.model": evt.model ?? "unknown",
+  };
+  if (evt.responseModel) {
+    genAiMetricAttrs["gen_ai.response.model"] = evt.responseModel;
+  }
+  if (evt.durationMs) {
+    hctx.metrics.genAiOperationDuration.record(evt.durationMs / 1000, genAiMetricAttrs);
+  }
+  if (usage.input) {
+    hctx.metrics.genAiTokenUsage.record(usage.input, {
+      ...genAiMetricAttrs,
+      "gen_ai.token.type": "input",
+    });
+  }
+  if (usage.output) {
+    hctx.metrics.genAiTokenUsage.record(usage.output, {
+      ...genAiMetricAttrs,
+      "gen_ai.token.type": "output",
+    });
+  }
+  if (typeof evt.ttftMs === "number") {
+    hctx.metrics.genAiTtft.record(evt.ttftMs / 1000, genAiMetricAttrs);
+  }
+  if (evt.error && evt.errorType) {
+    hctx.metrics.inferenceErrorCounter.add(1, {
+      ...genAiMetricAttrs,
+      "error.type": evt.errorType,
+    });
+  }
+
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+
+  const spanAttrs: Record<string, string | number | string[]> = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.provider": evt.provider ?? "unknown",
+    "openclaw.model": evt.model ?? "unknown",
+    "openclaw.sessionKey": evt.sessionKey ?? "",
+    "openclaw.sessionId": evt.sessionId ?? "",
+    "gen_ai.operation.name": opName,
+    "gen_ai.provider.name": mapProviderName(evt.provider),
+    "gen_ai.request.model": evt.model ?? "unknown",
+  };
+  if (typeof usage.input === "number") {
+    spanAttrs["openclaw.tokens.input"] = usage.input;
+  }
+  if (typeof usage.output === "number") {
+    spanAttrs["openclaw.tokens.output"] = usage.output;
+    spanAttrs["gen_ai.usage.output_tokens"] = usage.output;
+  }
+  if (typeof usage.cacheRead === "number") {
+    spanAttrs["openclaw.tokens.cache_read"] = usage.cacheRead;
+    spanAttrs["gen_ai.usage.cache_read.input_tokens"] = usage.cacheRead;
+  }
+  if (typeof usage.cacheWrite === "number") {
+    spanAttrs["openclaw.tokens.cache_write"] = usage.cacheWrite;
+    spanAttrs["gen_ai.usage.cache_creation.input_tokens"] = usage.cacheWrite;
+  }
+  if (typeof usage.total === "number") {
+    spanAttrs["openclaw.tokens.total"] = usage.total;
+  }
+  // OTEL GenAI semconv: gen_ai.usage.input_tokens SHOULD include all input
+  // tokens including cached tokens. Compute from components when promptTokens
+  // is unavailable to avoid under-counting.
+  const hasInputComponents =
+    typeof usage.input === "number" ||
+    typeof usage.cacheRead === "number" ||
+    typeof usage.cacheWrite === "number";
+  const inputTokensForOtel =
+    usage.promptTokens ??
+    (hasInputComponents
+      ? (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0)
+      : undefined);
+  if (typeof inputTokensForOtel === "number") {
+    spanAttrs["gen_ai.usage.input_tokens"] = inputTokensForOtel;
+  }
+  if (evt.responseModel) {
+    spanAttrs["gen_ai.response.model"] = evt.responseModel;
+  }
+  if (evt.responseId) {
+    spanAttrs["gen_ai.response.id"] = evt.responseId;
+  }
+  if (evt.finishReasons?.length) {
+    spanAttrs["gen_ai.response.finish_reasons"] = evt.finishReasons;
+  }
+  if (evt.sessionId) {
+    spanAttrs["gen_ai.conversation.id"] = evt.sessionId;
+  }
+  if (typeof evt.temperature === "number") {
+    spanAttrs["gen_ai.request.temperature"] = evt.temperature;
+  }
+  if (typeof evt.maxOutputTokens === "number") {
+    spanAttrs["gen_ai.request.max_tokens"] = evt.maxOutputTokens;
+  }
+  if (typeof evt.ttftMs === "number") {
+    spanAttrs["gen_ai.client.time_to_first_token"] = evt.ttftMs;
+  }
+  if (typeof evt.callIndex === "number") {
+    spanAttrs["openclaw.callIndex"] = evt.callIndex;
+  }
+  if (hctx.captureContent.outputMessages && evt.outputMessages) {
+    spanAttrs["gen_ai.output.messages"] = JSON.stringify(evt.outputMessages);
+  }
+  const span =
+    evt.runId && typeof evt.callIndex === "number"
+      ? hctx.inferenceSpans.get(`${evt.runId}:${evt.callIndex}`)?.span
+      : undefined;
+  const activeSpan = evt.runId ? hctx.activeInferenceSpanByRunId.get(evt.runId) : undefined;
+  const resolved = span ?? activeSpan;
+
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+
+  const spanName = `${opName} ${evt.model ?? "unknown"}`;
+  const runEntry = evt.runId ? hctx.runSpans.get(evt.runId) : undefined;
+  const parentCtx = runEntry ? trace.setSpan(context.active(), runEntry.span) : context.active();
+  const finalSpan =
+    resolved ??
+    hctx.spanWithDuration(spanName, spanAttrs, evt.durationMs, SpanKind.CLIENT, parentCtx);
+
+  for (const [key, value] of Object.entries(spanAttrs)) {
+    finalSpan.setAttribute(key, value);
+  }
+  if (hctx.captureContent.outputMessages && evt.outputMessages) {
+    finalSpan.setAttribute("gen_ai.output.messages", JSON.stringify(evt.outputMessages));
+  }
+  if (evt.error) {
+    finalSpan.setStatus({ code: SpanStatusCode.ERROR, message: evt.error });
+    if (evt.errorType) {
+      finalSpan.setAttribute("error.type", evt.errorType);
+    }
+    finalSpan.setAttribute("openclaw.error", evt.error);
+  }
+  finalSpan.end();
+
+  if (evt.runId) {
+    hctx.activeInferenceSpanByRunId.delete(evt.runId);
+    if (typeof evt.callIndex === "number") {
+      hctx.inferenceSpans.delete(`${evt.runId}:${evt.callIndex}`);
+    }
+  }
+}
+
+export function recordWebhookReceived(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "webhook.received" }>,
+): void {
+  const attrs = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.webhook": evt.updateType ?? "unknown",
+  };
+  hctx.metrics.webhookReceivedCounter.add(1, attrs);
+}
+
+export function recordWebhookProcessed(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "webhook.processed" }>,
+): void {
+  const attrs = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.webhook": evt.updateType ?? "unknown",
+  };
+  if (typeof evt.durationMs === "number") {
+    hctx.metrics.webhookDurationHistogram.record(evt.durationMs, attrs);
+  }
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+  const spanAttrs: Record<string, string | number> = { ...attrs };
+  if (evt.chatId !== undefined) {
+    spanAttrs["openclaw.chatId"] = String(evt.chatId);
+  }
+  const span = hctx.spanWithDuration("openclaw.webhook.processed", spanAttrs, evt.durationMs);
+  if (hctx.debugExports) {
+    hctx.logger.info(`diagnostics-otel: span created openclaw.webhook.processed`);
+  }
+  span.end();
+}
+
+export function recordWebhookError(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "webhook.error" }>,
+): void {
+  const attrs = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.webhook": evt.updateType ?? "unknown",
+  };
+  hctx.metrics.webhookErrorCounter.add(1, attrs);
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+  const spanAttrs: Record<string, string | number> = {
+    ...attrs,
+    "openclaw.error": evt.error,
+  };
+  if (evt.chatId !== undefined) {
+    spanAttrs["openclaw.chatId"] = String(evt.chatId);
+  }
+  const span = hctx.tracer.startSpan("openclaw.webhook.error", {
+    attributes: spanAttrs,
+  });
+  span.setStatus({ code: SpanStatusCode.ERROR, message: evt.error });
+  if (hctx.debugExports) {
+    hctx.logger.info(`diagnostics-otel: span created openclaw.webhook.error`);
+  }
+  span.end();
+}
+
+export function recordMessageQueued(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "message.queued" }>,
+): void {
+  const attrs = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.source": evt.source ?? "unknown",
+  };
+  hctx.metrics.messageQueuedCounter.add(1, attrs);
+  if (typeof evt.queueDepth === "number") {
+    hctx.metrics.queueDepthHistogram.record(evt.queueDepth, attrs);
+  }
+
+  // Create root span for nested trace hierarchy.
+  // The message lifecycle is: message.queued → run.started → model.inference → tools → run.completed → message.processed.
+  // This root span covers the entire lifecycle; agent.turn, LLM calls, and tool executions are nested as children.
+  // message.processed ends this span (it does not create a new child).
+  if (hctx.tracesEnabled && evt.sessionKey) {
+    const agentId = evt.sessionKey.split(":")[1] || "unknown";
+
+    const rootSpan = hctx.tracer.startSpan("openclaw.message", {
+      kind: SpanKind.SERVER,
+      attributes: {
+        "openclaw.sessionKey": evt.sessionKey,
+        "openclaw.channel": evt.channel ?? "unknown",
+        "openclaw.source": evt.source ?? "unknown",
+        ...(typeof evt.queueDepth === "number" ? { "openclaw.queueDepth": evt.queueDepth } : {}),
+        [hctx.TRACE_ATTRS.SESSION_ID]: evt.sessionKey,
+      },
+    });
+
+    const traceContext = trace.setSpan(context.active(), rootSpan);
+
+    hctx.activeTraces.set(evt.sessionKey, {
+      span: rootSpan,
+      context: traceContext,
+      startedAt: Date.now(),
+      sessionKey: evt.sessionKey,
+      channel: evt.channel,
+      agentId,
+    });
+
+    // Store W3C trace headers for propagation
+    const spanContext = rootSpan.spanContext();
+    if (isSpanContextValid(spanContext)) {
+      hctx.getTraceHeadersRegistry().set(evt.sessionKey, {
+        traceparent: formatTraceparent(spanContext),
+        ...(spanContext.traceState && { tracestate: spanContext.traceState.serialize() }),
+      });
+    }
+
+    if (hctx.debugExports) {
+      hctx.logger.info(`diagnostics-otel: created root span for session=${evt.sessionKey}`);
+    }
+  }
+}
+
+export function recordMessageProcessed(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "message.processed" }>,
+): void {
+  const attrs = {
+    "openclaw.channel": evt.channel ?? "unknown",
+    "openclaw.outcome": evt.outcome ?? "unknown",
+  };
+  hctx.metrics.messageProcessedCounter.add(1, attrs);
+  if (typeof evt.durationMs === "number") {
+    hctx.metrics.messageDurationHistogram.record(evt.durationMs, attrs);
+  }
+
+  // End root trace span created by message.queued.
+  // No standalone span here — the root span covers the full message lifecycle.
+  const sessionKey = evt.sessionKey;
+  const activeTrace = sessionKey ? hctx.activeTraces.get(sessionKey) : null;
+  if (activeTrace) {
+    activeTrace.span.setAttribute("openclaw.outcome", evt.outcome ?? "unknown");
+    if (typeof evt.durationMs === "number") {
+      activeTrace.span.setAttribute("openclaw.durationMs", evt.durationMs);
+    }
+    if (evt.messageId != null) {
+      activeTrace.span.setAttribute("openclaw.messageId", String(evt.messageId));
+    }
+    if (evt.outcome === "error" && evt.error) {
+      activeTrace.span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: evt.error,
+      });
+    } else {
+      activeTrace.span.setStatus({ code: SpanStatusCode.OK });
+    }
+    activeTrace.span.end();
+    hctx.activeTraces.delete(sessionKey!);
+    hctx.getTraceHeadersRegistry().delete(sessionKey!);
+    if (hctx.debugExports) {
+      hctx.logger.info(`diagnostics-otel: ended root span for session=${sessionKey}`);
+    }
+  } else if (hctx.debugExports) {
+    hctx.logger.info(
+      `diagnostics-otel: no active root trace for message.processed sessionKey=${sessionKey ?? "undefined"}`,
+    );
+  }
+}
+
+export function recordLaneEnqueue(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "queue.lane.enqueue" }>,
+): void {
+  const attrs = { "openclaw.lane": evt.lane };
+  hctx.metrics.laneEnqueueCounter.add(1, attrs);
+  hctx.metrics.queueDepthHistogram.record(evt.queueSize, attrs);
+}
+
+export function recordLaneDequeue(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "queue.lane.dequeue" }>,
+): void {
+  const attrs = { "openclaw.lane": evt.lane };
+  hctx.metrics.laneDequeueCounter.add(1, attrs);
+  hctx.metrics.queueDepthHistogram.record(evt.queueSize, attrs);
+  if (typeof evt.waitMs === "number") {
+    hctx.metrics.queueWaitHistogram.record(evt.waitMs, attrs);
+  }
+}
+
+export function recordSessionState(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "session.state" }>,
+): void {
+  const attrs: Record<string, string> = { "openclaw.state": evt.state };
+  if (evt.reason) {
+    attrs["openclaw.reason"] = evt.reason;
+  }
+  hctx.metrics.sessionStateCounter.add(1, attrs);
+}
+
+export function recordSessionStuck(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "session.stuck" }>,
+): void {
+  const attrs: Record<string, string> = { "openclaw.state": evt.state };
+  hctx.metrics.sessionStuckCounter.add(1, attrs);
+  if (typeof evt.ageMs === "number") {
+    hctx.metrics.sessionStuckAgeHistogram.record(evt.ageMs, attrs);
+  }
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+  const spanAttrs: Record<string, string | number> = { ...attrs };
+  if (evt.sessionKey) {
+    spanAttrs["openclaw.sessionKey"] = evt.sessionKey;
+  }
+  if (evt.sessionId) {
+    spanAttrs["openclaw.sessionId"] = evt.sessionId;
+  }
+  spanAttrs["openclaw.queueDepth"] = evt.queueDepth ?? 0;
+  spanAttrs["openclaw.ageMs"] = evt.ageMs;
+  const span = hctx.tracer.startSpan("openclaw.session.stuck", { attributes: spanAttrs });
+  span.setStatus({ code: SpanStatusCode.ERROR, message: "session stuck" });
+  if (hctx.debugExports) {
+    hctx.logger.info(`diagnostics-otel: span created openclaw.session.stuck`);
+  }
+  span.end();
+}
+
+export function recordRunAttempt(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "run.attempt" }>,
+): void {
+  hctx.metrics.runAttemptCounter.add(1, { "openclaw.attempt": evt.attempt });
+}
+
+export function recordToolExecution(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "tool.execution" }>,
+): void {
+  if (!hctx.tracesEnabled) {
+    return;
+  }
+
+  // Nest tool span under root message.process span (via activeTraces)
+  // or fallback to run/inference spans if activeTrace not found
+  const activeTrace = evt.sessionKey ? hctx.activeTraces.get(evt.sessionKey) : null;
+  if (activeTrace) {
+    hctx.createToolSpan(evt, activeTrace.context);
+    return;
+  }
+
+  // Fallback: try run/inference spans
+  const runId = evt.runId;
+  const inferenceSpan = runId ? hctx.activeInferenceSpanByRunId.get(runId) : undefined;
+  const runEntry = runId ? hctx.runSpans.get(runId) : undefined;
+  const parentSpan = inferenceSpan ?? runEntry?.span;
+  const parentCtx = parentSpan ? trace.setSpan(context.active(), parentSpan) : undefined;
+  hctx.createToolSpan(evt, parentCtx);
+
+  if (hctx.debugExports && !activeTrace && !parentCtx) {
+    hctx.logger.info(
+      `diagnostics-otel: no active trace for tool.execution sessionKey=${evt.sessionKey} tool=${evt.toolName}`,
+    );
+  }
+}
+
+export function recordHeartbeat(
+  hctx: OtelHandlerCtx,
+  evt: Extract<DiagnosticEventPayload, { type: "diagnostic.heartbeat" }>,
+): void {
+  hctx.metrics.queueDepthHistogram.record(evt.queued, { "openclaw.channel": "heartbeat" });
+}

--- a/extensions/diagnostics-otel/src/otel-metrics.ts
+++ b/extensions/diagnostics-otel/src/otel-metrics.ts
@@ -1,0 +1,119 @@
+import type { Counter, Histogram, Meter } from "@opentelemetry/api";
+
+export interface OtelMetricInstruments {
+  tokensCounter: Counter;
+  costCounter: Counter;
+  durationHistogram: Histogram;
+  contextHistogram: Histogram;
+  webhookReceivedCounter: Counter;
+  webhookErrorCounter: Counter;
+  webhookDurationHistogram: Histogram;
+  messageQueuedCounter: Counter;
+  messageProcessedCounter: Counter;
+  messageDurationHistogram: Histogram;
+  queueDepthHistogram: Histogram;
+  queueWaitHistogram: Histogram;
+  laneEnqueueCounter: Counter;
+  laneDequeueCounter: Counter;
+  sessionStateCounter: Counter;
+  sessionStuckCounter: Counter;
+  sessionStuckAgeHistogram: Histogram;
+  runAttemptCounter: Counter;
+  genAiOperationDuration: Histogram;
+  genAiTokenUsage: Histogram;
+  genAiTtft: Histogram;
+  inferenceErrorCounter: Counter;
+}
+
+export function createMetricInstruments(meter: Meter): OtelMetricInstruments {
+  return {
+    tokensCounter: meter.createCounter("openclaw.tokens", {
+      unit: "1",
+      description: "Token usage by type",
+    }),
+    costCounter: meter.createCounter("openclaw.cost.usd", {
+      unit: "1",
+      description: "Estimated model cost (USD)",
+    }),
+    durationHistogram: meter.createHistogram("openclaw.run.duration_ms", {
+      unit: "ms",
+      description: "Agent run duration",
+    }),
+    contextHistogram: meter.createHistogram("openclaw.context.tokens", {
+      unit: "1",
+      description: "Context window size and usage",
+    }),
+    webhookReceivedCounter: meter.createCounter("openclaw.webhook.received", {
+      unit: "1",
+      description: "Webhook requests received",
+    }),
+    webhookErrorCounter: meter.createCounter("openclaw.webhook.error", {
+      unit: "1",
+      description: "Webhook processing errors",
+    }),
+    webhookDurationHistogram: meter.createHistogram("openclaw.webhook.duration_ms", {
+      unit: "ms",
+      description: "Webhook processing duration",
+    }),
+    messageQueuedCounter: meter.createCounter("openclaw.message.queued", {
+      unit: "1",
+      description: "Messages queued for processing",
+    }),
+    messageProcessedCounter: meter.createCounter("openclaw.message.processed", {
+      unit: "1",
+      description: "Messages processed by outcome",
+    }),
+    messageDurationHistogram: meter.createHistogram("openclaw.message.duration_ms", {
+      unit: "ms",
+      description: "Message processing duration",
+    }),
+    queueDepthHistogram: meter.createHistogram("openclaw.queue.depth", {
+      unit: "1",
+      description: "Queue depth on enqueue/dequeue",
+    }),
+    queueWaitHistogram: meter.createHistogram("openclaw.queue.wait_ms", {
+      unit: "ms",
+      description: "Queue wait time before execution",
+    }),
+    laneEnqueueCounter: meter.createCounter("openclaw.queue.lane.enqueue", {
+      unit: "1",
+      description: "Command queue lane enqueue events",
+    }),
+    laneDequeueCounter: meter.createCounter("openclaw.queue.lane.dequeue", {
+      unit: "1",
+      description: "Command queue lane dequeue events",
+    }),
+    sessionStateCounter: meter.createCounter("openclaw.session.state", {
+      unit: "1",
+      description: "Session state transitions",
+    }),
+    sessionStuckCounter: meter.createCounter("openclaw.session.stuck", {
+      unit: "1",
+      description: "Sessions stuck in processing",
+    }),
+    sessionStuckAgeHistogram: meter.createHistogram("openclaw.session.stuck_age_ms", {
+      unit: "ms",
+      description: "Age of stuck sessions",
+    }),
+    runAttemptCounter: meter.createCounter("openclaw.run.attempt", {
+      unit: "1",
+      description: "Run attempts",
+    }),
+    genAiOperationDuration: meter.createHistogram("gen_ai.client.operation.duration", {
+      unit: "s",
+      description: "GenAI operation duration",
+    }),
+    genAiTokenUsage: meter.createHistogram("gen_ai.client.token.usage", {
+      unit: "{token}",
+      description: "GenAI token usage",
+    }),
+    genAiTtft: meter.createHistogram("gen_ai.client.time_to_first_token", {
+      unit: "s",
+      description: "Time to first token from the model",
+    }),
+    inferenceErrorCounter: meter.createCounter("openclaw.inference.error", {
+      unit: "1",
+      description: "Model inference errors by type",
+    }),
+  };
+}

--- a/extensions/diagnostics-otel/src/otel-utils.test.ts
+++ b/extensions/diagnostics-otel/src/otel-utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import { resolveCaptureContent } from "./otel-utils.js";
+
+describe("resolveCaptureContent", () => {
+  test("enables all fields when captureContent is true", () => {
+    expect(resolveCaptureContent(true)).toEqual({
+      inputMessages: true,
+      outputMessages: true,
+      systemInstructions: true,
+      toolDefinitions: true,
+      toolContent: true,
+    });
+  });
+
+  test("disables all fields when captureContent is false or undefined", () => {
+    expect(resolveCaptureContent(false)).toEqual({
+      inputMessages: false,
+      outputMessages: false,
+      systemInstructions: false,
+      toolDefinitions: false,
+      toolContent: false,
+    });
+    expect(resolveCaptureContent(undefined)).toEqual({
+      inputMessages: false,
+      outputMessages: false,
+      systemInstructions: false,
+      toolDefinitions: false,
+      toolContent: false,
+    });
+  });
+
+  test("uses strict opt-in in object mode", () => {
+    expect(resolveCaptureContent({})).toEqual({
+      inputMessages: false,
+      outputMessages: false,
+      systemInstructions: false,
+      toolDefinitions: false,
+      toolContent: false,
+    });
+    expect(resolveCaptureContent({ inputMessages: true })).toEqual({
+      inputMessages: true,
+      outputMessages: false,
+      systemInstructions: false,
+      toolDefinitions: false,
+      toolContent: false,
+    });
+    expect(resolveCaptureContent({ inputMessages: undefined })).toEqual({
+      inputMessages: false,
+      outputMessages: false,
+      systemInstructions: false,
+      toolDefinitions: false,
+      toolContent: false,
+    });
+  });
+});

--- a/extensions/diagnostics-otel/src/otel-utils.ts
+++ b/extensions/diagnostics-otel/src/otel-utils.ts
@@ -1,0 +1,208 @@
+import type { Span, SpanContext } from "@opentelemetry/api";
+import type { ExportResult } from "@opentelemetry/core";
+import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
+import { ExportResultCode, hrTimeToMilliseconds } from "@opentelemetry/core";
+import fs from "node:fs";
+
+export const DEFAULT_SERVICE_NAME = "openclaw";
+export const OTEL_DEBUG_ENV = "OPENCLAW_OTEL_DEBUG";
+export const OTEL_DUMP_ENV = "OPENCLAW_OTEL_DUMP";
+
+export function normalizeEndpoint(endpoint?: string): string | undefined {
+  const trimmed = endpoint?.trim();
+  return trimmed ? trimmed.replace(/\/+$/, "") : undefined;
+}
+
+export function resolveOtelUrl(endpoint: string | undefined, path: string): string | undefined {
+  if (!endpoint) {
+    return undefined;
+  }
+  if (endpoint.includes("/v1/")) {
+    return endpoint;
+  }
+  return `${endpoint}/${path}`;
+}
+
+export function resolveSampleRate(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  if (value < 0 || value > 1) {
+    return undefined;
+  }
+  return value;
+}
+
+/** Map internal provider names to gen_ai.provider.name enum values. */
+export function mapProviderName(provider?: string): string {
+  if (!provider) {
+    return "unknown";
+  }
+  const p = provider.toLowerCase();
+  if (p.includes("openai") || p === "orq") {
+    return "openai";
+  }
+  if (p.includes("anthropic") || p.includes("claude")) {
+    return "anthropic";
+  }
+  if (p.includes("google") || p.includes("gemini")) {
+    return "gcp.gemini";
+  }
+  if (p.includes("bedrock")) {
+    return "aws.bedrock";
+  }
+  if (p.includes("mistral")) {
+    return "mistral_ai";
+  }
+  if (p.includes("deepseek")) {
+    return "deepseek";
+  }
+  if (p.includes("groq")) {
+    return "groq";
+  }
+  if (p.includes("cohere")) {
+    return "cohere";
+  }
+  if (p.includes("perplexity")) {
+    return "perplexity";
+  }
+  return provider;
+}
+
+export class LoggingTraceExporter implements SpanExporter {
+  #inner: SpanExporter;
+  #log: { info: (msg: string) => void };
+  #dumpPath?: string;
+  #dumpFailed = false;
+
+  constructor(inner: SpanExporter, log: { info: (msg: string) => void }, dumpPath?: string) {
+    this.#inner = inner;
+    this.#log = log;
+    this.#dumpPath = dumpPath;
+  }
+
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void) {
+    const first = spans[0];
+    const details = first ? ` first=${first.name}` : "";
+    this.#log.info(`diagnostics-otel: exporting ${spans.length} spans.${details}`);
+    if (this.#dumpPath && !this.#dumpFailed) {
+      try {
+        for (const span of spans) {
+          const startMs = hrTimeToMilliseconds(span.startTime);
+          const endMs = hrTimeToMilliseconds(span.endTime);
+          const parentCtxField = (span as { parentSpanContext?: { spanId?: string } })
+            .parentSpanContext;
+          const payload = {
+            ts: new Date().toISOString(),
+            name: span.name,
+            traceId: span.spanContext().traceId,
+            spanId: span.spanContext().spanId,
+            parentSpanId: parentCtxField?.spanId,
+            kind: span.kind,
+            status: span.status,
+            attributes: span.attributes,
+            resource: span.resource?.attributes,
+            startTimeMs: startMs,
+            endTimeMs: endMs,
+            durationMs: endMs - startMs,
+          };
+          fs.appendFileSync(
+            this.#dumpPath,
+            `${JSON.stringify(payload, (_key, value) =>
+              typeof value === "bigint" ? Number(value) : value,
+            )}\n`,
+          );
+        }
+      } catch (err) {
+        this.#dumpFailed = true;
+        this.#log.info(`diagnostics-otel: failed to write dump file: ${String(err)}`);
+      }
+    }
+    try {
+      this.#inner.export(spans, (result) => {
+        if (result.code !== ExportResultCode.SUCCESS) {
+          this.#log.info(
+            `diagnostics-otel: export failed code=${result.code} error=${String(result.error)}`,
+          );
+        }
+        resultCallback(result);
+      });
+    } catch (err) {
+      this.#log.info(`diagnostics-otel: export threw: ${String(err)}`);
+      resultCallback({ code: ExportResultCode.FAILED, error: err as Error });
+    }
+  }
+
+  async shutdown() {
+    await this.#inner.shutdown();
+  }
+
+  async forceFlush() {
+    if (this.#inner.forceFlush) {
+      await this.#inner.forceFlush();
+    }
+  }
+}
+
+export type ResolvedCaptureContent = {
+  inputMessages: boolean;
+  outputMessages: boolean;
+  systemInstructions: boolean;
+  toolDefinitions: boolean;
+  toolContent: boolean;
+};
+
+/**
+ * Resolve captureContent config to granular booleans.
+ * - `true` → all enabled
+ * - `false` / `undefined` → all disabled
+ * - object → each field defaults to `true` if omitted (opt-out model)
+ */
+export function resolveCaptureContent(
+  raw: boolean | Record<string, boolean | undefined> | undefined,
+): ResolvedCaptureContent {
+  if (raw === true) {
+    return {
+      inputMessages: true,
+      outputMessages: true,
+      systemInstructions: true,
+      toolDefinitions: true,
+      toolContent: true,
+    };
+  }
+  if (!raw || typeof raw !== "object") {
+    return {
+      inputMessages: false,
+      outputMessages: false,
+      systemInstructions: false,
+      toolDefinitions: false,
+      toolContent: false,
+    };
+  }
+  return {
+    inputMessages: raw.inputMessages !== false,
+    outputMessages: raw.outputMessages !== false,
+    systemInstructions: raw.systemInstructions !== false,
+    toolDefinitions: raw.toolDefinitions !== false,
+    toolContent: raw.toolContent !== false,
+  };
+}
+
+/** Format a W3C Trace Context traceparent header from a SpanContext. */
+export function formatTraceparent(spanContext: SpanContext): string {
+  return `00-${spanContext.traceId}-${spanContext.spanId}-${spanContext.traceFlags.toString(16).padStart(2, "0")}`;
+}
+
+export type TraceHeaders = {
+  traceparent: string;
+  tracestate?: string;
+};
+
+export interface ActiveTrace {
+  span: Span;
+  context: ReturnType<typeof import("@opentelemetry/api").context.active>;
+  startedAt: number;
+  sessionKey?: string;
+  channel?: string;
+  agentId?: string;
+}

--- a/extensions/diagnostics-otel/src/otel-utils.ts
+++ b/extensions/diagnostics-otel/src/otel-utils.ts
@@ -156,7 +156,7 @@ export type ResolvedCaptureContent = {
  * Resolve captureContent config to granular booleans.
  * - `true` → all enabled
  * - `false` / `undefined` → all disabled
- * - object → each field defaults to `true` if omitted (opt-out model)
+ * - object → strict opt-in per field (`true` required; omitted/undefined = disabled)
  */
 export function resolveCaptureContent(
   raw: boolean | Record<string, boolean | undefined> | undefined,
@@ -180,11 +180,11 @@ export function resolveCaptureContent(
     };
   }
   return {
-    inputMessages: raw.inputMessages !== false,
-    outputMessages: raw.outputMessages !== false,
-    systemInstructions: raw.systemInstructions !== false,
-    toolDefinitions: raw.toolDefinitions !== false,
-    toolContent: raw.toolContent !== false,
+    inputMessages: raw.inputMessages === true,
+    outputMessages: raw.outputMessages === true,
+    systemInstructions: raw.systemInstructions === true,
+    toolDefinitions: raw.toolDefinitions === true,
+    toolContent: raw.toolContent === true,
   };
 }
 

--- a/extensions/diagnostics-otel/src/service.metrics.test.ts
+++ b/extensions/diagnostics-otel/src/service.metrics.test.ts
@@ -129,7 +129,7 @@ describe("diagnostics-otel service – metrics & inference", () => {
 
   afterEach(async () => {
     for (const service of startedServices.splice(0)) {
-      await service.stop?.().catch(() => undefined);
+      await Promise.resolve(service.stop?.({} as never)).catch(() => undefined);
     }
   });
 
@@ -174,6 +174,7 @@ describe("diagnostics-otel service – metrics & inference", () => {
         error: vi.fn(),
         debug: vi.fn(),
       },
+      stateDir: "/tmp/openclaw-diagnostics-otel-test",
     };
   }
 
@@ -206,6 +207,7 @@ describe("diagnostics-otel service – metrics & inference", () => {
         error: vi.fn(),
         debug: vi.fn(),
       },
+      stateDir: "/tmp/openclaw-diagnostics-otel-test",
     });
 
     emitDiagnosticEvent({
@@ -283,7 +285,7 @@ describe("diagnostics-otel service – metrics & inference", () => {
     });
     expect(logEmit).toHaveBeenCalled();
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("model.inference records gen_ai.client.operation.duration in seconds", async () => {
@@ -308,7 +310,7 @@ describe("diagnostics-otel service – metrics & inference", () => {
       }),
     );
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("model.inference records gen_ai.client.token.usage split by input/output", async () => {
@@ -332,7 +334,7 @@ describe("diagnostics-otel service – metrics & inference", () => {
       expect.objectContaining({ "gen_ai.token.type": "output" }),
     );
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("maps provider names to gen_ai.provider.name enum values", async () => {
@@ -356,11 +358,11 @@ describe("diagnostics-otel service – metrics & inference", () => {
         model: "test-model",
         usage: { input: 10, output: 5, total: 15 },
       });
-      const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+      const attrs = (telemetryState.tracer.startSpan.mock.calls[0]?.[1] as any)?.attributes;
       expect(attrs?.["gen_ai.provider.name"]).toBe(expected);
     }
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("existing openclaw.* metrics are still emitted alongside gen_ai.*", async () => {
@@ -396,7 +398,7 @@ describe("diagnostics-otel service – metrics & inference", () => {
     ).toHaveBeenCalled();
     expect(telemetryState.histograms.get("gen_ai.client.token.usage")?.record).toHaveBeenCalled();
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("finish_reason length is recorded for truncated responses", async () => {
@@ -411,10 +413,10 @@ describe("diagnostics-otel service – metrics & inference", () => {
       usage: { input: 10000, output: 4096, total: 14096 },
     });
 
-    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    const attrs = (telemetryState.tracer.startSpan.mock.calls[0]?.[1] as any)?.attributes;
     expect(attrs["gen_ai.response.finish_reasons"]).toEqual(["length"]);
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("TTFT histogram is recorded and span attribute is set", async () => {
@@ -440,10 +442,10 @@ describe("diagnostics-otel service – metrics & inference", () => {
       }),
     );
 
-    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    const attrs = (telemetryState.tracer.startSpan.mock.calls[0]?.[1] as any)?.attributes;
     expect(attrs["gen_ai.client.time_to_first_token"]).toBe(350);
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("gen_ai.usage.input_tokens includes cache tokens even without promptTokens", async () => {
@@ -458,14 +460,14 @@ describe("diagnostics-otel service – metrics & inference", () => {
       durationMs: 4000,
     });
 
-    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    const attrs = (telemetryState.tracer.startSpan.mock.calls[0]?.[1] as any)?.attributes;
     // gen_ai.usage.input_tokens should be input + cacheRead + cacheWrite
     expect(attrs["gen_ai.usage.input_tokens"]).toBe(12 + 28976 + 295);
     expect(attrs["gen_ai.usage.output_tokens"]).toBe(57);
     // openclaw.tokens.input stays as raw input
     expect(attrs["openclaw.tokens.input"]).toBe(12);
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("gen_ai.usage.input_tokens uses promptTokens when available", async () => {
@@ -480,10 +482,10 @@ describe("diagnostics-otel service – metrics & inference", () => {
       durationMs: 4000,
     });
 
-    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    const attrs = (telemetryState.tracer.startSpan.mock.calls[0]?.[1] as any)?.attributes;
     expect(attrs["gen_ai.usage.input_tokens"]).toBe(29283);
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("error event creates span with ERROR status and error.type attribute", async () => {
@@ -506,7 +508,7 @@ describe("diagnostics-otel service – metrics & inference", () => {
     );
 
     // Check span attributes directly from the startSpan call
-    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    const attrs = (telemetryState.tracer.startSpan.mock.calls[0]?.[1] as any)?.attributes;
     expect(attrs).toBeDefined();
 
     // error attributes are set via setAttribute, not in initial attrs
@@ -522,6 +524,6 @@ describe("diagnostics-otel service – metrics & inference", () => {
       }),
     );
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 });

--- a/extensions/diagnostics-otel/src/service.metrics.test.ts
+++ b/extensions/diagnostics-otel/src/service.metrics.test.ts
@@ -1,0 +1,527 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const registerLogTransportMock = vi.hoisted(() => vi.fn());
+
+const telemetryState = vi.hoisted(() => {
+  const counters = new Map<string, { add: ReturnType<typeof vi.fn> }>();
+  const histograms = new Map<string, { record: ReturnType<typeof vi.fn> }>();
+  const tracer = {
+    startSpan: vi.fn((_name: string, _opts?: unknown, _parentCtx?: unknown) => ({
+      end: vi.fn(),
+      setStatus: vi.fn(),
+      setAttribute: vi.fn(),
+      _parentCtx: _parentCtx,
+    })),
+  };
+  const meter = {
+    createCounter: vi.fn((name: string) => {
+      const counter = { add: vi.fn() };
+      counters.set(name, counter);
+      return counter;
+    }),
+    createHistogram: vi.fn((name: string) => {
+      const histogram = { record: vi.fn() };
+      histograms.set(name, histogram);
+      return histogram;
+    }),
+  };
+  return { counters, histograms, tracer, meter };
+});
+
+const sdkStart = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const sdkShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const logEmit = vi.hoisted(() => vi.fn());
+const logShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+const mockRootContext = vi.hoisted(() => ({ _type: "root" }));
+
+vi.mock("@opentelemetry/api", () => ({
+  context: {
+    active: () => mockRootContext,
+  },
+  metrics: {
+    getMeter: () => telemetryState.meter,
+  },
+  trace: {
+    getTracer: () => telemetryState.tracer,
+    setSpan: (_ctx: unknown, span: unknown) => ({ _type: "with-parent", _span: span }),
+  },
+  SpanKind: {
+    INTERNAL: 0,
+    SERVER: 1,
+    CLIENT: 2,
+    PRODUCER: 3,
+    CONSUMER: 4,
+  },
+  SpanStatusCode: {
+    UNSET: 0,
+    OK: 1,
+    ERROR: 2,
+  },
+}));
+
+vi.mock("@opentelemetry/sdk-node", () => ({
+  NodeSDK: class {
+    start = sdkStart;
+    shutdown = sdkShutdown;
+  },
+}));
+
+vi.mock("@opentelemetry/exporter-metrics-otlp-http", () => ({
+  OTLPMetricExporter: class {},
+}));
+
+vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
+  OTLPTraceExporter: class {},
+}));
+
+vi.mock("@opentelemetry/exporter-logs-otlp-http", () => ({
+  OTLPLogExporter: class {},
+}));
+
+vi.mock("@opentelemetry/sdk-logs", () => ({
+  BatchLogRecordProcessor: class {},
+  LoggerProvider: class {
+    addLogRecordProcessor = vi.fn();
+    getLogger = vi.fn(() => ({
+      emit: logEmit,
+    }));
+    shutdown = logShutdown;
+  },
+}));
+
+vi.mock("@opentelemetry/sdk-metrics", () => ({
+  PeriodicExportingMetricReader: class {},
+}));
+
+vi.mock("@opentelemetry/sdk-trace-base", () => ({
+  ParentBasedSampler: class {},
+  TraceIdRatioBasedSampler: class {},
+}));
+
+vi.mock("@opentelemetry/resources", () => ({
+  resourceFromAttributes: vi.fn((attrs: Record<string, unknown>) => attrs),
+  Resource: class {
+    // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+    constructor(_value?: unknown) {}
+  },
+}));
+
+vi.mock("@opentelemetry/semantic-conventions", () => ({
+  SemanticResourceAttributes: {
+    SERVICE_NAME: "service.name",
+  },
+}));
+
+vi.mock("openclaw/plugin-sdk", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk")>("openclaw/plugin-sdk");
+  return {
+    ...actual,
+    registerLogTransport: registerLogTransportMock,
+  };
+});
+
+import { emitDiagnosticEvent } from "openclaw/plugin-sdk";
+import { createDiagnosticsOtelService } from "./service.js";
+
+describe("diagnostics-otel service – metrics & inference", () => {
+  const startedServices: Array<ReturnType<typeof createDiagnosticsOtelService>> = [];
+
+  afterEach(async () => {
+    for (const service of startedServices.splice(0)) {
+      await service.stop?.().catch(() => undefined);
+    }
+  });
+
+  beforeEach(() => {
+    telemetryState.counters.clear();
+    telemetryState.histograms.clear();
+    telemetryState.tracer.startSpan.mockClear();
+    telemetryState.meter.createCounter.mockClear();
+    telemetryState.meter.createHistogram.mockClear();
+    sdkStart.mockClear();
+    sdkShutdown.mockClear();
+    logEmit.mockClear();
+    logShutdown.mockClear();
+    registerLogTransportMock.mockReset();
+  });
+
+  function createService() {
+    const service = createDiagnosticsOtelService();
+    startedServices.push(service);
+    return service;
+  }
+
+  function createTestCtx(otelOverrides?: { captureContent?: boolean }) {
+    return {
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: "http://otel-collector:4318",
+            protocol: "http/protobuf" as const,
+            traces: true,
+            metrics: true,
+            logs: false,
+            ...otelOverrides,
+          },
+        },
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    };
+  }
+
+  test("records message-flow metrics and spans", async () => {
+    const registeredTransports: Array<(logObj: Record<string, unknown>) => void> = [];
+    const stopTransport = vi.fn();
+    registerLogTransportMock.mockImplementation((transport) => {
+      registeredTransports.push(transport);
+      return stopTransport;
+    });
+
+    const service = createService();
+    await service.start({
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: "http://otel-collector:4318",
+            protocol: "http/protobuf",
+            traces: true,
+            metrics: true,
+            logs: true,
+          },
+        },
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+
+    emitDiagnosticEvent({
+      type: "webhook.received",
+      channel: "telegram",
+      updateType: "telegram-post",
+    });
+    emitDiagnosticEvent({
+      type: "webhook.processed",
+      channel: "telegram",
+      updateType: "telegram-post",
+      durationMs: 120,
+    });
+    emitDiagnosticEvent({
+      type: "message.queued",
+      channel: "telegram",
+      source: "telegram",
+      sessionKey: "telegram:test-agent:123",
+      queueDepth: 2,
+    });
+    emitDiagnosticEvent({
+      type: "message.processed",
+      channel: "telegram",
+      sessionKey: "telegram:test-agent:123",
+      outcome: "completed",
+      durationMs: 55,
+    });
+    emitDiagnosticEvent({
+      type: "queue.lane.dequeue",
+      lane: "main",
+      queueSize: 3,
+      waitMs: 10,
+    });
+    emitDiagnosticEvent({
+      type: "session.stuck",
+      state: "processing",
+      ageMs: 125_000,
+    });
+    emitDiagnosticEvent({
+      type: "run.attempt",
+      runId: "run-1",
+      attempt: 2,
+    });
+
+    expect(telemetryState.counters.get("openclaw.webhook.received")?.add).toHaveBeenCalled();
+    expect(
+      telemetryState.histograms.get("openclaw.webhook.duration_ms")?.record,
+    ).toHaveBeenCalled();
+    expect(telemetryState.counters.get("openclaw.message.queued")?.add).toHaveBeenCalled();
+    expect(telemetryState.counters.get("openclaw.message.processed")?.add).toHaveBeenCalled();
+    expect(
+      telemetryState.histograms.get("openclaw.message.duration_ms")?.record,
+    ).toHaveBeenCalled();
+    expect(telemetryState.histograms.get("openclaw.queue.wait_ms")?.record).toHaveBeenCalled();
+    expect(telemetryState.counters.get("openclaw.session.stuck")?.add).toHaveBeenCalled();
+    expect(
+      telemetryState.histograms.get("openclaw.session.stuck_age_ms")?.record,
+    ).toHaveBeenCalled();
+    expect(telemetryState.counters.get("openclaw.run.attempt")?.add).toHaveBeenCalled();
+
+    const spanNames = telemetryState.tracer.startSpan.mock.calls.map((call) => call[0]);
+    expect(spanNames).toContain("openclaw.webhook.processed");
+    // message.processed no longer creates its own span — it ends the root
+    // trace span started by message.queued (nesting approach).
+    expect(spanNames).toContain("openclaw.message");
+    expect(spanNames).not.toContain("openclaw.message.processed");
+    expect(spanNames).toContain("openclaw.session.stuck");
+
+    expect(registerLogTransportMock).toHaveBeenCalledTimes(1);
+    expect(registeredTransports).toHaveLength(1);
+    registeredTransports[0]?.({
+      0: '{"subsystem":"diagnostic"}',
+      1: "hello",
+      _meta: { logLevelName: "INFO", date: new Date() },
+    });
+    expect(logEmit).toHaveBeenCalled();
+
+    await service.stop?.();
+  });
+
+  test("model.inference records gen_ai.client.operation.duration in seconds", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5-20250929",
+      usage: { input: 200, output: 100, total: 300 },
+      durationMs: 3200,
+    });
+
+    const histogram = telemetryState.histograms.get("gen_ai.client.operation.duration");
+    expect(histogram?.record).toHaveBeenCalledWith(
+      3.2,
+      expect.objectContaining({
+        "gen_ai.operation.name": "chat",
+        "gen_ai.provider.name": "anthropic",
+        "gen_ai.request.model": "claude-sonnet-4-5-20250929",
+      }),
+    );
+
+    await service.stop?.();
+  });
+
+  test("model.inference records gen_ai.client.token.usage split by input/output", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 500, output: 120, total: 620 },
+    });
+
+    const histogram = telemetryState.histograms.get("gen_ai.client.token.usage");
+    expect(histogram?.record).toHaveBeenCalledWith(
+      500,
+      expect.objectContaining({ "gen_ai.token.type": "input" }),
+    );
+    expect(histogram?.record).toHaveBeenCalledWith(
+      120,
+      expect.objectContaining({ "gen_ai.token.type": "output" }),
+    );
+
+    await service.stop?.();
+  });
+
+  test("maps provider names to gen_ai.provider.name enum values", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    const cases = [
+      { input: "orq", expected: "openai" },
+      { input: "anthropic", expected: "anthropic" },
+      { input: "google-gemini", expected: "gcp.gemini" },
+      { input: "aws-bedrock", expected: "aws.bedrock" },
+      { input: "mistral", expected: "mistral_ai" },
+      { input: "some-custom-provider", expected: "some-custom-provider" },
+    ];
+
+    for (const { input, expected } of cases) {
+      telemetryState.tracer.startSpan.mockClear();
+      emitDiagnosticEvent({
+        type: "model.inference",
+        provider: input,
+        model: "test-model",
+        usage: { input: 10, output: 5, total: 15 },
+      });
+      const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+      expect(attrs?.["gen_ai.provider.name"]).toBe(expected);
+    }
+
+    await service.stop?.();
+  });
+
+  test("existing openclaw.* metrics are still emitted alongside gen_ai.*", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "run.completed",
+      runId: "run-metrics-1",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 100, output: 50, total: 150 },
+      durationMs: 2000,
+      costUsd: 0.005,
+    });
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 100, output: 50, total: 150 },
+      durationMs: 2000,
+    });
+
+    // Existing openclaw metrics still work
+    expect(telemetryState.counters.get("openclaw.tokens")?.add).toHaveBeenCalled();
+    expect(telemetryState.counters.get("openclaw.cost.usd")?.add).toHaveBeenCalled();
+    expect(telemetryState.histograms.get("openclaw.run.duration_ms")?.record).toHaveBeenCalled();
+
+    // New gen_ai metrics also emitted
+    expect(
+      telemetryState.histograms.get("gen_ai.client.operation.duration")?.record,
+    ).toHaveBeenCalled();
+    expect(telemetryState.histograms.get("gen_ai.client.token.usage")?.record).toHaveBeenCalled();
+
+    await service.stop?.();
+  });
+
+  test("finish_reason length is recorded for truncated responses", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      finishReasons: ["length"],
+      usage: { input: 10000, output: 4096, total: 14096 },
+    });
+
+    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    expect(attrs["gen_ai.response.finish_reasons"]).toEqual(["length"]);
+
+    await service.stop?.();
+  });
+
+  test("TTFT histogram is recorded and span attribute is set", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 100, output: 50, total: 150 },
+      durationMs: 2000,
+      ttftMs: 350,
+    });
+
+    const histogram = telemetryState.histograms.get("gen_ai.client.time_to_first_token");
+    expect(histogram?.record).toHaveBeenCalledWith(
+      0.35,
+      expect.objectContaining({
+        "gen_ai.operation.name": "chat",
+        "gen_ai.provider.name": "openai",
+        "gen_ai.request.model": "gpt-5.2",
+      }),
+    );
+
+    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    expect(attrs["gen_ai.client.time_to_first_token"]).toBe(350);
+
+    await service.stop?.();
+  });
+
+  test("gen_ai.usage.input_tokens includes cache tokens even without promptTokens", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5-20250929",
+      usage: { input: 12, output: 57, cacheRead: 28976, cacheWrite: 295 },
+      durationMs: 4000,
+    });
+
+    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    // gen_ai.usage.input_tokens should be input + cacheRead + cacheWrite
+    expect(attrs["gen_ai.usage.input_tokens"]).toBe(12 + 28976 + 295);
+    expect(attrs["gen_ai.usage.output_tokens"]).toBe(57);
+    // openclaw.tokens.input stays as raw input
+    expect(attrs["openclaw.tokens.input"]).toBe(12);
+
+    await service.stop?.();
+  });
+
+  test("gen_ai.usage.input_tokens uses promptTokens when available", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5-20250929",
+      usage: { input: 12, output: 57, cacheRead: 28976, cacheWrite: 295, promptTokens: 29283 },
+      durationMs: 4000,
+    });
+
+    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    expect(attrs["gen_ai.usage.input_tokens"]).toBe(29283);
+
+    await service.stop?.();
+  });
+
+  test("error event creates span with ERROR status and error.type attribute", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {},
+      durationMs: 500,
+      error: "Context window exceeded",
+      errorType: "context_overflow",
+    });
+
+    const span = telemetryState.tracer.startSpan.mock.results[0]?.value;
+    expect(span.setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 2, message: "Context window exceeded" }),
+    );
+
+    // Check span attributes directly from the startSpan call
+    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    expect(attrs).toBeDefined();
+
+    // error attributes are set via setAttribute, not in initial attrs
+    // Verify setAttribute was called (the mock span tracks these calls)
+    expect(span.setStatus).toHaveBeenCalled();
+
+    // Verify error counter metric
+    const errorCounter = telemetryState.counters.get("openclaw.inference.error");
+    expect(errorCounter?.add).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        "error.type": "context_overflow",
+      }),
+    );
+
+    await service.stop?.();
+  });
+});

--- a/extensions/diagnostics-otel/src/service.spans.test.ts
+++ b/extensions/diagnostics-otel/src/service.spans.test.ts
@@ -1,0 +1,612 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const registerLogTransportMock = vi.hoisted(() => vi.fn());
+
+const telemetryState = vi.hoisted(() => {
+  const counters = new Map<string, { add: ReturnType<typeof vi.fn> }>();
+  const histograms = new Map<string, { record: ReturnType<typeof vi.fn> }>();
+  const tracer = {
+    startSpan: vi.fn((_name: string, _opts?: unknown, _parentCtx?: unknown) => ({
+      end: vi.fn(),
+      setStatus: vi.fn(),
+      setAttribute: vi.fn(),
+      _parentCtx: _parentCtx,
+    })),
+  };
+  const meter = {
+    createCounter: vi.fn((name: string) => {
+      const counter = { add: vi.fn() };
+      counters.set(name, counter);
+      return counter;
+    }),
+    createHistogram: vi.fn((name: string) => {
+      const histogram = { record: vi.fn() };
+      histograms.set(name, histogram);
+      return histogram;
+    }),
+  };
+  return { counters, histograms, tracer, meter };
+});
+
+const sdkStart = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const sdkShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const logEmit = vi.hoisted(() => vi.fn());
+const logShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+const mockRootContext = vi.hoisted(() => ({ _type: "root" }));
+
+vi.mock("@opentelemetry/api", () => ({
+  context: {
+    active: () => mockRootContext,
+  },
+  metrics: {
+    getMeter: () => telemetryState.meter,
+  },
+  trace: {
+    getTracer: () => telemetryState.tracer,
+    setSpan: (_ctx: unknown, span: unknown) => ({ _type: "with-parent", _span: span }),
+  },
+  SpanKind: {
+    INTERNAL: 0,
+    SERVER: 1,
+    CLIENT: 2,
+    PRODUCER: 3,
+    CONSUMER: 4,
+  },
+  SpanStatusCode: {
+    UNSET: 0,
+    OK: 1,
+    ERROR: 2,
+  },
+}));
+
+vi.mock("@opentelemetry/sdk-node", () => ({
+  NodeSDK: class {
+    start = sdkStart;
+    shutdown = sdkShutdown;
+  },
+}));
+
+vi.mock("@opentelemetry/exporter-metrics-otlp-http", () => ({
+  OTLPMetricExporter: class {},
+}));
+
+vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
+  OTLPTraceExporter: class {},
+}));
+
+vi.mock("@opentelemetry/exporter-logs-otlp-http", () => ({
+  OTLPLogExporter: class {},
+}));
+
+vi.mock("@opentelemetry/sdk-logs", () => ({
+  BatchLogRecordProcessor: class {},
+  LoggerProvider: class {
+    addLogRecordProcessor = vi.fn();
+    getLogger = vi.fn(() => ({
+      emit: logEmit,
+    }));
+    shutdown = logShutdown;
+  },
+}));
+
+vi.mock("@opentelemetry/sdk-metrics", () => ({
+  PeriodicExportingMetricReader: class {},
+}));
+
+vi.mock("@opentelemetry/sdk-trace-base", () => ({
+  ParentBasedSampler: class {},
+  TraceIdRatioBasedSampler: class {},
+}));
+
+vi.mock("@opentelemetry/resources", () => ({
+  resourceFromAttributes: vi.fn((attrs: Record<string, unknown>) => attrs),
+  Resource: class {
+    // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+    constructor(_value?: unknown) {}
+  },
+}));
+
+vi.mock("@opentelemetry/semantic-conventions", () => ({
+  SemanticResourceAttributes: {
+    SERVICE_NAME: "service.name",
+  },
+}));
+
+vi.mock("openclaw/plugin-sdk", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk")>("openclaw/plugin-sdk");
+  return {
+    ...actual,
+    registerLogTransport: registerLogTransportMock,
+  };
+});
+
+import { emitDiagnosticEvent } from "openclaw/plugin-sdk";
+import { createDiagnosticsOtelService } from "./service.js";
+
+describe("diagnostics-otel service – span hierarchy", () => {
+  const startedServices: Array<ReturnType<typeof createDiagnosticsOtelService>> = [];
+
+  afterEach(async () => {
+    for (const service of startedServices.splice(0)) {
+      await service.stop?.().catch(() => undefined);
+    }
+  });
+
+  beforeEach(() => {
+    telemetryState.counters.clear();
+    telemetryState.histograms.clear();
+    telemetryState.tracer.startSpan.mockClear();
+    telemetryState.meter.createCounter.mockClear();
+    telemetryState.meter.createHistogram.mockClear();
+    sdkStart.mockClear();
+    sdkShutdown.mockClear();
+    logEmit.mockClear();
+    logShutdown.mockClear();
+    registerLogTransportMock.mockReset();
+  });
+
+  function createService() {
+    const service = createDiagnosticsOtelService();
+    startedServices.push(service);
+    return service;
+  }
+
+  function createTestCtx(otelOverrides?: { captureContent?: boolean }) {
+    return {
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: "http://otel-collector:4318",
+            protocol: "http/protobuf" as const,
+            traces: true,
+            metrics: true,
+            logs: false,
+            ...otelOverrides,
+          },
+        },
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    };
+  }
+
+  test("run.completed emits gen_ai.* span attributes alongside openclaw.*", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "run.completed",
+      runId: "run-usage-1",
+      channel: "webchat",
+      provider: "openai",
+      model: "gpt-5.2",
+      operationName: "chat",
+      responseId: "chatcmpl-abc123",
+      responseModel: "gpt-5.2-2025-06-01",
+      finishReasons: ["stop"],
+      sessionKey: "agent:main:main",
+      sessionId: "sess-001",
+      usage: {
+        input: 100,
+        output: 50,
+        cacheRead: 80,
+        cacheWrite: 0,
+        promptTokens: 180,
+        total: 230,
+      },
+      durationMs: 1500,
+    });
+
+    const spanCall = telemetryState.tracer.startSpan.mock.calls[0];
+    expect(spanCall[0]).toBe("invoke_agent");
+
+    const attrs = spanCall[1]?.attributes;
+    // gen_ai.* inference attributes should NOT be on the turn span —
+    // they belong on child chat spans only.
+    // gen_ai.operation.name IS set on the turn span (as "invoke_agent" per agent spec).
+    expect(attrs["gen_ai.operation.name"]).toBe("invoke_agent");
+    expect(attrs["gen_ai.provider.name"]).toBe("openai");
+    expect(attrs["gen_ai.request.model"]).toBeUndefined();
+    expect(attrs["gen_ai.response.id"]).toBeUndefined();
+    expect(attrs["gen_ai.response.model"]).toBeUndefined();
+    expect(attrs["gen_ai.response.finish_reasons"]).toBeUndefined();
+    // conversation.id is kept as it's a session-level attribute
+    expect(attrs["gen_ai.conversation.id"]).toBe("sess-001");
+
+    // gen_ai.agent.* identity attributes
+    expect(attrs["gen_ai.agent.id"]).toBe("main");
+    expect(attrs["gen_ai.agent.name"]).toBeUndefined(); // no identity configured
+
+    // openclaw.* envelope attributes preserved
+    expect(attrs["openclaw.channel"]).toBe("webchat");
+    expect(attrs["openclaw.provider"]).toBe("openai");
+    expect(attrs["openclaw.model"]).toBe("gpt-5.2");
+    expect(attrs["openclaw.tokens.input"]).toBe(100);
+    expect(attrs["openclaw.tokens.output"]).toBe(50);
+    expect(attrs["openclaw.tokens.cache_read"]).toBe(80);
+    // gen_ai.usage.* token attributes should NOT be on the turn span
+    expect(attrs["gen_ai.usage.cache_read.input_tokens"]).toBeUndefined();
+    expect(attrs["gen_ai.usage.cache_creation.input_tokens"]).toBeUndefined();
+    expect(attrs["gen_ai.usage.input_tokens"]).toBeUndefined();
+    expect(attrs["gen_ai.usage.output_tokens"]).toBeUndefined();
+
+    await service.stop?.();
+  });
+
+  test("model.inference spans are children of run.started span when runId is present", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-1",
+      sessionId: "sess-1",
+    });
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      runId: "run-1",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 20, output: 10, total: 30 },
+      durationMs: 100,
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    expect(calls[0]?.[0]).toBe("invoke_agent");
+    expect(calls[1]?.[0]).toBe("chat gpt-5.2");
+    expect(calls[1]?.[2]).toEqual(expect.objectContaining({ _type: "with-parent" }));
+
+    await service.stop?.();
+  });
+
+  test("inference spans use SpanKind.CLIENT, tool spans use SpanKind.INTERNAL", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 10, output: 5, total: 15 },
+    });
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      toolName: "web_search",
+      durationMs: 200,
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    // SpanKind.CLIENT = 2, SpanKind.INTERNAL = 0
+    expect(calls[0][1]?.kind).toBe(2);
+    expect(calls[1][1]?.kind).toBe(0);
+
+    await service.stop?.();
+  });
+
+  test("tool spans with matching runId are children of the run span", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-parent-child",
+      sessionId: "sess-1",
+    });
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      runId: "run-parent-child",
+      toolName: "web_search",
+      toolType: "function",
+      toolCallId: "call-1",
+      durationMs: 200,
+    });
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      runId: "run-parent-child",
+      toolName: "read",
+      toolType: "function",
+      toolCallId: "call-2",
+      durationMs: 50,
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    // 3 spans: 1 run parent + 2 child tool spans
+    expect(calls).toHaveLength(3);
+
+    // First call is the run span
+    expect(calls[0][0]).toBe("invoke_agent");
+    const parentSpan = telemetryState.tracer.startSpan.mock.results[0]?.value;
+
+    // Tool spans should have been created with a parent context derived from the run span
+    expect(calls[1][0]).toBe("execute_tool web_search");
+    const toolParentCtx1 = calls[1][2] as { _type: string; _span: unknown };
+    expect(toolParentCtx1._type).toBe("with-parent");
+    expect(toolParentCtx1._span).toBe(parentSpan);
+
+    expect(calls[2][0]).toBe("execute_tool read");
+    const toolParentCtx2 = calls[2][2] as { _type: string; _span: unknown };
+    expect(toolParentCtx2._type).toBe("with-parent");
+    expect(toolParentCtx2._span).toBe(parentSpan);
+
+    // Tool spans end immediately; the run span stays open until run.completed.
+    expect(parentSpan.end).not.toHaveBeenCalled();
+    expect(telemetryState.tracer.startSpan.mock.results[1]?.value.end).toHaveBeenCalled();
+    expect(telemetryState.tracer.startSpan.mock.results[2]?.value.end).toHaveBeenCalled();
+
+    await service.stop?.();
+  });
+
+  test("tool spans with matching runId are children of the active inference span when present", async () => {
+    const service = createService();
+    await service.start(createTestCtx({ captureContent: true }));
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-tool-parent-1",
+      sessionId: "sess-1",
+    });
+
+    emitDiagnosticEvent({
+      type: "model.inference.started",
+      runId: "run-tool-parent-1",
+      callIndex: 0,
+      provider: "openai",
+      model: "gpt-5.2",
+      inputMessages: [{ role: "user" as const, parts: [{ type: "text" as const, content: "hi" }] }],
+    });
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      runId: "run-tool-parent-1",
+      toolName: "web_search",
+      toolType: "function",
+      toolCallId: "call-1",
+      durationMs: 200,
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    const inferenceSpan = telemetryState.tracer.startSpan.mock.results.find(
+      (r, idx) => calls[idx]?.[0] === "chat gpt-5.2",
+    )?.value;
+    expect(inferenceSpan).toBeDefined();
+
+    const toolCall = calls.find((c) => c[0] === "execute_tool web_search");
+    expect(toolCall).toBeDefined();
+    const toolParentCtx = toolCall?.[2] as { _type: string; _span: unknown };
+    expect(toolParentCtx._type).toBe("with-parent");
+    expect(toolParentCtx._span).toBe(inferenceSpan);
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      runId: "run-tool-parent-1",
+      callIndex: 0,
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 10, output: 5, total: 15 },
+      outputMessages: [
+        { role: "assistant" as const, parts: [{ type: "text" as const, content: "ok" }] },
+      ],
+    });
+
+    await service.stop?.();
+  });
+
+  test("tool events without runId create standalone spans (backward compat)", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      toolName: "exec",
+      toolType: "function",
+      toolCallId: "call-no-run",
+      durationMs: 100,
+    });
+
+    // Span should be created immediately (no buffering)
+    expect(telemetryState.tracer.startSpan).toHaveBeenCalledTimes(1);
+    expect(telemetryState.tracer.startSpan.mock.calls[0][0]).toBe("execute_tool exec");
+    // No parent context
+    expect(telemetryState.tracer.startSpan.mock.calls[0][2]).toBeUndefined();
+
+    await service.stop?.();
+  });
+
+  test("tool events with runId but without run.started are standalone spans", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      runId: "run-orphaned",
+      toolName: "web_search",
+      durationMs: 200,
+    });
+
+    // Tool span should be created immediately without a parent
+    expect(telemetryState.tracer.startSpan).toHaveBeenCalledTimes(1);
+    expect(telemetryState.tracer.startSpan.mock.calls[0][0]).toBe("execute_tool web_search");
+    expect(telemetryState.tracer.startSpan.mock.calls[0][2]).toBeUndefined();
+
+    await service.stop?.();
+  });
+
+  test("agent.turn spans are nested under openclaw.message root span", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "message.queued",
+      channel: "telegram",
+      source: "telegram",
+      sessionKey: "telegram:agent:123",
+      queueDepth: 1,
+    });
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-nested-1",
+      sessionId: "sess-nested-1",
+      sessionKey: "telegram:agent:123",
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    expect(calls[0]?.[0]).toBe("openclaw.message");
+    expect(calls[1]?.[0]).toBe("invoke_agent");
+    // agent.turn should have a parent context pointing to the root span
+    expect(calls[1]?.[2]).toEqual(expect.objectContaining({ _type: "with-parent" }));
+
+    await service.stop?.();
+  });
+
+  test("agent span includes gen_ai.agent.name when identity is configured", async () => {
+    const service = createService();
+    await service.start({
+      ...createTestCtx(),
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: "http://otel-collector:4318",
+            protocol: "http/protobuf" as const,
+            traces: true,
+            metrics: true,
+          },
+        },
+        agents: {
+          list: [{ id: "main", workspace: "/tmp", identity: { name: "Samantha" } }],
+        },
+      },
+    });
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-identity-1",
+      sessionKey: "agent:main:telegram:group:123",
+      sessionId: "sess-identity",
+      channel: "telegram",
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    expect(calls[0]?.[0]).toBe("invoke_agent Samantha");
+    const attrs = calls[0]?.[1]?.attributes;
+    expect(attrs["gen_ai.agent.id"]).toBe("main");
+    expect(attrs["gen_ai.agent.name"]).toBe("Samantha");
+    expect(attrs["gen_ai.operation.name"]).toBe("invoke_agent");
+
+    await service.stop?.();
+  });
+
+  test("agent span uses agentId from subagent sessionKey", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "run.started",
+      runId: "run-sub-1",
+      sessionKey: "agent:helper:subagent:550e8400-e29b-41d4-a716-446655440000",
+      sessionId: "sess-sub",
+      channel: "telegram",
+    });
+
+    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    expect(attrs["gen_ai.agent.id"]).toBe("helper");
+    expect(attrs["gen_ai.operation.name"]).toBe("invoke_agent");
+
+    await service.stop?.();
+  });
+
+  test("message.processed ends the root span and sets attributes", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "message.queued",
+      channel: "telegram",
+      source: "telegram",
+      sessionKey: "telegram:agent:456",
+      queueDepth: 1,
+    });
+
+    const rootSpan = telemetryState.tracer.startSpan.mock.results[0]?.value;
+    expect(rootSpan).toBeDefined();
+
+    emitDiagnosticEvent({
+      type: "message.processed",
+      channel: "telegram",
+      sessionKey: "telegram:agent:456",
+      outcome: "completed",
+      durationMs: 250,
+      messageId: "msg-001",
+    });
+
+    expect(rootSpan.setAttribute).toHaveBeenCalledWith("openclaw.outcome", "completed");
+    expect(rootSpan.setAttribute).toHaveBeenCalledWith("openclaw.durationMs", 250);
+    expect(rootSpan.setAttribute).toHaveBeenCalledWith("openclaw.messageId", "msg-001");
+    expect(rootSpan.setStatus).toHaveBeenCalledWith({ code: 1 }); // SpanStatusCode.OK
+    expect(rootSpan.end).toHaveBeenCalled();
+
+    await service.stop?.();
+  });
+
+  test("message.processed sets ERROR status on error outcome", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "message.queued",
+      channel: "telegram",
+      source: "telegram",
+      sessionKey: "telegram:agent:789",
+      queueDepth: 1,
+    });
+
+    const rootSpan = telemetryState.tracer.startSpan.mock.results[0]?.value;
+
+    emitDiagnosticEvent({
+      type: "message.processed",
+      channel: "telegram",
+      sessionKey: "telegram:agent:789",
+      outcome: "error",
+      error: "Model timeout",
+    });
+
+    expect(rootSpan.setStatus).toHaveBeenCalledWith({
+      code: 2, // SpanStatusCode.ERROR
+      message: "Model timeout",
+    });
+    expect(rootSpan.end).toHaveBeenCalled();
+
+    await service.stop?.();
+  });
+
+  test("message.processed without matching message.queued does not crash", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    // No message.queued emitted — should not throw
+    emitDiagnosticEvent({
+      type: "message.processed",
+      channel: "telegram",
+      sessionKey: "telegram:agent:unknown",
+      outcome: "completed",
+    });
+
+    // Only metrics should be recorded, no span created
+    expect(telemetryState.counters.get("openclaw.message.processed")?.add).toHaveBeenCalled();
+    expect(telemetryState.tracer.startSpan).not.toHaveBeenCalled();
+
+    await service.stop?.();
+  });
+});

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const registerLogTransportMock = vi.hoisted(() => vi.fn());
 
@@ -6,9 +6,11 @@ const telemetryState = vi.hoisted(() => {
   const counters = new Map<string, { add: ReturnType<typeof vi.fn> }>();
   const histograms = new Map<string, { record: ReturnType<typeof vi.fn> }>();
   const tracer = {
-    startSpan: vi.fn((_name: string, _opts?: unknown) => ({
+    startSpan: vi.fn((_name: string, _opts?: unknown, _parentCtx?: unknown) => ({
       end: vi.fn(),
       setStatus: vi.fn(),
+      setAttribute: vi.fn(),
+      _parentCtx: _parentCtx,
     })),
   };
   const meter = {
@@ -32,14 +34,29 @@ const logEmit = vi.hoisted(() => vi.fn());
 const logShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const traceExporterCtor = vi.hoisted(() => vi.fn());
 
+const mockRootContext = vi.hoisted(() => ({ _type: "root" }));
+
 vi.mock("@opentelemetry/api", () => ({
+  context: {
+    active: () => mockRootContext,
+  },
   metrics: {
     getMeter: () => telemetryState.meter,
   },
   trace: {
     getTracer: () => telemetryState.tracer,
+    setSpan: (_ctx: unknown, span: unknown) => ({ _type: "with-parent", _span: span }),
+  },
+  SpanKind: {
+    INTERNAL: 0,
+    SERVER: 1,
+    CLIENT: 2,
+    PRODUCER: 3,
+    CONSUMER: 4,
   },
   SpanStatusCode: {
+    UNSET: 0,
+    OK: 1,
     ERROR: 2,
   },
 }));
@@ -51,11 +68,11 @@ vi.mock("@opentelemetry/sdk-node", () => ({
   },
 }));
 
-vi.mock("@opentelemetry/exporter-metrics-otlp-proto", () => ({
+vi.mock("@opentelemetry/exporter-metrics-otlp-http", () => ({
   OTLPMetricExporter: class {},
 }));
 
-vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => ({
+vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
   OTLPTraceExporter: class {
     constructor(options?: unknown) {
       traceExporterCtor(options);
@@ -63,7 +80,7 @@ vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => ({
   },
 }));
 
-vi.mock("@opentelemetry/exporter-logs-otlp-proto", () => ({
+vi.mock("@opentelemetry/exporter-logs-otlp-http", () => ({
   OTLPLogExporter: class {},
 }));
 
@@ -110,10 +127,6 @@ import type { OpenClawPluginServiceContext } from "openclaw/plugin-sdk";
 import { emitDiagnosticEvent } from "openclaw/plugin-sdk";
 import { createDiagnosticsOtelService } from "./service.js";
 
-const OTEL_TEST_STATE_DIR = "/tmp/openclaw-diagnostics-otel-test";
-const OTEL_TEST_ENDPOINT = "http://otel-collector:4318";
-const OTEL_TEST_PROTOCOL = "http/protobuf";
-
 function createLogger() {
   return {
     info: vi.fn(),
@@ -122,6 +135,10 @@ function createLogger() {
     debug: vi.fn(),
   };
 }
+
+const OTEL_TEST_STATE_DIR = "/tmp/openclaw-diagnostics-otel-test";
+const OTEL_TEST_ENDPOINT = "http://otel-collector:4318";
+const OTEL_TEST_PROTOCOL = "http/protobuf";
 
 type OtelContextFlags = {
   traces?: boolean;
@@ -274,46 +291,6 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
-  test("appends signal path when endpoint contains non-signal /v1 segment", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createTraceOnlyContext("https://www.comet.com/opik/api/v1/private/otel");
-    await service.start(ctx);
-
-    const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
-    expect(options?.url).toBe("https://www.comet.com/opik/api/v1/private/otel/v1/traces");
-    await service.stop?.(ctx);
-  });
-
-  test("keeps already signal-qualified endpoint unchanged", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createTraceOnlyContext("https://collector.example.com/v1/traces");
-    await service.start(ctx);
-
-    const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
-    expect(options?.url).toBe("https://collector.example.com/v1/traces");
-    await service.stop?.(ctx);
-  });
-
-  test("keeps signal-qualified endpoint unchanged when it has query params", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createTraceOnlyContext("https://collector.example.com/v1/traces?timeout=30s");
-    await service.start(ctx);
-
-    const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
-    expect(options?.url).toBe("https://collector.example.com/v1/traces?timeout=30s");
-    await service.stop?.(ctx);
-  });
-
-  test("keeps signal-qualified endpoint unchanged when signal path casing differs", async () => {
-    const service = createDiagnosticsOtelService();
-    const ctx = createTraceOnlyContext("https://collector.example.com/v1/Traces");
-    await service.start(ctx);
-
-    const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
-    expect(options?.url).toBe("https://collector.example.com/v1/Traces");
-    await service.stop?.(ctx);
-  });
-
   test("redacts sensitive data from log messages before export", async () => {
     const emitCall = await emitAndCaptureLog({
       0: "Using API key sk-1234567890abcdef1234567890abcdef",
@@ -362,6 +339,360 @@ describe("diagnostics-otel service", () => {
     expect(String(attrs?.["openclaw.reason"])).not.toContain(
       "ghp_abcdefghijklmnopqrstuvwxyz123456",
     );
+    await service.stop?.(ctx);
+  });
+});
+
+describe("diagnostics-otel service – content capture & tools", () => {
+  const startedServices: Array<ReturnType<typeof createDiagnosticsOtelService>> = [];
+
+  afterEach(async () => {
+    for (const service of startedServices.splice(0)) {
+      await service.stop?.({} as never).catch(() => undefined);
+    }
+  });
+
+  beforeEach(() => {
+    telemetryState.counters.clear();
+    telemetryState.histograms.clear();
+    telemetryState.tracer.startSpan.mockClear();
+    telemetryState.meter.createCounter.mockClear();
+    telemetryState.meter.createHistogram.mockClear();
+    sdkStart.mockClear();
+    sdkShutdown.mockClear();
+    logEmit.mockClear();
+    logShutdown.mockClear();
+    traceExporterCtor.mockClear();
+    registerLogTransportMock.mockReset();
+  });
+
+  function createService() {
+    const service = createDiagnosticsOtelService();
+    startedServices.push(service);
+    return service;
+  }
+
+  function createTestCtx(otelOverrides?: { captureContent?: boolean }) {
+    return {
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: "http://otel-collector:4318",
+            protocol: "http/protobuf" as const,
+            traces: true,
+            metrics: true,
+            logs: false,
+            ...otelOverrides,
+          },
+        },
+      },
+      logger: createLogger(),
+      stateDir: "/tmp/openclaw-diagnostics-otel-test",
+    };
+  }
+
+  test("records gen_ai.input.messages when captureContent is enabled", async () => {
+    const service = createService();
+    await service.start(createTestCtx({ captureContent: true }));
+
+    const inputMessages = [
+      {
+        role: "user" as const,
+        parts: [{ type: "text" as const, content: "Hello" }],
+      },
+    ];
+    const outputMessages = [
+      {
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, content: "Hi there!" }],
+        finish_reason: "stop",
+      },
+    ];
+
+    emitDiagnosticEvent({
+      type: "model.inference.started",
+      runId: "run-cap-1",
+      provider: "openai",
+      model: "gpt-5.2",
+      inputMessages,
+    });
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      runId: "run-cap-1",
+      callIndex: 0,
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 10, output: 5, total: 15 },
+      outputMessages,
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    const inferenceCall = calls.find((c) => c[0] === "chat gpt-5.2");
+    expect(inferenceCall).toBeDefined();
+    const attrs = inferenceCall?.[1]?.attributes as Record<string, unknown>;
+    expect(attrs["gen_ai.input.messages"]).toBe(JSON.stringify(inputMessages));
+
+    const span = telemetryState.tracer.startSpan.mock.results.find(
+      (r, idx) => telemetryState.tracer.startSpan.mock.calls[idx]?.[0] === "chat gpt-5.2",
+    )?.value;
+    expect(span.setAttribute).toHaveBeenCalledWith(
+      "gen_ai.output.messages",
+      JSON.stringify(outputMessages),
+    );
+
+    await service.stop?.();
+  });
+
+  test("does NOT record gen_ai.input.messages when captureContent is disabled", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "model.inference.started",
+      runId: "run-cap-2",
+      provider: "openai",
+      model: "gpt-5.2",
+      inputMessages: [
+        { role: "user" as const, parts: [{ type: "text" as const, content: "secret" }] },
+      ],
+    });
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      runId: "run-cap-2",
+      callIndex: 0,
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 10, output: 5, total: 15 },
+      outputMessages: [
+        { role: "assistant" as const, parts: [{ type: "text" as const, content: "x" }] },
+      ],
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    const inferenceCall = calls.find((c) => c[0] === "chat gpt-5.2");
+    const attrs = inferenceCall?.[1]?.attributes as Record<string, unknown>;
+    expect(attrs["gen_ai.input.messages"]).toBeUndefined();
+
+    await service.stop?.();
+  });
+
+  test("input messages with media parts use correct modality and type", async () => {
+    const service = createService();
+    await service.start(createTestCtx({ captureContent: true }));
+
+    const inputMessages = [
+      {
+        role: "user" as const,
+        parts: [
+          { type: "text" as const, content: "What's in this image?" },
+          {
+            type: "uri" as const,
+            modality: "image" as const,
+            mime_type: "image/png",
+            uri: "https://example.com/photo.png",
+          },
+        ],
+      },
+    ];
+
+    emitDiagnosticEvent({
+      type: "model.inference.started",
+      runId: "run-media-1",
+      provider: "openai",
+      model: "gpt-5.2",
+      inputMessages,
+    });
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      runId: "run-media-1",
+      callIndex: 0,
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 500, output: 50, total: 550 },
+      outputMessages: [
+        { role: "assistant" as const, parts: [{ type: "text" as const, content: "x" }] },
+      ],
+    });
+
+    const calls = telemetryState.tracer.startSpan.mock.calls;
+    const inferenceCall = calls.find((c) => c[0] === "chat gpt-5.2");
+    const attrs = inferenceCall?.[1]?.attributes as Record<string, unknown>;
+    const parsed = JSON.parse(attrs["gen_ai.input.messages"] as string);
+    expect(parsed[0].parts).toHaveLength(2);
+    expect(parsed[0].parts[0].type).toBe("text");
+    expect(parsed[0].parts[1].type).toBe("uri");
+    expect(parsed[0].parts[1].modality).toBe("image");
+    expect(parsed[0].parts[1].mime_type).toBe("image/png");
+
+    await service.stop?.();
+  });
+
+  test("output messages with tool_call parts are recorded correctly", async () => {
+    const service = createService();
+    await service.start(createTestCtx({ captureContent: true }));
+
+    const outputMessages = [
+      {
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool_call" as const,
+            id: "call_abc",
+            name: "get_weather",
+            arguments: { location: "Paris" },
+          },
+        ],
+        finish_reason: "tool_call",
+      },
+    ];
+
+    emitDiagnosticEvent({
+      type: "model.inference",
+      provider: "openai",
+      model: "gpt-5.2",
+      finishReasons: ["tool_call"],
+      usage: { input: 100, output: 20, total: 120 },
+      outputMessages,
+    });
+
+    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    expect(attrs["gen_ai.response.finish_reasons"]).toEqual(["tool_call"]);
+    const parsed = JSON.parse(attrs["gen_ai.output.messages"] as string);
+    expect(parsed[0].parts[0].type).toBe("tool_call");
+    expect(parsed[0].parts[0].name).toBe("get_weather");
+    expect(parsed[0].finish_reason).toBe("tool_call");
+
+    await service.stop?.();
+  });
+
+  test("tool.execution emits execute_tool span with gen_ai.tool.* attributes", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      toolName: "web_search",
+      toolType: "function",
+      toolCallId: "call_xyz",
+      channel: "webchat",
+      durationMs: 850,
+    });
+
+    const spanCall = telemetryState.tracer.startSpan.mock.calls[0];
+    expect(spanCall[0]).toBe("execute_tool web_search");
+
+    const attrs = spanCall[1]?.attributes;
+    expect(attrs["gen_ai.operation.name"]).toBe("execute_tool");
+    expect(attrs["gen_ai.tool.name"]).toBe("web_search");
+    expect(attrs["gen_ai.tool.type"]).toBe("function");
+    expect(attrs["gen_ai.tool.call.id"]).toBe("call_xyz");
+    expect(attrs["openclaw.channel"]).toBe("webchat");
+
+    await service.stop?.();
+  });
+
+  test("tool.execution with error sets ERROR span status", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "tool.execution",
+      toolName: "exec",
+      toolCallId: "call_err",
+      durationMs: 100,
+      error: "timeout",
+    });
+
+    const span = telemetryState.tracer.startSpan.mock.results[0]?.value;
+    expect(span.setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 2, message: "timeout" }),
+    );
+
+    await service.stop?.();
+  });
+
+  test("system instructions do NOT appear on agent.turn span (belong on child chat spans)", async () => {
+    const service = createService();
+    await service.start(createTestCtx({ captureContent: true }));
+
+    emitDiagnosticEvent({
+      type: "run.completed",
+      runId: "run-sys-1",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5-20250929",
+      usage: { input: 100, output: 50, total: 150 },
+      systemInstructions: [{ type: "text" as const, content: "You are a helpful assistant." }],
+    });
+
+    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    expect(attrs["gen_ai.system_instructions"]).toBeUndefined();
+
+    await service.stop?.();
+  });
+
+  test("temperature and maxOutputTokens do NOT appear on agent.turn span (belong on child chat spans)", async () => {
+    const service = createService();
+    await service.start(createTestCtx());
+
+    emitDiagnosticEvent({
+      type: "run.completed",
+      runId: "run-temp-1",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: { input: 100, output: 50, total: 150 },
+      temperature: 0.7,
+      maxOutputTokens: 4096,
+    });
+
+    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    expect(attrs["gen_ai.request.temperature"]).toBeUndefined();
+    expect(attrs["gen_ai.request.max_tokens"]).toBeUndefined();
+
+    await service.stop?.(ctx);
+  });
+
+  test("appends signal path when endpoint contains non-signal /v1 segment", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createTraceOnlyContext("https://www.comet.com/opik/api/v1/private/otel");
+    await service.start(ctx);
+
+    const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
+    expect(options?.url).toBe("https://www.comet.com/opik/api/v1/private/otel/v1/traces");
+    await service.stop?.(ctx);
+  });
+
+  test("keeps already signal-qualified endpoint unchanged", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createTraceOnlyContext("https://collector.example.com/v1/traces");
+    await service.start(ctx);
+
+    const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
+    expect(options?.url).toBe("https://collector.example.com/v1/traces");
+    await service.stop?.(ctx);
+  });
+
+  test("keeps signal-qualified endpoint unchanged when it has query params", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createTraceOnlyContext("https://collector.example.com/v1/traces?timeout=30s");
+    await service.start(ctx);
+
+    const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
+    expect(options?.url).toBe("https://collector.example.com/v1/traces?timeout=30s");
+    await service.stop?.(ctx);
+  });
+
+  test("keeps signal-qualified endpoint unchanged when signal path casing differs", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createTraceOnlyContext("https://collector.example.com/v1/Traces");
+    await service.start(ctx);
+
+    const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
+    expect(options?.url).toBe("https://collector.example.com/v1/Traces");
     await service.stop?.(ctx);
   });
 });

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -348,7 +348,7 @@ describe("diagnostics-otel service – content capture & tools", () => {
 
   afterEach(async () => {
     for (const service of startedServices.splice(0)) {
-      await service.stop?.({} as never).catch(() => undefined);
+      await Promise.resolve(service.stop?.({} as never)).catch(() => undefined);
     }
   });
 
@@ -432,7 +432,7 @@ describe("diagnostics-otel service – content capture & tools", () => {
     const calls = telemetryState.tracer.startSpan.mock.calls;
     const inferenceCall = calls.find((c) => c[0] === "chat gpt-5.2");
     expect(inferenceCall).toBeDefined();
-    const attrs = inferenceCall?.[1]?.attributes as Record<string, unknown>;
+    const attrs = (inferenceCall?.[1] as any)?.attributes as Record<string, unknown>;
     expect(attrs["gen_ai.input.messages"]).toBe(JSON.stringify(inputMessages));
 
     const span = telemetryState.tracer.startSpan.mock.results.find(
@@ -443,7 +443,7 @@ describe("diagnostics-otel service – content capture & tools", () => {
       JSON.stringify(outputMessages),
     );
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("does NOT record gen_ai.input.messages when captureContent is disabled", async () => {
@@ -474,10 +474,10 @@ describe("diagnostics-otel service – content capture & tools", () => {
 
     const calls = telemetryState.tracer.startSpan.mock.calls;
     const inferenceCall = calls.find((c) => c[0] === "chat gpt-5.2");
-    const attrs = inferenceCall?.[1]?.attributes as Record<string, unknown>;
+    const attrs = (inferenceCall?.[1] as any)?.attributes as Record<string, unknown>;
     expect(attrs["gen_ai.input.messages"]).toBeUndefined();
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("input messages with media parts use correct modality and type", async () => {
@@ -521,7 +521,7 @@ describe("diagnostics-otel service – content capture & tools", () => {
 
     const calls = telemetryState.tracer.startSpan.mock.calls;
     const inferenceCall = calls.find((c) => c[0] === "chat gpt-5.2");
-    const attrs = inferenceCall?.[1]?.attributes as Record<string, unknown>;
+    const attrs = (inferenceCall?.[1] as any)?.attributes as Record<string, unknown>;
     const parsed = JSON.parse(attrs["gen_ai.input.messages"] as string);
     expect(parsed[0].parts).toHaveLength(2);
     expect(parsed[0].parts[0].type).toBe("text");
@@ -529,7 +529,7 @@ describe("diagnostics-otel service – content capture & tools", () => {
     expect(parsed[0].parts[1].modality).toBe("image");
     expect(parsed[0].parts[1].mime_type).toBe("image/png");
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("output messages with tool_call parts are recorded correctly", async () => {
@@ -560,14 +560,14 @@ describe("diagnostics-otel service – content capture & tools", () => {
       outputMessages,
     });
 
-    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    const attrs = (telemetryState.tracer.startSpan.mock.calls[0]?.[1] as any)?.attributes;
     expect(attrs["gen_ai.response.finish_reasons"]).toEqual(["tool_call"]);
     const parsed = JSON.parse(attrs["gen_ai.output.messages"] as string);
     expect(parsed[0].parts[0].type).toBe("tool_call");
     expect(parsed[0].parts[0].name).toBe("get_weather");
     expect(parsed[0].finish_reason).toBe("tool_call");
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("tool.execution emits execute_tool span with gen_ai.tool.* attributes", async () => {
@@ -586,14 +586,14 @@ describe("diagnostics-otel service – content capture & tools", () => {
     const spanCall = telemetryState.tracer.startSpan.mock.calls[0];
     expect(spanCall[0]).toBe("execute_tool web_search");
 
-    const attrs = spanCall[1]?.attributes;
+    const attrs = (spanCall[1] as any)?.attributes;
     expect(attrs["gen_ai.operation.name"]).toBe("execute_tool");
     expect(attrs["gen_ai.tool.name"]).toBe("web_search");
     expect(attrs["gen_ai.tool.type"]).toBe("function");
     expect(attrs["gen_ai.tool.call.id"]).toBe("call_xyz");
     expect(attrs["openclaw.channel"]).toBe("webchat");
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("tool.execution with error sets ERROR span status", async () => {
@@ -613,7 +613,7 @@ describe("diagnostics-otel service – content capture & tools", () => {
       expect.objectContaining({ code: 2, message: "timeout" }),
     );
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("system instructions do NOT appear on agent.turn span (belong on child chat spans)", async () => {
@@ -629,10 +629,10 @@ describe("diagnostics-otel service – content capture & tools", () => {
       systemInstructions: [{ type: "text" as const, content: "You are a helpful assistant." }],
     });
 
-    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    const attrs = (telemetryState.tracer.startSpan.mock.calls[0]?.[1] as any)?.attributes;
     expect(attrs["gen_ai.system_instructions"]).toBeUndefined();
 
-    await service.stop?.();
+    await service.stop?.({} as never);
   });
 
   test("temperature and maxOutputTokens do NOT appear on agent.turn span (belong on child chat spans)", async () => {
@@ -649,11 +649,11 @@ describe("diagnostics-otel service – content capture & tools", () => {
       maxOutputTokens: 4096,
     });
 
-    const attrs = telemetryState.tracer.startSpan.mock.calls[0]?.[1]?.attributes;
+    const attrs = (telemetryState.tracer.startSpan.mock.calls[0]?.[1] as any)?.attributes;
     expect(attrs["gen_ai.request.temperature"]).toBeUndefined();
     expect(attrs["gen_ai.request.max_tokens"]).toBeUndefined();
 
-    await service.stop?.(ctx);
+    await service.stop?.({} as never);
   });
 
   test("appends signal path when endpoint contains non-signal /v1 segment", async () => {
@@ -663,7 +663,7 @@ describe("diagnostics-otel service – content capture & tools", () => {
 
     const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
     expect(options?.url).toBe("https://www.comet.com/opik/api/v1/private/otel/v1/traces");
-    await service.stop?.(ctx);
+    await service.stop?.({} as never);
   });
 
   test("keeps already signal-qualified endpoint unchanged", async () => {
@@ -673,7 +673,7 @@ describe("diagnostics-otel service – content capture & tools", () => {
 
     const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
     expect(options?.url).toBe("https://collector.example.com/v1/traces");
-    await service.stop?.(ctx);
+    await service.stop?.({} as never);
   });
 
   test("keeps signal-qualified endpoint unchanged when it has query params", async () => {
@@ -683,7 +683,7 @@ describe("diagnostics-otel service – content capture & tools", () => {
 
     const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
     expect(options?.url).toBe("https://collector.example.com/v1/traces?timeout=30s");
-    await service.stop?.(ctx);
+    await service.stop?.({} as never);
   });
 
   test("keeps signal-qualified endpoint unchanged when signal path casing differs", async () => {
@@ -693,6 +693,6 @@ describe("diagnostics-otel service – content capture & tools", () => {
 
     const options = traceExporterCtor.mock.calls[0]?.[0] as { url?: string } | undefined;
     expect(options?.url).toBe("https://collector.example.com/v1/Traces");
-    await service.stop?.(ctx);
+    await service.stop?.({} as never);
   });
 });

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -1,43 +1,77 @@
-import { metrics, trace, SpanStatusCode } from "@opentelemetry/api";
 import type { SeverityNumber } from "@opentelemetry/api-logs";
-import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-proto";
-import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import type {
+  DiagnosticEventPayload,
+  OpenClawConfig,
+  OpenClawPluginService,
+} from "openclaw/plugin-sdk";
+import {
+  context,
+  isSpanContextValid,
+  metrics,
+  trace,
+  SpanKind,
+  SpanStatusCode,
+  type Span,
+} from "@opentelemetry/api";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ParentBasedSampler, TraceIdRatioBasedSampler } from "@opentelemetry/sdk-trace-base";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
-import type { DiagnosticEventPayload, OpenClawPluginService } from "openclaw/plugin-sdk";
+import { resolveAgentIdFromSessionKey, resolveAgentIdentity } from "openclaw/plugin-sdk";
 import { onDiagnosticEvent, redactSensitiveText, registerLogTransport } from "openclaw/plugin-sdk";
+import {
+  recordRunCompleted,
+  recordRunStarted,
+  recordModelInferenceStarted,
+  recordModelInference,
+  recordWebhookReceived,
+  recordWebhookProcessed,
+  recordWebhookError,
+  recordMessageQueued,
+  recordMessageProcessed,
+  recordLaneEnqueue,
+  recordLaneDequeue,
+  recordSessionState,
+  recordSessionStuck,
+  recordRunAttempt,
+  recordToolExecution,
+  recordHeartbeat,
+  type AgentInfo,
+  type OtelHandlerCtx,
+} from "./otel-event-handlers.js";
+import { createMetricInstruments } from "./otel-metrics.js";
+import {
+  DEFAULT_SERVICE_NAME,
+  OTEL_DEBUG_ENV,
+  OTEL_DUMP_ENV,
+  normalizeEndpoint,
+  resolveCaptureContent,
+  resolveOtelUrl,
+  resolveSampleRate,
+  LoggingTraceExporter,
+  formatTraceparent,
+  type ActiveTrace,
+  type TraceHeaders,
+} from "./otel-utils.js";
 
-const DEFAULT_SERVICE_NAME = "openclaw";
+// Global trace context registry for W3C Trace Context propagation.
+// Stores pre-formatted headers to avoid requiring @opentelemetry/api in main package.
+// Shared via Symbol.for so trace-context-propagator.ts can read without importing this module.
+const TRACE_CONTEXT_REGISTRY_KEY = Symbol.for("openclaw.diagnostics-otel.trace-headers");
 
-function normalizeEndpoint(endpoint?: string): string | undefined {
-  const trimmed = endpoint?.trim();
-  return trimmed ? trimmed.replace(/\/+$/, "") : undefined;
-}
-
-function resolveOtelUrl(endpoint: string | undefined, path: string): string | undefined {
-  if (!endpoint) {
-    return undefined;
+function getTraceHeadersRegistry(): Map<string, TraceHeaders> {
+  const globalStore = globalThis as {
+    [TRACE_CONTEXT_REGISTRY_KEY]?: Map<string, TraceHeaders>;
+  };
+  if (!globalStore[TRACE_CONTEXT_REGISTRY_KEY]) {
+    globalStore[TRACE_CONTEXT_REGISTRY_KEY] = new Map();
   }
-  const endpointWithoutQueryOrFragment = endpoint.split(/[?#]/, 1)[0] ?? endpoint;
-  if (/\/v1\/(?:traces|metrics|logs)$/i.test(endpointWithoutQueryOrFragment)) {
-    return endpoint;
-  }
-  return `${endpoint}/${path}`;
-}
-
-function resolveSampleRate(value: number | undefined): number | undefined {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return undefined;
-  }
-  if (value < 0 || value > 1) {
-    return undefined;
-  }
-  return value;
+  return globalStore[TRACE_CONTEXT_REGISTRY_KEY];
 }
 
 function formatError(err: unknown): string {
@@ -67,6 +101,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
   let logProvider: LoggerProvider | null = null;
   let stopLogTransport: (() => void) | null = null;
   let unsubscribe: (() => void) | null = null;
+  let bufferCleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  // Active root traces keyed by sessionKey. Covers the full message lifecycle;
+  // child spans (agent.turn, LLM calls, tool executions) are nested under it.
+  const activeTraces = new Map<string, ActiveTrace>();
+  const ACTIVE_TRACE_TTL_MS = 10 * 60 * 1000;
 
   return {
     id: "diagnostics-otel",
@@ -88,12 +128,22 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const serviceName =
         otel.serviceName?.trim() || process.env.OTEL_SERVICE_NAME || DEFAULT_SERVICE_NAME;
       const sampleRate = resolveSampleRate(otel.sampleRate);
+      const debugExports = ["1", "true", "yes", "on"].includes(
+        (process.env[OTEL_DEBUG_ENV] ?? "").toLowerCase(),
+      );
+      const dumpPathRaw = process.env[OTEL_DUMP_ENV]?.trim();
+      const dumpPath = dumpPathRaw ? dumpPathRaw : undefined;
 
       const tracesEnabled = otel.traces !== false;
       const metricsEnabled = otel.metrics !== false;
       const logsEnabled = otel.logs === true;
       if (!tracesEnabled && !metricsEnabled && !logsEnabled) {
         return;
+      }
+      if (debugExports) {
+        ctx.logger.info(
+          `diagnostics-otel: debug enabled (traces=${tracesEnabled}, metrics=${metricsEnabled}, logs=${logsEnabled})`,
+        );
       }
 
       const resource = resourceFromAttributes({
@@ -104,10 +154,16 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const metricUrl = resolveOtelUrl(endpoint, "v1/metrics");
       const logUrl = resolveOtelUrl(endpoint, "v1/logs");
       const traceExporter = tracesEnabled
-        ? new OTLPTraceExporter({
-            ...(traceUrl ? { url: traceUrl } : {}),
-            ...(headers ? { headers } : {}),
-          })
+        ? (() => {
+            const base = new OTLPTraceExporter({
+              ...(traceUrl ? { url: traceUrl } : {}),
+              ...(headers ? { headers } : {}),
+            });
+            if (debugExports) {
+              return new LoggingTraceExporter(base, ctx.logger, dumpPath);
+            }
+            return base;
+          })()
         : undefined;
 
       const metricExporter = metricsEnabled
@@ -159,79 +215,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
       const meter = metrics.getMeter("openclaw");
       const tracer = trace.getTracer("openclaw");
+      const otelMetrics = createMetricInstruments(meter);
 
-      const tokensCounter = meter.createCounter("openclaw.tokens", {
-        unit: "1",
-        description: "Token usage by type",
-      });
-      const costCounter = meter.createCounter("openclaw.cost.usd", {
-        unit: "1",
-        description: "Estimated model cost (USD)",
-      });
-      const durationHistogram = meter.createHistogram("openclaw.run.duration_ms", {
-        unit: "ms",
-        description: "Agent run duration",
-      });
-      const contextHistogram = meter.createHistogram("openclaw.context.tokens", {
-        unit: "1",
-        description: "Context window size and usage",
-      });
-      const webhookReceivedCounter = meter.createCounter("openclaw.webhook.received", {
-        unit: "1",
-        description: "Webhook requests received",
-      });
-      const webhookErrorCounter = meter.createCounter("openclaw.webhook.error", {
-        unit: "1",
-        description: "Webhook processing errors",
-      });
-      const webhookDurationHistogram = meter.createHistogram("openclaw.webhook.duration_ms", {
-        unit: "ms",
-        description: "Webhook processing duration",
-      });
-      const messageQueuedCounter = meter.createCounter("openclaw.message.queued", {
-        unit: "1",
-        description: "Messages queued for processing",
-      });
-      const messageProcessedCounter = meter.createCounter("openclaw.message.processed", {
-        unit: "1",
-        description: "Messages processed by outcome",
-      });
-      const messageDurationHistogram = meter.createHistogram("openclaw.message.duration_ms", {
-        unit: "ms",
-        description: "Message processing duration",
-      });
-      const queueDepthHistogram = meter.createHistogram("openclaw.queue.depth", {
-        unit: "1",
-        description: "Queue depth on enqueue/dequeue",
-      });
-      const queueWaitHistogram = meter.createHistogram("openclaw.queue.wait_ms", {
-        unit: "ms",
-        description: "Queue wait time before execution",
-      });
-      const laneEnqueueCounter = meter.createCounter("openclaw.queue.lane.enqueue", {
-        unit: "1",
-        description: "Command queue lane enqueue events",
-      });
-      const laneDequeueCounter = meter.createCounter("openclaw.queue.lane.dequeue", {
-        unit: "1",
-        description: "Command queue lane dequeue events",
-      });
-      const sessionStateCounter = meter.createCounter("openclaw.session.state", {
-        unit: "1",
-        description: "Session state transitions",
-      });
-      const sessionStuckCounter = meter.createCounter("openclaw.session.stuck", {
-        unit: "1",
-        description: "Sessions stuck in processing",
-      });
-      const sessionStuckAgeHistogram = meter.createHistogram("openclaw.session.stuck_age_ms", {
-        unit: "ms",
-        description: "Age of stuck sessions",
-      });
-      const runAttemptCounter = meter.createCounter("openclaw.run.attempt", {
-        unit: "1",
-        description: "Run attempts",
-      });
+      // Trace attribute constants (standard OTEL semantic conventions only)
+      const TRACE_ATTRS = {
+        SESSION_ID: "session.id",
+      } as const;
 
       if (logsEnabled) {
         const logExporter = new OTLPLogExporter({
@@ -358,295 +347,321 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         });
       }
 
+      const captureContent = resolveCaptureContent(otel.captureContent);
+
       const spanWithDuration = (
         name: string,
-        attributes: Record<string, string | number>,
+        attributes: Record<string, string | number | string[]>,
         durationMs?: number,
+        kind?: SpanKind,
+        parentCtx?: ReturnType<typeof context.active>,
       ) => {
         const startTime =
           typeof durationMs === "number" ? Date.now() - Math.max(0, durationMs) : undefined;
-        const span = tracer.startSpan(name, {
-          attributes,
-          ...(startTime ? { startTime } : {}),
-        });
+        const span = tracer.startSpan(
+          name,
+          {
+            attributes,
+            ...(startTime ? { startTime } : {}),
+            ...(kind !== undefined ? { kind } : {}),
+          },
+          parentCtx,
+        );
         return span;
       };
 
-      const recordModelUsage = (evt: Extract<DiagnosticEventPayload, { type: "model.usage" }>) => {
-        const attrs = {
-          "openclaw.channel": evt.channel ?? "unknown",
-          "openclaw.provider": evt.provider ?? "unknown",
-          "openclaw.model": evt.model ?? "unknown",
-        };
+      const safeJsonStringify = (value: unknown): string => {
+        try {
+          return JSON.stringify(value);
+        } catch {
+          return String(value);
+        }
+      };
 
-        const usage = evt.usage;
-        if (usage.input) {
-          tokensCounter.add(usage.input, { ...attrs, "openclaw.token": "input" });
-        }
-        if (usage.output) {
-          tokensCounter.add(usage.output, { ...attrs, "openclaw.token": "output" });
-        }
-        if (usage.cacheRead) {
-          tokensCounter.add(usage.cacheRead, { ...attrs, "openclaw.token": "cache_read" });
-        }
-        if (usage.cacheWrite) {
-          tokensCounter.add(usage.cacheWrite, { ...attrs, "openclaw.token": "cache_write" });
-        }
-        if (usage.promptTokens) {
-          tokensCounter.add(usage.promptTokens, { ...attrs, "openclaw.token": "prompt" });
-        }
-        if (usage.total) {
-          tokensCounter.add(usage.total, { ...attrs, "openclaw.token": "total" });
-        }
+      const runSpans = new Map<string, { span: Span; createdAt: number }>();
+      const RUN_SPAN_TTL_MS = 10 * 60 * 1000;
+      const inferenceSpans = new Map<string, { span: Span; createdAt: number }>();
+      const INFERENCE_SPAN_TTL_MS = 10 * 60 * 1000;
+      const activeInferenceSpanByRunId = new Map<string, Span>();
+      const runProviderByRunId = new Map<string, string>();
 
-        if (evt.costUsd) {
-          costCounter.add(evt.costUsd, attrs);
-        }
-        if (evt.durationMs) {
-          durationHistogram.record(evt.durationMs, attrs);
-        }
-        if (evt.context?.limit) {
-          contextHistogram.record(evt.context.limit, {
-            ...attrs,
-            "openclaw.context": "limit",
-          });
-        }
-        if (evt.context?.used) {
-          contextHistogram.record(evt.context.used, {
-            ...attrs,
-            "openclaw.context": "used",
-          });
-        }
-
-        if (!tracesEnabled) {
-          return;
-        }
+      const createToolSpan = (
+        evt: Extract<DiagnosticEventPayload, { type: "tool.execution" }>,
+        parentCtx?: ReturnType<typeof context.active>,
+      ) => {
         const spanAttrs: Record<string, string | number> = {
-          ...attrs,
-          "openclaw.sessionKey": evt.sessionKey ?? "",
-          "openclaw.sessionId": evt.sessionId ?? "",
-          "openclaw.tokens.input": usage.input ?? 0,
-          "openclaw.tokens.output": usage.output ?? 0,
-          "openclaw.tokens.cache_read": usage.cacheRead ?? 0,
-          "openclaw.tokens.cache_write": usage.cacheWrite ?? 0,
-          "openclaw.tokens.total": usage.total ?? 0,
+          "gen_ai.operation.name": "execute_tool",
+          "gen_ai.tool.name": evt.toolName,
+          "gen_ai.tool.type": evt.toolType ?? "function",
         };
+        if (evt.runId) {
+          const provider = runProviderByRunId.get(evt.runId);
+          if (provider) {
+            spanAttrs["gen_ai.provider.name"] = provider;
+          }
+        }
+        if (evt.toolCallId) {
+          spanAttrs["gen_ai.tool.call.id"] = evt.toolCallId;
+        }
+        if (evt.channel) {
+          spanAttrs["openclaw.channel"] = evt.channel;
+        }
+        if (captureContent.toolContent) {
+          if (evt.toolInput != null) {
+            spanAttrs["gen_ai.tool.call.arguments"] = safeJsonStringify(evt.toolInput);
+          }
+          if (evt.toolOutput != null) {
+            spanAttrs["gen_ai.tool.call.result"] = safeJsonStringify(evt.toolOutput);
+          }
+        }
 
-        const span = spanWithDuration("openclaw.model.usage", spanAttrs, evt.durationMs);
-        span.end();
-      };
-
-      const recordWebhookReceived = (
-        evt: Extract<DiagnosticEventPayload, { type: "webhook.received" }>,
-      ) => {
-        const attrs = {
-          "openclaw.channel": evt.channel ?? "unknown",
-          "openclaw.webhook": evt.updateType ?? "unknown",
-        };
-        webhookReceivedCounter.add(1, attrs);
-      };
-
-      const recordWebhookProcessed = (
-        evt: Extract<DiagnosticEventPayload, { type: "webhook.processed" }>,
-      ) => {
-        const attrs = {
-          "openclaw.channel": evt.channel ?? "unknown",
-          "openclaw.webhook": evt.updateType ?? "unknown",
-        };
-        if (typeof evt.durationMs === "number") {
-          webhookDurationHistogram.record(evt.durationMs, attrs);
+        const spanName = `execute_tool ${evt.toolName}`;
+        const span = spanWithDuration(
+          spanName,
+          spanAttrs,
+          evt.durationMs,
+          SpanKind.INTERNAL,
+          parentCtx,
+        );
+        if (evt.error) {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: evt.error });
         }
-        if (!tracesEnabled) {
-          return;
-        }
-        const spanAttrs: Record<string, string | number> = { ...attrs };
-        if (evt.chatId !== undefined) {
-          spanAttrs["openclaw.chatId"] = String(evt.chatId);
-        }
-        const span = spanWithDuration("openclaw.webhook.processed", spanAttrs, evt.durationMs);
-        span.end();
-      };
-
-      const recordWebhookError = (
-        evt: Extract<DiagnosticEventPayload, { type: "webhook.error" }>,
-      ) => {
-        const attrs = {
-          "openclaw.channel": evt.channel ?? "unknown",
-          "openclaw.webhook": evt.updateType ?? "unknown",
-        };
-        webhookErrorCounter.add(1, attrs);
-        if (!tracesEnabled) {
-          return;
-        }
-        const redactedError = redactSensitiveText(evt.error);
-        const spanAttrs: Record<string, string | number> = {
-          ...attrs,
-          "openclaw.error": redactedError,
-        };
-        if (evt.chatId !== undefined) {
-          spanAttrs["openclaw.chatId"] = String(evt.chatId);
-        }
-        const span = tracer.startSpan("openclaw.webhook.error", {
-          attributes: spanAttrs,
-        });
-        span.setStatus({ code: SpanStatusCode.ERROR, message: redactedError });
-        span.end();
-      };
-
-      const recordMessageQueued = (
-        evt: Extract<DiagnosticEventPayload, { type: "message.queued" }>,
-      ) => {
-        const attrs = {
-          "openclaw.channel": evt.channel ?? "unknown",
-          "openclaw.source": evt.source ?? "unknown",
-        };
-        messageQueuedCounter.add(1, attrs);
-        if (typeof evt.queueDepth === "number") {
-          queueDepthHistogram.record(evt.queueDepth, attrs);
-        }
-      };
-
-      const addSessionIdentityAttrs = (
-        spanAttrs: Record<string, string | number>,
-        evt: { sessionKey?: string; sessionId?: string },
-      ) => {
-        if (evt.sessionKey) {
-          spanAttrs["openclaw.sessionKey"] = evt.sessionKey;
-        }
-        if (evt.sessionId) {
-          spanAttrs["openclaw.sessionId"] = evt.sessionId;
-        }
-      };
-
-      const recordMessageProcessed = (
-        evt: Extract<DiagnosticEventPayload, { type: "message.processed" }>,
-      ) => {
-        const attrs = {
-          "openclaw.channel": evt.channel ?? "unknown",
-          "openclaw.outcome": evt.outcome ?? "unknown",
-        };
-        messageProcessedCounter.add(1, attrs);
-        if (typeof evt.durationMs === "number") {
-          messageDurationHistogram.record(evt.durationMs, attrs);
-        }
-        if (!tracesEnabled) {
-          return;
-        }
-        const spanAttrs: Record<string, string | number> = { ...attrs };
-        addSessionIdentityAttrs(spanAttrs, evt);
-        if (evt.chatId !== undefined) {
-          spanAttrs["openclaw.chatId"] = String(evt.chatId);
-        }
-        if (evt.messageId !== undefined) {
-          spanAttrs["openclaw.messageId"] = String(evt.messageId);
-        }
-        if (evt.reason) {
-          spanAttrs["openclaw.reason"] = redactSensitiveText(evt.reason);
-        }
-        const span = spanWithDuration("openclaw.message.processed", spanAttrs, evt.durationMs);
-        if (evt.outcome === "error" && evt.error) {
-          span.setStatus({ code: SpanStatusCode.ERROR, message: redactSensitiveText(evt.error) });
+        if (debugExports) {
+          ctx.logger.info(`diagnostics-otel: span created ${spanName}`);
         }
         span.end();
       };
 
-      const recordLaneEnqueue = (
-        evt: Extract<DiagnosticEventPayload, { type: "queue.lane.enqueue" }>,
-      ) => {
-        const attrs = { "openclaw.lane": evt.lane };
-        laneEnqueueCounter.add(1, attrs);
-        queueDepthHistogram.record(evt.queueSize, attrs);
-      };
-
-      const recordLaneDequeue = (
-        evt: Extract<DiagnosticEventPayload, { type: "queue.lane.dequeue" }>,
-      ) => {
-        const attrs = { "openclaw.lane": evt.lane };
-        laneDequeueCounter.add(1, attrs);
-        queueDepthHistogram.record(evt.queueSize, attrs);
-        if (typeof evt.waitMs === "number") {
-          queueWaitHistogram.record(evt.waitMs, attrs);
+      const agentInfoCache = new Map<string, AgentInfo | null>();
+      const resolveAgentInfo = (sessionKey?: string): AgentInfo | null => {
+        if (!sessionKey) {
+          return null;
         }
-      };
-
-      const recordSessionState = (
-        evt: Extract<DiagnosticEventPayload, { type: "session.state" }>,
-      ) => {
-        const attrs: Record<string, string> = { "openclaw.state": evt.state };
-        if (evt.reason) {
-          attrs["openclaw.reason"] = redactSensitiveText(evt.reason);
+        const cached = agentInfoCache.get(sessionKey);
+        if (cached !== undefined) {
+          return cached;
         }
-        sessionStateCounter.add(1, attrs);
+        const agentId = resolveAgentIdFromSessionKey(sessionKey);
+        const identity = resolveAgentIdentity(ctx.config, agentId);
+        const info: AgentInfo = { id: agentId, name: identity?.name?.trim() || undefined };
+        agentInfoCache.set(sessionKey, info);
+        return info;
       };
 
-      const recordSessionStuck = (
-        evt: Extract<DiagnosticEventPayload, { type: "session.stuck" }>,
-      ) => {
-        const attrs: Record<string, string> = { "openclaw.state": evt.state };
-        sessionStuckCounter.add(1, attrs);
-        if (typeof evt.ageMs === "number") {
-          sessionStuckAgeHistogram.record(evt.ageMs, attrs);
+      const ensureRunSpan = (params: {
+        runId?: string;
+        sessionKey?: string;
+        sessionId?: string;
+        channel?: string;
+        startTimeMs?: number;
+        attributes?: Record<string, string | number | string[]>;
+      }): Span | null => {
+        const runId = params.runId;
+        if (!runId) {
+          return null;
         }
-        if (!tracesEnabled) {
-          return;
+        const existing = runSpans.get(runId);
+        if (existing) {
+          if (params.attributes) {
+            for (const [key, value] of Object.entries(params.attributes)) {
+              existing.span.setAttribute(key, value);
+            }
+          }
+          return existing.span;
         }
-        const spanAttrs: Record<string, string | number> = { ...attrs };
-        addSessionIdentityAttrs(spanAttrs, evt);
-        spanAttrs["openclaw.queueDepth"] = evt.queueDepth ?? 0;
-        spanAttrs["openclaw.ageMs"] = evt.ageMs;
-        const span = tracer.startSpan("openclaw.session.stuck", { attributes: spanAttrs });
-        span.setStatus({ code: SpanStatusCode.ERROR, message: "session stuck" });
-        span.end();
+        const spanAttrs: Record<string, string | number | string[]> = {
+          "openclaw.runId": runId,
+          "openclaw.type": "openclaw.agent.turn",
+          ...params.attributes,
+        };
+        if (params.sessionKey) {
+          spanAttrs["openclaw.sessionKey"] = params.sessionKey;
+          spanAttrs[TRACE_ATTRS.SESSION_ID] = params.sessionKey;
+        }
+        if (params.sessionId) {
+          spanAttrs["openclaw.sessionId"] = params.sessionId;
+          spanAttrs["gen_ai.conversation.id"] = params.sessionId;
+        }
+        if (params.channel) {
+          spanAttrs["openclaw.channel"] = params.channel;
+        }
+
+        // GenAI agent identity attributes (gen_ai.agent.*)
+        const agentInfo = resolveAgentInfo(params.sessionKey);
+        if (agentInfo) {
+          spanAttrs["gen_ai.agent.id"] = agentInfo.id;
+          if (agentInfo.name) {
+            spanAttrs["gen_ai.agent.name"] = agentInfo.name;
+          }
+        }
+        spanAttrs["gen_ai.operation.name"] = "invoke_agent";
+
+        // Parent under root trace span if available (created by message.queued)
+        const rootTrace = params.sessionKey ? activeTraces.get(params.sessionKey) : undefined;
+        const parentCtx = rootTrace
+          ? trace.setSpan(context.active(), rootTrace.span)
+          : context.active();
+
+        const spanName = agentInfo?.name ? `invoke_agent ${agentInfo.name}` : "invoke_agent";
+        const span = tracer.startSpan(
+          spanName,
+          {
+            attributes: spanAttrs,
+            ...(typeof params.startTimeMs === "number" ? { startTime: params.startTimeMs } : {}),
+            kind: SpanKind.INTERNAL,
+          },
+          parentCtx,
+        );
+        runSpans.set(runId, { span, createdAt: Date.now() });
+
+        // Store W3C trace headers for propagation to downstream LLM providers
+        if (params.sessionKey) {
+          const spanContext = span.spanContext();
+          if (isSpanContextValid(spanContext)) {
+            getTraceHeadersRegistry().set(params.sessionKey, {
+              traceparent: formatTraceparent(spanContext),
+              ...(spanContext.traceState && { tracestate: spanContext.traceState.serialize() }),
+            });
+          }
+        }
+
+        if (debugExports) {
+          ctx.logger.info(`diagnostics-otel: span created ${spanName}`);
+        }
+        return span;
       };
 
-      const recordRunAttempt = (evt: Extract<DiagnosticEventPayload, { type: "run.attempt" }>) => {
-        runAttemptCounter.add(1, { "openclaw.attempt": evt.attempt });
+      // Construct the handler context object used by all event handlers
+      const hctx: OtelHandlerCtx = {
+        tracer,
+        metrics: otelMetrics,
+        captureContent,
+        tracesEnabled,
+        debugExports,
+        logger: ctx.logger,
+        activeTraces,
+        runSpans,
+        inferenceSpans,
+        activeInferenceSpanByRunId,
+        runProviderByRunId,
+        resolveAgentInfo,
+        spanWithDuration,
+        safeJsonStringify,
+        createToolSpan,
+        ensureRunSpan,
+        TRACE_ATTRS,
+        getTraceHeadersRegistry,
       };
 
-      const recordHeartbeat = (
-        evt: Extract<DiagnosticEventPayload, { type: "diagnostic.heartbeat" }>,
-      ) => {
-        queueDepthHistogram.record(evt.queued, { "openclaw.channel": "heartbeat" });
-      };
+      // Periodic cleanup of orphaned buffer entries
+      bufferCleanupTimer = setInterval(() => {
+        const now = Date.now();
+        for (const [key, entry] of runSpans) {
+          if (now - entry.createdAt > RUN_SPAN_TTL_MS) {
+            try {
+              entry.span.end();
+            } catch {
+              // ignore
+            }
+            runSpans.delete(key);
+          }
+        }
+        for (const [key, entry] of inferenceSpans) {
+          if (now - entry.createdAt > INFERENCE_SPAN_TTL_MS) {
+            try {
+              entry.span.end();
+            } catch {
+              // ignore
+            }
+            inferenceSpans.delete(key);
+          }
+        }
+        // If we had to end inference spans due to TTL, don't keep dangling "active" parents.
+        for (const [runId, span] of activeInferenceSpanByRunId) {
+          if (Array.from(inferenceSpans.values()).every((e) => e.span !== span)) {
+            activeInferenceSpanByRunId.delete(runId);
+          }
+        }
+        // Clean up stale provider entries for completed/expired runs
+        for (const runId of runProviderByRunId.keys()) {
+          if (!runSpans.has(runId)) {
+            runProviderByRunId.delete(runId);
+          }
+        }
+        for (const [key, entry] of activeTraces) {
+          if (now - entry.startedAt > ACTIVE_TRACE_TTL_MS) {
+            try {
+              entry.span.setStatus({ code: SpanStatusCode.ERROR, message: "TTL expired" });
+              entry.span.end();
+            } catch {
+              // ignore
+            }
+            activeTraces.delete(key);
+          }
+        }
+        // Clean up orphaned trace headers whose session has no active trace or run span
+        const registry = getTraceHeadersRegistry();
+        for (const sessionKey of registry.keys()) {
+          if (!activeTraces.has(sessionKey)) {
+            registry.delete(sessionKey);
+          }
+        }
+      }, 60_000);
+      bufferCleanupTimer.unref?.();
 
       unsubscribe = onDiagnosticEvent((evt: DiagnosticEventPayload) => {
         try {
+          if (debugExports) {
+            ctx.logger.info(`diagnostics-otel: event received ${evt.type}`);
+          }
           switch (evt.type) {
-            case "model.usage":
-              recordModelUsage(evt);
+            case "model.inference.started":
+              recordModelInferenceStarted(hctx, evt);
+              return;
+            case "model.inference":
+              recordModelInference(hctx, evt);
+              return;
+            case "run.completed":
+              recordRunCompleted(hctx, evt);
               return;
             case "webhook.received":
-              recordWebhookReceived(evt);
+              recordWebhookReceived(hctx, evt);
               return;
             case "webhook.processed":
-              recordWebhookProcessed(evt);
+              recordWebhookProcessed(hctx, evt);
               return;
             case "webhook.error":
-              recordWebhookError(evt);
+              recordWebhookError(hctx, evt);
               return;
             case "message.queued":
-              recordMessageQueued(evt);
+              recordMessageQueued(hctx, evt);
               return;
             case "message.processed":
-              recordMessageProcessed(evt);
+              recordMessageProcessed(hctx, evt);
               return;
             case "queue.lane.enqueue":
-              recordLaneEnqueue(evt);
+              recordLaneEnqueue(hctx, evt);
               return;
             case "queue.lane.dequeue":
-              recordLaneDequeue(evt);
+              recordLaneDequeue(hctx, evt);
               return;
             case "session.state":
-              recordSessionState(evt);
+              recordSessionState(hctx, evt);
               return;
             case "session.stuck":
-              recordSessionStuck(evt);
+              recordSessionStuck(hctx, evt);
               return;
             case "run.attempt":
-              recordRunAttempt(evt);
+              recordRunAttempt(hctx, evt);
+              return;
+            case "run.started":
+              recordRunStarted(hctx, evt);
               return;
             case "diagnostic.heartbeat":
-              recordHeartbeat(evt);
+              recordHeartbeat(hctx, evt);
+              return;
+            case "tool.execution":
+              recordToolExecution(hctx, evt);
               return;
           }
         } catch (err) {
@@ -657,18 +672,34 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       });
 
       if (logsEnabled) {
-        ctx.logger.info("diagnostics-otel: logs exporter enabled (OTLP/Protobuf)");
+        ctx.logger.info("diagnostics-otel: logs exporter enabled (OTLP/HTTP)");
       }
     },
     async stop() {
+      // End any remaining root traces
+      for (const [, activeTrace] of activeTraces) {
+        try {
+          activeTrace.span.setStatus({ code: SpanStatusCode.ERROR, message: "Service stopped" });
+          activeTrace.span.end();
+        } catch {
+          // Ignore errors during cleanup
+        }
+      }
+      activeTraces.clear();
+
       unsubscribe?.();
       unsubscribe = null;
       stopLogTransport?.();
       stopLogTransport = null;
+      if (bufferCleanupTimer) {
+        clearInterval(bufferCleanupTimer);
+        bufferCleanupTimer = null;
+      }
       if (logProvider) {
         await logProvider.shutdown().catch(() => undefined);
         logProvider = null;
       }
+      getTraceHeadersRegistry().clear();
       if (sdk) {
         await sdk.shutdown().catch(() => undefined);
         sdk = null;

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -675,7 +675,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         ctx.logger.info("diagnostics-otel: logs exporter enabled (OTLP/HTTP)");
       }
     },
-    async stop() {
+    async stop(_ctx) {
       // End any remaining root traces
       for (const [, activeTrace] of activeTraces) {
         try {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -2,6 +2,8 @@ import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
+import type { RunEmbeddedPiAgentParams } from "./run/params.js";
+import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { PluginHookBeforeAgentStartResult } from "../../plugins/types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
@@ -55,13 +57,11 @@ import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { resolveModel } from "./model.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
-import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import {
   truncateOversizedToolResultsInSession,
   sessionLikelyHasOversizedToolResults,
 } from "./tool-result-truncation.js";
-import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { describeUnknownError } from "./utils.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;
@@ -1302,6 +1302,8 @@ export async function runEmbeddedPiAgent(
                     },
                   ]
                 : undefined,
+              systemPromptText: attempt.systemPromptText,
+              firstTokenMs: attempt.firstTokenAt ? attempt.firstTokenAt - started : undefined,
             },
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
             messagingToolSentTexts: attempt.messagingToolSentTexts,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs/promises";
-import os from "node:os";
 import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import {
@@ -7,9 +5,13 @@ import {
   DefaultResourceLoader,
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
+import fs from "node:fs/promises";
+import os from "node:os";
+import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import { emitDiagnosticEvent } from "../../../infra/diagnostic-events.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
@@ -77,6 +79,7 @@ import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../tool-fs-policy.js";
 import { normalizeToolName } from "../../tool-policy.js";
+import { wrapStreamFnWithTraceContext } from "../../trace-context-propagator.js";
 import { resolveTranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
@@ -115,7 +118,6 @@ import {
   shouldFlagCompactionTimeout,
 } from "./compaction-timeout.js";
 import { pruneProcessedHistoryImages } from "./history-image-prune.js";
-import { detectAndLoadPromptImages } from "./images.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 type PromptBuildHookRunner = {
@@ -418,6 +420,11 @@ export function resolveAttemptFsWorkspaceOnly(params: {
     agentId: params.sessionAgentId,
   });
 }
+import {
+  buildGenAiMessagesFromContext,
+  buildGenAiToolDefsFromContext,
+} from "./diagnostic-builders.js";
+import { detectAndLoadPromptImages, injectHistoryImagesIntoMessages } from "./images.js";
 
 function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
   const content = (msg as { content?: unknown }).content;
@@ -965,6 +972,12 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = wrapOllamaCompatNumCtx(activeSession.agent.streamFn, numCtx);
       }
 
+      // Wrap streamFn to inject W3C Trace Context headers for distributed tracing
+      activeSession.agent.streamFn = wrapStreamFnWithTraceContext(
+        activeSession.agent.streamFn,
+        params.sessionKey,
+      );
+
       applyExtraParamsToAgent(
         activeSession.agent,
         params.config,
@@ -1070,6 +1083,53 @@ export async function runEmbeddedAttempt(
         );
       }
 
+      const captureContent =
+        params.config?.diagnostics?.enabled === true &&
+        !!params.config?.diagnostics?.otel?.captureContent;
+      if (captureContent) {
+        // Capture the exact model request context at the point of the LLM call.
+        // This is more trustworthy than sampling AgentSession.state.messages from streaming events.
+        const inner = activeSession.agent.streamFn;
+        let callIndex = 0;
+        activeSession.agent.streamFn = ((model, context, options) => {
+          callIndex += 1;
+          emitDiagnosticEvent({
+            type: "model.inference.started",
+            runId: params.runId,
+            sessionId: activeSession.sessionId,
+            sessionKey: params.sessionKey,
+            channel: params.messageChannel,
+            provider: model.provider,
+            model: model.id,
+            operationName: "chat",
+            callIndex,
+            inputMessages: buildGenAiMessagesFromContext(
+              (context as { messages?: unknown }).messages,
+            ),
+            systemInstructions:
+              typeof (context as { systemPrompt?: unknown }).systemPrompt === "string" &&
+              (context as { systemPrompt?: string }).systemPrompt?.trim()
+                ? [
+                    {
+                      type: "text",
+                      content: String((context as { systemPrompt?: string }).systemPrompt),
+                    },
+                  ]
+                : undefined,
+            toolDefinitions: buildGenAiToolDefsFromContext((context as { tools?: unknown }).tools),
+            temperature:
+              typeof (options as { temperature?: unknown }).temperature === "number"
+                ? (options as { temperature?: number }).temperature
+                : undefined,
+            maxOutputTokens:
+              typeof (options as { maxTokens?: unknown }).maxTokens === "number"
+                ? (options as { maxTokens?: number }).maxTokens
+                : undefined,
+          });
+          return inner(model, context, options);
+        }) as typeof inner;
+      }
+
       try {
         const prior = await sanitizeSessionHistory({
           messages: activeSession.messages,
@@ -1167,6 +1227,10 @@ export async function runEmbeddedAttempt(
       const subscription = subscribeEmbeddedPiSession({
         session: activeSession,
         runId: params.runId,
+        captureContent,
+        sessionKey: params.sessionKey ?? params.sessionId,
+        sessionId: params.sessionId,
+        channel: params.messageChannel,
         hookRunner: getGlobalHookRunner() ?? undefined,
         verboseLevel: params.verboseLevel,
         reasoningMode: params.reasoningLevel ?? "off",
@@ -1185,7 +1249,6 @@ export async function runEmbeddedAttempt(
         onAgentEvent: params.onAgentEvent,
         enforceFinalTag: params.enforceFinalTag,
         config: params.config,
-        sessionKey: params.sessionKey ?? params.sessionId,
       });
 
       const {
@@ -1631,6 +1694,8 @@ export async function runEmbeddedAttempt(
         compactionCount: getCompactionCount(),
         // Client tool call detected (OpenResponses hosted tools)
         clientToolCall: clientToolCallDetected ?? undefined,
+        systemPromptText: systemPromptText,
+        firstTokenAt: subscription?.getFirstTokenAt?.(),
       };
     } finally {
       // Always tear down the session (and release the lock) before we leave this attempt.

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import {
@@ -5,9 +7,6 @@ import {
   DefaultResourceLoader,
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
-import fs from "node:fs/promises";
-import os from "node:os";
-import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
@@ -424,7 +423,7 @@ import {
   buildGenAiMessagesFromContext,
   buildGenAiToolDefsFromContext,
 } from "./diagnostic-builders.js";
-import { detectAndLoadPromptImages, injectHistoryImagesIntoMessages } from "./images.js";
+import { detectAndLoadPromptImages } from "./images.js";
 
 function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
   const content = (msg as { content?: unknown }).content;

--- a/src/agents/pi-embedded-runner/run/diagnostic-builders.ts
+++ b/src/agents/pi-embedded-runner/run/diagnostic-builders.ts
@@ -1,0 +1,120 @@
+import type { GenAiMessage, GenAiPart, GenAiToolDef } from "../../../infra/diagnostic-events.js";
+
+export function buildGenAiPartsFromContent(content: unknown): GenAiPart[] {
+  if (typeof content === "string") {
+    return [{ type: "text", content }];
+  }
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const parts: GenAiPart[] = [];
+  for (const item of content) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const record = item as Record<string, unknown>;
+    if (record.type === "text" && typeof record.text === "string") {
+      parts.push({ type: "text", content: record.text });
+      continue;
+    }
+    if (record.type === "image" && typeof record.data === "string") {
+      parts.push({
+        type: "blob",
+        modality: "image",
+        mime_type: typeof record.mimeType === "string" ? record.mimeType : undefined,
+        content: record.data,
+      });
+    }
+  }
+  return parts;
+}
+
+export function buildGenAiMessagesFromContext(messages: unknown): GenAiMessage[] | undefined {
+  if (!Array.isArray(messages)) {
+    return undefined;
+  }
+  const out: GenAiMessage[] = [];
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      continue;
+    }
+    const record = msg as Record<string, unknown>;
+    const role = typeof record.role === "string" ? record.role : "";
+    if (role === "user") {
+      out.push({ role: "user", parts: buildGenAiPartsFromContent(record.content) });
+      continue;
+    }
+    if (role === "assistant") {
+      const parts: GenAiPart[] = [];
+      const content = record.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (!block || typeof block !== "object") {
+            continue;
+          }
+          const b = block as Record<string, unknown>;
+          if (b.type === "text" && typeof b.text === "string") {
+            parts.push({ type: "text", content: b.text });
+          } else if (b.type === "toolCall" || b.type === "toolUse" || b.type === "functionCall") {
+            const id = typeof b.id === "string" ? b.id : "";
+            const name = typeof b.name === "string" ? b.name : "";
+            const args =
+              b.arguments && typeof b.arguments === "object"
+                ? (b.arguments as Record<string, unknown>)
+                : b.input && typeof b.input === "object"
+                  ? (b.input as Record<string, unknown>)
+                  : undefined;
+            parts.push({ type: "tool_call", id, name, arguments: args });
+          }
+        }
+      }
+      out.push({ role: "assistant", parts });
+      continue;
+    }
+    if (role === "toolResult") {
+      const toolCallId = typeof record.toolCallId === "string" ? record.toolCallId : "";
+      const toolName = typeof record.toolName === "string" ? record.toolName : "";
+      // Represent tool results as a tool message with a tool_call_response part.
+      out.push({
+        role: "tool",
+        parts: [
+          {
+            type: "tool_call_response",
+            id: toolCallId,
+            response: {
+              toolName,
+              isError: Boolean(record.isError),
+              parts: buildGenAiPartsFromContent(record.content),
+            },
+          },
+        ],
+      });
+    }
+  }
+  return out;
+}
+
+export function buildGenAiToolDefsFromContext(tools: unknown): GenAiToolDef[] | undefined {
+  if (!Array.isArray(tools)) {
+    return undefined;
+  }
+  const defs: GenAiToolDef[] = [];
+  for (const tool of tools) {
+    if (!tool || typeof tool !== "object") {
+      continue;
+    }
+    const record = tool as Record<string, unknown>;
+    const name = typeof record.name === "string" ? record.name : "";
+    if (!name) {
+      continue;
+    }
+    defs.push({
+      name,
+      ...(typeof record.description === "string" ? { description: record.description } : {}),
+      ...(record.parameters && typeof record.parameters === "object"
+        ? { parameters: record.parameters as Record<string, unknown> }
+        : {}),
+    });
+  }
+  return defs.length ? defs : undefined;
+}

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -1,8 +1,7 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ImageContent } from "@mariozechner/pi-ai";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ImageContent } from "@mariozechner/pi-ai";
-import { resolveUserPath } from "../../../utils.js";
-import { loadWebMedia } from "../../../web/media.js";
 import type { ImageSanitizationLimits } from "../../image-sanitization.js";
 import {
   createSandboxBridgeReadFile,
@@ -10,6 +9,8 @@ import {
 } from "../../sandbox-media-paths.js";
 import { assertSandboxPath } from "../../sandbox-paths.js";
 import type { SandboxFsBridge } from "../../sandbox/fs-bridge.js";
+import { resolveUserPath } from "../../../utils.js";
+import { loadWebMedia } from "../../../web/media.js";
 import { sanitizeImageBlocks } from "../../tool-images.js";
 import { log } from "../logger.js";
 
@@ -357,4 +358,52 @@ export async function detectAndLoadPromptImages(params: {
     loadedCount,
     skippedCount,
   };
+}
+
+export function injectHistoryImagesIntoMessages(
+  messages: AgentMessage[],
+  historyImagesByIndex: Map<number, ImageContent[]>,
+): boolean {
+  if (historyImagesByIndex.size === 0) {
+    return false;
+  }
+  let didMutate = false;
+
+  for (const [msgIndex, images] of historyImagesByIndex) {
+    // Bounds check: ensure index is valid before accessing
+    if (msgIndex < 0 || msgIndex >= messages.length) {
+      continue;
+    }
+    const msg = messages[msgIndex];
+    if (msg && msg.role === "user") {
+      // Convert string content to array format if needed
+      if (typeof msg.content === "string") {
+        msg.content = [{ type: "text", text: msg.content }];
+        didMutate = true;
+      }
+      if (Array.isArray(msg.content)) {
+        // Check for existing image content to avoid duplicates across turns
+        const existingImageData = new Set(
+          msg.content
+            .filter(
+              (c): c is ImageContent =>
+                c != null &&
+                typeof c === "object" &&
+                c.type === "image" &&
+                typeof c.data === "string",
+            )
+            .map((c) => c.data),
+        );
+        for (const img of images) {
+          // Only add if this image isn't already in the message
+          if (!existingImageData.has(img.data)) {
+            msg.content.push(img);
+            didMutate = true;
+          }
+        }
+      }
+    }
+  }
+
+  return didMutate;
 }

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -52,4 +52,8 @@ export type EmbeddedRunAttemptResult = {
   compactionCount?: number;
   /** Client tool call detected (OpenResponses hosted tools). */
   clientToolCall?: { name: string; params: Record<string, unknown> };
+  /** The full system prompt text sent to the model. */
+  systemPromptText?: string;
+  /** Timestamp (ms) when the first token arrived from the model. */
+  firstTokenAt?: number;
 };

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -52,6 +52,10 @@ export type EmbeddedPiRunMeta = {
     name: string;
     arguments: string;
   }>;
+  /** The full system prompt text sent to the model. */
+  systemPromptText?: string;
+  /** Time-to-first-token in milliseconds (relative to run start). */
+  firstTokenMs?: number;
 };
 
 export type EmbeddedPiRunResult = {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1,14 +1,14 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import { describe, expect, it, vi } from "vitest";
 import type { MessagingToolSend } from "./pi-embedded-messaging.js";
-import {
-  handleToolExecutionEnd,
-  handleToolExecutionStart,
-} from "./pi-embedded-subscribe.handlers.tools.js";
 import type {
   ToolCallSummary,
   ToolHandlerContext,
 } from "./pi-embedded-subscribe.handlers.types.js";
+import {
+  handleToolExecutionEnd,
+  handleToolExecutionStart,
+} from "./pi-embedded-subscribe.handlers.tools.js";
 
 type ToolExecutionStartEvent = Extract<AgentEvent, { type: "tool_execution_start" }>;
 type ToolExecutionEndEvent = Extract<AgentEvent, { type: "tool_execution_end" }>;
@@ -36,6 +36,8 @@ function createTestContext(): {
     state: {
       toolMetaById: new Map<string, ToolCallSummary>(),
       toolMetas: [],
+      toolStartTimeById: new Map<string, number>(),
+      toolArgsById: new Map<string, Record<string, unknown> | undefined>(),
       toolSummaryById: new Set<string>(),
       pendingMessagingTargets: new Map<string, MessagingToolSend>(),
       pendingMessagingTexts: new Map<string, string>(),

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1,13 +1,14 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
-import { emitAgentEvent } from "../infra/agent-events.js";
-import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
-import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
-import { isMessagingTool, isMessagingToolSendAction } from "./pi-embedded-messaging.js";
 import type {
   ToolCallSummary,
   ToolHandlerContext,
 } from "./pi-embedded-subscribe.handlers.types.js";
+import { emitAgentEvent } from "../infra/agent-events.js";
+import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
+import { isMessagingTool, isMessagingToolSendAction } from "./pi-embedded-messaging.js";
 import {
   extractMessagingToolSend,
   extractToolErrorMessage,
@@ -204,6 +205,11 @@ export async function handleToolExecutionStart(
 
   const meta = extendExecMeta(toolName, args, inferToolMetaFromArgs(toolName, args));
   ctx.state.toolMetaById.set(toolCallId, buildToolCallSummary(toolName, args, meta));
+  ctx.state.toolStartTimeById.set(toolCallId, Date.now());
+  ctx.state.toolArgsById.set(
+    toolCallId,
+    args && typeof args === "object" ? (args as Record<string, unknown>) : undefined,
+  );
   ctx.log.debug(
     `embedded run tool start: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
@@ -403,6 +409,26 @@ export async function handleToolExecutionEnd(
       meta,
       isError: isToolError,
     },
+  });
+
+  // Emit OTel diagnostic event for tool execution
+  const startTime = ctx.state.toolStartTimeById.get(toolCallId);
+  ctx.state.toolStartTimeById.delete(toolCallId);
+  const toolInput = ctx.state.toolArgsById.get(toolCallId);
+  ctx.state.toolArgsById.delete(toolCallId);
+  emitDiagnosticEvent({
+    type: "tool.execution",
+    runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
+    sessionId: ctx.params.sessionId,
+    channel: ctx.params.channel,
+    toolName,
+    toolType: "function",
+    toolCallId,
+    durationMs: typeof startTime === "number" ? Date.now() - startTime : undefined,
+    error: isToolError ? extractToolErrorMessage(sanitizedResult) : undefined,
+    toolInput,
+    toolOutput: sanitizedResult,
   });
 
   ctx.log.debug(

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -34,6 +34,8 @@ export type EmbeddedPiSubscribeState = {
   assistantTexts: string[];
   toolMetas: Array<{ toolName?: string; meta?: string }>;
   toolMetaById: Map<string, ToolCallSummary>;
+  toolStartTimeById: Map<string, number>;
+  toolArgsById: Map<string, Record<string, unknown> | undefined>;
   toolSummaryById: Set<string>;
   lastToolError?: ToolErrorSummary;
 
@@ -77,6 +79,12 @@ export type EmbeddedPiSubscribeState = {
   successfulCronAdds: number;
   pendingMessagingMediaUrls: Map<string, string[]>;
   lastAssistant?: AgentMessage;
+  /** Timestamp (ms) when the first token arrived from the model. */
+  firstTokenAt?: number;
+  /** Timestamp (ms) when the current assistant message started. */
+  currentMessageStartAt?: number;
+  /** Timestamp (ms) when the first token arrived for the current message. */
+  currentMessageFirstTokenAt?: number;
 };
 
 export type EmbeddedPiSubscribeContext = {

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -140,13 +140,21 @@ export type EmbeddedPiSubscribeContext = {
  */
 export type ToolHandlerParams = Pick<
   SubscribeEmbeddedPiSessionParams,
-  "runId" | "onBlockReplyFlush" | "onAgentEvent" | "onToolResult"
+  | "runId"
+  | "sessionKey"
+  | "sessionId"
+  | "channel"
+  | "onBlockReplyFlush"
+  | "onAgentEvent"
+  | "onToolResult"
 >;
 
 export type ToolHandlerState = Pick<
   EmbeddedPiSubscribeState,
   | "toolMetaById"
   | "toolMetas"
+  | "toolStartTimeById"
+  | "toolArgsById"
   | "toolSummaryById"
   | "lastToolError"
   | "pendingMessagingTargets"

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-diagnostic-sessionkey.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-diagnostic-sessionkey.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import { clearAgentRunContext, registerAgentRunContext } from "../infra/agent-events.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
+
+type StubSession = {
+  subscribe: (fn: (evt: unknown) => void) => () => void;
+};
+
+type SessionEventHandler = (evt: unknown) => void;
+
+describe("subscribeEmbeddedPiSession – sessionKey propagation", () => {
+  it("includes sessionKey on model.inference when run context is registered", () => {
+    resetDiagnosticEventsForTest();
+
+    const runId = "run-sk-inference";
+    registerAgentRunContext(runId, { sessionKey: "agent:main:sub:abc" });
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId,
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "hi" }],
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      usage: { input: 5, output: 3, totalTokens: 8 },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    handler?.({ type: "message_start", message: assistantMessage });
+    handler?.({ type: "message_end", message: assistantMessage });
+
+    unsub();
+    clearAgentRunContext(runId);
+
+    const evt = events.find((e) => e.type === "model.inference");
+    expect(evt).toBeDefined();
+    expect(evt?.sessionKey).toBe("agent:main:sub:abc");
+    expect(evt?.runId).toBe(runId);
+  });
+
+  it("omits sessionKey on model.inference when no run context exists", () => {
+    resetDiagnosticEventsForTest();
+
+    const runId = "run-sk-no-ctx";
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId,
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "hi" }],
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      usage: { input: 5, output: 3, totalTokens: 8 },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    handler?.({ type: "message_start", message: assistantMessage });
+    handler?.({ type: "message_end", message: assistantMessage });
+
+    unsub();
+
+    const evt = events.find((e) => e.type === "model.inference");
+    expect(evt).toBeDefined();
+    expect(evt?.sessionKey).toBeUndefined();
+  });
+
+  it("includes sessionKey on tool.execution when run context is registered", () => {
+    resetDiagnosticEventsForTest();
+
+    const runId = "run-sk-tool";
+    registerAgentRunContext(runId, { sessionKey: "agent:main:sub:def" });
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId,
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "web_search",
+      toolCallId: "call-sk-1",
+      args: { query: "test" },
+    });
+
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "web_search",
+      toolCallId: "call-sk-1",
+      isError: false,
+      result: { output: "results" },
+    });
+
+    unsub();
+    clearAgentRunContext(runId);
+
+    const evt = events.find((e) => e.type === "tool.execution");
+    expect(evt).toBeDefined();
+    expect(evt?.sessionKey).toBe("agent:main:sub:def");
+    expect(evt?.runId).toBe(runId);
+  });
+
+  it("omits sessionKey on tool.execution when no run context exists", () => {
+    resetDiagnosticEventsForTest();
+
+    const runId = "run-sk-tool-no-ctx";
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId,
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "call-sk-2",
+      args: { path: "/tmp/test" },
+    });
+
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "read",
+      toolCallId: "call-sk-2",
+      isError: false,
+      result: "contents",
+    });
+
+    unsub();
+
+    const evt = events.find((e) => e.type === "tool.execution");
+    expect(evt).toBeDefined();
+    expect(evt?.sessionKey).toBeUndefined();
+  });
+
+  it("run.started includes sessionKey from run context", () => {
+    resetDiagnosticEventsForTest();
+
+    const runId = "run-sk-started";
+    registerAgentRunContext(runId, { sessionKey: "agent:main:sub:ghi" });
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId,
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    handler?.({ type: "agent_start" });
+
+    unsub();
+    clearAgentRunContext(runId);
+
+    const evt = events.find((e) => e.type === "run.started");
+    expect(evt).toBeDefined();
+    expect(evt?.sessionKey).toBe("agent:main:sub:ghi");
+  });
+});

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-diagnostic-tool-execution-events.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-diagnostic-tool-execution-events.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
+
+type StubSession = {
+  subscribe: (fn: (evt: unknown) => void) => () => void;
+};
+
+type SessionEventHandler = (evt: unknown) => void;
+
+describe("subscribeEmbeddedPiSession", () => {
+  it("emits tool.execution diagnostic event on tool_execution_end", () => {
+    resetDiagnosticEventsForTest();
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-diag-tool",
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "web_search",
+      toolCallId: "call-diag-1",
+      args: { query: "test" },
+    });
+
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "web_search",
+      toolCallId: "call-diag-1",
+      isError: false,
+      result: { output: "search results" },
+    });
+
+    unsub();
+
+    const toolEvents = events.filter((e) => e.type === "tool.execution");
+    expect(toolEvents).toHaveLength(1);
+
+    const evt = toolEvents[0];
+    expect(evt.runId).toBe("run-diag-tool");
+    expect(evt.toolName).toBe("web_search");
+    expect(evt.toolCallId).toBe("call-diag-1");
+    expect(evt.toolType).toBe("function");
+    expect(evt.durationMs).toBeTypeOf("number");
+    expect(evt.durationMs).toBeGreaterThanOrEqual(0);
+    expect(evt.error).toBeUndefined();
+  });
+
+  it("emits tool.execution with error when tool fails", () => {
+    resetDiagnosticEventsForTest();
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-diag-tool-err",
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "exec",
+      toolCallId: "call-diag-err",
+      args: { command: "failing-cmd" },
+    });
+
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "exec",
+      toolCallId: "call-diag-err",
+      isError: true,
+      result: { details: { error: "command not found" } },
+    });
+
+    unsub();
+
+    const toolEvents = events.filter((e) => e.type === "tool.execution");
+    expect(toolEvents).toHaveLength(1);
+
+    const evt = toolEvents[0];
+    expect(evt.runId).toBe("run-diag-tool-err");
+    expect(evt.toolName).toBe("exec");
+    expect(evt.error).toBe("command not found");
+  });
+
+  it("records durationMs from tool start to end", () => {
+    resetDiagnosticEventsForTest();
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-diag-timing",
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    vi.useFakeTimers();
+    try {
+      handler?.({
+        type: "tool_execution_start",
+        toolName: "read",
+        toolCallId: "call-timing",
+        args: { path: "/tmp/test" },
+      });
+
+      vi.advanceTimersByTime(150);
+
+      handler?.({
+        type: "tool_execution_end",
+        toolName: "read",
+        toolCallId: "call-timing",
+        isError: false,
+        result: "file contents",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    unsub();
+
+    const evt = events.find((e) => e.type === "tool.execution");
+    expect(evt.durationMs).toBe(150);
+  });
+
+  it("emits run.started diagnostic event on agent_start", () => {
+    resetDiagnosticEventsForTest();
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-diag-start",
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    handler?.({ type: "agent_start" });
+
+    unsub();
+
+    const evt = events.find((e) => e.type === "run.started");
+    expect(evt?.runId).toBe("run-diag-start");
+  });
+
+  it("emits model.inference with usage and timings", () => {
+    resetDiagnosticEventsForTest();
+
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-diag-infer",
+    });
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+      api: "openai",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {
+        input: 10,
+        output: 5,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 15,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    vi.useFakeTimers();
+    try {
+      handler?.({ type: "message_start", message: assistantMessage });
+      vi.advanceTimersByTime(50);
+      handler?.({
+        type: "message_update",
+        message: assistantMessage,
+        assistantMessageEvent: {
+          type: "text_delta",
+          delta: "hello",
+          contentIndex: 0,
+          partial: assistantMessage,
+        },
+      });
+      vi.advanceTimersByTime(150);
+      handler?.({ type: "message_end", message: assistantMessage });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    unsub();
+
+    const evt = events.find((e) => e.type === "model.inference");
+    expect(evt?.runId).toBe("run-diag-infer");
+    expect(evt?.usage?.input).toBe(10);
+    expect(evt?.usage?.output).toBe(5);
+    expect(evt?.durationMs).toBe(200);
+    expect(evt?.ttftMs).toBe(50);
+  });
+});

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-diagnostic-tool-execution-events.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-diagnostic-tool-execution-events.test.ts
@@ -151,7 +151,7 @@ describe("subscribeEmbeddedPiSession", () => {
     unsub();
 
     const evt = events.find((e) => e.type === "tool.execution");
-    expect(evt.durationMs).toBe(150);
+    expect(evt!.durationMs).toBe(150);
   });
 
   it("emits run.started diagnostic event on agent_start", () => {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -1,10 +1,15 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { InlineCodeState } from "../markdown/code-spans.js";
+import type {
+  EmbeddedPiSubscribeContext,
+  EmbeddedPiSubscribeState,
+} from "./pi-embedded-subscribe.handlers.types.js";
+import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { createStreamingDirectiveAccumulator } from "../auto-reply/reply/streaming-directives.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import type { InlineCodeState } from "../markdown/code-spans.js";
 import { buildCodeSpanIndex, createInlineCodeState } from "../markdown/code-spans.js";
 import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import {
@@ -12,12 +17,7 @@ import {
   normalizeTextForComparison,
 } from "./pi-embedded-helpers.js";
 import { createEmbeddedPiSessionEventHandler } from "./pi-embedded-subscribe.handlers.js";
-import type {
-  EmbeddedPiSubscribeContext,
-  EmbeddedPiSubscribeState,
-} from "./pi-embedded-subscribe.handlers.types.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
-import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
 import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
@@ -39,6 +39,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     assistantTexts: [],
     toolMetas: [],
     toolMetaById: new Map(),
+    toolStartTimeById: new Map(),
+    toolArgsById: new Map(),
     toolSummaryById: new Set(),
     lastToolError: undefined,
     blockReplyBreak: params.blockReplyBreak ?? "text_end",
@@ -78,6 +80,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     pendingMessagingTargets: new Map(),
     successfulCronAdds: 0,
     pendingMessagingMediaUrls: new Map(),
+    firstTokenAt: undefined,
+    currentMessageStartAt: undefined,
+    currentMessageFirstTokenAt: undefined,
   };
   const usageTotals = {
     input: 0,
@@ -576,6 +581,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     assistantTexts.length = 0;
     toolMetas.length = 0;
     toolMetaById.clear();
+    state.toolStartTimeById.clear();
+    state.toolArgsById.clear();
     toolSummaryById.clear();
     state.lastToolError = undefined;
     messagingToolSentTexts.length = 0;
@@ -586,6 +593,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     pendingMessagingTargets.clear();
     state.successfulCronAdds = 0;
     state.pendingMessagingMediaUrls.clear();
+    state.firstTokenAt = undefined;
     resetAssistantMessageState(0);
   };
 
@@ -668,6 +676,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     unsubscribe,
     isCompacting: () => state.compactionInFlight || state.pendingCompactionRetry > 0,
     isCompactionInFlight: () => state.compactionInFlight,
+    getFirstTokenAt: () => state.firstTokenAt,
     getMessagingToolSentTexts: () => messagingToolSentTexts.slice(),
     getMessagingToolSentMediaUrls: () => messagingToolSentMediaUrls.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -38,7 +38,6 @@ export type SubscribeEmbeddedPiSessionParams = {
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void | Promise<void>;
   enforceFinalTag?: boolean;
   config?: OpenClawConfig;
-  sessionKey?: string;
 };
 
 export type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -10,6 +10,14 @@ export type ToolResultFormat = "markdown" | "plain";
 export type SubscribeEmbeddedPiSessionParams = {
   session: AgentSession;
   runId: string;
+  sessionKey?: string;
+  sessionId?: string;
+  channel?: string;
+  /**
+   * When true, diagnostic events may include message content.
+   * This is intentionally opt-in and typically controlled by `diagnostics.otel.captureContent`.
+   */
+  captureContent?: boolean;
   hookRunner?: HookRunner;
   verboseLevel?: VerboseLevel;
   reasoningMode?: ReasoningLevel;

--- a/src/agents/trace-context-propagator.ts
+++ b/src/agents/trace-context-propagator.ts
@@ -1,0 +1,46 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+
+// Shared symbol with diagnostics-otel extension for reading W3C Trace Context headers.
+// The extension writes headers into a global Map keyed by sessionKey;
+// this module reads them and injects into outgoing LLM requests.
+const TRACE_CONTEXT_REGISTRY_KEY = Symbol.for("openclaw.diagnostics-otel.trace-headers");
+
+type TraceHeaders = { traceparent: string; tracestate?: string };
+
+function getTraceHeaders(sessionKey: string): TraceHeaders | undefined {
+  const registry = (globalThis as { [TRACE_CONTEXT_REGISTRY_KEY]?: Map<string, TraceHeaders> })[
+    TRACE_CONTEXT_REGISTRY_KEY
+  ];
+  return registry?.get(sessionKey);
+}
+
+/**
+ * Wraps a StreamFn to inject W3C Trace Context headers (traceparent, tracestate)
+ * into every outgoing LLM request. Headers are read from the global trace context
+ * registry populated by the diagnostics-otel extension.
+ *
+ * If no trace context is available for the session, the inner stream function
+ * is called unchanged.
+ */
+export function wrapStreamFnWithTraceContext(streamFn: StreamFn, sessionKey?: string): StreamFn {
+  if (!sessionKey) {
+    return streamFn;
+  }
+
+  return ((model, context, options) => {
+    const traceHeaders = getTraceHeaders(sessionKey);
+    if (!traceHeaders) {
+      return streamFn(model, context, options);
+    }
+
+    const mergedOptions = {
+      ...options,
+      headers: {
+        ...(options as { headers?: Record<string, string> } | undefined)?.headers,
+        traceparent: traceHeaders.traceparent,
+        ...(traceHeaders.tracestate ? { tracestate: traceHeaders.tracestate } : {}),
+      },
+    };
+    return streamFn(model, context, mergedOptions);
+  }) as StreamFn;
+}

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,5 +1,10 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import type { TemplateContext } from "../templating.js";
+import type { VerboseLevel } from "../thinking.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { FollowupRun } from "./queue.js";
+import type { TypingSignaler } from "./typing-mode.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
@@ -41,9 +46,7 @@ import {
   resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
 import { type BlockReplyPipeline } from "./block-reply-pipeline.js";
-import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
-import type { TypingSignaler } from "./typing-mode.js";
 
 export type RuntimeFallbackAttempt = {
   provider: string;
@@ -67,7 +70,12 @@ export type AgentRunLoopResult =
       /** Payload keys sent directly (not via pipeline) during tool flush. */
       directlySentBlockKeys?: Set<string>;
     }
-  | { kind: "final"; payload: ReplyPayload };
+  | {
+      kind: "final";
+      runId: string;
+      payload: ReplyPayload;
+      errorInfo?: { message: string; errorType: string };
+    };
 
 export async function runAgentTurnWithFallback(params: {
   commandBody: string;
@@ -454,9 +462,11 @@ export async function runAgentTurnWithFallback(params: {
         didResetAfterCompactionFailure = true;
         return {
           kind: "final",
+          runId,
           payload: {
             text: "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
           },
+          errorInfo: { message: embeddedError.message, errorType: "context_overflow" },
         };
       }
       if (embeddedError?.kind === "role_ordering") {
@@ -464,9 +474,11 @@ export async function runAgentTurnWithFallback(params: {
         if (didReset) {
           return {
             kind: "final",
+            runId,
             payload: {
               text: "⚠️ Message ordering conflict. I've reset the conversation - please try again.",
             },
+            errorInfo: { message: embeddedError.message, errorType: "role_ordering" },
           };
         }
       }
@@ -488,9 +500,11 @@ export async function runAgentTurnWithFallback(params: {
         didResetAfterCompactionFailure = true;
         return {
           kind: "final",
+          runId,
           payload: {
             text: "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
           },
+          errorInfo: { message, errorType: "compaction_failure" },
         };
       }
       if (isRoleOrderingError) {
@@ -498,9 +512,11 @@ export async function runAgentTurnWithFallback(params: {
         if (didReset) {
           return {
             kind: "final",
+            runId,
             payload: {
               text: "⚠️ Message ordering conflict. I've reset the conversation - please try again.",
             },
+            errorInfo: { message, errorType: "role_ordering" },
           };
         }
       }
@@ -544,9 +560,11 @@ export async function runAgentTurnWithFallback(params: {
 
         return {
           kind: "final",
+          runId,
           payload: {
             text: "⚠️ Session history was corrupted. I've reset the conversation - please try again!",
           },
+          errorInfo: { message, errorType: "session_corruption" },
         };
       }
 
@@ -578,8 +596,17 @@ export async function runAgentTurnWithFallback(params: {
 
       return {
         kind: "final",
+        runId,
         payload: {
           text: fallbackText,
+        },
+        errorInfo: {
+          message,
+          errorType: isContextOverflow
+            ? "context_overflow"
+            : isRoleOrderingError
+              ? "role_ordering"
+              : "unknown",
         },
       };
     }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,10 +1,5 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
-import type { TemplateContext } from "../templating.js";
-import type { VerboseLevel } from "../thinking.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
-import type { FollowupRun } from "./queue.js";
-import type { TypingSignaler } from "./typing-mode.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
@@ -46,7 +41,9 @@ import {
   resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
 import { type BlockReplyPipeline } from "./block-reply-pipeline.js";
+import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
+import type { TypingSignaler } from "./typing-mode.js";
 
 export type RuntimeFallbackAttempt = {
   provider: string;
@@ -622,6 +619,7 @@ export async function runAgentTurnWithFallback(params: {
   if (finalEmbeddedError && isContextOverflowError(finalEmbeddedError.message) && !hasPayloadText) {
     return {
       kind: "final",
+      runId,
       payload: {
         text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
       },

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,10 +1,15 @@
 import fs from "node:fs";
+import type { TypingMode } from "../../config/types.js";
+import type { OriginatingChannelType, TemplateContext } from "../templating.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { TypingController } from "./typing.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
+import { resolveExtraParams } from "../../agents/pi-embedded-runner/extra-params.js";
 import { queueEmbeddedPiMessage } from "../../agents/pi-embedded.js";
-import { hasNonzeroUsage } from "../../agents/usage.js";
+import { derivePromptTokens, hasNonzeroUsage } from "../../agents/usage.js";
 import {
   resolveAgentIdFromSessionKey,
   resolveSessionFilePath,
@@ -14,9 +19,12 @@ import {
   updateSessionStore,
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
-import type { TypingMode } from "../../config/types.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
-import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import {
+  emitDiagnosticEvent,
+  isDiagnosticsEnabled,
+  type GenAiMessage,
+} from "../../infra/diagnostic-events.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -26,9 +34,7 @@ import {
   buildFallbackNotice,
   resolveFallbackTransition,
 } from "../fallback-state.js";
-import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { runAgentTurnWithFallback } from "./agent-runner-execution.js";
 import {
   createShouldEmitToolOutput,
@@ -50,7 +56,6 @@ import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queu
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
 import { createTypingSignaler } from "./typing-mode.js";
-import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 const UNSCHEDULED_REMINDER_NOTE =
@@ -389,6 +394,22 @@ export async function runReplyAgent(params: {
     });
 
     if (runOutcome.kind === "final") {
+      if (isDiagnosticsEnabled(cfg) && runOutcome.errorInfo) {
+        emitDiagnosticEvent({
+          type: "run.completed",
+          runId: runOutcome.runId,
+          sessionKey,
+          sessionId: followupRun.run.sessionId,
+          channel: replyToChannel,
+          provider: followupRun.run.provider,
+          model: defaultModel,
+          usage: {},
+          durationMs: Date.now() - runStartedAt,
+          operationName: "chat",
+          error: runOutcome.errorInfo.message,
+          errorType: runOutcome.errorInfo.errorType,
+        });
+      }
       return finalizeWithFollowup(runOutcome.payload, queueKey, runFollowupTurn);
     }
 
@@ -476,6 +497,11 @@ export async function runReplyAgent(params: {
         });
       }
     }
+    const resolvedModelParams = resolveExtraParams({
+      cfg,
+      provider: providerUsed,
+      modelId: modelUsed,
+    });
     const cliSessionId = isCliProvider(providerUsed, cfg)
       ? runResult.meta?.agentMeta?.sessionId?.trim()
       : undefined;
@@ -497,6 +523,103 @@ export async function runReplyAgent(params: {
       systemPromptReport: runResult.meta?.systemPromptReport,
       cliSessionId,
     });
+
+    if (isDiagnosticsEnabled(cfg)) {
+      const captureContent = !!cfg?.diagnostics?.otel?.captureContent;
+      const input = usage?.input;
+      const output = usage?.output;
+      const cacheRead = usage?.cacheRead;
+      const cacheWrite = usage?.cacheWrite;
+      const promptTokens = derivePromptTokens(usage);
+      const totalTokens =
+        usage?.total ??
+        (typeof promptTokens === "number" && typeof output === "number"
+          ? promptTokens + output
+          : undefined);
+      const costConfig = resolveModelCostConfig({
+        provider: providerUsed,
+        model: modelUsed,
+        config: cfg,
+      });
+      const costUsd = hasNonzeroUsage(usage)
+        ? estimateUsageCost({ usage, cost: costConfig })
+        : undefined;
+      // Map stopReason to GenAI finish_reasons
+      const stopReason = runResult.meta.stopReason;
+      const finishReasons = stopReason
+        ? [stopReason === "tool_calls" ? "tool_call" : stopReason]
+        : ["stop"];
+
+      // Content capture is intentionally opt-in and controlled by diagnostics.otel.captureContent.
+      // When disabled, we still emit aggregate usage/timings/errors but omit message content fields.
+      const inputMessages: GenAiMessage[] = captureContent
+        ? [{ role: "user", parts: [{ type: "text", content: commandBody }] }]
+        : [];
+      const outputParts = captureContent
+        ? payloadArray.map((p) => p.text?.trim()).filter((t): t is string => Boolean(t))
+        : [];
+      const pendingCalls = captureContent ? runResult.meta.pendingToolCalls : undefined;
+      const outputMessages: GenAiMessage[] = [];
+      if (captureContent && (outputParts.length > 0 || pendingCalls?.length)) {
+        const msg: GenAiMessage = {
+          role: "assistant",
+          parts: [
+            ...outputParts.map((t) => ({ type: "text" as const, content: t })),
+            ...(pendingCalls?.map((tc) => ({
+              type: "tool_call" as const,
+              id: tc.id,
+              name: tc.name,
+              arguments: (() => {
+                try {
+                  return JSON.parse(tc.arguments) as Record<string, unknown>;
+                } catch {
+                  return { raw: tc.arguments };
+                }
+              })(),
+            })) ?? []),
+          ],
+          finish_reason: finishReasons[0],
+        };
+        outputMessages.push(msg);
+      }
+
+      emitDiagnosticEvent({
+        type: "run.completed",
+        runId,
+        sessionKey,
+        sessionId: followupRun.run.sessionId,
+        channel: replyToChannel,
+        provider: providerUsed,
+        model: modelUsed,
+        usage: {
+          input,
+          output,
+          cacheRead,
+          cacheWrite,
+          promptTokens,
+          total: totalTokens,
+        },
+        context: {
+          limit: contextTokensUsed,
+          used: totalTokens,
+        },
+        costUsd,
+        durationMs: Date.now() - runStartedAt,
+        operationName: "chat",
+        finishReasons,
+        responseModel: runResult.meta.agentMeta?.model,
+        inputMessages: inputMessages.length > 0 ? inputMessages : undefined,
+        outputMessages: outputMessages.length > 0 ? outputMessages : undefined,
+        temperature:
+          typeof resolvedModelParams?.temperature === "number"
+            ? resolvedModelParams.temperature
+            : undefined,
+        maxOutputTokens:
+          typeof resolvedModelParams?.maxTokens === "number"
+            ? resolvedModelParams.maxTokens
+            : undefined,
+      });
+    }
 
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and
@@ -546,44 +669,6 @@ export async function runReplyAgent(params: {
         : replyPayloads;
 
     await signalTypingIfNeeded(guardedReplyPayloads, typingSignals);
-
-    if (isDiagnosticsEnabled(cfg) && hasNonzeroUsage(usage)) {
-      const input = usage.input ?? 0;
-      const output = usage.output ?? 0;
-      const cacheRead = usage.cacheRead ?? 0;
-      const cacheWrite = usage.cacheWrite ?? 0;
-      const promptTokens = input + cacheRead + cacheWrite;
-      const totalTokens = usage.total ?? promptTokens + output;
-      const costConfig = resolveModelCostConfig({
-        provider: providerUsed,
-        model: modelUsed,
-        config: cfg,
-      });
-      const costUsd = estimateUsageCost({ usage, cost: costConfig });
-      emitDiagnosticEvent({
-        type: "model.usage",
-        sessionKey,
-        sessionId: followupRun.run.sessionId,
-        channel: replyToChannel,
-        provider: providerUsed,
-        model: modelUsed,
-        usage: {
-          input,
-          output,
-          cacheRead,
-          cacheWrite,
-          promptTokens,
-          total: totalTokens,
-        },
-        lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
-        context: {
-          limit: contextTokensUsed,
-          used: totalTokens,
-        },
-        costUsd,
-        durationMs: Date.now() - runStartedAt,
-      });
-    }
 
     const responseUsageRaw =
       activeSessionEntry?.responseUsage ??

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1,25 +1,30 @@
 import crypto from "node:crypto";
+import type { TypingMode } from "../../config/types.js";
+import type { OriginatingChannelType } from "../templating.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { FollowupRun } from "./queue.js";
+import type { TypingController } from "./typing.js";
 import { resolveRunModelFallbacksOverride } from "../../agents/agent-scope.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
-import type { SessionEntry } from "../../config/sessions.js";
-import type { TypingMode } from "../../config/types.js";
+import { derivePromptTokens, hasNonzeroUsage } from "../../agents/usage.js";
+import { resolveAgentIdFromSessionKey, type SessionEntry } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
+import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { logMessageQueued, logMessageProcessed } from "../../logging/diagnostic.js";
 import { defaultRuntime } from "../../runtime.js";
+import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
-import type { OriginatingChannelType } from "../templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { resolveRunAuthProfile } from "./agent-runner-utils.js";
 import {
   resolveOriginAccountId,
   resolveOriginMessageProvider,
   resolveOriginMessageTo,
 } from "./origin-routing.js";
-import type { FollowupRun } from "./queue.js";
 import {
   applyReplyThreading,
   filterMessagingToolDuplicates,
@@ -30,7 +35,6 @@ import { resolveReplyToMode } from "./reply-threading.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
 import { createTypingSignaler } from "./typing-mode.js";
-import type { TypingController } from "./typing.js";
 
 export function createFollowupRunner(params: {
   opts?: GetReplyOptions;
@@ -128,6 +132,21 @@ export function createFollowupRunner(params: {
   };
 
   return async (queued: FollowupRun) => {
+    const diagnosticsEnabled = isDiagnosticsEnabled(queued.run.config);
+    const channel = queued.originatingChannel ?? queued.run.messageProvider?.toLowerCase();
+    const runStartedAt = diagnosticsEnabled ? Date.now() : 0;
+    let outcome: "completed" | "error" = "completed";
+    let outcomeError: string | undefined;
+
+    // Create root trace span so child spans (agent turn, inference, tools) nest under it.
+    if (diagnosticsEnabled && queued.run.sessionKey) {
+      logMessageQueued({
+        sessionKey: queued.run.sessionKey,
+        channel,
+        source: "followup",
+      });
+    }
+
     try {
       const runId = crypto.randomUUID();
       if (queued.run.sessionKey) {
@@ -208,6 +227,24 @@ export function createFollowupRunner(params: {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         defaultRuntime.error?.(`Followup agent failed before reply: ${message}`);
+        outcome = "error";
+        outcomeError = message;
+        if (diagnosticsEnabled) {
+          emitDiagnosticEvent({
+            type: "run.completed",
+            runId,
+            sessionKey: queued.run.sessionKey,
+            sessionId: queued.run.sessionId,
+            channel,
+            provider: queued.run.provider,
+            model: queued.run.model,
+            usage: {},
+            durationMs: Date.now() - runStartedAt,
+            operationName: "chat",
+            error: message,
+            errorType: err instanceof Error ? err.constructor.name : "UnknownError",
+          });
+        }
         return;
       }
 
@@ -231,6 +268,54 @@ export function createFollowupRunner(params: {
           providerUsed: fallbackProvider,
           contextTokensUsed,
           logLabel: "followup",
+        });
+      }
+
+      // Emit run.completed so the agent turn span is properly ended with usage data.
+      if (diagnosticsEnabled) {
+        const input = usage?.input;
+        const output = usage?.output;
+        const cacheRead = usage?.cacheRead;
+        const cacheWrite = usage?.cacheWrite;
+        const promptTokens = derivePromptTokens(usage);
+        const totalTokens =
+          usage?.total ??
+          (typeof promptTokens === "number" && typeof output === "number"
+            ? promptTokens + output
+            : undefined);
+        const costConfig = resolveModelCostConfig({
+          provider: fallbackProvider,
+          model: modelUsed,
+          config: queued.run.config,
+        });
+        const costUsd = hasNonzeroUsage(usage)
+          ? estimateUsageCost({ usage, cost: costConfig })
+          : undefined;
+
+        emitDiagnosticEvent({
+          type: "run.completed",
+          runId,
+          sessionKey: queued.run.sessionKey,
+          sessionId: queued.run.sessionId,
+          channel,
+          provider: fallbackProvider,
+          model: modelUsed,
+          usage: {
+            input,
+            output,
+            cacheRead,
+            cacheWrite,
+            promptTokens,
+            total: totalTokens,
+          },
+          context: {
+            limit: contextTokensUsed,
+            used: totalTokens,
+          },
+          costUsd,
+          durationMs: Date.now() - runStartedAt,
+          operationName: "chat",
+          responseModel: runResult.meta.agentMeta?.model,
         });
       }
 
@@ -323,6 +408,18 @@ export function createFollowupRunner(params: {
       // indefinitely until the TTL expires).
       typing.markRunComplete();
       typing.markDispatchIdle();
+
+      // End the root trace span created by logMessageQueued.
+      if (diagnosticsEnabled && queued.run.sessionKey) {
+        logMessageProcessed({
+          channel: channel ?? "unknown",
+          sessionKey: queued.run.sessionKey,
+          sessionId: queued.run.sessionId,
+          durationMs: Date.now() - runStartedAt,
+          outcome,
+          error: outcomeError,
+        });
+      }
     }
   };
 }

--- a/src/commands/agent.diagnostics.test.ts
+++ b/src/commands/agent.diagnostics.test.ts
@@ -1,0 +1,270 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+}));
+
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import * as configModule from "../config/config.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+import { agentCommand } from "./agent.js";
+
+const runtime: RuntimeEnv = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(() => {
+    throw new Error("exit");
+  }),
+};
+
+const configSpy = vi.spyOn(configModule, "loadConfig");
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(fn, { prefix: "openclaw-agent-diag-" });
+}
+
+function mockConfig(
+  home: string,
+  storePath: string,
+  overrides?: {
+    diagnostics?: boolean;
+    agentOverrides?: Partial<NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>>;
+  },
+) {
+  configSpy.mockReturnValue({
+    agents: {
+      defaults: {
+        model: { primary: "anthropic/claude-opus-4-5" },
+        models: { "anthropic/claude-opus-4-5": {} },
+        workspace: path.join(home, "openclaw"),
+        ...overrides?.agentOverrides,
+      },
+    },
+    session: { store: storePath, mainKey: "main" },
+    diagnostics: overrides?.diagnostics ? { enabled: true } : undefined,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetDiagnosticEventsForTest();
+  vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+    payloads: [{ text: "ok" }],
+    meta: {
+      durationMs: 5,
+      agentMeta: {
+        sessionId: "s",
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        usage: { input: 10, output: 5, cacheRead: 2, cacheWrite: 1, total: 18 },
+      },
+    },
+  });
+  vi.mocked(loadModelCatalog).mockResolvedValue([]);
+});
+
+describe("agentCommand – diagnostic events", () => {
+  it("emits message.queued when diagnostics are enabled", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await agentCommand({ message: "hello", to: "+1555" }, runtime);
+      unsub();
+
+      const queued = events.filter((e) => e.type === "message.queued");
+      expect(queued).toHaveLength(1);
+      expect(queued[0].source).toBe("agent-command");
+      expect(queued[0].sessionKey).toBeTruthy();
+      expect(queued[0].sessionId).toBeTruthy();
+    });
+  });
+
+  it("emits run.completed on successful run", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await agentCommand({ message: "hello", to: "+1555" }, runtime);
+      unsub();
+
+      const completed = events.filter((e) => e.type === "run.completed");
+      expect(completed).toHaveLength(1);
+
+      const evt = completed[0];
+      expect(evt.runId).toBeTruthy();
+      expect(evt.sessionKey).toBeTruthy();
+      expect(evt.provider).toBe("anthropic");
+      expect(evt.model).toBe("claude-opus-4-5");
+      expect(evt.operationName).toBe("chat");
+      expect(evt.durationMs).toBeTypeOf("number");
+      expect(evt.durationMs).toBeGreaterThanOrEqual(0);
+      expect(evt.usage).toEqual(
+        expect.objectContaining({
+          input: 10,
+          output: 5,
+          cacheRead: 2,
+          cacheWrite: 1,
+          total: 18,
+        }),
+      );
+      expect(evt.error).toBeUndefined();
+    });
+  });
+
+  it("emits run.completed with error info when run throws", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      vi.mocked(runEmbeddedPiAgent).mockRejectedValueOnce(new Error("model overloaded"));
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await expect(agentCommand({ message: "hello", to: "+1555" }, runtime)).rejects.toThrow(
+        "model overloaded",
+      );
+      unsub();
+
+      const completed = events.filter((e) => e.type === "run.completed");
+      expect(completed).toHaveLength(1);
+
+      const evt = completed[0];
+      expect(evt.error).toContain("model overloaded");
+      expect(evt.errorType).toBe("exception");
+      expect(evt.durationMs).toBeTypeOf("number");
+    });
+  });
+
+  it("emits message.processed on successful run", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await agentCommand({ message: "hello", to: "+1555" }, runtime);
+      unsub();
+
+      const processed = events.filter((e) => e.type === "message.processed");
+      expect(processed).toHaveLength(1);
+
+      const evt = processed[0];
+      expect(evt.sessionKey).toBeTruthy();
+      expect(evt.sessionId).toBeTruthy();
+      expect(evt.outcome).toBe("completed");
+      expect(evt.durationMs).toBeTypeOf("number");
+      expect(evt.durationMs).toBeGreaterThanOrEqual(0);
+      expect(evt.error).toBeUndefined();
+    });
+  });
+
+  it("emits message.processed with error outcome when run throws", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      vi.mocked(runEmbeddedPiAgent).mockRejectedValueOnce(new Error("timeout"));
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await expect(agentCommand({ message: "hello", to: "+1555" }, runtime)).rejects.toThrow(
+        "timeout",
+      );
+      unsub();
+
+      const processed = events.filter((e) => e.type === "message.processed");
+      expect(processed).toHaveLength(1);
+
+      const evt = processed[0];
+      expect(evt.outcome).toBe("error");
+      expect(evt.error).toContain("timeout");
+    });
+  });
+
+  it("emits full diagnostic event sequence in correct order", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await agentCommand({ message: "hello", to: "+1555" }, runtime);
+      unsub();
+
+      const types = events.map((e) => e.type);
+      const queuedIdx = types.indexOf("message.queued");
+      const completedIdx = types.indexOf("run.completed");
+      const processedIdx = types.indexOf("message.processed");
+
+      expect(queuedIdx).toBeGreaterThanOrEqual(0);
+      expect(completedIdx).toBeGreaterThanOrEqual(0);
+      expect(processedIdx).toBeGreaterThanOrEqual(0);
+
+      // message.queued must come before run.completed
+      expect(queuedIdx).toBeLessThan(completedIdx);
+      // run.completed must come before message.processed
+      expect(completedIdx).toBeLessThan(processedIdx);
+    });
+  });
+
+  it("does not emit diagnostic events when diagnostics are disabled", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: false });
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await agentCommand({ message: "hello", to: "+1555" }, runtime);
+      unsub();
+
+      const diagTypes = new Set(["message.queued", "run.completed", "message.processed"]);
+      const matched = events.filter((e) => diagTypes.has(e.type));
+      expect(matched).toHaveLength(0);
+    });
+  });
+
+  it("uses replyChannel for diagnostic event channel field", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, { diagnostics: true });
+
+      const events: DiagnosticEventPayload[] = [];
+      const unsub = onDiagnosticEvent((evt) => events.push(evt));
+
+      await agentCommand({ message: "hello", to: "+1555", replyChannel: "slack" }, runtime);
+      unsub();
+
+      const queued = events.find((e) => e.type === "message.queued");
+      expect(queued?.channel).toBe("slack");
+
+      const completed = events.find((e) => e.type === "run.completed");
+      expect(completed?.channel).toBe("slack");
+    });
+  });
+});

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,7 +1,9 @@
+import path from "node:path";
 import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../acp/policy.js";
 import { toAcpRuntimeError } from "../acp/runtime/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { AgentCommandOpts } from "./agent/types.js";
 
 const log = createSubsystemLogger("commands/agent");
 import {
@@ -65,8 +67,10 @@ import {
   emitAgentEvent,
   registerAgentRunContext,
 } from "../infra/agent-events.js";
+import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
+import { logMessageQueued, logMessageProcessed } from "../logging/diagnostic.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { applyVerboseOverride } from "../sessions/level-overrides.js";
@@ -77,7 +81,6 @@ import { deliverAgentCommandResult } from "./agent/delivery.js";
 import { resolveAgentRunContext } from "./agent/run-context.js";
 import { updateSessionStoreAfterAgentRun } from "./agent/session-store.js";
 import { resolveSession } from "./agent/session.js";
-import type { AgentCommandOpts } from "./agent/types.js";
 
 type PersistSessionEntryParams = {
   sessionStore: Record<string, SessionEntry>;
@@ -437,6 +440,10 @@ export async function agentCommand(
         sessionKey,
       })
     : null;
+  const diagnosticsEnabled = isDiagnosticsEnabled(cfg);
+  const diagStartedAt = Date.now();
+  let agentCommandOutcome: "completed" | "error" = "completed";
+  let agentCommandError: string | undefined;
 
   try {
     if (opts.deliver === true) {
@@ -581,6 +588,14 @@ export async function agentCommand(
       registerAgentRunContext(runId, {
         sessionKey,
         verboseLevel: resolvedVerboseLevel,
+      });
+    }
+    if (diagnosticsEnabled && sessionKey) {
+      logMessageQueued({
+        sessionId,
+        sessionKey,
+        channel: resolveMessageChannel(opts.replyChannel, opts.channel),
+        source: "agent-command",
       });
     }
 
@@ -862,6 +877,30 @@ export async function agentCommand(
       result = fallbackResult.result;
       fallbackProvider = fallbackResult.provider;
       fallbackModel = fallbackResult.model;
+      if (diagnosticsEnabled) {
+        const agentMeta = result.meta.agentMeta;
+        const usage = agentMeta?.usage;
+        emitDiagnosticEvent({
+          type: "run.completed",
+          runId,
+          sessionKey,
+          sessionId,
+          channel: resolveMessageChannel(opts.replyChannel, opts.channel),
+          provider: agentMeta?.provider ?? fallbackProvider,
+          model: agentMeta?.model ?? fallbackModel,
+          usage: {
+            input: usage?.input,
+            output: usage?.output,
+            cacheRead: usage?.cacheRead,
+            cacheWrite: usage?.cacheWrite,
+            total: usage?.total,
+          },
+          durationMs: Date.now() - startedAt,
+          operationName: "chat",
+          error: result.meta.error?.message,
+          errorType: result.meta.error?.kind,
+        });
+      }
       if (!lifecycleEnded) {
         emitAgentEvent({
           runId,
@@ -875,6 +914,24 @@ export async function agentCommand(
         });
       }
     } catch (err) {
+      agentCommandOutcome = "error";
+      agentCommandError = String(err);
+      if (diagnosticsEnabled) {
+        emitDiagnosticEvent({
+          type: "run.completed",
+          runId,
+          sessionKey,
+          sessionId,
+          channel: resolveMessageChannel(opts.replyChannel, opts.channel),
+          provider: fallbackProvider,
+          model: fallbackModel,
+          usage: {},
+          durationMs: Date.now() - startedAt,
+          operationName: "chat",
+          error: String(err),
+          errorType: "exception",
+        });
+      }
       if (!lifecycleEnded) {
         emitAgentEvent({
           runId,
@@ -919,6 +976,16 @@ export async function agentCommand(
       payloads,
     });
   } finally {
+    if (diagnosticsEnabled && sessionKey) {
+      logMessageProcessed({
+        channel: resolveMessageChannel(opts.replyChannel, opts.channel) ?? "agent-command",
+        sessionId,
+        sessionKey,
+        durationMs: Date.now() - diagStartedAt,
+        outcome: agentCommandOutcome,
+        error: agentCommandError,
+      });
+    }
     clearAgentRunContext(runId);
   }
 }

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -195,7 +195,7 @@ export type DiagnosticsOtelConfig = {
    * Record gen_ai content on inference spans (opt-in, sensitive).
    * `true` enables all content capture. An object form allows granular control:
    * `{ inputMessages: true, outputMessages: true, systemInstructions: false, toolDefinitions: true, toolContent: true }`
-   * When using the object form, each field defaults to `true` if omitted.
+   * When using the object form, fields are strict opt-in (`true` required; omitted = disabled).
    */
   captureContent?:
     | boolean

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -191,6 +191,21 @@ export type DiagnosticsOtelConfig = {
   sampleRate?: number;
   /** Metric export interval (ms). */
   flushIntervalMs?: number;
+  /**
+   * Record gen_ai content on inference spans (opt-in, sensitive).
+   * `true` enables all content capture. An object form allows granular control:
+   * `{ inputMessages: true, outputMessages: true, systemInstructions: false, toolDefinitions: true, toolContent: true }`
+   * When using the object form, each field defaults to `true` if omitted.
+   */
+  captureContent?:
+    | boolean
+    | {
+        inputMessages?: boolean;
+        outputMessages?: boolean;
+        systemInstructions?: boolean;
+        toolDefinitions?: boolean;
+        toolContent?: boolean;
+      };
 };
 
 export type DiagnosticsCacheTraceConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -192,6 +192,20 @@ export const OpenClawSchema = z
             logs: z.boolean().optional(),
             sampleRate: z.number().min(0).max(1).optional(),
             flushIntervalMs: z.number().int().nonnegative().optional(),
+            captureContent: z
+              .union([
+                z.boolean(),
+                z
+                  .object({
+                    inputMessages: z.boolean().optional(),
+                    outputMessages: z.boolean().optional(),
+                    systemInstructions: z.boolean().optional(),
+                    toolDefinitions: z.boolean().optional(),
+                    toolContent: z.boolean().optional(),
+                  })
+                  .strict(),
+              ])
+              .optional(),
           })
           .strict()
           .optional(),

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -282,6 +282,36 @@ export type DiagnosticToolExecutionEvent = DiagnosticBaseEvent & {
   toolOutput?: unknown;
 };
 
+export type DiagnosticModelUsageEvent = DiagnosticBaseEvent & {
+  type: "model.usage";
+  sessionKey?: string;
+  sessionId?: string;
+  channel?: string;
+  provider?: string;
+  model?: string;
+  usage: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    promptTokens?: number;
+    total?: number;
+  };
+  lastCallUsage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
+  context?: {
+    limit?: number;
+    used?: number;
+  };
+  costUsd?: number;
+  durationMs?: number;
+};
+
 export type DiagnosticEventPayload =
   | DiagnosticInferenceEvent
   | DiagnosticInferenceStartedEvent
@@ -299,7 +329,8 @@ export type DiagnosticEventPayload =
   | DiagnosticRunCompletedEvent
   | DiagnosticHeartbeatEvent
   | DiagnosticToolLoopEvent
-  | DiagnosticToolExecutionEvent;
+  | DiagnosticToolExecutionEvent
+  | DiagnosticModelUsageEvent;
 
 export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
   ? Event extends DiagnosticEventPayload

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -275,7 +275,8 @@ export type {
 export type { ChatType } from "../channels/chat-type.js";
 /** @deprecated Use ChatType instead */
 export type { RoutePeerKind } from "../routing/resolve-route.js";
-export { resolveAckReaction } from "../agents/identity.js";
+export { resolveAckReaction, resolveAgentIdentity } from "../agents/identity.js";
+export { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 export type { ReplyPayload } from "../auto-reply/types.js";
 export type { ChunkMode } from "../auto-reply/chunk.js";
 export { SILENT_REPLY_TOKEN, isSilentReplyText } from "../auto-reply/tokens.js";
@@ -471,18 +472,25 @@ export {
 export type {
   DiagnosticEventPayload,
   DiagnosticHeartbeatEvent,
+  DiagnosticInferenceEvent,
+  DiagnosticInferenceStartedEvent,
   DiagnosticLaneDequeueEvent,
   DiagnosticLaneEnqueueEvent,
   DiagnosticMessageProcessedEvent,
   DiagnosticMessageQueuedEvent,
   DiagnosticRunAttemptEvent,
+  DiagnosticRunStartedEvent,
+  DiagnosticRunCompletedEvent,
   DiagnosticSessionState,
   DiagnosticSessionStateEvent,
   DiagnosticSessionStuckEvent,
-  DiagnosticUsageEvent,
+  DiagnosticToolExecutionEvent,
   DiagnosticWebhookErrorEvent,
   DiagnosticWebhookProcessedEvent,
   DiagnosticWebhookReceivedEvent,
+  GenAiMessage,
+  GenAiPart,
+  GenAiToolDef,
 } from "../infra/diagnostic-events.js";
 export { detectMime, extensionForMime, getFileExtension } from "../media/mime.js";
 export { extractOriginalFilename } from "../media/store.js";

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,10 +1,16 @@
+import { createJiti } from "jiti";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { createJiti } from "jiti";
 import type { OpenClawConfig } from "../config/config.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
+import type {
+  OpenClawPluginDefinition,
+  OpenClawPluginModule,
+  PluginDiagnostic,
+  PluginLogger,
+} from "./types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveUserPath } from "../utils.js";
 import { clearPluginCommands } from "./commands.js";
@@ -23,12 +29,6 @@ import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./
 import { setActivePluginRegistry } from "./runtime.js";
 import { createPluginRuntime } from "./runtime/index.js";
 import { validateJsonSchemaValue } from "./schema-validator.js";
-import type {
-  OpenClawPluginDefinition,
-  OpenClawPluginModule,
-  PluginDiagnostic,
-  PluginLogger,
-} from "./types.js";
 
 export type PluginLoadResult = PluginRegistry;
 

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -89,6 +89,7 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
     { key: "GH_TOKEN", value: process.env.GH_TOKEN },
     { key: "GITHUB_TOKEN", value: process.env.GITHUB_TOKEN },
     { key: "NODE_OPTIONS", value: process.env.NODE_OPTIONS },
+    { key: "ZDOTDIR", value: process.env.ZDOTDIR },
   ];
 
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-home-"));
@@ -97,6 +98,9 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
   process.env.USERPROFILE = tempHome;
   process.env.OPENCLAW_TEST_HOME = tempHome;
   process.env.OPENCLAW_TEST_FAST = "1";
+  // Prevent spawned zsh subprocesses from sourcing the real user's .zshenv,
+  // which can fail (e.g. missing .cargo/env) and pollute test output.
+  process.env.ZDOTDIR = tempHome;
 
   // Ensure test runs never touch the developer's real config/state, even if they have overrides set.
   delete process.env.OPENCLAW_CONFIG_PATH;


### PR DESCRIPTION
Rebased version of #21290 by @Baukebrenninkmeijer onto current `main`.

All conflicts resolved and tests passing. Original PR: https://github.com/openclaw/openclaw/pull/21290

**Changes (from original PR):**
- OpenTelemetry diagnostics extension with GenAI semantic conventions
- Switched from `-otlp-proto` to `-otlp-http` exporters
- Added `@opentelemetry/core`
- Made `captureContent` object mode strict opt-in
- Resolved TypeScript errors and PR review comments after main merge