### PR TITLE
fix(ui): handle SecretInput union in config form analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Web UI/config form: support SecretInput string-or-secret-ref unions in map `additionalProperties`, so provider API key fields stay editable instead of being marked unsupported. (#31866) Thanks @ningding97.
 - Slack/Bolt startup compatibility: remove invalid `message.channels` and `message.groups` event registrations so Slack providers no longer crash on startup with Bolt 4.6+; channel/group traffic continues through the unified `message` handler (`channel_type`). (#32033) Thanks @mahopan.
 - Telegram: guard duplicate-token checks and gateway startup token normalization when account tokens are missing, preventing `token.trim()` crashes during status/start flows. (#31973) Thanks @ningding97.
 - Skills/sherpa-onnx-tts: run the `sherpa-onnx-tts` bin under ESM (replace CommonJS `require` imports) and add regression coverage to prevent `require is not defined in ES module scope` startup crashes. (#31965) Thanks @bmendonca3.

--- a/ui/src/ui/config-form.browser.test.ts
+++ b/ui/src/ui/config-form.browser.test.ts
@@ -304,6 +304,83 @@ describe("config form renderer", () => {
     expect(noMatchContainer.textContent).toContain('No settings match "mode tag:security"');
   });
 
+  it("supports SecretInput unions in additionalProperties maps", () => {
+    const onPatch = vi.fn();
+    const container = document.createElement("div");
+    const schema = {
+      type: "object",
+      properties: {
+        models: {
+          type: "object",
+          properties: {
+            providers: {
+              type: "object",
+              additionalProperties: {
+                type: "object",
+                properties: {
+                  apiKey: {
+                    anyOf: [
+                      { type: "string" },
+                      {
+                        oneOf: [
+                          {
+                            type: "object",
+                            properties: {
+                              source: { type: "string", const: "env" },
+                              provider: { type: "string" },
+                              id: { type: "string" },
+                            },
+                            required: ["source", "provider", "id"],
+                            additionalProperties: false,
+                          },
+                          {
+                            type: "object",
+                            properties: {
+                              source: { type: "string", const: "file" },
+                              provider: { type: "string" },
+                              id: { type: "string" },
+                            },
+                            required: ["source", "provider", "id"],
+                            additionalProperties: false,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const analysis = analyzeConfigSchema(schema);
+    expect(analysis.unsupportedPaths).not.toContain("models.providers");
+    expect(analysis.unsupportedPaths).not.toContain("models.providers.*.apiKey");
+
+    render(
+      renderConfigForm({
+        schema: analysis.schema,
+        uiHints: {
+          "models.providers.*.apiKey": { sensitive: true },
+        },
+        unsupportedPaths: analysis.unsupportedPaths,
+        value: { models: { providers: { openai: { apiKey: "old" } } } },
+        onPatch,
+      }),
+      container,
+    );
+
+    const apiKeyInput: HTMLInputElement | null = container.querySelector("input[type='password']");
+    expect(apiKeyInput).not.toBeNull();
+    if (!apiKeyInput) {
+      return;
+    }
+    apiKeyInput.value = "new-key";
+    apiKeyInput.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenCalledWith(["models", "providers", "openai", "apiKey"], "new-key");
+  });
+
   it("flags unsupported unions", () => {
     const schema = {
       type: "object",

--- a/ui/src/ui/views/config-form.analyze.ts
+++ b/ui/src/ui/views/config-form.analyze.ts
@@ -118,6 +118,58 @@ function normalizeSchemaNode(
   };
 }
 
+function isSecretRefVariant(entry: JsonSchema): boolean {
+  if (schemaType(entry) !== "object") {
+    return false;
+  }
+  const source = entry.properties?.source;
+  const provider = entry.properties?.provider;
+  const id = entry.properties?.id;
+  if (!source || !provider || !id) {
+    return false;
+  }
+  return (
+    typeof source.const === "string" &&
+    schemaType(provider) === "string" &&
+    schemaType(id) === "string"
+  );
+}
+
+function isSecretRefUnion(entry: JsonSchema): boolean {
+  const variants = entry.oneOf ?? entry.anyOf;
+  if (!variants || variants.length === 0) {
+    return false;
+  }
+  return variants.every((variant) => isSecretRefVariant(variant));
+}
+
+function normalizeSecretInputUnion(
+  schema: JsonSchema,
+  path: Array<string | number>,
+  remaining: JsonSchema[],
+  nullable: boolean,
+): ConfigSchemaAnalysis | null {
+  const stringIndex = remaining.findIndex((entry) => schemaType(entry) === "string");
+  if (stringIndex < 0) {
+    return null;
+  }
+  const nonString = remaining.filter((_, index) => index !== stringIndex);
+  if (nonString.length !== 1 || !isSecretRefUnion(nonString[0])) {
+    return null;
+  }
+  return normalizeSchemaNode(
+    {
+      ...schema,
+      ...remaining[stringIndex],
+      nullable,
+      anyOf: undefined,
+      oneOf: undefined,
+      allOf: undefined,
+    },
+    path,
+  );
+}
+
 function normalizeUnion(
   schema: JsonSchema,
   path: Array<string | number>,
@@ -159,6 +211,13 @@ function normalizeUnion(
       continue;
     }
     remaining.push(entry);
+  }
+
+  // Config secrets accept either a raw key string or a structured secret ref object.
+  // The form only supports editing the string path for now.
+  const secretInput = normalizeSecretInputUnion(schema, path, remaining, nullable);
+  if (secretInput) {
+    return secretInput;
   }
 
   if (literals.length > 0 && remaining.length === 0) {


### PR DESCRIPTION
## Summary
Fix Config Form view marking `models.providers` as unsupported due to SecretInputSchema union.

## Root Cause
SecretInputSchema creates a `oneOf` union (string | secret-ref object) that the form analyzer cannot handle, causing it to mark the entire providers section as unsupported.

## Fix
- Add `isSecretRefUnion()` detection for secret-ref object variants
- Normalize secret-input unions to plain string type for form display
- Users can still enter API keys as strings; secret-ref resolution happens at runtime

Closes #31490