### PR TITLE
feat(agents): raise flush default to 8000 tokens and support FLUSH.md

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -31,6 +31,7 @@ import {
   resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
 import {
+  readFlushInstructions,
   resolveMemoryFlushContextWindowTokens,
   resolveMemoryFlushPromptForRun,
   resolveMemoryFlushSettings,
@@ -457,9 +458,11 @@ export async function runMemoryFlushIfNeeded(params: {
     });
   }
   let memoryCompactionCompleted = false;
+  const flushInstructions = await readFlushInstructions(process.cwd());
   const flushSystemPrompt = [
     params.followupRun.run.extraSystemPrompt,
     memoryFlushSettings.systemPrompt,
+    flushInstructions,
   ]
     .filter(Boolean)
     .join("\n\n");

--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { resolveMemoryFlushPromptForRun } from "./memory-flush.js";
+import {
+  DEFAULT_MEMORY_FLUSH_SOFT_TOKENS,
+  readFlushInstructions,
+  resolveMemoryFlushPromptForRun,
+  resolveMemoryFlushSettings,
+} from "./memory-flush.js";
 
 describe("resolveMemoryFlushPromptForRun", () => {
   const cfg = {
@@ -33,5 +41,58 @@ describe("resolveMemoryFlushPromptForRun", () => {
 
     expect(prompt).toContain("Current time: already present");
     expect((prompt.match(/Current time:/g) ?? []).length).toBe(1);
+  });
+});
+
+describe("DEFAULT_MEMORY_FLUSH_SOFT_TOKENS", () => {
+  it("defaults to 8000", () => {
+    expect(DEFAULT_MEMORY_FLUSH_SOFT_TOKENS).toBe(8000);
+  });
+
+  it("resolveMemoryFlushSettings uses 8000 when no override", () => {
+    const settings = resolveMemoryFlushSettings({} as OpenClawConfig);
+    expect(settings?.softThresholdTokens).toBe(8000);
+  });
+});
+
+describe("readFlushInstructions", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "flush-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null when FLUSH.md does not exist", async () => {
+    const result = await readFlushInstructions(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it("returns flush instructions from FLUSH.md", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "FLUSH.md"),
+      "Update SESSION-STATE.md\nUpdate daily log\n",
+    );
+    const result = await readFlushInstructions(tmpDir);
+    expect(result).toContain("FLUSH.md");
+    expect(result).toContain("Update SESSION-STATE.md");
+    expect(result).toContain("Update daily log");
+  });
+
+  it("returns null for empty FLUSH.md", async () => {
+    await fs.writeFile(path.join(tmpDir, "FLUSH.md"), "   \n  ");
+    const result = await readFlushInstructions(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it("truncates oversized FLUSH.md", async () => {
+    const bigContent = "x".repeat(5000);
+    await fs.writeFile(path.join(tmpDir, "FLUSH.md"), bigContent);
+    const result = await readFlushInstructions(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBeLessThan(5100);
   });
 });

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { lookupContextTokens } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
@@ -7,7 +9,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 
-export const DEFAULT_MEMORY_FLUSH_SOFT_TOKENS = 4000;
+export const DEFAULT_MEMORY_FLUSH_SOFT_TOKENS = 8000;
 export const DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES = 2 * 1024 * 1024;
 
 export const DEFAULT_MEMORY_FLUSH_PROMPT = [
@@ -55,6 +57,29 @@ export function resolveMemoryFlushPromptForRun(params: {
     return withDate;
   }
   return `${withDate}\n${timeLine}`;
+}
+
+const MAX_FLUSH_MD_CHARS = 4000;
+const FLUSH_MD_FILENAME = "FLUSH.md";
+
+export async function readFlushInstructions(workspaceDir: string): Promise<string | null> {
+  try {
+    const filePath = path.join(workspaceDir, FLUSH_MD_FILENAME);
+    const resolved = path.resolve(filePath);
+    if (!resolved.startsWith(path.resolve(workspaceDir))) {
+      return null;
+    }
+    const content = await fs.readFile(resolved, "utf-8");
+    const trimmed = content.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const limited =
+      trimmed.length > MAX_FLUSH_MD_CHARS ? trimmed.slice(0, MAX_FLUSH_MD_CHARS) : trimmed;
+    return `Workspace flush instructions (${FLUSH_MD_FILENAME}):\n${limited}`;
+  } catch {
+    return null;
+  }
 }
 
 export type MemoryFlushSettings = {


### PR DESCRIPTION
## Summary

- **Problem**: The default `softThresholdTokens` (4000) does not give the model enough room for a thorough pre-compaction flush across multiple workspace files. Additionally, the generic flush prompt cannot know which files are critical for each workspace.
- **Why it matters**: Long-running agent sessions lose context during compaction because the flush turn runs out of tokens mid-way, and the model has no workspace-specific guidance on which files matter most.
- **What changed**:
  1. Raised `DEFAULT_MEMORY_FLUSH_SOFT_TOKENS` from 4000 to 8000.
  2. Added `readFlushInstructions()` to read a workspace-level `FLUSH.md` file and inject its contents into the flush system prompt.
  3. Wired `readFlushInstructions` into `runMemoryFlushIfNeeded` so each workspace can specify exactly which files MUST be updated before compaction.
- **What did NOT change**: Flush trigger logic, token threshold calculation, compaction flow, or any existing prompt/config behavior.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31435

## User-visible / Behavior Changes

- Default flush threshold is now 8000 tokens (was 4000). Users who had no explicit `softThresholdTokens` config will get more headroom for flush turns.
- If a `FLUSH.md` file exists in the workspace root, its contents (up to 4000 chars) are appended to the flush system prompt. This allows per-workspace flush instructions.
- Users with explicit `softThresholdTokens: 4000` in their config are unaffected (the config value always takes priority).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — reads only from workspace root, same trust boundary as AGENTS.md

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js 22+

### Steps

1. Create `FLUSH.md` in workspace root with content like:
   ```
   MANDATORY before compaction:
   1. Update SESSION-STATE.md with all current context
   2. Append new facts to today's daily log
   ```
2. Run a long agent session until flush triggers
3. Observe that the flush turn's system prompt includes the FLUSH.md contents

### Expected

- Flush fires at `contextWindow - reserveTokens - 8000` (more headroom)
- FLUSH.md contents injected into system prompt

### Actual

- Before: Flush fires at `contextWindow - reserveTokens - 4000`, no workspace-specific instructions
- After: More headroom, workspace flush instructions included

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```bash
npx vitest run src/auto-reply/reply/memory-flush.test.ts
# 8 tests pass (6 new: default 8000, resolveSettings 8000, FLUSH.md read, empty, missing, truncation)
```

## Human Verification (required)

- Verified scenarios: default value change, FLUSH.md read, empty file, missing file, oversized file truncation
- Edge cases checked: path traversal guard, whitespace-only content, existing softThresholdTokens config override
- What you did **not** verify: Live long-running session flush (unit tests only)

## Compatibility / Migration

- Backward compatible? `Yes` — additive; existing configs with explicit `softThresholdTokens` are unchanged
- Config/env changes? `No` — optional FLUSH.md file, not required
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable: Set `softThresholdTokens: 4000` in config to restore old default; delete FLUSH.md to disable workspace instructions
- Files to restore: `src/auto-reply/reply/memory-flush.ts`, `src/auto-reply/reply/agent-runner-memory.ts`

## Risks and Mitigations

- Risk: 8000 default may be too aggressive for small context window models
  - Mitigation: Users can override via `softThresholdTokens` config; the threshold calculation clamps to 0
- Risk: Malicious FLUSH.md could inject adversarial instructions
  - Mitigation: FLUSH.md is workspace-local (same trust as AGENTS.md); content capped at 4000 chars; path traversal check included