### PR TITLE
fix: forward skill env vars to exec child processes

### DIFF
--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -27,6 +27,13 @@ export type ExecToolDefaults = {
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   cwd?: string;
+  /**
+   * Skill-level env vars (from skills.entries.<skill>.env) to inject into
+   * child processes. These are merged into the subprocess environment so that
+   * sandboxed (Docker) executions also receive them -- process.env alone is
+   * not forwarded into the container.
+   */
+  skillEnv?: Record<string, string>;
 };
 
 export type ExecElevatedDefaults = {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -371,12 +371,20 @@ export function createExecTool(
 
       const mergedEnv = params.env ? { ...baseEnv, ...params.env } : baseEnv;
 
+      // Skill-level env vars (skills.entries.<skill>.env) must be forwarded to child
+      // processes.  For gateway/node hosts they are already on process.env and flow
+      // through `coerceEnv`, but sandbox (Docker) builds a fresh env via
+      // `buildSandboxEnv` which does not include process.env.  Merge them explicitly
+      // so both paths receive the overrides.
+      const skillEnv = defaults?.skillEnv;
+
       const env = sandbox
         ? buildSandboxEnv({
             defaultPath: DEFAULT_PATH,
             paramsEnv: params.env,
             sandboxEnv: sandbox.env,
             containerWorkdir: containerWorkdir ?? sandbox.containerWorkdir,
+            skillEnv,
           })
         : mergedEnv;
 

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -19,11 +19,17 @@ export function buildSandboxEnv(params: {
   paramsEnv?: Record<string, string>;
   sandboxEnv?: Record<string, string>;
   containerWorkdir: string;
+  /** Skill-level env overrides to forward into the container. */
+  skillEnv?: Record<string, string>;
 }) {
   const env: Record<string, string> = {
     PATH: params.defaultPath,
     HOME: params.containerWorkdir,
   };
+  // Skill env vars are applied first so that sandbox/params can override if needed.
+  for (const [key, value] of Object.entries(params.skillEnv ?? {})) {
+    env[key] = value;
+  }
   for (const [key, value] of Object.entries(params.sandboxEnv ?? {})) {
     env[key] = value;
   }

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -331,13 +331,14 @@ export async function compactEmbeddedPiSessionDirect(
   });
 
   let restoreSkillEnv: (() => void) | undefined;
+  let appliedSkillEnv: Record<string, string> = {};
   process.chdir(effectiveWorkspace);
   try {
     const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
     const skillEntries = shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(effectiveWorkspace)
       : [];
-    restoreSkillEnv = params.skillsSnapshot
+    const skillEnvResult = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({
           snapshot: params.skillsSnapshot,
           config: params.config,
@@ -346,6 +347,8 @@ export async function compactEmbeddedPiSessionDirect(
           skills: skillEntries ?? [],
           config: params.config,
         });
+    restoreSkillEnv = skillEnvResult.revert;
+    appliedSkillEnv = skillEnvResult.appliedEnv;
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
@@ -383,6 +386,7 @@ export async function compactEmbeddedPiSessionDirect(
       modelId,
       modelContextWindowTokens: model.contextWindow,
       modelAuthMode: resolveModelAuthMode(model.provider, params.config),
+      skillEnv: appliedSkillEnv,
     });
     const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider });
     const allowedToolNames = collectAllowedToolNames({ tools });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -509,13 +509,14 @@ export async function runEmbeddedAttempt(
   await fs.mkdir(effectiveWorkspace, { recursive: true });
 
   let restoreSkillEnv: (() => void) | undefined;
+  let appliedSkillEnv: Record<string, string> = {};
   process.chdir(effectiveWorkspace);
   try {
     const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
     const skillEntries = shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(effectiveWorkspace)
       : [];
-    restoreSkillEnv = params.skillsSnapshot
+    const skillEnvResult = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({
           snapshot: params.skillsSnapshot,
           config: params.config,
@@ -524,6 +525,8 @@ export async function runEmbeddedAttempt(
           skills: skillEntries ?? [],
           config: params.config,
         });
+    restoreSkillEnv = skillEnvResult.revert;
+    appliedSkillEnv = skillEnvResult.appliedEnv;
 
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
@@ -602,6 +605,7 @@ export async function runEmbeddedAttempt(
           requireExplicitMessageTarget:
             params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
           disableMessageTool: params.disableMessageTool,
+          skillEnv: appliedSkillEnv,
         });
     const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
     const allowedToolNames = collectAllowedToolNames({

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -236,6 +236,8 @@ export function createOpenClawCodingTools(options?: {
   disableMessageTool?: boolean;
   /** Whether the sender is an owner (required for owner-only tools). */
   senderIsOwner?: boolean;
+  /** Skill-level env vars to inject into exec child processes. */
+  skillEnv?: Record<string, string>;
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;
@@ -406,6 +408,7 @@ export function createOpenClawCodingTools(options?: {
           env: sandbox.docker.env,
         }
       : undefined,
+    skillEnv: options?.skillEnv,
   });
   const processTool = createProcessTool({
     cleanupMs: cleanupMsOverride ?? execConfig.cleanupMs,

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -255,15 +255,16 @@ describe("applySkillEnvOverrides", () => {
     const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
 
     withClearedEnv(["ENV_KEY"], () => {
-      const restore = applySkillEnvOverrides({
+      const result = applySkillEnvOverrides({
         skills: entries,
         config: { skills: { entries: { "env-skill": { apiKey: "injected" } } } },
       });
 
       try {
         expect(process.env.ENV_KEY).toBe("injected");
+        expect(result.appliedEnv).toEqual({ ENV_KEY: "injected" });
       } finally {
-        restore();
+        result.revert();
         expect(process.env.ENV_KEY).toBeUndefined();
       }
     });
@@ -285,15 +286,16 @@ describe("applySkillEnvOverrides", () => {
     });
 
     withClearedEnv(["ENV_KEY"], () => {
-      const restore = applySkillEnvOverridesFromSnapshot({
+      const result = applySkillEnvOverridesFromSnapshot({
         snapshot,
         config: { skills: { entries: { "env-skill": { apiKey: "snap-key" } } } },
       });
 
       try {
         expect(process.env.ENV_KEY).toBe("snap-key");
+        expect(result.appliedEnv).toEqual({ ENV_KEY: "snap-key" });
       } finally {
-        restore();
+        result.revert();
         expect(process.env.ENV_KEY).toBeUndefined();
       }
     });
@@ -313,7 +315,7 @@ describe("applySkillEnvOverrides", () => {
     const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
 
     withClearedEnv(["OPENAI_API_KEY", "NODE_OPTIONS"], () => {
-      const restore = applySkillEnvOverrides({
+      const result = applySkillEnvOverrides({
         skills: entries,
         config: {
           skills: {
@@ -332,8 +334,10 @@ describe("applySkillEnvOverrides", () => {
       try {
         expect(process.env.OPENAI_API_KEY).toBe("sk-test");
         expect(process.env.NODE_OPTIONS).toBeUndefined();
+        // appliedEnv should only contain the allowed key
+        expect(result.appliedEnv).toEqual({ OPENAI_API_KEY: "sk-test" });
       } finally {
-        restore();
+        result.revert();
         expect(process.env.OPENAI_API_KEY).toBeUndefined();
         expect(process.env.NODE_OPTIONS).toBeUndefined();
       }
@@ -353,7 +357,7 @@ describe("applySkillEnvOverrides", () => {
     const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
 
     withClearedEnv(["BASH_ENV", "SHELL"], () => {
-      const restore = applySkillEnvOverrides({
+      const result = applySkillEnvOverrides({
         skills: entries,
         config: {
           skills: {
@@ -372,8 +376,10 @@ describe("applySkillEnvOverrides", () => {
       try {
         expect(process.env.BASH_ENV).toBeUndefined();
         expect(process.env.SHELL).toBeUndefined();
+        // Dangerous vars should not appear in appliedEnv
+        expect(result.appliedEnv).toEqual({});
       } finally {
-        restore();
+        result.revert();
         expect(process.env.BASH_ENV).toBeUndefined();
         expect(process.env.SHELL).toBeUndefined();
       }
@@ -407,15 +413,16 @@ describe("applySkillEnvOverrides", () => {
     });
 
     withClearedEnv(["OPENAI_API_KEY"], () => {
-      const restore = applySkillEnvOverridesFromSnapshot({
+      const result = applySkillEnvOverridesFromSnapshot({
         snapshot,
         config,
       });
 
       try {
         expect(process.env.OPENAI_API_KEY).toBe("snap-secret");
+        expect(result.appliedEnv).toEqual({ OPENAI_API_KEY: "snap-secret" });
       } finally {
-        restore();
+        result.revert();
         expect(process.env.OPENAI_API_KEY).toBeUndefined();
       }
     });

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -14,6 +14,7 @@ export {
   applySkillEnvOverrides,
   applySkillEnvOverridesFromSnapshot,
 } from "./skills/env-overrides.js";
+export type { SkillEnvResult } from "./skills/env-overrides.js";
 export type {
   OpenClawSkillMetadata,
   SkillEligibilityContext,

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -133,19 +133,38 @@ function applySkillConfigEnvOverrides(params: {
   }
 }
 
-function createEnvReverter(updates: EnvUpdate[]) {
-  return () => {
-    for (const update of updates) {
-      if (update.prev === undefined) {
-        delete process.env[update.key];
-      } else {
-        process.env[update.key] = update.prev;
-      }
+export type SkillEnvResult = {
+  revert: () => void;
+  /** The env vars that were applied to process.env (key -> value). */
+  appliedEnv: Record<string, string>;
+};
+
+function createEnvResult(updates: EnvUpdate[]): SkillEnvResult {
+  const appliedEnv: Record<string, string> = {};
+  for (const update of updates) {
+    const value = process.env[update.key];
+    if (typeof value === "string") {
+      appliedEnv[update.key] = value;
     }
+  }
+  return {
+    revert: () => {
+      for (const update of updates) {
+        if (update.prev === undefined) {
+          delete process.env[update.key];
+        } else {
+          process.env[update.key] = update.prev;
+        }
+      }
+    },
+    appliedEnv,
   };
 }
 
-export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: OpenClawConfig }) {
+export function applySkillEnvOverrides(params: {
+  skills: SkillEntry[];
+  config?: OpenClawConfig;
+}): SkillEnvResult {
   const { skills, config } = params;
   const updates: EnvUpdate[] = [];
 
@@ -165,16 +184,16 @@ export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: 
     });
   }
 
-  return createEnvReverter(updates);
+  return createEnvResult(updates);
 }
 
 export function applySkillEnvOverridesFromSnapshot(params: {
   snapshot?: SkillSnapshot;
   config?: OpenClawConfig;
-}) {
+}): SkillEnvResult {
   const { snapshot, config } = params;
   if (!snapshot) {
-    return () => {};
+    return { revert: () => {}, appliedEnv: {} };
   }
   const updates: EnvUpdate[] = [];
 
@@ -193,5 +212,5 @@ export function applySkillEnvOverridesFromSnapshot(params: {
     });
   }
 
-  return createEnvReverter(updates);
+  return createEnvResult(updates);
 }


### PR DESCRIPTION
## Summary

Fixes #31583 -- environment variables configured under `skills.entries.<skill>.env` in `openclaw.json` were not passed through to subprocesses spawned by the `exec` tool in sandbox (Docker) mode.

**Root cause:** `buildSandboxEnv` creates a fresh environment with only `PATH`, `HOME`, sandbox-specific vars, and per-call params. Skill env vars applied to `process.env` by `applySkillEnvOverrides` were never forwarded into the container environment. For gateway/node hosts the vars were already present via `coerceEnv(process.env)`, but sandbox mode lost them entirely.

**Fix:**
- `applySkillEnvOverrides` / `applySkillEnvOverridesFromSnapshot` now return `{ revert, appliedEnv }` so callers can capture which env vars were actually applied
- Thread the applied skill env through `attempt.ts` / `compact.ts` -> `createOpenClawCodingTools` -> `createExecTool` via a new `skillEnv` field on `ExecToolDefaults`
- `buildSandboxEnv` merges `skillEnv` into the container environment (before sandbox and params layers, so they can override if needed)

## Test plan

- [x] `pnpm tsgo` passes (type check)
- [x] `skills.test.ts` -- all 12 tests pass, including new assertions for `appliedEnv`
- [x] `bash-tools.test.ts` -- all 15 tests pass
- [x] `bash-tools.exec.path.test.ts` -- all 8 tests pass
- [x] `bash-tools.exec.pty.test.ts` -- all 2 tests pass
- [x] `bash-tools.exec.script-preflight.test.ts` -- all 4 tests pass
- [x] `bash-tools.exec.approval-id.test.ts` -- all 8 tests pass
- [x] `pi-tools-agent-config.test.ts` -- all 21 tests pass
- [x] Formatting and lint pass on all changed files