### PR TITLE
cron: resolve store path at call time to respect --profile

### DIFF
--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -2,7 +2,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCronStoreHarness } from "./service.test-harness.js";
-import { loadCronStore, resolveCronStorePath, saveCronStore } from "./store.js";
+import {
+  getDefaultCronStorePath,
+  loadCronStore,
+  resolveCronStorePath,
+  saveCronStore,
+} from "./store.js";
 import type { CronStoreFile } from "./types.js";
 
 const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-store-" });
@@ -39,6 +44,25 @@ describe("resolveCronStorePath", () => {
 
     const result = resolveCronStorePath("~/cron/jobs.json");
     expect(result).toBe(path.resolve("/srv/openclaw-home", "cron", "jobs.json"));
+  });
+
+  it("respects OPENCLAW_STATE_DIR for default cron store path", () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/custom/state-dir");
+
+    const result = resolveCronStorePath();
+    expect(result).toBe(path.join("/custom/state-dir", "cron", "jobs.json"));
+  });
+
+  it("getDefaultCronStorePath reflects OPENCLAW_STATE_DIR at call time", () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/profile-a");
+    const pathA = getDefaultCronStorePath();
+
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/profile-b");
+    const pathB = getDefaultCronStorePath();
+
+    expect(pathA).toBe(path.join("/profile-a", "cron", "jobs.json"));
+    expect(pathB).toBe(path.join("/profile-b", "cron", "jobs.json"));
+    expect(pathA).not.toBe(pathB);
   });
 });
 

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -3,11 +3,23 @@ import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
 import { expandHomePrefix } from "../infra/home-dir.js";
-import { CONFIG_DIR } from "../utils.js";
+import { resolveConfigDir } from "../utils.js";
 import type { CronStoreFile } from "./types.js";
 
-export const DEFAULT_CRON_DIR = path.join(CONFIG_DIR, "cron");
-export const DEFAULT_CRON_STORE_PATH = path.join(DEFAULT_CRON_DIR, "jobs.json");
+/** Resolve cron dir at call time so `--profile` / `OPENCLAW_STATE_DIR` is respected. */
+export function getDefaultCronDir(): string {
+  return path.join(resolveConfigDir(), "cron");
+}
+
+/** Resolve default cron store path at call time so profile overrides apply. */
+export function getDefaultCronStorePath(): string {
+  return path.join(getDefaultCronDir(), "jobs.json");
+}
+
+// Keep legacy constants for backwards compat with external consumers.
+// These still resolve once at import time; prefer the functions above.
+export const DEFAULT_CRON_DIR = getDefaultCronDir();
+export const DEFAULT_CRON_STORE_PATH = getDefaultCronStorePath();
 const serializedStoreCache = new Map<string, string>();
 
 export function resolveCronStorePath(storePath?: string) {
@@ -18,7 +30,7 @@ export function resolveCronStorePath(storePath?: string) {
     }
     return path.resolve(raw);
   }
-  return DEFAULT_CRON_STORE_PATH;
+  return getDefaultCronStorePath();
 }
 
 export async function loadCronStore(storePath: string): Promise<CronStoreFile> {


### PR DESCRIPTION
## Summary

- **Problem:** `cron list` returns the same jobs for all `--profile` instances because `DEFAULT_CRON_STORE_PATH` is derived from `CONFIG_DIR`, a module-level constant evaluated at import time — before `--profile` sets `OPENCLAW_STATE_DIR`.
- **Why it matters:** Users running multiple gateway profiles (e.g. `openclaw --profile travis gateway`) see cron jobs from the default profile, not their own. Jobs may also execute from the wrong store.
- **What changed:** Replaced the static `DEFAULT_CRON_STORE_PATH` / `DEFAULT_CRON_DIR` derivation with `getDefaultCronStorePath()` / `getDefaultCronDir()` functions that call `resolveConfigDir()` at invocation time. `resolveCronStorePath()` now calls the function instead of referencing the constant.
- **What did NOT change:** Legacy `DEFAULT_CRON_DIR` / `DEFAULT_CRON_STORE_PATH` exports are preserved for backwards compatibility. `loadCronStore` / `saveCronStore` are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: cron jobs not isolated across `--profile` instances

## User-visible / Behavior Changes

- `openclaw --profile <name> cron list` now correctly shows only the cron jobs belonging to that profile's store, instead of always showing the default profile's jobs.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 25.2.0
- Runtime: Node 22, OpenClaw v2026.3.1
- Two profiles: default (`~/.openclaw`, port 18789) and travis (`~/.openclaw-travis`, port 19001)

### Steps

1. Create two profiles with separate cron jobs (`~/.openclaw/cron/jobs.json` has 5 jobs, `~/.openclaw-travis/cron/jobs.json` has 1 job)
2. Start both gateways: `openclaw gateway` and `openclaw --profile travis gateway`
3. Run `openclaw --profile travis cron list`

### Expected

- Travis profile shows 1 cron job (from its own store)

### Actual (before fix)

- Travis profile shows all 5 cron jobs (from the default store)

## Evidence

- [x] Failing test/log before + passing after

Added two new tests:
- `respects OPENCLAW_STATE_DIR for default cron store path` — verifies `resolveCronStorePath()` without explicit path uses the env-var-derived directory
- `getDefaultCronStorePath reflects OPENCLAW_STATE_DIR at call time` — verifies changing the env var between calls produces different paths

All 10 tests pass (`pnpm test -- --run src/cron/store.test.ts`).

## Human Verification (required)

- Verified: both gateways previously returned identical cron lists; after the fix, `resolveCronStorePath()` returns profile-specific paths when `OPENCLAW_STATE_DIR` is set
- Edge cases: no explicit `storePath` (falls back to profile-aware default), explicit `storePath` (unchanged behavior), tilde expansion (unchanged)
- Not verified: full gateway restart with patched build (source change only; dist not rebuilt)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert this single commit; no config or data changes needed
- Legacy `DEFAULT_CRON_DIR` / `DEFAULT_CRON_STORE_PATH` exports still work identically to before for any external consumers using the constants

## Risks and Mitigations

- **Risk:** `resolveConfigDir()` is called on every `resolveCronStorePath()` invocation instead of once at import time
  - **Mitigation:** `resolveConfigDir()` is a fast synchronous function (reads env var + `existsSync` check); cron store resolution happens infrequently (gateway startup, cron list RPC). No measurable perf impact.