### PR TITLE
fix(reply): always show auth fallback notices with reauth guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/Node dangerous-command parity: include `sms.send` in default onboarding node `denyCommands`, share onboarding deny defaults with the gateway dangerous-command source of truth, and include `sms.send` in phone-control `/phone arm writes` handling so SMS follows the same break-glass flow as other dangerous node commands. Thanks @zpbrent.
+- Model fallback/auth visibility: always surface model fallback notices for auth-related fallback reasons (even with verbose mode off), and include explicit re-authentication guidance so channel users can recover from expired/invalid provider auth without silent behavior drift. (#31570)
 - Zalo/Pairing auth tests: add webhook regression coverage asserting DM pairing-store reads/writes remain account-scoped, preventing cross-account authorization bleed in multi-account setups. (#26121) Thanks @bmendonca3.
 - Logging: use local time for logged timestamps instead of UTC, aligning log output with documented local timezone behavior and avoiding confusion during local diagnostics. (#28434) Thanks @liuy.
 - Zalouser/Pairing auth tests: add account-scoped DM pairing-store regression coverage (`monitor.account-scope.test.ts`) to prevent cross-account allowlist bleed in multi-account setups. (#26672) Thanks @bmendonca3.

--- a/src/auto-reply/fallback-state.test.ts
+++ b/src/auto-reply/fallback-state.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildFallbackNotice,
   resolveActiveFallbackState,
   resolveFallbackTransition,
+  shouldForceFallbackNotice,
   type FallbackNoticeState,
 } from "./fallback-state.js";
 
@@ -119,5 +121,38 @@ describe("fallback-state", () => {
     expect(resolved.nextState.selectedModel).toBeUndefined();
     expect(resolved.nextState.activeModel).toBeUndefined();
     expect(resolved.nextState.reason).toBeUndefined();
+  });
+
+  it("forces fallback notice for auth-related fallback attempts", () => {
+    const forced = shouldForceFallbackNotice([
+      {
+        provider: "openai-codex",
+        model: "gpt-5.3-codex",
+        error: "Token refresh failed: 401 refresh_token_reused",
+        reason: "auth",
+      },
+    ]);
+
+    expect(forced).toBe(true);
+  });
+
+  it("appends re-authentication guidance to auth fallback notices", () => {
+    const notice = buildFallbackNotice({
+      selectedProvider: "openai-codex",
+      selectedModel: "gpt-5.3-codex",
+      activeProvider: "openai",
+      activeModel: "gpt-4.1",
+      attempts: [
+        {
+          provider: "openai-codex",
+          model: "gpt-5.3-codex",
+          error: "Token refresh failed: 401 refresh_token_reused",
+          reason: "auth",
+        },
+      ],
+    });
+
+    expect(notice).toContain("Model Fallback:");
+    expect(notice).toContain("Re-authenticate the selected provider");
   });
 });

--- a/src/auto-reply/fallback-state.ts
+++ b/src/auto-reply/fallback-state.ts
@@ -3,11 +3,47 @@ import { formatProviderModelRef } from "./model-runtime.js";
 import type { RuntimeFallbackAttempt } from "./reply/agent-runner-execution.js";
 
 const FALLBACK_REASON_PART_MAX = 80;
+const AUTH_REAUTH_HINT =
+  " Re-authenticate the selected provider to restore it as the active model.";
+const AUTH_RELATED_REASON_CODES = new Set(["auth", "auth_permanent", "session_expired"]);
+const AUTH_RELATED_ERROR_HINTS = [
+  "oauth token refresh failed",
+  "token refresh failed",
+  "refresh token",
+  "refresh_token",
+  "invalid token",
+  "token has expired",
+  "unauthorized",
+  "forbidden",
+  "re-authenticate",
+  "no credentials found",
+  "no api key found",
+];
 
 export type FallbackNoticeState = Pick<
   SessionEntry,
   "fallbackNoticeSelectedModel" | "fallbackNoticeActiveModel" | "fallbackNoticeReason"
 >;
+
+function isAuthRelatedFallbackAttempt(attempt: RuntimeFallbackAttempt): boolean {
+  const normalizedReason = String(attempt.reason ?? "")
+    .trim()
+    .toLowerCase();
+  if (normalizedReason && AUTH_RELATED_REASON_CODES.has(normalizedReason)) {
+    return true;
+  }
+  const errorText = String(attempt.error ?? "")
+    .trim()
+    .toLowerCase();
+  if (!errorText) {
+    return false;
+  }
+  return AUTH_RELATED_ERROR_HINTS.some((hint) => errorText.includes(hint));
+}
+
+export function shouldForceFallbackNotice(attempts: RuntimeFallbackAttempt[]): boolean {
+  return attempts.some((attempt) => isAuthRelatedFallbackAttempt(attempt));
+}
 
 export function normalizeFallbackModelRef(value?: string): string | undefined {
   const trimmed = String(value ?? "").trim();
@@ -71,7 +107,8 @@ export function buildFallbackNotice(params: {
     return null;
   }
   const reasonSummary = buildFallbackReasonSummary(params.attempts);
-  return `↪️ Model Fallback: ${active} (selected ${selected}; ${reasonSummary})`;
+  const authHint = shouldForceFallbackNotice(params.attempts) ? AUTH_REAUTH_HINT : "";
+  return `↪️ Model Fallback: ${active} (selected ${selected}; ${reasonSummary})${authHint}`;
 }
 
 export function buildFallbackClearedNotice(params: {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -304,6 +304,91 @@ describe("runReplyAgent authProfileId fallback scoping", () => {
   });
 });
 
+describe("runReplyAgent auth fallback notices", () => {
+  it("announces auth fallback guidance even when verbose mode is off", async () => {
+    runWithModelFallbackMock.mockImplementationOnce(
+      async ({ run }: RunWithModelFallbackParams) => ({
+        result: await run("openai", "gpt-4.1"),
+        provider: "openai",
+        model: "gpt-4.1",
+        attempts: [
+          {
+            provider: "openai-codex",
+            model: "gpt-5.3-codex",
+            error: "Token refresh failed: 401 refresh_token_reused",
+            reason: "auth",
+          },
+        ],
+      }),
+    );
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({ payloads: [{ text: "ok" }], meta: {} });
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      OriginatingTo: "chat",
+      AccountId: "primary",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        sessionId: "session",
+        sessionKey: "main",
+        messageProvider: "telegram",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "openai-codex",
+        model: "gpt-5.3-codex",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      defaultModel: "openai-codex/gpt-5.3-codex",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    const responseText = Array.isArray(result)
+      ? result
+          .map((payload) => payload?.text ?? "")
+          .filter(Boolean)
+          .join("\n")
+      : (result?.text ?? "");
+    expect(responseText).toContain("Model Fallback:");
+    expect(responseText).toContain("Re-authenticate the selected provider");
+  });
+});
+
 describe("runReplyAgent auto-compaction token update", () => {
   type EmbeddedRunParams = {
     prompt?: string;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -25,6 +25,7 @@ import {
   buildFallbackClearedNotice,
   buildFallbackNotice,
   resolveFallbackTransition,
+  shouldForceFallbackNotice,
 } from "../fallback-state.js";
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
@@ -636,7 +637,9 @@ export async function runReplyAgent(params: {
           attempts: fallbackAttempts,
         },
       });
-      if (verboseEnabled) {
+      const shouldShowFallbackNotice =
+        verboseEnabled || shouldForceFallbackNotice(fallbackAttempts);
+      if (shouldShowFallbackNotice) {
         const fallbackNotice = buildFallbackNotice({
           selectedProvider,
           selectedModel,


### PR DESCRIPTION
## Summary

- Problem: auth-related provider fallbacks were only announced when verbose mode was enabled.
- Why it matters: in normal (verbose off) channel usage, users could silently fall back to a different model/provider and only see degraded behavior (e.g., "cannot run commands") with no recovery hint.
- What changed: added auth-aware fallback notice forcing + explicit re-auth guidance, while keeping non-auth fallback notices verbose-gated.
- What did NOT change (scope boundary): no model selection order changes, no fallback routing changes, no new auth flows.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31570
- Related #31324

## User-visible / Behavior Changes

- Auth-related model fallback transitions are now surfaced to users even when verbose mode is off.
- Fallback notice now includes re-authentication guidance for auth/session-expired style failures.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: fallback simulation (`openai-codex` -> `openai`)
- Integration/channel (if any): channel reply path (non-verbose runtime)
- Relevant config (redacted): N/A

### Steps

1. Trigger a model fallback with auth-related reason (e.g., token refresh 401).
2. Keep runtime verbose mode off.
3. Observe final payload text and fallback notice behavior.

### Expected

- User sees a fallback notice with re-authentication guidance, even with verbose off.

### Actual

- Before fix: fallback notice suppressed when verbose off.
- After fix: auth fallback notice is always shown with recovery guidance.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/auto-reply/fallback-state.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
  - Added regression: `runReplyAgent auth fallback notices > announces auth fallback guidance even when verbose mode is off`.
- Edge cases checked:
  - Non-auth fallback behavior remains verbose-gated.
  - Fallback reason summaries and session transition state remain intact.
- What you did **not** verify:
  - Live Telegram/WhatsApp end-to-end with real expired OAuth token.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/auto-reply/reply/agent-runner.ts`
  - `src/auto-reply/fallback-state.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected fallback notices for non-auth reasons in verbose-off sessions.

## Risks and Mitigations

- Risk: false-positive auth classification could show a fallback notice in some ambiguous errors.
  - Mitigation: force-notice path requires auth reason code or explicit auth-like error hints; non-auth fallback remains unchanged.
