### PR TITLE
fix(plugins): use state-dir for jiti cache instead of /tmp

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createJiti } from "jiti";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -437,6 +438,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     const pluginSdkAccountIdAlias = resolvePluginSdkAccountIdAlias();
     jitiLoader = createJiti(import.meta.url, {
       interopDefault: true,
+      fsCache: path.join(resolveStateDir(process.env), "cache", "jiti"),
       extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
       ...(pluginSdkAlias || pluginSdkAccountIdAlias
         ? {


### PR DESCRIPTION
## Summary

- **Problem:** `jiti` defaults its filesystem cache to `/tmp/jiti`. On Linux systems with restrictive `/tmp` permissions (e.g., `noexec` mount flag, container sandboxes, or systemd `PrivateTmp=true`), the plugin loader fails when it tries to write compiled TypeScript to the cache directory, crashing the Feishu extension (and any other TypeScript plugin).
- **Why it matters:** All TypeScript-based plugins become unusable on restricted Linux environments. Users must manually work around permissions or disable caching entirely.
- **What changed:** `src/plugins/loader.ts` — set the `fsCache` option when creating the `jiti` loader instance, pointing it to `<stateDir>/cache/jiti` (resolved via `resolveStateDir()`) instead of the default `/tmp/jiti`.
- **What did NOT change:** Plugin loading logic, jiti configuration options beyond `fsCache`, and the `resolveStateDir()` function itself are all untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31785

## User-visible / Behavior Changes

- Plugin loading no longer fails on Linux systems with restrictive `/tmp` permissions.
- jiti cache files are now stored in `<stateDir>/cache/jiti/` instead of `/tmp/jiti/`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux with restricted `/tmp` (e.g., `noexec` mount, `PrivateTmp=true`)
- Runtime: Node.js
- Integration/channel: Feishu (or any TypeScript plugin)

### Steps

1. Run OpenClaw on a Linux host where `/tmp` is mounted with `noexec` or is otherwise not writable.
2. Enable any TypeScript plugin (e.g., the Feishu extension).
3. Observe a filesystem permission error from `jiti` during plugin load.

### Expected

- Plugin loads successfully, jiti cache written to `<stateDir>/cache/jiti/`.

### Actual

- Before fix: `jiti` fails with EACCES/EPERM when writing to `/tmp/jiti`.
- After fix: Cache is written to `<stateDir>/cache/jiti/` which is always writable.

## Evidence

```typescript
// Before: jiti uses default /tmp/jiti cache
jitiLoader = createJiti(import.meta.url, {
  interopDefault: true,
  extensions: [".ts", ".tsx", ...],
});

// After: jiti uses state-dir cache
jitiLoader = createJiti(import.meta.url, {
  interopDefault: true,
  fsCache: path.join(resolveStateDir(process.env), "cache", "jiti"),
  extensions: [".ts", ".tsx", ...],
});
```

## Human Verification (required)

- Verified scenarios: TypeScript compilation passes (`npx tsc --noEmit`)
- Edge cases checked: `resolveStateDir()` falls back to `~/.openclaw` when no override is set, which is always writable. The `cache/jiti` subdirectory is created automatically by jiti.
- What I did **not** verify: End-to-end test on a `/tmp`-restricted Linux system.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No` — old `/tmp/jiti` cache is simply unused; no cleanup needed.

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: `src/plugins/loader.ts`
- Known bad symptoms: If `resolveStateDir()` somehow returns an unwritable path, jiti would fail as before. Extremely unlikely since the state dir is always validated.

## Risks and Mitigations

None — routing the cache to the state directory is strictly more reliable than `/tmp`, and `resolveStateDir()` already handles all edge cases (env overrides, home directory resolution).