### PR TITLE
fix(telegram): truncate long callback_data instead of silently dropping buttons

### DIFF
--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -56,9 +56,9 @@ export function readTelegramButtons(
       if (!text || !callbackData) {
         throw new Error(`buttons[${rowIndex}][${buttonIndex}] requires text and callback_data`);
       }
-      if (callbackData.length > 64) {
+      if (Buffer.byteLength(callbackData, "utf8") > 64) {
         throw new Error(
-          `buttons[${rowIndex}][${buttonIndex}] callback_data too long (max 64 chars)`,
+          `buttons[${rowIndex}][${buttonIndex}] callback_data too long (max 64 bytes)`,
         );
       }
       const styleRaw = (button as { style?: unknown }).style;

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -63,6 +63,7 @@ import {
   calculateTotalPages,
   getModelsPageSize,
   parseModelCallbackData,
+  resolveModelFromCallback,
   type ProviderInfo,
 } from "./model-buttons.js";
 import { buildInlineKeyboard } from "./send.js";
@@ -1261,11 +1262,12 @@ export const registerTelegramHandlers = ({
 
         if (modelCallback.type === "select") {
           const { provider, model } = modelCallback;
-          // Process model selection as a synthetic message with /model command
+          const providerModels = [...(byProvider.get(provider) ?? [])];
+          const resolvedModel = resolveModelFromCallback(model, providerModels);
           const syntheticMessage = buildSyntheticTextMessage({
             base: callbackMessage,
             from: callback.from,
-            text: `/model ${provider}/${model}`,
+            text: `/model ${provider}/${resolvedModel}`,
           });
           await processMessage(buildSyntheticContext(ctx, syntheticMessage), [], storeAllowFrom, {
             forceWasMentioned: true,

--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -296,12 +296,10 @@ describe("large model lists (OpenRouter-scale)", () => {
     }
   });
 
-  it("skips models that would exceed callback_data limit", () => {
-    const models = [
-      "short-model",
-      "this-is-an-extremely-long-model-name-that-definitely-exceeds-the-sixty-four-byte-limit",
-      "another-short",
-    ];
+  it("truncates models that would exceed callback_data limit", () => {
+    const longModel =
+      "this-is-an-extremely-long-model-name-that-definitely-exceeds-the-sixty-four-byte-limit";
+    const models = ["short-model", longModel, "another-short"];
     const result = buildModelsKeyboard({
       provider: "openrouter",
       models,
@@ -309,10 +307,25 @@ describe("large model lists (OpenRouter-scale)", () => {
       totalPages: 1,
     });
 
-    // Should have 2 model buttons (skipping the long one) + back
     const modelButtons = result.filter((row) => !row[0]?.callback_data.startsWith("mdl_back"));
-    expect(modelButtons.length).toBe(2);
+    expect(modelButtons.length).toBe(3);
     expect(modelButtons[0]?.[0]?.text).toBe("short-model");
-    expect(modelButtons[1]?.[0]?.text).toBe("another-short");
+    expect(modelButtons[2]?.[0]?.text).toBe("another-short");
+
+    const truncatedButton = modelButtons[1]?.[0];
+    expect(truncatedButton).toBeDefined();
+    expect(Buffer.byteLength(truncatedButton!.callback_data, "utf8")).toBeLessThanOrEqual(64);
+    expect(truncatedButton!.callback_data.startsWith("mdl_sel_openrouter/")).toBe(true);
+    expect(longModel.startsWith(truncatedButton!.callback_data.replace("mdl_sel_openrouter/", ""))).toBe(true);
+  });
+
+  it("resolveModelFromCallback finds exact and prefix matches", async () => {
+    const { resolveModelFromCallback } = await import("./model-buttons.js");
+    const models = ["claude-3-5-sonnet-20241022-v2:0", "claude-3-opus", "gpt-4o"];
+    expect(resolveModelFromCallback("claude-3-opus", models)).toBe("claude-3-opus");
+    expect(resolveModelFromCallback("claude-3-5-sonnet-2024102", models)).toBe(
+      "claude-3-5-sonnet-20241022-v2:0",
+    );
+    expect(resolveModelFromCallback("unknown", models)).toBe("unknown");
   });
 });

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -133,12 +133,19 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
     : currentModel;
 
   for (const model of pageModels) {
-    const callbackData = `mdl_sel_${provider}/${model}`;
-    // Skip models that would exceed Telegram's callback_data limit
-    if (Buffer.byteLength(callbackData, "utf8") > MAX_CALLBACK_DATA_BYTES) {
-      continue;
+    const prefix = `mdl_sel_${provider}/`;
+    let modelForCallback = model;
+    const fullCallbackData = `${prefix}${model}`;
+
+    if (Buffer.byteLength(fullCallbackData, "utf8") > MAX_CALLBACK_DATA_BYTES) {
+      const prefixBytes = Buffer.byteLength(prefix, "utf8");
+      const maxModelBytes = MAX_CALLBACK_DATA_BYTES - prefixBytes;
+      while (Buffer.byteLength(modelForCallback, "utf8") > maxModelBytes) {
+        modelForCallback = modelForCallback.slice(0, -1);
+      }
     }
 
+    const callbackData = `${prefix}${modelForCallback}`;
     const isCurrentModel = model === currentModelId;
     const displayText = truncateModelId(model, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
@@ -199,6 +206,19 @@ function truncateModelId(modelId: string, maxLen: number): string {
   }
   // Show last part with ellipsis prefix
   return `…${modelId.slice(-(maxLen - 1))}`;
+}
+
+/**
+ * Resolve a potentially truncated model ID back to its full name by
+ * prefix-matching against the provider's model list.
+ */
+export function resolveModelFromCallback(
+  callbackModel: string,
+  providerModels: readonly string[],
+): string {
+  const exact = providerModels.find((m) => m === callbackModel);
+  if (exact) return exact;
+  return providerModels.find((m) => m.startsWith(callbackModel)) ?? callbackModel;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Problem:** Bedrock and other providers with long model IDs exceed Telegram's 64-byte `callback_data` limit. Model buttons are silently dropped from the inline keyboard, making these models invisible in the UI.
- **Secondary bug:** `telegram-actions.ts` uses `callbackData.length > 64` (character count), not byte count. Multi-byte characters could pass validation but exceed Telegram's actual 64-byte limit.
- **Fix:**
  1. `model-buttons.ts`: Truncate model ID to fit within 64 bytes instead of skipping. Added `resolveModelFromCallback()` helper for prefix-matching truncated IDs.
  2. `bot-handlers.ts`: Use `resolveModelFromCallback()` to resolve truncated callback model IDs back to full names before constructing the `/model` command.
  3. `telegram-actions.ts`: Changed `.length > 64` to `Buffer.byteLength(callbackData, "utf8") > 64`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31815

## User-visible / Behavior Changes

- All models now appear in the Telegram model selection keyboard, even Bedrock models with long IDs
- Models with truncated callback_data are resolved via prefix matching when selected
- Agent tool `callback_data` validation now correctly enforces 64-byte (not 64-char) limit

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps

1. Configure a Bedrock provider with models like `us.anthropic.claude-3-5-sonnet-20241022-v2:0`
2. In Telegram, run `/model` → click the Bedrock provider
3. All models appear in the keyboard (no silent drops)
4. Selecting a truncated model correctly resolves to the full model ID

### Expected

All models appear and are selectable, even with long IDs.

### Actual (before fix)

Models exceeding 64-byte callback_data limit are silently dropped.

## Evidence

```
✓ src/telegram/model-buttons.test.ts (15 tests) 5ms
```

Updated test: `truncates models that would exceed callback_data limit` verifies the button is present with truncated callback_data. New test: `resolveModelFromCallback finds exact and prefix matches` verifies resolution logic.

## Human Verification (required)

- Verified scenarios: All 15 model-buttons tests pass, TS compiles cleanly
- Edge cases checked: Exact match, prefix match, no match fallback, multi-byte characters
- What I did **not** verify: Live Telegram bot interaction with Bedrock models

## Compatibility / Migration

- Backward compatible? `Yes` — short model IDs are unchanged, only long ones gain truncation
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the 4 file changes
- Known bad symptoms: If prefix matching produces false positives, wrong model could be selected (mitigated by `startsWith` requiring exact prefix)
