### PR TITLE
fix(skills): scope skill-command APIs to respect agent allowlists

### DIFF
--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -1,5 +1,5 @@
 import { logVerbose } from "../../globals.js";
-import { listSkillCommandsForAgents } from "../skill-commands.js";
+import { listSkillCommandsForAgentIds, listSkillCommandsForAllAgents } from "../skill-commands.js";
 import {
   buildCommandsMessage,
   buildCommandsMessagePaginated,
@@ -44,10 +44,14 @@ export const handleCommandsListCommand: CommandHandler = async (params, allowTex
   }
   const skillCommands =
     params.skillCommands ??
-    listSkillCommandsForAgents({
-      cfg: params.cfg,
-      agentIds: params.agentId ? [params.agentId] : undefined,
-    });
+    (params.agentId
+      ? listSkillCommandsForAgentIds({
+          cfg: params.cfg,
+          agentIds: [params.agentId],
+        })
+      : listSkillCommandsForAllAgents({
+          cfg: params.cfg,
+        }));
   const surface = params.ctx.Surface;
 
   if (surface === "telegram") {

--- a/src/auto-reply/skill-commands.test.ts
+++ b/src/auto-reply/skill-commands.test.ts
@@ -44,14 +44,21 @@ vi.mock("../agents/skills.js", () => {
   return {
     buildWorkspaceSkillCommandSpecs: (
       workspaceDir: string,
-      opts?: { reservedNames?: Set<string> },
+      opts?: { reservedNames?: Set<string>; skillFilter?: string[] },
     ) => {
       const used = new Set<string>();
       for (const reserved of opts?.reservedNames ?? []) {
         used.add(String(reserved).toLowerCase());
       }
+      const filter = opts?.skillFilter;
+      const entries =
+        filter === undefined
+          ? resolveWorkspaceSkills(workspaceDir)
+          : resolveWorkspaceSkills(workspaceDir).filter((entry) =>
+              filter.some((skillName) => skillName === entry.skillName),
+            );
 
-      return resolveWorkspaceSkills(workspaceDir).map((entry) => {
+      return entries.map((entry) => {
         const base = entry.skillName.replace(/-/g, "_");
         const name = resolveUniqueName(base, used);
         return { name, skillName: entry.skillName, description: entry.description };
@@ -60,11 +67,12 @@ vi.mock("../agents/skills.js", () => {
   };
 });
 
-let listSkillCommandsForAgents: typeof import("./skill-commands.js").listSkillCommandsForAgents;
+let listSkillCommandsForAllAgents: typeof import("./skill-commands.js").listSkillCommandsForAllAgents;
+let listSkillCommandsForAgentIds: typeof import("./skill-commands.js").listSkillCommandsForAgentIds;
 let resolveSkillCommandInvocation: typeof import("./skill-commands.js").resolveSkillCommandInvocation;
 
 beforeAll(async () => {
-  ({ listSkillCommandsForAgents, resolveSkillCommandInvocation } =
+  ({ listSkillCommandsForAllAgents, listSkillCommandsForAgentIds, resolveSkillCommandInvocation } =
     await import("./skill-commands.js"));
 });
 
@@ -105,7 +113,7 @@ describe("resolveSkillCommandInvocation", () => {
   });
 });
 
-describe("listSkillCommandsForAgents", () => {
+describe("listSkillCommandsForAllAgents/listSkillCommandsForAgentIds", () => {
   it("merges command names across agents and de-duplicates", async () => {
     const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-"));
     const mainWorkspace = path.join(baseDir, "main");
@@ -113,7 +121,7 @@ describe("listSkillCommandsForAgents", () => {
     await fs.mkdir(mainWorkspace, { recursive: true });
     await fs.mkdir(researchWorkspace, { recursive: true });
 
-    const commands = listSkillCommandsForAgents({
+    const commands = listSkillCommandsForAllAgents({
       cfg: {
         agents: {
           list: [
@@ -127,5 +135,67 @@ describe("listSkillCommandsForAgents", () => {
     expect(names).toContain("demo_skill");
     expect(names).toContain("demo_skill_2");
     expect(names).toContain("extra_skill");
+  });
+
+  it("applies per-agent skills allowlist when listing commands", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-filter-"));
+    const researchWorkspace = path.join(baseDir, "research");
+    await fs.mkdir(researchWorkspace, { recursive: true });
+
+    const commands = listSkillCommandsForAgentIds({
+      cfg: {
+        agents: {
+          list: [{ id: "research", workspace: researchWorkspace, skills: ["extra-skill"] }],
+        },
+      },
+      agentIds: ["research"],
+    });
+
+    expect(commands.map((entry) => entry.name)).toEqual(["extra_skill"]);
+    expect(commands.map((entry) => entry.skillName)).toEqual(["extra-skill"]);
+  });
+
+  it("prevents cross-agent skill leakage when each agent has a skills allowlist", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-leak-"));
+    const mainWorkspace = path.join(baseDir, "main");
+    const researchWorkspace = path.join(baseDir, "research");
+    await fs.mkdir(mainWorkspace, { recursive: true });
+    await fs.mkdir(researchWorkspace, { recursive: true });
+
+    const commands = listSkillCommandsForAgentIds({
+      cfg: {
+        agents: {
+          list: [
+            { id: "main", workspace: mainWorkspace, skills: ["demo-skill"] },
+            { id: "research", workspace: researchWorkspace, skills: ["extra-skill"] },
+          ],
+        },
+      },
+      agentIds: ["main", "research"],
+    });
+
+    expect(commands.map((entry) => entry.skillName)).toEqual(["demo-skill", "extra-skill"]);
+    expect(commands.map((entry) => entry.name)).toEqual(["demo_skill", "extra_skill"]);
+  });
+
+  it("merges allowlists for agents that share one workspace", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-shared-"));
+    const sharedWorkspace = path.join(baseDir, "research");
+    await fs.mkdir(sharedWorkspace, { recursive: true });
+
+    const commands = listSkillCommandsForAgentIds({
+      cfg: {
+        agents: {
+          list: [
+            { id: "main", workspace: sharedWorkspace, skills: ["demo-skill"] },
+            { id: "research", workspace: sharedWorkspace, skills: ["extra-skill"] },
+          ],
+        },
+      },
+      agentIds: ["main", "research"],
+    });
+
+    expect(commands.map((entry) => entry.skillName)).toEqual(["demo-skill", "extra-skill"]);
+    expect(commands.map((entry) => entry.name)).toEqual(["demo_skill", "extra_skill"]);
   });
 });

--- a/src/auto-reply/skill-commands.test.ts
+++ b/src/auto-reply/skill-commands.test.ts
@@ -198,4 +198,46 @@ describe("listSkillCommandsForAllAgents/listSkillCommandsForAgentIds", () => {
     expect(commands.map((entry) => entry.skillName)).toEqual(["demo-skill", "extra-skill"]);
     expect(commands.map((entry) => entry.name)).toEqual(["demo_skill", "extra_skill"]);
   });
+
+  it("keeps workspace unrestricted when one co-tenant agent has no skills filter", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-unfiltered-"));
+    const sharedWorkspace = path.join(baseDir, "research");
+    await fs.mkdir(sharedWorkspace, { recursive: true });
+
+    const commands = listSkillCommandsForAgentIds({
+      cfg: {
+        agents: {
+          list: [
+            { id: "restricted", workspace: sharedWorkspace, skills: ["extra-skill"] },
+            { id: "unrestricted", workspace: sharedWorkspace },
+          ],
+        },
+      },
+      agentIds: ["restricted", "unrestricted"],
+    });
+
+    const skillNames = commands.map((entry) => entry.skillName);
+    expect(skillNames).toContain("demo-skill");
+    expect(skillNames).toContain("extra-skill");
+  });
+
+  it("merges empty allowlist with non-empty allowlist for shared workspace", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-empty-"));
+    const sharedWorkspace = path.join(baseDir, "research");
+    await fs.mkdir(sharedWorkspace, { recursive: true });
+
+    const commands = listSkillCommandsForAgentIds({
+      cfg: {
+        agents: {
+          list: [
+            { id: "locked", workspace: sharedWorkspace, skills: [] },
+            { id: "partial", workspace: sharedWorkspace, skills: ["extra-skill"] },
+          ],
+        },
+      },
+      agentIds: ["locked", "partial"],
+    });
+
+    expect(commands.map((entry) => entry.skillName)).toEqual(["extra-skill"]);
+  });
 });

--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -50,10 +50,12 @@ export function listSkillCommandsForAgentIds(params: {
   agentIds: string[];
 }): SkillCommandSpec[] {
   const mergeSkillFilters = (existing?: string[], incoming?: string[]): string[] | undefined => {
+    // undefined = no allowlist (unrestricted); [] = explicit empty allowlist (no skills).
     // If any agent is unrestricted for this workspace, keep command discovery unrestricted.
     if (existing === undefined || incoming === undefined) {
       return undefined;
     }
+    // An empty allowlist contributes no skills but does not widen the merge to unrestricted.
     if (existing.length === 0) {
       return Array.from(new Set(incoming));
     }

--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -1,5 +1,9 @@
 import fs from "node:fs";
-import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import {
+  listAgentIds,
+  resolveAgentSkillsFilter,
+  resolveAgentWorkspaceDir,
+} from "../agents/agent-scope.js";
 import { buildWorkspaceSkillCommandSpecs, type SkillCommandSpec } from "../agents/skills.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
@@ -41,29 +45,51 @@ export function listSkillCommandsForWorkspace(params: {
   });
 }
 
-export function listSkillCommandsForAgents(params: {
+export function listSkillCommandsForAgentIds(params: {
   cfg: OpenClawConfig;
-  agentIds?: string[];
+  agentIds: string[];
 }): SkillCommandSpec[] {
+  const mergeSkillFilters = (existing?: string[], incoming?: string[]): string[] | undefined => {
+    // If any agent is unrestricted for this workspace, keep command discovery unrestricted.
+    if (existing === undefined || incoming === undefined) {
+      return undefined;
+    }
+    if (existing.length === 0) {
+      return Array.from(new Set(incoming));
+    }
+    if (incoming.length === 0) {
+      return Array.from(new Set(existing));
+    }
+    return Array.from(new Set([...existing, ...incoming]));
+  };
+
   const used = listReservedChatSlashCommandNames();
   const entries: SkillCommandSpec[] = [];
-  const agentIds = params.agentIds ?? listAgentIds(params.cfg);
-  // Track visited workspace dirs to avoid registering duplicate commands
-  // when multiple agents share the same workspace directory (#5717).
-  const visitedDirs = new Set<string>();
-  for (const agentId of agentIds) {
+  // Group by canonical workspace to avoid duplicate registration when multiple
+  // agents share the same directory (#5717), while still honoring per-agent filters.
+  const workspaceFilters = new Map<string, { workspaceDir: string; skillFilter?: string[] }>();
+  for (const agentId of params.agentIds) {
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
     if (!fs.existsSync(workspaceDir)) {
       continue;
     }
-    // Resolve to canonical path to handle symlinks and relative paths
     const canonicalDir = fs.realpathSync(workspaceDir);
-    if (visitedDirs.has(canonicalDir)) {
+    const skillFilter = resolveAgentSkillsFilter(params.cfg, agentId);
+    const existing = workspaceFilters.get(canonicalDir);
+    if (existing) {
+      existing.skillFilter = mergeSkillFilters(existing.skillFilter, skillFilter);
       continue;
     }
-    visitedDirs.add(canonicalDir);
+    workspaceFilters.set(canonicalDir, {
+      workspaceDir,
+      skillFilter,
+    });
+  }
+
+  for (const { workspaceDir, skillFilter } of workspaceFilters.values()) {
     const commands = buildWorkspaceSkillCommandSpecs(workspaceDir, {
       config: params.cfg,
+      skillFilter,
       eligibility: { remote: getRemoteSkillEligibility() },
       reservedNames: used,
     });
@@ -73,6 +99,23 @@ export function listSkillCommandsForAgents(params: {
     }
   }
   return entries;
+}
+
+export function listSkillCommandsForAllAgents(params: { cfg: OpenClawConfig }): SkillCommandSpec[] {
+  return listSkillCommandsForAgentIds({
+    cfg: params.cfg,
+    agentIds: listAgentIds(params.cfg),
+  });
+}
+
+/** @deprecated Use listSkillCommandsForAllAgents or listSkillCommandsForAgentIds. */
+export function listSkillCommandsForAgents(params: {
+  cfg: OpenClawConfig;
+  agentIds?: string[];
+}): SkillCommandSpec[] {
+  return params.agentIds
+    ? listSkillCommandsForAgentIds({ cfg: params.cfg, agentIds: params.agentIds })
+    : listSkillCommandsForAllAgents({ cfg: params.cfg });
 }
 
 function normalizeSkillCommandLookup(value: string): string {

--- a/src/discord/monitor/provider.test.ts
+++ b/src/discord/monitor/provider.test.ts
@@ -13,7 +13,7 @@ const {
   reconcileAcpThreadBindingsOnStartupMock,
   createdBindingManagers,
   listNativeCommandSpecsForConfigMock,
-  listSkillCommandsForAgentsMock,
+  listSkillCommandsForAllAgentsMock,
   monitorLifecycleMock,
   resolveDiscordAccountMock,
   resolveDiscordAllowlistConfigMock,
@@ -43,7 +43,7 @@ const {
     })),
     createdBindingManagers,
     listNativeCommandSpecsForConfigMock: vi.fn(() => [{ name: "cmd" }]),
-    listSkillCommandsForAgentsMock: vi.fn(() => []),
+    listSkillCommandsForAllAgentsMock: vi.fn(() => []),
     monitorLifecycleMock: vi.fn(async (params: { threadBindings: { stop: () => void } }) => {
       params.threadBindings.stop();
     }),
@@ -108,7 +108,7 @@ vi.mock("../../auto-reply/commands-registry.js", () => ({
 }));
 
 vi.mock("../../auto-reply/skill-commands.js", () => ({
-  listSkillCommandsForAgents: listSkillCommandsForAgentsMock,
+  listSkillCommandsForAllAgents: listSkillCommandsForAllAgentsMock,
 }));
 
 vi.mock("../../config/commands.js", () => ({
@@ -272,7 +272,7 @@ describe("monitorDiscordProvider", () => {
     });
     createdBindingManagers.length = 0;
     listNativeCommandSpecsForConfigMock.mockClear().mockReturnValue([{ name: "cmd" }]);
-    listSkillCommandsForAgentsMock.mockClear().mockReturnValue([]);
+    listSkillCommandsForAllAgentsMock.mockClear().mockReturnValue([]);
     monitorLifecycleMock.mockClear().mockImplementation(async (params) => {
       params.threadBindings.stop();
     });

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -13,7 +13,7 @@ import { Routes } from "discord-api-types/v10";
 import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import { listNativeCommandSpecsForConfig } from "../../auto-reply/commands-registry.js";
 import type { HistoryEntry } from "../../auto-reply/reply/history.js";
-import { listSkillCommandsForAgents } from "../../auto-reply/skill-commands.js";
+import { listSkillCommandsForAllAgents } from "../../auto-reply/skill-commands.js";
 import {
   isNativeCommandsExplicitlyDisabled,
   resolveNativeCommandsEnabled,
@@ -169,10 +169,10 @@ function formatThreadBindingDurationForConfigLabel(durationMs: number): string {
 }
 
 function dedupeSkillCommandsForDiscord(
-  skillCommands: ReturnType<typeof listSkillCommandsForAgents>,
+  skillCommands: ReturnType<typeof listSkillCommandsForAllAgents>,
 ) {
   const seen = new Set<string>();
-  const deduped: ReturnType<typeof listSkillCommandsForAgents> = [];
+  const deduped: ReturnType<typeof listSkillCommandsForAllAgents> = [];
   for (const command of skillCommands) {
     const key = command.skillName.trim().toLowerCase();
     if (!key) {
@@ -358,7 +358,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   const maxDiscordCommands = 100;
   let skillCommands =
     nativeEnabled && nativeSkillsEnabled
-      ? dedupeSkillCommandsForDiscord(listSkillCommandsForAgents({ cfg }))
+      ? dedupeSkillCommandsForDiscord(listSkillCommandsForAllAgents({ cfg }))
       : [];
   let commandSpecs = nativeEnabled
     ? listNativeCommandSpecsForConfig(cfg, { skillCommands, provider: "discord" })

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -662,7 +662,7 @@ export async function registerSlackMonitorSlashCommands(params: {
   if (nativeEnabled) {
     reg = await getCommandsRegistry();
     const skillCommands = nativeSkillsEnabled
-      ? (await import("../../auto-reply/skill-commands.js")).listSkillCommandsForAgents({ cfg })
+      ? (await import("../../auto-reply/skill-commands.js")).listSkillCommandsForAllAgents({ cfg })
       : [];
     nativeCommands = reg.listNativeCommandSpecsForConfig(cfg, { skillCommands, provider: "slack" });
   }

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -11,7 +11,7 @@ import {
   formatModelsAvailableHeader,
 } from "../auto-reply/reply/commands-models.js";
 import { resolveStoredModelOverride } from "../auto-reply/reply/model-selection.js";
-import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
+import { listSkillCommandsForAgentIds } from "../auto-reply/skill-commands.js";
 import { buildCommandsMessagePaginated } from "../auto-reply/status.js";
 import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js";
 import { loadConfig } from "../config/config.js";
@@ -1142,9 +1142,9 @@ export const registerTelegramHandlers = ({
         }
 
         const agentId = paginationMatch[2]?.trim() || resolveDefaultAgentId(cfg) || undefined;
-        const skillCommands = listSkillCommandsForAgents({
+        const skillCommands = listSkillCommandsForAgentIds({
           cfg,
-          agentIds: agentId ? [agentId] : undefined,
+          agentIds: agentId ? [agentId] : [resolveDefaultAgentId(cfg)],
         });
         const result = buildCommandsMessagePaginated(cfg, skillCommands, {
           page,

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1141,10 +1141,10 @@ export const registerTelegramHandlers = ({
           return;
         }
 
-        const agentId = paginationMatch[2]?.trim() || resolveDefaultAgentId(cfg) || undefined;
+        const agentId = paginationMatch[2]?.trim() || resolveDefaultAgentId(cfg);
         const skillCommands = listSkillCommandsForAgentIds({
           cfg,
-          agentIds: agentId ? [agentId] : [resolveDefaultAgentId(cfg)],
+          agentIds: [agentId],
         });
         const result = buildCommandsMessagePaginated(cfg, skillCommands, {
           page,

--- a/src/telegram/bot-native-commands.session-meta.test.ts
+++ b/src/telegram/bot-native-commands.session-meta.test.ts
@@ -31,7 +31,7 @@ vi.mock("../channels/reply-prefix.js", () => ({
 }));
 vi.mock("../auto-reply/skill-commands.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../auto-reply/skill-commands.js")>();
-  return { ...actual, listSkillCommandsForAgents: vi.fn(() => []) };
+  return { ...actual, listSkillCommandsForAgentIds: vi.fn(() => []) };
 });
 vi.mock("../plugins/commands.js", () => ({
   getPluginCommandSpecs: vi.fn(() => []),

--- a/src/telegram/bot-native-commands.skills-allowlist.test.ts
+++ b/src/telegram/bot-native-commands.skills-allowlist.test.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeSkill } from "../agents/skills.e2e-test-helpers.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { TelegramAccountConfig } from "../config/types.js";
+import { registerTelegramNativeCommands } from "./bot-native-commands.js";
+import { createNativeCommandTestParams } from "./bot-native-commands.test-helpers.js";
+
+const pluginCommandMocks = vi.hoisted(() => ({
+  getPluginCommandSpecs: vi.fn(() => []),
+  matchPluginCommand: vi.fn(() => null),
+  executePluginCommand: vi.fn(async () => ({ text: "ok" })),
+}));
+const deliveryMocks = vi.hoisted(() => ({
+  deliverReplies: vi.fn(async () => ({ delivered: true })),
+}));
+
+vi.mock("../plugins/commands.js", () => ({
+  getPluginCommandSpecs: pluginCommandMocks.getPluginCommandSpecs,
+  matchPluginCommand: pluginCommandMocks.matchPluginCommand,
+  executePluginCommand: pluginCommandMocks.executePluginCommand,
+}));
+vi.mock("./bot/delivery.js", () => ({
+  deliverReplies: deliveryMocks.deliverReplies,
+}));
+
+const tempDirs: string[] = [];
+
+async function makeWorkspace(prefix: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("registerTelegramNativeCommands skill allowlist integration", () => {
+  afterEach(async () => {
+    pluginCommandMocks.getPluginCommandSpecs.mockClear().mockReturnValue([]);
+    pluginCommandMocks.matchPluginCommand.mockClear().mockReturnValue(null);
+    pluginCommandMocks.executePluginCommand.mockClear().mockResolvedValue({ text: "ok" });
+    deliveryMocks.deliverReplies.mockClear().mockResolvedValue({ delivered: true });
+    await Promise.all(
+      tempDirs
+        .splice(0, tempDirs.length)
+        .map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("registers only allowlisted skills for the bound agent menu", async () => {
+    const workspaceDir = await makeWorkspace("openclaw-telegram-skills-");
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "alpha-skill"),
+      name: "alpha-skill",
+      description: "Alpha skill",
+    });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "beta-skill"),
+      name: "beta-skill",
+      description: "Beta skill",
+    });
+
+    const setMyCommands = vi.fn().mockResolvedValue(undefined);
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "alpha", workspace: workspaceDir, skills: ["alpha-skill"] },
+          { id: "beta", workspace: workspaceDir, skills: ["beta-skill"] },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "alpha",
+          match: { channel: "telegram", accountId: "bot-a" },
+        },
+      ],
+    };
+
+    registerTelegramNativeCommands({
+      ...createNativeCommandTestParams({
+        bot: {
+          api: {
+            setMyCommands,
+            sendMessage: vi.fn().mockResolvedValue(undefined),
+          },
+          command: vi.fn(),
+        } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+        cfg,
+        accountId: "bot-a",
+        telegramCfg: {} as TelegramAccountConfig,
+      }),
+    });
+
+    await vi.waitFor(() => {
+      expect(setMyCommands).toHaveBeenCalled();
+    });
+    const registeredCommands = setMyCommands.mock.calls[0]?.[0] as Array<{
+      command: string;
+      description: string;
+    }>;
+
+    expect(registeredCommands.some((entry) => entry.command === "alpha_skill")).toBe(true);
+    expect(registeredCommands.some((entry) => entry.command === "beta_skill")).toBe(false);
+  });
+});

--- a/src/telegram/bot-native-commands.test.ts
+++ b/src/telegram/bot-native-commands.test.ts
@@ -8,8 +8,8 @@ import type { RuntimeEnv } from "../runtime.js";
 import { registerTelegramNativeCommands } from "./bot-native-commands.js";
 import { createNativeCommandTestParams } from "./bot-native-commands.test-helpers.js";
 
-const { listSkillCommandsForAgents } = vi.hoisted(() => ({
-  listSkillCommandsForAgents: vi.fn(() => []),
+const { listSkillCommandsForAgentIds } = vi.hoisted(() => ({
+  listSkillCommandsForAgentIds: vi.fn(() => []),
 }));
 const pluginCommandMocks = vi.hoisted(() => ({
   getPluginCommandSpecs: vi.fn(() => []),
@@ -24,7 +24,7 @@ vi.mock("../auto-reply/skill-commands.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../auto-reply/skill-commands.js")>();
   return {
     ...actual,
-    listSkillCommandsForAgents,
+    listSkillCommandsForAgentIds,
   };
 });
 vi.mock("../plugins/commands.js", () => ({
@@ -52,8 +52,8 @@ describe("registerTelegramNativeCommands", () => {
   }
 
   beforeEach(() => {
-    listSkillCommandsForAgents.mockClear();
-    listSkillCommandsForAgents.mockReturnValue([]);
+    listSkillCommandsForAgentIds.mockClear();
+    listSkillCommandsForAgentIds.mockReturnValue([]);
     pluginCommandMocks.getPluginCommandSpecs.mockClear();
     pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([]);
     pluginCommandMocks.matchPluginCommand.mockClear();
@@ -94,7 +94,7 @@ describe("registerTelegramNativeCommands", () => {
 
     registerTelegramNativeCommands(buildParams(cfg, "bot-a"));
 
-    expect(listSkillCommandsForAgents).toHaveBeenCalledWith({
+    expect(listSkillCommandsForAgentIds).toHaveBeenCalledWith({
       cfg,
       agentIds: ["butler"],
     });
@@ -109,7 +109,7 @@ describe("registerTelegramNativeCommands", () => {
 
     registerTelegramNativeCommands(buildParams(cfg, "bot-a"));
 
-    expect(listSkillCommandsForAgents).toHaveBeenCalledWith({
+    expect(listSkillCommandsForAgentIds).toHaveBeenCalledWith({
       cfg,
       agentIds: ["main"],
     });

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -11,7 +11,7 @@ import {
 } from "../auto-reply/commands-registry.js";
 import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
-import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
+import { listSkillCommandsForAgentIds } from "../auto-reply/skill-commands.js";
 import { resolveCommandAuthorizedFromAuthorizers } from "../channels/command-gating.js";
 import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -324,10 +324,9 @@ export const registerTelegramNativeCommands = ({
     nativeEnabled && nativeSkillsEnabled
       ? resolveAgentRoute({ cfg, channel: "telegram", accountId })
       : null;
-  const boundAgentIds = boundRoute ? [boundRoute.agentId] : null;
   const skillCommands =
-    nativeEnabled && nativeSkillsEnabled
-      ? listSkillCommandsForAgents(boundAgentIds ? { cfg, agentIds: boundAgentIds } : { cfg })
+    nativeEnabled && nativeSkillsEnabled && boundRoute
+      ? listSkillCommandsForAgentIds({ cfg, agentIds: [boundRoute.agentId] })
       : [];
   const nativeCommands = nativeEnabled
     ? listNativeCommandSpecsForConfig(cfg, {

--- a/src/telegram/bot.create-telegram-bot.test-harness.ts
+++ b/src/telegram/bot.create-telegram-bot.test-harness.ts
@@ -74,12 +74,15 @@ vi.mock("../pairing/pairing-store.js", () => ({
 }));
 
 const skillCommandsHoisted = vi.hoisted(() => ({
-  listSkillCommandsForAgents: vi.fn(() => []),
+  listSkillCommandsForAllAgents: vi.fn(() => []),
+  listSkillCommandsForAgentIds: vi.fn(() => []),
 }));
-export const listSkillCommandsForAgents = skillCommandsHoisted.listSkillCommandsForAgents;
+export const listSkillCommandsForAllAgents = skillCommandsHoisted.listSkillCommandsForAllAgents;
+export const listSkillCommandsForAgentIds = skillCommandsHoisted.listSkillCommandsForAgentIds;
 
 vi.mock("../auto-reply/skill-commands.js", () => ({
-  listSkillCommandsForAgents,
+  listSkillCommandsForAllAgents,
+  listSkillCommandsForAgentIds,
 }));
 
 const systemEventsHoisted = vi.hoisted(() => ({
@@ -314,8 +317,10 @@ beforeEach(() => {
   enqueueSystemEventSpy.mockReset();
   wasSentByBot.mockReset();
   wasSentByBot.mockReturnValue(false);
-  listSkillCommandsForAgents.mockReset();
-  listSkillCommandsForAgents.mockReturnValue([]);
+  listSkillCommandsForAllAgents.mockReset();
+  listSkillCommandsForAllAgents.mockReturnValue([]);
+  listSkillCommandsForAgentIds.mockReset();
+  listSkillCommandsForAgentIds.mockReturnValue([]);
   middlewareUseSpy.mockReset();
   sequentializeSpy.mockReset();
   botCtorSpy.mockReset();

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -15,7 +15,8 @@ import {
   getLoadConfigMock,
   getReadChannelAllowFromStoreMock,
   getOnHandler,
-  listSkillCommandsForAgents,
+  listSkillCommandsForAgentIds,
+  listSkillCommandsForAllAgents,
   onSpy,
   replySpy,
   sendMessageSpy,
@@ -29,7 +30,7 @@ const readChannelAllowFromStore = getReadChannelAllowFromStoreMock();
 
 function resolveSkillCommands(config: Parameters<typeof listNativeCommandSpecsForConfig>[0]) {
   void config;
-  return listSkillCommandsForAgents() as NonNullable<
+  return listSkillCommandsForAllAgents() as NonNullable<
     Parameters<typeof listNativeCommandSpecsForConfig>[1]
   >["skillCommands"];
 }
@@ -197,7 +198,7 @@ describe("createTelegramBot", () => {
   it("allows callback_query in groups when group policy authorizes the sender", async () => {
     onSpy.mockClear();
     editMessageTextSpy.mockClear();
-    listSkillCommandsForAgents.mockClear();
+    listSkillCommandsForAgentIds.mockClear();
 
     createTelegramBot({
       token: "tok",
@@ -240,7 +241,7 @@ describe("createTelegramBot", () => {
 
   it("edits commands list for pagination callbacks", async () => {
     onSpy.mockClear();
-    listSkillCommandsForAgents.mockClear();
+    listSkillCommandsForAgentIds.mockClear();
 
     createTelegramBot({ token: "tok" });
     const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
@@ -263,7 +264,7 @@ describe("createTelegramBot", () => {
       getFile: async () => ({ download: async () => new Uint8Array() }),
     });
 
-    expect(listSkillCommandsForAgents).toHaveBeenCalledWith({
+    expect(listSkillCommandsForAgentIds).toHaveBeenCalledWith({
       cfg: expect.any(Object),
       agentIds: ["main"],
     });


### PR DESCRIPTION
## Summary

- **Problem:** `listSkillCommandsForAgents` took an optional `agentIds` parameter, making it easy to accidentally widen scope and expose skills across agent boundaries in command menus.
- **Why it matters:** Agent-level `agents.list[].skills` allowlists must be respected to prevent skill leakage in native command menus and `/commands` listings.
- **What changed:** Split into two explicit APIs — `listSkillCommandsForAgentIds` (required agent IDs, respects per-agent `skills` allowlists) and `listSkillCommandsForAllAgents` (config-driven, all agents). Migrated all call sites (Telegram, Discord, Slack, `/commands`). When multiple agents share a workspace, their allowlists are now unioned per-workspace — an unrestricted agent keeps discovery open, while explicit allowlists are merged without cross-agent leakage. The old function is preserved as a deprecated shim with no remaining callers.
- **What did NOT change (scope boundary):** No auth model changes, no new channel features, no dependency changes, no config schema changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Telegram native menu and `/commands` pagination now consistently scope skills to the bound agent's allowlist.
- Shared-workspace agents merge allowlists for command discovery instead of first-agent-wins.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation:
  - Scope is narrowed/explicitly controlled for skill command surfacing. Mitigated by new unit/integration tests for per-agent filtering and cross-agent leakage.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Telegram, Slack, Discord command surfaces
- Relevant config (redacted): multi-agent config with `agents.list[].skills` and Telegram binding

### Steps

1. Create two agents with different `skills` allowlists and bind a Telegram account to one agent.
2. Build native command menu and command list pages.
3. Observe surfaced skill commands.

### Expected

- Only allowlisted skills for the scoped/bound agent are surfaced.

### Actual

- After this change: scoped/bound agent allowlist is respected; no cross-agent leakage in tested paths.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test -- src/auto-reply/skill-commands.test.ts src/telegram/bot-native-commands.test.ts src/telegram/bot-native-commands.session-meta.test.ts src/telegram/bot.test.ts src/discord/monitor/provider.test.ts src/telegram/bot-native-commands.skills-allowlist.test.ts`
- Edge cases checked:
  - Per-agent allowlist filtering
  - Cross-agent leakage prevention (separate workspaces)
  - Shared-workspace allowlist merging (both restricted)
  - Unrestricted co-tenant keeps workspace discovery open
  - Empty allowlist merge with non-empty allowlist
  - Telegram menu integration with binding-scoped allowlist
- What you did **not** verify:
  - Full repo `pnpm check` currently fails on unrelated upstream/main TypeScript issues in `extensions/*` and `ui/*` not touched by this PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR to restore prior command-scope behavior.
- Files/config to restore:
  - `src/auto-reply/skill-commands.ts` and call sites in Telegram/Slack/Discord.
- Known bad symptoms reviewers should watch for:
  - Missing expected skill commands in native menu when using shared workspaces or scoped agent lists.

## Risks and Mitigations

- Risk: Shared-workspace allowlist union semantics may differ from prior implicit behavior.
  - Mitigation: Added explicit regression tests and made scope APIs explicit at call sites.