### PR TITLE
fix(ci): restore install-smoke cli verify helper path in docker images

### DIFF
--- a/extensions/feishu/src/monitor.test-mocks.ts
+++ b/extensions/feishu/src/monitor.test-mocks.ts
@@ -1,6 +1,6 @@
-import { vi } from "vitest";
+import { type Mock, vi } from "vitest";
 
-export const probeFeishuMock: ReturnType<typeof vi.fn> = vi.hoisted(() => vi.fn());
+export const probeFeishuMock: Mock = vi.hoisted(() => vi.fn());
 
 vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -37,10 +37,11 @@ function buildIMessageSetupPatch(input: {
   service?: string;
   region?: string;
 }) {
+  const service = input.service as "auto" | "imessage" | "sms" | undefined;
   return {
     ...(input.cliPath ? { cliPath: input.cliPath } : {}),
     ...(input.dbPath ? { dbPath: input.dbPath } : {}),
-    ...(input.service ? { service: input.service } : {}),
+    ...(service ? { service } : {}),
     ...(input.region ? { region: input.region } : {}),
   };
 }

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -362,7 +362,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         accountId: accountId ?? undefined,
         deps,
         replyToId,
-        threadId,
+        threadId: threadId != null ? String(threadId) : threadId,
       });
       const result = await send(to, text, {
         threadTs: threadTsValue != null ? String(threadTsValue) : undefined,
@@ -377,7 +377,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         accountId: accountId ?? undefined,
         deps,
         replyToId,
-        threadId,
+        threadId: threadId != null ? String(threadId) : threadId,
       });
       const result = await send(to, text, {
         mediaUrl,

--- a/scripts/docker/install-sh-nonroot/run.sh
+++ b/scripts/docker/install-sh-nonroot/run.sh
@@ -4,10 +4,8 @@ set -euo pipefail
 INSTALL_URL="${OPENCLAW_INSTALL_URL:-https://openclaw.bot/install.sh}"
 DEFAULT_PACKAGE="openclaw"
 PACKAGE_NAME="${OPENCLAW_INSTALL_PACKAGE:-$DEFAULT_PACKAGE}"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-
 # shellcheck source=../install-sh-common/cli-verify.sh
-source "$SCRIPT_DIR/../install-sh-common/cli-verify.sh"
+source "/usr/local/install-sh-common/cli-verify.sh"
 
 echo "==> Pre-flight: ensure git absent"
 if command -v git >/dev/null; then

--- a/scripts/docker/install-sh-smoke/run.sh
+++ b/scripts/docker/install-sh-smoke/run.sh
@@ -6,10 +6,8 @@ SMOKE_PREVIOUS_VERSION="${OPENCLAW_INSTALL_SMOKE_PREVIOUS:-}"
 SKIP_PREVIOUS="${OPENCLAW_INSTALL_SMOKE_SKIP_PREVIOUS:-0}"
 DEFAULT_PACKAGE="openclaw"
 PACKAGE_NAME="${OPENCLAW_INSTALL_PACKAGE:-$DEFAULT_PACKAGE}"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-
 # shellcheck source=../install-sh-common/cli-verify.sh
-source "$SCRIPT_DIR/../install-sh-common/cli-verify.sh"
+source "/usr/local/install-sh-common/cli-verify.sh"
 
 echo "==> Resolve npm versions"
 LATEST_VERSION="$(npm view "$PACKAGE_NAME" version)"

--- a/ui/src/ui/views/nodes.ts
+++ b/ui/src/ui/views/nodes.ts
@@ -433,7 +433,7 @@ function resolveAgentBindings(config: Record<string, unknown> | null): {
     return { defaultBinding, agents: [fallbackAgent] };
   }
 
-  const agents = resolveConfigAgents(config).map((entry) => {
+  const agents: BindingAgent[] = resolveConfigAgents(config).map((entry) => {
     const toolsEntry = (entry.record.tools ?? {}) as Record<string, unknown>;
     const execEntry = (toolsEntry.exec ?? {}) as Record<string, unknown>;
     const binding =


### PR DESCRIPTION
## Summary
This PR now contains **both** baseline CI unblock fixes from #31511:

- **Part A**: `install-smoke` Docker path/context break
- **Part B**: `check/tsgo` baseline typing regressions

## Part A — install-smoke fix
### Root cause
`cli-verify.sh` was moved to:
- `scripts/docker/install-sh-common/cli-verify.sh`

But smoke/non-root images and run scripts still used old relative assumptions.

### Changes
1. **Dockerfiles** (`install-sh-smoke`, `install-sh-nonroot`)
   - copy helper into image:
   - `/usr/local/install-sh-common/cli-verify.sh`
2. **Run scripts** (`install-sh-smoke/run.sh`, `install-sh-nonroot/run.sh`)
   - source helper from absolute in-image path
3. **Smoke test build context** (`scripts/test-install-sh-docker.sh`)
   - use `scripts/docker` as build context so shared + image-specific files are both available

## Part B — check/tsgo baseline typing fixes
Includes strict typing alignment across channels/UI/tests (same baseline error family discussed in #31511), including:
- nullable handling alignment in channel code paths (`null` vs `undefined`)
- missing type imports in synology-chat test
- UI test fixture/type updates required by newer usage totals typing
- explicit typing in feishu monitor test mocks to avoid non-portable inferred type errors

## Scope
- CI/stability/type fixes only
- no intended behavior changes in runtime logic

## Tracking
- Resolves **Part A + Part B** in: #31511
