### PR TITLE
fix(agents): prevent and recover from tool_use_id transcript corruption

### DIFF
--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -203,15 +203,15 @@ export function installSessionToolResultGuard(
       return originalAppend(persisted as never);
     }
 
-    // Skip tool call extraction for aborted/errored assistant messages.
-    // When stopReason is "error" or "aborted", the tool_use blocks may be incomplete
-    // and should not have synthetic tool_results created. Creating synthetic results
-    // for incomplete tool calls causes API 400 errors:
-    // "unexpected tool_use_id found in tool_result blocks"
-    // This matches the behavior in repairToolUseResultPairing (session-transcript-repair.ts)
+    // Skip tool call extraction for aborted/errored/terminated assistant messages.
+    // When stopReason indicates an abnormal end, the tool_use blocks may be
+    // incomplete and should not have synthetic tool_results created.
+    // This matches the behavior in repairToolUseResultPairing (session-transcript-repair.ts).
     const stopReason = (nextMessage as { stopReason?: string }).stopReason;
+    const skipToolExtraction =
+      stopReason === "aborted" || stopReason === "error" || stopReason === "terminated";
     const toolCalls =
-      nextRole === "assistant" && stopReason !== "aborted" && stopReason !== "error"
+      nextRole === "assistant" && !skipToolExtraction
         ? extractToolCallsFromAssistant(nextMessage as Extract<AgentMessage, { role: "assistant" }>)
         : [];
 

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -188,6 +188,24 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(result.messages[1]?.role).toBe("user");
   });
 
