### PR TITLE
BlueBubbles: fallback unsupported reactions instead of throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- BlueBubbles/Reactions: gracefully fall back unsupported tapback emoji reactions to `like`/`-like` instead of throwing, so reaction handling continues when users send non-tapback emoji. Fixes #31813.
 - Webchat/Feishu session continuation: preserve routable `OriginatingChannel`/`OriginatingTo` metadata from session delivery context in `chat.send`, and prefer provider-normalized channel when deciding cross-channel route dispatch so Webchat replies continue on the selected Feishu session instead of falling back to main/internal session routing. (#31573)
 - Feishu/Duplicate replies: suppress same-target reply dispatch when message-tool sends use generic provider metadata (`provider: "message"`) and normalize `lark`/`feishu` provider aliases during duplicate-target checks, preventing double-delivery in Feishu sessions. (#31526)
 - Feishu/Plugin sdk compatibility: add safe webhook default fallbacks when loading Feishu monitor state so mixed-version installs no longer crash if older `openclaw/plugin-sdk` builds omit webhook default constants. (#31606)

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -42,7 +42,7 @@ import type {
   WebhookTarget,
 } from "./monitor-shared.js";
 import { isBlueBubblesPrivateApiEnabled } from "./probe.js";
-import { normalizeBlueBubblesReactionInput, sendBlueBubblesReaction } from "./reactions.js";
+import { isSupportedBlueBubblesReactionInput, sendBlueBubblesReaction } from "./reactions.js";
 import { resolveChatGuidForTarget, sendMessageBlueBubbles } from "./send.js";
 import { formatBlueBubblesChatTarget, isAllowedBlueBubblesSender } from "./targets.js";
 
@@ -228,21 +228,19 @@ function resolveBlueBubblesAckReaction(params: {
   if (!raw) {
     return null;
   }
-  try {
-    normalizeBlueBubblesReactionInput(raw);
+  if (isSupportedBlueBubblesReactionInput(raw)) {
     return raw;
-  } catch {
-    const key = raw.toLowerCase();
-    if (!invalidAckReactions.has(key)) {
-      invalidAckReactions.add(key);
-      logVerbose(
-        params.core,
-        params.runtime,
-        `ack reaction skipped (unsupported for BlueBubbles): ${raw}`,
-      );
-    }
-    return null;
   }
+  const key = raw.toLowerCase();
+  if (!invalidAckReactions.has(key)) {
+    invalidAckReactions.add(key);
+    logVerbose(
+      params.core,
+      params.runtime,
+      `ack reaction skipped (unsupported for BlueBubbles): ${raw}`,
+    );
+  }
+  return null;
 }
 
 /**

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -2216,6 +2216,50 @@ describe("BlueBubbles webhook monitor", () => {
         }),
       );
     });
+
+    it("skips unsupported ack reactions", async () => {
+      const { sendBlueBubblesReaction } = await import("./reactions.js");
+      vi.mocked(sendBlueBubblesReaction).mockClear();
+
+      const account = createMockAccount({ dmPolicy: "open" });
+      const config: OpenClawConfig = {
+        messages: {
+          ackReaction: "👀",
+          ackReactionScope: "direct",
+        },
+      };
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: "hello",
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-1",
+          chatGuid: "iMessage;-;+15551234567",
+          date: Date.now(),
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(sendBlueBubblesReaction).not.toHaveBeenCalled();
+    });
   });
 
   describe("command gating", () => {

--- a/extensions/bluebubbles/src/reactions.test.ts
+++ b/extensions/bluebubbles/src/reactions.test.ts
@@ -106,18 +106,45 @@ describe("reactions", () => {
       ).rejects.toThrow("password is required");
     });
 
-    it("throws for unsupported reaction type", async () => {
-      await expect(
-        sendBlueBubblesReaction({
-          chatGuid: "chat-123",
-          messageGuid: "msg-123",
-          emoji: "unsupported",
-          opts: {
-            serverUrl: "http://localhost:1234",
-            password: "test",
-          },
-        }),
-      ).rejects.toThrow("Unsupported BlueBubbles reaction");
+    it("falls back to like for unsupported reaction type", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(""),
+      });
+
+      await sendBlueBubblesReaction({
+        chatGuid: "chat-123",
+        messageGuid: "msg-123",
+        emoji: "unsupported",
+        opts: {
+          serverUrl: "http://localhost:1234",
+          password: "test",
+        },
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.reaction).toBe("like");
+    });
+
+    it("falls back to -like for unsupported reaction removal", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(""),
+      });
+
+      await sendBlueBubblesReaction({
+        chatGuid: "chat-123",
+        messageGuid: "msg-123",
+        emoji: "unsupported",
+        remove: true,
+        opts: {
+          serverUrl: "http://localhost:1234",
+          password: "test",
+        },
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.reaction).toBe("-like");
     });
 
     describe("reaction type normalization", () => {

--- a/extensions/bluebubbles/src/reactions.ts
+++ b/extensions/bluebubbles/src/reactions.ts
@@ -115,17 +115,30 @@ function resolveAccount(params: BlueBubblesReactionOpts) {
   return resolveBlueBubblesServerAccount(params);
 }
 
-export function normalizeBlueBubblesReactionInput(emoji: string, remove?: boolean): string {
+function resolveBlueBubblesReactionType(emoji: string): string | null {
   const trimmed = emoji.trim();
   if (!trimmed) {
-    throw new Error("BlueBubbles reaction requires an emoji or name.");
+    return null;
   }
   let raw = trimmed.toLowerCase();
   if (raw.startsWith("-")) {
     raw = raw.slice(1);
   }
   const aliased = REACTION_ALIASES.get(raw) ?? raw;
-  const mapped = REACTION_EMOJIS.get(trimmed) ?? REACTION_EMOJIS.get(raw) ?? aliased;
+  return REACTION_EMOJIS.get(trimmed) ?? REACTION_EMOJIS.get(raw) ?? aliased;
+}
+
+export function isSupportedBlueBubblesReactionInput(emoji: string): boolean {
+  const mapped = resolveBlueBubblesReactionType(emoji);
+  return mapped !== null && REACTION_TYPES.has(mapped);
+}
+
+export function normalizeBlueBubblesReactionInput(emoji: string, remove?: boolean): string {
+  const trimmed = emoji.trim();
+  if (!trimmed) {
+    throw new Error("BlueBubbles reaction requires an emoji or name.");
+  }
+  const mapped = resolveBlueBubblesReactionType(trimmed);
   if (!REACTION_TYPES.has(mapped)) {
     return remove ? "-like" : "like";
   }

--- a/extensions/bluebubbles/src/reactions.ts
+++ b/extensions/bluebubbles/src/reactions.ts
@@ -127,7 +127,7 @@ export function normalizeBlueBubblesReactionInput(emoji: string, remove?: boolea
   const aliased = REACTION_ALIASES.get(raw) ?? raw;
   const mapped = REACTION_EMOJIS.get(trimmed) ?? REACTION_EMOJIS.get(raw) ?? aliased;
   if (!REACTION_TYPES.has(mapped)) {
-    throw new Error(`Unsupported BlueBubbles reaction: ${trimmed}`);
+    return remove ? "-like" : "like";
   }
   return remove ? `-${mapped}` : mapped;
 }


### PR DESCRIPTION
## Summary
- change BlueBubbles reaction normalization to gracefully fall back to `like` / `-like` when an unsupported emoji/name is provided
- keep existing behavior for supported tapback aliases and emoji mappings
- add regression tests for unsupported add/remove reactions
- add changelog entry under 2026.3.2 (Unreleased) Fixes

## Testing
- pnpm test extensions/bluebubbles/src/reactions.test.ts

Fixes #31813
