### PR TITLE
fix(memory-lancedb): pass dimensions to embedding API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/LanceDB embeddings: forward configured `embedding.dimensions` into OpenAI embeddings requests so vector size and API output dimensions stay aligned when dimensions are explicitly configured. (#32036) Thanks @scotthuang.
 - Mentions/Slack formatting hardening: add null-safe guards for runtime text normalization paths so malformed/undefined text payloads do not crash mention stripping or mrkdwn conversion. (#31865) Thanks @stone-jin.
 - Failover/error classification: treat HTTP `529` (provider overloaded, common with Anthropic-compatible APIs) as `rate_limit` so model failover can engage instead of misclassifying the error path. (#31854) Thanks @bugkill3r.
 - Voice-call/webhook routing: require exact webhook path matches (instead of prefix matches) so lookalike paths cannot reach provider verification/dispatch logic. (#31930) Thanks @afurm.

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -11,7 +11,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? "test-key";
 const HAS_OPENAI_KEY = Boolean(process.env.OPENAI_API_KEY);
@@ -133,6 +133,89 @@ describe("memory plugin e2e", () => {
 
     expect(config?.autoCapture).toBe(false);
     expect(config?.autoRecall).toBe(true);
+  });
+
+  test("passes configured dimensions to OpenAI embeddings API", async () => {
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ limit }));
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          countRows: vi.fn(async () => 0),
+          add: vi.fn(async () => undefined),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          embedding: {
+            apiKey: OPENAI_API_KEY,
+            model: "text-embedding-3-small",
+            dimensions: 1024,
+          },
+          dbPath,
+          autoCapture: false,
+          autoRecall: false,
+        },
+        runtime: {},
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        // oxlint-disable-next-line typescript/no-explicit-any
+        registerTool: (tool: any, opts: any) => {
+          registeredTools.push({ tool, opts });
+        },
+        // oxlint-disable-next-line typescript/no-explicit-any
+        registerCli: vi.fn(),
+        // oxlint-disable-next-line typescript/no-explicit-any
+        registerService: vi.fn(),
+        // oxlint-disable-next-line typescript/no-explicit-any
+        on: vi.fn(),
+        resolvePath: (p: string) => p,
+      };
+
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+      const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+      expect(recallTool).toBeDefined();
+      await recallTool.execute("test-call-dims", { query: "hello dimensions" });
+
+      expect(embeddingsCreate).toHaveBeenCalledWith({
+        model: "text-embedding-3-small",
+        input: "hello dimensions",
+        dimensions: 1024,
+      });
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
   });
 
   test("shouldCapture applies real capture rules", async () => {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -167,15 +167,20 @@ class Embeddings {
     apiKey: string,
     private model: string,
     baseUrl?: string,
+    private dimensions?: number,
   ) {
     this.client = new OpenAI({ apiKey, baseURL: baseUrl });
   }
 
   async embed(text: string): Promise<number[]> {
-    const response = await this.client.embeddings.create({
+    const params: { model: string; input: string; dimensions?: number } = {
       model: this.model,
       input: text,
-    });
+    };
+    if (this.dimensions) {
+      params.dimensions = this.dimensions;
+    }
+    const response = await this.client.embeddings.create(params);
     return response.data[0].embedding;
   }
 }
@@ -298,7 +303,7 @@ const memoryPlugin = {
 
     const vectorDim = dimensions ?? vectorDimsForModel(model);
     const db = new MemoryDB(resolvedDbPath, vectorDim);
-    const embeddings = new Embeddings(apiKey, model, baseUrl);
+    const embeddings = new Embeddings(apiKey, model, baseUrl, dimensions);
 
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
 


### PR DESCRIPTION
## Summary
Fixes dimension mismatch when using custom embedding models (like DashScope text-embedding-v4).

## Problem
Commit 6675aacb5 added `dimensions` config support for the memory-lancedb plugin, but the implementation was incomplete. The `dimensions` value is only used when creating the LanceDB table schema, but it's never passed to the OpenAI embeddings API call. This causes dimension mismatches when:
- Using custom embedding models (e.g., DashScope text-embedding-v4)
- Specifying custom dimensions in config

The error message was: `No vector column found to match with the query vector dimension: 1024`

## Fix
1. Pass `dimensions` to the Embeddings constructor
2. Forward `dimensions` to `embeddings.create()` API call

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
Related 6675aacb5

## User-visible / Behavior Changes
None - dimensions is optional.

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: macOS
- Runtime/container: OpenClaw Gateway
- Model/provider: DashScope text-embedding-v3 / text-embedding-v4 (with custom dimensions)
- Integration/channel (if any): memory-lancedb plugin
- Relevant config:
```json
{
  "plugins": {
    "entries": {
      "memory-lancedb": {
        "config": {
          "embedding": {
            "model": "text-embedding-v3",
            "dimensions": 1024,
            "baseUrl": "https://dashscope.aliyuncs.com/compatible-mode/v1"
          }
        }
      }
    }
  }
}
```

### Steps
1. Configure memory-lancedb plugin with custom model (e.g., text-embedding-v4, which defaults to 1536 dimensions) AND specify a different dimensions value (e.g., 1024) in config
2. Attempt to store a memory
3. Try to recall memories using memory_recall

### Expected
Vector search works correctly with specified dimensions

### Actual
- The API returns vectors in model's default dimensions (1536 for text-embedding-v4)
- But LanceDB table was created with configured dimensions (1024)
- Error: `No vector column found to match with the query vector dimension: 1024`

### Evidence
- [-] Failing test/log before + passing after
- [x] Trace/log snippets:
```
2026-03-02T16:03:35.010Z [gateway] memory-lancedb: recall failed: Error: Failed to execute query stream: GenericFailure, Invalid input, No vector column found to match with the query vector dimension: 1024
```

## Human Verification
- Verified scenarios: Code compiles, fix passes dimensions to both LanceDB and Embeddings API
- Edge cases checked: dimensions is optional
- What you did not verify: Actual runtime test

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
None