### PR TITLE
fix(agents): disable Claude 1M context by default for claude-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Claude CLI context default: set `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` by default for `claude-cli` backend runs to avoid unexpected 1M context usage unless operators explicitly override the env setting. (#31645)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -33,4 +33,31 @@ describe("resolveCliBackendConfig reliability merge", () => {
     expect(resolved?.config.reliability?.watchdog?.resume?.maxMs).toBe(180_000);
     expect(resolved?.config.reliability?.watchdog?.fresh?.noOutputTimeoutRatio).toBe(0.8);
   });
+
+  it("sets CLAUDE_CODE_DISABLE_1M_CONTEXT=1 by default for claude-cli", () => {
+    const resolved = resolveCliBackendConfig("claude-cli");
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.config.env?.CLAUDE_CODE_DISABLE_1M_CONTEXT).toBe("1");
+  });
+
+  it("allows claude-cli env override to re-enable 1M context", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "claude",
+              env: { CLAUDE_CODE_DISABLE_1M_CONTEXT: "0" },
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveCliBackendConfig("claude-cli", cfg);
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.config.env?.CLAUDE_CODE_DISABLE_1M_CONTEXT).toBe("0");
+  });
 });

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -54,6 +54,7 @@ const DEFAULT_CLAUDE_BACKEND: CliBackendConfig = {
   systemPromptArg: "--append-system-prompt",
   systemPromptMode: "append",
   systemPromptWhen: "first",
+  env: { CLAUDE_CODE_DISABLE_1M_CONTEXT: "1" },
   clearEnv: ["ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY_OLD"],
   reliability: {
     watchdog: {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Claude CLI runs could silently use 1M context defaults, surprising operators with much higher token usage.
- Why it matters: this can dramatically increase costs without obvious UI indicators.
- What changed: set `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` in the default `claude-cli` backend env, while keeping config overrides authoritative.
- What did NOT change (scope boundary): no provider routing/model selection logic changed; only default CLI backend env.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31645
- Related #31544

## User-visible / Behavior Changes

- By default, `claude-cli` backend runs now export `CLAUDE_CODE_DISABLE_1M_CONTEXT=1`.
- Operators can opt back in by overriding `agents.defaults.cliBackends.claude-cli.env.CLAUDE_CODE_DISABLE_1M_CONTEXT`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS/Linux (unit tests)
- Runtime/container: Node 22+
- Model/provider: `claude-cli` backend defaults
- Integration/channel (if any): N/A
- Relevant config (redacted): optional backend env override in `agents.defaults.cliBackends`

### Steps

1. Resolve default `claude-cli` backend config.
2. Verify default env includes `CLAUDE_CODE_DISABLE_1M_CONTEXT=1`.
3. Provide override `CLAUDE_CODE_DISABLE_1M_CONTEXT=0` and verify override wins.

### Expected

- Default value is `1`, and explicit config override is respected.

### Actual

- Added tests for both default and override paths; both pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `src/agents/cli-backends.test.ts` with new assertions for default + override env behavior.
- Edge cases checked: ensured merge logic keeps override precedence.
- What you did **not** verify: did not run a live external Claude CLI process in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `agents.defaults.cliBackends.claude-cli.env.CLAUDE_CODE_DISABLE_1M_CONTEXT=0` or revert this commit.
- Files/config to restore: `src/agents/cli-backends.ts`.
- Known bad symptoms reviewers should watch for: none expected beyond changed default context behavior.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: users relying on implicit 1M context may see reduced context by default.
  - Mitigation: explicit opt-in override remains available through backend env config.
