### PR TITLE
fix(nodes): avoid rawCommand mismatch after prepare path pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Nodes/Run: preserve `rawCommand` as explicit-only in `system.run.prepare` plans so canonical executable-path pinning no longer triggers false `INVALID_REQUEST: rawCommand does not match command` failures for argv-based `nodes run`. (#31751)
 - Pairing/AllowFrom account fallback: handle omitted `accountId` values in `readChannelAllowFromStore` and `readChannelAllowFromStoreSync` as `default`, while preserving legacy unscoped allowFrom merges for default-account flows. Thanks @Sid-Qin and @vincentkoc.
 - Agents/Subagent announce cleanup: keep completion-message runs pending while descendants settle, add a 30 minute hard-expiry backstop to avoid indefinite pending state, and keep retry bookkeeping resumable across deferred wakes. (#23970) Thanks @tyler6204.
 - BlueBubbles/Message metadata: harden send response ID extraction, include sender identity in DM context, and normalize inbound `message_id` selection to avoid duplicate ID metadata. (#23970) Thanks @tyler6204.

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { buildSystemRunApprovalPlan } from "./invoke-system-run-plan.js";
+
+describe("buildSystemRunApprovalPlan", () => {
+  it("keeps rawCommand null for direct argv execution", () => {
+    const prepared = buildSystemRunApprovalPlan({
+      command: [process.execPath, "--version"],
+    });
+
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) {
+      return;
+    }
+    expect(prepared.plan.rawCommand).toBeNull();
+  });
+});

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -159,7 +159,7 @@ export function buildSystemRunApprovalPlan(params: {
     plan: {
       argv: hardening.argv,
       cwd: hardening.cwd ?? null,
-      rawCommand: command.cmdText.trim() || null,
+      rawCommand: command.rawCommand,
       agentId: normalizeString(params.agentId),
       sessionKey: normalizeString(params.sessionKey),
     },


### PR DESCRIPTION
## Summary
- preserve `system.run.prepare` plan `rawCommand` only when it was explicitly provided by the caller
- avoid forwarding derived display text as `rawCommand` for direct argv runs after executable path hardening
- add regression test covering direct argv prepare flow
- add changelog entry under Unreleased Fixes

## Problem
`nodes run` began failing with `INVALID_REQUEST: rawCommand does not match command` after path hardening because prepare returned:
- hardened argv (e.g. `/usr/bin/echo hello`)
- derived `rawCommand` text from pre-hardened display (e.g. `echo hello`)

The later `system.run` validation compares these and rejects.

## Fix
Store `plan.rawCommand` from `resolveSystemRunCommand().rawCommand` (explicit raw-only), not from `cmdText`.

- direct argv runs now carry `rawCommand: null` and validate cleanly with hardened argv
- explicit `--raw` flows still preserve caller-supplied raw shell text

Closes #31751

## Validation
- `pnpm test src/node-host/invoke-system-run-plan.test.ts`
- `pnpm exec oxlint src/node-host/invoke-system-run-plan.ts src/node-host/invoke-system-run-plan.test.ts`
