### PR TITLE
fix(bluebubbles): propagate SSRF policy to fetchRemoteMedia

### DIFF
--- a/extensions/bluebubbles/src/media-send.test.ts
+++ b/extensions/bluebubbles/src/media-send.test.ts
@@ -58,6 +58,8 @@ function createConfig(overrides?: Record<string, unknown>): OpenClawConfig {
   return {
     channels: {
       bluebubbles: {
+        serverUrl: "https://bb.example.com",
+        password: "test-pass",
         ...overrides,
       },
     },
@@ -252,5 +254,33 @@ describe("sendBlueBubblesMedia local-path hardening", () => {
       expect.objectContaining({ url: "https://example.com/file.png" }),
     );
     expect(sendBlueBubblesAttachmentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes ssrfPolicy with allowPrivateNetwork for localhost server", async () => {
+    await sendBlueBubblesMedia({
+      cfg: createConfig({ serverUrl: "http://localhost:1234", allowPrivateNetwork: true }),
+      to: "chat:123",
+      mediaUrl: "https://example.com/file.png",
+    });
+
+    expect(runtimeMocks.fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ssrfPolicy: { allowPrivateNetwork: true },
+      }),
+    );
+  });
+
+  it("passes ssrfPolicy with allowedHostnames when serverUrl is set", async () => {
+    await sendBlueBubblesMedia({
+      cfg: createConfig({ serverUrl: "https://my-bb-server.example.com:8080" }),
+      to: "chat:123",
+      mediaUrl: "https://example.com/file.png",
+    });
+
+    expect(runtimeMocks.fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ssrfPolicy: { allowedHostnames: ["my-bb-server.example.com"] },
+      }),
+    );
   });
 });

--- a/extensions/bluebubbles/src/media-send.ts
+++ b/extensions/bluebubbles/src/media-send.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveChannelMediaMaxBytes, type OpenClawConfig } from "openclaw/plugin-sdk";
+import { resolveBlueBubblesServerAccount } from "./account-resolve.js";
 import { resolveBlueBubblesAccount } from "./accounts.js";
 import { sendBlueBubblesAttachment } from "./attachments.js";
 import { resolveBlueBubblesMessageId } from "./monitor.js";
@@ -11,6 +12,16 @@ import { getBlueBubblesRuntime } from "./runtime.js";
 import { sendMessageBlueBubbles } from "./send.js";
 
 const HTTP_URL_RE = /^https?:\/\//i;
+
+function safeExtractHostname(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const hostname = new URL(url).hostname.trim();
+    return hostname || undefined;
+  } catch {
+    return undefined;
+  }
+}
 const MB = 1024 * 1024;
 
 function assertMediaWithinLimit(sizeBytes: number, maxBytes?: number): void {
@@ -220,6 +231,7 @@ export async function sendBlueBubblesMedia(params: {
     asVoice,
   } = params;
   const core = getBlueBubblesRuntime();
+  const serverAccount = resolveBlueBubblesServerAccount({ cfg, accountId });
   const maxBytes = resolveChannelMediaMaxBytes({
     cfg,
     resolveChannelLimitMb: ({ cfg, accountId }) =>
@@ -253,9 +265,15 @@ export async function sendBlueBubblesMedia(params: {
       throw new Error("BlueBubbles media delivery requires mediaUrl, mediaPath, or mediaBuffer.");
     }
     if (HTTP_URL_RE.test(source)) {
+      const trustedHostname = safeExtractHostname(serverAccount.baseUrl);
       const fetched = await core.channel.media.fetchRemoteMedia({
         url: source,
         maxBytes: typeof maxBytes === "number" && maxBytes > 0 ? maxBytes : undefined,
+        ssrfPolicy: serverAccount.allowPrivateNetwork
+          ? { allowPrivateNetwork: true }
+          : trustedHostname
+            ? { allowedHostnames: [trustedHostname] }
+            : undefined,
       });
       buffer = fetched.buffer;
       resolvedContentType = resolvedContentType ?? fetched.contentType ?? undefined;


### PR DESCRIPTION
## Summary

Fixes #31814.

BlueBubbles media sends (`sendBlueBubblesMedia`) did not forward an `ssrfPolicy` when calling `fetchRemoteMedia`, so requests targeting a localhost or private-network BlueBubbles server were rejected by the default SSRF guard.

## Changes

### `extensions/bluebubbles/src/media-send.ts`
- Import `resolveBlueBubblesServerAccount` and resolve the server account early in `sendBlueBubblesMedia`.
- Add `safeExtractHostname` helper to safely parse the hostname from the server URL.
- Pass `ssrfPolicy` to `fetchRemoteMedia`:
  - `{ allowPrivateNetwork: true }` when the account config has `allowPrivateNetwork: true`.
  - `{ allowedHostnames: [hostname] }` when a public `serverUrl` is configured (trusted hostname passthrough).

### `extensions/bluebubbles/src/media-send.test.ts`
- Add `serverUrl` and `password` to the test helper `createConfig` so that `resolveBlueBubblesServerAccount` does not throw in all existing tests.
- Add two new test cases:
  - `"passes ssrfPolicy with allowPrivateNetwork for localhost server"` — verifies the `allowPrivateNetwork` policy shape.
  - `"passes ssrfPolicy with allowedHostnames when serverUrl is set"` — verifies the `allowedHostnames` policy shape.

## Impact

- **Security**: Maintains SSRF protection by default while allowing legitimate private-network BlueBubbles servers that have opted in via `allowPrivateNetwork`.
- **Backwards compatible**: No config changes required; the new `ssrfPolicy` field is optional in `fetchRemoteMedia`.

## How to reproduce

1. Configure a BlueBubbles server at `http://localhost:1234`.
2. Send a media message with a remote URL.
3. Before this fix: the request is blocked by the SSRF guard.
4. After this fix: the request succeeds when `allowPrivateNetwork: true` is set in the account config.

## Verification

- [x] `npx tsc --noEmit` passes (no new type errors).
- [x] New and existing tests pass.
- [x] Follows existing patterns used by other channel extensions (e.g., `attachments.ts`, `chat.ts`).