### PR TITLE
fix(matrix): increase startup grace window from 5s to 10min

### DIFF
--- a/extensions/matrix/src/matrix/monitor/index.test.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test.ts
@@ -13,6 +13,6 @@ describe("monitorMatrixProvider helpers", () => {
   });
 
   it("uses a non-zero startup grace window", () => {
-    expect(DEFAULT_STARTUP_GRACE_MS).toBe(5000);
+    expect(DEFAULT_STARTUP_GRACE_MS).toBe(10 * 60 * 1000);
   });
 });

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -36,7 +36,7 @@ export type MonitorMatrixOpts = {
 };
 
 const DEFAULT_MEDIA_MAX_MB = 20;
-export const DEFAULT_STARTUP_GRACE_MS = 5000;
+export const DEFAULT_STARTUP_GRACE_MS = 10 * 60 * 1000;
 
 export function isConfiguredMatrixRoomEntry(entry: string): boolean {
   return entry.startsWith("!") || (entry.startsWith("#") && entry.includes(":"));


### PR DESCRIPTION
## Summary

- **Problem:** Messages sent to a Matrix room during a gateway restart are silently dropped. Matrix sync delivers a backlog of recent messages on reconnect, but the 5-second startup grace window is too narrow — messages with server timestamps older than 5 seconds before startup are discarded.
- **Why it matters:** Users lose messages sent just before or during a restart. In busy rooms or crash-restart cycles, this can mean missing important conversations entirely.
- **What changed:** `extensions/matrix/src/matrix/monitor/index.ts` — increased `DEFAULT_STARTUP_GRACE_MS` from 5,000 ms (5 seconds) to 600,000 ms (10 minutes).
- **What did NOT change:** The filtering logic in `handler.ts` is unchanged. Only the default window size is increased.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30670

## User-visible / Behavior Changes

- Messages sent to Matrix rooms up to 10 minutes before a gateway restart are now processed after reconnect (previously only 5 seconds).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.4 / any
- Runtime: Node.js
- Integration/channel: Matrix (via matrix-js-sdk)

### Steps

1. Configure a Matrix channel.
2. Send a message to the bot.
3. Restart the OpenClaw gateway within seconds of sending.
4. Observe whether the message is processed after reconnect.

### Expected

- Messages sent within 10 minutes before restart are processed after reconnect.

### Actual

- Before fix: Messages sent more than 5 seconds before restart are silently dropped.
- After fix: Messages sent within 10 minutes are processed.

## Evidence

```typescript
// Before
export const DEFAULT_STARTUP_GRACE_MS = 5000;

// After
export const DEFAULT_STARTUP_GRACE_MS = 10 * 60 * 1000;
```

The filtering logic in `handler.ts` (lines 139-150) uses this value to discard messages with `origin_server_ts` older than `startupMs - startupGraceMs`, or `unsigned.age` greater than `startupGraceMs`.

## Human Verification (required)

- Verified scenarios: Reviewed the timestamp filtering logic — increasing the grace window directly addresses the root cause of dropped messages.
- Edge cases checked: Very old backlog messages (>10 min) are still filtered out to prevent replay of stale history.
- What I did **not** verify: End-to-end Matrix restart test (requires a running Matrix homeserver).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert `DEFAULT_STARTUP_GRACE_MS` to `5000` in `extensions/matrix/src/matrix/monitor/index.ts`.
- Files/config to restore: `extensions/matrix/src/matrix/monitor/index.ts`
- Known bad symptoms: If the grace window is too large, very old messages might be replayed on restart. 10 minutes is a reasonable upper bound.

## Risks and Mitigations

- A 10-minute window means messages up to 10 minutes old are processed on reconnect. This is intentional and matches the behavior expected by users who send messages during brief restart windows. The gateway's deduplication and session continuity logic handles any potential duplicates.

