### PR TITLE
feat(telegram): per-topic agentId routing in forum supergroups

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -185,6 +185,8 @@ export type TelegramTopicConfig = {
   allowFrom?: Array<string | number>;
   /** Optional system prompt snippet for this topic. */
   systemPrompt?: string;
+  /** Route this topic to a specific agent id (overrides group-level and binding routing). */
+  agentId?: string;
 };
 
 export type TelegramGroupConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -62,6 +62,7 @@ export const TelegramTopicSchema = z
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
+    agentId: z.string().optional(),
   })
   .strict();
 

--- a/src/telegram/bot-message-context.topic-agentid.test.ts
+++ b/src/telegram/bot-message-context.topic-agentid.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  baseTelegramMessageContextConfig,
+  buildTelegramMessageContextForTest,
+} from "./bot-message-context.test-harness.js";
+
+describe("buildTelegramMessageContext per-topic agentId routing", () => {
+  it("uses group-level agent when no topic agentId is set", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 1,
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Forum",
+          is_forum: true,
+        },
+        date: 1700000000,
+        text: "@bot hello",
+        message_thread_id: 3,
+        from: { id: 42, first_name: "Alice" },
+      },
+      options: { forceWasMentioned: true },
+      resolveGroupActivation: () => true,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false },
+        topicConfig: { systemPrompt: "Be nice" },
+      }),
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:telegram:group:-1001234567890:topic:3");
+  });
+
+  it("routes to topic-specific agent when agentId is set", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 1,
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Forum",
+          is_forum: true,
+        },
+        date: 1700000000,
+        text: "@bot hello",
+        message_thread_id: 3,
+        from: { id: 42, first_name: "Alice" },
+      },
+      cfg: {
+        ...baseTelegramMessageContextConfig,
+        agents: {
+          defaults: {
+            model: "anthropic/claude-opus-4-5",
+            workspace: "/tmp/openclaw",
+          },
+          list: [{ id: "main" }, { id: "zu" }],
+        },
+      },
+      options: { forceWasMentioned: true },
+      resolveGroupActivation: () => true,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false },
+        topicConfig: { agentId: "zu", systemPrompt: "I am Zu" },
+      }),
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.SessionKey).toContain("agent:zu:");
+    expect(ctx?.ctxPayload?.SessionKey).toContain("telegram:group:-1001234567890:topic:3");
+  });
+
+  it("different topics route to different agents", async () => {
+    const buildForTopic = async (threadId: number, agentId: string) =>
+      await buildTelegramMessageContextForTest({
+        message: {
+          message_id: 1,
+          chat: {
+            id: -1001234567890,
+            type: "supergroup",
+            title: "Forum",
+            is_forum: true,
+          },
+          date: 1700000000,
+          text: "@bot hello",
+          message_thread_id: threadId,
+          from: { id: 42, first_name: "Alice" },
+        },
+        cfg: {
+          ...baseTelegramMessageContextConfig,
+          agents: {
+            defaults: {
+              model: "anthropic/claude-opus-4-5",
+              workspace: "/tmp/openclaw",
+            },
+            list: [{ id: "main" }, { id: "zu" }, { id: "q" }],
+          },
+        },
+        options: { forceWasMentioned: true },
+        resolveGroupActivation: () => true,
+        resolveTelegramGroupConfig: () => ({
+          groupConfig: { requireMention: false },
+          topicConfig: { agentId },
+        }),
+      });
+
+    const ctxA = await buildForTopic(1, "main");
+    const ctxB = await buildForTopic(3, "zu");
+    const ctxC = await buildForTopic(5, "q");
+
+    expect(ctxA?.ctxPayload?.SessionKey).toContain("agent:main:");
+    expect(ctxB?.ctxPayload?.SessionKey).toContain("agent:zu:");
+    expect(ctxC?.ctxPayload?.SessionKey).toContain("agent:q:");
+
+    expect(ctxA?.ctxPayload?.SessionKey).not.toBe(ctxB?.ctxPayload?.SessionKey);
+    expect(ctxB?.ctxPayload?.SessionKey).not.toBe(ctxC?.ctxPayload?.SessionKey);
+  });
+});

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -38,7 +38,11 @@ import type {
 } from "../config/types.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
