### PR TITLE
docs: add Chinese quick start guide

### DIFF
--- a/docs/start/quickstart-zh.md
+++ b/docs/start/quickstart-zh.md
@@ -9,7 +9,6 @@
 npm install -g openclaw
 ```
 
-
 ## 运行向导
 
 ```bash
@@ -17,8 +16,8 @@ npm install -g openclaw
 openclaw onboard --install-daemon
 ```
 
-
 向导会引导你完成：
+
 1. Gateway 设置
 2. Workspace 配置
 3. Channels 连接 (Telegram, WhatsApp, etc.)
@@ -26,12 +25,12 @@ openclaw onboard --install-daemon
 
 ## 常用命令
 
-| 命令 | 说明 |
-|------|------|
-| `openclaw status` | 查看状态 |
-| `openclaw gateway start` | 启动 Gateway |
-| `openclaw gateway stop` | 停止 Gateway |
-| `openclaw memory search "关键词"` | 搜索记忆 |
+| 命令                              | 说明         |
+| --------------------------------- | ------------ |
+| `openclaw status`                 | 查看状态     |
+| `openclaw gateway start`          | 启动 Gateway |
+| `openclaw gateway stop`           | 停止 Gateway |
+| `openclaw memory search "关键词"` | 搜索记忆     |
 
 ## 下一步
 

--- a/docs/start/quickstart-zh.md
+++ b/docs/start/quickstart-zh.md
@@ -5,14 +5,18 @@
 ## 安装
 
 ```bash
+
 npm install -g openclaw
 ```
+
 
 ## 运行向导
 
 ```bash
+
 openclaw onboard --install-daemon
 ```
+
 
 向导会引导你完成：
 1. Gateway 设置

--- a/docs/start/quickstart-zh.md
+++ b/docs/start/quickstart-zh.md
@@ -11,7 +11,7 @@ npm install -g openclaw
 ## 运行向导
 
 ```bash
-openclaw onboard
+openclaw onboard --install-daemon
 ```
 
 向导会引导你完成：

--- a/docs/start/quickstart-zh.md
+++ b/docs/start/quickstart-zh.md
@@ -1,0 +1,40 @@
+# OpenClaw 快速开始 (中文)
+
+> 这是由社区贡献的中文快速开始指南
+
+## 安装
+
+```bash
+npm install -g openclaw
+```
+
+## 运行向导
+
+```bash
+openclaw onboard
+```
+
+向导会引导你完成：
+1. Gateway 设置
+2. Workspace 配置
+3. Channels 连接 (Telegram, WhatsApp, etc.)
+4. Skills 安装
+
+## 常用命令
+
+| 命令 | 说明 |
+|------|------|
+| `openclaw status` | 查看状态 |
+| `openclaw gateway start` | 启动 Gateway |
+| `openclaw gateway stop` | 停止 Gateway |
+| `openclaw memory search "关键词"` | 搜索记忆 |
+
+## 下一步
+
+- [完整文档](https://docs.openclaw.ai)
+- [Discord 社区](https://discord.gg/clawd)
+- [GitHub Issues](https://github.com/openclaw/openclaw/issues)
+
+## 贡献
+
+欢迎改进这个中文指南！在 GitHub 上提交 PR 即可。


### PR DESCRIPTION
## Summary

Add community-contributed Chinese documentation to help Chinese-speaking users get started faster.

## Changes

- Add `docs/start/quickstart-zh.md` with:
  - Installation instructions
  - Onboarding wizard guide
  - Common commands table
  - Links to full docs and community

## Motivation

OpenClaw has a growing Chinese user base but no official Chinese documentation. This provides a quick start for Chinese speakers.

## Testing

- [x] Markdown renders correctly
- [x] Links are valid

## Related

Community contribution from a happy OpenClaw user 🦞