### PR TITLE
fix(gateway): add connection settle grace period to health monitor

### DIFF
--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -18,6 +18,15 @@ const ONE_HOUR_MS = 60 * 60_000;
  */
 const DEFAULT_STALE_EVENT_THRESHOLD_MS = 30 * 60_000;
 
+/**
+ * Grace period after a channel starts before `connected === false` is treated
+ * as unhealthy.  This covers the normal startup window where the WebSocket is
+ * still negotiating (hello, identify, resume) and `connected` has not yet
+ * flipped to `true`.  Without this, the health monitor can restart a channel
+ * that is in the middle of its normal connection sequence.
+ */
+const CONNECTION_SETTLE_MS = 2 * 60_000;
+
 export type ChannelHealthMonitorDeps = {
   channelManager: ChannelManager;
   checkIntervalMs?: number;
@@ -59,7 +68,11 @@ function isChannelHealthy(
     return false;
   }
   if (snapshot.connected === false) {
-    return false;
+    const startAge = snapshot.lastStartAt != null ? opts.now - snapshot.lastStartAt : Infinity;
+    if (startAge > CONNECTION_SETTLE_MS) {
+      return false;
+    }
+    return true;
   }
 
   // Stale socket detection: if the channel has been running long enough


### PR DESCRIPTION
## Summary

- **Problem:** The channel health monitor treats `connected === false` as immediately unhealthy and triggers a channel restart. For Discord (and other WebSocket-based channels), the `connected` flag stays `false` during the normal startup sequence (hello → identify → resume) until the Carbon gateway reports `isConnected === true`. If the health check runs during this window, or if a brief reconnect temporarily sets `connected = false`, the monitor triggers a restart — creating a stuck-restart loop every ~10 minutes (the cooldown period).
- **Why it matters:** Messages sent to Discord during the restart window are silently dropped, cron jobs fail, and the bot appears unresponsive despite the config being correct. Multiple users reported 19+ consecutive stuck restarts.
- **What changed:** `src/gateway/channel-health-monitor.ts` — added a 2-minute `CONNECTION_SETTLE_MS` grace period in `isChannelHealthy()`. Channels with `connected === false` are only flagged unhealthy if they have been running longer than the settle window (based on `lastStartAt`), giving the WebSocket time to establish its connection.
- **What did NOT change:** Stale socket detection (30-minute threshold), cooldown logic, restart limits, stopped/gave-up detection — all untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31760

## User-visible / Behavior Changes

- Discord (and other channels) are no longer restarted during their normal connection startup sequence
- Channels that are genuinely stuck (`connected === false` for > 2 minutes after start) are still restarted as before

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any (reported on macOS 26.3, arm64)
- Runtime: Node.js v25.5.0
- Integration/channel: Discord (also affects Telegram, Slack, BlueBubbles)

### Steps

1. Upgrade to 2026.3.1
2. Configure Discord with 1 guild, ~50 channels
3. Start gateway, observe health-monitor logs

### Expected

- Discord connects normally, health-monitor does not restart it during initial connection

### Actual

- Before fix: `health-monitor: restarting (reason: stuck)` every ~10 minutes in an infinite loop
- After fix: Health monitor gives 2-minute grace period for connection establishment; only restarts if `connected === false` persists beyond that window

## Evidence

```typescript
// Before: connected=false immediately flagged as unhealthy
if (snapshot.connected === false) {
  return false;
}

// After: grace period for recently started channels
if (snapshot.connected === false) {
  const startAge = snapshot.lastStartAt != null ? opts.now - snapshot.lastStartAt : Infinity;
  if (startAge > CONNECTION_SETTLE_MS) {
    return false;
  }
  return true; // still within settle window
}
```

All 21 existing health monitor tests pass unchanged.

## Human Verification (required)

- Verified scenarios: TypeScript compilation passes, all 21 unit tests pass (`npx vitest run src/gateway/channel-health-monitor.test.ts`)
- Edge cases checked: Channels without `lastStartAt` (defaults to `Infinity`, treated as past settle window — preserves existing behavior). Channels that are genuinely stuck after 2 minutes are still restarted.
- What I did **not** verify: End-to-end Discord connection lifecycle with health-monitor enabled

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit, or set `gateway.channelHealthCheckMinutes: 0` to disable health monitoring entirely
- Files/config to restore: `src/gateway/channel-health-monitor.ts`
- Known bad symptoms: If the settle window is too long, genuinely stuck channels would take 2 extra minutes to be detected

## Risks and Mitigations

- **Risk:** 2-minute grace period delays detection of genuinely stuck connections. **Mitigation:** 2 minutes is well below the 5-minute check interval, so worst-case detection delay is one extra check cycle.

