### PR TITLE
fix(gateway): allow loopback host bind fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Loopback bind fallback: when dual-loopback binding is enabled (`127.0.0.1` + `::1`), startup now continues if one loopback host fails to bind but another succeeds, avoiding false hard-fail startup loops on environments with asymmetric loopback behavior (for example WSL2 mirrored networking). (#31980)
 - Sandbox/Docker setup command parsing: accept `agents.*.sandbox.docker.setupCommand` as either a string or a string array, and normalize arrays to newline-delimited shell scripts so multi-step setup commands no longer concatenate without separators. (#31953) Thanks @liuxiaopai-ai.
 - Gateway/Plugin HTTP route precedence: run explicit plugin HTTP routes before the Control UI SPA catch-all so registered plugin webhook/custom paths remain reachable, while unmatched paths still fall through to Control UI handling. (#31885) Thanks @Sid-Qin.
 - Security/Node exec approvals: preserve shell/dispatch-wrapper argv semantics during approval hardening so approved wrapper commands (for example `env sh -c ...`) cannot drift into a different runtime command shape, and add regression coverage for both approval-plan generation and approved runtime execution paths. Thanks @tdjackey for reporting.

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -138,6 +138,7 @@ export async function createGatewayRuntimeState(params: {
   }
   const httpServers: HttpServer[] = [];
   const httpBindHosts: string[] = [];
+  let firstBindError: unknown = null;
   for (const host of bindHosts) {
     const httpServer = createGatewayHttpServer({
       canvasHost,
@@ -165,16 +166,23 @@ export async function createGatewayRuntimeState(params: {
       httpServers.push(httpServer);
       httpBindHosts.push(host);
     } catch (err) {
-      if (host === bindHosts[0]) {
+      firstBindError ??= err;
+      if (bindHosts.length === 1) {
         throw err;
       }
       params.log.warn(
-        `gateway: failed to bind loopback alias ${host}:${params.port} (${String(err)})`,
+        `gateway: failed to bind listen host ${host}:${params.port} (${String(err)})`,
       );
+      await new Promise<void>((resolve) => {
+        httpServer.close(() => resolve());
+      });
     }
   }
   const httpServer = httpServers[0];
   if (!httpServer) {
+    if (firstBindError) {
+      throw firstBindError;
+    }
     throw new Error("Gateway HTTP server failed to start");
   }
 

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -13,6 +13,7 @@ import { createOutboundTestPlugin } from "../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { createTempHomeEnv } from "../test-utils/temp-home.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { canBindToHost } from "./net.js";
 import { createRegistry } from "./server.e2e-registry-helpers.js";
 import {
   connectOk,
@@ -458,10 +459,45 @@ describe("gateway server misc", () => {
 
   test("refuses to start when port already bound", async () => {
     const { server: blocker, port: blockedPort } = await occupyPort();
+    let blockerV6: ReturnType<typeof createServer> | null = null;
+    if (await canBindToHost("::1")) {
+      blockerV6 = createServer();
+      await new Promise<void>((resolve, reject) => {
+        blockerV6?.once("error", reject);
+        blockerV6?.listen(blockedPort, "::1", () => resolve());
+      });
+    }
     const startup = startGatewayServer(blockedPort);
     await expect(startup).rejects.toBeInstanceOf(GatewayLockError);
     await expect(startup).rejects.toThrow(/already listening/i);
-    blocker.close();
+    await new Promise<void>((resolve, reject) =>
+      blocker.close((err) => (err ? reject(err) : resolve())),
+    );
+    await new Promise<void>(
+      (resolve, reject) => blockerV6?.close((err) => (err ? reject(err) : resolve())) ?? resolve(),
+    );
+  });
+
+  test("falls back to ipv6 loopback when ipv4 loopback is already occupied", async () => {
+    if (!(await canBindToHost("::1"))) {
+      return;
+    }
+    const { server: blocker, port: blockedPort } = await occupyPort();
+    let fallbackServer: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
+    try {
+      fallbackServer = await startGatewayServer(blockedPort, { host: "127.0.0.1" });
+      const probe = new WebSocket(`ws://[::1]:${blockedPort}`);
+      await new Promise<void>((resolve, reject) => {
+        probe.once("open", () => resolve());
+        probe.once("error", reject);
+      });
+      probe.close();
+    } finally {
+      await fallbackServer?.close();
+      await new Promise<void>((resolve, reject) =>
+        blocker.close((err) => (err ? reject(err) : resolve())),
+      );
+    }
   });
 
   test("releases port after close", async () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Gateway dual-loopback startup (`127.0.0.1` + `::1`) could hard-fail when one host bind failed, even if another loopback host could bind successfully.
- Why it matters: Environments with asymmetric loopback behavior (for example WSL2 mirrored networking) could get false "already listening" startup failures.
- What changed: Loopback host binding now attempts all resolved hosts, keeps successful listeners, and only fails startup when no host can bind.
- What changed: Added regression coverage for both cases: (a) both loopbacks occupied should still fail, and (b) IPv4 occupied but IPv6 available should start via fallback.
- What did NOT change (scope boundary): No auth/routing changes and no non-loopback bind behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31980

## User-visible / Behavior Changes

- Gateway startup no longer fails if one loopback alias fails to bind but another resolved loopback host is available.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux/macOS (unit/integration-style tests)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): gateway startup/bind path
- Relevant config (redacted): `host: "127.0.0.1"`

### Steps

1. Occupy only `127.0.0.1:<port>` and start gateway with loopback host resolution enabled.
2. Verify gateway starts and accepts websocket connections via `[::1]:<port>` when available.
3. Occupy both loopback hosts and verify startup still fails with lock error.

### Expected

- Fallback to another loopback host when available.
- Hard-fail only when no resolved loopback host can bind.

### Actual

- Verified with updated tests and local run outputs.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run src/gateway/server.models-voicewake-misc.test.ts`
  - `pnpm lint`
  - `pnpm tsgo`
- Edge cases checked:
  - Dual-host occupied path still errors
  - IPv6-unavailable environments skip fallback-specific assertion safely
- What you did **not** verify:
  - Full live WSL2 mirrored host reproduction with systemd service lifecycle

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/gateway/server-runtime-state.ts`
  - `src/gateway/server.models-voicewake-misc.test.ts`
- Known bad symptoms reviewers should watch for:
  - Startup succeeding with unexpected host list when no bind should be possible.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: On partial bind success, startup warning text now reports generic listen-host fallback instead of loopback-alias-specific wording.
  - Mitigation: Warning still includes host/port/error and startup proceeds only when at least one concrete listener is active.
