### PR TITLE
fix: Auto-label group/channel sessions with human-friendly names (#31661)

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -592,6 +592,20 @@ export async function initSessionState(params: {
     (store) => {
       // Preserve per-session overrides while resetting compaction state on /new.
       store[sessionKey] = { ...store[sessionKey], ...sessionEntry };
+      
+      // Revalidate auto-label uniqueness under the lock to prevent race conditions.
+      // If another concurrent request set the same label, clear it to avoid ambiguity.
+      const entry = store[sessionKey];
+      if (entry?.label) {
+        for (const [key, other] of Object.entries(store)) {
+          if (key !== sessionKey && other?.label === entry.label) {
+            // Label conflict detected — clear the auto-assigned label
+            delete entry.label;
+            break;
+          }
+        }
+      }
+      
       if (retiredLegacyMainDelivery) {
         store[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
       }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -598,7 +598,11 @@ export async function initSessionState(params: {
       const entry = store[sessionKey];
       if (entry?.label) {
         for (const [key, other] of Object.entries(store)) {
-          if (key !== sessionKey && other?.label === entry.label) {
+          // Skip the current session and its legacy case-aliases
+          if (key.toLowerCase() === sessionKey.toLowerCase()) {
+            continue;
+          }
+          if (other?.label === entry.label) {
             // Label conflict detected — clear the auto-assigned label
             delete entry.label;
             // Also clear sessionEntry.label to prevent later persistence code paths

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -601,6 +601,9 @@ export async function initSessionState(params: {
           if (key !== sessionKey && other?.label === entry.label) {
             // Label conflict detected — clear the auto-assigned label
             delete entry.label;
+            // Also clear sessionEntry.label to prevent later persistence code paths
+            // from reintroducing the duplicate label
+            delete sessionEntry.label;
             break;
           }
         }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -510,6 +510,7 @@ export async function initSessionState(params: {
     sessionKey,
     existing: sessionEntry,
     groupResolution,
+    allSessions: sessionStore,
   });
   if (metaPatch) {
     sessionEntry = { ...sessionEntry, ...metaPatch };

--- a/src/config/sessions/metadata.test.ts
+++ b/src/config/sessions/metadata.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import { deriveGroupSessionPatch } from "./metadata.js";
+import type { SessionEntry } from "./types.js";
+
+describe("deriveGroupSessionPatch auto-labeling", () => {
+  const baseCtx: MsgContext = {
+    Provider: "discord",
+    From: "discord:channel:123",
+    ChatType: "channel",
+  };
+
+  it("sets label from groupChannel for new channel sessions", () => {
+    const ctx = { ...baseCtx, GroupChannel: "#config" };
+    const patch = deriveGroupSessionPatch({ ctx, sessionKey: "test-key" });
+    expect(patch?.label).toBe("#config");
+    expect(patch?.groupChannel).toBe("#config");
+  });
+
+  it("sets label from subject for group sessions", () => {
+    const ctx = { ...baseCtx, ChatType: "group", GroupSubject: "My Group Chat" };
+    const patch = deriveGroupSessionPatch({ ctx, sessionKey: "test-key" });
+    expect(patch?.label).toBe("My Group Chat");
+    expect(patch?.subject).toBe("My Group Chat");
+  });
+
+  it("does not overwrite an existing label", () => {
+    const ctx = { ...baseCtx, GroupChannel: "#config" };
+    const existing: SessionEntry = {
+      sessionId: "s1",
+      updatedAt: 123,
+      label: "My Custom Label",
+    };
+    const patch = deriveGroupSessionPatch({ ctx, sessionKey: "test-key", existing });
+    expect(patch?.label).toBeUndefined();
+  });
+
+  it("falls back to existing groupChannel when no new channel is derived", () => {
+    const ctx = { ...baseCtx }; // No GroupChannel in context
+    const existing: SessionEntry = {
+      sessionId: "s1",
+      updatedAt: 123,
+      groupChannel: "#existing-channel",
+    };
+    const patch = deriveGroupSessionPatch({ ctx, sessionKey: "test-key", existing });
+    expect(patch?.label).toBe("#existing-channel");
+  });
+});

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -6,6 +6,7 @@ import { normalizeChannelId } from "../../channels/plugins/index.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { buildGroupDisplayName, resolveGroupSessionKey } from "./group.js";
 import type { GroupKeyResolution, SessionEntry, SessionOrigin } from "./types.js";
+import { parseSessionLabel } from "../../sessions/session-label.js";
 
 const mergeOrigin = (
   existing: SessionOrigin | undefined,
@@ -198,6 +199,34 @@ export function deriveSessionMetaPatch(params: {
   const mergedOrigin = mergeOrigin(params.existing?.origin, origin);
   if (mergedOrigin) {
     patch.origin = mergedOrigin;
+  }
+
+  // Auto-label group/channel sessions with a human-friendly name when no
+  // explicit label has been set yet. Only applies when existing label is undefined.
+  if (params.existing?.label === undefined && !patch.label) {
+    const nextGroupChannel = (groupPatch as any)?.groupChannel;
+    const nextSubject = (groupPatch as any)?.subject;
+    const autoLabel =
+      nextGroupChannel ?? params.existing?.groupChannel ?? nextSubject ?? params.existing?.subject;
+    if (autoLabel) {
+      // Validate the auto-generated label using parseSessionLabel to avoid creating unresolvable labels
+      const parsed = parseSessionLabel(autoLabel);
+      if (parsed.ok) {
+        // Check for label uniqueness if we have access to all sessions
+        if (params.allSessions) {
+          const isUnique = Object.entries(params.allSessions).every(([key, entry]) => {
+            if (key === params.sessionKey) return true;
+            return entry?.label !== parsed.label;
+          });
+          if (isUnique) {
+            patch.label = parsed.label;
+          }
+        } else {
+          // Fallback: set the label without uniqueness check (best-effort)
+          patch.label = parsed.label;
+        }
+      }
+    }
   }
 
   return Object.keys(patch).length > 0 ? patch : null;

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -147,6 +147,17 @@ export function deriveGroupSessionPatch(params: {
     patch.displayName = displayName;
   }
 
+  // Auto-label group/channel sessions with a human-friendly name when no
+  // explicit label has been set yet. This surfaces the channel or group
+  // subject in dashboard label columns (e.g. "#config" or "My Group Chat").
+  if (!params.existing?.label) {
+    const autoLabel =
+      nextGroupChannel ?? params.existing?.groupChannel ?? nextSubject ?? params.existing?.subject;
+    if (autoLabel) {
+      patch.label = autoLabel;
+    }
+  }
+
   return patch;
 }
 

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -98,6 +98,8 @@ export function deriveGroupSessionPatch(params: {
   sessionKey: string;
   existing?: SessionEntry;
   groupResolution?: GroupKeyResolution | null;
+  /** Optional map of all session keys to entries for label uniqueness validation */
+  allSessions?: Record<string, SessionEntry>;
 }): Partial<SessionEntry> | null {
   const resolution = params.groupResolution ?? resolveGroupSessionKey(params.ctx);
   if (!resolution?.channel) {
@@ -111,13 +113,13 @@ export function deriveGroupSessionPatch(params: {
   const normalizedChannel = normalizeChannelId(channel);
   const isChannelProvider = Boolean(
     normalizedChannel &&
-    getChannelDock(normalizedChannel)?.capabilities.chatTypes.includes("channel"),
+      getChannelDock(normalizedChannel)?.capabilities.chatTypes.includes("channel"),
   );
   const nextGroupChannel =
     explicitChannel ??
-    ((resolution.chatType === "channel" || isChannelProvider) && subject && subject.startsWith("#")
-      ? subject
-      : undefined);
+      ((resolution.chatType === "channel" || isChannelProvider) && subject && subject.startsWith("#")
+        ? subject
+        : undefined);
   const nextSubject = nextGroupChannel ? undefined : subject;
 
   const patch: Partial<SessionEntry> = {
@@ -150,11 +152,29 @@ export function deriveGroupSessionPatch(params: {
   // Auto-label group/channel sessions with a human-friendly name when no
   // explicit label has been set yet. This surfaces the channel or group
   // subject in dashboard label columns (e.g. "#config" or "My Group Chat").
-  if (!params.existing?.label) {
+  // Only applies when existing label is undefined (never set), not null (explicitly cleared).
+  if (params.existing?.label === undefined) {
     const autoLabel =
       nextGroupChannel ?? params.existing?.groupChannel ?? nextSubject ?? params.existing?.subject;
     if (autoLabel) {
-      patch.label = autoLabel;
+      // Check for label uniqueness if we have access to all sessions
+      if (params.allSessions) {
+        const isUnique = Object.entries(params.allSessions).every(([key, entry]) => {
+          // Skip the current session
+          if (key === params.sessionKey) {
+            return true;
+          }
+          // Check if the label is already in use
+          return entry?.label !== autoLabel;
+        });
+        // Only set the label if it's unique
+        if (isUnique) {
+          patch.label = autoLabel;
+        }
+      } else {
+        // Fallback: set the label without uniqueness check (best-effort)
+        patch.label = autoLabel;
+      }
     }
   }
 
@@ -166,6 +186,7 @@ export function deriveSessionMetaPatch(params: {
   sessionKey: string;
   existing?: SessionEntry;
   groupResolution?: GroupKeyResolution | null;
+  allSessions?: Record<string, SessionEntry>;
 }): Partial<SessionEntry> | null {
   const groupPatch = deriveGroupSessionPatch(params);
   const origin = deriveSessionOrigin(params.ctx);

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1049,6 +1049,7 @@ export async function recordSessionMetaFromInbound(params: {
         sessionKey: resolved.normalizedKey,
         existing,
         groupResolution: params.groupResolution,
+        allSessions: store,
       });
       if (!patch) {
         if (existing && resolved.legacyKeys.length > 0) {
@@ -1132,6 +1133,7 @@ export async function updateLastRoute(params: {
           sessionKey: resolved.normalizedKey,
           existing,
           groupResolution: params.groupResolution,
+          allSessions: store,
         })
       : null;
     const basePatch: Partial<SessionEntry> = {


### PR DESCRIPTION
## Description

This PR addresses Issue #31661 by automatically populating the `label` field for group/channel sessions when no explicit label has been set.

## Changes

- **Auto-label logic**: When updating session metadata, automatically set the label from:
  1. `groupChannel` (e.g., "#config") for channel sessions
  2. `subject` (e.g., "My Group Chat") for group sessions
  3. Falls back to existing values when no new channel is derived

- **Preserves existing labels**: Only sets label when `!params.existing?.label`, ensuring user-set labels are never overwritten

- **Dashboard readability**: Improves UX by showing human-friendly names in dashboard label columns

## Testing

Added comprehensive test coverage in [`metadata.test.ts`](src/config/sessions/metadata.test.ts):
- ✅ Sets label from groupChannel for new channel sessions
- ✅ Sets label from subject for group sessions  
- ✅ Does not overwrite existing labels
- ✅ Falls back to existing groupChannel when no new channel derived

## Related

- Split from PR #31707 (original mixed commit)
- Fixes Issue #31661