### PR TITLE
fix(slack): add actionable no-mention hint for channel skips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/channel visibility diagnostics: when channel messages are skipped by mention gating, log an actionable hint for disabling `channels.slack.requireMention` (or `channels.slack.channels["*"].requireMention`) so operators can distinguish config gating from missing event delivery. (#31674)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -516,6 +516,28 @@ Legacy keys:
 - Media and non-text payloads fall back to normal delivery.
 - If streaming fails mid-reply, OpenClaw falls back to normal delivery for remaining payloads.
 
+## Troubleshooting channel events
+
+If `app_mention` events work but regular channel messages do not trigger replies:
+
+1. Confirm your Slack app has `message.channels` / `message.groups` event subscriptions and `channels:history` / `groups:history` scopes.
+2. Check mention gating. By default, channel replies often require a bot mention.
+3. To allow non-mention channel messages, configure:
+
+```json
+{
+  "channels": {
+    "slack": {
+      "groupPolicy": "open",
+      "requireMention": false,
+      "channels": {
+        "*": { "requireMention": false }
+      }
+    }
+  }
+}
+```
+
 ## Configuration reference pointers
 
 Primary reference:

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -12,7 +12,7 @@ import type { ResolvedSlackAccount } from "../../accounts.js";
 import type { SlackMessageEvent } from "../../types.js";
 import type { SlackMonitorContext } from "../context.js";
 import { createSlackMonitorContext } from "../context.js";
-import { prepareSlackMessage } from "./prepare.js";
+import { prepareSlackMessage, SLACK_NO_MENTION_HINT } from "./prepare.js";
 
 describe("slack prepareSlackMessage inbound contract", () => {
   let fixtureRoot = "";
@@ -255,6 +255,36 @@ describe("slack prepareSlackMessage inbound contract", () => {
     }
     return slackCtx;
   }
+
+  it("logs an actionable hint when channel messages are skipped for missing @mention", async () => {
+    const slackCtx = createReplyToAllSlackCtx({
+      groupPolicy: "open",
+      defaultRequireMention: true,
+      asChannel: true,
+    });
+    const infoMock = vi.fn();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    (slackCtx as any).logger = { info: infoMock };
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount(),
+      createThreadReplyMessage({
+        thread_ts: undefined,
+        text: "hello channel",
+      }),
+    );
+
+    expect(prepared).toBeNull();
+    expect(infoMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        reason: "no-mention",
+        hint: SLACK_NO_MENTION_HINT,
+      }),
+      "skipping channel message",
+    );
+  });
 
   it("produces a finalized MsgContext", async () => {
     const message: SlackMessageEvent = {

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -51,6 +51,9 @@ import {
 import { resolveSlackRoomContextHints } from "../room-context.js";
 import type { PreparedSlackMessage } from "./types.js";
 
+export const SLACK_NO_MENTION_HINT =
+  'Set channels.slack.requireMention=false or channels.slack.channels["*"].requireMention=false to handle channel messages without @mentions.';
+
 export async function prepareSlackMessage(params: {
   ctx: SlackMonitorContext;
   account: ResolvedSlackAccount;
@@ -311,7 +314,14 @@ export async function prepareSlackMessage(params: {
   });
   const effectiveWasMentioned = mentionGate.effectiveWasMentioned;
   if (isRoom && shouldRequireMention && mentionGate.shouldSkip) {
-    ctx.logger.info({ channel: message.channel, reason: "no-mention" }, "skipping channel message");
+    ctx.logger.info(
+      {
+        channel: message.channel,
+        reason: "no-mention",
+        hint: SLACK_NO_MENTION_HINT,
+      },
+      "skipping channel message",
+    );
     const pendingText = (message.text ?? "").trim();
     const fallbackFile = message.files?.[0]?.name
       ? `[Slack file: ${message.files[0].name}]`


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Slack channel messages can be skipped by mention gating (`requireMention`) while operators interpret it as missing `message.channels`/`message.groups` event delivery.
- Why it matters: debugging channel visibility is slow and confusing when logs only say “skipping channel message” without configuration guidance.
- What changed: added an actionable no-mention hint to Slack channel-skip logs and documented the same troubleshooting path in Slack channel docs.
- What did NOT change (scope boundary): no changes to Slack mention-gating behavior, authorization logic, or event subscriptions/handlers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31674
- Related #31692

## User-visible / Behavior Changes

- When Slack channel messages are skipped due missing bot mention, logs now include a concrete config hint:
  - `channels.slack.requireMention=false`
  - `channels.slack.channels["*"].requireMention=false`
- Slack docs now include a troubleshooting section for “app_mention works but channel messages do not”.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Slack
- Relevant config (redacted): `channels.slack.groupPolicy=open`, default mention gating enabled

### Steps

1. Send a non-mention Slack channel message while `requireMention` is enabled.
2. Observe prepare flow skip.
3. Check structured log payload.

### Expected

- Skip log includes actionable config hint rather than only `reason: no-mention`.

### Actual

- Log now includes `hint` with exact config keys to disable mention gating for channels.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Added test: `src/slack/monitor/message-handler/prepare.test.ts`.
- Ran: `pnpm test src/slack/monitor/message-handler/prepare.test.ts`.
- Ran: `pnpm exec oxfmt --check src/slack/monitor/message-handler/prepare.ts src/slack/monitor/message-handler/prepare.test.ts docs/channels/slack.md CHANGELOG.md`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: no-mention channel path logs the new hint and returns `null` (message skipped as designed).
- Edge cases checked: behavior unchanged for existing mention-gated flow; only observability text and docs changed.
- What you did **not** verify: live Slack workspace runtime logs with real token/app setup.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `0700531af`.
- Files/config to restore: `src/slack/monitor/message-handler/prepare.ts`, `src/slack/monitor/message-handler/prepare.test.ts`, `docs/channels/slack.md`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: none expected beyond log payload differences.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: additional hint text may increase log verbosity in busy channels.
  - Mitigation: hint is emitted only on existing no-mention skip path and keeps current gating behavior unchanged.
