### PR TITLE
fix(feishu): prevent duplicate delivery when message tool uses generic provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/Duplicate replies: suppress same-target reply dispatch when message-tool sends use generic provider metadata (`provider: "message"`) and normalize `lark`/`feishu` provider aliases during duplicate-target checks, preventing double-delivery in Feishu sessions. (#31526)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -86,6 +86,34 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
+  it("suppresses same-target replies when message tool target provider is generic", () => {
+    const { replyPayloads } = buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "hello world!" }],
+      messageProvider: "heartbeat",
+      originatingChannel: "feishu",
+      originatingTo: "ou_abc123",
+      messagingToolSentTexts: ["different message"],
+      messagingToolSentTargets: [{ tool: "message", provider: "message", to: "ou_abc123" }],
+    });
+
+    expect(replyPayloads).toHaveLength(0);
+  });
+
+  it("suppresses same-target replies when target provider is channel alias", () => {
+    const { replyPayloads } = buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "hello world!" }],
+      messageProvider: "heartbeat",
+      originatingChannel: "feishu",
+      originatingTo: "ou_abc123",
+      messagingToolSentTexts: ["different message"],
+      messagingToolSentTargets: [{ tool: "message", provider: "lark", to: "ou_abc123" }],
+    });
+
+    expect(replyPayloads).toHaveLength(0);
+  });
+
   it("does not suppress same-target replies when accountId differs", () => {
     const { replyPayloads } = buildReplyPayloads({
       ...baseParams,


### PR DESCRIPTION
## Summary
- prevent same-target reply duplication when the message tool sends without explicit channel/provider metadata
- treat generic `provider: "message"` sends as originating-channel sends for suppression checks
- normalize `lark` -> `feishu` alias in provider comparisons to avoid alias mismatches
- add regression tests for both generic-provider and alias paths

## Change Type
- [x] Bug fix

## Scope
- [x] Integrations
- [x] API / contracts

## Linked Issue/PR
- Closes #31526

## User-visible / Behavior Changes
Feishu users no longer receive duplicate assistant replies when a run includes a same-target message-tool send that defaults to the current channel.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Steps
1. Trigger a Feishu run where the assistant performs a same-target `message` send without explicit channel.
2. Observe outbound behavior.

### Expected (after fix)
- only one user-visible reply is delivered

### Testing
- `pnpm exec vitest run src/auto-reply/reply/agent-runner-payloads.test.ts`
- `pnpm exec vitest run src/auto-reply/reply/followup-runner.test.ts`