### PR TITLE
fix(webchat): allow image-only Control UI sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
+- Webchat/Image-only sends: treat `chat.send` image attachments (`opts.images`) as media-bearing input in reply preflight so Control UI image-only messages run normally instead of returning `I didn't receive any text in your message.` (#30818)
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.
 - Gateway/Control UI method guard: allow POST requests to non-UI routes to fall through when no base path is configured, and add POST regression coverage for fallthrough and base-path 405 behavior. (#23970) Thanks @tyler6204.

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -208,6 +208,31 @@ describe("runPreparedReply media-only handling", () => {
     expect(vi.mocked(runReplyAgent)).not.toHaveBeenCalled();
   });
 
+  it("allows media-only prompts when images are provided via reply options", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "webchat",
+        },
+        opts: {
+          images: [{ type: "image", data: "aGVsbG8=", mimeType: "image/png" }],
+        },
+      }),
+    );
+
+    expect(result).toEqual({ text: "ok" });
+    expect(vi.mocked(runReplyAgent)).toHaveBeenCalledOnce();
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call?.commandBody).toContain("[User sent media without caption]");
+  });
+
   it("omits auth key labels from /new and /reset confirmation messages", async () => {
     await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -306,7 +306,10 @@ export async function runPreparedReply(
     : [inboundUserContext, baseBodyFinal].filter(Boolean).join("\n\n");
   const baseBodyTrimmed = baseBodyForPrompt.trim();
   const hasMediaAttachment = Boolean(
-    sessionCtx.MediaPath || (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0),
+    sessionCtx.MediaPath ||
+    (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0) ||
+    // Webchat image uploads are passed as opts.images (not session media paths).
+    (opts?.images && opts.images.length > 0),
   );
   if (!baseBodyTrimmed && !hasMediaAttachment) {
     await typing.onReplyStart();


### PR DESCRIPTION
## Summary

- Problem: Control UI image-only messages (paste image, no text) could be rejected as empty with `I didn't receive any text in your message.`
- Why it matters: Webchat attachments are sent via `chat.send` images, so image-only turns should still run the agent.
- What changed: Treat `opts.images` as media-bearing input in `runPreparedReply` preflight; added regression test coverage for media-only turns via reply options.
- What did NOT change (scope boundary): No RPC contract change, no attachment parsing format change, no model/runtime behavior change beyond empty-body preflight gating.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30818
- Related #31689

## User-visible / Behavior Changes

- Webchat/Control UI now accepts image-only messages (no text) when attachments are present, instead of returning the empty-text prompt.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: n/a (unit-level)
- Integration/channel (if any): internal webchat flow
- Relevant config (redacted): default test mocks

### Steps

1. Build a media-only turn with empty body and `opts.images` set (webchat attachment path).
2. Run `runPreparedReply`.
3. Assert runner is invoked and prompt includes media-only fallback text.

### Expected

- Media-only turns with `opts.images` proceed to agent run.

### Actual

- Before fix, empty-body preflight returned `I didn't receive any text in your message.`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: unit regression for media-only via `opts.images`; existing media-only behavior via `MediaPath` unchanged.
- Edge cases checked: empty text + no media still returns empty-text guard response.
- What you did **not** verify: manual browser E2E against running gateway in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/auto-reply/reply/get-reply-run.ts` and associated test.
- Known bad symptoms reviewers should watch for: unexpected non-media empty turns bypassing guard (covered by unchanged no-media test).

## Risks and Mitigations

- Risk: Treating `opts.images` as media might let malformed image arrays bypass empty-body guard.
  - Mitigation: malformed/unsupported images still fail downstream validation/parsing; guard change only affects media presence check.
