### PR TITLE
fix(hooks): emit message:sent hook for normal agent replies on all channels

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1185,6 +1185,7 @@ export async function handleFeishuMessage(params: {
       rootId: ctx.rootId,
       mentionTargets: ctx.mentionTargets,
       accountId: account.accountId,
+      sessionKey: route.sessionKey,
       messageCreateTimeMs,
     });
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -48,6 +48,8 @@ export type CreateFeishuReplyDispatcherParams = {
   rootId?: string;
   mentionTargets?: MentionTarget[];
   accountId?: string;
+  /** Session key used for emitting message:sent hooks after delivery. */
+  sessionKey?: string;
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
@@ -185,6 +187,16 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       responsePrefix: prefixContext.responsePrefix,
       responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
+      ...(params.sessionKey
+        ? {
+            onDelivered: core.channel.reply.createMessageSentEmitter({
+              sessionKey: params.sessionKey,
+              channel: "feishu",
+              to: chatId,
+              accountId,
+            }),
+          }
+        : {}),
       onReplyStart: () => {
         if (streamingEnabled && renderMode === "card") {
           startStreaming();

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -636,6 +636,12 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           ...prefixOptions,
           humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
           typingCallbacks,
+          onDelivered: core.channel.reply.createMessageSentEmitter({
+            sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+            channel: "matrix",
+            to: roomId,
+            accountId: route.accountId,
+          }),
           deliver: async (payload) => {
             await deliverMatrixReplies({
               replies: [payload],

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -753,6 +753,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         ...prefixOptions,
         humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
         typingCallbacks,
+        onDelivered: core.channel.reply.createMessageSentEmitter({
+          sessionKey: sessionKey,
+          channel: "mattermost",
+          to: channelId,
+          accountId: account.accountId,
+        }),
         deliver: async (payload: ReplyPayload) => {
           const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
           const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -548,6 +548,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       context,
       replyStyle,
       textLimit,
+      sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
       onSentMessageIds: (ids) => {
         for (const id of ids) {
           recordMSTeamsSentMessage(conversationId, id);

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -40,6 +40,8 @@ export function createMSTeamsReplyDispatcher(params: {
   tokenProvider?: MSTeamsAccessTokenProvider;
   /** SharePoint site ID for file uploads in group chats/channels */
   sharePointSiteId?: string;
+  /** Session key for emitting message:sent hooks. */
+  sessionKey?: string;
 }) {
   const core = getMSTeamsRuntime();
   const sendTypingIndicator = async () => {
@@ -68,6 +70,16 @@ export function createMSTeamsReplyDispatcher(params: {
     core.channel.reply.createReplyDispatcherWithTyping({
       ...prefixOptions,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(params.cfg, params.agentId),
+      ...(params.sessionKey
+        ? {
+            onDelivered: core.channel.reply.createMessageSentEmitter({
+              sessionKey: params.sessionKey,
+              channel: "msteams",
+              to: params.conversationRef.conversation?.id ?? "",
+              accountId: params.accountId,
+            }),
+          }
+        : {}),
       typingCallbacks,
       deliver: async (payload) => {
         const tableMode = core.channel.text.resolveMarkdownTableMode({

--- a/src/auto-reply/reply/emit-message-sent.ts
+++ b/src/auto-reply/reply/emit-message-sent.ts
@@ -1,0 +1,63 @@
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import type { ReplyPayload } from "../types.js";
+import type { ReplyDispatchDeliveredHandler, ReplyDispatchKind } from "./reply-dispatcher.js";
+
+export type MessageSentHookContext = {
+  sessionKey: string;
+  channel: string;
+  to: string;
+  accountId?: string;
+};
+
+/**
+ * Creates an `onDelivered` callback for `ReplyDispatcherOptions` that emits
+ * both the plugin `message_sent` hook and the internal `message:sent` hook
+ * after each delivery attempt.
+ */
+export function createMessageSentEmitter(
+  ctx: MessageSentHookContext,
+): ReplyDispatchDeliveredHandler {
+  return (
+    payload: ReplyPayload,
+    info: { kind: ReplyDispatchKind; success: boolean; error?: string },
+  ) => {
+    const content = [
+      payload.text ?? "",
+      ...(payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : [])),
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    const hookRunner = getGlobalHookRunner();
+    if (hookRunner?.hasHooks("message_sent")) {
+      void hookRunner
+        .runMessageSent(
+          {
+            to: ctx.to,
+            content,
+            success: info.success,
+            ...(info.error ? { error: info.error } : {}),
+          },
+          {
+            channelId: ctx.channel,
+            accountId: ctx.accountId,
+            conversationId: ctx.to,
+          },
+        )
+        .catch(() => {});
+    }
+
+    void triggerInternalHook(
+      createInternalHookEvent("message", "sent", ctx.sessionKey, {
+        to: ctx.to,
+        content,
+        success: info.success,
+        ...(info.error ? { error: info.error } : {}),
+        channelId: ctx.channel,
+        accountId: ctx.accountId,
+        conversationId: ctx.to,
+      }),
+    ).catch(() => {});
+  };
+}

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -40,6 +40,11 @@ function getHumanDelay(config: HumanDelayConfig | undefined): number {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
+export type ReplyDispatchDeliveredHandler = (
+  payload: ReplyPayload,
+  info: { kind: ReplyDispatchKind; success: boolean; error?: string },
+) => void;
+
 export type ReplyDispatcherOptions = {
   deliver: ReplyDispatchDeliverer;
   responsePrefix?: string;
@@ -53,6 +58,8 @@ export type ReplyDispatcherOptions = {
   onError?: ReplyDispatchErrorHandler;
   // AIDEV-NOTE: onSkip lets channels detect silent/empty drops (e.g. Telegram empty-response fallback).
   onSkip?: ReplyDispatchSkipHandler;
+  /** Called after each delivery attempt (success or failure). */
+  onDelivered?: ReplyDispatchDeliveredHandler;
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
 };
@@ -156,8 +163,14 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         // Safe: deliver is called inside an async .then() callback, so even a synchronous
         // throw becomes a rejection that flows through .catch()/.finally(), ensuring cleanup.
         await options.deliver(normalized, { kind });
+        options.onDelivered?.(normalized, { kind, success: true });
       })
       .catch((err) => {
+        options.onDelivered?.(normalized, {
+          kind,
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
         options.onError?.(err, { kind });
       })
       .finally(() => {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -4,6 +4,7 @@ import { EmbeddedBlockChunker } from "../../agents/pi-embedded-block-chunker.js"
 import { resolveChunkMode } from "../../auto-reply/chunk.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import { formatInboundEnvelope, resolveEnvelopeFormatOptions } from "../../auto-reply/envelope.js";
+import { createMessageSentEmitter } from "../../auto-reply/reply/emit-message-sent.js";
 import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
@@ -575,6 +576,12 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     ...prefixOptions,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     typingCallbacks,
+    onDelivered: createMessageSentEmitter({
+      sessionKey: persistedSessionKey,
+      channel: "discord",
+      to: deliverTarget,
+      accountId: route.accountId,
+    }),
     deliver: async (payload: ReplyPayload, info) => {
       const isFinal = info.kind === "final";
       if (payload.isReasoning) {

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -7,6 +7,7 @@ import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
 } from "../../auto-reply/inbound-debounce.js";
+import { createMessageSentEmitter } from "../../auto-reply/reply/emit-message-sent.js";
 import {
   clearHistoryEntriesIfEnabled,
   DEFAULT_GROUP_HISTORY_LIMIT,
@@ -357,6 +358,12 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     const dispatcher = createReplyDispatcher({
       ...prefixOptions,
       humanDelay: resolveHumanDelayConfig(cfg, decision.route.agentId),
+      onDelivered: createMessageSentEmitter({
+        sessionKey: ctxPayload.SessionKey ?? decision.route.sessionKey,
+        channel: "imessage",
+        to: ctxPayload.To ?? "",
+        accountId: accountInfo.accountId,
+      }),
       deliver: async (payload) => {
         const target = ctxPayload.To;
         if (!target) {

--- a/src/line/monitor.ts
+++ b/src/line/monitor.ts
@@ -1,5 +1,6 @@
 import type { WebhookRequestBody } from "@line/bot-sdk";
 import { chunkMarkdownText } from "../auto-reply/chunk.js";
+import { createMessageSentEmitter } from "../auto-reply/reply/emit-message-sent.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
 import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -204,6 +205,12 @@ export async function monitorLineProvider(
           cfg: config,
           dispatcherOptions: {
             ...prefixOptions,
+            onDelivered: createMessageSentEmitter({
+              sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+              channel: "line",
+              to: ctxPayload.To ?? "",
+              accountId: route.accountId,
+            }),
             deliver: async (payload, _info) => {
               const lineData = (payload.channelData?.line as LineChannelData | undefined) ?? {};
 

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -28,6 +28,7 @@ import {
   resolveInboundDebounceMs,
 } from "../../auto-reply/inbound-debounce.js";
 import { dispatchReplyFromConfig } from "../../auto-reply/reply/dispatch-from-config.js";
+import { createMessageSentEmitter } from "../../auto-reply/reply/emit-message-sent.js";
 import { finalizeInboundContext } from "../../auto-reply/reply/inbound-context.js";
 import {
   buildMentionRegexes,
@@ -302,6 +303,7 @@ function createRuntimeChannel(): PluginRuntime["channel"] {
     reply: {
       dispatchReplyWithBufferedBlockDispatcher,
       createReplyDispatcherWithTyping,
+      createMessageSentEmitter,
       resolveEffectiveMessagesConfig,
       resolveHumanDelayConfig,
       dispatchReplyFromConfig,

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -3,6 +3,8 @@ import type { LogLevel } from "../../logging/levels.js";
 type ShouldLogVerbose = typeof import("../../globals.js").shouldLogVerbose;
 type DispatchReplyWithBufferedBlockDispatcher =
   typeof import("../../auto-reply/reply/provider-dispatcher.js").dispatchReplyWithBufferedBlockDispatcher;
+type CreateMessageSentEmitter =
+  typeof import("../../auto-reply/reply/emit-message-sent.js").createMessageSentEmitter;
 type CreateReplyDispatcherWithTyping =
   typeof import("../../auto-reply/reply/reply-dispatcher.js").createReplyDispatcherWithTyping;
 type ResolveEffectiveMessagesConfig =
@@ -228,6 +230,7 @@ export type PluginRuntime = {
     reply: {
       dispatchReplyWithBufferedBlockDispatcher: DispatchReplyWithBufferedBlockDispatcher;
       createReplyDispatcherWithTyping: CreateReplyDispatcherWithTyping;
+      createMessageSentEmitter: CreateMessageSentEmitter;
       resolveEffectiveMessagesConfig: ResolveEffectiveMessagesConfig;
       resolveHumanDelayConfig: ResolveHumanDelayConfig;
       dispatchReplyFromConfig: DispatchReplyFromConfig;

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -10,6 +10,7 @@ import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
 } from "../../auto-reply/inbound-debounce.js";
+import { createMessageSentEmitter } from "../../auto-reply/reply/emit-message-sent.js";
 import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
@@ -228,6 +229,12 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       ...prefixOptions,
       humanDelay: resolveHumanDelayConfig(deps.cfg, route.agentId),
       typingCallbacks,
+      onDelivered: createMessageSentEmitter({
+        sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+        channel: "signal",
+        to: ctxPayload.To ?? "",
+        accountId: deps.accountId,
+      }),
       deliver: async (payload) => {
         await deps.deliverReplies({
           replies: [payload],

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -1,5 +1,6 @@
 import { resolveHumanDelayConfig } from "../../../agents/identity.js";
 import { dispatchInboundMessage } from "../../../auto-reply/dispatch.js";
+import { createMessageSentEmitter } from "../../../auto-reply/reply/emit-message-sent.js";
 import { clearHistoryEntriesIfEnabled } from "../../../auto-reply/reply/history.js";
 import { createReplyDispatcherWithTyping } from "../../../auto-reply/reply/reply-dispatcher.js";
 import type { ReplyPayload } from "../../../auto-reply/types.js";
@@ -263,6 +264,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     ...prefixOptions,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     typingCallbacks,
+    onDelivered: createMessageSentEmitter({
+      sessionKey: route.mainSessionKey,
+      channel: "slack",
+      to: `user:${message.user}`,
+      accountId: route.accountId,
+    }),
     deliver: async (payload) => {
       if (useStreaming) {
         await deliverWithStreaming(payload);

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -7,6 +7,7 @@ import {
 } from "../agents/model-catalog.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
+import { createMessageSentEmitter } from "../auto-reply/reply/emit-message-sent.js";
 import { clearHistoryEntriesIfEnabled } from "../auto-reply/reply/history.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
@@ -465,6 +466,12 @@ export const dispatchTelegramMessage = async ({
       dispatcherOptions: {
         ...prefixOptions,
         typingCallbacks,
+        onDelivered: createMessageSentEmitter({
+          sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+          channel: "telegram",
+          to: ctxPayload.To ?? "",
+          accountId: route.accountId,
+        }),
         deliver: async (payload, info) => {
           const previewButtons = (
             payload.channelData?.telegram as { buttons?: TelegramInlineButtons } | undefined


### PR DESCRIPTION
## Summary

- **Problem:** The `message:sent` internal hook and plugin `message_sent` hook never fire for normal agent replies on any channel (Telegram, Discord, Slack, Signal, iMessage, LINE, Feishu, Matrix, Mattermost, MSTeams). They only fire when using the `message` tool (`action=send`). Each channel's delivery path bypasses `deliverOutboundPayloads` / `emitMessageSent` entirely.
- **Why it matters:** Users cannot capture outbound agent replies via hooks. This breaks use cases like conversation logging, memory sync, analytics, and any plugin that depends on `message:sent` or `message_sent` events. The hook registers successfully at startup but silently never fires.
- **What changed:** Added an `onDelivered` callback to `ReplyDispatcherOptions` and a shared `createMessageSentEmitter` helper. Each channel now passes a small context object so the dispatcher emits both hooks after every delivery attempt. 16 files changed across core and all channel extensions.
- **What did NOT change:** The existing `deliverOutboundPayloads` / `emitMessageSent` path (used by the `message` tool) is untouched. Hook registration, dispatch, and the internal hook system are unmodified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31293

## User-visible / Behavior Changes

- `message:sent` hooks now fire for every outbound agent reply on all channels.
- Plugin `message_sent` hooks also fire for agent replies (previously only for `message` tool sends).
- No change to existing behavior when `onDelivered` is not provided (fully backward compatible).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: All channels (Telegram, Discord, Slack, Signal, iMessage, LINE, Feishu, Matrix, Mattermost, MSTeams)

### Steps

1. Create a `HOOK.md` in workspace with `events: ["message:sent"]`.
2. Create `handler.ts` that logs when event fires.
3. Restart gateway — hook registers successfully in logs.
4. Send a message to the agent via any channel.
5. Agent replies normally.

### Expected

- `message:sent` hook fires after every successful outbound agent reply.

### Actual

- Before fix: Hook is registered but zero events are emitted for agent replies.
- After fix: Hook fires after each delivery attempt (success or failure).

## Evidence

```typescript
// New: src/auto-reply/reply/emit-message-sent.ts
export function createMessageSentEmitter(ctx: MessageSentHookContext): ReplyDispatchDeliveredHandler {
  return (payload, info) => {
    // Emit plugin hook
    hookRunner?.runMessageSent({ to: ctx.to, content, success: info.success, ... }, { ... });
    // Emit internal hook
    triggerInternalHook(createInternalHookEvent("message", "sent", ctx.sessionKey, { ... }));
  };
}

// Each channel passes onDelivered:
createReplyDispatcherWithTyping({
  onDelivered: createMessageSentEmitter({
    sessionKey: route.sessionKey,
    channel: "telegram",
    to: ctxPayload.To,
    accountId: route.accountId,
  }),
  deliver: async (payload) => { ... },
});
```

### Files changed

- `src/auto-reply/reply/reply-dispatcher.ts` — added `onDelivered` callback
- `src/auto-reply/reply/emit-message-sent.ts` — new shared emitter helper
- `src/plugins/runtime/index.ts` + `types.ts` — exported for extensions
- Channel handlers: `telegram/bot-message-dispatch.ts`, `discord/monitor/message-handler.process.ts`, `slack/monitor/message-handler/dispatch.ts`, `signal/monitor/event-handler.ts`, `imessage/monitor/monitor-provider.ts`, `line/monitor.ts`
- Extensions: `feishu/reply-dispatcher.ts` + `bot.ts`, `matrix/monitor/handler.ts`, `mattermost/monitor.ts`, `msteams/reply-dispatcher.ts` + `monitor-handler/message-handler.ts`

## Human Verification (required)

- Verified scenarios: TypeScript compilation passes (`npx tsc --noEmit`) — zero type errors across all 16 files.
- Edge cases checked: `onDelivered` is optional — channels that don't provide it behave exactly as before. Both success and failure paths emit the hook. Plugin hooks use fire-and-forget to avoid blocking delivery.
- What I did **not** verify: End-to-end test with an actual `HOOK.md` handler.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit (16 files)
- Files/config to restore: All files listed above
- Known bad symptoms: If `createMessageSentEmitter` throws, the `.catch(() => {})` guards prevent it from affecting delivery. Worst case: hooks don't fire (same as before this fix).

## Risks and Mitigations

- **Risk:** Hook handlers that throw could slow down delivery. **Mitigation:** Both `hookRunner.runMessageSent` and `triggerInternalHook` are fire-and-forget (wrapped in `void ... .catch(() => {})`), matching the existing pattern in `deliver.ts`.
- **Risk:** Adding `onDelivered` to every channel increases surface area. **Mitigation:** The emitter is a thin wrapper with no channel-specific logic; all channel-specific behavior stays in the `deliver` callback.