### PR TITLE
fix(signal): ignore non-deliver group update events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Signal/Group system updates: ignore non-delivery `groupInfo.type` events (for example permission/admin update notifications) so group-setting system messages are not forwarded to agents as user input. (#30981)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/signal/monitor/event-handler.inbound-contract.test.ts
+++ b/src/signal/monitor/event-handler.inbound-contract.test.ts
@@ -85,6 +85,33 @@ describe("signal createSignalEventHandler inbound contract", () => {
     expect(String(contextWithBody.Body ?? "")).not.toContain("[from:");
   });
 
+  it("ignores non-deliver Signal group update events", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "Alice changed group settings",
+          attachments: [],
+          groupInfo: {
+            groupId: "g1",
+            groupName: "Test Group",
+            type: "UPDATE",
+          },
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeUndefined();
+    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+  });
+
   it("normalizes direct chat To/OriginatingTo targets to canonical Signal ids", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -54,6 +54,10 @@ import type {
 import { renderSignalMentions } from "./mentions.js";
 export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   const inboundDebounceMs = resolveInboundDebounceMs({ cfg: deps.cfg, channel: "signal" });
+  const isDeliverGroupMessageType = (value: string | null | undefined): boolean => {
+    const normalized = value?.trim().toLowerCase();
+    return !normalized || normalized === "deliver";
+  };
 
   type SignalInboundEntry = {
     senderName: string;
@@ -500,6 +504,14 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const groupId = dataMessage.groupInfo?.groupId ?? undefined;
     const groupName = dataMessage.groupInfo?.groupName ?? undefined;
     const isGroup = Boolean(groupId);
+    const groupMessageType = dataMessage.groupInfo?.type ?? undefined;
+
+    if (isGroup && !isDeliverGroupMessageType(groupMessageType)) {
+      logVerbose(
+        `signal: ignoring non-deliver group event type=${String(groupMessageType)} groupId=${groupId}`,
+      );
+      return;
+    }
 
     if (!isGroup) {
       const allowedDirectMessage = await handleSignalDirectMessageAccess({

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -32,6 +32,7 @@ export type SignalDataMessage = {
   groupInfo?: {
     groupId?: string | null;
     groupName?: string | null;
+    type?: string | null;
   } | null;
   quote?: { text?: string | null } | null;
   reaction?: SignalReactionMessage | null;


### PR DESCRIPTION
## Summary
- add `groupInfo.type` support to Signal inbound data-message typing
- ignore group events where `groupInfo.type` is present and not `DELIVER`, so group admin/permission/system update notifications do not enter agent prompts
- add inbound contract regression coverage for `groupInfo.type = "UPDATE"`
- add changelog entry for Signal group system-message filtering

Fixes #30981

## Security Impact
- none

## Repro
1. Configure Signal group chat with OpenClaw in the group.
2. Trigger a group admin/permission update event.
3. Before this patch, non-delivery group system updates can be interpreted as normal inbound user messages.

## Verification
- `pnpm test src/signal/monitor/event-handler.inbound-contract.test.ts`
- `pnpm exec oxfmt --check src/signal/monitor/event-handler.ts src/signal/monitor/event-handler.types.ts src/signal/monitor/event-handler.inbound-contract.test.ts CHANGELOG.md`
