### PR TITLE
fix(plugins): expose requestHeartbeatNow in runtime system API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugins/Runtime heartbeat wake API: expose `requestHeartbeatNow` on `PluginRuntime.system` so plugins can wake targeted heartbeat sessions directly after enqueueing system events. (#31564)
 - CLI/Config validation: add `openclaw config validate` (with `--json`) to validate config files before gateway startup, and include detailed invalid-key paths in startup invalid-config errors. (#31220) thanks @Sid-Qin.
 - Sessions/Attachments: add inline file attachment support for `sessions_spawn` (subagent runtime only) with base64/utf8 encoding, transcript content redaction, lifecycle cleanup, and configurable limits via `tools.sessions_spawn.attachments`. (#16761) Thanks @napetrov.
 - Agents/Thinking defaults: set `adaptive` as the default thinking level for Anthropic Claude 4.6 models (including Bedrock Claude 4.6 refs) while keeping other reasoning-capable models at `low` unless explicitly configured.

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const runCommandWithTimeoutMock = vi.hoisted(() => vi.fn());
+const { runCommandWithTimeoutMock, requestHeartbeatNowMock } = vi.hoisted(() => ({
+  runCommandWithTimeoutMock: vi.fn(),
+  requestHeartbeatNowMock: vi.fn(),
+}));
 
 vi.mock("../../process/exec.js", () => ({
   runCommandWithTimeout: (...args: unknown[]) => runCommandWithTimeoutMock(...args),
+}));
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
 }));
 
 import { createPluginRuntime } from "./index.js";
@@ -11,6 +17,7 @@ import { createPluginRuntime } from "./index.js";
 describe("plugin runtime command execution", () => {
   beforeEach(() => {
     runCommandWithTimeoutMock.mockClear();
+    requestHeartbeatNowMock.mockClear();
   });
 
   it("exposes runtime.system.runCommandWithTimeout by default", async () => {
@@ -38,5 +45,15 @@ describe("plugin runtime command execution", () => {
       runtime.system.runCommandWithTimeout(["echo", "hello"], { timeoutMs: 1000 }),
     ).rejects.toThrow("boom");
     expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(["echo", "hello"], { timeoutMs: 1000 });
+  });
+
+  it("exposes runtime.system.requestHeartbeatNow by default", () => {
+    const runtime = createPluginRuntime();
+    runtime.system.requestHeartbeatNow({ reason: "hook:test", sessionKey: "session:abc" });
+
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "hook:test",
+      sessionKey: "session:abc",
+    });
   });
 });

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -72,6 +72,7 @@ import { monitorIMessageProvider } from "../../imessage/monitor.js";
 import { probeIMessage } from "../../imessage/probe.js";
 import { sendMessageIMessage } from "../../imessage/send.js";
 import { getChannelActivity, recordChannelActivity } from "../../infra/channel-activity.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import {
   listLineAccountIds,
@@ -261,6 +262,7 @@ function createRuntimeConfig(): PluginRuntime["config"] {
 function createRuntimeSystem(): PluginRuntime["system"] {
   return {
     enqueueSystemEvent,
+    requestHeartbeatNow,
     runCommandWithTimeout,
     formatNativeDependencyHint,
   };

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -82,6 +82,7 @@ type WriteConfigFile = typeof import("../../config/config.js").writeConfigFile;
 type RecordChannelActivity = typeof import("../../infra/channel-activity.js").recordChannelActivity;
 type GetChannelActivity = typeof import("../../infra/channel-activity.js").getChannelActivity;
 type EnqueueSystemEvent = typeof import("../../infra/system-events.js").enqueueSystemEvent;
+type RequestHeartbeatNow = typeof import("../../infra/heartbeat-wake.js").requestHeartbeatNow;
 type RunCommandWithTimeout = typeof import("../../process/exec.js").runCommandWithTimeout;
 type FormatNativeDependencyHint = typeof import("./native-deps.js").formatNativeDependencyHint;
 type LoadWebMedia = typeof import("../../web/media.js").loadWebMedia;
@@ -193,6 +194,7 @@ export type PluginRuntime = {
   };
   system: {
     enqueueSystemEvent: EnqueueSystemEvent;
+    requestHeartbeatNow: RequestHeartbeatNow;
     runCommandWithTimeout: RunCommandWithTimeout;
     formatNativeDependencyHint: FormatNativeDependencyHint;
   };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `requestHeartbeatNow` exists in core but was not exposed through `PluginRuntime.system`, forcing plugins into webhook workarounds.
- Why it matters: plugins could not trigger targeted heartbeat wakeups in-process after enqueueing session-scoped system events.
- What changed: exposed `requestHeartbeatNow` in runtime system API wiring and type definitions, plus test coverage in plugin runtime tests.
- What did NOT change (scope boundary): no heartbeat wake semantics changed; only plugin runtime API surface exposure.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31564
- Related #31544

## User-visible / Behavior Changes

- Plugin runtime now exposes `runtime.system.requestHeartbeatNow(...)`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS/Linux (unit tests)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): plugin runtime
- Relevant config (redacted): N/A

### Steps

1. Create plugin runtime via `createPluginRuntime()`.
2. Call `runtime.system.requestHeartbeatNow({ reason, sessionKey })`.
3. Verify underlying heartbeat wake function is invoked with same params.

### Expected

- Plugin runtime forwards `requestHeartbeatNow` calls.

### Actual

- Added mock-based runtime test that validates forwarding and call args.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `src/plugins/runtime/index.test.ts` including new forwarding assertion.
- Edge cases checked: existing `runCommandWithTimeout` system API behavior remains unchanged.
- What you did **not** verify: end-to-end plugin execution on a live gateway process.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/plugins/runtime/index.ts` and `src/plugins/runtime/types.ts`.
- Known bad symptoms reviewers should watch for: runtime.system missing function or type mismatch in plugin builds.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: plugin authors may assume heartbeat wake was previously unavailable and keep workaround code.
  - Mitigation: API is additive and non-breaking; both paths can coexist during migration.
