### PR TITLE
fix(browser): clear tab operation locks on relay disconnect

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -203,6 +203,7 @@ function onRelayClosed(reason) {
   }
 
   reattachPending.clear()
+  tabOperationLocks.clear()
 
   for (const [tabId, tab] of tabs.entries()) {
     if (tab.state === 'connected') {


### PR DESCRIPTION
## Summary

- **Problem:** `tabOperationLocks` is not cleared in `onRelayClosed()`. If a tab attach/detach operation is in progress when the relay WebSocket disconnects, the lock remains permanently. After relay reconnect, `connectOrToggleForActiveTab()` returns immediately at the lock check, making the extension unresponsive.
- **Why it matters:** All subsequent browser automation silently fails. The badge may appear ON but no CDP commands go through. Only recovery is reloading the entire extension.
- **What changed:** `assets/chrome-extension/background.js` — added `tabOperationLocks.clear()` in `onRelayClosed()`, right after `reattachPending.clear()`.
- **What did NOT change:** Lock acquisition/release in `connectOrToggleForActiveTab()` is untouched. `reattachPending.clear()` was already present.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31663

## User-visible / Behavior Changes

- Chrome extension recovers correctly after relay disconnect — tab attach/detach works immediately after reconnect

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any (Chrome extension)
- Runtime: Chrome
- Integration/channel: Browser relay

### Steps

1. Start a browser automation job
2. During a tab attach/detach, disconnect the relay WebSocket
3. Wait for relay to reconnect
4. Try to toggle the extension badge

### Expected

- Extension reconnects and tab operations work normally

### Actual

- Before fix: Extension badge is unresponsive, zombie lock blocks all operations
- After fix: Locks cleared on disconnect, operations resume after reconnect

## Evidence

```javascript
// Before: tabOperationLocks NOT cleared
function onRelayClosed(reason) {
  relayWs = null
  reattachPending.clear()
  // tabOperationLocks still holds stale entries ← zombie lock
}

// After: cleared alongside reattachPending
function onRelayClosed(reason) {
  relayWs = null
  reattachPending.clear()
  tabOperationLocks.clear()  // ← prevents zombie locks
}
```

## Human Verification (required)

- Verified scenarios: One-line change matches the pattern used for `reattachPending`
- Edge cases checked: Clearing locks during an active operation is safe — the operation's `finally` block calls `tabOperationLocks.delete(tabId)`, which is a no-op on a cleared set
- What I did **not** verify: End-to-end relay disconnect/reconnect test

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: `assets/chrome-extension/background.js`
- Known bad symptoms: None expected

## Risks and Mitigations

None — clearing per-tab locks on relay disconnect is the correct behavior, matching `reattachPending.clear()`.

