### PR TITLE
CLI: expose tool deny/sandbox status in agents list

### DIFF
--- a/src/commands/agents.commands.list.ts
+++ b/src/commands/agents.commands.list.ts
@@ -51,6 +51,13 @@ function formatSummary(summary: AgentSummary) {
     lines.push(`  Model: ${summary.model}`);
   }
   lines.push(`  Routing rules: ${summary.bindings}`);
+  if (summary.execBlocked) {
+    const denyDetail = summary.toolDeny?.length ? ` (${summary.toolDeny.join(", ")} denied)` : "";
+    lines.push(`  Tools: exec blocked${denyDetail}`);
+  }
+  if (summary.sandbox.mode !== "off") {
+    lines.push(`  Sandbox: ${summary.sandbox.mode}`);
+  }
 
   if (summary.routes?.length) {
     lines.push(`  Routing: ${summary.routes.join(", ")}`);

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -1,5 +1,6 @@
 import {
   listAgentEntries,
+  resolveAgentConfig,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
@@ -10,6 +11,7 @@ import {
   loadAgentIdentityFromWorkspace,
   parseIdentityMarkdown as parseIdentityMarkdownFile,
 } from "../agents/identity-file.js";
+import { expandToolGroups } from "../agents/tool-policy-shared.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 
@@ -27,6 +29,12 @@ export type AgentSummary = {
   routes?: string[];
   providers?: string[];
   isDefault: boolean;
+  /** Effective deny list for this agent (merged global + per-agent). */
+  toolDeny?: string[];
+  /** True when exec is blocked via the effective deny list. */
+  execBlocked: boolean;
+  /** Sandbox configuration for this agent. */
+  sandbox: { mode: string };
 };
 
 type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];
@@ -80,6 +88,36 @@ export function loadAgentIdentity(workspace: string): AgentIdentity | null {
   return identityHasValues(parsed) ? parsed : null;
 }
 
+/** Resolve effective deny list by merging global tools.deny with per-agent tools.deny. */
+function resolveEffectiveDeny(cfg: OpenClawConfig, agentId: string): string[] {
+  const globalDeny = cfg.tools?.deny ?? [];
+  const agentConfig = resolveAgentConfig(cfg, agentId);
+  const agentDeny = agentConfig?.tools?.deny ?? [];
+  const merged = [...globalDeny, ...agentDeny];
+  if (merged.length === 0) {
+    return [];
+  }
+  return Array.from(new Set(merged));
+}
+
+/** Check whether exec is blocked by the effective deny list (supports group expansion). */
+function isExecBlocked(denyList: string[]): boolean {
+  if (denyList.length === 0) {
+    return false;
+  }
+  const expanded = expandToolGroups(denyList);
+  return expanded.includes("exec");
+}
+
+/** Resolve sandbox mode for an agent (per-agent overrides global defaults.sandbox.mode). */
+function resolveAgentSandboxMode(cfg: OpenClawConfig, agentId: string): string {
+  const agentConfig = resolveAgentConfig(cfg, agentId);
+  if (agentConfig?.sandbox?.mode) {
+    return agentConfig.sandbox.mode;
+  }
+  return cfg.agents?.defaults?.sandbox?.mode ?? "off";
+}
+
 export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
   const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(cfg));
   const configuredAgents = listAgentEntries(cfg);
@@ -108,6 +146,7 @@ export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
       : configIdentity && (identityName || identityEmoji)
         ? "config"
         : undefined;
