### PR TITLE
docs(windows): add pre-login WSL2 gateway auto-start flow

### DIFF
--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -55,6 +55,45 @@ Repair/migrate:
 openclaw doctor
 ```
 
+## Gateway auto start before Windows login
+
+For headless setups, enabling the WSL user service alone is not enough. You
+also need Windows to start WSL during boot.
+
+### 1) Enable user linger in WSL
+
+`linger` allows systemd user services to run without an interactive login.
+
+```bash
+sudo loginctl enable-linger "$(whoami)"
+```
+
+### 2) Install the gateway service in WSL
+
+```bash
+openclaw gateway install
+```
+
+### 3) Start WSL at Windows boot
+
+Run in PowerShell as Administrator:
+
+```powershell
+schtasks /create /tn "WSL Boot" /tr "wsl.exe -d Ubuntu --exec /bin/true" /sc onstart /ru SYSTEM
+```
+
+Use your distro name instead of `Ubuntu` if different.
+
+Verify after a reboot:
+
+```powershell
+schtasks /query /tn "WSL Boot" /v /fo list
+```
+
+```bash
+systemctl --user status "openclaw-gateway.service"
+```
+
 ## Advanced: expose WSL services over LAN (portproxy)
 
 WSL has its own virtual network. If another machine needs to reach a service

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -68,7 +68,7 @@ also need Windows to start WSL during boot.
 sudo loginctl enable-linger "$(whoami)"
 ```
 
-### 2) Install the gateway service in WSL
+### 2) Install the gateway service in WSL (if not already done)
 
 ```bash
 openclaw gateway install
@@ -79,7 +79,7 @@ openclaw gateway install
 Run in PowerShell as Administrator:
 
 ```powershell
-schtasks /create /tn "WSL Boot" /tr "wsl.exe -d Ubuntu --exec /bin/true" /sc onstart /ru SYSTEM
+schtasks /create /f /tn "WSL Boot" /tr "wsl.exe -d Ubuntu --exec /bin/true" /sc onstart /ru SYSTEM
 ```
 
 Use your distro name instead of `Ubuntu` if different.


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: WSL2 docs explained gateway service install, but missed the extra boot chain needed for startup before any Windows user login.
- Why it matters: headless setups can reboot into a state where gateway is not running until someone logs in or opens WSL.
- What changed: added a dedicated section documenting linger + service install + Windows scheduled task startup flow with verification commands.
- What did NOT change (scope boundary): no runtime/service code changes; docs only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31589
- Related #11805

## User-visible / Behavior Changes

- Docs now include a “Gateway auto start before Windows login” section for WSL2 users.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: N/A (docs-only)
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Open `/platforms/windows` docs page source.
2. Confirm new headless auto-start section includes all three required steps.
3. Confirm verification commands are included.

### Expected

- Operators can follow a complete boot chain for pre-login gateway startup on Windows+WSL2.

### Actual

- New section documents linger + `openclaw gateway install` + `schtasks /create ... /sc onstart`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: checked section placement and command correctness against existing docs style.
- Edge cases checked: included distro-name note for non-default Ubuntu distro names.
- What you did **not** verify: did not execute reboot flow in a live Windows host from this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this docs commit.
- Files/config to restore: `docs/platforms/windows.md`.
- Known bad symptoms reviewers should watch for: none (docs-only).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: distro name in scheduled task command can be copied as-is and fail on non-Ubuntu distros.
  - Mitigation: added explicit note to replace `Ubuntu` with local distro name.
