### PR TITLE
fix: Strip ANSI codes from skills list JSON output (#27530)

### DIFF
--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -67,13 +67,16 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
   const skills = opts.eligible ? report.skills.filter((s) => s.eligible) : report.skills;
 
   if (opts.json) {
+    // eslint-disable-next-line no-control-regex
+    const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
     const jsonReport = {
       workspaceDir: report.workspaceDir,
       managedSkillsDir: report.managedSkillsDir,
       skills: skills.map((s) => ({
         name: s.name,
         description: s.description,
-        emoji: s.emoji,
+        // Strip ANSI codes from emoji for JSON output
+        emoji: s.emoji ? s.emoji.replace(ANSI_PATTERN, "") : null,
         eligible: s.eligible,
         disabled: s.disabled,
         blockedByAllowlist: s.blockedByAllowlist,

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -76,7 +76,8 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
         name: s.name,
         description: s.description,
         // Strip ANSI codes from emoji for JSON output
-        emoji: s.emoji ? s.emoji.replace(ANSI_PATTERN, "") : null,
+        // Returns null if emoji becomes empty after stripping ANSI codes
+        emoji: s.emoji ? (s.emoji.replace(ANSI_PATTERN, "") || null) : null,
         eligible: s.eligible,
         disabled: s.disabled,
         blockedByAllowlist: s.blockedByAllowlist,


### PR DESCRIPTION
## Description

This PR addresses Issue #27530 by stripping ANSI escape codes from the emoji field in JSON output.

## Changes

- **ANSI code removal**: Adds regex pattern to detect and remove ANSI escape codes from emoji
- **JSON cleanliness**: Ensures `--json` output doesn't contain terminal formatting codes
- **Null safety**: Returns `null` if emoji is empty after stripping codes

## Related

- Split from PR #31707 (original mixed commit)
- Fixes Issue #27530