### PR TITLE
fix(feishu): handle group: prefix in send target to fix announce in groups

### DIFF
--- a/extensions/feishu/src/targets.test.ts
+++ b/extensions/feishu/src/targets.test.ts
@@ -1,5 +1,29 @@
 import { describe, expect, it } from "vitest";
-import { resolveReceiveIdType } from "./targets.js";
+import { normalizeFeishuTarget, resolveReceiveIdType } from "./targets.js";
+
+describe("normalizeFeishuTarget", () => {
+  it("strips group: prefix to extract chat_id", () => {
+    expect(normalizeFeishuTarget("group:oc_524f00307b58bc1da7bbd046afed326f")).toBe(
+      "oc_524f00307b58bc1da7bbd046afed326f",
+    );
+  });
+
+  it("strips chat: prefix", () => {
+    expect(normalizeFeishuTarget("chat:oc_abc123")).toBe("oc_abc123");
+  });
+
+  it("strips user: prefix", () => {
+    expect(normalizeFeishuTarget("user:ou_abc123")).toBe("ou_abc123");
+  });
+
+  it("returns raw value when no prefix", () => {
+    expect(normalizeFeishuTarget("oc_abc123")).toBe("oc_abc123");
+  });
+
+  it("returns null for empty string", () => {
+    expect(normalizeFeishuTarget("")).toBeNull();
+  });
+});
 
 describe("resolveReceiveIdType", () => {
   it("resolves chat IDs by oc_ prefix", () => {

--- a/extensions/feishu/src/targets.ts
+++ b/extensions/feishu/src/targets.ts
@@ -28,6 +28,9 @@ export function normalizeFeishuTarget(raw: string): string | null {
   if (lowered.startsWith("chat:")) {
     return trimmed.slice("chat:".length).trim() || null;
   }
+  if (lowered.startsWith("group:")) {
+    return trimmed.slice("group:".length).trim() || null;
+  }
   if (lowered.startsWith("user:")) {
     return trimmed.slice("user:".length).trim() || null;
   }


### PR DESCRIPTION
## Problem

When `sessions_send` announce targets a Feishu group chat, the `to` field uses the generic OpenClaw peer ID format `group:oc_xxx`. `normalizeFeishuTarget` only recognized `chat:`, `user:`, and `open_id:` prefixes, so `group:oc_xxx` passed through as-is.

`resolveReceiveIdType` then classified the full string (including the `group:` prefix) as `user_id` instead of `chat_id`, causing Feishu API to reject with HTTP 400:

```
Invalid ids: [group:oc_524f00307b58bc1da7bbd046afed326f]
```

## Fix

Add `group:` prefix handling in `normalizeFeishuTarget` to strip the prefix and expose the underlying `oc_xxx` chat ID, which correctly resolves to `chat_id` type via `resolveReceiveIdType`.

### Changes
- `extensions/feishu/src/targets.ts`: Handle `group:` prefix in `normalizeFeishuTarget`
- `extensions/feishu/src/targets.test.ts`: Add test coverage for `normalizeFeishuTarget` including `group:` prefix

Closes #31426
Fixes #28783