### PR TITLE
Agents: clear stale edit warnings when retry succeeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Edit tool warning recovery: normalize snake_case mutating target aliases (`file_path`, `message_id`, `session_key`, `job_id`) into stable mutation fingerprints so successful edit retries clear stale tool-failure warnings instead of surfacing false post-success warnings. (#31461)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -37,6 +37,21 @@ describe("tool mutation helpers", () => {
     expect(readFingerprint).toBeUndefined();
   });
 
+  it("normalizes snake_case aliases into stable fingerprint targets", () => {
+    const editFingerprint = buildToolActionFingerprint(
+      "edit",
+      {
+        file_path: "/tmp/demo.txt",
+        old_string: "hello",
+        new_string: "hi",
+      },
+      "edit /tmp/demo.txt",
+    );
+    expect(editFingerprint).toContain("tool=edit");
+    expect(editFingerprint).toContain("path=/tmp/demo.txt");
+    expect(editFingerprint).not.toContain("meta=edit /tmp/demo.txt");
+  });
+
   it("exposes mutation state for downstream payload rendering", () => {
     expect(
       buildToolMutationState("message", { action: "send", to: "telegram:1" }).mutatingAction,

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -82,6 +82,22 @@ function normalizeFingerprintValue(value: unknown): string | undefined {
   return undefined;
 }
 
+function resolveFingerprintField(
+  record: Record<string, unknown> | undefined,
+  aliases: readonly string[],
+): string | undefined {
+  if (!record) {
+    return undefined;
+  }
+  for (const key of aliases) {
+    const value = normalizeFingerprintValue(record[key]);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 export function isLikelyMutatingToolName(toolName: string): boolean {
   const normalized = toolName.trim().toLowerCase();
   if (!normalized) {
@@ -151,23 +167,23 @@ export function buildToolActionFingerprint(
   if (action) {
     parts.push(`action=${action}`);
   }
+  const stableTargetFields: ReadonlyArray<{ key: string; aliases: readonly string[] }> = [
+    { key: "path", aliases: ["path", "filePath", "file_path"] },
+    { key: "oldpath", aliases: ["oldPath", "old_path"] },
+    { key: "newpath", aliases: ["newPath", "new_path"] },
+    { key: "to", aliases: ["to"] },
+    { key: "target", aliases: ["target"] },
+    { key: "messageid", aliases: ["messageId", "message_id"] },
+    { key: "sessionkey", aliases: ["sessionKey", "session_key"] },
+    { key: "jobid", aliases: ["jobId", "job_id"] },
+    { key: "id", aliases: ["id"] },
+    { key: "model", aliases: ["model"] },
+  ];
   let hasStableTarget = false;
-  for (const key of [
-    "path",
-    "filePath",
-    "oldPath",
-    "newPath",
-    "to",
-    "target",
-    "messageId",
-    "sessionKey",
-    "jobId",
-    "id",
-    "model",
-  ]) {
-    const value = normalizeFingerprintValue(record?.[key]);
+  for (const field of stableTargetFields) {
+    const value = resolveFingerprintField(record, field.aliases);
     if (value) {
-      parts.push(`${key.toLowerCase()}=${value}`);
+      parts.push(`${field.key}=${value}`);
       hasStableTarget = true;
     }
   }


### PR DESCRIPTION
## Summary
- normalize snake_case target aliases in mutating action fingerprints (`file_path`, `message_id`, `session_key`, `job_id`)
- keep fingerprint matching stable for `edit` retries so successful retry clears prior mutating tool error
- add regression coverage for alias-normalized fingerprints
- add changelog fix entry for #31461

## Testing
- `pnpm test src/agents/tool-mutation.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts`
- `pnpm exec oxlint src/agents/tool-mutation.ts src/agents/tool-mutation.test.ts`

Closes #31461
