### PR TITLE
fix(agents): add provider-specific missing API key guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Auth missing-key guidance: include provider-specific setup hints (for example `GEMINI_API_KEY` and matching `models.providers.<provider>.apiKey` path) when model execution fails due to missing API keys. (#31544)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -187,6 +187,29 @@ describe("getApiKeyForModel", () => {
     );
   });
 
+  it("includes provider-specific setup guidance when Google API key is missing", async () => {
+    await withEnvAsync(
+      {
+        GEMINI_API_KEY: undefined,
+      },
+      async () => {
+        let error: unknown = null;
+        try {
+          await resolveApiKeyForProvider({
+            provider: "google",
+            store: { version: 1, profiles: {} },
+          });
+        } catch (err) {
+          error = err;
+        }
+
+        expect(String(error)).toContain('No API key found for provider "google".');
+        expect(String(error)).toContain("Set GEMINI_API_KEY");
+        expect(String(error)).toContain("models.providers.google.apiKey");
+      },
+    );
+  });
+
   it("accepts legacy Z_AI_API_KEY for zai", async () => {
     await withEnvAsync(
       {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -98,7 +98,7 @@ function resolveMissingApiKeyHint(provider: string): string | null {
   if (normalized === "google-vertex") {
     return 'Authenticate with gcloud ADC, or set models.providers.google-vertex.apiKey in config (for example, `openclaw config set models.providers.google-vertex.apiKey "<key>"`).';
   }
-  const envVar = PROVIDER_ENV_API_KEY_MAP[normalized] ?? getEnvApiKey(normalized);
+  const envVar = PROVIDER_ENV_API_KEY_MAP[normalized];
   if (!envVar) {
     return null;
   }

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -24,6 +24,32 @@ const AWS_BEARER_ENV = "AWS_BEARER_TOKEN_BEDROCK";
 const AWS_ACCESS_KEY_ENV = "AWS_ACCESS_KEY_ID";
 const AWS_SECRET_KEY_ENV = "AWS_SECRET_ACCESS_KEY";
 const AWS_PROFILE_ENV = "AWS_PROFILE";
+const PROVIDER_ENV_API_KEY_MAP: Record<string, string> = {
+  openai: "OPENAI_API_KEY",
+  google: "GEMINI_API_KEY",
+  voyage: "VOYAGE_API_KEY",
+  groq: "GROQ_API_KEY",
+  deepgram: "DEEPGRAM_API_KEY",
+  cerebras: "CEREBRAS_API_KEY",
+  xai: "XAI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+  litellm: "LITELLM_API_KEY",
+  "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
+  "cloudflare-ai-gateway": "CLOUDFLARE_AI_GATEWAY_API_KEY",
+  moonshot: "MOONSHOT_API_KEY",
+  minimax: "MINIMAX_API_KEY",
+  nvidia: "NVIDIA_API_KEY",
+  xiaomi: "XIAOMI_API_KEY",
+  synthetic: "SYNTHETIC_API_KEY",
+  venice: "VENICE_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  opencode: "OPENCODE_API_KEY",
+  together: "TOGETHER_API_KEY",
+  qianfan: "QIANFAN_API_KEY",
+  ollama: "OLLAMA_API_KEY",
+  vllm: "VLLM_API_KEY",
+  kilocode: "KILOCODE_API_KEY",
+};
 
 function resolveProviderConfig(
   cfg: OpenClawConfig | undefined,
@@ -65,6 +91,18 @@ function resolveProviderAuthOverride(
     return auth;
   }
   return undefined;
+}
+
+function resolveMissingApiKeyHint(provider: string): string | null {
+  const normalized = normalizeProviderId(provider);
+  if (normalized === "google-vertex") {
+    return 'Authenticate with gcloud ADC, or set models.providers.google-vertex.apiKey in config (for example, `openclaw config set models.providers.google-vertex.apiKey "<key>"`).';
+  }
+  const envVar = PROVIDER_ENV_API_KEY_MAP[normalized] ?? getEnvApiKey(normalized);
+  if (!envVar) {
+    return null;
+  }
+  return `Set ${envVar}, or set models.providers.${normalized}.apiKey in config (for example, ${formatCliCommand(`openclaw config set models.providers.${normalized}.apiKey "<key>"`)}).`;
 }
 
 function resolveEnvSourceLabel(params: {
@@ -223,12 +261,16 @@ export async function resolveApiKeyForProvider(params: {
 
   const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
   const resolvedAgentDir = path.dirname(authStorePath);
+  const missingKeyHint = resolveMissingApiKeyHint(provider);
   throw new Error(
     [
       `No API key found for provider "${provider}".`,
+      missingKeyHint,
       `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
       `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
-    ].join(" "),
+    ]
+      .filter(Boolean)
+      .join(" "),
   );
 }
 
@@ -298,33 +340,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     return pick("HUGGINGFACE_HUB_TOKEN") ?? pick("HF_TOKEN");
   }
 
-  const envMap: Record<string, string> = {
-    openai: "OPENAI_API_KEY",
-    google: "GEMINI_API_KEY",
-    voyage: "VOYAGE_API_KEY",
-    groq: "GROQ_API_KEY",
-    deepgram: "DEEPGRAM_API_KEY",
-    cerebras: "CEREBRAS_API_KEY",
-    xai: "XAI_API_KEY",
-    openrouter: "OPENROUTER_API_KEY",
-    litellm: "LITELLM_API_KEY",
-    "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
-    "cloudflare-ai-gateway": "CLOUDFLARE_AI_GATEWAY_API_KEY",
-    moonshot: "MOONSHOT_API_KEY",
-    minimax: "MINIMAX_API_KEY",
-    nvidia: "NVIDIA_API_KEY",
-    xiaomi: "XIAOMI_API_KEY",
-    synthetic: "SYNTHETIC_API_KEY",
-    venice: "VENICE_API_KEY",
-    mistral: "MISTRAL_API_KEY",
-    opencode: "OPENCODE_API_KEY",
-    together: "TOGETHER_API_KEY",
-    qianfan: "QIANFAN_API_KEY",
-    ollama: "OLLAMA_API_KEY",
-    vllm: "VLLM_API_KEY",
-    kilocode: "KILOCODE_API_KEY",
-  };
-  const envVar = envMap[normalized];
+  const envVar = PROVIDER_ENV_API_KEY_MAP[normalized];
   if (!envVar) {
     return null;
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: missing API key failures were verbose but not actionable, especially after selecting a provider model in `/model`.
- Why it matters: users saw raw auth-store paths without quick guidance for how to fix provider auth.
- What changed: added provider-specific setup hints to missing-key errors (env var + config path + command example), and covered the Google/Gemini path with regression tests.
- What did NOT change (scope boundary): no auth resolution precedence changed; this is error-message guidance only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31544
- Related #31645

## User-visible / Behavior Changes

- Missing API key errors now include provider-specific setup guidance (for example `Set GEMINI_API_KEY` and `models.providers.google.apiKey`).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS/Linux (unit tests)
- Runtime/container: Node 22+
- Model/provider: `google` in missing-key path
- Integration/channel (if any): N/A
- Relevant config (redacted): none

### Steps

1. Resolve provider auth for `google` with no configured API key.
2. Capture thrown error.
3. Verify message includes env/config guidance.

### Expected

- Error includes explicit setup text (`GEMINI_API_KEY`, `models.providers.google.apiKey`).

### Actual

- New test asserts these guidance snippets and passes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `src/agents/model-auth.profiles.test.ts` with a new missing-google-key case.
- Edge cases checked: existing auth-store and agent-setup guidance remains present; openai-codex special-case guidance remains unchanged.
- What you did **not** verify: full TUI `/model` interactive flow in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/agents/model-auth.ts`.
- Known bad symptoms reviewers should watch for: error text missing provider-specific hint content.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: hint text could drift from provider env naming if provider mappings change.
  - Mitigation: mapping now reuses shared env-var map used by env auth resolution for covered providers.
