### PR TITLE
fix(openai): enforce 40-char tool call ID limit to prevent API 400 errors

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts
@@ -34,7 +34,7 @@ describe("sanitizeSessionHistory e2e smoke", () => {
     });
   });
 
-  it("keeps images-only sanitize policy without tool-call id rewriting for openai-responses", async () => {
+  it("applies images-only sanitize with strict tool-call id rewriting for openai-responses", async () => {
     vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 
     await sanitizeWithOpenAIResponses({
@@ -48,7 +48,7 @@ describe("sanitizeSessionHistory e2e smoke", () => {
       "session:history",
       expect.objectContaining({
         sanitizeMode: "images-only",
-        sanitizeToolCallIds: false,
+        sanitizeToolCallIds: true,
       }),
     );
   });

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -175,7 +175,7 @@ describe("sanitizeSessionHistory", () => {
     );
   });
 
-  it("does not sanitize tool call ids for openai-responses", async () => {
+  it("sanitizes tool call ids for openai-responses with strict mode", async () => {
     setNonGoogleModelApi();
 
     await sanitizeWithOpenAIResponses({
@@ -187,7 +187,7 @@ describe("sanitizeSessionHistory", () => {
     expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
       mockMessages,
       "session:history",
-      expect.objectContaining({ sanitizeMode: "images-only", sanitizeToolCallIds: false }),
+      expect.objectContaining({ sanitizeMode: "images-only", sanitizeToolCallIds: true }),
     );
   });
 

--- a/src/agents/tool-call-id.test.ts
+++ b/src/agents/tool-call-id.test.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import {
   isValidCloudCodeAssistToolId,
+  sanitizeToolCallId,
   sanitizeToolCallIdsForCloudCodeAssist,
 } from "./tool-call-id.js";
 
@@ -139,6 +140,20 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       const { aId, bId } = expectCollisionIdsRemainDistinct(out, "strict");
       expect(aId.length).toBeLessThanOrEqual(40);
       expect(bId.length).toBeLessThanOrEqual(40);
+    });
+
+    it("sanitizeToolCallId truncates individual IDs exceeding 40 chars", () => {
+      const longId = `call_${"x".repeat(60)}`;
+      const sanitized = sanitizeToolCallId(longId, "strict");
+      // After stripping underscore: "call" + 60 "x"s = 64 chars, must be capped at 40
+      expect(sanitized.length).toBeLessThanOrEqual(40);
+      expect(sanitized).toMatch(/^[a-zA-Z0-9]+$/);
+    });
+
+    it("isValidCloudCodeAssistToolId rejects IDs exceeding 40 chars", () => {
+      const longId = "a".repeat(41);
+      expect(isValidCloudCodeAssistToolId(longId, "strict")).toBe(false);
+      expect(isValidCloudCodeAssistToolId("a".repeat(40), "strict")).toBe(true);
     });
   });
 

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -37,8 +37,15 @@ export function sanitizeToolCallId(id: string, mode: ToolCallIdMode = "strict"):
   }
 
   // Some providers require strictly alphanumeric tool call IDs.
+  // Cap at 40 chars — OpenAI rejects tool call IDs longer than this.
+  const MAX_STRICT_LEN = 40;
   const alphanumericOnly = id.replace(/[^a-zA-Z0-9]/g, "");
-  return alphanumericOnly.length > 0 ? alphanumericOnly : "sanitizedtoolid";
+  if (alphanumericOnly.length > 0) {
+    return alphanumericOnly.length <= MAX_STRICT_LEN
+      ? alphanumericOnly
+      : alphanumericOnly.slice(0, MAX_STRICT_LEN);
+  }
+  return "sanitizedtoolid";
 }
 
 export function extractToolCallsFromAssistant(
@@ -89,8 +96,8 @@ export function isValidCloudCodeAssistToolId(id: string, mode: ToolCallIdMode = 
   if (mode === "strict9") {
     return /^[a-zA-Z0-9]{9}$/.test(id);
   }
-  // Strictly alphanumeric for providers with tighter tool ID constraints
-  return /^[a-zA-Z0-9]+$/.test(id);
+  // Strictly alphanumeric, max 40 chars for providers with tighter tool ID constraints
+  return /^[a-zA-Z0-9]+$/.test(id) && id.length <= 40;
 }
 
 function shortHash(text: string, length = 8): string {

--- a/src/agents/transcript-policy.policy.test.ts
+++ b/src/agents/transcript-policy.policy.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from "vitest";
 import { resolveTranscriptPolicy } from "./transcript-policy.js";
 
 describe("resolveTranscriptPolicy e2e smoke", () => {
-  it("uses images-only sanitization without tool-call id rewriting for OpenAI models", () => {
+  it("uses images-only sanitization with strict tool-call id rewriting for OpenAI models", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openai",
       modelId: "gpt-4o",
       modelApi: "openai",
     });
     expect(policy.sanitizeMode).toBe("images-only");
-    expect(policy.sanitizeToolCallIds).toBe(false);
-    expect(policy.toolCallIdMode).toBeUndefined();
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
   });
 
   it("uses strict9 tool-call sanitization for Mistral-family models", () => {

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -34,14 +34,14 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBe("strict9");
   });
 
-  it("disables sanitizeToolCallIds for OpenAI provider", () => {
+  it("enables sanitizeToolCallIds for OpenAI provider (40-char limit)", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openai",
       modelId: "gpt-4o",
       modelApi: "openai",
     });
-    expect(policy.sanitizeToolCallIds).toBe(false);
-    expect(policy.toolCallIdMode).toBeUndefined();
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
   });
 
   it("enables user-turn merge for strict OpenAI-compatible providers", () => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -102,7 +102,7 @@ export function resolveTranscriptPolicy(params: {
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
-  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
+  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic || isOpenAi;
   const toolCallIdMode: ToolCallIdMode | undefined = isMistral
     ? "strict9"
     : sanitizeToolCallIds
@@ -117,7 +117,7 @@ export function resolveTranscriptPolicy(params: {
 
   return {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
-    sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds,
+    sanitizeToolCallIds,
     toolCallIdMode,
     repairToolUseResultPairing,
     preserveSignatures: false,


### PR DESCRIPTION
## Summary
- Enable strict tool call ID sanitization for OpenAI provider — previously OpenAI was explicitly excluded from `sanitizeToolCallIds`, so IDs from external providers (LiteLLM, Ollama, Bedrock) could exceed the 40-character limit and trigger API 400 errors
- Add 40-char length cap to `sanitizeToolCallId()` in strict mode as defense-in-depth
- Add length check to `isValidCloudCodeAssistToolId()` validator

The existing `makeUniqueToolId` infrastructure already handles 40-char truncation with collision avoidance — the bug was that OpenAI was gated out of this path entirely.

Closes #31934

## Test plan
- [x] `vitest run src/agents/tool-call-id.test.ts` — 10 tests pass (2 new: length cap, validation)
- [x] `vitest run src/agents/transcript-policy.test.ts` — 7 tests pass (updated OpenAI expectation)
- [x] `vitest run src/agents/transcript-policy.policy.test.ts` — 2 tests pass
- [x] `vitest run src/agents/pi-embedded-runner.sanitize-session-history.test.ts` — 22 tests pass
- [x] `vitest run src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts` — 3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)