### PR TITLE
fix(agents): fallback for thinking-only assistant outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/vLLM empty-reply fallback: when providers return thinking content but no assistant text, use extracted thinking as a fallback reply only when reasoning output is not otherwise enabled, preventing empty user-visible responses. (#31598)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveSilentReplyFallbackText } from "./pi-embedded-subscribe.handlers.messages.js";
+import {
+  resolveSilentReplyFallbackText,
+  resolveThinkingOnlyFallbackText,
+} from "./pi-embedded-subscribe.handlers.messages.js";
 
 describe("resolveSilentReplyFallbackText", () => {
   it("replaces NO_REPLY with latest messaging tool text when available", () => {
@@ -27,5 +30,43 @@ describe("resolveSilentReplyFallbackText", () => {
         messagingToolSentTexts: [],
       }),
     ).toBe("NO_REPLY");
+  });
+});
+
+describe("resolveThinkingOnlyFallbackText", () => {
+  it("falls back to extracted thinking when assistant text is empty", () => {
+    expect(
+      resolveThinkingOnlyFallbackText({
+        text: "",
+        hasMedia: false,
+        extractedThinking: "final answer text",
+        includeReasoning: false,
+        streamReasoning: false,
+      }),
+    ).toBe("final answer text");
+  });
+
+  it("does not replace existing assistant text", () => {
+    expect(
+      resolveThinkingOnlyFallbackText({
+        text: "assistant reply",
+        hasMedia: false,
+        extractedThinking: "thinking text",
+        includeReasoning: false,
+        streamReasoning: false,
+      }),
+    ).toBe("assistant reply");
+  });
+
+  it("does not fallback when reasoning output is explicitly enabled", () => {
+    expect(
+      resolveThinkingOnlyFallbackText({
+        text: "",
+        hasMedia: false,
+        extractedThinking: "thinking text",
+        includeReasoning: true,
+        streamReasoning: false,
+      }),
+    ).toBe("");
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -56,6 +56,23 @@ export function resolveSilentReplyFallbackText(params: {
   return fallback;
 }
 
+export function resolveThinkingOnlyFallbackText(params: {
+  text: string;
+  hasMedia: boolean;
+  extractedThinking: string;
+  includeReasoning: boolean;
+  streamReasoning: boolean;
+}): string {
+  if (params.text || params.hasMedia) {
+    return params.text;
+  }
+  if (params.includeReasoning || params.streamReasoning) {
+    return params.text;
+  }
+  const thinking = params.extractedThinking.trim();
+  return thinking || params.text;
+}
+
 export function handleMessageStart(
   ctx: EmbeddedPiSubscribeContext,
   evt: AgentEvent & { message: AgentMessage },
@@ -277,10 +294,10 @@ export function handleMessageEnd(
     text: ctx.stripBlockTags(rawText, { thinking: false, final: false }),
     messagingToolSentTexts: ctx.state.messagingToolSentTexts,
   });
+  const extractedThinking =
+    extractAssistantThinking(assistantMessage) || extractThinkingFromTaggedText(rawText);
   const rawThinking =
-    ctx.state.includeReasoning || ctx.state.streamReasoning
-      ? extractAssistantThinking(assistantMessage) || extractThinkingFromTaggedText(rawText)
-      : "";
+    ctx.state.includeReasoning || ctx.state.streamReasoning ? extractedThinking : "";
   const formattedReasoning = rawThinking ? formatReasoningMessage(rawThinking) : "";
   const trimmedText = text.trim();
   const parsedText = trimmedText ? parseReplyDirectives(stripTrailingDirective(trimmedText)) : null;
@@ -299,6 +316,14 @@ export function handleMessageEnd(
       hasMedia = Boolean(mediaUrls && mediaUrls.length > 0);
     }
   }
+
+  cleanedText = resolveThinkingOnlyFallbackText({
+    text: cleanedText,
+    hasMedia,
+    extractedThinking,
+    includeReasoning: ctx.state.includeReasoning,
+    streamReasoning: ctx.state.streamReasoning,
+  });
 
   if (!ctx.state.emittedAssistantUpdate && (cleanedText || hasMedia)) {
     emitAgentEvent({


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: some OpenAI-compatible providers (reported with vLLM deployments) can produce assistant messages with thinking content but no final text, which surfaces as an empty reply.
- Why it matters: users see blank/empty responses even though the model executed and produced useful content.
- What changed: added a targeted fallback in embedded subscribe message handling: when assistant text is empty and no media is present, use extracted thinking as reply text only if reasoning output is not already enabled.
- What did NOT change (scope boundary): no changes to tool error fallback policy, no synthetic completion text injection rules, and no behavior change when normal assistant text exists.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31598
- Related #31689

## User-visible / Behavior Changes

- Empty assistant replies caused by thinking-only outputs are now converted into visible text replies (when reasoning output is otherwise off), reducing blank response outcomes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: OpenAI-compatible / vLLM-style paths
- Integration/channel (if any): N/A
- Relevant config (redacted): default reasoning output disabled

### Steps

1. Simulate assistant output with empty `text` and non-empty extracted thinking.
2. Run message-end fallback logic.
3. Verify non-empty user-visible text is produced only when reasoning output is disabled.

### Expected

- Non-empty fallback reply for thinking-only output.
- No replacement when normal assistant text exists.
- No fallback when reasoning output is explicitly enabled.

### Actual

- All expected behaviors now hold and are covered by unit tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Added tests in `src/agents/pi-embedded-subscribe.handlers.messages.test.ts`.
- Ran: `pnpm test src/agents/pi-embedded-subscribe.handlers.messages.test.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts`.
- Ran: `pnpm exec oxfmt --check src/agents/pi-embedded-subscribe.handlers.messages.ts src/agents/pi-embedded-subscribe.handlers.messages.test.ts CHANGELOG.md`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: thinking-only fallback engages only for empty-text/no-media path and keeps existing text untouched.
- Edge cases checked: reasoning-enabled paths still do not apply this fallback.
- What you did **not** verify: live end-to-end vLLM deployment behavior on a remote gateway.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `7ab4acb56`.
- Files/config to restore: `src/agents/pi-embedded-subscribe.handlers.messages.ts`, `src/agents/pi-embedded-subscribe.handlers.messages.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: unexpected fallback text replacing intended empty completions in niche provider flows.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some providers may place intermediate reasoning in thinking blocks that is not intended as final answer text.
  - Mitigation: fallback is narrowly scoped to empty-text/no-media replies and disabled when reasoning output is explicitly enabled.
