### PR TITLE
Discord: keep slash interaction reply when using message.send (#31246)

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -40,6 +40,7 @@ export function buildReplyPayloads(params: {
   originatingChannel?: OriginatingChannelType;
   originatingTo?: string;
   accountId?: string;
+  skipMessagingToolReplySuppression?: boolean;
 }): { replyPayloads: ReplyPayload[]; didLogHeartbeatStrip: boolean } {
   let didLogHeartbeatStrip = params.didLogHeartbeatStrip;
   const sanitizedPayloads = params.isHeartbeat
@@ -91,7 +92,7 @@ export function buildReplyPayloads(params: {
     !params.blockReplyPipeline?.isAborted();
   const messagingToolSentTexts = params.messagingToolSentTexts ?? [];
   const messagingToolSentTargets = params.messagingToolSentTargets ?? [];
-  const suppressMessagingToolReplies = shouldSuppressMessagingToolReplies({
+  const shouldSuppressForMessagingTool = shouldSuppressMessagingToolReplies({
     messageProvider: resolveOriginMessageProvider({
       originatingChannel: params.originatingChannel,
       provider: params.messageProvider,
@@ -104,12 +105,15 @@ export function buildReplyPayloads(params: {
       originatingAccountId: params.accountId,
     }),
   });
+  const suppressMessagingToolReplies = params.skipMessagingToolReplySuppression
+    ? false
+    : shouldSuppressForMessagingTool;
   // Only dedupe against messaging tool sends for the same origin target.
   // Cross-target sends (for example posting to another channel) must not
   // suppress the current conversation's final reply.
   // If target metadata is unavailable, keep legacy dedupe behavior.
   const dedupeMessagingToolPayloads =
-    suppressMessagingToolReplies || messagingToolSentTargets.length === 0;
+    shouldSuppressForMessagingTool || messagingToolSentTargets.length === 0;
   const dedupedPayloads = dedupeMessagingToolPayloads
     ? filterMessagingToolDuplicates({
         payloads: replyTaggedPayloads,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -525,6 +525,7 @@ export async function runReplyAgent(params: {
         to: sessionCtx.To,
       }),
       accountId: sessionCtx.AccountId,
+      skipMessagingToolReplySuppression: followupRun.skipMessagingToolReplySuppression,
     });
     const { replyPayloads } = payloadResult;
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -275,7 +275,7 @@ export function createFollowupRunner(params: {
         payloads: dedupedPayloads,
         sentMediaUrls: runResult.messagingToolSentMediaUrls ?? [],
       });
-      const suppressMessagingToolReplies = shouldSuppressMessagingToolReplies({
+      const shouldSuppressForMessagingTool = shouldSuppressMessagingToolReplies({
         messageProvider: resolveOriginMessageProvider({
           originatingChannel: queued.originatingChannel,
           provider: queued.run.messageProvider,
@@ -289,6 +289,9 @@ export function createFollowupRunner(params: {
           accountId: queued.run.agentAccountId,
         }),
       });
+      const suppressMessagingToolReplies = queued.skipMessagingToolReplySuppression
+        ? false
+        : shouldSuppressForMessagingTool;
       const finalPayloads = suppressMessagingToolReplies ? [] : mediaFilteredPayloads;
 
       if (finalPayloads.length === 0) {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -459,6 +459,10 @@ export async function runPreparedReply(
     isNewSession,
   });
   const authProfileIdSource = sessionEntry?.authProfileOverrideSource;
+  const isDiscordNativeSlashContext =
+    commandSource === "native" &&
+    typeof sessionCtx.To === "string" &&
+    sessionCtx.To.startsWith("slash:");
   const followupRun = {
     prompt: queuedBody,
     messageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
@@ -470,6 +474,7 @@ export async function runPreparedReply(
     originatingAccountId: ctx.AccountId,
     originatingThreadId: ctx.MessageThreadId,
     originatingChatType: ctx.ChatType,
+    skipMessagingToolReplySuppression: isDiscordNativeSlashContext,
     run: {
       agentId,
       agentDir,

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -41,6 +41,11 @@ export type FollowupRun = {
   originatingThreadId?: string | number;
   /** Chat type for context-aware threading (e.g., DM vs channel). */
   originatingChatType?: string;
+  /**
+   * When true, bypass messaging tool reply suppression for this run
+   * while keeping duplicate filtering behavior.
+   */
+  skipMessagingToolReplySuppression?: boolean;
   run: {
     agentId: string;
     agentDir: string;

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -1623,6 +1623,17 @@ async function dispatchDiscordCommandInteraction(params: {
       onModelSelected,
     },
   });
+
+  if (!didReply && !suppressReplies) {
+    await safeDiscordInteractionCall("interaction ack", async () => {
+      const payload = { content: "✓" };
+      if (preferFollowUp) {
+        await interaction.followUp(payload);
+        return;
+      }
+      await interaction.reply(payload);
+    });
+  }
 }
 
 async function deliverDiscordInteractionReply(params: {


### PR DESCRIPTION
## Summary

- **Problem:** When a user-invocable skill uses the message tool (action: send) during a Discord native slash command turn, the interaction can get stuck on “Bot is responding...” and the agent's text reply is never delivered via the interaction.
- **Why it matters:** Slash commands that send messages via `message.send` to the same Discord target have a broken UX; users see the channel message but the slash interaction never resolves.
- **What changed:** (1) Added `skipMessagingToolReplySuppression` to `FollowupRun` and set it for Discord native slash contexts (`CommandSource === "native"` and `To` starts with `slash:`). (2) Inline and queued reply paths bypass same-target messaging-tool reply suppression when this flag is set, while still deduping duplicates. (3) After `dispatchReplyWithDispatcher` completes, if no reply was sent and replies are not suppressed, send a minimal `✓` acknowledgement so the deferred interaction closes.
- **What did NOT change (scope boundary):** No behavior changes for non-Discord channels or non-slash flows; no new config/env; existing dedupe behavior is preserved.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31246
- Related #31285, #31301

## User-visible / Behavior Changes

- Discord native slash commands that use `message.send` to the same target now receive the agent's reply via the interaction, and the interaction closes instead of hanging.
- When the dispatcher emits no reply payload and replies are not suppressed, a minimal `✓` acknowledgement is sent to close the interaction.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows 10 / WSL2 (or macOS)
- Runtime/container: Node 22+, pnpm
- Model/provider: Any
- Integration/channel: Discord (native slash commands)
- Relevant config (redacted): Discord channel enabled, slash command registered with `message` tool access

### Steps

1. Create a user-invocable skill that uses `message` (action: send) to send a message into the same Discord channel during a slash command turn, then responds with a text reply.
2. Restart the gateway so the slash command is registered.
3. Invoke the slash command from Discord.
4. Observe that the `message.send` content appears in the channel and the slash interaction receives a reply (or `✓` when no payload is emitted) and closes instead of hanging on “Bot is responding...”.

### Expected

- Interaction closes; user sees both the `message.send` content and the agent's reply (or `✓` when no reply payload is emitted).

### Actual

- Before this change: interaction could hang forever with “Bot is responding...”.  
- After this change: interaction resolves correctly in the above scenarios.

## Evidence

- [x] Trace/log snippets showing interaction reply/ack is delivered
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:** Inline reply and queued followup paths with `skipMessagingToolReplySuppression` set for Discord native slash; fallback `✓` ack when dispatcher emits no reply payload.
- **Edge cases checked:** Respecting `suppressReplies`; using `preferFollowUp` when present; interaction expiry handled by `safeDiscordInteractionCall`.
- **What you did not verify:** Full end-to-end run against live Discord API in production.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- Revert this PR or temporarily disable Discord native slash commands.
- Watch for symptoms where `✓` appears but a richer reply should have been sent, or where Discord interactions still hang.

## Risks and Mitigations

- **Risk:** In a misconfigured flow where the dispatcher silently drops payloads, users may see `✓` instead of a full reply.
  - **Mitigation:** Fallback ack is only sent when `!didReply && !suppressReplies`; logs still capture dispatcher errors.