### PR TITLE
fix(session): share identity-linked DMs across Telegram and Webchat

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -52,7 +52,13 @@ describe("resolveAgentRoute", () => {
         dmScope: "per-channel-peer" as const,
         channel: "discord",
         peerId: "222222222222222222",
-        expected: "agent:main:discord:direct:alice",
+        expected: "agent:main:direct:alice",
+      },
+      {
+        dmScope: "per-account-channel-peer" as const,
+        channel: "webchat",
+        peerId: "+15551234567",
+        expected: "agent:main:direct:alice",
       },
     ];
     for (const testCase of cases) {
@@ -60,7 +66,7 @@ describe("resolveAgentRoute", () => {
         session: {
           dmScope: testCase.dmScope,
           identityLinks: {
-            alice: ["telegram:111111111", "discord:222222222222222222"],
+            alice: ["telegram:111111111", "discord:222222222222222222", "webchat:+15551234567"],
           },
         },
       };

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -139,6 +139,14 @@ export function buildAgentPeerSessionKey(params: {
       peerId = linkedPeerId;
     }
     peerId = peerId.toLowerCase();
+
+    // identityLinks intentionally collapses direct-message sessions to a canonical
+    // peer identity across channels/accounts. This keeps dmScope isolation for
+    // unrelated users while allowing explicitly linked identities to share memory.
+    if (linkedPeerId && peerId) {
+      return `agent:${normalizeAgentId(params.agentId)}:direct:${peerId}`;
+    }
+
     if (dmScope === "per-account-channel-peer" && peerId) {
       const channel = (params.channel ?? "").trim().toLowerCase() || "unknown";
       const accountId = normalizeAccountId(params.accountId);


### PR DESCRIPTION
## Summary
- fix direct-message session key generation so `session.identityLinks` always collapses to `agent:<id>:direct:<canonical>` when a linked identity is found
- preserve existing dmScope behavior for users that are **not** identity-linked
- add/adjust tests covering `per-peer`, `per-channel-peer`, and `per-account-channel-peer`

## Root cause
For `dmScope: per-channel-peer` (and `per-account-channel-peer`), even when `identityLinks` resolved the same canonical person, the code still emitted channel/account-prefixed keys (`agent:...:<channel>:...:direct:<canonical>`). That kept Telegram and Webchat in separate sessions.

## Fix
When `identityLinks` resolves a canonical direct peer, return a canonical cross-channel DM key:
`agent:<agentId>:direct:<canonicalPeer>`

This makes explicitly linked identities share one session across channels (Telegram/Webchat), which matches issue expectations while keeping isolation for unrelated users.

## Validation
- `pnpm vitest run src/routing/resolve-route.test.ts`
- all tests in that suite pass

Closes #31440
