### PR TITLE
fix(feishu): suppress reasoning/thinking block payloads from delivery

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -185,6 +185,23 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
+  it("suppresses internal block payload delivery", async () => {
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "internal reasoning chunk" }, { kind: "block" });
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+  });
+
   it("uses streaming session for auto mode markdown payloads", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -194,7 +194,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       deliver: async (payload: ReplyPayload, info) => {
         // FIX: Filter out internal 'block' reasoning chunks immediately to prevent
         // data leak and race conditions with streaming state initialization.
-        if (info?.kind === 'block') {
+        if (info?.kind === "block") {
           return;
         }
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -192,36 +192,42 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         void typingCallbacks.onReplyStart?.();
       },
       deliver: async (payload: ReplyPayload, info) => {
-        const text = payload.text ?? "";
-        const mediaList =
-          payload.mediaUrls && payload.mediaUrls.length > 0
-            ? payload.mediaUrls
-            : payload.mediaUrl
-              ? [payload.mediaUrl]
-              : [];
-        const hasText = Boolean(text.trim());
-        const hasMedia = mediaList.length > 0;
-
-        if (!hasText && !hasMedia) {
-          return;
-        }
-
-        if (hasText) {
-          const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
-
-          if ((info?.kind === "block" || info?.kind === "final") && streamingEnabled && useCard) {
-            startStreaming();
-            if (streamingStartPromise) {
-              await streamingStartPromise;
+            // FIX: Filter out internal 'block' reasoning chunks immediately to prevent
+            // data leak and race conditions with streaming state initialization.
+            if (info?.kind === 'block') {
+              return;
             }
-          }
 
-          if (streaming?.isActive()) {
-            if (info?.kind === "final") {
-              streamText = text;
-              await closeStreaming();
+            const text = payload.text ?? "";
+            const mediaList =
+              payload.mediaUrls && payload.mediaUrls.length > 0
+                ? payload.mediaUrls
+                : payload.mediaUrl
+                  ? [payload.mediaUrl]
+                  : [];
+            const hasText = Boolean(text.trim());
+            const hasMedia = mediaList.length > 0;
+
+            if (!hasText && !hasMedia) {
+              return;
             }
-            // Send media even when streaming handled the text
+
+            if (hasText) {
+              const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
+
+              if (info?.kind === "final" && streamingEnabled && useCard) {
+                startStreaming();
+                if (streamingStartPromise) {
+                  await streamingStartPromise;
+                }
+              }
+
+              if (streaming?.isActive()) {
+                if (info?.kind === "final") {
+                  streamText = text;
+                  await closeStreaming();
+                }
+                // Send media even when streaming handled the text
             if (hasMedia) {
               for (const mediaUrl of mediaList) {
                 await sendMediaFeishu({

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -192,42 +192,42 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         void typingCallbacks.onReplyStart?.();
       },
       deliver: async (payload: ReplyPayload, info) => {
-            // FIX: Filter out internal 'block' reasoning chunks immediately to prevent
-            // data leak and race conditions with streaming state initialization.
-            if (info?.kind === 'block') {
-              return;
+        // FIX: Filter out internal 'block' reasoning chunks immediately to prevent
+        // data leak and race conditions with streaming state initialization.
+        if (info?.kind === 'block') {
+          return;
+        }
+
+        const text = payload.text ?? "";
+        const mediaList =
+          payload.mediaUrls && payload.mediaUrls.length > 0
+            ? payload.mediaUrls
+            : payload.mediaUrl
+              ? [payload.mediaUrl]
+              : [];
+        const hasText = Boolean(text.trim());
+        const hasMedia = mediaList.length > 0;
+
+        if (!hasText && !hasMedia) {
+          return;
+        }
+
+        if (hasText) {
+          const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
+
+          if (info?.kind === "final" && streamingEnabled && useCard) {
+            startStreaming();
+            if (streamingStartPromise) {
+              await streamingStartPromise;
             }
+          }
 
-            const text = payload.text ?? "";
-            const mediaList =
-              payload.mediaUrls && payload.mediaUrls.length > 0
-                ? payload.mediaUrls
-                : payload.mediaUrl
-                  ? [payload.mediaUrl]
-                  : [];
-            const hasText = Boolean(text.trim());
-            const hasMedia = mediaList.length > 0;
-
-            if (!hasText && !hasMedia) {
-              return;
+          if (streaming?.isActive()) {
+            if (info?.kind === "final") {
+              streamText = text;
+              await closeStreaming();
             }
-
-            if (hasText) {
-              const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
-
-              if (info?.kind === "final" && streamingEnabled && useCard) {
-                startStreaming();
-                if (streamingStartPromise) {
-                  await streamingStartPromise;
-                }
-              }
-
-              if (streaming?.isActive()) {
-                if (info?.kind === "final") {
-                  streamText = text;
-                  await closeStreaming();
-                }
-                // Send media even when streaming handled the text
+            // Send media even when streaming handled the text
             if (hasMedia) {
               for (const mediaUrl of mediaList) {
                 await sendMediaFeishu({


### PR DESCRIPTION
The delivery callback did not filter out payloads where info.kind === 'block', causing internal reasoning data to be sent to external users in partial stream mode. Also fixed a race condition in streaming initialization.

**Changes:**
- Added early return guard to filter 'block' payloads immediately
- Prevents internal reasoning/thinking data from leaking to external Feishu users
- Fixed race condition where 'block' payloads triggered streaming initialization
- Removed 'block' from streaming trigger condition to prevent empty stream failures

**Risk level:** low