### PR TITLE
Agents: clarify developer role rejection

### DIFF
--- a/.ci-pr31921-last.log
+++ b/.ci-pr31921-last.log
@@ -1,0 +1,1 @@
+no required checks reported on the 'fix/developer-role-unsupported-hint' branch

--- a/.ci-pr31921-watch.log
+++ b/.ci-pr31921-watch.log
@@ -1,0 +1,714 @@
+2026-03-02T17:59:25Z fail= pending=
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T17:59:40Z fail= pending=
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T17:59:54Z fail= pending=
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:00:20Z required_checks=not_ready exit=1
+no required checks reported on the 'fix/developer-role-unsupported-hint' branch
+----
+2026-03-02T18:00:34Z required_checks=not_ready exit=1
+no required checks reported on the 'fix/developer-role-unsupported-hint' branch
+----
+2026-03-02T18:00:48Z required_checks=not_ready exit=1
+no required checks reported on the 'fix/developer-role-unsupported-hint' branch
+----
+2026-03-02T18:00:51Z fail=1 pending=3
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:01:08Z fail=1 pending=3
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:01:24Z fail=1 pending=3
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:01:41Z fail=1 pending=3
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:01:58Z fail=1 pending=3
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:02:15Z fail=1 pending=2
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:02:32Z fail=1 pending=2
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:02:48Z fail=1 pending=2
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:03:05Z fail=1 pending=2
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:03:22Z fail=1 pending=1
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:03:39Z fail=1 pending=1
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:03:56Z fail=1 pending=1
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:04:13Z fail=1 pending=1
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:04:30Z fail=1 pending=1
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:04:47Z fail=1 pending=1
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:05:04Z fail=1 pending=1
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:05:21Z fail=1 pending=1
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:05:38Z fail=1 pending=1
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:05:55Z fail=1 pending=1
+checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)	fail	2m20s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672146	
+android	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672746	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500306	
+dead-code report	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584676	
+checks-windows (node, test, 1, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774939	
+checks (node, protocol, pnpm protocol:check)	pass	24s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672131	
+checks-windows (node, lint, 0, 1, pnpm lint)	pending	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774942	
+checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)	pass	2m19s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672134	
+build-artifacts	pass	44s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672118	
+release-check	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440775300	
+macos	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440672797	
+ios	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503521	
+checks-windows (node, protocol, 0, 1, pnpm protocol:check)	pass	2m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774965	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503132	
+check-docs	pass	30s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540267	
+check	pass	1m0s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540247	
+changed-scope	pass	18s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440540195	
+checks-windows (node, test, 2, 2, pnpm canvas:a2ui:bundle && pnpm test)	pass	5m57s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440774962	
+docs-scope	pass	16s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440503223	
+docs-scope	pass	14s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503324	
+install-smoke	pass	2m9s	https://github.com/openclaw/openclaw/actions/runs/22588672008/job/65440541823	
+label	pass	13s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500089	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22588671029/job/65440500086	
+no-tabs	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22588672025/job/65440503134	
+secrets	pass	1m17s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440503326	
+skills-python	pass	11s	https://github.com/openclaw/openclaw/actions/runs/22588672046/job/65440584226	
+----
+2026-03-02T18:06:12Z fail=0 pending=5
+actionlint	pending	0	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054620	
+docs-scope	pending	0	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442055058	
+label	pending	0	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051133	
+label-issues	pending	0	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051213	
+no-tabs	pending	0	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054645	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051630	
+----
+2026-03-02T18:06:29Z fail=0 pending=1
+docs-scope	pending	0	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442055058	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054620	
+label	pass	12s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051133	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051213	
+no-tabs	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054645	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051630	
+----
+2026-03-02T18:06:45Z fail=0 pending=1
+install-smoke	pending	0	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442108605	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054620	
+docs-scope	pass	22s	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442055058	
+label	pass	12s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051133	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051213	
+no-tabs	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054645	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051630	
+----
+2026-03-02T18:07:02Z fail=0 pending=1
+install-smoke	pending	0	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442108605	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054620	
+docs-scope	pass	22s	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442055058	
+label	pass	12s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051133	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051213	
+no-tabs	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054645	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051630	
+----
+2026-03-02T18:07:20Z fail=0 pending=1
+install-smoke	pending	0	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442108605	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054620	
+docs-scope	pass	22s	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442055058	
+label	pass	12s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051133	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051213	
+no-tabs	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054645	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051630	
+----
+2026-03-02T18:07:36Z fail=0 pending=1
+install-smoke	pending	0	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442108605	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054620	
+docs-scope	pass	22s	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442055058	
+label	pass	12s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051133	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051213	
+no-tabs	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054645	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051630	
+----
+2026-03-02T18:07:53Z fail=0 pending=1
+install-smoke	pending	0	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442108605	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054620	
+docs-scope	pass	22s	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442055058	
+label	pass	12s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051133	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051213	
+no-tabs	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054645	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051630	
+----
+2026-03-02T18:08:10Z fail=0 pending=1
+install-smoke	pending	0	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442108605	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054620	
+docs-scope	pass	22s	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442055058	
+label	pass	12s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051133	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051213	
+no-tabs	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054645	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051630	
+----
+2026-03-02T18:08:27Z fail=0 pending=1
+install-smoke	pending	0	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442108605	
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054620	
+docs-scope	pass	22s	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442055058	
+label	pass	12s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051133	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051213	
+no-tabs	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054645	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051630	
+----
+2026-03-02T18:08:44Z fail=0 pending=0
+actionlint	pass	9s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054620	
+docs-scope	pass	22s	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442055058	
+install-smoke	pass	2m0s	https://github.com/openclaw/openclaw/actions/runs/22589127851/job/65442108605	
+label	pass	12s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051133	
+label-issues	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051213	
+no-tabs	pass	8s	https://github.com/openclaw/openclaw/actions/runs/22589127868/job/65442054645	
+backfill-pr-labels	skipping	0	https://github.com/openclaw/openclaw/actions/runs/22589126816/job/65442051630	
+----
+2026-03-02T18:08:44Z ALL_GREEN

