### PR TITLE
fix(discord): default to online status when no presence config provided

### DIFF
--- a/src/discord/monitor/monitor.test.ts
+++ b/src/discord/monitor/monitor.test.ts
@@ -711,23 +711,23 @@ describe("presence-cache", () => {
 });
 
 describe("resolveDiscordPresenceUpdate", () => {
-  it("returns null when no presence config provided", () => {
-    expect(resolveDiscordPresenceUpdate({})).toBeNull();
+  it("returns online status with no activities when no presence config provided", () => {
+    const presence = resolveDiscordPresenceUpdate({});
+    expect(presence.status).toBe("online");
+    expect(presence.activities).toEqual([]);
   });
 
   it("returns status-only presence when activity is omitted", () => {
     const presence = resolveDiscordPresenceUpdate({ status: "dnd" });
-    expect(presence).not.toBeNull();
-    expect(presence?.status).toBe("dnd");
-    expect(presence?.activities).toEqual([]);
+    expect(presence.status).toBe("dnd");
+    expect(presence.activities).toEqual([]);
   });
 
   it("defaults to custom activity type when activity is set without type", () => {
     const presence = resolveDiscordPresenceUpdate({ activity: "Focus time" });
-    expect(presence).not.toBeNull();
-    expect(presence?.status).toBe("online");
-    expect(presence?.activities).toHaveLength(1);
-    expect(presence?.activities[0]).toMatchObject({
+    expect(presence.status).toBe("online");
+    expect(presence.activities).toHaveLength(1);
+    expect(presence.activities[0]).toMatchObject({
       type: 4,
       name: "Custom Status",
       state: "Focus time",
@@ -740,9 +740,8 @@ describe("resolveDiscordPresenceUpdate", () => {
       activityType: 1,
       activityUrl: "https://twitch.tv/openclaw",
     });
-    expect(presence).not.toBeNull();
-    expect(presence?.activities).toHaveLength(1);
-    expect(presence?.activities[0]).toMatchObject({
+    expect(presence.activities).toHaveLength(1);
+    expect(presence.activities[0]).toMatchObject({
       type: 1,
       name: "Live",
       url: "https://twitch.tv/openclaw",

--- a/src/discord/monitor/presence.ts
+++ b/src/discord/monitor/presence.ts
@@ -9,20 +9,13 @@ type DiscordPresenceConfig = Pick<
   "activity" | "status" | "activityType" | "activityUrl"
 >;
 
-export function resolveDiscordPresenceUpdate(
-  config: DiscordPresenceConfig,
-): UpdatePresenceData | null {
+export function resolveDiscordPresenceUpdate(config: DiscordPresenceConfig): UpdatePresenceData {
   const activityText = typeof config.activity === "string" ? config.activity.trim() : "";
   const status = typeof config.status === "string" ? config.status.trim() : "";
   const activityType = config.activityType;
   const activityUrl = typeof config.activityUrl === "string" ? config.activityUrl.trim() : "";
 
   const hasActivity = Boolean(activityText);
-  const hasStatus = Boolean(status);
-
-  if (!hasActivity && !hasStatus) {
-    return null;
-  }
 
   const activities: Activity[] = [];
 

--- a/src/discord/monitor/provider.test.ts
+++ b/src/discord/monitor/provider.test.ts
@@ -217,7 +217,12 @@ vi.mock("./native-command.js", () => ({
 }));
 
 vi.mock("./presence.js", () => ({
-  resolveDiscordPresenceUpdate: () => undefined,
+  resolveDiscordPresenceUpdate: () => ({
+    status: "online",
+    activities: [],
+    since: null,
+    afk: false,
+  }),
 }));
 
 vi.mock("./provider.allowlist.js", () => ({

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -503,10 +503,6 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         }
 
         const presence = resolveDiscordPresenceUpdate(discordCfg);
-        if (!presence) {
-          return;
-        }
-
         gateway.updatePresence(presence);
       }
     }


### PR DESCRIPTION
## Summary

Fixes #31260 - Discord bot shows as offline despite being functional.

## Problem

When no presence configuration is set in the Discord channel config, the bot appears offline (gray status) in Discord even though it's connected and functional. This is because `resolveDiscordPresenceUpdate()` returned `null` when no `activity` or `status` was configured, and no presence update was sent to Discord.

## Root Cause

In `presence.ts`:
```typescript
if (!hasActivity && !hasStatus) {
  return null;  // This caused the bot to stay offline
}
```

When this function returned `null`, the `DiscordStatusReadyListener` would skip calling `gateway.updatePresence()`, leaving the bot in its default offline state.

## Solution

Changed `resolveDiscordPresenceUpdate()` to always return a valid presence object:
- Return type changed from `UpdatePresenceData | null` to `UpdatePresenceData`
- Removed the early return when no config is provided
- Default status is now `"online"` (was already the fallback, but now always applied)

## Changes

1. **`presence.ts`**: 
   - Removed the `null` return path
   - Function now always returns a presence object with `status: "online"` as default

2. **`provider.ts`**:
   - Removed the `if (!presence)` check since it's no longer needed

3. **Tests updated**:
   - `monitor.test.ts`: Updated test expectations to match new behavior
   - `provider.test.ts`: Updated mock to return a valid presence object

## Testing

- All existing Discord presence tests pass
- TypeScript type checking passes
- Lint passes

## Behavior Change

| Config | Before | After |
|--------|--------|-------|
| No presence config | Bot appears **offline** | Bot appears **online** |
| `status: "dnd"` | Bot appears **dnd** | Bot appears **dnd** |
| `activity: "..."` | Bot appears **online** with activity | Bot appears **online** with activity |