### PR TITLE
fix(exec): resolve PATH key case-insensitively for Windows pathPrepend

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -4,12 +4,12 @@ import { Type } from "@sinclair/typebox";
 import type { ExecAsk, ExecHost, ExecSecurity } from "../infra/exec-approvals.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
-import { mergePathPrepend } from "../infra/path-prepend.js";
+import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
-export { applyPathPrepend, normalizePathPrepend } from "../infra/path-prepend.js";
+export { applyPathPrepend, findPathKey, normalizePathPrepend } from "../infra/path-prepend.js";
 import { logWarn } from "../logger.js";
 import type { ManagedRun } from "../process/supervisor/index.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
@@ -210,9 +210,10 @@ export function applyShellPath(env: Record<string, string>, shellPath?: string |
   if (entries.length === 0) {
     return;
   }
-  const merged = mergePathPrepend(env.PATH, entries);
+  const pathKey = findPathKey(env);
+  const merged = mergePathPrepend(env[pathKey], entries);
   if (merged) {
-    env.PATH = merged;
+    env[pathKey] = merged;
   }
 }
 

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { applyPathPrepend, findPathKey } from "../infra/path-prepend.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
 import { captureEnv } from "../test-utils/env.js";
 import { getFinishedSession, resetProcessRegistryForTests } from "./bash-process-registry.js";
@@ -545,5 +546,59 @@ describe("exec PATH handling", () => {
     for (const index of prependIndexes) {
       expect(index).toBeLessThan(baseIndex);
     }
+  });
+});
+
+describe("findPathKey", () => {
+  it("returns PATH when key is uppercase", () => {
+    expect(findPathKey({ PATH: "/usr/bin" })).toBe("PATH");
+  });
+
+  it("returns Path when key is mixed-case (Windows style)", () => {
+    expect(findPathKey({ Path: "C:\\Windows\\System32" })).toBe("Path");
+  });
+
+  it("returns PATH as default when no PATH-like key exists", () => {
+    expect(findPathKey({ HOME: "/home/user" })).toBe("PATH");
+  });
+
+  it("prefers uppercase PATH when both PATH and Path exist", () => {
+    expect(findPathKey({ PATH: "/usr/bin", Path: "C:\\Windows" })).toBe("PATH");
+  });
+});
+
+describe("applyPathPrepend with case-insensitive PATH key", () => {
+  it("prepends to Path key on Windows-style env (no uppercase PATH)", () => {
+    const env: Record<string, string> = { Path: "C:\\Windows\\System32" };
+    applyPathPrepend(env, ["C:\\custom\\bin"]);
+    // Should write back to the same `Path` key, not create a new `PATH`
+    expect(env.Path).toContain("C:\\custom\\bin");
+    expect(env.Path).toContain("C:\\Windows\\System32");
+    expect("PATH" in env).toBe(false);
+  });
+
+  it("preserves all existing entries when prepending via Path key", () => {
+    // Use platform-appropriate paths and delimiters
+    const delim = path.delimiter;
+    const existing = isWin
+      ? ["C:\\Windows\\System32", "C:\\Windows", "C:\\Program Files\\nodejs"]
+      : ["/usr/bin", "/usr/local/bin", "/opt/node/bin"];
+    const prepend = isWin ? ["C:\\custom\\bin"] : ["/custom/bin"];
+    const existingPath = existing.join(delim);
+    const env: Record<string, string> = { Path: existingPath };
+    applyPathPrepend(env, prepend);
+    const parts = env.Path.split(delim);
+    expect(parts[0]).toBe(prepend[0]);
+    for (const entry of existing) {
+      expect(parts).toContain(entry);
+    }
+  });
+
+  it("respects requireExisting option with Path key", () => {
+    const env: Record<string, string> = { HOME: "/home/user" };
+    applyPathPrepend(env, ["C:\\custom\\bin"], { requireExisting: true });
+    // No Path/PATH key exists, so nothing should be written
+    expect("PATH" in env).toBe(false);
+    expect("Path" in env).toBe(false);
   });
 });

--- a/src/infra/path-prepend.ts
+++ b/src/infra/path-prepend.ts
@@ -1,5 +1,22 @@
 import path from "node:path";
 
+/**
+ * Find the actual key used for PATH in the env object.
+ * On Windows, `process.env` stores it as `Path` (not `PATH`),
+ * and after copying to a plain object the original casing is preserved.
+ */
+export function findPathKey(env: Record<string, string>): string {
+  if ("PATH" in env) {
+    return "PATH";
+  }
+  for (const key of Object.keys(env)) {
+    if (key.toUpperCase() === "PATH") {
+      return key;
+    }
+  }
+  return "PATH";
+}
+
 export function normalizePathPrepend(entries?: string[]) {
   if (!Array.isArray(entries)) {
     return [];
@@ -48,11 +65,15 @@ export function applyPathPrepend(
   if (!Array.isArray(prepend) || prepend.length === 0) {
     return;
   }
-  if (options?.requireExisting && !env.PATH) {
+  // On Windows the PATH key may be stored as `Path` (case-insensitive env vars).
+  // After coercing to a plain object the original casing is preserved, so we must
+  // look up the actual key to read the existing value and write the merged result back.
+  const pathKey = findPathKey(env);
+  if (options?.requireExisting && !env[pathKey]) {
     return;
   }
-  const merged = mergePathPrepend(env.PATH, prepend);
+  const merged = mergePathPrepend(env[pathKey], prepend);
   if (merged) {
-    env.PATH = merged;
+    env[pathKey] = merged;
   }
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: #28821 became unmergeable due a persistent GitHub head-ref sync mismatch (`head out of date` / stale reported head SHA).
- Why it matters: Windows PATH prepend behavior remains incorrect when PATH env key casing differs, and the original PR could not be landed reliably.
- What changed: this replacement PR carries the same patch from #28821 on top of current `main`.
- What did NOT change (scope boundary): no additional behavior beyond #28821 patch; no unrelated refactors.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #28821

## User-visible / Behavior Changes

- On Windows, PATH key resolution is now case-insensitive for path prepend logic, preventing missed PATH updates when env key casing differs.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (validation), Windows behavior covered by tests in patch
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Use the #28821 replacement branch on latest main.
2. Run full default gates.
3. Verify no regressions and patch semantics match original.

### Expected

- Full gates pass and Windows PATH case-insensitive behavior fix is present.

### Actual

- `pnpm build`, `pnpm check`, and `pnpm test:macmini` all pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm build`, `pnpm check`, `pnpm test:macmini` on replacement branch.
- Edge cases checked: ensured commit content/author of replacement commit matches original patch intent.
- What you did **not** verify: separate Windows host manual run.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/infra/path-prepend.ts`, `src/agents/bash-tools.exec-runtime.ts`, `src/agents/bash-tools.test.ts`.
- Known bad symptoms reviewers should watch for: PATH prepend not applying on Windows when key casing differs.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: behavior differences in non-Windows env path handling.
  - Mitigation: patch is constrained to case-insensitive key resolution logic and validated by full gate suite.

## Attribution

- Replacement for #28821 due GitHub head-sync merge blocker.
- Original patch author: @Glucksberg
