### PR TITLE
fix(feishu): 支持本地文件路径发送图片

### DIFF
--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,7 +1,22 @@
+import fs from "fs";
+import path from "path";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk";
 import { sendMediaFeishu } from "./media.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMessageFeishu } from "./send.js";
+
+// Check if a path is a local file path (not a URL)
+function isLocalPath(str: string | undefined): boolean {
+  if (!str) return false;
+  // Check if it's an absolute path or relative path (not a URL)
+  return (
+    str.startsWith("/") ||
+    str.startsWith("./") ||
+    str.startsWith("../") ||
+    /^[a-zA-Z]:\\/.test(str) ||
+    (str.includes(":") && !str.startsWith("http"))
+  );
+}
 
 export const feishuOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
@@ -18,21 +33,38 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
     }
 
-    // Upload and send media if URL provided
+    // Upload and send media if URL or local path provided
     if (mediaUrl) {
       try {
-        const result = await sendMediaFeishu({
-          cfg,
-          to,
-          mediaUrl,
-          accountId: accountId ?? undefined,
-        });
+        let result;
+        if (isLocalPath(mediaUrl) && fs.existsSync(mediaUrl)) {
+          // It's a local file path - read file and send
+          const fileName = path.basename(mediaUrl);
+          const buffer = fs.readFileSync(mediaUrl);
+          result = await sendMediaFeishu({
+            cfg,
+            to,
+            mediaBuffer: buffer,
+            fileName,
+            accountId: accountId ?? undefined,
+          });
+        } else {
+          // It's a URL - use existing logic
+          result = await sendMediaFeishu({
+            cfg,
+            to,
+            mediaUrl,
+            accountId: accountId ?? undefined,
+          });
+        }
         return { channel: "feishu", ...result };
       } catch (err) {
         // Log the error for debugging
         console.error(`[feishu] sendMediaFeishu failed:`, err);
-        // Fallback to URL link if upload fails
-        const fallbackText = `📎 ${mediaUrl}`;
+        // Fallback to URL/link if upload fails
+        const fallbackText = isLocalPath(mediaUrl)
+          ? `📎 本地文件: ${path.basename(mediaUrl)}`
+          : `📎 ${mediaUrl}`;
         const result = await sendMessageFeishu({
           cfg,
           to,


### PR DESCRIPTION
## 描述

修复飞书插件不支持本地文件路径发送图片的问题。

## 改动

- 新增 isLocalPath 函数判断是否为本地路径
- 支持读取本地文件并上传到飞书
- 修复本地文件路径被当成 URL 发送的问题

## 测试

已在本地测试通过，可发送本地图片文件。

---