### PR TITLE
fix(slack): guard against undefined text in includes calls during mention handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Mentions/Slack formatting hardening: add null-safe guards for runtime text normalization paths so malformed/undefined text payloads do not crash mention stripping or mrkdwn conversion. (#31865) Thanks @stone-jin.
 - Failover/error classification: treat HTTP `529` (provider overloaded, common with Anthropic-compatible APIs) as `rate_limit` so model failover can engage instead of misclassifying the error path. (#31854) Thanks @bugkill3r.
 - Voice-call/webhook routing: require exact webhook path matches (instead of prefix matches) so lookalike paths cannot reach provider verification/dispatch logic. (#31930) Thanks @afurm.
 - Web UI/config form: support SecretInput string-or-secret-ref unions in map `additionalProperties`, so provider API key fields stay editable instead of being marked unsupported. (#31866) Thanks @ningding97.

--- a/src/auto-reply/reply/mentions.test.ts
+++ b/src/auto-reply/reply/mentions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { stripStructuralPrefixes } from "./mentions.js";
+
+describe("stripStructuralPrefixes", () => {
+  it("returns empty string for undefined input at runtime", () => {
+    expect(stripStructuralPrefixes(undefined as unknown as string)).toBe("");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripStructuralPrefixes("")).toBe("");
+  });
+
+  it("strips sender prefix labels", () => {
+    expect(stripStructuralPrefixes("John: hello")).toBe("hello");
+  });
+
+  it("passes through plain text", () => {
+    expect(stripStructuralPrefixes("just a message")).toBe("just a message");
+  });
+});

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -111,6 +111,9 @@ export function matchesMentionWithExplicit(params: {
 }
 
 export function stripStructuralPrefixes(text: string): string {
+  if (!text) {
+    return "";
+  }
   // Ignore wrapper labels, timestamps, and sender prefixes so directive-only
   // detection still works in group batches that include history/context.
   const afterMarker = text.includes(CURRENT_MESSAGE_MARKER)

--- a/src/slack/format.test.ts
+++ b/src/slack/format.test.ts
@@ -57,6 +57,10 @@ describe("markdownToSlackMrkdwn", () => {
       "*Important:* Check the _docs_ at <https://example.com|link>\n\n• first\n• second",
     );
   });
+
+  it("does not throw when input is undefined at runtime", () => {
+    expect(markdownToSlackMrkdwn(undefined as unknown as string)).toBe("");
+  });
 });
 
 describe("escapeSlackMrkdwn", () => {

--- a/src/slack/format.ts
+++ b/src/slack/format.ts
@@ -28,6 +28,9 @@ function isAllowedSlackAngleToken(token: string): boolean {
 }
 
 function escapeSlackMrkdwnContent(text: string): string {
+  if (!text) {
+    return "";
+  }
   if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
     return text;
   }
@@ -53,6 +56,9 @@ function escapeSlackMrkdwnContent(text: string): string {
 }
 
 function escapeSlackMrkdwnText(text: string): string {
+  if (!text) {
+    return "";
+  }
   if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
     return text;
   }


### PR DESCRIPTION
## Summary

- Add defensive null/undefined guards to `stripStructuralPrefixes` in `src/auto-reply/reply/mentions.ts` and `escapeSlackMrkdwnContent`/`escapeSlackMrkdwnText` in `src/slack/format.ts`
- These functions call `.includes()` on their `text` parameter without checking for undefined, causing `Cannot read properties of undefined (reading 'includes')` when the bot is @mentioned in Slack

Closes #31851

## Changes

- **`src/auto-reply/reply/mentions.ts`**: Add early return for falsy `text` in `stripStructuralPrefixes`
- **`src/slack/format.ts`**: Add early return for falsy `text` in `escapeSlackMrkdwnContent` and `escapeSlackMrkdwnText`
- **`src/auto-reply/reply/mentions.test.ts`**: New test file covering undefined/empty/normal inputs
- **`src/slack/format.test.ts`**: Added test for undefined input to `markdownToSlackMrkdwn`

## Test plan

- [x] Unit tests pass for undefined input scenarios
- [x] Existing tests continue to pass
- [ ] Manual test: mention @Bot in Slack channel — should respond without throwing

Made with [Cursor](https://cursor.com)