### PR TITLE
fix(slack): prevent stale thread routing on top-level turns

### DIFF
--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -28,7 +28,7 @@ const discoverGatewayBeacons = vi.fn<(opts: unknown) => Promise<DiscoveredBeacon
 );
 const gatewayStatusCommand = vi.fn<(opts: unknown) => Promise<void>>(async () => {});
 const inspectPortUsage = vi.fn(async (_port: number) => ({ status: "free" as const }));
-const formatPortDiagnostics = vi.fn(() => [] as string[]);
+const formatPortDiagnostics = vi.fn<(diagnostics: unknown) => string[]>(() => []);
 
 const { runtimeLogs, runtimeErrors, defaultRuntime, resetRuntimeCapture } =
   createCliRuntimeCapture();

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -7,6 +7,7 @@ import {
   buildGroupDisplayName,
   deriveSessionKey,
   loadSessionStore,
+  recordSessionMetaFromInbound,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   resolveSessionKey,
@@ -321,6 +322,103 @@ describe("sessions", () => {
       to: "222",
     });
     expect(store[mainSessionKey]?.lastThreadId).toBeUndefined();
+  });
+
+  it("recordSessionMetaFromInbound clears stale origin threadId on top-level turns", async () => {
+    const sessionKey = "agent:main:slack:channel:C123";
+    const dir = await createCaseDir("recordSessionMetaFromInbound");
+    const storePath = path.join(dir, "sessions.json");
+    await fs.writeFile(storePath, "{}", "utf-8");
+
+    await recordSessionMetaFromInbound({
+      storePath,
+      sessionKey,
+      ctx: {
+        Provider: "slack",
+        Surface: "slack",
+        ChatType: "channel",
+        From: "slack:channel:C123",
+        To: "channel:C123",
+        SessionKey: sessionKey,
+        OriginatingChannel: "slack",
+        OriginatingTo: "channel:C123",
+        MessageThreadId: "1739142736.000100",
+      },
+    });
+
+    await recordSessionMetaFromInbound({
+      storePath,
+      sessionKey,
+      ctx: {
+        Provider: "slack",
+        Surface: "slack",
+        ChatType: "channel",
+        From: "slack:channel:C123",
+        To: "channel:C123",
+        SessionKey: sessionKey,
+        OriginatingChannel: "slack",
+        OriginatingTo: "channel:C123",
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.origin?.threadId).toBeUndefined();
+  });
+
+  it("recordSessionMetaFromInbound clears stale persisted delivery threadId on top-level turns", async () => {
+    const sessionKey = "agent:main:slack:channel:C999";
+    const staleThreadId = "1739142736.000100";
+    const dir = await createCaseDir("recordSessionMetaFromInbound-route");
+    const storePath = path.join(dir, "sessions.json");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [sessionKey]: {
+            sessionId: "sess-route-stale",
+            updatedAt: 1,
+            chatType: "channel",
+            channel: "slack",
+            deliveryContext: {
+              channel: "slack",
+              to: "channel:C999",
+              threadId: staleThreadId,
+            },
+            lastChannel: "slack",
+            lastTo: "channel:C999",
+            lastThreadId: staleThreadId,
+            origin: {
+              provider: "slack",
+              to: "channel:C999",
+              threadId: staleThreadId,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    await recordSessionMetaFromInbound({
+      storePath,
+      sessionKey,
+      ctx: {
+        Provider: "slack",
+        Surface: "slack",
+        ChatType: "channel",
+        From: "slack:channel:C999",
+        To: "channel:C999",
+        SessionKey: sessionKey,
+        OriginatingChannel: "slack",
+        OriginatingTo: "channel:C999",
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.origin?.threadId).toBeUndefined();
+    expect(store[sessionKey]?.deliveryContext?.threadId).toBeUndefined();
+    expect(store[sessionKey]?.lastThreadId).toBeUndefined();
   });
 
   it("updateLastRoute records origin + group metadata when ctx is provided", async () => {

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -36,6 +36,10 @@ const mergeOrigin = (
   if (next?.accountId) {
     merged.accountId = next.accountId;
   }
+  // Clear stale thread metadata when a fresh origin update arrives without a thread id.
+  if (next && !Object.prototype.hasOwnProperty.call(next, "threadId")) {
+    delete merged.threadId;
+  }
   if (next?.threadId != null && next.threadId !== "") {
     merged.threadId = next.threadId;
   }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -75,7 +75,9 @@ function normalizeSessionEntryDelivery(entry: SessionEntry): SessionEntry {
     lastChannel: entry.lastChannel,
     lastTo: entry.lastTo,
     lastAccountId: entry.lastAccountId,
-    lastThreadId: entry.lastThreadId ?? entry.deliveryContext?.threadId ?? entry.origin?.threadId,
+    // Delivery routing must be sourced from explicit route fields only.
+    // origin.threadId is message metadata and can be stale for top-level turns.
+    lastThreadId: entry.lastThreadId ?? entry.deliveryContext?.threadId,
     deliveryContext: entry.deliveryContext,
   });
   const nextDelivery = normalized.deliveryContext;
@@ -1039,6 +1041,7 @@ export async function recordSessionMetaFromInbound(params: {
 }): Promise<SessionEntry | null> {
   const { storePath, sessionKey, ctx } = params;
   const createIfMissing = params.createIfMissing ?? true;
+  const hasInboundThreadId = ctx.MessageThreadId != null && ctx.MessageThreadId !== "";
   return await updateSessionStore(
     storePath,
     (store) => {
@@ -1050,7 +1053,30 @@ export async function recordSessionMetaFromInbound(params: {
         existing,
         groupResolution: params.groupResolution,
       });
-      if (!patch) {
+      const shouldClearPersistedThread =
+        !hasInboundThreadId &&
+        Boolean(existing?.lastThreadId != null || existing?.deliveryContext?.threadId != null);
+      const routePatch = shouldClearPersistedThread
+        ? (() => {
+            const cleared = normalizeSessionDeliveryFields({
+              channel: existing?.channel,
+              lastChannel: existing?.lastChannel,
+              lastTo: existing?.lastTo,
+              lastAccountId: existing?.lastAccountId,
+              deliveryContext: removeThreadFromDeliveryContext(existing?.deliveryContext),
+            });
+            return {
+              deliveryContext: cleared.deliveryContext,
+              lastChannel: cleared.lastChannel,
+              lastTo: cleared.lastTo,
+              lastAccountId: cleared.lastAccountId,
+              lastThreadId: cleared.lastThreadId,
+            } satisfies Partial<SessionEntry>;
+          })()
+        : null;
+      const combinedPatch = patch || routePatch ? { ...routePatch, ...patch } : null;
+
+      if (!combinedPatch) {
         if (existing && resolved.legacyKeys.length > 0) {
           store[resolved.normalizedKey] = existing;
           for (const legacyKey of resolved.legacyKeys) {
@@ -1062,7 +1088,7 @@ export async function recordSessionMetaFromInbound(params: {
       if (!existing && !createIfMissing) {
         return null;
       }
-      const next = mergeSessionEntry(existing, patch);
+      const next = mergeSessionEntry(existing, combinedPatch);
       store[resolved.normalizedKey] = next;
       for (const legacyKey of resolved.legacyKeys) {
         delete store[legacyKey];

--- a/src/infra/outbound/targets.integration.test.ts
+++ b/src/infra/outbound/targets.integration.test.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  loadSessionStore,
+  recordSessionMetaFromInbound,
+  updateLastRoute,
+} from "../../config/sessions.js";
+import { resolveSessionDeliveryTarget } from "./targets.js";
+
+describe("resolveSessionDeliveryTarget e2e (Slack stale thread cleanup)", () => {
+  it("keeps top-level Slack delivery off-thread after inbound top-level update", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-targets-e2e-"));
+    const storePath = path.join(dir, "sessions.json");
+    const sessionKey = "agent:main:slack:channel:c0afn6nsp8x";
+    const staleThreadId = "1772342888.242789";
+
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [sessionKey]: {
+            sessionId: "2ce7b2d0-3d90-4106-b33a-6fbb27b65fe9",
+            updatedAt: 1,
+            chatType: "channel",
+            channel: "slack",
+            groupId: "c0afn6nsp8x",
+            groupChannel: "#claw",
+            deliveryContext: {
+              channel: "slack",
+              to: "channel:C0AFN6NSP8X",
+              accountId: "default",
+              threadId: staleThreadId,
+            },
+            lastChannel: "slack",
+            lastTo: "channel:C0AFN6NSP8X",
+            lastAccountId: "default",
+            lastThreadId: staleThreadId,
+            origin: {
+              provider: "slack",
+              surface: "slack",
+              chatType: "channel",
+              from: "slack:channel:C0AFN6NSP8X",
+              to: "channel:C0AFN6NSP8X",
+              accountId: "default",
+              threadId: staleThreadId,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    // Simulate a fresh top-level inbound turn in #claw:
+    // 1) route update without thread id, 2) inbound metadata update.
+    await updateLastRoute({
+      storePath,
+      sessionKey,
+      deliveryContext: {
+        channel: "slack",
+        to: "channel:C0AFN6NSP8X",
+        accountId: "default",
+      },
+    });
+    await recordSessionMetaFromInbound({
+      storePath,
+      sessionKey,
+      ctx: {
+        Provider: "slack",
+        Surface: "slack",
+        ChatType: "channel",
+        From: "slack:channel:C0AFN6NSP8X",
+        To: "channel:C0AFN6NSP8X",
+        SessionKey: sessionKey,
+        OriginatingChannel: "slack",
+        OriginatingTo: "channel:C0AFN6NSP8X",
+        AccountId: "default",
+      },
+    });
+
+    const entry = loadSessionStore(storePath)[sessionKey];
+    expect(entry).toBeDefined();
+    expect(entry?.lastThreadId).toBeUndefined();
+    expect(entry?.deliveryContext?.threadId).toBeUndefined();
+    expect(entry?.origin?.threadId).toBeUndefined();
+
+    const resolved = resolveSessionDeliveryTarget({
+      entry,
+      requestedChannel: "last",
+    });
+    expect(resolved.channel).toBe("slack");
+    expect(resolved.to).toBe("channel:C0AFN6NSP8X");
+    expect(resolved.threadId).toBeUndefined();
+  });
+});

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -200,6 +200,28 @@ describe("resolveSessionDeliveryTarget", () => {
     expect(resolved.threadId).toBeUndefined();
   });
 
+  it("prefers persisted delivery threadId over stale origin threadId", () => {
+    const resolved = resolveSessionDeliveryTarget({
+      entry: {
+        sessionId: "sess-persisted-thread",
+        updatedAt: 1,
+        lastChannel: "slack",
+        lastTo: "channel:C123",
+        lastThreadId: "1739142000.000001",
+        origin: {
+          provider: "slack",
+          to: "channel:C123",
+          threadId: "1739141000.000001",
+        },
+      },
+      requestedChannel: "last",
+    });
+
+    expect(resolved.channel).toBe("slack");
+    expect(resolved.to).toBe("channel:C123");
+    expect(resolved.threadId).toBe("1739142000.000001");
+  });
+
   it("does not inherit lastThreadId in heartbeat mode", () => {
     const resolved = resolveSessionDeliveryTarget({
       entry: {

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -179,6 +179,27 @@ describe("resolveSessionDeliveryTarget", () => {
     expect(resolved.threadId).toBe(999);
   });
 
+  it("does not inherit stale origin threadId when delivery route has no thread", () => {
+    const resolved = resolveSessionDeliveryTarget({
+      entry: {
+        sessionId: "sess-origin-thread-stale",
+        updatedAt: 1,
+        lastChannel: "slack",
+        lastTo: "channel:C123",
+        origin: {
+          provider: "slack",
+          to: "channel:C123",
+          threadId: "1739142736.000100",
+        },
+      },
+      requestedChannel: "last",
+    });
+
+    expect(resolved.channel).toBe("slack");
+    expect(resolved.to).toBe("channel:C123");
+    expect(resolved.threadId).toBeUndefined();
+  });
+
   it("does not inherit lastThreadId in heartbeat mode", () => {
     const resolved = resolveSessionDeliveryTarget({
       entry: {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -102,11 +102,15 @@ export function resolveSessionDeliveryTarget(params: {
   // Thread routing should only use explicit delivery-route fields, not origin metadata.
   // origin.threadId can become stale after top-level turns and must not drive replies.
   const persistedThreadId = params.entry?.lastThreadId ?? params.entry?.deliveryContext?.threadId;
+  const normalizedPersistedThreadId =
+    persistedThreadId != null && persistedThreadId !== ""
+      ? typeof persistedThreadId === "string"
+        ? persistedThreadId.trim() || undefined
+        : persistedThreadId
+      : undefined;
   const lastThreadId = hasTurnSourceChannel
     ? params.turnSourceThreadId
-    : persistedThreadId != null && persistedThreadId !== ""
-      ? context?.threadId
-      : undefined;
+    : normalizedPersistedThreadId;
 
   const rawRequested = params.requestedChannel ?? "last";
   const requested = rawRequested === "last" ? "last" : normalizeMessageChannel(rawRequested);

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -99,7 +99,14 @@ export function resolveSessionDeliveryTarget(params: {
   const lastChannel = hasTurnSourceChannel ? params.turnSourceChannel : sessionLastChannel;
   const lastTo = hasTurnSourceChannel ? params.turnSourceTo : context?.to;
   const lastAccountId = hasTurnSourceChannel ? params.turnSourceAccountId : context?.accountId;
-  const lastThreadId = hasTurnSourceChannel ? params.turnSourceThreadId : context?.threadId;
+  // Thread routing should only use explicit delivery-route fields, not origin metadata.
+  // origin.threadId can become stale after top-level turns and must not drive replies.
+  const persistedThreadId = params.entry?.lastThreadId ?? params.entry?.deliveryContext?.threadId;
+  const lastThreadId = hasTurnSourceChannel
+    ? params.turnSourceThreadId
+    : persistedThreadId != null && persistedThreadId !== ""
+      ? context?.threadId
+      : undefined;
 
   const rawRequested = params.requestedChannel ?? "last";
   const requested = rawRequested === "last" ? "last" : normalizeMessageChannel(rawRequested);

--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -19,6 +19,7 @@ describe("secret ref resolver", () => {
   let execProtocolV2ScriptPath = "";
   let execMissingIdScriptPath = "";
   let execInvalidJsonScriptPath = "";
+  let execClosedStdinScriptPath = "";
 
   const createCaseDir = async (label: string): Promise<string> => {
     const dir = path.join(fixtureRoot, `${label}-${caseId++}`);
@@ -66,6 +67,17 @@ describe("secret ref resolver", () => {
     await writeSecureFile(
       execInvalidJsonScriptPath,
       ["#!/bin/sh", "printf 'not-json'"].join("\n"),
+      0o700,
+    );
+
+    execClosedStdinScriptPath = path.join(sharedExecDir, "resolver-closed-stdin.sh");
+    await writeSecureFile(
+      execClosedStdinScriptPath,
+      [
+        "#!/bin/sh",
+        "exec 0<&-",
+        'printf \'{"protocolVersion":1,"values":{"openai/api-key":"value:openai/api-key"}}\'',
+      ].join("\n"),
       0o700,
     );
   });
@@ -172,6 +184,31 @@ describe("secret ref resolver", () => {
       },
     );
     expect(value).toBe("plain-secret");
+  });
+
+  it("handles exec providers that close stdin early", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const value = await resolveSecretRefString(
+      { source: "exec", provider: "execmain", id: "openai/api-key" },
+      {
+        config: {
+          secrets: {
+            providers: {
+              execmain: {
+                source: "exec",
+                command: execClosedStdinScriptPath,
+                passEnv: ["PATH"],
+              },
+            },
+          },
+        },
+      },
+    );
+
+    expect(value).toBe("value:openai/api-key");
   });
 
   it("rejects symlink command paths unless allowSymlinkCommand is enabled", async () => {

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -405,7 +405,36 @@ async function runExecResolver(params: {
       });
     });
 
-    child.stdin?.end(params.input);
+    const stdin = child.stdin;
+    if (!stdin) {
+      return;
+    }
+    stdin.on("error", (error) => {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code === "EPIPE" || code === "ERR_STREAM_DESTROYED") {
+        return;
+      }
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimers();
+      reject(error);
+    });
+    try {
+      stdin.end(params.input);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code === "EPIPE" || code === "ERR_STREAM_DESTROYED") {
+        return;
+      }
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimers();
+      reject(error);
+    }
   });
 }
 


### PR DESCRIPTION
## Problem
Top-level Slack channel messages could receive replies inside a stale/older thread instead of channel root. In practice this looks like "missing" replies in desktop/channel view.

## Fix
This change hardens thread routing so top-level turns stay top-level:

1. `src/infra/outbound/targets.ts`
- Thread resolution now uses explicit delivery-route thread metadata only (`lastThreadId`, `deliveryContext.threadId`).
- It no longer falls back to stale origin metadata.

2. `src/config/sessions/store.ts`
- Session delivery normalization no longer rehydrates route thread id from `origin.threadId`.
- On inbound top-level turns, persisted route thread metadata is cleared (`deliveryContext.threadId`, `lastThreadId`).

3. Regression coverage
- `src/infra/outbound/targets.integration.test.ts` adds an e2e scenario with contaminated real-world session state.
- `src/config/sessions.test.ts` adds explicit top-level stale-thread cleanup coverage.
- `src/infra/outbound/targets.test.ts` covers stale-origin-thread non-inheritance.

## Prompt Request (for coding agent)
```
Review Slack thread-routing behavior for top-level channel messages.
Verify with realistic contaminated session state whether replies can still be misrouted into old threads.
If needed, patch routing/session-store behavior so top-level turns clear stale thread route metadata.
Add e2e + regression tests and run the relevant session/target suites.
```

## Validation
- `pnpm vitest run src/config/sessions.test.ts src/infra/outbound/targets.test.ts src/infra/outbound/targets.integration.test.ts src/channels/session.test.ts src/utils/delivery-context.test.ts`
- Passed on this branch.
