### PR TITLE
fix: unblock baseline tsgo typecheck for gateway and plugins

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -7,7 +7,6 @@ import {
   readJsonBodyWithLimit,
   registerPluginHttpRoute,
   registerWebhookTarget,
-  registerPluginHttpRoute,
   rejectNonPostWebhookRequest,
   isDangerousNameMatchingEnabled,
   resolveAllowlistProviderRuntimeGroupPolicy,

--- a/extensions/phone-control/index.test.ts
+++ b/extensions/phone-control/index.test.ts
@@ -33,7 +33,6 @@ function createApi(params: {
     logger: { info() {}, warn() {}, error() {} },
     registerTool() {},
     registerHook() {},
-    registerHttpHandler() {},
     registerHttpRoute() {},
     registerChannel() {},
     registerGatewayMethod() {},

--- a/src/gateway/server-http.test-harness.ts
+++ b/src/gateway/server-http.test-harness.ts
@@ -128,7 +128,7 @@ export async function sendRequest(
     authorization?: string;
     method?: string;
   },
-) {
+): Promise<ReturnType<typeof createResponse>> {
   const response = createResponse();
   await dispatchRequest(server, createRequest(params), response.res);
   return response;


### PR DESCRIPTION
## Summary
- remove a duplicate `registerPluginHttpRoute` import in Google Chat monitor while keeping the required import
- align `phone-control` plugin test API stub with current plugin interface (drop obsolete `registerHttpHandler`)
- add an explicit return type to `sendRequest` test harness helper to satisfy TS2742 portability checks

## Testing
- pnpm tsgo
- pnpm check
- pnpm test -- extensions/phone-control/index.test.ts src/gateway/server-http.test-harness.ts

## Changelog
- no changelog (internal baseline/typecheck unblock)
