### PR TITLE
fix(agents): allow keyless native ollama auth fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Control UI CSP: allow required Google Fonts origins in Control UI CSP. (#29279) Thanks @Glucksberg and @vincentkoc.
 - CLI/Install: add an npm-link fallback to fix CLI startup `Permission denied` failures (`exit 127`) on affected installs. (#17151) Thanks @sskyu and @vincentkoc.
 - Onboarding/Custom providers: improve verification reliability for slower local endpoints (for example Ollama) during setup. (#27380) Thanks @Sid-Qin.
+- Agents/Ollama auth fallback: allow native Ollama provider runs to proceed without preconfigured auth-profiles API keys by applying a local default placeholder during runtime auth resolution, while preserving strict key enforcement for explicit OpenAI-compatible Ollama provider configs. (#31577)
 - Plugins/NPM spec install: fix npm-spec plugin installs when `npm pack` output is empty by detecting newly created `.tgz` archives in the pack directory. (#21039) Thanks @graysurf and @vincentkoc.
 - Plugins/Install: clear stale install errors when an npm package is not found so follow-up install attempts report current state correctly. (#25073) Thanks @dalefrieswthat.
 - Security/Feishu webhook ingress: bound unauthenticated webhook rate-limit state with stale-window pruning and a hard key cap to prevent unbounded pre-auth memory growth from rotating source keys. (#26050) Thanks @bmendonca3.

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -187,6 +187,55 @@ describe("getApiKeyForModel", () => {
     );
   });
 
+  it("falls back to a local placeholder key for native ollama when no auth is configured", async () => {
+    await withEnvAsync(
+      {
+        OLLAMA_API_KEY: undefined,
+      },
+      async () => {
+        const resolved = await resolveApiKeyForProvider({
+          provider: "ollama",
+          store: { version: 1, profiles: {} },
+        });
+
+        expect(resolved.apiKey).toBe("ollama-local");
+        expect(resolved.source).toContain("provider-default");
+      },
+    );
+  });
+
+  it("keeps key enforcement for ollama providers configured as openai-compatible", async () => {
+    await withEnvAsync(
+      {
+        OLLAMA_API_KEY: undefined,
+      },
+      async () => {
+        let error: unknown = null;
+        try {
+          await resolveApiKeyForProvider({
+            provider: "ollama",
+            store: { version: 1, profiles: {} },
+            cfg: {
+              models: {
+                providers: {
+                  ollama: {
+                    api: "openai-completions",
+                    baseUrl: "http://127.0.0.1:11434/v1",
+                    models: [],
+                  },
+                },
+              },
+            } as never,
+          });
+        } catch (err) {
+          error = err;
+        }
+
+        expect(String(error)).toContain('No API key found for provider "ollama".');
+      },
+    );
+  });
+
   it("accepts legacy Z_AI_API_KEY for zai", async () => {
     await withEnvAsync(
       {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -67,6 +67,22 @@ function resolveProviderAuthOverride(
   return undefined;
 }
 
+function resolveApiKeyFallbackForLocalProvider(params: {
+  provider: string;
+  cfg: OpenClawConfig | undefined;
+}): string | undefined {
+  const normalized = normalizeProviderId(params.provider);
+  if (normalized !== "ollama") {
+    return undefined;
+  }
+  const providerConfig = resolveProviderConfig(params.cfg, params.provider);
+  // Keep strict API-key checks for explicitly OpenAI-compatible ollama setups.
+  if (providerConfig?.api && providerConfig.api !== "ollama") {
+    return undefined;
+  }
+  return "ollama-local";
+}
+
 function resolveEnvSourceLabel(params: {
   applied: Set<string>;
   envVars: string[];
@@ -210,6 +226,18 @@ export async function resolveApiKeyForProvider(params: {
   const normalized = normalizeProviderId(provider);
   if (authOverride === undefined && normalized === "amazon-bedrock") {
     return resolveAwsSdkAuthInfo();
+  }
+
+  const localFallbackApiKey = resolveApiKeyFallbackForLocalProvider({
+    provider,
+    cfg,
+  });
+  if (localFallbackApiKey) {
+    return {
+      apiKey: localFallbackApiKey,
+      source: `provider-default: ${localFallbackApiKey}`,
+      mode: "api-key",
+    };
   }
 
   if (provider === "openai") {


### PR DESCRIPTION
## Summary

- Problem: Local `ollama` runs could fail with `No API key found for provider "ollama"` when auth profiles/env keys were not configured, even though native Ollama does not require real auth.
- Why it matters: This blocks `ollama launch openclaw` local-model workflows and regresses a core local-provider path.
- What changed: Added a native Ollama auth fallback in provider auth resolution that supplies a local placeholder key when no key/profile/env is available.
- What changed: Added regression tests for both native-Ollama fallback and explicit OpenAI-compatible Ollama strict-key enforcement.
- What did NOT change (scope boundary): Explicit OpenAI-compatible Ollama provider configs still require a real configured API key.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31577
- Related #17328

## User-visible / Behavior Changes

- Native Ollama runs no longer hard-fail on missing auth profile/API key; OpenClaw now uses a local default placeholder for native `api: "ollama"` auth resolution.
- Explicit OpenAI-compatible Ollama provider configs remain strict and still fail when keyless.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev), issue repro on Ubuntu 24.04
- Runtime/container: local CLI/gateway
- Model/provider: `ollama/qwen3:8b`
- Integration/channel (if any): TUI/Web
- Relevant config (redacted): provider `ollama` with native API path

### Steps

1. Run auth resolution for provider `ollama` without auth profiles and with `OLLAMA_API_KEY` unset.
2. Run auth resolution for provider `ollama` configured explicitly as `api: "openai-completions"` with key unset.
3. Verify fallback behavior in case (1) and strict failure in case (2).

### Expected

- Native Ollama path resolves successfully with local placeholder auth.
- OpenAI-compatible Ollama path remains key-required.

### Actual

- Matches expected after patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `resolveApiKeyForProvider({ provider: "ollama" })` succeeds keyless and returns placeholder key.
  - `resolveApiKeyForProvider({ provider: "ollama", cfg: { models.providers.ollama.api = "openai-completions" } })` still throws missing-key error.
- Edge cases checked:
  - Existing env/profile key paths still unchanged.
  - Bedrock/aws-sdk and other provider auth paths unchanged by targeted tests.
- What you did **not** verify:
  - Full end-to-end live Ollama session on Ubuntu host in this PR run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/model-auth.ts`
  - `src/agents/model-auth.profiles.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected auth acceptance for non-native OpenAI-compatible Ollama configs (guarded by regression test).

## Risks and Mitigations

- Risk: Over-broad fallback could mask missing auth for explicit OpenAI-compatible Ollama endpoints.
  - Mitigation: Fallback is gated to native Ollama mode; explicit `api !== "ollama"` remains strict and is covered by test.
