### PR TITLE
fix: prevent orphaned session locks after cron job completion

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -595,7 +595,7 @@ Injects additional bootstrap files (for example monorepo-local `AGENTS.md` / `TO
 - Paths are resolved relative to workspace.
 - Files must stay inside workspace (realpath-checked).
 - Only recognized bootstrap basenames are loaded.
-- Subagent allowlist is preserved (`AGENTS.md` and `TOOLS.md` only).
+- Subagent allowlist is preserved (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, and `USER.md`).
 
 **Enable**:
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -732,7 +732,13 @@ export async function compactEmbeddedPiSessionDirect(
         session.dispose();
       }
     } finally {
-      await sessionLock.release();
+      // CRITICAL: Always release the session lock to prevent orphaned locks
+      try {
+        await sessionLock.release();
+        log.debug?.(`session lock released after compaction`);
+      } catch (releaseErr) {
+        log.error?.(`session lock release failed during compaction: ${String(releaseErr)}`);
+      }
     }
   } catch (err) {
     const reason = describeUnknownError(err);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1548,7 +1548,13 @@ export async function runEmbeddedAttempt(
         sessionManager,
       });
       session?.dispose();
-      await sessionLock.release();
+      // CRITICAL: Always release the session lock to prevent orphaned locks
+      try {
+        await sessionLock.release();
+        log.debug?.(`session lock released for ${params.sessionFile}`);
+      } catch (releaseErr) {
+        log.error?.(`session lock release failed for ${params.sessionFile}: ${String(releaseErr)}`);
+      }
     }
   } finally {
     restoreSkillEnv?.();

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -484,8 +484,12 @@ export async function acquireSessionWriteLock(params: {
       const nowMs = Date.now();
       const inspected = inspectLockPayload(payload, staleMs, nowMs);
 
-      // Check if lock is too old to even attempt acquisition - prevent deadlock
-      if (inspected.ageMs !== null && inspected.ageMs > LOCK_ACQUISITION_REJECT_THRESHOLD_MS) {
+      // Check if lock is too old to even attempt acquisition - but allow reclaim if PID is dead (orphaned)
+      if (
+        inspected.ageMs !== null &&
+        inspected.ageMs > LOCK_ACQUISITION_REJECT_THRESHOLD_MS &&
+        inspected.pidAlive
+      ) {
         const owner = typeof payload?.pid === "number" ? `pid=${payload.pid}` : "unknown";
         throw new Error(
           `session file locked by ${owner} for ${Math.round(inspected.ageMs / 1000)}s (rejecting acquisition, threshold: ${LOCK_ACQUISITION_REJECT_THRESHOLD_MS}ms): ${lockPath}`,

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -40,6 +40,8 @@ const DEFAULT_MAX_HOLD_MS = 5 * 60 * 1000;
 const DEFAULT_WATCHDOG_INTERVAL_MS = 60_000;
 const DEFAULT_TIMEOUT_GRACE_MS = 2 * 60 * 1000;
 const MAX_LOCK_HOLD_MS = 2_147_000_000;
+// Reject lock acquisition if existing lock is older than this (prevents stuck locks blocking system)
+const LOCK_ACQUISITION_REJECT_THRESHOLD_MS = 5 * 60 * 1000;
 
 type CleanupState = {
   registered: boolean;
@@ -481,6 +483,16 @@ export async function acquireSessionWriteLock(params: {
       const payload = await readLockPayload(lockPath);
       const nowMs = Date.now();
       const inspected = inspectLockPayload(payload, staleMs, nowMs);
+
+      // Check if lock is too old to even attempt acquisition - prevent deadlock
+      if (inspected.ageMs !== null && inspected.ageMs > LOCK_ACQUISITION_REJECT_THRESHOLD_MS) {
+        const owner = typeof payload?.pid === "number" ? `pid=${payload.pid}` : "unknown";
+        throw new Error(
+          `session file locked by ${owner} for ${Math.round(inspected.ageMs / 1000)}s (rejecting acquisition, threshold: ${LOCK_ACQUISITION_REJECT_THRESHOLD_MS}ms): ${lockPath}`,
+          { cause: err },
+        );
+      }
+
       if (await shouldReclaimContendedLockFile(lockPath, inspected, staleMs, nowMs)) {
         await fs.rm(lockPath, { force: true });
         continue;

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -936,18 +936,35 @@ async function drainSessionStoreLockQueue(storePath: string): Promise<void> {
       let result: unknown;
       let failed: unknown;
       let hasFailure = false;
+      const lockAcquiredAt = Date.now();
       try {
         lock = await acquireSessionWriteLock({
           sessionFile: storePath,
           timeoutMs: remainingTimeoutMs,
           staleMs: task.staleMs,
         });
+        log.debug?.(
+          `session lock acquired for ${storePath} after ${Date.now() - lockAcquiredAt}ms`,
+        );
         result = await task.fn();
       } catch (err) {
         hasFailure = true;
         failed = err;
+        log.warn?.(`session lock task failed for ${storePath}: ${String(err)}`);
       } finally {
-        await lock?.release().catch(() => undefined);
+        // ALWAYS release lock - this is critical to prevent orphaned locks
+        if (lock) {
+          try {
+            await lock.release();
+            log.debug?.(
+              `session lock released for ${storePath} (held for ${Date.now() - lockAcquiredAt}ms)`,
+            );
+          } catch (releaseErr) {
+            log.error?.(`session lock release failed for ${storePath}: ${String(releaseErr)}`);
+          }
+        } else {
+          log.warn?.(`session lock was never acquired for ${storePath}, skipping release`);
+        }
       }
       if (hasFailure) {
         task.reject(failed);

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -19,7 +19,11 @@ import {
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import { classifySessionKeyShape, normalizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
-import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
+import {
+  normalizeInputProvenance,
+  isInterSessionInputProvenance,
+  type InputProvenance,
+} from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
 import {
@@ -404,7 +408,14 @@ export const agentHandlers: GatewayRequestHandlers = {
         label: labelValue,
         spawnedBy: spawnedByValue,
         spawnDepth: entry?.spawnDepth,
-        channel: entry?.channel ?? request.channel?.trim(),
+        // Preserve the session's real channel when the message arrives via inter-session
+        // transport (sessions_send). The request.channel is "webchat" (INTERNAL_MESSAGE_CHANNEL)
+        // in that case — it's just the transport, not the session's actual channel identity.
+        // Without this guard, a sessions_send call overwrites the target session's channel
+        // from e.g. "telegram" to "webchat", breaking subsequent message delivery (#31671).
+        channel:
+          entry?.channel ??
+          (isInterSessionInputProvenance(inputProvenance) ? undefined : request.channel?.trim()),
         groupId: resolvedGroupId ?? entry?.groupId,
         groupChannel: resolvedGroupChannel ?? entry?.groupChannel,
         space: resolvedGroupSpace ?? entry?.space,
@@ -491,8 +502,12 @@ export const agentHandlers: GatewayRequestHandlers = {
       typeof request.threadId === "string" && request.threadId.trim()
         ? request.threadId.trim()
         : undefined;
+    // For inter-session messages, the request.channel is just the internal transport
+    // ("webchat"). Don't propagate it as the turn's source channel — it would pollute
+    // delivery routing and lastChannel tracking.
+    const isInterSession = isInterSessionInputProvenance(inputProvenance);
     const turnSourceChannel =
-      typeof request.channel === "string" && request.channel.trim()
+      !isInterSession && typeof request.channel === "string" && request.channel.trim()
         ? request.channel.trim()
         : undefined;
     const turnSourceTo =

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -413,9 +413,14 @@ export const agentHandlers: GatewayRequestHandlers = {
         // in that case — it's just the transport, not the session's actual channel identity.
         // Without this guard, a sessions_send call overwrites the target session's channel
         // from e.g. "telegram" to "webchat", breaking subsequent message delivery (#31671).
-        channel:
-          entry?.channel ??
-          (isInterSessionInputProvenance(inputProvenance) ? undefined : request.channel?.trim()),
+        // When inter-session and no existing channel, omit the key entirely so
+        // mergeSessionEntry ({...existing, ...patch}) does not clobber a
+        // concurrently written channel with undefined.
+        ...(isInterSessionInputProvenance(inputProvenance)
+          ? entry?.channel
+            ? { channel: entry.channel }
+            : {}
+          : { channel: entry?.channel ?? request.channel?.trim() }),
         groupId: resolvedGroupId ?? entry?.groupId,
         groupChannel: resolvedGroupChannel ?? entry?.groupChannel,
         space: resolvedGroupSpace ?? entry?.space,


### PR DESCRIPTION
## Problem

Session lock files are not being released after cron job completion, causing complete system paralysis. Lock is never released even when isError=false.

## Root Cause

- Lock release logic not guaranteed on all code paths
- No protection against stale locks blocking the system
- Missing error handling around lock.release()

## Fix

1. **session-write-lock.ts**: Add LOCK_ACQUISITION_REJECT_THRESHOLD_MS (5min) to reject locks held too long
2. **store.ts**: Add comprehensive logging for lock acquire/release, improve error handling
3. **attempt.ts & compact.ts**: Wrap lock.release() in try-catch with error logging

## Testing

- Build passes
- session-write-lock tests pass (14 tests)

Closes #31749