### PR TITLE
fix(heartbeat): relay exec results back to originating channel after approval

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -264,7 +264,7 @@ export function emitExecSystemEvent(
     return;
   }
   enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
-  requestHeartbeatNow({ reason: "exec-event" });
+  requestHeartbeatNow({ reason: "exec-event", sessionKey });
 }
 
 export async function runExecProcess(opts: {

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
   type ExecApprovalDecision,
 } from "../../infra/exec-approvals.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { buildSystemRunApprovalBinding } from "../../infra/system-run-approval-binding.js";
 import { resolveSystemRunApprovalRequestContext } from "../../infra/system-run-approval-context.js";
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
@@ -282,6 +283,11 @@ export function createExecApprovalHandlers(
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown approval id"));
         return;
       }
+      // Wake the session that's awaiting this approval decision.
+      requestHeartbeatNow({
+        reason: "exec-approval:resolve",
+        sessionKey: snapshot?.request?.sessionKey ?? undefined,
+      });
       context.broadcast(
         "exec.approval.resolved",
         { id: p.id, decision, resolvedBy, ts: Date.now(), request: snapshot?.request },

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { buildSystemRunApprovalBinding } from "../../infra/system-run-approval-binding.js";
 import { resetLogger, setLoggerOverride } from "../../logging.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
@@ -19,6 +20,10 @@ import { logsHandlers } from "./logs.js";
 
 vi.mock("../../commands/status.js", () => ({
   getStatusSummary: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: vi.fn(),
 }));
 
 describe("waitForAgentJob", () => {
@@ -257,6 +262,10 @@ describe("gateway chat transcript writes (guardrail)", () => {
 });
 
 describe("exec approval handlers", () => {
+  beforeEach(() => {
+    vi.mocked(requestHeartbeatNow).mockClear();
+  });
+
   const execApprovalNoop = () => false;
   type ExecApprovalHandlers = ReturnType<typeof createExecApprovalHandlers>;
   type ExecApprovalRequestArgs = Parameters<ExecApprovalHandlers["exec.approval.request"]>[0];
@@ -492,6 +501,29 @@ describe("exec approval handlers", () => {
       undefined,
     );
     expect(broadcasts.some((entry) => entry.event === "exec.approval.resolved")).toBe(true);
+  });
+
+  it("triggers heartbeat wake with sessionKey on resolve", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+
+    const requestPromise = requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: { twoPhase: true, sessionKey: "agent:main:main" },
+    });
+
+    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
+    const id = (requested?.payload as { id?: string })?.id ?? "";
+    expect(id).not.toBe("");
+
+    const resolveRespond = vi.fn();
+    await resolveExecApproval({ handlers, id, respond: resolveRespond, context });
+    await requestPromise;
+
+    expect(requestHeartbeatNow).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "exec-approval:resolve", sessionKey: "agent:main:main" }),
+    );
   });
 
   it("stores versioned system.run binding and sorted env keys on approval request", async () => {

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -94,6 +94,7 @@ describe("node exec events", () => {
   beforeEach(() => {
     enqueueSystemEventMock.mockClear();
     requestHeartbeatNowMock.mockClear();
+    enqueueSystemEventMock.mockReturnValue(true);
   });
 
   it("enqueues exec.started events", async () => {
@@ -111,7 +112,10 @@ describe("node exec events", () => {
       "Exec started (node=node-1 id=run-1): ls -la",
       { sessionKey: "agent:main:main", contextKey: "exec:run-1" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:main:main",
+    });
   });
 
   it("enqueues exec.finished events with output", async () => {
@@ -130,7 +134,10 @@ describe("node exec events", () => {
       "Exec finished (node=node-2 id=run-2, code 0)\ndone",
       { sessionKey: "node-node-2", contextKey: "exec:run-2" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "node-node-2",
+    });
   });
 
   it("suppresses noisy exec.finished success events with empty output", async () => {
@@ -166,7 +173,10 @@ describe("node exec events", () => {
     expect(text.startsWith("Exec finished (node=node-2 id=run-long, code 0)\n")).toBe(true);
     expect(text.endsWith("…")).toBe(true);
     expect(text.length).toBeLessThan(280);
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "node-node-2",
+    });
   });
 
   it("enqueues exec.denied events with reason", async () => {
@@ -185,7 +195,27 @@ describe("node exec events", () => {
       "Exec denied (node=node-3 id=run-3, allowlist-miss): rm -rf /",
       { sessionKey: "agent:demo:main", contextKey: "exec:run-3" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:demo:main",
+    });
+  });
+
+  it("does not wake heartbeat when exec event is deduped", async () => {
+    enqueueSystemEventMock.mockReset();
+    enqueueSystemEventMock.mockReturnValueOnce(false);
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-1", {
+      event: "exec.started",
+      payloadJSON: JSON.stringify({
+        sessionKey: "agent:main:main",
+        runId: "run-dupe",
+        command: "ls -la",
+      }),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
   });
 
   it("suppresses exec.started when notifyOnExit is false", async () => {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -573,8 +573,13 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         }
       }
 
-      enqueueSystemEvent(text, { sessionKey, contextKey: runId ? `exec:${runId}` : "exec" });
-      requestHeartbeatNow({ reason: "exec-event" });
+      const queued = enqueueSystemEvent(text, {
+        sessionKey,
+        contextKey: runId ? `exec:${runId}` : "exec",
+      });
+      if (queued) {
+        requestHeartbeatNow({ reason: "exec-event", sessionKey });
+      }
       return;
     }
     case "push.apns.register": {

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -45,11 +45,7 @@ export function buildExecEventPrompt(opts?: { deliverToUser?: boolean }): string
       "Handle the result internally. Do not relay it to the user unless explicitly requested."
     );
   }
-  return (
-    "An async command you ran earlier has completed. The result is shown in the system messages above. " +
-    "Please relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
-    "If it failed, explain what went wrong."
-  );
+  return "An async command you ran earlier has completed. Share the result briefly.";
 }
 
 const HEARTBEAT_OK_PREFIX = HEARTBEAT_TOKEN.toLowerCase();

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -614,7 +614,13 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: "quiet-hours" };
   }
 
-  const queueSize = (opts.deps?.getQueueSize ?? getQueueSize)(CommandLane.Main);
+  // For exec-event wakes targeting a specific session, only gate on that
+  // session's own lane being busy. Unrelated channel activity (other users,
+  // rate-limit retries) should not delay exec-result delivery.
+  const execEventSessionKey =
+    resolveHeartbeatReasonKind(opts.reason) === "exec-event" ? opts.sessionKey : undefined;
+  const queueLane = execEventSessionKey ?? CommandLane.Main;
+  const queueSize = (opts.deps?.getQueueSize ?? getQueueSize)(queueLane);
   if (queueSize > 0) {
     return { status: "skipped", reason: "requests-in-flight" };
   }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -637,7 +637,17 @@ export async function runHeartbeatOnce(opts: {
   }
   const { entry, sessionKey, storePath } = preflight.session;
   const previousUpdatedAt = entry?.updatedAt;
-  const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat });
+  // For exec-completion events targeting a specific session, fall back to the
+  // session's last channel when the heartbeat has no explicit delivery target.
+  // This enables exec results to be relayed back to the originating channel
+  // (e.g. Discord) even when heartbeat.target is "none".
+  const execEventHeartbeat =
+    preflight.isExecEventReason &&
+    opts.sessionKey &&
+    (!heartbeat?.target || heartbeat.target === "none")
+      ? { ...heartbeat, target: "last" as const }
+      : heartbeat;
+  const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat: execEventHeartbeat });
   const heartbeatAccountId = heartbeat?.accountId?.trim();
   if (delivery.reason === "unknown-account") {
     log.warn("heartbeat: unknown accountId", {


### PR DESCRIPTION
## Summary

- Pass `sessionKey` to `requestHeartbeatNow` in `emitExecSystemEvent` so the exec-event heartbeat targets the correct session (e.g. the Discord channel that triggered the command)
- In `runHeartbeatOnce`, override `heartbeat.target` to `"last"` for exec-event heartbeats when a `sessionKey` is present and no explicit target is configured — routes the result back to the originating channel instead of silently dropping it
- For exec-event wakes with a `sessionKey`, check only that session's lane queue instead of the global main lane — unrelated channel activity (rate-limit retries, other users) no longer delays exec-result delivery
- Shorten the exec-completion prompt to "Share the result briefly"

## Test plan

- [ ] Approve an exec command in Discord — bot should auto-reply with the result promptly, without needing a follow-up message
- [ ] Trigger exec in channel A while channel B has active rate-limit retries — reply should still arrive quickly in channel A
- [ ] Verify heartbeat-only sessions (no sessionKey) are unaffected
- [ ] Verify agents with an explicit `heartbeat.target` configured are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)