### PR TITLE
fix(ui): unstick cron new-job form panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/Cron layout: make the New Job form column scroll with the Cron workspace and remove the independent sticky/inner scroller behavior that caused overlap and viewport pinning. (#31412)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -606,10 +606,7 @@
 }
 
 .cron-workspace-form {
-  position: sticky;
-  top: 74px;
-  max-height: calc(100vh - 74px - 32px);
-  overflow-y: auto;
+  position: static;
 }
 
 .cron-form {


### PR DESCRIPTION
## Summary
- remove sticky/viewport-pinned behavior from `.cron-workspace-form`
- remove the panel-local scroll region so the New Job form scrolls with the Cron workspace content
- add changelog entry for the Cron layout regression

Fixes #31412

## Security Impact
- none

## Repro
1. Open Control UI and go to the Cron Jobs tab.
2. Scroll the page with the New Job form visible.
3. Before this patch, the form column remains sticky and uses its own inner scroll area, causing overlap/pinning behavior.

## Verification
- `pnpm exec oxfmt --check ui/src/styles/components.css CHANGELOG.md`
- Note: `ui/src/ui/views/cron.test.ts` is not included in this repo's active Vitest include set, so no direct cron-view unit test target is available via `pnpm test` for this file path.
