### PR TITLE
fix(sessions): guarantee lock release when teardown throws

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1641,14 +1641,17 @@ export async function runEmbeddedAttempt(
       // flushPendingToolResults() fires while tools are still executing, inserting
       // synthetic "missing tool result" errors and causing silent agent failures.
       // See: https://github.com/openclaw/openclaw/issues/8643
-      removeToolResultContextGuard?.();
-      await flushPendingToolResultsAfterIdle({
-        agent: session?.agent,
-        sessionManager,
-      });
-      session?.dispose();
-      releaseWsSession(params.sessionId);
-      await sessionLock.release();
+      try {
+        removeToolResultContextGuard?.();
+        await flushPendingToolResultsAfterIdle({
+          agent: session?.agent,
+          sessionManager,
+        });
+        session?.dispose();
+        releaseWsSession(params.sessionId);
+      } finally {
+        await sessionLock.release();
+      }
     }
   } finally {
     restoreSkillEnv?.();


### PR DESCRIPTION
## Summary

- **Problem:** Session transcript lock files (`.jsonl.lock`) are not released when teardown steps throw an exception after a cron job or agent run completes. This leaves orphaned lock files that block all subsequent session writes, causing complete system paralysis with "session file locked" errors.
- **Why it matters:** Users must manually delete `.lock` files and restart the container to recover — a critical production issue observed recurring ~2x in 14 hours.
- **What changed:** `src/agents/pi-embedded-runner/run/attempt.ts` — wrapped the teardown steps (`flushPendingToolResultsAfterIdle`, `session.dispose`, `releaseWsSession`) in an inner `try` block and moved `sessionLock.release()` into a nested `finally`, so the lock is always released even if any teardown step throws.
- **What did NOT change:** Lock acquisition logic, session store locks (already correct in `store.ts`), and compact path (already correct in `compact.ts`). The fix matches the existing pattern in `compact.ts`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31749

## User-visible / Behavior Changes

- Session lock files are now always released after a run completes, even if teardown steps fail. This prevents the "session file locked" timeout error that previously required manual intervention.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any (reported on Linux 6.8.0-101-generic x64, Docker)
- Runtime: Node.js v22.22.0
- Integration/channel: Cron jobs / any channel

### Steps

1. Create a cron job with `sessionTarget="main"`
2. Wait for job to execute
3. If `flushPendingToolResultsAfterIdle` or `session.dispose` throws, observe behavior

### Expected

- Lock file is always released, subsequent messages are processed normally

### Actual

- Before fix: Lock file orphaned, all subsequent operations timeout with "session file locked"
- After fix: Lock file always released via nested `finally` block

## Evidence

```typescript
// Before: all steps sequential in one finally — if any throws, release() is skipped
} finally {
  removeToolResultContextGuard?.();
  await flushPendingToolResultsAfterIdle({ ... }); // if this throws...
  session?.dispose();
  releaseWsSession(params.sessionId);
  await sessionLock.release(); // ...this never runs → orphaned lock
}

// After: nested try/finally guarantees release
} finally {
  try {
    removeToolResultContextGuard?.();
    await flushPendingToolResultsAfterIdle({ ... });
    session?.dispose();
    releaseWsSession(params.sessionId);
  } finally {
    await sessionLock.release(); // always runs
  }
}
```

This matches the existing pattern in `compact.ts` (line 727–735).

## Human Verification (required)

- Verified scenarios: TypeScript compilation passes (`npx tsc --noEmit`), pattern matches existing correct implementation in `compact.ts`
- Edge cases checked: Even if multiple teardown steps throw, the lock is still released. The outer `finally` (restoreSkillEnv, process.chdir) remains unaffected.
- What I did **not** verify: End-to-end cron job test with forced teardown failure

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms: None expected — the change only adds a safety net around existing code

## Risks and Mitigations

None — the nested try/finally pattern is standard and already proven in the codebase (`compact.ts`).

