### PR TITLE
fix(feishu): use msg_type file for video files instead of invalid media type

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -108,7 +108,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     messageResourceGetMock.mockResolvedValue(Buffer.from("resource-bytes"));
   });
 
-  it("uses msg_type=media for mp4", async () => {
+  it("uses msg_type=file for mp4", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -124,7 +124,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "media" }),
+        data: expect.objectContaining({ msg_type: "file" }),
       }),
     );
   });
@@ -171,7 +171,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses msg_type=media when replying with mp4", async () => {
+  it("uses msg_type=file when replying with mp4", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -183,7 +183,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(messageReplyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { message_id: "om_parent" },
-        data: expect.objectContaining({ msg_type: "media" }),
+        data: expect.objectContaining({ msg_type: "file" }),
       }),
     );
 

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -308,8 +308,8 @@ export async function sendFileFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
-  /** Use "media" for video, "audio" for audio, "file" for documents */
-  msgType?: "file" | "media" | "audio";
+  /** Use "audio" for audio, "file" for documents/video */
+  msgType?: "file" | "audio";
   replyToMessageId?: string;
   replyInThread?: boolean;
   accountId?: string;
@@ -447,8 +447,9 @@ export async function sendMediaFeishu(params: {
       fileType,
       accountId,
     });
-    // Feishu API: opus -> "audio", mp4 -> "media", everything else -> "file"
-    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
+    // Feishu API msg_type only supports: file, image, audio.
+    // "media" and "video" are not valid — use "file" for video/mp4 and other generic files.
+    const msgType = fileType === "opus" ? "audio" : "file";
     return sendFileFeishu({
       cfg,
       to,


### PR DESCRIPTION
## Problem

Feishu API rejects MP4 video sends with error 230001 (invalid msg_type). The plugin was using `msg_type: "media"` for MP4 files, but Feishu's `im.message.create` API only supports: `file`, `image`, `audio`.

Per [Feishu API docs](https://open.feishu.cn/document/server-docs/im-v1/message-content-description/create_json), `"media"` and `"video"` are not valid msg_type values.

## Fix

Change the msg_type mapping so MP4 and all non-audio files use `"file"` instead of the invalid `"media"` type. Also narrow the `msgType` type from `"file" | "media" | "audio"` to `"file" | "audio"`.

### Changes
- `extensions/feishu/src/media.ts`: Remove invalid `"media"` msg_type, use `"file"` for video files

Closes #29560