### PR TITLE
Agent runner: coalesce fragmented assistant text into one final payload

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1239,6 +1239,7 @@ export async function runEmbeddedPiAgent(
             suppressToolErrorWarnings: params.suppressToolErrorWarnings,
             inlineToolResultsAllowed: false,
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+            preserveAssistantTextChunks: Boolean(params.onBlockReply),
           });
 
           // Timeout aborts can leave the run without any assistant payloads.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1239,7 +1239,7 @@ export async function runEmbeddedPiAgent(
             suppressToolErrorWarnings: params.suppressToolErrorWarnings,
             inlineToolResultsAllowed: false,
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-            preserveAssistantTextChunks: Boolean(params.onBlockReply),
+            preserveAssistantTextChunks: Boolean(params.blockStreamingEnabled),
           });
 
           // Timeout aborts can leave the run without any assistant payloads.

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -94,6 +94,7 @@ export type RunEmbeddedPiAgentParams = {
   onAssistantMessageStart?: () => void | Promise<void>;
   onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
   onBlockReplyFlush?: () => void | Promise<void>;
+  blockStreamingEnabled?: boolean;
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -138,6 +138,19 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.text).toBe("errorserver error");
   });
 
+  it("preserves chunk boundaries when block replies were already streamed", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["First block line", "Second block line"],
+      lastAssistant: makeStoppedAssistant(),
+      preserveAssistantTextChunks: true,
+    });
+
+    expect(payloads.map((payload) => payload.text)).toEqual([
+      "First block line",
+      "Second block line",
+    ]);
+  });
+
   it("adds a fallback error when a tool fails and no assistant output exists", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "browser", error: "tab not found" },

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -108,6 +108,26 @@ describe("buildEmbeddedRunPayloads", () => {
     expectSinglePayloadText(payloads, errorJsonPretty.trim());
   });
 
+  it("coalesces fragmented assistant text chunks into one payload", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Per", "feito, @jarbas! 👊"],
+      lastAssistant: makeStoppedAssistant(),
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Perfeito, @jarbas! 👊");
+  });
+
+  it("prefers longer snapshot updates over shorter assistant text snapshots", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Per", "Perfeito, @jarbas! 👊"],
+      lastAssistant: makeStoppedAssistant(),
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Perfeito, @jarbas! 👊");
+  });
+
   it("adds a fallback error when a tool fails and no assistant output exists", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "browser", error: "tab not found" },

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -128,6 +128,16 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.text).toBe("Perfeito, @jarbas! 👊");
   });
 
