### PR TITLE
feat(config): add configurable bootstrapFiles list

### DIFF
--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -5,13 +5,14 @@ const cache = new Map<string, WorkspaceBootstrapFile[]>();
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
   sessionKey: string;
+  customNames?: readonly string[];
 }): Promise<WorkspaceBootstrapFile[]> {
   const existing = cache.get(params.sessionKey);
   if (existing) {
     return existing;
   }
 
-  const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
+  const files = await loadWorkspaceBootstrapFiles(params.workspaceDir, params.customNames);
   cache.set(params.sessionKey, files);
   return files;
 }

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -72,12 +72,14 @@ export async function resolveBootstrapFilesForRun(params: {
   runKind?: BootstrapContextRunKind;
 }): Promise<WorkspaceBootstrapFile[]> {
   const sessionKey = params.sessionKey ?? params.sessionId;
+  const customNames = params.config?.agents?.defaults?.bootstrapFiles;
   const rawFiles = params.sessionKey
     ? await getOrLoadBootstrapFiles({
         workspaceDir: params.workspaceDir,
         sessionKey: params.sessionKey,
+        customNames,
       })
-    : await loadWorkspaceBootstrapFiles(params.workspaceDir);
+    : await loadWorkspaceBootstrapFiles(params.workspaceDir, customNames);
   const bootstrapFiles = applyContextModeFilter({
     files: filterBootstrapFilesForSession(rawFiles, sessionKey),
     contextMode: params.contextMode,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -138,7 +138,8 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_HEARTBEAT_FILENAME
   | typeof DEFAULT_BOOTSTRAP_FILENAME
   | typeof DEFAULT_MEMORY_FILENAME
-  | typeof DEFAULT_MEMORY_ALT_FILENAME;
+  | typeof DEFAULT_MEMORY_ALT_FILENAME
+  | (string & {});
 
 export type WorkspaceBootstrapFile = {
   name: WorkspaceBootstrapFileName;
@@ -495,44 +496,54 @@ async function resolveMemoryBootstrapEntries(
   return deduped;
 }
 
-export async function loadWorkspaceBootstrapFiles(dir: string): Promise<WorkspaceBootstrapFile[]> {
+export async function loadWorkspaceBootstrapFiles(
+  dir: string,
+  customNames?: readonly string[],
+): Promise<WorkspaceBootstrapFile[]> {
   const resolvedDir = resolveUserPath(dir);
 
   const entries: Array<{
     name: WorkspaceBootstrapFileName;
     filePath: string;
-  }> = [
-    {
-      name: DEFAULT_AGENTS_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_AGENTS_FILENAME),
-    },
-    {
-      name: DEFAULT_SOUL_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_SOUL_FILENAME),
-    },
-    {
-      name: DEFAULT_TOOLS_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_TOOLS_FILENAME),
-    },
-    {
-      name: DEFAULT_IDENTITY_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_IDENTITY_FILENAME),
-    },
-    {
-      name: DEFAULT_USER_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_USER_FILENAME),
-    },
-    {
-      name: DEFAULT_HEARTBEAT_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_HEARTBEAT_FILENAME),
-    },
-    {
-      name: DEFAULT_BOOTSTRAP_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_BOOTSTRAP_FILENAME),
-    },
-  ];
+  }> = customNames
+    ? customNames.map((name) => ({
+        name: path.basename(name) as WorkspaceBootstrapFileName,
+        filePath: path.join(resolvedDir, path.basename(name)),
+      }))
+    : [
+        {
+          name: DEFAULT_AGENTS_FILENAME,
+          filePath: path.join(resolvedDir, DEFAULT_AGENTS_FILENAME),
+        },
+        {
+          name: DEFAULT_SOUL_FILENAME,
+          filePath: path.join(resolvedDir, DEFAULT_SOUL_FILENAME),
+        },
+        {
+          name: DEFAULT_TOOLS_FILENAME,
+          filePath: path.join(resolvedDir, DEFAULT_TOOLS_FILENAME),
+        },
+        {
+          name: DEFAULT_IDENTITY_FILENAME,
+          filePath: path.join(resolvedDir, DEFAULT_IDENTITY_FILENAME),
+        },
+        {
+          name: DEFAULT_USER_FILENAME,
+          filePath: path.join(resolvedDir, DEFAULT_USER_FILENAME),
+        },
+        {
+          name: DEFAULT_HEARTBEAT_FILENAME,
+          filePath: path.join(resolvedDir, DEFAULT_HEARTBEAT_FILENAME),
+        },
+        {
+          name: DEFAULT_BOOTSTRAP_FILENAME,
+          filePath: path.join(resolvedDir, DEFAULT_BOOTSTRAP_FILENAME),
+        },
+      ];
 
