### PR TITLE
fix(telegram): add outbound send guard to prevent spam loops

### DIFF
--- a/src/telegram/outbound-send-guard.test.ts
+++ b/src/telegram/outbound-send-guard.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearTelegramOutboundSendGuard,
+  markTelegramOutboundSendFailure,
+  markTelegramOutboundSendSuccess,
+  reserveTelegramOutboundSend,
+  type TelegramOutboundSendIdentity,
+} from "./outbound-send-guard.js";
+
+const baseIdentity: TelegramOutboundSendIdentity = {
+  accountId: "default",
+  chatId: "123",
+  text: "hello world",
+};
+
+describe("telegram outbound send guard", () => {
+  it("blocks duplicate outbound sends in a short window", () => {
+    clearTelegramOutboundSendGuard();
+    expect(reserveTelegramOutboundSend(baseIdentity, 1_000)).toEqual({ blocked: false });
+    expect(reserveTelegramOutboundSend(baseIdentity, 5_000)).toEqual({
+      blocked: true,
+      reason: "duplicate",
+      retryAfterMs: 4_000,
+    });
+    expect(reserveTelegramOutboundSend(baseIdentity, 9_001)).toEqual({ blocked: false });
+  });
+
+  it("opens a circuit after repeated failures and recovers after cooldown", () => {
+    clearTelegramOutboundSendGuard();
+    for (let i = 0; i < 5; i += 1) {
+      const now = 10_000 + i * 9_000;
+      expect(reserveTelegramOutboundSend(baseIdentity, now)).toEqual({ blocked: false });
+      markTelegramOutboundSendFailure(baseIdentity, now);
+    }
+
+    const blocked = reserveTelegramOutboundSend(baseIdentity, 55_000);
+    expect(blocked).toMatchObject({
+      blocked: true,
+      reason: "circuit_open",
+    });
+    if (blocked.blocked) {
+      expect(blocked.retryAfterMs).toBe(21_000);
+    }
+
+    expect(reserveTelegramOutboundSend(baseIdentity, 76_001)).toEqual({ blocked: false });
+  });
+
+  it("resets failure streak after a successful send", () => {
+    clearTelegramOutboundSendGuard();
+    const threadIdentity: TelegramOutboundSendIdentity = {
+      ...baseIdentity,
+      messageThreadId: 271,
+    };
+
+    for (let i = 0; i < 4; i += 1) {
+      const now = 100_000 + i * 9_000;
+      expect(reserveTelegramOutboundSend(threadIdentity, now)).toEqual({ blocked: false });
+      markTelegramOutboundSendFailure(threadIdentity, now);
+    }
+
+    const successAt = 140_001;
+    expect(reserveTelegramOutboundSend(threadIdentity, successAt)).toEqual({ blocked: false });
+    markTelegramOutboundSendSuccess(threadIdentity, successAt);
+
+    for (let i = 0; i < 4; i += 1) {
+      const now = 150_000 + i * 9_000;
+      expect(reserveTelegramOutboundSend(threadIdentity, now)).toEqual({ blocked: false });
+      markTelegramOutboundSendFailure(threadIdentity, now);
+    }
+
+    expect(reserveTelegramOutboundSend(threadIdentity, 186_001)).toEqual({ blocked: false });
+  });
+});

