### PR TITLE
TUI: make missing API key fallback errors actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI/Auth errors: rewrite missing-API-key fallback failures into concise, actionable guidance (for example `google/*` now points to `GEMINI_API_KEY` + `openclaw agents add <id>`), instead of surfacing noisy multi-model auth-store traces. (#31544)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -80,6 +80,22 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
+  it("rewrites missing provider API key errors with actionable setup guidance", () => {
+    const input =
+      'No API key found for provider "google". Auth store: /tmp/openclaw/auth-profiles.json.';
+    expect(sanitizeUserFacingText(input, { errorContext: true })).toBe(
+      'Missing API key for provider "google". Set GEMINI_API_KEY and retry, or run openclaw agents add <id> to configure auth for this agent.',
+    );
+  });
+
+  it("rewrites all-models fallback summaries when primary provider API key is missing", () => {
+    const input =
+      'All models failed (2): google/gemini-3-flash: No API key found for provider "google". Auth store: /tmp/openclaw/auth-profiles.json. | openai-codex/gpt-5.3-codex: OAuth token refresh failed for openai-codex.';
+    expect(sanitizeUserFacingText(input, { errorContext: true })).toBe(
+      'Missing API key for provider "google". Set GEMINI_API_KEY and retry, or run openclaw agents add <id> to configure auth for this agent.',
+    );
+  });
+
   it.each([
     {
       input: "Hello there!\n\nHello there!",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -23,6 +23,70 @@ export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
 const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
+const MISSING_API_KEY_PROVIDER_RE = /no api key found for provider\s+"?([a-z0-9._-]+)"?/i;
+const PROVIDER_API_KEY_ENV_HINTS: Record<string, string[]> = {
+  anthropic: ["ANTHROPIC_API_KEY"],
+  cerebras: ["CEREBRAS_API_KEY"],
+  deepgram: ["DEEPGRAM_API_KEY"],
+  google: ["GEMINI_API_KEY"],
+  groq: ["GROQ_API_KEY"],
+  kilocode: ["KILOCODE_API_KEY"],
+  litellm: ["LITELLM_API_KEY"],
+  minimax: ["MINIMAX_API_KEY"],
+  mistral: ["MISTRAL_API_KEY"],
+  moonshot: ["MOONSHOT_API_KEY"],
+  nvidia: ["NVIDIA_API_KEY"],
+  ollama: ["OLLAMA_API_KEY"],
+  opencode: ["OPENCODE_API_KEY"],
+  openai: ["OPENAI_API_KEY"],
+  openrouter: ["OPENROUTER_API_KEY"],
+  qianfan: ["QIANFAN_API_KEY"],
+  synthetic: ["SYNTHETIC_API_KEY"],
+  together: ["TOGETHER_API_KEY"],
+  venice: ["VENICE_API_KEY"],
+  voyage: ["VOYAGE_API_KEY"],
+  vllm: ["VLLM_API_KEY"],
+  xai: ["XAI_API_KEY"],
+  xiaomi: ["XIAOMI_API_KEY"],
+};
+
+function formatApiKeyEnvVarHint(vars: string[]): string | null {
+  if (vars.length === 0) {
+    return null;
+  }
+  if (vars.length === 1) {
+    return vars[0];
+  }
+  if (vars.length === 2) {
+    return `${vars[0]} or ${vars[1]}`;
+  }
+  const head = vars.slice(0, -1).join(", ");
+  return `${head}, or ${vars[vars.length - 1]}`;
+}
+
+function formatMissingApiKeyErrorCopy(raw: string): string | undefined {
+  const providerMatch = raw.match(MISSING_API_KEY_PROVIDER_RE);
+  if (!providerMatch?.[1]) {
+    return undefined;
+  }
+
+  const provider = providerMatch[1];
+  const providerKey = provider.toLowerCase();
+  if (providerKey === "openai" && /authenticated with openai codex oauth/i.test(raw)) {
+    return (
+      'Missing API key for provider "openai". ' +
+      "You currently have OpenAI Codex OAuth configured. " +
+      "Use an openai-codex/* model or set OPENAI_API_KEY."
+    );
+  }
+
+  const envHint = formatApiKeyEnvVarHint(PROVIDER_API_KEY_ENV_HINTS[providerKey] ?? []);
+  const envClause = envHint ? `Set ${envHint} and retry, or ` : "";
+  return (
+    `Missing API key for provider "${provider}". ` +
+    `${envClause}run openclaw agents add <id> to configure auth for this agent.`
+  );
+}
 
 function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
   if (isRateLimitErrorMessage(raw)) {
@@ -583,6 +647,11 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
 
     if (isBillingErrorMessage(trimmed)) {
       return BILLING_ERROR_USER_MESSAGE;
+    }
+
+    const missingApiKeyCopy = formatMissingApiKeyErrorCopy(trimmed);
+    if (missingApiKeyCopy) {
+      return missingApiKeyCopy;
     }
 
     if (isRawApiErrorPayload(trimmed) || isLikelyHttpErrorText(trimmed)) {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -566,7 +566,11 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
-      const safeMessage = isTransientHttp
+      const shouldSanitizeMessage =
+        isTransientHttp ||
+        /no api key found for provider/i.test(message) ||
+        /all models failed\s*\(\d+\):/i.test(message);
+      const safeMessage = shouldSanitizeMessage
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -177,7 +177,7 @@ describe("runReplyAgent onAgentRunStart", () => {
 
     expect(onAgentRunStart).not.toHaveBeenCalled();
     expect(result).toMatchObject({
-      text: expect.stringContaining('No API key found for provider "anthropic".'),
+      text: expect.stringContaining('Missing API key for provider "anthropic".'),
     });
   });
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `/model` can switch to a provider with no configured key, but the follow-up run failure shows a long multi-model fallback trace that is hard to act on.
- Why it matters: users cannot quickly tell which key is missing (for example Gemini) and what exact next step to take.
- What changed: added targeted user-facing error rewriting for missing-provider-API-key failures (including `All models failed (...)` summaries), with provider-specific key hinting (`google` -> `GEMINI_API_KEY`) and actionable `openclaw agents add <id>` guidance.
- What did NOT change (scope boundary): no auth resolution logic changed, no fallback order changed, no model-selection behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31544
- Related #31579

## User-visible / Behavior Changes

- Missing API key failures now render concise actionable guidance instead of raw fallback traces.
- `google/*` missing-key errors now explicitly point to `GEMINI_API_KEY`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: google + fallback chain sample
- Integration/channel (if any): TUI/webchat reply path
- Relevant config (redacted): default fallback setup

### Steps

1. Trigger an auth-missing error text with `No API key found for provider "google"` (including fallback summary shape).
2. Run through `runReplyAgent`/user-facing sanitize path.
3. Verify rendered message content.

### Expected

- User sees concise setup guidance that identifies provider and next action.

### Actual

- Now shows `Missing API key for provider "google". Set GEMINI_API_KEY ... or run openclaw agents add <id> ...`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted unit tests for sanitize and runReplyAgent fallback copy.
- Edge cases checked: `All models failed (...)` summary containing multiple provider errors; direct missing-key message; OpenAI+Codex OAuth-specific missing-key wording path.
- What you did **not** verify: interactive TUI screenshot/manual walkthrough against a live keyless provider account.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `9b03f573b`.
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`, `src/auto-reply/reply/agent-runner-execution.ts`.
- Known bad symptoms reviewers should watch for: unexpectedly rewritten non-auth errors that mention API keys.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: over-matching could rewrite unrelated text that contains `No API key found for provider`.
  - Mitigation: rewrite only in `errorContext` path and kept regex scoped to provider-auth failure phrase.
