### PR TITLE
fix: resolve two pre-existing TS errors blocking CI check job

### DIFF
--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -136,6 +136,7 @@ async function processMessage(
   }
 
   const isGroup = message.isGroup;
+  const chatId = message.threadId;
   const senderId = message.senderId?.trim();
   if (!senderId) {
     logVerbose(core, runtime, `zalouser: drop message ${chatId} (missing senderId)`);
@@ -143,7 +144,6 @@ async function processMessage(
   }
   const senderName = message.senderName ?? "";
   const groupName = message.groupName ?? "";
-  const chatId = message.threadId;
 
   const defaultGroupPolicy = resolveDefaultGroupPolicy(config);
   const { groupPolicy, providerMissingFallbackApplied } = resolveOpenProviderRuntimeGroupPolicy({

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../../runtime.js";
 
 const loadAndMaybeMigrateDoctorConfigMock = vi.hoisted(() => vi.fn());
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
@@ -44,8 +45,8 @@ async function withCapturedStdout(run: () => Promise<void>): Promise<string> {
 
 describe("ensureConfigReady", () => {
   let ensureConfigReady: (params: {
-    runtime: unknown;
-    commandPath: string[];
+    runtime: RuntimeEnv;
+    commandPath?: string[];
     suppressDoctorStdout?: boolean;
   }) => Promise<void>;
   let resetConfigGuardStateForTests: () => void;


### PR DESCRIPTION
## Summary

- Problem: Two pre-existing TypeScript errors on `main` cause the CI `check` job to fail for all open PRs
- Why it matters: Blocks CI for every PR targeting `main`
- What changed:
  1. `extensions/zalouser/src/monitor.ts`: moved `const chatId = message.threadId` above the `senderId` guard that references it (TS2448: variable used before declaration)
  2. `src/cli/program/config-guard.test.ts`: aligned the local type annotation for `ensureConfigReady` with the actual function signature (`runtime: RuntimeEnv`, `commandPath?: string[]`) — was `runtime: unknown`, `commandPath: string[]` (TS2322)
- What did NOT change (scope boundary): No logic changes — declaration ordering fix and type annotation fix only

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations
- [x] UI / DX

## Linked Issue/PR

- Related: zalouser error introduced by ee1b14763 (`fix(zalouser): harden inbound sender id handling`)
- Related: config-guard error introduced by 22c3eed36 (`fix(cli): config guard test adjustments`)

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node 22+

### Steps

1. `pnpm tsgo` on current `main`

### Expected

- Clean typecheck (ignoring optional-dep module-not-found errors)

### Actual

- `TS2448` at `extensions/zalouser/src/monitor.ts:141:57`
- `TS2322` at `src/cli/program/config-guard.test.ts:71:7`

## Evidence

- [x] Failing test/log before + passing after: `pnpm tsgo` shows both errors on `main`, neither after this fix
- [x] Tests pass: `pnpm test extensions/zalouser/` (5/5 that run), `pnpm test src/cli/program/config-guard.test.ts` (8/8)

## Human Verification (required)

- Verified scenarios: `pnpm tsgo` clean after fix; both test suites pass
- Edge cases checked: zalouser `chatId` value (`message.threadId`) doesn't depend on anything between old and new positions; config-guard test uses `as never` cast at call site so the type change is safe
- What you did **not** verify: Runtime zalouser message flow (no zalouser account available)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the two commits
- Known bad symptoms reviewers should watch for: None

## Risks and Mitigations

None