### PR TITLE
fix: improve prompt caching by stabilizing identity prefix

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -5,6 +5,196 @@ import { buildSubagentSystemPrompt } from "./subagent-announce.js";
 import { buildAgentSystemPrompt, buildRuntimeLine } from "./system-prompt.js";
 
 describe("buildAgentSystemPrompt", () => {
+  it("uses runtime agent id in the identity line when available", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      runtimeInfo: { agentId: "agent:main" },
+    });
+
+    expect(
+      prompt.startsWith("You are agent:main, a personal assistant running inside OpenClaw."),
+    ).toBe(true);
+  });
+
+  it("uses ownerDisplaySecret to derive a stable installation fingerprint in identity line", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      ownerDisplaySecret: "owner-secret-1",
+    });
+
+    expect(prompt).toMatch(
+      /^You are a personal assistant running inside OpenClaw\. Installation: [a-f0-9]{12}\./,
+    );
+  });
+
+  it("keeps installation fingerprint stable for the same ownerDisplaySecret", () => {
+    const promptA = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      ownerDisplaySecret: "same-secret",
+    });
+    const promptB = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      ownerDisplaySecret: "same-secret",
+    });
+
+    const lineA = promptA.split("\n", 1)[0];
+    const lineB = promptB.split("\n", 1)[0];
+    expect(lineA).toBe(lineB);
+  });
+
+  it("changes installation fingerprint when ownerDisplaySecret changes", () => {
+    const promptA = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      ownerDisplaySecret: "secret-a",
+    });
+    const promptB = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      ownerDisplaySecret: "secret-b",
+    });
+
+    const lineA = promptA.split("\n", 1)[0];
+    const lineB = promptB.split("\n", 1)[0];
+    expect(lineA).not.toBe(lineB);
+  });
+
+  it("uses derived identity line for none prompt mode", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "none",
+      runtimeInfo: { agentId: "agent:none" },
+    });
+
+    expect(prompt).toBe("You are agent:none, a personal assistant running inside OpenClaw.");
+  });
+
+  it("prefers runtime agent id over installation fingerprint when both are present", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      runtimeInfo: { agentId: "agent:preferred" },
+      ownerDisplaySecret: "owner-secret",
+    });
+
+    expect(
+      prompt.startsWith("You are agent:preferred, a personal assistant running inside OpenClaw."),
+    ).toBe(true);
+    expect(prompt).not.toContain("Installation:");
+  });
+
+  it("falls back to generic identity line when no differentiator is available", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "none",
+    });
+
+    expect(prompt).toBe("You are a personal assistant running inside OpenClaw.");
+  });
+
+  it("ignores blank runtime agent id and falls back to installation fingerprint", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      runtimeInfo: { agentId: "   " },
+      ownerDisplaySecret: "owner-secret-fallback",
+    });
+
+    expect(prompt).toMatch(
+      /^You are a personal assistant running inside OpenClaw\. Installation: [a-f0-9]{12}\./,
+    );
+  });
+
+  it("ignores blank ownerDisplaySecret and keeps generic identity line", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      ownerDisplaySecret: "   ",
+      promptMode: "none",
+    });
+
+    expect(prompt).toBe("You are a personal assistant running inside OpenClaw.");
+  });
+
+  it("does not expose raw ownerDisplaySecret in prompt output", () => {
+    const secret = "super-sensitive-owner-secret";
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      ownerDisplaySecret: secret,
+    });
+
+    expect(prompt).not.toContain(secret);
+  });
+
+  it("does not expose owner numbers in the identity line when using fingerprint", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      ownerDisplaySecret: "owner-secret-anon",
+      ownerNumbers: ["+123456789"],
+      ownerDisplay: "hash",
+    });
+
+    const firstLine = prompt.split("\n", 1)[0] ?? "";
+    expect(firstLine).not.toContain("+123456789");
+    expect(firstLine).toMatch(/Installation: [a-f0-9]{12}\./);
+  });
+
+  it("keeps identity line deterministic regardless of other prompt sections", () => {
+    const promptA = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      ownerDisplaySecret: "stable-secret",
+      toolNames: ["exec"],
+      skillsPrompt: "<available_skills></available_skills>",
+    });
+    const promptB = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      ownerDisplaySecret: "stable-secret",
+      toolNames: ["exec", "read", "write"],
+      skillsPrompt: "<available_skills><skill></skill></available_skills>",
+    });
+
+    const firstLineA = promptA.split("\n", 1)[0];
+    const firstLineB = promptB.split("\n", 1)[0];
+    expect(firstLineA).toBe(firstLineB);
+  });
+
+  it("uses lowercase hex fingerprint format", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      ownerDisplaySecret: "hex-format-secret",
+    });
+
+    const firstLine = prompt.split("\n", 1)[0] ?? "";
+    const match = firstLine.match(/Installation: ([a-f0-9]{12})\./);
+    expect(match).toBeTruthy();
+    expect(match?.[1]).toBe(match?.[1]?.toLowerCase());
+  });
+
+  it("does not include installation fingerprint when runtime agent id is present in none mode", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "none",
+      runtimeInfo: { agentId: "agent:none-priority" },
+      ownerDisplaySecret: "secret-ignored",
+    });
+
+    expect(prompt).toBe(
+      "You are agent:none-priority, a personal assistant running inside OpenClaw.",
+    );
+    expect(prompt).not.toContain("Installation:");
+  });
+
+  it("keeps identity line unchanged between full and minimal mode for same identifiers", () => {
+    const fullPrompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      ownerDisplaySecret: "mode-stable-secret",
+      promptMode: "full",
+    });
+    const minimalPrompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      ownerDisplaySecret: "mode-stable-secret",
+      promptMode: "minimal",
+    });
+
+    const fullFirst = fullPrompt.split("\n", 1)[0];
+    const minimalFirst = minimalPrompt.split("\n", 1)[0];
+    expect(fullFirst).toBe(minimalFirst);
+  });
   it("formats owner section for plain, hash, and missing owner lists", () => {
     const cases = typedCases<{
       name: string;

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -93,6 +93,24 @@ function buildOwnerIdentityLine(
   return `Authorized senders: ${displayOwnerNumbers.join(", ")}. These senders are allowlisted; do not assume they are the owner.`;
 }
 
+function buildPromptIdentityLine(params: { runtimeAgentId?: string; ownerDisplaySecret?: string }) {
+  const agentId = params.runtimeAgentId?.trim();
+  if (agentId) {
+    return `You are ${agentId}, a personal assistant running inside OpenClaw.`;
+  }
+
+  const secret = params.ownerDisplaySecret?.trim();
+  if (secret) {
+    const installationFingerprint = createHmac("sha256", secret)
+      .update("openclaw-system-prompt-identity")
+      .digest("hex")
+      .slice(0, 12);
+    return `You are a personal assistant running inside OpenClaw. Installation: ${installationFingerprint}.`;
+  }
+
+  return "You are a personal assistant running inside OpenClaw.";
+}
+
 function buildTimeSection(params: { userTimezone?: string }) {
   if (!params.userTimezone) {
     return [];
@@ -408,14 +426,18 @@ export function buildAgentSystemPrompt(params: {
     readToolName,
   });
   const workspaceNotes = (params.workspaceNotes ?? []).map((note) => note.trim()).filter(Boolean);
+  const identityLine = buildPromptIdentityLine({
+    runtimeAgentId: params.runtimeInfo?.agentId,
+    ownerDisplaySecret: params.ownerDisplaySecret,
+  });
 
   // For "none" mode, return just the basic identity line
   if (promptMode === "none") {
-    return "You are a personal assistant running inside OpenClaw.";
+    return identityLine;
   }
 
   const lines = [
-    "You are a personal assistant running inside OpenClaw.",
+    identityLine,
     "",
     "## Tooling",
     "Tool availability (filtered by policy):",


### PR DESCRIPTION
## Summary
Fixes #31708 (re-file of #23715).

Prompt caching was ineffective because the first system prompt line was globally constant across installations ("You are a personal assistant running inside OpenClaw."). For providers that cache from the prompt prefix, this caused cross-install cache pollution/misses and poor cache hit rates.

This PR makes the first line installation-stable and cache-friendly:

- Prefer runtime agent id when available:
  - 
- Otherwise derive a stable installation fingerprint from :
  - 
- Fall back to generic line only when no differentiator exists.

## Why this fixes the issue
- Cache keys now vary by install/session identity instead of being globally shared.
- The prefix remains deterministic for a given install, maximizing repeated cache hits.
- No secret leakage: only a short HMAC-derived fingerprint is exposed (never raw secret).

## Tests
Added/updated  coverage for:
- runtime agent id precedence
- deterministic fingerprint derivation
- fingerprint changes when secret changes
-  behavior
- blank value fallbacks
- no raw secret exposure
- stability across prompt modes/sections

Ran:
- 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/tmp/tmp.SB7pJ0tOUt/openclaw[39m

 [32m✓[39m src/agents/system-prompt.test.ts [2m([22m[2m56 tests[22m[2m)[22m[32m 37[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m56 passed[39m[22m[90m (56)[39m
[2m   Start at [22m 00:47:27
[2m   Duration [22m 13.18s[2m (transform 8.69s, setup 370ms, import 12.60s, tests 37ms, environment 0ms)[22m
