### PR TITLE
Fix exec heartbeat wake scoping to prevent cross-agent fan-out

### DIFF
--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: vi.fn(),
+}));
+
+vi.mock("../infra/system-events.js", () => ({
+  enqueueSystemEvent: vi.fn(),
+}));
+
+import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
+import { emitExecSystemEvent } from "./bash-tools.exec-runtime.js";
+
+const requestHeartbeatNowMock = vi.mocked(requestHeartbeatNow);
+const enqueueSystemEventMock = vi.mocked(enqueueSystemEvent);
+
+describe("emitExecSystemEvent", () => {
+  beforeEach(() => {
+    requestHeartbeatNowMock.mockClear();
+    enqueueSystemEventMock.mockClear();
+  });
+
+  it("scopes heartbeat wake to the event session key", () => {
+    emitExecSystemEvent("Exec finished", {
+      sessionKey: "agent:ops:main",
+      contextKey: "exec:run-1",
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith("Exec finished", {
+      sessionKey: "agent:ops:main",
+      contextKey: "exec:run-1",
+    });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:ops:main",
+    });
+  });
+
+  it("ignores events without a session key", () => {
+    emitExecSystemEvent("Exec finished", {
+      sessionKey: "  ",
+      contextKey: "exec:run-2",
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -37,6 +37,21 @@ describe("emitExecSystemEvent", () => {
     });
   });
 
+  it("keeps wake unscoped for non-agent session keys", () => {
+    emitExecSystemEvent("Exec finished", {
+      sessionKey: "global",
+      contextKey: "exec:run-global",
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith("Exec finished", {
+      sessionKey: "global",
+      contextKey: "exec:run-global",
+    });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+    });
+  });
+
   it("ignores events without a session key", () => {
     emitExecSystemEvent("Exec finished", {
       sessionKey: "  ",

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -239,7 +239,7 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
   enqueueSystemEvent(summary, { sessionKey });
-  requestHeartbeatNow({ reason: `exec:${session.id}:exit` });
+  requestHeartbeatNow({ reason: `exec:${session.id}:exit`, sessionKey });
 }
 
 export function createApprovalSlug(id: string) {
@@ -265,7 +265,7 @@ export function emitExecSystemEvent(
     return;
   }
   enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
-  requestHeartbeatNow({ reason: "exec-event" });
+  requestHeartbeatNow({ reason: "exec-event", sessionKey });
 }
 
 export async function runExecProcess(opts: {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -6,6 +6,7 @@ import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
 import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -239,7 +240,11 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
   enqueueSystemEvent(summary, { sessionKey });
-  requestHeartbeatNow({ reason: `exec:${session.id}:exit`, sessionKey });
+  requestHeartbeatNow(
+    parseAgentSessionKey(sessionKey)
+      ? { reason: `exec:${session.id}:exit`, sessionKey }
+      : { reason: `exec:${session.id}:exit` },
+  );
 }
 
 export function createApprovalSlug(id: string) {
@@ -265,7 +270,11 @@ export function emitExecSystemEvent(
     return;
   }
   enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
-  requestHeartbeatNow({ reason: "exec-event", sessionKey });
+  requestHeartbeatNow(
+    parseAgentSessionKey(sessionKey)
+      ? { reason: "exec-event", sessionKey }
+      : { reason: "exec-event" },
+  );
 }
 
 export async function runExecProcess(opts: {

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -550,6 +550,25 @@ describe("exec notifyOnExit", () => {
     }
   });
 
+  it("keeps notifyOnExit heartbeat wake unscoped for non-agent session keys", async () => {
+    const tool = createNotifyOnExitExecTool({ sessionKey: "global" });
+    const wakeHandler = vi.fn().mockResolvedValue({ status: "skipped", reason: "disabled" });
+    const dispose = setHeartbeatWakeHandler(
+      wakeHandler as unknown as Parameters<typeof setHeartbeatWakeHandler>[0],
+    );
+    try {
+      const sessionId = await startBackgroundCommand(tool, echoAfterDelay("notify"));
+
+      await expect
+        .poll(() => wakeHandler.mock.calls[0]?.[0], NOTIFY_POLL_OPTIONS)
+        .toEqual({
+          reason: `exec:${sessionId}:exit`,
+        });
+    } finally {
+      dispose();
+    }
+  });
+
   it.each<NotifyNoopCase>(NOOP_NOTIFY_CASES)("$label", runNotifyNoopCase);
 });
 

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -1,5 +1,9 @@
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetHeartbeatWakeStateForTests,
+  setHeartbeatWakeHandler,
+} from "../infra/heartbeat-wake.js";
 import { applyPathPrepend, findPathKey } from "../infra/path-prepend.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
 import { captureEnv } from "../test-utils/env.js";
@@ -507,6 +511,14 @@ describe("exec exit codes", () => {
 });
 
 describe("exec notifyOnExit", () => {
+  beforeEach(() => {
+    resetHeartbeatWakeStateForTests();
+  });
+
+  afterEach(() => {
+    resetHeartbeatWakeStateForTests();
+  });
+
   it("enqueues a system event when a backgrounded exec exits", async () => {
     const tool = createNotifyOnExitExecTool();
 
@@ -516,6 +528,26 @@ describe("exec notifyOnExit", () => {
 
     expect(finished).toBeTruthy();
     expect(hasEvent).toBe(true);
+  });
+
+  it("scopes notifyOnExit heartbeat wake to the exec session key", async () => {
+    const tool = createNotifyOnExitExecTool();
+    const wakeHandler = vi.fn().mockResolvedValue({ status: "skipped", reason: "disabled" });
+    const dispose = setHeartbeatWakeHandler(
+      wakeHandler as unknown as Parameters<typeof setHeartbeatWakeHandler>[0],
+    );
+    try {
+      const sessionId = await startBackgroundCommand(tool, echoAfterDelay("notify"));
+
+      await expect
+        .poll(() => wakeHandler.mock.calls[0]?.[0], NOTIFY_POLL_OPTIONS)
+        .toMatchObject({
+          reason: `exec:${sessionId}:exit`,
+          sessionKey: DEFAULT_NOTIFY_SESSION_KEY,
+        });
+    } finally {
+      dispose();
+    }
   });
 
   it.each<NotifyNoopCase>(NOOP_NOTIFY_CASES)("$label", runNotifyNoopCase);

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -111,7 +111,10 @@ describe("node exec events", () => {
       "Exec started (node=node-1 id=run-1): ls -la",
       { sessionKey: "agent:main:main", contextKey: "exec:run-1" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:main:main",
+    });
   });
 
   it("enqueues exec.finished events with output", async () => {
@@ -130,7 +133,10 @@ describe("node exec events", () => {
       "Exec finished (node=node-2 id=run-2, code 0)\ndone",
       { sessionKey: "node-node-2", contextKey: "exec:run-2" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "node-node-2",
+    });
   });
 
   it("suppresses noisy exec.finished success events with empty output", async () => {
@@ -166,7 +172,10 @@ describe("node exec events", () => {
     expect(text.startsWith("Exec finished (node=node-2 id=run-long, code 0)\n")).toBe(true);
     expect(text.endsWith("…")).toBe(true);
     expect(text.length).toBeLessThan(280);
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "node-node-2",
+    });
   });
 
   it("enqueues exec.denied events with reason", async () => {
@@ -185,7 +194,10 @@ describe("node exec events", () => {
       "Exec denied (node=node-3 id=run-3, allowlist-miss): rm -rf /",
       { sessionKey: "agent:demo:main", contextKey: "exec:run-3" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:demo:main",
+    });
   });
 
   it("suppresses exec.started when notifyOnExit is false", async () => {

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -133,10 +133,7 @@ describe("node exec events", () => {
       "Exec finished (node=node-2 id=run-2, code 0)\ndone",
       { sessionKey: "node-node-2", contextKey: "exec:run-2" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
-      reason: "exec-event",
-      sessionKey: "node-node-2",
-    });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
   });
 
   it("suppresses noisy exec.finished success events with empty output", async () => {
@@ -172,10 +169,7 @@ describe("node exec events", () => {
     expect(text.startsWith("Exec finished (node=node-2 id=run-long, code 0)\n")).toBe(true);
     expect(text.endsWith("…")).toBe(true);
     expect(text.length).toBeLessThan(280);
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
-      reason: "exec-event",
-      sessionKey: "node-node-2",
-    });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
   });
 
   it("enqueues exec.denied events with reason", async () => {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -574,7 +574,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       }
 
       enqueueSystemEvent(text, { sessionKey, contextKey: runId ? `exec:${runId}` : "exec" });
-      requestHeartbeatNow({ reason: "exec-event" });
+      requestHeartbeatNow({ reason: "exec-event", sessionKey });
       return;
     }
     case "push.apns.register": {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -10,7 +10,7 @@ import { buildOutboundSessionContext } from "../infra/outbound/session-context.j
 import { resolveOutboundTarget } from "../infra/outbound/targets.js";
 import { registerApnsToken } from "../infra/push-apns.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
-import { normalizeMainKey } from "../routing/session-key.js";
+import { normalizeMainKey, parseAgentSessionKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import { parseMessageWithAttachments } from "./chat-attachments.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
@@ -574,7 +574,14 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       }
 
       enqueueSystemEvent(text, { sessionKey, contextKey: runId ? `exec:${runId}` : "exec" });
-      requestHeartbeatNow({ reason: "exec-event", sessionKey });
+      // Scope wakes only for canonical agent sessions. Synthetic node-* fallback
+      // keys should keep legacy unscoped behavior so enabled non-main heartbeat
+      // agents still run when no explicit agent session is provided.
+      requestHeartbeatNow(
+        parseAgentSessionKey(sessionKey)
+          ? { reason: "exec-event", sessionKey }
+          : { reason: "exec-event" },
+      );
       return;
     }
     case "push.apns.register": {

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -202,4 +202,42 @@ describe("startHeartbeatRunner", () => {
 
     runner.stop();
   });
+
+  it("does not fan out to unrelated agents for session-scoped exec wakes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: {
+          defaults: { heartbeat: { every: "30m" } },
+          list: [
+            { id: "main", heartbeat: { every: "30m" } },
+            { id: "finance", heartbeat: { every: "30m" } },
+          ],
+        },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    requestHeartbeatNow({
+      reason: "exec-event",
+      sessionKey: "agent:main:main",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(runSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "main",
+        reason: "exec-event",
+        sessionKey: "agent:main:main",
+      }),
+    );
+    expect(runSpy.mock.calls.some((call) => call[0]?.agentId === "finance")).toBe(false);
+
+    runner.stop();
+  });
 });


### PR DESCRIPTION
## Summary

- Exec completion wake events were emitted unscoped in key paths, which could trigger heartbeat evaluation outside the originating context.
- In multi-agent setups, that can produce duplicate/unexpected heartbeats (for example unrelated agent sessions), adding token cost and noise.
- Fix: exec-driven wake sources now include `sessionKey` when calling `requestHeartbeatNow`, and regression tests enforce no cross-agent fan-out for scoped exec wakes.
- Out of scope: heartbeat scheduling semantics, heartbeat prompt content, and session-store architecture redesign.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: None (no issue number provided)
- Related: None

## User-visible / Behavior Changes

- Exec-triggered heartbeat wakes are now session-scoped instead of global in:
  - exec runtime notify-on-exit path
  - node exec event forwarding path
- Unrelated agents are no longer woken by non-origin exec completions.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node + pnpm + Vitest
- Model/provider: N/A
- Integration/channel (if any): multi-agent heartbeat flow; node exec event ingestion
- Relevant config (redacted): multiple heartbeat-enabled agents, exec notify-on-exit enabled

### Steps

1. Trigger exec completion events in one session/agent context.
2. Observe heartbeat wake dispatch and runner routing.
3. Confirm unrelated agents are not invoked for session-scoped exec wakes.

### Expected

- Only the originating session/agent context is woken.

### Actual

- Scoped wake payloads are emitted and runner executes only the targeted context.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Trace/log snippets (local):

- `pnpm test src/agents/bash-tools.exec-runtime.test.ts src/gateway/server-node-events.test.ts src/agents/bash-tools.test.ts`
  - `Test Files  3 passed (3)`
  - `Tests  38 passed (38)`
- `pnpm test src/infra/heartbeat-runner.scheduler.test.ts src/infra/heartbeat-wake.test.ts`
  - `Test Files  2 passed (2)`
  - `Tests  20 passed (20)`
- `pnpm check` (format/type/lint guardrails passed)

## Human Verification (required)

- Verified scenarios:
  - `emitExecSystemEvent` emits scoped wake calls with `sessionKey`.
  - Node exec event handling emits scoped wake calls with `sessionKey`.
  - Scheduler regression confirms scoped `exec-event` wakes do not trigger unrelated agents.
- Edge cases checked:
  - Empty/no-op exec completion paths remain suppressed where expected.
  - Existing wake scheduler behavior (coalescing/retry/target routing) remains green.
- Not verified:
  - Live end-to-end run against production-like stale/orphan session-store data outside tests.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert quickly:
  - Revert commit `6124db32a`.
  - Temporary mitigation: set `tools.exec.notifyOnExit=false` to stop exec-driven wake paths.
- Files/config to restore:
  - `src/agents/bash-tools.exec-runtime.ts`
  - `src/gateway/server-node-events.ts`
- Known bad symptoms to watch for:
  - Missing heartbeat wake after valid session-scoped exec completion.
  - Unexpected fallback to unrelated-agent execution after scoped exec wakes.

## Risks and Mitigations

- Risk: Non-agent session keys still resolve to `main` by existing session-key semantics.
  - Mitigation: This PR still prevents multi-agent fan-out; regression tests assert no unrelated-agent runs for scoped wakes.
- Risk: Any caller that omits `sessionKey` still gets unscoped behavior.
  - Mitigation: Updated key exec-event sources now pass `sessionKey`; tests enforce this contract.

