### PR TITLE
fix(docs): apply oxfmt formatting to docs/help/faq.md

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -590,6 +590,7 @@ Docs: [Windows](/platforms/windows).
 This is usually a console code page mismatch on native Windows shells.
 
 Symptoms:
+
 - `system.run`/`exec` output renders Chinese as mojibake
 - The same command looks fine in another terminal profile
 
@@ -609,6 +610,7 @@ openclaw gateway restart
 ```
 
 If you still reproduce this on latest OpenClaw, track/report it in:
+
 - [Issue #30640](https://github.com/openclaw/openclaw/issues/30640)
 
 ### The docs didn't answer my question how do I get a better answer


### PR DESCRIPTION
## Summary
- Apply `oxfmt` formatting to `docs/help/faq.md` which currently fails the `format:check` CI step on `main`, blocking the `check` job for **all open PRs**

## Test plan
- [x] `pnpm check` passes locally (format:check, tsgo, all lint rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)