### PR TITLE
fix(auth): add missing API key setup hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
+- Auth/Missing API key guidance: include provider-specific environment variable hints (for example `google` → `GEMINI_API_KEY`) in missing-key auth errors so `/model` failures are actionable. (#31544)
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.
 - Gateway/Control UI method guard: allow POST requests to non-UI routes to fall through when no base path is configured, and add POST regression coverage for fallthrough and base-path 405 behavior. (#23970) Thanks @tyler6204.

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -183,6 +183,31 @@ describe("getApiKeyForModel", () => {
         }
 
         expect(String(error)).toContain('No API key found for provider "zai".');
+        expect(String(error)).toContain("ZAI_API_KEY");
+        expect(String(error)).toContain("Z_AI_API_KEY");
+      },
+    );
+  });
+
+  it("suggests GEMINI_API_KEY when google API key is missing", async () => {
+    await withEnvAsync(
+      {
+        GEMINI_API_KEY: undefined,
+      },
+      async () => {
+        let error: unknown = null;
+        try {
+          await resolveApiKeyForProvider({
+            provider: "google",
+            store: { version: 1, profiles: {} },
+          });
+        } catch (err) {
+          error = err;
+        }
+
+        expect(String(error)).toContain('No API key found for provider "google".');
+        expect(String(error)).toContain("GEMINI_API_KEY");
+        expect(String(error)).toContain("openclaw agents add <id>");
       },
     );
   });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -24,6 +24,32 @@ const AWS_BEARER_ENV = "AWS_BEARER_TOKEN_BEDROCK";
 const AWS_ACCESS_KEY_ENV = "AWS_ACCESS_KEY_ID";
 const AWS_SECRET_KEY_ENV = "AWS_SECRET_ACCESS_KEY";
 const AWS_PROFILE_ENV = "AWS_PROFILE";
