### PR TITLE
fix(infra): treat undici terminated aborts as transient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Infra/Unhandled rejections: classify Node/undici `TypeError: terminated` fetch-abort failures (`Fetch.onAborted`) as transient network errors so gateway runtime keeps running instead of exiting on these recoverable disconnects. (#31855)
 - Zalo/Pairing auth tests: add webhook regression coverage asserting DM pairing-store reads/writes remain account-scoped, preventing cross-account authorization bleed in multi-account setups. (#26121) Thanks @bmendonca3.
 - Zalouser/Pairing auth tests: add account-scoped DM pairing-store regression coverage (`monitor.account-scope.test.ts`) to prevent cross-account allowlist bleed in multi-account setups. (#26672) Thanks @bmendonca3.
 - Agents/Sessions list transcript paths: handle missing/non-string/relative `sessions.list.path` values and per-agent `{agentId}` templates when deriving `transcriptPath`, so cross-agent session listings resolve to concrete agent session files instead of workspace-relative paths. (#24775) Thanks @martinfrancois.

--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -90,6 +90,12 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
         Object.assign(new TypeError("fetch failed"), {
           cause: { code: "UND_ERR_CONNECT_TIMEOUT", syscall: "connect" },
         }),
+        Object.assign(new TypeError("terminated"), {
+          stack:
+            "TypeError: terminated\n" +
+            "    at Fetch.onAborted (node:internal/deps/undici/undici:1234:56)\n" +
+            "    at Fetch.emit (node:events:525:35)",
+        }),
         Object.assign(new Error("DNS resolve failed"), { code: "UND_ERR_DNS_RESOLVE_FAILED" }),
         Object.assign(new Error("Connection reset"), { code: "ECONNRESET" }),
         Object.assign(new Error("Timeout"), { code: "ETIMEDOUT" }),

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -73,6 +73,16 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(error)).toBe(true);
   });
 
+  it('returns true for undici "terminated" TypeError from Fetch.onAborted', () => {
+    const error = Object.assign(new TypeError("terminated"), {
+      stack:
+        "TypeError: terminated\n" +
+        "    at Fetch.onAborted (node:internal/deps/undici/undici:1234:56)\n" +
+        "    at Fetch.emit (node:events:525:35)",
+    });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
   it("returns true for fetch failed with network cause", () => {
     const cause = Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" });
     const error = Object.assign(new TypeError("fetch failed"), { cause });
@@ -126,6 +136,7 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(new Error("Something went wrong"))).toBe(false);
     expect(isTransientNetworkError(new TypeError("Cannot read property"))).toBe(false);
     expect(isTransientNetworkError(new RangeError("Invalid array length"))).toBe(false);
+    expect(isTransientNetworkError(new TypeError("terminated"))).toBe(false);
   });
 
   it("returns false for errors with non-network codes", () => {

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -70,6 +70,14 @@ function getErrorName(err: unknown): string {
   return typeof name === "string" ? name : "";
 }
 
+function getErrorMessage(err: unknown): string {
+  if (!err || typeof err !== "object") {
+    return "";
+  }
+  const message = (err as { message?: unknown }).message;
+  return typeof message === "string" ? message : "";
+}
+
 function extractErrorCodeOrErrno(err: unknown): string | undefined {
   const code = extractErrorCode(err);
   if (code) {
@@ -142,13 +150,46 @@ export function isAbortError(err: unknown): boolean {
   if (!err || typeof err !== "object") {
     return false;
   }
-  const name = "name" in err ? String(err.name) : "";
+  const name = getErrorName(err);
   if (name === "AbortError") {
     return true;
   }
   // Check for "This operation was aborted" message from Node's undici
-  const message = "message" in err && typeof err.message === "string" ? err.message : "";
+  const message = getErrorMessage(err);
   if (message === "This operation was aborted") {
+    return true;
+  }
+  return false;
+}
+
+function isUndiciTerminatedFetchError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const name = getErrorName(err);
+  const message = getErrorMessage(err);
+  if (name !== "TypeError" || message !== "terminated") {
+    return false;
+  }
+
+  const stack = (err as { stack?: unknown }).stack;
+  if (typeof stack === "string") {
+    const lowerStack = stack.toLowerCase();
+    if (lowerStack.includes("undici") || lowerStack.includes("fetch.onaborted")) {
+      return true;
+    }
+  }
+
+  const cause = getErrorCause(err);
+  if (isAbortError(cause)) {
+    return true;
+  }
+  const causeCode = extractErrorCodeOrErrno(cause);
+  if (causeCode?.startsWith("UND_ERR_")) {
+    return true;
+  }
+  const causeMessage = getErrorMessage(cause).toLowerCase();
+  if (causeMessage.includes("aborted") || causeMessage.includes("terminated")) {
     return true;
   }
   return false;
@@ -173,6 +214,10 @@ export function isTransientNetworkError(err: unknown): boolean {
     return false;
   }
   for (const candidate of collectErrorCandidates(err)) {
+    if (isUndiciTerminatedFetchError(candidate)) {
+      return true;
+    }
+
     const code = extractErrorCodeOrErrno(candidate);
     if (code && TRANSIENT_NETWORK_CODES.has(code)) {
       return true;
@@ -190,8 +235,7 @@ export function isTransientNetworkError(err: unknown): boolean {
     if (!candidate || typeof candidate !== "object") {
       continue;
     }
-    const rawMessage = (candidate as { message?: unknown }).message;
-    const message = typeof rawMessage === "string" ? rawMessage.toLowerCase().trim() : "";
+    const message = getErrorMessage(candidate).toLowerCase().trim();
     if (!message) {
       continue;
     }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Gateway could exit on unhandled rejection when Node/undici surfaced `TypeError: terminated` from `Fetch.onAborted`.
- Why it matters: transient upstream disconnect/abort paths should not crash the whole gateway process.
- What changed: added targeted detection for undici-style `TypeError("terminated")` (stack/cause-aware) and classify it as transient network error.
- What did NOT change (scope boundary): no retry policy, no provider-specific request logic, no change to fatal/config error handling paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31855
- Related #31760

## User-visible / Behavior Changes

- Gateway no longer exits on undici `TypeError: terminated` abort/disconnect rejections; it logs as non-fatal transient network error and continues running.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25.x local test run
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Trigger `installUnhandledRejectionHandler` with an unhandled rejection reason matching undici abort shape: `TypeError("terminated")` with `Fetch.onAborted` stack.
2. Observe gateway unhandled rejection handling path.
3. Run infra unhandled-rejection unit tests.

### Expected

- Reason is classified transient; process is not exited.

### Actual

- Before fix: generic unhandled rejection branch could exit process.
- After fix: non-fatal branch logs warning and continues.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test src/infra/unhandled-rejections.test.ts src/infra/unhandled-rejections.fatal-detection.test.ts`
- Passed: 2 files, 36 tests
- Added regression cases for `TypeError: terminated` and fatal-detector non-exit behavior

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `isTransientNetworkError` returns true for undici `TypeError: terminated` with `Fetch.onAborted` stack.
  - plain `TypeError: terminated` without undici/abort context remains non-transient.
  - `installUnhandledRejectionHandler` does not exit for undici-terminated transient case.
- Edge cases checked:
  - Existing `TypeError: fetch failed` and nested-cause transient paths still pass.
  - Non-transient generic errors still exit.
- What you did **not** verify:
  - Live upstream reproduction from real gateway runtime logs.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `28d93597a`.
- Files/config to restore:
  - `src/infra/unhandled-rejections.ts`
  - `src/infra/unhandled-rejections.test.ts`
  - `src/infra/unhandled-rejections.fatal-detection.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected suppression of truly fatal non-network `TypeError: terminated` errors (guarded by stack/cause checks).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: over-classifying generic `TypeError: terminated` as transient.
  - Mitigation: detection requires undici-specific stack marker or abort/UND_ERR cause evidence; added negative regression test for plain `TypeError: terminated`.