+    const toolDeny = resolveEffectiveDeny(cfg, id);
     return {
       id,
       name: resolveAgentName(cfg, id),
@@ -119,6 +158,9 @@ export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
       model: resolveAgentModel(cfg, id),
       bindings: bindingCounts.get(id) ?? 0,
       isDefault: id === defaultAgentId,
+      toolDeny: toolDeny.length > 0 ? toolDeny : undefined,
+      execBlocked: isExecBlocked(toolDeny),
+      sandbox: { mode: resolveAgentSandboxMode(cfg, id) },
     };
   });
 }

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -58,6 +58,94 @@ describe("agents helpers", () => {
     expect(work?.agentDir).toBe(path.resolve("/state/agents/work/agent"));
     expect(work?.bindings).toBe(1);
     expect(work?.isDefault).toBe(true);
+
+    // New fields: sandbox defaults to off, exec not blocked
+    expect(main?.execBlocked).toBe(false);
+    expect(main?.sandbox).toEqual({ mode: "off" });
+    expect(main?.toolDeny).toBeUndefined();
+  });
+
+  it("buildAgentSummaries exposes toolDeny and execBlocked from global deny", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main" }],
+      },
+      tools: {
+        deny: ["group:runtime"],
+      },
+    };
+
+    const summaries = buildAgentSummaries(cfg);
+    const main = summaries.find((summary) => summary.id === "main");
+    expect(main?.toolDeny).toEqual(["group:runtime"]);
+    expect(main?.execBlocked).toBe(true);
+  });
+
+  it("buildAgentSummaries exposes toolDeny and execBlocked from per-agent deny", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", tools: { deny: ["exec"] } }],
+      },
+    };
+
+    const summaries = buildAgentSummaries(cfg);
+    const main = summaries.find((summary) => summary.id === "main");
+    expect(main?.toolDeny).toEqual(["exec"]);
+    expect(main?.execBlocked).toBe(true);
+  });
+
+  it("buildAgentSummaries merges global and per-agent deny lists", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", tools: { deny: ["web_search"] } }],
+      },
+      tools: {
+        deny: ["exec"],
+      },
+    };
+
+    const summaries = buildAgentSummaries(cfg);
+    const main = summaries.find((summary) => summary.id === "main");
+    expect(main?.toolDeny).toEqual(["exec", "web_search"]);
+    expect(main?.execBlocked).toBe(true);
+  });
+
+  it("buildAgentSummaries exposes sandbox mode from agent config", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", sandbox: { mode: "all" } }],
+      },
+    };
+
+    const summaries = buildAgentSummaries(cfg);
+    const main = summaries.find((summary) => summary.id === "main");
+    expect(main?.sandbox).toEqual({ mode: "all" });
+  });
+
+  it("buildAgentSummaries exposes sandbox mode from agent defaults", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { sandbox: { mode: "non-main" } },
+        list: [{ id: "main" }],
+      },
+    };
+
+    const summaries = buildAgentSummaries(cfg);
+    const main = summaries.find((summary) => summary.id === "main");
+    expect(main?.sandbox).toEqual({ mode: "non-main" });
+  });
+
+  it("buildAgentSummaries per-agent sandbox overrides defaults", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { sandbox: { mode: "non-main" } },
+        list: [{ id: "main", sandbox: { mode: "all" } }],
+      },
+    };
+
+    const summaries = buildAgentSummaries(cfg);
+    const main = summaries.find((summary) => summary.id === "main");
+    expect(main?.sandbox).toEqual({ mode: "all" });
   });
 
   it("applyAgentConfig merges updates", () => {


### PR DESCRIPTION
## Summary

- Add `toolDeny`, `execBlocked`, and `sandbox` fields to `openclaw agents list` output (both text and `--json`)
- Merge global `tools.deny` with per-agent `tools.deny` to compute effective deny list
- Resolve sandbox mode from per-agent config with fallback to `agents.defaults.sandbox.mode`
- Display "Tools: exec blocked" and "Sandbox: <mode>" lines in text output only when non-default

Closes #31510

## Test plan

- [x] Existing `buildAgentSummaries` test updated to verify new fields default correctly
- [x] New tests: global deny, per-agent deny, merged deny, sandbox from agent config, sandbox from defaults, per-agent sandbox overrides defaults
- [x] All 13 tests pass
- [x] TypeScript compiles cleanly (`pnpm tsgo`)
- [x] Lint passes (`pnpm lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)