### PR TITLE
fix(webchat): suppress NO_REPLY control token in chat UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Web UI/config form: support SecretInput string-or-secret-ref unions in map `additionalProperties`, so provider API key fields stay editable instead of being marked unsupported. (#31866) Thanks @ningding97.
+- Webchat/Silent token rendering: suppress assistant messages whose visible text is exactly `NO_REPLY` so Control UI chat history no longer leaks silent housekeeping control tokens as user-facing bubbles. (#32015) Thanks @liuxiaopai-ai.
 - Slack/Bolt startup compatibility: remove invalid `message.channels` and `message.groups` event registrations so Slack providers no longer crash on startup with Bolt 4.6+; channel/group traffic continues through the unified `message` handler (`channel_type`). (#32033) Thanks @mahopan.
 - Telegram: guard duplicate-token checks and gateway startup token normalization when account tokens are missing, preventing `token.trim()` crashes during status/start flows. (#31973) Thanks @ningding97.
 - Skills/sherpa-onnx-tts: run the `sherpa-onnx-tts` bin under ESM (replace CommonJS `require` imports) and add regression coverage to prevent `require is not defined in ES module scope` startup crashes. (#31965) Thanks @bmendonca3.

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { handleChatEvent, type ChatEventPayload, type ChatState } from "./chat.ts";
+import { describe, expect, it, vi } from "vitest";
+import { handleChatEvent, loadChatHistory, type ChatEventPayload, type ChatState } from "./chat.ts";
 
 function createState(overrides: Partial<ChatState> = {}): ChatState {
   return {
@@ -77,6 +77,30 @@ describe("handleChatEvent", () => {
     expect(state.chatMessages[0]).toEqual(payload.message);
   });
 
+  it("drops NO_REPLY final payload from another run", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-user",
+      chatStream: "Working...",
+      chatStreamStartedAt: 123,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-announce",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([]);
+    expect(state.chatRunId).toBe("run-user");
+    expect(state.chatStream).toBe("Working...");
+    expect(state.chatStreamStartedAt).toBe(123);
+  });
+
   it("returns final for another run when payload has no message", () => {
     const state = createState({
       sessionKey: "main",
@@ -131,6 +155,30 @@ describe("handleChatEvent", () => {
     };
     expect(handleChatEvent(state, payload)).toBe("final");
     expect(state.chatMessages).toEqual([payload.message]);
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
+  });
+
+  it("drops NO_REPLY final payload from own run", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "NO_REPLY",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([]);
     expect(state.chatRunId).toBe(null);
     expect(state.chatStream).toBe(null);
     expect(state.chatStreamStartedAt).toBe(null);
@@ -200,6 +248,25 @@ describe("handleChatEvent", () => {
     });
   });
 
+  it("does not append NO_REPLY fallback text when aborted payload is invalid", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "NO_REPLY",
+      chatStreamStartedAt: 100,
+      chatMessages: [],
+    });
+    const payload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "aborted",
+      message: "not-an-assistant-message",
+    } as unknown as ChatEventPayload;
+
+    expect(handleChatEvent(state, payload)).toBe("aborted");
+    expect(state.chatMessages).toEqual([]);
+  });
+
   it("falls back to streamed partial when aborted payload has non-assistant role", () => {
     const existingMessage = {
       role: "user",
@@ -255,5 +322,53 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe(null);
     expect(state.chatStreamStartedAt).toBe(null);
     expect(state.chatMessages).toEqual([existingMessage]);
+  });
+
+  it("ignores NO_REPLY delta updates", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Hello",
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(state.chatStream).toBe("Hello");
+  });
+});
+
+describe("loadChatHistory", () => {
+  it("filters NO_REPLY assistant messages from loaded history", async () => {
+    const request = vi.fn().mockResolvedValue({
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+        { role: "assistant", content: [{ type: "text", text: "visible answer" }] },
+        { role: "user", content: [{ type: "text", text: "question" }] },
+      ],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    await loadChatHistory(state);
+
+    expect(request).toHaveBeenCalledWith("chat.history", {
+      sessionKey: "main",
+      limit: 200,
+    });
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "visible answer" }] },
+      { role: "user", content: [{ type: "text", text: "question" }] },
+    ]);
+    expect(state.chatThinkingLevel).toBe("low");
+    expect(state.chatLoading).toBe(false);
+    expect(state.lastError).toBeNull();
   });
 });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -3,6 +3,13 @@ import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ChatAttachment } from "../ui-types.ts";
 import { generateUUID } from "../uuid.ts";
 
+const SILENT_REPLY_TOKEN = "NO_REPLY";
+const SILENT_REPLY_REGEX = new RegExp(`^\\s*${SILENT_REPLY_TOKEN}\\s*$`);
+
+function isSilentReplyTokenText(text: string | undefined): boolean {
+  return Boolean(text && SILENT_REPLY_REGEX.test(text));
+}
+
 export type ChatState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
