### PR TITLE
fix(agents): truncate tool call IDs exceeding 40 chars for OpenAI provider

### DIFF
--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
-export type ToolCallIdMode = "strict" | "strict9";
+export type ToolCallIdMode = "strict" | "strict9" | "lenonly";
 
 const STRICT9_LEN = 9;
 const TOOL_CALL_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
@@ -23,6 +23,10 @@ export function sanitizeToolCallId(id: string, mode: ToolCallIdMode = "strict"):
       return "defaultid";
     }
     return "defaulttoolid";
+  }
+
+  if (mode === "lenonly") {
+    return id.length > 40 ? id.slice(0, 40) : id;
   }
 
   if (mode === "strict9") {
@@ -90,7 +94,7 @@ export function isValidCloudCodeAssistToolId(id: string, mode: ToolCallIdMode = 
     return /^[a-zA-Z0-9]{9}$/.test(id);
   }
   // Strictly alphanumeric for providers with tighter tool ID constraints
-  return /^[a-zA-Z0-9]+$/.test(id);
+  return mode === "lenonly" ? id.length <= 40 : /^[a-zA-Z0-9]+$/.test(id);
 }
 
 function shortHash(text: string, length = 8): string {

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -34,14 +34,14 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBe("strict9");
   });
 
-  it("disables sanitizeToolCallIds for OpenAI provider", () => {
+  it("enables lenonly sanitizeToolCallIds for OpenAI provider", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openai",
       modelId: "gpt-4o",
       modelApi: "openai",
     });
-    expect(policy.sanitizeToolCallIds).toBe(false);
-    expect(policy.toolCallIdMode).toBeUndefined();
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("lenonly");
   });
 
   it("enables user-turn merge for strict OpenAI-compatible providers", () => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -102,12 +102,14 @@ export function resolveTranscriptPolicy(params: {
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
-  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
+  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic || isOpenAi;
   const toolCallIdMode: ToolCallIdMode | undefined = isMistral
     ? "strict9"
-    : sanitizeToolCallIds
-      ? "strict"
-      : undefined;
+    : isOpenAi
+      ? "lenonly"
+      : sanitizeToolCallIds
+        ? "strict"
+        : undefined;
   // All providers need orphaned tool_result repair after history truncation.
   // OpenAI rejects function_call_output items whose call_id has no matching
   // function_call in the conversation, so the repair must run universally.
@@ -117,7 +119,7 @@ export function resolveTranscriptPolicy(params: {
 
   return {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
-    sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds,
+    sanitizeToolCallIds,
     toolCallIdMode,
     repairToolUseResultPairing,
     preserveSignatures: false,


### PR DESCRIPTION
## Summary

Fixes #31934

OpenAI-compatible models accessed via LiteLLM or other proxies can generate tool call IDs exceeding OpenAI's 40-character limit, causing `400 Bad Request: tool_call_id too long` errors.

This PR adds a `"lenonly"` sanitization mode that truncates IDs to 40 characters **without stripping** non-alphanumeric characters (preserving underscores in IDs like `call_abc_123`), and enables it for the OpenAI provider.

## Changes

- **`tool-call-id.ts`**: Add `"lenonly"` mode to `sanitizeToolCallId` and `isValidCloudCodeAssistToolId`
- **`transcript-policy.ts`**: Enable tool call ID sanitization for OpenAI with `"lenonly"` mode
- **`transcript-policy.test.ts`**: Update OpenAI policy test to verify new behavior

## Test plan

- [x] Existing `tool-call-id.test.ts` tests pass (8 tests)
- [x] Updated `transcript-policy.test.ts` tests pass (7 tests)
- [x] Verified `lenonly` mode preserves underscores while truncating to 40 chars
- [x] Pre-commit lint passes