### PR TITLE
Hooks: persist session-memory on automatic session:end rollovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
+- Hooks/Session memory: emit internal `session:end` on automatic session freshness rollovers and have bundled `session-memory` save from `session:end`, so timed-out sessions persist without requiring manual `/new` or `/reset`. (#31266)
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.
 - Gateway/Control UI method guard: allow POST requests to non-UI routes to fall through when no base path is configured, and add POST regression coverage for fallthrough and base-path 405 behavior. (#23970) Thanks @tyler6204.

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -6,6 +6,8 @@ import { buildModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { saveSessionStore } from "../../config/sessions.js";
+import type { InternalHookEvent } from "../../hooks/internal-hooks.js";
+import { clearInternalHooks, registerInternalHook } from "../../hooks/internal-hooks.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.ts";
 import { enqueueSystemEvent, resetSystemEventsForTest } from "../../infra/system-events.js";
 import { applyResetModelOverride } from "./session-reset-model.js";
@@ -1601,5 +1603,86 @@ describe("initSessionState internal channel routing preservation", () => {
     });
 
     expect(result.sessionEntry.lastChannel).toBe("webchat");
+  });
+});
+
+describe("initSessionState session lifecycle hooks", () => {
+  beforeEach(() => {
+    clearInternalHooks();
+  });
+
+  afterEach(() => {
+    clearInternalHooks();
+  });
+
+  const waitForAsyncHookDelivery = async (): Promise<void> => {
+    for (let i = 0; i < 5; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  };
+
+  it("emits session:end when replacing a stale session automatically", async () => {
+    const storePath = await createStorePath("session-end-auto-rollover-");
+    const sessionKey = "agent:main:main";
+    const existingSessionId = "stale-session-id";
+    await saveSessionStore(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: 0,
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const captured: InternalHookEvent[] = [];
+    registerInternalHook("session:end", async (event) => {
+      captured.push(event);
+    });
+
+    const result = await initSessionState({
+      ctx: { Body: "hello", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false);
+    await waitForAsyncHookDelivery();
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.sessionKey).toBe(sessionKey);
+    expect(captured[0]?.context).toMatchObject({
+      sessionEntry: { sessionId: existingSessionId },
+      commandSource: "session:freshness",
+    });
+  });
+
+  it("does not emit session:end for manual /new resets", async () => {
+    const storePath = await createStorePath("session-end-manual-reset-");
+    const sessionKey = "agent:main:main";
+    const existingSessionId = "fresh-session-id";
+    await saveSessionStore(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const captured: InternalHookEvent[] = [];
+    registerInternalHook("session:end", async (event) => {
+      captured.push(event);
+    });
+
+    const result = await initSessionState({
+      ctx: { Body: "/new", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    await waitForAsyncHookDelivery();
+
+    expect(captured).toHaveLength(0);
   });
 });

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -27,6 +27,7 @@ import {
 } from "../../config/sessions.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { archiveSessionTranscripts } from "../../gateway/session-utils.fs.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -381,7 +382,6 @@ export async function initSessionState(params: {
     sessionStore[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
   }
   const entry = sessionStore[sessionKey];
-  const previousSessionEntry = resetTriggered && entry ? { ...entry } : undefined;
   const now = Date.now();
   const isThread = resolveThreadFlag({
     sessionKey,
@@ -437,6 +437,8 @@ export async function initSessionState(params: {
       persistedLabel = entry.label;
     }
   }
+  const endedSessionEntry = isNewSession && entry ? { ...entry } : undefined;
+  const previousSessionEntry = resetTriggered ? endedSessionEntry : undefined;
 
   const baseEntry = !isNewSession && freshEntry ? entry : undefined;
   // Track the originating channel/to for announce routing (subagent announce-back).
@@ -635,36 +637,49 @@ export async function initSessionState(params: {
     IsNewSession: isNewSession ? "true" : "false",
   };
 
-  // Run session plugin hooks (fire-and-forget)
+  // Run session plugin + internal lifecycle hooks (fire-and-forget)
   const hookRunner = getGlobalHookRunner();
-  if (hookRunner && isNewSession) {
+  if (isNewSession) {
     const effectiveSessionId = sessionId ?? "";
 
     // If replacing an existing session, fire session_end for the old one
-    if (previousSessionEntry?.sessionId && previousSessionEntry.sessionId !== effectiveSessionId) {
-      if (hookRunner.hasHooks("session_end")) {
+    if (endedSessionEntry?.sessionId && endedSessionEntry.sessionId !== effectiveSessionId) {
+      if (hookRunner?.hasHooks("session_end")) {
         void hookRunner
           .runSessionEnd(
             {
-              sessionId: previousSessionEntry.sessionId,
+              sessionId: endedSessionEntry.sessionId,
               messageCount: 0,
             },
             {
-              sessionId: previousSessionEntry.sessionId,
+              sessionId: endedSessionEntry.sessionId,
               agentId: resolveSessionAgentId({ sessionKey, config: cfg }),
             },
           )
           .catch(() => {});
       }
+
+      // /new and /reset already trigger command hooks. Emit session:end only for
+      // automatic freshness rollovers so session-memory doesn't double-save.
+      if (!resetTriggered) {
+        void triggerInternalHook(
+          createInternalHookEvent("session", "end", sessionKey, {
+            sessionEntry: endedSessionEntry,
+            previousSessionEntry: endedSessionEntry,
+            commandSource: "session:freshness",
+            cfg,
+          }),
+        ).catch(() => {});
+      }
     }
 
     // Fire session_start for the new session
-    if (hookRunner.hasHooks("session_start")) {
+    if (hookRunner?.hasHooks("session_start")) {
       void hookRunner
         .runSessionStart(
           {
             sessionId: effectiveSessionId,
-            resumedFrom: previousSessionEntry?.sessionId,
+            resumedFrom: endedSessionEntry?.sessionId,
           },
           {
             sessionId: effectiveSessionId,

--- a/src/hooks/bundled/README.md
+++ b/src/hooks/bundled/README.md
@@ -6,9 +6,10 @@ This directory contains hooks that ship with OpenClaw. These hooks are automatic
 
 ### 💾 session-memory
 
-Automatically saves session context to memory when you issue `/new` or `/reset`.
+Automatically saves session context to memory when you issue `/new`/`/reset` or when a session
+ends automatically.
 
-**Events**: `command:new`, `command:reset`
+**Events**: `command:new`, `command:reset`, `session:end`
 **What it does**: Creates a dated memory file with LLM-generated slug based on conversation content.
 **Output**: `<workspace>/memory/YYYY-MM-DD-slug.md` (defaults to `~/.openclaw/workspace`)
 

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -1,13 +1,13 @@
 ---
 name: session-memory
-description: "Save session context to memory when /new or /reset command is issued"
+description: "Save session context to memory on /new, /reset, and session end"
 homepage: https://docs.openclaw.ai/automation/hooks#session-memory
 metadata:
   {
     "openclaw":
       {
         "emoji": "💾",
-        "events": ["command:new", "command:reset"],
+        "events": ["command:new", "command:reset", "session:end"],
         "requires": { "config": ["workspace.dir"] },
         "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
       },
@@ -16,11 +16,12 @@ metadata:
 
 # Session Memory Hook
 
-Automatically saves session context to your workspace memory when you issue `/new` or `/reset`.
+Automatically saves session context to your workspace memory when you issue `/new`, `/reset`, or
+when a session ends due to freshness rollover (for example idle timeout / daily reset).
 
 ## What It Does
 
-When you run `/new` or `/reset` to start a fresh session:
+When you run `/new` or `/reset`, or a session ends automatically:
 
 1. **Finds the previous session** - Uses the pre-reset session entry to locate the correct transcript
 2. **Extracts conversation** - Reads the last N user/assistant messages from the session (default: 15, configurable)

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -42,17 +42,24 @@ function createMockSessionContent(
 
 async function runNewWithPreviousSessionEntry(params: {
   tempDir: string;
-  previousSessionEntry: { sessionId: string; sessionFile?: string };
+  previousSessionEntry?: { sessionId: string; sessionFile?: string };
+  sessionEntry?: { sessionId: string; sessionFile?: string };
   cfg?: OpenClawConfig;
   action?: "new" | "reset";
+  eventType?: "command" | "session";
+  eventAction?: string;
 }): Promise<{ files: string[]; memoryContent: string }> {
-  const event = createHookEvent("command", params.action ?? "new", "agent:main:main", {
+  const eventType = params.eventType ?? "command";
+  const eventAction =
+    params.eventAction ?? (eventType === "command" ? (params.action ?? "new") : "end");
+  const event = createHookEvent(eventType, eventAction, "agent:main:main", {
     cfg:
       params.cfg ??
       ({
         agents: { defaults: { workspace: params.tempDir } },
       } satisfies OpenClawConfig),
     previousSessionEntry: params.previousSessionEntry,
+    sessionEntry: params.sessionEntry,
   });
 
   await handler(event);
@@ -220,6 +227,35 @@ describe("session-memory hook", () => {
     expect(files.length).toBe(1);
     expect(memoryContent).toContain("user: Please reset and keep notes");
     expect(memoryContent).toContain("assistant: Captured before reset");
+  });
+
+  it("creates memory file when session:end is emitted", async () => {
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Need autosave on timeout" },
+      { role: "assistant", content: "Session ending automatically" },
+    ]);
+    const { tempDir, sessionsDir } = await createSessionMemoryWorkspace();
+    const sessionId = "session-end-123";
+    const sessionFile = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: `${sessionId}.jsonl`,
+      content: sessionContent,
+    });
+
+    const { files, memoryContent } = await runNewWithPreviousSessionEntry({
+      tempDir,
+      cfg: makeSessionMemoryConfig(tempDir),
+      sessionEntry: {
+        sessionId,
+        sessionFile,
+      },
+      eventType: "session",
+      eventAction: "end",
+    });
+
+    expect(files.length).toBe(1);
+    expect(memoryContent).toContain("user: Need autosave on timeout");
+    expect(memoryContent).toContain("assistant: Session ending automatically");
   });
 
   it("filters out non-message entries (tool calls, system)", async () => {

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -1,7 +1,7 @@
 /**
  * Session memory hook handler
  *
- * Saves session context to memory when /new or /reset command is triggered
+ * Saves session context to memory on reset commands and session end events.
  * Creates a new dated memory file with LLM-generated slug
  */
 
@@ -167,17 +167,21 @@ async function findPreviousSessionFile(params: {
 }
 
 /**
- * Save session context to memory when /new or /reset command is triggered
+ * Save session context to memory when reset commands or session:end fire.
  */
 const saveSessionToMemory: HookHandler = async (event) => {
-  // Only trigger on reset/new commands
-  const isResetCommand = event.action === "new" || event.action === "reset";
-  if (event.type !== "command" || !isResetCommand) {
+  const isResetCommand =
+    event.type === "command" && (event.action === "new" || event.action === "reset");
+  const isSessionEnd = event.type === "session" && event.action === "end";
+  if (!isResetCommand && !isSessionEnd) {
     return;
   }
 
   try {
-    log.debug("Hook triggered for reset/new command", { action: event.action });
+    log.debug("Hook triggered for session-memory save", {
+      type: event.type,
+      action: event.action,
+    });
 
     const context = event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;

--- a/src/hooks/frontmatter.test.ts
+++ b/src/hooks/frontmatter.test.ts
@@ -232,14 +232,14 @@ describe("resolveOpenClawMetadata", () => {
     // This is the actual format used in the bundled hooks
     const content = `---
 name: session-memory
-description: "Save session context to memory when /new or /reset command is issued"
+description: "Save session context to memory on /new, /reset, and session end"
 homepage: https://docs.openclaw.ai/automation/hooks#session-memory
 metadata:
   {
     "openclaw":
       {
         "emoji": "💾",
-        "events": ["command:new", "command:reset"],
+        "events": ["command:new", "command:reset", "session:end"],
         "requires": { "config": ["workspace.dir"] },
         "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
       },
@@ -256,7 +256,7 @@ metadata:
     const openclaw = resolveOpenClawMetadata(frontmatter);
     expect(openclaw).toBeDefined();
     expect(openclaw?.emoji).toBe("💾");
-    expect(openclaw?.events).toEqual(["command:new", "command:reset"]);
+    expect(openclaw?.events).toEqual(["command:new", "command:reset", "session:end"]);
     expect(openclaw?.requires?.config).toEqual(["workspace.dir"]);
     expect(openclaw?.install?.[0].kind).toBe("bundled");
   });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: bundled `session-memory` only listened to `command:new`/`command:reset`, so sessions ending by freshness rollover (idle timeout / daily reset) were not persisted.
- Why it matters: users lose cross-session memory unless they manually run `/new` or `/reset`.
- What changed: `initSessionState` now emits internal `session:end` for automatic freshness rollovers; `session-memory` now handles `session:end`; metadata/docs/tests updated accordingly.
- What did NOT change (scope boundary): manual `/new` and `/reset` command hook flow is unchanged; no new network calls; no new external dependencies.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31266
- Related #31557

## User-visible / Behavior Changes

- Session memory now auto-saves when a stale session is replaced automatically (session freshness rollover), not only on manual `/new`/`/reset`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default session reset policy

### Steps

1. Seed a session store entry with an old `updatedAt` and an existing transcript.
2. Call `initSessionState` with a normal message (no `/new`/`/reset`) so freshness rollover creates a new session.
3. Verify `session:end` internal hook fires and `session-memory` can persist from that event.

### Expected

- Old stale session triggers `session:end` and memory file is written.

### Actual

- ✅ `session:end` is emitted for freshness rollovers.
- ✅ `session-memory` saves from `session:end`.
- ✅ `/new` path does not double-trigger `session:end` (command hooks still handle manual resets).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Added/updated tests:
  - `src/auto-reply/reply/session.test.ts`
  - `src/hooks/bundled/session-memory/handler.test.ts`
  - `src/hooks/frontmatter.test.ts`
- Ran:
  - `pnpm test src/hooks/bundled/session-memory/handler.test.ts src/hooks/frontmatter.test.ts src/auto-reply/reply/session.test.ts`
  - `pnpm format`
  - `pnpm check` (fails in unrelated pre-existing files; see below)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - automatic stale-session rollover emits `session:end`
  - manual `/new` does not emit duplicate `session:end`
  - `session-memory` writes memory file on `session:end`
- Edge cases checked:
  - non-matching events still ignored by `session-memory`
  - hook metadata/frontmatter parsing includes `session:end`
- What you did **not** verify:
  - full end-to-end channel runtime behavior on a live messaging surface

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - `openclaw hooks disable session-memory`
  - or revert this PR commit
- Files/config to restore:
  - `src/auto-reply/reply/session.ts`
  - `src/hooks/bundled/session-memory/*`
- Known bad symptoms reviewers should watch for:
  - duplicate memory saves on manual reset (guarded by only emitting `session:end` on non-reset freshness rollovers)

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: asynchronous internal hook dispatch timing can make tests flaky.
  - Mitigation: added explicit async wait in lifecycle test and scoped assertions to emitted event payload.
