### PR TITLE
fix(matrix): bootstrap missing crypto runtime after script-skipped installs

### DIFF
--- a/extensions/matrix/index.ts
+++ b/extensions/matrix/index.ts
@@ -1,5 +1,6 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { matrixPlugin } from "./src/channel.js";
 import { ensureMatrixCryptoRuntime } from "./src/matrix/deps.js";
 import { setMatrixRuntime } from "./src/runtime.js";
 
@@ -8,10 +9,12 @@ const plugin = {
   name: "Matrix",
   description: "Matrix channel plugin (matrix-js-sdk)",
   configSchema: emptyPluginConfigSchema(),
-  async register(api: OpenClawPluginApi) {
+  register(api: OpenClawPluginApi) {
     setMatrixRuntime(api.runtime);
-    await ensureMatrixCryptoRuntime();
-    const { matrixPlugin } = await import("./src/channel.js");
+    void ensureMatrixCryptoRuntime({ log: api.logger.info }).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      api.logger.warn?.(`matrix: crypto runtime bootstrap failed: ${message}`);
+    });
     api.registerChannel({ plugin: matrixPlugin });
   },
 };

--- a/extensions/matrix/index.ts
+++ b/extensions/matrix/index.ts
@@ -1,6 +1,6 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
-import { matrixPlugin } from "./src/channel.js";
+import { ensureMatrixCryptoRuntime } from "./src/matrix/deps.js";
 import { setMatrixRuntime } from "./src/runtime.js";
 
 const plugin = {
@@ -8,8 +8,10 @@ const plugin = {
   name: "Matrix",
   description: "Matrix channel plugin (matrix-js-sdk)",
   configSchema: emptyPluginConfigSchema(),
-  register(api: OpenClawPluginApi) {
+  async register(api: OpenClawPluginApi) {
     setMatrixRuntime(api.runtime);
+    await ensureMatrixCryptoRuntime();
+    const { matrixPlugin } = await import("./src/channel.js");
     api.registerChannel({ plugin: matrixPlugin });
   },
 };

--- a/extensions/matrix/src/matrix/deps.test.ts
+++ b/extensions/matrix/src/matrix/deps.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { ensureMatrixCryptoRuntime } from "./deps.js";
+
+const logStub = vi.fn();
+
+describe("ensureMatrixCryptoRuntime", () => {
+  it("returns immediately when matrix SDK loads", async () => {
+    const runCommand = vi.fn();
+    const requireFn = vi.fn(() => ({}));
+
+    await ensureMatrixCryptoRuntime({
+      log: logStub,
+      requireFn,
+      runCommand,
+      resolveFn: () => "/tmp/download-lib.js",
+      nodeExecutable: "/usr/bin/node",
+    });
+
+    expect(requireFn).toHaveBeenCalledTimes(1);
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("bootstraps missing crypto runtime and retries matrix SDK load", async () => {
+    let bootstrapped = false;
+    const requireFn = vi.fn(() => {
+      if (!bootstrapped) {
+        throw new Error(
+          "Cannot find module '@matrix-org/matrix-sdk-crypto-nodejs-linux-x64-gnu' (required by matrix sdk)",
+        );
+      }
+      return {};
+    });
+    const runCommand = vi.fn(async () => {
+      bootstrapped = true;
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await ensureMatrixCryptoRuntime({
+      log: logStub,
+      requireFn,
+      runCommand,
+      resolveFn: () => "/tmp/download-lib.js",
+      nodeExecutable: "/usr/bin/node",
+    });
+
+    expect(runCommand).toHaveBeenCalledWith({
+      argv: ["/usr/bin/node", "/tmp/download-lib.js"],
+      cwd: "/tmp",
+      timeoutMs: 300_000,
+      env: { COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
+    });
+    expect(requireFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("rethrows non-crypto module errors without bootstrapping", async () => {
+    const runCommand = vi.fn();
+    const requireFn = vi.fn(() => {
+      throw new Error("Cannot find module '@vector-im/matrix-bot-sdk'");
+    });
+
+    await expect(
+      ensureMatrixCryptoRuntime({
+        log: logStub,
+        requireFn,
+        runCommand,
+        resolveFn: () => "/tmp/download-lib.js",
+        nodeExecutable: "/usr/bin/node",
+      }),
+    ).rejects.toThrow("Cannot find module '@vector-im/matrix-bot-sdk'");
+
+    expect(runCommand).not.toHaveBeenCalled();
+    expect(requireFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/matrix/src/matrix/deps.ts
+++ b/extensions/matrix/src/matrix/deps.ts
@@ -5,6 +5,27 @@ import { fileURLToPath } from "node:url";
 import { runPluginCommandWithTimeout, type RuntimeEnv } from "openclaw/plugin-sdk";
 
 const MATRIX_SDK_PACKAGE = "@vector-im/matrix-bot-sdk";
+const MATRIX_CRYPTO_DOWNLOAD_HELPER = "@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js";
+
+function formatCommandError(result: { stderr: string; stdout: string }): string {
+  const stderr = result.stderr.trim();
+  if (stderr) {
+    return stderr;
+  }
+  const stdout = result.stdout.trim();
+  if (stdout) {
+    return stdout;
+  }
+  return "unknown error";
+}
+
+function isMissingMatrixCryptoRuntimeError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err ?? "");
+  return (
+    message.includes("Cannot find module") &&
+    message.includes("@matrix-org/matrix-sdk-crypto-nodejs-")
+  );
+}
 
 export function isMatrixSdkAvailable(): boolean {
   try {
@@ -19,6 +40,51 @@ export function isMatrixSdkAvailable(): boolean {
 function resolvePluginRoot(): string {
   const currentDir = path.dirname(fileURLToPath(import.meta.url));
   return path.resolve(currentDir, "..", "..");
+}
+
+export async function ensureMatrixCryptoRuntime(
+  params: {
+    log?: (message: string) => void;
+    requireFn?: (id: string) => unknown;
+    resolveFn?: (id: string) => string;
+    runCommand?: typeof runPluginCommandWithTimeout;
+    nodeExecutable?: string;
+  } = {},
+): Promise<void> {
+  const req = createRequire(import.meta.url);
+  const requireFn = params.requireFn ?? ((id: string) => req(id));
+  const resolveFn = params.resolveFn ?? ((id: string) => req.resolve(id));
+  const runCommand = params.runCommand ?? runPluginCommandWithTimeout;
+  const nodeExecutable = params.nodeExecutable ?? process.execPath;
+
+  try {
+    requireFn(MATRIX_SDK_PACKAGE);
+    return;
+  } catch (err) {
+    if (!isMissingMatrixCryptoRuntimeError(err)) {
+      throw err;
+    }
+  }
+
+  const scriptPath = resolveFn(MATRIX_CRYPTO_DOWNLOAD_HELPER);
+  params.log?.("matrix: crypto runtime missing; downloading platform library…");
+  const result = await runCommand({
+    argv: [nodeExecutable, scriptPath],
+    cwd: path.dirname(scriptPath),
+    timeoutMs: 300_000,
+    env: { COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
+  });
+  if (result.code !== 0) {
+    throw new Error(`Matrix crypto runtime bootstrap failed: ${formatCommandError(result)}`);
+  }
+
+  try {
+    requireFn(MATRIX_SDK_PACKAGE);
+  } catch (err) {
+    throw new Error(
+      `Matrix crypto runtime remains unavailable after bootstrap: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 export async function ensureMatrixSdkInstalled(params: {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: plugin installs run `npm install --ignore-scripts`, so `@matrix-org/matrix-sdk-crypto-nodejs` never runs `postinstall` and the native crypto library is missing.
- Why it matters: Matrix plugin fails to load at startup with `Cannot find module '@matrix-org/matrix-sdk-crypto-nodejs-<platform>'`.
- What changed: Matrix plugin registration now proactively bootstraps the crypto runtime (runs `download-lib.js`) only when that specific missing-native-module error is detected, then retries loading.
- What did NOT change (scope boundary): no global plugin-installer behavior change, no dependency patching, no channel behavior changes beyond startup recovery for missing Matrix crypto runtime.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31928
- Related #

## User-visible / Behavior Changes

- Matrix plugin can self-recover from missing `matrix-sdk-crypto` native runtime after plugin install/update paths that skip npm scripts.
- Startup no longer hard-fails on the missing native module; plugin attempts one bootstrap and retries load.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Yes: on the specific missing-native-runtime error path, the plugin runs the existing `@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js` helper to fetch the platform binary. This mirrors the documented manual workaround and is scoped to Matrix plugin startup only.

## Repro + Verification

### Environment

- OS: macOS 15 (repro equivalent to Linux issue path)
- Runtime/container: Node v22.22.0
- Model/provider: N/A
- Integration/channel (if any): Matrix plugin install/load
- Relevant config (redacted): default plugin install flow

### Steps

1. Fresh install in a temp matrix plugin copy with scripts disabled:
   `npm install --omit=dev --silent --ignore-scripts`
2. Attempt to load Matrix SDK:
   `node -e 'require("@vector-im/matrix-bot-sdk")'`
3. Observe missing crypto runtime module error.

### Expected

- Matrix plugin startup should recover from the missing crypto runtime produced by script-skipping installs.

### Actual

- Before fix: hard crash with `Cannot find module '@matrix-org/matrix-sdk-crypto-nodejs-<platform>'`.
- After fix: plugin bootstrap path downloads runtime and retries SDK load.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced failure in temp plugin install with:
    - `npm install --omit=dev --silent --ignore-scripts`
    - `node -e 'require("@vector-im/matrix-bot-sdk")'` -> missing module error
  - Verified manual bootstrap workaround succeeds in same temp install:
    - `node node_modules/@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js`
    - `node -e 'require("@vector-im/matrix-bot-sdk")'` -> success
  - Verified new bootstrap logic via unit tests:
    - `pnpm test extensions/matrix/src/matrix/deps.test.ts`
  - Verified matrix channel wiring still passes:
    - `pnpm test extensions/matrix/src/channel.directory.test.ts`
  - Verified type/lint:
    - `pnpm tsgo`
    - `pnpm lint`
- Edge cases checked:
  - Missing crypto-runtime error triggers bootstrap path.
  - Unrelated module load errors are rethrown (no unintended bootstrap).
- What you did **not** verify:
  - Live Matrix message flow against a real homeserver after bootstrap.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `extensions/matrix/index.ts`
  - `extensions/matrix/src/matrix/deps.ts`
  - `extensions/matrix/src/matrix/deps.test.ts`
- Known bad symptoms reviewers should watch for:
  - Matrix startup delay/failure when download helper invocation fails.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: startup now invokes a download helper on a specific error path, which can fail under restricted egress.
  - Mitigation: scope is narrow (only this known missing-runtime error), failures remain explicit and actionable.
