### PR TITLE
Feat add Claude Code SDK provider and onboarding auth choice

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -70,6 +70,17 @@ Interactive onboarding behavior with reference mode:
 - Onboarding performs a fast preflight validation before saving the ref.
   - If validation fails, onboarding shows the error and lets you retry.
 
+Non-interactive Claude Code SDK (no API key):
+
+```bash
+openclaw onboard --non-interactive \
+  --auth-choice claude-sdk \
+  --accept-risk
+```
+
+No credentials flags needed. Requires the `claude` CLI to be installed and
+signed in on the gateway host (Max subscription).
+
 Non-interactive Z.AI endpoint choices:
 
 Note: `--auth-choice zai-api-key` now auto-detects the best Z.AI endpoint for your key (prefers the general API with `zai/glm-5`).

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -67,6 +67,23 @@ OpenClaw ships with the pi‑ai catalog. These providers require **no**
 }
 ```
 
+### Claude Code SDK
+
+- Provider: `claude-sdk`
+- Auth: None (reuses local `claude` CLI authentication)
+- Requires: Claude Max subscription + `claude` CLI installed and signed in
+- Example model: `claude-sdk/opus`
+- CLI: `openclaw onboard --auth-choice claude-sdk`
+
+```json5
+{
+  agents: { defaults: { model: { primary: "claude-sdk/opus" } } },
+}
+```
+
+No API key or token is needed. The SDK forwards requests through the locally
+authenticated `claude` CLI session.
+
 ### OpenAI Code (Codex)
 
 - Provider: `openai-codex`

--- a/docs/gateway/authentication.md
+++ b/docs/gateway/authentication.md
@@ -102,6 +102,27 @@ Optional ops scripts (systemd/Termux) are documented here:
 
 > `claude setup-token` requires an interactive TTY.
 
+## Claude Code SDK (no API key)
+
+If you have a Claude Max subscription and the `claude` CLI installed, you can
+skip API keys entirely. The Claude Code SDK provider reuses the local CLI
+authentication session.
+
+```bash
+openclaw onboard --auth-choice claude-sdk
+```
+
+Or set the model directly:
+
+```bash
+openclaw models set claude-sdk/opus
+```
+
+Requirements:
+
+- `claude` CLI installed and signed in (`claude --version` should work)
+- Active Claude Max subscription on the signed-in account
+
 ## Checking model auth status
 
 ```bash

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -63,8 +63,8 @@ The wizard starts with **QuickStart** (defaults) vs **Advanced** (full control).
 
 **Local mode (default)** walks you through these steps:
 
-1. **Model/Auth** — Anthropic API key (recommended), OpenAI, or Custom Provider
-   (OpenAI-compatible, Anthropic-compatible, or Unknown auto-detect). Pick a default model.
+1. **Model/Auth** — Anthropic API key (recommended), Claude Code SDK (no API key, uses local `claude` CLI auth),
+   OpenAI, or Custom Provider (OpenAI-compatible, Anthropic-compatible, or Unknown auto-detect). Pick a default model.
    For non-interactive runs, `--secret-input-mode ref` stores env-backed refs in auth profiles instead of plaintext API key values.
    In non-interactive `ref` mode, the provider env var must be set; passing inline key flags without that env var fails fast.
    In interactive runs, choosing secret reference mode lets you point at either an environment variable or a configured provider ref (`file` or `exec`), with a fast preflight validation before saving.

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "0.14.1",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.63",
     "@aws-sdk/client-bedrock": "^3.1000.0",
     "@buape/carbon": "0.0.0-beta-20260216184201",
     "@clack/prompts": "^1.0.1",
