### PR TITLE
fix(agents): check supportsReasoningEffort compat before injecting reasoning_effort

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -575,7 +575,7 @@ export async function compactEmbeddedPiSessionDirect(
         authStorage,
         modelRegistry,
         model,
-        thinkingLevel: mapThinkingLevel(params.thinkLevel),
+        thinkingLevel: mapThinkingLevel(params.thinkLevel, model?.compat),
         tools: builtInTools,
         customTools,
         sessionManager,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -872,7 +872,7 @@ export async function runEmbeddedAttempt(
         authStorage: params.authStorage,
         modelRegistry: params.modelRegistry,
         model: params.model,
-        thinkingLevel: mapThinkingLevel(params.thinkLevel),
+        thinkingLevel: mapThinkingLevel(params.thinkLevel, params.model?.compat),
         tools: builtInTools,
         customTools: allCustomTools,
         sessionManager,

--- a/src/agents/pi-embedded-runner/utils.ts
+++ b/src/agents/pi-embedded-runner/utils.ts
@@ -1,7 +1,18 @@
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
+import type { ModelCompatConfig } from "../../config/types.models.js";
 
-export function mapThinkingLevel(level?: ThinkLevel): ThinkingLevel {
+export function mapThinkingLevel(
+  level?: ThinkLevel,
+  modelCompat?: ModelCompatConfig,
+): ThinkingLevel | undefined {
+  // When the model explicitly declares it does not support the reasoning_effort
+  // parameter, return undefined so pi-agent-core omits it entirely from the
+  // API payload. This prevents 400 errors on providers like xAI/Grok that
+  // reject unknown parameters.
+  if (modelCompat?.supportsReasoningEffort === false) {
+    return undefined;
+  }
   // pi-agent-core supports "xhigh"; OpenClaw enables it for specific models.
   if (!level) {
     return "off";


### PR DESCRIPTION
## Summary

Models that don't support the `reasoning_effort` parameter (e.g. xAI/Grok) receive 400 errors when pi-agent-core injects it into the API payload. The compaction code path is particularly affected because it doesn't apply the OpenRouter wrapper that strips `reasoning_effort`.

This is a minimal, targeted fix for the same underlying issue addressed by #11561, which bundles xAI provider integration. This PR extracts just the core compat check.

- Updated `mapThinkingLevel()` to accept an optional `modelCompat` parameter
- Returns `undefined` when `supportsReasoningEffort === false`, telling pi-agent-core to omit the parameter entirely
- Updated both call sites (`attempt.ts`, `compact.ts`) to pass `model.compat`

Relates to #11561

## Test plan

- [x] Verified `mapThinkingLevel(level, { supportsReasoningEffort: false })` returns `undefined`
- [x] Verified `mapThinkingLevel(level)` (no compat) preserves existing behavior
- [x] Verified `mapThinkingLevel(level, { supportsReasoningEffort: true })` preserves existing behavior
- [x] Manual test: xAI/Grok model via OpenRouter no longer receives `reasoning_effort` in compaction path