### PR TITLE
fix: Cap cache hit rate at 100% (#26643)

### DIFF
--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -40,7 +40,8 @@ export const formatTokensCompact = (
       typeof used === "number"
         ? used
         : cacheRead + (typeof cacheWrite === "number" ? cacheWrite : 0);
-    const hitRate = Math.round((cacheRead / total) * 100);
+    // Cap at 100% since cache read can exceed tokens used in some edge cases
+    const hitRate = Math.min(100, Math.round((cacheRead / total) * 100));
     result += ` · 🗄️ ${hitRate}% cached`;
   }
 


### PR DESCRIPTION
## Description

This PR addresses Issue #26643 by capping the cache hit rate at 100%.

## Changes

- **Prevent >100% hit rate**: In edge cases where cache read exceeds tokens used, the hit rate calculation could exceed 100%
- **Use Math.min()**: Caps the calculated hit rate at 100% maximum
- **Defensive calculation**: Handles scenarios where `total` may be less than `cacheRead` due to timing or estimation differences

## Related

- Split from PR #31707 (original mixed commit)
- Fixes Issue #26643