### PR TITLE
fix(cli): initialize compinit when zsh compdef is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Zsh completion: initialize `compinit` when `compdef` is unavailable in generated zsh completion scripts, so startup no longer fails with `command not found: compdef` when users source dynamic completion before zsh completion init. (#14289)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -376,10 +376,15 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
   }
 }
 
-function generateZshCompletion(program: Command): string {
+export function generateZshCompletion(program: Command): string {
   const rootCmd = program.name();
   const script = `
 #compdef ${rootCmd}
+
+if (( ! $+functions[compdef] )); then
+  autoload -Uz compinit
+  compinit
+fi
 
 _${rootCmd}_root_completion() {
   local -a commands

--- a/src/cli/completion-cli.zsh.test.ts
+++ b/src/cli/completion-cli.zsh.test.ts
@@ -1,0 +1,26 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { generateZshCompletion } from "./completion-cli.js";
+
+describe("generateZshCompletion", () => {
+  it("initializes compinit when compdef is unavailable", () => {
+    const program = new Command("openclaw");
+    program.command("agent").description("Manage agents");
+
+    const script = generateZshCompletion(program);
+
+    expect(script).toContain("if (( ! $+functions[compdef] )); then");
+    expect(script).toContain("autoload -Uz compinit");
+    expect(script).toContain("compinit");
+  });
+
+  it("still registers root completion handler", () => {
+    const program = new Command("openclaw");
+    program.command("status").description("Show status");
+
+    const script = generateZshCompletion(program);
+
+    expect(script).toContain("_openclaw_root_completion()");
+    expect(script).toContain("compdef _openclaw_root_completion openclaw");
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: zsh users who source `openclaw completion --shell zsh` before running `compinit` hit `command not found: compdef` on shell startup (#14289).
- Why it matters: completion setup fails noisily for valid user configs and can leave users thinking completion is broken.
- What changed: generated zsh completion scripts now auto-run `autoload -Uz compinit && compinit` only when `compdef` is unavailable.
- What did NOT change (scope boundary): no changes to bash/fish/powershell completion generation or completion install flow.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #14289
- Related #31637

## User-visible / Behavior Changes

- zsh completion scripts produced by `openclaw completion --shell zsh` now self-initialize completion when `compdef` is missing, preventing startup errors in shells that have not run `compinit` yet.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default CLI config

### Steps

1. Generate zsh completion: `openclaw completion --shell zsh`.
2. Source script in a zsh session without prior `compinit` init.
3. Verify no `command not found: compdef` error and completion registration line remains present.

### Expected

- Script works even when `compdef` is initially unavailable.

### Actual

- With this patch, script includes a guard that initializes `compinit` before `compdef` registration when needed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Added test: `src/cli/completion-cli.zsh.test.ts`.
- Ran: `pnpm test src/cli/completion-cli.zsh.test.ts`.
- Ran: `pnpm exec oxfmt --check src/cli/completion-cli.ts src/cli/completion-cli.zsh.test.ts CHANGELOG.md`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: generated script now contains `compinit` guard and still registers `compdef` root completion.
- Edge cases checked: script keeps existing completion registration structure and only initializes when needed (`compdef` absent).
- What you did **not** verify: live interactive shell behavior across all zsh plugin frameworks.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `e326cc201`.
- Files/config to restore: `src/cli/completion-cli.ts`, `src/cli/completion-cli.zsh.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: zsh startup slowdown if repeated `compinit` path unexpectedly triggers (guard should prevent this when `compdef` exists).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: running `compinit` inside completion script may have side effects in custom zsh setups.
  - Mitigation: guarded execution (`compdef` missing only), plus unit coverage that verifies script structure and registration behavior.
