### PR TITLE
fix(line): skip gateway auth for LINE webhook route

### DIFF
--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -152,4 +152,17 @@ describe("plugin HTTP registry helpers", () => {
     expect(shouldEnforceGatewayAuthForPluginPath(registry, "/api/channels/status")).toBe(true);
     expect(shouldEnforceGatewayAuthForPluginPath(registry, "/not-plugin")).toBe(false);
   });
+
+  it("skips gateway auth for routes with skipGatewayAuth", () => {
+    const registry = createTestRegistry({
+      httpRoutes: [
+        { path: "/line/webhook", handler: () => {}, skipGatewayAuth: true },
+        createRoute({ path: "/api/demo" }),
+      ],
+    });
+    expect(isRegisteredPluginHttpRoutePath(registry, "/line/webhook")).toBe(false);
+    expect(shouldEnforceGatewayAuthForPluginPath(registry, "/line/webhook")).toBe(false);
+    expect(isRegisteredPluginHttpRoutePath(registry, "/api/demo")).toBe(true);
+    expect(shouldEnforceGatewayAuthForPluginPath(registry, "/api/demo")).toBe(true);
+  });
 });

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -25,11 +25,14 @@ export function findRegisteredPluginHttpRoute(
 // Only checks specific routes registered via registerHttpRoute, not wildcard handlers
 // registered via registerHttpHandler. Wildcard handlers (e.g., webhooks) implement
 // their own signature-based auth and are handled separately in the auth enforcement logic.
+// Routes with skipGatewayAuth are also excluded (e.g., webhook routes that use
+// provider-level signature verification like LINE).
 export function isRegisteredPluginHttpRoutePath(
   registry: PluginRegistry,
   pathname: string,
 ): boolean {
-  return findRegisteredPluginHttpRoute(registry, pathname) !== undefined;
+  const route = findRegisteredPluginHttpRoute(registry, pathname);
+  return route !== undefined && !route.skipGatewayAuth;
 }
 
 export function shouldEnforceGatewayAuthForPluginPath(

--- a/src/line/monitor.ts
+++ b/src/line/monitor.ts
@@ -290,6 +290,7 @@ export async function monitorLineProvider(
     path: normalizedPath,
     pluginId: "line",
     accountId: resolvedAccountId,
+    skipGatewayAuth: true,
     log: (msg) => logVerbose(msg),
     handler: createLineNodeWebhookHandler({ channelSecret: secret, bot, runtime }),
   });

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -15,6 +15,7 @@ export function registerPluginHttpRoute(params: {
   pluginId?: string;
   source?: string;
   accountId?: string;
+  skipGatewayAuth?: boolean;
   log?: (message: string) => void;
   registry?: PluginRegistry;
 }): () => void {
@@ -41,6 +42,7 @@ export function registerPluginHttpRoute(params: {
     handler: params.handler,
     pluginId: params.pluginId,
     source: params.source,
+    skipGatewayAuth: params.skipGatewayAuth,
   };
   routes.push(entry);
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -60,6 +60,7 @@ export type PluginHttpRouteRegistration = {
   path: string;
   handler: OpenClawPluginHttpRouteHandler;
   source?: string;
+  skipGatewayAuth?: boolean;
 };
 
 export type PluginChannelRegistration = {


### PR DESCRIPTION
## Summary

- Problem: LINE webhook returns 401 Unauthorized because `shouldEnforceGatewayAuthForPluginPath` enforces gateway token auth on routes registered via `registerPluginHttpRoute` (which adds to `registry.httpRoutes`), but LINE Platform sends requests with LINE signature — not a gateway bearer token.
- Why it matters: LINE channel is completely broken for inbound messages when gateway auth is enabled. Outbound still works, but the agent cannot receive any messages from LINE.
- What changed: Added `skipGatewayAuth` option to `PluginHttpRouteRegistration`. When `true`, `isRegisteredPluginHttpRoutePath` excludes the route from gateway auth enforcement. LINE webhook registration sets `skipGatewayAuth: true`.
- What did NOT change (scope boundary): No changes to gateway auth logic for `registerHttpHandler` (wildcard handlers), protected plugin prefix paths (`/api/channels/*`), or any other auth flow.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes openclaw/openclaw#31653
- Related #29198

## User-visible / Behavior Changes

- LINE webhook endpoint (`/line/webhook`) is no longer blocked by gateway token auth when `gateway.auth.mode` is configured.
- LINE's own signature verification (`@line/bot-sdk`) remains the sole auth mechanism for the webhook endpoint, as intended.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- LINE webhook was never intended to be behind gateway token auth — it has its own signature-based verification via `@line/bot-sdk`. This change restores the intended behavior.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node.js
- Integration/channel (if any): LINE
- Relevant config (redacted): `gateway.auth.mode: "token"`

### Steps

1. Configure gateway with `gateway.auth.mode: "token"`
2. Enable LINE channel with valid channelAccessToken and channelSecret
3. `curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost:18789/line/webhook`

### Expected

- 200 (signature verification request with no body returns 200)

### Actual

- 401 Unauthorized (gateway auth blocks the request before it reaches the LINE handler)

## Evidence

- [x] Failing test/log before + passing after

New test in `src/gateway/server/plugins-http.test.ts`: verifies that routes with `skipGatewayAuth: true` are excluded from `isRegisteredPluginHttpRoutePath` and `shouldEnforceGatewayAuthForPluginPath`.

## Human Verification (required)

- Verified scenarios: `pnpm check` passes, related tests pass (plugins-http, http-registry, monitor.lifecycle)
- Edge cases checked: Route without `skipGatewayAuth` still enforced; protected prefix paths (`/api/channels/*`) still enforced
- What you did **not** verify: Full gateway integration test with real LINE Platform webhook

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; LINE webhook will return to 401 behavior (which is the current broken state).
- Files/config to restore: `src/plugins/registry.ts`, `src/plugins/http-registry.ts`, `src/gateway/server/plugins-http.ts`, `src/line/monitor.ts`
- Known bad symptoms reviewers should watch for: Any route unexpectedly bypassing gateway auth

## Risks and Mitigations

- Risk: Other `registerPluginHttpRoute` callers could set `skipGatewayAuth: true` without proper provider-level auth, weakening security.
  - Mitigation: `skipGatewayAuth` is opt-in and defaults to `false`. Only routes with their own signature-based verification (like LINE) should use it. The flag name makes the security implication explicit.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)
