### PR TITLE
fix(dashboard): broadcast inbound user message before session write lock

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -65,6 +65,7 @@ import {
   acquireSessionWriteLock,
   resolveSessionLockMaxHoldFromTimeout,
 } from "../../session-write-lock.js";
+import { emitAgentEvent } from "../../../infra/agent-events.js";
 import { detectRuntimeShell } from "../../shell-utils.js";
 import {
   applySkillEnvOverrides,
@@ -763,6 +764,25 @@ export async function runEmbeddedAttempt(
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
     let systemPromptText = systemPromptOverride();
+
+    // Emit the inbound user message BEFORE acquiring the session write lock so
+    // that the dashboard (and any WebSocket listeners) can display it immediately
+    // rather than waiting for lock acquisition + session initialisation to complete.
+    // This is a fire-and-forget broadcast that does NOT write to the transcript
+    // file — the actual transcript write still happens inside the session as normal,
+    // ensuring no duplicate messages.
+    if (params.runId && params.sessionKey && params.prompt) {
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "inbound",
+        sessionKey: params.sessionKey,
+        data: {
+          role: "user",
+          text: typeof params.prompt === "string" ? params.prompt : "",
+          timestamp: Date.now(),
+        },
+      });
+    }
 
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -453,7 +453,27 @@ export function createAgentEventHandler({
       if (!isToolEvent || toolVerbose !== "off") {
         nodeSendToSession(sessionKey, "agent", isToolEvent ? toolPayload : agentPayload);
       }
-      if (!isAborted && evt.stream === "assistant" && typeof evt.data?.text === "string") {
+      if (evt.stream === "inbound" && typeof evt.data?.text === "string" && evt.data.text) {
+        // Broadcast the inbound user message to the dashboard immediately —
+        // before the session write lock is acquired and before the AI responds.
+        // This eliminates the "message appears only after AI reply" delay on
+        // all channels (Telegram, Discord, Signal, etc.).
+        const now = typeof evt.data.timestamp === "number" ? evt.data.timestamp : Date.now();
+        const seq = nextChatSeq({ agentRunSeq }, clientRunId);
+        const inboundPayload = {
+          runId: clientRunId,
+          sessionKey,
+          seq,
+          state: "inbound" as const,
+          message: {
+            role: "user",
+            content: [{ type: "text", text: evt.data.text as string }],
+            timestamp: now,
+          },
+        };
+        broadcast("chat", inboundPayload);
+        nodeSendToSession(sessionKey, "chat", inboundPayload);
+      } else if (!isAborted && evt.stream === "assistant" && typeof evt.data?.text === "string") {
         emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text);
       } else if (!isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {
         if (chatLink) {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -1,6 +1,6 @@
 import type { VerboseLevel } from "../auto-reply/thinking.js";
 
-export type AgentEventStream = "lifecycle" | "tool" | "assistant" | "error" | (string & {});
+export type AgentEventStream = "lifecycle" | "tool" | "assistant" | "error" | "inbound" | (string & {});
 
 export type AgentEventPayload = {
   runId: string;


### PR DESCRIPTION
## Problem

On non-webchat channels (Telegram, Discord, Signal, etc.), inbound user messages appear in the OpenClaw dashboard only **after the AI response completes** — sometimes with a delay of several minutes.

### Root Cause

In `runEmbeddedAttempt()`, the user message is written to the JSONL transcript file *inside* the session write lock:

```
acquireSessionWriteLock()          ← delay starts here
  └─ SessionManager.open(file)
  └─ prepareSessionManagerForRun() ← loads MEMORY.md, SOUL.md, context files…
  └─ createAgentSession()
  └─ session.run(prompt)           ← user msg written to disk HERE
       └─ emitSessionTranscriptUpdate() ← dashboard notified HERE
```

The write lock can be delayed when a previous session run is still active (queue wait), and `prepareSessionManagerForRun` adds further latency loading workspace files. The dashboard only receives the message via WebSocket broadcast *after* `emitSessionTranscriptUpdate()` fires, which is deep inside this chain.

## Fix

Emit a new `"inbound"` `AgentEvent` **immediately before** `acquireSessionWriteLock()`, carrying the user message text and session key. This event does **not** write to the transcript file, so no duplicate messages are produced.

`createAgentEventHandler()` in `server-chat.ts` handles the `"inbound"` stream by broadcasting a `"chat"` WebSocket message with `state: "inbound"` and `role: "user"` to all connected dashboard clients for that session.

### Result
The dashboard shows the inbound message **instantly on receive**, regardless of channel (Telegram, Discord, Signal, webchat, etc.).

## Files Changed

| File | Change |
|---|---|
| `src/infra/agent-events.ts` | Add `'inbound'` to `AgentEventStream` union |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Emit `inbound` event before write lock |
| `src/gateway/server-chat.ts` | Handle `inbound` event → broadcast `chat` WS message |

## Testing

1. Connect Telegram to an OpenClaw gateway
2. Open the dashboard in a browser
3. Send a message from Telegram
4. **Before this fix:** message appears only after AI responds
5. **After this fix:** message appears in the dashboard immediately on receive