### PR TITLE
feat(telegram): use sendMessageDraft for private chat streaming

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -57,6 +57,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       update: vi.fn(),
       flush: vi.fn().mockResolvedValue(undefined),
       messageId: vi.fn().mockReturnValue(messageId),
+      previewMode: vi.fn().mockReturnValue("message"),
       clear: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(undefined),
       forceNewMessage: vi.fn(),
@@ -74,6 +75,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       }),
       flush: vi.fn().mockResolvedValue(undefined),
       messageId: vi.fn().mockImplementation(() => activeMessageId),
+      previewMode: vi.fn().mockReturnValue("message"),
       clear: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(undefined),
       forceNewMessage: vi.fn().mockImplementation(() => {
@@ -1214,6 +1216,54 @@ describe("dispatchTelegramMessage draft streaming", () => {
             text: expect.stringContaining("Reasoning:\nIf I count r in strawberry"),
           }),
         ],
+      }),
+    );
+  });
+
+  it("keeps DM draft reasoning block updates in preview flow without sending duplicates", async () => {
+    const answerDraftStream = createDraftStream(999);
+    const reasoningDraftStream = {
+      update: vi.fn(),
+      flush: vi.fn().mockResolvedValue(undefined),
+      messageId: vi.fn().mockReturnValue(undefined),
+      previewMode: vi.fn().mockReturnValue("draft"),
+      clear: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      forceNewMessage: vi.fn(),
+    };
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onReasoningStream?.({
+          text: "Reasoning:\nI am counting letters...",
+        });
+        await replyOptions?.onReasoningEnd?.();
+        await replyOptions?.onPartialReply?.({ text: "3" });
+        await dispatcherOptions.deliver({ text: "3" }, { kind: "final" });
+        await dispatcherOptions.deliver(
+          {
+            text: "Reasoning:\nI am counting letters. The total is 3.",
+          },
+          { kind: "block" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({ context: createReasoningStreamContext(), streamMode: "partial" });
+
+    expect(editMessageTelegram).toHaveBeenCalledWith(123, 999, "3", expect.any(Object));
+    expect(reasoningDraftStream.update).toHaveBeenCalledWith(
+      "Reasoning:\nI am counting letters. The total is 3.",
+    );
+    expect(reasoningDraftStream.flush).toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ text: expect.stringContaining("Reasoning:\nI am") })],
       }),
     );
   });

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -53,11 +53,15 @@ describe("dispatchTelegramMessage draft streaming", () => {
   });
 
   function createDraftStream(messageId?: number) {
+    let previewRevision = 0;
     return {
-      update: vi.fn(),
-      flush: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockImplementation(() => {
+        previewRevision += 1;
+      }),
+      flush: vi.fn().mockResolvedValue(true),
       messageId: vi.fn().mockReturnValue(messageId),
       previewMode: vi.fn().mockReturnValue("message"),
+      previewRevision: vi.fn().mockImplementation(() => previewRevision),
       clear: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(undefined),
       forceNewMessage: vi.fn(),
@@ -67,15 +71,18 @@ describe("dispatchTelegramMessage draft streaming", () => {
   function createSequencedDraftStream(startMessageId = 1001) {
     let activeMessageId: number | undefined;
     let nextMessageId = startMessageId;
+    let previewRevision = 0;
     return {
       update: vi.fn().mockImplementation(() => {
         if (activeMessageId == null) {
           activeMessageId = nextMessageId++;
         }
+        previewRevision += 1;
       }),
-      flush: vi.fn().mockResolvedValue(undefined),
+      flush: vi.fn().mockResolvedValue(true),
       messageId: vi.fn().mockImplementation(() => activeMessageId),
       previewMode: vi.fn().mockReturnValue("message"),
+      previewRevision: vi.fn().mockImplementation(() => previewRevision),
       clear: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(undefined),
       forceNewMessage: vi.fn().mockImplementation(() => {
@@ -1252,15 +1259,20 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
   it("keeps DM draft reasoning block updates in preview flow without sending duplicates", async () => {
     const answerDraftStream = createDraftStream(999);
+    let previewRevision = 0;
     const reasoningDraftStream = {
       update: vi.fn(),
-      flush: vi.fn().mockResolvedValue(undefined),
+      flush: vi.fn().mockResolvedValue(true),
       messageId: vi.fn().mockReturnValue(undefined),
       previewMode: vi.fn().mockReturnValue("draft"),
+      previewRevision: vi.fn().mockImplementation(() => previewRevision),
       clear: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(undefined),
       forceNewMessage: vi.fn(),
     };
+    reasoningDraftStream.update.mockImplementation(() => {
+      previewRevision += 1;
+    });
     createTelegramDraftStream
       .mockImplementationOnce(() => answerDraftStream)
       .mockImplementationOnce(() => reasoningDraftStream);
@@ -1294,6 +1306,45 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalledWith(
       expect.objectContaining({
         replies: [expect.objectContaining({ text: expect.stringContaining("Reasoning:\nI am") })],
+      }),
+    );
+  });
+
+  it("falls back to normal send when DM draft reasoning flush emits no preview update", async () => {
+    const answerDraftStream = createDraftStream(999);
+    const previewRevision = 0;
+    const reasoningDraftStream = {
+      update: vi.fn(),
+      flush: vi.fn().mockResolvedValue(false),
+      messageId: vi.fn().mockReturnValue(undefined),
+      previewMode: vi.fn().mockReturnValue("draft"),
+      previewRevision: vi.fn().mockReturnValue(previewRevision),
+      clear: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      forceNewMessage: vi.fn(),
+    };
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onReasoningStream?.({ text: "Reasoning:\n_step one_" });
+        await replyOptions?.onReasoningEnd?.();
+        await dispatcherOptions.deliver(
+          { text: "Reasoning:\n_step one expanded_" },
+          { kind: "block" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createReasoningStreamContext(), streamMode: "partial" });
+
+    expect(reasoningDraftStream.flush).toHaveBeenCalled();
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ text: "Reasoning:\n_step one expanded_" })],
       }),
     );
   });

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1086,6 +1086,36 @@ describe("dispatchTelegramMessage draft streaming", () => {
     },
   );
 
+  it("uses message preview transport for DM reasoning lane when answer preview lane is active", async () => {
+    setupDraftStreams({ answerMessageId: 999, reasoningMessageId: 111 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onReasoningStream?.({ text: "Reasoning:\n_Working on it..._" });
+        await replyOptions?.onPartialReply?.({ text: "Checking the directory..." });
+        await dispatcherOptions.deliver({ text: "Checking the directory..." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({ context: createReasoningStreamContext(), streamMode: "partial" });
+
+    expect(createTelegramDraftStream).toHaveBeenCalledTimes(2);
+    expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        thread: { id: 777, scope: "dm" },
+        previewTransport: "auto",
+      }),
+    );
+    expect(createTelegramDraftStream.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        thread: { id: 777, scope: "dm" },
+        previewTransport: "message",
+      }),
+    );
+  });
+
   it("keeps reasoning and answer streaming in separate preview lanes", async () => {
     const { answerDraftStream, reasoningDraftStream } = setupDraftStreams({
       answerMessageId: 999,

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -190,12 +190,15 @@ export const dispatchTelegramMessage = async ({
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
+    const useMessagePreviewTransportForDmReasoning =
+      laneName === "reasoning" && threadSpec?.scope === "dm" && canStreamAnswerDraft;
     const stream = enabled
       ? createTelegramDraftStream({
           api: bot.api,
           chatId,
           maxChars: draftMaxChars,
           thread: threadSpec,
+          previewTransport: useMessagePreviewTransportForDmReasoning ? "message" : "auto",
           replyToMessageId: draftReplyToMessageId,
           minInitialChars: draftMinInitialChars,
           renderText: renderDraftPreview,

--- a/src/telegram/bot.create-telegram-bot.test-harness.ts
+++ b/src/telegram/bot.create-telegram-bot.test-harness.ts
@@ -111,6 +111,7 @@ export const botCtorSpy: AnyMock = vi.fn();
 export const answerCallbackQuerySpy: AnyAsyncMock = vi.fn(async () => undefined);
 export const sendChatActionSpy: AnyMock = vi.fn();
 export const editMessageTextSpy: AnyAsyncMock = vi.fn(async () => ({ message_id: 88 }));
+export const sendMessageDraftSpy: AnyAsyncMock = vi.fn(async () => true);
 export const setMessageReactionSpy: AnyAsyncMock = vi.fn(async () => undefined);
 export const setMyCommandsSpy: AnyAsyncMock = vi.fn(async () => undefined);
 export const getMeSpy: AnyAsyncMock = vi.fn(async () => ({
@@ -127,6 +128,7 @@ type ApiStub = {
   answerCallbackQuery: typeof answerCallbackQuerySpy;
   sendChatAction: typeof sendChatActionSpy;
   editMessageText: typeof editMessageTextSpy;
+  sendMessageDraft: typeof sendMessageDraftSpy;
   setMessageReaction: typeof setMessageReactionSpy;
   setMyCommands: typeof setMyCommandsSpy;
   getMe: typeof getMeSpy;
@@ -141,6 +143,7 @@ const apiStub: ApiStub = {
   answerCallbackQuery: answerCallbackQuerySpy,
   sendChatAction: sendChatActionSpy,
   editMessageText: editMessageTextSpy,
+  sendMessageDraft: sendMessageDraftSpy,
   setMessageReaction: setMessageReactionSpy,
   setMyCommands: setMyCommandsSpy,
   getMe: getMeSpy,
@@ -311,6 +314,8 @@ beforeEach(() => {
   });
   editMessageTextSpy.mockReset();
   editMessageTextSpy.mockResolvedValue({ message_id: 88 });
+  sendMessageDraftSpy.mockReset();
+  sendMessageDraftSpy.mockResolvedValue(true);
   enqueueSystemEventSpy.mockReset();
   wasSentByBot.mockReset();
   wasSentByBot.mockReturnValue(false);

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -7,6 +7,7 @@ type TelegramDraftStreamParams = Parameters<typeof createTelegramDraftStream>[0]
 function createMockDraftApi(sendMessageImpl?: () => Promise<{ message_id: number }>) {
   return {
     sendMessage: vi.fn(sendMessageImpl ?? (async () => ({ message_id: 17 }))),
+    sendMessageDraft: vi.fn().mockResolvedValue(true),
     editMessageText: vi.fn().mockResolvedValue(true),
     deleteMessage: vi.fn().mockResolvedValue(true),
   };
@@ -107,17 +108,37 @@ describe("createTelegramDraftStream", () => {
     await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined));
   });
 
-  it("includes message_thread_id for dm threads and clears preview on cleanup", async () => {
+  it("uses sendMessageDraft for dm threads and does not create a preview message", async () => {
     const api = createMockDraftApi();
     const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });
 
     stream.update("Hello");
     await vi.waitFor(() =>
-      expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", { message_thread_id: 42 }),
+      expect(api.sendMessageDraft).toHaveBeenCalledWith(123, expect.any(Number), "Hello", {
+        message_thread_id: 42,
+      }),
     );
+    expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(api.editMessageText).not.toHaveBeenCalled();
     await stream.clear();
 
-    expect(api.deleteMessage).toHaveBeenCalledWith(123, 17);
+    expect(api.deleteMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not edit or delete messages after DM draft stream finalization", async () => {
+    const api = createMockDraftApi();
+    const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });
+
+    stream.update("Hello");
+    await stream.flush();
+    stream.update("Hello again");
+    await stream.stop();
+    await stream.clear();
+
+    expect(api.sendMessageDraft).toHaveBeenCalled();
+    expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(api.editMessageText).not.toHaveBeenCalled();
+    expect(api.deleteMessage).not.toHaveBeenCalled();
   });
 
   it("creates new message after forceNewMessage is called", async () => {

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -125,6 +125,21 @@ describe("createTelegramDraftStream", () => {
     expect(api.deleteMessage).not.toHaveBeenCalled();
   });
 
+  it("supports forcing message transport in dm threads", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "message",
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined);
+    expect(api.sendMessageDraft).not.toHaveBeenCalled();
+    expect(api.editMessageText).not.toHaveBeenCalled();
+  });
+
   it("does not edit or delete messages after DM draft stream finalization", async () => {
     const api = createMockDraftApi();
     const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -135,9 +135,51 @@ describe("createTelegramDraftStream", () => {
     stream.update("Hello");
     await stream.flush();
 
-    expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined);
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", { message_thread_id: 42 });
     expect(api.sendMessageDraft).not.toHaveBeenCalled();
     expect(api.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to message transport when sendMessageDraft is unavailable", async () => {
+    const api = createMockDraftApi();
+    delete (api as { sendMessageDraft?: unknown }).sendMessageDraft;
+    const warn = vi.fn();
+    const stream = createDraftStream(api, {
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "draft",
+      warn,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", { message_thread_id: 42 });
+    expect(api.editMessageText).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "telegram stream preview: sendMessageDraft unavailable; falling back to sendMessage/editMessageText",
+    );
+  });
+
+  it("retries DM message preview send without thread when thread is not found", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockRejectedValueOnce(new Error("400: Bad Request: message thread not found"))
+      .mockResolvedValueOnce({ message_id: 17 });
+    const warn = vi.fn();
+    const stream = createDraftStream(api, {
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "message",
+      warn,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "Hello", { message_thread_id: 42 });
+    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "Hello", undefined);
+    expect(warn).toHaveBeenCalledWith(
+      "telegram stream preview send failed with message_thread_id, retrying without thread",
+    );
   });
 
   it("does not edit or delete messages after DM draft stream finalization", async () => {

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -141,6 +141,42 @@ describe("createTelegramDraftStream", () => {
     expect(api.deleteMessage).not.toHaveBeenCalled();
   });
 
+  it("rotates draft_id when forceNewMessage races an in-flight DM draft send", async () => {
+    let resolveFirstDraft: ((value: boolean) => void) | undefined;
+    const firstDraftSend = new Promise<boolean>((resolve) => {
+      resolveFirstDraft = resolve;
+    });
+    const api = {
+      sendMessageDraft: vi.fn().mockReturnValueOnce(firstDraftSend).mockResolvedValueOnce(true),
+      sendMessage: vi.fn().mockResolvedValue({ message_id: 17 }),
+      editMessageText: vi.fn().mockResolvedValue(true),
+      deleteMessage: vi.fn().mockResolvedValue(true),
+    };
+    const stream = createThreadedDraftStream(
+      api as unknown as ReturnType<typeof createMockDraftApi>,
+      { id: 42, scope: "dm" },
+    );
+
+    stream.update("Message A");
+    await vi.waitFor(() => expect(api.sendMessageDraft).toHaveBeenCalledTimes(1));
+
+    stream.forceNewMessage();
+    stream.update("Message B");
+
+    resolveFirstDraft?.(true);
+    await stream.flush();
+
+    expect(api.sendMessageDraft).toHaveBeenCalledTimes(2);
+    const firstDraftId = api.sendMessageDraft.mock.calls[0]?.[1];
+    const secondDraftId = api.sendMessageDraft.mock.calls[1]?.[1];
+    expect(typeof firstDraftId).toBe("number");
+    expect(typeof secondDraftId).toBe("number");
+    expect(firstDraftId).not.toBe(secondDraftId);
+    expect(api.sendMessageDraft.mock.calls[1]?.[2]).toBe("Message B");
+    expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(api.editMessageText).not.toHaveBeenCalled();
+  });
+
   it("creates new message after forceNewMessage is called", async () => {
     const { api, stream } = createForceNewMessageHarness();
 

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -59,6 +59,7 @@ export function createTelegramDraftStream(params: {
   chatId: number;
   maxChars?: number;
   thread?: TelegramThreadSpec | null;
+  previewTransport?: "auto" | "message" | "draft";
   replyToMessageId?: number;
   throttleMs?: number;
   /** Minimum chars before sending first message (debounce for push notifications) */
@@ -77,8 +78,16 @@ export function createTelegramDraftStream(params: {
   const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
   const minInitialChars = params.minInitialChars;
   const chatId = params.chatId;
-  const isDirectStream = params.thread?.scope === "dm";
-  const threadParams = buildTelegramThreadParams(params.thread);
+  const requestedPreviewTransport = params.previewTransport ?? "auto";
+  const isDirectStream =
+    requestedPreviewTransport === "draft"
+      ? true
+      : requestedPreviewTransport === "message"
+        ? false
+        : params.thread?.scope === "dm";
+  const resolvedThread =
+    !isDirectStream && params.thread?.scope === "dm" ? undefined : params.thread;
+  const threadParams = buildTelegramThreadParams(resolvedThread);
   const replyParams =
     params.replyToMessageId != null
       ? { ...threadParams, reply_to_message_id: params.replyToMessageId }

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -36,6 +36,7 @@ export type TelegramDraftStream = {
   update: (text: string) => void;
   flush: () => Promise<void>;
   messageId: () => number | undefined;
+  previewMode?: () => "message" | "draft";
   clear: () => Promise<void>;
   stop: () => Promise<void>;
   /** Reset internal state so the next update creates a new message instead of editing. */
@@ -254,6 +255,7 @@ export function createTelegramDraftStream(params: {
     update,
     flush: loop.flush,
     messageId: () => streamMessageId,
+    previewMode: () => (isDirectStream ? "draft" : "message"),
     clear,
     stop,
     forceNewMessage,

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -4,6 +4,33 @@ import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helper
 
 const TELEGRAM_STREAM_MAX_CHARS = 4096;
 const DEFAULT_THROTTLE_MS = 1000;
+const TELEGRAM_DRAFT_ID_MAX = 2_147_483_647;
+
+type TelegramSendMessageDraft = (
+  chatId: number,
+  draftId: number,
+  text: string,
+  params?: {
+    message_thread_id?: number;
+    parse_mode?: "HTML";
+  },
+) => Promise<unknown>;
+
+let nextDraftId = 0;
+
+function allocateTelegramDraftId(): number {
+  nextDraftId = nextDraftId >= TELEGRAM_DRAFT_ID_MAX ? 1 : nextDraftId + 1;
+  return nextDraftId;
+}
+
+function resolveSendMessageDraftApi(api: Bot["api"]): TelegramSendMessageDraft | undefined {
+  const sendMessageDraft = (api as Bot["api"] & { sendMessageDraft?: TelegramSendMessageDraft })
+    .sendMessageDraft;
+  if (typeof sendMessageDraft !== "function") {
+    return undefined;
+  }
+  return sendMessageDraft.bind(api as object);
+}
 
 export type TelegramDraftStream = {
   update: (text: string) => void;
@@ -49,17 +76,92 @@ export function createTelegramDraftStream(params: {
   const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
   const minInitialChars = params.minInitialChars;
   const chatId = params.chatId;
+  const isDirectStream = params.thread?.scope === "dm";
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyParams =
     params.replyToMessageId != null
       ? { ...threadParams, reply_to_message_id: params.replyToMessageId }
       : threadParams;
+  const sendMessageDraft = isDirectStream ? resolveSendMessageDraftApi(params.api) : undefined;
+  if (isDirectStream && !sendMessageDraft) {
+    throw new Error("telegram stream preview failed: bot API missing sendMessageDraft");
+  }
 
   const streamState = { stopped: false, final: false };
   let streamMessageId: number | undefined;
+  let streamDraftId = isDirectStream ? allocateTelegramDraftId() : undefined;
   let lastSentText = "";
   let lastSentParseMode: "HTML" | undefined;
   let generation = 0;
+  const sendStreamPreview = isDirectStream
+    ? async ({
+        renderedText,
+        renderedParseMode,
+      }: {
+        renderedText: string;
+        renderedParseMode: "HTML" | undefined;
+        sendGeneration: number;
+      }): Promise<boolean> => {
+        const draftId = streamDraftId ?? allocateTelegramDraftId();
+        streamDraftId = draftId;
+        const draftParams = {
+          ...(threadParams?.message_thread_id != null
+            ? { message_thread_id: threadParams.message_thread_id }
+            : {}),
+          ...(renderedParseMode ? { parse_mode: renderedParseMode } : {}),
+        };
+        await sendMessageDraft!(
+          chatId,
+          draftId,
+          renderedText,
+          Object.keys(draftParams).length > 0 ? draftParams : undefined,
+        );
+        return true;
+      }
+    : async ({
+        renderedText,
+        renderedParseMode,
+        sendGeneration,
+      }: {
+        renderedText: string;
+        renderedParseMode: "HTML" | undefined;
+        sendGeneration: number;
+      }): Promise<boolean> => {
+        if (typeof streamMessageId === "number") {
+          if (renderedParseMode) {
+            await params.api.editMessageText(chatId, streamMessageId, renderedText, {
+              parse_mode: renderedParseMode,
+            });
+          } else {
+            await params.api.editMessageText(chatId, streamMessageId, renderedText);
+          }
+          return true;
+        }
+        const sendParams = renderedParseMode
+          ? {
+              ...replyParams,
+              parse_mode: renderedParseMode,
+            }
+          : replyParams;
+        const sent = await params.api.sendMessage(chatId, renderedText, sendParams);
+        const sentMessageId = sent?.message_id;
+        if (typeof sentMessageId !== "number" || !Number.isFinite(sentMessageId)) {
+          streamState.stopped = true;
+          params.warn?.("telegram stream preview stopped (missing message id from sendMessage)");
+          return false;
+        }
+        const normalizedMessageId = Math.trunc(sentMessageId);
+        if (sendGeneration !== generation) {
+          params.onSupersededPreview?.({
+            messageId: normalizedMessageId,
+            textSnapshot: renderedText,
+            parseMode: renderedParseMode,
+          });
+          return true;
+        }
+        streamMessageId = normalizedMessageId;
+        return true;
+      };
 
   const sendOrEditStreamMessage = async (text: string): Promise<boolean> => {
     // Allow final flush even if stopped (e.g., after clear()).
@@ -100,40 +202,11 @@ export function createTelegramDraftStream(params: {
     lastSentText = renderedText;
     lastSentParseMode = renderedParseMode;
     try {
-      if (typeof streamMessageId === "number") {
-        if (renderedParseMode) {
-          await params.api.editMessageText(chatId, streamMessageId, renderedText, {
-            parse_mode: renderedParseMode,
-          });
-        } else {
-          await params.api.editMessageText(chatId, streamMessageId, renderedText);
-        }
-        return true;
-      }
-      const sendParams = renderedParseMode
-        ? {
-            ...replyParams,
-            parse_mode: renderedParseMode,
-          }
-        : replyParams;
-      const sent = await params.api.sendMessage(chatId, renderedText, sendParams);
-      const sentMessageId = sent?.message_id;
-      if (typeof sentMessageId !== "number" || !Number.isFinite(sentMessageId)) {
-        streamState.stopped = true;
-        params.warn?.("telegram stream preview stopped (missing message id from sendMessage)");
-        return false;
-      }
-      const normalizedMessageId = Math.trunc(sentMessageId);
-      if (sendGeneration !== generation) {
-        params.onSupersededPreview?.({
-          messageId: normalizedMessageId,
-          textSnapshot: renderedText,
-          parseMode: renderedParseMode,
-        });
-        return true;
-      }
-      streamMessageId = normalizedMessageId;
-      return true;
+      return await sendStreamPreview({
+        renderedText,
+        renderedParseMode,
+        sendGeneration,
+      });
     } catch (err) {
       streamState.stopped = true;
       params.warn?.(
@@ -166,6 +239,9 @@ export function createTelegramDraftStream(params: {
   const forceNewMessage = () => {
     generation += 1;
     streamMessageId = undefined;
+    if (isDirectStream) {
+      streamDraftId = allocateTelegramDraftId();
+    }
     lastSentText = "";
     lastSentParseMode = undefined;
     loop.resetPending();

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -5,6 +5,7 @@ import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helper
 const TELEGRAM_STREAM_MAX_CHARS = 4096;
 const DEFAULT_THROTTLE_MS = 1000;
 const TELEGRAM_DRAFT_ID_MAX = 2_147_483_647;
+const THREAD_NOT_FOUND_RE = /400:\s*Bad Request:\s*message thread not found/i;
 
 type TelegramSendMessageDraft = (
   chatId: number,
@@ -37,6 +38,7 @@ export type TelegramDraftStream = {
   flush: () => Promise<void>;
   messageId: () => number | undefined;
   previewMode?: () => "message" | "draft";
+  previewRevision?: () => number;
   clear: () => Promise<void>;
   stop: () => Promise<void>;
   /** Reset internal state so the next update creates a new message instead of editing. */
@@ -79,31 +81,35 @@ export function createTelegramDraftStream(params: {
   const minInitialChars = params.minInitialChars;
   const chatId = params.chatId;
   const requestedPreviewTransport = params.previewTransport ?? "auto";
-  const isDirectStream =
+  const prefersDraftTransport =
     requestedPreviewTransport === "draft"
       ? true
       : requestedPreviewTransport === "message"
         ? false
         : params.thread?.scope === "dm";
-  const resolvedThread =
-    !isDirectStream && params.thread?.scope === "dm" ? undefined : params.thread;
-  const threadParams = buildTelegramThreadParams(resolvedThread);
+  const threadParams = buildTelegramThreadParams(params.thread);
   const replyParams =
     params.replyToMessageId != null
       ? { ...threadParams, reply_to_message_id: params.replyToMessageId }
       : threadParams;
-  const sendMessageDraft = isDirectStream ? resolveSendMessageDraftApi(params.api) : undefined;
-  if (isDirectStream && !sendMessageDraft) {
-    throw new Error("telegram stream preview failed: bot API missing sendMessageDraft");
+  const resolvedDraftApi = prefersDraftTransport
+    ? resolveSendMessageDraftApi(params.api)
+    : undefined;
+  const usesDraftTransport = Boolean(prefersDraftTransport && resolvedDraftApi);
+  if (prefersDraftTransport && !usesDraftTransport) {
+    params.warn?.(
+      "telegram stream preview: sendMessageDraft unavailable; falling back to sendMessage/editMessageText",
+    );
   }
 
   const streamState = { stopped: false, final: false };
   let streamMessageId: number | undefined;
-  let streamDraftId = isDirectStream ? allocateTelegramDraftId() : undefined;
+  let streamDraftId = usesDraftTransport ? allocateTelegramDraftId() : undefined;
   let lastSentText = "";
   let lastSentParseMode: "HTML" | undefined;
+  let previewRevision = 0;
   let generation = 0;
-  const sendStreamPreview = isDirectStream
+  const sendStreamPreview = usesDraftTransport
     ? async ({
         renderedText,
         renderedParseMode,
@@ -120,7 +126,7 @@ export function createTelegramDraftStream(params: {
             : {}),
           ...(renderedParseMode ? { parse_mode: renderedParseMode } : {}),
         };
-        await sendMessageDraft!(
+        await resolvedDraftApi!(
           chatId,
           draftId,
           renderedText,
@@ -153,7 +159,29 @@ export function createTelegramDraftStream(params: {
               parse_mode: renderedParseMode,
             }
           : replyParams;
-        const sent = await params.api.sendMessage(chatId, renderedText, sendParams);
+        let sent;
+        try {
+          sent = await params.api.sendMessage(chatId, renderedText, sendParams);
+        } catch (err) {
+          const hasThreadParam =
+            "message_thread_id" in (sendParams ?? {}) &&
+            typeof (sendParams as { message_thread_id?: unknown }).message_thread_id === "number";
+          if (!hasThreadParam || !THREAD_NOT_FOUND_RE.test(String(err))) {
+            throw err;
+          }
+          const threadlessParams = {
+            ...(sendParams as Record<string, unknown>),
+          };
+          delete threadlessParams.message_thread_id;
+          params.warn?.(
+            "telegram stream preview send failed with message_thread_id, retrying without thread",
+          );
+          sent = await params.api.sendMessage(
+            chatId,
+            renderedText,
+            Object.keys(threadlessParams).length > 0 ? threadlessParams : undefined,
+          );
+        }
         const sentMessageId = sent?.message_id;
         if (typeof sentMessageId !== "number" || !Number.isFinite(sentMessageId)) {
           streamState.stopped = true;
@@ -212,11 +240,15 @@ export function createTelegramDraftStream(params: {
     lastSentText = renderedText;
     lastSentParseMode = renderedParseMode;
     try {
-      return await sendStreamPreview({
+      const sent = await sendStreamPreview({
         renderedText,
         renderedParseMode,
         sendGeneration,
       });
+      if (sent) {
+        previewRevision += 1;
+      }
+      return sent;
     } catch (err) {
       streamState.stopped = true;
       params.warn?.(
@@ -249,7 +281,7 @@ export function createTelegramDraftStream(params: {
   const forceNewMessage = () => {
     generation += 1;
     streamMessageId = undefined;
-    if (isDirectStream) {
+    if (usesDraftTransport) {
       streamDraftId = allocateTelegramDraftId();
     }
     lastSentText = "";
@@ -264,7 +296,8 @@ export function createTelegramDraftStream(params: {
     update,
     flush: loop.flush,
     messageId: () => streamMessageId,
-    previewMode: () => (isDirectStream ? "draft" : "message"),
+    previewMode: () => (usesDraftTransport ? "draft" : "message"),
+    previewRevision: () => previewRevision,
     clear,
     stop,
     forceNewMessage,

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -340,9 +340,18 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     if (allowPreviewUpdateForNonFinal && canEditViaPreview) {
       if (isDraftPreviewLane(lane)) {
         // DM draft flow has no message_id to edit; updates are sent via sendMessageDraft.
-        // Treat non-final reasoning blocks as preview updates to avoid duplicate sends.
+        // Only mark as updated when the draft flush actually emits an update.
+        const previewRevisionBeforeFlush = lane.stream?.previewRevision?.() ?? 0;
         lane.stream?.update(text);
         await params.flushDraftLane(lane);
+        const previewUpdated = (lane.stream?.previewRevision?.() ?? 0) > previewRevisionBeforeFlush;
+        if (!previewUpdated) {
+          params.log(
+            `telegram: ${laneName} draft preview update not emitted; falling back to standard send`,
+          );
+          const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
+          return delivered ? "sent" : "skipped";
+        }
         lane.lastPartialText = text;
         params.markDelivered();
         return "preview-updated";

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -103,6 +103,7 @@ type ConsumeArchivedAnswerPreviewParams = {
 
 export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
   const getLanePreviewText = (lane: DraftLaneState) => lane.lastPartialText;
+  const isDraftPreviewLane = (lane: DraftLaneState) => lane.stream?.previewMode?.() === "draft";
 
   const shouldSkipRegressivePreviewUpdate = (args: {
     currentPreviewText: string | undefined;
@@ -337,6 +338,15 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
 
     if (allowPreviewUpdateForNonFinal && canEditViaPreview) {
+      if (isDraftPreviewLane(lane)) {
+        // DM draft flow has no message_id to edit; updates are sent via sendMessageDraft.
+        // Treat non-final reasoning blocks as preview updates to avoid duplicate sends.
+        lane.stream?.update(text);
+        await params.flushDraftLane(lane);
+        lane.lastPartialText = text;
+        params.markDelivered();
+        return "preview-updated";
+      }
       const updated = await tryUpdatePreviewForLane({
         lane,
         laneName,


### PR DESCRIPTION
## Summary
- use Telegram `sendMessageDraft` for private-chat draft streaming
- keep existing preview message edit/delete flow unchanged for groups/forums/other scopes
- add tests to assert DM draft flow never sends/edits/deletes preview messages

## Validation
- `pnpm test src/telegram/draft-stream.test.ts`
- `pnpm tsgo`