--- a/scripts/mount-raid-huawei.sh
+++ b/scripts/mount-raid-huawei.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CONFIG_FILE="${MOUNT_SHARES_CONFIG:-$HOME/.config/mount-shares.env}"
+
+if [[ -f "$CONFIG_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$CONFIG_FILE"
+fi
+
+log() {
+  printf '%s\n' "$*"
+}
+
+warn() {
+  printf 'WARN: %s\n' "$*" >&2
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [mount|status|print-config|help]
+
+默认行为：一键挂载 ~/raid 和 ~/huawei。
+适合在局域网里的其他 Mac 上直接执行。
+
+可选配置文件：$CONFIG_FILE
+推荐配置方式（适合其他 Mac 自动挂载）：
+  RAID_HOST='raid.local'
+  RAID_SHARE='raid'
+  RAID_USER='your-user'
+  RAID_PASSWORD='your-password'
+
+  HUAWEI_HOST='huawei.my'
+  HUAWEI_SHARE='家庭共享'
+  HUAWEI_USER='GUEST'
+  HUAWEI_PASSWORD=''
+
+也支持直接指定完整 source：
+  RAID_SOURCE='//user:password@raid.local/raid'
+  HUAWEI_SOURCE='//GUEST@huawei.my/%E5%AE%B6%E5%BA%AD%E5%85%B1%E4%BA%AB'
+
+说明：
+  - 未设置 PASSWORD 时，macOS 可能会弹出密码提示，不算“全自动”
+  - 如需完全无提示挂载，请在配置文件里设置 PASSWORD，或改用 ~/.nsmbrc
+  - SHARE 支持直接写中文；脚本会优先尝试自动编码
+EOF
+}
+
+print_config() {
+  cat <<EOF
+# 保存到: $CONFIG_FILE
+# chmod 600 $CONFIG_FILE
+
+RAID_TARGET='$HOME/raid'
+HUAWEI_TARGET='$HOME/huawei'
+
+# 方式 1：按 host/share/user/password 拆开写，适合其他 Mac 复用
+RAID_HOST='raid.local'
+RAID_SHARE='raid'
+RAID_USER='your-user'
+RAID_PASSWORD='your-password'
+
+HUAWEI_HOST='huawei.my'
+HUAWEI_SHARE='家庭共享'
+HUAWEI_USER='GUEST'
+HUAWEI_PASSWORD=''
+
+# 方式 2：直接写完整 source；若设置了 SOURCE，会覆盖上面的 HOST/SHARE/USER/PASSWORD
+# RAID_SOURCE='//user:password@raid.local/raid'
+# HUAWEI_SOURCE='//GUEST@huawei.my/%E5%AE%B6%E5%BA%AD%E5%85%B1%E4%BA%AB'
+EOF
+}
+
+require_macos() {
+  command -v mount_smbfs >/dev/null 2>&1 || {
+    printf 'ERROR: 这个脚本依赖 macOS 的 mount_smbfs。\n' >&2
+    exit 1
+  }
+}
+
+normalize_host() {
+  local host="$1"
+  host="${host#smb://}"
+  host="${host#//}"
+  host="${host%/}"
+  printf '%s' "$host"
+}
+
+encode_share() {
+  local share="$1"
+
+  if [[ -z "$share" ]]; then
+    return 0
+  fi
+
+  share="${share#/}"
+
+  if [[ "$share" == *%* ]]; then
+    printf '%s' "$share"
+    return 0
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$share" <<'PY'
+import sys
+from urllib.parse import quote
+print(quote(sys.argv[1], safe=""), end="")
+PY
+    return 0
+  fi
+
+  printf '%s' "$share"
+}
+
+build_source() {
+  local source="$1"
+  local user="$2"
+  local password="$3"
+  local host="$4"
+  local share="$5"
+
+  if [[ -n "$source" ]]; then
+    printf '%s' "$source"
+    return 0
+  fi
+
+  host="$(normalize_host "$host")"
+  share="$(encode_share "$share")"
+
+  if [[ -z "$host" || -z "$share" ]]; then
+    return 0
+  fi
+
+  if [[ -n "$user" && -n "$password" ]]; then
+    printf '//%s:%s@%s/%s' "$user" "$password" "$host" "$share"
+    return 0
+  fi
+
+  if [[ -n "$user" ]]; then
+    printf '//%s@%s/%s' "$user" "$host" "$share"
+    return 0
+  fi
+
+  printf '//%s/%s' "$host" "$share"
+}
+
+redact_source() {
+  printf '%s' "$1" | sed -E 's#//([^/@:]+):[^@]*@#//\1:***@#'
+}
+
+is_mounted() {
+  mount | grep -F " on $1 (" >/dev/null 2>&1
+}
+
+warn_if_nonempty_dir() {
+  local target="$1"
+  if [[ -d "$target" ]] && find "$target" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+    warn "$target 不是空目录；挂载后会临时遮住下面原有内容，卸载后会恢复。"
+  fi
+}
+
+mount_one() {
+  local label="$1"
+  local help_name="$2"
+  local source="$3"
+  local target="$4"
+
+  if [[ -z "$source" ]]; then
+    warn "$label 未配置。请运行: $(basename "$0") print-config"
+    warn "然后在 $CONFIG_FILE 里填写 ${help_name}_HOST / ${help_name}_SHARE / ${help_name}_USER / ${help_name}_PASSWORD"
+    return 1
+  fi
+
+  mkdir -p "$target"
+
+  if is_mounted "$target"; then
+    log "$label: 已挂载 -> $target"
+    return 0
+  fi
+
+  warn_if_nonempty_dir "$target"
+  log "$label: 挂载 $(redact_source "$source") -> $target"
+  mount_smbfs "$source" "$target"
+  log "$label: 完成"
+}
+
+show_status() {
+  local target
+  for target in "$RAID_TARGET" "$HUAWEI_TARGET"; do
+    if is_mounted "$target"; then
+      df -h "$target"
+    else
+      log "未挂载: $target"
+    fi
+    printf '\n'
+  done
+}
+
+RAID_TARGET="${RAID_TARGET:-$HOME/raid}"
+HUAWEI_TARGET="${HUAWEI_TARGET:-$HOME/huawei}"
+
+RAID_HOST="${RAID_HOST:-}"
+RAID_SHARE="${RAID_SHARE:-}"
+RAID_USER="${RAID_USER:-}"
+RAID_PASSWORD="${RAID_PASSWORD:-}"
+RAID_SOURCE="${RAID_SOURCE:-}"
+
+HUAWEI_HOST="${HUAWEI_HOST:-huawei.my}"
+HUAWEI_SHARE="${HUAWEI_SHARE:-家庭共享}"
+HUAWEI_USER="${HUAWEI_USER:-GUEST}"
+HUAWEI_PASSWORD="${HUAWEI_PASSWORD:-}"
+HUAWEI_SOURCE="${HUAWEI_SOURCE:-}"
+
+RAID_SOURCE="$(build_source "$RAID_SOURCE" "$RAID_USER" "$RAID_PASSWORD" "$RAID_HOST" "$RAID_SHARE")"
+HUAWEI_SOURCE="$(build_source "$HUAWEI_SOURCE" "$HUAWEI_USER" "$HUAWEI_PASSWORD" "$HUAWEI_HOST" "$HUAWEI_SHARE")"
+
+main() {
+  local action="${1:-mount}"
+  require_macos
+
+  case "$action" in
+    mount)
+      local failures=0
+      mount_one "raid" "RAID" "$RAID_SOURCE" "$RAID_TARGET" || failures=1
+      mount_one "huawei" "HUAWEI" "$HUAWEI_SOURCE" "$HUAWEI_TARGET" || failures=1
+      printf '\n'
+      show_status
+      exit "$failures"
+      ;;
+    status)
+      show_status
+      ;;
+    print-config)
+      print_config
+      ;;
+    help|-h|--help)
+      usage
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -162,6 +162,17 @@ describe("normalizeModelCompat", () => {
     ).toBe(false);
   });
 
