### PR TITLE
fix(feishu): respect renderMode config in outbound message sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/Outbound render mode: respect Feishu account `renderMode` in outbound sends so card mode (and auto-detected markdown tables/code blocks) uses markdown card delivery instead of always sending plain text. (#31562) Thanks @arkyu2077.
 - Plugin command/runtime hardening: validate and normalize plugin command name/description at registration boundaries, and guard Telegram native menu normalization paths so malformed plugin command specs cannot crash startup (`trim` on undefined). (#31997) Fixes #31944. Thanks @liuxiaopai-ai.
 - Telegram: guard duplicate-token checks and gateway startup token normalization when account tokens are missing, preventing `token.trim()` crashes during status/start flows. (#31973) Thanks @ningding97.
 - Discord/lifecycle startup status: push an immediate `connected` status snapshot when the gateway is already connected before lifecycle debug listeners attach, with abort-guarding to avoid contradictory status flips during pre-aborted startup. (#32336) Thanks @mitchmcalister.


### PR DESCRIPTION
## Problem

The Feishu outbound adapter (`outbound.ts`) always uses `sendMessageFeishu()` which sends `post` type messages with the `md` tag. The `md` tag does **not** support markdown table rendering, so tables are silently dropped from outbound messages.

Meanwhile, the reply dispatcher (`reply-dispatcher.ts`) correctly checks `renderMode` and switches to `sendMarkdownCardFeishu()` (interactive card with `markdown` tag) when card mode is active. This inconsistency means `renderMode: "card"` only works for replies, not for proactive sends via the message tool.

## Fix

Apply the same `renderMode` logic from the reply dispatcher to the outbound `sendText` path:

- `renderMode: "card"` → always use `sendMarkdownCardFeishu()`
- `renderMode: "auto"` → use card when text contains code fences or markdown tables (same `shouldUseCard()` heuristic)
- `renderMode: "raw"` or default → use `sendMessageFeishu()` (post format)

### Changes
- `extensions/feishu/src/outbound.ts`: Import `resolveFeishuAccount` and `sendMarkdownCardFeishu`, add `shouldUseCard()` heuristic, apply renderMode check in `sendText`

Closes #28616