### PR TITLE
docs(windows): document WSL2 gateway auto-start before login

### DIFF
--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -55,6 +55,50 @@ Repair/migrate:
 openclaw doctor
 ```
 
+## Gateway auto-start before Windows login
+
+For headless setups, ensure the full boot chain runs even when no one logs into
+Windows.
+
+### 1) Keep user services running without login
+
+Inside WSL:
+
+```bash
+sudo loginctl enable-linger "$(whoami)"
+```
+
+### 2) Install the OpenClaw gateway user service
+
+Inside WSL:
+
+```bash
+openclaw gateway install
+```
+
+### 3) Start WSL automatically at Windows boot
+
+In PowerShell as Administrator:
+
+```powershell
+schtasks /create /tn "WSL Boot" /tr "wsl.exe -d Ubuntu --exec /bin/true" /sc onstart /ru SYSTEM
+```
+
+Replace `Ubuntu` with your distro name from:
+
+```powershell
+wsl --list --verbose
+```
+
+### Verify startup chain
+
+After a reboot (before Windows sign-in), check from WSL:
+
+```bash
+systemctl --user is-enabled openclaw-gateway
+systemctl --user status openclaw-gateway --no-pager
+```
+
 ## Advanced: expose WSL services over LAN (portproxy)
 
 WSL has its own virtual network. If another machine needs to reach a service


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `docs/platforms/windows` did not describe how to auto-start Gateway before Windows user login.
- Why it matters: headless or always-on setups can miss bot availability after reboot until someone signs in.
- What changed: added a dedicated `Gateway auto-start before Windows login` section with 3-step boot chain (linger, gateway install, scheduled WSL boot) and verification commands.
- What did NOT change (scope boundary): no gateway runtime/service behavior changes, no script changes, docs-only patch.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31589
- Related #11805

## User-visible / Behavior Changes

- Windows (WSL2) docs now include a copy-paste path to make Gateway come up before Windows sign-in.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (authoring docs), target docs for Windows 11 + WSL2
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Open `docs/platforms/windows.md` and locate Gateway section.
2. Confirm new `Gateway auto-start before Windows login` section includes linger + service install + scheduled task commands.
3. Run markdown formatter check.

### Expected

- Docs provide complete startup chain and verification commands for headless startup.

### Actual

- Added section now documents complete startup chain with explicit commands.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Formatter check:

```bash
pnpm exec oxfmt --check docs/platforms/windows.md
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed rendered markdown structure and command blocks for the 3-step chain.
- Edge cases checked: distro name mismatch addressed with `wsl --list --verbose` guidance.
- What you did **not** verify: did not execute commands on a live Windows host in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or remove the section from `docs/platforms/windows.md`.
- Files/config to restore: `docs/platforms/windows.md`
- Known bad symptoms reviewers should watch for: none beyond potential distro-name confusion, already mitigated by listing command.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: users may copy the scheduled task with wrong distro name.
  - Mitigation: explicit `wsl --list --verbose` step and replacement note.
