### PR TITLE
fix(telegram): preserve original document filename from Telegram API

### DIFF
--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -203,4 +203,85 @@ describe("resolveMedia getFile retry", () => {
     // Should retry transient errors.
     expect(result).not.toBeNull();
   });
+
+  it("preserves original document filename from msg.document.file_name", async () => {
+    const msg: Record<string, unknown> = {
+      message_id: 2,
+      date: 0,
+      chat: { id: 1, type: "private" },
+      document: { file_id: "d1", file_unique_id: "du1", file_name: "business-plan.docx" },
+    };
+    const getFile = vi.fn().mockResolvedValue({ file_path: "documents/file_99.docx" });
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("doc"),
+      contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      fileName: null,
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/business-plan---uuid.docx",
+      contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+
+    const ctx: TelegramContext = {
+      message: msg as unknown as Message,
+      me: {
+        id: 1,
+        is_bot: true,
+        first_name: "bot",
+        username: "bot",
+      } as unknown as TelegramContext["me"],
+      getFile,
+    };
+
+    const result = await resolveMedia(ctx, MAX_MEDIA_BYTES, BOT_TOKEN);
+    expect(result).not.toBeNull();
+    // saveMediaBuffer should receive the original Telegram filename, not the server-side path
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "inbound",
+      MAX_MEDIA_BYTES,
+      "business-plan.docx",
+    );
+  });
+
+  it("preserves original audio filename from msg.audio.file_name", async () => {
+    const msg: Record<string, unknown> = {
+      message_id: 3,
+      date: 0,
+      chat: { id: 1, type: "private" },
+      audio: { file_id: "a2", duration: 120, file_unique_id: "au2", file_name: "podcast-ep42.mp3" },
+    };
+    const getFile = vi.fn().mockResolvedValue({ file_path: "music/file_55.mp3" });
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("mp3"),
+      contentType: "audio/mpeg",
+      fileName: null,
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/podcast-ep42---uuid.mp3",
+      contentType: "audio/mpeg",
+    });
+
+    const ctx: TelegramContext = {
+      message: msg as unknown as Message,
+      me: {
+        id: 1,
+        is_bot: true,
+        first_name: "bot",
+        username: "bot",
+      } as unknown as TelegramContext["me"],
+      getFile,
+    };
+
+    const result = await resolveMedia(ctx, MAX_MEDIA_BYTES, BOT_TOKEN);
+    expect(result).not.toBeNull();
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "inbound",
+      MAX_MEDIA_BYTES,
+      "podcast-ep42.mp3",
+    );
+  });
 });

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -53,7 +53,11 @@ export async function resolveMedia(
   stickerMetadata?: StickerMetadata;
 } | null> {
   const msg = ctx.message;
-  const downloadAndSaveTelegramFile = async (filePath: string, fetchImpl: typeof fetch) => {
+  const downloadAndSaveTelegramFile = async (
+    filePath: string,
+    fetchImpl: typeof fetch,
+    telegramFileName?: string,
+  ) => {
     const url = `https://api.telegram.org/file/bot${token}/${filePath}`;
     const fetched = await fetchRemoteMedia({
       url,
@@ -62,7 +66,9 @@ export async function resolveMedia(
       maxBytes,
       ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
     });
-    const originalName = fetched.fileName ?? filePath;
+    // Prefer the original filename from the Telegram Bot API (msg.document.file_name
+    // etc.) over the server-side file_path which uses opaque identifiers.
+    const originalName = telegramFileName ?? fetched.fileName ?? filePath;
     return saveMediaBuffer(fetched.buffer, fetched.contentType, "inbound", maxBytes, originalName);
   };
 
@@ -184,7 +190,10 @@ export async function resolveMedia(
   if (!fetchImpl) {
     throw new Error("fetch is not available; set channels.telegram.proxy in config");
   }
-  const saved = await downloadAndSaveTelegramFile(file.file_path, fetchImpl);
+  // Telegram Bot API exposes the original filename on document/audio/video objects.
+  // Without this, the saved file gets an opaque server-side name (e.g. file_123.pdf).
+  const telegramFileName = msg.document?.file_name ?? msg.audio?.file_name ?? msg.video?.file_name;
+  const saved = await downloadAndSaveTelegramFile(file.file_path, fetchImpl, telegramFileName);
   const placeholder = resolveTelegramMediaPlaceholder(msg) ?? "<media:document>";
   return { path: saved.path, contentType: saved.contentType, placeholder };
 }


### PR DESCRIPTION
## Summary
- `resolveMedia()` now reads `msg.document.file_name` (and `audio`/`video` equivalents) and passes it to `saveMediaBuffer` so saved files retain the user's original filename
- Without this fix, files are saved with opaque server-side names like `file_123---uuid.pdf` instead of `business-plan---uuid.pdf`

## Test plan
- [x] New test: preserves original document filename from `msg.document.file_name`
- [x] New test: preserves original audio filename from `msg.audio.file_name`
- [x] All existing `resolveMedia` retry tests pass (13 total)

Closes #31768

🤖 Generated with [Claude Code](https://claude.com/claude-code)