### PR TITLE
fix(ui): replace Array.prototype.toSorted with sort for browser compatibility

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -175,7 +175,10 @@ export function renderApp(state: AppViewState) {
           .filter(Boolean),
       ].filter(Boolean),
     ),
-  ).toSorted((a, b) => a.localeCompare(b));
+  )
+    .slice()
+    // oxlint-disable-next-line unicorn/no-array-sort -- toSorted unavailable in older browsers
+    .sort((a, b) => a.localeCompare(b));
   const cronModelSuggestions = Array.from(
     new Set(
       [
@@ -191,7 +194,10 @@ export function renderApp(state: AppViewState) {
           .filter(Boolean),
       ].filter(Boolean),
     ),
-  ).toSorted((a, b) => a.localeCompare(b));
+  )
+    .slice()
+    // oxlint-disable-next-line unicorn/no-array-sort -- toSorted unavailable in older browsers
+    .sort((a, b) => a.localeCompare(b));
   const visibleCronJobs = getVisibleCronJobs(state);
   const selectedDeliveryChannel =
     state.cronForm.deliveryChannel && state.cronForm.deliveryChannel.trim()


### PR DESCRIPTION
## Summary

- Replace `.toSorted()` with `.slice().sort()` in `ui/src/ui/app-render.ts` for older browser compatibility
- Added `oxlint-disable-next-line` comments to prevent the pre-commit hook from reverting `.sort()` back to `.toSorted()`

Supersedes #30473 (rebased on latest `main`).

Fixes #30467

## Test plan

- [x] Lint passes (`pnpm check`)
- [x] Verified `.sort()` calls are not reverted by pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)