### PR TITLE
fix(agents): sanitize openai-completions tool call ids before dispatch

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -146,7 +146,7 @@ describe("sanitizeSessionMessagesImages", () => {
     expect(toolResult.toolUseId).toBe("callabcitem123");
   });
 
-  it("does not sanitize tool IDs in images-only mode", async () => {
+  it("sanitizes tool IDs in images-only mode when explicitly enabled", async () => {
     const input = [
       {
         role: "assistant",
@@ -169,10 +169,10 @@ describe("sanitizeSessionMessagesImages", () => {
 
     const assistant = out[0] as unknown as { content?: Array<{ type?: string; id?: string }> };
     const toolCall = assistant.content?.find((b) => b.type === "toolCall");
-    expect(toolCall?.id).toBe("call_123|fc_456");
+    expect(toolCall?.id).toBe("call123fc456");
 
     const toolResult = out[1] as unknown as { toolCallId?: string };
-    expect(toolResult.toolCallId).toBe("call_123|fc_456");
+    expect(toolResult.toolCallId).toBe("call123fc456");
   });
   it("filters whitespace-only assistant text blocks", async () => {
     const input = [

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -54,12 +54,12 @@ export async function sanitizeSessionMessagesImages(
     maxDimensionPx: options?.maxDimensionPx,
     maxBytes: options?.maxBytes,
   };
+  const shouldSanitizeToolCallIds = options?.sanitizeToolCallIds === true;
   // We sanitize historical session messages because Anthropic can reject a request
   // if the transcript contains oversized base64 images (default max side 1200px).
-  const sanitizedIds =
-    allowNonImageSanitization && options?.sanitizeToolCallIds
-      ? sanitizeToolCallIdsForCloudCodeAssist(messages, options.toolCallIdMode)
-      : messages;
+  const sanitizedIds = shouldSanitizeToolCallIds
+    ? sanitizeToolCallIdsForCloudCodeAssist(messages, options.toolCallIdMode)
+    : messages;
   const out: AgentMessage[] = [];
   for (const msg of sanitizedIds) {
     if (!msg || typeof msg !== "object") {

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -191,6 +191,29 @@ describe("sanitizeSessionHistory", () => {
     );
   });
 
+  it("sanitizes tool call ids for openai-completions", async () => {
+    setNonGoogleModelApi();
+
+    await sanitizeSessionHistory({
+      messages: mockMessages,
+      modelApi: "openai-completions",
+      provider: "openai",
+      modelId: "gpt-5.2",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
+      mockMessages,
+      "session:history",
+      expect.objectContaining({
+        sanitizeMode: "images-only",
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict",
+      }),
+    );
+  });
+
   it("annotates inter-session user messages before context sanitization", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -44,6 +44,16 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBeUndefined();
   });
 
+  it("enables strict tool call id sanitization for openai-completions APIs", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-5.2",
+      modelApi: "openai-completions",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
   it("enables user-turn merge for strict OpenAI-compatible providers", () => {
     const policy = resolveTranscriptPolicy({
       provider: "moonshot",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -94,6 +94,7 @@ export function resolveTranscriptPolicy(params: {
     (provider === "openrouter" || provider === "opencode" || provider === "kilocode") &&
     modelId.toLowerCase().includes("gemini");
   const isCopilotClaude = provider === "github-copilot" && modelId.toLowerCase().includes("claude");
+  const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").
@@ -102,7 +103,8 @@ export function resolveTranscriptPolicy(params: {
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
-  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
+  const sanitizeToolCallIds =
+    isGoogle || isMistral || isAnthropic || requiresOpenAiCompatibleToolIdSanitization;
   const toolCallIdMode: ToolCallIdMode | undefined = isMistral
     ? "strict9"
     : sanitizeToolCallIds
@@ -117,7 +119,8 @@ export function resolveTranscriptPolicy(params: {
 
   return {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
-    sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds,
+    sanitizeToolCallIds:
+      (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
     toolCallIdMode,
     repairToolUseResultPairing,
     preserveSignatures: false,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenAI-compatible (`openai-completions`) runs were not sanitizing tool call IDs, allowing overlong IDs through to provider requests.
- Why it matters: providers enforcing stricter tool call ID constraints can reject requests (`400 tool_call_id too long`) during tool-heavy runs.
- What changed: transcript policy now enables strict tool-call ID sanitization for `openai-completions`; image/history sanitizer now applies ID sanitization whenever explicitly requested (independent of full vs images-only text sanitization mode).
- What did NOT change (scope boundary): no changes to tool execution semantics, tool selection, or non-requested transcript sanitization paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31934
- Related #30923

## User-visible / Behavior Changes

- For `openai-completions` model API paths, tool call IDs in transcript history are now normalized to strict provider-safe IDs before request dispatch.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22 + Vitest
- Model/provider: openai-completions transcript policy path
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Build transcript policy for `provider=openai`, `modelApi=openai-completions`.
2. Pass assistant/toolResult messages containing long/non-strict tool call IDs through session-history sanitization.
3. Observe sanitizer options and resulting IDs.

### Expected

- Tool call IDs are sanitized for openai-completions and remain paired/consistent across assistant + toolResult messages.

### Actual

- Before fix: policy disabled tool-call ID sanitization for openai-completions, allowing long IDs to pass through.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before:

- `pnpm vitest src/agents/transcript-policy.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts -t "openai-completions"`
- Failures:
  - transcript policy expected `sanitizeToolCallIds=true` but got `false`
  - sanitize-session-history expected strict ID sanitization config but got disabled

After:

- `pnpm vitest src/agents/transcript-policy.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts src/agents/tool-call-id.test.ts src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - openai-completions now requests strict tool-call-ID sanitization in transcript policy.
  - images-only sanitization path still performs ID sanitization when explicitly requested.
  - openai-responses behavior remains unchanged (no forced tool-call-ID sanitization).
- Edge cases checked:
  - helper/unit tests around ID rewriting, uniqueness, and session-history policy all pass.
- What you did **not** verify:
  - live provider API rejection behavior against a real OpenAI/LiteLLM endpoint.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: N/A.
- Known bad symptoms reviewers should watch for: unexpected strict ID normalization where callers rely on exact historical ID formatting.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: stricter ID normalization could alter legacy non-alphanumeric IDs in openai-completions flows.
  - Mitigation: sanitization preserves transcript pairing consistency and has dedicated unit coverage for collision handling and bounded length.
