### PR TITLE
fix: add stream idle timeout for hung proxy connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,6 +248,9 @@
   "packageManager": "pnpm@10.23.0",
   "pnpm": {
     "minimumReleaseAge": 2880,
+    "patchedDependencies": {
+      "@mariozechner/pi-ai@0.55.0": "patches/@mariozechner__pi-ai@0.55.0.patch"
+    },
     "overrides": {
       "hono": "4.11.10",
       "fast-xml-parser": "5.3.6",

--- a/patches/@mariozechner__pi-ai@0.55.0.patch
+++ b/patches/@mariozechner__pi-ai@0.55.0.patch
@@ -1,0 +1,27 @@
+diff --git a/dist/providers/openai-completions.js b/dist/providers/openai-completions.js
+index 1111111..2222222 100644
+--- a/dist/providers/openai-completions.js
++++ b/dist/providers/openai-completions.js
+@@ -103,7 +103,14 @@
+                     }
+                 }
+             };
++            // Stream idle timeout: if no SSE event arrives within 120s, abort.
++            // Prevents hung connections where LiteLLM/proxy accepted the request
++            // (HTTP 200) but the backend stalls and never sends stream data.
++            const _IDLE_MS = 120000;
++            let _idleTimer = setTimeout(() => openaiStream.controller.abort(), _IDLE_MS);
+             for await (const chunk of openaiStream) {
++                clearTimeout(_idleTimer);
++                _idleTimer = setTimeout(() => openaiStream.controller.abort(), _IDLE_MS);
+                 if (chunk.usage) {
+                     const cachedTokens = chunk.usage.prompt_tokens_details?.cached_tokens || 0;
+                     const reasoningTokens = chunk.usage.completion_tokens_details?.reasoning_tokens || 0;
+@@ -241,6 +248,7 @@
+                     }
+                 }
+             }
++            clearTimeout(_idleTimer);
+             finishCurrentBlock(currentBlock);
+             if (options?.signal?.aborted) {
+                 throw new Error("Request was aborted");


### PR DESCRIPTION
## Summary

- Adds a 120-second idle timeout to the `openai-completions` streaming loop via a pnpm patch on `@mariozechner/pi-ai`
- Prevents subagent sessions from hanging indefinitely when a proxy (e.g. LiteLLM) accepts a request (HTTP 200) but the backend stalls and never sends SSE events
- The timer resets on every received SSE chunk, so active long-running streams are unaffected

## Problem

When using OpenClaw with a proxy like LiteLLM in front of Vertex AI:
1. The proxy responds with HTTP 200 headers immediately
2. The OpenAI SDK's 10-minute fetch timeout is cleared (headers received)
3. If the backend stalls, the SSE stream hangs silently — no timeout fires
4. Only the session-level `runTimeoutSeconds` (default 600s, configurable up to hours) can kill it

This caused subagent sessions to hang for hours with no output.

## Fix

The patch wraps the `for await (const chunk of openaiStream)` loop with an idle timer:
- Timer starts when streaming begins (after HTTP 200 headers)
- Resets on every SSE chunk received
- If 120 seconds pass with no chunk, aborts the stream via `openaiStream.controller.abort()`
- The error propagates through the agent loop for retry or failure reporting

## Test plan

- [x] Verify normal streaming responses still work (timer resets on each chunk)
- [x] Verify long-running responses with extended thinking (>2min between tool calls) still work — thinking tokens reset the timer
- [x] Simulate a hung proxy connection — should abort after 120s instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)