### PR TITLE
fix(cli): expose tool deny and sandbox status in agents list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
+- CLI/Agents list capability audit: include per-agent `toolDeny`, `execBlocked`, and sandbox mode/scope in `openclaw agents list` text and `--json` output so operators can quickly verify exec/sandbox posture. (#31510)
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.
 - Gateway/Control UI method guard: allow POST requests to non-UI routes to fall through when no base path is configured, and add POST regression coverage for fallthrough and base-path 405 behavior. (#23970) Thanks @tyler6204.

--- a/src/commands/agents.commands.list.test.ts
+++ b/src/commands/agents.commands.list.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+
+vi.mock("./agents.command-shared.js", () => ({
+  requireValidConfig: vi.fn(),
+}));
+
+vi.mock("./agents.providers.js", () => ({
+  buildProviderStatusIndex: vi.fn(async () => new Map()),
+  listProvidersForAgent: vi.fn(() => []),
+  summarizeBindings: vi.fn(() => []),
+}));
+
+import { requireValidConfig } from "./agents.command-shared.js";
+import { agentsListCommand } from "./agents.commands.list.js";
+
+function createRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+  } as unknown as RuntimeEnv;
+}
+
+describe("agentsListCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("includes execBlocked/toolDeny/sandbox fields in --json output", async () => {
+    vi.mocked(requireValidConfig).mockResolvedValue({
+      agents: {
+        defaults: {
+          model: "anthropic/claude-sonnet-4-6",
+          sandbox: { mode: "off" },
+        },
+        list: [
+          {
+            id: "ada",
+            name: "Ada",
+            model: "openai-codex/gpt-5.3-codex",
+            sandbox: { mode: "off" },
+            tools: {
+              sandbox: {
+                tools: {
+                  deny: ["group:runtime"],
+                },
+              },
+            },
+          },
+        ],
+      },
+    } as never);
+    const runtime = createRuntime();
+
+    await agentsListCommand({ json: true }, runtime);
+
+    expect(runtime.log).toHaveBeenCalledTimes(1);
+    const firstLogArg = vi.mocked(runtime.log).mock.calls[0]?.[0];
+    expect(typeof firstLogArg).toBe("string");
+    const payload = JSON.parse((firstLogArg as string | undefined) ?? "[]") as Array<
+      Record<string, unknown>
+    >;
+    expect(payload).toHaveLength(1);
+    expect(payload[0]).toMatchObject({
+      id: "ada",
+      toolDeny: ["group:runtime"],
+      execBlocked: true,
+      sandbox: {
+        mode: "off",
+        scope: "agent",
+      },
+    });
+  });
+
+  it("renders tool and sandbox status in text output", async () => {
+    vi.mocked(requireValidConfig).mockResolvedValue({
+      agents: {
+        defaults: {
+          model: "anthropic/claude-sonnet-4-6",
+          sandbox: { mode: "off" },
+        },
+        list: [
+          {
+            id: "ada",
+            name: "Ada",
+            model: "openai-codex/gpt-5.3-codex",
+            sandbox: { mode: "off" },
+            tools: {
+              sandbox: {
+                tools: {
+                  deny: ["group:runtime"],
+                },
+              },
+            },
+          },
+        ],
+      },
+    } as never);
+    const runtime = createRuntime();
+
+    await agentsListCommand({}, runtime);
+
+    const firstLogArg = vi.mocked(runtime.log).mock.calls[0]?.[0];
+    expect(typeof firstLogArg).toBe("string");
+    const output = (firstLogArg as string | undefined) ?? "";
+    expect(output).toContain("Tools: exec blocked (group:runtime denied)");
+    expect(output).toContain("Sandbox: off (scope: agent)");
+  });
+});

--- a/src/commands/agents.commands.list.ts
+++ b/src/commands/agents.commands.list.ts
@@ -1,4 +1,8 @@
+import { resolveAgentConfig } from "../agents/agent-scope.js";
+import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
+import { isToolAllowed } from "../agents/sandbox/tool-policy.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
 import type { AgentBinding } from "../config/types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -18,6 +22,25 @@ type AgentsListOptions = {
   json?: boolean;
   bindings?: boolean;
 };
