### PR TITLE
fix(ci): skip macOS TS tests for native-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,7 @@ jobs:
 
       # --- Run all checks sequentially (fast gates first) ---
       - name: TS tests (macOS)
+        if: needs.changed-scope.outputs.run_node == 'true'
         env:
           NODE_OPTIONS: --max-old-space-size=4096
         run: pnpm test


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the `macos` CI job always ran `pnpm test`, even for native-only (`apps/ios/*`, `apps/macos/*`, `apps/shared/*`) PRs where Node test coverage already runs on Linux lanes.
- Why it matters: iOS-only PRs were blocked by unrelated macOS Node test failures/timeouts before Swift checks even started.
- What changed: gated the `TS tests (macOS)` step behind `needs.changed-scope.outputs.run_node == 'true'`.
- What did NOT change (scope boundary): macOS Swift lint/build/test steps still run; Node tests still run for Node-relevant PRs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #31542
- Related #30885

## User-visible / Behavior Changes

- None (CI behavior only).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: N/A (workflow change)
- Runtime/container: GitHub Actions macOS lane
- Model/provider: N/A
- Integration/channel (if any): CI `changed-scope` + `macos` jobs
- Relevant config (redacted): N/A

### Steps

1. Open `.github/workflows/ci.yml` `macos` job.
2. Confirm `TS tests (macOS)` step now has `if: needs.changed-scope.outputs.run_node == 'true'`.
3. Verify no changes to Swift lint/build/test steps.

### Expected

- Native-only PRs skip macOS TS tests while still running Swift checks.

### Actual

- Workflow now conditionally runs macOS TS tests only when Node-relevant scope is detected.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Diff evidence:
- `.github/workflows/ci.yml`: added step-level `if` condition on `TS tests (macOS)`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed `changed-scope` outputs and confirmed `run_node` is the correct signal for Node-relevant changes.
- Edge cases checked: docs-only and non-native Node changes remain unaffected by this step-level gate.
- What you did **not** verify: did not execute a live GitHub Actions run in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or remove the step `if` condition.
- Files/config to restore: `.github/workflows/ci.yml`
- Known bad symptoms reviewers should watch for: macOS TS tests not running on Node-relevant PRs (guarded by `run_node` signal).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: incorrect scope detection could skip TS tests unexpectedly.
  - Mitigation: gate uses existing `run_node` signal already used by other Node jobs.
