### PR TITLE
feat(agents): inject timestamp into bare session reset prompt

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -15,6 +15,10 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import {
+  injectTimestamp,
+  timestampOptsFromConfig,
+} from "../../gateway/server-methods/agent-timestamp.js";
 import { logVerbose } from "../../globals.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
@@ -302,7 +306,7 @@ export async function runPreparedReply(
       : { ...sessionCtx, ThreadStarterBody: undefined },
   );
   const baseBodyForPrompt = isBareSessionReset
-    ? baseBodyFinal
+    ? injectTimestamp(baseBodyFinal, timestampOptsFromConfig(cfg))
     : [inboundUserContext, baseBodyFinal].filter(Boolean).join("\n\n");
   const baseBodyTrimmed = baseBodyForPrompt.trim();
   const hasMediaAttachment = Boolean(

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -326,8 +326,6 @@ export const agentHandlers: GatewayRequestHandlers = {
     let bestEffortDeliver = requestedBestEffortDeliver ?? false;
     let cfgForAgent: ReturnType<typeof loadConfig> | undefined;
     let resolvedSessionKey = requestedSessionKey;
-    let skipTimestampInjection = false;
-
     const resetCommandMatch = message.match(RESET_COMMAND_RE);
     if (resetCommandMatch && requestedSessionKey) {
       const resetReason = resetCommandMatch[1]?.toLowerCase() === "new" ? "new" : "reset";
@@ -349,10 +347,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       if (postResetMessage) {
         message = postResetMessage;
       } else {
-        // Keep bare /new and /reset behavior aligned with chat.send:
-        // reset first, then run a fresh-session greeting prompt in-place.
         message = BARE_SESSION_RESET_PROMPT;
-        skipTimestampInjection = true;
       }
     }
 
@@ -360,9 +355,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     // Channel messages (Discord, Telegram, etc.) get timestamps via envelope
     // formatting in a separate code path — they never reach this handler.
     // See: https://github.com/moltbot/moltbot/issues/3658
-    if (!skipTimestampInjection) {
-      message = injectTimestamp(message, timestampOptsFromConfig(cfg));
-    }
+    message = injectTimestamp(message, timestampOptsFromConfig(cfg));
 
     if (requestedSessionKey) {
       const { cfg, storePath, entry, canonicalKey } = loadSessionEntry(requestedSessionKey);

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { BARE_SESSION_RESET_PROMPT } from "../../auto-reply/reply/session-reset-prompt.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js";
 import { buildSystemRunApprovalBinding } from "../../infra/system-run-approval-binding.js";
@@ -180,6 +181,14 @@ describe("injectTimestamp", () => {
     });
 
     expect(result).toMatch(/^\[Fri 2025-07-04 12:00 EDT\]/);
+  });
+
+  it("injects timestamp into bare session reset prompt", () => {
+    const result = injectTimestamp(BARE_SESSION_RESET_PROMPT, {
+      timezone: "America/New_York",
+    });
+
+    expect(result).toMatch(/^\[Wed 2026-01-28 20:30 EST\] A new session was started/);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Problem:** When a session starts via /new or /reset, the agent receives no date/time context in the startup prompt, causing frequent date misidentification when reading memory files from recent days.
- **Why it matters:** Agents that manage calendars, daily notes, and time-sensitive tasks (morning briefs, cron jobs, scheduling) frequently say "yesterday" or "today" incorrectly.
- **What changed:** Removed the `skipTimestampInjection` guard for bare resets in the gateway handler and applied `injectTimestamp` in the auto-reply path, so both TUI/webchat and channel surfaces include a compact timestamp prefix in the startup prompt.
- **What did NOT change:** System prompt caching behavior is unaffected — the timestamp lives in the user message, not the system prompt. Normal (non-reset) message flow is unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31893

## User-visible / Behavior Changes

- Bare /new and /reset commands now include a timestamp prefix (e.g. \`[Wed 2026-03-02 14:30 EST]\`) in the startup prompt sent to the agent.
- The agent can now reliably identify the current date, time, and day of week at session startup.

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime: Node.js
- Integration/channel: All (webchat, TUI, Discord, Telegram, etc.)

### Steps

1. Send \`/new\` or \`/reset\` to start a new session.
2. The agent reads memory files and greets the user.

### Expected

- The startup prompt contains a timestamp so the agent knows today's date.

### Actual

- Before fix: No timestamp in bare reset prompt; agent infers date from file names and often gets it wrong.
- After fix: Timestamp prefix is injected (e.g. \`[Wed 2026-03-02 14:30 EST] A new session was started...\`).

## Evidence

Gateway path: removed \`skipTimestampInjection = true\` so existing \`injectTimestamp()\` applies.
Auto-reply path: added \`injectTimestamp(baseBodyFinal, timestampOptsFromConfig(cfg))\` for bare session resets.
Test: added test case verifying timestamp is injected into BARE_SESSION_RESET_PROMPT.

## Human Verification (required)

- Verified scenarios: bare /new, bare /reset, /new with follow-up message, normal messages
- Edge cases checked: cron-injected timestamps not double-stamped, channel envelope timestamps not double-stamped
- What I did **not** verify: timezone edge cases across all possible IANA timezone identifiers

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert commit; re-add \`skipTimestampInjection = true\` in gateway handler
- Files/config to restore: \`src/gateway/server-methods/agent.ts\`, \`src/auto-reply/reply/get-reply-run.ts\`
- Known bad symptoms: If broken, agent would receive a malformed timestamp prefix

## Risks and Mitigations

- Risk: Prompt caching invalidation — Mitigated: timestamp is in user message, not system prompt
- Risk: Double-stamping — Mitigated: \`injectTimestamp\` has pattern detection for existing timestamps

