### PR TITLE
fix(mentions): ignore malformed mention pattern entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Mentions/Slack gating hardening: ignore invalid/non-string/empty mention pattern entries before regex compilation so malformed pattern arrays cannot crash mention handling with `Cannot read properties of undefined (reading 'includes')`. (#31851)
 - Zalo/Pairing auth tests: add webhook regression coverage asserting DM pairing-store reads/writes remain account-scoped, preventing cross-account authorization bleed in multi-account setups. (#26121) Thanks @bmendonca3.
 - Zalouser/Pairing auth tests: add account-scoped DM pairing-store regression coverage (`monitor.account-scope.test.ts`) to prevent cross-account allowlist bleed in multi-account setups. (#26672) Thanks @bmendonca3.
 - Agents/Sessions list transcript paths: handle missing/non-string/relative `sessions.list.path` values and per-agent `{agentId}` templates when deriving `transcriptPath`, so cross-agent session listings resolve to concrete agent session files instead of workspace-relative paths. (#24775) Thanks @martinfrancois.

--- a/src/auto-reply/reply/mentions.test.ts
+++ b/src/auto-reply/reply/mentions.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { MsgContext } from "../templating.js";
+import { buildMentionRegexes, stripMentions } from "./mentions.js";
+
+describe("buildMentionRegexes", () => {
+  it("ignores non-string, empty, and invalid mention patterns", () => {
+    const cfg = {
+      messages: {
+        groupChat: {
+          mentionPatterns: [undefined, null, "   ", "@openclaw", "(["],
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const regexes = buildMentionRegexes(cfg);
+    expect(regexes).toHaveLength(1);
+    expect(regexes[0]?.test("@openclaw hi")).toBe(true);
+  });
+});
+
+describe("stripMentions", () => {
+  it("does not throw when mentionPatterns contains undefined entries", () => {
+    const cfg = {
+      messages: {
+        groupChat: {
+          mentionPatterns: [undefined, "@openclaw"],
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const ctx = {} as MsgContext;
+
+    expect(() => stripMentions("@openclaw hello", ctx, cfg)).not.toThrow();
+    expect(stripMentions("@openclaw hello", ctx, cfg)).toBe("hello");
+  });
+});

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -24,15 +24,22 @@ const BACKSPACE_CHAR = "\u0008";
 
 export const CURRENT_MESSAGE_MARKER = "[Current message - respond to this]";
 
-function normalizeMentionPattern(pattern: string): string {
-  if (!pattern.includes(BACKSPACE_CHAR)) {
-    return pattern;
+function normalizeMentionPattern(pattern: unknown): string | null {
+  if (typeof pattern !== "string") {
+    return null;
   }
-  return pattern.split(BACKSPACE_CHAR).join("\\b");
+  const trimmed = pattern.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (!trimmed.includes(BACKSPACE_CHAR)) {
+    return trimmed;
+  }
+  return trimmed.split(BACKSPACE_CHAR).join("\\b");
 }
 
-function normalizeMentionPatterns(patterns: string[]): string[] {
-  return patterns.map(normalizeMentionPattern);
+function normalizeMentionPatterns(patterns: Array<unknown>): string[] {
+  return patterns.map(normalizeMentionPattern).filter((value): value is string => Boolean(value));
 }
 
 function resolveMentionPatterns(cfg: OpenClawConfig | undefined, agentId?: string): string[] {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: mention handling could crash with `Cannot read properties of undefined (reading 'includes')` when mention pattern arrays contained invalid entries.
- Why it matters: this can break Slack mention processing and drop inbound handling for affected messages.
- What changed: hardened mention pattern normalization to ignore non-string/empty entries, and added regression tests for malformed pattern arrays.
- What did NOT change (scope boundary): no change to mention matching semantics for valid patterns.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31851
- Related #31674

## User-visible / Behavior Changes

- Malformed mention pattern arrays no longer crash mention handling; valid patterns continue to work.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25.x local test run
- Model/provider: N/A
- Integration/channel (if any): Slack mention path + shared mention utilities
- Relevant config (redacted): `messages.groupChat.mentionPatterns` with malformed entries

### Steps

1. Set mention patterns with mixed invalid values (e.g. `undefined`, `null`, empty string, invalid regex).
2. Trigger mention regex build / strip path.
3. Verify no crash and valid patterns still apply.

### Expected

- Invalid pattern entries are ignored safely.
- Mention handling continues for valid entries.

### Actual

- Before fix: could throw on `pattern.includes(...)` for non-string entries.
- After fix: no throw; valid patterns compile/use normally.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test src/auto-reply/reply/mentions.test.ts src/auto-reply/reply/reply-utils.test.ts src/slack/monitor.tool-result.test.ts`
- Passed: 3 files, 60 tests
- New regression tests in `src/auto-reply/reply/mentions.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `buildMentionRegexes` ignores non-string/empty/invalid entries.
  - `stripMentions` handles malformed `mentionPatterns` without throwing and still strips valid patterns.
  - Slack mention-related tool-result tests remain green.
- Edge cases checked:
  - Empty pattern and invalid regex (`([`) are skipped.
- What you did **not** verify:
  - Live Slack runtime log reproduction from production gateway process.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `85066b1b9`.
- Files/config to restore:
  - `src/auto-reply/reply/mentions.ts`
  - `src/auto-reply/reply/mentions.test.ts`
- Known bad symptoms reviewers should watch for:
  - Mention patterns unexpectedly over-matching if invalid entries are incorrectly transformed (guarded by tests).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: dropping malformed entries may hide config mistakes.
  - Mitigation: behavior now fail-soft and keeps valid patterns active; no crash in message pipeline.