+
+function normalizeToolDenyEntries(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function resolveConfiguredToolDeny(cfg: OpenClawConfig, agentId: string): string[] {
+  const agentConfig = resolveAgentConfig(cfg, agentId);
+  const agentDeny = normalizeToolDenyEntries(agentConfig?.tools?.sandbox?.tools?.deny);
+  if (agentDeny.length > 0) {
+    return agentDeny;
+  }
+  return normalizeToolDenyEntries(cfg.tools?.sandbox?.tools?.deny);
+}
 
 function formatSummary(summary: AgentSummary) {
   const defaultTag = summary.isDefault ? " (default)" : "";
@@ -49,6 +72,15 @@ function formatSummary(summary: AgentSummary) {
   lines.push(`  Agent dir: ${shortenHomePath(summary.agentDir)}`);
   if (summary.model) {
     lines.push(`  Model: ${summary.model}`);
+  }
+  const execStatus = summary.execBlocked ? "exec blocked" : "exec allowed";
+  if (summary.execBlocked && summary.toolDeny && summary.toolDeny.length > 0) {
+    lines.push(`  Tools: ${execStatus} (${summary.toolDeny.join(", ")} denied)`);
+  } else {
+    lines.push(`  Tools: ${execStatus}`);
+  }
+  if (summary.sandbox) {
+    lines.push(`  Sandbox: ${summary.sandbox.mode} (scope: ${summary.sandbox.scope})`);
   }
   lines.push(`  Routing rules: ${summary.bindings}`);
 
@@ -118,6 +150,14 @@ export async function agentsListCommand(
     if (providerLines.length > 0) {
       summary.providers = providerLines;
     }
+
+    const sandbox = resolveSandboxConfigForAgent(cfg, summary.id);
+    summary.toolDeny = resolveConfiguredToolDeny(cfg, summary.id);
+    summary.execBlocked = !isToolAllowed(sandbox.tools, "exec");
+    summary.sandbox = {
+      mode: sandbox.mode,
+      scope: sandbox.scope,
+    };
   }
 
   if (opts.json) {

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -10,6 +10,7 @@ import {
   loadAgentIdentityFromWorkspace,
   parseIdentityMarkdown as parseIdentityMarkdownFile,
 } from "../agents/identity-file.js";
+import type { SandboxConfig } from "../agents/sandbox/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 
@@ -26,6 +27,9 @@ export type AgentSummary = {
   bindingDetails?: string[];
   routes?: string[];
   providers?: string[];
+  toolDeny?: string[];
+  execBlocked?: boolean;
+  sandbox?: Pick<SandboxConfig, "mode" | "scope">;
   isDefault: boolean;
 };
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw agents list` and `openclaw agents list --json` did not expose per-agent exec/tool deny posture or sandbox mode.
- Why it matters: operators could not quickly audit whether an agent can run `exec` without manually parsing config.
- What changed: added `toolDeny`, `execBlocked`, and `sandbox` (`mode` + `scope`) to agent summaries; surfaced corresponding text lines in non-JSON output.
- What did NOT change (scope boundary): no runtime policy enforcement changes; only summary/reporting output changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31510
- Related #31510

## User-visible / Behavior Changes

- `openclaw agents list` now prints:
  - `Tools: exec allowed|blocked ...`
  - `Sandbox: <mode> (scope: <scope>)`
- `openclaw agents list --json` now includes:
  - `toolDeny: string[]`
  - `execBlocked: boolean`
  - `sandbox: { mode, scope }`

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + Vitest
- Model/provider: N/A
- Integration/channel (if any): CLI
- Relevant config (redacted): agent-level `tools.sandbox.tools.deny=["group:runtime"]`

### Steps

1. Configure an agent with sandbox tool deny including `group:runtime`.
2. Run `openclaw agents list --json` and inspect fields.
3. Run `openclaw agents list` and inspect text summary lines.

### Expected

- JSON includes tool deny/exec blocked/sandbox fields.
- Text output includes tool + sandbox status lines.

### Actual

- Both outputs now include these status fields/lines.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```bash
pnpm test src/commands/agents.commands.list.test.ts
pnpm exec oxfmt --check src/commands/agents.commands.list.ts src/commands/agents.config.ts src/commands/agents.commands.list.test.ts CHANGELOG.md
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: JSON output contains `toolDeny`, `execBlocked`, and sandbox mode/scope; text output renders `Tools` and `Sandbox` lines.
- Edge cases checked: tool deny source precedence favors agent-level config, then global config.
- What you did **not** verify: no live multi-agent production config check in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/commands/agents.commands.list.ts`, `src/commands/agents.config.ts`, `src/commands/agents.commands.list.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: downstream scripts relying on previous JSON shape without ignoring unknown fields.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: consumers parsing strict JSON schemas may need to tolerate new fields.
  - Mitigation: additive-only fields; existing keys and semantics unchanged.
