### PR TITLE
CI: skip macOS TS tests when run_node is false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,7 @@ jobs:
 
       # --- Run all checks sequentially (fast gates first) ---
       - name: TS tests (macOS)
+        if: needs.changed-scope.outputs.run_node == 'true'
         env:
           NODE_OPTIONS: --max-old-space-size=4096
         run: pnpm test


### PR DESCRIPTION
## Summary

- Problem: macOS CI currently runs full `pnpm test` even for native-only PRs (e.g. `apps/ios/*`), causing long unrelated failures/timeouts.
- Why it matters: iOS/macOS-native changes are blocked by Node test instability already covered by Linux jobs.
- What changed: gate the `TS tests (macOS)` step behind `needs.changed-scope.outputs.run_node == 'true'`.
- What did NOT change (scope boundary): macOS Swift/Xcode lint/build/test steps still run whenever `run_macos == true`.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #31542
- Related #30885

## User-visible / Behavior Changes

- None (CI-only change).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local dev
- Runtime/container: GitHub workflow YAML change
- Model/provider: N/A
- Integration/channel (if any): CI pipeline
- Relevant config (redacted): `changed-scope` outputs

### Steps

1. Keep `run_macos=true` (native app changes).
2. Ensure `run_node=false` (native-only scope).
3. macOS job runs, but `TS tests (macOS)` step is skipped while Swift steps still execute.

### Expected

- TS step is skipped for native-only PRs.
- Swift macOS checks still run.

### Actual

- Workflow condition updated accordingly.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - YAML condition resolves against existing `changed-scope` outputs (`run_node`, `run_macos`).
  - `pnpm format:check` passes.
- Edge cases checked:
  - PRs with Node changes (`run_node=true`) still run macOS TS tests.
  - Native-only PRs (`run_node=false`) skip only the TS step.
- What you did **not** verify:
  - Full GitHub Actions run in this local environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `5caea7c7a`.
- Files/config to restore:
  - `.github/workflows/ci.yml`
- Known bad symptoms reviewers should watch for:
  - macOS TS tests unexpectedly not running on PRs that include Node scope changes.

## Risks and Mitigations

- Risk: incorrect scope classification could skip macOS TS tests more often than intended.
  - Mitigation: condition uses existing `run_node` signal already used across CI; no new scope logic introduced.
