### PR TITLE
fix(config): recover misplaced agents.gateway auth config

### DIFF
--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { normalizeProviders } from "./models-config.providers.js";
+
+describe("normalizeProviders", () => {
+  it("trims provider keys so image models remain discoverable for custom providers", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    try {
+      const providers: NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]> = {
+        " dashscope-vision ": {
+          baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+          api: "openai-completions",
+          apiKey: "DASHSCOPE_API_KEY",
+          models: [
+            {
+              id: "qwen-vl-max",
+              name: "Qwen VL Max",
+              input: ["text", "image"],
+              reasoning: false,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 32000,
+              maxTokens: 4096,
+            },
+          ],
+        },
+      };
+
+      const normalized = normalizeProviders({ providers, agentDir });
+      expect(Object.keys(normalized ?? {})).toEqual(["dashscope-vision"]);
+      expect(normalized?.["dashscope-vision"]?.models?.[0]?.id).toBe("qwen-vl-max");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -185,6 +185,19 @@ describe("legacy config detection", () => {
     expect(res.config?.tools?.media?.audio).toBeUndefined();
     expect(res.config?.audio).toBeUndefined();
   });
+  it("migrates misplaced agents.gateway to top-level gateway", async () => {
+    const res = migrateLegacyConfig({
+      agents: {
+        gateway: {
+          auth: { mode: "token", token: "abc123" },
+        },
+      },
+    });
+    expect(res.changes).toContain("Moved agents.gateway → gateway.");
+    expect(res.config?.gateway?.auth).toEqual({ mode: "token", token: "abc123" });
+    expect((res.config?.agents as Record<string, unknown> | undefined)?.gateway).toBeUndefined();
+  });
+
   it("migrates agent config into agents.defaults and tools", async () => {
     const res = migrateLegacyConfig({
       agent: {

--- a/src/config/legacy.migrations.part-3.ts
+++ b/src/config/legacy.migrations.part-3.ts
@@ -66,6 +66,33 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_3: LegacyConfigMigration[] = [
     },
   },
   {
+    id: "agents.gateway->gateway",
+    describe: "Move misplaced agents.gateway to top-level gateway",
+    apply: (raw, changes) => {
+      const agents = getRecord(raw.agents);
+      if (!agents) {
+        return;
+      }
+      const misplacedGateway = getRecord(agents.gateway);
+      if (!misplacedGateway) {
+        return;
+      }
+
+      const gateway = getRecord(raw.gateway);
+      if (!gateway) {
+        raw.gateway = structuredClone(misplacedGateway);
+        changes.push("Moved agents.gateway → gateway.");
+      } else {
+        mergeMissing(gateway, misplacedGateway);
+        raw.gateway = gateway;
+        changes.push("Merged missing keys from agents.gateway → gateway.");
+      }
+
+      delete agents.gateway;
+      raw.agents = agents;
+    },
+  },
+  {
     id: "memorySearch->agents.defaults.memorySearch",
     describe: "Move top-level memorySearch to agents.defaults.memorySearch",
     apply: (raw, changes) => {


### PR DESCRIPTION
## Summary
- add a legacy migration that moves misplaced `agents.gateway` config back to top-level `gateway`
- merge missing keys when both `gateway` and `agents.gateway` exist
- add regression test to ensure token auth survives this malformed config shape

## Root cause
Issue #31481 reported `token missing` even with a configured token. The posted config placed gateway auth under `agents.gateway.auth.token` instead of `gateway.auth.token`. Runtime auth only reads top-level `gateway`, so token resolution returned empty and websocket auth failed with `token_missing`.

## Validation
- `pnpm -s vitest run src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts`

Closes #31481
