### PR TITLE
fix(reply): hard-stop inline command flow to prevent /help model passthrough

### DIFF
--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -221,4 +221,89 @@ describe("handleInlineActions", () => {
     expect(sessionStore["s:main"]?.abortCutoffTimestamp).toBeUndefined();
     expect(handleCommandsMock).toHaveBeenCalledTimes(1);
   });
+
+  it("hard-stops when inline command returns shouldContinue=false", async () => {
+    const typing = createTypingController();
+    handleCommandsMock.mockResolvedValueOnce({
+      shouldContinue: false,
+      reply: { text: "help" },
+    });
+
+    const ctx = buildTestCtx({
+      Body: "/help hello",
+      CommandBody: "/help hello",
+    });
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "/help hello",
+        command: {
+          isAuthorizedSender: true,
+          senderId: "sender-inline",
+          rawBodyNormalized: "/help hello",
+          commandBodyNormalized: "/help hello",
+        },
+        overrides: {
+          cfg: { commands: { text: true } },
+          allowTextCommands: true,
+        },
+      }),
+    );
+
+    expect(result).toEqual({ kind: "reply", reply: { text: "help" } });
+    expect(typing.cleanup).toHaveBeenCalled();
+    expect(handleCommandsMock).toHaveBeenCalledTimes(1);
+    expect(handleCommandsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: expect.objectContaining({
+          commandBodyNormalized: "/help",
+          rawBodyNormalized: "/help",
+        }),
+      }),
+    );
+  });
+
+  it("detects inline command from rawBodyNormalized fallback", async () => {
+    const typing = createTypingController();
+    handleCommandsMock.mockResolvedValueOnce({
+      shouldContinue: false,
+      reply: { text: "help" },
+    });
+
+    const ctx = buildTestCtx({
+      Body: "help panel", // cleaned body can lose slash command on some surfaces
+      CommandBody: "help panel",
+    });
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "help panel",
+        command: {
+          isAuthorizedSender: true,
+          senderId: "sender-inline-raw",
+          rawBodyNormalized: "/help",
+          commandBodyNormalized: "help panel",
+        },
+        overrides: {
+          cfg: { commands: { text: true } },
+          allowTextCommands: true,
+        },
+      }),
+    );
+
+    expect(result).toEqual({ kind: "reply", reply: { text: "help" } });
+    expect(handleCommandsMock).toHaveBeenCalledTimes(1);
+    expect(handleCommandsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: expect.objectContaining({
+          commandBodyNormalized: "/help",
+          rawBodyNormalized: "/help",
+        }),
+      }),
+    );
+  });
 });

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -286,7 +286,8 @@ export async function handleInlineActions(params: {
 
   const inlineCommand =
     allowTextCommands && command.isAuthorizedSender
-      ? extractInlineSimpleCommand(cleanedBody)
+      ? (extractInlineSimpleCommand(cleanedBody) ??
+        extractInlineSimpleCommand(command.rawBodyNormalized))
       : null;
   if (inlineCommand) {
     cleanedBody = inlineCommand.cleaned;
@@ -361,6 +362,7 @@ export async function handleInlineActions(params: {
       skillCommands,
     });
 
+  const primaryCommandInput = command;
   if (inlineCommand) {
     const inlineCommandContext = {
       ...command,
@@ -368,12 +370,9 @@ export async function handleInlineActions(params: {
       commandBodyNormalized: inlineCommand.command,
     };
     const inlineResult = await runCommands(inlineCommandContext);
-    if (inlineResult.reply) {
-      if (!inlineCommand.cleaned) {
-        typing.cleanup();
-        return { kind: "reply", reply: inlineResult.reply };
-      }
-      await sendInlineReply(inlineResult.reply);
+    if (!inlineResult.shouldContinue) {
+      typing.cleanup();
+      return { kind: "reply", reply: inlineResult.reply };
     }
   }
 
@@ -401,7 +400,7 @@ export async function handleInlineActions(params: {
     abortedLastRun = getAbortMemory(command.abortKey) ?? false;
   }
 
-  const commandResult = await runCommands(command);
+  const commandResult = await runCommands(primaryCommandInput);
   if (!commandResult.shouldContinue) {
     typing.cleanup();
     return { kind: "reply", reply: commandResult.reply };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: In Feishu, `/help`/`/commands` inline commands can still fall through to the model path after command handling, producing an extra model reply after the built-in command reply.
- Why it matters: Command surfaces should be deterministic; command matches must not invoke the model path.
- What changed:
  - Added inline command extraction fallback from `command.rawBodyNormalized` when `cleanedBody` does not retain slash command text.
  - Switched inline command branch to hard-stop on `!inlineResult.shouldContinue` (return immediately instead of only checking `inlineResult.reply`).
  - Added regression tests for hard-stop behavior and raw-body fallback extraction.
- What did NOT change (scope boundary): No Feishu plugin behavior changes; no command registry changes; no new commands.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #10556
- Related #10575

## User-visible / Behavior Changes

- Inline `/help`/`/commands` handling now hard-stops command flow when command handler returns `shouldContinue=false`.
- In affected Feishu inline scenarios, command messages no longer continue into model execution after command reply.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Linux)
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A for unit tests
- Integration/channel (if any): Feishu behavior path addressed; tests are unit-level in auto-reply
- Relevant config (redacted): commands.text enabled in tests

### Steps

1. Send inline command message (e.g., `/help` with mixed body context).
2. Command handler returns `shouldContinue=false`.
3. Verify flow returns immediately and does not invoke follow-up model path.

### Expected

- Single command reply, no model passthrough.

### Actual

- With this patch, expected behavior is observed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Unit tests added/passed:
- `src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts` (6/6)
- Existing regression file still passes:
  - `src/auto-reply/reply/dispatch-from-config.test.ts` (34/34)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - inline command branch hard-stops on `shouldContinue=false`
  - inline command extraction fallback from `rawBodyNormalized`
- Edge cases checked:
  - Existing inline-actions test suite remains passing
  - Existing dispatch-from-config tests remain passing
- What you did **not** verify:
  - Full end-to-end channel replay across all providers in this PR run

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore:
  - `src/auto-reply/reply/get-reply-inline-actions.ts`
  - `src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts`
- Known bad symptoms reviewers should watch for:
  - Inline command messages unexpectedly continuing into model reply flow.

## Risks and Mitigations

- Risk: Over-eager hard-stop could suppress intended continuation for inline command cases that should continue.
  - Mitigation: Hard-stop is conditioned on `!inlineResult.shouldContinue`, which is the existing command contract for terminal command handling; added targeted tests for this contract.

## AI Disclosure

- [x] AI-assisted
- Testing level: Fully tested for touched unit paths (targeted tests + related regression file).