### PR TITLE
docs(macOS): clarify kickstart vs bootstrap launchctl flows

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -201,6 +201,38 @@ If you’re supervised:
 - Windows (WSL2): `systemctl --user restart openclaw-gateway[-<profile>].service`
   - `launchctl`/`systemctl` only work if the service is installed; otherwise run `openclaw gateway install`.
 
+### macOS launchd restart modes
+
+Use the service **label** with `kickstart`, and the LaunchAgent **plist path** with `bootstrap`.
+
+When to use each:
+
+- `launchctl kickstart -k gui/$UID/<label>`:
+  - the job is already loaded (`launchctl print gui/$UID/<label>` succeeds)
+  - you want a quick restart without reloading plist metadata
+- `launchctl bootout ...` + `launchctl bootstrap ...`:
+  - the job is not loaded yet (common with manual-start `.nop` profiles)
+  - plist content changed (env, args, ports, paths)
+  - you want a full reload after upgrades or launchd state drift
+
+Examples:
+
+```bash
+# Quick restart of a loaded job by label.
+launchctl kickstart -k gui/$UID/ai.openclaw.gateway
+
+# Full reload: unload by label, then load by plist path.
+launchctl bootout gui/$UID/ai.openclaw.gateway
+launchctl bootstrap gui/$UID ~/Library/LaunchAgents/ai.openclaw.gateway.plist
+```
+
+For manual-start profiles, replace the label/path with the `.nop` variant:
+
+```bash
+launchctl bootout gui/$UID/ai.openclaw.gateway.nop
+launchctl bootstrap gui/$UID ~/Library/LaunchAgents/ai.openclaw.gateway.nop.plist
+```
+
 Runbook + exact service labels: [Gateway runbook](/gateway)
 
 ## Rollback / pinning (when something breaks)

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -44,6 +44,17 @@ launchctl bootout gui/$UID/ai.openclaw.gateway
 
 Replace the label with `ai.openclaw.<profile>` when running a named profile.
 
+`kickstart -k` restarts an already loaded job by label.
+If the job is unloaded, or after plist edits, run `bootout` + `bootstrap`:
+
+```bash
+launchctl bootout gui/$UID/ai.openclaw.gateway
+launchctl bootstrap gui/$UID ~/Library/LaunchAgents/ai.openclaw.gateway.plist
+```
+
+For manual-start profiles, use `ai.openclaw.gateway.nop` and
+`~/Library/LaunchAgents/ai.openclaw.gateway.nop.plist`.
+
 If the LaunchAgent isn’t installed, enable it from the app or run
 `openclaw gateway install`.
 


### PR DESCRIPTION
## Summary

- Problem: update/restart docs implied `launchctl kickstart -k` as a universal restart path, which is confusing for unloaded jobs and `.nop` setups.
- Why it matters: operators can think restart failed when launchd actually needs a `bootout + bootstrap` reload cycle.
- What changed: added explicit restart-mode guidance in Updating + macOS platform docs, including label vs plist-path terminology and concrete `.nop` examples.
- What did NOT change (scope boundary): no CLI/runtime behavior changes; docs-only update.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31623
- Related #29078

## User-visible / Behavior Changes

- Docs now clearly explain when to use `launchctl kickstart -k` vs `launchctl bootout` + `launchctl bootstrap`, including manual-start `.nop` cases.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: docs-only
- Model/provider: N/A
- Integration/channel (if any): launchd operations
- Relevant config (redacted): N/A

### Steps

1. Read restart section in `docs/install/updating.md`.
2. Verify quick-restart and full-reload paths are explicitly separated.
3. Verify `.nop` label/plist examples are included.

### Expected

- Clear guidance for loaded-job restart vs unloaded/plist-change reload.

### Actual

- Added explicit sections and runnable command examples in both docs pages.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Reviewed both docs pages after edit for clarity and consistency.
  - Ran `pnpm exec oxfmt --check docs/install/updating.md docs/platforms/macos.md`.
- Edge cases checked:
  - `.nop` manual-start variant commands and label/path wording.
- What you did **not** verify:
  - Runtime behavior of launchd commands (docs-only change).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `b1d6a595e`.
- Files/config to restore:
  - `docs/install/updating.md`
  - `docs/platforms/macos.md`
- Known bad symptoms reviewers should watch for:
  - Conflicting label vs plist path instructions.

## Risks and Mitigations

- Risk: docs drift with future launchd behavior changes.
  - Mitigation: examples are framed as mode-based guidance and point to the gateway runbook.
