### PR TITLE
feat(agents): add allowAgents to agents.defaults.subagents

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -7,6 +7,7 @@ import {
   resolveAgentDir,
   resolveAgentEffectiveModelPrimary,
   resolveAgentExplicitModelPrimary,
+  resolveEffectiveAllowAgents,
   resolveFallbackAgentId,
   resolveEffectiveModelFallbacks,
   resolveAgentModelFallbacksOverride,
@@ -426,5 +427,67 @@ describe("resolveAgentConfig", () => {
 
     const agentDir = resolveAgentDir({} as OpenClawConfig, "main");
     expect(agentDir).toBe(path.join(path.resolve(home), ".openclaw", "agents", "main", "agent"));
+  });
+});
+
+describe("resolveEffectiveAllowAgents", () => {
+  it("returns empty when no allowAgents configured", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "main" }] },
+    };
+    expect(resolveEffectiveAllowAgents(cfg, "main")).toEqual([]);
+  });
+
+  it("returns per-agent allowAgents when no defaults", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", subagents: { allowAgents: ["coder", "researcher"] } }],
+      },
+    };
+    expect(resolveEffectiveAllowAgents(cfg, "main")).toEqual(["coder", "researcher"]);
+  });
+
+  it("returns defaults allowAgents when no per-agent config", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { subagents: { allowAgents: ["coder", "researcher"] } },
+        list: [{ id: "main" }],
+      },
+    };
+    expect(resolveEffectiveAllowAgents(cfg, "main")).toEqual(["coder", "researcher"]);
+  });
+
+  it("merges defaults and per-agent allowAgents additively", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { subagents: { allowAgents: ["coder"] } },
+        list: [{ id: "main", subagents: { allowAgents: ["researcher"] } }],
+      },
+    };
+    const result = resolveEffectiveAllowAgents(cfg, "main");
+    expect(result).toContain("coder");
+    expect(result).toContain("researcher");
+    expect(result).toHaveLength(2);
+  });
+
+  it("deduplicates overlapping entries case-insensitively", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { subagents: { allowAgents: ["Coder"] } },
+        list: [{ id: "main", subagents: { allowAgents: ["coder", "researcher"] } }],
+      },
+    };
+    const result = resolveEffectiveAllowAgents(cfg, "main");
+    expect(result).toHaveLength(2);
+  });
+
+  it("preserves wildcard from defaults", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { subagents: { allowAgents: ["*"] } },
+        list: [{ id: "main" }],
+      },
+    };
+    expect(resolveEffectiveAllowAgents(cfg, "main")).toEqual(["*"]);
   });
 });

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -252,6 +252,21 @@ export function resolveEffectiveModelFallbacks(params: {
   return agentFallbacksOverride ?? defaultFallbacks;
 }
 
+export function resolveEffectiveAllowAgents(cfg: OpenClawConfig, agentId: string): string[] {
+  const defaultsAllowAgents = cfg.agents?.defaults?.subagents?.allowAgents ?? [];
+  const agentAllowAgents = resolveAgentConfig(cfg, agentId)?.subagents?.allowAgents ?? [];
+  const merged = [...defaultsAllowAgents, ...agentAllowAgents];
+  const seen = new Set<string>();
+  return merged.filter((entry) => {
+    const key = entry.trim().toLowerCase();
+    if (!key || seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
 export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
   const id = normalizeAgentId(agentId);
   const configured = resolveAgentConfig(cfg, id)?.workspace?.trim();

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -155,6 +155,113 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     });
   });
 
+  it("sessions_spawn inherits allowAgents from agents.defaults.subagents", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          subagents: {
+            allowAgents: ["coder", "researcher"],
+          },
+        },
+        list: [{ id: "main" }],
+      },
+    });
+    const getChildSessionKey = mockAcceptedSpawn(5300);
+
+    const result = await executeSpawn("call-defaults-1", "coder");
+
+    expect(result.details).toMatchObject({ status: "accepted" });
+    expect(getChildSessionKey()?.startsWith("agent:coder:subagent:")).toBe(true);
+  });
+
+  it("sessions_spawn merges defaults allowAgents with per-agent allowAgents", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          subagents: {
+            allowAgents: ["coder"],
+          },
+        },
+        list: [
+          {
+            id: "main",
+            subagents: {
+              allowAgents: ["researcher"],
+            },
+          },
+        ],
+      },
+    });
+    const getChildSessionKey1 = mockAcceptedSpawn(5400);
+
+    const result1 = await executeSpawn("call-merge-1", "coder");
+    expect(result1.details).toMatchObject({ status: "accepted" });
+    expect(getChildSessionKey1()?.startsWith("agent:coder:subagent:")).toBe(true);
+
+    const getChildSessionKey2 = mockAcceptedSpawn(5500);
+    const result2 = await executeSpawn("call-merge-2", "researcher");
+    expect(result2.details).toMatchObject({ status: "accepted" });
+    expect(getChildSessionKey2()?.startsWith("agent:researcher:subagent:")).toBe(true);
+  });
+
+  it("sessions_spawn rejects agents not in either defaults or per-agent allowAgents", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          subagents: {
+            allowAgents: ["coder"],
+          },
+        },
+        list: [
+          {
+            id: "main",
+            subagents: {
+              allowAgents: ["researcher"],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await executeSpawn("call-merge-reject", "unknown-agent");
+    expect(result.details).toMatchObject({ status: "forbidden" });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("sessions_spawn defaults allowAgents wildcard applies to all agents", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          subagents: {
+            allowAgents: ["*"],
+          },
+        },
+        list: [{ id: "main" }],
+      },
+    });
+    const getChildSessionKey = mockAcceptedSpawn(5600);
+
+    const result = await executeSpawn("call-defaults-wildcard", "any-agent");
+    expect(result.details).toMatchObject({ status: "accepted" });
+    expect(getChildSessionKey()?.startsWith("agent:any-agent:subagent:")).toBe(true);
+  });
+
   it("forbids sandboxed cross-agent spawns that would unsandbox the child", async () => {
     setSessionsSpawnConfigOverride({
       session: {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -12,7 +12,11 @@ import {
   parseAgentSessionKey,
 } from "../routing/session-key.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
-import { resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
+import {
+  resolveAgentConfig,
+  resolveAgentWorkspaceDir,
+  resolveEffectiveAllowAgents,
+} from "./agent-scope.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
@@ -332,7 +336,7 @@ export async function spawnSubagentDirect(
   );
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   if (targetAgentId !== requesterAgentId) {
-    const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+    const allowAgents = resolveEffectiveAllowAgents(cfg, requesterAgentId);
     const allowAny = allowAgents.some((value) => value.trim() === "*");
     const normalizedTargetId = targetAgentId.toLowerCase();
     const allowSet = new Set(

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -5,7 +5,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
-import { resolveAgentConfig } from "../agent-scope.js";
+import { resolveEffectiveAllowAgents } from "../agent-scope.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
@@ -46,7 +46,7 @@ export function createAgentsListTool(opts?: {
           DEFAULT_AGENT_ID,
       );
 
-      const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+      const allowAgents = resolveEffectiveAllowAgents(cfg, requesterAgentId);
       const allowAny = allowAgents.some((value) => value.trim() === "*");
       const allowSet = new Set(
         allowAgents

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -274,6 +274,8 @@ export type AgentDefaultsConfig = {
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 60000). */
     announceTimeoutMs?: number;
+    /** Default allowAgents list for cross-agent spawning. Per-agent lists are additive. Use "*" to allow any. */
+    allowAgents?: string[];
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -173,6 +173,7 @@ export const AgentDefaultsSchema = z
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
+        allowAgents: z.array(z.string()).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

- **Problem**: Multi-agent setups require every agent to individually list shared utility sub-agents (e.g. `coder`, `cron-architect`, `researcher`) in `subagents.allowAgents`. Adding a new utility agent means patching every existing agent config.
- **Why it matters**: Reduces config boilerplate and makes multi-agent orchestration easier to maintain.
- **What changed**: Added `allowAgents` to `agents.defaults.subagents` schema and type. Per-agent `allowAgents` lists are merged additively with defaults (union, not replace). Added `resolveEffectiveAllowAgents()` helper used by both `subagent-spawn.ts` and `agents-list-tool.ts`.
- **What did NOT change (scope boundary)**: Per-agent `allowAgents` behavior is unchanged when no defaults are set. No changes to spawn depth, concurrency, model selection, or sandbox gating.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31416

## User-visible / Behavior Changes

- Users can now set `agents.defaults.subagents.allowAgents` to define a baseline set of allowed sub-agent ids inherited by all agents.
- Per-agent `subagents.allowAgents` lists are merged additively with defaults (e.g. defaults `["coder"]` + agent-specific `["newsbot"]` → effective `["coder", "newsbot"]`).
- Wildcard `"*"` in defaults applies to all agents.

## Security Impact (required)

- New permissions/capabilities? `No` — this only extends existing allowAgents resolution; no new permissions surface.
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — sub-agent spawning gates are unchanged.
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22+

### Steps

1. Set `agents.defaults.subagents.allowAgents: ["coder", "researcher"]` in `openclaw.json`
2. Do **not** set per-agent `subagents.allowAgents` for any agent
3. From any agent, use `sessions_spawn` with `agentId: "coder"`

### Expected

- Spawn succeeds because `coder` is in the defaults allowlist.

### Actual

- Before: `agentId is not allowed for sessions_spawn (allowed: none)`
- After: Spawn accepted; child session created under `agent:coder:subagent:*`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: defaults-only, per-agent-only, merged additive, wildcard in defaults, rejection when not in either list
- Edge cases checked: duplicate entries (case-insensitive dedup), empty defaults, empty per-agent, wildcard `"*"`
- What you did **not** verify: UI config editor rendering of the new field (no UI changes)

## Compatibility / Migration

- Backward compatible? `Yes` — no defaults = previous behavior unchanged
- Config/env changes? `No` — new optional key only
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable: Remove `allowAgents` from `agents.defaults.subagents`; per-agent lists still work as before
- Files to restore: `src/agents/agent-scope.ts`, `src/agents/subagent-spawn.ts`, `src/agents/tools/agents-list-tool.ts`, `src/config/types.agent-defaults.ts`, `src/config/zod-schema.agent-defaults.ts`

## Risks and Mitigations

- Risk: Overly broad defaults wildcard could allow unintended cross-agent spawns
  - Mitigation: Same risk exists today with per-agent `"*"` — no change in surface area; admins control their own config