+const PROVIDER_API_KEY_ENV_MAP: Record<string, string> = {
+  openai: "OPENAI_API_KEY",
+  google: "GEMINI_API_KEY",
+  voyage: "VOYAGE_API_KEY",
+  groq: "GROQ_API_KEY",
+  deepgram: "DEEPGRAM_API_KEY",
+  cerebras: "CEREBRAS_API_KEY",
+  xai: "XAI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+  litellm: "LITELLM_API_KEY",
+  "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
+  "cloudflare-ai-gateway": "CLOUDFLARE_AI_GATEWAY_API_KEY",
+  moonshot: "MOONSHOT_API_KEY",
+  minimax: "MINIMAX_API_KEY",
+  nvidia: "NVIDIA_API_KEY",
+  xiaomi: "XIAOMI_API_KEY",
+  synthetic: "SYNTHETIC_API_KEY",
+  venice: "VENICE_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  opencode: "OPENCODE_API_KEY",
+  together: "TOGETHER_API_KEY",
+  qianfan: "QIANFAN_API_KEY",
+  ollama: "OLLAMA_API_KEY",
+  vllm: "VLLM_API_KEY",
+  kilocode: "KILOCODE_API_KEY",
+};
 
 function resolveProviderConfig(
   cfg: OpenClawConfig | undefined,
@@ -45,6 +71,45 @@ function resolveProviderConfig(
     (providers[normalized] as ModelProviderConfig | undefined) ??
     Object.entries(providers).find(([key]) => normalizeProviderId(key) === normalized)?.[1]
   );
+}
+
+function resolveProviderApiKeyEnvVarHints(provider: string): string[] {
+  const normalized = normalizeProviderId(provider);
+  if (normalized === "github-copilot") {
+    return ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
+  }
+  if (normalized === "anthropic") {
+    return ["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"];
+  }
+  if (normalized === "chutes") {
+    return ["CHUTES_API_KEY", "CHUTES_OAUTH_TOKEN"];
+  }
+  if (normalized === "zai") {
+    return ["ZAI_API_KEY", "Z_AI_API_KEY"];
+  }
+  if (normalized === "opencode") {
+    return ["OPENCODE_API_KEY", "OPENCODE_ZEN_API_KEY"];
+  }
+  if (normalized === "qwen-portal") {
+    return ["QWEN_PORTAL_API_KEY", "QWEN_OAUTH_TOKEN"];
+  }
+  if (normalized === "volcengine" || normalized === "volcengine-plan") {
+    return ["VOLCANO_ENGINE_API_KEY"];
+  }
+  if (normalized === "byteplus" || normalized === "byteplus-plan") {
+    return ["BYTEPLUS_API_KEY"];
+  }
+  if (normalized === "minimax-portal") {
+    return ["MINIMAX_API_KEY", "MINIMAX_OAUTH_TOKEN"];
+  }
+  if (normalized === "kimi-coding") {
+    return ["KIMI_API_KEY", "KIMICODE_API_KEY"];
+  }
+  if (normalized === "huggingface") {
+    return ["HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"];
+  }
+  const envVar = PROVIDER_API_KEY_ENV_MAP[normalized];
+  return envVar ? [envVar] : [];
 }
 
 export function getCustomProviderApiKey(
@@ -223,9 +288,17 @@ export async function resolveApiKeyForProvider(params: {
 
   const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
   const resolvedAgentDir = path.dirname(authStorePath);
+  const envHints = resolveProviderApiKeyEnvVarHints(provider);
+  const envHintText =
+    envHints.length > 0
+      ? `Set ${envHints.join(" or ")} in your environment.`
+      : normalizeProviderId(provider) === "google-vertex"
+        ? "Authenticate with gcloud ADC (`gcloud auth application-default login`)."
+        : undefined;
   throw new Error(
     [
       `No API key found for provider "${provider}".`,
+      envHintText,
       `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
       `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
     ].join(" "),
@@ -298,33 +371,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     return pick("HUGGINGFACE_HUB_TOKEN") ?? pick("HF_TOKEN");
   }
 
-  const envMap: Record<string, string> = {
-    openai: "OPENAI_API_KEY",
-    google: "GEMINI_API_KEY",
-    voyage: "VOYAGE_API_KEY",
-    groq: "GROQ_API_KEY",
-    deepgram: "DEEPGRAM_API_KEY",
-    cerebras: "CEREBRAS_API_KEY",
-    xai: "XAI_API_KEY",
-    openrouter: "OPENROUTER_API_KEY",
-    litellm: "LITELLM_API_KEY",
-    "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
-    "cloudflare-ai-gateway": "CLOUDFLARE_AI_GATEWAY_API_KEY",
-    moonshot: "MOONSHOT_API_KEY",
-    minimax: "MINIMAX_API_KEY",
-    nvidia: "NVIDIA_API_KEY",
-    xiaomi: "XIAOMI_API_KEY",
-    synthetic: "SYNTHETIC_API_KEY",
-    venice: "VENICE_API_KEY",
-    mistral: "MISTRAL_API_KEY",
-    opencode: "OPENCODE_API_KEY",
-    together: "TOGETHER_API_KEY",
-    qianfan: "QIANFAN_API_KEY",
-    ollama: "OLLAMA_API_KEY",
-    vllm: "VLLM_API_KEY",
-    kilocode: "KILOCODE_API_KEY",
-  };
-  const envVar = envMap[normalized];
+  const envVar = PROVIDER_API_KEY_ENV_MAP[normalized];
   if (!envVar) {
     return null;
   }


### PR DESCRIPTION
## Summary

- Problem: when a model is selected but credentials are missing, the user-facing failure text is verbose and not actionable.
- Why it matters: `/model` failures should immediately tell users what to configure (for example which env var).
- What changed: added provider-specific env var hints to missing-key auth errors (for example `google` -> `GEMINI_API_KEY`), and reused a shared env-map constant for consistency.
- What did NOT change (scope boundary): no model fallback policy changes, no auth profile storage format changes, no networking/runtime behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31544
- Related #31709

## User-visible / Behavior Changes

- Missing API key errors now include provider-specific setup hints (for example `GEMINI_API_KEY`, `ZAI_API_KEY`/`Z_AI_API_KEY`) so users can fix config faster.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: auth resolution unit tests
- Integration/channel (if any): n/a
- Relevant config (redacted): default mocked auth store

### Steps

1. Call provider auth resolution without env key/profile for `google` and `zai`.
2. Observe thrown missing-key message.
3. Assert message includes specific env var hints and setup command reference.

### Expected

- Error text includes actionable provider-specific env variable guidance.

### Actual

- Before fix, message lacked direct env var hint and mostly surfaced store-path details.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `src/agents/model-auth.profiles.test.ts` includes missing-key assertions for `google` and `zai`.
- Edge cases checked: existing env resolution behavior still passes with unchanged precedence.
- What you did **not** verify: interactive `/model` flow in TUI end-to-end.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/model-auth.ts` and `src/agents/model-auth.profiles.test.ts`.
- Known bad symptoms reviewers should watch for: missing-key errors no longer mentioning expected env vars.

## Risks and Mitigations

- Risk: hint text may diverge from future env-key naming changes.
  - Mitigation: centralized `PROVIDER_API_KEY_ENV_MAP` now backs both resolution and hint generation.
