### PR TITLE
Agent UX: show clear hint for missing provider API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.
 - Gateway/Control UI method guard: allow POST requests to non-UI routes to fall through when no base path is configured, and add POST regression coverage for fallthrough and base-path 405 behavior. (#23970) Thanks @tyler6204.
 - Authentication: classify `permission_error` as `auth_permanent` for profile fallback. (#31324) Thanks @Sid-Qin.
+- TUI/Model auth errors: when a selected model fails due to missing provider API key, show a concise actionable hint (`openclaw configure`) instead of only surfacing the long fallback-chain error blob. (#31544)
 - Security/Prompt spoofing hardening: stop injecting queued runtime events into user-role prompt text, route them through trusted system-prompt context, and neutralize inbound spoof markers like `[System Message]` and line-leading `System:` in untrusted message content. (#30448)
 - Gateway/Node browser proxy routing: honor `profile` from `browser.request` JSON body when query params omit it, while preserving query-profile precedence when both are present. (#28852) Thanks @Sid-Qin.
 - Browser/Extension relay reconnect tolerance: keep `/json/version` and `/cdp` reachable during short MV3 worker disconnects when attached targets still exist, and retain clients across reconnect grace windows. (#30232) Thanks @Sid-Qin.

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -69,6 +69,12 @@ export type AgentRunLoopResult =
     }
   | { kind: "final"; payload: ReplyPayload };
 
+function resolveMissingApiKeyProvider(message: string): string | null {
+  const match = message.match(/No API key found for provider "([^"]+)"/i);
+  const provider = match?.[1]?.trim();
+  return provider || null;
+}
+
 export async function runAgentTurnWithFallback(params: {
   commandBody: string;
   followupRun: FollowupRun;
@@ -570,11 +576,14 @@ export async function runAgentTurnWithFallback(params: {
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
+      const missingApiKeyProvider = resolveMissingApiKeyProvider(trimmedMessage);
       const fallbackText = isContextOverflow
         ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
         : isRoleOrderingError
           ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-          : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+          : missingApiKeyProvider
+            ? `⚠️ Missing API key for provider "${missingApiKeyProvider}".\nRun openclaw configure (or set the provider API key), then retry.\nLogs: openclaw logs --follow`
+            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -177,8 +177,9 @@ describe("runReplyAgent onAgentRunStart", () => {
 
     expect(onAgentRunStart).not.toHaveBeenCalled();
     expect(result).toMatchObject({
-      text: expect.stringContaining('No API key found for provider "anthropic".'),
+      text: expect.stringContaining('Missing API key for provider "anthropic".'),
     });
+    expect(result.text).toContain("openclaw configure");
   });
 
   it("emits start callback when cli runner starts", async () => {


### PR DESCRIPTION
## Summary

- Problem: when a `/model` selection fails due to missing provider credentials, users see a long fallback-chain error blob that is hard to act on.
- Why it matters: onboarding friction and confusion; users may not know the immediate next step.
- What changed: detect `No API key found for provider "..."` failures and show a concise actionable hint (`openclaw configure`) in the user-facing final error text.
- What did NOT change (scope boundary): no auth resolution logic changes, no provider fallback behavior changes, no retries added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31544
- Related #

## User-visible / Behavior Changes

- Missing-provider-key failures now surface as:
  - `Missing API key for provider "<provider>"`
  - actionable next step: `openclaw configure`
- This replaces only the generic final error text for that specific failure pattern.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local test env
- Runtime/container: Node + Vitest
- Model/provider: auth failure simulation
- Integration/channel (if any): agent reply error path
- Relevant config (redacted): N/A

### Steps

1. Mock model fallback to fail with `No API key found for provider "anthropic"`.
2. Run `runReplyAgent` path with `onAgentRunStart` callback.
3. Assert final user text contains concise missing-key hint and configure guidance.

### Expected

- User-facing text is concise and actionable.

### Actual

- Test passes with new message shape.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
  - `pnpm format:check`
- Edge cases checked:
  - Existing non-auth error fallback path unchanged.
  - Existing context-overflow and role-ordering messages unchanged.
- What you did **not** verify:
  - Full repo `pnpm check` (known unrelated existing failures in other areas).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `4831cb36d`.
- Files/config to restore:
  - `src/auto-reply/reply/agent-runner-execution.ts`
  - `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
  - `CHANGELOG.md`
- Known bad symptoms reviewers should watch for:
  - Missing-key errors no longer include explicit provider hints.

## Risks and Mitigations

- Risk: regex match could miss variants of missing-key messages.
  - Mitigation: fallback keeps existing generic error text when pattern is not matched.
