### PR TITLE
docs: add AbacusAI Auth to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,11 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **AbacusAI Auth** — Integrate AbacusAI RouteLLM models (Claude, Gemini, GPT, DeepSeek, Qwen, Grok, Kimi, Llama) into OpenClaw with full multi-tool calling support.
+  npm: `openclaw-abacusai-auth`
+  repo: `https://github.com/tonyhu2006/openclaw-abacusai-auth`
+  install: `openclaw plugins install openclaw-abacusai-auth`
+
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`


### PR DESCRIPTION
## Summary

Add **AbacusAI Auth** plugin to the community plugins page.

## Plugin Details

- **Plugin Name**: AbacusAI Auth
- **npm package**: openclaw-abacusai-auth
- **GitHub repo**: https://github.com/tonyhu2006/openclaw-abacusai-auth
- **Description**: Integrate AbacusAI RouteLLM models (Claude, Gemini, GPT, DeepSeek, Qwen, Grok, Kimi, Llama) into OpenClaw with full multi-tool calling support.
- **Install command**: openclaw plugins install openclaw-abacusai-auth

## Features

- Direct connection to AbacusAI RouteLLM endpoint
- Auto-detect credentials from AbacusAI Code Mode installation
- Full multi-tool calling support with schema normalization
- Supports 30+ models from various providers (Claude, Gemini, GPT, DeepSeek, Qwen, Grok, Kimi, Llama, etc.)

## Checklist

- [x] Plugin published on npm
- [x] Source code hosted on GitHub (public repository)
- [x] Repository includes setup/use docs
- [x] Issue tracker enabled