--- a/src/telegram/outbound-send-guard.ts
+++ b/src/telegram/outbound-send-guard.ts
@@ -1,0 +1,172 @@
+import { createHash } from "node:crypto";
+import { pruneMapToMaxSize } from "../infra/map-size.js";
+
+const OUTBOUND_DEDUPE_WINDOW_MS = 8_000;
+const OUTBOUND_GUARD_MAX_KEYS = 4_000;
+const OUTBOUND_CIRCUIT_FAILURE_WINDOW_MS = 120_000;
+const OUTBOUND_CIRCUIT_MAX_FAILURES = 5;
+const OUTBOUND_CIRCUIT_COOLDOWN_MS = 30_000;
+const OUTBOUND_GUARD_STALE_MS = Math.max(
+  OUTBOUND_DEDUPE_WINDOW_MS,
+  OUTBOUND_CIRCUIT_FAILURE_WINDOW_MS,
+  OUTBOUND_CIRCUIT_COOLDOWN_MS,
+);
+
+type OutboundGuardEntry = {
+  lastAttemptAt: number;
+  lastFailureAt?: number;
+  consecutiveFailures: number;
+  blockedUntil?: number;
+};
+
+export type TelegramOutboundSendIdentity = {
+  accountId: string;
+  chatId: string;
+  text: string;
+  messageThreadId?: number;
+};
+
+export type TelegramOutboundSendDecision =
+  | {
+      blocked: false;
+    }
+  | {
+      blocked: true;
+      reason: "duplicate" | "circuit_open";
+      retryAfterMs: number;
+    };
+
+const outboundGuardEntries = new Map<string, OutboundGuardEntry>();
+
+function normalizeOutboundText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function resolveOutboundKey(identity: TelegramOutboundSendIdentity): string | undefined {
+  const normalizedText = normalizeOutboundText(identity.text);
+  if (!normalizedText) {
+    return undefined;
+  }
+  const messageThreadId =
+    typeof identity.messageThreadId === "number" && Number.isFinite(identity.messageThreadId)
+      ? String(Math.trunc(identity.messageThreadId))
+      : "-";
+  const digest = createHash("sha256").update(normalizedText).digest("hex");
+  return `${identity.accountId}:${identity.chatId}:${messageThreadId}:${digest}`;
+}
+
+function pruneOutboundGuard(now: number): void {
+  const staleCutoff = now - OUTBOUND_GUARD_STALE_MS;
+  for (const [key, entry] of outboundGuardEntries) {
+    if ((entry.blockedUntil ?? 0) > now) {
+      continue;
+    }
+    if (entry.lastAttemptAt < staleCutoff) {
+      outboundGuardEntries.delete(key);
+    }
+  }
+  pruneMapToMaxSize(outboundGuardEntries, OUTBOUND_GUARD_MAX_KEYS);
+}
+
+function touchOutboundEntry(key: string, entry: OutboundGuardEntry): void {
+  outboundGuardEntries.delete(key);
+  outboundGuardEntries.set(key, entry);
+}
+
+export function reserveTelegramOutboundSend(
+  identity: TelegramOutboundSendIdentity,
+  now = Date.now(),
+): TelegramOutboundSendDecision {
+  const key = resolveOutboundKey(identity);
+  if (!key) {
+    return { blocked: false };
+  }
+  pruneOutboundGuard(now);
+
+  const entry = outboundGuardEntries.get(key);
+  if (entry?.blockedUntil && entry.blockedUntil > now) {
+    touchOutboundEntry(key, entry);
+    return {
+      blocked: true,
+      reason: "circuit_open",
+      retryAfterMs: Math.max(1, entry.blockedUntil - now),
+    };
+  }
+  if (entry?.lastAttemptAt && now - entry.lastAttemptAt < OUTBOUND_DEDUPE_WINDOW_MS) {
+    const retryAfterMs = OUTBOUND_DEDUPE_WINDOW_MS - (now - entry.lastAttemptAt);
+    touchOutboundEntry(key, entry);
+    return {
+      blocked: true,
+      reason: "duplicate",
+      retryAfterMs: Math.max(1, retryAfterMs),
+    };
+  }
+
+  const nextEntry: OutboundGuardEntry = entry ?? {
+    lastAttemptAt: now,
+    consecutiveFailures: 0,
+  };
+  nextEntry.lastAttemptAt = now;
+  if (entry?.blockedUntil && entry.blockedUntil <= now) {
+    nextEntry.blockedUntil = undefined;
+  }
+  touchOutboundEntry(key, nextEntry);
+  return { blocked: false };
+}
+
+export function markTelegramOutboundSendSuccess(
+  identity: TelegramOutboundSendIdentity,
+  now = Date.now(),
+): void {
+  const key = resolveOutboundKey(identity);
+  if (!key) {
+    return;
+  }
+  const entry =
+    outboundGuardEntries.get(key) ??
+    ({
+      lastAttemptAt: now,
+      consecutiveFailures: 0,
+    } satisfies OutboundGuardEntry);
+  entry.lastAttemptAt = now;
+  entry.consecutiveFailures = 0;
+  entry.lastFailureAt = undefined;
+  entry.blockedUntil = undefined;
+  touchOutboundEntry(key, entry);
+  pruneOutboundGuard(now);
+}
+
+export function markTelegramOutboundSendFailure(
+  identity: TelegramOutboundSendIdentity,
+  now = Date.now(),
+): void {
+  const key = resolveOutboundKey(identity);
+  if (!key) {
+    return;
+  }
+  const entry =
+    outboundGuardEntries.get(key) ??
+    ({
+      lastAttemptAt: now,
+      consecutiveFailures: 0,
+    } satisfies OutboundGuardEntry);
+
+  entry.lastAttemptAt = now;
+  const withinWindow =
+    typeof entry.lastFailureAt === "number" &&
+    now - entry.lastFailureAt <= OUTBOUND_CIRCUIT_FAILURE_WINDOW_MS;
+  entry.consecutiveFailures = withinWindow ? entry.consecutiveFailures + 1 : 1;
+  entry.lastFailureAt = now;
+
+  if (entry.consecutiveFailures >= OUTBOUND_CIRCUIT_MAX_FAILURES) {
+    entry.blockedUntil = now + OUTBOUND_CIRCUIT_COOLDOWN_MS;
+    entry.consecutiveFailures = 0;
+  }
+
+  touchOutboundEntry(key, entry);
+  pruneOutboundGuard(now);
+}
+
+export function clearTelegramOutboundSendGuard(): void {
+  outboundGuardEntries.clear();
+}

