### PR TITLE
fix(msteams): await file consent handler to prevent TurnContext proxy revocation

### DIFF
--- a/extensions/msteams/src/monitor-handler.file-consent.test.ts
+++ b/extensions/msteams/src/monitor-handler.file-consent.test.ts
@@ -155,11 +155,8 @@ describe("msteams file consent invoke authz", () => {
       }),
     );
 
-    // Wait for async upload to complete
-    await vi.waitFor(() => {
-      expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledTimes(1);
-    });
-
+    // Upload runs synchronously within the turn now (no vi.waitFor needed)
+    expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledTimes(1);
     expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://upload.example.com/put",
@@ -192,12 +189,10 @@ describe("msteams file consent invoke authz", () => {
       }),
     );
 
-    // Wait for async handler to complete
-    await vi.waitFor(() => {
-      expect(sendActivity).toHaveBeenCalledWith(
-        "The file upload request has expired. Please try sending the file again.",
-      );
-    });
+    // Handler runs synchronously within the turn now (no vi.waitFor needed)
+    expect(sendActivity).toHaveBeenCalledWith(
+      "The file upload request has expired. Please try sending the file again.",
+    );
 
     expect(fileConsentMockState.uploadToConsentUrl).not.toHaveBeenCalled();
     expect(getPendingUpload(uploadId)).toBeDefined();

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -146,10 +146,12 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
         // Send invoke response IMMEDIATELY to prevent Teams timeout
         await ctx.sendActivity({ type: "invokeResponse", value: { status: 200 } });
 
-        // Handle file upload asynchronously (don't await)
-        handleFileConsentInvoke(ctx, deps.log).catch((err) => {
+        // Handle file upload within the turn (context proxy revokes after return)
+        try {
+          await handleFileConsentInvoke(ctx, deps.log);
+        } catch (err) {
           deps.log.debug?.("file consent handler error", { error: String(err) });
-        });
+        }
         return;
       }
       return originalRun.call(handler, context);


### PR DESCRIPTION
## Summary

- **Root cause:** `handleFileConsentInvoke()` was called as fire-and-forget (no `await`) inside the `fileConsent/invoke` handler in `registerMSTeamsHandlers`. The Bot Framework SDK revokes the `TurnContext` proxy after the turn handler returns, so by the time the async upload completed and attempted to send the `FileInfoCard` confirmation, the proxy was already revoked.
- **Fix:** Await the `handleFileConsentInvoke()` call so the upload and confirmation card are sent within the turn's lifetime. The invoke response (`{ status: 200 }`) is already sent *before* this code runs, so Teams will not timeout waiting for the invoke acknowledgment.
- **Tests:** Updated `monitor-handler.file-consent.test.ts` to remove `vi.waitFor()` wrappers that were compensating for the fire-and-forget pattern. Assertions now run synchronously after `handler.run()` since the handler is properly awaited.

## Reproduction

1. Send a large file (>50KB) to an OpenClaw bot in MS Teams
2. Accept the file consent card
3. The upload succeeds, but the FileInfoCard confirmation fails with: `Cannot perform 'get' on a proxy that has been revoked`

With this fix, the FileInfoCard is sent successfully within the same turn.

## Related Issues

Fixes #29847 — FileConsent upload succeeds but FileInfoCard fails — TurnContext proxy revoked
Fixes #27189 — MS Teams replies fail with 'Cannot perform set on a proxy that has been revoked'
Fixes #18636 — Final reply fails with "proxy revoked" when agent takes >15s

## Test plan

- [x] `vitest run --config vitest.extensions.config.ts extensions/msteams/src/monitor-handler.file-consent.test.ts` — all 3 tests pass
- [ ] Manual: send a large file to a Teams bot, accept consent, verify FileInfoCard appears
- [ ] Manual: decline file consent, verify no upload occurs and pending upload is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)