### PR TITLE
fix(cli): apply --profile before dotenv bootstrap in runCli

### DIFF
--- a/src/cli/run-main.profile-env.test.ts
+++ b/src/cli/run-main.profile-env.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const dotenvState = vi.hoisted(() => {
+  const state = {
+    profileAtDotenvLoad: undefined as string | undefined,
+  };
+  return {
+    state,
+    loadDotEnv: vi.fn(() => {
+      state.profileAtDotenvLoad = process.env.OPENCLAW_PROFILE;
+    }),
+  };
+});
+
+vi.mock("../infra/dotenv.js", () => ({
+  loadDotEnv: dotenvState.loadDotEnv,
+}));
+
+vi.mock("../infra/env.js", () => ({
+  normalizeEnv: vi.fn(),
+}));
+
+vi.mock("../infra/runtime-guard.js", () => ({
+  assertSupportedRuntime: vi.fn(),
+}));
+
+vi.mock("../infra/path-env.js", () => ({
+  ensureOpenClawCliOnPath: vi.fn(),
+}));
+
+vi.mock("./route.js", () => ({
+  tryRouteCli: vi.fn(async () => true),
+}));
+
+vi.mock("./windows-argv.js", () => ({
+  normalizeWindowsArgv: (argv: string[]) => argv,
+}));
+
+import { runCli } from "./run-main.js";
+
+describe("runCli profile env bootstrap", () => {
+  const originalProfile = process.env.OPENCLAW_PROFILE;
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+  const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+
+  beforeEach(() => {
+    delete process.env.OPENCLAW_PROFILE;
+    delete process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_CONFIG_PATH;
+    dotenvState.state.profileAtDotenvLoad = undefined;
+    dotenvState.loadDotEnv.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalProfile === undefined) {
+      delete process.env.OPENCLAW_PROFILE;
+    } else {
+      process.env.OPENCLAW_PROFILE = originalProfile;
+    }
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
+    if (originalConfigPath === undefined) {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
+    }
+  });
+
+  it("applies --profile before dotenv loading", async () => {
+    await runCli(["node", "openclaw", "--profile", "rawdog", "status"]);
+
+    expect(dotenvState.loadDotEnv).toHaveBeenCalledOnce();
+    expect(dotenvState.state.profileAtDotenvLoad).toBe("rawdog");
+    expect(process.env.OPENCLAW_PROFILE).toBe("rawdog");
+  });
+});

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -9,6 +9,7 @@ import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import { installUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "../logging.js";
 import { getCommandPath, getPrimaryCommand, hasHelpOrVersion } from "./argv.js";
+import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
 import { tryRouteCli } from "./route.js";
 import { normalizeWindowsArgv } from "./windows-argv.js";
 
@@ -62,7 +63,16 @@ export function shouldEnsureCliPath(argv: string[]): boolean {
 }
 
 export async function runCli(argv: string[] = process.argv) {
-  const normalizedArgv = normalizeWindowsArgv(argv);
+  let normalizedArgv = normalizeWindowsArgv(argv);
+  const parsedProfile = parseCliProfileArgs(normalizedArgv);
+  if (!parsedProfile.ok) {
+    throw new Error(parsedProfile.error);
+  }
+  if (parsedProfile.profile) {
+    applyCliProfileEnv({ profile: parsedProfile.profile });
+  }
+  normalizedArgv = parsedProfile.argv;
+
   loadDotEnv({ quiet: true });
   normalizeEnv();
   if (shouldEnsureCliPath(normalizedArgv)) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `runCli()` loaded dotenv before applying `--profile`, so profile-specific `.env` resolution could be wrong when `runCli` is invoked directly.
- Why it matters: multi-profile setups rely on profile-specific `.env` values (for example token/env isolation).
- What changed: `runCli()` now parses/applies CLI profile flags before calling `loadDotEnv()`, then proceeds with normalized argv.
- What did NOT change (scope boundary): no changes to profile parsing rules, dotenv lookup order, or command routing semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31936
- Related #31595

## User-visible / Behavior Changes

- `--profile` is now consistently honored before dotenv bootstrap in `runCli` execution path.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): profile-specific env values

### Steps

1. Run CLI with `--profile <name>` through `runCli` path.
2. Observe env state at dotenv load time.
3. Compare profile env application ordering.

### Expected

- `OPENCLAW_PROFILE` is already set from CLI args before `loadDotEnv` executes.

### Actual

- Before fix: dotenv loaded before profile application in `runCli`, so profile-specific env context was unavailable at load time.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before:

- `pnpm vitest src/cli/run-main.profile-env.test.ts`
- Failure: expected profile at dotenv load time to equal `rawdog`, got `undefined`.

After:

- `pnpm vitest src/cli/run-main.profile-env.test.ts src/cli/run-main.test.ts src/cli/profile.test.ts`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `runCli` applies `--profile` before dotenv bootstrap.
  - argv is normalized after profile extraction.
  - existing run-main/profile tests remain green.
- Edge cases checked:
  - no-profile path still works.
  - invalid profile still throws via existing parse semantics.
- What you did **not** verify:
  - full end-to-end runtime behavior against an external deployment wrapper.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: N/A.
- Known bad symptoms reviewers should watch for: unexpected profile parsing errors in direct `runCli` callers.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: direct `runCli` callers now receive parse errors earlier for invalid profile flags.
  - Mitigation: this matches existing CLI profile parsing contract and is covered by tests.
