### PR TITLE
fix: resolve Discord slash command hanging on message.send

### DIFF
--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -1578,7 +1578,7 @@ async function dispatchDiscordCommandInteraction(params: {
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, effectiveRoute.agentId);
 
   let didReply = false;
-  await dispatchReplyWithDispatcher({
+  const dispatchResult = await dispatchReplyWithDispatcher({
     ctx: ctxPayload,
     cfg,
     dispatcherOptions: {
@@ -1623,6 +1623,29 @@ async function dispatchDiscordCommandInteraction(params: {
       onModelSelected,
     },
   });
+
+  // Fallback: if the agent turn produced no deliverable replies (for example,
+  // a skill only used message.send side effects), close the interaction with
+  // a minimal acknowledgment so Discord does not stay in a pending state.
+  if (
+    !suppressReplies &&
+    !didReply &&
+    dispatchResult.counts.final === 0 &&
+    dispatchResult.counts.block === 0 &&
+    dispatchResult.counts.tool === 0
+  ) {
+    await safeDiscordInteractionCall("interaction empty fallback", async () => {
+      const payload = {
+        content: "✅ Done.",
+        ephemeral: true,
+      };
+      if (preferFollowUp) {
+        await interaction.followUp(payload);
+        return;
+      }
+      await interaction.reply(payload);
+    });
+  }
 }
 
 async function deliverDiscordInteractionReply(params: {


### PR DESCRIPTION
## Summary
- Problem: Discord native skill slash commands that only invoke the message tool with action=send (and produce no textual reply) never call interaction.reply/followUp, so Discord keeps showing “Bot is responding…” and the interaction never completes.
- Why it matters: Users already see the side-effect message sent by message.send in the channel, but the slash command stays in a pending state, which looks like the bot or gateway is hung and degrades trust and usability.
- What changed: In the Discord native command handler (dispatchDiscordCommandInteraction), we added a fallback: if an agent turn produces no deliverable replies at all (counts.tool/block/final are all 0) and no interaction reply has been sent (didReply === false), and replies are not explicitly suppressed, we now send a minimal ephemeral “✅ Done.” reply to the interaction so it closes.
- What did NOT change (scope boundary): The outbound path and behavior of the message tool (message.send) are unchanged (still regular channel messages, not interaction replies).
Non-Discord channels and non-native commands (plain text commands, etc.) are untouched.
Native commands that already produce block/final/tool replies behave exactly as before (no extra fallback message).
No changes to tool permissions, model selection, session storage, or routing policies.

## Change Type (select all)

- [x] Bug fix


## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] Integrations


## Linked Issue/PR

- Closes # https://github.com/openclaw/openclaw/issues/31246#issue-4009113700

## User-visible / Behavior Changes
For Discord native skill slash commands (e.g. /ztest) that only send messages via the message tool (action=send) and end up with no deliverable reply, the interaction now receives a short ephemeral “✅ Done.” reply so the “Bot is responding…” banner clears.
Native commands that already produce a normal text/media reply still show only that reply; the fallback is only used when the agent turn would have produced no reply at all.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node with global openclaw@2026.2.26, local gateway
- Model/provider: Anthropic (e.g. claude-opus-4-5), any default chat model
- Integration/channel (if any): Discord with native commands enabled (commands.native: true)
- Relevant config (redacted): 
channels.discord.dm.policy: open
commands.native: true (or equivalent default)
Test skill at ~/.openclaw/skills/ztest/SKILL.md, e.g.:
user-invocable: true
allowed-tools: ["exec", "message"]
Flow: run exec (e.g. echo "hello"), then message tool with action=send to send "test" to the current channel, optionally followed by a final text reply like ✅ done.

### Steps

1. Create skill ztest under ~/.openclaw/skills/ztest/SKILL.md with user-invocable: true and allowed-tools: ["exec", "message"]. In a single turn, have it:
run an exec tool call (e.g. echo "hello"), and
call the message tool with action=send to send "test" to the current Discord channel,
optionally skip any final text reply to simulate side-effect-only behavior.
2. Restart the gateway so the skill is registered as a Discord native slash command /ztest.
3. In the Discord client, invoke /ztest from the native slash menu.


## Evidence

- [x] Trace/log snippets


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: (to be done manually in a real environment; this is the checklist):
Discord DM: invoke /ztest where the skill only calls message.send and returns no text; interaction receives “✅ Done.” and completes.
Discord guild channel: invoke a native command that returns a normal text reply (no message.send); behavior is unchanged, with no extra fallback message.
Non-Discord channels (e.g. Telegram native commands) and text commands continue to behave as before.
- Edge cases checked: (via static reasoning and code-level review):
When suppressReplies === true, the fallback is not triggered, so system/internal commands that intentionally don’t reply remain silent.
If any tool/block/final reply is produced, didReply and/or counts.* prevent the fallback from sending a duplicate interaction.reply.
safeDiscordInteractionCall still wraps the fallback; if the interaction has already expired (Unknown interaction), we log and skip without throwing.
- What you did **not** verify: Full end-to-end manual testing with a real Discord server + gateway for complex skill scenarios (multiple tool calls, multi-agent runs, etc.) has not yet been performed; those should be exercised by a human before/after merging.

## Compatibility / Migration

- Backward compatible? Yes (we only add a reply where previously there was a hung interaction; all other paths retain their original semantics).
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None
