### PR TITLE
fix(docs): replace stale VibeTunnel branding with OpenClaw

### DIFF
--- a/docs/platforms/mac/signing.md
+++ b/docs/platforms/mac/signing.md
@@ -44,4 +44,4 @@ The About tab reads these keys to show version, build date, git commit, and whet
 
 ## Why
 
-TCC permissions are tied to the bundle identifier _and_ code signature. Unsigned debug builds with changing UUIDs were causing macOS to forget grants after each rebuild. Signing the binaries (ad‑hoc by default) and keeping a fixed bundle id/path (`dist/OpenClaw.app`) preserves the grants between builds, matching the VibeTunnel approach.
+TCC permissions are tied to the bundle identifier _and_ code signature. Unsigned debug builds with changing UUIDs were causing macOS to forget grants after each rebuild. Signing the binaries (ad‑hoc by default) and keeping a fixed bundle id/path (`dist/OpenClaw.app`) preserves the grants between builds, matching the original approach.

--- a/scripts/clawlog.sh
+++ b/scripts/clawlog.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# VibeTunnel Logging Utility
-# Simplifies access to VibeTunnel logs using macOS unified logging system
+# OpenClaw Logging Utility
+# Simplifies access to OpenClaw logs using macOS unified logging system
 
 set -euo pipefail
 
@@ -124,7 +124,7 @@ EOF
 
 # Function to list categories
 list_categories() {
-    echo -e "${BLUE}Fetching VibeTunnel log categories from the last hour...${NC}\n"
+    echo -e "${BLUE}Fetching OpenClaw log categories from the last hour...${NC}\n"
 
     # Get unique categories from recent logs
     log show --predicate "subsystem == \"$SUBSYSTEM\"" --last 1h 2>/dev/null | \
@@ -243,7 +243,7 @@ if [[ "$STREAM_MODE" == true ]]; then
     # Streaming mode
     LOG_CMD+=(stream --predicate "$PREDICATE" --level "$LOG_LEVEL" --info)
 
-    echo -e "${GREEN}Streaming VibeTunnel logs continuously...${NC}"
+    echo -e "${GREEN}Streaming OpenClaw logs continuously...${NC}"
     echo -e "${YELLOW}Press Ctrl+C to stop${NC}\n"
 else
     # Show mode


### PR DESCRIPTION
## Summary

- Replace 4 leftover "VibeTunnel" references in `scripts/clawlog.sh` with "OpenClaw"
- Replace 1 leftover "VibeTunnel" reference in `docs/platforms/mac/signing.md` with neutral wording
- Skipped `docs/zh-CN/` (auto-generated i18n)

These were missed during the project rename from VibeTunnel to OpenClaw.

## Test plan

- [x] `grep -r VibeTunnel scripts/ docs/platforms/` returns no hits (excluding auto-generated zh-CN)
- [x] No functional changes — string-only replacements in comments and echo output

🤖 Generated with [Claude Code](https://claude.com/claude-code)