### PR TITLE
feat(cron): add sessionKeyPrefix filter to cron list

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -38,11 +38,16 @@ export function registerCronListCommand(cron: Command) {
       .command("list")
       .description("List cron jobs")
       .option("--all", "Include disabled jobs", false)
+      .option(
+        "--context <prefix>",
+        "Filter by session key prefix (e.g. agent:main:telegram:group:123)",
+      )
       .option("--json", "Output JSON", false)
       .action(async (opts) => {
         try {
           const res = await callGatewayFromCli("cron.list", opts, {
             includeDisabled: Boolean(opts.all),
+            ...(opts.context ? { sessionKeyPrefix: opts.context } : {}),
           });
           if (opts.json) {
             defaultRuntime.log(JSON.stringify(res, null, 2));

--- a/src/cron/service.list-session-key-prefix.test.ts
+++ b/src/cron/service.list-session-key-prefix.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import { setupCronServiceSuite } from "./service.test-harness.js";
+
+const { logger, makeStorePath } = setupCronServiceSuite({
+  prefix: "openclaw-cron-skprefix-",
+  baseTimeIso: "2026-03-02T00:00:00.000Z",
+});
+
+function createCron(storePath: string) {
+  return new CronService({
+    storePath,
+    cronEnabled: true,
+    log: logger,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeatNow: vi.fn(),
+    runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+  });
+}
+
+describe("cron.listPage sessionKeyPrefix filter", () => {
+  it("returns all jobs when sessionKeyPrefix is not provided", async () => {
+    const store = await makeStorePath();
+    const cron = createCron(store.storePath);
+    await cron.start();
+
+    await cron.add({
+      name: "job-a",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 8 * * *" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "a" },
+      sessionKey: "agent:main:telegram:group:111",
+    });
+    await cron.add({
+      name: "job-b",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 9 * * *" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "b" },
+      sessionKey: "agent:main:discord:channel:222",
+    });
+
+    const page = await cron.listPage({});
+    expect(page.jobs).toHaveLength(2);
+
+    cron.stop();
+  });
+
+  it("filters jobs by sessionKeyPrefix", async () => {
+    const store = await makeStorePath();
+    const cron = createCron(store.storePath);
+    await cron.start();
+
+    await cron.add({
+      name: "telegram-job",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 8 * * *" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tg" },
+      sessionKey: "agent:main:telegram:group:111",
+    });
+    await cron.add({
+      name: "discord-job",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 9 * * *" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "dc" },
+      sessionKey: "agent:main:discord:channel:222",
+    });
+    await cron.add({
+      name: "telegram-job-2",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 10 * * *" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tg2" },
+      sessionKey: "agent:main:telegram:group:333",
+    });
+
+    const page = await cron.listPage({
+      sessionKeyPrefix: "agent:main:telegram",
+    });
+    expect(page.jobs).toHaveLength(2);
+    expect(page.jobs.map((j) => j.name).toSorted()).toEqual(["telegram-job", "telegram-job-2"]);
+
+    const discordPage = await cron.listPage({
+      sessionKeyPrefix: "agent:main:discord",
+    });
+    expect(discordPage.jobs).toHaveLength(1);
+    expect(discordPage.jobs[0].name).toBe("discord-job");
+
+    cron.stop();
+  });
+
+  it("sessionKeyPrefix matching is case-insensitive", async () => {
+    const store = await makeStorePath();
+    const cron = createCron(store.storePath);
+    await cron.start();
+
+    await cron.add({
+      name: "mixed-case-job",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 8 * * *" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "mc" },
+      sessionKey: "Agent:Main:Telegram:Group:111",
+    });
+
+    const page = await cron.listPage({
+      sessionKeyPrefix: "agent:main:telegram",
+    });
+    expect(page.jobs).toHaveLength(1);
+    expect(page.jobs[0].name).toBe("mixed-case-job");
+
+    cron.stop();
+  });
+
+  it("returns empty when no jobs match sessionKeyPrefix", async () => {
+    const store = await makeStorePath();
+    const cron = createCron(store.storePath);
+    await cron.start();
+
+    await cron.add({
+      name: "telegram-only",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 8 * * *" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tg" },
+      sessionKey: "agent:main:telegram:group:111",
+    });
+
+    const page = await cron.listPage({
+      sessionKeyPrefix: "agent:main:slack",
+    });
+    expect(page.jobs).toHaveLength(0);
+    expect(page.total).toBe(0);
+
+    cron.stop();
+  });
+});

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -34,6 +34,8 @@ export type CronListPageOptions = {
   enabled?: CronJobsEnabledFilter;
   sortBy?: CronJobsSortBy;
   sortDir?: CronSortDir;
+  /** Filter jobs whose sessionKey starts with this prefix. */
+  sessionKeyPrefix?: string;
 };
 
 export type CronListPageResult = {
@@ -199,12 +201,19 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
     const sortBy = opts?.sortBy ?? "nextRunAtMs";
     const sortDir = opts?.sortDir ?? "asc";
     const source = state.store?.jobs ?? [];
+    const sessionKeyPrefix = opts?.sessionKeyPrefix?.trim().toLowerCase() ?? "";
     const filtered = source.filter((job) => {
       if (enabledFilter === "enabled" && !job.enabled) {
         return false;
       }
       if (enabledFilter === "disabled" && job.enabled) {
         return false;
+      }
+      if (sessionKeyPrefix) {
+        const jobKey = (job.sessionKey ?? "").toLowerCase();
+        if (!jobKey.startsWith(sessionKeyPrefix)) {
+          return false;
+        }
       }
       if (!query) {
         return true;

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -247,6 +247,7 @@ export const CronListParamsSchema = Type.Object(
     enabled: Type.Optional(CronJobsEnabledFilterSchema),
     sortBy: Type.Optional(CronJobsSortBySchema),
     sortDir: Type.Optional(CronSortDirSchema),
+    sessionKeyPrefix: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -61,6 +61,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       enabled?: "all" | "enabled" | "disabled";
       sortBy?: "nextRunAtMs" | "updatedAtMs" | "name";
       sortDir?: "asc" | "desc";
+      sessionKeyPrefix?: string;
     };
     const page = await context.cron.listPage({
       includeDisabled: p.includeDisabled,
@@ -70,6 +71,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       enabled: p.enabled,
       sortBy: p.sortBy,
       sortDir: p.sortDir,
+      sessionKeyPrefix: p.sessionKeyPrefix,
     });
     respond(true, page, undefined);
   },


### PR DESCRIPTION
## Summary

- **Problem**: `cron list` shows all cron jobs regardless of group context, leaking job names and schedules from other groups. Users in Telegram group A see cron jobs created for group B.
- **Why it matters**: Privacy and usability — group-scoped cron management should only show relevant jobs.
- **What changed**: Added `sessionKeyPrefix` parameter to `cron.list` API and `listPage()` service method. Jobs are filtered by matching `sessionKey` prefix (case-insensitive). Added `--context <prefix>` CLI option.
- **What did NOT change**: No changes to cron execution, scheduling, or permissions. Existing behavior unchanged when `sessionKeyPrefix` is omitted.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31464

## User-visible / Behavior Changes

- New `sessionKeyPrefix` parameter in `cron.list` API: filters jobs whose `sessionKey` starts with the given prefix.
- New `--context <prefix>` CLI option for `openclaw cron list`: e.g. `openclaw cron list --context agent:main:telegram:group:123`.
- Case-insensitive matching.
- No behavior change when parameter is omitted (backward compatible).

## Security Impact (required)

- New permissions/capabilities? `No` — this is a client-side filter, not an access control gate.
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — clients can still omit the filter to see all jobs (same as before).

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22+

### Steps

1. Create cron jobs with different sessionKeys (e.g. `agent:main:telegram:group:111`, `agent:main:discord:channel:222`)
2. Call `cron.list` with `sessionKeyPrefix: "agent:main:telegram"`

### Expected

- Only Telegram-scoped jobs returned.

### Actual (before fix)

- All jobs returned regardless of sessionKey.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: no filter (all jobs), prefix filter (subset), case-insensitive match, empty result set
- Edge cases checked: empty prefix (no-op), no sessionKey on job (excluded when prefix set), whitespace trimming
- What you did **not** verify: UI cron list integration (no UI changes made)

## Compatibility / Migration

- Backward compatible? `Yes` — new optional parameter, existing calls unchanged
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable: Omit `sessionKeyPrefix` parameter; all jobs shown as before
- Files to restore: `src/cron/service/ops.ts`, `src/gateway/protocol/schema/cron.ts`, `src/gateway/server-methods/cron.ts`, `src/cli/cron-cli/register.cron-add.ts`

## Risks and Mitigations

- Risk: Large prefix could match too broadly
  - Mitigation: This is a filter (reduces results), not a permission gate — no security risk from broad matches