### PR TITLE
fix(msteams): await abort signal in monitorMSTeamsProvider to prevent crash loop

### DIFF
--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -294,11 +294,20 @@ export async function monitorMSTeamsProvider(
     });
   };
 
-  // Handle abort signal
+  // Handle abort signal — block until shutdown is requested.
+  // Without this, the promise resolves immediately and the gateway
+  // interprets it as "provider exited", triggering an auto-restart loop.
   if (opts.abortSignal) {
     opts.abortSignal.addEventListener("abort", () => {
       void shutdown();
+    }, { once: true });
+    await new Promise<void>((resolve) => {
+      if (opts.abortSignal!.aborted) { resolve(); return; }
+      opts.abortSignal!.addEventListener("abort", () => resolve(), { once: true });
     });
+  } else {
+    // No abort signal — block forever (matches Slack/Telegram provider behavior)
+    await new Promise<void>(() => {});
   }
 
   return { app: expressApp, shutdown };


### PR DESCRIPTION
## Summary

- **Root cause:** `monitorMSTeamsProvider()` returns immediately after `expressApp.listen()` — the gateway channel manager interprets the resolved promise as "provider exited" and triggers auto-restart with exponential backoff, causing an infinite crash loop with EADDRINUSE errors as the port is still bound.
- **Fix:** Add a blocking `await` on a Promise that only resolves when the abort signal fires, keeping the provider promise pending while the server is healthy. This matches the established pattern used by the Slack provider (`src/slack/monitor/provider.ts:530-534`) and Google Chat provider (`extensions/googlechat/src/channel.ts:567-573`).
- **Also:** Added `{ once: true }` to the shutdown abort listener to prevent event listener leaks. Added an `else` branch that blocks forever when no abort signal is provided.

## Root Cause

The `startAccount` contract requires the returned promise to stay pending while the provider is running. When the promise resolves, the gateway assumes the provider has stopped and schedules a restart. Since `monitorMSTeamsProvider` resolved immediately after starting the Express server, the gateway entered a restart loop:

1. Gateway calls `startAccount()` → `monitorMSTeamsProvider()`
2. Express server starts on port 3978
3. Function returns `{ app, shutdown }` — promise resolves immediately
4. Gateway sees resolved promise → schedules restart
5. Restart tries to start Express on the same port → EADDRINUSE
6. Repeat with backoff until max attempts

## The Fix

```typescript
// Before: returns immediately
if (opts.abortSignal) {
  opts.abortSignal.addEventListener("abort", () => { void shutdown(); });
}
return { app: expressApp, shutdown };

// After: blocks until abort signal fires
if (opts.abortSignal) {
  opts.abortSignal.addEventListener("abort", () => { void shutdown(); }, { once: true });
  await new Promise<void>((resolve) => {
    if (opts.abortSignal!.aborted) { resolve(); return; }
    opts.abortSignal!.addEventListener("abort", () => resolve(), { once: true });
  });
} else {
  await new Promise<void>(() => {});
}
return { app: expressApp, shutdown };
```

## How to Reproduce

1. Enable the MS Teams channel with valid credentials
2. Start the gateway
3. Observe logs: `starting provider (port 3978)` followed by `auto-restart attempt 1/10`
4. Loop continues with backoff until max restart attempts

## Test Plan

- [ ] Start msteams provider and verify it stays running (no auto-restart messages in logs)
- [ ] Send abort signal and verify clean shutdown (no leaked listeners)
- [ ] Verify EADDRINUSE errors no longer occur on gateway boot
- [ ] Confirm no regression in provider startup/shutdown lifecycle

Closes #27885
Closes #24522
Relates to #22169

🤖 Generated with [Claude Code](https://claude.com/claude-code)