### PR TITLE
fix(ui): keep cron New Job panel in normal scroll flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Web UI/Cron layout: make the New Job panel scroll with the page (remove sticky + inner scroll behavior) so it no longer overlaps the jobs list while scrolling. (#31412)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -606,10 +606,9 @@
 }
 
 .cron-workspace-form {
-  position: sticky;
-  top: 74px;
-  max-height: calc(100vh - 74px - 32px);
-  overflow-y: auto;
+  position: static;
+  max-height: none;
+  overflow: visible;
 }
 
 .cron-form {


### PR DESCRIPTION
## Summary

- Problem: Cron tab New Job panel used desktop `position: sticky` with its own `overflow-y: auto`, causing overlap and split scrolling behavior.
- Why it matters: users scrolling the jobs list see the form pinned against viewport edges and overlapping nearby content.
- What changed: removed sticky/inner-scroll behavior from `.cron-workspace-form` so it stays in normal page flow.
- What did NOT change (scope boundary): no cron data logic, filtering, or job CRUD behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31412
- Related #29315

## User-visible / Behavior Changes

- In Cron tab, New Job section now scrolls with the page and no longer has an independent inner scrollbar on desktop.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local UI assets
- Model/provider: N/A
- Integration/channel (if any): Control UI
- Relevant config (redacted): N/A

### Steps

1. Open Control UI Cron tab on desktop width.
2. Scroll the page with jobs list and New Job panel visible.
3. Observe layout/scroll behavior of New Job panel.

### Expected

- New Job panel remains in normal document flow and does not overlay neighboring content.

### Actual

- Updated CSS removes sticky and inner-scroll behavior.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - CSS check: `pnpm exec oxfmt --check ui/src/styles/components.css CHANGELOG.md`
  - Selector references confirmed (`.cron-workspace-form` desktop + responsive blocks).
- Edge cases checked:
  - Mobile override block remains intact.
- What you did **not** verify:
  - Full browser screenshot diff in this run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `c6c0ce839`.
- Files/config to restore:
  - `ui/src/styles/components.css`
- Known bad symptoms reviewers should watch for:
  - Reappearance of sticky/right-panel overlap during Cron page scrolling.

## Risks and Mitigations

- Risk: reduced persistent visibility of New Job form while scrolling long job lists.
  - Mitigation: resolves overlap and dual-scroll UX regression reported by users.
