### PR TITLE
fix(update): resolve symlinked global bin roots for updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
+- Update/Global npm installs: resolve package roots from symlinked global `openclaw` bin paths during `update.run`/`openclaw update` discovery so updates no longer fail with `not-openclaw-root` when service cwd points at an unrelated git repo. (#31382)
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.
 - Gateway/Control UI method guard: allow POST requests to non-UI routes to fall through when no base path is configured, and add POST regression coverage for fallthrough and base-path 405 behavior. (#23970) Thanks @tyler6204.

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -155,10 +156,11 @@ describe("runGatewayUpdate", () => {
 
   async function runWithCommand(
     runCommand: (argv: string[]) => Promise<CommandResult>,
-    options?: { channel?: "stable" | "beta"; tag?: string; cwd?: string },
+    options?: { channel?: "stable" | "beta"; tag?: string; cwd?: string; argv1?: string },
   ) {
     return runGatewayUpdate({
       cwd: options?.cwd ?? tempDir,
+      argv1: options?.argv1,
       runCommand: async (argv, _runOptions) => runCommand(argv),
       timeoutMs: 5000,
       ...(options?.channel ? { channel: options.channel } : {}),
@@ -168,7 +170,7 @@ describe("runGatewayUpdate", () => {
 
   async function runWithRunner(
     runner: (argv: string[]) => Promise<CommandResult>,
-    options?: { channel?: "stable" | "beta"; tag?: string; cwd?: string },
+    options?: { channel?: "stable" | "beta"; tag?: string; cwd?: string; argv1?: string },
   ) {
     return runWithCommand(runner, options);
   }
@@ -502,6 +504,73 @@ describe("runGatewayUpdate", () => {
       expect(result.after?.version).toBe("2.0.0");
       expect(calls.some((call) => call === "bun add -g openclaw@latest")).toBe(true);
     });
+  });
+
+  it("updates global npm installs even when argv1 is a symlinked global bin path", async () => {
+    const serviceDir = path.join(tempDir, "service-workspace");
+    await fs.mkdir(path.join(serviceDir, ".git"), { recursive: true });
+
+    const nodeModules = path.join(tempDir, "npm-global", "lib", "node_modules");
+    const pkgRoot = path.join(nodeModules, "openclaw");
+    const binPath = path.join(tempDir, "npm-global", "bin", "openclaw");
+    const realEntry = path.join(pkgRoot, "dist", "entry.js");
+
+    await seedGlobalPackageRoot(pkgRoot);
+    await fs.mkdir(path.dirname(realEntry), { recursive: true });
+    await fs.writeFile(realEntry, "export {};\n", "utf-8");
+
+    const installCommand = "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error";
+    const calls: string[] = [];
+    const runCommand = async (argv: string[]): Promise<CommandResult> => {
+      const key = argv.join(" ");
+      calls.push(key);
+      if (key === `git -C ${serviceDir} rev-parse --show-toplevel`) {
+        return { stdout: serviceDir, stderr: "", code: 0 };
+      }
+      if (key === `git -C ${path.dirname(binPath)} rev-parse --show-toplevel`) {
+        return { stdout: "", stderr: "not a git repository", code: 128 };
+      }
+      if (key === `git -C ${pkgRoot} rev-parse --show-toplevel`) {
+        return { stdout: "", stderr: "not a git repository", code: 128 };
+      }
+      if (key === "npm root -g") {
+        return { stdout: nodeModules, stderr: "", code: 0 };
+      }
+      if (key === "pnpm root -g") {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      if (key === installCommand) {
+        await fs.writeFile(
+          path.join(pkgRoot, "package.json"),
+          JSON.stringify({ name: "openclaw", version: "2.0.0" }),
+          "utf-8",
+        );
+        return { stdout: "ok", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const originalRealpathSync = fsSync.realpathSync.bind(fsSync);
+    const realpathSpy = vi.spyOn(fsSync, "realpathSync").mockImplementation((target) => {
+      if (String(target) === binPath) {
+        return realEntry;
+      }
+      return originalRealpathSync(target);
+    });
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(serviceDir);
+
+    try {
+      const result = await runWithCommand(runCommand, { cwd: serviceDir, argv1: binPath });
+
+      expect(result.status).toBe("ok");
+      expect(result.mode).toBe("npm");
+      expect(result.root).toBe(pkgRoot);
+      expect(result.reason).toBeUndefined();
+      expect(calls).toContain(installCommand);
+    } finally {
+      cwdSpy.mockRestore();
+      realpathSpy.mockRestore();
+    }
   });
 
   it("rejects git roots that are not a openclaw checkout", async () => {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -112,6 +113,48 @@ function resolveNodeModulesBinPackageRoot(argv1: string): string | null {
   return path.join(nodeModulesDir, binName);
 }
 
+function resolveNodeModulesPackageRootFromPath(filePath: string): string | null {
+  const normalized = path.resolve(filePath);
+  const marker = `${path.sep}node_modules${path.sep}${DEFAULT_PACKAGE_NAME}`;
+  const markerIndex = normalized.lastIndexOf(marker);
+  if (markerIndex < 0) {
+    return null;
+  }
+  const packageRootEnd = markerIndex + marker.length;
+  const nextChar = normalized.charAt(packageRootEnd);
+  if (nextChar && nextChar !== path.sep) {
+    return null;
+  }
+  return normalized.slice(0, packageRootEnd);
+}
+
+function resolveRealpathSync(filePath: string): string | null {
+  try {
+    return fsSync.realpathSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function appendArgv1Candidates(dirs: string[], argv1: string) {
+  const appendFromPath = (candidatePath: string) => {
+    dirs.push(path.dirname(candidatePath));
+    const packageRoot =
+      resolveNodeModulesBinPackageRoot(candidatePath) ??
+      resolveNodeModulesPackageRootFromPath(candidatePath);
+    if (packageRoot) {
+      dirs.push(packageRoot);
+    }
+  };
+
+  const normalized = path.resolve(argv1);
+  appendFromPath(normalized);
+  const realpath = resolveRealpathSync(normalized);
+  if (realpath && realpath !== normalized) {
+    appendFromPath(realpath);
+  }
+}
+
 function buildStartDirs(opts: UpdateRunnerOptions): string[] {
   const dirs: string[] = [];
   const cwd = normalizeDir(opts.cwd);
@@ -120,11 +163,7 @@ function buildStartDirs(opts: UpdateRunnerOptions): string[] {
   }
   const argv1 = normalizeDir(opts.argv1);
   if (argv1) {
-    dirs.push(path.dirname(argv1));
-    const packageRoot = resolveNodeModulesBinPackageRoot(argv1);
-    if (packageRoot) {
-      dirs.push(packageRoot);
-    }
+    appendArgv1Candidates(dirs, argv1);
   }
   const proc = normalizeDir(process.cwd());
   if (proc) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `update.run`/`openclaw update` can fail with `not-openclaw-root` when process cwd is an unrelated git repo and `argv1` points to a symlinked global `openclaw` bin path.
- Why it matters: npm global users can get update failures even though OpenClaw is correctly installed globally.
- What changed: update discovery now expands `argv1` candidates via `realpath`, and extracts package roots from `.../node_modules/openclaw/...` paths (including symlink targets).
- What did NOT change (scope boundary): no update command behavior changes for git checkouts; no service restart policy changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31382
- Related #31382

## User-visible / Behavior Changes

- Global package installs discovered via symlinked `openclaw` bin paths now update correctly instead of returning `not-openclaw-root`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + Vitest
- Model/provider: N/A
- Integration/channel (if any): gateway `update.run` / CLI update path
- Relevant config (redacted): N/A

### Steps

1. Simulate service cwd as unrelated git workspace.
2. Provide `argv1` as symlinked global bin path and resolve to real `.../node_modules/openclaw/dist/entry.js`.
3. Run `runGatewayUpdate` and verify global npm update is selected.

### Expected

- Update mode resolves to `npm` and proceeds with global install command.

### Actual

- Regression test now passes with status `ok`, mode `npm`, and package root set to the global install root.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```bash
pnpm test src/infra/update-runner.test.ts
pnpm exec oxfmt --check src/infra/update-runner.ts src/infra/update-runner.test.ts CHANGELOG.md
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added regression test for unrelated git cwd + symlinked global bin argv1; confirmed update path reaches npm global update flow.
- Edge cases checked: fallback still preserves existing `.bin` and direct `node_modules/openclaw` path detection.
- What you did **not** verify: no live systemd downtime/restart race mitigation in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/infra/update-runner.ts`, `src/infra/update-runner.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: update runner selecting wrong root when argv1 path is malformed.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: broader node_modules-path matching could mis-detect non-core packages.
  - Mitigation: matching is constrained to `node_modules/openclaw` with path-boundary checks.