-  entries.push(...(await resolveMemoryBootstrapEntries(resolvedDir)));
+  if (!customNames) {
+    entries.push(...(await resolveMemoryBootstrapEntries(resolvedDir)));
+  }
 
   const result: WorkspaceBootstrapFile[] = [];
   for (const entry of entries) {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -716,6 +716,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
   "agents.defaults.bootstrapTotalMaxChars":
     "Max total characters across all injected workspace bootstrap files (default: 150000).",
+  "agents.defaults.bootstrapFiles":
+    "Custom list of workspace filenames to inject at session start. When omitted, the built-in defaults (AGENTS.md, SOUL.md, TOOLS.md, IDENTITY.md, USER.md, HEARTBEAT.md, BOOTSTRAP.md, MEMORY.md) are used. When set, only the listed files are injected.",
   "agents.defaults.repoRoot":
     "Optional repository root shown in the system prompt runtime line (overrides auto-detect).",
   "agents.defaults.envelopeTimezone":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -282,6 +282,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.repoRoot": "Repo Root",
   "agents.defaults.bootstrapMaxChars": "Bootstrap Max Chars",
   "agents.defaults.bootstrapTotalMaxChars": "Bootstrap Total Max Chars",
+  "agents.defaults.bootstrapFiles": "Bootstrap Files",
   "agents.defaults.envelopeTimezone": "Envelope Timezone",
   "agents.defaults.envelopeTimestamp": "Envelope Timestamp",
   "agents.defaults.envelopeElapsed": "Envelope Elapsed",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -140,6 +140,8 @@ export type AgentDefaultsConfig = {
   bootstrapMaxChars?: number;
   /** Max total chars across all injected bootstrap files (default: 150000). */
   bootstrapTotalMaxChars?: number;
+  /** Custom list of workspace filenames to inject at session start (replaces defaults when set). */
+  bootstrapFiles?: string[];
   /** Optional IANA timezone for the user (used in system prompt; defaults to host timezone). */
   userTimezone?: string;
   /** Time format in system prompt: auto (OS preference), 12-hour, or 24-hour. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -40,6 +40,7 @@ export const AgentDefaultsSchema = z
     skipBootstrap: z.boolean().optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
     bootstrapTotalMaxChars: z.number().int().positive().optional(),
+    bootstrapFiles: z.array(z.string().min(1)).optional(),
     userTimezone: z.string().optional(),
     timeFormat: z.union([z.literal("auto"), z.literal("12"), z.literal("24")]).optional(),
     envelopeTimezone: z.string().optional(),


### PR DESCRIPTION
## Summary

- **Problem:** The bootstrap file list is hardcoded to a fixed set (AGENTS.md, SOUL.md, etc.). Users cannot add custom workspace files to the bootstrap injection without fragile workarounds like symlinking.
- **Why it matters:** Users who build custom memory/state systems (session buffers, project context, domain knowledge) need those files available from session start — especially after compaction wipes context.
- **What changed:** Added `agents.defaults.bootstrapFiles` config field (string array) that lets users specify exactly which workspace files are injected. Config type, Zod schema, help text, label, and the bootstrap loading pipeline (`workspace.ts`, `bootstrap-cache.ts`, `bootstrap-files.ts`) were updated.
- **What did NOT change:** Default behavior when the field is omitted. Existing `bootstrapMaxChars` / `bootstrapTotalMaxChars` limits still apply. File security validation via `readWorkspaceFileWithGuards` still enforced.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31883

## User-visible / Behavior Changes

- New optional config field `agents.defaults.bootstrapFiles` (string array)
- When set, only listed filenames are loaded from workspace root at session start
- When omitted, existing default list is used (no behavioral change)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — files are still validated via `readWorkspaceFileWithGuards` (boundary check, no path traversal)

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime: Node.js v22
- Integration/channel: All

### Steps

1. Add to config: `"agents": { "defaults": { "bootstrapFiles": ["AGENTS.md", "SOUL.md", "SESSION_BUFFER.md"] } }`
2. Create `SESSION_BUFFER.md` in workspace root
3. Start a new session
4. Verify that `SESSION_BUFFER.md` content appears in system prompt context
5. Verify that `TOOLS.md`, `IDENTITY.md` etc. are NOT injected (since they're not in the list)

### Expected

- Only listed files are injected at session start

### Actual

- Before fix: hardcoded list, no way to add custom files
- After fix: custom list respected when configured

## Evidence

Config type addition:
```typescript
bootstrapFiles?: string[];
```

Zod schema:
```typescript
bootstrapFiles: z.array(z.string().min(1)).optional(),
```

Loading logic change in `loadWorkspaceBootstrapFiles`:
```typescript
const entries = customNames
  ? customNames.map((name) => ({
      name: path.basename(name),
      filePath: path.join(resolvedDir, path.basename(name)),
    }))
  : [/* ...default entries... */];
```

## Human Verification (required)

- Verified scenarios: TypeScript compilation passes, config field validates, loading logic correct
- Edge cases checked: empty array, filenames with path separators (basename extracted), omitted field (backward compat)
- What I did **not** verify: runtime integration test with live gateway

## Compatibility / Migration

- Backward compatible? `Yes` — omitting the field preserves existing behavior
- Config/env changes? `No` — new optional field only
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `bootstrapFiles` from config to restore defaults
- Files/config to restore: `openclaw.json` — remove the `bootstrapFiles` key
- Known bad symptoms: Missing bootstrap context if wrong filenames specified

## Risks and Mitigations

- Risk: User specifies non-existent files → those entries are marked `missing: true` and skipped (existing behavior for missing defaults)
- Risk: Path traversal via filenames → mitigated by `path.basename()` extraction and `readWorkspaceFileWithGuards` boundary check
