### PR TITLE
Feishu: normalize group announce targets to chat ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@ Docs: https://docs.openclaw.ai
 - Security/Feishu webhook ingress: bound unauthenticated webhook rate-limit state with stale-window pruning and a hard key cap to prevent unbounded pre-auth memory growth from rotating source keys. (#26050) Thanks @bmendonca3.
 - Security/Compaction audit: remove the post-compaction audit injection message. (#28507) Thanks @fuller-stack-dev and @vincentkoc.
 - Web tools/RFC2544 fake-IP compatibility: allow RFC2544 benchmark range (`198.18.0.0/15`) for trusted web-tool fetch endpoints so proxy fake-IP networking modes do not trigger false SSRF blocks. Landed from contributor PR #31176 by @sunkinux. Thanks @sunkinux.
+- Feishu/Sessions announce group targets: normalize `group:` and `channel:` Feishu targets to `chat_id` routing so `sessions_send` announce delivery no longer sends group chat IDs via `user_id` API params. Fixes #31426.
 - Windows/Plugin install: avoid `spawn EINVAL` on Windows npm/npx invocations by resolving to `node` + npm CLI scripts instead of spawning `.cmd` directly. Landed from contributor PR #31147 by @codertony. Thanks @codertony.
 - Web UI/Cron: include configured agent model defaults/fallbacks in cron model suggestions so scheduled-job model autocomplete reflects configured models. (#29709) Thanks @Sid-Qin.
 - Cron/Delivery: disable the agent messaging tool when `delivery.mode` is `"none"` so cron output is not sent to Telegram or other channels. (#21808) Thanks @lailoo.

--- a/extensions/feishu/src/targets.test.ts
+++ b/extensions/feishu/src/targets.test.ts
@@ -18,6 +18,10 @@ describe("resolveReceiveIdType", () => {
     expect(resolveReceiveIdType("group:oc_123")).toBe("chat_id");
   });
 
+  it("treats explicit channel targets as chat_id", () => {
+    expect(resolveReceiveIdType("channel:oc_123")).toBe("chat_id");
+  });
+
   it("treats dm-prefixed open IDs as open_id", () => {
     expect(resolveReceiveIdType("dm:ou_123")).toBe("open_id");
   });
@@ -33,8 +37,11 @@ describe("normalizeFeishuTarget", () => {
     expect(normalizeFeishuTarget("feishu:chat:oc_123")).toBe("oc_123");
   });
 
-  it("strips provider and group prefixes", () => {
+  it("normalizes group/channel prefixes to chat ids", () => {
+    expect(normalizeFeishuTarget("group:oc_123")).toBe("oc_123");
     expect(normalizeFeishuTarget("feishu:group:oc_123")).toBe("oc_123");
+    expect(normalizeFeishuTarget("channel:oc_456")).toBe("oc_456");
+    expect(normalizeFeishuTarget("lark:channel:oc_456")).toBe("oc_456");
   });
 
   it("accepts provider-prefixed raw ids", () => {
@@ -55,7 +62,9 @@ describe("looksLikeFeishuId", () => {
     expect(looksLikeFeishuId("lark:chat:oc_123")).toBe(true);
   });
 
-  it("accepts provider-prefixed group targets", () => {
+  it("accepts group/channel targets", () => {
     expect(looksLikeFeishuId("feishu:group:oc_123")).toBe(true);
+    expect(looksLikeFeishuId("group:oc_123")).toBe(true);
+    expect(looksLikeFeishuId("channel:oc_456")).toBe(true);
   });
 });

--- a/extensions/feishu/src/targets.ts
+++ b/extensions/feishu/src/targets.ts
@@ -36,6 +36,9 @@ export function normalizeFeishuTarget(raw: string): string | null {
   if (lowered.startsWith("group:")) {
     return withoutProvider.slice("group:".length).trim() || null;
   }
+  if (lowered.startsWith("channel:")) {
+    return withoutProvider.slice("channel:".length).trim() || null;
+  }
   if (lowered.startsWith("user:")) {
     return withoutProvider.slice("user:".length).trim() || null;
   }
@@ -87,7 +90,7 @@ export function looksLikeFeishuId(raw: string): boolean {
   if (!trimmed) {
     return false;
   }
-  if (/^(chat|group|user|dm|open_id):/i.test(trimmed)) {
+  if (/^(chat|group|channel|user|dm|open_id):/i.test(trimmed)) {
     return true;
   }
   if (trimmed.startsWith(CHAT_ID_PREFIX)) {


### PR DESCRIPTION
## Summary
- normalize Feishu targets with `group:` and `channel:` prefixes to chat IDs
- keep existing `chat:`/`user:`/`open_id:` behavior unchanged
- add regression tests so normalized `group:oc_*` and `channel:oc_*` resolve as `chat_id`

## Problem
`sessions_send` announce can route Feishu group targets as `group:oc_*`.
Feishu target normalization previously left that prefix intact, so send path defaulted to `user_id`, causing API 400 errors for group announce delivery.

## Validation
- `pnpm test extensions/feishu/src/targets.test.ts`
- `pnpm exec oxlint extensions/feishu/src/targets.ts extensions/feishu/src/targets.test.ts`

Fixes #31426