+  it("skips tool call extraction for assistant messages with stopReason 'terminated'", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_terminated", name: "exec", arguments: {} }],
+        stopReason: "terminated",
+      },
+      { role: "user", content: "session was terminated mid-stream" },
+    ] as unknown as AgentMessage[];
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.added).toHaveLength(0);
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]?.role).toBe("assistant");
+    expect(result.messages[1]?.role).toBe("user");
+  });
+
   it("still repairs tool results for normal assistant messages with stopReason 'toolUse'", () => {
     // Normal tool calls (stopReason: "toolUse" or "stop") should still be repaired
     const input = [

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -390,14 +390,15 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
 
     const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
 
-    // Skip tool call extraction for aborted or errored assistant messages.
-    // When stopReason is "error" or "aborted", the tool_use blocks may be incomplete
-    // (e.g., partialJson: true) and should not have synthetic tool_results created.
-    // Creating synthetic results for incomplete tool calls causes API 400 errors:
-    // "unexpected tool_use_id found in tool_result blocks"
+    // Skip tool call extraction for aborted, errored, or terminated assistant
+    // messages.  When stopReason indicates an abnormal end, the tool_use blocks
+    // may be incomplete (e.g., partialJson: true) and should not have synthetic
+    // tool_results created.  Creating synthetic results for incomplete tool calls
+    // causes API 400 errors: "unexpected tool_use_id found in tool_result blocks"
     // See: https://github.com/openclaw/openclaw/issues/4597
+    //      https://github.com/openclaw/openclaw/issues/31625
     const stopReason = (assistant as { stopReason?: string }).stopReason;
-    if (stopReason === "error" || stopReason === "aborted") {
+    if (stopReason === "error" || stopReason === "aborted" || stopReason === "terminated") {
       out.push(msg);
       continue;
     }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -477,6 +477,7 @@ export async function runAgentTurnWithFallback(params: {
       const isContextOverflow = isLikelyContextOverflowError(message);
       const isCompactionFailure = isCompactionFailureError(message);
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
+      const isToolUseIdCorruption = /unexpected tool_use_id found in tool_result/i.test(message);
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
       const isTransientHttp = isTransientHttpError(message);
 
@@ -546,6 +547,45 @@ export async function runAgentTurnWithFallback(params: {
           kind: "final",
           payload: {
             text: "⚠️ Session history was corrupted. I've reset the conversation - please try again!",
+          },
+        };
+      }
+
+      if (
+        isToolUseIdCorruption &&
+        params.sessionKey &&
+        params.activeSessionStore &&
+        params.storePath
+      ) {
+        const sessionKey = params.sessionKey;
+        const corruptedSessionId = params.getActiveSessionEntry()?.sessionId;
+        defaultRuntime.error(
+          `Session transcript corrupted (orphaned tool_result without matching tool_use). Resetting session: ${params.sessionKey}`,
+        );
+
+        try {
+          if (corruptedSessionId) {
+            const transcriptPath = resolveSessionTranscriptPath(corruptedSessionId);
+            try {
+              fs.unlinkSync(transcriptPath);
+            } catch {
+              // Ignore if file doesn't exist
+            }
+          }
+          delete params.activeSessionStore[sessionKey];
+          await updateSessionStore(params.storePath, (store) => {
+            delete store[sessionKey];
+          });
+        } catch (cleanupErr) {
+          defaultRuntime.error(
+            `Failed to reset corrupted session ${params.sessionKey}: ${String(cleanupErr)}`,
+          );
+        }
+
+        return {
+          kind: "final",
+          payload: {
+            text: "⚠️ Session transcript was corrupted (tool call mismatch). I've reset the conversation - please try again!",
           },
         };
       }


### PR DESCRIPTION
## Summary

- **Problem:** When an assistant response is terminated mid-generation during a tool_use block (stopReason: terminated), the transcript repair mechanism creates synthetic tool_results for incomplete tool_use entries. This leaves orphaned tool_result entries that cause every subsequent API call to fail with 400: "unexpected tool_use_id found in tool_result blocks". The session never recovers.
- **Why it matters:** 5+ hours of downtime per incident. All cron jobs, heartbeats, and user messages silently fail with no notification.
- **What changed:** (1) Added "terminated" to the stopReason guard in both `repairToolUseResultPairing` and the tool-result guard, preventing synthetic tool_results for incomplete tool_use blocks. (2) Added auto-recovery in `agent-runner-execution.ts` that detects the "unexpected tool_use_id" 400 error and resets the corrupted session.
- **What did NOT change:** Handling of "error" and "aborted" stopReasons is unchanged. Normal tool_use/tool_result pairing for "toolUse" stopReason is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31625

## User-visible / Behavior Changes

- Sessions no longer get permanently stuck in 400 error loops after truncated tool_use.
- When a corrupted session is detected, it is automatically reset with a user-visible notification.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js v22+
- Integration/channel: Any (Telegram reported in issue)

### Steps

1. Run a long agent turn with tool calls
2. Terminate the response mid-stream during a tool_use block
3. Send another message to the same session

### Expected

- Session either continues normally (prevention) or auto-recovers (detection)

### Actual

- Before fix: Session permanently stuck with 400 errors on every message
- After fix: (Prevention) No synthetic tool_results for terminated responses. (Recovery) Auto-reset if corruption is detected.

## Evidence

New test: `"skips tool call extraction for assistant messages with stopReason 'terminated'"` verifies the prevention logic.
Auto-recovery follows the same pattern as the existing Gemini session corruption handler.

## Human Verification (required)

- Verified scenarios: terminated stopReason, error stopReason (unchanged), aborted (unchanged), normal toolUse (unchanged)
- Edge cases checked: Multiple tool calls in terminated message, orphaned tool_result after terminated message
- What I did **not** verify: Live reproduction of the exact 400 error scenario

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove "terminated" from stopReason guards and remove isToolUseIdCorruption handler
- Files/config to restore: `src/agents/session-transcript-repair.ts`, `src/agents/session-tool-result-guard.ts`, `src/auto-reply/reply/agent-runner-execution.ts`
- Known bad symptoms: If terminated messages need synthetic tool_results (unlikely), they would be skipped

## Risks and Mitigations

The auto-recovery resets the session (deletes transcript + session entry). This is the same behavior as the existing Gemini corruption handler and is preferable to a permanently stuck session.

