### PR TITLE
fix: handle Telegram callback_data limit for long Bedrock model IDs

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1262,10 +1262,12 @@ export const registerTelegramHandlers = ({
         if (modelCallback.type === "select") {
           const { provider, model } = modelCallback;
           // Process model selection as a synthetic message with /model command
+          // Handle both provider/model format and model-only format (for long IDs)
+          const modelArg = provider ? `${provider}/${model}` : model;
           const syntheticMessage = buildSyntheticTextMessage({
             base: callbackMessage,
             from: callback.from,
-            text: `/model ${provider}/${model}`,
+            text: `/model ${modelArg}`,
           });
           await processMessage(buildSyntheticContext(ctx, syntheticMessage), [], storeAllowFrom, {
             forceWasMentioned: true,

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -57,7 +57,7 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
     }
   }
 
-  // mdl_sel_{provider/model}
+  // mdl_sel_{provider/model} or mdl_sel_{model} (fallback for long IDs)
   const selMatch = trimmed.match(/^mdl_sel_(.+)$/);
   if (selMatch) {
     const modelRef = selMatch[1];
@@ -70,6 +70,12 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
           model: modelRef.slice(slashIndex + 1),
         };
       }
+      // Fallback: no provider prefix (model-only format for long IDs)
+      return {
+        type: "select",
+        provider: "",
+        model: modelRef,
+      };
     }
   }
 
@@ -133,10 +139,14 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
     : currentModel;
 
   for (const model of pageModels) {
-    const callbackData = `mdl_sel_${provider}/${model}`;
-    // Skip models that would exceed Telegram's callback_data limit
+    let callbackData = `mdl_sel_${provider}/${model}`;
+    // If full format exceeds Telegram's 64-byte limit, try model-only format
     if (Buffer.byteLength(callbackData, "utf8") > MAX_CALLBACK_DATA_BYTES) {
-      continue;
+      callbackData = `mdl_sel_${model}`;
+      // Skip model if even the fallback format exceeds the limit
+      if (Buffer.byteLength(callbackData, "utf8") > MAX_CALLBACK_DATA_BYTES) {
+        continue;
+      }
     }
 
     const isCurrentModel = model === currentModelId;


### PR DESCRIPTION
**Bug Description**

When using Amazon Bedrock models, the provider/model callback data string (e.g., `amazon-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0`) can exceed Telegram's 64-byte `callback_data` limit. The current code silently skips these buttons with `continue`, making these models completely unselectable from the Telegram /model picker UI.

**Expected Behavior**

When the full `provider/model` callback data exceeds 64 bytes, the code should try a shorter format (model-only: `mdl_sel_{model}`) and only skip if that also exceeds the limit. The callback parser and handler should support both formats.

**Changes Made**

1. **parseModelCallbackData** - Support model-only format with empty provider
   - When no `/` is found in the model reference, return `provider: ""
   - Backward compatible with existing `provider/model` format

2. **buildModelsKeyboard** - Fallback to model-only format
   - Try full `mdl_sel_{provider}/{model}` first
   - If that exceeds 64 bytes, try `mdl_sel_{model}`
   - Only skip button if even fallback exceeds limit

3. **bot-handlers** - Handle empty provider
   - When provider is empty, use model-only format: `/model {model}`
   - Otherwise use `/model {provider}/{model}`

**Impact**

Bedrock models with long IDs (e.g., `global.anthropic.claude-sonnet-4-6`, `us.anthropic.claude-haiku-4-5-20251001-v1:0`) are now selectable via Telegram model picker.

Fixes #31815

--- 

*Automated by Minions workflow*