### PR TITLE
fix(skills): run sherpa-onnx-tts bin under ESM

### DIFF
--- a/skills/sherpa-onnx-tts/bin/sherpa-onnx-tts
+++ b/skills/sherpa-onnx-tts/bin/sherpa-onnx-tts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const fs = require("node:fs");
-const path = require("node:path");
-const { spawnSync } = require("node:child_process");
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
 
 function usage(message) {
   if (message) {

--- a/src/agents/skills.sherpa-onnx-tts-bin.test.ts
+++ b/src/agents/skills.sherpa-onnx-tts-bin.test.ts
@@ -1,0 +1,23 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("skills/sherpa-onnx-tts bin script", () => {
+  it("loads as ESM and falls through to usage output when env is missing", () => {
+    const scriptPath = path.resolve(
+      process.cwd(),
+      "skills",
+      "sherpa-onnx-tts",
+      "bin",
+      "sherpa-onnx-tts",
+    );
+    const result = spawnSync(process.execPath, [scriptPath], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Missing runtime/model directory.");
+    expect(result.stderr).toContain("Usage: sherpa-onnx-tts");
+    expect(result.stderr).not.toContain("require is not defined in ES module scope");
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `skills/sherpa-onnx-tts/bin/sherpa-onnx-tts` used CommonJS `require(...)` in a `type: module` repo, so direct `node` execution fails before argument parsing.
- Why it matters: the built-in sherpa local-TTS skill cannot run at all for Node 22+ users invoking the bin script.
- What changed: converted the bin entrypoint imports to ESM (`import fs/path/spawnSync ...`) and added a regression test that executes the bin script as a real Node entrypoint.
- What did NOT change (scope boundary): no behavior changes to arg parsing, env resolution, model/runtime selection, or sherpa invocation flags.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31956
- Related #

## User-visible / Behavior Changes

- `node skills/sherpa-onnx-tts/bin/sherpa-onnx-tts ...` now loads correctly in ESM mode and reaches normal usage/runtime validation instead of crashing at module load.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15
- Runtime/container: Node v22.22.0
- Model/provider: N/A
- Integration/channel (if any): sherpa-onnx-tts bundled skill bin
- Relevant config (redacted): none required to reproduce module-load failure

### Steps

1. On `upstream/main`, run: `node skills/sherpa-onnx-tts/bin/sherpa-onnx-tts --help`
2. Observe startup crash: `ReferenceError: require is not defined in ES module scope`.
3. Apply this branch and rerun the same command.

### Expected

- Bin script should run under ESM and proceed to usage/runtime validation.

### Actual

- Before fix: hard crash at line 3 on `require(...)`.
- After fix: script prints usage/missing env guidance (expected path when runtime/model env is not set).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced failure before patch with: `node skills/sherpa-onnx-tts/bin/sherpa-onnx-tts --help` (module-load `require` crash).
  - Verified post-fix behavior with: `node skills/sherpa-onnx-tts/bin/sherpa-onnx-tts` (usage output path).
  - Ran regression test: `pnpm test src/agents/skills.sherpa-onnx-tts-bin.test.ts`.
  - Ran static/type checks for touched code path: `pnpm tsgo`, `pnpm lint`.
- Edge cases checked:
  - Entry script executed with no env still exits with usage (status 1), not module-load exception.
- What you did **not** verify:
  - Full live sherpa runtime execution with downloaded models/binaries.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `skills/sherpa-onnx-tts/bin/sherpa-onnx-tts`
  - `src/agents/skills.sherpa-onnx-tts-bin.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected import/loader errors in the sherpa skill bin entrypoint.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: none observed; import syntax migration only.
  - Mitigation: regression test executes the exact bin script path with Node entrypoint semantics.
