### PR TITLE
fix(macos): add system.run.prepare support for node mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- macOS/Nodes: include `system.run.prepare` in the macOS node command list and add runtime handling for prepare-plan payloads so `openclaw nodes run` no longer fails preflight command checks on paired macOS nodes. (#31959)
 - Security/Node exec approvals: preserve shell/dispatch-wrapper argv semantics during approval hardening so approved wrapper commands (for example `env sh -c ...`) cannot drift into a different runtime command shape, and add regression coverage for both approval-plan generation and approved runtime execution paths. Thanks @tdjackey for reporting.
 - Sandbox/Bootstrap context boundary hardening: reject symlink/hardlink alias bootstrap seed files that resolve outside the source workspace and switch post-compaction `AGENTS.md` context reads to boundary-verified file opens, preventing host file content from being injected via workspace aliasing. Thanks @tdjackey for reporting.
 - Browser/Security output boundary hardening: replace check-then-rename output commits with root-bound fd-verified writes, unify install/skills canonical path-boundary checks, and add regression coverage for symlink-rebind race paths across browser output and shared fs-safe write flows. Thanks @tdjackey for reporting.

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -136,6 +136,7 @@ final class MacNodeModeCoordinator {
             MacNodeScreenCommand.record.rawValue,
             OpenClawSystemCommand.notify.rawValue,
             OpenClawSystemCommand.which.rawValue,
+            OpenClawSystemCommand.runPrepare.rawValue,
             OpenClawSystemCommand.run.rawValue,
             OpenClawSystemCommand.execApprovalsGet.rawValue,
             OpenClawSystemCommand.execApprovalsSet.rawValue,

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -58,6 +58,8 @@ actor MacNodeRuntime {
                 return try await self.handleLocationInvoke(req)
             case MacNodeScreenCommand.record.rawValue:
                 return try await self.handleScreenRecordInvoke(req)
+            case OpenClawSystemCommand.runPrepare.rawValue:
+                return try await self.handleSystemRunPrepare(req)
             case OpenClawSystemCommand.run.rawValue:
                 return try await self.handleSystemRun(req)
             case OpenClawSystemCommand.which.rawValue:
@@ -433,6 +435,37 @@ actor MacNodeRuntime {
             guard poll, Date() < deadline else { return false }
             try? await Task.sleep(nanoseconds: 120_000_000)
         }
+    }
+
+    private func handleSystemRunPrepare(_ req: BridgeInvokeRequest) async throws -> BridgeInvokeResponse {
+        let params = try Self.decodeParams(OpenClawSystemRunParams.self, from: req.paramsJSON)
+        guard !params.command.isEmpty else {
+            return Self.errorResponse(req, code: .invalidRequest, message: "INVALID_REQUEST: command required")
+        }
+
+        let validation = ExecSystemRunCommandValidator.resolve(
+            command: params.command,
+            rawCommand: params.rawCommand)
+        let cmdText: String
+        switch validation {
+        case let .ok(resolved):
+            cmdText = resolved.displayCommand
+        case let .invalid(message):
+            return Self.errorResponse(req, code: .invalidRequest, message: message)
+        }
+
+        let normalizedCwd = params.cwd?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedAgentId = params.agentId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedSessionKey = params.sessionKey?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let payload = OpenClawSystemRunPreparePayload(
+            cmdText: cmdText,
+            plan: OpenClawSystemRunApprovalPlan(
+                argv: params.command,
+                cwd: normalizedCwd?.isEmpty == false ? normalizedCwd : nil,
+                rawCommand: cmdText,
+                agentId: normalizedAgentId?.isEmpty == false ? normalizedAgentId : nil,
+                sessionKey: normalizedSessionKey?.isEmpty == false ? normalizedSessionKey : nil))
+        return BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: try Self.encodePayload(payload))
     }
 
     private func handleSystemRun(_ req: BridgeInvokeRequest) async throws -> BridgeInvokeResponse {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Darwin
 import Foundation
 import OpenClawIPC
 import OpenClawKit
@@ -437,6 +438,92 @@ actor MacNodeRuntime {
         }
     }
 
+    private static func fileStatus(at path: String, followSymlink: Bool) -> stat? {
+        var info = stat()
+        let status = path.withCString { cPath in
+            followSymlink ? Darwin.stat(cPath, &info) : Darwin.lstat(cPath, &info)
+        }
+        return status == 0 ? info : nil
+    }
+
+    private static func isDirectory(_ info: stat) -> Bool {
+        (info.st_mode & S_IFMT) == S_IFDIR
+    }
+
+    private static func isSymlink(_ info: stat) -> Bool {
+        (info.st_mode & S_IFMT) == S_IFLNK
+    }
+
+    private static func sameFileIdentity(_ lhs: stat, _ rhs: stat) -> Bool {
+        lhs.st_dev == rhs.st_dev && lhs.st_ino == rhs.st_ino
+    }
+
+    private static func isWritableByCurrentProcess(_ path: String) -> Bool {
+        path.withCString { Darwin.access($0, W_OK) == 0 }
+    }
+
+    private static func hasMutableSymlinkPathComponent(_ targetPath: String) -> Bool {
+        let absolutePath = URL(fileURLWithPath: targetPath).standardizedFileURL.path
+        let components = (absolutePath as NSString).pathComponents
+        guard !components.isEmpty else { return false }
+
+        var cursor = components[0] == "/" ? "/" : components[0]
+        for component in components.dropFirst() {
+            cursor = (cursor as NSString).appendingPathComponent(component)
+            guard let componentStatus = self.fileStatus(at: cursor, followSymlink: false) else {
+                return true
+            }
+            if !self.isSymlink(componentStatus) {
+                continue
+            }
+            let parent = (cursor as NSString).deletingLastPathComponent
+            let parentDir = parent.isEmpty ? "/" : parent
+            if self.isWritableByCurrentProcess(parentDir) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func resolvePreparedCwd(_ rawCwd: String?) -> Result<String?, String> {
+        let trimmed = rawCwd?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else {
+            return .success(nil)
+        }
+
+        let base = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let requestedCwd = URL(fileURLWithPath: trimmed, relativeTo: base).standardizedFileURL.path
+        guard let requestedLStat = self.fileStatus(at: requestedCwd, followSymlink: false),
+              let requestedStat = self.fileStatus(at: requestedCwd, followSymlink: true)
+        else {
+            return .failure("SYSTEM_RUN_DENIED: approval requires an existing canonical cwd")
+        }
+        guard self.isDirectory(requestedStat) else {
+            return .failure("SYSTEM_RUN_DENIED: approval requires cwd to be a directory")
+        }
+        if self.hasMutableSymlinkPathComponent(requestedCwd) {
+            return .failure(
+                "SYSTEM_RUN_DENIED: approval requires canonical cwd (no symlink path components)")
+        }
+        if self.isSymlink(requestedLStat) {
+            return .failure("SYSTEM_RUN_DENIED: approval requires canonical cwd (no symlink cwd)")
+        }
+
+        let resolvedCwd = URL(fileURLWithPath: requestedCwd).resolvingSymlinksInPath().path
+        guard let resolvedStat = self.fileStatus(at: resolvedCwd, followSymlink: true) else {
+            return .failure("SYSTEM_RUN_DENIED: approval requires an existing canonical cwd")
+        }
+        let identityMatches =
+            self.sameFileIdentity(requestedStat, requestedLStat) &&
+            self.sameFileIdentity(requestedStat, resolvedStat) &&
+            self.sameFileIdentity(requestedLStat, resolvedStat)
+        guard identityMatches else {
+            return .failure("SYSTEM_RUN_DENIED: approval cwd identity mismatch")
+        }
+
+        return .success(resolvedCwd)
+    }
+
     private func handleSystemRunPrepare(_ req: BridgeInvokeRequest) async throws -> BridgeInvokeResponse {
         let params = try Self.decodeParams(OpenClawSystemRunParams.self, from: req.paramsJSON)
         guard !params.command.isEmpty else {
@@ -454,7 +541,13 @@ actor MacNodeRuntime {
             return Self.errorResponse(req, code: .invalidRequest, message: message)
         }
 
-        let normalizedCwd = params.cwd?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let preparedCwd: String?
+        switch Self.resolvePreparedCwd(params.cwd) {
+        case let .success(value):
+            preparedCwd = value
+        case let .failure(message):
+            return Self.errorResponse(req, code: .unavailable, message: message)
+        }
         let normalizedAgentId = params.agentId?.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedSessionKey = params.sessionKey?.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedRawCommand = params.rawCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -462,7 +555,7 @@ actor MacNodeRuntime {
             cmdText: cmdText,
             plan: OpenClawSystemRunApprovalPlan(
                 argv: params.command,
-                cwd: normalizedCwd?.isEmpty == false ? normalizedCwd : nil,
+                cwd: preparedCwd,
                 rawCommand: normalizedRawCommand?.isEmpty == false ? normalizedRawCommand : nil,
                 agentId: normalizedAgentId?.isEmpty == false ? normalizedAgentId : nil,
                 sessionKey: normalizedSessionKey?.isEmpty == false ? normalizedSessionKey : nil))

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -457,12 +457,13 @@ actor MacNodeRuntime {
         let normalizedCwd = params.cwd?.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedAgentId = params.agentId?.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedSessionKey = params.sessionKey?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedRawCommand = params.rawCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
         let payload = OpenClawSystemRunPreparePayload(
             cmdText: cmdText,
             plan: OpenClawSystemRunApprovalPlan(
                 argv: params.command,
                 cwd: normalizedCwd?.isEmpty == false ? normalizedCwd : nil,
-                rawCommand: cmdText,
+                rawCommand: normalizedRawCommand?.isEmpty == false ? normalizedRawCommand : nil,
                 agentId: normalizedAgentId?.isEmpty == false ? normalizedAgentId : nil,
                 sessionKey: normalizedSessionKey?.isEmpty == false ? normalizedSessionKey : nil))
         return BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: try Self.encodePayload(payload))

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -21,6 +21,31 @@ struct MacNodeRuntimeTests {
         #expect(response.ok == false)
     }
 
+    @Test func handleInvokeSystemRunPrepareReturnsApprovalPlan() async throws {
+        let runtime = MacNodeRuntime()
+        let params = OpenClawSystemRunParams(
+            command: ["echo", "hello"],
+            rawCommand: "echo hello",
+            cwd: " /tmp ",
+            agentId: " main ",
+            sessionKey: " session-key ")
+        let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
+        let response = await runtime.handleInvoke(
+            BridgeInvokeRequest(
+                id: "req-2prepare",
+                command: OpenClawSystemCommand.runPrepare.rawValue,
+                paramsJSON: json))
+        #expect(response.ok == true)
+
+        let payloadJSON = try #require(response.payloadJSON)
+        let payload = try JSONDecoder().decode(OpenClawSystemRunPreparePayload.self, from: Data(payloadJSON.utf8))
+        #expect(payload.cmdText == "echo hello")
+        #expect(payload.plan.argv == ["echo", "hello"])
+        #expect(payload.plan.cwd == "/tmp")
+        #expect(payload.plan.agentId == "main")
+        #expect(payload.plan.sessionKey == "session-key")
+    }
+
     @Test func handleInvokeRejectsEmptySystemWhich() async throws {
         let runtime = MacNodeRuntime()
         let params = OpenClawSystemWhichParams(bins: [])

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -42,8 +42,27 @@ struct MacNodeRuntimeTests {
         #expect(payload.cmdText == "echo hello")
         #expect(payload.plan.argv == ["echo", "hello"])
         #expect(payload.plan.cwd == "/tmp")
+        #expect(payload.plan.rawCommand == "echo hello")
         #expect(payload.plan.agentId == "main")
         #expect(payload.plan.sessionKey == "session-key")
+    }
+
+    @Test func handleInvokeSystemRunPrepareKeepsRawCommandNilWhenNotProvided() async throws {
+        let runtime = MacNodeRuntime()
+        let params = OpenClawSystemRunParams(
+            command: ["/usr/bin/env", "BASH_ENV=/tmp/test", "bash", "-lc", "echo hi"])
+        let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
+        let response = await runtime.handleInvoke(
+            BridgeInvokeRequest(
+                id: "req-2prepare-noraw",
+                command: OpenClawSystemCommand.runPrepare.rawValue,
+                paramsJSON: json))
+        #expect(response.ok == true)
+
+        let payloadJSON = try #require(response.payloadJSON)
+        let payload = try JSONDecoder().decode(OpenClawSystemRunPreparePayload.self, from: Data(payloadJSON.utf8))
+        #expect(!payload.cmdText.isEmpty)
+        #expect(payload.plan.rawCommand == nil)
     }
 
     @Test func handleInvokeRejectsEmptySystemWhich() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -65,6 +65,22 @@ struct MacNodeRuntimeTests {
         #expect(payload.plan.rawCommand == nil)
     }
 
+    @Test func handleInvokeSystemRunPrepareRejectsMissingCwd() async throws {
+        let runtime = MacNodeRuntime()
+        let params = OpenClawSystemRunParams(
+            command: ["echo", "hello"],
+            cwd: "/tmp/openclaw-missing-cwd-\(UUID().uuidString)")
+        let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
+        let response = await runtime.handleInvoke(
+            BridgeInvokeRequest(
+                id: "req-2prepare-missing-cwd",
+                command: OpenClawSystemCommand.runPrepare.rawValue,
+                paramsJSON: json))
+        #expect(response.ok == false)
+        #expect(
+            response.error?.message == "SYSTEM_RUN_DENIED: approval requires an existing canonical cwd")
+    }
+
     @Test func handleInvokeRejectsEmptySystemWhich() async throws {
         let runtime = MacNodeRuntime()
         let params = OpenClawSystemWhichParams(bins: [])

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/SystemCommands.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/SystemCommands.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public enum OpenClawSystemCommand: String, Codable, Sendable {
+    case runPrepare = "system.run.prepare"
     case run = "system.run"
     case which = "system.which"
     case notify = "system.notify"
@@ -54,6 +55,38 @@ public struct OpenClawSystemRunParams: Codable, Sendable, Equatable {
         self.sessionKey = sessionKey
         self.approved = approved
         self.approvalDecision = approvalDecision
+    }
+}
+
+public struct OpenClawSystemRunApprovalPlan: Codable, Sendable, Equatable {
+    public var argv: [String]
+    public var cwd: String?
+    public var rawCommand: String?
+    public var agentId: String?
+    public var sessionKey: String?
+
+    public init(
+        argv: [String],
+        cwd: String? = nil,
+        rawCommand: String? = nil,
+        agentId: String? = nil,
+        sessionKey: String? = nil)
+    {
+        self.argv = argv
+        self.cwd = cwd
+        self.rawCommand = rawCommand
+        self.agentId = agentId
+        self.sessionKey = sessionKey
+    }
+}
+
+public struct OpenClawSystemRunPreparePayload: Codable, Sendable, Equatable {
+    public var cmdText: String
+    public var plan: OpenClawSystemRunApprovalPlan
+
+    public init(cmdText: String, plan: OpenClawSystemRunApprovalPlan) {
+        self.cmdText = cmdText
+        self.plan = plan
     }
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: macOS companion nodes did not declare `system.run.prepare`, and runtime did not handle that command.
- Why it matters: `openclaw nodes run` preflight always invokes `system.run.prepare`, so macOS nodes failed before execution.
- What changed: added `system.run.prepare` to shared system command enum, included it in macOS node advertised commands, and implemented prepare handling in `MacNodeRuntime` returning `{ cmdText, plan }` payload.
- What did NOT change (scope boundary): no changes to actual `system.run` execution logic, exec approval policy behavior, or iOS command surfaces.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31959
- Related #31960

## User-visible / Behavior Changes

- Paired macOS nodes now advertise and support `system.run.prepare`, so `openclaw nodes run ...` no longer fails with "node command not allowed ... system.run.prepare" during preflight.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS companion node path (code-level change)
- Runtime/container: Swift package target `apps/macos`
- Model/provider: N/A
- Integration/channel (if any): Node mode (`openclaw nodes run`)
- Relevant config (redacted): N/A

### Steps

1. Connect a macOS node to gateway.
2. Run `openclaw nodes describe --node <id> --json | jq '.commands'`.
3. Run `openclaw nodes run --node <id> --command '["which","ls"]'`.

### Expected

- Commands include `system.run.prepare`, and `nodes.run` passes preflight.

### Actual

- Before fix: `system.run.prepare` missing and `nodes.run` fails preflight.
- After fix: `system.run.prepare` declared and handled in runtime.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected command registration and runtime invoke switch paths; added regression test `handleInvokeSystemRunPrepareReturnsApprovalPlan`.
- Edge cases checked: command-required validation path for prepare uses same invalid-request style.
- What you did **not** verify: local execution of Swift tests was blocked by toolchain mismatch (repo requires Swift 6.2, environment has 6.0.3).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift`, `apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift`, `apps/shared/OpenClawKit/Sources/OpenClawKit/SystemCommands.swift`.
- Known bad symptoms reviewers should watch for: macOS node invoke path returning unknown-command for prepare or malformed prepare payload.

## Risks and Mitigations

- Risk: prepare payload format drifts from gateway normalization expectations.
  - Mitigation: response uses explicit typed payload (`OpenClawSystemRunPreparePayload` / `OpenClawSystemRunApprovalPlan`) and added runtime regression test.
