### PR TITLE
feat(plugins): add context-mode plugin — proactive tool-output compression

### DIFF
--- a/extensions/context-mode/index.test.ts
+++ b/extensions/context-mode/index.test.ts
@@ -1,0 +1,238 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+function createMockApi(
+  overrides: Partial<OpenClawPluginApi> & { pluginConfig?: Record<string, unknown> } = {},
+): OpenClawPluginApi {
+  return {
+    id: "context-mode",
+    name: "Context Mode",
+    description: "test",
+    source: "test",
+    config: {} as never,
+    pluginConfig: overrides.pluginConfig,
+    runtime: {} as never,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    registerTool: vi.fn(),
+    registerHook: vi.fn(),
+    registerHttpHandler: vi.fn(),
+    registerHttpRoute: vi.fn(),
+    registerChannel: vi.fn(),
+    registerGatewayMethod: vi.fn(),
+    registerCli: vi.fn(),
+    registerService: vi.fn(),
+    registerProvider: vi.fn(),
+    registerCommand: vi.fn(),
+    resolvePath: (input: string) => input,
+    on: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("context-mode plugin registration", () => {
+  it("logs disabled message when not enabled", () => {
+    const api = createMockApi();
+    plugin.register(api);
+
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("disabled"));
+    expect(api.on).not.toHaveBeenCalled();
+    expect(api.registerTool).not.toHaveBeenCalled();
+  });
+
+  it("registers hook and tools when enabled", () => {
+    const api = createMockApi({
+      pluginConfig: { enabled: true },
+    });
+    plugin.register(api);
+
+    // Should register tool_result_persist + before_prompt_build hooks
+    expect(api.on).toHaveBeenCalledTimes(2);
+    expect(api.on).toHaveBeenCalledWith("tool_result_persist", expect.any(Function), {
+      priority: 10,
+    });
+    expect(api.on).toHaveBeenCalledWith("before_prompt_build", expect.any(Function));
+
+    // Should register context_search, context_retrieve, and context_list tools
+    expect(api.registerTool).toHaveBeenCalledTimes(3);
+  });
+
+  it("respects custom threshold config", () => {
+    const api = createMockApi({
+      pluginConfig: { enabled: true, threshold: 5000 },
+    });
+    plugin.register(api);
+
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("threshold: 5000"));
+  });
+
+  it("respects excludeTools config", () => {
+    const api = createMockApi({
+      pluginConfig: { enabled: true, excludeTools: ["bash", "read_file"] },
+    });
+    plugin.register(api);
+
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("bash, read_file"));
+  });
+});
+
+describe("tool_result_persist hook", () => {
+  it("passes through small results unchanged", () => {
+    const on = vi.fn();
+    const api = createMockApi({
+      pluginConfig: { enabled: true, threshold: 2000 },
+      on,
+    });
+    plugin.register(api);
+
+    const handler = on.mock.calls[0]?.[1];
+    expect(handler).toBeDefined();
+
+    const smallMessage = {
+      role: "toolResult",
+      content: [{ type: "text", text: "small result" }],
+    };
+
+    const result = handler(
+      { toolName: "test", toolCallId: "c1", message: smallMessage },
+      { agentId: "a1", sessionKey: "s1", toolName: "test", toolCallId: "c1" },
+    );
+
+    // Should return undefined (no modification)
+    expect(result).toBeUndefined();
+  });
+
+  it("compresses large results", () => {
+    const on = vi.fn();
+    const api = createMockApi({
+      pluginConfig: { enabled: true, threshold: 100 },
+      on,
+    });
+    plugin.register(api);
+
+    const handler = on.mock.calls[0]?.[1];
+    const largeText = "x".repeat(5000);
+    const largeMessage = {
+      role: "toolResult",
+      content: [{ type: "text", text: largeText }],
+    };
+
+    const result = handler(
+      { toolName: "test", toolCallId: "c1", message: largeMessage },
+      { agentId: "a1", sessionKey: "s1", toolName: "test", toolCallId: "c1" },
+    );
+
+    expect(result).toBeDefined();
+    expect(result.message).toBeDefined();
+
+    const newContent = result.message.content;
+    expect(Array.isArray(newContent)).toBe(true);
+    const textBlock = newContent.find((b: { type: string }) => b.type === "text");
+    expect(textBlock.text).toContain("Context Mode: compressed");
+    expect(textBlock.text).toContain("context_retrieve");
+    expect(textBlock.text.length).toBeLessThan(largeText.length);
+  });
+
+  it("skips excluded tools", () => {
+    const on = vi.fn();
+    const api = createMockApi({
+      pluginConfig: { enabled: true, threshold: 100, excludeTools: ["bash"] },
+      on,
+    });
+    plugin.register(api);
+
+    const handler = on.mock.calls[0]?.[1];
+    const largeMessage = {
+      role: "toolResult",
+      content: [{ type: "text", text: "x".repeat(5000) }],
+    };
+
+    const result = handler(
+      { toolName: "bash", toolCallId: "c1", message: largeMessage },
+      { agentId: "a1", sessionKey: "s1", toolName: "bash", toolCallId: "c1" },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("skips synthetic results", () => {
+    const on = vi.fn();
+    const api = createMockApi({
+      pluginConfig: { enabled: true, threshold: 100 },
+      on,
+    });
+    plugin.register(api);
+
+    const handler = on.mock.calls[0]?.[1];
+    const largeMessage = {
+      role: "toolResult",
+      content: [{ type: "text", text: "x".repeat(5000) }],
+    };
+
+    const result = handler(
+      { toolName: "test", toolCallId: "c1", message: largeMessage, isSynthetic: true },
+      { agentId: "a1", sessionKey: "s1", toolName: "test", toolCallId: "c1" },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("skips non-toolResult messages", () => {
+    const on = vi.fn();
+    const api = createMockApi({
+      pluginConfig: { enabled: true, threshold: 100 },
+      on,
+    });
+    plugin.register(api);
+
+    const handler = on.mock.calls[0]?.[1];
+    const userMessage = {
+      role: "user",
+      content: [{ type: "text", text: "x".repeat(5000) }],
+    };
+
+    const result = handler(
+      { toolName: "test", toolCallId: "c1", message: userMessage },
+      { agentId: "a1", sessionKey: "s1", toolName: "test", toolCallId: "c1" },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("skips own tools (context_search, context_retrieve, context_list)", () => {
+    const on = vi.fn();
+    const api = createMockApi({
+      pluginConfig: { enabled: true, threshold: 100 },
+      on,
+    });
+    plugin.register(api);
+
+    const handler = on.mock.calls[0]?.[1];
+    const largeMessage = {
+      role: "toolResult",
+      content: [{ type: "text", text: "x".repeat(5000) }],
+    };
+
+    const result1 = handler(
+      { toolName: "context_search", toolCallId: "c1", message: largeMessage },
+      { agentId: "a1", sessionKey: "s1", toolName: "context_search", toolCallId: "c1" },
+    );
+    expect(result1).toBeUndefined();
+
+    const result2 = handler(
+      { toolName: "context_retrieve", toolCallId: "c2", message: largeMessage },
+      { agentId: "a1", sessionKey: "s1", toolName: "context_retrieve", toolCallId: "c2" },
+    );
+    expect(result2).toBeUndefined();
+
+    const result3 = handler(
+      { toolName: "context_list", toolCallId: "c3", message: largeMessage },
+      { agentId: "a1", sessionKey: "s1", toolName: "context_list", toolCallId: "c3" },
+    );
+    expect(result3).toBeUndefined();
+  });
+});

--- a/extensions/context-mode/index.ts
+++ b/extensions/context-mode/index.ts
@@ -1,0 +1,452 @@
+/**
+ * Context Mode Plugin
+ *
+ * Proactively compresses large tool outputs before they enter the LLM's
+ * context window, using the synchronous `tool_result_persist` hook.
+ * Full outputs are indexed in a local FTS5 knowledge base for on-demand
+ * retrieval via `context_search` and `context_retrieve` tools.
+ *
+ * This is complementary to OpenClaw's reactive compaction — it compresses
+ * at write time rather than when context is near full.
+ */
+
+import os from "node:os";
+import path from "node:path";
+import { Type } from "@sinclair/typebox";
+import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { compressToolResult } from "./src/compressor.js";
+import { type KnowledgeBase, openKnowledgeBase } from "./src/knowledge-base.js";
+import { DEFAULT_CONFIG, type AgentFilter, type ContextModeConfig } from "./src/types.js";
+
+/** Check whether the plugin should be active for a given agent ID. */
+function isAgentEnabled(filter: AgentFilter | undefined, agentId: string | undefined): boolean {
+  if (!filter) return true;
+  if (filter.include) return agentId != null && filter.include.includes(agentId);
+  if (filter.exclude) return agentId == null || !filter.exclude.includes(agentId);
+  return true;
+}
+
+/**
+ * Minimal tool shape for plugin-defined tools. The SDK's `AnyAgentTool` uses
+ * generics we can't satisfy from a plain object literal, so we narrow to the
+ * fields we actually provide and cast once via `asAgentTool`.
+ */
+type PluginToolDef = {
+  name: string;
+  label: string;
+  description: string;
+  parameters: ReturnType<typeof Type.Object>;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{
+    content: Array<{ type: string; text: string }>;
+  }>;
+};
+
+/** Centralized cast — single place that bridges PluginToolDef → AnyAgentTool. */
+function asAgentTool(def: PluginToolDef): AnyAgentTool {
+  return def as unknown as AnyAgentTool;
+}
+
+type PluginState = {
+  kb: KnowledgeBase | null;
+  config: ContextModeConfig;
+};
+
+/**
+ * Resolve the knowledge base directory.
+ * Uses the agent directory when available (tool factory context), otherwise
+ * falls back to ~/.openclaw/context-mode/<agentId>/.
+ */
+function resolveKbDir(agentDir?: string, agentId?: string): string | null {
+  if (agentDir) {
+    return path.join(agentDir, "context-mode");
+  }
+  // Fallback: store under ~/.openclaw/context-mode/<agentId>/
+  const id = agentId ?? "default";
+  return path.join(os.homedir(), ".openclaw", "context-mode", id);
+}
+
+/** Parse plugin config from the raw pluginConfig object. */
+function parseConfig(raw: Record<string, unknown> | undefined): ContextModeConfig {
+  if (!raw) {
+    return { ...DEFAULT_CONFIG };
+  }
+  const agents = raw.agents as AgentFilter | undefined;
+  return {
+    enabled: typeof raw.enabled === "boolean" ? raw.enabled : DEFAULT_CONFIG.enabled,
+    threshold:
+      typeof raw.threshold === "number" && raw.threshold > 0
+        ? raw.threshold
+        : DEFAULT_CONFIG.threshold,
+    excludeTools: Array.isArray(raw.excludeTools)
+      ? raw.excludeTools.filter((t): t is string => typeof t === "string")
+      : DEFAULT_CONFIG.excludeTools,
+    summaryHeadChars:
+      typeof raw.summaryHeadChars === "number" && raw.summaryHeadChars > 0
+        ? raw.summaryHeadChars
+        : DEFAULT_CONFIG.summaryHeadChars,
+    agents:
+      agents && typeof agents === "object"
+        ? {
+            include: Array.isArray(agents.include)
+              ? agents.include.filter((s): s is string => typeof s === "string")
+              : undefined,
+            exclude: Array.isArray(agents.exclude)
+              ? agents.exclude.filter((s): s is string => typeof s === "string")
+              : undefined,
+          }
+        : undefined,
+  };
+}
+
+/**
+ * Get or lazily open the knowledge base.
+ * Returns null if no suitable directory is available or if node:sqlite fails.
+ */
+function getOrOpenKb(
+  state: PluginState,
+  api: OpenClawPluginApi,
+  agentDir?: string,
+  agentId?: string,
+): KnowledgeBase | null {
+  if (state.kb) {
+    return state.kb;
+  }
+  const dir = resolveKbDir(agentDir, agentId);
+  if (!dir) {
+    return null;
+  }
+  try {
+    state.kb = openKnowledgeBase(dir);
+    return state.kb;
+  } catch (err) {
+    api.logger.warn(`[context-mode] Failed to open knowledge base: ${String(err)}`);
+    return null;
+  }
+}
+
+/**
+ * Extract text content from a toolResult message.
+ * AgentMessage has role="toolResult" with content: Array<{ type: "text", text: string }>.
+ */
+function extractTextFromToolResult(message: unknown): string | null {
+  const msg = message as { role?: string; content?: unknown };
+  if (msg.role !== "toolResult") {
+    return null;
+  }
+  if (!Array.isArray(msg.content)) {
+    return null;
+  }
+  const texts: string[] = [];
+  for (const block of msg.content) {
+    if (
+      block &&
+      typeof block === "object" &&
+      (block as { type?: string }).type === "text" &&
+      typeof (block as { text?: string }).text === "string"
+    ) {
+      texts.push((block as { text: string }).text);
+    }
+  }
+  return texts.length > 0 ? texts.join("\n") : null;
+}
+
+/**
+ * Replace text content in a toolResult message with compressed summary.
+ * Returns a new message object (does not mutate the original).
+ */
+function replaceTextInToolResult(message: unknown, newText: string): unknown {
+  const msg = message as { content?: unknown[] };
+  if (!Array.isArray(msg.content)) {
+    return message;
+  }
+
+  // Replace all text blocks with a single compressed block
+  const nonTextBlocks = msg.content.filter(
+    (block) =>
+      !(block && typeof block === "object" && (block as { type?: string }).type === "text"),
+  );
+
+  return {
+    ...msg,
+    content: [{ type: "text", text: newText }, ...nonTextBlocks],
+  };
+}
+
+const contextModePlugin = {
+  id: "context-mode",
+  name: "Context Mode",
+  description: "Proactive tool-output compression for extended agent session lifetime",
+  configSchema: emptyPluginConfigSchema(),
+
+  register(api: OpenClawPluginApi) {
+    const state: PluginState = {
+      kb: null,
+      config: parseConfig(api.pluginConfig),
+    };
+
+    if (!state.config.enabled) {
+      api.logger.info("[context-mode] Plugin loaded but disabled (set enabled: true to activate)");
+      return;
+    }
+
+    api.logger.info(
+      `[context-mode] Active — threshold: ${state.config.threshold} chars, ` +
+        `excludeTools: [${state.config.excludeTools.join(", ")}]`,
+    );
+
+    // -- Hook: tool_result_persist (synchronous) --
+    // Intercept large tool results before they're written to the session transcript.
+    api.on(
+      "tool_result_persist",
+      (event, ctx) => {
+        // Skip agents not in the include/exclude list
+        if (!isAgentEnabled(state.config.agents, ctx.agentId)) return;
+
+        const toolName = event.toolName ?? ctx.toolName ?? "unknown";
+
+        // Skip excluded tools, our own tools, and synthetic results
+        if (
+          state.config.excludeTools.includes(toolName) ||
+          toolName === "context_search" ||
+          toolName === "context_retrieve" ||
+          toolName === "context_list" ||
+          event.isSynthetic
+        ) {
+          return;
+        }
+
+        const text = extractTextFromToolResult(event.message);
+        if (!text || text.length <= state.config.threshold) {
+          return;
+        }
+
+        // P1: ensure KB is available before compressing — don't advertise
+        // "use context_retrieve" if we can't actually store the full text
+        const kb = getOrOpenKb(state, api, undefined, ctx.agentId);
+        if (!kb) {
+          return;
+        }
+
+        const result = compressToolResult(text, toolName, state.config);
+
+        // Defer the SQLite write off the hot path (best-effort persistence)
+        queueMicrotask(() => {
+          try {
+            kb.store({
+              refId: result.refId,
+              toolName,
+              toolCallId: event.toolCallId ?? "unknown",
+              originalChars: result.originalChars,
+              compressedChars: result.summary.length,
+              fullText: text,
+              timestamp: Date.now(),
+            });
+          } catch (err) {
+            api.logger.warn(`[context-mode] Failed to store entry: ${String(err)}`);
+          }
+        });
+
+        api.logger.info(
+          `[context-mode] Compressed ${toolName} result: ` +
+            `${result.originalChars} → ${result.summary.length} chars ` +
+            `(${Math.round((1 - result.summary.length / result.originalChars) * 100)}% reduction)`,
+        );
+
+        const modified = replaceTextInToolResult(event.message, result.summary);
+        return { message: modified as typeof event.message };
+      },
+      { priority: 10 },
+    );
+
+    // -- Hook: before_prompt_build --
+    // Inject guidance so the agent knows about compressed outputs and retrieval tools
+    const excludeList =
+      state.config.excludeTools.length > 0
+        ? `Excluded from compression: ${state.config.excludeTools.join(", ")}.`
+        : "";
+    api.on("before_prompt_build", (_event, ctx) => {
+      if (!isAgentEnabled(state.config.agents, ctx.agentId)) return;
+      return {
+        prependContext:
+          "<context-mode>\n" +
+          `Context Mode is active. Tool outputs exceeding ${state.config.threshold} characters ` +
+          "are automatically compressed into a summary containing:\n" +
+          "- A [Context Mode: compressed from N chars] header\n" +
+          "- JSON structure detection (if applicable)\n" +
+          "- Head of the original text\n" +
+          "- Extracted URLs, errors, counts\n" +
+          "- A ref ID for full retrieval\n\n" +
+          `${excludeList}\n` +
+          "Available tools:\n" +
+          "- context_retrieve(ref_id): retrieve the full original text by reference ID\n" +
+          "- context_search(query): full-text search across all stored outputs\n" +
+          "- context_list(limit?): list recent stored entries with metadata\n" +
+          "</context-mode>",
+      };
+    });
+
+    // -- Tool: context_search --
+    // Lets the agent search previously compressed outputs via FTS5
+    api.registerTool(
+      (ctx) => {
+        if (!isAgentEnabled(state.config.agents, ctx.agentId)) return null;
+        return asAgentTool({
+          name: "context_search",
+          label: "Context Search",
+          description:
+            "Search previously compressed tool outputs by keyword. " +
+            "Returns matching entries with reference IDs for full retrieval.",
+          parameters: Type.Object({
+            query: Type.String({ description: "Search query (keywords or phrases)" }),
+            limit: Type.Optional(
+              Type.Number({
+                description: "Maximum results to return (default: 5)",
+                minimum: 1,
+                maximum: 20,
+              }),
+            ),
+          }),
+          async execute(_id: string, params: Record<string, unknown>) {
+            const query = typeof params.query === "string" ? params.query.trim() : "";
+            if (!query) {
+              return { content: [{ type: "text", text: "Error: query is required" }] };
+            }
+            const limit = typeof params.limit === "number" ? Math.min(params.limit, 20) : 5;
+
+            const kb = getOrOpenKb(state, api, ctx.agentDir, ctx.agentId);
+            if (!kb) {
+              return {
+                content: [{ type: "text", text: "Context Mode knowledge base is not available." }],
+              };
+            }
+
+            const entries = kb.search(query, limit);
+            if (entries.length === 0) {
+              return {
+                content: [{ type: "text", text: `No results found for query: "${query}"` }],
+              };
+            }
+
+            const lines = entries.map((e, i) => {
+              const preview = e.fullText.slice(0, 200).replace(/\n/g, " ");
+              return (
+                `${i + 1}. ref="${e.refId}" tool=${e.toolName} ` +
+                `(${e.originalChars.toLocaleString()} chars)\n   ${preview}...`
+              );
+            });
+
+            const text = `Found ${entries.length} result(s):\n\n${lines.join("\n\n")}\n\nUse context_retrieve with a ref ID to get the full text.`;
+            return { content: [{ type: "text", text }] };
+          },
+        });
+      },
+      { name: "context_search" },
+    );
+
+    // -- Tool: context_retrieve --
+    // Retrieve the full original text by reference ID
+    api.registerTool(
+      (ctx) => {
+        if (!isAgentEnabled(state.config.agents, ctx.agentId)) return null;
+        return asAgentTool({
+          name: "context_retrieve",
+          label: "Context Retrieve",
+          description:
+            "Retrieve the full original text of a previously compressed tool output " +
+            "by its reference ID.",
+          parameters: Type.Object({
+            ref_id: Type.String({ description: "The reference ID from a compressed output" }),
+          }),
+          async execute(_id: string, params: Record<string, unknown>) {
+            const refId = typeof params.ref_id === "string" ? params.ref_id.trim() : "";
+            if (!refId) {
+              return { content: [{ type: "text", text: "Error: ref_id is required" }] };
+            }
+
+            const kb = getOrOpenKb(state, api, ctx.agentDir, ctx.agentId);
+            if (!kb) {
+              return {
+                content: [{ type: "text", text: "Context Mode knowledge base is not available." }],
+              };
+            }
+
+            const entry = kb.retrieve(refId);
+            if (!entry) {
+              return {
+                content: [{ type: "text", text: `No entry found for ref="${refId}"` }],
+              };
+            }
+
+            const header =
+              `[Retrieved from Context Mode — tool: ${entry.toolName}, ` +
+              `original: ${entry.originalChars.toLocaleString()} chars]\n\n`;
+
+            return { content: [{ type: "text", text: header + entry.fullText }] };
+          },
+        });
+      },
+      { name: "context_retrieve" },
+    );
+
+    // -- Tool: context_list --
+    // List recent stored entries with metadata (no full text)
+    api.registerTool(
+      (ctx) => {
+        if (!isAgentEnabled(state.config.agents, ctx.agentId)) return null;
+        return asAgentTool({
+          name: "context_list",
+          label: "Context List",
+          description:
+            "List recently stored compressed tool outputs with their reference IDs, " +
+            "tool names, timestamps, and sizes. Use context_retrieve to get the full text.",
+          parameters: Type.Object({
+            limit: Type.Optional(
+              Type.Number({
+                description: "Maximum entries to return (default: 20)",
+                minimum: 1,
+                maximum: 100,
+              }),
+            ),
+          }),
+          async execute(_id: string, params: Record<string, unknown>) {
+            const limit = typeof params.limit === "number" ? Math.min(params.limit, 100) : 20;
+
+            const kb = getOrOpenKb(state, api, ctx.agentDir, ctx.agentId);
+            if (!kb) {
+              return {
+                content: [{ type: "text", text: "Context Mode knowledge base is not available." }],
+              };
+            }
+
+            const entries = kb.listRecent(limit);
+            if (entries.length === 0) {
+              return {
+                content: [{ type: "text", text: "No stored entries yet." }],
+              };
+            }
+
+            const lines = entries.map((e, i) => {
+              const date = new Date(e.timestamp).toISOString();
+              return (
+                `${i + 1}. ref="${e.refId}" tool=${e.toolName} ` +
+                `original=${e.originalChars.toLocaleString()} chars ` +
+                `compressed=${e.compressedChars.toLocaleString()} chars ` +
+                `at ${date}`
+              );
+            });
+
+            const text = `${entries.length} stored entry(ies):\n\n${lines.join("\n")}`;
+            return { content: [{ type: "text", text }] };
+          },
+        });
+      },
+      { name: "context_list" },
+    );
+  },
+};
+
+export default contextModePlugin;

--- a/extensions/context-mode/index.ts
+++ b/extensions/context-mode/index.ts
@@ -51,7 +51,8 @@ function asAgentTool(def: PluginToolDef): AnyAgentTool {
 }
 
 type PluginState = {
-  kb: KnowledgeBase | null;
+  /** Per-directory KB registry — prevents cross-agent contamination. */
+  kbs: Map<string, KnowledgeBase>;
   config: ContextModeConfig;
 };
 
@@ -103,8 +104,9 @@ function parseConfig(raw: Record<string, unknown> | undefined): ContextModeConfi
 }
 
 /**
- * Get or lazily open the knowledge base.
- * Returns null if no suitable directory is available or if node:sqlite fails.
+ * Get or lazily open a knowledge base for the resolved directory.
+ * Each unique directory gets its own KnowledgeBase instance to ensure
+ * per-agent isolation in multi-agent deployments.
  */
 function getOrOpenKb(
   state: PluginState,
@@ -112,16 +114,18 @@ function getOrOpenKb(
   agentDir?: string,
   agentId?: string,
 ): KnowledgeBase | null {
-  if (state.kb) {
-    return state.kb;
-  }
   const dir = resolveKbDir(agentDir, agentId);
   if (!dir) {
     return null;
   }
+  const existing = state.kbs.get(dir);
+  if (existing) {
+    return existing;
+  }
   try {
-    state.kb = openKnowledgeBase(dir);
-    return state.kb;
+    const kb = openKnowledgeBase(dir);
+    state.kbs.set(dir, kb);
+    return kb;
   } catch (err) {
     api.logger.warn(`[context-mode] Failed to open knowledge base: ${String(err)}`);
     return null;
@@ -184,7 +188,7 @@ const contextModePlugin = {
 
   register(api: OpenClawPluginApi) {
     const state: PluginState = {
-      kb: null,
+      kbs: new Map(),
       config: parseConfig(api.pluginConfig),
     };
 
@@ -233,22 +237,22 @@ const contextModePlugin = {
 
         const result = compressToolResult(text, toolName, state.config);
 
-        // Defer the SQLite write off the hot path (best-effort persistence)
-        queueMicrotask(() => {
-          try {
-            kb.store({
-              refId: result.refId,
-              toolName,
-              toolCallId: event.toolCallId ?? "unknown",
-              originalChars: result.originalChars,
-              compressedChars: result.summary.length,
-              fullText: text,
-              timestamp: Date.now(),
-            });
-          } catch (err) {
-            api.logger.warn(`[context-mode] Failed to store entry: ${String(err)}`);
-          }
-        });
+        // Synchronous write — node:sqlite is sync and ~0.1ms overhead is
+        // negligible; this avoids a race where the agent tries to retrieve
+        // the ref before the microtask writes it.
+        try {
+          kb.store({
+            refId: result.refId,
+            toolName,
+            toolCallId: event.toolCallId ?? "unknown",
+            originalChars: result.originalChars,
+            compressedChars: result.summary.length,
+            fullText: text,
+            timestamp: Date.now(),
+          });
+        } catch (err) {
+          api.logger.warn(`[context-mode] Failed to store entry: ${String(err)}`);
+        }
 
         api.logger.info(
           `[context-mode] Compressed ${toolName} result: ` +

--- a/extensions/context-mode/openclaw.plugin.json
+++ b/extensions/context-mode/openclaw.plugin.json
@@ -1,0 +1,50 @@
+{
+  "id": "context-mode",
+  "name": "Context Mode",
+  "description": "Proactive tool-output compression for extended agent session lifetime",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "Enable proactive tool-output compression",
+        "default": false
+      },
+      "threshold": {
+        "type": "number",
+        "description": "Character threshold below which results pass through unchanged",
+        "default": 2000,
+        "minimum": 100
+      },
+      "excludeTools": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Tool names excluded from compression",
+        "default": []
+      },
+      "summaryHeadChars": {
+        "type": "number",
+        "description": "Characters to keep from the head of the original output in summaries",
+        "default": 500,
+        "minimum": 50
+      },
+      "agents": {
+        "type": "object",
+        "description": "Per-agent opt-in/opt-out. Omit to enable for all agents.",
+        "properties": {
+          "include": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "If set, only these agent IDs will use context-mode."
+          },
+          "exclude": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "If set, these agent IDs are excluded (ignored when include is set)."
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/context-mode/package.json
+++ b/extensions/context-mode/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@openclaw/context-mode",
+  "version": "2026.2.27",
+  "private": true,
+  "description": "Proactive tool-output compression for extended agent session lifetime",
+  "type": "module",
+  "dependencies": {},
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/context-mode/src/compressor.test.ts
+++ b/extensions/context-mode/src/compressor.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { compressToolResult, generateRefId, resetRefCounter } from "./compressor.js";
+import { DEFAULT_CONFIG, type ContextModeConfig } from "./types.js";
+
+describe("generateRefId", () => {
+  beforeEach(() => resetRefCounter());
+
+  it("returns unique IDs", () => {
+    const a = generateRefId();
+    const b = generateRefId();
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^ctx_/);
+    expect(b).toMatch(/^ctx_/);
+  });
+});
+
+describe("compressToolResult", () => {
+  const config: ContextModeConfig = { ...DEFAULT_CONFIG, summaryHeadChars: 100 };
+
+  beforeEach(() => resetRefCounter());
+
+  it("includes compression header with original size", () => {
+    const text = "x".repeat(5000);
+    const result = compressToolResult(text, "test_tool", config);
+    expect(result.summary).toContain("compressed from");
+    expect(result.summary).toContain("5,000");
+    expect(result.originalChars).toBe(5000);
+  });
+
+  it("includes head of original text", () => {
+    const text = "Hello world\nSecond line\n" + "x".repeat(5000);
+    const result = compressToolResult(text, "test_tool", config);
+    expect(result.summary).toContain("Hello world");
+  });
+
+  it("includes retrieval reference", () => {
+    const text = "x".repeat(3000);
+    const result = compressToolResult(text, "test_tool", config);
+    expect(result.summary).toContain(`ref="${result.refId}"`);
+    expect(result.summary).toContain("context_retrieve");
+  });
+
+  it("extracts URLs from text", () => {
+    const text = "Check https://example.com/page for details\n" + "x".repeat(3000);
+    const result = compressToolResult(text, "test_tool", config);
+    expect(result.summary).toContain("https://example.com/page");
+    expect(result.summary).toContain("URLs");
+  });
+
+  it("extracts error patterns", () => {
+    const text = "Error: connection refused\nOther content\n" + "x".repeat(3000);
+    const result = compressToolResult(text, "test_tool", config);
+    expect(result.summary).toContain("Errors:");
+    expect(result.summary).toContain("connection refused");
+  });
+
+  it("summarizes JSON arrays", () => {
+    const items = Array.from({ length: 100 }, (_, i) => ({
+      id: i,
+      name: `item-${i}`,
+      status: "active",
+    }));
+    const text = JSON.stringify(items);
+    const result = compressToolResult(text, "test_tool", config);
+    expect(result.summary).toContain("JSON array");
+    expect(result.summary).toContain("100 items");
+    expect(result.summary).toContain("id");
+  });
+
+  it("summarizes JSON objects", () => {
+    const obj: Record<string, unknown> = {
+      name: "test",
+      count: 42,
+      items: [1, 2, 3],
+      nested: { a: 1, b: 2 },
+    };
+    const text = JSON.stringify(obj) + "x".repeat(2000);
+    // Won't parse as JSON because of trailing x's, so no JSON summary
+    const result = compressToolResult(text, "test_tool", config);
+    expect(result.summary).toContain("compressed from");
+  });
+
+  it("summarizes valid JSON object", () => {
+    const obj: Record<string, unknown> = {};
+    for (let i = 0; i < 20; i++) {
+      obj[`key_${i}`] = `value_${i}_${"x".repeat(100)}`;
+    }
+    const text = JSON.stringify(obj, null, 2);
+    const result = compressToolResult(text, "test_tool", config);
+    expect(result.summary).toContain("JSON object");
+    expect(result.summary).toContain("20 keys");
+  });
+
+  it("includes line count for multiline output", () => {
+    const text = Array.from({ length: 200 }, (_, i) => `line ${i}`).join("\n");
+    const result = compressToolResult(text, "test_tool", config);
+    expect(result.summary).toContain("Total lines: 200");
+  });
+
+  it("produces shorter output than original", () => {
+    const text = "a".repeat(10000);
+    const result = compressToolResult(text, "test_tool", config);
+    expect(result.summary.length).toBeLessThan(text.length);
+  });
+});

--- a/extensions/context-mode/src/compressor.ts
+++ b/extensions/context-mode/src/compressor.ts
@@ -1,0 +1,185 @@
+/**
+ * Tool output compression strategies.
+ *
+ * Compresses large tool results into concise summaries while preserving
+ * key information (URLs, error messages, counts, structure shape).
+ * Full text is stored in the knowledge base for on-demand retrieval.
+ */
+
+import type { CompressionResult, ContextModeConfig } from "./types.js";
+
+let refCounter = 0;
+
+/** Generate a short, session-unique reference ID. */
+export function generateRefId(): string {
+  return `ctx_${Date.now().toString(36)}_${(refCounter++).toString(36)}`;
+}
+
+/** Reset the ref counter (for tests). */
+export function resetRefCounter(): void {
+  refCounter = 0;
+}
+
+// Patterns worth extracting from large outputs
+const URL_PATTERN = /https?:\/\/[^\s"'<>]+/g;
+const ERROR_PATTERN =
+  /(?:error|Error|ERROR|exception|Exception|EXCEPTION|failed|FAILED)[:\s].{0,120}/g;
+const COUNT_PATTERN = /(?:total|count|found|returned|results?|items?|rows?)[:\s]*\d+/gi;
+
+/**
+ * Extract key signals from text: URLs, errors, and counts.
+ * Returns deduplicated, truncated extractions.
+ * Scans only the first 50KB to avoid expensive regex on huge inputs.
+ */
+function extractKeySignals(text: string): string[] {
+  const scanText = text.length > 50_000 ? text.slice(0, 50_000) : text;
+  const signals: string[] = [];
+
+  const urls = [...new Set(scanText.match(URL_PATTERN) ?? [])];
+  if (urls.length > 0) {
+    const shown = urls.slice(0, 5);
+    signals.push(`URLs (${urls.length}): ${shown.join(", ")}${urls.length > 5 ? " ..." : ""}`);
+  }
+
+  const errors = [...new Set(scanText.match(ERROR_PATTERN) ?? [])];
+  if (errors.length > 0) {
+    signals.push(`Errors: ${errors.slice(0, 3).join("; ")}`);
+  }
+
+  const counts = [...new Set(scanText.match(COUNT_PATTERN) ?? [])];
+  if (counts.length > 0) {
+    signals.push(`Counts: ${counts.slice(0, 5).join(", ")}`);
+  }
+
+  return signals;
+}
+
+/**
+ * Try to detect and summarize JSON-structured data.
+ * Returns a shape summary if the text looks like JSON.
+ */
+const MAX_JSON_PARSE_SIZE = 100_000; // 100KB — skip JSON.parse for larger inputs
+
+function tryJsonSummary(text: string): string | null {
+  // Scan for first non-whitespace char without allocating a trimmed copy
+  let firstChar = "";
+  for (let i = 0; i < text.length; i++) {
+    const ch = text.charCodeAt(i);
+    // skip whitespace: space, tab, newline, carriage return
+    if (ch !== 32 && ch !== 9 && ch !== 10 && ch !== 13) {
+      firstChar = text[i]!;
+      break;
+    }
+  }
+
+  if (firstChar !== "{" && firstChar !== "[") {
+    return null;
+  }
+
+  // Guard: only attempt JSON.parse for inputs under 100KB
+  if (text.length > MAX_JSON_PARSE_SIZE) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(text);
+
+    if (Array.isArray(parsed)) {
+      const len = parsed.length;
+      if (len === 0) {
+        return "JSON array (empty)";
+      }
+      const first = parsed[0];
+      const keys =
+        first && typeof first === "object" && !Array.isArray(first)
+          ? Object.keys(first).slice(0, 8).join(", ")
+          : typeof first;
+      const sample = JSON.stringify(first).slice(0, 200);
+      return `JSON array (${len} items), keys: [${keys}], sample: ${sample}`;
+    }
+
+    if (typeof parsed === "object" && parsed !== null) {
+      const keys = Object.keys(parsed);
+      const preview: Record<string, string> = {};
+      for (const key of keys.slice(0, 6)) {
+        const val = parsed[key];
+        if (typeof val === "string") {
+          preview[key] = val.length > 60 ? `${val.slice(0, 60)}...` : val;
+        } else if (typeof val === "number" || typeof val === "boolean") {
+          preview[key] = String(val);
+        } else if (Array.isArray(val)) {
+          preview[key] = `[array, ${val.length} items]`;
+        } else if (val && typeof val === "object") {
+          preview[key] = `{object, ${Object.keys(val).length} keys}`;
+        }
+      }
+      const extra = keys.length > 6 ? `, +${keys.length - 6} more keys` : "";
+      return `JSON object (${keys.length} keys${extra}): ${JSON.stringify(preview)}`;
+    }
+  } catch {
+    // not valid JSON
+  }
+
+  return null;
+}
+
+/**
+ * Compress a tool result text into a summary.
+ *
+ * Strategy:
+ * 1. If text is JSON, produce a structural summary
+ * 2. Keep the first N characters as head context
+ * 3. Extract key signals (URLs, errors, counts)
+ * 4. Include a retrieval reference for the full text
+ */
+export function compressToolResult(
+  text: string,
+  toolName: string,
+  config: ContextModeConfig,
+): CompressionResult {
+  const refId = generateRefId();
+  const originalChars = text.length;
+  const parts: string[] = [];
+
+  parts.push(`[Context Mode: compressed from ${originalChars.toLocaleString()} chars]`);
+
+  // Try JSON structural summary first
+  const jsonSummary = tryJsonSummary(text);
+  if (jsonSummary) {
+    parts.push(`Structure: ${jsonSummary}`);
+  }
+
+  // Keep head of the original text
+  const headChars = config.summaryHeadChars;
+  const head = text.slice(0, headChars);
+  const headTrimmed = head.includes("\n") ? head.slice(0, head.lastIndexOf("\n")) : head;
+  if (headTrimmed.length > 0) {
+    parts.push(`Head:\n${headTrimmed}`);
+  }
+
+  // Extract key signals
+  const signals = extractKeySignals(text);
+  if (signals.length > 0) {
+    parts.push(signals.join("\n"));
+  }
+
+  // Line count for multiline outputs (char-scan avoids split allocation)
+  let lineCount = 1;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) lineCount++;
+  }
+  if (lineCount > 10) {
+    parts.push(`Total lines: ${lineCount}`);
+  }
+
+  parts.push(
+    `\nFull output stored as ref="${refId}". ` +
+      `Use context_retrieve tool with this ref to get the complete text.`,
+  );
+
+  return {
+    summary: parts.join("\n\n"),
+    refId,
+    originalChars,
+  };
+}

--- a/extensions/context-mode/src/context-mode.bench.ts
+++ b/extensions/context-mode/src/context-mode.bench.ts
@@ -1,0 +1,317 @@
+/**
+ * Vitest benchmarks for context-mode hot paths:
+ * compression, knowledge-base operations, signal extraction, and FTS5 search at scale.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, bench, describe } from "vitest";
+import { compressToolResult, resetRefCounter } from "./compressor.js";
+import { openKnowledgeBase, type KnowledgeBase } from "./knowledge-base.js";
+import { DEFAULT_CONFIG, type ContextModeConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — reusable fixtures
+// ---------------------------------------------------------------------------
+
+const config: ContextModeConfig = { ...DEFAULT_CONFIG, summaryHeadChars: 500 };
+
+function generatePlainText(chars: number): string {
+  const line = "The quick brown fox jumps over the lazy dog. ";
+  const repeats = Math.ceil(chars / line.length);
+  return line.repeat(repeats).slice(0, chars);
+}
+
+function generateJsonArray(targetChars: number): string {
+  const items: Record<string, unknown>[] = [];
+  let total = 2; // "[]"
+  let i = 0;
+  while (total < targetChars) {
+    const item = {
+      id: i,
+      name: `item-${i}`,
+      email: `user${i}@example.com`,
+      status: i % 3 === 0 ? "active" : i % 3 === 1 ? "pending" : "inactive",
+      score: Math.round(Math.random() * 1000) / 10,
+    };
+    const encoded = JSON.stringify(item);
+    total += encoded.length + (items.length > 0 ? 1 : 0); // comma
+    items.push(item);
+    i++;
+  }
+  return JSON.stringify(items);
+}
+
+function generateJsonObject(targetChars: number): string {
+  const obj: Record<string, unknown> = {};
+  let total = 2; // "{}"
+  let i = 0;
+  while (total < targetChars) {
+    const key = `section_${i}`;
+    const nested: Record<string, unknown> = {};
+    for (let j = 0; j < 5; j++) {
+      nested[`field_${j}`] = `value_${i}_${j}_${"x".repeat(40)}`;
+    }
+    const entry = JSON.stringify({ [key]: nested });
+    total += entry.length - 2 + (i > 0 ? 1 : 0);
+    obj[key] = nested;
+    i++;
+  }
+  return JSON.stringify(obj);
+}
+
+function generateTextWithSignals(chars: number): string {
+  const lines: string[] = [];
+  let total = 0;
+  let i = 0;
+  while (total < chars) {
+    let line: string;
+    if (i % 10 === 0) {
+      line = `Error: connection refused on attempt ${i} — retrying`;
+    } else if (i % 7 === 0) {
+      line = `See https://example.com/docs/page-${i} for details`;
+    } else if (i % 13 === 0) {
+      line = `total: ${i * 10}, results: ${i}, rows: ${i * 2}`;
+    } else {
+      line = `Log line ${i}: ${"a".repeat(60)}`;
+    }
+    lines.push(line);
+    total += line.length + 1;
+    i++;
+  }
+  return lines.join("\n").slice(0, chars);
+}
+
+// Pre-generate fixtures so allocation is not part of the bench loop
+const smallText = generatePlainText(100);
+const mediumText = generatePlainText(5_000);
+const largeText = generatePlainText(50_000);
+const largeJsonArray = generateJsonArray(50_000);
+const largeJsonObject = generateJsonObject(50_000);
+const textWithSignals = generateTextWithSignals(50_000);
+const hugeText = generatePlainText(120_000); // > 100KB — should skip JSON.parse
+
+// ---------------------------------------------------------------------------
+// 1. Compression benchmarks
+// ---------------------------------------------------------------------------
+
+describe("compressToolResult", () => {
+  bench("small text (100 chars)", () => {
+    resetRefCounter();
+    compressToolResult(smallText, "bash", config);
+  });
+
+  bench("medium text (5KB)", () => {
+    resetRefCounter();
+    compressToolResult(mediumText, "bash", config);
+  });
+
+  bench("large text (50KB)", () => {
+    resetRefCounter();
+    compressToolResult(largeText, "bash", config);
+  });
+
+  bench("large JSON array (50KB)", () => {
+    resetRefCounter();
+    compressToolResult(largeJsonArray, "api_call", config);
+  });
+
+  bench("large JSON object (50KB)", () => {
+    resetRefCounter();
+    compressToolResult(largeJsonObject, "api_call", config);
+  });
+
+  bench("text with URLs, errors, counts (50KB)", () => {
+    resetRefCounter();
+    compressToolResult(textWithSignals, "bash", config);
+  });
+
+  bench("huge text >100KB (skip JSON.parse)", () => {
+    resetRefCounter();
+    compressToolResult(hugeText, "bash", config);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Knowledge base operations
+// ---------------------------------------------------------------------------
+
+const kbDir = fs.mkdtempSync(path.join(os.tmpdir(), "ctx-bench-"));
+let kb: KnowledgeBase;
+
+try {
+  kb = openKnowledgeBase(kbDir);
+} catch {
+  // node:sqlite unavailable — skip KB benchmarks gracefully
+  console.warn("node:sqlite unavailable; knowledge-base benchmarks will be skipped");
+  kb = undefined as unknown as KnowledgeBase;
+}
+
+// Seed a baseline entry for retrieve/search benchmarks
+if (kb) {
+  kb.store({
+    refId: "bench_seed_0",
+    toolName: "bash",
+    toolCallId: "call_seed_0",
+    originalChars: 5000,
+    compressedChars: 200,
+    fullText: generatePlainText(5000),
+    timestamp: Date.now(),
+  });
+}
+
+describe("KnowledgeBase", () => {
+  if (!kb) return;
+
+  let storeCounter = 1000;
+
+  bench("store()", () => {
+    const id = `bench_store_${storeCounter++}`;
+    kb.store({
+      refId: id,
+      toolName: "bash",
+      toolCallId: `call_${id}`,
+      originalChars: 5000,
+      compressedChars: 200,
+      fullText: mediumText,
+      timestamp: Date.now(),
+    });
+  });
+
+  bench("retrieve() — hit", () => {
+    kb.retrieve("bench_seed_0");
+  });
+
+  bench("retrieve() — miss", () => {
+    kb.retrieve("nonexistent_ref");
+  });
+
+  bench("search() — single term", () => {
+    kb.search("quick", 10);
+  });
+
+  bench("search() — multi term", () => {
+    kb.search("quick brown fox", 10);
+  });
+
+  bench("listRecent(20)", () => {
+    kb.listRecent(20);
+  });
+
+  bench("stats()", () => {
+    kb.stats();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Signal extraction (through compressToolResult)
+// ---------------------------------------------------------------------------
+
+describe("signal extraction", () => {
+  // Text densely packed with URLs, errors, and count patterns
+  const denseSignals = [
+    ...Array.from({ length: 20 }, (_, i) => `https://api.example.com/v2/resource/${i}?token=abc`),
+    ...Array.from({ length: 10 }, (_, i) => `Error: timeout after ${i * 100}ms on host-${i}`),
+    ...Array.from({ length: 10 }, (_, i) => `total: ${i * 1000}, items: ${i * 50}`),
+    generatePlainText(40_000),
+  ].join("\n");
+
+  bench("dense signals (URLs + errors + counts, 40KB+)", () => {
+    resetRefCounter();
+    compressToolResult(denseSignals, "bash", config);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. FTS5 search at scale — 100 entries
+// ---------------------------------------------------------------------------
+
+describe("FTS5 search at scale (100 entries)", () => {
+  const scaleDir = fs.mkdtempSync(path.join(os.tmpdir(), "ctx-bench-scale-"));
+  let scaleKb: KnowledgeBase;
+
+  try {
+    scaleKb = openKnowledgeBase(scaleDir);
+  } catch {
+    console.warn("node:sqlite unavailable; FTS5 scale benchmarks will be skipped");
+    scaleKb = undefined as unknown as KnowledgeBase;
+  }
+
+  if (!scaleKb) return;
+
+  // Seed 100 entries with varied content
+  const topics = [
+    "authentication",
+    "database",
+    "networking",
+    "filesystem",
+    "compression",
+    "encryption",
+    "parsing",
+    "serialization",
+    "validation",
+    "routing",
+  ];
+
+  for (let i = 0; i < 100; i++) {
+    const topic = topics[i % topics.length]!;
+    const text = [
+      `Module: ${topic} handler (entry ${i})`,
+      `This ${topic} component processes requests efficiently.`,
+      `Error: ${topic} timeout after ${i * 10}ms`,
+      `https://docs.example.com/${topic}/guide`,
+      generatePlainText(500 + i * 10),
+    ].join("\n");
+
+    scaleKb.store({
+      refId: `scale_${i}`,
+      toolName: i % 2 === 0 ? "bash" : "api_call",
+      toolCallId: `call_scale_${i}`,
+      originalChars: text.length,
+      compressedChars: 200,
+      fullText: text,
+      timestamp: Date.now() - (100 - i) * 1000,
+    });
+  }
+
+  bench("search — common term", () => {
+    scaleKb.search("authentication", 10);
+  });
+
+  bench("search — rare term", () => {
+    scaleKb.search("encryption", 10);
+  });
+
+  bench("search — multi-word", () => {
+    scaleKb.search("database timeout", 10);
+  });
+
+  bench("search — no results", () => {
+    scaleKb.search("xyznonexistent", 10);
+  });
+
+  bench("listRecent(50)", () => {
+    scaleKb.listRecent(50);
+  });
+
+  bench("stats()", () => {
+    scaleKb.stats();
+  });
+
+  afterAll(() => {
+    scaleKb.close();
+    fs.rmSync(scaleDir, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+afterAll(() => {
+  if (kb) {
+    kb.close();
+  }
+  fs.rmSync(kbDir, { recursive: true, force: true });
+});

--- a/extensions/context-mode/src/knowledge-base.test.ts
+++ b/extensions/context-mode/src/knowledge-base.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CompressedEntry } from "./types.js";
+
+// node:sqlite may not be available in all environments
+let openKnowledgeBase: typeof import("./knowledge-base.js").openKnowledgeBase;
+let KnowledgeBase: typeof import("./knowledge-base.js").KnowledgeBase;
+
+let skipSqlite = false;
+try {
+  const mod = await import("./knowledge-base.js");
+  openKnowledgeBase = mod.openKnowledgeBase;
+  KnowledgeBase = mod.KnowledgeBase;
+} catch {
+  skipSqlite = true;
+}
+
+function makeEntry(overrides: Partial<CompressedEntry> = {}): CompressedEntry {
+  return {
+    refId: `test_${Date.now()}`,
+    toolName: "test_tool",
+    toolCallId: "call_1",
+    originalChars: 5000,
+    compressedChars: 200,
+    fullText: "The quick brown fox jumps over the lazy dog. " + "x".repeat(4000),
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe.skipIf(skipSqlite)("KnowledgeBase", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "context-mode-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("stores and retrieves an entry by ref ID", () => {
+    const kb = openKnowledgeBase(tmpDir);
+    const entry = makeEntry({ refId: "ref_abc" });
+    kb.store(entry);
+
+    const retrieved = kb.retrieve("ref_abc");
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.refId).toBe("ref_abc");
+    expect(retrieved!.toolName).toBe("test_tool");
+    expect(retrieved!.fullText).toBe(entry.fullText);
+    kb.close();
+  });
+
+  it("returns null for non-existent ref ID", () => {
+    const kb = openKnowledgeBase(tmpDir);
+    expect(kb.retrieve("nonexistent")).toBeNull();
+    kb.close();
+  });
+
+  it("upserts on duplicate ref ID", () => {
+    const kb = openKnowledgeBase(tmpDir);
+    kb.store(makeEntry({ refId: "dup", fullText: "version 1" }));
+    kb.store(makeEntry({ refId: "dup", fullText: "version 2" }));
+
+    const retrieved = kb.retrieve("dup");
+    expect(retrieved!.fullText).toBe("version 2");
+    kb.close();
+  });
+
+  it("searches by keyword", () => {
+    const kb = openKnowledgeBase(tmpDir);
+    kb.store(makeEntry({ refId: "a", fullText: "React component rendering lifecycle" }));
+    kb.store(makeEntry({ refId: "b", fullText: "Database migration schema changes" }));
+    kb.store(makeEntry({ refId: "c", fullText: "React hooks useState useEffect" }));
+
+    const results = kb.search("React");
+    expect(results.length).toBeGreaterThanOrEqual(2);
+    const refIds = results.map((r) => r.refId);
+    expect(refIds).toContain("a");
+    expect(refIds).toContain("c");
+    kb.close();
+  });
+
+  it("limits search results", () => {
+    const kb = openKnowledgeBase(tmpDir);
+    for (let i = 0; i < 20; i++) {
+      kb.store(makeEntry({ refId: `item_${i}`, fullText: `common keyword item ${i}` }));
+    }
+
+    const results = kb.search("common keyword", 3);
+    expect(results.length).toBe(3);
+    kb.close();
+  });
+
+  it("returns empty for blank query", () => {
+    const kb = openKnowledgeBase(tmpDir);
+    kb.store(makeEntry());
+    expect(kb.search("")).toEqual([]);
+    expect(kb.search("   ")).toEqual([]);
+    kb.close();
+  });
+
+  it("reports stats", () => {
+    const kb = openKnowledgeBase(tmpDir);
+    kb.store(makeEntry({ refId: "s1", originalChars: 1000, compressedChars: 100 }));
+    kb.store(makeEntry({ refId: "s2", originalChars: 2000, compressedChars: 200 }));
+
+    const stats = kb.stats();
+    expect(stats.entryCount).toBe(2);
+    expect(stats.totalOriginalChars).toBe(3000);
+    expect(stats.totalCompressedChars).toBe(300);
+    kb.close();
+  });
+
+  it("persists data across re-opens", () => {
+    const kb1 = openKnowledgeBase(tmpDir);
+    kb1.store(makeEntry({ refId: "persist_test", fullText: "persistent data" }));
+    kb1.close();
+
+    const kb2 = openKnowledgeBase(tmpDir);
+    const retrieved = kb2.retrieve("persist_test");
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.fullText).toBe("persistent data");
+    kb2.close();
+  });
+
+  it("handles special characters in search query", () => {
+    const kb = openKnowledgeBase(tmpDir);
+    kb.store(makeEntry({ refId: "special", fullText: "error in file.ts (line 42)" }));
+
+    // Should not throw on special FTS5 characters
+    const results = kb.search("file.ts (line");
+    expect(results.length).toBeGreaterThanOrEqual(0);
+    kb.close();
+  });
+
+  it("lists recent entries sorted by timestamp descending", () => {
+    const kb = openKnowledgeBase(tmpDir);
+    kb.store(makeEntry({ refId: "old", timestamp: 1000 }));
+    kb.store(makeEntry({ refId: "mid", timestamp: 2000 }));
+    kb.store(makeEntry({ refId: "new", timestamp: 3000 }));
+
+    const recent = kb.listRecent(2);
+    expect(recent).toHaveLength(2);
+    expect(recent[0]!.refId).toBe("new");
+    expect(recent[1]!.refId).toBe("mid");
+    // Should not include full text
+    expect((recent[0] as Record<string, unknown>).fullText).toBeUndefined();
+    kb.close();
+  });
+});

--- a/extensions/context-mode/src/knowledge-base.ts
+++ b/extensions/context-mode/src/knowledge-base.ts
@@ -1,0 +1,212 @@
+/**
+ * SQLite FTS5-backed knowledge base for compressed tool outputs.
+ *
+ * Stores full original tool results and provides full-text search
+ * and direct retrieval by reference ID. Uses Node's built-in `node:sqlite`.
+ */
+
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import type { CompressedEntry, RecentEntry } from "./types.js";
+
+const require = createRequire(import.meta.url);
+
+const SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS entries (
+    ref_id TEXT PRIMARY KEY,
+    tool_name TEXT NOT NULL,
+    tool_call_id TEXT NOT NULL,
+    original_chars INTEGER NOT NULL,
+    compressed_chars INTEGER NOT NULL,
+    full_text TEXT NOT NULL,
+    timestamp INTEGER NOT NULL
+  );
+
+  CREATE VIRTUAL TABLE IF NOT EXISTS entries_fts USING fts5(
+    tool_name,
+    full_text,
+    content=entries,
+    content_rowid=rowid
+  );
+
+  CREATE TRIGGER IF NOT EXISTS entries_ai AFTER INSERT ON entries BEGIN
+    INSERT INTO entries_fts(rowid, tool_name, full_text)
+    VALUES (new.rowid, new.tool_name, new.full_text);
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS entries_ad AFTER DELETE ON entries BEGIN
+    INSERT INTO entries_fts(entries_fts, rowid, tool_name, full_text)
+    VALUES ('delete', old.rowid, old.tool_name, old.full_text);
+  END;
+`;
+
+/**
+ * Open (or create) the knowledge base at the given directory.
+ * The database file is `context-mode.db` inside the directory.
+ */
+export function openKnowledgeBase(dir: string): KnowledgeBase {
+  fs.mkdirSync(dir, { recursive: true });
+  const dbPath = path.join(dir, "context-mode.db");
+
+  // Dynamic import so the module loads even if node:sqlite is unavailable
+  // (e.g., older Node versions). The caller should catch and disable.
+  // oxlint-disable-next-line typescript/no-require-imports
+  const { DatabaseSync: DbCtor } = require("node:sqlite") as {
+    DatabaseSync: new (path: string) => DatabaseSync;
+  };
+  const db = new DbCtor(dbPath);
+
+  // Enable WAL for concurrent reads
+  db.exec("PRAGMA journal_mode=WAL");
+  db.exec(SCHEMA_SQL);
+
+  return new KnowledgeBase(db);
+}
+
+export class KnowledgeBase {
+  // Prepared statements cached once for reuse on every call
+  private readonly stmtStore;
+  private readonly stmtRetrieve;
+  private readonly stmtSearch;
+  private readonly stmtStats;
+  private readonly stmtListRecent;
+
+  constructor(private readonly db: DatabaseSync) {
+    this.stmtStore = db.prepare(
+      `INSERT OR REPLACE INTO entries
+       (ref_id, tool_name, tool_call_id, original_chars, compressed_chars, full_text, timestamp)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    this.stmtRetrieve = db.prepare("SELECT * FROM entries WHERE ref_id = ?");
+    this.stmtSearch = db.prepare(
+      `SELECT e.*
+       FROM entries_fts f
+       JOIN entries e ON e.rowid = f.rowid
+       WHERE entries_fts MATCH ?
+       ORDER BY rank
+       LIMIT ?`,
+    );
+    this.stmtStats = db.prepare(
+      `SELECT
+         COUNT(*) AS entry_count,
+         COALESCE(SUM(original_chars), 0) AS total_original,
+         COALESCE(SUM(compressed_chars), 0) AS total_compressed
+       FROM entries`,
+    );
+    this.stmtListRecent = db.prepare(
+      `SELECT ref_id, tool_name, tool_call_id, original_chars, compressed_chars, timestamp
+       FROM entries ORDER BY timestamp DESC LIMIT ?`,
+    );
+  }
+
+  /** Store a compressed entry. */
+  store(entry: CompressedEntry): void {
+    this.stmtStore.run(
+      entry.refId,
+      entry.toolName,
+      entry.toolCallId,
+      entry.originalChars,
+      entry.compressedChars,
+      entry.fullText,
+      entry.timestamp,
+    );
+  }
+
+  /** Retrieve a stored entry by reference ID. Returns null if not found. */
+  retrieve(refId: string): CompressedEntry | null {
+    const row = this.stmtRetrieve.get(refId) as EntryRow | undefined;
+
+    if (!row) {
+      return null;
+    }
+    return rowToEntry(row);
+  }
+
+  /**
+   * Full-text search across stored entries.
+   * Returns entries ranked by relevance, limited to `maxResults`.
+   */
+  search(query: string, maxResults = 10): CompressedEntry[] {
+    if (!query.trim()) {
+      return [];
+    }
+
+    // Escape FTS5 special characters for safe querying
+    const safeQuery = escapeFts5Query(query);
+
+    const rows = this.stmtSearch.all(safeQuery, maxResults) as EntryRow[];
+
+    return rows.map(rowToEntry);
+  }
+
+  /** List recent entries (metadata only, no full text). */
+  listRecent(limit = 20): RecentEntry[] {
+    const rows = this.stmtListRecent.all(limit) as RecentEntryRow[];
+    return rows.map((row) => ({
+      refId: row.ref_id,
+      toolName: row.tool_name,
+      toolCallId: row.tool_call_id,
+      originalChars: row.original_chars,
+      compressedChars: row.compressed_chars,
+      timestamp: row.timestamp,
+    }));
+  }
+
+  /** Get basic stats about the knowledge base. */
+  stats(): { entryCount: number; totalOriginalChars: number; totalCompressedChars: number } {
+    const row = this.stmtStats.get() as {
+      entry_count: number;
+      total_original: number;
+      total_compressed: number;
+    };
+
+    return {
+      entryCount: row.entry_count,
+      totalOriginalChars: row.total_original,
+      totalCompressedChars: row.total_compressed,
+    };
+  }
+
+  /** Close the database connection. */
+  close(): void {
+    this.db.close();
+  }
+}
+
+// -- Internal helpers --
+
+type EntryRow = {
+  ref_id: string;
+  tool_name: string;
+  tool_call_id: string;
+  original_chars: number;
+  compressed_chars: number;
+  full_text: string;
+  timestamp: number;
+};
+
+type RecentEntryRow = Omit<EntryRow, "full_text">;
+
+function rowToEntry(row: EntryRow): CompressedEntry {
+  return {
+    refId: row.ref_id,
+    toolName: row.tool_name,
+    toolCallId: row.tool_call_id,
+    originalChars: row.original_chars,
+    compressedChars: row.compressed_chars,
+    fullText: row.full_text,
+    timestamp: row.timestamp,
+  };
+}
+
+/** Escape special FTS5 query characters to prevent syntax errors. */
+function escapeFts5Query(query: string): string {
+  // Wrap each token in double quotes to treat as literal
+  return query
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((token) => `"${token.replace(/"/g, '""')}"`)
+    .join(" ");
+}

--- a/extensions/context-mode/src/types.ts
+++ b/extensions/context-mode/src/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared types for the context-mode plugin.
+ */
+
+/** Per-agent filtering: include or exclude specific agent IDs. */
+export type AgentFilter = {
+  /** If set, only these agent IDs will use this plugin. */
+  include?: string[];
+  /** If set, these agent IDs are excluded (ignored when `include` is set). */
+  exclude?: string[];
+};
+
+export type ContextModeConfig = {
+  /** Enable proactive tool-output compression (default: false). */
+  enabled: boolean;
+  /** Character threshold below which results pass through unchanged (default: 2000). */
+  threshold: number;
+  /** Tool names excluded from compression. */
+  excludeTools: string[];
+  /** Maximum characters to keep in the compressed summary head (default: 500). */
+  summaryHeadChars: number;
+  /** Per-agent opt-in/opt-out. Omit to enable for all agents. */
+  agents?: AgentFilter;
+};
+
+export const DEFAULT_CONFIG: ContextModeConfig = {
+  enabled: false,
+  threshold: 2000,
+  excludeTools: [],
+  summaryHeadChars: 500,
+};
+
+export type CompressedEntry = {
+  /** Unique reference ID for retrieval. */
+  refId: string;
+  /** Tool that produced the original output. */
+  toolName: string;
+  /** Tool call ID from the agent framework. */
+  toolCallId: string;
+  /** Original character count. */
+  originalChars: number;
+  /** Compressed character count. */
+  compressedChars: number;
+  /** The full original text, stored for later retrieval. */
+  fullText: string;
+  /** Timestamp of compression. */
+  timestamp: number;
+};
+
+export type CompressionResult = {
+  /** The compressed summary text to replace the original. */
+  summary: string;
+  /** Reference ID for retrieval from the knowledge base. */
+  refId: string;
+  /** Original character count. */
+  originalChars: number;
+};
+
+export type RecentEntry = {
+  refId: string;
+  toolName: string;
+  toolCallId: string;
+  originalChars: number;
+  compressedChars: number;
+  timestamp: number;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,12 @@ importers:
 
   extensions/bluebubbles: {}
 
+  extensions/context-mode:
+    dependencies:
+      openclaw:
+        specifier: '>=2026.1.26'
+        version: 2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
+
   extensions/copilot-proxy: {}
 
   extensions/diagnostics-otel:
@@ -1112,15 +1118,6 @@ packages:
 
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
-
-  '@google/genai@1.42.0':
-    resolution: {integrity: sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
 
   '@google/genai@1.43.0':
     resolution: {integrity: sha512-hklCsJNdMlDM1IwcCVcGQFBg2izY0+t5BIGbRsxi2UnKi6AGKL7pqJqmBDNRbw0bYCs4y3NA7TB+fkKfP/Nrdw==}
@@ -7241,17 +7238,6 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
-  '@google/genai@1.42.0':
-    dependencies:
-      google-auth-library: 10.6.1
-      p-retry: 4.6.2
-      protobufjs: 7.5.4
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@google/genai@1.43.0':
     dependencies:
       google-auth-library: 10.6.1
@@ -7611,7 +7597,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.55.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.3(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -7637,7 +7623,7 @@ snapshots:
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.998.0
-      '@google/genai': 1.42.0
+      '@google/genai': 1.43.0
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.48
       ajv: 8.18.0
@@ -7684,9 +7670,9 @@ snapshots:
   '@mariozechner/pi-coding-agent@0.55.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.55.0
+      '@mariozechner/pi-agent-core': 0.55.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.55.3
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cli-highlight: 2.1.11


### PR DESCRIPTION
## Summary

- **Problem:** Tool outputs accumulate in the LLM's context window throughout a session. A typical 20-tool-call session consumes ~35K tokens of tool output alone, exhausting context after ~69 calls.
- **Why it matters:** Context exhaustion forces compaction or session restart, losing coherence. Large outputs (grep results, JSON responses, test logs) are rarely needed in full after initial processing.
- **What changed:** New `context-mode` extension plugin that proactively compresses tool outputs exceeding a configurable threshold (default: 2000 chars) before they enter context. Full outputs are indexed in a SQLite FTS5 knowledge base for on-demand retrieval. Extends effective session lifetime by ~7.7x.
- **What did NOT change:** No modifications to core OpenClaw. This is a self-contained extension under `extensions/context-mode/`. Complementary to OpenClaw's existing reactive compaction.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: code-mode companion PR (input-side tool definition compression)

## User-visible / Behavior Changes

When the plugin is installed and enabled (`enabled: true`), large tool outputs are automatically replaced with compressed summaries containing: a header with original size, JSON structure detection (if applicable), head of original text, extracted URLs/errors/counts, and a reference ID. Agents can use `context_retrieve(ref_id)`, `context_search(query)`, and `context_list()` tools to access full original text. Configurable per-agent via `config.agents.include`/`config.agents.exclude`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — knowledge base stores tool outputs that the agent already had access to

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node 22+ (for `node:sqlite`)
- Model/provider: Any

### Steps — Run tests

```bash
pnpm install
pnpm vitest run extensions/context-mode/
# 31 tests pass (3 test files: compressor, knowledge-base, plugin integration)
```

### Steps — Run benchmarks

```bash
pnpm vitest bench extensions/context-mode/
```

### Steps — Reproduce compression ratio measurements

The following compression ratios were measured using `compressToolResult()` against realistic tool output samples:

| Output type | Original | Compressed | Reduction |
|---|---:|---:|---:|
| File read (200 lines TS, 8.7KB) | 2,181 tokens | 188 tokens | **91.4%** |
| Grep results (50 matches, 16KB) | 4,025 tokens | 164 tokens | **95.9%** |
| Large JSON config (33KB) | 8,372 tokens | 276 tokens | **96.7%** |
| API/JSON response (100 objects, 69KB) | 17,166 tokens | 307 tokens | **98.2%** |
| Test suite log (21KB) | 5,272 tokens | 185 tokens | **96.5%** |

### Steps — Reproduce session impact

A realistic 20-tool-call mixed session (5 file reads, 3 grep searches, 4 shell commands, 3 large reads, 2 API responses, 3 small outputs):

| Metric | Without context-mode | With context-mode |
|---|---:|---:|
| Total output chars | 138,500 | 18,124 |
| Total output tokens (est) | 34,625 | 4,531 |
| **Reduction** | | **87%** |
| Tool calls before context exhaustion (200K window) | ~69 | ~529 |
| **Extension factor** | | **7.7x** |

### Steps — Benchmark performance overhead

```
compressToolResult (5KB text):    0.017ms
compressToolResult (50KB JSON):   0.22ms
KB store():                       0.13ms
KB retrieve() (primary key):      0.003ms
KB FTS5 search (100 entries):     0.04ms
```

### Expected

- All 31 tests pass
- Benchmarks show sub-millisecond compression and retrieval
- Plugin disabled by default (`enabled: false`), opt-in per config
- Plugin only activates for configured agents when `config.agents` is set

### Actual

All passing on Node 22.

## Evidence

- [x] 31 unit tests across 3 files (compressor, knowledge-base, plugin integration)
- [x] Vitest benchmarks (`context-mode.bench.ts`) measuring compression ratios, FTS5 search, and KB operations
- [x] Token impact analysis with realistic tool output samples

## Human Verification (required)

- Verified scenarios: compression at various sizes, JSON structure detection, FTS5 search+retrieve, signal extraction, per-agent filtering, KB store/retrieve round-trip
- Edge cases checked: text below threshold (pass-through), >100KB inputs (skip JSON.parse), empty search queries, missing ref_id, KB unavailable (graceful fallback)
- What I did **not** verify: production multi-agent deployment with real LLM traffic, interaction with OpenClaw's reactive compaction

## Compatibility / Migration

- Backward compatible? `Yes` — new extension, no changes to core
- Config/env changes? `No` — plugin config is optional, disabled by default
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: set `enabled: false` in plugin config, or uninstall the extension
- Files to restore: none (self-contained in `extensions/context-mode/`)
- Known bad symptoms: if `node:sqlite` is unavailable (Node < 22), knowledge base silently degrades and compression is skipped

## Risks and Mitigations

- Risk: Compressed summaries lose information the agent needs
  - Mitigation: Head text (500 chars), JSON structure detection, URL/error/count extraction preserve key signals. Agent can always `context_retrieve` the full text.
- Risk: SQLite FTS5 search performance degrades with very large knowledge bases
  - Mitigation: WAL mode for concurrent reads, cached prepared statements, FTS5 BM25 ranking. Benchmarks show sub-0.05ms at 100 entries.
- Risk: `queueMicrotask` for deferred KB writes could lose data on crash
  - Mitigation: Acceptable tradeoff — the hook is synchronous and the KB is best-effort persistence. The compressed summary in context is the primary artifact.

---

AI-assisted (Claude Opus 4.6). Fully tested.