+  it("does not replace fragments on non-prefix substring overlap", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["error", "server error"],
+      lastAssistant: makeStoppedAssistant(),
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("errorserver error");
+  });
+
   it("adds a fallback error when a tool fails and no assistant output exists", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "browser", error: "tab not found" },

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -127,6 +127,7 @@ export function buildEmbeddedRunPayloads(params: {
   suppressToolErrorWarnings?: boolean;
   inlineToolResultsAllowed: boolean;
   didSendViaMessagingTool?: boolean;
+  preserveAssistantTextChunks?: boolean;
 }): Array<{
   text?: string;
   mediaUrl?: string;
@@ -276,7 +277,9 @@ export function buildEmbeddedRunPayloads(params: {
         : []
   ).filter((text) => !shouldSuppressRawErrorText(text));
   const answerTexts =
-    rawAnswerTexts.length > 1 ? [coalesceAssistantTexts(rawAnswerTexts)] : rawAnswerTexts;
+    params.preserveAssistantTextChunks || rawAnswerTexts.length <= 1
+      ? rawAnswerTexts
+      : [coalesceAssistantTexts(rawAnswerTexts)];
 
   let hasUserFacingAssistantReply = false;
   for (const text of answerTexts) {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -43,6 +43,31 @@ const RECOVERABLE_TOOL_ERROR_KEYWORDS = [
   "requires",
 ] as const;
 
+function coalesceAssistantTexts(chunks: string[]): string {
+  let merged = "";
+  for (const chunk of chunks) {
+    if (!chunk) {
+      continue;
+    }
+    if (!merged) {
+      merged = chunk;
+      continue;
+    }
+    // Some providers emit incremental snapshots ("Per" -> "Perfeito"), while
+    // others emit hard fragments ("Per" + "feito"). Prefer the longer snapshot
+    // when one contains the other; otherwise append the fragment.
+    if (chunk.startsWith(merged) || chunk.includes(merged)) {
+      merged = chunk;
+      continue;
+    }
+    if (merged.startsWith(chunk) || merged.includes(chunk)) {
+      continue;
+    }
+    merged += chunk;
+  }
+  return merged;
+}
+
 function isRecoverableToolError(error: string | undefined): boolean {
   const errorLower = (error ?? "").toLowerCase();
   return RECOVERABLE_TOOL_ERROR_KEYWORDS.some((keyword) => errorLower.includes(keyword));
@@ -243,13 +268,15 @@ export function buildEmbeddedRunPayloads(params: {
     }
     return isRawApiErrorPayload(trimmed);
   };
-  const answerTexts = (
+  const rawAnswerTexts = (
     params.assistantTexts.length
       ? params.assistantTexts
       : fallbackAnswerText
         ? [fallbackAnswerText]
         : []
   ).filter((text) => !shouldSuppressRawErrorText(text));
+  const answerTexts =
+    rawAnswerTexts.length > 1 ? [coalesceAssistantTexts(rawAnswerTexts)] : rawAnswerTexts;
 
   let hasUserFacingAssistantReply = false;
   for (const text of answerTexts) {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -55,12 +55,12 @@ function coalesceAssistantTexts(chunks: string[]): string {
     }
     // Some providers emit incremental snapshots ("Per" -> "Perfeito"), while
     // others emit hard fragments ("Per" + "feito"). Prefer the longer snapshot
-    // when one contains the other; otherwise append the fragment.
-    if (chunk.startsWith(merged) || chunk.includes(merged)) {
+    // only for prefix growth; otherwise append the fragment.
+    if (chunk.startsWith(merged)) {
       merged = chunk;
       continue;
     }
-    if (merged.startsWith(chunk) || merged.includes(chunk)) {
+    if (merged.startsWith(chunk)) {
       continue;
     }
     merged += chunk;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -318,6 +318,7 @@ export async function runAgentTurnWithFallback(params: {
             bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
             images: params.opts?.images,
             abortSignal: params.opts?.abortSignal,
+            blockStreamingEnabled: params.blockStreamingEnabled,
             blockReplyBreak: params.resolvedBlockStreamingBreak,
             blockReplyChunking: params.blockReplyChunking,
             onPartialReply: async (payload) => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: fragmented assistant text (`assistantTexts`) was forwarded as multiple final payloads, which surfaces as split Discord messages when block streaming is not being used for final delivery.
- Why it matters: short user-facing replies can be broken into multiple sends (for example `"Per"` + `"feito"`) even though they belong to one logical assistant response.
- What changed: added coalescing in `buildEmbeddedRunPayloads` to collapse fragmented/snapshot assistant text into a single final answer payload.
- What did NOT change (scope boundary): no Discord transport changes, no channel chunk-limit changes, no block-streaming behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31679
- Related #

## User-visible / Behavior Changes

- Fragmented assistant text is now delivered as one final message payload instead of multiple split payloads.
- Incremental snapshot fragments now prefer the longest snapshot (`"Per"` then `"Perfeito..."` resolves to one payload).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (Darwin)
- Runtime/container: Node 22 + pnpm
- Model/provider: ollama/OpenAI-completions style fragmented assistant text
- Integration/channel (if any): Discord (delivery symptom), fix applied at shared embedded-run payload layer
- Relevant config (redacted): Discord account with preview streaming off; standard message delivery path

### Steps

1. Build payloads from fragmented assistant text chunks (for example `assistantTexts=["Per","feito, @jarbas! 👊"]`).
2. Observe current behavior emits multiple final payloads.
3. Dispatch sends each payload separately, producing split user-visible messages.

### Expected

- One final payload for one logical assistant reply.

### Actual

- Multiple final payloads for fragmented/snapshot assistant text.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced failure before patch with:
    - `pnpm test -- src/agents/pi-embedded-runner/run/payloads.errors.test.ts`
    - failures: `coalesces fragmented assistant text chunks into one payload`, `prefers longer snapshot updates over shorter assistant text snapshots`
  - Verified post-fix pass with:
    - `pnpm test -- src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts`
    - `pnpm test -- src/auto-reply/reply/dispatch-from-config.test.ts`
- Edge cases checked:
  - raw fragment concatenation (`"Per" + "feito"`)
  - incremental snapshot upgrade (`"Per" -> "Perfeito..."`)
  - no regression in existing payload error/formatting tests
- What you did **not** verify:
  - live Discord run against a real bot account

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `15b79caba`.
- Files/config to restore:
  - `src/agents/pi-embedded-runner/run/payloads.ts`
  - `src/agents/pi-embedded-runner/run/payloads.errors.test.ts`
- Known bad symptoms reviewers should watch for:
  - duplicated or malformed final assistant text if unusual fragment ordering occurs

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: coalescing could over-merge truly independent assistant fragments.
  - Mitigation: merge logic prefers longer snapshots when one contains the other, and only appends when fragments are disjoint.
