### PR TITLE
fix(gateway): use bootout+bootstrap for macOS LaunchAgent restart

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -64,7 +64,11 @@ describe("restart-helper", () => {
       });
       expect(scriptPath.endsWith(".sh")).toBe(true);
       expect(content).toContain("#!/bin/sh");
-      expect(content).toContain("launchctl kickstart -k 'gui/501/ai.openclaw.gateway'");
+      expect(content).toContain("domain='gui/501'");
+      expect(content).toContain("label='ai.openclaw.gateway'");
+      expect(content).toContain('launchctl bootout "$domain/$label" >/dev/null 2>&1 || true');
+      expect(content).toContain('if ! launchctl bootstrap "$domain" "$plist"; then');
+      expect(content).toContain('launchctl kill SIGTERM "$domain/$label" >/dev/null 2>&1 || true');
       expect(content).toContain('rm -f "$0"');
       await cleanupScript(scriptPath);
     });
@@ -77,7 +81,7 @@ describe("restart-helper", () => {
         OPENCLAW_PROFILE: "default",
         OPENCLAW_LAUNCHD_LABEL: "com.custom.openclaw",
       });
-      expect(content).toContain("launchctl kickstart -k 'gui/501/com.custom.openclaw'");
+      expect(content).toContain("label='com.custom.openclaw'");
       await cleanupScript(scriptPath);
     });
 
@@ -124,7 +128,8 @@ describe("restart-helper", () => {
       const { scriptPath, content } = await prepareAndReadScript({
         OPENCLAW_PROFILE: "staging",
       });
-      expect(content).toContain("gui/502/ai.openclaw.staging");
+      expect(content).toContain("domain='gui/502'");
+      expect(content).toContain("label='ai.openclaw.staging'");
       await cleanupScript(scriptPath);
     });
 

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -86,7 +86,13 @@ rm -f "$0"
 # Standalone restart script — survives parent process termination.
 # Wait briefly to ensure file locks are released after update.
 sleep 1
-launchctl kickstart -k 'gui/${uid}/${escaped}'
+domain='gui/${uid}'
+label='${escaped}'
+plist="$HOME/Library/LaunchAgents/$label.plist"
+launchctl bootout "$domain/$label" >/dev/null 2>&1 || true
+if ! launchctl bootstrap "$domain" "$plist"; then
+  launchctl kill SIGTERM "$domain/$label" >/dev/null 2>&1 || true
+fi
 # Self-cleanup
 rm -f "$0"
 `;
@@ -123,7 +129,7 @@ del "%~f0"
  *
  * The script must outlive the CLI process because the CLI itself is part
  * of the service being restarted — `systemctl restart` / `launchctl
- * kickstart -k` will terminate the current process tree.  Using
+ * bootout` will terminate the current process tree.  Using
  * `spawn({ detached: true })` + `unref()` ensures the script survives
  * the parent's exit.
  *

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -203,7 +203,7 @@ describe("launchd install", () => {
     expect(plist).toContain(`<integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>`);
   });
 
-  it("restarts LaunchAgent with bootout-bootstrap-kickstart order", async () => {
+  it("restarts LaunchAgent with bootout-bootstrap order", async () => {
     const env = createDefaultLaunchdEnv();
     await restartLaunchAgent({
       env,
@@ -219,15 +219,15 @@ describe("launchd install", () => {
     const bootstrapIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
     );
-    const kickstartIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
-    );
 
     expect(bootoutIndex).toBeGreaterThanOrEqual(0);
     expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
-    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
     expect(bootoutIndex).toBeLessThan(bootstrapIndex);
-    expect(bootstrapIndex).toBeLessThan(kickstartIndex);
+    expect(
+      state.launchctlCalls.some(
+        (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
+      ),
+    ).toBe(false);
   });
 
   it("waits for previous launchd pid to exit before bootstrapping", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -481,11 +481,8 @@ export async function restartLaunchAgent({
     }
     throw new Error(`launchctl bootstrap failed: ${detail}`);
   }
-
-  const start = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
-  if (start.code !== 0) {
-    throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
-  }
+  // bootstrap+RunAtLoad is the canonical restart for LaunchAgents. A trailing
+  // kickstart can spuriously report "service not found" after successful bootstrap.
   try {
     stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);
   } catch (err: unknown) {


### PR DESCRIPTION
## Summary
Fix `openclaw gateway restart` failing on macOS with LaunchAgent service management.

## Root Cause
`launchctl kickstart` cannot find user domain services (`Could not find service "ai.openclaw.gateway"`), causing the restart to fail.

## Fix
- Replace `kickstart` with `bootout` + `bootstrap` (canonical restart method for LaunchAgents)
- Add `launchctl kill SIGTERM` as fallback
- Updated restart helper script with same pattern

## Tests
- 31/31 tests pass (launchd + restart-helper)

Closes #31280