### PR TITLE
fix(auth): add actionable missing provider key guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
+- Models/Auth missing-key guidance: include actionable auth setup hints in provider missing-API-key errors (for example `openclaw models auth login --provider google` and `GEMINI_API_KEY`) so `/model` follow-up failures are easier to recover. (#31544)
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.
 - Gateway/Control UI method guard: allow POST requests to non-UI routes to fall through when no base path is configured, and add POST regression coverage for fallthrough and base-path 405 behavior. (#23970) Thanks @tyler6204.

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -187,6 +187,50 @@ describe("getApiKeyForModel", () => {
     );
   });
 
+  it("includes provider login and env guidance when Google API key is missing", async () => {
+    await withEnvAsync(
+      {
+        GEMINI_API_KEY: undefined,
+      },
+      async () => {
+        let error: unknown = null;
+        try {
+          await resolveApiKeyForProvider({
+            provider: "google",
+            store: { version: 1, profiles: {} },
+            agentDir: "/tmp/openclaw-agent-abc",
+          });
+        } catch (err) {
+          error = err;
+        }
+
+        const message = String(error);
+        expect(message).toContain('No API key found for provider "google".');
+        expect(message).toContain("openclaw models auth login --provider google");
+        expect(message).toContain("GEMINI_API_KEY");
+      },
+    );
+  });
+
+  it("includes provider login guidance when env var mapping is unknown", async () => {
+    let error: unknown = null;
+    try {
+      await resolveApiKeyForProvider({
+        provider: "provider-without-env",
+        store: { version: 1, profiles: {} },
+        agentDir: "/tmp/openclaw-agent-abc",
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    const message = String(error);
+    expect(message).toContain('No API key found for provider "provider-without-env".');
+    expect(message).toContain("Quick setup: run");
+    expect(message).toContain("openclaw models auth login --provider provider-without-env");
+    expect(message).not.toContain("or set ");
+  });
+
   it("accepts legacy Z_AI_API_KEY for zai", async () => {
     await withEnvAsync(
       {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -24,6 +24,32 @@ const AWS_BEARER_ENV = "AWS_BEARER_TOKEN_BEDROCK";
 const AWS_ACCESS_KEY_ENV = "AWS_ACCESS_KEY_ID";
 const AWS_SECRET_KEY_ENV = "AWS_SECRET_ACCESS_KEY";
 const AWS_PROFILE_ENV = "AWS_PROFILE";
+const PROVIDER_API_KEY_ENV_MAP: Readonly<Record<string, string>> = {
+  openai: "OPENAI_API_KEY",
+  google: "GEMINI_API_KEY",
+  voyage: "VOYAGE_API_KEY",
+  groq: "GROQ_API_KEY",
+  deepgram: "DEEPGRAM_API_KEY",
+  cerebras: "CEREBRAS_API_KEY",
+  xai: "XAI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+  litellm: "LITELLM_API_KEY",
+  "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
+  "cloudflare-ai-gateway": "CLOUDFLARE_AI_GATEWAY_API_KEY",
+  moonshot: "MOONSHOT_API_KEY",
+  minimax: "MINIMAX_API_KEY",
+  nvidia: "NVIDIA_API_KEY",
+  xiaomi: "XIAOMI_API_KEY",
+  synthetic: "SYNTHETIC_API_KEY",
+  venice: "VENICE_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  opencode: "OPENCODE_API_KEY",
+  together: "TOGETHER_API_KEY",
+  qianfan: "QIANFAN_API_KEY",
+  ollama: "OLLAMA_API_KEY",
+  vllm: "VLLM_API_KEY",
+  kilocode: "KILOCODE_API_KEY",
+};
 
 function resolveProviderConfig(
   cfg: OpenClawConfig | undefined,
@@ -132,6 +158,16 @@ export type ResolvedProviderAuth = {
   mode: "api-key" | "oauth" | "token" | "aws-sdk";
 };
 
+function buildMissingProviderAuthHint(provider: string): string {
+  const normalized = normalizeProviderId(provider);
+  const loginCommand = formatCliCommand(`openclaw models auth login --provider ${normalized}`);
+  const envVar = PROVIDER_API_KEY_ENV_MAP[normalized];
+  if (envVar) {
+    return `Quick setup: run ${loginCommand} or set ${envVar}.`;
+  }
+  return `Quick setup: run ${loginCommand}.`;
+}
+
 export async function resolveApiKeyForProvider(params: {
   provider: string;
   cfg?: OpenClawConfig;
@@ -228,6 +264,7 @@ export async function resolveApiKeyForProvider(params: {
       `No API key found for provider "${provider}".`,
       `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
       `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
+      buildMissingProviderAuthHint(provider),
     ].join(" "),
   );
 }
@@ -298,33 +335,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     return pick("HUGGINGFACE_HUB_TOKEN") ?? pick("HF_TOKEN");
   }
 
-  const envMap: Record<string, string> = {
-    openai: "OPENAI_API_KEY",
-    google: "GEMINI_API_KEY",
-    voyage: "VOYAGE_API_KEY",
-    groq: "GROQ_API_KEY",
-    deepgram: "DEEPGRAM_API_KEY",
-    cerebras: "CEREBRAS_API_KEY",
-    xai: "XAI_API_KEY",
-    openrouter: "OPENROUTER_API_KEY",
-    litellm: "LITELLM_API_KEY",
-    "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
-    "cloudflare-ai-gateway": "CLOUDFLARE_AI_GATEWAY_API_KEY",
-    moonshot: "MOONSHOT_API_KEY",
-    minimax: "MINIMAX_API_KEY",
-    nvidia: "NVIDIA_API_KEY",
-    xiaomi: "XIAOMI_API_KEY",
-    synthetic: "SYNTHETIC_API_KEY",
-    venice: "VENICE_API_KEY",
-    mistral: "MISTRAL_API_KEY",
-    opencode: "OPENCODE_API_KEY",
-    together: "TOGETHER_API_KEY",
-    qianfan: "QIANFAN_API_KEY",
-    ollama: "OLLAMA_API_KEY",
-    vllm: "VLLM_API_KEY",
-    kilocode: "KILOCODE_API_KEY",
-  };
-  const envVar = envMap[normalized];
+  const envVar = PROVIDER_API_KEY_ENV_MAP[normalized];
   if (!envVar) {
     return null;
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: missing-provider-key failures after `/model` selection show a long generic auth-store error but not a direct next step for the chosen provider.
- Why it matters: users can get stuck after model switch (for example `google/gemini-*`) and do not know the fastest recovery path.
- What changed: provider missing-key errors now append a quick setup hint with `openclaw models auth login --provider <provider>`, and include provider env var guidance when known (for example `GEMINI_API_KEY`).
- What did NOT change (scope boundary): no auth resolution behavior changes, no fallback-order changes, no `/model` UI flow changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31544
- Related #31544

## User-visible / Behavior Changes

- Missing API-key errors are now actionable with a direct command and (when available) provider env var hint.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + Vitest
- Model/provider: provider auth path (`google`, unknown provider)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run auth resolution for a provider with no configured key (for example `google`).
2. Observe thrown error text.
3. Verify quick setup command and env var guidance are included.

### Expected

- Error includes direct recovery command and known env var guidance.

### Actual

- Error now includes `openclaw models auth login --provider <provider>` and known env hint (for `google`: `GEMINI_API_KEY`).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```bash
pnpm test src/agents/model-auth.profiles.test.ts
pnpm exec oxfmt --check src/agents/model-auth.ts src/agents/model-auth.profiles.test.ts CHANGELOG.md
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: missing `google` API key includes command + `GEMINI_API_KEY`; unknown provider still includes command hint.
- Edge cases checked: unknown provider has no env-var recommendation (`or set ...` omitted).
- What you did **not** verify: no live `/model` TUI manual run in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/agents/model-auth.ts`, `src/agents/model-auth.profiles.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: none beyond message text regression.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: users may assume `models auth login` exists for every provider plugin.
  - Mitigation: keep legacy `agents add` guidance and env var hints in the same message.