@@ -262,13 +263,13 @@
       "tough-cookie": "4.1.3"
     },
     "onlyBuiltDependencies": [
+      "@discordjs/opus",
       "@lydell/node-pty",
       "@matrix-org/matrix-sdk-crypto-nodejs",
       "@napi-rs/canvas",
       "@whiskeysockets/baileys",
       "authenticate-pam",
       "esbuild",
-      "koffi",
       "node-llama-cpp",
       "protobufjs",
       "sharp"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@agentclientprotocol/sdk':
         specifier: 0.14.1
         version: 0.14.1(zod@4.3.6)
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.63
+        version: 0.2.63(zod@4.3.6)
       '@aws-sdk/client-bedrock':
         specifier: ^3.1000.0
         version: 3.1000.0
@@ -536,6 +539,12 @@ packages:
     resolution: {integrity: sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  '@anthropic-ai/claude-agent-sdk@0.2.63':
+    resolution: {integrity: sha512-ZNiaQb/v6xkbrGt3dtq5J0DGY+AaOhoehUyposa3msvlAlkTHWNGR+NhbCcTE0ML1U91xhPqMAAwZIUqrlkKyQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@anthropic-ai/sdk@0.73.0':
     resolution: {integrity: sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==}
@@ -6085,6 +6094,20 @@ snapshots:
   '@agentclientprotocol/sdk@0.14.1(zod@4.3.6)':
     dependencies:
       zod: 4.3.6
+
+  '@anthropic-ai/claude-agent-sdk@0.2.63(zod@4.3.6)':
+    dependencies:
+      zod: 4.3.6
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   '@anthropic-ai/sdk@0.73.0(zod@4.3.6)':
     dependencies:

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -150,6 +150,7 @@ function mergeBackendConfig(base: CliBackendConfig, override?: CliBackendConfig)
 export function resolveCliBackendIds(cfg?: OpenClawConfig): Set<string> {
   const ids = new Set<string>([
     normalizeBackendKey("claude-cli"),
+    normalizeBackendKey("claude-sdk"),
     normalizeBackendKey("codex-cli"),
   ]);
   const configured = cfg?.agents?.defaults?.cliBackends ?? {};
@@ -157,6 +158,11 @@ export function resolveCliBackendIds(cfg?: OpenClawConfig): Set<string> {
     ids.add(normalizeBackendKey(key));
   }
   return ids;
+}
+
+/** Returns true if the provider uses the Claude Agent SDK instead of direct CLI spawning. */
+export function isSdkProvider(provider: string): boolean {
+  return normalizeBackendKey(provider) === "claude-sdk";
 }
 
 export function resolveCliBackendConfig(

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -90,10 +90,7 @@ export function findNormalizedProviderKey(
 
 export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {
   const normalized = normalizeProviderId(provider);
-  if (normalized === "claude-cli") {
-    return true;
-  }
-  if (normalized === "codex-cli") {
+  if (normalized === "claude-cli" || normalized === "claude-sdk" || normalized === "codex-cli") {
     return true;
   }
   const backends = cfg?.agents?.defaults?.cliBackends ?? {};

--- a/src/agents/sdk-runner.ts
+++ b/src/agents/sdk-runner.ts
@@ -1,0 +1,193 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { FailoverError, resolveFailoverStatus } from "./failover-error.js";
+import type { EmbeddedPiRunResult } from "./pi-embedded-runner.js";
+
+const log = createSubsystemLogger("agent/claude-sdk");
+
+/**
+ * Runs a single query via the Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`).
+ *
+ * The SDK spawns a Claude Code CLI process internally and communicates via
+ * stdin/stdout JSON protocol, providing native streaming (content_block_delta)
+ * without the CLI `-p` flag limitations.
+ */
+export async function runSdkAgent(params: {
+  sessionId: string;
+  prompt: string;
+  model?: string;
+  workspaceDir: string;
+  config?: OpenClawConfig;
+  timeoutMs: number;
+  runId: string;
+  systemPrompt?: string;
+  onStreamText?: (text: string) => void;
+  cliSessionId?: string;
+}): Promise<EmbeddedPiRunResult> {
+  const started = Date.now();
+  const modelId = (params.model ?? "opus").trim() || "opus";
+
+  const abortController = new AbortController();
+  const timer = setTimeout(() => abortController.abort(), params.timeoutMs);
+
+  let fullText = "";
+  let sessionId: string | undefined;
+  let usage:
+    | { input?: number; output?: number; cacheRead?: number; cacheWrite?: number }
+    | undefined;
+
+  try {
+    // Dynamic import: SDK is ESM-only and may not be installed in all environments
+    const { query: agentQuery } = await import("@anthropic-ai/claude-agent-sdk");
+
+    const env: Record<string, string | undefined> = { ...process.env };
+    // Clear API keys so SDK uses CLI's own auth (Max subscription)
+    delete env.ANTHROPIC_API_KEY;
+    delete env.ANTHROPIC_API_KEY_OLD;
+
+    log.info(
+      `sdk exec: model=${modelId} promptChars=${params.prompt.length} resume=${params.cliSessionId ?? "none"}`,
+    );
+
+    const response = agentQuery({
+      prompt: params.prompt,
+      options: {
+        cwd: params.workspaceDir,
+        model: modelId,
+        permissionMode: "bypassPermissions",
+        allowDangerouslySkipPermissions: true,
+        systemPrompt: params.systemPrompt,
+        resume: params.cliSessionId,
+        abortController,
+        env,
+        // Disable session persistence — OpenClaw manages its own sessions
+        persistSession: true,
+      },
+    });
+
+    for await (const message of response) {
+      if (message.type === "system" && message.subtype === "init") {
+        sessionId = message.session_id;
+        log.info(`sdk session: ${sessionId}`);
+      }
+
+      log.debug(
+        `sdk msg: type=${message.type} subtype=${"subtype" in message ? message.subtype : "-"}`,
+      );
+
+      // Result message — SDK may send final text here
+      if (message.type === "result") {
+        const text = "text" in message && typeof message.text === "string" ? message.text : "";
+        if (text && !fullText) {
+          fullText += text;
+          params.onStreamText?.(text);
+        }
+      }
+
+      // Streaming text deltas
+      if (message.type === "stream_event") {
+        const event = message.event;
+        if (
+          event?.type === "content_block_delta" &&
+          "delta" in event &&
+          event.delta?.type === "text_delta" &&
+          "text" in event.delta &&
+          typeof event.delta.text === "string"
+        ) {
+          fullText += event.delta.text;
+          params.onStreamText?.(event.delta.text);
+        }
+      }
+
+      // Final assistant message with usage + text content fallback
+      if (message.type === "assistant" && message.message) {
+        const msg = message.message;
+        if (msg.usage) {
+          const u = msg.usage;
+          usage = {
+            input: u.input_tokens,
+            output: u.output_tokens,
+            cacheRead:
+              "cache_read_input_tokens" in u ? (u.cache_read_input_tokens as number) : undefined,
+            cacheWrite:
+              "cache_creation_input_tokens" in u
+                ? (u.cache_creation_input_tokens as number)
+                : undefined,
+          };
+        }
+        // Extract text from content blocks when streaming deltas were not received
+        if (!fullText && Array.isArray(msg.content)) {
+          for (const block of msg.content) {
+            if (
+              block &&
+              typeof block === "object" &&
+              "type" in block &&
+              block.type === "text" &&
+              "text" in block &&
+              typeof block.text === "string"
+            ) {
+              fullText += block.text;
+            }
+          }
+          if (fullText) {
+            params.onStreamText?.(fullText);
+          }
+        }
+      }
+    }
+  } catch (err) {
+    // AbortError from timeout
+    if (abortController.signal.aborted) {
+      const reason = `SDK query exceeded timeout (${Math.round(params.timeoutMs / 1000)}s) and was aborted.`;
+      throw new FailoverError(reason, {
+        reason: "timeout",
+        provider: "claude-sdk",
+        model: modelId,
+        status: resolveFailoverStatus("timeout"),
+        cause: err,
+      });
+    }
+    // SDK-specific error classification
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(`sdk error: ${message}`);
+    throw new FailoverError(message, {
+      reason: classifySdkError(message),
+      provider: "claude-sdk",
+      model: modelId,
+      status: resolveFailoverStatus(classifySdkError(message)),
+      cause: err,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const text = fullText.trim();
+  const durationMs = Date.now() - started;
+  log.info(`sdk done: model=${modelId} chars=${text.length} durationMs=${durationMs}`);
+
+  return {
+    payloads: text ? [{ text }] : undefined,
+    meta: {
+      durationMs,
+      agentMeta: {
+        sessionId: sessionId ?? params.cliSessionId ?? "",
+        provider: "claude-sdk",
+        model: modelId,
+        usage,
+      },
+    },
+  };
+}
+
+function classifySdkError(message: string): "auth" | "rate_limit" | "timeout" | "unknown" {
+  if (/auth|unauthorized|unauthenticated/i.test(message)) {
+    return "auth";
+  }
+  if (/rate.?limit|too many requests/i.test(message)) {
+    return "rate_limit";
+  }
+  if (/timeout|timed out|abort/i.test(message)) {
+    return "timeout";
+  }
+  return "unknown";
+}

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import { isSdkProvider } from "../../agents/cli-backends.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
@@ -12,6 +13,7 @@ import {
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
+import { runSdkAgent } from "../../agents/sdk-runner.js";
 import {
   resolveGroupSessionKey,
   resolveSessionTranscriptPath,
@@ -206,28 +208,47 @@ export async function runAgentTurnWithFallback(params: {
             return (async () => {
               let lifecycleTerminalEmitted = false;
               try {
-                const result = await runCliAgent({
-                  sessionId: params.followupRun.run.sessionId,
-                  sessionKey: params.sessionKey,
-                  agentId: params.followupRun.run.agentId,
-                  sessionFile: params.followupRun.run.sessionFile,
-                  workspaceDir: params.followupRun.run.workspaceDir,
-                  config: params.followupRun.run.config,
-                  prompt: params.commandBody,
-                  provider,
-                  model,
-                  thinkLevel: params.followupRun.run.thinkLevel,
-                  timeoutMs: params.followupRun.run.timeoutMs,
-                  runId,
-                  extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-                  ownerNumbers: params.followupRun.run.ownerNumbers,
-                  cliSessionId,
-                  images: params.opts?.images,
-                });
+                // SDK provider: uses Claude Agent SDK with native streaming
+                const result = isSdkProvider(provider)
+                  ? await runSdkAgent({
+                      sessionId: params.followupRun.run.sessionId,
+                      prompt: params.commandBody,
+                      model,
+                      workspaceDir: params.followupRun.run.workspaceDir,
+                      config: params.followupRun.run.config,
+                      timeoutMs: params.followupRun.run.timeoutMs,
+                      runId,
+                      systemPrompt: params.followupRun.run.extraSystemPrompt,
+                      onStreamText: (text) => {
+                        emitAgentEvent({
+                          runId,
+                          stream: "assistant",
+                          data: { text, delta: true },
+                        });
+                      },
+                      cliSessionId,
+                    })
+                  : await runCliAgent({
+                      sessionId: params.followupRun.run.sessionId,
+                      sessionKey: params.sessionKey,
+                      agentId: params.followupRun.run.agentId,
+                      sessionFile: params.followupRun.run.sessionFile,
+                      workspaceDir: params.followupRun.run.workspaceDir,
+                      config: params.followupRun.run.config,
+                      prompt: params.commandBody,
+                      provider,
+                      model,
+                      thinkLevel: params.followupRun.run.thinkLevel,
+                      timeoutMs: params.followupRun.run.timeoutMs,
+                      runId,
+                      extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                      ownerNumbers: params.followupRun.run.ownerNumbers,
+                      cliSessionId,
+                      images: params.opts?.images,
+                    });
 
-                // CLI backends don't emit streaming assistant events, so we need to
-                // emit one with the final text so server-chat can populate its buffer
-                // and send the response to TUI/WebSocket clients.
+                // Emit final assistant text event for server-chat to populate its
+                // buffer and send the response to TUI/WebSocket clients.
                 const cliText = result.payloads?.[0]?.text?.trim();
                 if (cliText) {
                   emitAgentEvent({

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -36,6 +36,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     choices: ["token", "apiKey"],
   },
   {
+    value: "claude-sdk",
+    label: "Claude Code SDK",
+    hint: "No API key (uses local claude CLI auth)",
+    choices: ["claude-sdk"],
+  },
+  {
     value: "chutes",
     label: "Chutes",
     hint: "OAuth",
@@ -281,6 +287,11 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
     hint: "Local proxy for VS Code Copilot models",
   },
   { value: "apiKey", label: "Anthropic API key" },
+  {
+    value: "claude-sdk",
+    label: "Claude Code SDK (no API key)",
+    hint: "uses local `claude` CLI authentication (Max subscription)",
+  },
   {
     value: "opencode-zen",
     label: "OpenCode Zen (multi-model proxy)",

--- a/src/commands/auth-choice.apply.claude-sdk.ts
+++ b/src/commands/auth-choice.apply.claude-sdk.ts
@@ -1,0 +1,27 @@
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
+import { applyAgentDefaultModelPrimary } from "./onboard-auth.config-shared.js";
+
+const DEFAULT_CLAUDE_SDK_MODEL = "claude-sdk/opus";
+
+export async function applyAuthChoiceClaudeSdk(
+  params: ApplyAuthChoiceParams,
+): Promise<ApplyAuthChoiceResult | null> {
+  if (params.authChoice !== "claude-sdk") {
+    return null;
+  }
+
+  await params.prompter.note(
+    [
+      "Claude Code SDK reuses your local `claude` CLI authentication.",
+      "Make sure the `claude` CLI is installed and signed in (Max subscription).",
+    ].join("\n"),
+    "Claude Code SDK",
+  );
+
+  let nextConfig = params.config;
+  if (params.setDefaultModel) {
+    nextConfig = applyAgentDefaultModelPrimary(nextConfig, DEFAULT_CLAUDE_SDK_MODEL);
+  }
+
+  return { config: nextConfig, agentModelOverride: DEFAULT_CLAUDE_SDK_MODEL };
+}

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -4,6 +4,7 @@ import type { WizardPrompter } from "../wizard/prompts.js";
 import { applyAuthChoiceAnthropic } from "./auth-choice.apply.anthropic.js";
 import { applyAuthChoiceApiProviders } from "./auth-choice.apply.api-providers.js";
 import { applyAuthChoiceBytePlus } from "./auth-choice.apply.byteplus.js";
+import { applyAuthChoiceClaudeSdk } from "./auth-choice.apply.claude-sdk.js";
 import { applyAuthChoiceCopilotProxy } from "./auth-choice.apply.copilot-proxy.js";
 import { applyAuthChoiceGitHubCopilot } from "./auth-choice.apply.github-copilot.js";
 import { applyAuthChoiceGoogleGeminiCli } from "./auth-choice.apply.google-gemini-cli.js";
@@ -37,6 +38,7 @@ export async function applyAuthChoice(
 ): Promise<ApplyAuthChoiceResult> {
   const handlers: Array<(p: ApplyAuthChoiceParams) => Promise<ApplyAuthChoiceResult | null>> = [
     applyAuthChoiceAnthropic,
+    applyAuthChoiceClaudeSdk,
     applyAuthChoiceVllm,
     applyAuthChoiceOpenAI,
     applyAuthChoiceOAuth,

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -6,6 +6,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "claude-cli": "anthropic",
   token: "anthropic",
   apiKey: "anthropic",
+  "claude-sdk": "claude-sdk",
   vllm: "vllm",
   "openai-codex": "openai-codex",
   "codex-cli": "openai-codex",

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -7,6 +7,7 @@ export type AuthChoice =
   | "oauth"
   | "setup-token"
   | "claude-cli"
+  | "claude-sdk"
   | "token"
   | "chutes"
   | "vllm"
@@ -54,6 +55,7 @@ export type AuthChoice =
 export type AuthChoiceGroupId =
   | "openai"
   | "anthropic"
+  | "claude-sdk"
   | "chutes"
   | "vllm"
   | "google"


### PR DESCRIPTION
## Summary

- **Problem:** Users with a Claude Max subscription and `claude` CLI installed have no way to use OpenClaw without separately managing an API key or setup-token.
- **Why it matters:** The Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`) can reuse the local `claude` CLI authentication session, enabling zero-credential setup for Max subscribers.
- **What changed:** Added `claude-sdk` as a new provider (SDK-based, not CLI-spawned), a new `claude-sdk` onboarding auth choice (no credential prompts), and documentation across 4 doc pages. Also fixed a bug where the SDK runner silently dropped response text when it arrived via `assistant` content blocks or `result` messages instead of streaming deltas.
- **What did NOT change (scope boundary):** No changes to existing providers, auth flows, or the `claude-cli` CLI backend. The SDK runner is only invoked when `claude-sdk/*` models are explicitly selected.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Docs

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Auth / tokens
- [x] UI / DX

## Linked Issue/PR

- Related # (none — new feature)

## User-visible / Behavior Changes

- New auth choice `claude-sdk` in `openclaw onboard` menu under its own "Claude Code SDK" group.
- Selecting it sets `agents.defaults.model.primary: "claude-sdk/opus"` with no credential input required.
- Non-interactive: `openclaw onboard --non-interactive --auth-choice claude-sdk --accept-risk`.
- SDK runner now correctly captures response text from `result` messages and `assistant` content blocks (previously returned `chars=0`).

## Security Impact (required)

- New permissions/capabilities? `No` — SDK reuses existing local `claude` CLI session; no new permissions granted.
- Secrets/tokens handling changed? `No` — no credentials are collected or stored. The handler explicitly clears `ANTHROPIC_API_KEY` env vars so the SDK uses CLI auth only.
- New/changed network calls? `No` — the SDK internally manages communication with Anthropic via the `claude` CLI subprocess.
- Command/tool execution surface changed? `Yes` — new SDK subprocess spawned via `@anthropic-ai/claude-agent-sdk` `query()`. Runs with `permissionMode: "bypassPermissions"` (same as existing `claude-cli` backend).
  - Risk + mitigation: Same trust boundary as the existing `claude-cli` backend. Only invoked when user explicitly selects `claude-sdk/*` models.
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin 24.2.0)
- Runtime/container: Node 22+ / pnpm
- Model/provider: `claude-sdk/opus`
- Integration/channel: TUI

### Steps

1. `pnpm build && pnpm openclaw onboard --install-daemon`
2. Select "Claude Code SDK" in the Model/Auth provider menu
3. Confirm no credential prompt appears; model is set to `claude-sdk/opus`
4. Open TUI: `pnpm openclaw tui`
5. Send a message

### Expected

- Onboarding completes without credential input
- Config shows `agents.defaults.model.primary: "claude-sdk/opus"`
- TUI receives model response with non-zero chars

### Actual

- Matches expected after the streaming text capture fix

## Evidence

- [x] Trace/log snippets

```
sdk exec: model=opus promptChars=34 resume=none
sdk session: <id>
sdk done: model=opus chars=247 durationMs=8500
```

## Human Verification (required)

- Verified scenarios: Full onboarding flow with `claude-sdk` choice, TUI chat session, `pnpm tsgo && pnpm check` pass
- Edge cases checked: SDK response text arriving only via `assistant.content[]` blocks (no streaming deltas) — the original bug that returned `chars=0`
- What you did **not** verify: Telegram/WhatsApp channel delivery, non-macOS platforms, `claude` CLI not installed error path

## Compatibility / Migration

- Backward compatible? `Yes` — additive only; no existing behavior changed
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Switch model to any other provider (`openclaw models set anthropic/claude-opus-4-6`); the `claude-sdk` code path is only entered when explicitly selected.
- Files/config to restore: `agents.defaults.model.primary` in `openclaw.json`
- Known bad symptoms: `sdk done: chars=0` in logs means text capture regression; `sdk error: Cannot find module` means `@anthropic-ai/claude-agent-sdk` not installed.

## Risks and Mitigations

- Risk: `@anthropic-ai/claude-agent-sdk` is dynamically imported and may not be installed in all environments.
  - Mitigation: Import is wrapped in try/catch; error is classified and surfaced as a `FailoverError` with clear messaging.
- Risk: SDK `query()` API may change in future SDK versions, breaking message type handling.
  - Mitigation: Response parsing handles 3 independent text sources (`stream_event` deltas, `result.text`, `assistant.content[]`) with debug logging for unknown message types.
