### PR TITLE
fix(auth): normalize volcengine-plan/byteplus-plan to base provider

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -62,6 +62,18 @@ describe("model-selection", () => {
       expect(normalizeProviderId("aws-bedrock")).toBe("amazon-bedrock");
       expect(normalizeProviderId("amazon-bedrock")).toBe("amazon-bedrock");
     });
+
+    it("should handle provider groups that share auth credentials", () => {
+      // Volcano Engine general and coding plans share the same auth
+      expect(normalizeProviderId("volcengine")).toBe("volcengine");
+      expect(normalizeProviderId("volcengine-plan")).toBe("volcengine");
+      expect(normalizeProviderId("bytedance")).toBe("volcengine");
+      expect(normalizeProviderId("doubao")).toBe("volcengine");
+
+      // BytePlus general and coding plans share the same auth
+      expect(normalizeProviderId("byteplus")).toBe("byteplus");
+      expect(normalizeProviderId("byteplus-plan")).toBe("byteplus");
+    });
   });
 
   describe("parseModelRef", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -58,6 +58,15 @@ export function normalizeProviderId(provider: string): string {
   if (normalized === "bytedance" || normalized === "doubao") {
     return "volcengine";
   }
+  // Provider groups that share authentication credentials.
+  // For auth purposes, volcengine-plan uses the same credentials as volcengine,
+  // and byteplus-plan uses the same credentials as byteplus.
+  if (normalized === "volcengine-plan") {
+    return "volcengine";
+  }
+  if (normalized === "byteplus-plan") {
+    return "byteplus";
+  }
   return normalized;
 }
 


### PR DESCRIPTION
## Summary
Fix authentication resolution for volcengine-plan and byteplus-plan providers by normalizing them to their base providers (volcengine, byteplus).

## Problem
When configuring Volcano Engine authentication via `openclaw configure`:
- Auth Profile: `volcengine:default` (stored with provider `volcengine`)
- Default Model: `volcengine-plan/ark-code-latest` (provider `volcengine-plan`)

This caused Subagents to fail with:
```
No API key found for provider "volcengine-plan"
```

## Root Cause
The authentication system had two separate code paths:

1. **Environment variable lookup** (`resolveEnvApiKey`): ✅ Correctly handled both providers
2. **Auth profile lookup** (`listProfilesForProvider`): ❌ Did NOT normalize `volcengine-plan` to `volcengine`

## Solution
Add provider group mappings to `normalizeProviderId` in `src/agents/model-selection.ts`, consistent with the existing behavior in `resolveEnvApiKey`.

The same fix applies to `byteplus-plan` → `byteplus`.

## Changes
- `src/agents/model-selection.ts`: Add normalization for `volcengine-plan` and `byteplus-plan`
- `src/agents/model-selection.test.ts`: Add tests verifying provider group normalization

## Test Plan
- [x] Unit tests pass: `bun test src/agents/model-selection.test.ts`
- [x] Auth tests pass: `bun test src/agents/model-auth.*.test.ts`
- [x] New tests verify provider group normalization works correctly

## Related Issues
Fixes #31731