### PR TITLE
fix(agents): recover reasoning-only vLLM OpenAI-compat replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
+- Agents/OpenAI-compat reasoning fallback: recover assistant text for non-OpenAI `openai-completions` providers (for example vLLM) when responses arrive as reasoning-only blocks with empty text content, while keeping OpenAI provider behavior unchanged and avoiding tool-call turns. Fixes #31598.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.
 - Gateway/Control UI method guard: allow POST requests to non-UI routes to fall through when no base path is configured, and add POST regression coverage for fallthrough and base-path 405 behavior. (#23970) Thanks @tyler6204.

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractAssistantText,
   formatReasoningMessage,
+  promoteThinkingTagsToBlocks,
   stripDowngradedToolCallText,
 } from "./pi-embedded-utils.js";
 
@@ -471,6 +472,59 @@ File contents here`,
       });
       expect(extractAssistantText(msg), testCase.name).toBe(testCase.expected);
     }
+  });
+
+  it("falls back to reasoning blocks for non-openai openai-completions providers", () => {
+    const msg = makeAssistantMessage({
+      api: "openai-completions",
+      provider: "vllm",
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "Recovered reasoning answer" }],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantText(msg)).toBe("Recovered reasoning answer");
+  });
+
+  it("does not fall back to reasoning blocks for openai provider", () => {
+    const msg = makeAssistantMessage({
+      api: "openai-completions",
+      provider: "openai",
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "internal reasoning" }],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantText(msg)).toBe("");
+  });
+
+  it("does not fall back to reasoning blocks when tool calls are present", () => {
+    const msg = makeAssistantMessage({
+      api: "openai-completions",
+      provider: "vllm",
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "reasoning should stay hidden for tool turns" },
+        { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+      ],
+      stopReason: "toolUse",
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantText(msg)).toBe("");
+  });
+
+  it("recovers think-tagged-only replies after thinking promotion for compat providers", () => {
+    const msg = makeAssistantMessage({
+      api: "openai-completions",
+      provider: "vllm",
+      role: "assistant",
+      content: [{ type: "text", text: "<think>Tagged answer only</think>" }],
+      timestamp: Date.now(),
+    });
+    promoteThinkingTagsToBlocks(msg);
+
+    expect(extractAssistantText(msg)).toBe("Tagged answer only");
   });
 });
 

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -207,6 +207,35 @@ export function stripThinkingTagsFromText(text: string): string {
   return stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
 }
 
+function hasAssistantToolCalls(msg: AssistantMessage): boolean {
+  if (!Array.isArray(msg.content)) {
+    return false;
+  }
+  return msg.content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const type = (block as { type?: unknown }).type;
+    return type === "toolCall" || type === "toolUse" || type === "functionCall";
+  });
+}
+
+function shouldFallbackToThinkingText(msg: AssistantMessage): boolean {
+  if (msg.api !== "openai-completions") {
+    return false;
+  }
+  const provider = typeof msg.provider === "string" ? msg.provider.trim().toLowerCase() : "";
+  // Keep OpenAI/OpenAI Codex behavior unchanged; only recover for strict
+  // OpenAI-compatible providers that may place final text in reasoning blocks.
+  if (!provider || provider === "openai" || provider === "openai-codex") {
+    return false;
+  }
+  if (msg.stopReason === "error" || msg.stopReason === "toolUse") {
+    return false;
+  }
+  return !hasAssistantToolCalls(msg);
+}
+
 export function extractAssistantText(msg: AssistantMessage): string {
   const extracted =
     extractTextFromChatContent(msg.content, {
@@ -217,10 +246,15 @@ export function extractAssistantText(msg: AssistantMessage): string {
       joinWith: "\n",
       normalizeText: (text) => text.trim(),
     }) ?? "";
+  const fallbackThinkingText =
+    !extracted && shouldFallbackToThinkingText(msg)
+      ? stripThinkingTagsFromText(extractAssistantThinking(msg)).trim()
+      : "";
+  const textForUser = extracted || fallbackThinkingText;
   // Only apply keyword-based error rewrites when the assistant message is actually an error.
   // Otherwise normal prose that *mentions* errors (e.g. "context overflow") can get clobbered.
   const errorContext = msg.stopReason === "error" || Boolean(msg.errorMessage?.trim());
-  return sanitizeUserFacingText(extracted, { errorContext });
+  return sanitizeUserFacingText(textForUser, { errorContext });
 }
 
 export function extractAssistantThinking(msg: AssistantMessage): string {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: some non-OpenAI `openai-completions` providers (reported with vLLM + DeepSeek) can return assistant turns where user-visible `content` is empty while reasoning is present, resulting in empty OpenClaw replies.
- Why it matters: users see blank assistant output even though inference succeeded.
- What changed: added a guarded fallback in `extractAssistantText` to recover text from reasoning blocks only for non-OpenAI providers on `openai-completions`, and only when the turn is not a tool-call/error turn.
- What did NOT change (scope boundary): OpenAI/OpenAI Codex provider behavior is unchanged; tool-call turns still do not surface reasoning as normal reply text.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31598
- Related #31293

## User-visible / Behavior Changes

- For non-OpenAI providers configured with `api: openai-completions` (for example vLLM), reasoning-only assistant responses no longer get dropped as empty text in the normal reply path.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local test run)
- Runtime/container: Node 22 + pnpm
- Model/provider: unit-test coverage for `openai-completions` + provider gating
- Integration/channel (if any): embedded agent subscribe/extract path
- Relevant config (redacted): `models.providers.vllm.api = "openai-completions"`

### Steps

1. Create an assistant message where user-visible text is empty and only thinking/reasoning content exists.
2. Run extraction through `extractAssistantText`.
3. Compare output for `provider=vllm` vs `provider=openai` and for tool-call turns.

### Expected

- Non-OpenAI OpenAI-compat providers recover text instead of returning empty.
- OpenAI provider behavior remains unchanged.
- Tool-call turns do not leak reasoning as reply text.

### Actual

- Matches expected with new tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/agents/pi-embedded-utils.test.ts`
  - `pnpm test src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts`
  - `pnpm check`
- Edge cases checked:
  - openai provider does not use fallback
  - tool-call turn does not use fallback
  - think-tag-only content recovers after promotion to thinking blocks
- What you did **not** verify:
  - live vLLM endpoint end-to-end in this branch run

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `fix(agents): recover reasoning-only openai-compat replies`.
- Files/config to restore: `src/agents/pi-embedded-utils.ts`.
- Known bad symptoms reviewers should watch for: unexpected reasoning text shown for providers that previously returned empty replies.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: non-OpenAI OpenAI-compat providers could surface reasoning text in edge cases where a provider intentionally separates private reasoning.
  - Mitigation: fallback is strictly gated (non-openai provider, `openai-completions` API, no tool calls, non-error turn) and covered by regression tests.
