### PR TITLE
fix(chat): add null guards to prevent undefined .includes() crashes

### DIFF
--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -111,8 +111,9 @@ export function matchesMentionWithExplicit(params: {
 }
 
 export function stripStructuralPrefixes(text: string): string {
-  // Ignore wrapper labels, timestamps, and sender prefixes so directive-only
-  // detection still works in group batches that include history/context.
+  if (!text) {
+    return text ?? "";
+  }
   const afterMarker = text.includes(CURRENT_MESSAGE_MARKER)
     ? text.slice(text.indexOf(CURRENT_MESSAGE_MARKER) + CURRENT_MESSAGE_MARKER.length).trimStart()
     : text;

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -27,6 +27,9 @@ function looksLikeEnvelopeHeader(header: string): boolean {
 }
 
 export function stripEnvelope(text: string): string {
+  if (!text) {
+    return text ?? "";
+  }
   const match = text.match(ENVELOPE_PREFIX);
   if (!match) {
     return text;
@@ -39,6 +42,9 @@ export function stripEnvelope(text: string): string {
 }
 
 export function stripMessageIdHints(text: string): string {
+  if (!text) {
+    return text ?? "";
+  }
   if (!text.includes("[message_id:")) {
     return text;
   }

--- a/src/web/auto-reply/mentions.ts
+++ b/src/web/auto-reply/mentions.ts
@@ -59,7 +59,8 @@ export function isBotMentionedFromTargets(
   } else if (hasMentions && isSelfChat) {
     // Self-chat mode: ignore WhatsApp @mention JIDs, otherwise @mentioning the owner in group chats triggers the bot.
   }
-  const bodyClean = clean(msg.body);
+  const body = msg.body ?? "";
+  const bodyClean = clean(body);
   if (mentionCfg.mentionRegexes.some((re) => re.test(bodyClean))) {
     return true;
   }
@@ -72,7 +73,7 @@ export function isBotMentionedFromTargets(
       if (bodyDigits.includes(selfDigits)) {
         return true;
       }
-      const bodyNoSpace = msg.body.replace(/[\s-]/g, "");
+      const bodyNoSpace = body.replace(/[\s-]/g, "");
       const pattern = new RegExp(`\\+?${selfDigits}`, "i");
       if (pattern.test(bodyNoSpace)) {
         return true;
@@ -93,7 +94,7 @@ export function debugMention(
   const details = {
     from: msg.from,
     body: msg.body,
-    bodyClean: normalizeMentionText(msg.body),
+    bodyClean: normalizeMentionText(msg.body ?? ""),
     mentionedJids: msg.mentionedJids ?? null,
     normalizedMentionedJids: mentionTargets.normalizedMentions.length
       ? mentionTargets.normalizedMentions


### PR DESCRIPTION
## Summary

- **Problem:** Slack (and other channel) mentions crash with `Cannot read properties of undefined (reading 'includes')` when `text` or `msg.body` is null/undefined.
- **Root cause:** `stripEnvelope`, `stripMessageIdHints`, `stripStructuralPrefixes`, and `isBotMentionedFromTargets` call `.includes()` / `.match()` / `.replace()` on their text argument without null guards.
- **Fix:** Add early-return guards for falsy inputs in envelope/mention helpers, and coalesce `msg.body` with `?? ""` in the mention matcher.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31851

## User-visible / Behavior Changes

- Bot no longer crashes on Slack (and WhatsApp) mentions with undefined message body
- Gracefully returns empty string instead of throwing

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps

1. Mention @Bot in a Slack channel
2. Bot processes normally without error

### Expected

Bot processes the mention and responds.

### Actual (before fix)

`Cannot read properties of undefined (reading 'includes')` — bot responds with error instead of content.

## Evidence

```
✓ src/gateway/chat-sanitize.test.ts (9 tests) 3ms
```

## Human Verification (required)

- Verified scenarios: chat-sanitize tests pass, TS compiles cleanly
- Edge cases checked: null text, undefined msg.body, empty string
- What I did **not** verify: Live Slack mention test

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the 3 file changes
- Known bad symptoms: None — guards are purely additive
