### PR TITLE
fix(discord): convert single newlines to paragraph breaks in bot messages

### DIFF
--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -7,6 +7,7 @@ import type { MarkdownTableMode, ReplyToMode } from "../../config/types.base.js"
 import { convertMarkdownTables } from "../../markdown/tables.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
+import { convertNewlinesForDiscord } from "../newline-breaks.js";
 import { sendMessageDiscord, sendVoiceMessageDiscord, sendWebhookMessageDiscord } from "../send.js";
 
 export type DiscordThreadBindingLookupRecord = {
@@ -179,7 +180,7 @@ export async function deliverDiscordReply(params: {
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
     const rawText = payload.text ?? "";
     const tableMode = params.tableMode ?? "code";
-    const text = convertMarkdownTables(rawText, tableMode);
+    const text = convertNewlinesForDiscord(convertMarkdownTables(rawText, tableMode));
     if (!text && mediaList.length === 0) {
       continue;
     }

--- a/src/discord/newline-breaks.test.ts
+++ b/src/discord/newline-breaks.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { convertNewlinesForDiscord } from "./newline-breaks.js";
+
+describe("convertNewlinesForDiscord", () => {
+  it("returns empty string unchanged", () => {
+    expect(convertNewlinesForDiscord("")).toBe("");
+  });
+
+  it("returns text without newlines unchanged", () => {
+    expect(convertNewlinesForDiscord("hello world")).toBe("hello world");
+  });
+
+  it("converts a single newline to a double newline", () => {
+    expect(convertNewlinesForDiscord("line1\nline2")).toBe("line1\n\nline2");
+  });
+
+  it("converts multiple isolated single newlines", () => {
+    expect(convertNewlinesForDiscord("a\nb\nc")).toBe("a\n\nb\n\nc");
+  });
+
+  it("preserves existing double newlines", () => {
+    expect(convertNewlinesForDiscord("line1\n\nline2")).toBe("line1\n\nline2");
+  });
+
+  it("preserves triple-or-more newlines", () => {
+    expect(convertNewlinesForDiscord("line1\n\n\nline2")).toBe("line1\n\n\nline2");
+  });
+
+  it("handles mixed single and double newlines", () => {
+    expect(convertNewlinesForDiscord("a\nb\n\nc\nd")).toBe("a\n\nb\n\nc\n\nd");
+  });
+
+  it("does not modify content inside fenced code blocks", () => {
+    const input = "before\n```\ncode\nblock\n```\nafter";
+    const expected = "before\n\n```\ncode\nblock\n```\n\nafter";
+    expect(convertNewlinesForDiscord(input)).toBe(expected);
+  });
+
+  it("handles multiple fenced code blocks", () => {
+    const input = "a\nb\n```\nx\ny\n```\nc\nd\n```js\ne\nf\n```\ng";
+    const expected = "a\n\nb\n\n```\nx\ny\n```\n\nc\n\nd\n\n```js\ne\nf\n```\n\ng";
+    expect(convertNewlinesForDiscord(input)).toBe(expected);
+  });
+
+  it("handles text with only code blocks", () => {
+    const input = "```\nonly\ncode\n```";
+    expect(convertNewlinesForDiscord(input)).toBe(input);
+  });
+
+  it("converts a trailing single newline to double", () => {
+    // A trailing \n is isolated (not preceded or followed by \n) so it becomes \n\n.
+    expect(convertNewlinesForDiscord("hello\n")).toBe("hello\n\n");
+  });
+
+  it("preserves a trailing double newline", () => {
+    expect(convertNewlinesForDiscord("hello\n\n")).toBe("hello\n\n");
+  });
+});

--- a/src/discord/newline-breaks.ts
+++ b/src/discord/newline-breaks.ts
@@ -1,0 +1,48 @@
+/**
+ * Discord renders single `\n` as a soft break (space) in bot messages,
+ * making multi-line replies unreadable. Convert isolated single newlines
+ * to paragraph breaks (`\n\n`) so Discord renders them as hard breaks.
+ *
+ * Fenced code blocks are preserved: newlines inside ``` ... ``` are left
+ * untouched because Discord renders them literally.
+ */
+
+const FENCED_CODE_BLOCK_RE = /```[\s\S]*?```/g;
+
+/**
+ * Replace every isolated single `\n` with `\n\n` outside of fenced code
+ * blocks.  Runs of two-or-more newlines are left as-is.
+ */
+export function convertNewlinesForDiscord(text: string): string {
+  if (!text) {
+    return text;
+  }
+
+  // Split the text into alternating segments: [non-code, code, non-code, ...]
+  // We only transform non-code segments.
+  const parts: string[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(FENCED_CODE_BLOCK_RE)) {
+    const start = match.index;
+    // Push the text before this code block (to be transformed).
+    parts.push(convertSingleNewlines(text.slice(lastIndex, start)));
+    // Push the code block verbatim.
+    parts.push(match[0]);
+    lastIndex = start + match[0].length;
+  }
+
+  // Push any remaining text after the last code block.
+  parts.push(convertSingleNewlines(text.slice(lastIndex)));
+
+  return parts.join("");
+}
+
+/**
+ * Replace isolated single newlines with double newlines.
+ * `(?<!\n)\n(?!\n)` matches a `\n` that is not preceded or followed by
+ * another `\n`, i.e. a truly single newline.
+ */
+function convertSingleNewlines(segment: string): string {
+  return segment.replace(/(?<!\n)\n(?!\n)/g, "\n\n");
+}


### PR DESCRIPTION
## Summary
- Discord renders single `\n` as soft breaks (spaces) in bot messages, making multi-line replies unreadable
- Adds `convertNewlinesForDiscord()` post-processing in the reply delivery path that converts isolated single `\n` to `\n\n` (paragraph breaks) for proper hard-break rendering
- Preserves newlines inside fenced code blocks (``` ... ```) so code formatting is unaffected

Closes #30962

## Test plan
- [x] Unit tests for `convertNewlinesForDiscord` covering single newlines, double newlines, triple newlines, mixed, code blocks, trailing newlines
- [x] Existing `reply-delivery.test.ts` tests pass
- [x] Lint and format checks pass
- [ ] Manual verification: send a multi-line bot message in Discord and confirm line breaks render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)