### PR TITLE
UI/Config: keep provider maps editable with wildcard unsupported paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
+- Config/Form provider maps: stop bubbling `additionalProperties` child schema failures to parent map paths, and apply wildcard unsupported-path matching for dynamic keys so `models.providers` stays editable even when nested fields (like mixed `apiKey` unions) remain unsupported. (#31490)
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.
 - Gateway/Control UI method guard: allow POST requests to non-UI routes to fall through when no base path is configured, and add POST regression coverage for fallthrough and base-path 405 behavior. (#23970) Thanks @tyler6204.

--- a/test/ui/config-form-unsupported.test.ts
+++ b/test/ui/config-form-unsupported.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { analyzeConfigSchema } from "../../ui/src/ui/views/config-form.analyze.ts";
+import { isUnsupportedNodePath } from "../../ui/src/ui/views/config-form.node.ts";
+
+const providersWithSecretUnionSchema = {
+  type: "object",
+  properties: {
+    models: {
+      type: "object",
+      properties: {
+        providers: {
+          type: "object",
+          additionalProperties: {
+            type: "object",
+            properties: {
+              baseUrl: { type: "string" },
+              apiKey: {
+                anyOf: [
+                  { type: "string" },
+                  {
+                    type: "object",
+                    properties: {
+                      source: { const: "env" },
+                      id: { type: "string" },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+describe("config form unsupported-path handling", () => {
+  it("keeps models.providers map supported when only nested wildcard field is unsupported", () => {
+    const analysis = analyzeConfigSchema(providersWithSecretUnionSchema);
+
+    expect(analysis.unsupportedPaths).toContain("models.providers.*.apiKey");
+    expect(analysis.unsupportedPaths).not.toContain("models.providers");
+  });
+
+  it("matches wildcard unsupported paths against concrete map keys", () => {
+    const analysis = analyzeConfigSchema(providersWithSecretUnionSchema);
+    const unsupported = new Set(analysis.unsupportedPaths);
+
+    expect(isUnsupportedNodePath(unsupported, "models.providers.xai.apiKey")).toBe(true);
+    expect(isUnsupportedNodePath(unsupported, "models.providers.openai.apiKey")).toBe(true);
+    expect(isUnsupportedNodePath(unsupported, "models.providers.xai.baseUrl")).toBe(false);
+  });
+});

--- a/ui/src/ui/views/config-form.analyze.ts
+++ b/ui/src/ui/views/config-form.analyze.ts
@@ -86,8 +86,8 @@ function normalizeSchemaNode(
       if (!isAnySchema(schema.additionalProperties)) {
         const res = normalizeSchemaNode(schema.additionalProperties, [...path, "*"]);
         normalized.additionalProperties = res.schema ?? schema.additionalProperties;
-        if (res.unsupportedPaths.length > 0) {
-          unsupported.add(pathLabel);
+        for (const entry of res.unsupportedPaths) {
+          unsupported.add(entry);
         }
       }
     }

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -225,6 +225,29 @@ function matchesNodeSelf(params: {
   ]);
 }
 
+function matchesUnsupportedPattern(pattern: string, key: string): boolean {
+  if (pattern === key) {
+    return true;
+  }
+  const patternSegments = pattern.split(".");
+  const keySegments = key.split(".");
+  if (patternSegments.length !== keySegments.length) {
+    return false;
+  }
+  return patternSegments.every(
+    (segment, index) => segment === "*" || segment === keySegments[index],
+  );
+}
+
+export function isUnsupportedNodePath(unsupported: Set<string>, key: string): boolean {
+  for (const pattern of unsupported) {
+    if (matchesUnsupportedPattern(pattern, key)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function matchesNodeSearch(params: {
   schema: JsonSchema;
   value: unknown;
@@ -340,7 +363,7 @@ export function renderNode(params: {
   const key = pathKey(path);
   const criteria = params.searchCriteria;
 
-  if (unsupported.has(key)) {
+  if (isUnsupportedNodePath(unsupported, key)) {
     return html`<div class="cfg-field cfg-field--error">
       <div class="cfg-field__label">${label}</div>
       <div class="cfg-field__error">Unsupported schema node. Use Raw mode.</div>


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Form analysis was bubbling unsupported `additionalProperties` child schemas (for example `models.providers.*.apiKey`) up to the parent (`models.providers`), so the entire provider map became uneditable.
- Why it matters: users lose Form-mode editing for provider configs and get forced into Raw mode for unrelated sibling fields.
- What changed: preserve child unsupported paths (including wildcard paths) instead of marking the whole map unsupported; add wildcard-aware unsupported matching when rendering dynamic map keys.
- What did NOT change (scope boundary): mixed unions like `apiKey` (`string | SecretRef`) are still marked unsupported at the leaf itself; this PR does not add full mixed-union form editing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31490
- Related #31511

## User-visible / Behavior Changes

- `models.providers` (and similar dynamic maps) remains editable in Form mode even if one nested wildcard field is unsupported.
- Unsupported nested fields continue to show field-level "Unsupported schema node. Use Raw mode." messaging.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Control UI config form
- Relevant config (redacted): schema with `models.providers.*.apiKey` as mixed `anyOf`

### Steps

1. Analyze schema where `models.providers.additionalProperties.properties.apiKey` is `anyOf` (`string` + object).
2. Verify unsupported paths no longer include `models.providers`, but include `models.providers.*.apiKey`.
3. Verify wildcard unsupported matcher resolves concrete keys like `models.providers.xai.apiKey`.

### Expected

- Parent map remains supported; only leaf unsupported paths are flagged.

### Actual

- ✅ Parent map no longer marked unsupported.
- ✅ Wildcard leaf paths correctly match dynamic concrete keys.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Added: `test/ui/config-form-unsupported.test.ts`
- Ran:
  - `pnpm test test/ui/config-form-unsupported.test.ts`
  - `pnpm format`
  - `pnpm check` (fails in unrelated pre-existing files; details below)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - wildcard unsupported paths are preserved from analysis
  - wildcard unsupported paths match concrete map keys at render-path decision points
- Edge cases checked:
  - sibling map fields are not treated as unsupported by wildcard leaf errors
- What you did **not** verify:
  - end-to-end browser interaction with the full Control UI in this environment

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR commit
- Files/config to restore:
  - `ui/src/ui/views/config-form.analyze.ts`
  - `ui/src/ui/views/config-form.node.ts`
- Known bad symptoms reviewers should watch for:
  - map sections incorrectly showing unsupported banner for all fields
  - wildcard unsupported paths not resolving for dynamic keys

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: wildcard matching could over-match unrelated keys if segment counts differ.
  - Mitigation: matcher requires exact segment-count parity and only treats `*` as single-segment wildcard.
