### PR TITLE
fix(feishu): tolerate missing webhook defaults in older plugin-sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Feishu/Duplicate replies: suppress same-target reply dispatch when message-tool sends use generic provider metadata (`provider: "message"`) and normalize `lark`/`feishu` provider aliases during duplicate-target checks, preventing double-delivery in Feishu sessions. (#31526)
+- Feishu/Plugin sdk compatibility: add safe webhook default fallbacks when loading Feishu monitor state so mixed-version installs no longer crash if older `openclaw/plugin-sdk` builds omit webhook default constants. (#31606)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/extensions/feishu/src/monitor.state.defaults.test.ts
+++ b/extensions/feishu/src/monitor.state.defaults.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveFeishuWebhookAnomalyDefaultsForTest,
+  resolveFeishuWebhookRateLimitDefaultsForTest,
+} from "./monitor.state.js";
+
+describe("feishu monitor state defaults", () => {
+  it("falls back to hard defaults when sdk defaults are missing", () => {
+    expect(resolveFeishuWebhookRateLimitDefaultsForTest(undefined)).toEqual({
+      windowMs: 60_000,
+      maxRequests: 120,
+      maxTrackedKeys: 4_096,
+    });
+    expect(resolveFeishuWebhookAnomalyDefaultsForTest(undefined)).toEqual({
+      maxTrackedKeys: 4_096,
+      ttlMs: 21_600_000,
+      logEvery: 25,
+    });
+  });
+
+  it("keeps valid sdk values and repairs invalid fields", () => {
+    expect(
+      resolveFeishuWebhookRateLimitDefaultsForTest({
+        windowMs: 45_000,
+        maxRequests: 0,
+        maxTrackedKeys: -1,
+      }),
+    ).toEqual({
+      windowMs: 45_000,
+      maxRequests: 120,
+      maxTrackedKeys: 4_096,
+    });
+
+    expect(
+      resolveFeishuWebhookAnomalyDefaultsForTest({
+        maxTrackedKeys: 2048,
+        ttlMs: Number.NaN,
+        logEvery: 10,
+      }),
+    ).toEqual({
+      maxTrackedKeys: 2048,
+      ttlMs: 21_600_000,
+      logEvery: 10,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: Feishu plugin monitor state read `WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs` and `WEBHOOK_ANOMALY_COUNTER_DEFAULTS.*` at module load, which can be `undefined` in mixed-version installs.
- Why it matters: Feishu plugin can fail to load during onboarding/runtime with `TypeError: Cannot read properties of undefined (reading 'windowMs')`.
- What changed: added safe default resolvers for webhook rate-limit/anomaly defaults and used them when initializing Feishu monitor state.
- What did NOT change (scope boundary): no behavior change for current SDK exports; only fallback behavior for missing/invalid defaults.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31606
- Related #26050

## User-visible / Behavior Changes

- Feishu plugin now starts cleanly in mixed-version setups where `openclaw/plugin-sdk` does not expose webhook default constants.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): Feishu plugin
- Relevant config (redacted): Feishu webhook mode

### Steps

1. Load Feishu monitor state with missing webhook-default constants from plugin-sdk.
2. Initialize rate limiter / anomaly tracker.
3. Verify plugin initialization succeeds with safe fallback defaults.

### Expected

- No module-load crash when defaults are missing; fallback values are applied.

### Actual

- Added deterministic fallback resolution and regression tests for missing/invalid defaults.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/feishu/src/monitor.state.defaults.test.ts`
  - `pnpm exec oxfmt --check extensions/feishu/src/monitor.state.ts extensions/feishu/src/monitor.state.defaults.test.ts CHANGELOG.md`
- Edge cases checked:
  - missing defaults
  - partially invalid defaults (zero/negative/NaN)
- What you did **not** verify:
  - full live Feishu end-to-end webhook flow in this run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `985cb5446`.
- Files/config to restore:
  - `extensions/feishu/src/monitor.state.ts`
  - `extensions/feishu/src/monitor.state.defaults.test.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected fallback behavior when SDK defaults are present and valid.

## Risks and Mitigations

- Risk: fallback normalization may hide malformed values.
  - Mitigation: fallback only applies to missing/invalid numeric fields and keeps valid provided values unchanged.
