### PR TITLE
fix(cron): persist lightContext on cron edit (fixes #31425)

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -242,6 +242,43 @@ describe("Cron issue regressions", () => {
     cron.stop();
   });
 
+  it("persists lightContext on cron update when patch only has lightContext (no message)", async () => {
+    const store = await makeStorePath();
+    const cron = await startCronForStore({ storePath: store.storePath });
+
+    const created = await cron.add({
+      name: "light-context-edit",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: Date.now() },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "test" },
+    });
+    expect(created.payload.kind).toBe("agentTurn");
+    if (created.payload.kind === "agentTurn") {
+      expect(created.payload.lightContext).toBeUndefined();
+    }
+
+    const patched = await cron.update(created.id, {
+      payload: { kind: "agentTurn", lightContext: true },
+    });
+    expect(patched.payload.kind).toBe("agentTurn");
+    if (patched.payload.kind === "agentTurn") {
+      expect(patched.payload.lightContext).toBe(true);
+      expect(patched.payload.message).toBe("test");
+    }
+
+    const cleared = await cron.update(created.id, {
+      payload: { kind: "agentTurn", lightContext: false },
+    });
+    expect(cleared.payload.kind).toBe("agentTurn");
+    if (cleared.payload.kind === "agentTurn") {
+      expect(cleared.payload.lightContext).toBe(false);
+    }
+
+    cron.stop();
+  });
+
   it("repairs isolated every jobs missing createdAtMs and sets nextWakeAtMs", async () => {
     const store = await makeStorePath();
     await fs.writeFile(

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -579,6 +579,9 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   if (typeof patch.bestEffortDeliver === "boolean") {
     next.bestEffortDeliver = patch.bestEffortDeliver;
   }
+  if (typeof patch.lightContext === "boolean") {
+    next.lightContext = patch.lightContext;
+  }
   return next;
 }
 
@@ -642,6 +645,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     thinking: patch.thinking,
     timeoutSeconds: patch.timeoutSeconds,
     allowUnsafeExternalContent: patch.allowUnsafeExternalContent,
+    lightContext: patch.lightContext,
     deliver: patch.deliver,
     channel: patch.channel,
     to: patch.to,


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw cron edit <id> --light-context` (or `--no-light-context`) accepts the flag but does not persist `lightContext` in the job payload; `cron list --json` shows no `lightContext` after edit.
- **Why it matters:** Users cannot enable/disable lightweight bootstrap context on existing cron jobs without recreating the job or editing `~/.openclaw/cron/jobs.json` by hand.
- **What changed:** In `src/cron/service/jobs.ts`, `mergeCronPayload` now merges `patch.lightContext` into the payload when both existing and patch are `agentTurn`. `buildPayloadFromPatch` now includes `lightContext` in the returned payload so full payload replacement preserves it.
- **What did NOT change:** CLI already sends `lightContext` in the patch; no CLI or API contract changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration (cron service)
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31425
- Related: none

## User-visible / Behavior Changes

- **Before:** `openclaw cron edit <id> --light-context` (or `--no-light-context`) had no effect on the stored job payload.
- **After:** The same commands persist `lightContext: true` or `lightContext: false` in the job payload; `openclaw cron list --json` reflects the value.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any Yes, explain: N/A

## Repro + Verification

### Environment

- OS: Linux (reporter); verified on same
- Runtime: Node 22+
- Relevant: cron jobs with `sessionTarget: isolated` and `payload.kind: agentTurn`

### Steps

1. Create a cron job without light context: `openclaw cron add --name test2 --at "1h" --message "test2"`.
2. Edit to enable light context: `openclaw cron edit <test2-id> --light-context` (or `--light-context --message "test2"` to keep message).
3. Run `openclaw cron list --json` and inspect the job payload.

### Expected

- The job payload includes `lightContext: true`.

### Actual (before fix)

- Payload had no `lightContext` key.

### After fix

- Payload contains `lightContext: true` (or `false` when using `--no-light-context`).

## Evidence

- [x] New regression test in `service.issue-regressions.test.ts`: "persists lightContext on cron update when patch only has lightContext (no message)" — creates job, updates with only `payload: { kind: "agentTurn", lightContext: true }`, asserts persisted value and clearing via `lightContext: false`.
- [x] Existing CLI tests in `cron-cli.test.ts` for "sets and clears lightContext on cron edit" remain passing.

## Human Verification (required)

- **Verified:** Unit tests for merge and for CLI patch shape; full `cron-cli.test.ts` and `service.issue-regressions.test.ts` run (65 tests).
- **Edge cases:** Patch with only `lightContext` (no message); set then clear `lightContext`.
- **Not verified:** Live gateway + cron scheduler with real job store on a specific OS.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- Upgrade steps: N/A

## Failure Recovery (if this breaks)

- Revert the commit; no config or migration to restore.
- Symptom to watch: cron edit with `--light-context` / `--no-light-context` not persisting would indicate regression.

## Risks and Mitigations

- **Risk:** None identified; change only adds merging of an existing optional field already sent by CLI and defined in types.
- **Mitigation:** N/A
