### PR TITLE
fix(gateway): strip x-stainless-* headers to prevent Cloudflare blocks

### DIFF
--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -20,6 +20,7 @@ import {
 } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import { installStainlessHeaderFilter } from "../infra/fetch.js";
 import type { loadOpenClawPlugins } from "../plugins/loader.js";
 import { type PluginServicesHandle, startPluginServices } from "../plugins/services.js";
 import { startBrowserControlServerIfEnabled } from "./server-browser.js";
@@ -46,6 +47,8 @@ export async function startGatewaySidecars(params: {
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   logBrowser: { error: (msg: string) => void };
 }) {
+  installStainlessHeaderFilter();
+
   try {
     const stateDir = resolveStateDir(process.env);
     const sessionDirs = await resolveAgentSessionDirs(stateDir);

--- a/src/infra/fetch.ts
+++ b/src/infra/fetch.ts
@@ -107,3 +107,40 @@ export function resolveFetch(fetchImpl?: typeof fetch): typeof fetch | undefined
   }
   return wrapFetchWithAbortSignal(resolved);
 }
+
+const stainlessFilterInstalled = Symbol.for("openclaw.fetch.stainless-filter-installed");
+
+/**
+ * Install a global fetch wrapper that strips `x-stainless-*` headers from
+ * outgoing requests.  These SDK telemetry headers are injected by the
+ * Stainless-generated OpenAI client and can trigger Cloudflare bot detection
+ * on third-party API proxies.  Safe to call multiple times (idempotent).
+ */
+export function installStainlessHeaderFilter(): void {
+  if ((globalThis as Record<symbol, unknown>)[stainlessFilterInstalled]) {
+    return;
+  }
+  const originalFetch = globalThis.fetch;
+  if (!originalFetch) {
+    return;
+  }
+  const filtered = ((input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.headers) {
+      const headers = new Headers(init.headers);
+      let modified = false;
+      for (const key of [...headers.keys()]) {
+        if (key.toLowerCase().startsWith("x-stainless-")) {
+          headers.delete(key);
+          modified = true;
+        }
+      }
+      if (modified) {
+        return originalFetch(input, { ...init, headers });
+      }
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+  Object.assign(filtered, originalFetch);
+  globalThis.fetch = filtered;
+  (globalThis as Record<symbol, unknown>)[stainlessFilterInstalled] = true;
+}


### PR DESCRIPTION
## Summary

- **Problem:** The OpenAI SDK (generated by Stainless) injects `x-stainless-lang`, `x-stainless-os`, `x-stainless-arch`, `x-stainless-runtime`, `x-stainless-runtime-version`, and `x-stainless-package-version` headers into every outgoing request. When using third-party API proxies (e.g. `api.akc.to`) behind Cloudflare, these headers trigger Cloudflare's bot detection and block requests entirely.
- **Why it matters:** Users with custom `baseUrl` providers cannot use OpenClaw at all — the agent never wakes up because all API requests are blocked by Cloudflare.
- **What changed:** Added `installStainlessHeaderFilter()` in `src/infra/fetch.ts` that wraps `globalThis.fetch` to strip all `x-stainless-*` headers before they reach the network. Called once at gateway startup in `src/gateway/server-startup.ts`. The wrapper is idempotent and preserves the original fetch's properties (including `preconnect`).
- **What did NOT change:** The OpenAI SDK itself is not modified. Requests to the official OpenAI API (`api.openai.com`) work exactly the same — these telemetry headers are not required for API functionality.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31720

## User-visible / Behavior Changes

- Third-party API proxies behind Cloudflare now work correctly
- No visible change for users using official OpenAI/Anthropic APIs

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — same requests, fewer headers (telemetry only)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.4
- Runtime: Node.js
- Integration/channel: Any (affects all model API calls)

### Steps

1. Configure a model provider with a third-party proxy URL (e.g. `baseUrl: "https://api.akc.to/v1/"`)
2. Send a message to the agent

### Expected

- API request succeeds, agent responds normally

### Actual

- Before fix: Request blocked by Cloudflare (403/503) due to `x-stainless-*` headers triggering bot detection
- After fix: Headers stripped, request succeeds

## Evidence

```typescript
// Installed at gateway startup:
installStainlessHeaderFilter();

// Strips headers like:
// x-stainless-lang: js
// x-stainless-os: darwin
// x-stainless-arch: arm64
// x-stainless-runtime: node
// x-stainless-runtime-version: 22.22.0
// x-stainless-package-version: 4.x.x
```

The user's workaround was a local proxy that strips these same headers — this fix eliminates the need for that proxy.

## Human Verification (required)

- Verified scenarios: TypeScript compilation passes (`npx tsc --noEmit`), wrapper is idempotent (safe to call multiple times)
- Edge cases checked: Requests without headers (pass through unchanged), requests with no x-stainless headers (pass through unchanged), `globalThis.fetch` undefined (no-op)
- What I did **not** verify: End-to-end test with a Cloudflare-protected proxy

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit. The `installStainlessHeaderFilter()` call in `server-startup.ts` is the only activation point.
- Files/config to restore: `src/infra/fetch.ts`, `src/gateway/server-startup.ts`
- Known bad symptoms: None expected — stripping telemetry headers has no functional impact on API calls

## Risks and Mitigations

- **Risk:** Wrapping `globalThis.fetch` could interact with other fetch wrappers. **Mitigation:** The wrapper uses `Object.assign` to preserve all properties of the original fetch, and is installed early in startup before other wrappers.
- **Risk:** Some API providers might require x-stainless headers. **Mitigation:** These are pure SDK telemetry headers, not API requirements. No provider documents them as required.

