### PR TITLE
fix(slack): apply mrkdwn conversion in streaming delivery path

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -12,6 +12,7 @@ import { danger, logVerbose, shouldLogVerbose } from "../../../globals.js";
 import { resolveAgentOutboundIdentity } from "../../../infra/outbound/identity.js";
 import { removeSlackReaction } from "../../actions.js";
 import { createSlackDraftStream } from "../../draft-stream.js";
+import { markdownToSlackMrkdwn } from "../../format.js";
 import { recordSlackThreadParticipation } from "../../sent-thread-cache.js";
 import {
   applyAppendOnlyStreamUpdate,
@@ -218,7 +219,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       return;
     }
 
-    const text = payload.text.trim();
+    const text = markdownToSlackMrkdwn(payload.text.trim());
     let plannedThreadTs: string | undefined;
     try {
       if (!streamSession) {


### PR DESCRIPTION
## Summary

- The non-streaming reply path converts markdown to Slack mrkdwn via `markdownToSlackMrkdwnChunks`, but the native streaming path (`chatStream`) passes raw markdown directly to the Slack API
- Slack's `markdown_text` field does not auto-convert standard markdown, so `**bold**` renders literally instead of as **bold**
- Apply `markdownToSlackMrkdwn` to payload text before passing to `startSlackStream` / `appendSlackStream`

## Test plan

- [x] Verified non-streaming path already uses `markdownToSlackMrkdwnChunks` in `replies.ts`
- [ ] Manual: enable `slack.streaming: true`, send a message triggering bold/italic response, verify correct rendering

Fixes #31892

🤖 Coded with [Claude Code](https://github.com/claude)