### PR TITLE
fix(discord): shard message queue by channel to avoid cross-channel blocking

### DIFF
--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -119,7 +119,7 @@ export function registerDiscordListener(listeners: Array<object>, listener: obje
 }
 
 export class DiscordMessageListener extends MessageCreateListener {
-  private messageQueue: Promise<void> = Promise.resolve();
+  private messageQueues = new Map<string, Promise<void>>();
 
   constructor(
     private handler: DiscordMessageHandler,
@@ -131,9 +131,9 @@ export class DiscordMessageListener extends MessageCreateListener {
 
   async handle(data: DiscordMessageEvent, client: Client) {
     this.onEvent?.();
-    // Release Carbon's dispatch lane immediately, but keep our message handler
-    // serialized to avoid unbounded parallel model/IO work on traffic bursts.
-    this.messageQueue = this.messageQueue
+    const channelId = String(data.channel_id ?? "global");
+    const prev = this.messageQueues.get(channelId) ?? Promise.resolve();
+    const next = prev
       .catch(() => {})
       .then(() =>
         runDiscordListenerWithSlowLog({
@@ -146,8 +146,14 @@ export class DiscordMessageListener extends MessageCreateListener {
             logger.error(danger(`discord handler failed: ${String(err)}`));
           },
         }),
-      );
-    void this.messageQueue.catch((err) => {
+      )
+      .finally(() => {
+        if (this.messageQueues.get(channelId) === next) {
+          this.messageQueues.delete(channelId);
+        }
+      });
+    this.messageQueues.set(channelId, next);
+    void next.catch((err) => {
       const logger = this.logger ?? discordEventQueueLog;
       logger.error(danger(`discord handler failed: ${String(err)}`));
     });


### PR DESCRIPTION
## Summary

- **Problem:** `DiscordMessageListener` chains all incoming messages onto a single `messageQueue: Promise<void>` per account. A slow agent turn (30–300s with tool calls) in one channel blocks processing for all channels and DMs under the same account.
- **Why it matters:** Users experience multi-minute delays on messages in unrelated channels. The health-monitor may detect these delays as "stuck" and restart the provider, compounding the problem with duplicate messages.
- **What changed:** Replaced the single `messageQueue` with a `Map<string, Promise<void>>` keyed by `data.channel_id`. Messages within the same channel remain serialized; cross-channel messages process in parallel. Map entries are cleaned up in `.finally()` to prevent unbounded growth.
- **What did NOT change:** Per-channel message ordering is preserved. Error handling and slow-log behavior unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31808

## User-visible / Behavior Changes

- Messages in different Discord channels now process concurrently instead of being serialized behind one global queue
- Reduces perceived latency for multi-channel Discord deployments

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime: Node.js v22
- Integration/channel: Discord

### Steps

1. Configure multiple Discord channels under one account
2. Send a message in channel A that triggers a long agent turn (tool calls, etc.)
3. Send a message in channel B during channel A's processing

### Expected

- Channel B message processes immediately, not blocked by channel A

### Actual

- Before fix: Channel B waits for channel A's turn to complete
- After fix: Channel B processes in parallel

## Evidence

Test results (40/40 passing):
```
✓ src/discord/monitor.test.ts (40 tests) 118ms
  Tests  40 passed (40)
```

## Human Verification (required)

- Verified scenarios: All 40 Discord monitor tests pass, per-channel serialization preserved, cleanup in .finally()
- Edge cases checked: missing channel_id (falls back to "global" key), Map entry cleanup on completion, concurrent access to same channel
- What I did **not** verify: Live multi-channel Discord test

## Compatibility / Migration

- Backward compatible? `Yes` — per-channel ordering preserved
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Restore single `messageQueue` field
- Files/config to restore: `src/discord/monitor/listeners.ts`
- Known bad symptoms: If sharding causes issues, messages might process out of order across channels (but they were never ordered cross-channel before either)

## Risks and Mitigations

- Risk: Increased concurrent model/IO load from parallel channel processing → Mitigated by existing `maxConcurrent` agent setting and per-channel debouncer
- Risk: Map memory growth → Mitigated by `.finally()` cleanup that deletes entries when the promise chain settles
