### PR TITLE
fix(telegram): use hash fallback for Bedrock model buttons exceeding 64 bytes

### DIFF
--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -296,7 +296,7 @@ describe("large model lists (OpenRouter-scale)", () => {
     }
   });
 
-  it("skips models that would exceed callback_data limit", () => {
+  it("uses hash-based callback_data for models that would exceed 64-byte limit", () => {
     const models = [
       "short-model",
       "this-is-an-extremely-long-model-name-that-definitely-exceeds-the-sixty-four-byte-limit",
@@ -309,10 +309,39 @@ describe("large model lists (OpenRouter-scale)", () => {
       totalPages: 1,
     });
 
-    // Should have 2 model buttons (skipping the long one) + back
+    // All 3 model buttons should be present (none skipped) + back
     const modelButtons = result.filter((row) => !row[0]?.callback_data.startsWith("mdl_back"));
-    expect(modelButtons.length).toBe(2);
+    expect(modelButtons.length).toBe(3);
     expect(modelButtons[0]?.[0]?.text).toBe("short-model");
-    expect(modelButtons[1]?.[0]?.text).toBe("another-short");
+    expect(modelButtons[0]?.[0]?.callback_data).toMatch(/^mdl_sel_/);
+    // Long model should use hash-based callback
+    expect(modelButtons[1]?.[0]?.callback_data).toMatch(/^mdl_h_[0-9a-f]{12}$/);
+    expect(
+      Buffer.byteLength(modelButtons[1]?.[0]?.callback_data ?? "", "utf8"),
+    ).toBeLessThanOrEqual(64);
+    expect(modelButtons[2]?.[0]?.text).toBe("another-short");
+  });
+
+  it("hash-based callback_data resolves back to provider/model via parseModelCallbackData", () => {
+    const longModel = "us.anthropic.claude-4-sonnet-20260514-v2:0";
+    const provider = "bedrock-us-east-1";
+    const result = buildModelsKeyboard({
+      provider,
+      models: [longModel],
+      currentPage: 1,
+      totalPages: 1,
+    });
+
+    const modelButton = result.find((row) => row[0]?.callback_data.startsWith("mdl_h_"));
+    expect(modelButton).toBeDefined();
+    const callbackData = modelButton?.[0]?.callback_data ?? "";
+    expect(Buffer.byteLength(callbackData, "utf8")).toBeLessThanOrEqual(64);
+
+    const parsed = parseModelCallbackData(callbackData);
+    expect(parsed).toEqual({
+      type: "select",
+      provider,
+      model: longModel,
+    });
   });
 });

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -4,9 +4,12 @@
  * Callback data patterns (max 64 bytes for Telegram):
  * - mdl_prov              - show providers list
  * - mdl_list_{prov}_{pg}  - show models for provider (page N, 1-indexed)
- * - mdl_sel_{provider/id} - select model
+ * - mdl_sel_{provider/id} - select model (when under 64 bytes)
+ * - mdl_h_{hash}          - select model via hash lookup (when full ID exceeds 64 bytes)
  * - mdl_back              - back to providers list
  */
+
+import { createHash } from "node:crypto";
 
 export type ButtonRow = Array<{ text: string; callback_data: string }>;
 
@@ -34,6 +37,30 @@ const MODELS_PAGE_SIZE = 8;
 const MAX_CALLBACK_DATA_BYTES = 64;
 
 /**
+ * Maps short hash keys to their full "provider/model" references so that
+ * models with callback_data exceeding 64 bytes can still be selected.
+ * Entries are added when building keyboards and read when parsing callbacks.
+ * The map is bounded: older entries are evicted when the cap is reached.
+ */
+const callbackHashMap = new Map<string, string>();
+const HASH_MAP_MAX_SIZE = 512;
+
+function modelRefToHash(modelRef: string): string {
+  return createHash("sha256").update(modelRef).digest("hex").slice(0, 12);
+}
+
+function storeHashAlias(hash: string, modelRef: string): void {
+  if (callbackHashMap.size >= HASH_MAP_MAX_SIZE) {
+    // Evict oldest entry (first inserted)
+    const firstKey = callbackHashMap.keys().next().value;
+    if (firstKey) {
+      callbackHashMap.delete(firstKey);
+    }
+  }
+  callbackHashMap.set(hash, modelRef);
+}
+
+/**
  * Parse a model callback_data string into a structured object.
  * Returns null if the data doesn't match a known pattern.
  */
@@ -55,6 +82,24 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
     if (provider && Number.isFinite(page) && page >= 1) {
       return { type: "list", provider, page };
     }
+  }
+
+  // mdl_h_{hash} — hashed model reference for long IDs
+  const hashMatch = trimmed.match(/^mdl_h_([0-9a-f]{12})$/);
+  if (hashMatch) {
+    const hash = hashMatch[1];
+    const modelRef = hash ? callbackHashMap.get(hash) : undefined;
+    if (modelRef) {
+      const slashIndex = modelRef.indexOf("/");
+      if (slashIndex > 0 && slashIndex < modelRef.length - 1) {
+        return {
+          type: "select",
+          provider: modelRef.slice(0, slashIndex),
+          model: modelRef.slice(slashIndex + 1),
+        };
+      }
+    }
+    return null;
   }
 
   // mdl_sel_{provider/model}
@@ -133,10 +178,14 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
     : currentModel;
 
   for (const model of pageModels) {
-    const callbackData = `mdl_sel_${provider}/${model}`;
-    // Skip models that would exceed Telegram's callback_data limit
+    const modelRef = `${provider}/${model}`;
+    let callbackData = `mdl_sel_${modelRef}`;
+    // Fall back to a short hash when the full callback_data would exceed
+    // Telegram's 64-byte limit (common with long Bedrock model IDs).
     if (Buffer.byteLength(callbackData, "utf8") > MAX_CALLBACK_DATA_BYTES) {
-      continue;
+      const hash = modelRefToHash(modelRef);
+      storeHashAlias(hash, modelRef);
+      callbackData = `mdl_h_${hash}`;
     }
 
     const isCurrentModel = model === currentModelId;


### PR DESCRIPTION
## Summary
- When a model's `callback_data` would exceed Telegram's 64-byte limit (common with long Bedrock IDs like `us.anthropic.claude-4-sonnet-20260514-v2:0`), fall back to a short SHA-256 hash (`mdl_h_{12hex}`) instead of silently dropping the button
- A bounded module-level map (512 entries max with FIFO eviction) resolves hashes back to the full `provider/model` reference on callback
- All model buttons are now always displayed — no more silently missing models

## Test plan
- [x] New test: long model uses `mdl_h_` prefixed hash callback
- [x] New test: hash resolves back to correct provider/model via `parseModelCallbackData`
- [x] Updated test: all 3 models shown (previously 2 with long one skipped)
- [x] All existing callback_data 64-byte limit tests pass (15 total)

Closes #31815

🤖 Generated with [Claude Code](https://claude.com/claude-code)