### PR TITLE
feat(telegram): native sendMessageDraft streaming (Bot API 9.5)

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -159,6 +159,23 @@ export type TelegramAccountConfig = {
   /** Controls whether link previews are shown in outbound messages. Default: true. */
   linkPreview?: boolean;
   /**
+   * Enable native `sendMessageDraft` streaming (Bot API 9.3+).
+   *
+   * When `true`, OpenClaw uses `sendMessageDraft` for animated streaming
+   * previews instead of the legacy sendMessage + editMessageText loop.
+   * This produces smoother, animated "typing" without leaving "edited"
+   * markers or consuming extra message IDs.
+   *
+   * Since Bot API 9.5 (March 1, 2026), `sendMessageDraft` is available
+   * to **all bots** — the earlier forum-topic-mode restriction was lifted.
+   *
+   * On any API failure, the stream automatically falls back to the legacy
+   * edit-based path for that session.
+   *
+   * Default: `false` (safe default; existing edit-based preview preserved).
+   */
+  nativeDraftStreaming?: boolean;
+  /**
    * Per-channel outbound response prefix override.
    *
    * When set, this takes precedence over the global `messages.responsePrefix`.

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -228,6 +228,7 @@ export const TelegramAccountSchemaBase = z
     reactionLevel: z.enum(["off", "ack", "minimal", "extensive"]).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     linkPreview: z.boolean().optional(),
+    nativeDraftStreaming: z.boolean().optional(),
     responsePrefix: z.string().optional(),
     ackReaction: z.string().optional(),
   })

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -195,15 +195,15 @@ export const dispatchTelegramMessage = async ({
   const useNativeDraft = telegramCfg.nativeDraftStreaming === true;
 
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
-    // Derive a stable non-zero draft_id for this streaming session.
-    // Use chatId XOR msg.message_id (when available) so retried updates reuse
-    // the same draft slot.  Falls back to timestamp within int32 range.
+    // Derive a stable non-zero draft_id for this streaming session, unique per
+    // lane so that answer and reasoning drafts don't overwrite each other.
+    const laneOffset = laneName === "answer" ? 0 : laneName === "reasoning" ? 1 : 2;
     const nativeDraftId = useNativeDraft
       ? Math.max(
           1,
-          (typeof msg.message_id === "number"
-            ? (chatId ^ msg.message_id) >>> 0
-            : Date.now()) % 2147483647,
+          ((typeof msg.message_id === "number" ? (chatId ^ msg.message_id) >>> 0 : Date.now()) +
+            laneOffset) %
+            2147483647,
         )
       : undefined;
     const stream = enabled

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -189,7 +189,23 @@ export const dispatchTelegramMessage = async ({
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
+  // Use Bot API 9.3+ native sendMessageDraft when configured.
+  // Since Bot API 9.5 (March 2026), this is available for all bots.
+  // Falls back automatically on any API error.
+  const useNativeDraft = telegramCfg.nativeDraftStreaming === true;
+
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
+    // Derive a stable non-zero draft_id for this streaming session.
+    // Use chatId XOR msg.message_id (when available) so retried updates reuse
+    // the same draft slot.  Falls back to timestamp within int32 range.
+    const nativeDraftId = useNativeDraft
+      ? Math.max(
+          1,
+          (typeof msg.message_id === "number"
+            ? (chatId ^ msg.message_id) >>> 0
+            : Date.now()) % 2147483647,
+        )
+      : undefined;
     const stream = enabled
       ? createTelegramDraftStream({
           api: bot.api,
@@ -199,6 +215,8 @@ export const dispatchTelegramMessage = async ({
           replyToMessageId: draftReplyToMessageId,
           minInitialChars: draftMinInitialChars,
           renderText: renderDraftPreview,
+          useNativeDraft,
+          draftId: nativeDraftId,
           onSupersededPreview:
             laneName === "answer" || laneName === "reasoning"
               ? (preview) => {

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -441,9 +441,7 @@ describe("draft stream initial message debounce", () => {
       await stream.flush();
 
       expect(api.sendMessageDraft).toHaveBeenCalledTimes(1);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("telegram native draft failed"),
-      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("telegram native draft failed"));
       expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined);
     });
 
@@ -502,6 +500,36 @@ describe("draft stream initial message debounce", () => {
       await stream.flush();
 
       expect(api.sendMessageDraft).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes parse_mode when renderText returns HTML", async () => {
+      const api = createNativeDraftApi();
+      const stream = createNativeDraftStream(api, {
+        renderText: (text) => ({ text: `<b>${text}</b>`, parseMode: "HTML" }),
+      });
+
+      stream.update("Hello");
+      await stream.flush();
+
+      expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "<b>Hello</b>", {
+        parse_mode: "HTML",
+      });
+    });
+
+    it("passes both parse_mode and message_thread_id when both present", async () => {
+      const api = createNativeDraftApi();
+      const stream = createNativeDraftStream(api, {
+        thread: { id: 99, scope: "forum" },
+        renderText: (text) => ({ text: `<b>${text}</b>`, parseMode: "HTML" }),
+      });
+
+      stream.update("Hello");
+      await stream.flush();
+
+      expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "<b>Hello</b>", {
+        message_thread_id: 99,
+        parse_mode: "HTML",
+      });
     });
 
     it("clear() is a no-op in native draft mode (no message to delete)", async () => {

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -371,4 +371,148 @@ describe("draft stream initial message debounce", () => {
       expect(api.sendMessage).toHaveBeenCalledWith(123, "Hi", undefined);
     });
   });
+
+  describe("native sendMessageDraft streaming", () => {
+    function createNativeDraftApi() {
+      return {
+        sendMessage: vi.fn(async () => ({ message_id: 17 })),
+        editMessageText: vi.fn().mockResolvedValue(true),
+        deleteMessage: vi.fn().mockResolvedValue(true),
+        sendMessageDraft: vi.fn().mockResolvedValue(true),
+      };
+    }
+
+    function createNativeDraftStream(
+      api: ReturnType<typeof createNativeDraftApi>,
+      overrides: Partial<TelegramDraftStreamParams> = {},
+    ) {
+      return createTelegramDraftStream({
+        api: api as unknown as Bot["api"],
+        chatId: 123,
+        useNativeDraft: true,
+        draftId: 42,
+        ...overrides,
+      });
+    }
+
+    it("uses sendMessageDraft instead of sendMessage + editMessageText", async () => {
+      const api = createNativeDraftApi();
+      const stream = createNativeDraftStream(api);
+
+      stream.update("Hello");
+      await stream.flush();
+
+      expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", undefined);
+      expect(api.sendMessage).not.toHaveBeenCalled();
+      expect(api.editMessageText).not.toHaveBeenCalled();
+    });
+
+    it("passes message_thread_id when thread is specified", async () => {
+      const api = createNativeDraftApi();
+      const stream = createNativeDraftStream(api, {
+        thread: { id: 99, scope: "forum" },
+      });
+
+      stream.update("Hello");
+      await stream.flush();
+
+      expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", {
+        message_thread_id: 99,
+      });
+    });
+
+    it("returns undefined for messageId() in native draft mode", async () => {
+      const api = createNativeDraftApi();
+      const stream = createNativeDraftStream(api);
+
+      stream.update("Hello");
+      await stream.flush();
+
+      expect(stream.messageId()).toBeUndefined();
+    });
+
+    it("falls back to legacy edit mode on sendMessageDraft failure", async () => {
+      const api = createNativeDraftApi();
+      api.sendMessageDraft.mockRejectedValueOnce(new Error("Method not supported"));
+      const warnSpy = vi.fn();
+      const stream = createNativeDraftStream(api, { warn: warnSpy });
+
+      stream.update("Hello");
+      await stream.flush();
+
+      expect(api.sendMessageDraft).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("telegram native draft failed"),
+      );
+      expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined);
+    });
+
+    it("stays on legacy path after fallback (does not retry native)", async () => {
+      const api = createNativeDraftApi();
+      api.sendMessageDraft.mockRejectedValueOnce(new Error("Method not supported"));
+      const stream = createNativeDraftStream(api);
+
+      stream.update("Hello");
+      await stream.flush();
+      expect(api.sendMessage).toHaveBeenCalledTimes(1);
+
+      stream.update("Hello world");
+      await stream.flush();
+
+      expect(api.sendMessageDraft).toHaveBeenCalledTimes(1);
+      expect(api.editMessageText).toHaveBeenCalled();
+    });
+
+    it("regenerates draftId on forceNewMessage()", async () => {
+      const api = createNativeDraftApi();
+      const stream = createNativeDraftStream(api);
+
+      stream.update("Part 1");
+      await stream.flush();
+      const firstDraftId = api.sendMessageDraft.mock.calls[0][1];
+
+      stream.forceNewMessage();
+      stream.update("Part 2");
+      await stream.flush();
+      const secondDraftId = api.sendMessageDraft.mock.calls[1][1];
+
+      expect(secondDraftId).not.toBe(firstDraftId);
+    });
+
+    it("debounces first send with minInitialChars", async () => {
+      const api = createNativeDraftApi();
+      const stream = createNativeDraftStream(api, { minInitialChars: 10 });
+
+      stream.update("Hi");
+      await stream.flush();
+      expect(api.sendMessageDraft).not.toHaveBeenCalled();
+
+      stream.update("Hello world!");
+      await stream.flush();
+      expect(api.sendMessageDraft).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips duplicate text in native draft mode", async () => {
+      const api = createNativeDraftApi();
+      const stream = createNativeDraftStream(api);
+
+      stream.update("Hello");
+      await stream.flush();
+      stream.update("Hello");
+      await stream.flush();
+
+      expect(api.sendMessageDraft).toHaveBeenCalledTimes(1);
+    });
+
+    it("clear() is a no-op in native draft mode (no message to delete)", async () => {
+      const api = createNativeDraftApi();
+      const stream = createNativeDraftStream(api);
+
+      stream.update("Hello");
+      await stream.flush();
+      await stream.clear();
+
+      expect(api.deleteMessage).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -149,11 +149,18 @@ export function createTelegramDraftStream(params: {
     // --- Native draft path (Bot API 9.3+) ---
     if (useNativeDraft) {
       try {
+        const draftOptions: Record<string, unknown> = {};
+        if (messageThreadId != null) {
+          draftOptions.message_thread_id = messageThreadId;
+        }
+        if (renderedParseMode) {
+          draftOptions.parse_mode = renderedParseMode;
+        }
         await params.api.sendMessageDraft(
           chatId,
           draftId,
           renderedText,
-          messageThreadId != null ? { message_thread_id: messageThreadId } : undefined,
+          Object.keys(draftOptions).length > 0 ? draftOptions : undefined,
         );
         return true;
       } catch (err) {

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -34,6 +34,8 @@ export type TelegramDraftStream = {
   stop: () => Promise<void>;
   /** Reset internal state so the next update creates a new message instead of editing. */
   forceNewMessage: () => void;
+  /** True when using Bot API 9.3+ native sendMessageDraft (no preview message created). */
+  isNativeDraft: () => boolean;
 };
 
 type TelegramDraftPreview = {
@@ -81,7 +83,9 @@ export function createTelegramDraftStream(params: {
     params.maxChars ?? TELEGRAM_STREAM_MAX_CHARS,
     TELEGRAM_STREAM_MAX_CHARS,
   );
-  const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
+  const throttleMs = params.useNativeDraft
+    ? Math.max(100, params.throttleMs ?? 100) // native draft: 100ms floor (fast but safe)
+    : Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS); // legacy edit: 250ms floor
   const minInitialChars = params.minInitialChars;
   const chatId = params.chatId;
   const threadParams = buildTelegramThreadParams(params.thread);
@@ -263,5 +267,6 @@ export function createTelegramDraftStream(params: {
     clear,
     stop,
     forceNewMessage,
+    isNativeDraft: () => useNativeDraft,
   };
 }

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -5,6 +5,27 @@ import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helper
 const TELEGRAM_STREAM_MAX_CHARS = 4096;
 const DEFAULT_THROTTLE_MS = 1000;
 
+/**
+ * Two streaming modes are supported:
+ *
+ * 1. **Native draft mode** (`useNativeDraft: true`):
+ *    Uses Bot API 9.3's `sendMessageDraft` method to push animated streaming
+ *    previews to the client without sending/editing a real message.  Since
+ *    Bot API 9.5 (March 1, 2026), this is available to **all** bots — the
+ *    earlier forum-topic-mode restriction was lifted.  The method returns
+ *    `true` instead of a `Message`, so `messageId()` returns `undefined` in
+ *    this mode.  On any API failure the stream automatically falls back to
+ *    the legacy path.
+ *
+ * 2. **Legacy edit mode** (`useNativeDraft: false`, the default):
+ *    Sends an initial message via `sendMessage`, then repeatedly edits it via
+ *    `editMessageText` as new content arrives.  Compatible with all bots and
+ *    chat types, but produces visible "edited" markers and consumes message IDs.
+ *
+ * @see https://core.telegram.org/bots/api#sendmessagedraft
+ * @see https://core.telegram.org/bots/api-changelog#march-1-2026 (Bot API 9.5)
+ */
+
 export type TelegramDraftStream = {
   update: (text: string) => void;
   flush: () => Promise<void>;
@@ -41,6 +62,20 @@ export function createTelegramDraftStream(params: {
   onSupersededPreview?: (preview: SupersededTelegramPreview) => void;
   log?: (message: string) => void;
   warn?: (message: string) => void;
+  /**
+   * When true, use Bot API 9.3+ `sendMessageDraft` for animated streaming
+   * previews.  Available to all bots since Bot API 9.5.  Falls back to the
+   * legacy editMessageText path on any API failure.
+   * Default: false.
+   */
+  useNativeDraft?: boolean;
+  /**
+   * Stable non-zero draft identifier for this streaming session.
+   * The same `draft_id` animates updates to the same draft bubble.
+   * Must be a non-zero int32.  Regenerated on `forceNewMessage()` to start
+   * a fresh draft bubble.  Defaults to `Date.now() % 2147483647`.
+   */
+  draftId?: number;
 }): TelegramDraftStream {
   const maxChars = Math.min(
     params.maxChars ?? TELEGRAM_STREAM_MAX_CHARS,
@@ -54,6 +89,14 @@ export function createTelegramDraftStream(params: {
     params.replyToMessageId != null
       ? { ...threadParams, reply_to_message_id: params.replyToMessageId }
       : threadParams;
+
+  // Native draft state
+  let useNativeDraft = params.useNativeDraft === true;
+  let draftId =
+    params.draftId != null && params.draftId !== 0
+      ? params.draftId
+      : Math.max(1, Date.now() % 2147483647);
+  const messageThreadId = threadParams?.message_thread_id;
 
   const streamState = { stopped: false, final: false };
   let streamMessageId: number | undefined;
@@ -91,7 +134,10 @@ export function createTelegramDraftStream(params: {
     const sendGeneration = generation;
 
     // Debounce first preview send for better push notification quality.
-    if (typeof streamMessageId !== "number" && minInitialChars != null && !streamState.final) {
+    // In legacy mode, gate on streamMessageId not yet being set.
+    // In native draft mode, gate on lastSentText still being empty (first send).
+    const isFirstSend = useNativeDraft ? lastSentText === "" : typeof streamMessageId !== "number";
+    if (isFirstSend && minInitialChars != null && !streamState.final) {
       if (renderedText.length < minInitialChars) {
         return false;
       }
@@ -99,6 +145,28 @@ export function createTelegramDraftStream(params: {
 
     lastSentText = renderedText;
     lastSentParseMode = renderedParseMode;
+
+    // --- Native draft path (Bot API 9.3+) ---
+    if (useNativeDraft) {
+      try {
+        await params.api.sendMessageDraft(
+          chatId,
+          draftId,
+          renderedText,
+          messageThreadId != null ? { message_thread_id: messageThreadId } : undefined,
+        );
+        return true;
+      } catch (err) {
+        // Fall back to the legacy editMessageText path on any failure.
+        params.warn?.(
+          `telegram native draft failed, falling back to legacy edit: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        useNativeDraft = false;
+        // Fall through to the legacy path below.
+      }
+    }
+
+    // --- Legacy path: sendMessage + editMessageText ---
     try {
       if (typeof streamMessageId === "number") {
         if (renderedParseMode) {
@@ -168,11 +236,18 @@ export function createTelegramDraftStream(params: {
     streamMessageId = undefined;
     lastSentText = "";
     lastSentParseMode = undefined;
+    // Regenerate draftId so the next native draft update creates a fresh draft
+    // bubble instead of animating the previous one (fixes block-mode splitting).
+    if (useNativeDraft) {
+      draftId = Math.max(1, Date.now() % 2147483647);
+    }
     loop.resetPending();
     loop.resetThrottleWindow();
   };
 
-  params.log?.(`telegram stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs})`);
+  params.log?.(
+    `telegram stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs}, nativeDraft=${useNativeDraft})`,
+  );
 
   return {
     update,

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -344,6 +344,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       }
       await params.stopDraftLane(lane);
       const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
+      // Native draft: pause briefly after sending the permanent message so the
+      // Telegram client has time to render it before a new draft bubble arrives
+      // (prevents the next message's draft from visually overwriting this one).
+      if (isNativeDraftStream && delivered) {
+        await new Promise((resolve) => setTimeout(resolve, 300));
+      }
       return delivered ? "sent" : "skipped";
     }
 

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -299,7 +299,13 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           return archivedResult;
         }
       }
-      if (canEditViaPreview && !params.finalizedPreviewByLane[laneName]) {
+      // Native draft mode (Bot API 9.3+): drafts are ephemeral and never create a
+      // preview message, so skip the preview-edit finalization entirely.  Just stop
+      // the draft stream and fall through to sendPayload which sends the permanent
+      // message — the draft auto-clears when the real message arrives.
+      const isNativeDraftStream = lane.stream?.isNativeDraft() === true;
+
+      if (!isNativeDraftStream && canEditViaPreview && !params.finalizedPreviewByLane[laneName]) {
         await params.flushDraftLane(lane);
         if (laneName === "answer") {
           const archivedResultAfterFlush = await consumeArchivedAnswerPreviewForFinal({
@@ -326,7 +332,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           params.finalizedPreviewByLane[laneName] = true;
           return "preview-finalized";
         }
-      } else if (!hasMedia && !payload.isError && text.length > params.draftMaxChars) {
+      } else if (
+        !isNativeDraftStream &&
+        !hasMedia &&
+        !payload.isError &&
+        text.length > params.draftMaxChars
+      ) {
         params.log(
           `telegram: preview final too long for edit (${text.length} > ${params.draftMaxChars}); falling back to standard send`,
         );


### PR DESCRIPTION
## Summary

**Problem:** Telegram bot streaming uses `sendMessage` + repeated `editMessageText`, causing visible flickering. Bot API 9.3 introduced `sendMessageDraft` for smooth animated streaming, but the original PR (#19665 by @edonadei) was stale and missing tests.

**Why:** Bot API 9.5 (March 1, 2026) lifted the forum-topic restriction — `sendMessageDraft` is now available to ALL bots, not just those with topics enabled. This makes native draft streaming viable as a general-purpose streaming method.

**Changed:**
- Added `nativeDraftStreaming: boolean` config option (opt-in, default `false`)
- New `createTelegramDraftStream` native draft path using `sendMessageDraft` with auto-fallback to legacy `editMessageText` on any failure
- Fixed `draftId` reuse bug in `forceNewMessage()` (flagged in original PR review)
- Fixed finalization path: native drafts are ephemeral (no message ID), so skip preview-edit finalization and go straight to `sendPayload` for the permanent `sendMessage`
- Added `isNativeDraft()` to `TelegramDraftStream` for finalization detection
- 100ms throttle floor for native drafts (vs 250ms for legacy edit)
- `parse_mode` forwarded in native draft calls
- Unique `draftId` per streaming lane (answer vs reasoning)

**Not Changed:** Legacy `editMessageText` streaming path is completely untouched. Default behavior is unchanged (`nativeDraftStreaming: false`).

## Change Type
- [x] Feature (non-breaking)

## Scope
- [x] Telegram channel only

## Linked Issue
Supersedes #19665 (stale). References #15714. Related: #7803 (TEXTDRAFT_PEER_INVALID pre-9.5), #19001 (draft cleanup race).

## User-visible Changes
When `nativeDraftStreaming: true` is set in Telegram channel config:
- Streaming responses show smooth animated text (like ChatGPT) instead of flickery message edits
- Falls back to legacy edit-based streaming automatically if native draft fails
- No visible change when config is `false` (default)

## Security Impact
| Category | Impact |
|----------|--------|
| Auth/Permissions | No — uses existing bot token |
| Data exposure | No — same chat_id targeting |
| Config validation | Yes — new field validated by Zod schema |
| Rate limiting | Improved — native drafts use 100ms throttle vs 250ms |

## Repro + Verification

**Environment:** Telegram Bot API 9.5+, any bot token

**Steps:**
1. Set `nativeDraftStreaming: true` in `channels.telegram` config
2. Restart gateway
3. Send a message that triggers a multi-paragraph response
4. Observe streaming behavior in Telegram client

**Expected:** Text streams in smoothly with animated transitions (no message flickering)
**Actual:** ✅ Confirmed working — text streams smoothly, permanent message persists after streaming completes

## Evidence
- 28 tests passing (18 existing + 10 new)
- Live tested on Telegram with Claude Opus 4.6 responses
- `sendMessage ok` confirmed in gateway logs after streaming completes
- Finalization fix verified: message persists (previously disappeared)

## Human Verification
- [x] Tested locally with real Telegram bot
- [x] Verified streaming + finalization with extended thinking enabled
- [x] Verified fallback to legacy path works when native draft fails
- [x] Verified config hot-reload picks up `nativeDraftStreaming` changes

## Compatibility / Migration
- **Backward compatible:** Default is `false`, no behavior change for existing users
- **Zod schema:** `nativeDraftStreaming` added as `z.boolean().optional()` — no migration needed
- **Fallback:** Per-session sticky fallback to legacy edit if native draft fails

## Failure Recovery
- If `sendMessageDraft` returns an error, falls back to legacy `editMessageText` for the rest of that stream session
- If finalization `sendMessage` fails, standard OpenClaw error handling applies
- Config can be toggled back to `false` at any time via hot-reload

## Risks and Mitigations
| Risk | Mitigation |
|------|-----------|
| Telegram rate-limits on draft calls | 100ms throttle floor (~10 updates/sec) |
| Draft disappears before sendMessage | Fixed: skip preview-edit path, go straight to sendPayload |
| Bot API regression on sendMessageDraft | Auto-fallback to legacy edit on any error |
| Config stripped by Zod .strict() | Fixed: added to zod-schema.providers-core.ts |