### PR TITLE
fix(slack): avoid invalid Bolt typed message handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Sandbox/Docker setup command parsing: accept `agents.*.sandbox.docker.setupCommand` as either a string or a string array, and normalize arrays to newline-delimited shell scripts so multi-step setup commands no longer concatenate without separators. (#31953) Thanks @liuxiaopai-ai.
+- Slack/Startup handler registration: stop registering invalid Bolt event names (`message.channels`, `message.groups`) and route channel/group message payloads through the standard `message` event handler so Slack providers no longer crash on startup under `@slack/bolt@4.6`. (#32032) Thanks @liuxiaopai-ai.
 - Gateway/Plugin HTTP route precedence: run explicit plugin HTTP routes before the Control UI SPA catch-all so registered plugin webhook/custom paths remain reachable, while unmatched paths still fall through to Control UI handling. (#31885) Thanks @Sid-Qin.
 - Security/Node exec approvals: preserve shell/dispatch-wrapper argv semantics during approval hardening so approved wrapper commands (for example `env sh -c ...`) cannot drift into a different runtime command shape, and add regression coverage for both approval-plan generation and approved runtime execution paths. Thanks @tdjackey for reporting.
 - Sandbox/Bootstrap context boundary hardening: reject symlink/hardlink alias bootstrap seed files that resolve outside the source workspace and switch post-compaction `AGENTS.md` context reads to boundary-verified file opens, preventing host file content from being injected via workspace aliasing. Thanks @tdjackey for reporting.

--- a/src/slack/monitor/events/messages.test.ts
+++ b/src/slack/monitor/events/messages.test.ts
@@ -33,8 +33,6 @@ function createMessageHandlers(overrides?: SlackSystemEventTestOverrides) {
   });
   return {
     handler: harness.getHandler("message") as MessageHandler | null,
-    channelHandler: harness.getHandler("message.channels") as MessageHandler | null,
-    groupHandler: harness.getHandler("message.groups") as MessageHandler | null,
     handleSlackMessage,
   };
 }
@@ -159,16 +157,15 @@ describe("registerSlackMessageEvents", () => {
     expect(messageQueueMock).not.toHaveBeenCalled();
   });
 
-  it("registers and forwards message.channels and message.groups events", async () => {
+  it("forwards channel and group message payloads from message events", async () => {
     messageQueueMock.mockClear();
     messageAllowMock.mockReset().mockResolvedValue([]);
-    const { channelHandler, groupHandler, handleSlackMessage } = createMessageHandlers({
+    const { handler, handleSlackMessage } = createMessageHandlers({
       dmPolicy: "open",
       channelType: "channel",
     });
 
-    expect(channelHandler).toBeTruthy();
-    expect(groupHandler).toBeTruthy();
+    expect(handler).toBeTruthy();
 
     const channelMessage = {
       type: "message",
@@ -178,8 +175,8 @@ describe("registerSlackMessageEvents", () => {
       text: "hello channel",
       ts: "123.100",
     };
-    await channelHandler!({ event: channelMessage, body: {} });
-    await groupHandler!({
+    await handler!({ event: channelMessage, body: {} });
+    await handler!({
       event: {
         ...channelMessage,
         channel_type: "group",
@@ -193,17 +190,17 @@ describe("registerSlackMessageEvents", () => {
     expect(messageQueueMock).not.toHaveBeenCalled();
   });
 
-  it("applies subtype system-event handling for message.channels events", async () => {
+  it("applies subtype system-event handling for channel messages", async () => {
     messageQueueMock.mockClear();
     messageAllowMock.mockReset().mockResolvedValue([]);
-    const { channelHandler, handleSlackMessage } = createMessageHandlers({
+    const { handler, handleSlackMessage } = createMessageHandlers({
       dmPolicy: "open",
       channelType: "channel",
     });
 
-    expect(channelHandler).toBeTruthy();
+    expect(handler).toBeTruthy();
 
-    await channelHandler!({
+    await handler!({
       event: {
         ...makeChangedEvent({ channel: "C1", user: "U1" }),
         channel_type: "channel",

--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -49,20 +49,6 @@ export function registerSlackMessageEvents(params: {
   ctx.app.event("message", async ({ event, body }: SlackEventMiddlewareArgs<"message">) => {
     await handleIncomingMessageEvent({ event, body });
   });
-  // Slack may dispatch channel/group message subscriptions under typed event
-  // names. Register explicit handlers so both delivery styles are supported.
-  ctx.app.event(
-    "message.channels",
-    async ({ event, body }: SlackEventMiddlewareArgs<"message.channels">) => {
-      await handleIncomingMessageEvent({ event, body });
-    },
-  );
-  ctx.app.event(
-    "message.groups",
-    async ({ event, body }: SlackEventMiddlewareArgs<"message.groups">) => {
-      await handleIncomingMessageEvent({ event, body });
-    },
-  );
 
   ctx.app.event("app_mention", async ({ event, body }: SlackEventMiddlewareArgs<"app_mention">) => {
     try {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Slack provider startup crashes after registering `app.event("message.channels")` / `app.event("message.groups")`.
- Why it matters: with `@slack/bolt@4.6`, these typed registrations throw `AppInitializationError`, causing provider crash loops and breaking Slack connectivity.
- What changed: removed typed `message.channels` and `message.groups` registrations; kept a single `app.event("message")` path and updated tests to verify channel/group payloads (`channel_type`) still flow correctly through the unified handler.
- What did NOT change (scope boundary): Slack app manifest event subscription names, message subtype routing logic, mention handling, and any non-Slack channel behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32032
- Related #31701
- Related #31758

## User-visible / Behavior Changes

Slack providers no longer crash on startup with `@slack/bolt@4.6` due to invalid typed message event registration.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Slack (`@slack/bolt@4.6`)
- Relevant config (redacted): standard Slack bot/app token setup via Socket Mode

### Steps

1. Start OpenClaw Slack provider with code that registers `app.event("message.channels")` / `app.event("message.groups")`.
2. Observe provider startup failure with Bolt `AppInitializationError`.
3. Apply this PR and start provider again.

### Expected

- Provider starts successfully.
- Regular message events (including channel/group payloads) continue to route through existing message handling.

### Actual

- Before fix: startup crash loop.
- After fix: startup succeeds and message event handling remains functional.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run on this branch:

- `pnpm exec vitest run src/slack/monitor/events/messages.test.ts`
- `pnpm lint src/slack/monitor/events/messages.ts src/slack/monitor/events/messages.test.ts CHANGELOG.md`
- `pnpm tsgo`
- `pnpm exec oxfmt --check src/slack/monitor/events/messages.ts src/slack/monitor/events/messages.test.ts CHANGELOG.md`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: message events in direct/default path still call `handleSlackMessage`; channel/group payloads with `channel_type` are accepted via the unified `message` handler; subtype (`message_changed`) still routes to system-event pipeline.
- Edge cases checked: `channel_type` variations (`channel`, `group`) via a single handler registration.
- What you did **not** verify: live Slack workspace end-to-end run in this local iteration.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/slack/monitor/events/messages.ts`, `src/slack/monitor/events/messages.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: missing message handling for Slack channels/groups would appear as no inbound message processing.

## Risks and Mitigations

- Risk: if any runtime truly dispatched only typed Bolt events, removing typed registrations could drop those events.
  - Mitigation: Bolt 4.6 explicitly rejects typed event names; tests now validate channel/group payloads continue through `message` handler.
