### PR TITLE
fix(feishu): support group: prefix as alias for chat: in target resolution

### DIFF
--- a/extensions/feishu/src/targets.test.ts
+++ b/extensions/feishu/src/targets.test.ts
@@ -25,6 +25,11 @@ describe("normalizeFeishuTarget", () => {
     expect(normalizeFeishuTarget("feishu:chat:oc_123")).toBe("oc_123");
   });
 
+  it("strips provider and group prefixes (alias for chat)", () => {
+    expect(normalizeFeishuTarget("feishu:group:oc_123")).toBe("oc_123");
+    expect(normalizeFeishuTarget("group:oc_123")).toBe("oc_123");
+  });
+
   it("accepts provider-prefixed raw ids", () => {
     expect(normalizeFeishuTarget("feishu:ou_123")).toBe("ou_123");
   });
@@ -37,5 +42,10 @@ describe("looksLikeFeishuId", () => {
 
   it("accepts provider-prefixed chat targets", () => {
     expect(looksLikeFeishuId("lark:chat:oc_123")).toBe(true);
+  });
+
+  it("accepts provider-prefixed group targets (alias for chat)", () => {
+    expect(looksLikeFeishuId("feishu:group:oc_123")).toBe(true);
+    expect(looksLikeFeishuId("group:oc_123")).toBe(true);
   });
 });

--- a/extensions/feishu/src/targets.ts
+++ b/extensions/feishu/src/targets.ts
@@ -33,6 +33,9 @@ export function normalizeFeishuTarget(raw: string): string | null {
   if (lowered.startsWith("chat:")) {
     return withoutProvider.slice("chat:".length).trim() || null;
   }
+  if (lowered.startsWith("group:")) {
+    return withoutProvider.slice("group:".length).trim() || null;
+  }
   if (lowered.startsWith("user:")) {
     return withoutProvider.slice("user:".length).trim() || null;
   }
@@ -70,7 +73,7 @@ export function looksLikeFeishuId(raw: string): boolean {
   if (!trimmed) {
     return false;
   }
-  if (/^(chat|user|open_id):/i.test(trimmed)) {
+  if (/^(chat|group|user|open_id):/i.test(trimmed)) {
     return true;
   }
   if (trimmed.startsWith(CHAT_ID_PREFIX)) {

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -51,8 +51,8 @@ describe("windows command wrapper behavior", () => {
   it("wraps .cmd commands via cmd.exe in runCommandWithTimeout", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
-    let captured: { command: string; args: string[]; options: Record<string, unknown> } | null =
-      null;
+    type CapturedCall = { command: string; args: string[]; options: Record<string, unknown> };
+    let captured: CapturedCall | null = null;
 
     spawnMock.mockImplementation(
       (command: string, args: string[], options: Record<string, unknown>) => {
@@ -64,10 +64,11 @@ describe("windows command wrapper behavior", () => {
     try {
       const result = await runCommandWithTimeout(["pnpm", "--version"], { timeoutMs: 1000 });
       expect(result.code).toBe(0);
-      expect(captured?.command).toBe(expectedComSpec);
-      expect(captured?.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
-      expect(captured?.args[3]).toContain("pnpm.cmd --version");
-      expect(captured?.options.windowsVerbatimArguments).toBe(true);
+      expect(captured).not.toBeNull();
+      expect(captured!.command).toBe(expectedComSpec);
+      expect(captured!.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+      expect(captured!.args[3]).toContain("pnpm.cmd --version");
+      expect(captured!.options.windowsVerbatimArguments).toBe(true);
     } finally {
       platformSpy.mockRestore();
     }
@@ -76,8 +77,8 @@ describe("windows command wrapper behavior", () => {
   it("uses cmd.exe wrapper with windowsVerbatimArguments in runExec for .cmd shims", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
-    let captured: { command: string; args: string[]; options: Record<string, unknown> } | null =
-      null;
+    type CapturedCall = { command: string; args: string[]; options: Record<string, unknown> };
+    let captured: CapturedCall | null = null;
 
     execFileMock.mockImplementation(
       (
@@ -93,10 +94,11 @@ describe("windows command wrapper behavior", () => {
 
     try {
       await runExec("pnpm", ["--version"], 1000);
-      expect(captured?.command).toBe(expectedComSpec);
-      expect(captured?.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
-      expect(captured?.args[3]).toContain("pnpm.cmd --version");
-      expect(captured?.options.windowsVerbatimArguments).toBe(true);
+      expect(captured).not.toBeNull();
+      expect(captured!.command).toBe(expectedComSpec);
+      expect(captured!.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+      expect(captured!.args[3]).toContain("pnpm.cmd --version");
+      expect(captured!.options.windowsVerbatimArguments).toBe(true);
     } finally {
       platformSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary

Fixes #31426 - sessions_send announce fails in Feishu group: passes group ID as user_id

## Problem

When `sessions_send` announce targets a Feishu group chat, the target format is `group:oc_xxx`. Previously, this format was not recognized by `normalizeFeishuTarget()`, causing the `group:` prefix to be passed through to the Feishu API as a `user_id`, which fails with error code 99992360:

```
Invalid ids: [group:oc_524f00307b58bc1da7bbd046afed326f]
```

## Root Cause

The `normalizeFeishuTarget()` function supports `chat:`, `user:`, and `open_id:` prefixes, but not `group:`. When `group:oc_xxx` is passed:

1. `normalizeFeishuTarget()` doesn't recognize `group:` and returns `group:oc_xxx` unchanged
2. `resolveReceiveIdType()` checks if it starts with `oc_` or `ou_` - it doesn't
3. Defaults to `user_id` type
4. Feishu API receives `user_id: "group:oc_xxx"` and rejects it

## Solution

Added support for `group:` as an alias for `chat:` in:

1. **`normalizeFeishuTarget()`**: Now strips `group:` prefix like `chat:`
2. **`looksLikeFeishuId()`**: Now recognizes `group:` prefixed targets

### Before

| Input | Output | receive_id_type |
|-------|--------|-----------------|
| `group:oc_xxx` | `group:oc_xxx` | `user_id` ❌ |

### After

| Input | Output | receive_id_type |
|-------|--------|-----------------|
| `group:oc_xxx` | `oc_xxx` | `chat_id` ✅ |

## Changes

- `extensions/feishu/src/targets.ts`: Added `group:` prefix handling
- `extensions/feishu/src/targets.test.ts`: Added test cases for `group:` prefix

## Testing

- All existing tests pass
- Added new test cases for `group:` prefix
- TypeScript type checking passes
- Lint passes