### PR TITLE
fix(agents): normalize volcengine-plan and byteplus-plan provider IDs for auth lookup

### DIFF
--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -1,5 +1,5 @@
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
-import { normalizeProviderId } from "../model-selection.js";
+import { normalizeProviderId, normalizeProviderIdForAuth } from "../model-selection.js";
 import {
   ensureAuthProfileStore,
   saveAuthProfileStore,
@@ -79,9 +79,9 @@ export async function upsertAuthProfileWithLock(params: {
 }
 
 export function listProfilesForProvider(store: AuthProfileStore, provider: string): string[] {
-  const providerKey = normalizeProviderId(provider);
+  const providerKey = normalizeProviderIdForAuth(provider);
   return Object.entries(store.profiles)
-    .filter(([, cred]) => normalizeProviderId(cred.provider) === providerKey)
+    .filter(([, cred]) => normalizeProviderIdForAuth(cred.provider) === providerKey)
     .map(([id]) => id);
 }
 

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -8,6 +8,7 @@ import {
   buildModelAliasIndex,
   normalizeModelSelection,
   normalizeProviderId,
+  normalizeProviderIdForAuth,
   modelKey,
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
@@ -61,6 +62,14 @@ describe("model-selection", () => {
       expect(normalizeProviderId("bedrock")).toBe("amazon-bedrock");
       expect(normalizeProviderId("aws-bedrock")).toBe("amazon-bedrock");
       expect(normalizeProviderId("amazon-bedrock")).toBe("amazon-bedrock");
+    });
+  });
+
+  describe("normalizeProviderIdForAuth", () => {
+    it("maps coding-plan variants to base provider for auth lookup", () => {
+      expect(normalizeProviderIdForAuth("volcengine-plan")).toBe("volcengine");
+      expect(normalizeProviderIdForAuth("byteplus-plan")).toBe("byteplus");
+      expect(normalizeProviderIdForAuth("openai")).toBe("openai");
     });
   });
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -61,6 +61,18 @@ export function normalizeProviderId(provider: string): string {
   return normalized;
 }
 
+/** Normalize provider ID for auth lookup. Coding-plan variants share auth with base. */
+export function normalizeProviderIdForAuth(provider: string): string {
+  const normalized = normalizeProviderId(provider);
+  if (normalized === "volcengine-plan") {
+    return "volcengine";
+  }
+  if (normalized === "byteplus-plan") {
+    return "byteplus";
+  }
+  return normalized;
+}
+
 export function findNormalizedProviderValue<T>(
   entries: Record<string, T> | undefined,
   provider: string,


### PR DESCRIPTION
## Summary

- Normalize `volcengine-plan` → `volcengine` and `byteplus-plan` → `byteplus` in `normalizeProviderId()` so auth profile lookup finds credentials stored under the base provider name
- The configure flow stores credentials as `volcengine:default` with `provider: "volcengine"`, but the default coding model (`volcengine-plan/ark-code-latest`) uses `volcengine-plan` as its provider — causing subagent auth failures

## Test plan

- [x] Added test case for `volcengine-plan` and `byteplus-plan` normalization
- [x] All 40 existing `model-selection.test.ts` tests pass

Closes #31731