### PR TITLE
fix(anthropic): drop replayed thinking blocks in transcript replay

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -556,7 +556,7 @@ describe("sanitizeSessionHistory", () => {
     expect(types).not.toContain("thinking");
   });
 
-  it("does not drop thinking blocks for non-copilot providers", async () => {
+  it("drops thinking blocks for Anthropic providers", async () => {
     setNonGoogleModelApi();
 
     const messages = makeThinkingAndTextAssistantMessages();
@@ -571,7 +571,8 @@ describe("sanitizeSessionHistory", () => {
     });
 
     const types = getAssistantContentTypes(result);
-    expect(types).toContain("thinking");
+    expect(types).toContain("text");
+    expect(types).not.toContain("thinking");
   });
 
   it("does not drop thinking blocks for non-claude copilot models", async () => {

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -10,6 +10,7 @@ describe("resolveTranscriptPolicy", () => {
     });
     expect(policy.sanitizeToolCallIds).toBe(true);
     expect(policy.toolCallIdMode).toBe("strict");
+    expect(policy.dropThinkingBlocks).toBe(true);
   });
 
   it("enables sanitizeToolCallIds for Google provider", () => {
@@ -64,6 +65,7 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.allowSyntheticToolResults).toBe(true);
     expect(policy.sanitizeToolCallIds).toBe(true);
     expect(policy.sanitizeMode).toBe("full");
+    expect(policy.dropThinkingBlocks).toBe(true);
   });
 
   it("keeps OpenRouter on its existing turn-validation path", () => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -97,8 +97,10 @@ export function resolveTranscriptPolicy(params: {
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").
-  // Drop these blocks at send-time to keep sessions usable.
-  const dropThinkingBlocks = isCopilotClaude;
+  // Anthropic endpoints can also reject replayed thinking blocks when any upstream
+  // transcript normalization changes payload structure across turns.
+  // Drop these blocks at send-time to keep long-lived sessions usable.
+  const dropThinkingBlocks = isCopilotClaude || isAnthropic;
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 


### PR DESCRIPTION
While trying to enable voice transcription feature on a local running whisper model, I ran into a weird error:

```
LLM request rejected: messages.1.content.20: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.
```

I have no idea how thinking blocks affect voice transcription, but this PR fixes it

I just don't want to create an issue busting prompt cache, needs to be scrutinized

## Summary
- enable `dropThinkingBlocks` for Anthropic transcript policy (not only Copilot Claude)
- keep replayed Anthropic sessions from failing with `thinking/redacted_thinking blocks ... cannot be modified`
- update policy + sanitize-session-history tests

## Validation
- pnpm vitest run src/agents/transcript-policy.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts
- all tests passed (29/29)
