### PR TITLE
fix(feishu): guard rate-limit config access against undefined

### DIFF
--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -16,15 +16,15 @@ export const FEISHU_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 export const FEISHU_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
 
 export const feishuWebhookRateLimiter = createFixedWindowRateLimiter({
-  windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
-  maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
-  maxTrackedKeys: WEBHOOK_RATE_LIMIT_DEFAULTS.maxTrackedKeys,
+  windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS?.windowMs ?? 60_000,
+  maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS?.maxRequests ?? 120,
+  maxTrackedKeys: WEBHOOK_RATE_LIMIT_DEFAULTS?.maxTrackedKeys ?? 4_096,
 });
 
 const feishuWebhookAnomalyTracker = createWebhookAnomalyTracker({
-  maxTrackedKeys: WEBHOOK_ANOMALY_COUNTER_DEFAULTS.maxTrackedKeys,
-  ttlMs: WEBHOOK_ANOMALY_COUNTER_DEFAULTS.ttlMs,
-  logEvery: WEBHOOK_ANOMALY_COUNTER_DEFAULTS.logEvery,
+  maxTrackedKeys: WEBHOOK_ANOMALY_COUNTER_DEFAULTS?.maxTrackedKeys ?? 4_096,
+  ttlMs: WEBHOOK_ANOMALY_COUNTER_DEFAULTS?.ttlMs ?? 21_600_000,
+  logEvery: WEBHOOK_ANOMALY_COUNTER_DEFAULTS?.logEvery ?? 25,
 });
 
 export function clearFeishuWebhookRateLimitStateForTest(): void {


### PR DESCRIPTION
## Summary
- Adds optional chaining (`?.`) and nullish coalescing (`??`) fallbacks when accessing `WEBHOOK_RATE_LIMIT_DEFAULTS` and `WEBHOOK_ANOMALY_COUNTER_DEFAULTS` in the Feishu plugin's module-level initializers
- Prevents `TypeError: Cannot read properties of undefined (reading 'windowMs')` during plugin load when the imported constants resolve to `undefined` (e.g. duplicate plugin detection or version mismatch during onboarding)
- Fallback values match the canonical defaults defined in `src/plugin-sdk/webhook-memory-guards.ts`

Closes #31606

## Test plan
- [ ] `pnpm oxlint extensions/feishu/src/monitor.state.ts` passes (verified)
- [ ] `pnpm oxfmt --check extensions/feishu/src/monitor.state.ts` passes (verified)
- [ ] `openclaw onboard --install-daemon` with Feishu plugin selected no longer crashes during configuration
- [ ] Existing Feishu webhook rate-limiting behavior is unchanged when constants import correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)