### PR TITLE
fix(slack): apply markdownToSlackMrkdwn conversion in native streaming path

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -7,11 +7,13 @@ import { removeAckReactionAfterReply } from "../../../channels/ack-reactions.js"
 import { logAckFailure, logTypingFailure } from "../../../channels/logging.js";
 import { createReplyPrefixOptions } from "../../../channels/reply-prefix.js";
 import { createTypingCallbacks } from "../../../channels/typing.js";
+import { resolveMarkdownTableMode } from "../../../config/markdown-tables.js";
 import { resolveStorePath, updateLastRoute } from "../../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../../globals.js";
 import { resolveAgentOutboundIdentity } from "../../../infra/outbound/identity.js";
 import { removeSlackReaction } from "../../actions.js";
 import { createSlackDraftStream } from "../../draft-stream.js";
+import { markdownToSlackMrkdwn } from "../../format.js";
 import { recordSlackThreadParticipation } from "../../sent-thread-cache.js";
 import {
   applyAppendOnlyStreamUpdate,
@@ -191,6 +193,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let streamSession: SlackStreamSession | null = null;
   let streamFailed = false;
   let usedReplyThreadTs: string | undefined;
+  const streamTableMode = resolveMarkdownTableMode({
+    cfg,
+    channel: "slack",
+    accountId: account.accountId,
+  });
 
   const deliverNormally = async (payload: ReplyPayload, forcedThreadTs?: string): Promise<void> => {
     const replyThreadTs = forcedThreadTs ?? replyPlan.nextThreadTs();
@@ -218,7 +225,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       return;
     }
 
-    const text = payload.text.trim();
+    const rawText = payload.text.trim();
+    const text = markdownToSlackMrkdwn(rawText, { tableMode: streamTableMode });
     let plannedThreadTs: string | undefined;
     try {
       if (!streamSession) {


### PR DESCRIPTION
## Summary

- **Problem:** Native streaming delivery (`deliverWithStreaming`) sends raw markdown to the Slack streaming API without converting to Slack mrkdwn, causing formatting like `**bold**` to render literally instead of as **bold**.
- **Why it matters:** All streamed Slack replies show broken formatting for bold, italic, links, code blocks, etc.
- **What changed:** Apply `markdownToSlackMrkdwn` conversion in the streaming path, matching the existing non-streaming path in `send.ts`.
- **What did NOT change:** Non-streaming delivery, draft/preview streaming, fallback paths.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #31892

## User-visible / Behavior Changes

Streamed Slack messages now render markdown formatting correctly (bold, italic, links, code blocks, strikethrough, etc.) instead of showing raw markdown syntax.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Integration/channel: Slack (Socket Mode, native streaming enabled)

### Steps

1. Configure a Slack channel with `nativeStreaming: true` and `streamMode: partial`
2. Send a message that triggers a markdown-formatted response (e.g. bold, links, code blocks)
3. Observe the streamed reply in Slack

### Expected

Markdown renders correctly using Slack mrkdwn format (`*bold*`, `<url|text>`, etc.)

### Actual

Raw markdown syntax shown literally (`**bold**`, `[text](url)`)

## Evidence

- [x] Code inspection: the non-streaming path in `send.ts:305-306` applies `markdownToSlackMrkdwnChunks` before sending; the streaming path in `dispatch.ts:deliverWithStreaming` was missing this conversion

## Human Verification (required)

- Verified scenarios: Traced both streaming and non-streaming code paths to confirm the conversion gap
- Edge cases checked: fallback to `deliverNormally` still passes original `payload` (no double conversion), empty text guarded, media messages bypass streaming correctly
- What you did **not** verify: Live Slack workspace end-to-end test (no Slack instance available)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Set `nativeStreaming: false` in Slack channel config to use the non-streaming path
- Known bad symptoms: If conversion produces unexpected output, streamed messages would show garbled mrkdwn (revert by disabling streaming)

## Risks and Mitigations

- Risk: `markdownToSlackMrkdwn` adds overhead per streamed chunk
  - Mitigation: The function is lightweight (regex-based IR transform) and already called on every non-streamed message without issue

🤖 AI-assisted (Claude). Code reviewed and verified by human.