### PR TITLE
Agents: pass skill env into exec subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.
 - Gateway/Control UI method guard: allow POST requests to non-UI routes to fall through when no base path is configured, and add POST regression coverage for fallthrough and base-path 405 behavior. (#23970) Thanks @tyler6204.
+- Exec/Skill env propagation: merge `skills.entries.*.env` into default `exec` subprocess env and allow per-call `env` overrides to take precedence, restoring CLI auth flows that depend on skill-scoped environment variables. (#31583)
 - Authentication: classify `permission_error` as `auth_permanent` for profile fallback. (#31324) Thanks @Sid-Qin.
 - Security/Prompt spoofing hardening: stop injecting queued runtime events into user-role prompt text, route them through trusted system-prompt context, and neutralize inbound spoof markers like `[System Message]` and line-leading `System:` in untrusted message content. (#30448)
 - Gateway/Node browser proxy routing: honor `profile` from `browser.request` JSON body when query params omit it, while preserving query-profile precedence when both are present. (#28852) Thanks @Sid-Qin.

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -3,6 +3,7 @@ import type { SafeBinProfileFixture } from "../infra/exec-safe-bin-policy.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 
 export type ExecToolDefaults = {
+  env?: Record<string, string>;
   host?: ExecHost;
   security?: ExecSecurity;
   ask?: ExecAsk;

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -169,6 +169,43 @@ describe("exec PATH login shell merge", () => {
 });
 
 describe("exec host env validation", () => {
+  it("applies default env values from exec tool defaults", async () => {
+    if (isWin) {
+      return;
+    }
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      env: { GOG_KEYRING_PASSWORD: "from-defaults" },
+    });
+
+    const result = await tool.execute("call-default-env", {
+      command: 'printf "%s" "${GOG_KEYRING_PASSWORD:-}"',
+    });
+    const output = normalizeText(result.content.find((c) => c.type === "text")?.text);
+    expect(output).toBe("from-defaults");
+  });
+
+  it("lets request env override default exec env values", async () => {
+    if (isWin) {
+      return;
+    }
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      env: { GOG_KEYRING_PASSWORD: "from-defaults" },
+    });
+
+    const result = await tool.execute("call-default-env-override", {
+      command: 'printf "%s" "${GOG_KEYRING_PASSWORD:-}"',
+      env: { GOG_KEYRING_PASSWORD: "from-request" },
+    });
+    const output = normalizeText(result.content.find((c) => c.type === "text")?.text);
+    expect(output).toBe("from-request");
+  });
+
   it("blocks LD_/DYLD_ env vars on host execution", async () => {
     const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
 

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -362,25 +362,36 @@ export function createExecTool(
 
       const inheritedBaseEnv = coerceEnv(process.env);
       const baseEnv = host === "sandbox" ? inheritedBaseEnv : sanitizeHostBaseEnv(inheritedBaseEnv);
+      const defaultEnv = coerceEnv(defaults?.env);
+      const requestedEnv = params.env ? coerceEnv(params.env) : undefined;
 
       // Logic: Sandbox gets raw env. Host (gateway/node) must pass validation.
       // We validate BEFORE merging to prevent any dangerous vars from entering the stream.
-      if (host !== "sandbox" && params.env) {
-        validateHostEnv(params.env);
+      if (host !== "sandbox" && Object.keys(defaultEnv).length > 0) {
+        validateHostEnv(defaultEnv);
+      }
+      if (host !== "sandbox" && requestedEnv) {
+        validateHostEnv(requestedEnv);
       }
 
-      const mergedEnv = params.env ? { ...baseEnv, ...params.env } : baseEnv;
+      const mergedEnv =
+        Object.keys(defaultEnv).length > 0 || requestedEnv
+          ? { ...baseEnv, ...defaultEnv, ...requestedEnv }
+          : baseEnv;
 
       const env = sandbox
         ? buildSandboxEnv({
             defaultPath: DEFAULT_PATH,
-            paramsEnv: params.env,
+            paramsEnv:
+              Object.keys(defaultEnv).length > 0 || requestedEnv
+                ? { ...defaultEnv, ...requestedEnv }
+                : undefined,
             sandboxEnv: sandbox.env,
             containerWorkdir: containerWorkdir ?? sandbox.containerWorkdir,
           })
         : mergedEnv;
 
-      if (!sandbox && host === "gateway" && !params.env?.PATH) {
+      if (!sandbox && host === "gateway" && !requestedEnv?.PATH) {
         const shellPath = getShellPathFromLoginShell({
           env: process.env,
           timeoutMs: resolveShellEnvFallbackTimeoutMs(process.env),
@@ -403,7 +414,7 @@ export function createExecTool(
           command: params.command,
           workdir,
           env,
-          requestedEnv: params.env,
+          requestedEnv,
           requestedNode: params.node?.trim(),
           boundNode: defaults?.node?.trim(),
           sessionKey: defaults?.sessionKey,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -144,6 +144,28 @@ function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
   };
 }
 
+function resolveExecSkillEnvDefaults(cfg?: OpenClawConfig): Record<string, string> | undefined {
+  const entries = cfg?.skills?.entries;
+  if (!entries) {
+    return undefined;
+  }
+  const resolved: Record<string, string> = {};
+  for (const skillConfig of Object.values(entries)) {
+    if (!skillConfig || skillConfig.enabled === false || !skillConfig.env) {
+      continue;
+    }
+    for (const [rawKey, rawValue] of Object.entries(skillConfig.env)) {
+      const key = rawKey.trim();
+      if (!key) {
+        continue;
+      }
+      const value = String(rawValue);
+      resolved[key] = value;
+    }
+  }
+  return Object.keys(resolved).length > 0 ? resolved : undefined;
+}
+
 export function resolveToolLoopDetectionConfig(params: {
   cfg?: OpenClawConfig;
   agentId?: string;
@@ -395,6 +417,7 @@ export function createOpenClawCodingTools(options?: {
     timeoutSec: options?.exec?.timeoutSec ?? execConfig.timeoutSec,
     approvalRunningNoticeMs:
       options?.exec?.approvalRunningNoticeMs ?? execConfig.approvalRunningNoticeMs,
+    env: options?.exec?.env ?? resolveExecSkillEnvDefaults(options?.config),
     notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
     notifyOnExitEmptySuccess:
       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,


### PR DESCRIPTION
## Summary
- wire `skills.entries.*.env` into `exec` default env injection so subprocesses receive skill-scoped env vars
- keep precedence explicit: per-call `exec.env` overrides default injected values
- apply the same default env chain for sandbox runs so skill env reaches sandboxed subprocesses too

## Testing
- pnpm test src/agents/bash-tools.exec.path.test.ts
- pnpm exec oxlint src/agents/bash-tools.exec.ts src/agents/bash-tools.exec-types.ts src/agents/pi-tools.ts src/agents/bash-tools.exec.path.test.ts

## Issue
- fixes #31583
