### PR TITLE
Gateway: shrink config.patch/config.apply responses (AI-assisted)

### DIFF
--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -55,6 +55,7 @@ const GatewayToolSchema = Type.Object({
   // config.apply, config.patch
   raw: Type.Optional(Type.String()),
   baseHash: Type.Optional(Type.String()),
+  returnFull: Type.Optional(Type.Boolean()),
   // config.apply, config.patch, update.run
   sessionKey: Type.Optional(Type.String()),
   note: Type.Optional(Type.String()),
@@ -152,6 +153,7 @@ export function createGatewayTool(opts?: {
       const resolveConfigWriteParams = async (): Promise<{
         raw: string;
         baseHash: string;
+        returnFull: boolean | undefined;
         sessionKey: string | undefined;
         note: string | undefined;
         restartDelayMs: number | undefined;
@@ -165,7 +167,8 @@ export function createGatewayTool(opts?: {
         if (!baseHash) {
           throw new Error("Missing baseHash from config snapshot.");
         }
-        return { raw, baseHash, ...resolveGatewayWriteMeta() };
+        const returnFull = typeof params.returnFull === "boolean" ? params.returnFull : undefined;
+        return { raw, baseHash, returnFull, ...resolveGatewayWriteMeta() };
       };
 
       if (action === "config.get") {
@@ -177,11 +180,12 @@ export function createGatewayTool(opts?: {
         return jsonResult({ ok: true, result });
       }
       if (action === "config.apply") {
-        const { raw, baseHash, sessionKey, note, restartDelayMs } =
+        const { raw, baseHash, returnFull, sessionKey, note, restartDelayMs } =
           await resolveConfigWriteParams();
         const result = await callGatewayTool("config.apply", gatewayOpts, {
           raw,
           baseHash,
+          returnFull,
           sessionKey,
           note,
           restartDelayMs,
@@ -189,11 +193,12 @@ export function createGatewayTool(opts?: {
         return jsonResult({ ok: true, result });
       }
       if (action === "config.patch") {
-        const { raw, baseHash, sessionKey, note, restartDelayMs } =
+        const { raw, baseHash, returnFull, sessionKey, note, restartDelayMs } =
           await resolveConfigWriteParams();
         const result = await callGatewayTool("config.patch", gatewayOpts, {
           raw,
           baseHash,
+          returnFull,
           sessionKey,
           note,
           restartDelayMs,

--- a/src/gateway/protocol/schema/config.ts
+++ b/src/gateway/protocol/schema/config.ts
@@ -18,6 +18,7 @@ const ConfigApplyLikeParamsSchema = Type.Object(
     sessionKey: Type.Optional(Type.String()),
     note: Type.Optional(Type.String()),
     restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    returnFull: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -174,6 +174,10 @@ function resolveConfigRestartRequest(params: unknown): {
   };
 }
 
+function shouldReturnFullConfig(params: unknown): boolean {
+  return (params as { returnFull?: unknown }).returnFull === true;
+}
+
 function buildConfigRestartSentinelPayload(params: {
   kind: RestartSentinelPayload["kind"];
   mode: string;
@@ -388,12 +392,17 @@ export const configHandlers: GatewayRequestHandlers = {
         `config.patch restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
       );
     }
+    const includeFullConfig = shouldReturnFullConfig(params);
     respond(
       true,
       {
         ok: true,
         path: CONFIG_PATH,
-        config: redactConfigObject(validated.config, schemaPatch.uiHints),
+        changedPaths,
+        restarting: true,
+        ...(includeFullConfig
+          ? { config: redactConfigObject(validated.config, schemaPatch.uiHints) }
+          : {}),
         restart,
         sentinel: {
           path: sentinelPath,
@@ -448,12 +457,17 @@ export const configHandlers: GatewayRequestHandlers = {
         `config.apply restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
       );
     }
+    const includeFullConfig = shouldReturnFullConfig(params);
     respond(
       true,
       {
         ok: true,
         path: CONFIG_PATH,
-        config: redactConfigObject(parsed.config, parsed.schema.uiHints),
+        changedPaths,
+        restarting: true,
+        ...(includeFullConfig
+          ? { config: redactConfigObject(parsed.config, parsed.schema.uiHints) }
+          : {}),
         restart,
         sentinel: {
           path: sentinelPath,

--- a/src/gateway/server.config-apply.test.ts
+++ b/src/gateway/server.config-apply.test.ts
@@ -1,5 +1,8 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { WebSocket } from "ws";
+import { __testing as controlPlaneRateLimitTesting } from "./control-plane-rate-limit.js";
 import {
   connectOk,
   getFreePort,
@@ -19,6 +22,10 @@ beforeAll(async () => {
   server = await startGatewayServer(port, { controlUiEnabled: true });
 });
 
+beforeEach(() => {
+  controlPlaneRateLimitTesting.resetControlPlaneRateLimitState();
+});
+
 afterAll(async () => {
   await server.close();
 });
@@ -27,7 +34,9 @@ const openClient = async () => {
   const ws = new WebSocket(`ws://127.0.0.1:${port}`);
   trackConnectChallengeNonce(ws);
   await new Promise<void>((resolve) => ws.once("open", resolve));
-  await connectOk(ws);
+  await connectOk(ws, {
+    deviceIdentityPath: path.join(os.tmpdir(), "openclaw-test-device-config-apply.json"),
+  });
   return ws;
 };
 
@@ -41,6 +50,30 @@ const sendConfigApply = async (ws: WebSocket, id: string, raw: unknown) => {
     }),
   );
   return onceMessage<{ ok: boolean; error?: { message?: string } }>(ws, (o) => {
+    const msg = o as { type?: string; id?: string };
+    return msg.type === "res" && msg.id === id;
+  });
+};
+
+const sendRpc = async (
+  ws: WebSocket,
+  id: string,
+  method: string,
+  params: Record<string, unknown>,
+) => {
+  ws.send(
+    JSON.stringify({
+      type: "req",
+      id,
+      method,
+      params,
+    }),
+  );
+  return onceMessage<{
+    ok: boolean;
+    payload?: Record<string, unknown>;
+    error?: { message?: string };
+  }>(ws, (o) => {
     const msg = o as { type?: string; id?: string };
     return msg.type === "res" && msg.id === id;
   });
@@ -66,6 +99,50 @@ describe("gateway config.apply", () => {
       const res = await sendConfigApply(ws, id, { gateway: { mode: "local" } });
       expect(res.ok).toBe(false);
       expect(res.error?.message ?? "").toContain("raw");
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("omits full config from config.apply response by default", async () => {
+    const ws = await openClient();
+    try {
+      const snapshot = await sendRpc(ws, "req-3-get", "config.get", {});
+      expect(snapshot.ok).toBe(true);
+      const snapshotConfig = snapshot.payload?.config;
+      expect(snapshotConfig).toBeTruthy();
+      const baseHash = snapshot.payload?.hash;
+      const res = await sendRpc(ws, "req-3-apply", "config.apply", {
+        raw: JSON.stringify(snapshotConfig),
+        restartDelayMs: 60_000,
+        ...(typeof baseHash === "string" ? { baseHash } : {}),
+      });
+      expect(res.ok).toBe(true);
+      expect(res.payload?.config).toBeUndefined();
+      expect(Array.isArray(res.payload?.changedPaths)).toBe(true);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("returns full config when config.apply sets returnFull=true", async () => {
+    const ws = await openClient();
+    try {
+      const snapshot = await sendRpc(ws, "req-4-get", "config.get", {});
+      expect(snapshot.ok).toBe(true);
+      const snapshotConfig = snapshot.payload?.config;
+      expect(snapshotConfig).toBeTruthy();
+      const baseHash = snapshot.payload?.hash;
+      const res = await sendRpc(ws, "req-4-apply", "config.apply", {
+        raw: JSON.stringify(snapshotConfig),
+        returnFull: true,
+        restartDelayMs: 60_000,
+        ...(typeof baseHash === "string" ? { baseHash } : {}),
+      });
+      if (!res.ok) {
+        throw new Error(`config.apply failed: ${res.error?.message ?? "unknown error"}`);
+      }
+      expect(res.payload?.config).toBeTruthy();
     } finally {
       ws.close();
     }

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { __testing as controlPlaneRateLimitTesting } from "./control-plane-rate-limit.js";
 import {
   connectOk,
   installGatewayTestHooks,
@@ -26,7 +27,13 @@ function requireWs(): Awaited<ReturnType<typeof startServerWithClient>>["ws"] {
 beforeAll(async () => {
   sharedTempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-config-"));
   startedServer = await startServerWithClient(undefined, { controlUiEnabled: true });
-  await connectOk(requireWs());
+  await connectOk(requireWs(), {
+    deviceIdentityPath: path.join(os.tmpdir(), "openclaw-test-device-config-patch.json"),
+  });
+});
+
+beforeEach(() => {
+  controlPlaneRateLimitTesting.resetControlPlaneRateLimitState();
 });
 
 afterAll(async () => {
@@ -72,6 +79,54 @@ describe("gateway config methods", () => {
     const issues = (res.error as { details?: { issues?: Array<{ path?: string }> } } | undefined)
       ?.details?.issues;
     expect(issues?.some((issue) => issue.path === "gateway.bind")).toBe(true);
+  });
+
+  it("omits full config from config.patch response by default", async () => {
+    const snapshot = await rpcReq<{ hash?: unknown }>(requireWs(), "config.get", {});
+    const baseHash = snapshot.payload?.hash;
+    const res = await rpcReq<{ config?: unknown; changedPaths?: string[] }>(
+      requireWs(),
+      "config.patch",
+      {
+        raw: JSON.stringify({
+          channels: {
+            telegram: {
+              groups: {
+                "*": { requireMention: false },
+              },
+            },
+          },
+        }),
+        restartDelayMs: 60_000,
+        ...(typeof baseHash === "string" ? { baseHash } : {}),
+      },
+    );
+    expect(res.ok).toBe(true);
+    expect(res.payload?.config).toBeUndefined();
+    expect(Array.isArray(res.payload?.changedPaths)).toBe(true);
+  });
+
+  it("returns full config when config.patch sets returnFull=true", async () => {
+    const snapshot = await rpcReq<{ hash?: unknown }>(requireWs(), "config.get", {});
+    const baseHash = snapshot.payload?.hash;
+    const res = await rpcReq<{ config?: unknown }>(requireWs(), "config.patch", {
+      raw: JSON.stringify({
+        channels: {
+          telegram: {
+            groups: {
+              "*": { requireMention: true },
+            },
+          },
+        },
+      }),
+      restartDelayMs: 60_000,
+      ...(typeof baseHash === "string" ? { baseHash } : {}),
+      returnFull: true,
+    });
+    if (!res.ok) {
+      throw new Error(`config.patch failed: ${res.error?.message ?? "unknown error"}`);
+    }
+    expect(res.payload?.config).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Summary

- Problem: `config.patch` and `config.apply` returned the full merged config payload by default, bloating LLM context on every write call.
- Why it matters: large configs add thousands of unnecessary tokens per tool response and degrade turn stability/performance.
- What changed: both handlers now return a minimal ack by default (`ok`, `changedPaths`, restart/sentinel metadata) and only include `config` when `returnFull: true` is explicitly set.
- What did NOT change (scope boundary): merge/validation/write/restart behavior, base-hash safety checks, and sentinel/restart scheduling semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28698
- Related #

## User-visible / Behavior Changes

- `config.patch` and `config.apply` no longer include `payload.config` by default.
- New optional request flag: `returnFull: true` restores previous behavior for callers that need full config echo.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): Gateway RPC
- Relevant config (redacted): default gateway test config

### Steps

1. Run `config.patch` with a small patch.
2. Observe `payload.config` is absent by default.
3. Re-run with `returnFull: true`.

### Expected

- Default response is minimal and includes no full config body.
- `returnFull: true` includes redacted full config.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted tests for default/minimal and `returnFull` for both `config.patch` and `config.apply`.
- Edge cases checked: invalid input tests still pass; rate-limit isolation in tests reset per case.
- What you did **not** verify: full repository test suite.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: use `returnFull: true` in callers that depend on echoed config, or revert commit `a494fbd9d`.
- Files/config to restore: `src/gateway/server-methods/config.ts`, `src/gateway/protocol/schema/config.ts`.
- Known bad symptoms reviewers should watch for: callers expecting `payload.config` without setting `returnFull`.

## Risks and Mitigations

- Risk: downstream callers assumed `payload.config` is always present.
  - Mitigation: added explicit opt-in (`returnFull`) and tests covering both default/minimal and opt-in/full behavior.

---

AI-assisted: built with Codex. Tested locally with targeted gateway tests + build; `pnpm check` currently fails on an unrelated pre-existing lint error in `src/i18n/registry.test.ts` (`readNestedString` unused).
