### PR TITLE
fix(slack): apply mrkdwn conversion to all outbound text paths

### DIFF
--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -5,6 +5,7 @@ import { resolveSlackAccount } from "./accounts.js";
 import { buildSlackBlocksFallbackText } from "./blocks-fallback.js";
 import { validateSlackBlocksArray } from "./blocks-input.js";
 import { createSlackWebClient } from "./client.js";
+import { normalizeSlackOutboundText } from "./format.js";
 import { resolveSlackMedia } from "./monitor/media.js";
 import type { SlackMediaResult } from "./monitor/media.js";
 import { sendMessageSlack } from "./send.js";
@@ -182,10 +183,11 @@ export async function editSlackMessage(
   const client = await getClient(opts);
   const blocks = opts.blocks == null ? undefined : validateSlackBlocksArray(opts.blocks);
   const trimmedContent = content.trim();
+  const converted = trimmedContent ? normalizeSlackOutboundText(trimmedContent) : trimmedContent;
   await client.chat.update({
     channel: channelId,
     ts: messageId,
-    text: trimmedContent || (blocks ? buildSlackBlocksFallbackText(blocks) : " "),
+    text: converted || (blocks ? buildSlackBlocksFallbackText(blocks) : " "),
     ...(blocks ? { blocks } : {}),
   });
 }

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -18,7 +18,7 @@ import { resolveSlackAccount } from "./accounts.js";
 import { buildSlackBlocksFallbackText } from "./blocks-fallback.js";
 import { validateSlackBlocksArray } from "./blocks-input.js";
 import { createSlackWebClient } from "./client.js";
-import { markdownToSlackMrkdwnChunks } from "./format.js";
+import { markdownToSlackMrkdwnChunks, normalizeSlackOutboundText } from "./format.js";
 import { parseSlackTarget } from "./targets.js";
 import { resolveSlackBotToken } from "./token.js";
 
@@ -280,7 +280,8 @@ export async function sendMessageSlack(
     if (opts.mediaUrl) {
       throw new Error("Slack send does not support blocks with mediaUrl");
     }
-    const fallbackText = trimmedMessage || buildSlackBlocksFallbackText(blocks);
+    const fallbackRaw = trimmedMessage || buildSlackBlocksFallbackText(blocks);
+    const fallbackText = fallbackRaw ? normalizeSlackOutboundText(fallbackRaw) : fallbackRaw;
     const response = await postSlackMessageBestEffort({
       client,
       channelId,
@@ -310,7 +311,7 @@ export async function sendMessageSlack(
     markdownToSlackMrkdwnChunks(markdown, chunkLimit, { tableMode }),
   );
   if (!chunks.length && trimmedMessage) {
-    chunks.push(trimmedMessage);
+    chunks.push(normalizeSlackOutboundText(trimmedMessage));
   }
   const mediaMaxBytes =
     typeof account.config.mediaMaxMb === "number"


### PR DESCRIPTION
## Summary

- **Problem:** Several Slack outbound text paths bypass the existing Markdown-to-mrkdwn conversion, causing raw Markdown syntax to appear in Slack messages (bold as `**text**` instead of `*text*`, links as `[text](url)` instead of `<url|text>`).
- **Why it matters:** Users see unrendered Markdown in editMessage tool results, preview finalizations, and block fallback text.
- **What changed:** Applied `normalizeSlackOutboundText` to 3 remaining uncovered paths: (1) `editSlackMessage` in actions.ts, (2) blocks fallback text in send.ts, (3) empty-chunks fallback in send.ts. The dispatch.ts preview path was fixed upstream.
- **What did NOT change:** The main `sendMessageSlack` path already used `markdownToSlackMrkdwnChunks` — that path is unchanged. Native streaming (`markdown_text`) is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31682

## User-visible / Behavior Changes

- Slack messages edited via the `editMessage` tool now render bold, links, and strikethrough correctly.
- Preview finalization edits now render correctly.
- Block fallback text is now properly converted.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js v22+
- Integration/channel: Slack

### Steps

1. Use the editMessage tool to update a Slack message with `**bold**` text
2. Observe the rendered output

### Expected

- Text renders as bold in Slack

### Actual

- Before fix: Raw `**bold**` appears
- After fix: Text renders as bold

## Evidence

The existing `markdownToSlackMrkdwn` function handles all conversion logic — this PR simply extends its usage to previously uncovered code paths.

## Human Verification (required)

- Verified scenarios: editSlackMessage, preview finalization, blocks fallback, empty-chunks fallback
- Edge cases checked: Empty text, partial streaming text (safe — incomplete patterns pass through)
- What I did **not** verify: Live Slack deployment

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the `markdownToSlackMrkdwn` calls from the 4 paths
- Files/config to restore: `src/slack/actions.ts`, `src/slack/send.ts`, `src/slack/monitor/message-handler/dispatch.ts`
- Known bad symptoms: Over-conversion of already-converted text (unlikely — conversion is idempotent for mrkdwn)

## Risks and Mitigations

None — the conversion function is already battle-tested on the main send path.
