### PR TITLE
fix(auth): improve missing API key guidance for model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
+- Models/Auth missing-key guidance: include provider-specific env var hints (for example `$GEMINI_API_KEY`) and exact config key paths (`models.providers.<provider>.apiKey`) in missing API key errors to make model-switch setup failures actionable. Fixes #31544.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.
 - Gateway/Control UI method guard: allow POST requests to non-UI routes to fall through when no base path is configured, and add POST regression coverage for fallthrough and base-path 405 behavior. (#23970) Thanks @tyler6204.

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -183,8 +183,28 @@ describe("getApiKeyForModel", () => {
         }
 
         expect(String(error)).toContain('No API key found for provider "zai".');
+        expect(String(error)).toContain("$ZAI_API_KEY or $Z_AI_API_KEY");
+        expect(String(error)).toContain("models.providers.zai.apiKey");
       },
     );
+  });
+
+  it("includes provider-specific env hint when google API key is missing", async () => {
+    await withEnvAsync({ GEMINI_API_KEY: undefined }, async () => {
+      let error: unknown = null;
+      try {
+        await resolveApiKeyForProvider({
+          provider: "google",
+          store: { version: 1, profiles: {} },
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(String(error)).toContain('No API key found for provider "google".');
+      expect(String(error)).toContain("$GEMINI_API_KEY");
+      expect(String(error)).toContain("models.providers.google.apiKey");
+    });
   });
 
   it("accepts legacy Z_AI_API_KEY for zai", async () => {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -24,6 +24,32 @@ const AWS_BEARER_ENV = "AWS_BEARER_TOKEN_BEDROCK";
 const AWS_ACCESS_KEY_ENV = "AWS_ACCESS_KEY_ID";
 const AWS_SECRET_KEY_ENV = "AWS_SECRET_ACCESS_KEY";
 const AWS_PROFILE_ENV = "AWS_PROFILE";
+const PROVIDER_API_KEY_ENV_MAP: Record<string, string> = {
+  openai: "OPENAI_API_KEY",
+  google: "GEMINI_API_KEY",
+  voyage: "VOYAGE_API_KEY",
+  groq: "GROQ_API_KEY",
+  deepgram: "DEEPGRAM_API_KEY",
+  cerebras: "CEREBRAS_API_KEY",
+  xai: "XAI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+  litellm: "LITELLM_API_KEY",
+  "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
+  "cloudflare-ai-gateway": "CLOUDFLARE_AI_GATEWAY_API_KEY",
+  moonshot: "MOONSHOT_API_KEY",
+  minimax: "MINIMAX_API_KEY",
+  nvidia: "NVIDIA_API_KEY",
+  xiaomi: "XIAOMI_API_KEY",
+  synthetic: "SYNTHETIC_API_KEY",
+  venice: "VENICE_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  opencode: "OPENCODE_API_KEY",
+  together: "TOGETHER_API_KEY",
+  qianfan: "QIANFAN_API_KEY",
+  ollama: "OLLAMA_API_KEY",
+  vllm: "VLLM_API_KEY",
+  kilocode: "KILOCODE_API_KEY",
+};
 
 function resolveProviderConfig(
   cfg: OpenClawConfig | undefined,
@@ -65,6 +91,45 @@ function resolveProviderAuthOverride(
     return auth;
   }
   return undefined;
+}
+
+function resolveProviderApiKeyEnvHints(provider: string): string[] {
+  const normalized = normalizeProviderId(provider);
+  if (normalized === "github-copilot") {
+    return ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
+  }
+  if (normalized === "anthropic") {
+    return ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"];
+  }
+  if (normalized === "chutes") {
+    return ["CHUTES_OAUTH_TOKEN", "CHUTES_API_KEY"];
+  }
+  if (normalized === "zai") {
+    return ["ZAI_API_KEY", "Z_AI_API_KEY"];
+  }
+  if (normalized === "opencode") {
+    return ["OPENCODE_API_KEY", "OPENCODE_ZEN_API_KEY"];
+  }
+  if (normalized === "qwen-portal") {
+    return ["QWEN_OAUTH_TOKEN", "QWEN_PORTAL_API_KEY"];
+  }
+  if (normalized === "volcengine" || normalized === "volcengine-plan") {
+    return ["VOLCANO_ENGINE_API_KEY"];
+  }
+  if (normalized === "byteplus" || normalized === "byteplus-plan") {
+    return ["BYTEPLUS_API_KEY"];
+  }
+  if (normalized === "minimax-portal") {
+    return ["MINIMAX_OAUTH_TOKEN", "MINIMAX_API_KEY"];
+  }
+  if (normalized === "kimi-coding") {
+    return ["KIMI_API_KEY", "KIMICODE_API_KEY"];
+  }
+  if (normalized === "huggingface") {
+    return ["HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"];
+  }
+  const envVar = PROVIDER_API_KEY_ENV_MAP[normalized];
+  return envVar ? [envVar] : [];
 }
 
 function resolveEnvSourceLabel(params: {
@@ -223,10 +288,17 @@ export async function resolveApiKeyForProvider(params: {
 
   const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
   const resolvedAgentDir = path.dirname(authStorePath);
+  const envHints = resolveProviderApiKeyEnvHints(provider);
+  const providerConfigHint = `models.providers.${provider}.apiKey`;
+  const envHintText =
+    envHints.length > 0
+      ? envHints.map((envVar) => `$${envVar}`).join(" or ")
+      : "a provider env var";
   throw new Error(
     [
       `No API key found for provider "${provider}".`,
       `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
+      `Set ${envHintText}, or configure ${providerConfigHint} in openclaw.json.`,
       `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
     ].join(" "),
   );
@@ -298,33 +370,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     return pick("HUGGINGFACE_HUB_TOKEN") ?? pick("HF_TOKEN");
   }
 
-  const envMap: Record<string, string> = {
-    openai: "OPENAI_API_KEY",
-    google: "GEMINI_API_KEY",
-    voyage: "VOYAGE_API_KEY",
-    groq: "GROQ_API_KEY",
-    deepgram: "DEEPGRAM_API_KEY",
-    cerebras: "CEREBRAS_API_KEY",
-    xai: "XAI_API_KEY",
-    openrouter: "OPENROUTER_API_KEY",
-    litellm: "LITELLM_API_KEY",
-    "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
-    "cloudflare-ai-gateway": "CLOUDFLARE_AI_GATEWAY_API_KEY",
-    moonshot: "MOONSHOT_API_KEY",
-    minimax: "MINIMAX_API_KEY",
-    nvidia: "NVIDIA_API_KEY",
-    xiaomi: "XIAOMI_API_KEY",
-    synthetic: "SYNTHETIC_API_KEY",
-    venice: "VENICE_API_KEY",
-    mistral: "MISTRAL_API_KEY",
-    opencode: "OPENCODE_API_KEY",
-    together: "TOGETHER_API_KEY",
-    qianfan: "QIANFAN_API_KEY",
-    ollama: "OLLAMA_API_KEY",
-    vllm: "VLLM_API_KEY",
-    kilocode: "KILOCODE_API_KEY",
-  };
-  const envVar = envMap[normalized];
+  const envVar = PROVIDER_API_KEY_ENV_MAP[normalized];
   if (!envVar) {
     return null;
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: when a selected model fails due to missing provider API key, the error is technically correct but not actionable enough (for example, users do not see the exact env var/config key to set).
- Why it matters: model switching in TUI/interactive flows feels broken/confusing and increases setup friction.
- What changed: missing-key errors now include provider-specific env var hints (for example `$GEMINI_API_KEY`) and the exact config path (`models.providers.<provider>.apiKey`) to set.
- What did NOT change (scope boundary): auth resolution logic/order is unchanged; this PR only improves missing-key guidance text.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31544
- Related #31746

## User-visible / Behavior Changes

- Missing provider API key errors now tell users exactly what to set next (env var + config path), instead of only generic auth-store guidance.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local test run)
- Runtime/container: Node 22 + pnpm
- Model/provider: `google`, `zai` missing-key cases
- Integration/channel (if any): N/A
- Relevant config (redacted): default auth store + empty provider key env

### Steps

1. Attempt auth resolution for a provider without configured key (for example `google`).
2. Observe thrown missing-key error.
3. Validate the message includes provider-specific env/config hints.

### Expected

- Error includes actionable hints such as `$GEMINI_API_KEY` and `models.providers.google.apiKey`.

### Actual

- Matches expected with updated tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/agents/model-auth.profiles.test.ts`
  - `pnpm check`
- Edge cases checked:
  - multi-env hint provider (`zai`) includes both `$ZAI_API_KEY` and `$Z_AI_API_KEY`
  - single-env hint provider (`google`) includes `$GEMINI_API_KEY`
- What you did **not** verify:
  - full interactive TUI flow end-to-end on a remote Linux host

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `fix(auth): add provider-specific missing-key guidance`.
- Files/config to restore: `src/agents/model-auth.ts`.
- Known bad symptoms reviewers should watch for: unexpected wording regressions in missing-key error messages.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: copy text changes could make tests brittle if message wording changes frequently.
  - Mitigation: tests assert key actionable substrings (env/config hints) instead of full exact message blocks.
