### PR TITLE
fix: prevent synthetic toolResult for aborted/errored assistant messages

### DIFF
--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -183,11 +183,15 @@ export function convertMessagesToInputItems(messages: Message[]): InputItem[] {
       continue;
     }
 
-    if (m.role === "assistant") {
-      const content = m.content;
-      if (Array.isArray(content)) {
-        // Collect text blocks and tool calls separately
-        const textParts: string[] = [];
+        if (m.role === "assistant") {
+          // Ensure the assistant message completed successfully before extracting tool calls.
+          // 'end_turn' is the only state indicating the message was not cut off or filtered.
+          if ((m as any)?.stopReason !== "end_turn") {
+            continue;
+          }
+          const content = m.content;
+          if (Array.isArray(content)) {
+            // Collect text blocks and tool calls separately
         for (const block of content as Array<{
           type?: string;
           text?: string;


### PR DESCRIPTION
The code extracted tool calls from assistant messages to track pending results but failed to check the message's `stopReason`. Aborted or errored messages may contain incomplete tool call blocks that should not be treated as valid pending requests.

**Changes:**
- Added guard clause to check stopReason === 'end_turn' before extracting tool calls
- Only fully completed assistant messages are now processed for tool calls
- This prevents API 400 errors caused by creating synthetic results for incomplete tool calls

**Risk level:** low

**Test suggestions:**
- Verify behavior when stopReason is 'stop' (user interruption) - tool calls should be ignored
- Verify behavior when stopReason is 'content_filter' - tool calls should be ignored  
- Verify behavior when stopReason is 'end_turn' - tool calls are processed correctly
- Verify behavior when stopReason is undefined - treated as incomplete and skipped