### PR TITLE
fix(config): clean up backup files after successful write

### DIFF
--- a/src/config/backup-rotation.ts
+++ b/src/config/backup-rotation.ts
@@ -24,3 +24,28 @@ export async function rotateConfigBackups(
     // best-effort
   });
 }
+
+/**
+ * Remove all config backup files after a successful write.
+ * Backup files contain sensitive data (API keys, tokens) and should not persist
+ * beyond the write operation where they serve as crash recovery.
+ * @see https://github.com/OpenClaw/openclaw/issues/31699
+ */
+export async function cleanupConfigBackups(
+  configPath: string,
+  ioFs: {
+    unlink: (path: string) => Promise<void>;
+  },
+): Promise<void> {
+  const backupBase = `${configPath}.bak`;
+  // Remove the primary backup
+  await ioFs.unlink(backupBase).catch(() => {
+    // best-effort: file may not exist
+  });
+  // Remove numbered backups (.bak.1 through .bak.N)
+  for (let index = 1; index < CONFIG_BACKUP_COUNT; index += 1) {
+    await ioFs.unlink(`${backupBase}.${index}`).catch(() => {
+      // best-effort: file may not exist
+    });
+  }
+}

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { rotateConfigBackups } from "./backup-rotation.js";
+import { cleanupConfigBackups, rotateConfigBackups } from "./backup-rotation.js";
 import { withTempHome } from "./test-helpers.js";
 import type { OpenClawConfig } from "./types.js";
 
@@ -47,6 +47,60 @@ describe("config backup rotation", () => {
       await expect(readName(".bak.3")).resolves.toBe("v2");
       await expect(readName(".bak.4")).resolves.toBe("v1");
       await expect(fs.stat(`${configPath}.bak.5`)).rejects.toThrow();
+    });
+  });
+
+  it("cleanupConfigBackups removes all backup files", async () => {
+    await withTempHome(async () => {
+      const stateDir = process.env.OPENCLAW_STATE_DIR?.trim();
+      if (!stateDir) {
+        throw new Error("Expected OPENCLAW_STATE_DIR to be set by withTempHome");
+      }
+      const configPath = path.join(stateDir, "openclaw.json");
+
+      // Create main config and several backup files
+      await fs.writeFile(configPath, '{"version": "main"}', "utf-8");
+      await fs.writeFile(`${configPath}.bak`, '{"version": "bak"}', "utf-8");
+      await fs.writeFile(`${configPath}.bak.1`, '{"version": "bak.1"}', "utf-8");
+      await fs.writeFile(`${configPath}.bak.2`, '{"version": "bak.2"}', "utf-8");
+      await fs.writeFile(`${configPath}.bak.3`, '{"version": "bak.3"}', "utf-8");
+      await fs.writeFile(`${configPath}.bak.4`, '{"version": "bak.4"}', "utf-8");
+
+      // Verify backups exist before cleanup
+      await expect(fs.stat(`${configPath}.bak`)).resolves.toBeDefined();
+      await expect(fs.stat(`${configPath}.bak.1`)).resolves.toBeDefined();
+
+      // Run cleanup
+      await cleanupConfigBackups(configPath, fs);
+
+      // Verify main config still exists
+      await expect(fs.stat(configPath)).resolves.toBeDefined();
+
+      // Verify all backup files are removed
+      await expect(fs.stat(`${configPath}.bak`)).rejects.toThrow();
+      await expect(fs.stat(`${configPath}.bak.1`)).rejects.toThrow();
+      await expect(fs.stat(`${configPath}.bak.2`)).rejects.toThrow();
+      await expect(fs.stat(`${configPath}.bak.3`)).rejects.toThrow();
+      await expect(fs.stat(`${configPath}.bak.4`)).rejects.toThrow();
+    });
+  });
+
+  it("cleanupConfigBackups handles missing backup files gracefully", async () => {
+    await withTempHome(async () => {
+      const stateDir = process.env.OPENCLAW_STATE_DIR?.trim();
+      if (!stateDir) {
+        throw new Error("Expected OPENCLAW_STATE_DIR to be set by withTempHome");
+      }
+      const configPath = path.join(stateDir, "openclaw.json");
+
+      // Create main config but no backups
+      await fs.writeFile(configPath, '{"version": "main"}', "utf-8");
+
+      // Should not throw even when no backup files exist
+      await expect(cleanupConfigBackups(configPath, fs)).resolves.not.toThrow();
+
+      // Main config should still exist
+      await expect(fs.stat(configPath)).resolves.toBeDefined();
     });
   });
 });

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -15,7 +15,7 @@ import {
 } from "../infra/shell-env.js";
 import { VERSION } from "../version.js";
 import { DuplicateAgentDirError, findDuplicateAgentDirs } from "./agent-dirs.js";
-import { rotateConfigBackups } from "./backup-rotation.js";
+import { cleanupConfigBackups, rotateConfigBackups } from "./backup-rotation.js";
 import {
   applyCompactionDefaults,
   applyContextPruningDefaults,
@@ -1263,6 +1263,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           logConfigOverwrite();
           logConfigWriteAnomalies();
           await appendWriteAudit("copy-fallback");
+          // Clean up backup files after successful write to avoid persisting sensitive data.
+          // See: https://github.com/OpenClaw/openclaw/issues/31699
+          await cleanupConfigBackups(configPath, deps.fs.promises);
           return;
         }
         await deps.fs.promises.unlink(tmp).catch(() => {
@@ -1273,6 +1276,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       logConfigOverwrite();
       logConfigWriteAnomalies();
       await appendWriteAudit("rename");
+      // Clean up backup files after successful write to avoid persisting sensitive data.
+      // See: https://github.com/OpenClaw/openclaw/issues/31699
+      await cleanupConfigBackups(configPath, deps.fs.promises);
     } catch (err) {
       await appendWriteAudit("failed", err);
       throw err;


### PR DESCRIPTION
## Summary

Config backup files (`.bak`, `.bak.1`, etc.) contain sensitive data including:
- Gateway tokens
- API keys (Anthropic, Notion, etc.)
- Channel credentials

Previously, these backup files persisted indefinitely after config writes, creating unnecessary credential exposure. They are only needed for crash recovery during the write operation itself.

## Changes

- Add `cleanupConfigBackups()` function to `backup-rotation.ts`
- Call cleanup after successful config writes (both rename and copy-fallback paths)
- Add tests for the new cleanup function

## Security Impact

This reduces the credential footprint by removing backup files that previously persisted indefinitely, containing duplicate copies of all secrets.

Fixes #31699