### PR TITLE
fix(gateway): move plugin HTTP handler before Control UI SPA catch-all

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -489,6 +489,27 @@ export function createGatewayHttpServer(opts: {
           return;
         }
       }
+      // Plugin HTTP handlers must run before Control UI SPA catch-all to allow
+      // POST requests to webhook endpoints (e.g., BlueBubbles). Otherwise, the
+      // SPA handler returns 405 Method Not Allowed for non-GET methods.
+      if (handlePluginRequest) {
+        if ((shouldEnforcePluginGatewayAuth ?? isProtectedPluginRoutePath)(requestPath)) {
+          const pluginAuthOk = await enforcePluginRouteGatewayAuth({
+            req,
+            res,
+            auth: resolvedAuth,
+            trustedProxies,
+            allowRealIpFallback,
+            rateLimiter,
+          });
+          if (!pluginAuthOk) {
+            return;
+          }
+        }
+        if (await handlePluginRequest(req, res)) {
+          return;
+        }
+      }
       if (controlUiEnabled) {
         if (
           handleControlUiAvatarRequest(req, res, {
@@ -505,26 +526,6 @@ export function createGatewayHttpServer(opts: {
             root: controlUiRoot,
           })
         ) {
-          return;
-        }
-      }
-      // Plugins run after built-in gateway routes so core surfaces keep
-      // precedence on overlapping paths.
-      if (handlePluginRequest) {
-        if ((shouldEnforcePluginGatewayAuth ?? isProtectedPluginRoutePath)(requestPath)) {
-          const pluginAuthOk = await enforcePluginRouteGatewayAuth({
-            req,
-            res,
-            auth: resolvedAuth,
-            trustedProxies,
-            allowRealIpFallback,
-            rateLimiter,
-          });
-          if (!pluginAuthOk) {
-            return;
-          }
-        }
-        if (await handlePluginRequest(req, res)) {
           return;
         }
       }


### PR DESCRIPTION
## Summary
- Fixes #31809
- Swaps the order of `handlePluginRequest` and `handleControlUiHttpRequest` in the HTTP request handler chain

## Problem
In v2026.3.1, the Control UI SPA catch-all handler was positioned before the plugin HTTP handler. This caused all POST requests to plugin webhook endpoints (e.g., \`/bluebubbles-webhook\`) to be intercepted by the SPA handler, which returns \`405 Method Not Allowed\` for non-GET methods.

As a result, BlueBubbles (and potentially other webhook-based channel plugins) could not receive any inbound messages.

## Solution
This PR moves \`handlePluginRequest\` to run before \`handleControlUiHttpRequest\`, allowing webhook-based plugins to properly handle POST requests.

## Handler Order (Before)
1. handleHooksRequest
2. handleToolsInvokeHttpRequest
3. handleSlackHttpRequest
4. ...
5. **handleControlUiHttpRequest** ← SPA catch-all (POSTを405で拒否)
6. **handlePluginRequest** ← プラグインwebhook (届かない)

## Handler Order (After)
1. handleHooksRequest
2. handleToolsInvokeHttpRequest
3. handleSlackHttpRequest
4. ...
5. **handlePluginRequest** ← プラグインwebhook (先に処理)
6. **handleControlUiHttpRequest** ← SPA catch-all (残りを処理)

## Testing
- Unit tests pass (5927 passed, 1 existing failure unrelated to this change)

Fixes #31809