### PR TITLE
fix(logging): keep subsystem console timestamps in local timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
+- Logging/Subsystem timestamps: use local-time console timestamp formatting for subsystem logs (including `hooks:loader` startup lines and JSON/compact output) instead of UTC `toISOString()`, preventing mixed UTC/local timestamps during gateway startup on non-UTC hosts. (#31427)
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.
 - Gateway/Control UI method guard: allow POST requests to non-UI routes to fall through when no base path is configured, and add POST regression coverage for fallthrough and base-path 405 behavior. (#23970) Thanks @tyler6204.

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -1,12 +1,15 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { setConsoleSubsystemFilter } from "./console.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { stripAnsi } from "../terminal/ansi.js";
+import { setConsoleSubsystemFilter, setConsoleTimestampPrefix } from "./console.js";
 import { resetLogger, setLoggerOverride } from "./logger.js";
 import { createSubsystemLogger } from "./subsystem.js";
 
 afterEach(() => {
   setConsoleSubsystemFilter(null);
+  setConsoleTimestampPrefix(false);
   setLoggerOverride(null);
   resetLogger();
+  vi.restoreAllMocks();
 });
 
 describe("createSubsystemLogger().isEnabled", () => {
@@ -52,5 +55,33 @@ describe("createSubsystemLogger().isEnabled", () => {
 
     expect(log.isEnabled("info", "file")).toBe(true);
     expect(log.isEnabled("info")).toBe(true);
+  });
+
+  it("emits json console timestamps using local offset format (not UTC Z)", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "info", consoleStyle: "json" });
+    const logger = createSubsystemLogger("hooks:loader");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    logger.info("Registered hook");
+
+    const line = String(logSpy.mock.calls.at(-1)?.[0] ?? "");
+    const parsed = JSON.parse(line) as { time?: string };
+    const time = parsed.time ?? "";
+    expect(time).toMatch(/[+-]\d{2}:\d{2}$/);
+    expect(time.endsWith("Z")).toBe(false);
+  });
+
+  it("emits compact console timestamp prefix using local offset format when enabled", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "info", consoleStyle: "compact" });
+    setConsoleTimestampPrefix(true);
+    const logger = createSubsystemLogger("hooks:loader");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    logger.info("Registered hook");
+
+    const line = String(logSpy.mock.calls.at(-1)?.[0] ?? "");
+    const plainLine = stripAnsi(line);
+    expect(plainLine).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?[+-]\d{2}:\d{2}\s/);
+    expect(plainLine.includes("Z ")).toBe(false);
   });
 });

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -4,7 +4,11 @@ import { CHAT_CHANNEL_ORDER } from "../channels/registry.js";
 import { isVerbose } from "../globals.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { clearActiveProgressLine } from "../terminal/progress-line.js";
-import { getConsoleSettings, shouldLogSubsystemToConsole } from "./console.js";
+import {
+  formatConsoleTimestamp,
+  getConsoleSettings,
+  shouldLogSubsystemToConsole,
+} from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
 import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
@@ -188,7 +192,7 @@ function formatConsoleLine(opts: {
     opts.style === "json" ? opts.subsystem : formatSubsystemForConsole(opts.subsystem);
   if (opts.style === "json") {
     return JSON.stringify({
-      time: new Date().toISOString(),
+      time: formatConsoleTimestamp("json"),
       level: opts.level,
       subsystem: displaySubsystem,
       message: opts.message,
@@ -209,10 +213,10 @@ function formatConsoleLine(opts: {
   const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
   const time = (() => {
     if (opts.style === "pretty") {
-      return color.gray(new Date().toISOString().slice(11, 19));
+      return color.gray(formatConsoleTimestamp("pretty"));
     }
     if (loggingState.consoleTimestampPrefix) {
-      return color.gray(new Date().toISOString());
+      return color.gray(formatConsoleTimestamp(opts.style));
     }
     return "";
   })();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: gateway startup logs mixed local-time and UTC timestamps (notably `hooks:loader` lines in UTC while other logs were local-time).
- Why it matters: mixed timezone output is confusing during incident/debug timelines and made startup logs look out-of-order on non-UTC hosts.
- What changed: `src/logging/subsystem.ts` now uses shared local timestamp formatting (`formatConsoleTimestamp`) for pretty/compact/json console output instead of `toISOString()`.
- What did NOT change (scope boundary): file logger payloads, log level filtering, and hook loading behavior were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31427
- Related #14771

## User-visible / Behavior Changes

- Console subsystem logs now use local-time formatting consistently across styles (`pretty`, `compact` with timestamp prefix, and `json`).
- On non-UTC systems, startup lines such as `[hooks:loader] Registered hook ...` no longer display UTC timestamps.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev) + timezone-aware timestamp assertions
- Runtime/container: local node runtime
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Set console style to `json` and emit a subsystem log.
2. Set console style to `compact` + timestamp prefix and emit a subsystem log.
3. Inspect timestamp format.

### Expected

- Subsystem console timestamps use local-offset format (`...+08:00`, `...+00:00`, etc.), not UTC `Z` format.

### Actual

- After fix, both json and compact timestamped output use local-offset format.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran targeted logging tests and confirmed expected local-offset formatting assertions.
- Edge cases checked: compact mode with ANSI stripping and json mode parsing.
- What you did **not** verify: full end-to-end gateway startup logs on Windows host.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `31dd6aeea`.
- Files/config to restore: `src/logging/subsystem.ts`, `src/logging/subsystem.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: timestamps unexpectedly reverting to UTC `...Z` in subsystem console lines.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: consumers parsing subsystem json logs may have assumed `Z` suffix.
  - Mitigation: format remains ISO-like and includes explicit offset; change is documented in changelog and covered by tests.
