### PR TITLE
fix(telegram): guard malformed plugin command specs in menu sync

### DIFF
--- a/src/telegram/bot-native-command-menu.test.ts
+++ b/src/telegram/bot-native-command-menu.test.ts
@@ -60,6 +60,21 @@ describe("bot-native-command-menu", () => {
     expect(result.issues).toEqual([]);
   });
 
+  it("does not throw when plugin command specs are malformed", () => {
+    const result = buildPluginTelegramMenuCommands({
+      specs: [{ name: "missing-description" } as never, { description: "Missing name" } as never],
+      existingCommands: new Set<string>(),
+    });
+
+    expect(result.commands).toEqual([]);
+    expect(result.issues).toContain(
+      'Plugin command "/missing_description" is missing a description.',
+    );
+    expect(result.issues).toContain(
+      'Plugin command "/" is invalid for Telegram (use a-z, 0-9, underscore; max 32 chars).',
+    );
+  });
+
   it("deletes stale commands before setting new menu", async () => {
     const callOrder: string[] = [];
     const deleteMyCommands = vi.fn(async () => {

--- a/src/telegram/bot-native-command-menu.ts
+++ b/src/telegram/bot-native-command-menu.ts
@@ -54,14 +54,15 @@ export function buildPluginTelegramMenuCommands(params: {
   const pluginCommandNames = new Set<string>();
 
   for (const spec of specs) {
-    const normalized = normalizeTelegramCommandName(spec.name);
+    const rawName = typeof spec?.name === "string" ? spec.name : "";
+    const normalized = normalizeTelegramCommandName(rawName);
     if (!normalized || !TELEGRAM_COMMAND_NAME_PATTERN.test(normalized)) {
       issues.push(
-        `Plugin command "/${spec.name}" is invalid for Telegram (use a-z, 0-9, underscore; max 32 chars).`,
+        `Plugin command "/${rawName}" is invalid for Telegram (use a-z, 0-9, underscore; max 32 chars).`,
       );
       continue;
     }
-    const description = spec.description.trim();
+    const description = typeof spec?.description === "string" ? spec.description.trim() : "";
     if (!description) {
       issues.push(`Plugin command "/${normalized}" is missing a description.`);
       continue;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram native command menu sync assumes plugin command specs always have string `name`/`description`; malformed plugin specs crash startup with `Cannot read properties of undefined (reading 'trim')`.
- Why it matters: Telegram provider can fail during startup command registration instead of isolating the bad plugin command.
- What changed: hardened `buildPluginTelegramMenuCommands` to safely coerce/validate non-string spec fields before trimming/normalizing.
- What did NOT change (scope boundary): no changes to Telegram transport, command execution, auth policy, or plugin command handler semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31944
- Related #

## User-visible / Behavior Changes

- Telegram startup no longer crashes when a plugin exposes malformed command metadata.
- Invalid plugin command specs are reported as issues and skipped, while valid commands continue to register.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15
- Runtime/container: Node v22.22.0
- Model/provider: N/A
- Integration/channel (if any): Telegram native command registration path
- Relevant config (redacted): none required for unit-level repro

### Steps

1. On `upstream/main`, run:
   `pnpm exec tsx -e 'import { buildPluginTelegramMenuCommands } from "./src/telegram/bot-native-command-menu.ts"; console.log(buildPluginTelegramMenuCommands({ specs: [{ name: "bad" } as any], existingCommands: new Set<string>() }));'`
2. Observe crash:
   `TypeError: Cannot read properties of undefined (reading 'trim')`
3. Apply this branch and run the same command.

### Expected

- Invalid/malformed plugin command specs should be treated as validation issues and skipped.

### Actual

- Before fix: hard crash at startup path due to unguarded `.trim()`.
- After fix: returns a structured issue list (no throw), e.g. missing description.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced pre-fix crash with direct `tsx` call into `buildPluginTelegramMenuCommands` using malformed spec.
  - Verified post-fix no-throw behavior for same repro.
  - Ran `pnpm test src/telegram/bot-native-command-menu.test.ts`.
  - Ran `pnpm test src/telegram/bot-native-commands.test.ts`.
  - Ran `pnpm tsgo` and `pnpm lint`.
- Edge cases checked:
  - Missing `description` field.
  - Missing `name` field.
- What you did **not** verify:
  - Live Telegram bot startup with real plugin package producing malformed command metadata.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/telegram/bot-native-command-menu.ts`
  - `src/telegram/bot-native-command-menu.test.ts`
- Known bad symptoms reviewers should watch for:
  - Plugin command menu entries unexpectedly missing due to stricter malformed-field handling.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: malformed plugin specs now emit validation issues instead of crashing, which may hide faulty plugin metadata if operators ignore logs.
  - Mitigation: issue strings are explicit and startup remains healthy; existing valid commands continue to register.
