### PR TITLE
fix(feishu): strip group: and channel: prefixes in normalizeFeishuTarget

### DIFF
--- a/extensions/feishu/src/targets.test.ts
+++ b/extensions/feishu/src/targets.test.ts
@@ -28,6 +28,15 @@ describe("normalizeFeishuTarget", () => {
   it("accepts provider-prefixed raw ids", () => {
     expect(normalizeFeishuTarget("feishu:ou_123")).toBe("ou_123");
   });
+
+  it("strips group: prefix used by session-key derived targets", () => {
+    expect(normalizeFeishuTarget("group:oc_123")).toBe("oc_123");
+    expect(normalizeFeishuTarget("feishu:group:oc_456")).toBe("oc_456");
+  });
+
+  it("strips channel: prefix used by bound delivery targets", () => {
+    expect(normalizeFeishuTarget("channel:oc_789")).toBe("oc_789");
+  });
 });
 
 describe("looksLikeFeishuId", () => {

--- a/extensions/feishu/src/targets.ts
+++ b/extensions/feishu/src/targets.ts
@@ -39,6 +39,12 @@ export function normalizeFeishuTarget(raw: string): string | null {
   if (lowered.startsWith("open_id:")) {
     return withoutProvider.slice("open_id:".length).trim() || null;
   }
+  if (lowered.startsWith("group:")) {
+    return withoutProvider.slice("group:".length).trim() || null;
+  }
+  if (lowered.startsWith("channel:")) {
+    return withoutProvider.slice("channel:".length).trim() || null;
+  }
 
   return withoutProvider;
 }


### PR DESCRIPTION
## Summary

- **Problem:** `sessions_send` announce fails in Feishu groups with Lark API error 99992360 ("not a valid user_id"). When the announce target is derived from a Feishu group session key (e.g., `agent:main:feishu:group:oc_xxx`), the target comes through as `group:oc_xxx`. `normalizeFeishuTarget` only stripped `chat:`, `user:`, and `open_id:` prefixes — not `group:` or `channel:`. The raw `group:oc_xxx` string was passed to `resolveReceiveIdType`, which defaulted to `user_id` because the string doesn't start with `oc_`.
- **Why it matters:** All announce-mode deliveries to Feishu group chats fail silently — cron summaries, subagent results, and scheduled messages never reach the group. Users have no workaround.
- **What changed:** `extensions/feishu/src/targets.ts` — added `group:` and `channel:` prefix stripping to `normalizeFeishuTarget()`. Also added test coverage in `targets.test.ts`.
- **What did NOT change:** `resolveReceiveIdType()`, `formatFeishuTarget()`, and the send/delivery pipeline are all untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31426

## User-visible / Behavior Changes

- Announce-mode delivery to Feishu group chats now works correctly.
- No impact on existing user/chat targets.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Feishu

### Steps

1. Configure a Feishu group channel.
2. Use `sessions_send` with announce mode targeting the group.
3. Observe Lark API error 99992360: "Invalid ids: [group:oc_xxx]".

### Expected

- Message delivered to Feishu group successfully.

### Actual

- Before fix: Lark API error 99992360 — `group:oc_xxx` treated as user_id.
- After fix: `normalizeFeishuTarget("group:oc_xxx")` → `"oc_xxx"`, `resolveReceiveIdType("oc_xxx")` → `"chat_id"`.

## Evidence

```typescript
// Before: group: prefix not recognized
normalizeFeishuTarget("group:oc_xxx") → "group:oc_xxx"
resolveReceiveIdType("group:oc_xxx") → "user_id" // WRONG

// After: group: prefix stripped
normalizeFeishuTarget("group:oc_xxx") → "oc_xxx"
resolveReceiveIdType("oc_xxx") → "chat_id" // CORRECT
```

## Human Verification (required)

- Verified scenarios: All 10 tests pass (`npx vitest run extensions/feishu/src/targets.test.ts`)
- Edge cases checked: `group:` prefix with and without provider prefix (`feishu:group:oc_xxx`), `channel:` prefix, empty strings after stripping.
- What I did **not** verify: End-to-end Feishu group announce delivery.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: `extensions/feishu/src/targets.ts`
- Known bad symptoms: None expected — the new branches only match `group:` and `channel:` prefixes.

## Risks and Mitigations

None — the new prefix stripping only applies to `group:` and `channel:` prefixes, which are internal conventions that should never reach the Lark API.