### PR TITLE
fix(cli): prefer .nop launchd plist in start hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/macOS launchd hints: prefer `ai.openclaw.gateway.nop.plist` in bootstrap guidance when present, with fallback to the default plist name so manual-start launch-agent setups get the correct command. (#31622)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/cli/daemon-cli/shared.test.ts
+++ b/src/cli/daemon-cli/shared.test.ts
@@ -1,6 +1,22 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { theme } from "../../terminal/theme.js";
-import { resolveRuntimeStatusColor } from "./shared.js";
+import { renderGatewayServiceStartHints, resolveRuntimeStatusColor } from "./shared.js";
+
+async function withPlatform<T>(platform: NodeJS.Platform, run: () => Promise<T> | T): Promise<T> {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  if (!originalPlatform) {
+    throw new Error("missing process.platform descriptor");
+  }
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  try {
+    return await run();
+  } finally {
+    Object.defineProperty(process, "platform", originalPlatform);
+  }
+}
 
 describe("resolveRuntimeStatusColor", () => {
   it("maps known runtime states to expected theme colors", () => {
@@ -12,5 +28,44 @@ describe("resolveRuntimeStatusColor", () => {
   it("falls back to warning color for unexpected states", () => {
     expect(resolveRuntimeStatusColor("degraded")).toBe(theme.warn);
     expect(resolveRuntimeStatusColor(undefined)).toBe(theme.muted);
+  });
+});
+
+describe("renderGatewayServiceStartHints", () => {
+  it("prefers .nop launch agent plist when both .nop and default files exist", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-launchd-hints-"));
+    const launchAgentsDir = path.join(home, "Library", "LaunchAgents");
+    try {
+      await fs.mkdir(launchAgentsDir, { recursive: true });
+      await fs.writeFile(path.join(launchAgentsDir, "ai.openclaw.gateway.plist"), "");
+      await fs.writeFile(path.join(launchAgentsDir, "ai.openclaw.gateway.nop.plist"), "");
+
+      await withPlatform("darwin", async () => {
+        const hints = renderGatewayServiceStartHints({ HOME: home });
+        expect(hints.at(-1)).toBe(
+          "launchctl bootstrap gui/$UID ~/Library/LaunchAgents/ai.openclaw.gateway.nop.plist",
+        );
+      });
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to default launch agent plist when .nop variant is missing", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-launchd-hints-"));
+    const launchAgentsDir = path.join(home, "Library", "LaunchAgents");
+    try {
+      await fs.mkdir(launchAgentsDir, { recursive: true });
+      await fs.writeFile(path.join(launchAgentsDir, "ai.openclaw.gateway.plist"), "");
+
+      await withPlatform("darwin", async () => {
+        const hints = renderGatewayServiceStartHints({ HOME: home });
+        expect(hints.at(-1)).toBe(
+          "launchctl bootstrap gui/$UID ~/Library/LaunchAgents/ai.openclaw.gateway.plist",
+        );
+      });
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import {
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
@@ -167,8 +169,18 @@ export function renderGatewayServiceStartHints(env: NodeJS.ProcessEnv = process.
   const profile = env.OPENCLAW_PROFILE;
   switch (process.platform) {
     case "darwin": {
-      const label = resolveGatewayLaunchAgentLabel(profile);
-      return [...base, `launchctl bootstrap gui/$UID ~/Library/LaunchAgents/${label}.plist`];
+      const launchdLabel =
+        env.OPENCLAW_LAUNCHD_LABEL?.trim() || resolveGatewayLaunchAgentLabel(profile);
+      const home = env.HOME?.trim() || env.USERPROFILE?.trim() || "";
+      const launchAgentsDir = home ? path.join(home, "Library", "LaunchAgents") : "";
+      const plistCandidates = launchdLabel.endsWith(".nop")
+        ? [`${launchdLabel}.plist`]
+        : [`${launchdLabel}.nop.plist`, `${launchdLabel}.plist`];
+      const plistName =
+        plistCandidates.find((candidate) => {
+          return Boolean(launchAgentsDir && fs.existsSync(path.join(launchAgentsDir, candidate)));
+        }) ?? `${launchdLabel}.plist`;
+      return [...base, `launchctl bootstrap gui/$UID ~/Library/LaunchAgents/${plistName}`];
     }
     case "linux": {
       const unit = resolveGatewaySystemdServiceName(profile);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: when macOS users run with a `.nop` LaunchAgent variant, CLI start hints always suggested `${label}.plist` and could point to the wrong file.
- Why it matters: users get a misleading recovery command when the gateway is not loaded, especially in manual-start setups.
- What changed: `renderGatewayServiceStartHints` now checks `~/Library/LaunchAgents` and prefers `${label}.nop.plist` when present (with `OPENCLAW_LAUNCHD_LABEL` support), otherwise falls back to `${label}.plist`.
- What did NOT change (scope boundary): no daemon install/start behavior changed; only the hint text selection path was updated.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31622
- Related #31606

## User-visible / Behavior Changes

- On macOS, `Start with: launchctl bootstrap ...` now suggests `.nop.plist` when that variant exists for the resolved launchd label.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (behavior gated to darwin path)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): optional `OPENCLAW_LAUNCHD_LABEL`

### Steps

1. Create both `~/Library/LaunchAgents/ai.openclaw.gateway.plist` and `~/Library/LaunchAgents/ai.openclaw.gateway.nop.plist`.
2. Invoke `renderGatewayServiceStartHints` on darwin path (covered by test).
3. Inspect the final bootstrap hint.

### Expected

- Last hint uses `.nop.plist` when present.

### Actual

- Test now asserts `.nop.plist` preference and `.plist` fallback.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added/ran darwin-platform tests for both `.nop`-present and `.nop`-missing cases.
- Edge cases checked: no-HOME fallback still emits `${label}.plist`; explicit `OPENCLAW_LAUNCHD_LABEL` is used as label source.
- What you did **not** verify: live launchctl interaction on a real host in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/cli/daemon-cli/shared.ts`.
- Known bad symptoms reviewers should watch for: macOS hint shows an unexpected plist suffix.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: preferring `.nop` when both files exist may differ from an operator's intended default plist.
  - Mitigation: fallback remains deterministic and scoped to hint text only; no service control behavior changed.
