### PR TITLE
fix(whatsapp): strip HTML tags before delivery to plain-text surface

### DIFF
--- a/src/markdown/whatsapp.test.ts
+++ b/src/markdown/whatsapp.test.ts
@@ -36,4 +36,29 @@ describe("markdownToWhatsApp", () => {
       "Before ```**bold** and ~~strike~~``` after *real bold*",
     );
   });
+
+  it("converts HTML tags to WhatsApp-compatible text", () => {
+    const cases = [
+      ["converts <br> to newline", "line1<br>line2", "line1\nline2"],
+      ["converts <br/> to newline", "line1<br/>line2", "line1\nline2"],
+      ["converts <br /> to newline", "line1<br />line2", "line1\nline2"],
+      ["converts <b> to bold markers", "<b>bold</b>", "*bold*"],
+      ["converts <strong> to bold markers", "<strong>text</strong>", "*text*"],
+      ["converts <i> to italic markers", "<i>italic</i>", "_italic_"],
+      ["converts <em> to italic markers", "<em>text</em>", "_text_"],
+      ["converts <s> to strikethrough markers", "<s>deleted</s>", "~deleted~"],
+      ["converts <del> to strikethrough markers", "<del>removed</del>", "~removed~"],
+      ["converts <a> to text with URL", '<a href="https://example.com">click</a>', "click (https://example.com)"],
+      ["strips unknown HTML tags", "<div>content</div>", "content"],
+      ["strips self-closing tags", "text<hr/>more", "textmore"],
+    ] as const;
+    for (const [name, input, expected] of cases) {
+      expect(markdownToWhatsApp(input), name).toBe(expected);
+    }
+  });
+
+  it("does not strip HTML tags inside code blocks", () => {
+    const input = "```\n<br>tag\n```";
+    expect(markdownToWhatsApp(input)).toBe(input);
+  });
 });

--- a/src/markdown/whatsapp.ts
+++ b/src/markdown/whatsapp.ts
@@ -61,6 +61,14 @@ export function markdownToWhatsApp(text: string): string {
   // 4. Convert ~~strikethrough~~ → ~strikethrough~
   result = result.replace(/~~(.+?)~~/g, "~$1~");
 
+  // 4b. Convert/strip HTML tags for plain-text surfaces
+  result = result.replace(/<br\s*\/?>/gi, "\n");
+  result = result.replace(/<\/?(b|strong)>/gi, "*");
+  result = result.replace(/<\/?(i|em)>/gi, "_");
+  result = result.replace(/<\/?(s|strike|del)>/gi, "~");
+  result = result.replace(/<a\s+[^>]*href="([^"]*)"[^>]*>([^<]*)<\/a>/gi, "$2 ($1)");
+  result = result.replace(/<[^>]+>/g, "");
+
   // 5. Restore inline code
   result = result.replace(
     new RegExp(`${escapeRegExp(INLINE_CODE_PLACEHOLDER)}(\\d+)`, "g"),


### PR DESCRIPTION
## Summary

- **Problem:** Model output containing HTML tags (e.g. `<br>`, `<b>`, `<a>`) is sent as literal text to WhatsApp, since the delivery pipeline has no HTML sanitization.
- **Why it matters:** Users see raw HTML markup in WhatsApp messages instead of formatted text or line breaks.
- **What changed:** Added HTML-to-WhatsApp conversion in `markdownToWhatsApp()` that runs after Markdown conversion but before code block restoration. Converts semantic tags to WhatsApp formatting and strips the rest.
- **What did NOT change:** Code blocks are protected and not affected. Existing Markdown conversion is preserved. Other channels are not impacted.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31884

## User-visible / Behavior Changes

- `<br>` / `<br/>` → newline
- `<b>` / `<strong>` → `*bold*`
- `<i>` / `<em>` → `_italic_`
- `<s>` / `<del>` → `~strike~`
- `<a href="url">text</a>` → `text (url)`
- Other HTML tags → stripped

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime: Node.js v22
- Integration/channel: WhatsApp

### Steps

1. Send a message through any model that produces HTML (e.g. Claude with `<br>` in output)
2. Observe the WhatsApp message

### Expected

- HTML tags are converted to WhatsApp formatting or stripped

### Actual

- Before fix: `<br>` and other HTML tags appear as literal text
- After fix: `<br>` becomes newline, `<b>text</b>` becomes `*text*`, etc.

## Evidence

Test results (5/5 passing):
```
✓ src/markdown/whatsapp.test.ts (5 tests) 3ms
  Tests  5 passed (5)
```

New test cases added:
- `<br>` variants → newline
- `<b>`, `<strong>`, `<i>`, `<em>`, `<s>`, `<del>` → WhatsApp markers
- `<a href>` → text with URL
- Unknown tags → stripped
- Code blocks protected from stripping

## Human Verification (required)

- Verified scenarios: All 5 tests pass including 12 new HTML test cases
- Edge cases checked: self-closing `<br/>`, `<br />`, `<hr/>`, unknown tags, nested tags, code block protection
- What I did **not** verify: Live WhatsApp delivery test

## Compatibility / Migration

- Backward compatible? `Yes` — additive conversion; previously unsupported tags now handled
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the HTML conversion lines in `markdownToWhatsApp()`
- Files/config to restore: `src/markdown/whatsapp.ts`
- Known bad symptoms: If a model intentionally outputs HTML for display, it would now be stripped

## Risks and Mitigations

- Risk: Stripping HTML that was intentionally part of the message → Low risk since WhatsApp is a plain-text surface and HTML should never be rendered as-is
