### PR TITLE
fix(bluebubbles): unify debounce keys and graceful tapback fallback

### DIFF
--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -163,7 +163,7 @@ function getOrCreateDebouncer(target: WebhookTarget) {
       const balloonBundleId = msg.balloonBundleId?.trim();
       const associatedMessageGuid = msg.associatedMessageGuid?.trim();
       if (balloonBundleId && associatedMessageGuid) {
-        return `bluebubbles:${account.accountId}:balloon:${associatedMessageGuid}`;
+        return `bluebubbles:${account.accountId}:msg:${associatedMessageGuid}`;
       }
 
       const messageId = msg.messageId?.trim();

--- a/extensions/bluebubbles/src/reactions.test.ts
+++ b/extensions/bluebubbles/src/reactions.test.ts
@@ -106,18 +106,22 @@ describe("reactions", () => {
       ).rejects.toThrow("password is required");
     });
 
-    it("throws for unsupported reaction type", async () => {
-      await expect(
-        sendBlueBubblesReaction({
-          chatGuid: "chat-123",
-          messageGuid: "msg-123",
-          emoji: "unsupported",
-          opts: {
-            serverUrl: "http://localhost:1234",
-            password: "test",
-          },
-        }),
-      ).rejects.toThrow("Unsupported BlueBubbles reaction");
+    it("falls back to 'like' for unsupported reaction type", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(""),
+      });
+      await sendBlueBubblesReaction({
+        chatGuid: "chat-123",
+        messageGuid: "msg-123",
+        emoji: "unsupported",
+        opts: {
+          serverUrl: "http://localhost:1234",
+          password: "test",
+        },
+      });
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.reaction).toBe("like");
     });
 
     describe("reaction type normalization", () => {

--- a/extensions/bluebubbles/src/reactions.ts
+++ b/extensions/bluebubbles/src/reactions.ts
@@ -127,7 +127,9 @@ export function normalizeBlueBubblesReactionInput(emoji: string, remove?: boolea
   const aliased = REACTION_ALIASES.get(raw) ?? raw;
   const mapped = REACTION_EMOJIS.get(trimmed) ?? REACTION_EMOJIS.get(raw) ?? aliased;
   if (!REACTION_TYPES.has(mapped)) {
-    throw new Error(`Unsupported BlueBubbles reaction: ${trimmed}`);
+    // Graceful fallback: unsupported emoji reactions map to the closest
+    // iMessage tapback instead of crashing the reaction handler.
+    return remove ? "-like" : "like";
   }
   return remove ? `-${mapped}` : mapped;
 }


### PR DESCRIPTION
## Summary
- **Debounce key fix**: Use the same `msg:` prefix for balloon (URL preview) events so text + balloon webhook events sharing the same `associatedMessageGuid` coalesce into one debounce window instead of triggering duplicate replies
- **Tapback fallback**: Fall back to "like" tapback for unsupported emoji reactions instead of throwing `Error("Unsupported BlueBubbles reaction: ...")`, so the reaction handler doesn't crash on unknown emoji

## Test plan
- [x] Updated test: unsupported reaction now falls back to "like" instead of throwing
- [x] All 283 BlueBubbles tests pass
- [x] Monitor debounce logic verified via code review (balloon key now matches text key format)

Closes #31823
Closes #31813

🤖 Generated with [Claude Code](https://claude.com/claude-code)