### PR TITLE
Plugins: expose runtime.system.requestHeartbeatNow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - CLI/Config validation: add `openclaw config validate` (with `--json`) to validate config files before gateway startup, and include detailed invalid-key paths in startup invalid-config errors. (#31220) thanks @Sid-Qin.
+- Plugins/Runtime API: expose `runtime.system.requestHeartbeatNow(...)` so plugins can trigger targeted heartbeat wakes (including `sessionKey`/`agentId`) without loopback HTTP `/hooks/wake` workarounds. (#31564)
 - Sessions/Attachments: add inline file attachment support for `sessions_spawn` (subagent runtime only) with base64/utf8 encoding, transcript content redaction, lifecycle cleanup, and configurable limits via `tools.sessions_spawn.attachments`. (#16761) Thanks @napetrov.
 - Agents/Thinking defaults: set `adaptive` as the default thinking level for Anthropic Claude 4.6 models (including Bedrock Claude 4.6 refs) while keeping other reasoning-capable models at `low` unless explicitly configured.
 - Tools/PDF analysis: add a first-class `pdf` tool with native Anthropic and Google PDF provider support, extraction fallback for non-native models, configurable defaults (`agents.defaults.pdfModel`, `pdfMaxBytesMb`, `pdfMaxPages`), and docs/tests covering routing, validation, and registration. (#31319) Thanks @tyler6204.

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -103,6 +103,7 @@ function createMockRuntime(): PluginRuntime {
     system: {
       enqueueSystemEvent:
         mockEnqueueSystemEvent as unknown as PluginRuntime["system"]["enqueueSystemEvent"],
+      requestHeartbeatNow: vi.fn() as unknown as PluginRuntime["system"]["requestHeartbeatNow"],
       runCommandWithTimeout: vi.fn() as unknown as PluginRuntime["system"]["runCommandWithTimeout"],
       formatNativeDependencyHint: vi.fn(
         () => "",

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -1,9 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const runCommandWithTimeoutMock = vi.hoisted(() => vi.fn());
+const requestHeartbeatNowMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../process/exec.js", () => ({
   runCommandWithTimeout: (...args: unknown[]) => runCommandWithTimeoutMock(...args),
+}));
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
 }));
 
 import { createPluginRuntime } from "./index.js";
@@ -11,6 +15,7 @@ import { createPluginRuntime } from "./index.js";
 describe("plugin runtime command execution", () => {
   beforeEach(() => {
     runCommandWithTimeoutMock.mockClear();
+    requestHeartbeatNowMock.mockClear();
   });
 
   it("exposes runtime.system.runCommandWithTimeout by default", async () => {
@@ -38,5 +43,23 @@ describe("plugin runtime command execution", () => {
       runtime.system.runCommandWithTimeout(["echo", "hello"], { timeoutMs: 1000 }),
     ).rejects.toThrow("boom");
     expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(["echo", "hello"], { timeoutMs: 1000 });
+  });
+
+  it("exposes runtime.system.requestHeartbeatNow", () => {
+    const runtime = createPluginRuntime();
+
+    runtime.system.requestHeartbeatNow({
+      reason: "hook:test",
+      sessionKey: "agent:main:main",
+      agentId: "main",
+      coalesceMs: 25,
+    });
+
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "hook:test",
+      sessionKey: "agent:main:main",
+      agentId: "main",
+      coalesceMs: 25,
+    });
   });
 });

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -72,6 +72,7 @@ import { monitorIMessageProvider } from "../../imessage/monitor.js";
 import { probeIMessage } from "../../imessage/probe.js";
 import { sendMessageIMessage } from "../../imessage/send.js";
 import { getChannelActivity, recordChannelActivity } from "../../infra/channel-activity.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import {
   listLineAccountIds,
@@ -261,6 +262,7 @@ function createRuntimeConfig(): PluginRuntime["config"] {
 function createRuntimeSystem(): PluginRuntime["system"] {
   return {
     enqueueSystemEvent,
+    requestHeartbeatNow,
     runCommandWithTimeout,
     formatNativeDependencyHint,
   };

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -82,6 +82,7 @@ type WriteConfigFile = typeof import("../../config/config.js").writeConfigFile;
 type RecordChannelActivity = typeof import("../../infra/channel-activity.js").recordChannelActivity;
 type GetChannelActivity = typeof import("../../infra/channel-activity.js").getChannelActivity;
 type EnqueueSystemEvent = typeof import("../../infra/system-events.js").enqueueSystemEvent;
+type RequestHeartbeatNow = typeof import("../../infra/heartbeat-wake.js").requestHeartbeatNow;
 type RunCommandWithTimeout = typeof import("../../process/exec.js").runCommandWithTimeout;
 type FormatNativeDependencyHint = typeof import("./native-deps.js").formatNativeDependencyHint;
 type LoadWebMedia = typeof import("../../web/media.js").loadWebMedia;
@@ -193,6 +194,7 @@ export type PluginRuntime = {
   };
   system: {
     enqueueSystemEvent: EnqueueSystemEvent;
+    requestHeartbeatNow: RequestHeartbeatNow;
     runCommandWithTimeout: RunCommandWithTimeout;
     formatNativeDependencyHint: FormatNativeDependencyHint;
   };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `requestHeartbeatNow(...)` exists in core heartbeat infra but is not exposed through `PluginRuntime.system`, forcing plugins to use `/hooks/wake` loopback workarounds.
- Why it matters: plugins cannot target a specific `sessionKey` wake in-process, and loopback wake only covers main-session behavior.
- What changed: added `requestHeartbeatNow` to plugin runtime system surface (runtime implementation + runtime types), and added runtime test coverage.
- What did NOT change (scope boundary): no heartbeat scheduling semantics changed; no change to `/hooks/wake` behavior; no routing logic changes.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31564
- Related #31511

## User-visible / Behavior Changes

- Plugin authors can now call `runtime.system.requestHeartbeatNow({ reason, sessionKey, agentId, coalesceMs })` directly.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): plugin runtime
- Relevant config (redacted): N/A

### Steps

1. Create plugin runtime via `createPluginRuntime()`.
2. Call `runtime.system.requestHeartbeatNow({ reason, sessionKey, agentId, coalesceMs })`.
3. Verify runtime forwards args to heartbeat wake infra function.

### Expected

- Runtime exposes and forwards `requestHeartbeatNow` unchanged.

### Actual

- ✅ Runtime now exposes `requestHeartbeatNow`.
- ✅ Argument forwarding verified by tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Updated tests:
  - `src/plugins/runtime/index.test.ts`
  - `extensions/bluebubbles/src/monitor.test.ts` (runtime mock updated for new required system field)
- Ran:
  - `pnpm test src/plugins/runtime/index.test.ts extensions/bluebubbles/src/monitor.test.ts`
  - `pnpm format`
  - `pnpm check` (fails in unrelated pre-existing files)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - runtime includes `system.requestHeartbeatNow`
  - call forwarding preserves full options object
- Edge cases checked:
  - downstream typed runtime mocks updated where strict PluginRuntime objects are built
- What you did **not** verify:
  - full end-to-end plugin execution in a live gateway process

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR commit
- Files/config to restore:
  - `src/plugins/runtime/index.ts`
  - `src/plugins/runtime/types.ts`
- Known bad symptoms reviewers should watch for:
  - plugin runtime type mismatches in tests/extensions that build strict `PluginRuntime` mocks

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: extending `PluginRuntime.system` can break strict mock objects in tests/extensions.
  - Mitigation: updated strict runtime mock in BlueBubbles test and added runtime exposure test.
