### PR TITLE
fix(slack): use channel-level session key when replyToMode=off and message is top-level

### DIFF
--- a/src/slack/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/src/slack/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -61,8 +61,8 @@ const account: ResolvedSlackAccount = {
 };
 
 describe("thread-level session keys", () => {
-  it("uses thread-level session key for channel messages", async () => {
-    const ctx = buildCtx();
+  it("uses thread-level session key for channel messages when replyToMode=all", async () => {
+    const ctx = buildCtx({ replyToMode: "all" });
     ctx.resolveUserName = async () => ({ name: "Alice" });
 
     const message: SlackMessageEvent = {
@@ -81,7 +81,7 @@ describe("thread-level session keys", () => {
     });
 
     expect(prepared).toBeTruthy();
-    // Channel messages should get thread-level session key with :thread: suffix
+    // Channel messages should get thread-level session key with :thread: suffix when replyToMode=all
     // The resolved session key is in ctxPayload.SessionKey, not route.sessionKey
     const sessionKey = prepared!.ctxPayload.SessionKey as string;
     expect(sessionKey).toContain(":thread:");
@@ -138,5 +138,87 @@ describe("thread-level session keys", () => {
     // DMs should NOT have :thread: in the session key
     const sessionKey = prepared!.ctxPayload.SessionKey as string;
     expect(sessionKey).not.toContain(":thread:");
+  });
+
+  it("uses channel-level session key for top-level messages when replyToMode=off", async () => {
+    const ctx = buildCtx({ replyToMode: "off" });
+    ctx.resolveUserName = async () => ({ name: "Dave" });
+
+    const message: SlackMessageEvent = {
+      channel: "C123",
+      channel_type: "channel",
+      user: "U4",
+      text: "top-level message",
+      ts: "1770408540.123456",
+    } as SlackMessageEvent;
+
+    const prepared = await prepareSlackMessage({
+      ctx,
+      account,
+      message,
+      opts: { source: "message" },
+    });
+
+    expect(prepared).toBeTruthy();
+    // When replyToMode=off and message is top-level, should use channel-level session key
+    const sessionKey = prepared!.ctxPayload.SessionKey as string;
+    expect(sessionKey).not.toContain(":thread:");
+    // Should contain channel identifier
+    expect(sessionKey).toContain("slack:channel:C123");
+  });
+
+  it("still uses thread-level session key for thread replies when replyToMode=off", async () => {
+    const ctx = buildCtx({ replyToMode: "off" });
+    ctx.resolveUserName = async () => ({ name: "Eve" });
+
+    const message: SlackMessageEvent = {
+      channel: "C123",
+      channel_type: "channel",
+      user: "U5",
+      text: "thread reply",
+      ts: "1770408550.789012",
+      thread_ts: "1770408540.123456",
+    } as SlackMessageEvent;
+
+    const prepared = await prepareSlackMessage({
+      ctx,
+      account,
+      message,
+      opts: { source: "message" },
+    });
+
+    expect(prepared).toBeTruthy();
+    // Thread replies should still use thread-level session key even when replyToMode=off
+    const sessionKey = prepared!.ctxPayload.SessionKey as string;
+    expect(sessionKey).toContain(":thread:");
+    expect(sessionKey).toContain("1770408540.123456");
+    expect(sessionKey).not.toContain("1770408550.789012");
+  });
+
+  it("uses thread-level session key for top-level messages when replyToMode=first", async () => {
+    const ctx = buildCtx({ replyToMode: "first" });
+    ctx.resolveUserName = async () => ({ name: "Frank" });
+
+    const message: SlackMessageEvent = {
+      channel: "C123",
+      channel_type: "channel",
+      user: "U6",
+      text: "top-level message",
+      ts: "1770408560.456789",
+    } as SlackMessageEvent;
+
+    const prepared = await prepareSlackMessage({
+      ctx,
+      account,
+      message,
+      opts: { source: "message" },
+    });
+
+    expect(prepared).toBeTruthy();
+    // When replyToMode=first, top-level messages should use thread-level session key
+    // (threading is enabled, so each message gets its own thread session)
+    const sessionKey = prepared!.ctxPayload.SessionKey as string;
+    expect(sessionKey).toContain(":thread:");
+    expect(sessionKey).toContain("1770408560.456789");
   });
 });

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -183,12 +183,18 @@ export async function prepareSlackMessage(params: {
   const isThreadReply = threadContext.isThreadReply;
   // Keep channel/group sessions thread-scoped to avoid cross-thread context bleed.
   // For DMs, preserve existing auto-thread behavior when replyToMode="all".
+  // For channels/groups with replyToMode="off" and top-level messages (no thread_ts),
+  // use channel-level session key instead of thread-level to maintain conversation continuity.
   const autoThreadId =
     !isThreadReply && replyToMode === "all" && threadContext.messageTs
       ? threadContext.messageTs
       : undefined;
   const canonicalThreadId = isRoomish
-    ? (threadContext.incomingThreadTs ?? message.ts)
+    ? // For channels/groups: use thread-level sessions only when:
+      // 1. Message is in a thread (has thread_ts), OR
+      // 2. replyToMode is "all" or "first" (threading enabled)
+      // Otherwise (replyToMode="off" and top-level), use channel-level session
+      threadContext.incomingThreadTs || (replyToMode !== "off" ? message.ts : undefined)
     : isThreadReply
       ? threadTs
       : autoThreadId;


### PR DESCRIPTION
## Problem

After upgrading from `2026.2.26` to `2026.3.1`, every message in a Slack channel creates a separate agent context when `replyToMode="off"` and messages are top-level (not in threads).

Previously, chatting with OpenClaw in a Slack channel worked like a normal chatbot — each message in the channel shared the same agent session, so the agent remembered prior context. Now each message is completely isolated with no memory of previous messages.

## Root Cause

Commit `11d34700c` changed the session key to always include thread-level sessions for channels:
- Old: `agent:main:slack:channel:${channelId}`
- New: `agent:main:slack:channel:${channelId}:thread:${messageTs}`

For users who chat in channels **without threads** and `replyToMode="off"`, each top-level message gets its own `ts`, so every message creates a brand new isolated session.

## Solution

Modified the session key resolution logic to:
- Use thread-level sessions only when:
  1. Message is in a thread (has `thread_ts`), OR
  2. `replyToMode` is `"all"` or `"first"` (threading enabled)
- Otherwise (`replyToMode="off"` and top-level), use channel-level session key
- Thread replies always use thread-level session key regardless of `replyToMode`

This restores the behavior from v2026.2.26 where channel-level messages shared the same agent context when `replyToMode="off"`.

## Testing

Added test cases to verify:
- Top-level messages with `replyToMode="off"` use channel-level session key
- Thread replies with `replyToMode="off"` still use thread-level session key
- Top-level messages with `replyToMode="all"` or `"first"` use thread-level session key

Fixes #31613