--- a/src/telegram/send.test-harness.ts
+++ b/src/telegram/send.test-harness.ts
@@ -1,5 +1,6 @@
 import { beforeEach, vi } from "vitest";
 import type { MockFn } from "../test-utils/vitest-mock-fn.js";
+import { clearTelegramOutboundSendGuard } from "./outbound-send-guard.js";
 
 const { botApi, botCtorSpy } = vi.hoisted(() => ({
   botApi: {
@@ -77,6 +78,7 @@ export function getTelegramSendTestMocks(): TelegramSendTestMocks {
 
 export function installTelegramSendTestHooks() {
   beforeEach(() => {
+    clearTelegramOutboundSendGuard();
     loadConfig.mockReturnValue({});
     loadWebMedia.mockReset();
     maybePersistResolvedTelegramTarget.mockReset();

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -762,6 +762,64 @@ describe("sendMessageTelegram", () => {
     vi.useRealTimers();
   });
 
+  it("suppresses duplicate text sends to the same chat within the dedupe window", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      const chatId = "123";
+      const sendMessage = vi.fn().mockResolvedValue({
+        message_id: 1,
+        chat: { id: chatId },
+      });
+      const api = { sendMessage } as unknown as {
+        sendMessage: typeof sendMessage;
+      };
+
+      await expect(
+        sendMessageTelegram(chatId, "hello world", { token: "tok", api }),
+      ).resolves.toEqual({ messageId: "1", chatId });
+      await expect(
+        sendMessageTelegram(chatId, "hello   world", {
+          token: "tok",
+          api,
+        }),
+      ).rejects.toThrow(/duplicate message suppressed/i);
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(8_001);
+      await expect(
+        sendMessageTelegram(chatId, "hello world", { token: "tok", api }),
+      ).resolves.toEqual({ messageId: "1", chatId });
+      expect(sendMessage).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("caps retry attempts to avoid runaway resend loops", async () => {
+    vi.useFakeTimers();
+    try {
+      const chatId = "123";
+      const sendMessage = vi.fn().mockRejectedValue(new Error("timeout"));
+      const api = { sendMessage } as unknown as {
+        sendMessage: typeof sendMessage;
+      };
+
+      const promise = sendMessageTelegram(chatId, "hi", {
+        token: "tok",
+        api,
+        retry: { attempts: 50, minDelayMs: 1, maxDelayMs: 1, jitter: 0 },
+      });
+
+      const rejection = expect(promise).rejects.toThrow(/timeout/i);
+      await vi.runAllTimersAsync();
+      await rejection;
+      expect(sendMessage).toHaveBeenCalledTimes(5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not retry on non-transient errors", async () => {
     const chatId = "123";
     const sendMessage = vi.fn().mockRejectedValue(new Error("400: Bad Request"));

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -28,6 +28,12 @@ import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
+import {
+  markTelegramOutboundSendFailure,
+  markTelegramOutboundSendSuccess,
+  reserveTelegramOutboundSend,
+  type TelegramOutboundSendIdentity,
+} from "./outbound-send-guard.js";
 import { makeProxyFetch } from "./proxy.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 import { maybePersistResolvedTelegramTarget } from "./target-writeback.js";
@@ -102,6 +108,7 @@ const THREAD_NOT_FOUND_RE = /400:\s*Bad Request:\s*message thread not found/i;
 const MESSAGE_NOT_MODIFIED_RE =
   /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
 const CHAT_NOT_FOUND_RE = /400: Bad Request: chat not found/i;
+const MAX_TELEGRAM_SEND_RETRY_ATTEMPTS = 5;
 const sendLogger = createSubsystemLogger("telegram/send");
 const diagLogger = createSubsystemLogger("telegram/diagnostic");
 
@@ -342,6 +349,81 @@ type TelegramRequestWithDiag = <T>(
   options?: { shouldLog?: (err: unknown) => boolean },
 ) => Promise<T>;
 
+function resolveBoundedTelegramSendRetryConfig(params: {
+  retry?: RetryConfig;
+  configRetry?: RetryConfig;
+  verbose?: boolean;
+}): RetryConfig {
+  const merged: RetryConfig = {
+    ...params.configRetry,
+    ...params.retry,
+  };
+  if (typeof merged.attempts !== "number" || !Number.isFinite(merged.attempts)) {
+    return merged;
+  }
+  const boundedAttempts = Math.min(
+    MAX_TELEGRAM_SEND_RETRY_ATTEMPTS,
+    Math.max(1, Math.round(merged.attempts)),
+  );
+  if (params.verbose && boundedAttempts !== merged.attempts) {
+    sendLogger.warn(
+      `telegram send retry attempts capped at ${MAX_TELEGRAM_SEND_RETRY_ATTEMPTS} (requested ${merged.attempts})`,
+    );
+  }
+  return { ...merged, attempts: boundedAttempts };
+}
+
+function resolveThreadIdParamValue(params?: Record<string, unknown>): number | undefined {
+  const value = params?.message_thread_id;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value.trim(), 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+async function withTelegramOutboundSendGuard<T>(params: {
+  accountId: string;
+  chatId: string;
+  text: string;
+  messageThreadId?: number;
+  verbose?: boolean;
+  label: string;
+  send: () => Promise<T>;
+}): Promise<T> {
+  const identity: TelegramOutboundSendIdentity = {
+    accountId: params.accountId,
+    chatId: params.chatId,
+    text: params.text,
+    messageThreadId: params.messageThreadId,
+  };
+  const decision = reserveTelegramOutboundSend(identity);
+  if (decision.blocked) {
+    const retryAfter = `${Math.max(1, Math.ceil(decision.retryAfterMs / 1000))}s`;
+    if (params.verbose) {
+      sendLogger.warn(
+        `telegram ${params.label} blocked (${decision.reason}) for chat ${params.chatId}; retry in ${retryAfter}`,
+      );
+    }
+    throw new Error(
+      decision.reason === "duplicate"
+        ? `Telegram duplicate message suppressed for chat ${params.chatId}; retry in ${retryAfter}`
+        : `Telegram send circuit breaker is open for chat ${params.chatId}; retry in ${retryAfter}`,
+    );
+  }
+  try {
+    const result = await params.send();
+    markTelegramOutboundSendSuccess(identity);
+    return result;
+  } catch (err) {
+    markTelegramOutboundSendFailure(identity);
+    throw err;
+  }
+}
+
 function createTelegramRequestWithDiag(params: {
   cfg: ReturnType<typeof loadConfig>;
   account: ResolvedTelegramAccount;
@@ -350,9 +432,13 @@ function createTelegramRequestWithDiag(params: {
   shouldRetry?: (err: unknown) => boolean;
   useApiErrorLogging?: boolean;
 }): TelegramRequestWithDiag {
-  const request = createTelegramRetryRunner({
+  const retry = resolveBoundedTelegramSendRetryConfig({
     retry: params.retry,
     configRetry: params.account.config.retry,
+    verbose: params.verbose,
+  });
+  const request = createTelegramRetryRunner({
+    retry,
     verbose: params.verbose,
     ...(params.shouldRetry ? { shouldRetry: params.shouldRetry } : {}),
   });
@@ -512,50 +598,59 @@ export async function sendMessageTelegram(
     params?: Record<string, unknown>,
     fallbackText?: string,
   ) => {
-    return await withTelegramThreadFallback(
-      params,
-      "message",
-      opts.verbose,
-      async (effectiveParams, label) => {
-        const htmlText = renderHtmlText(rawText);
-        const baseParams = effectiveParams ? { ...effectiveParams } : {};
-        if (linkPreviewOptions) {
-          baseParams.link_preview_options = linkPreviewOptions;
-        }
-        const hasBaseParams = Object.keys(baseParams).length > 0;
-        const sendParams = {
-          parse_mode: "HTML" as const,
-          ...baseParams,
-          ...(opts.silent === true ? { disable_notification: true } : {}),
-        };
-        return await withTelegramHtmlParseFallback({
-          label,
-          verbose: opts.verbose,
-          requestHtml: (retryLabel) =>
-            requestWithChatNotFound(
-              () =>
-                api.sendMessage(
-                  chatId,
-                  htmlText,
-                  sendParams as Parameters<typeof api.sendMessage>[2],
+    return await withTelegramOutboundSendGuard({
+      accountId: account.accountId,
+      chatId,
+      text: fallbackText ?? rawText,
+      messageThreadId: resolveThreadIdParamValue(params),
+      verbose: opts.verbose,
+      label: "message",
+      send: async () =>
+        await withTelegramThreadFallback(
+          params,
+          "message",
+          opts.verbose,
+          async (effectiveParams, label) => {
+            const htmlText = renderHtmlText(rawText);
+            const baseParams = effectiveParams ? { ...effectiveParams } : {};
+            if (linkPreviewOptions) {
+              baseParams.link_preview_options = linkPreviewOptions;
+            }
+            const hasBaseParams = Object.keys(baseParams).length > 0;
+            const sendParams = {
+              parse_mode: "HTML" as const,
+              ...baseParams,
+              ...(opts.silent === true ? { disable_notification: true } : {}),
+            };
+            return await withTelegramHtmlParseFallback({
+              label,
+              verbose: opts.verbose,
+              requestHtml: (retryLabel) =>
+                requestWithChatNotFound(
+                  () =>
+                    api.sendMessage(
+                      chatId,
+                      htmlText,
+                      sendParams as Parameters<typeof api.sendMessage>[2],
+                    ),
+                  retryLabel,
                 ),
-              retryLabel,
-            ),
-          requestPlain: (retryLabel) => {
-            const plainParams = hasBaseParams
-              ? (baseParams as Parameters<typeof api.sendMessage>[2])
-              : undefined;
-            return requestWithChatNotFound(
-              () =>
-                plainParams
-                  ? api.sendMessage(chatId, fallbackText ?? rawText, plainParams)
-                  : api.sendMessage(chatId, fallbackText ?? rawText),
-              retryLabel,
-            );
+              requestPlain: (retryLabel) => {
+                const plainParams = hasBaseParams
+                  ? (baseParams as Parameters<typeof api.sendMessage>[2])
+                  : undefined;
+                return requestWithChatNotFound(
+                  () =>
+                    plainParams
+                      ? api.sendMessage(chatId, fallbackText ?? rawText, plainParams)
+                      : api.sendMessage(chatId, fallbackText ?? rawText),
+                  retryLabel,
+                );
+              },
+            });
           },
-        });
-      },
-    );
+        ),
+    });
   };
 
   if (mediaUrl) {


### PR DESCRIPTION
## Summary
Fix Telegram bot spam loop where duplicate messages are sent repeatedly.

## Changes
- Add `outbound-send-guard.ts`: deduplication guard tracking recent message hashes per chat
- Cap retry attempts to prevent infinite retry loops
- Add circuit breaker for repeated send failures to same chat
- 56 tests pass

Closes #31101