### PR TITLE
fix(hooks): emit message:sent for dispatcher-based replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Hooks/Outbound replies: emit `message:sent` plugin + internal hooks for provider-dispatched agent replies (success and failure), not only `message` tool sends routed through outbound delivery. (#31293)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { dispatchInboundMessage, withReplyDispatcher } from "./dispatch.js";
+import * as internalHooks from "../hooks/internal-hooks.js";
+import * as hookRunnerGlobal from "../plugins/hook-runner-global.js";
+import {
+  dispatchInboundMessage,
+  dispatchInboundMessageWithDispatcher,
+  withReplyDispatcher,
+} from "./dispatch.js";
 import type { ReplyDispatcher } from "./reply/reply-dispatcher.js";
 import { buildTestCtx } from "./reply/test-ctx.js";
 
@@ -20,6 +26,10 @@ function createDispatcher(record: string[]): ReplyDispatcher {
 }
 
 describe("withReplyDispatcher", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("always marks complete and waits for idle after success", async () => {
     const order: string[] = [];
     const dispatcher = createDispatcher(order);
@@ -87,5 +97,122 @@ describe("withReplyDispatcher", () => {
     });
 
     expect(order).toEqual(["sendFinalReply", "markComplete", "waitForIdle"]);
+  });
+
+  it("emits message:sent hooks for successful dispatcher deliveries", async () => {
+    const runMessageSent = vi.fn(async () => {});
+    const triggerInternalHookSpy = vi
+      .spyOn(internalHooks, "triggerInternalHook")
+      .mockResolvedValue(undefined);
+    vi.spyOn(hookRunnerGlobal, "getGlobalHookRunner").mockReturnValue({
+      hasHooks: (name: string) => name === "message_sent",
+      runMessageSent,
+    } as unknown as ReturnType<typeof hookRunnerGlobal.getGlobalHookRunner>);
+
+    await dispatchInboundMessageWithDispatcher({
+      ctx: buildTestCtx({
+        SessionKey: "agent:main:main",
+        Surface: "discord",
+        Provider: "discord",
+        To: "channel:C1",
+        AccountId: "work",
+      }),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: {
+        deliver: async () => {},
+      },
+      replyResolver: async () => ({ text: "hello hook" }),
+    });
+
+    expect(runMessageSent).toHaveBeenCalledTimes(1);
+    expect(runMessageSent).toHaveBeenCalledWith(
+      {
+        to: "channel:C1",
+        content: "hello hook",
+        success: true,
+      },
+      {
+        channelId: "discord",
+        accountId: "work",
+        conversationId: "channel:C1",
+      },
+    );
+    const sentCalls = triggerInternalHookSpy.mock.calls.filter(
+      (call) =>
+        (call[0] as internalHooks.InternalHookEvent | undefined)?.type === "message" &&
+        (call[0] as internalHooks.InternalHookEvent | undefined)?.action === "sent",
+    );
+    expect(sentCalls).toHaveLength(1);
+    const hookEvent = sentCalls[0]?.[0] as internalHooks.InternalHookEvent | undefined;
+    expect(hookEvent?.type).toBe("message");
+    expect(hookEvent?.action).toBe("sent");
+    expect(hookEvent?.sessionKey).toBe("agent:main:main");
+    expect(hookEvent?.context).toMatchObject({
+      to: "channel:C1",
+      content: "hello hook",
+      success: true,
+      channelId: "discord",
+      accountId: "work",
+      conversationId: "channel:C1",
+    });
+  });
+
+  it("emits message:sent hooks with success=false when delivery fails", async () => {
+    const runMessageSent = vi.fn(async () => {});
+    const deliver = vi.fn(async () => {
+      throw new Error("send failed");
+    });
+    const triggerInternalHookSpy = vi
+      .spyOn(internalHooks, "triggerInternalHook")
+      .mockResolvedValue(undefined);
+    vi.spyOn(hookRunnerGlobal, "getGlobalHookRunner").mockReturnValue({
+      hasHooks: (name: string) => name === "message_sent",
+      runMessageSent,
+    } as unknown as ReturnType<typeof hookRunnerGlobal.getGlobalHookRunner>);
+
+    await dispatchInboundMessageWithDispatcher({
+      ctx: buildTestCtx({
+        SessionKey: "agent:main:main",
+        Surface: "slack",
+        Provider: "slack",
+        To: "channel:C2",
+      }),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: {
+        deliver,
+      },
+      replyResolver: async () => ({ text: "will fail" }),
+    });
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(runMessageSent).toHaveBeenCalledTimes(1);
+    expect(runMessageSent).toHaveBeenCalledWith(
+      {
+        to: "channel:C2",
+        content: "will fail",
+        success: false,
+        error: "send failed",
+      },
+      {
+        channelId: "slack",
+        accountId: undefined,
+        conversationId: "channel:C2",
+      },
+    );
+    const sentCalls = triggerInternalHookSpy.mock.calls.filter(
+      (call) =>
+        (call[0] as internalHooks.InternalHookEvent | undefined)?.type === "message" &&
+        (call[0] as internalHooks.InternalHookEvent | undefined)?.action === "sent",
+    );
+    expect(sentCalls).toHaveLength(1);
+    const hookEvent = sentCalls[0]?.[0] as internalHooks.InternalHookEvent | undefined;
+    expect(hookEvent?.context).toMatchObject({
+      to: "channel:C2",
+      content: "will fail",
+      success: false,
+      error: "send failed",
+      channelId: "slack",
+      conversationId: "channel:C2",
+    });
   });
 });

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -1,4 +1,7 @@
+import { normalizeChannelId } from "../channels/plugins/index.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
@@ -13,6 +16,109 @@ import type { FinalizedMsgContext, MsgContext } from "./templating.js";
 import type { GetReplyOptions } from "./types.js";
 
 export type DispatchInboundResult = DispatchFromConfigResult;
