### PR TITLE
fix(tui): reset activity status when cross-channel run completes

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -426,4 +426,87 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-silent");
     expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
   });
+
+  it("resets status to idle when cross-channel run completes and no active run remains", () => {
+    const h = createHandlersHarness({ state: { activeChatRunId: null } });
+
+    h.handleChatEvent({
+      runId: "cross-run-1",
+      sessionKey: h.state.currentSessionKey,
+      state: "delta",
+      message: { content: "hello from telegram" },
+    } as ChatEvent);
+    expect(h.setActivityStatus).toHaveBeenCalledWith("streaming");
+
+    h.setActivityStatus.mockClear();
+
+    h.handleChatEvent({
+      runId: "cross-run-1",
+      sessionKey: h.state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    } as ChatEvent);
+    expect(h.setActivityStatus).toHaveBeenCalledWith("idle");
+  });
+
+  it("resets status to idle when non-active cross-channel run ends and no runs remain", () => {
+    const h = createHandlersHarness({
+      state: { activeChatRunId: "local-run" },
+    });
+
+    h.handleChatEvent({
+      runId: "local-run",
+      sessionKey: h.state.currentSessionKey,
+      state: "delta",
+      message: { content: "local" },
+    } as ChatEvent);
+
+    h.handleChatEvent({
+      runId: "cross-run-2",
+      sessionKey: h.state.currentSessionKey,
+      state: "delta",
+      message: { content: "cross" },
+    } as ChatEvent);
+    expect(h.setActivityStatus).toHaveBeenCalledWith("streaming");
+    h.setActivityStatus.mockClear();
+
+    h.handleChatEvent({
+      runId: "local-run",
+      sessionKey: h.state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    } as ChatEvent);
+    expect(h.setActivityStatus).toHaveBeenCalledWith("idle");
+    h.setActivityStatus.mockClear();
+
+    h.handleChatEvent({
+      runId: "cross-run-2",
+      sessionKey: h.state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    } as ChatEvent);
+    expect(h.setActivityStatus).toHaveBeenCalledWith("idle");
+  });
+
+  it("does not leave status stuck on streaming when cross-channel run is aborted", () => {
+    const h = createHandlersHarness({ state: { activeChatRunId: null } });
+
+    h.handleChatEvent({
+      runId: "cross-abort",
+      sessionKey: h.state.currentSessionKey,
+      state: "delta",
+      message: { content: "streaming" },
+    } as ChatEvent);
+    expect(h.setActivityStatus).toHaveBeenCalledWith("streaming");
+    h.setActivityStatus.mockClear();
+
+    h.handleChatEvent({
+      runId: "cross-abort",
+      sessionKey: h.state.currentSessionKey,
+      state: "aborted",
+    } as ChatEvent);
+    expect(h.setActivityStatus).toHaveBeenCalled();
+    const lastCall = h.setActivityStatus.mock.calls[h.setActivityStatus.mock.calls.length - 1];
+    expect(lastCall[0]).not.toBe("streaming");
+  });
 });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -109,6 +109,8 @@ export function createEventHandlers(context: EventHandlerContext) {
     clearActiveRunIfMatch(params.runId);
     if (params.wasActiveRun) {
       setActivityStatus(params.status);
+    } else if (!state.activeChatRunId || !sessionRuns.has(state.activeChatRunId)) {
+      setActivityStatus("idle");
     }
     void refreshSessionInfo?.();
   };
@@ -123,6 +125,8 @@ export function createEventHandlers(context: EventHandlerContext) {
     clearActiveRunIfMatch(params.runId);
     if (params.wasActiveRun) {
       setActivityStatus(params.status);
+    } else if (!state.activeChatRunId || !sessionRuns.has(state.activeChatRunId)) {
+      setActivityStatus("idle");
     }
     void refreshSessionInfo?.();
   };


### PR DESCRIPTION
## Summary

- **Problem**: When a chat run starts from another channel (e.g. Telegram) while the TUI observes the same session, delta events set the status bar to "streaming". But `finalizeRun` / `terminateRun` only reset the status when `wasActiveRun` is true. If the TUI already has a different `activeChatRunId`, the cross-channel run is never adopted, so its completion never clears the stuck "streaming" indicator.
- **Why it matters**: Users see "streaming · 147m" indefinitely after a conversation ends on another channel, requiring a TUI restart to clear.
- **What changed**: In both `finalizeRun` and `terminateRun`, after handling the active-run case, check whether any run is still in progress (`sessionRuns`). If not, reset status to "idle" to prevent stuck indicators.
- **What did NOT change**: Active run adoption logic, delta event handling, event filtering, or any other TUI behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31575

## User-visible / Behavior Changes

- TUI status bar correctly resets to "idle" when a cross-channel run completes or is aborted, even if it was never adopted as the active run.
- No change when runs originate from the TUI itself.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js 22+

### Steps

1. Open TUI on session `agent:main:main`
2. Chat with the same agent via Telegram (same session key)
3. Conversation completes normally on Telegram

### Expected

- TUI status resets to "idle" after the Telegram run completes.

### Actual

- Before: Status stuck on "streaming · 147m" indefinitely
- After: Status resets to "idle"

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```bash
npx vitest run src/tui/tui-event-handlers.test.ts
# 16 tests pass (3 new: cross-channel final resets idle, multi-run final resets idle, abort not stuck streaming)
```

## Human Verification (required)

- Verified scenarios: cross-channel run final, multi-run final sequence, cross-channel abort
- Edge cases checked: adopted vs non-adopted runs, concurrent runs, empty session runs
- What you did **not** verify: Live TUI + Telegram cross-channel testing (unit tests only)

## Compatibility / Migration

- Backward compatible? `Yes` — additive guard; existing active-run behavior unchanged
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable: Revert the two `else if` guards in `finalizeRun` and `terminateRun`
- Files to restore: `src/tui/tui-event-handlers.ts`

## Risks and Mitigations

- Risk: Premature "idle" reset during concurrent runs
  - Mitigation: The guard checks `!state.activeChatRunId || !sessionRuns.has(state.activeChatRunId)`, ensuring we only reset when no run is tracked as active.