### PR TITLE
fix(slack): type message.channels/group handlers

### DIFF
--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -102,12 +102,18 @@ export function registerSlackMessageEvents(params: {
   });
   // Slack may dispatch channel/group message subscriptions under typed event
   // names. Register explicit handlers so both delivery styles are supported.
-  ctx.app.event("message.channels", async ({ event, body }: SlackEventMiddlewareArgs) => {
-    await handleIncomingMessageEvent({ event, body });
-  });
-  ctx.app.event("message.groups", async ({ event, body }: SlackEventMiddlewareArgs) => {
-    await handleIncomingMessageEvent({ event, body });
-  });
+  ctx.app.event(
+    "message.channels",
+    async ({ event, body }: SlackEventMiddlewareArgs<"message.channels">) => {
+      await handleIncomingMessageEvent({ event, body });
+    },
+  );
+  ctx.app.event(
+    "message.groups",
+    async ({ event, body }: SlackEventMiddlewareArgs<"message.groups">) => {
+      await handleIncomingMessageEvent({ event, body });
+    },
+  );
 
   ctx.app.event("app_mention", async ({ event, body }: SlackEventMiddlewareArgs<"app_mention">) => {
     try {


### PR DESCRIPTION
## Summary

- Fixes a global TypeScript gate failure in Slack monitor event registration.
- Type `message.channels` and `message.groups` handlers with explicit `SlackEventMiddlewareArgs<...>` generics.
- Keeps runtime behavior unchanged; this is compile-time typing correctness only.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #28821
- Related #29698
- Related #21859

## User-visible / Behavior Changes

None (typing-only fix for build gate).

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm

### Steps

1. Build current branch.
2. Confirm no TS2769 in `src/slack/monitor/events/messages.ts`.

### Evidence

- `pnpm build` passes.
- `pnpm check` passes.
- `pnpm test:macmini` passes.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery

- Revert this single commit.
