### PR TITLE
fix(agents): include env var hint in missing API key error message

### DIFF
--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { AuthProfileStore } from "./auth-profiles.js";
-import { requireApiKey, resolveAwsSdkEnvVarName, resolveModelAuthMode } from "./model-auth.js";
+import {
+  requireApiKey,
+  resolveAwsSdkEnvVarName,
+  resolveEnvVarNameForProvider,
+  resolveModelAuthMode,
+} from "./model-auth.js";
 
 describe("resolveAwsSdkEnvVarName", () => {
   it("prefers bearer token over access keys and profile", () => {
@@ -115,5 +120,31 @@ describe("requireApiKey", () => {
         "openai",
       ),
     ).toThrow('No API key resolved for provider "openai"');
+  });
+});
+
+describe("resolveEnvVarNameForProvider", () => {
+  it("returns GEMINI_API_KEY for google", () => {
+    expect(resolveEnvVarNameForProvider("google")).toBe("GEMINI_API_KEY");
+  });
+
+  it("returns OPENAI_API_KEY for openai", () => {
+    expect(resolveEnvVarNameForProvider("openai")).toBe("OPENAI_API_KEY");
+  });
+
+  it("returns ANTHROPIC_API_KEY for anthropic", () => {
+    expect(resolveEnvVarNameForProvider("anthropic")).toBe("ANTHROPIC_API_KEY");
+  });
+
+  it("returns ZAI_API_KEY for zai", () => {
+    expect(resolveEnvVarNameForProvider("zai")).toBe("ZAI_API_KEY");
+  });
+
+  it("returns null for unknown providers", () => {
+    expect(resolveEnvVarNameForProvider("custom-unknown")).toBeNull();
+  });
+
+  it("normalizes provider id before lookup", () => {
+    expect(resolveEnvVarNameForProvider("Google")).toBe("GEMINI_API_KEY");
   });
 });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { type Api, getEnvApiKey, type Model } from "@mariozechner/pi-ai";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -14,7 +13,6 @@ import {
   listProfilesForProvider,
   resolveApiKeyForProfile,
   resolveAuthProfileOrder,
-  resolveAuthStorePathForDisplay,
 } from "./auth-profiles.js";
 import { normalizeProviderId } from "./model-selection.js";
 
@@ -221,15 +219,17 @@ export async function resolveApiKeyForProvider(params: {
     }
   }
 
-  const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
-  const resolvedAgentDir = path.dirname(authStorePath);
-  throw new Error(
-    [
-      `No API key found for provider "${provider}".`,
-      `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
-      `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
-    ].join(" "),
+  const envVarHint = resolveEnvVarNameForProvider(provider);
+  const hints: string[] = [`No API key found for provider "${provider}".`];
+  if (envVarHint) {
+    hints.push(
+      `Set ${envVarHint} in your environment or openclaw.json (models.providers.${provider}.apiKey).`,
+    );
+  }
+  hints.push(
+    `Alternatively, run ${formatCliCommand(`openclaw auth login --provider ${provider}`)} or ${formatCliCommand("openclaw agents add <id>")}.`,
   );
+  throw new Error(hints.join(" "));
 }
 
 export type EnvApiKeyResult = { apiKey: string; source: string };
@@ -329,6 +329,34 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     return null;
   }
   return pick(envVar);
+}
+
+export function resolveEnvVarNameForProvider(provider: string): string | null {
+  const normalized = normalizeProviderId(provider);
+  const envMap: Record<string, string> = {
+    openai: "OPENAI_API_KEY",
+    anthropic: "ANTHROPIC_API_KEY",
+    google: "GEMINI_API_KEY",
+    zai: "ZAI_API_KEY",
+    groq: "GROQ_API_KEY",
+    cerebras: "CEREBRAS_API_KEY",
+    xai: "XAI_API_KEY",
+    openrouter: "OPENROUTER_API_KEY",
+    moonshot: "MOONSHOT_API_KEY",
+    minimax: "MINIMAX_API_KEY",
+    mistral: "MISTRAL_API_KEY",
+    together: "TOGETHER_API_KEY",
+    deepgram: "DEEPGRAM_API_KEY",
+    nvidia: "NVIDIA_API_KEY",
+    voyage: "VOYAGE_API_KEY",
+    ollama: "OLLAMA_API_KEY",
+    vllm: "VLLM_API_KEY",
+    kilocode: "KILOCODE_API_KEY",
+    "github-copilot": "GH_TOKEN",
+    volcengine: "VOLCANO_ENGINE_API_KEY",
+    byteplus: "BYTEPLUS_API_KEY",
+  };
+  return envMap[normalized] ?? null;
 }
 
 export function resolveModelAuthMode(


### PR DESCRIPTION
## Summary

- **Problem**: When a user selects a model whose provider has no API key configured, the error message shows internal file paths and generic instructions like "copy auth-profiles.json from the main agentDir" — confusing for new users.
- **Why it matters**: Users need actionable guidance to fix auth issues. The current message requires reading docs to figure out which env var to set.
- **What changed**: Replaced the generic error with a targeted message that includes the specific environment variable name (e.g. `GEMINI_API_KEY`) and suggests both `openclaw auth login --provider <name>` and config-based setup. Added `resolveEnvVarNameForProvider` helper function.
- **What did NOT change (scope boundary)**: Auth resolution logic, profile lookup, env var reading, or any existing auth behavior. Only the thrown error message text changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31544

## User-visible / Behavior Changes

Before:
```
No API key found for provider "google". Auth store: /home/user/.openclaw/agents/main/agent/auth-profiles.json (agentDir: /home/user/.openclaw/agents/main/agent). Configure auth for this agent (openclaw agents add <id>) or copy auth-profiles.json from the main agentDir.
```

After:
```
No API key found for provider "google". Set GEMINI_API_KEY in your environment or openclaw.json (models.providers.google.apiKey). Alternatively, run openclaw auth login --provider google or openclaw agents add <id>.
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Start OpenClaw without setting `GEMINI_API_KEY`
2. Run `/model` and select `google/gemini-3-flash-preview`
3. Send any prompt

### Expected

- Error message includes `GEMINI_API_KEY` and `openclaw auth login --provider google`.

### Actual

- Before: Generic message with file paths and "copy auth-profiles.json" instruction.
- After: Actionable message with specific env var and CLI command.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```bash
npx vitest run src/agents/model-auth.test.ts
# 16 tests pass (6 new: resolveEnvVarNameForProvider for google, openai, anthropic, zai, unknown, case-normalization)
```

## Human Verification (required)

- Verified scenarios: known providers (google, openai, anthropic, zai), unknown custom provider (graceful fallback)
- Edge cases checked: case-insensitive provider lookup, providers with no env var mapping
- What you did **not** verify: Live TUI `/model` selection flow (unit tests only)

## Compatibility / Migration

- Backward compatible? `Yes` — only error message text changed
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable: Revert `model-auth.ts` error construction
- Files to restore: `src/agents/model-auth.ts`

## Risks and Mitigations

- Risk: None — this is a display-only change affecting error messages
  - Mitigation: N/A