### PR TITLE
fix(feishu): correct invalid scope name in permission grant URL

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -44,6 +44,22 @@ type PermissionError = {
   grantUrl?: string;
 };
 
+// Feishu API sometimes returns incorrect scope names in permission error
+// responses (e.g. "contact:contact.base:readonly" instead of the valid
+// "contact:user.base:readonly"). This map corrects known mismatches.
+const FEISHU_SCOPE_CORRECTIONS: Record<string, string> = {
+  "contact:contact.base:readonly": "contact:user.base:readonly",
+};
+
+function correctFeishuScopeInUrl(url: string): string {
+  let corrected = url;
+  for (const [wrong, right] of Object.entries(FEISHU_SCOPE_CORRECTIONS)) {
+    corrected = corrected.replaceAll(encodeURIComponent(wrong), encodeURIComponent(right));
+    corrected = corrected.replaceAll(wrong, right);
+  }
+  return corrected;
+}
+
 function extractPermissionError(err: unknown): PermissionError | null {
   if (!err || typeof err !== "object") return null;
 
@@ -64,7 +80,7 @@ function extractPermissionError(err: unknown): PermissionError | null {
   // Extract the grant URL from the error message (contains the direct link)
   const msg = feishuErr.msg ?? "";
   const urlMatch = msg.match(/https:\/\/[^\s,]+\/app\/[^\s,]+/);
-  const grantUrl = urlMatch?.[0];
+  const grantUrl = urlMatch?.[0] ? correctFeishuScopeInUrl(urlMatch[0]) : undefined;
 
   return {
     code: feishuErr.code,


### PR DESCRIPTION
## Summary

- **Problem:** The Feishu API returns permission error (code 99991672) with a grant URL containing the non-existent scope `contact:contact.base:readonly`. The correct scope is `contact:user.base:readonly`.
- **Impact:** Every message triggers a system-injected error with a useless authorization URL. Users/admins cannot grant the permission because the scope doesn't exist.
- **Fix:** Added a scope correction map in `extractPermissionError` that replaces known incorrect scope names (both raw and URL-encoded) in the grant URL before presenting it to the user.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31761

## User-visible / Behavior Changes

- Permission grant URL now contains the correct scope `contact:user.base:readonly`
- Admins can successfully authorize the permission via the corrected URL

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps

1. Configure Feishu bot without `contact:user.base:readonly` granted
2. Send message to bot in direct chat
3. System injects error with corrected grant URL

### Expected

Grant URL contains `contact:user.base:readonly`, admin can authorize.

### Actual (before fix)

Grant URL contains `contact:contact.base:readonly`, which doesn't exist on Feishu Open Platform.

## Evidence

```
✓ extensions/feishu tests: 220 passed
```

## Human Verification (required)

- Verified scenarios: 220 Feishu tests pass, TS compiles cleanly, URL-encoded and raw scope replacement both tested
- Edge cases checked: Multiple incorrect scopes in URL, no match (passthrough), URL without scope
- What I did **not** verify: Live Feishu API call with permission error

## Compatibility / Migration

- Backward compatible? `Yes` — only affects grant URL correction
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `FEISHU_SCOPE_CORRECTIONS` and `correctFeishuScopeInUrl` from `bot.ts`
- Known bad symptoms: If Feishu fixes the scope name in their API, the correction map becomes a no-op (harmless)
