### PR TITLE
feat(skills): enhance cursor-agent support in coding-agent skill

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: coding-agent
-description: 'Delegate coding tasks to Codex, Claude Code, or Pi agents via background process. Use when: (1) building/creating new features or apps, (2) reviewing PRs (spawn in temp dir), (3) refactoring large codebases, (4) iterative coding that needs file exploration. NOT for: simple one-liner fixes (just edit), reading code (use read tool), thread-bound ACP harness requests in chat (for example spawn/run Codex or Claude Code in a Discord thread; use sessions_spawn with runtime:"acp"), or any work in ~/clawd workspace (never spawn agents here). Claude Code: use --print --permission-mode bypassPermissions (no PTY). Codex/Pi/OpenCode: pty:true required.'
+description: 'Delegate coding tasks to Codex, Claude Code, Cursor Agent, or Pi agents via background process. Use when: (1) building/creating new features or apps, (2) reviewing PRs (spawn in temp dir), (3) refactoring large codebases, (4) iterative coding that needs file exploration. NOT for: simple one-liner fixes (just edit), reading code (use read tool), thread-bound ACP harness requests in chat (for example spawn/run Codex or Claude Code in a Discord thread; use sessions_spawn with runtime:"acp"), or any work in ~/clawd workspace (never spawn agents here). Claude Code: use --print --permission-mode bypassPermissions (no PTY). Codex/Pi/OpenCode/Cursor Agent: pty:true required.'
 metadata:
   {
     "openclaw":
       {
         "emoji": "🧩",
-        "requires": { "anyBins": ["claude", "codex", "opencode", "pi"] },
+        "requires": { "anyBins": ["claude", "codex", "opencode", "pi", "cursor-agent"] },
         "install":
           [
             {
@@ -32,9 +32,9 @@ metadata:
 
 Use **bash** (with optional background mode) for all coding agent work. Simple and effective.
 
-## ⚠️ PTY Mode: Codex/Pi/OpenCode yes, Claude Code no
+## ⚠️ PTY Mode: Codex/Pi/OpenCode/Cursor Agent yes, Claude Code no
 
-For **Codex, Pi, and OpenCode**, PTY is still required (interactive terminal apps):
+For **Codex, Pi, OpenCode, and Cursor Agent**, PTY is still required (interactive terminal apps):
 
 ```bash
 # ✅ Correct for Codex/Pi/OpenCode
@@ -202,6 +202,26 @@ bash workdir:~/project background:true command:"claude --permission-mode bypassP
 ```bash
 bash pty:true workdir:~/project command:"opencode run 'Your task'"
 ```
+
+---
+
+## Cursor Agent CLI
+
+```bash
+# Note: the local binary is usually `cursor-agent` (not `cursor`)
+
+# One-shot headless run
+bash pty:true workdir:~/project command:"cursor-agent --print --output-format text 'Implement retry logic for API calls'"
+
+# Background run for longer tasks
+bash pty:true workdir:~/project background:true command:"cursor-agent --print --output-format stream-json 'Refactor auth module and summarize file-by-file changes'"
+```
+
+Helpful flags:
+
+- `--workspace <path>` to pin workspace explicitly
+- `--mode plan|ask` for planning/Q&A only
+- `--model <model>` to select a specific Cursor model
 
 ---
 

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -6,7 +6,7 @@ metadata:
     "openclaw":
       {
         "emoji": "🧩",
-        "requires": { "anyBins": ["claude", "codex", "opencode", "pi", "cursor-agent"] },
+        "requires": { "anyBins": ["claude", "codex", "opencode", "pi", "cursor-agent", "agent"] },
         "install":
           [
             {
@@ -207,7 +207,31 @@ bash pty:true workdir:~/project command:"opencode run 'Your task'"
 
 ## Cursor Agent CLI
 
-**Binary note:** on most setups the executable is `cursor-agent` (not `cursor`).
+**Binary note:** Cursor's official installer exposes `agent`. Some setups also provide or alias `cursor-agent`. In the examples below, use whichever binary exists locally.
+
+### Installation
+
+Official Cursor docs: <https://cursor.com/docs/cli/installation>
+
+```bash
+# macOS / Linux / WSL
+curl https://cursor.com/install -fsS | bash
+
+# Verify
+agent --version
+```
+
+Post-install PATH fix if needed:
+
+```bash
+# bash
+export PATH="$HOME/.local/bin:$PATH"
+
+# zsh
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+If your machine exposes `cursor-agent` instead of `agent`, substitute that name in the commands below.
 
 ### Quick Start
 

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -207,8 +207,13 @@ bash pty:true workdir:~/project command:"opencode run 'Your task'"
 
 ## Cursor Agent CLI
 
+**Binary note:** on most setups the executable is `cursor-agent` (not `cursor`).
+
+### Quick Start
+
 ```bash
-# Note: the local binary is usually `cursor-agent` (not `cursor`)
+# Auth check
+bash pty:true command:"cursor-agent status"
 
 # One-shot headless run
 bash pty:true workdir:~/project command:"cursor-agent --print --output-format text 'Implement retry logic for API calls'"
@@ -217,11 +222,34 @@ bash pty:true workdir:~/project command:"cursor-agent --print --output-format te
 bash pty:true workdir:~/project background:true command:"cursor-agent --print --output-format stream-json 'Refactor auth module and summarize file-by-file changes'"
 ```
 
-Helpful flags:
+### Common Flags
 
-- `--workspace <path>` to pin workspace explicitly
-- `--mode plan|ask` for planning/Q&A only
-- `--model <model>` to select a specific Cursor model
+| Flag                       | Effect                                                    |
+| -------------------------- | --------------------------------------------------------- |
+| `--print` / `-p`           | Non-interactive/headless mode (best for automation)       |
+| `--output-format <format>` | `text`, `json`, or `stream-json` output in `--print` mode |
+| `--workspace <path>`       | Pin workspace explicitly instead of relying on CWD        |
+| `--mode plan\|ask`         | Read-only planning or Q&A mode                            |
+| `--model <model>`          | Pick a specific model                                     |
+| `--resume [chatId]`        | Resume an existing chat session                           |
+| `--continue`               | Resume the latest chat session                            |
+| `--approve-mcps`           | Auto-approve MCP servers (headless/print flows)           |
+
+### PR Review Example
+
+```bash
+REVIEW_DIR=$(mktemp -d)
+git clone https://github.com/user/repo.git "$REVIEW_DIR"
+cd "$REVIEW_DIR" && gh pr checkout 130
+
+bash pty:true workdir:"$REVIEW_DIR" command:"cursor-agent --print --output-format text 'Review this PR against origin/main. Summarize risks, test gaps, and suggested fixes.'"
+```
+
+### Structured Output Example
+
+```bash
+bash pty:true workdir:~/project command:"cursor-agent --print --output-format stream-json 'Create a migration plan for the auth module'"
+```
 
 ---
 

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -263,7 +263,7 @@ REVIEW_DIR=$(mktemp -d)
 git clone https://github.com/user/repo.git "$REVIEW_DIR"
 cd "$REVIEW_DIR" && gh pr checkout 130
 
-bash pty:true workdir:"$REVIEW_DIR" command:"cursor-agent --print --output-format text 'Review this PR against origin/main. Summarize risks, test gaps, and suggested fixes.'"
+bash pty:true workdir:"$REVIEW_DIR" command:"cursor-agent --trust --yolo --print --output-format text 'Review this PR against origin/main. Summarize risks, test gaps, and suggested fixes.'"
 ```
 
 ### Structured Output Example

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -216,11 +216,32 @@ bash pty:true workdir:~/project command:"opencode run 'Your task'"
 bash pty:true command:"cursor-agent status"
 
 # One-shot headless run
-bash pty:true workdir:~/project command:"cursor-agent --print --output-format text 'Implement retry logic for API calls'"
+bash pty:true workdir:~/project command:"cursor-agent --trust --yolo --print --output-format text 'Implement retry logic for API calls'"
 
 # Background run for longer tasks
-bash pty:true workdir:~/project background:true command:"cursor-agent --print --output-format stream-json 'Refactor auth module and summarize file-by-file changes'"
+bash pty:true workdir:~/project background:true command:"cursor-agent --trust --yolo --print --output-format text 'Refactor auth module and summarize file-by-file changes'"
 ```
+
+### ⚡ Best Practices (learned the hard way)
+
+**Output format:** Always use `--output-format text`. Alternatives:
+
+- `stream-json` produces noisy token-by-token deltas — unreadable in logs
+- `json` is a single blob at the end — no advantage over text
+- `text` gives clean, readable final output via `process log`
+
+**Keep prompts small and focused.** Cursor spends a long time thinking before acting. A big combined prompt (e.g. "create 20 files + tests + commit") can burn 10+ minutes just thinking and timeout with nothing written. Split into focused steps:
+
+- ✅ "Create the 7 Parse infrastructure files" (3-5 min)
+- ✅ "Create the 10 model files" (3-5 min)
+- ✅ "Create tests and commit everything" (3-5 min)
+- ❌ "Create Parse infra + models + tests + commit" (10+ min thinking, timeout)
+
+**Always use `--trust --yolo`** for autonomous headless work. Without `--trust`, Cursor prompts for workspace trust and hangs. Without `--yolo`, it asks for approval on file writes.
+
+**Silence during thinking is normal.** With `text` format, there's no output until thinking finishes and it starts acting. Don't kill the process just because it's quiet — check with `process poll`.
+
+**Set generous timeouts.** 600s (10 min) minimum for single-step tasks. 900s for anything involving build + test cycles.
 
 ### Common Flags
 
@@ -248,7 +269,7 @@ bash pty:true workdir:"$REVIEW_DIR" command:"cursor-agent --print --output-forma
 ### Structured Output Example
 
 ```bash
-bash pty:true workdir:~/project command:"cursor-agent --print --output-format stream-json 'Create a migration plan for the auth module'"
+bash pty:true workdir:~/project command:"cursor-agent --trust --yolo --print --output-format text 'Create a migration plan for the auth module'"
 ```
 
 ---

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -207,7 +207,7 @@ bash pty:true workdir:~/project command:"opencode run 'Your task'"
 
 ## Cursor Agent CLI
 
-**Binary note:** Cursor's official installer exposes `agent`. Some setups also provide or alias `cursor-agent`. In the examples below, use whichever binary exists locally.
+**Binary note:** Cursor's official installer exposes `agent`. Some setups also provide or alias `cursor-agent`, but the examples below use the official `agent` binary so fresh installs work out of the box.
 
 ### Installation
 
@@ -237,13 +237,13 @@ If your machine exposes `cursor-agent` instead of `agent`, substitute that name 
 
 ```bash
 # Auth check
-bash pty:true command:"cursor-agent status"
+bash pty:true command:"agent status"
 
 # One-shot headless run
-bash pty:true workdir:~/project command:"cursor-agent --trust --yolo --print --output-format text 'Implement retry logic for API calls'"
+bash pty:true workdir:~/project command:"agent --trust --yolo --print --output-format text 'Implement retry logic for API calls'"
 
 # Background run for longer tasks
-bash pty:true workdir:~/project background:true command:"cursor-agent --trust --yolo --print --output-format text 'Refactor auth module and summarize file-by-file changes'"
+bash pty:true workdir:~/project background:true command:"agent --trust --yolo --print --output-format text 'Refactor auth module and summarize file-by-file changes'"
 ```
 
 ### ⚡ Best Practices (learned the hard way)
@@ -287,13 +287,13 @@ REVIEW_DIR=$(mktemp -d)
 git clone https://github.com/user/repo.git "$REVIEW_DIR"
 cd "$REVIEW_DIR" && gh pr checkout 130
 
-bash pty:true workdir:"$REVIEW_DIR" command:"cursor-agent --trust --yolo --print --output-format text 'Review this PR against origin/main. Summarize risks, test gaps, and suggested fixes.'"
+bash pty:true workdir:"$REVIEW_DIR" command:"agent --trust --yolo --print --output-format text 'Review this PR against origin/main. Summarize risks, test gaps, and suggested fixes.'"
 ```
 
 ### Structured Output Example
 
 ```bash
-bash pty:true workdir:~/project command:"cursor-agent --trust --yolo --print --output-format text 'Create a migration plan for the auth module'"
+bash pty:true workdir:~/project command:"agent --trust --yolo --print --output-format text 'Create a migration plan for the auth module'"
 ```
 
 ---


### PR DESCRIPTION
## Overview

Adds comprehensive cursor-agent CLI documentation to the coding-agent skill, enabling Cursor subscription holders to leverage their subscription tokens for autonomous coding tasks outside the IDE.

## Key Improvements

### 🎯 Rationale
Cursor subscription holders can now use `cursor-agent` CLI to consume their subscription tokens for OpenClaw-orchestrated coding tasks—unlocking headless, background, and parallel execution workflows that aren't practical in the IDE.

### 📝 Documentation Enhancements
- **Mandatory flags for headless operation**: All examples now use `--trust --yolo` (required for non-interactive use)
- **Output format guidance**: Switched from `stream-json` to `text` for readable logs
- **Prompt sizing strategies**: Concrete advice to avoid 10+ minute thinking timeouts (split big prompts into focused steps)
- **Timeout recommendations**: 600s for single-step tasks, 900s for build+test cycles
- **"Silence is normal"**: Documents that Cursor thinks before acting—don't kill quiet sessions

### ✨ Best Practices Section
Added battle-tested learnings from real usage:
- Why `--trust` is needed (workspace trust prompt otherwise hangs)
- Why `--yolo` is needed (file write approvals otherwise block)
- Why `text` format works better than `stream-json` (token-by-token deltas are unreadable)
- How to structure prompts for predictable completion times

## Examples

Before:
```bash
cursor-agent --print --output-format stream-json 'Build feature X'
```

After:
```bash
cursor-agent --trust --yolo --print --output-format text 'Build feature X'
```

## Testing
- [x] Verified examples work in practice
- [x] Confirmed `--trust --yolo` prevents hangs
- [x] Validated `text` format produces clean output

## Related
Part of ongoing effort to document all coding agent CLIs (Codex, Claude Code, OpenCode, Pi, Cursor Agent) for OpenClaw orchestration.