### PR TITLE
fix: strip x-stainless headers for OpenAI-compatible providers

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.openai-header-sanitizer.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openai-header-sanitizer.test.ts
@@ -1,0 +1,80 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+function runSanitizer(params: {
+  provider: string;
+  modelApi: "openai-completions" | "openai-responses" | "anthropic-messages";
+  inputHeaders: Record<string, string>;
+}) {
+  const seen: Array<Record<string, string> | undefined> = [];
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    seen.push(options?.headers);
+    return createAssistantMessageEventStream();
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(agent, undefined, params.provider, "test-model");
+
+  const model = {
+    api: params.modelApi,
+    provider: params.provider,
+    id: "test-model",
+  } as Model<typeof params.modelApi>;
+  const context: Context = { messages: [] };
+
+  void agent.streamFn?.(model, context, { headers: params.inputHeaders });
+  return seen[0];
+}
+
+describe("extra-params: OpenAI compat header sanitizer", () => {
+  it("strips x-stainless-* headers for openai-completions", () => {
+    const headers = runSanitizer({
+      provider: "custom",
+      modelApi: "openai-completions",
+      inputHeaders: {
+        Authorization: "Bearer test",
+        "User-Agent": "OpenClaw/1.0",
+        "x-stainless-os": "MacOS",
+        "x-stainless-runtime": "node",
+      },
+    });
+
+    expect(headers).toEqual({
+      Authorization: "Bearer test",
+      "User-Agent": "OpenClaw/1.0",
+    });
+  });
+
+  it("preserves non-stainless headers", () => {
+    const headers = runSanitizer({
+      provider: "custom",
+      modelApi: "openai-responses",
+      inputHeaders: {
+        Authorization: "Bearer test",
+        "x-foo": "bar",
+      },
+    });
+
+    expect(headers).toEqual({
+      Authorization: "Bearer test",
+      "x-foo": "bar",
+    });
+  });
+
+  it("does not sanitize non-openai-compatible apis", () => {
+    const inputHeaders = {
+      Authorization: "Bearer test",
+      "x-stainless-os": "MacOS",
+    };
+    const headers = runSanitizer({
+      provider: "anthropic",
+      modelApi: "anthropic-messages",
+      inputHeaders,
+    });
+
+    expect(headers).toEqual(inputHeaders);
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -15,6 +15,12 @@ const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as cons
 // Codex responses (chatgpt.com/backend-api/codex/responses) require `store=false`.
 const OPENAI_RESPONSES_APIS = new Set(["openai-responses"]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai-responses"]);
+const OPENAI_COMPAT_APIS = new Set([
+  "openai-completions",
+  "openai-responses",
+  "openai-codex-responses",
+]);
+const STAINLESS_HEADER_PREFIX = "x-stainless-";
 
 /**
  * Resolve provider-specific extra params from model config.
@@ -742,6 +748,40 @@ function createZaiToolStreamWrapper(
   };
 }
 
+function createOpenAICompatHeaderSanitizerWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const api = typeof model.api === "string" ? model.api : undefined;
+    if (!api || !OPENAI_COMPAT_APIS.has(api)) {
+      return underlying(model, context, options);
+    }
+
+    const headers = options?.headers;
+    if (!headers || Object.keys(headers).length === 0) {
+      return underlying(model, context, options);
+    }
+
+    let changed = false;
+    const sanitized: Record<string, string> = {};
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase().startsWith(STAINLESS_HEADER_PREFIX)) {
+        changed = true;
+        continue;
+      }
+      sanitized[key] = value;
+    }
+
+    if (!changed) {
+      return underlying(model, context, options);
+    }
+
+    return underlying(model, context, {
+      ...options,
+      headers: sanitized,
+    });
+  };
+}
+
 /**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also adds OpenRouter app attribution headers when using the OpenRouter provider.
@@ -811,6 +851,12 @@ export function applyExtraParamsToAgent(
     agent.streamFn = createOpenRouterWrapper(agent.streamFn, openRouterThinkingLevel);
     agent.streamFn = createOpenRouterSystemCacheWrapper(agent.streamFn);
   }
+
+  // Some OpenAI-compatible transit/aggregator endpoints behind Cloudflare block
+  // requests when SDK fingerprint headers (x-stainless-*) are present.
+  // Strip those headers right before request dispatch while preserving all other
+  // headers (including user-provided provider/model headers).
+  agent.streamFn = createOpenAICompatHeaderSanitizerWrapper(agent.streamFn);
 
   if (provider === "amazon-bedrock" && !isAnthropicBedrockModel(modelId)) {
     log.debug(`disabling prompt caching for non-Anthropic Bedrock model ${provider}/${modelId}`);


### PR DESCRIPTION
## Summary
- strip `x-stainless-*` request headers for OpenAI-compatible model APIs right before dispatch
- keep all other headers intact (including user custom headers)
- add unit tests for sanitizer behavior

## Why
Some OpenAI-compatible transit/aggregator endpoints (e.g. `https://api.akc.to/v1`) are protected by Cloudflare/WAF rules that block SDK fingerprint headers like `x-stainless-*`.

Issue reporter showed that removing these headers makes requests pass. This PR makes OpenClaw do that automatically for OpenAI-compatible transports.

## Scope
Applies only to model APIs:
- `openai-completions`
- `openai-responses`
- `openai-codex-responses`

No behavior change for non-OpenAI-compatible APIs (e.g. `anthropic-messages`).

Fixes #31720
