### PR TITLE
Telegram: preserve original file_name from Bot API when saving inbound documents (#31768)

### DIFF
--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -31,8 +31,9 @@ const MAX_MEDIA_BYTES = 10_000_000;
 const BOT_TOKEN = "tok123";
 
 function makeCtx(
-  mediaField: "voice" | "audio" | "photo" | "video",
+  mediaField: "voice" | "audio" | "photo" | "video" | "document",
   getFile: TelegramContext["getFile"],
+  fileNameOverride?: string,
 ): TelegramContext {
   const msg: Record<string, unknown> = {
     message_id: 1,
@@ -43,13 +44,21 @@ function makeCtx(
     msg.voice = { file_id: "v1", duration: 5, file_unique_id: "u1" };
   }
   if (mediaField === "audio") {
-    msg.audio = { file_id: "a1", duration: 5, file_unique_id: "u2" };
+    msg.audio = { file_id: "a1", duration: 5, file_unique_id: "u2", file_name: fileNameOverride };
   }
   if (mediaField === "photo") {
     msg.photo = [{ file_id: "p1", width: 100, height: 100 }];
   }
   if (mediaField === "video") {
-    msg.video = { file_id: "vid1", duration: 10, file_unique_id: "u3" };
+    msg.video = {
+      file_id: "vid1",
+      duration: 10,
+      file_unique_id: "u3",
+      file_name: fileNameOverride,
+    };
+  }
+  if (mediaField === "document") {
+    msg.document = { file_id: "d1", file_unique_id: "u4", file_name: fileNameOverride };
   }
   return {
     message: msg as unknown as Message,
@@ -202,5 +211,68 @@ describe("resolveMedia getFile retry", () => {
     const result = await expectTransientGetFileRetrySuccess();
     // Should retry transient errors.
     expect(result).not.toBeNull();
+  });
+});
+
+describe("resolveMedia original filename preservation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchRemoteMedia.mockClear();
+    saveMediaBuffer.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ["document", "business-plan.docx"],
+    ["audio", "meeting-recording.mp3"],
+    ["video", "demo.mp4"],
+  ] as const)(
+    "passes msg.%s.file_name to saveMediaBuffer instead of server-side path",
+    async (mediaField, originalName) => {
+      const getFile = vi.fn().mockResolvedValue({ file_path: `documents/file_abc123xyz.pdf` });
+      fetchRemoteMedia.mockResolvedValue({
+        buffer: Buffer.from("data"),
+        contentType: "application/octet-stream",
+        // Simulates what fetchRemoteMedia derives from the server-side URL path —
+        // NOT the original user filename.
+        fileName: "file_abc123xyz.pdf",
+      });
+      saveMediaBuffer.mockResolvedValue({ path: "/tmp/saved", contentType: "application/pdf" });
+
+      await resolveMedia(makeCtx(mediaField, getFile, originalName), MAX_MEDIA_BYTES, BOT_TOKEN);
+
+      // saveMediaBuffer must receive the original Telegram filename, not the server-side path.
+      expect(saveMediaBuffer).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        "inbound",
+        MAX_MEDIA_BYTES,
+        originalName,
+      );
+    },
+  );
+
+  it("falls back to server-derived name when file_name is absent (e.g. voice)", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
+    fetchRemoteMedia.mockResolvedValue({
+      buffer: Buffer.from("audio"),
+      contentType: "audio/ogg",
+      fileName: "file_0.oga",
+    });
+    saveMediaBuffer.mockResolvedValue({ path: "/tmp/file_0.oga", contentType: "audio/ogg" });
+
+    await resolveMedia(makeCtx("voice", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+
+    // Voice has no file_name; falls back to fetched.fileName from the server path.
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "inbound",
+      MAX_MEDIA_BYTES,
+      "file_0.oga",
+    );
   });
 });

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -53,7 +53,11 @@ export async function resolveMedia(
   stickerMetadata?: StickerMetadata;
 } | null> {
   const msg = ctx.message;
-  const downloadAndSaveTelegramFile = async (filePath: string, fetchImpl: typeof fetch) => {
+  const downloadAndSaveTelegramFile = async (
+    filePath: string,
+    fetchImpl: typeof fetch,
+    telegramFileName?: string,
+  ) => {
     const url = `https://api.telegram.org/file/bot${token}/${filePath}`;
     const fetched = await fetchRemoteMedia({
       url,
@@ -62,7 +66,9 @@ export async function resolveMedia(
       maxBytes,
       ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
     });
-    const originalName = fetched.fileName ?? filePath;
+    // Prefer the original filename from the Telegram Bot API (e.g. msg.document.file_name)
+    // over the server-side path derived name (e.g. "file_<server-id>.pdf").
+    const originalName = telegramFileName ?? fetched.fileName ?? filePath;
     return saveMediaBuffer(fetched.buffer, fetched.contentType, "inbound", maxBytes, originalName);
   };
 
@@ -184,7 +190,11 @@ export async function resolveMedia(
   if (!fetchImpl) {
     throw new Error("fetch is not available; set channels.telegram.proxy in config");
   }
-  const saved = await downloadAndSaveTelegramFile(file.file_path, fetchImpl);
+  // Extract original filename from Telegram Bot API metadata before it is lost.
+  // document/audio/video carry file_name; photo/voice/video_note do not.
+  const telegramFileName =
+    msg.document?.file_name ?? msg.audio?.file_name ?? msg.video?.file_name ?? undefined;
+  const saved = await downloadAndSaveTelegramFile(file.file_path, fetchImpl, telegramFileName);
   const placeholder = resolveTelegramMediaPlaceholder(msg) ?? "<media:document>";
   return { path: saved.path, contentType: saved.contentType, placeholder };
 }


### PR DESCRIPTION
## Summary

- **Problem:** When a Telegram user sends a document (or audio/video), the original filename (e.g. `business-plan.docx`) is permanently lost; the saved file ends up with a double-UUID name like `file_abc123xyz---<new-uuid>.pdf`.
- **Why it matters:** Agents cannot identify files by their original name when multiple documents are sent. Workflows where filenames carry semantic meaning (numbered annexes, versioned reports, etc.) are broken, and users must manually re-specify filenames every time.
- **Root cause:** `resolveMedia()` in `src/telegram/bot/delivery.resolve-media.ts` calls `downloadAndSaveTelegramFile(file.file_path, fetchImpl)` without passing the original filename from the Telegram Bot API. `fetchRemoteMedia` derives `fileName` from the server-side URL path (e.g. `documents/file_abc123xyz.pdf`) because Telegram's download server sends no `Content-Disposition` header. `saveMediaBuffer` then treats this server-generated ID as the "original" name and embeds it, producing the double-UUID pattern.
- **What changed:** `downloadAndSaveTelegramFile` now accepts an optional `telegramFileName` parameter. Before calling it, `resolveMedia` extracts `msg.document?.file_name ?? msg.audio?.file_name ?? msg.video?.file_name` from the Telegram Bot API message object and passes it as `telegramFileName`. The priority chain inside the helper becomes `telegramFileName ?? fetched.fileName ?? filePath`, so the user's original filename always wins when available.
- **What did NOT change (scope boundary):** Stickers, photos, voice notes, and `video_note` have no `file_name` in the Telegram API and are unaffected — they continue to fall back to the server-derived name as before.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31768
- Related #31757

## User-visible / Behavior Changes

- **Before:** Sending `business-plan.docx` via Telegram resulted in a saved file named `file_abc123xyz---<new-uuid>.pdf` — the original name was permanently lost.
- **After:** The same file is saved as `business-plan---<new-uuid>.docx`, preserving the original name with a UUID suffix for uniqueness.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node / Bun
- OpenClaw version: `2026.2.26`
- Integration/channel: Telegram (Bot API)
- Relevant config: Any Telegram channel configuration

### Steps

1. Configure a Telegram bot channel in OpenClaw
2. Send a document (e.g. `business-plan.docx`) to the bot
3. Observe the filename of the saved inbound media file under `~/.openclaw/media/inbound/`

### Expected

- File saved as `business-plan---<uuid>.docx`

### Actual (before fix)

- File saved as `file_<server-id>---<new-uuid>.pdf` — double-UUID, original name gone

## Evidence

- [x] New unit tests in `src/telegram/bot/delivery.resolve-media-retry.test.ts` — new `"resolveMedia original filename preservation"` suite covering `document`, `audio`, `video` (original name passed through), and `voice` (falls back to server-derived name)
- [x] All 15 tests in `delivery.resolve-media-retry.test.ts` pass (11 existing + 4 new)
- [x] TypeScript (`pnpm tsgo`) and lint checks pass

## Human Verification (required)

- **Verified scenarios:** `document`, `audio`, `video` messages receive `file_name` from the Bot API and it is passed correctly to `saveMediaBuffer`; `voice` and `photo` messages (no `file_name`) continue to use the server-derived name
- **Edge cases checked:** Missing `file_name` (e.g. documents uploaded without a name) — falls back gracefully to `fetched.fileName ?? filePath`
- **What you did NOT verify:** Live end-to-end Telegram bot test with a real token

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert 4856205b4`
- Files/config to restore: `src/telegram/bot/delivery.resolve-media.ts`
- Known bad symptoms reviewers should watch for: None expected — the `telegramFileName` parameter is optional and the fallback chain is identical to the previous behavior when it is absent

## Risks and Mitigations

Minimal. The change is additive: `telegramFileName` is an optional parameter with a strict priority chain. When `file_name` is absent (photos, voice, stickers), the behavior is identical to before. No network calls, auth, or storage paths are altered.
