### PR TITLE
feat(telegram): add nativeStreaming via sendMessageDraft (Bot API 9.5)

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1387,6 +1387,8 @@ export const FIELD_HELP: Record<string, string> = {
     'Direct message access control ("pairing" recommended). "open" requires channels.telegram.allowFrom=["*"].',
   "channels.telegram.streaming":
     'Unified Telegram stream preview mode: "off" | "partial" | "block" | "progress". "progress" maps to "partial" on Telegram. Legacy boolean/streamMode keys are auto-mapped.',
+  "channels.telegram.nativeStreaming":
+    "Use Bot API sendMessageDraft (Bot API 9.5+, March 2026) for smooth streaming without message flicker instead of sendMessage + editMessageText. Requires streaming to be enabled (partial or block).",
   "channels.discord.streaming":
     'Unified Discord stream preview mode: "off" | "partial" | "block" | "progress". "progress" maps to "partial" on Discord. Legacy boolean/streamMode keys are auto-mapped.',
   "channels.discord.streamMode":

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -122,6 +122,12 @@ export type TelegramAccountConfig = {
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
   /** @deprecated Legacy key; migrated automatically to `streaming`. */
   streamMode?: "off" | "partial" | "block";
+  /**
+   * Use Bot API sendMessageDraft (Bot API 9.5+, March 2026) for smooth
+   * streaming without flicker instead of sendMessage + editMessageText.
+   * Requires streaming to be enabled (partial or block).
+   */
+  nativeStreaming?: boolean;
   mediaMaxMb?: number;
   /** Telegram API client timeout in seconds (grammY ApiClientOptions). */
   timeoutSeconds?: number;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -171,6 +171,8 @@ export const TelegramAccountSchemaBase = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     // Legacy key kept for automatic migration to `streaming`.
     streamMode: z.enum(["off", "partial", "block"]).optional(),
+    // Use Bot API sendMessageDraft (9.5+) for smooth flicker-free streaming.
+    nativeStreaming: z.boolean().optional(),
     mediaMaxMb: z.number().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     retry: RetryConfigSchema,

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -170,6 +170,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       runtime: createRuntime(),
       replyToMode: "first",
       streamMode: params.streamMode ?? "partial",
+      nativeStreaming: false,
       textLimit: 4096,
       telegramCfg: params.telegramCfg ?? {},
       opts: { token: "token" },

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -98,6 +98,7 @@ type DispatchTelegramMessageParams = {
   runtime: RuntimeEnv;
   replyToMode: ReplyToMode;
   streamMode: TelegramStreamMode;
+  nativeStreaming: boolean;
   textLimit: number;
   telegramCfg: TelegramAccountConfig;
   opts: Pick<TelegramBotOptions, "token">;
@@ -135,6 +136,7 @@ export const dispatchTelegramMessage = async ({
   runtime,
   replyToMode,
   streamMode,
+  nativeStreaming,
   textLimit,
   telegramCfg,
   opts,
@@ -199,6 +201,7 @@ export const dispatchTelegramMessage = async ({
           replyToMessageId: draftReplyToMessageId,
           minInitialChars: draftMinInitialChars,
           renderText: renderDraftPreview,
+          nativeStreaming,
           onSupersededPreview:
             laneName === "answer" || laneName === "reasoning"
               ? (preview) => {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -191,6 +191,9 @@ export const dispatchTelegramMessage = async ({
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
+  // Use separate draft slot IDs for answer/reasoning lanes to prevent
+  // both lanes from overwriting each other when nativeStreaming is enabled.
+  const DRAFT_IDS: Record<LaneName, number> = { answer: 1, reasoning: 2 };
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
     const stream = enabled
       ? createTelegramDraftStream({
@@ -202,6 +205,7 @@ export const dispatchTelegramMessage = async ({
           minInitialChars: draftMinInitialChars,
           renderText: renderDraftPreview,
           nativeStreaming,
+          draftId: DRAFT_IDS[laneName],
           onSupersededPreview:
             laneName === "answer" || laneName === "reasoning"
               ? (preview) => {

--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -19,6 +19,7 @@ type TelegramMessageProcessorDeps = Omit<
   runtime: RuntimeEnv;
   replyToMode: ReplyToMode;
   streamMode: TelegramStreamMode;
+  nativeStreaming: boolean;
   textLimit: number;
   opts: Pick<TelegramBotOptions, "token">;
 };
@@ -43,6 +44,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     runtime,
     replyToMode,
     streamMode,
+    nativeStreaming,
     textLimit,
     opts,
   } = deps;
@@ -85,6 +87,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       runtime,
       replyToMode,
       streamMode,
+      nativeStreaming,
       textLimit,
       telegramCfg,
       opts,

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -38,6 +38,7 @@ import {
   buildTelegramGroupPeerId,
   resolveTelegramForumThreadId,
   resolveTelegramStreamMode,
+  resolveTelegramNativeStreaming,
 } from "./bot/helpers.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
@@ -291,6 +292,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   const mediaMaxBytes = (opts.mediaMaxMb ?? telegramCfg.mediaMaxMb ?? 5) * 1024 * 1024;
   const logger = getChildLogger({ module: "telegram-auto-reply" });
   const streamMode = resolveTelegramStreamMode(telegramCfg);
+  const nativeStreaming = resolveTelegramNativeStreaming(telegramCfg);
   const resolveGroupPolicy = (chatId: string | number) =>
     resolveChannelGroupPolicy({
       cfg,
@@ -391,6 +393,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     runtime,
     replyToMode,
     streamMode,
+    nativeStreaming,
     textLimit,
     opts,
   });

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -171,6 +171,17 @@ export function resolveTelegramStreamMode(telegramCfg?: {
   return resolveTelegramPreviewStreamMode(telegramCfg);
 }
 
+/**
+ * Resolve whether to use Bot API sendMessageDraft (Bot API 9.5+) for smooth
+ * streaming instead of the default sendMessage + editMessageText approach.
+ * Enable via `channels.telegram.nativeStreaming: true` in config.
+ */
+export function resolveTelegramNativeStreaming(telegramCfg?: {
+  nativeStreaming?: unknown;
+}): boolean {
+  return telegramCfg?.nativeStreaming === true;
+}
+
 export function buildTelegramGroupPeerId(chatId: number | string, messageThreadId?: number) {
   return messageThreadId != null ? `${chatId}:topic:${messageThreadId}` : String(chatId);
 }

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -114,7 +114,9 @@ export function createTelegramDraftStream(params: {
       if (nativeStreaming) {
         // Use Bot API 9.5 sendMessageDraft for smooth streaming without flicker.
         // No message_id tracking needed — draft slot is identified by draftId.
-        await params.api.sendMessageDraft({
+        // Cast to any: grammy typings may lag behind Bot API 9.5.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (params.api as any).sendMessageDraft({
           chat_id: chatId,
           draft_id: draftId,
           text: renderedText,

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -114,7 +114,15 @@ export function createTelegramDraftStream(params: {
       if (nativeStreaming) {
         // Use Bot API 9.5 sendMessageDraft for smooth streaming without flicker.
         // No message_id tracking needed — draft slot is identified by draftId.
-        await params.api.sendMessageDraft(chatId, draftId, renderedText, threadParams);
+        await params.api.sendMessageDraft({
+          chat_id: chatId,
+          draft_id: draftId,
+          text: renderedText,
+          ...(threadParams?.message_thread_id != null && {
+            message_thread_id: threadParams.message_thread_id,
+          }),
+          ...(renderedParseMode && { parse_mode: renderedParseMode }),
+        });
         return true;
       }
       if (typeof streamMessageId === "number") {

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -63,7 +63,7 @@ export function createTelegramDraftStream(params: {
       ? { ...threadParams, reply_to_message_id: params.replyToMessageId }
       : threadParams;
 
-  const nativeStreaming = params.nativeStreaming === true;
+  let nativeStreaming = params.nativeStreaming === true;
   const draftId = params.draftId ?? 1;
 
   const streamState = { stopped: false, final: false };
@@ -114,18 +114,28 @@ export function createTelegramDraftStream(params: {
       if (nativeStreaming) {
         // Use Bot API 9.5 sendMessageDraft for smooth streaming without flicker.
         // No message_id tracking needed — draft slot is identified by draftId.
-        // Cast to any: grammy typings may lag behind Bot API 9.5.
+        // Runtime check: grammy v1.41.0 may not have sendMessageDraft yet.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await (params.api as any).sendMessageDraft({
-          chat_id: chatId,
-          draft_id: draftId,
-          text: renderedText,
-          ...(threadParams?.message_thread_id != null && {
-            message_thread_id: threadParams.message_thread_id,
-          }),
-          ...(renderedParseMode && { parse_mode: renderedParseMode }),
-        });
-        return true;
+        const api = params.api as any;
+        if (typeof api.sendMessageDraft !== "function") {
+          // Fallback: disable native streaming and proceed with editMessageText.
+          params.warn?.(
+            "sendMessageDraft not available in current grammy version, falling back to editMessageText",
+          );
+          nativeStreaming = false;
+          // Fall through to the standard send/edit path below.
+        } else {
+          await api.sendMessageDraft({
+            chat_id: chatId,
+            draft_id: draftId,
+            text: renderedText,
+            ...(threadParams?.message_thread_id != null && {
+              message_thread_id: threadParams.message_thread_id,
+            }),
+            ...(renderedParseMode && { parse_mode: renderedParseMode }),
+          });
+          return true;
+        }
       }
       if (typeof streamMessageId === "number") {
         if (renderedParseMode) {

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -39,6 +39,14 @@ export function createTelegramDraftStream(params: {
   renderText?: (text: string) => TelegramDraftPreview;
   /** Called when a late send resolves after forceNewMessage() switched generations. */
   onSupersededPreview?: (preview: SupersededTelegramPreview) => void;
+  /**
+   * Use Telegram Bot API sendMessageDraft for streaming updates instead of
+   * sendMessage + editMessageText. Requires Bot API 9.5+ (March 2026).
+   * Produces smoother streaming without message flicker.
+   */
+  nativeStreaming?: boolean;
+  /** Draft slot id used with sendMessageDraft (default: 1). */
+  draftId?: number;
   log?: (message: string) => void;
   warn?: (message: string) => void;
 }): TelegramDraftStream {
@@ -54,6 +62,9 @@ export function createTelegramDraftStream(params: {
     params.replyToMessageId != null
       ? { ...threadParams, reply_to_message_id: params.replyToMessageId }
       : threadParams;
+
+  const nativeStreaming = params.nativeStreaming === true;
+  const draftId = params.draftId ?? 1;
 
   const streamState = { stopped: false, final: false };
   let streamMessageId: number | undefined;
@@ -100,6 +111,12 @@ export function createTelegramDraftStream(params: {
     lastSentText = renderedText;
     lastSentParseMode = renderedParseMode;
     try {
+      if (nativeStreaming) {
+        // Use Bot API 9.5 sendMessageDraft for smooth streaming without flicker.
+        // No message_id tracking needed — draft slot is identified by draftId.
+        await params.api.sendMessageDraft(chatId, draftId, renderedText, threadParams);
+        return true;
+      }
       if (typeof streamMessageId === "number") {
         if (renderedParseMode) {
           await params.api.editMessageText(chatId, streamMessageId, renderedText, {


### PR DESCRIPTION
## What

Adds opt-in support for Telegram Bot API `sendMessageDraft` (Bot API 9.5, March 2026) as the streaming backend, replacing the current `sendMessage` + `editMessageText` approach.

## Why

The current preview streaming works, but `editMessageText` causes visible message flicker on every update. `sendMessageDraft` is a native Telegram streaming primitive that produces smooth, flicker-free output — similar to what users see in ChatGPT's Telegram integration.

## How to enable

```json
{
  "channels": {
    "telegram": {
      "streaming": "partial",
      "nativeStreaming": true
    }
  }
}
```

## Changes

| File | Change |
|------|--------|
| `draft-stream.ts` | Add `nativeStreaming` + `draftId` params; branch to `sendMessageDraft` when enabled |
| `bot/helpers.ts` | Add `resolveTelegramNativeStreaming()` config resolver |
| `bot.ts` | Resolve and forward `nativeStreaming` flag |
| `bot-message.ts` | Thread `nativeStreaming` through processor deps |
| `bot-message-dispatch.ts` | Pass `nativeStreaming` into `createTelegramDraftStream` |
| `schema.help.ts` | Document `channels.telegram.nativeStreaming` |

## Backwards compatibility

Default behaviour is unchanged (`nativeStreaming` defaults to `false`). Opt-in only.

Closes #31843