### PR TITLE
fix(tui): avoid stuck streaming status on non-active runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI/Cross-channel streaming status: only mark activity as `streaming` for the active run so external/concurrent run deltas no longer leave the status bar stuck in `streaming` after completion. (#31575)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -403,6 +403,22 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(state.activeChatRunId).toBe("run-active");
   });
 
+  it("does not set streaming status for non-active run deltas", () => {
+    const { state, setActivityStatus, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-active" },
+    });
+
+    handleChatEvent({
+      runId: "run-other",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "external stream" },
+    });
+
+    expect(setActivityStatus).not.toHaveBeenCalledWith("streaming");
+    expect(state.activeChatRunId).toBe("run-active");
+  });
+
   it("drops streaming assistant when chat final has no message", () => {
     const { state, chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -173,7 +173,9 @@ export function createEventHandlers(context: EventHandlerContext) {
         return;
       }
       chatLog.updateAssistant(displayText, evt.runId);
-      setActivityStatus("streaming");
+      if (state.activeChatRunId === evt.runId) {
+        setActivityStatus("streaming");
+      }
     }
     if (evt.state === "final") {
       const wasActiveRun = state.activeChatRunId === evt.runId;


### PR DESCRIPTION
## Summary
- only set TUI activity to `streaming` when the incoming chat delta belongs to the current active run
- add a regression test to cover non-active run deltas so concurrent/external runs cannot force the status bar into streaming
- add changelog note under `2026.3.2 (Unreleased)` fixes

## Testing
- `pnpm test src/tui/tui-event-handlers.test.ts`

Closes #31575
