### PR TITLE
fix: Add host header origin fallback for Podman gateway (#27473)

### DIFF
--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -200,12 +200,14 @@ else
 fi
 
 # The gateway refuses to start unless gateway.mode=local is set in config.
+# For Podman/rootless deployments, we also need to allow host header origin fallback
+# since the container binds to a non-loopback address.
 # Make first-run non-interactive; users can run the wizard later to configure channels/providers.
 OPENCLAW_JSON="$OPENCLAW_CONFIG/openclaw.json"
 if ! run_as_openclaw test -f "$OPENCLAW_JSON"; then
-  printf '%s\n' '{ gateway: { mode: "local" } }' | run_as_openclaw tee "$OPENCLAW_JSON" >/dev/null
+  printf '%s\n' '{ "gateway": { "mode": "local", "controlUi": { "dangerouslyAllowHostHeaderOriginFallback": true } } }' | run_as_openclaw tee "$OPENCLAW_JSON" >/dev/null
   run_as_openclaw chmod 600 "$OPENCLAW_JSON" 2>/dev/null || true
-  echo "Created $OPENCLAW_JSON (minimal gateway.mode=local)."
+  echo "Created $OPENCLAW_JSON (minimal gateway.mode=local with controlUi fallback)."
 fi
 
 echo "Building image from $REPO_PATH..."


### PR DESCRIPTION
## Description

This PR addresses Issue #27473 by adding host header origin fallback configuration for Podman gateway deployments.

## Changes

- **Enable host header fallback**: Adds `dangerouslyAllowHostHeaderOriginFallback: true` to gateway config
- **Podman/rootless support**: Required for rootless Podman deployments where container binds to non-loopback addresses
- **JSON formatting**: Fixes JSON syntax with properly quoted keys
- **Updated messaging**: Reflects new configuration in echo message

## Related

- Split from PR #31707 (original mixed commit)
- Fixes Issue #27473