+
+type DispatcherDeliveredParams = Parameters<NonNullable<ReplyDispatcherOptions["onDelivered"]>>[0];
+
+function resolveDispatcherMessageSentContext(ctx: FinalizedMsgContext): {
+  channelId: string;
+  to: string;
+  accountId?: string;
+  sessionKey?: string;
+} | null {
+  const rawChannel = ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider;
+  const channelId =
+    typeof rawChannel === "string" && rawChannel.trim()
+      ? (normalizeChannelId(rawChannel) ?? rawChannel.trim())
+      : undefined;
+  const toRaw =
+    (typeof ctx.OriginatingTo === "string" && ctx.OriginatingTo.trim()) ||
+    (typeof ctx.To === "string" && ctx.To.trim()) ||
+    undefined;
+  if (!channelId || !toRaw) {
+    return null;
+  }
+  const accountId =
+    typeof ctx.AccountId === "string" && ctx.AccountId.trim() ? ctx.AccountId.trim() : undefined;
+  const sessionKey =
+    (typeof ctx.SessionKey === "string" && ctx.SessionKey.trim()) ||
+    (typeof ctx.CommandTargetSessionKey === "string" && ctx.CommandTargetSessionKey.trim()) ||
+    undefined;
+  return {
+    channelId,
+    to: toRaw,
+    accountId,
+    sessionKey,
+  };
+}
+
+function emitDispatcherMessageSentHook(params: {
+  context: {
+    channelId: string;
+    to: string;
+    accountId?: string;
+    sessionKey?: string;
+  };
+  delivered: DispatcherDeliveredParams;
+}) {
+  if (params.delivered.payload.isReasoning) {
+    return;
+  }
+  const content =
+    typeof params.delivered.payload.text === "string" ? params.delivered.payload.text : "";
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("message_sent")) {
+    void hookRunner
+      .runMessageSent(
+        {
+          to: params.context.to,
+          content,
+          success: params.delivered.success,
+          ...(params.delivered.error ? { error: params.delivered.error } : {}),
+        },
+        {
+          channelId: params.context.channelId,
+          accountId: params.context.accountId,
+          conversationId: params.context.to,
+        },
+      )
+      .catch(() => {});
+  }
+
+  if (!params.context.sessionKey) {
+    return;
+  }
+  void triggerInternalHook(
+    createInternalHookEvent("message", "sent", params.context.sessionKey, {
+      to: params.context.to,
+      content,
+      success: params.delivered.success,
+      ...(params.delivered.error ? { error: params.delivered.error } : {}),
+      channelId: params.context.channelId,
+      accountId: params.context.accountId,
+      conversationId: params.context.to,
+    }),
+  ).catch(() => {});
+}
+
+function withDispatcherMessageSentHook<
+  T extends { onDelivered?: (params: DispatcherDeliveredParams) => void },
+>(options: T, ctx: FinalizedMsgContext): T {
+  const messageSentContext = resolveDispatcherMessageSentContext(ctx);
+  if (!messageSentContext) {
+    return options;
+  }
+  const existingOnDelivered = options.onDelivered;
+  return {
+    ...options,
+    onDelivered: (params) => {
+      existingOnDelivered?.(params);
+      emitDispatcherMessageSentHook({
+        context: messageSentContext,
+        delivered: params,
+      });
+    },
+  };
+}
 
 export async function withReplyDispatcher<T>(params: {
   dispatcher: ReplyDispatcher;
@@ -60,12 +166,13 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping(
-    params.dispatcherOptions,
-  );
+  const finalized = finalizeInboundContext(params.ctx);
+  const dispatcherOptions = withDispatcherMessageSentHook(params.dispatcherOptions, finalized);
+  const { dispatcher, replyOptions, markDispatchIdle } =
+    createReplyDispatcherWithTyping(dispatcherOptions);
   try {
     return await dispatchInboundMessage({
-      ctx: params.ctx,
+      ctx: finalized,
       cfg: params.cfg,
       dispatcher,
       replyResolver: params.replyResolver,
@@ -86,9 +193,12 @@ export async function dispatchInboundMessageWithDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const dispatcher = createReplyDispatcher(params.dispatcherOptions);
+  const finalized = finalizeInboundContext(params.ctx);
+  const dispatcher = createReplyDispatcher(
+    withDispatcherMessageSentHook(params.dispatcherOptions, finalized),
+  );
   return await dispatchInboundMessage({
-    ctx: params.ctx,
+    ctx: finalized,
     cfg: params.cfg,
     dispatcher,
     replyResolver: params.replyResolver,

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -21,6 +21,13 @@ type ReplyDispatchDeliverer = (
   info: { kind: ReplyDispatchKind },
 ) => Promise<void>;
 
+type ReplyDispatchDeliveredHandler = (params: {
+  payload: ReplyPayload;
+  info: { kind: ReplyDispatchKind };
+  success: boolean;
+  error?: string;
+}) => void;
+
 const DEFAULT_HUMAN_DELAY_MIN_MS = 800;
 const DEFAULT_HUMAN_DELAY_MAX_MS = 2500;
 
@@ -51,6 +58,7 @@ export type ReplyDispatcherOptions = {
   onHeartbeatStrip?: () => void;
   onIdle?: () => void;
   onError?: ReplyDispatchErrorHandler;
+  onDelivered?: ReplyDispatchDeliveredHandler;
   // AIDEV-NOTE: onSkip lets channels detect silent/empty drops (e.g. Telegram empty-response fallback).
   onSkip?: ReplyDispatchSkipHandler;
   /** Human-like delay between block replies for natural rhythm. */
@@ -156,8 +164,19 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         // Safe: deliver is called inside an async .then() callback, so even a synchronous
         // throw becomes a rejection that flows through .catch()/.finally(), ensuring cleanup.
         await options.deliver(normalized, { kind });
+        options.onDelivered?.({
+          payload: normalized,
+          info: { kind },
+          success: true,
+        });
       })
       .catch((err) => {
+        options.onDelivered?.({
+          payload: normalized,
+          info: { kind },
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
         options.onError?.(err, { kind });
       })
       .finally(() => {


### PR DESCRIPTION
## Summary
- add `onDelivered` callbacks to the shared reply dispatcher so each normalized outbound payload reports success/failure after provider delivery attempts
- wire dispatcher-based reply flows to emit both plugin `message_sent` hooks and internal `message:sent` hooks using inbound context (`Surface/Provider`, `To`, `SessionKey`)
- keep existing behavior for outbound routes that already go through `deliverOutboundPayloads` unchanged
- add regression tests that cover both successful and failed dispatcher delivery hook emissions

Fixes #31293

## Security Impact
- none

## Repro
1. Register a `message:sent` HOOK.md handler.
2. Send a normal inbound message on a provider path that uses dispatcher-based delivery (for example Discord/Slack/Signal monitor reply path).
3. Before this patch, only `message` tool sends (via `deliverOutboundPayloads`) emit `message:sent`; direct dispatcher reply paths do not.

## Verification
- `pnpm test src/auto-reply/dispatch.test.ts src/auto-reply/reply/reply-flow.test.ts`
- `pnpm exec oxfmt --check src/auto-reply/reply/reply-dispatcher.ts src/auto-reply/dispatch.ts src/auto-reply/dispatch.test.ts CHANGELOG.md`
