### PR TITLE
voice-call: enforce exact webhook path matching for inbound webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Voice-call/webhook routing: require exact webhook path matches (instead of prefix matches) so lookalike paths cannot reach provider verification/dispatch logic. (#31930) Thanks @afurm.
 - Web UI/config form: support SecretInput string-or-secret-ref unions in map `additionalProperties`, so provider API key fields stay editable instead of being marked unsupported. (#31866) Thanks @ningding97.
 - Slack/Bolt startup compatibility: remove invalid `message.channels` and `message.groups` event registrations so Slack providers no longer crash on startup with Bolt 4.6+; channel/group traffic continues through the unified `message` handler (`channel_type`). (#32033) Thanks @mahopan.
 - Telegram: guard duplicate-token checks and gateway startup token normalization when account tokens are missing, preventing `token.trim()` crashes during status/start flows. (#31973) Thanks @ningding97.

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -134,7 +134,7 @@ describe("VoiceCallWebhookServer stale call reaper", () => {
   });
 });
 
-describe("VoiceCallWebhookServer replay handling", () => {
+describe("VoiceCallWebhookServer path matching", () => {
   it("rejects lookalike webhook paths that only match by prefix", async () => {
     const verifyWebhook = vi.fn(() => ({ ok: true, verifiedRequestKey: "verified:req:prefix" }));
     const parseWebhookEvent = vi.fn(() => ({ events: [], statusCode: 200 }));
@@ -171,7 +171,9 @@ describe("VoiceCallWebhookServer replay handling", () => {
       await server.stop();
     }
   });
+});
 
+describe("VoiceCallWebhookServer replay handling", () => {
   it("acknowledges replayed webhook requests and skips event side effects", async () => {
     const replayProvider: VoiceCallProvider = {
       ...provider,

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -135,6 +135,43 @@ describe("VoiceCallWebhookServer stale call reaper", () => {
 });
 
 describe("VoiceCallWebhookServer replay handling", () => {
+  it("rejects lookalike webhook paths that only match by prefix", async () => {
+    const verifyWebhook = vi.fn(() => ({ ok: true, verifiedRequestKey: "verified:req:prefix" }));
+    const parseWebhookEvent = vi.fn(() => ({ events: [], statusCode: 200 }));
+    const strictProvider: VoiceCallProvider = {
+      ...provider,
+      verifyWebhook,
+      parseWebhookEvent,
+    };
+    const { manager } = createManager([]);
+    const config = createConfig({ serve: { port: 0, bind: "127.0.0.1", path: "/voice/webhook" } });
+    const server = new VoiceCallWebhookServer(config, manager, strictProvider);
+
+    try {
+      const baseUrl = await server.start();
+      const address = (
+        server as unknown as { server?: { address?: () => unknown } }
+      ).server?.address?.();
+      const requestUrl = new URL(baseUrl);
+      if (address && typeof address === "object" && "port" in address && address.port) {
+        requestUrl.port = String(address.port);
+      }
+      requestUrl.pathname = "/voice/webhook-evil";
+
+      const response = await fetch(requestUrl.toString(), {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: "CallSid=CA123&SpeechResult=hello",
+      });
+
+      expect(response.status).toBe(404);
+      expect(verifyWebhook).not.toHaveBeenCalled();
+      expect(parseWebhookEvent).not.toHaveBeenCalled();
+    } finally {
+      await server.stop();
+    }
+  });
+
   it("acknowledges replayed webhook requests and skips event side effects", async () => {
     const replayProvider: VoiceCallProvider = {
       ...provider,

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -255,6 +255,25 @@ export class VoiceCallWebhookServer {
     }
   }
 
+  private normalizeWebhookPathForMatch(pathname: string): string {
+    const trimmed = pathname.trim();
+    if (!trimmed) {
+      return "/";
+    }
+    const prefixed = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+    if (prefixed === "/") {
+      return prefixed;
+    }
+    return prefixed.endsWith("/") ? prefixed.slice(0, -1) : prefixed;
+  }
+
+  private isWebhookPathMatch(requestPath: string, configuredPath: string): boolean {
+    return (
+      this.normalizeWebhookPathForMatch(requestPath) ===
+      this.normalizeWebhookPathForMatch(configuredPath)
+    );
+  }
+
   /**
    * Handle incoming HTTP request.
    */
@@ -266,7 +285,7 @@ export class VoiceCallWebhookServer {
     const url = new URL(req.url || "/", `http://${req.headers.host}`);
 
     // Check path
-    if (!url.pathname.startsWith(webhookPath)) {
+    if (!this.isWebhookPathMatch(url.pathname, webhookPath)) {
       res.statusCode = 404;
       res.end("Not Found");
       return;

--- a/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
+++ b/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
@@ -3,9 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { clearRuntimeAuthProfileStoreSnapshots } from "../agents/auth-profiles.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
-import { _probeThrottleInternals } from "../agents/model-fallback.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import type { CliDeps } from "../cli/deps.js";
 import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
@@ -215,8 +213,6 @@ describe("runCronIsolatedAgentTurn", () => {
   });
 
   beforeEach(() => {
-    clearRuntimeAuthProfileStoreSnapshots();
-    _probeThrottleInternals.lastProbeAttempt.clear();
     vi.mocked(runEmbeddedPiAgent).mockClear();
     vi.mocked(loadModelCatalog).mockResolvedValue([]);
   });

--- a/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
+++ b/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
@@ -3,7 +3,9 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRuntimeAuthProfileStoreSnapshots } from "../agents/auth-profiles.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
+import { _probeThrottleInternals } from "../agents/model-fallback.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import type { CliDeps } from "../cli/deps.js";
 import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
@@ -213,6 +215,8 @@ describe("runCronIsolatedAgentTurn", () => {
   });
 
   beforeEach(() => {
+    clearRuntimeAuthProfileStoreSnapshots();
+    _probeThrottleInternals.lastProbeAttempt.clear();
     vi.mocked(runEmbeddedPiAgent).mockClear();
     vi.mocked(loadModelCatalog).mockResolvedValue([]);
   });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `VoiceCallWebhookServer` matched incoming webhook paths using `startsWith`, so lookalike paths such as `/voice/webhook-evil` were treated as valid webhook endpoints.
- Why it matters: Prefix-based matching widens the exposed request surface and can route unintended paths into webhook verification/parsing logic.
- What changed: Replaced prefix path matching with normalized exact-path matching (including safe trailing-slash normalization) and added a regression test for the lookalike-path case.
- What did NOT change (scope boundary): No provider signature algorithms, auth token handling, call processing logic, or webhook body parsing behavior were changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Requests to lookalike paths (for example `/voice/webhook-evil`) now return `404 Not Found` instead of being processed by the voice webhook handler.
- Valid configured webhook path behavior remains unchanged.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm + Vitest
- Model/provider: N/A
- Integration/channel (if any): `extensions/voice-call` webhook server
- Relevant config (redacted): `serve.path=/voice/webhook`

### Steps

1. Start `VoiceCallWebhookServer` with `serve.path=/voice/webhook`.
2. Send `POST` to `/voice/webhook-evil`.
3. Observe response code and whether webhook verification/parsing handlers are invoked.

### Expected

- Lookalike path is rejected with `404`.
- Webhook verification and event parsing are not invoked.

### Actual

- After this fix, behavior matches expected.
- Before this fix, prefix lookalike paths were accepted by the path gate.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran `vitest` for `extensions/voice-call/src/webhook.test.ts` and `extensions/voice-call/src/webhook-security.test.ts`; confirmed new regression test passes and existing webhook security tests still pass.
- Edge cases checked: Exact configured path still works; lookalike prefix path is rejected.
- What you did **not** verify: Live end-to-end webhook traffic from Twilio/Plivo/Telnyx in an external environment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `b04bb8d77`.
- Files/config to restore: `extensions/voice-call/src/webhook.ts`, `extensions/voice-call/src/webhook.test.ts`.
- Known bad symptoms reviewers should watch for: Legitimate webhook requests unexpectedly returning `404` due to path mismatch with provider-configured URL.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Deployments that relied on non-exact subpath/prefix routing under the webhook path will now be rejected.
- Mitigation: Ensure provider webhook URL matches the configured `serve.path` exactly.
