### PR TITLE
fix(heartbeat): reload config on wake runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
+- Heartbeat/Config reloads: reload config before each heartbeat wake so external model/config updates (for example `openclaw models set ...`) take effect without restarting gateway. (#31705)
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.
 - Gateway/Control UI method guard: allow POST requests to non-UI routes to fall through when no base path is configured, and add POST regression coverage for fallthrough and base-path 405 behavior. (#23970) Thanks @tyler6204.

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import * as configModule from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { startHeartbeatRunner } from "./heartbeat-runner.js";
 import { requestHeartbeatNow, resetHeartbeatWakeStateForTests } from "./heartbeat-wake.js";
@@ -10,6 +11,7 @@ describe("startHeartbeatRunner", () => {
         agents: { defaults: { heartbeat: { every: "30m" } } },
       } as OpenClawConfig,
       runOnce,
+      reloadConfigOnRun: false,
     });
   }
 
@@ -100,10 +102,10 @@ describe("startHeartbeatRunner", () => {
     } as OpenClawConfig;
 
     // Start runner A
-    const runnerA = startHeartbeatRunner({ cfg, runOnce: runSpy1 });
+    const runnerA = startHeartbeatRunner({ cfg, runOnce: runSpy1, reloadConfigOnRun: false });
 
     // Start runner B (simulates lifecycle reload)
-    const runnerB = startHeartbeatRunner({ cfg, runOnce: runSpy2 });
+    const runnerB = startHeartbeatRunner({ cfg, runOnce: runSpy2, reloadConfigOnRun: false });
 
     // Stop runner A (stale cleanup) — should NOT kill runner B's handler
     runnerA.stop();
@@ -152,6 +154,7 @@ describe("startHeartbeatRunner", () => {
         agents: { defaults: { heartbeat: { every: "30m" } } },
       } as OpenClawConfig,
       runOnce: runSpy,
+      reloadConfigOnRun: false,
     });
 
     // First heartbeat returns requests-in-flight
@@ -181,6 +184,7 @@ describe("startHeartbeatRunner", () => {
         },
       } as OpenClawConfig,
       runOnce: runSpy,
+      reloadConfigOnRun: false,
     });
 
     requestHeartbeatNow({
@@ -197,6 +201,45 @@ describe("startHeartbeatRunner", () => {
         agentId: "ops",
         reason: "cron:job-123",
         sessionKey: "agent:ops:discord:channel:alerts",
+      }),
+    );
+
+    runner.stop();
+  });
+
+  it("reloads config before wake runs so heartbeat uses updated model/interval config", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const initialCfg = {
+      agents: {
+        defaults: { heartbeat: { every: "30m" } },
+      },
+    } as OpenClawConfig;
+    const reloadedCfg = {
+      agents: {
+        defaults: { heartbeat: { every: "30m" } },
+        list: [{ id: "main", heartbeat: { every: "5m" } }],
+      },
+    } as OpenClawConfig;
+    const loadSpy = vi.spyOn(configModule, "loadConfig").mockReturnValue(reloadedCfg);
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: initialCfg,
+      runOnce: runSpy,
+      reloadConfigOnRun: true,
+    });
+
+    requestHeartbeatNow({ reason: "manual", coalesceMs: 0 });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(loadSpy).toHaveBeenCalled();
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(runSpy.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        cfg: reloadedCfg,
+        agentId: "main",
+        heartbeat: { every: "5m" },
       }),
     );
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -988,6 +988,8 @@ export function startHeartbeatRunner(opts: {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   runOnce?: typeof runHeartbeatOnce;
+  /** Reload config from disk before each wake (default: true). */
+  reloadConfigOnRun?: boolean;
 }): HeartbeatRunner {
   const runtime = opts.runtime ?? defaultRuntime;
   const runOnce = opts.runOnce ?? runHeartbeatOnce;
@@ -1109,6 +1111,21 @@ export function startHeartbeatRunner(opts: {
         status: "skipped",
         reason: "disabled",
       } satisfies HeartbeatRunResult;
+    }
+
+    if (opts.reloadConfigOnRun !== false) {
+      // Keep heartbeat model/interval selection in sync with external `openclaw models set`
+      // and other config edits that may occur outside the running gateway process.
+      try {
+        updateConfig(loadConfig());
+      } catch {}
+      if (state.agents.size === 0) {
+        scheduleNext();
+        return {
+          status: "skipped",
+          reason: "disabled",
+        } satisfies HeartbeatRunResult;
+      }
     }
 
     const reason = params?.reason;


### PR DESCRIPTION
## Summary

- Problem: heartbeat runner keeps an in-memory config snapshot; external config edits (for example `openclaw models set`) may not be applied to heartbeat runs until restart.
- Why it matters: users can switch models successfully for regular flows, but heartbeat may continue using stale model settings.
- What changed: heartbeat runner now reloads config before each wake by default and refreshes scheduling state; added regression coverage for config reload behavior.
- What did NOT change (scope boundary): no heartbeat payload formatting changes, no model fallback logic changes, no channel delivery routing changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31705
- Related #31544

## User-visible / Behavior Changes

- Heartbeat picks up updated config/model settings on wake without requiring gateway restart.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: heartbeat scheduler unit tests
- Integration/channel (if any): heartbeat runner
- Relevant config (redacted): test fixtures with heartbeat interval updates

### Steps

1. Start heartbeat runner with initial config.
2. Mock `loadConfig()` to return updated heartbeat settings.
3. Trigger a wake and assert `runOnce` receives reloaded config/heartbeat fields.

### Expected

- Wake run uses latest config values from disk.

### Actual

- Before fix, wake run used stale in-memory `state.cfg` until explicit `updateConfig`/restart.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: scheduler suite with new reload regression test (`runOnce` sees updated config).
- Edge cases checked: existing scheduling tests with reload disabled remain stable.
- What you did **not** verify: full end-to-end heartbeat model switch against a live provider.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `reloadConfigOnRun: false` where runner is created, or revert this PR.
- Files/config to restore: `src/infra/heartbeat-runner.ts` and scheduler test.
- Known bad symptoms reviewers should watch for: repeated unexpected disabled state due bad config reloads.

## Risks and Mitigations

- Risk: repeated config parse failures on wake could hide updates.
  - Mitigation: reload is best-effort; runner retains last known good state and continues scheduling.
