### PR TITLE
fix(telegram): include chatId in DM topic outbound session key

### DIFF
--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -307,10 +307,11 @@ function resolveTelegramSession(
     accountId: params.accountId,
     peer,
   });
-  // Use thread suffix for DM topics to match inbound session key format
+  // Use thread suffix for DM topics to match inbound session key format.
+  // Include chatId so that different DMs with the same topicId don't collide.
   const threadKeys =
     resolvedThreadId && !isGroup
-      ? { sessionKey: `${baseSessionKey}:thread:${resolvedThreadId}` }
+      ? { sessionKey: `${baseSessionKey}:thread:${chatId}:${resolvedThreadId}` }
       : null;
   return {
     sessionKey: threadKeys?.sessionKey ?? baseSessionKey,

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -931,7 +931,7 @@ describe("resolveOutboundSessionRoute", () => {
         channel: "telegram",
         target: "123456789:topic:99",
         expected: {
-          sessionKey: "agent:main:telegram:direct:123456789:thread:99",
+          sessionKey: "agent:main:telegram:direct:123456789:thread:123456789:99",
           from: "telegram:123456789:topic:99",
           to: "telegram:123456789",
           threadId: 99,
@@ -955,7 +955,7 @@ describe("resolveOutboundSessionRoute", () => {
         target: "12345",
         threadId: "12345:99",
         expected: {
-          sessionKey: "agent:main:telegram:direct:12345:thread:99",
+          sessionKey: "agent:main:telegram:direct:12345:thread:12345:99",
           from: "telegram:12345:topic:99",
           to: "telegram:12345",
           threadId: 99,


### PR DESCRIPTION
## Summary

- **Problem**: Outbound delivery (cron, message tool) builds DM topic session keys as `thread:<topicId>`, while inbound Telegram updates use `thread:<chatId>:<topicId>`. The same Telegram topic ends up with two separate sessions, causing context divergence.
- **Why it matters**: Users mixing automation (cron) with manual chat in the same DM topic lose conversational continuity — the agent sees two unrelated sessions.
- **What changed**: Modified `resolveTelegramSession` in `outbound-session.ts` to include `chatId` in the DM topic thread suffix, matching the inbound format.
- **What did NOT change (scope boundary)**: Group topic session keys (already use `peerId` with chatId+topicId). Inbound session key logic. No changes to message delivery, target parsing, or session store.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31494

## User-visible / Behavior Changes

- DM topic session keys now include chatId: `agent:<agent>:telegram:direct:<chatId>:thread:<chatId>:<topicId>`.
- Outbound and inbound paths produce identical session keys for the same DM topic.
- Existing sessions using the old key format will appear as new sessions (one-time context break, then consistent going forward).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22+

### Steps

1. Create a cron job that sends to a Telegram DM topic target: `telegram:123456789:topic:99`
2. Let cron run and send the message
3. Chat normally in the same DM topic

### Expected

- Both cron-sent messages and manual chat messages share the same session key.

### Actual

- Before: Cron uses `thread:99`, manual chat uses `thread:123456789:99` — two separate sessions.
- After: Both use `thread:123456789:99` — single unified session.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```bash
npx vitest run src/infra/outbound/outbound.test.ts
# 58 tests pass — updated "Telegram DM with topic" and "Telegram DM scoped threadId fallback" expectations
```

## Human Verification (required)

- Verified scenarios: DM topic outbound, DM topic inbound, group topic (unchanged), DM scoped threadId fallback
- Edge cases checked: group topics still use peerId-based keys (no change), DM without topic (no change)
- What you did **not** verify: Live Telegram end-to-end (unit tests only)

## Compatibility / Migration

- Backward compatible? `Yes` — existing DM topic sessions using old key format will appear as new sessions once, then stay consistent.
- Config/env changes? `No`
- Migration needed? `No` — old sessions remain accessible but new messages will use the corrected key.

## Failure Recovery (if this breaks)

- How to disable: Revert `outbound-session.ts` to remove chatId from thread suffix
- Files to restore: `src/infra/outbound/outbound-session.ts`

## Risks and Mitigations

- Risk: One-time session key change means existing DM topic sessions start fresh
  - Mitigation: This is expected and documented. The alternative (keeping inconsistent keys) causes ongoing context divergence which is worse.