### PR TITLE
fix(slack): handle channel-scoped message events [AI-assisted]

### DIFF
--- a/src/slack/monitor/events/messages.test.ts
+++ b/src/slack/monitor/events/messages.test.ts
@@ -32,7 +32,7 @@ function createMessageHandlers(overrides?: SlackSystemEventTestOverrides) {
     handleSlackMessage,
   });
   return {
-    handler: harness.getHandler("message") as MessageHandler | null,
+    getHandler: (name: string) => harness.getHandler(name) as MessageHandler | null,
     handleSlackMessage,
   };
 }
@@ -78,7 +78,8 @@ function makeThreadBroadcastEvent(overrides?: { channel?: string; user?: string 
 async function runMessageCase(input: MessageCase = {}): Promise<void> {
   messageQueueMock.mockClear();
   messageAllowMock.mockReset().mockResolvedValue([]);
-  const { handler } = createMessageHandlers(input.overrides);
+  const { getHandler } = createMessageHandlers(input.overrides);
+  const handler = getHandler("message");
   expect(handler).toBeTruthy();
   await handler!({
     event: (input.event ?? makeChangedEvent()) as Record<string, unknown>,
@@ -139,7 +140,8 @@ describe("registerSlackMessageEvents", () => {
   it("passes regular message events to the message handler", async () => {
     messageQueueMock.mockClear();
     messageAllowMock.mockReset().mockResolvedValue([]);
-    const { handler, handleSlackMessage } = createMessageHandlers({ dmPolicy: "open" });
+    const { getHandler, handleSlackMessage } = createMessageHandlers({ dmPolicy: "open" });
+    const handler = getHandler("message");
     expect(handler).toBeTruthy();
 
     await handler!({
@@ -155,5 +157,51 @@ describe("registerSlackMessageEvents", () => {
 
     expect(handleSlackMessage).toHaveBeenCalledTimes(1);
     expect(messageQueueMock).not.toHaveBeenCalled();
+  });
+
+  it("registers and handles message.channels events", async () => {
+    messageQueueMock.mockClear();
+    messageAllowMock.mockReset().mockResolvedValue([]);
+    const { getHandler, handleSlackMessage } = createMessageHandlers({ dmPolicy: "open" });
+    const handler = getHandler("message.channels");
+    expect(handler).toBeTruthy();
+
+    await handler!({
+      event: {
+        type: "message",
+        channel: "C1",
+        user: "U1",
+        text: "hello from channel",
+        ts: "123.456",
+      },
+      body: { event_id: "Ev123" },
+    });
+
+    expect(handleSlackMessage).toHaveBeenCalledTimes(1);
+    expect(messageQueueMock).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates duplicated payloads delivered through multiple message handlers", async () => {
+    messageQueueMock.mockClear();
+    messageAllowMock.mockReset().mockResolvedValue([]);
+    const { getHandler, handleSlackMessage } = createMessageHandlers({ dmPolicy: "open" });
+    const generic = getHandler("message");
+    const channelScoped = getHandler("message.channels");
+    expect(generic).toBeTruthy();
+    expect(channelScoped).toBeTruthy();
+
+    const event = {
+      type: "message",
+      channel: "C1",
+      user: "U1",
+      text: "hello",
+      ts: "123.456",
+    };
+    const body = { event_id: "Ev-dup-1" };
+
+    await generic!({ event, body });
+    await channelScoped!({ event, body });
+
+    expect(handleSlackMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -11,6 +11,19 @@ import type {
 } from "../types.js";
 import { authorizeAndResolveSlackSystemEventContext } from "./system-event-context.js";
 
+const MESSAGE_EVENT_NAMES = [
+  "message",
+  "message.channels",
+  "message.groups",
+  "message.im",
+  "message.mpim",
+] as const;
+const MAX_RECENT_MESSAGE_EVENT_KEYS = 256;
+
+type SlackMessageEventBody = {
+  event_id?: unknown;
+};
+
 export function registerSlackMessageEvents(params: {
   ctx: SlackMonitorContext;
   handleSlackMessage: SlackMessageHandler;
@@ -27,75 +40,120 @@ export function registerSlackMessageEvents(params: {
   const resolveThreadBroadcastSenderId = (thread: SlackThreadBroadcastEvent): string | undefined =>
     thread.user ?? thread.message?.user ?? thread.message?.bot_id;
 
-  ctx.app.event("message", async ({ event, body }: SlackEventMiddlewareArgs<"message">) => {
-    try {
-      if (ctx.shouldDropMismatchedSlackEvent(body)) {
-        return;
-      }
+  const recentEventKeys: string[] = [];
+  const recentEventSet = new Set<string>();
 
-      const message = event as SlackMessageEvent;
-      if (message.subtype === "message_changed") {
-        const changed = event as SlackMessageChangedEvent;
-        const channelId = changed.channel;
-        const ingressContext = await authorizeAndResolveSlackSystemEventContext({
-          ctx,
-          senderId: resolveChangedSenderId(changed),
-          channelId,
-          eventKind: "message_changed",
-        });
-        if (!ingressContext) {
-          return;
-        }
-        const messageId = changed.message?.ts ?? changed.previous_message?.ts;
-        enqueueSystemEvent(`Slack message edited in ${ingressContext.channelLabel}.`, {
-          sessionKey: ingressContext.sessionKey,
-          contextKey: `slack:message:changed:${channelId ?? "unknown"}:${messageId ?? changed.event_ts ?? "unknown"}`,
-        });
-        return;
-      }
-      if (message.subtype === "message_deleted") {
-        const deleted = event as SlackMessageDeletedEvent;
-        const channelId = deleted.channel;
-        const ingressContext = await authorizeAndResolveSlackSystemEventContext({
-          ctx,
-          senderId: resolveDeletedSenderId(deleted),
-          channelId,
-          eventKind: "message_deleted",
-        });
-        if (!ingressContext) {
-          return;
-        }
-        enqueueSystemEvent(`Slack message deleted in ${ingressContext.channelLabel}.`, {
-          sessionKey: ingressContext.sessionKey,
-          contextKey: `slack:message:deleted:${channelId ?? "unknown"}:${deleted.deleted_ts ?? deleted.event_ts ?? "unknown"}`,
-        });
-        return;
-      }
-      if (message.subtype === "thread_broadcast") {
-        const thread = event as SlackThreadBroadcastEvent;
-        const channelId = thread.channel;
-        const ingressContext = await authorizeAndResolveSlackSystemEventContext({
-          ctx,
-          senderId: resolveThreadBroadcastSenderId(thread),
-          channelId,
-          eventKind: "thread_broadcast",
-        });
-        if (!ingressContext) {
-          return;
-        }
-        const messageId = thread.message?.ts ?? thread.event_ts;
-        enqueueSystemEvent(`Slack thread reply broadcast in ${ingressContext.channelLabel}.`, {
-          sessionKey: ingressContext.sessionKey,
-          contextKey: `slack:thread:broadcast:${channelId ?? "unknown"}:${messageId ?? "unknown"}`,
-        });
-        return;
-      }
-
-      await handleSlackMessage(message, { source: "message" });
-    } catch (err) {
-      ctx.runtime.error?.(danger(`slack handler failed: ${String(err)}`));
+  const resolveDeduplicationKey = (message: SlackMessageEvent, body: unknown): string | null => {
+    const bodyEventId =
+      body && typeof body === "object" ? (body as SlackMessageEventBody).event_id : undefined;
+    const eventId = typeof bodyEventId === "string" ? bodyEventId : "";
+    const messageTs = message.ts ?? message.event_ts;
+    if (!eventId && !messageTs) {
+      return null;
     }
-  });
+    return `${eventId || "no-event-id"}:${message.channel ?? "unknown"}:${messageTs ?? "unknown"}:${message.subtype ?? "none"}`;
+  };
+
+  const shouldSkipDuplicateMessageEvent = (message: SlackMessageEvent, body: unknown): boolean => {
+    const dedupKey = resolveDeduplicationKey(message, body);
+    if (!dedupKey) {
+      return false;
+    }
+    if (recentEventSet.has(dedupKey)) {
+      return true;
+    }
+    recentEventSet.add(dedupKey);
+    recentEventKeys.push(dedupKey);
+    if (recentEventKeys.length > MAX_RECENT_MESSAGE_EVENT_KEYS) {
+      const removed = recentEventKeys.shift();
+      if (removed) {
+        recentEventSet.delete(removed);
+      }
+    }
+    return false;
+  };
+
+  const registerMessageHandler = (eventName: (typeof MESSAGE_EVENT_NAMES)[number]) => {
+    ctx.app.event(
+      eventName as never,
+      async ({ event, body }: SlackEventMiddlewareArgs<"message">) => {
+        try {
+          if (ctx.shouldDropMismatchedSlackEvent(body)) {
+            return;
+          }
+
+          const message = event as SlackMessageEvent;
+          if (shouldSkipDuplicateMessageEvent(message, body)) {
+            return;
+          }
+          if (message.subtype === "message_changed") {
+            const changed = event as SlackMessageChangedEvent;
+            const channelId = changed.channel;
+            const ingressContext = await authorizeAndResolveSlackSystemEventContext({
+              ctx,
+              senderId: resolveChangedSenderId(changed),
+              channelId,
+              eventKind: "message_changed",
+            });
+            if (!ingressContext) {
+              return;
+            }
+            const messageId = changed.message?.ts ?? changed.previous_message?.ts;
+            enqueueSystemEvent(`Slack message edited in ${ingressContext.channelLabel}.`, {
+              sessionKey: ingressContext.sessionKey,
+              contextKey: `slack:message:changed:${channelId ?? "unknown"}:${messageId ?? changed.event_ts ?? "unknown"}`,
+            });
+            return;
+          }
+          if (message.subtype === "message_deleted") {
+            const deleted = event as SlackMessageDeletedEvent;
+            const channelId = deleted.channel;
+            const ingressContext = await authorizeAndResolveSlackSystemEventContext({
+              ctx,
+              senderId: resolveDeletedSenderId(deleted),
+              channelId,
+              eventKind: "message_deleted",
+            });
+            if (!ingressContext) {
+              return;
+            }
+            enqueueSystemEvent(`Slack message deleted in ${ingressContext.channelLabel}.`, {
+              sessionKey: ingressContext.sessionKey,
+              contextKey: `slack:message:deleted:${channelId ?? "unknown"}:${deleted.deleted_ts ?? deleted.event_ts ?? "unknown"}`,
+            });
+            return;
+          }
+          if (message.subtype === "thread_broadcast") {
+            const thread = event as SlackThreadBroadcastEvent;
+            const channelId = thread.channel;
+            const ingressContext = await authorizeAndResolveSlackSystemEventContext({
+              ctx,
+              senderId: resolveThreadBroadcastSenderId(thread),
+              channelId,
+              eventKind: "thread_broadcast",
+            });
+            if (!ingressContext) {
+              return;
+            }
+            const messageId = thread.message?.ts ?? thread.event_ts;
+            enqueueSystemEvent(`Slack thread reply broadcast in ${ingressContext.channelLabel}.`, {
+              sessionKey: ingressContext.sessionKey,
+              contextKey: `slack:thread:broadcast:${channelId ?? "unknown"}:${messageId ?? "unknown"}`,
+            });
+            return;
+          }
+
+          await handleSlackMessage(message, { source: "message" });
+        } catch (err) {
+          ctx.runtime.error?.(danger(`slack handler failed: ${String(err)}`));
+        }
+      },
+    );
+  };
+
+  for (const eventName of MESSAGE_EVENT_NAMES) {
+    registerMessageHandler(eventName);
+  }
 
   ctx.app.event("app_mention", async ({ event, body }: SlackEventMiddlewareArgs<"app_mention">) => {
     try {


### PR DESCRIPTION
## Summary

- Problem: Some Slack workspaces only delivered channel traffic via channel-scoped message subscriptions (`message.channels`, `message.groups`, etc.), so OpenClaw only reacted to `app_mention` events and ignored regular channel traffic.
- Why it matters: Bots appear "blind" in channels unless explicitly mentioned, breaking normal room workflows.
- What changed: Registered explicit handlers for channel-scoped Slack message events and routed them through the existing message pipeline.
- What did NOT change (scope boundary): Mention gating / authorization behavior in `prepareSlackMessage` remains unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31674
- Related #

## User-visible / Behavior Changes

Slack connectors now accept channel-scoped message subscriptions (`message.channels`, `message.groups`, `message.im`, `message.mpim`) in addition to the generic `message` event.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (Debian)
- Runtime/container: local Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Slack
- Relevant config (redacted): N/A

### Steps

1. Register Slack message handlers.
2. Trigger `message.channels` payload.
3. Verify it is processed by `handleSlackMessage`.
4. Trigger duplicate payload through both `message` + `message.channels` handlers.
5. Verify dedupe prevents double-processing.

### Expected

- Channel-scoped events are processed exactly once.

### Actual

- ✅ Channel-scoped events now route through the normal message handler.
- ✅ Duplicate payloads are deduplicated when delivered through multiple handler routes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

```bash
pnpm vitest src/slack/monitor/events/messages.test.ts
pnpm exec oxlint --type-aware src/slack/monitor/events/messages.ts src/slack/monitor/events/messages.test.ts
pnpm exec oxfmt --check src/slack/monitor/events/messages.ts src/slack/monitor/events/messages.test.ts
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `message.channels` events are registered and passed to `handleSlackMessage`.
  - Duplicate payloads across generic + channel-scoped handlers are handled once.
- Edge cases checked:
  - Existing `message_changed` / `message_deleted` / `thread_broadcast` flows still run through system-event auth checks.
- What you did **not** verify:
  - End-to-end live Slack workspace traffic.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/slack/monitor/events/messages.ts`, `src/slack/monitor/events/messages.test.ts`
- Known bad symptoms reviewers should watch for: duplicate Slack inbound processing.

## Risks and Mitigations

- Risk: Slack payload may be emitted through both generic and scoped handlers in some setups.
  - Mitigation: dedupe key cache (event_id + channel + timestamp + subtype) drops duplicate deliveries.
