### PR TITLE
fix(telegram): preserve original filename from document/audio/video/animation

### DIFF
--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -320,7 +320,11 @@ export async function resolveMedia(
   stickerMetadata?: StickerMetadata;
 } | null> {
   const msg = ctx.message;
-  const downloadAndSaveTelegramFile = async (filePath: string, fetchImpl: typeof fetch) => {
+  const downloadAndSaveTelegramFile = async (
+    filePath: string,
+    fetchImpl: typeof fetch,
+    senderFileName?: string,
+  ) => {
     const url = `https://api.telegram.org/file/bot${token}/${filePath}`;
     const fetched = await fetchRemoteMedia({
       url,
@@ -329,7 +333,9 @@ export async function resolveMedia(
       maxBytes,
       ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
     });
-    const originalName = fetched.fileName ?? filePath;
+    // Prefer the original filename from the sender (msg.document.file_name etc.)
+    // over the server-side file path which uses Telegram's internal naming scheme.
+    const originalName = senderFileName ?? fetched.fileName ?? filePath;
     return saveMediaBuffer(fetched.buffer, fetched.contentType, "inbound", maxBytes, originalName);
   };
 
@@ -451,7 +457,16 @@ export async function resolveMedia(
   if (!fetchImpl) {
     throw new Error("fetch is not available; set channels.telegram.proxy in config");
   }
-  const saved = await downloadAndSaveTelegramFile(file.file_path, fetchImpl);
+  // Telegram Bot API provides the original filename on document, audio, video,
+  // and animation objects.  ctx.getFile() only returns a server-side path like
+  // "documents/file_42---UUID.pdf" — the sender's filename is lost if we don't
+  // read it from the message object explicitly.
+  const senderFileName =
+    msg.document?.file_name ??
+    msg.audio?.file_name ??
+    msg.video?.file_name ??
+    msg.animation?.file_name;
+  const saved = await downloadAndSaveTelegramFile(file.file_path, fetchImpl, senderFileName);
   const placeholder = resolveTelegramMediaPlaceholder(msg) ?? "<media:document>";
   return { path: saved.path, contentType: saved.contentType, placeholder };
 }


### PR DESCRIPTION
## Summary

Fixes #31768 — Telegram inbound documents lose their original filename because `resolveMedia()` never reads `msg.document.file_name`.

## Root Cause

`resolveMedia()` downloads files using the path from `ctx.getFile()`, which returns Telegram's **server-side** path (e.g. `documents/file_42---UUID.pdf`). The sender's original filename (`msg.document.file_name`) was in scope but never read.

A user sending `quarterly-report.pdf` would see it saved as `file_42---UUID.pdf`.

## Fix

`downloadAndSaveTelegramFile()` now accepts an optional `senderFileName` parameter. At the call site, the original filename is read from whichever message object is present:

```typescript
const senderFileName =
  msg.document?.file_name ??
  msg.audio?.file_name ??
  msg.video?.file_name ??
  msg.animation?.file_name;
```

Priority chain for the final filename: **sender filename > HTTP Content-Disposition > server-side path**.

## Verification

```
✓ 49 test files passed (570 tests)
  TypeScript: 0 errors
```