### PR TITLE
fix(models): throttle implicit ollama discovery failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/Ollama autodiscovery: add a short negative-failure cache for implicit local probes so repeated unreachable `127.0.0.1:11434` discovery attempts are throttled instead of hammering proxy/network stacks on every provider rebuild. (#31846)
 - Zalo/Pairing auth tests: add webhook regression coverage asserting DM pairing-store reads/writes remain account-scoped, preventing cross-account authorization bleed in multi-account setups. (#26121) Thanks @bmendonca3.
 - Zalouser/Pairing auth tests: add account-scoped DM pairing-store regression coverage (`monitor.account-scope.test.ts`) to prevent cross-account allowlist bleed in multi-account setups. (#26672) Thanks @bmendonca3.
 - Agents/Sessions list transcript paths: handle missing/non-string/relative `sessions.list.path` values and per-agent `{agentId}` templates when deriving `transcriptPath`, so cross-agent session listings resolve to concrete agent session files instead of workspace-relative paths. (#24775) Thanks @martinfrancois.

--- a/src/agents/models-config.providers.ollama-autodiscovery.test.ts
+++ b/src/agents/models-config.providers.ollama-autodiscovery.test.ts
@@ -2,7 +2,10 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveImplicitProviders } from "./models-config.providers.js";
+import {
+  resetOllamaDiscoveryFailureCacheForTests,
+  resolveImplicitProviders,
+} from "./models-config.providers.js";
 
 describe("Ollama auto-discovery", () => {
   let originalVitest: string | undefined;
@@ -22,6 +25,7 @@ describe("Ollama auto-discovery", () => {
     }
     globalThis.fetch = originalFetch;
     delete process.env.OLLAMA_API_KEY;
+    resetOllamaDiscoveryFailureCacheForTests();
   });
 
   function setupDiscoveryEnv() {
@@ -105,5 +109,21 @@ describe("Ollama auto-discovery", () => {
     );
     expect(ollamaWarnings.length).toBeGreaterThan(0);
     warnSpy.mockRestore();
+  });
+
+  it("negative-caches implicit unreachable discovery failures", async () => {
+    setupDiscoveryEnv();
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("connect ECONNREFUSED 127.0.0.1:11434"),
+      ) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    await resolveImplicitProviders({ agentDir });
+    await resolveImplicitProviders({ agentDir });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/models-config.providers.ollama.test.ts
+++ b/src/agents/models-config.providers.ollama.test.ts
@@ -3,11 +3,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
-import { resolveImplicitProviders, resolveOllamaApiBase } from "./models-config.providers.js";
+import {
+  resetOllamaDiscoveryFailureCacheForTests,
+  resolveImplicitProviders,
+  resolveOllamaApiBase,
+} from "./models-config.providers.js";
 
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
+  resetOllamaDiscoveryFailureCacheForTests();
 });
 
 describe("resolveOllamaApiBase", () => {

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -146,6 +146,7 @@ const OLLAMA_BASE_URL = OLLAMA_NATIVE_BASE_URL;
 const OLLAMA_API_BASE_URL = OLLAMA_BASE_URL;
 const OLLAMA_SHOW_CONCURRENCY = 8;
 const OLLAMA_SHOW_MAX_MODELS = 200;
+const OLLAMA_DISCOVERY_FAILURE_TTL_MS = 5 * 60 * 1000;
 const OLLAMA_DEFAULT_CONTEXT_WINDOW = 128000;
 const OLLAMA_DEFAULT_MAX_TOKENS = 8192;
 const OLLAMA_DEFAULT_COST = {
@@ -154,6 +155,7 @@ const OLLAMA_DEFAULT_COST = {
   cacheRead: 0,
   cacheWrite: 0,
 };
+const ollamaDiscoveryFailureCacheUntilByApiBase = new Map<string, number>();
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 const OPENROUTER_DEFAULT_MODEL_ID = "auto";
@@ -238,6 +240,33 @@ export function resolveOllamaApiBase(configuredBaseUrl?: string): string {
   return trimmed.replace(/\/v1$/i, "");
 }
 
+export function resetOllamaDiscoveryFailureCacheForTests(): void {
+  ollamaDiscoveryFailureCacheUntilByApiBase.clear();
+}
+
+function hasRecentOllamaDiscoveryFailure(apiBase: string): boolean {
+  const expiresAt = ollamaDiscoveryFailureCacheUntilByApiBase.get(apiBase);
+  if (!expiresAt) {
+    return false;
+  }
+  if (expiresAt <= Date.now()) {
+    ollamaDiscoveryFailureCacheUntilByApiBase.delete(apiBase);
+    return false;
+  }
+  return true;
+}
+
+function noteOllamaDiscoveryFailure(apiBase: string): void {
+  ollamaDiscoveryFailureCacheUntilByApiBase.set(
+    apiBase,
+    Date.now() + OLLAMA_DISCOVERY_FAILURE_TTL_MS,
+  );
+}
+
+function clearOllamaDiscoveryFailure(apiBase: string): void {
+  ollamaDiscoveryFailureCacheUntilByApiBase.delete(apiBase);
+}
+
 async function queryOllamaContextWindow(
   apiBase: string,
   modelName: string,
@@ -278,17 +307,24 @@ async function discoverOllamaModels(
   if (process.env.VITEST || process.env.NODE_ENV === "test") {
     return [];
   }
+  const apiBase = resolveOllamaApiBase(baseUrl);
+  if (opts?.quiet && hasRecentOllamaDiscoveryFailure(apiBase)) {
+    return [];
+  }
   try {
-    const apiBase = resolveOllamaApiBase(baseUrl);
     const response = await fetch(`${apiBase}/api/tags`, {
       signal: AbortSignal.timeout(5000),
     });
     if (!response.ok) {
+      if (opts?.quiet) {
+        noteOllamaDiscoveryFailure(apiBase);
+      }
       if (!opts?.quiet) {
         log.warn(`Failed to discover Ollama models: ${response.status}`);
       }
       return [];
     }
+    clearOllamaDiscoveryFailure(apiBase);
     const data = (await response.json()) as OllamaTagsResponse;
     if (!data.models || data.models.length === 0) {
       log.debug("No Ollama models found on local instance");
@@ -324,6 +360,9 @@ async function discoverOllamaModels(
     }
     return discovered;
   } catch (error) {
+    if (opts?.quiet) {
+      noteOllamaDiscoveryFailure(apiBase);
+    }
     if (!opts?.quiet) {
       log.warn(`Failed to discover Ollama models: ${String(error)}`);
     }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: implicit Ollama autodiscovery retried `/api/tags` on every provider rebuild when local Ollama was unreachable, causing repeated network/proxy hits.
- Why it matters: in proxy environments this can create request storms and high CPU usage.
- What changed: added short negative-failure caching for implicit (`quiet`) Ollama discovery failures, with automatic cache clear on successful probe.
- What did NOT change (scope boundary): explicit Ollama configuration behavior and successful model discovery flow are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31846
- Related #29201

## User-visible / Behavior Changes

- When implicit local Ollama discovery fails repeatedly, OpenClaw now throttles re-probes for a short TTL instead of probing every rebuild loop.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node local test run
- Model/provider: Ollama implicit provider discovery
- Integration/channel (if any): N/A
- Relevant config (redacted): no explicit Ollama config, local Ollama unreachable

### Steps

1. Simulate unreachable local Ollama for implicit discovery (`fetch` rejects on `127.0.0.1:11434/api/tags`).
2. Trigger provider resolution multiple times.
3. Verify repeated calls are suppressed within TTL.

### Expected

- First failure probes network once.
- Subsequent implicit probes within TTL skip network call.

### Actual

- Before fix: each provider rebuild retried network probe.
- After fix: implicit failures are negative-cached and throttled.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test src/agents/models-config.providers.ollama-autodiscovery.test.ts src/agents/models-config.providers.ollama.test.ts`
- Passed: 2 files, 17 tests
- Added regression test: `negative-caches implicit unreachable discovery failures`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - implicit unreachable discovery now caches failures and suppresses immediate retries.
  - cache is cleared on successful `/api/tags` response.
  - existing Ollama discovery tests remain green.
- Edge cases checked:
  - cache reset helper used in tests to avoid cross-test contamination.
- What you did **not** verify:
  - live proxy CPU behavior in a production environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `adac5ffd8`.
- Files/config to restore:
  - `src/agents/models-config.providers.ts`
  - `src/agents/models-config.providers.ollama-autodiscovery.test.ts`
  - `src/agents/models-config.providers.ollama.test.ts`
- Known bad symptoms reviewers should watch for:
  - stale throttling if cache is not cleared after Ollama becomes reachable (covered by success-path cache clear).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: transient failures may delay immediate rediscovery for up to TTL.
  - Mitigation: TTL is short and only applied to implicit quiet probes; explicit configured paths still surface warnings and perform normal probing.