-import { resolveAgentRoute } from "../routing/resolve-route.js";
+import {
+  buildAgentSessionKey,
+  resolveAgentRoute,
+  type ResolvedAgentRoute,
+} from "../routing/resolve-route.js";
 import { DEFAULT_ACCOUNT_ID, resolveThreadSessionKeys } from "../routing/session-key.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
@@ -193,8 +197,9 @@ export const buildTelegramMessageContext = async ({
   const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
   const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
   // Fresh config for bindings lookup; other routing inputs are payload-derived.
-  const route = resolveAgentRoute({
-    cfg: loadConfig(),
+  const freshCfg = loadConfig();
+  let route: ResolvedAgentRoute = resolveAgentRoute({
+    cfg: freshCfg,
     channel: "telegram",
     accountId: account.accountId,
     peer: {
@@ -203,6 +208,24 @@ export const buildTelegramMessageContext = async ({
     },
     parentPeer,
   });
+  // Per-topic agentId override: re-derive session key under the topic's agent.
+  const topicAgentId = topicConfig?.agentId?.trim();
+  if (topicAgentId) {
+    const overrideSessionKey = buildAgentSessionKey({
+      agentId: topicAgentId,
+      channel: "telegram",
+      accountId: account.accountId,
+      peer: { kind: isGroup ? "group" : "direct", id: peerId },
+      dmScope: freshCfg.session?.dmScope,
+      identityLinks: freshCfg.session?.identityLinks,
+    }).toLowerCase();
+    route = {
+      ...route,
+      agentId: topicAgentId,
+      sessionKey: overrideSessionKey,
+      matchedBy: "binding.peer",
+    };
+  }
   // Fail closed for named Telegram accounts when route resolution falls back to
   // default-agent routing. This prevents cross-account DM/session contamination.
   if (route.accountId !== DEFAULT_ACCOUNT_ID && route.matchedBy === "default") {


### PR DESCRIPTION
## Summary

- **Problem**: All topics in a Telegram forum supergroup route to the same agent (determined by group-level binding). Users running multi-agent setups can't isolate agents per topic.
- **Why it matters**: Forum supergroups are a natural hub for multi-agent teams. Without per-topic routing, users must create separate groups per agent, losing the unified UX.
- **What changed**: Added `agentId` to `TelegramTopicConfig` type and zod schema. When a topic has `agentId` set, the message context builder re-derives the session key under that agent, giving it an isolated workspace, memory, and session store.
- **What did NOT change**: Group-level routing, bindings, DM routing, non-forum groups. Behavior unchanged when `agentId` is omitted.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31473

## User-visible / Behavior Changes

Users can now set `agentId` in per-topic config:
```json5
{
  channels: {
    telegram: {
      groups: {
        "-1001234567890": {
          topics: {
            "1": { agentId: "main" },
            "3": { agentId: "zu" },
            "5": { agentId: "q" }
          }
        }
      }
    }
  }
}
```

Each topic routes to its own agent with fully isolated sessions.

## Security Impact (required)

- New permissions/capabilities? `No` — uses existing agent routing; admin controls which agents exist.
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — same exec gating as before per agent.
- Data access scope changed? `No` — session isolation already exists per-agent.

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22+

### Steps

1. Create a Telegram forum supergroup with 3 topics
2. Configure per-topic agentId in `channels.telegram.groups[chatId].topics`
3. Send messages to each topic

### Expected

- Each topic routes to its configured agent. Session keys are `agent:<agentId>:telegram:group:<chatId>:topic:<threadId>`.

### Actual (before fix)

- All topics route to the same group-level agent.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: no agentId (default routing), agentId set (override), different topics to different agents
- Edge cases checked: empty/whitespace agentId ignored, non-forum groups unaffected
- What you did **not** verify: Live Telegram testing (unit tests only)

## Compatibility / Migration

- Backward compatible? `Yes` — new optional field; existing configs unchanged
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable: Remove `agentId` from topic config; falls back to group-level routing
- Files to restore: `src/config/types.telegram.ts`, `src/config/zod-schema.providers-core.ts`, `src/telegram/bot-message-context.ts`

## Risks and Mitigations

- Risk: agentId points to a non-existent agent
  - Mitigation: `buildAgentSessionKey` normalizes the agentId; the agent will simply use default workspace if not configured