### PR TITLE
test(windows): fix exec wrapper tsgo gate regression

### DIFF
--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -51,23 +51,24 @@ describe("windows command wrapper behavior", () => {
   it("wraps .cmd commands via cmd.exe in runCommandWithTimeout", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
-    let captured: { command: string; args: string[]; options: Record<string, unknown> } | null =
-      null;
 
     spawnMock.mockImplementation(
-      (command: string, args: string[], options: Record<string, unknown>) => {
-        captured = { command, args, options };
-        return createMockChild();
-      },
+      (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
     );
 
     try {
       const result = await runCommandWithTimeout(["pnpm", "--version"], { timeoutMs: 1000 });
       expect(result.code).toBe(0);
-      expect(captured?.command).toBe(expectedComSpec);
-      expect(captured?.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
-      expect(captured?.args[3]).toContain("pnpm.cmd --version");
-      expect(captured?.options.windowsVerbatimArguments).toBe(true);
+      const captured = spawnMock.mock.calls[0] as
+        | [string, string[], Record<string, unknown>]
+        | undefined;
+      if (!captured) {
+        throw new Error("spawn mock was not called");
+      }
+      expect(captured[0]).toBe(expectedComSpec);
+      expect(captured[1].slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+      expect(captured[1][3]).toContain("pnpm.cmd --version");
+      expect(captured[2].windowsVerbatimArguments).toBe(true);
     } finally {
       platformSpy.mockRestore();
     }
@@ -76,27 +77,35 @@ describe("windows command wrapper behavior", () => {
   it("uses cmd.exe wrapper with windowsVerbatimArguments in runExec for .cmd shims", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
-    let captured: { command: string; args: string[]; options: Record<string, unknown> } | null =
-      null;
 
     execFileMock.mockImplementation(
       (
-        command: string,
-        args: string[],
-        options: Record<string, unknown>,
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
         cb: (err: Error | null, stdout: string, stderr: string) => void,
       ) => {
-        captured = { command, args, options };
         cb(null, "ok", "");
       },
     );
 
     try {
       await runExec("pnpm", ["--version"], 1000);
-      expect(captured?.command).toBe(expectedComSpec);
-      expect(captured?.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
-      expect(captured?.args[3]).toContain("pnpm.cmd --version");
-      expect(captured?.options.windowsVerbatimArguments).toBe(true);
+      const captured = execFileMock.mock.calls[0] as
+        | [
+            string,
+            string[],
+            Record<string, unknown>,
+            (err: Error | null, stdout: string, stderr: string) => void,
+          ]
+        | undefined;
+      if (!captured) {
+        throw new Error("execFile mock was not called");
+      }
+      expect(captured[0]).toBe(expectedComSpec);
+      expect(captured[1].slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+      expect(captured[1][3]).toContain("pnpm.cmd --version");
+      expect(captured[2].windowsVerbatimArguments).toBe(true);
     } finally {
       platformSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `pnpm tsgo` on current `main` fails in `src/process/exec.windows.test.ts` due TS2339 (`Property ... does not exist on type 'never'`).
- Why it matters: this is a global gate blocker that stops unrelated PRs from landing.
- What changed: switched assertions to inspect `spawnMock.mock.calls[0]` / `execFileMock.mock.calls[0]` tuples directly instead of closure-mutated capture locals.
- What did NOT change (scope boundary): no runtime process execution logic changed; test coverage scope is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #28821
- Related #29698
- Related #21859

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm tsgo` on the baseline where this test used closure-mutated captures.
2. Observe TS2339 errors in `src/process/exec.windows.test.ts`.
3. Apply this patch and rerun `pnpm tsgo`.

### Expected

- Typecheck completes successfully.

### Actual

- Typecheck now completes successfully.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm tsgo`, `pnpm check`, and `pnpm test src/process/exec.windows.test.ts` pass locally.
- Edge cases checked: both `runCommandWithTimeout` and `runExec` wrapper expectations still validate `cmd.exe` wrapping and `windowsVerbatimArguments`.
- What you did **not** verify: full `pnpm test` suite.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/process/exec.windows.test.ts`.
- Known bad symptoms reviewers should watch for: recurrence of TS2339 `never` errors in this test file.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Test assertions could miss call-shape regressions if tuple casts are wrong.
  - Mitigation: assertions explicitly validate command, args, and options positions for both mock call types.
