### PR TITLE
refactor(ui): name GatewayBrowserClient reconnect constants

### DIFF
--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -90,6 +90,10 @@ export type GatewayBrowserClientOptions = {
 
 // 4008 = application-defined code (browser rejects 1008 "Policy Violation")
 const CONNECT_FAILED_CLOSE_CODE = 4008;
+const INITIAL_RECONNECT_BACKOFF_MS = 800;
+const RECONNECT_BACKOFF_MULTIPLIER = 1.7;
+const MAX_RECONNECT_BACKOFF_MS = 15_000;
+const CONNECT_QUEUE_DELAY_MS = 750;
 
 export class GatewayBrowserClient {
   private ws: WebSocket | null = null;
@@ -99,7 +103,7 @@ export class GatewayBrowserClient {
   private connectNonce: string | null = null;
   private connectSent = false;
   private connectTimer: number | null = null;
-  private backoffMs = 800;
+  private backoffMs = INITIAL_RECONNECT_BACKOFF_MS;
   private pendingConnectError: GatewayErrorInfo | undefined;
 
   constructor(private opts: GatewayBrowserClientOptions) {}
@@ -147,7 +151,10 @@ export class GatewayBrowserClient {
       return;
     }
     const delay = this.backoffMs;
-    this.backoffMs = Math.min(this.backoffMs * 1.7, 15_000);
+    this.backoffMs = Math.min(
+      this.backoffMs * RECONNECT_BACKOFF_MULTIPLIER,
+      MAX_RECONNECT_BACKOFF_MS,
+    );
     window.setTimeout(() => this.connect(), delay);
   }
 
@@ -257,7 +264,7 @@ export class GatewayBrowserClient {
             scopes: hello.auth.scopes ?? [],
           });
         }
-        this.backoffMs = 800;
+        this.backoffMs = INITIAL_RECONNECT_BACKOFF_MS;
         this.opts.onHello?.(hello);
       })
       .catch((err: unknown) => {
@@ -355,6 +362,6 @@ export class GatewayBrowserClient {
     }
     this.connectTimer = window.setTimeout(() => {
       void this.sendConnect();
-    }, 750);
+    }, CONNECT_QUEUE_DELAY_MS);
   }
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `GatewayBrowserClient` reconnect behavior relied on inline magic numbers (`800`, `1.7`, `15_000`, `750`) in multiple methods.
- Why it matters: The reconnect flow is harder to understand, review, and tune safely without named values.
- What changed: Extracted reconnect tuning values into top-level named constants and replaced inline literals.
- What did NOT change (scope boundary): No reconnect behavior change; only readability/maintainability improvements.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30402
- Related #31817

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: local Node/pnpm + UI Vitest
- Model/provider: N/A
- Integration/channel (if any): Control UI gateway websocket client
- Relevant config (redacted): default control UI gateway connection settings

### Steps

1. Inspect reconnect/backoff logic in `ui/src/ui/gateway.ts`.
2. Verify literals are replaced by named constants.
3. Run gateway UI and repo checks.

### Expected

- Reconnect behavior remains unchanged and code is easier to tune safely.

### Actual

- Backoff/queue timings now use named constants only.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing tests/checks run locally:

- `pnpm --dir ui test src/ui/app-gateway.node.test.ts`
- `pnpm exec oxfmt --check ui/src/ui/gateway.ts`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Initial backoff, multiplier, cap, and connect queue delay all map to explicit constants.
  - Existing reconnect flow structure is unchanged.
- Edge cases checked:
  - Backoff reset path after successful `connect` still sets initial value.
- What you did **not** verify:
  - Long-duration manual websocket reconnect soak test in browser runtime.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `ui/src/ui/gateway.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected reconnect timing drift relative to previous behavior.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Future edits may assume behavior changed because constants were introduced.
  - Mitigation: Constants preserve existing numeric values; no logic changes were introduced.
