### PR TITLE
UI: replace gateway reconnect magic numbers with constants

### DIFF
--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -90,6 +90,10 @@ export type GatewayBrowserClientOptions = {
 
 // 4008 = application-defined code (browser rejects 1008 "Policy Violation")
 const CONNECT_FAILED_CLOSE_CODE = 4008;
+const INITIAL_RECONNECT_BACKOFF_MS = 800;
+const RECONNECT_BACKOFF_MULTIPLIER = 1.7;
+const MAX_RECONNECT_BACKOFF_MS = 15_000;
+const CONNECT_QUEUE_DELAY_MS = 750;
 
 export class GatewayBrowserClient {
   private ws: WebSocket | null = null;
@@ -99,7 +103,7 @@ export class GatewayBrowserClient {
   private connectNonce: string | null = null;
   private connectSent = false;
   private connectTimer: number | null = null;
-  private backoffMs = 800;
+  private backoffMs = INITIAL_RECONNECT_BACKOFF_MS;
   private pendingConnectError: GatewayErrorInfo | undefined;
 
   constructor(private opts: GatewayBrowserClientOptions) {}
@@ -147,7 +151,10 @@ export class GatewayBrowserClient {
       return;
     }
     const delay = this.backoffMs;
-    this.backoffMs = Math.min(this.backoffMs * 1.7, 15_000);
+    this.backoffMs = Math.min(
+      this.backoffMs * RECONNECT_BACKOFF_MULTIPLIER,
+      MAX_RECONNECT_BACKOFF_MS,
+    );
     window.setTimeout(() => this.connect(), delay);
   }
 
@@ -257,7 +264,7 @@ export class GatewayBrowserClient {
             scopes: hello.auth.scopes ?? [],
           });
         }
-        this.backoffMs = 800;
+        this.backoffMs = INITIAL_RECONNECT_BACKOFF_MS;
         this.opts.onHello?.(hello);
       })
       .catch((err: unknown) => {
@@ -355,6 +362,6 @@ export class GatewayBrowserClient {
     }
     this.connectTimer = window.setTimeout(() => {
       void this.sendConnect();
-    }, 750);
+    }, CONNECT_QUEUE_DELAY_MS);
   }
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `GatewayBrowserClient` reconnect flow used inline magic numbers (`800`, `1.7`, `15000`, `750`) in multiple places.
- Why it matters: reconnect behavior tuning/review was harder because the same values were repeated without semantic names.
- What changed: extracted reconnect timing knobs into named constants (`INITIAL_RECONNECT_BACKOFF_MS`, `RECONNECT_BACKOFF_MULTIPLIER`, `MAX_RECONNECT_BACKOFF_MS`, `CONNECT_QUEUE_DELAY_MS`) and replaced inline literals.
- What did NOT change (scope boundary): no reconnect algorithm/ordering changes, no protocol changes, no behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30402
- Related #31585

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: N/A
- Integration/channel (if any): Control UI gateway client
- Relevant config (redacted): default

### Steps

1. Open `ui/src/ui/gateway.ts`.
2. Inspect reconnect queue/backoff code paths (`backoffMs` init, growth/cap, reset, connect queue delay).
3. Verify literals are replaced by named constants and references compile.

### Expected

- Reconnect constants are named and centralized.

### Actual

- Constants are now declared once and reused in reconnect logic.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reconnect code paths now reference named constants only.
- Edge cases checked: backoff reset after successful connect still uses initial backoff value.
- What you did **not** verify: live browser reconnect timing against a running gateway.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `947609308`.
- Files/config to restore: `ui/src/ui/gateway.ts`.
- Known bad symptoms reviewers should watch for: unexpected reconnect delay changes (should not occur; value-only extraction).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: accidental constant mismatch could alter reconnect cadence.
  - Mitigation: constants preserve original literal values exactly.
