### PR TITLE
fix(ci): fix TypeScript errors in exec.windows.test.ts

### DIFF
--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -51,8 +51,8 @@ describe("windows command wrapper behavior", () => {
   it("wraps .cmd commands via cmd.exe in runCommandWithTimeout", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
-    let captured: { command: string; args: string[]; options: Record<string, unknown> } | null =
-      null;
+    type CapturedCall = { command: string; args: string[]; options: Record<string, unknown> };
+    let captured: CapturedCall | null = null;
 
     spawnMock.mockImplementation(
       (command: string, args: string[], options: Record<string, unknown>) => {
@@ -64,10 +64,11 @@ describe("windows command wrapper behavior", () => {
     try {
       const result = await runCommandWithTimeout(["pnpm", "--version"], { timeoutMs: 1000 });
       expect(result.code).toBe(0);
-      expect(captured?.command).toBe(expectedComSpec);
-      expect(captured?.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
-      expect(captured?.args[3]).toContain("pnpm.cmd --version");
-      expect(captured?.options.windowsVerbatimArguments).toBe(true);
+      expect(captured).not.toBeNull();
+      expect(captured!.command).toBe(expectedComSpec);
+      expect(captured!.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+      expect(captured!.args[3]).toContain("pnpm.cmd --version");
+      expect(captured!.options.windowsVerbatimArguments).toBe(true);
     } finally {
       platformSpy.mockRestore();
     }
@@ -76,8 +77,8 @@ describe("windows command wrapper behavior", () => {
   it("uses cmd.exe wrapper with windowsVerbatimArguments in runExec for .cmd shims", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
-    let captured: { command: string; args: string[]; options: Record<string, unknown> } | null =
-      null;
+    type CapturedCall = { command: string; args: string[]; options: Record<string, unknown> };
+    let captured: CapturedCall | null = null;
 
     execFileMock.mockImplementation(
       (
@@ -93,10 +94,11 @@ describe("windows command wrapper behavior", () => {
 
     try {
       await runExec("pnpm", ["--version"], 1000);
-      expect(captured?.command).toBe(expectedComSpec);
-      expect(captured?.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
-      expect(captured?.args[3]).toContain("pnpm.cmd --version");
-      expect(captured?.options.windowsVerbatimArguments).toBe(true);
+      expect(captured).not.toBeNull();
+      expect(captured!.command).toBe(expectedComSpec);
+      expect(captured!.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+      expect(captured!.args[3]).toContain("pnpm.cmd --version");
+      expect(captured!.options.windowsVerbatimArguments).toBe(true);
     } finally {
       platformSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation errors in `src/process/exec.windows.test.ts` that are causing CI failures on main branch.

## Problem

The `captured` variable type was being narrowed to `never` due to TypeScript's control flow analysis not tracking assignments in mock callbacks. This caused errors like:

```
error TS2339: Property 'command' does not exist on type 'never'.
```

## Solution

1. Use explicit type alias (`CapturedCall`) for better type inference
2. Add explicit null check (`expect(captured).not.toBeNull()`) before accessing properties
3. Use non-null assertion (`captured!`) after the null check

## Testing

- [x] TypeScript compilation passes
- [x] Tests pass locally

## AI Disclosure

This PR was developed with AI assistance.