### PR TITLE
fix(gateway): skip gateway auth for LINE webhook routes

### DIFF
--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -477,6 +477,40 @@ describe("gateway plugin HTTP auth boundary", () => {
     });
   });
 
+  test("allows POST to webhook routes with noGatewayAuth without auth token", async () => {
+    const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+      const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+      if (pathname === "/line/webhook") {
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "application/json; charset=utf-8");
+        res.end(JSON.stringify({ ok: true, route: "line-webhook" }));
+        return true;
+      }
+      return false;
+    });
+
+    await withGatewayServer({
+      prefix: "openclaw-plugin-http-auth-webhook-noauth-test-",
+      resolvedAuth: AUTH_TOKEN,
+      overrides: {
+        handlePluginRequest,
+        // Simulate a predicate that exempts noGatewayAuth routes (like the real one)
+        shouldEnforcePluginGatewayAuth: (requestPath) =>
+          requestPath.startsWith("/api/channels") || requestPath === "/managed/route",
+      },
+      run: async (server) => {
+        // POST to /line/webhook without auth should reach the plugin handler
+        const postResponse = await sendRequest(server, {
+          path: "/line/webhook",
+          method: "POST",
+        });
+        expect(postResponse.res.statusCode).toBe(200);
+        expect(postResponse.getBody()).toContain('"route":"line-webhook"');
+        expect(handlePluginRequest).toHaveBeenCalledTimes(1);
+      },
+    });
+  });
+
   test("uses /api/channels auth by default while keeping wildcard handlers ungated with no predicate", async () => {
     const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
       const pathname = new URL(req.url ?? "/", "http://localhost").pathname;

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -152,4 +152,17 @@ describe("plugin HTTP registry helpers", () => {
     expect(shouldEnforceGatewayAuthForPluginPath(registry, "/api/channels/status")).toBe(true);
     expect(shouldEnforceGatewayAuthForPluginPath(registry, "/not-plugin")).toBe(false);
   });
+
+  it("skips auth enforcement for routes with noGatewayAuth", () => {
+    const registry = createTestRegistry({
+      httpRoutes: [
+        { ...createRoute({ path: "/line/webhook" }), noGatewayAuth: true },
+        createRoute({ path: "/api/managed" }),
+      ],
+    });
+    expect(shouldEnforceGatewayAuthForPluginPath(registry, "/line/webhook")).toBe(false);
+    expect(shouldEnforceGatewayAuthForPluginPath(registry, "/api/managed")).toBe(true);
+    // Protected prefix routes are always gated regardless of noGatewayAuth
+    expect(shouldEnforceGatewayAuthForPluginPath(registry, "/api/channels/status")).toBe(true);
+  });
 });

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -36,9 +36,15 @@ export function shouldEnforceGatewayAuthForPluginPath(
   registry: PluginRegistry,
   pathname: string,
 ): boolean {
-  return (
-    isProtectedPluginRoutePath(pathname) || isRegisteredPluginHttpRoutePath(registry, pathname)
-  );
+  if (isProtectedPluginRoutePath(pathname)) {
+    return true;
+  }
+  // Only enforce gateway auth on registered plugin routes that have NOT
+  // opted out via noGatewayAuth.  Channel webhook routes (e.g. LINE)
+  // implement their own signature-based auth and must remain reachable
+  // without a gateway token.
+  const route = findRegisteredPluginHttpRoute(registry, pathname);
+  return route !== undefined && !route.noGatewayAuth;
 }
 
 export function createGatewayPluginRequestHandler(params: {

--- a/src/line/monitor.ts
+++ b/src/line/monitor.ts
@@ -292,6 +292,7 @@ export async function monitorLineProvider(
     accountId: resolvedAccountId,
     log: (msg) => logVerbose(msg),
     handler: createLineNodeWebhookHandler({ channelSecret: secret, bot, runtime }),
+    noGatewayAuth: true,
   });
 
   logVerbose(`line: registered webhook handler at ${normalizedPath}`);

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -17,6 +17,8 @@ export function registerPluginHttpRoute(params: {
   accountId?: string;
   log?: (message: string) => void;
   registry?: PluginRegistry;
+  /** When true, skip gateway-level auth enforcement for this route. */
+  noGatewayAuth?: boolean;
 }): () => void {
   const registry = params.registry ?? requireActivePluginRegistry();
   const routes = registry.httpRoutes ?? [];
@@ -41,6 +43,7 @@ export function registerPluginHttpRoute(params: {
     handler: params.handler,
     pluginId: params.pluginId,
     source: params.source,
+    noGatewayAuth: params.noGatewayAuth,
   };
   routes.push(entry);
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -60,6 +60,10 @@ export type PluginHttpRouteRegistration = {
   path: string;
   handler: OpenClawPluginHttpRouteHandler;
   source?: string;
+  /** When true, skip gateway-level auth enforcement for this route.
+   *  Webhook routes that implement their own signature-based auth
+   *  (e.g., LINE webhook) should set this to true. */
+  noGatewayAuth?: boolean;
 };
 
 export type PluginChannelRegistration = {


### PR DESCRIPTION
## Summary

- Add `noGatewayAuth` flag to `PluginHttpRouteRegistration` allowing webhook routes to opt out of gateway-level auth enforcement
- Update `shouldEnforceGatewayAuthForPluginPath` to respect the new flag, so routes with `noGatewayAuth: true` bypass the gateway auth gate
- Set `noGatewayAuth: true` on the LINE webhook route registration in `monitorLineProvider`

## Problem

After upgrading to v2026.3.1, `POST /line/webhook` returns 401/405 Method Not Allowed. The root cause is that `shouldEnforceGatewayAuthForPluginPath` (introduced in cef5fae0a) enforces gateway auth on **all** registered plugin HTTP routes, including LINE's webhook route which implements its own signature-based authentication via the LINE Bot SDK.

LINE webhook requests from LINE's platform do not carry gateway auth tokens, so the gateway auth gate rejects them before they reach the LINE webhook handler.

## Fix

Introduce a `noGatewayAuth` opt-out flag on `PluginHttpRouteRegistration`. Routes that implement their own authentication (like LINE's HMAC signature verification) set this flag to bypass the gateway auth layer while still being served by the plugin HTTP route system.

Protected prefix routes (e.g. `/api/channels/*`) always enforce auth regardless of the flag, preserving security for internal management endpoints.

## Files changed

- `src/plugins/registry.ts` -- add `noGatewayAuth` field to `PluginHttpRouteRegistration`
- `src/plugins/http-registry.ts` -- accept and forward `noGatewayAuth` param
- `src/gateway/server/plugins-http.ts` -- respect `noGatewayAuth` in auth enforcement
- `src/line/monitor.ts` -- set `noGatewayAuth: true` on LINE webhook route
- `src/gateway/server/plugins-http.test.ts` -- test `noGatewayAuth` skips auth
- `src/gateway/server.plugin-http-auth.test.ts` -- test webhook auth bypass

## Test plan

- [x] `plugins-http.test.ts` -- 9/9 tests pass (including new `noGatewayAuth` test)
- [x] `server.plugin-http-auth.test.ts` -- 15/15 tests pass (including new webhook bypass test)
- [ ] Manual: deploy and verify `POST /line/webhook` returns 200 with valid LINE signature

Fixes #31599

🤖 Generated with [Claude Code](https://claude.com/claude-code)