### PR TITLE
feat(canvas): broadcast UI commands to all connected nodes

### DIFF
--- a/src/agents/tools/canvas-tool.ts
+++ b/src/agents/tools/canvas-tool.ts
@@ -13,7 +13,7 @@ import { resolveImageSanitizationLimits } from "../image-sanitization.js";
 import { optionalStringEnum, stringEnum } from "../schema/typebox.js";
 import { type AnyAgentTool, imageResult, jsonResult, readStringParam } from "./common.js";
 import { callGatewayTool, readGatewayCallOptions } from "./gateway.js";
-import { resolveNodeId } from "./nodes-utils.js";
+import { resolveCanvasNodeIds, resolveNodeId } from "./nodes-utils.js";
 
 const CANVAS_ACTIONS = [
   "present",
@@ -89,20 +89,32 @@ export function createCanvasTool(options?: { config?: OpenClawConfig }): AnyAgen
       const params = args as Record<string, unknown>;
       const action = readStringParam(params, "action", { required: true });
       const gatewayOpts = readGatewayCallOptions(params);
+      const nodeQuery = readStringParam(params, "node", { trim: true });
 
-      const nodeId = await resolveNodeId(
-        gatewayOpts,
-        readStringParam(params, "node", { trim: true }),
-        true,
-      );
-
-      const invoke = async (command: string, invokeParams?: Record<string, unknown>) =>
+      const invoke = async (
+        targetNodeId: string,
+        command: string,
+        invokeParams?: Record<string, unknown>,
+      ) =>
         await callGatewayTool("node.invoke", gatewayOpts, {
-          nodeId,
+          nodeId: targetNodeId,
           command,
           params: invokeParams,
           idempotencyKey: crypto.randomUUID(),
         });
+
+      const broadcast = async (command: string, invokeParams?: Record<string, unknown>) => {
+        const nodeIds = await resolveCanvasNodeIds(gatewayOpts, nodeQuery);
+        const results = await Promise.allSettled(
+          nodeIds.map((id) => invoke(id, command, invokeParams)),
+        );
+        const anyOk = results.some((r) => r.status === "fulfilled");
+        if (!anyOk) {
+          // All failed — surface the first error.
+          const first = results.find((r) => r.status === "rejected");
+          throw first?.reason ?? new Error("broadcast failed: all nodes rejected");
+        }
+      };
 
       switch (action) {
         case "present": {
@@ -129,25 +141,26 @@ export function createCanvasTool(options?: { config?: OpenClawConfig }): AnyAgen
           ) {
             invokeParams.placement = placement;
           }
-          await invoke("canvas.present", invokeParams);
+          await broadcast("canvas.present", invokeParams);
           return jsonResult({ ok: true });
         }
         case "hide":
-          await invoke("canvas.hide", undefined);
+          await broadcast("canvas.hide", undefined);
           return jsonResult({ ok: true });
         case "navigate": {
           // Support `target` as an alias so callers can reuse the same field across present/navigate.
           const url =
             readStringParam(params, "url", { trim: true }) ??
             readStringParam(params, "target", { required: true, trim: true, label: "url" });
-          await invoke("canvas.navigate", { url });
+          await broadcast("canvas.navigate", { url });
           return jsonResult({ ok: true });
         }
         case "eval": {
+          const nodeId = await resolveNodeId(gatewayOpts, nodeQuery, true);
           const javaScript = readStringParam(params, "javaScript", {
             required: true,
           });
-          const raw = (await invoke("canvas.eval", { javaScript })) as {
+          const raw = (await invoke(nodeId, "canvas.eval", { javaScript })) as {
             payload?: { result?: string };
           };
           const result = raw?.payload?.result;
@@ -160,6 +173,7 @@ export function createCanvasTool(options?: { config?: OpenClawConfig }): AnyAgen
           return jsonResult({ ok: true });
         }
         case "snapshot": {
+          const nodeId = await resolveNodeId(gatewayOpts, nodeQuery, true);
           const formatRaw =
             typeof params.outputFormat === "string" ? params.outputFormat.toLowerCase() : "png";
           const format = formatRaw === "jpg" || formatRaw === "jpeg" ? "jpeg" : "png";
@@ -171,7 +185,7 @@ export function createCanvasTool(options?: { config?: OpenClawConfig }): AnyAgen
             typeof params.quality === "number" && Number.isFinite(params.quality)
               ? params.quality
               : undefined;
-          const raw = (await invoke("canvas.snapshot", {
+          const raw = (await invoke(nodeId, "canvas.snapshot", {
             format,
             maxWidth,
             quality,
@@ -201,11 +215,11 @@ export function createCanvasTool(options?: { config?: OpenClawConfig }): AnyAgen
           if (!jsonl.trim()) {
             throw new Error("jsonl or jsonlPath required");
           }
-          await invoke("canvas.a2ui.pushJSONL", { jsonl });
+          await broadcast("canvas.a2ui.pushJSONL", { jsonl });
           return jsonResult({ ok: true });
         }
         case "a2ui_reset":
-          await invoke("canvas.a2ui.reset", undefined);
+          await broadcast("canvas.a2ui.reset", undefined);
           return jsonResult({ ok: true });
         default:
           throw new Error(`Unknown action: ${action}`);

--- a/src/agents/tools/nodes-utils.test.ts
+++ b/src/agents/tools/nodes-utils.test.ts
@@ -118,6 +118,21 @@ describe("resolveCanvasNodeIds", () => {
     await expect(resolveCanvasNodeIds({})).rejects.toThrow("no connected canvas-capable nodes");
   });
 
+  it("includes pair-list fallback nodes that lack caps/connected fields", async () => {
+    gatewayMocks.callGatewayTool
+      .mockRejectedValueOnce(new Error("unknown method: node.list"))
+      .mockResolvedValueOnce({
+        pending: [],
+        paired: [
+          { nodeId: "pair-1", displayName: "Pair 1", platform: "ios", remoteIp: "1.2.3.4" },
+          { nodeId: "pair-2", displayName: "Pair 2", platform: "macos", remoteIp: "5.6.7.8" },
+        ],
+      });
+
+    const ids = await resolveCanvasNodeIds({});
+    expect(ids).toEqual(["pair-1", "pair-2"]);
+  });
+
   it("resolves to a single node when a query is provided", async () => {
     gatewayMocks.callGatewayTool.mockResolvedValue({
       nodes: [

--- a/src/agents/tools/nodes-utils.test.ts
+++ b/src/agents/tools/nodes-utils.test.ts
@@ -8,7 +8,7 @@ vi.mock("./gateway.js", () => ({
 }));
 
 import type { NodeListNode } from "./nodes-utils.js";
-import { listNodes, resolveNodeIdFromList } from "./nodes-utils.js";
+import { listNodes, resolveCanvasNodeIds, resolveNodeIdFromList } from "./nodes-utils.js";
 
 function node({ nodeId, ...overrides }: Partial<NodeListNode> & { nodeId: string }): NodeListNode {
   return {
@@ -81,5 +81,52 @@ describe("listNodes", () => {
     await expect(listNodes({})).rejects.toThrow("gateway closed (1008): unauthorized");
     expect(gatewayMocks.callGatewayTool).toHaveBeenCalledTimes(1);
     expect(gatewayMocks.callGatewayTool).toHaveBeenCalledWith("node.list", {}, {});
+  });
+});
+
+describe("resolveCanvasNodeIds", () => {
+  it("returns all connected canvas-capable nodes", async () => {
+    gatewayMocks.callGatewayTool.mockResolvedValue({
+      nodes: [
+        { nodeId: "mac-1", caps: ["canvas"], connected: true },
+        { nodeId: "ios-1", caps: ["canvas"], connected: true },
+        { nodeId: "cli-1", caps: [], connected: true },
+      ],
+    });
+
+    const ids = await resolveCanvasNodeIds({});
+    expect(ids).toEqual(["mac-1", "ios-1"]);
+  });
+
+  it("excludes disconnected nodes", async () => {
+    gatewayMocks.callGatewayTool.mockResolvedValue({
+      nodes: [
+        { nodeId: "mac-1", caps: ["canvas"], connected: true },
+        { nodeId: "ios-1", caps: ["canvas"], connected: false },
+      ],
+    });
+
+    const ids = await resolveCanvasNodeIds({});
+    expect(ids).toEqual(["mac-1"]);
+  });
+
+  it("throws when no canvas-capable nodes are connected", async () => {
+    gatewayMocks.callGatewayTool.mockResolvedValue({
+      nodes: [{ nodeId: "cli-1", caps: [], connected: true }],
+    });
+
+    await expect(resolveCanvasNodeIds({})).rejects.toThrow("no connected canvas-capable nodes");
+  });
+
+  it("resolves to a single node when a query is provided", async () => {
+    gatewayMocks.callGatewayTool.mockResolvedValue({
+      nodes: [
+        { nodeId: "mac-1", caps: ["canvas"], connected: true },
+        { nodeId: "ios-1", caps: ["canvas"], connected: true },
+      ],
+    });
+
+    const ids = await resolveCanvasNodeIds({}, "ios-1");
+    expect(ids).toEqual(["ios-1"]);
   });
 });

--- a/src/agents/tools/nodes-utils.test.ts
+++ b/src/agents/tools/nodes-utils.test.ts
@@ -133,6 +133,17 @@ describe("resolveCanvasNodeIds", () => {
     expect(ids).toEqual(["pair-1", "pair-2"]);
   });
 
+  it("throws when all canvas nodes are explicitly disconnected", async () => {
+    gatewayMocks.callGatewayTool.mockResolvedValue({
+      nodes: [
+        { nodeId: "mac-1", caps: ["canvas"], connected: false },
+        { nodeId: "ios-1", caps: ["canvas"], connected: false },
+      ],
+    });
+
+    await expect(resolveCanvasNodeIds({})).rejects.toThrow("no connected canvas-capable nodes");
+  });
+
   it("resolves to a single node when a query is provided", async () => {
     gatewayMocks.callGatewayTool.mockResolvedValue({
       nodes: [

--- a/src/agents/tools/nodes-utils.ts
+++ b/src/agents/tools/nodes-utils.ts
@@ -182,11 +182,17 @@ export async function resolveCanvasNodeIds(
   if (q) {
     return [resolveNodeIdFromList(nodes, q)];
   }
-  const canvasConnected = nodes.filter(
-    (n) => n.connected && Array.isArray(n.caps) && n.caps.includes("canvas"),
+  // When caps is available, filter to canvas-capable nodes; when caps is
+  // absent (pair-list fallback), assume the node may support canvas.
+  const withCanvas = nodes.filter((n) =>
+    Array.isArray(n.caps) ? n.caps.includes("canvas") : true,
   );
-  if (canvasConnected.length === 0) {
+  // Prefer connected nodes; fall back to all candidates when the connected
+  // field is missing (pair-list fallback does not populate it).
+  const connected = withCanvas.filter((n) => n.connected);
+  const candidates = connected.length > 0 ? connected : withCanvas;
+  if (candidates.length === 0) {
     throw new Error("no connected canvas-capable nodes");
   }
-  return canvasConnected.map((n) => n.nodeId);
+  return candidates.map((n) => n.nodeId);
 }

--- a/src/agents/tools/nodes-utils.ts
+++ b/src/agents/tools/nodes-utils.ts
@@ -187,10 +187,12 @@ export async function resolveCanvasNodeIds(
   const withCanvas = nodes.filter((n) =>
     Array.isArray(n.caps) ? n.caps.includes("canvas") : true,
   );
-  // Prefer connected nodes; fall back to all candidates when the connected
-  // field is missing (pair-list fallback does not populate it).
+  // Prefer connected nodes; fall back to all candidates only when no node
+  // has a `connected` field at all (pair-list fallback does not populate it).
+  // When nodes explicitly report `connected: false`, respect that.
+  const hasConnectedField = withCanvas.some((n) => typeof n.connected === "boolean");
   const connected = withCanvas.filter((n) => n.connected);
-  const candidates = connected.length > 0 ? connected : withCanvas;
+  const candidates = hasConnectedField ? connected : withCanvas;
   if (candidates.length === 0) {
     throw new Error("no connected canvas-capable nodes");
   }

--- a/src/agents/tools/nodes-utils.ts
+++ b/src/agents/tools/nodes-utils.ts
@@ -167,3 +167,26 @@ export async function resolveNode(
     pickDefaultNode: pickDefaultNode,
   });
 }
+
+/**
+ * Returns all connected canvas-capable node IDs for broadcast commands.
+ * If a specific node query is provided, resolves to just that single node.
+ * Throws if no canvas-capable nodes are connected.
+ */
+export async function resolveCanvasNodeIds(
+  opts: GatewayCallOptions,
+  query?: string,
+): Promise<string[]> {
+  const q = String(query ?? "").trim();
+  const nodes = await loadNodes(opts);
+  if (q) {
+    return [resolveNodeIdFromList(nodes, q)];
+  }
+  const canvasConnected = nodes.filter(
+    (n) => n.connected && Array.isArray(n.caps) && n.caps.includes("canvas"),
+  );
+  if (canvasConnected.length === 0) {
+    throw new Error("no connected canvas-capable nodes");
+  }
+  return canvasConnected.map((n) => n.nodeId);
+}


### PR DESCRIPTION
## Summary

- Canvas UI commands (`a2ui_push`, `a2ui_reset`, `present`, `hide`, `navigate`) are now broadcast to **all connected canvas-capable nodes** instead of routing to a single node
- Device-specific commands (`eval`, `snapshot`) remain single-node since they return a result
- Uses `Promise.allSettled` with "at least one success" semantics — if one device is unreachable, others still get the update
- Adds `resolveCanvasNodeIds()` helper that returns all connected canvas-capable node IDs

## Motivation

Users with multiple devices (desktop + phone, or multiple browsers) only see canvas/a2ui updates on one device. The canvas tool resolved to a single node via `resolveNodeId()` with `preferLocalMac: true`, so the Mac desktop always won. The other device never received UI updates.

Canvas state is inherently device-independent — it's UI data, not system commands. Broadcasting it matches how chat events already work (all clients see them).

## Test plan

- [ ] Single node connected: behavior unchanged, commands go to that node
- [ ] Two nodes connected (e.g. desktop + mobile): both receive `a2ui_push` updates
- [ ] Explicit `node` parameter still targets a single node
- [ ] `snapshot` and `eval` still go to single node
- [ ] One node offline during broadcast: other node still gets the update, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)