### PR TITLE
fix(doctor): avoid false warning for local memory defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Sandbox/Docker setup command parsing: accept `agents.*.sandbox.docker.setupCommand` as either a string or a string array, and normalize arrays to newline-delimited shell scripts so multi-step setup commands no longer concatenate without separators. (#31953) Thanks @liuxiaopai-ai.
+- Doctor/Memory search local provider: stop warning about missing local model files when `memorySearch.provider` is explicitly `local` and `local.modelPath` is unset, so doctor aligns with runtime default local embedding model fallback behavior. (#31998) Thanks @liuxiaopai-ai.
 - Gateway/Plugin HTTP route precedence: run explicit plugin HTTP routes before the Control UI SPA catch-all so registered plugin webhook/custom paths remain reachable, while unmatched paths still fall through to Control UI handling. (#31885) Thanks @Sid-Qin.
 - Security/Node exec approvals: preserve shell/dispatch-wrapper argv semantics during approval hardening so approved wrapper commands (for example `env sh -c ...`) cannot drift into a different runtime command shape, and add regression coverage for both approval-plan generation and approved runtime execution paths. Thanks @tdjackey for reporting.
 - Sandbox/Bootstrap context boundary hardening: reject symlink/hardlink alias bootstrap seed files that resolve outside the source workspace and switch post-compaction `AGENTS.md` context reads to boundary-verified file opens, preventing host file content from being injected via workspace aliasing. Thanks @tdjackey for reporting.

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -76,6 +76,18 @@ describe("noteMemorySearchHealth", () => {
     expect(note).not.toHaveBeenCalled();
   });
 
+  it("does not warn when local provider relies on the default local model", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {});
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
   it("does not warn when remote apiKey is configured for explicit provider", async () => {
     await expectNoWarningWithConfiguredRemoteApiKey("openai");
   });

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -42,7 +42,7 @@ export async function noteMemorySearchHealth(
   // If a specific provider is configured (not "auto"), check only that one.
   if (resolved.provider !== "auto") {
     if (resolved.provider === "local") {
-      if (hasLocalEmbeddings(resolved.local)) {
+      if (hasLocalEmbeddings(resolved.local, { assumeDefaultModelWhenUnset: true })) {
         return; // local model file exists
       }
       note(
@@ -135,10 +135,13 @@ export async function noteMemorySearchHealth(
   );
 }
 
-function hasLocalEmbeddings(local: { modelPath?: string }): boolean {
+function hasLocalEmbeddings(
+  local: { modelPath?: string },
+  opts?: { assumeDefaultModelWhenUnset?: boolean },
+): boolean {
   const modelPath = local.modelPath?.trim();
   if (!modelPath) {
-    return false;
+    return opts?.assumeDefaultModelWhenUnset ?? false;
   }
   // Remote/downloadable models (hf: or http:) aren't pre-resolved on disk,
   // so we can't confirm availability without a network call. Treat as


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw doctor` warns that no local model file exists when `memorySearch.provider` is set to `local` but `local.modelPath` is omitted.
- Why it matters: this is a false-positive warning because runtime local embeddings already support a default model fallback when `modelPath` is unset.
- What changed: in the explicit `provider: local` doctor path, treat unset `local.modelPath` as valid (default local model fallback), and add regression coverage for this scenario.
- What did NOT change (scope boundary): `provider: auto` resolution behavior, remote provider API-key checks, and explicit local-path file existence checks.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31998

## User-visible / Behavior Changes

`openclaw doctor` no longer emits a false warning for local memory search when `provider=local` and `local.modelPath` is intentionally left unset.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: local memory search provider
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.memorySearch.provider: "local"`, no explicit `local.modelPath`

### Steps

1. Configure memory search provider as `local` with no `local.modelPath`.
2. Run `openclaw doctor`.
3. Observe warning behavior.

### Expected

- No warning about missing local model file, because runtime can use default local embedding model.

### Actual

- Before fix: warning shown.
- After fix: warning is suppressed in this valid configuration.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run on this branch:

- `pnpm exec vitest run src/commands/doctor-memory-search.test.ts`
- `pnpm lint src/commands/doctor-memory-search.ts src/commands/doctor-memory-search.test.ts CHANGELOG.md`
- `pnpm tsgo`
- `pnpm exec oxfmt --check src/commands/doctor-memory-search.ts src/commands/doctor-memory-search.test.ts CHANGELOG.md`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: explicit `provider: local` + unset `modelPath` no longer triggers doctor warning; existing auto-provider warning behavior remains covered.
- Edge cases checked: local explicit path check logic still active when `modelPath` is set.
- What you did **not** verify: full live `openclaw doctor` run against a real local embedding runtime on this machine in this iteration.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/commands/doctor-memory-search.ts`, `src/commands/doctor-memory-search.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: unexpected suppression of warnings when explicit invalid local paths are configured.

## Risks and Mitigations

- Risk: warning suppression could hide real local embedding setup issues in explicit-local mode.
  - Mitigation: only unset-path case is suppressed; explicit non-existent local paths still fail existing file checks and continue warning.
