### PR TITLE
fix(gateway): use VERSION constant for Web UI version display

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -23,7 +23,7 @@ import { rawDataToString } from "../../../infra/ws.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import { isGatewayCliClient, isWebchatClient } from "../../../utils/message-channel.js";
-import { resolveRuntimeServiceVersion } from "../../../version.js";
+import { VERSION } from "../../../version.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
 import { isLocalDirectRequest } from "../../auth.js";
@@ -1013,7 +1013,7 @@ export function attachGatewayWsMessageHandler(params: {
           type: "hello-ok",
           protocol: PROTOCOL_VERSION,
           server: {
-            version: resolveRuntimeServiceVersion(process.env, "dev"),
+            version: VERSION,
             connId,
           },
           features: { methods: gatewayMethods, events },


### PR DESCRIPTION
## Summary

- **Problem:** The Web UI dashboard shows a stale or incorrect version (e.g. `2026.2.13` instead of `2026.2.26`). The gateway's `hello-ok` WebSocket payload uses `resolveRuntimeServiceVersion`, which only reads environment variables (`OPENCLAW_VERSION`, `npm_package_version`, etc.) and falls back to `"dev"`. In many install methods, these env vars are not set or reflect a different version.
- **Why it matters:** Users see a wrong version in the dashboard, causing confusion about whether their upgrade succeeded.
- **What changed:** `src/gateway/server/ws-connection/message-handler.ts` — switched from `resolveRuntimeServiceVersion(process.env, "dev")` to `VERSION` (from `src/version.ts`), which reads the actual `package.json` version with proper build-time and bundled-build fallbacks.
- **What did NOT change:** The `VERSION` constant itself, `resolveRuntimeServiceVersion` (still used by `system-presence.ts`), or any UI code.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30922

## User-visible / Behavior Changes

- Web UI dashboard version pill now shows the correct installed version (e.g. `2026.2.26`) instead of a stale env-based value or `"dev"`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Debian 13 (or any)
- Runtime: Node.js
- Integration/channel: Web UI dashboard

### Steps

1. Install OpenClaw via `curl -fsSL https://openclaw.ai/install.sh | bash`.
2. Open the dashboard at `http://localhost:18789`.
3. Look at the version pill in the top bar.

### Expected

- Version matches the installed package version (e.g. `2026.2.26`).

### Actual

- Before fix: Shows `2026.2.13` or `dev` (from stale env vars).
- After fix: Shows the correct version from `package.json`.

## Evidence

```typescript
// Before
import { resolveRuntimeServiceVersion } from "../../../version.js";
// ...
version: resolveRuntimeServiceVersion(process.env, "dev"),

// After
import { VERSION } from "../../../version.js";
// ...
version: VERSION,
```

The `VERSION` constant (defined in `src/version.ts`) uses `resolveBinaryVersion` which reads from:
1. `__OPENCLAW_VERSION__` (build-time injection)
2. `package.json` (via `resolveVersionFromModuleUrl`)
3. `build-info.json`
4. `OPENCLAW_BUNDLED_VERSION`
5. `"0.0.0"` fallback

This covers all install methods correctly, unlike the env-only approach.

## Human Verification (required)

- Verified scenarios: Checked that `VERSION` resolves correctly for npm global installs (reads `package.json` via `import.meta.url`).
- Edge cases checked: Dev mode falls back to `package.json` version instead of `"dev"`, which is more useful.
- What I did **not** verify: Bundled/binary builds (these use `__OPENCLAW_VERSION__` injection, which `VERSION` already handles).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the import change in `message-handler.ts` to use `resolveRuntimeServiceVersion`.
- Files/config to restore: `src/gateway/server/ws-connection/message-handler.ts`
- Known bad symptoms: Version shows `0.0.0` if all resolution strategies fail (extremely unlikely — only happens if `package.json` is missing AND no build injection).

## Risks and Mitigations

None. The `VERSION` constant is already the canonical version source used by the CLI, status display, and update checker. Using it for the WebSocket hello-ok payload aligns the dashboard with these other surfaces.

