### PR TITLE
fix(slack): scope debounce key by message timestamp to prevent cross-thread collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/Heartbeat model reload: treat `models.*` and `agents.defaults.model` config updates as heartbeat hot-reload triggers so heartbeat picks up model changes without a full gateway restart. (#32046) Thanks @stakeswky.
+- Slack/inbound debounce routing: isolate top-level non-DM message debounce keys by message timestamp to avoid cross-thread collisions, preserve DM batching, and flush pending top-level buffers before immediate non-debounce follow-ups to keep ordering stable. (#31951) Thanks @scoootscooob.
 - Memory/LanceDB embeddings: forward configured `embedding.dimensions` into OpenAI embeddings requests so vector size and API output dimensions stay aligned when dimensions are explicitly configured. (#32036) Thanks @scotthuang.
 - Mentions/Slack formatting hardening: add null-safe guards for runtime text normalization paths so malformed/undefined text payloads do not crash mention stripping or mrkdwn conversion. (#31865) Thanks @stone-jin.
 - Failover/error classification: treat HTTP `529` (provider overloaded, common with Anthropic-compatible APIs) as `rate_limit` so model failover can engage instead of misclassifying the error path. (#31854) Thanks @bugkill3r.

--- a/src/slack/monitor/message-handler.debounce-key.test.ts
+++ b/src/slack/monitor/message-handler.debounce-key.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { SlackMessageEvent } from "../types.js";
+import { buildSlackDebounceKey } from "./message-handler.js";
+
+function makeMessage(overrides: Partial<SlackMessageEvent> = {}): SlackMessageEvent {
+  return {
+    type: "message",
+    channel: "C123",
+    user: "U456",
+    ts: "1709000000.000100",
+    text: "hello",
+    ...overrides,
+  } as SlackMessageEvent;
+}
+
+describe("buildSlackDebounceKey", () => {
+  const accountId = "default";
+
+  it("returns null when message has no sender", () => {
+    const msg = makeMessage({ user: undefined, bot_id: undefined });
+    expect(buildSlackDebounceKey(msg, accountId)).toBeNull();
+  });
+
+  it("scopes thread replies by thread_ts", () => {
+    const msg = makeMessage({ thread_ts: "1709000000.000001" });
+    expect(buildSlackDebounceKey(msg, accountId)).toBe("slack:default:C123:1709000000.000001:U456");
+  });
+
+  it("isolates unresolved thread replies with maybe-thread prefix", () => {
+    const msg = makeMessage({
+      parent_user_id: "U789",
+      thread_ts: undefined,
+      ts: "1709000000.000200",
+    });
+    expect(buildSlackDebounceKey(msg, accountId)).toBe(
+      "slack:default:C123:maybe-thread:1709000000.000200:U456",
+    );
+  });
+
+  it("scopes top-level messages by their own timestamp to prevent cross-thread collisions", () => {
+    const msgA = makeMessage({ ts: "1709000000.000100" });
+    const msgB = makeMessage({ ts: "1709000000.000200" });
+
+    const keyA = buildSlackDebounceKey(msgA, accountId);
+    const keyB = buildSlackDebounceKey(msgB, accountId);
+
+    // Different timestamps => different debounce keys
+    expect(keyA).not.toBe(keyB);
+    expect(keyA).toBe("slack:default:C123:1709000000.000100:U456");
+    expect(keyB).toBe("slack:default:C123:1709000000.000200:U456");
+  });
+
+  it("falls back to bare channel when no timestamp is available", () => {
+    const msg = makeMessage({ ts: undefined, event_ts: undefined });
+    expect(buildSlackDebounceKey(msg, accountId)).toBe("slack:default:C123:U456");
+  });
+
+  it("uses bot_id as sender fallback", () => {
+    const msg = makeMessage({ user: undefined, bot_id: "B999" });
+    expect(buildSlackDebounceKey(msg, accountId)).toBe("slack:default:C123:1709000000.000100:B999");
+  });
+});

--- a/src/slack/monitor/message-handler.debounce-key.test.ts
+++ b/src/slack/monitor/message-handler.debounce-key.test.ts
@@ -50,6 +50,13 @@ describe("buildSlackDebounceKey", () => {
     expect(keyB).toBe("slack:default:C123:1709000000.000200:U456");
   });
 
+  it("keeps top-level DMs channel-scoped to preserve short-message batching", () => {
+    const dmA = makeMessage({ channel: "D123", ts: "1709000000.000100" });
+    const dmB = makeMessage({ channel: "D123", ts: "1709000000.000200" });
+    expect(buildSlackDebounceKey(dmA, accountId)).toBe("slack:default:D123:U456");
+    expect(buildSlackDebounceKey(dmB, accountId)).toBe("slack:default:D123:U456");
+  });
+
   it("falls back to bare channel when no timestamp is available", () => {
     const msg = makeMessage({ ts: undefined, event_ts: undefined });
     expect(buildSlackDebounceKey(msg, accountId)).toBe("slack:default:C123:U456");

--- a/src/slack/monitor/message-handler.test.ts
+++ b/src/slack/monitor/message-handler.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSlackMessageHandler } from "./message-handler.js";
 
 const enqueueMock = vi.fn(async (_entry: unknown) => {});
+const flushKeyMock = vi.fn(async (_key: string) => {});
 const resolveThreadTsMock = vi.fn(async ({ message }: { message: Record<string, unknown> }) => ({
   ...message,
 }));
@@ -10,6 +11,7 @@ vi.mock("../../auto-reply/inbound-debounce.js", () => ({
   resolveInboundDebounceMs: () => 10,
   createInboundDebouncer: () => ({
     enqueue: (entry: unknown) => enqueueMock(entry),
+    flushKey: (key: string) => flushKeyMock(key),
   }),
 }));
 
@@ -37,6 +39,7 @@ function createContext(overrides?: {
 describe("createSlackMessageHandler", () => {
   beforeEach(() => {
     enqueueMock.mockClear();
+    flushKeyMock.mockClear();
     resolveThreadTsMock.mockClear();
   });
 
@@ -112,5 +115,39 @@ describe("createSlackMessageHandler", () => {
     expect(trackEvent).toHaveBeenCalledTimes(1);
     expect(resolveThreadTsMock).toHaveBeenCalledTimes(1);
     expect(enqueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes pending top-level buffered keys before immediate non-debounce follow-ups", async () => {
+    const handler = createSlackMessageHandler({
+      ctx: createContext(),
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+
+    await handler(
+      {
+        type: "message",
+        channel: "C111",
+        user: "U111",
+        ts: "1709000000.000100",
+        text: "first buffered text",
+      } as never,
+      { source: "message" },
+    );
+    await handler(
+      {
+        type: "message",
+        subtype: "file_share",
+        channel: "C111",
+        user: "U111",
+        ts: "1709000000.000200",
+        text: "file follows",
+        files: [{ id: "F1" }],
+      } as never,
+      { source: "message" },
+    );
+
+    expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
   });
 });

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -16,17 +16,57 @@ export type SlackMessageHandler = (
   opts: { source: "message" | "app_mention"; wasMentioned?: boolean },
 ) => Promise<void>;
 
+function resolveSlackSenderId(message: SlackMessageEvent): string | null {
+  return message.user ?? message.bot_id ?? null;
+}
+
+function isSlackDirectMessageChannel(channelId: string): boolean {
+  return channelId.startsWith("D");
+}
+
+function isTopLevelSlackMessage(message: SlackMessageEvent): boolean {
+  return !message.thread_ts && !message.parent_user_id;
+}
+
+function buildTopLevelSlackConversationKey(
+  message: SlackMessageEvent,
+  accountId: string,
+): string | null {
+  if (!isTopLevelSlackMessage(message)) {
+    return null;
+  }
+  const senderId = resolveSlackSenderId(message);
+  if (!senderId) {
+    return null;
+  }
+  return `slack:${accountId}:${message.channel}:${senderId}`;
+}
+
+function shouldDebounceSlackMessage(message: SlackMessageEvent, cfg: SlackMonitorContext["cfg"]) {
+  const text = message.text ?? "";
+  if (!text.trim()) {
+    return false;
+  }
+  if (message.files && message.files.length > 0) {
+    return false;
+  }
+  const textForCommandDetection = stripSlackMentionsForCommandDetection(text);
+  return !hasControlCommand(textForCommandDetection, cfg);
+}
+
 /**
  * Build a debounce key that isolates messages by thread (or by message timestamp
- * for top-level channel messages). Without per-message scoping, concurrent
- * top-level messages from the same sender would share a key and get merged
+ * for top-level non-DM channel messages). Without per-message scoping, concurrent
+ * top-level messages from the same sender can share a key and get merged
  * into a single reply on the wrong thread.
+ *
+ * DMs intentionally stay channel-scoped to preserve short-message batching.
  */
 export function buildSlackDebounceKey(
   message: SlackMessageEvent,
   accountId: string,
 ): string | null {
-  const senderId = message.user ?? message.bot_id;
+  const senderId = resolveSlackSenderId(message);
   if (!senderId) {
     return null;
   }
@@ -35,7 +75,7 @@ export function buildSlackDebounceKey(
     ? `${message.channel}:${message.thread_ts}`
     : message.parent_user_id && messageTs
       ? `${message.channel}:maybe-thread:${messageTs}`
-      : messageTs
+      : messageTs && !isSlackDirectMessageChannel(message.channel)
         ? `${message.channel}:${messageTs}`
         : message.channel;
   return `slack:${accountId}:${threadKey}:${senderId}`;
@@ -50,6 +90,7 @@ export function createSlackMessageHandler(params: {
   const { ctx, account, trackEvent } = params;
   const debounceMs = resolveInboundDebounceMs({ cfg: ctx.cfg, channel: "slack" });
   const threadTsResolver = createSlackThreadTsResolver({ client: ctx.app.client });
+  const pendingTopLevelDebounceKeys = new Map<string, Set<string>>();
 
   const debouncer = createInboundDebouncer<{
     message: SlackMessageEvent;
@@ -57,21 +98,25 @@ export function createSlackMessageHandler(params: {
   }>({
     debounceMs,
     buildKey: (entry) => buildSlackDebounceKey(entry.message, ctx.accountId),
-    shouldDebounce: (entry) => {
-      const text = entry.message.text ?? "";
-      if (!text.trim()) {
-        return false;
-      }
-      if (entry.message.files && entry.message.files.length > 0) {
-        return false;
-      }
-      const textForCommandDetection = stripSlackMentionsForCommandDetection(text);
-      return !hasControlCommand(textForCommandDetection, ctx.cfg);
-    },
+    shouldDebounce: (entry) => shouldDebounceSlackMessage(entry.message, ctx.cfg),
     onFlush: async (entries) => {
       const last = entries.at(-1);
       if (!last) {
         return;
+      }
+      const flushedKey = buildSlackDebounceKey(last.message, ctx.accountId);
+      const topLevelConversationKey = buildTopLevelSlackConversationKey(
+        last.message,
+        ctx.accountId,
+      );
+      if (flushedKey && topLevelConversationKey) {
+        const pendingKeys = pendingTopLevelDebounceKeys.get(topLevelConversationKey);
+        if (pendingKeys) {
+          pendingKeys.delete(flushedKey);
+          if (pendingKeys.size === 0) {
+            pendingTopLevelDebounceKeys.delete(topLevelConversationKey);
+          }
+        }
       }
       const combinedText =
         entries.length === 1
@@ -129,6 +174,23 @@ export function createSlackMessageHandler(params: {
     }
     trackEvent?.();
     const resolvedMessage = await threadTsResolver.resolve({ message, source: opts.source });
+    const debounceKey = buildSlackDebounceKey(resolvedMessage, ctx.accountId);
+    const conversationKey = buildTopLevelSlackConversationKey(resolvedMessage, ctx.accountId);
+    const canDebounce = debounceMs > 0 && shouldDebounceSlackMessage(resolvedMessage, ctx.cfg);
+    if (!canDebounce && conversationKey) {
+      const pendingKeys = pendingTopLevelDebounceKeys.get(conversationKey);
+      if (pendingKeys && pendingKeys.size > 0) {
+        const keysToFlush = Array.from(pendingKeys);
+        for (const pendingKey of keysToFlush) {
+          await debouncer.flushKey(pendingKey);
+        }
+      }
+    }
+    if (canDebounce && debounceKey && conversationKey) {
+      const pendingKeys = pendingTopLevelDebounceKeys.get(conversationKey) ?? new Set<string>();
+      pendingKeys.add(debounceKey);
+      pendingTopLevelDebounceKeys.set(conversationKey, pendingKeys);
+    }
     await debouncer.enqueue({ message: resolvedMessage, opts });
   };
 }

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -16,6 +16,31 @@ export type SlackMessageHandler = (
   opts: { source: "message" | "app_mention"; wasMentioned?: boolean },
 ) => Promise<void>;
 
+/**
+ * Build a debounce key that isolates messages by thread (or by message timestamp
+ * for top-level channel messages). Without per-message scoping, concurrent
+ * top-level messages from the same sender would share a key and get merged
+ * into a single reply on the wrong thread.
+ */
+export function buildSlackDebounceKey(
+  message: SlackMessageEvent,
+  accountId: string,
+): string | null {
+  const senderId = message.user ?? message.bot_id;
+  if (!senderId) {
+    return null;
+  }
+  const messageTs = message.ts ?? message.event_ts;
+  const threadKey = message.thread_ts
+    ? `${message.channel}:${message.thread_ts}`
+    : message.parent_user_id && messageTs
+      ? `${message.channel}:maybe-thread:${messageTs}`
+      : messageTs
+        ? `${message.channel}:${messageTs}`
+        : message.channel;
+  return `slack:${accountId}:${threadKey}:${senderId}`;
+}
+
 export function createSlackMessageHandler(params: {
   ctx: SlackMonitorContext;
   account: ResolvedSlackAccount;
@@ -31,20 +56,7 @@ export function createSlackMessageHandler(params: {
     opts: { source: "message" | "app_mention"; wasMentioned?: boolean };
   }>({
     debounceMs,
-    buildKey: (entry) => {
-      const senderId = entry.message.user ?? entry.message.bot_id;
-      if (!senderId) {
-        return null;
-      }
-      const messageTs = entry.message.ts ?? entry.message.event_ts;
-      // If Slack flags a thread reply but omits thread_ts, isolate it from root debouncing.
-      const threadKey = entry.message.thread_ts
-        ? `${entry.message.channel}:${entry.message.thread_ts}`
-        : entry.message.parent_user_id && messageTs
-          ? `${entry.message.channel}:maybe-thread:${messageTs}`
-          : entry.message.channel;
-      return `slack:${ctx.accountId}:${threadKey}:${senderId}`;
-    },
+    buildKey: (entry) => buildSlackDebounceKey(entry.message, ctx.accountId),
     shouldDebounce: (entry) => {
       const text = entry.message.text ?? "";
       if (!text.trim()) {


### PR DESCRIPTION
## Summary
- Top-level channel messages from the same sender shared a bare channel debounce key (`slack:{account}:{channel}:{sender}`), causing concurrent messages in different threads to merge into a single reply on the wrong thread
- Now the debounce key includes the message timestamp for top-level messages (`slack:{account}:{channel}:{ts}:{sender}`), matching how the downstream session layer already scopes by `canonicalThreadId`
- Extracted `buildSlackDebounceKey()` as a separate exported function for testability

Closes #31935

## Test plan
- [x] `vitest run src/slack/monitor/message-handler.debounce-key.test.ts` — 6 new tests pass:
  - Returns null for messages with no sender
  - Scopes thread replies by `thread_ts`
  - Isolates unresolved thread replies with `maybe-thread` prefix
  - **Scopes top-level messages by their own timestamp** (the fix)
  - Falls back to bare channel when no timestamp available
  - Uses `bot_id` as sender fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)