### PR TITLE
fix(mattermost): use thread root post ID for reply_to_current in threads

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -760,7 +760,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               }
               await sendMessageMattermost(to, chunk, {
                 accountId: account.accountId,
-                replyToId: threadRootId,
+                // Prefer threadRootId (the actual thread root post) over payload.replyToId,
+                // because Mattermost requires root_id to reference the root post — a post
+                // that itself has a root_id cannot be used as root_id (#30977).
+                replyToId: threadRootId || payload.replyToId,
               });
             }
           } else {
@@ -771,7 +774,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               await sendMessageMattermost(to, caption, {
                 accountId: account.accountId,
                 mediaUrl,
-                replyToId: threadRootId,
+                // Prefer threadRootId over payload.replyToId (see #30977).
+                replyToId: threadRootId || payload.replyToId,
               });
             }
           }


### PR DESCRIPTION
## Summary

- When `[[reply_to_current]]` resolves to a threaded reply, its post ID was being used as `root_id`, but Mattermost requires `root_id` to reference the actual root post of a thread. This caused a 400 Bad Request with "Invalid RootId parameter".
- Changed `replyToId` assignment from `threadRootId` (only) to `threadRootId || payload.replyToId`, so the actual thread root is preferred when available, and `payload.replyToId` is used as fallback for non-threaded messages.

Closes #30977

## Test plan

- [ ] Send a top-level DM (post A), bot replies in thread (post B, root_id=A), user replies in thread (post C, root_id=A), trigger `[[reply_to_current]]` — bot should reply using post A's ID as root_id (not post C's ID)
- [ ] Verify `[[reply_to_current]]` on a top-level post (no thread) still works correctly using payload.replyToId
- [ ] Verify standard threaded replies (without `[[reply_to_current]]`) continue to use threadRootId correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)