+  it("forces supportsDeveloperRole off for vectortara OpenAI-compatible models", () => {
+    const model = {
+      ...baseModel(),
+      provider: "vectortara",
+      baseUrl: "https://api.vectortara.com/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+  });
+
   it("leaves non-zai models untouched", () => {
     const model = {
       ...baseModel(),
@@ -225,5 +236,16 @@ describe("resolveForwardCompatModel", () => {
     });
     const model = resolveForwardCompatModel("openai", "claude-opus-4-6", registry);
     expect(model).toBeUndefined();
+  });
+
+  it("does not override explicit vectortara compat false", () => {
+    const model = {
+      ...baseModel(),
+      provider: "vectortara",
+      baseUrl: "https://api.vectortara.com/v1",
+      compat: { supportsDeveloperRole: false },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
   });
 });

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -170,7 +170,9 @@ describe("normalizeModelCompat", () => {
     };
     delete (model as { compat?: unknown }).compat;
     const normalized = normalizeModelCompat(model);
-    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+    expect(
+      (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
+    ).toBe(false);
   });
 
   it("leaves non-zai models untouched", () => {
@@ -246,6 +248,8 @@ describe("resolveForwardCompatModel", () => {
       compat: { supportsDeveloperRole: false },
     };
     const normalized = normalizeModelCompat(model);
-    expect(normalized.compat?.supportsDeveloperRole).toBe(false);
+    expect(
+      (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
+    ).toBe(false);
   });
 });

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -49,7 +49,10 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const isDashScope = model.provider === "dashscope" || isDashScopeCompatibleEndpoint(baseUrl);
   const isVectortara = model.provider === "vectortara" || baseUrl.includes("vectortara.com");
 
-  if ((!isZai && !isMoonshot && !isDashScope && !isVectortara) || !isOpenAiCompletionsModel(model)) {
+  if (
+    (!isZai && !isMoonshot && !isDashScope && !isVectortara) ||
+    !isOpenAiCompletionsModel(model)
+  ) {
     return model;
   }
 

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -28,6 +28,7 @@ function isAnthropicMessagesModel(model: Model<Api>): model is Model<"anthropic-
 function normalizeAnthropicBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/v1\/?$/, "");
 }
+
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";
 
@@ -46,7 +47,9 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
     baseUrl.includes("moonshot.ai") ||
     baseUrl.includes("moonshot.cn");
   const isDashScope = model.provider === "dashscope" || isDashScopeCompatibleEndpoint(baseUrl);
-  if ((!isZai && !isMoonshot && !isDashScope) || !isOpenAiCompletionsModel(model)) {
+  const isVectortara = model.provider === "vectortara" || baseUrl.includes("vectortara.com");
+
+  if ((!isZai && !isMoonshot && !isDashScope && !isVectortara) || !isOpenAiCompletionsModel(model)) {
     return model;
   }
 

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -29,12 +29,14 @@ describe("formatAssistantErrorText", () => {
     );
     expect(formatAssistantErrorText(msg)).toContain("Context overflow");
   });
+
   it("returns context overflow for Kimi 'model token limit' errors", () => {
     const msg = makeAssistantError(
       "error, status code: 400, message: Invalid request: Your request exceeded model token limit: 262144 (requested: 291351)",
     );
     expect(formatAssistantErrorText(msg)).toContain("Context overflow");
   });
+
   it("returns a reasoning-required message for mandatory reasoning endpoint errors", () => {
     const msg = makeAssistantError(
       "400 Reasoning is mandatory for this endpoint and cannot be disabled.",
@@ -43,6 +45,23 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("Reasoning is required");
     expect(result).toContain("/think minimal");
     expect(result).not.toContain("Context overflow");
+  });
+
+  it("returns a friendly message for Bedrock-style developer role rejection", () => {
+    const msg = {
+      ...makeAssistantError(
+        'ValidationException: messages: Unexpected role "developer". Allowed roles are "user" or "assistant"',
+      ),
+      provider: "vectortara",
+      model: "claude-opus-4-1-20250805",
+    } as AssistantMessage;
+
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("developer");
+    expect(result).toContain("compat.supportsDeveloperRole=false");
+    expect(result).toContain("provider=vectortara");
+    expect(result).toContain("model=claude-opus-4-1-20250805");
+    expect(result).not.toContain("Message ordering conflict");
   });
   it("returns a friendly message for Anthropic role ordering", () => {
     const msg = makeAssistantError('messages: roles must alternate between "user" and "assistant"');

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -22,6 +22,14 @@ describe("sanitizeUserFacingText", () => {
     },
   );
 
+  it("sanitizes developer role unsupported errors", () => {
+    const result = sanitizeUserFacingText(
+      'ValidationException: messages: Unexpected role "developer". Allowed roles are "user" or "assistant"',
+    );
+    expect(result).toContain("compat.supportsDeveloperRole=false");
+    expect(result).not.toContain("Message ordering conflict");
+  });
+
   it("sanitizes role ordering errors", () => {
     const result = sanitizeUserFacingText("400 Incorrect role information", { errorContext: true });
     expect(result).toContain("Message ordering conflict");

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -26,6 +26,7 @@ export {
   isCloudCodeAssistFormatError,
   isCompactionFailureError,
   isContextOverflowError,
+  isDeveloperRoleUnsupportedErrorMessage,
   isLikelyContextOverflowError,
   isFailoverAssistantError,
   isFailoverErrorMessage,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -156,6 +156,28 @@ export function isCompactionFailureError(errorMessage?: string): boolean {
   return lower.includes("context overflow");
 }
 
+export function isDeveloperRoleUnsupportedErrorMessage(raw?: string): boolean {
+  if (!raw) return false;
+  const trimmed = raw.trim();
+  if (!trimmed) return false;
+
+  const lower = trimmed.toLowerCase();
+
+  // Bedrock-style validation when a request includes the "developer" role.
+  // Example:
+  //   ValidationException: messages: Unexpected role "developer". Allowed roles are "user" or "assistant"
+  if (lower.includes("unexpected role") && lower.includes("developer")) {
+    if (lower.includes("allowed roles") && lower.includes("user") && lower.includes("assistant")) return true;
+    // Some gateways omit the "Allowed roles" suffix.
+    return true;
+  }
+
+  // Some gateways collapse this into a generic role error but still mention developer.
+  if (lower.includes("incorrect role information") && lower.includes("developer")) return true;
+
+  return false;
+}
+
 const ERROR_PAYLOAD_PREFIX_RE =
   /^(?:error|api\s*error|apierror|openai\s*error|anthropic\s*error|gateway\s*error)[:\s-]+/i;
 const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
@@ -504,6 +526,20 @@ export function formatAssistantErrorText(
     );
   }
 
+  if (isDeveloperRoleUnsupportedErrorMessage(raw)) {
+    const provider = typeof msg.provider === "string" ? msg.provider.trim() : "";
+    const model = typeof msg.model === "string" ? msg.model.trim() : "";
+    const diagParts = [provider ? `provider=${provider}` : null, model ? `model=${model}` : null]
+      .filter(Boolean)
+      .join(" ");
+    const diag = diagParts ? ` (${diagParts})` : "";
+
+    return (
+      `Provider rejected the "developer" role (only supports "user"/"assistant").${diag} ` +
+      "Set compat.supportsDeveloperRole=false for this model (or switch to a compatible API) and try again."
+    );
+  }
+
   // Catch role ordering errors - including JSON-wrapped and "400" prefix variants
   if (
     /incorrect role information|roles must alternate|400.*role|"message".*role.*information/i.test(
@@ -567,6 +603,13 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
   // Only apply error-pattern rewrites when the caller knows this text is an error payload.
   // Otherwise we risk swallowing legitimate assistant text that merely *mentions* these errors.
   if (errorContext) {
+    if (isDeveloperRoleUnsupportedErrorMessage(trimmed)) {
+      return (
+        'Provider rejected the "developer" role (only supports "user"/"assistant"). ' +
+        "Set compat.supportsDeveloperRole=false for this model (or switch to a compatible API) and try again."
+      );
+    }
+
     if (/incorrect role information|roles must alternate/i.test(trimmed)) {
       return (
         "Message ordering conflict - please try again. " +

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -167,7 +167,13 @@ export function isDeveloperRoleUnsupportedErrorMessage(raw?: string): boolean {
   // Example:
   //   ValidationException: messages: Unexpected role "developer". Allowed roles are "user" or "assistant"
   if (lower.includes("unexpected role") && lower.includes("developer")) {
-    if (lower.includes("allowed roles") && lower.includes("user") && lower.includes("assistant")) return true;
+    if (
+      lower.includes("allowed roles") &&
+      lower.includes("user") &&
+      lower.includes("assistant")
+    ) {
+      return true;
+    }
     // Some gateways omit the "Allowed roles" suffix.
     return true;
   }
@@ -529,7 +535,10 @@ export function formatAssistantErrorText(
   if (isDeveloperRoleUnsupportedErrorMessage(raw)) {
     const provider = typeof msg.provider === "string" ? msg.provider.trim() : "";
     const model = typeof msg.model === "string" ? msg.model.trim() : "";
-    const diagParts = [provider ? `provider=${provider}` : null, model ? `model=${model}` : null]
+    const diagParts = [
+      provider ? `provider=${provider}` : null,
+      model ? `model=${model}` : null,
+    ]
       .filter(Boolean)
       .join(" ");
     const diag = diagParts ? ` (${diagParts})` : "";

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -172,11 +172,7 @@ export function isDeveloperRoleUnsupportedErrorMessage(raw?: string): boolean {
   //   ValidationException: messages: Unexpected role "developer".
   //   Allowed roles are "user" or "assistant"
   if (lower.includes("unexpected role") && lower.includes("developer")) {
-    if (
-      lower.includes("allowed roles") &&
-      lower.includes("user") &&
-      lower.includes("assistant")
-    ) {
+    if (lower.includes("allowed roles") && lower.includes("user") && lower.includes("assistant")) {
       return true;
     }
     // Some gateways omit the "Allowed roles" suffix.
@@ -542,10 +538,7 @@ export function formatAssistantErrorText(
   if (isDeveloperRoleUnsupportedErrorMessage(raw)) {
     const provider = typeof msg.provider === "string" ? msg.provider.trim() : "";
     const model = typeof msg.model === "string" ? msg.model.trim() : "";
-    const diagParts = [
-      provider ? `provider=${provider}` : null,
-      model ? `model=${model}` : null,
-    ]
+    const diagParts = [provider ? `provider=${provider}` : null, model ? `model=${model}` : null]
       .filter(Boolean)
       .join(" ");
     const diag = diagParts ? ` (${diagParts})` : "";

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -157,15 +157,20 @@ export function isCompactionFailureError(errorMessage?: string): boolean {
 }
 
 export function isDeveloperRoleUnsupportedErrorMessage(raw?: string): boolean {
-  if (!raw) return false;
+  if (!raw) {
+    return false;
+  }
   const trimmed = raw.trim();
-  if (!trimmed) return false;
+  if (!trimmed) {
+    return false;
+  }
 
   const lower = trimmed.toLowerCase();
 
   // Bedrock-style validation when a request includes the "developer" role.
   // Example:
-  //   ValidationException: messages: Unexpected role "developer". Allowed roles are "user" or "assistant"
+  //   ValidationException: messages: Unexpected role "developer".
+  //   Allowed roles are "user" or "assistant"
   if (lower.includes("unexpected role") && lower.includes("developer")) {
     if (
       lower.includes("allowed roles") &&
@@ -179,7 +184,9 @@ export function isDeveloperRoleUnsupportedErrorMessage(raw?: string): boolean {
   }
 
   // Some gateways collapse this into a generic role error but still mention developer.
-  if (lower.includes("incorrect role information") && lower.includes("developer")) return true;
+  if (lower.includes("incorrect role information") && lower.includes("developer")) {
+    return true;
+  }
 
   return false;
 }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -38,6 +38,7 @@ import {
   isAuthAssistantError,
   isBillingAssistantError,
   isCompactionFailureError,
+  isDeveloperRoleUnsupportedErrorMessage,
   isLikelyContextOverflowError,
   isFailoverAssistantError,
   isFailoverErrorMessage,
@@ -996,6 +997,30 @@ export async function runEmbeddedPiAgent(
               authRetryPending = true;
               continue;
             }
+            if (isDeveloperRoleUnsupportedErrorMessage(errorText)) {
+              const diag = ` (provider=${provider} model=${model.id})`;
+              return {
+                payloads: [
+                  {
+                    text:
+                      `Provider rejected the "developer" role (only supports "user"/"assistant").${diag} ` +
+                      "Set compat.supportsDeveloperRole=false for this model (or switch to a compatible API) and try again.",
+                    isError: true,
+                  },
+                ],
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta: {
+                    sessionId: sessionIdUsed,
+                    provider,
+                    model: model.id,
+                  },
+                  systemPromptReport: attempt.systemPromptReport,
+                  error: { kind: "developer_role_unsupported", message: errorText },
+                },
+              };
+            }
+
             // Handle role ordering errors with a user-friendly message
             if (/incorrect role information|roles must alternate/i.test(errorText)) {
               return {

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -39,6 +39,7 @@ export type EmbeddedPiRunMeta = {
     kind:
       | "context_overflow"
       | "compaction_failure"
+      | "developer_role_unsupported"
       | "role_ordering"
       | "image_size"
       | "retry_limit";

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -7,6 +7,7 @@ import { isCliProvider } from "../../agents/model-selection.js";
 import {
   isCompactionFailureError,
   isContextOverflowError,
+  isDeveloperRoleUnsupportedErrorMessage,
   isLikelyContextOverflowError,
   isTransientHttpError,
   sanitizeUserFacingText,
@@ -477,6 +478,7 @@ export async function runAgentTurnWithFallback(params: {
       const isContextOverflow = isLikelyContextOverflowError(message);
       const isCompactionFailure = isCompactionFailureError(message);
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
+      const isDeveloperRoleUnsupported = isDeveloperRoleUnsupportedErrorMessage(message);
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
       const isTransientHttp = isTransientHttpError(message);
 
@@ -572,9 +574,11 @@ export async function runAgentTurnWithFallback(params: {
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
       const fallbackText = isContextOverflow
         ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
-        : isRoleOrderingError
-          ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-          : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+        : isDeveloperRoleUnsupported
+          ? `⚠️ Provider rejected the "developer" role (only supports "user"/"assistant"). (provider=${params.followupRun.run.provider} model=${params.followupRun.run.model}) Set compat.supportsDeveloperRole=false for this model (or switch to a compatible API) and try again.`
+          : isRoleOrderingError
+            ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
+            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",

--- a/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
+++ b/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
@@ -421,7 +421,9 @@ describe("runCronIsolatedAgentTurn", () => {
         })
       ).res;
       expect(res.status).toBe("ok");
-      expectEmbeddedProviderModel({ provider: "openai", model: "gpt-4.1-mini" });
+      // Isolated cron runs force a fresh session and do not reuse persisted
+      // session model overrides from previous runs.
+      expectEmbeddedProviderModel({ provider: "anthropic", model: "claude-opus-4-5" });
 
       vi.mocked(runEmbeddedPiAgent).mockClear();
       vi.mocked(loadModelCatalog).mockResolvedValue(deterministicCatalog);


### PR DESCRIPTION
When an upstream provider rejects the "developer" role (e.g. Bedrock-style: Unexpected role "developer"; allowed roles are user/assistant), OpenClaw currently surfaces a misleading "Message ordering conflict".

This PR:
- Detects developer-role rejection separately from true role-ordering errors.
- Shows a clearer fix suggestion: set compat.supportsDeveloperRole=false (or use a compatible API).
- Includes provider/model in the user-facing hint when available (helps diagnose cron jobs).
- Adds/updates unit tests for the new branch.