### PR TITLE
fix(discord): honor agent-scoped media roots in monitor replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/Agent-scoped media roots: pass `mediaLocalRoots` through Discord monitor reply delivery (message and component interaction paths) so local media attachments honor per-agent workspace roots instead of falling back to default global roots. (#31633)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -34,6 +34,7 @@ import type { DiscordAccountConfig } from "../../config/types.discord.js";
 import { logVerbose } from "../../globals.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { logDebug, logError } from "../../logger.js";
+import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { buildPairingReply } from "../../pairing/pairing-messages.js";
 import { upsertChannelPairingRequest } from "../../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
@@ -953,6 +954,7 @@ async function dispatchDiscordComponentEvent(params: {
     fallbackLimit: 2000,
   });
   const token = ctx.token ?? "";
+  const mediaLocalRoots = getAgentScopedMediaLocalRoots(ctx.cfg, agentId);
   const replyToMode =
     ctx.discordConfig?.replyToMode ?? ctx.cfg.channels?.discord?.replyToMode ?? "off";
   const replyReference = createReplyReferencePlanner({
@@ -982,6 +984,7 @@ async function dispatchDiscordComponentEvent(params: {
           maxLinesPerMessage: ctx.discordConfig?.maxLinesPerMessage,
           tableMode,
           chunkMode: resolveChunkMode(ctx.cfg, "discord", accountId),
+          mediaLocalRoots,
         });
         replyReference.markSent();
       },

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -27,6 +27,7 @@ import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../globals.js";
 import { convertMarkdownTables } from "../../markdown/tables.js";
+import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { buildAgentSessionKey } from "../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../routing/session-key.js";
 import { buildUntrustedChannelMetadata } from "../../security/channel-metadata.js";
@@ -126,6 +127,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     accountId,
   });
   const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
+  const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const shouldAckReaction = () =>
     Boolean(
       ackReaction &&
@@ -665,6 +667,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         chunkMode,
         sessionKey: ctxPayload.SessionKey,
         threadBindings,
+        mediaLocalRoots,
       });
       replyReference.markSent();
     },

--- a/src/discord/monitor/reply-delivery.test.ts
+++ b/src/discord/monitor/reply-delivery.test.ts
@@ -126,6 +126,45 @@ describe("deliverDiscordReply", () => {
     expect(sendMessageDiscordMock).not.toHaveBeenCalled();
   });
 
+  it("passes mediaLocalRoots through media sends", async () => {
+    const mediaLocalRoots = ["/tmp/workspace-agent"] as const;
+    await deliverDiscordReply({
+      replies: [
+        {
+          text: "Media reply",
+          mediaUrls: ["https://example.com/first.png", "https://example.com/second.png"],
+        },
+      ],
+      target: "channel:654",
+      token: "token",
+      runtime,
+      textLimit: 2000,
+      mediaLocalRoots,
+    });
+
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageDiscordMock).toHaveBeenNthCalledWith(
+      1,
+      "channel:654",
+      "Media reply",
+      expect.objectContaining({
+        token: "token",
+        mediaUrl: "https://example.com/first.png",
+        mediaLocalRoots,
+      }),
+    );
+    expect(sendMessageDiscordMock).toHaveBeenNthCalledWith(
+      2,
+      "channel:654",
+      "",
+      expect.objectContaining({
+        token: "token",
+        mediaUrl: "https://example.com/second.png",
+        mediaLocalRoots,
+      }),
+    );
+  });
+
   it("uses replyToId only for the first chunk when replyToMode is first", async () => {
     await deliverDiscordReply({
       replies: [

--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -118,6 +118,7 @@ async function sendAdditionalDiscordMedia(params: {
   token: string;
   rest?: RequestClient;
   accountId?: string;
+  mediaLocalRoots?: readonly string[];
   mediaUrls: string[];
   resolveReplyTo: () => string | undefined;
 }) {
@@ -128,6 +129,7 @@ async function sendAdditionalDiscordMedia(params: {
       rest: params.rest,
       mediaUrl,
       accountId: params.accountId,
+      mediaLocalRoots: params.mediaLocalRoots,
       replyTo,
     });
   }
@@ -148,6 +150,7 @@ export async function deliverDiscordReply(params: {
   chunkMode?: ChunkMode;
   sessionKey?: string;
   threadBindings?: DiscordThreadBindingLookup;
+  mediaLocalRoots?: readonly string[];
 }) {
   const chunkLimit = Math.min(params.textLimit, 2000);
   const replyTo = params.replyToId?.trim() || undefined;
@@ -247,6 +250,7 @@ export async function deliverDiscordReply(params: {
         token: params.token,
         rest: params.rest,
         accountId: params.accountId,
+        mediaLocalRoots: params.mediaLocalRoots,
         mediaUrls: mediaList.slice(1),
         resolveReplyTo,
       });
@@ -259,6 +263,7 @@ export async function deliverDiscordReply(params: {
       rest: params.rest,
       mediaUrl: firstMedia,
       accountId: params.accountId,
+      mediaLocalRoots: params.mediaLocalRoots,
       replyTo,
     });
     deliveredAny = true;
@@ -267,6 +272,7 @@ export async function deliverDiscordReply(params: {
       token: params.token,
       rest: params.rest,
       accountId: params.accountId,
+      mediaLocalRoots: params.mediaLocalRoots,
       mediaUrls: mediaList.slice(1),
       resolveReplyTo,
     });


### PR DESCRIPTION
## Summary

- Problem: Discord monitor reply delivery did not pass `mediaLocalRoots` into `sendMessageDiscord` for media payloads, so local attachments could fall back to default global roots.
- Why it matters: agents with custom workspace roots (for example `workspace-<agent>`) could hit `LocalMediaAccessError` for valid local files.
- What changed: threaded `mediaLocalRoots` through Discord monitor reply delivery (`message-handler.process` and `agent-components`) into media sends (primary + additional attachments).
- What did NOT change (scope boundary): no changes to Discord token/account resolution, webhook routing, or non-media text delivery behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31633
- Related #27884

## User-visible / Behavior Changes

- Discord replies with local media attachments now honor agent-scoped local media roots in monitor reply paths, avoiding false `LocalMediaAccessError` when files are inside the active agent workspace.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): agent with custom workspace root

### Steps

1. Route Discord monitor replies through an agent with non-default workspace root.
2. Return a reply payload with local media attachment(s).
3. Verify outbound send path receives `mediaLocalRoots` and succeeds instead of using global fallback roots.

### Expected

- Media send uses agent-scoped roots for local path allowance checks.

### Actual

- Verified by tests and call-path assertions; media options now include `mediaLocalRoots`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/discord/monitor/reply-delivery.test.ts src/discord/monitor/message-handler.process.test.ts src/discord/monitor/agent-components.wildcard.test.ts`
  - New regression assertion verifies `mediaLocalRoots` is passed on first and additional media sends.
- Edge cases checked:
  - Existing reply chunk/replyTo and webhook fallback paths stay unchanged.
- What you did **not** verify:
  - Live Discord end-to-end send against external Discord API in this run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `da78d3794`.
- Files/config to restore:
  - `src/discord/monitor/reply-delivery.ts`
  - `src/discord/monitor/message-handler.process.ts`
  - `src/discord/monitor/agent-components.ts`
- Known bad symptoms reviewers should watch for:
  - Missing `mediaLocalRoots` in `sendMessageDiscord` options for monitor reply media payloads.

## Risks and Mitigations

- Risk: unintended option propagation affecting non-media sends.
  - Mitigation: changes are scoped to media send call sites; existing text-only behavior/tests unchanged.
