### PR TITLE
fix: handle HTTP 529 (Anthropic overloaded) in failover error classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Failover/error classification: treat HTTP `529` (provider overloaded, common with Anthropic-compatible APIs) as `rate_limit` so model failover can engage instead of misclassifying the error path. (#31854) Thanks @bugkill3r.
 - Voice-call/webhook routing: require exact webhook path matches (instead of prefix matches) so lookalike paths cannot reach provider verification/dispatch logic. (#31930) Thanks @afurm.
 - Web UI/config form: support SecretInput string-or-secret-ref unions in map `additionalProperties`, so provider API key fields stay editable instead of being marked unsupported. (#31866) Thanks @ningding97.
 - Slack/Bolt startup compatibility: remove invalid `message.channels` and `message.groups` event registrations so Slack providers no longer crash on startup with Bolt 4.6+; channel/group traffic continues through the unified `message` handler (`channel_type`). (#32033) Thanks @mahopan.

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -18,6 +18,8 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");
+    // Anthropic 529 (overloaded) should trigger failover as rate_limit.
+    expect(resolveFailoverReasonFromError({ status: 529 })).toBe("rate_limit");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -178,6 +178,9 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 502 || status === 503 || status === 504) {
     return "timeout";
   }
+  if (status === 529) {
+    return "rate_limit";
+  }
   if (status === 400) {
     return "format";
   }


### PR DESCRIPTION
## Summary

- Add explicit `529 → "rate_limit"` mapping in `resolveFailoverReasonFromError` so Anthropic's overloaded response triggers model fallback reliably
- The message-based fallback (`classifyFailoverReason`) can catch this if the error message contains "overloaded", but this is fragile and depends on SDK message formatting
- Uses `"rate_limit"` (not `"timeout"`) — consistent with how `isOverloadedErrorMessage` classifies overloaded errors, and because rate_limit cooldowns are model-scoped, allowing same-provider fallback (e.g. Sonnet → Haiku)

## Changes

- `src/agents/failover-error.ts` — 3-line `if (status === 529)` block after the existing 502/503/504 handling
- `src/agents/failover-error.test.ts` — test assertion for 529 → `"rate_limit"` in existing HTTP status test

## Test plan

- [x] `pnpm vitest run src/agents/failover-error.test.ts` — all 13 tests pass
- [x] `pnpm check` (lint) — clean

Closes #28502

---

AI-assisted: Yes (Claude). Fully tested locally. I understand what the code does.