### PR TITLE
fix(gateway): allow trusted-proxy and token/password auth to skip device pairing

### DIFF
--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -139,7 +139,10 @@ export async function resolveConnectAuthState(params: {
   const sharedAuthOk =
     (sharedAuthResult?.ok === true &&
       (sharedAuthResult.method === "token" || sharedAuthResult.method === "password")) ||
-    (authResult.ok && authResult.method === "trusted-proxy");
+    (authResult.ok &&
+      (authResult.method === "trusted-proxy" ||
+        authResult.method === "token" ||
+        authResult.method === "password"));
 
   return {
     authResult,


### PR DESCRIPTION
## Summary

Fixes missing condition in guard clause for authentication methods that should skip device pairing.

## Bug Pattern

- **Type**: missing condition in guard clause
- **Source**: PR #25428
- **Root Cause**: The `sharedAuthOk` check only included `trusted-proxy` method for the primary auth, but was missing `token` and `password` methods.

## Changes

**File**: `src/gateway/server/ws-connection/auth-context.ts`

Extended the `sharedAuthOk` logic to include:
- `authResult.method === "token"`
- `authResult.method === "password"`

This ensures that all shared authentication methods (token, password, trusted-proxy) properly allow operator connections to skip device identity checks via `roleCanSkipDeviceIdentity()`.

## Testing

- Test connection using trusted-proxy auth: Verify `sharedAuthOk` is true and device pairing is NOT requested
- Test connection using token/password auth: Verify `sharedAuthOk` is true
- Test standard auth: Verify `sharedAuthOk` is false and device pairing IS requested (if required)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)