### PR TITLE
feat: Add 'xai' to reasoning tag providers (#27533)

### DIFF
--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -21,7 +21,8 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   if (
     normalized === "google" ||
     normalized === "google-gemini-cli" ||
-    normalized === "google-generative-ai"
+    normalized === "google-generative-ai" ||
+    normalized === "xai"
   ) {
     return true;
   }

--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -74,6 +74,7 @@ describe("isReasoningTagProvider", () => {
       value: "google-generative-ai",
       expected: true,
     },
+    { name: "returns true for xai (grok models)", value: "xai", expected: true },
     { name: "returns true for minimax", value: "minimax", expected: true },
     { name: "returns true for minimax-cn", value: "minimax-cn", expected: true },
     { name: "returns false for null", value: null, expected: false },


### PR DESCRIPTION
## Description

This PR addresses Issue #27533 by adding `xai` to the list of reasoning tag providers.

## Changes

- **Add xai provider**: Enables proper reasoning support for xAI (Grok) models
- **Tag-based reasoning**: xAI uses tag-based reasoning similar to Google providers
- **Test coverage**: Added test case for xai provider detection

## Related

- Split from PR #31707 (original mixed commit)
- Fixes Issue #27533
- Note: Issue #26551 (google provider) was already addressed