### PR TITLE
fix(cli): add direct fallback hints for update failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Update recovery hints: add explicit package-manager fallback commands (`npm update -g openclaw@latest` / `pnpm add -g openclaw@latest`) when global update steps fail, alongside existing npm-specific remediation hints. (#31624)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -33,6 +33,7 @@ describe("inferUpdateFailureHints", () => {
     );
     const hints = inferUpdateFailureHints(result);
     expect(hints.join("\n")).toContain("EACCES");
+    expect(hints.join("\n")).toContain("npm update -g openclaw@latest");
     expect(hints.join("\n")).toContain("npm config set prefix ~/.local");
   });
 
@@ -42,15 +43,17 @@ describe("inferUpdateFailureHints", () => {
       "node-pre-gyp ERR!\n@discordjs/opus\nnode-gyp rebuild failed",
     );
     const hints = inferUpdateFailureHints(result);
+    expect(hints.join("\n")).toContain("npm update -g openclaw@latest");
     expect(hints.join("\n")).toContain("--omit=optional");
   });
 
-  it("does not return npm hints for non-npm install modes", () => {
+  it("returns manager-specific fallback hint for non-npm install modes", () => {
     const result = makeResult(
       "global update",
       "npm ERR! code EACCES\nnpm ERR! Error: EACCES: permission denied",
       "pnpm",
     );
-    expect(inferUpdateFailureHints(result)).toEqual([]);
+    const hints = inferUpdateFailureHints(result);
+    expect(hints).toEqual(["Fallback: run pnpm add -g openclaw@latest directly."]);
   });
 });

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -37,7 +37,7 @@ function getStepLabel(step: UpdateStepInfo): string {
 }
 
 export function inferUpdateFailureHints(result: UpdateRunResult): string[] {
-  if (result.status !== "error" || result.mode !== "npm") {
+  if (result.status !== "error") {
     return [];
   }
   const failedStep = [...result.steps].toReversed().find((step) => step.exitCode !== 0);
@@ -47,8 +47,21 @@ export function inferUpdateFailureHints(result: UpdateRunResult): string[] {
 
   const stderr = (failedStep.stderrTail ?? "").toLowerCase();
   const hints: string[] = [];
+  const failedGlobalUpdate = failedStep.name.startsWith("global update");
 
-  if (failedStep.name.startsWith("global update") && stderr.includes("eacces")) {
+  if (failedGlobalUpdate) {
+    if (result.mode === "npm") {
+      hints.push("Fallback: run npm update -g openclaw@latest directly.");
+    } else if (result.mode === "pnpm") {
+      hints.push("Fallback: run pnpm add -g openclaw@latest directly.");
+    }
+  }
+
+  if (result.mode !== "npm") {
+    return hints;
+  }
+
+  if (failedGlobalUpdate && stderr.includes("eacces")) {
     hints.push(
       "Detected permission failure (EACCES). Re-run with a writable global prefix or sudo (for system-managed Node installs).",
     );
@@ -56,7 +69,7 @@ export function inferUpdateFailureHints(result: UpdateRunResult): string[] {
   }
 
   if (
-    failedStep.name.startsWith("global update") &&
+    failedGlobalUpdate &&
     (stderr.includes("node-gyp") ||
       stderr.includes("@discordjs/opus") ||
       stderr.includes("prebuild"))


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: when `openclaw update` package-manager steps fail, users may not get an immediate direct fallback command to recover quickly.
- Why it matters: update failures (including perceived stalls/timeouts) are easier to recover from when a concrete manual command is shown.
- What changed: added manager-specific fallback hints in update failure output (`npm update -g openclaw@latest` for npm, `pnpm add -g openclaw@latest` for pnpm).
- What did NOT change (scope boundary): no update execution flow/preflight behavior changed; this is recovery hint output only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31624
- Related #31542

## User-visible / Behavior Changes

- `openclaw update` failure hints now include a direct fallback command for npm/pnpm global installs.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS/Linux (unit tests)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): CLI update path
- Relevant config (redacted): N/A

### Steps

1. Build an `UpdateRunResult` representing failed `global update` in npm mode.
2. Verify hint output includes direct npm fallback command.
3. Build same in pnpm mode and verify pnpm fallback command.

### Expected

- Failure hints include package-manager-specific direct fallback command.

### Actual

- Added tests covering npm + pnpm fallback hints; all pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `src/cli/update-cli/progress.test.ts` with updated assertions.
- Edge cases checked: existing npm-specific EACCES and node-gyp hints still appear.
- What you did **not** verify: full live `openclaw update` run under real network/disk-pressure conditions.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/cli/update-cli/progress.ts`.
- Known bad symptoms reviewers should watch for: missing or incorrect package-manager fallback text in update error output.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: fallback command may not match uncommon custom global install setups.
  - Mitigation: hint is additive guidance; existing detailed error output remains unchanged.
