### PR TITLE
fix(slack): register message.channels and message.groups handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/Channel visibility: register explicit `message.channels` and `message.groups` handlers alongside the base `message` handler so channel/group message events are dispatched even when Slack subscriptions emit typed message event names. (#31674)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/slack/monitor/events/messages.test.ts
+++ b/src/slack/monitor/events/messages.test.ts
@@ -32,7 +32,9 @@ function createMessageHandlers(overrides?: SlackSystemEventTestOverrides) {
     handleSlackMessage,
   });
   return {
-    handler: harness.getHandler("message") as MessageHandler | null,
+    message: harness.getHandler("message") as MessageHandler | null,
+    channels: harness.getHandler("message.channels") as MessageHandler | null,
+    groups: harness.getHandler("message.groups") as MessageHandler | null,
     handleSlackMessage,
   };
 }
@@ -78,9 +80,9 @@ function makeThreadBroadcastEvent(overrides?: { channel?: string; user?: string 
 async function runMessageCase(input: MessageCase = {}): Promise<void> {
   messageQueueMock.mockClear();
   messageAllowMock.mockReset().mockResolvedValue([]);
-  const { handler } = createMessageHandlers(input.overrides);
-  expect(handler).toBeTruthy();
-  await handler!({
+  const { message } = createMessageHandlers(input.overrides);
+  expect(message).toBeTruthy();
+  await message!({
     event: (input.event ?? makeChangedEvent()) as Record<string, unknown>,
     body: input.body ?? {},
   });
@@ -136,24 +138,34 @@ describe("registerSlackMessageEvents", () => {
     expect(messageQueueMock).toHaveBeenCalledTimes(calls);
   });
 
-  it("passes regular message events to the message handler", async () => {
-    messageQueueMock.mockClear();
-    messageAllowMock.mockReset().mockResolvedValue([]);
-    const { handler, handleSlackMessage } = createMessageHandlers({ dmPolicy: "open" });
-    expect(handler).toBeTruthy();
+  const inboundMessageCases = [
+    { label: "message", key: "message" },
+    { label: "message.channels", key: "channels" },
+    { label: "message.groups", key: "groups" },
+  ] as const;
 
-    await handler!({
-      event: {
-        type: "message",
-        channel: "D1",
-        user: "U1",
-        text: "hello",
-        ts: "123.456",
-      },
-      body: {},
-    });
+  it.each(inboundMessageCases)(
+    "passes regular $label events to the message handler",
+    async ({ key }) => {
+      messageQueueMock.mockClear();
+      messageAllowMock.mockReset().mockResolvedValue([]);
+      const handlers = createMessageHandlers({ dmPolicy: "open" });
+      const handler = handlers[key];
+      expect(handler).toBeTruthy();
 
-    expect(handleSlackMessage).toHaveBeenCalledTimes(1);
-    expect(messageQueueMock).not.toHaveBeenCalled();
-  });
+      await handler!({
+        event: {
+          type: "message",
+          channel: "D1",
+          user: "U1",
+          text: "hello",
+          ts: "123.456",
+        },
+        body: {},
+      });
+
+      expect(handlers.handleSlackMessage).toHaveBeenCalledTimes(1);
+      expect(messageQueueMock).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -11,6 +11,8 @@ import type {
 } from "../types.js";
 import { authorizeAndResolveSlackSystemEventContext } from "./system-event-context.js";
 
+type SlackMessageEventName = "message" | "message.channels" | "message.groups";
+
 export function registerSlackMessageEvents(params: {
   ctx: SlackMonitorContext;
   handleSlackMessage: SlackMessageHandler;
@@ -27,15 +29,19 @@ export function registerSlackMessageEvents(params: {
   const resolveThreadBroadcastSenderId = (thread: SlackThreadBroadcastEvent): string | undefined =>
     thread.user ?? thread.message?.user ?? thread.message?.bot_id;
 
-  ctx.app.event("message", async ({ event, body }: SlackEventMiddlewareArgs<"message">) => {
+  const handleMessageEvent = async (params: {
+    eventName: SlackMessageEventName;
+    event: SlackMessageEvent;
+    body: unknown;
+  }) => {
     try {
-      if (ctx.shouldDropMismatchedSlackEvent(body)) {
+      if (ctx.shouldDropMismatchedSlackEvent(params.body)) {
         return;
       }
 
-      const message = event as SlackMessageEvent;
+      const message = params.event;
       if (message.subtype === "message_changed") {
-        const changed = event as SlackMessageChangedEvent;
+        const changed = params.event as SlackMessageChangedEvent;
         const channelId = changed.channel;
         const ingressContext = await authorizeAndResolveSlackSystemEventContext({
           ctx,
@@ -54,7 +60,7 @@ export function registerSlackMessageEvents(params: {
         return;
       }
       if (message.subtype === "message_deleted") {
-        const deleted = event as SlackMessageDeletedEvent;
+        const deleted = params.event as SlackMessageDeletedEvent;
         const channelId = deleted.channel;
         const ingressContext = await authorizeAndResolveSlackSystemEventContext({
           ctx,
@@ -72,7 +78,7 @@ export function registerSlackMessageEvents(params: {
         return;
       }
       if (message.subtype === "thread_broadcast") {
-        const thread = event as SlackThreadBroadcastEvent;
+        const thread = params.event as SlackThreadBroadcastEvent;
         const channelId = thread.channel;
         const ingressContext = await authorizeAndResolveSlackSystemEventContext({
           ctx,
@@ -93,9 +99,26 @@ export function registerSlackMessageEvents(params: {
 
       await handleSlackMessage(message, { source: "message" });
     } catch (err) {
-      ctx.runtime.error?.(danger(`slack handler failed: ${String(err)}`));
+      ctx.runtime.error?.(danger(`slack ${params.eventName} handler failed: ${String(err)}`));
     }
-  });
+  };
+
+  const registerMessageEvent = (eventName: SlackMessageEventName) => {
+    ctx.app.event(
+      eventName as "message",
+      async ({ event, body }: SlackEventMiddlewareArgs<"message">) => {
+        await handleMessageEvent({
+          eventName,
+          event: event as SlackMessageEvent,
+          body,
+        });
+      },
+    );
+  };
+
+  registerMessageEvent("message");
+  registerMessageEvent("message.channels");
+  registerMessageEvent("message.groups");
 
   ctx.app.event("app_mention", async ({ event, body }: SlackEventMiddlewareArgs<"app_mention">) => {
     try {


### PR DESCRIPTION
## Summary
- register explicit Slack message event handlers for `message.channels` and `message.groups` in addition to the existing `message` handler
- route all three message entrypoints through the same shared Slack message processing path
- add regression coverage to verify `message`, `message.channels`, and `message.groups` all dispatch to `handleSlackMessage`
- add changelog entry for channel/group visibility fix

Fixes #31674

## Security Impact
- none

## Repro
1. Configure Slack app subscriptions with `message.channels` and `message.groups`.
2. Post a non-mention message in a channel/group where OpenClaw is present.
3. Before this change, only the generic event registration path is present and typed channel/group names may not be dispatched in some subscription setups.

## Verification
- `pnpm test src/slack/monitor/events/messages.test.ts`
- `pnpm exec oxfmt --check src/slack/monitor/events/messages.ts src/slack/monitor/events/messages.test.ts CHANGELOG.md`