@@ -41,7 +48,9 @@ export async function loadChatHistory(state: ChatState) {
         limit: 200,
       },
     );
-    state.chatMessages = Array.isArray(res.messages) ? res.messages : [];
+    state.chatMessages = Array.isArray(res.messages)
+      ? res.messages.filter((message) => !isSilentAssistantMessage(message))
+      : [];
     state.chatThinkingLevel = res.thinkingLevel ?? null;
   } catch (err) {
     state.lastError = String(err);
@@ -105,6 +114,19 @@ function normalizeFinalAssistantMessage(message: unknown): Record<string, unknow
     roleRequirement: "optional",
     allowTextField: true,
   });
+}
+
+function isSilentAssistantMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const candidate = message as Record<string, unknown>;
+  const roleValue = candidate.role;
+  if (typeof roleValue === "string" && roleValue.toLowerCase() !== "assistant") {
+    return false;
+  }
+  const text = extractText(message);
+  return isSilentReplyTokenText(text ?? undefined);
 }
 
 export async function sendChatMessage(
@@ -230,7 +252,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (payload.runId && state.chatRunId && payload.runId !== state.chatRunId) {
     if (payload.state === "final") {
       const finalMessage = normalizeFinalAssistantMessage(payload.message);
-      if (finalMessage) {
+      if (finalMessage && !isSilentAssistantMessage(finalMessage)) {
         state.chatMessages = [...state.chatMessages, finalMessage];
         return null;
       }
@@ -241,7 +263,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
 
   if (payload.state === "delta") {
     const next = extractText(payload.message);
-    if (typeof next === "string") {
+    if (typeof next === "string" && !isSilentReplyTokenText(next)) {
       const current = state.chatStream ?? "";
       if (!current || next.length >= current.length) {
         state.chatStream = next;
@@ -249,7 +271,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
-    if (finalMessage) {
+    if (finalMessage && !isSilentAssistantMessage(finalMessage)) {
       state.chatMessages = [...state.chatMessages, finalMessage];
     }
     state.chatStream = null;
@@ -257,11 +279,11 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     state.chatStreamStartedAt = null;
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
-    if (normalizedMessage) {
+    if (normalizedMessage && !isSilentAssistantMessage(normalizedMessage)) {
       state.chatMessages = [...state.chatMessages, normalizedMessage];
     } else {
       const streamedText = state.chatStream ?? "";
-      if (streamedText.trim()) {
+      if (streamedText.trim() && !isSilentReplyTokenText(streamedText)) {
         state.chatMessages = [
           ...state.chatMessages,
           {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Control UI chat history/event handling can surface assistant messages whose text is exactly `NO_REPLY`, leaking a silent control token into visible chat.
- Why it matters: users see confusing ghost assistant replies during housekeeping turns (for example compaction/memory flush), even though these turns are meant to stay silent.
- What changed: add controller-side filtering for silent assistant payloads in both history load (`chat.history`) and live chat events (`delta`/`final`/`aborted` fallback paths).
- What did NOT change (scope boundary): gateway-side token semantics, core auto-reply token behavior, and non-UI delivery channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32015

## User-visible / Behavior Changes

Control UI no longer renders assistant messages that are exact `NO_REPLY` control tokens when loading chat history or processing live chat events.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Control UI / webchat
- Relevant config (redacted): local gateway + chat history/event flow

### Steps

1. Load Control UI chat history containing assistant messages with exact text `NO_REPLY`.
2. Observe live `chat.event` flows where assistant delta/final/aborted fallback can carry `NO_REPLY` text.
3. Validate rendered message history and stream state after this PR.

### Expected

- `NO_REPLY` control-token messages are not visible in chat history.
- Live stream state does not adopt exact `NO_REPLY` token text.

### Actual

- Before fix: `NO_REPLY` could appear as a visible assistant message.
- After fix: silent token payloads are filtered at controller boundaries.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run on this branch:

- `pnpm --dir ui exec vitest run src/ui/controllers/chat.test.ts --config vitest.config.ts`
- `pnpm lint ui/src/ui/controllers/chat.ts ui/src/ui/controllers/chat.test.ts CHANGELOG.md`
- `pnpm tsgo`
- `pnpm exec oxfmt --check ui/src/ui/controllers/chat.ts ui/src/ui/controllers/chat.test.ts CHANGELOG.md`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: NO_REPLY filtering on history load; NO_REPLY ignored on live delta; NO_REPLY final/aborted fallback payloads are not appended.
- Edge cases checked: non-assistant messages remain untouched; normal assistant replies continue to append normally.
- What you did **not** verify: full end-to-end browser interaction against a running gateway in this iteration.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `ui/src/ui/controllers/chat.ts`, `ui/src/ui/controllers/chat.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: legitimate assistant replies being suppressed when they are not exact control tokens.

## Risks and Mitigations

- Risk: over-filtering could suppress legitimate assistant content.
  - Mitigation: filter condition is strict exact-token match with surrounding whitespace only; coverage added for normal message paths.
