### PR TITLE
fix(tsgo): unblock baseline type errors

### DIFF
--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -136,6 +136,7 @@ async function processMessage(
   }
 
   const isGroup = message.isGroup;
+  const chatId = message.threadId;
   const senderId = message.senderId?.trim();
   if (!senderId) {
     logVerbose(core, runtime, `zalouser: drop message ${chatId} (missing senderId)`);
@@ -143,7 +144,6 @@ async function processMessage(
   }
   const senderName = message.senderName ?? "";
   const groupName = message.groupName ?? "";
-  const chatId = message.threadId;
 
   const defaultGroupPolicy = resolveDefaultGroupPolicy(config);
   const { groupPolicy, providerMissingFallbackApplied } = resolveOpenProviderRuntimeGroupPolicy({

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../../runtime.js";
 
 const loadAndMaybeMigrateDoctorConfigMock = vi.hoisted(() => vi.fn());
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
@@ -44,8 +45,8 @@ async function withCapturedStdout(run: () => Promise<void>): Promise<string> {
 
 describe("ensureConfigReady", () => {
   let ensureConfigReady: (params: {
-    runtime: unknown;
-    commandPath: string[];
+    runtime: RuntimeEnv;
+    commandPath?: string[];
     suppressDoctorStdout?: boolean;
   }) => Promise<void>;
   let resetConfigGuardStateForTests: () => void;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: latest `main` fails `pnpm tsgo` on two unrelated baseline errors.
- Why it matters: these baseline failures block landing unrelated PRs, including the #28821 replacement.
- What changed: moved `chatId` initialization before first usage in Zalo user monitor and aligned `ensureConfigReady` test typing to the imported function signature.
- What did NOT change (scope boundary): no runtime behavior changes beyond fixing an obvious variable-ordering bug in logging path; no config flow logic changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #28821

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): zalouser + CLI program tests
- Relevant config (redacted): N/A

### Steps

1. On pre-fix baseline, run `pnpm tsgo`.
2. Observe TS errors in `extensions/zalouser/src/monitor.ts` and `src/cli/program/config-guard.test.ts`.
3. Apply this patch and rerun checks.

### Expected

- Typecheck and repo checks pass.

### Actual

- `pnpm tsgo` and `pnpm check` both pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm tsgo`, `pnpm check`, `pnpm test extensions/zalouser/src/monitor.test.ts src/cli/program/config-guard.test.ts`.
- Edge cases checked: missing senderId log path still references stable thread id variable; config-guard tests still execute/passed.
- What you did **not** verify: full `pnpm test` suite.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `extensions/zalouser/src/monitor.ts`, `src/cli/program/config-guard.test.ts`.
- Known bad symptoms reviewers should watch for: `pnpm tsgo` regressions on the same two files.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: test typing alignment could conceal future signature drift.
  - Mitigation: typing now exactly follows imported signature constraints, so drift surfaces in compile-time checks.
