### PR TITLE
fix(gateway): restart heartbeat when model config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Heartbeat model reload: treat `models.*` and `agents.defaults.model` config updates as heartbeat hot-reload triggers so heartbeat picks up model changes without a full gateway restart. (#32046) Thanks @stakeswky.
 - Memory/LanceDB embeddings: forward configured `embedding.dimensions` into OpenAI embeddings requests so vector size and API output dimensions stay aligned when dimensions are explicitly configured. (#32036) Thanks @scotthuang.
 - Mentions/Slack formatting hardening: add null-safe guards for runtime text normalization paths so malformed/undefined text payloads do not crash mention stripping or mrkdwn conversion. (#31865) Thanks @stone-jin.
 - Failover/error classification: treat HTTP `529` (provider overloaded, common with Anthropic-compatible APIs) as `rate_limit` so model failover can engage instead of misclassifying the error path. (#31854) Thanks @bugkill3r.

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -147,6 +147,18 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartChannels).toEqual(expected);
   });
 
+  it("restarts heartbeat when model-related config changes", () => {
+    const plan = buildGatewayReloadPlan([
+      "models.providers.openai.models",
+      "agents.defaults.model",
+    ]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartHeartbeat).toBe(true);
+    expect(plan.hotReasons).toEqual(
+      expect.arrayContaining(["models.providers.openai.models", "agents.defaults.model"]),
+    );
+  });
+
   it("treats gateway.remote as no-op", () => {
     const plan = buildGatewayReloadPlan(["gateway.remote.url"]);
     expect(plan.restartGateway).toBe(false);

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -59,6 +59,16 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     kind: "hot",
     actions: ["restart-heartbeat"],
   },
+  {
+    prefix: "agents.defaults.model",
+    kind: "hot",
+    actions: ["restart-heartbeat"],
+  },
+  {
+    prefix: "models",
+    kind: "hot",
+    actions: ["restart-heartbeat"],
+  },
   { prefix: "agent.heartbeat", kind: "hot", actions: ["restart-heartbeat"] },
   { prefix: "cron", kind: "hot", actions: ["restart-cron"] },
   {
@@ -73,7 +83,6 @@ const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
   { prefix: "identity", kind: "none" },
   { prefix: "wizard", kind: "none" },
   { prefix: "logging", kind: "none" },
-  { prefix: "models", kind: "none" },
   { prefix: "agents", kind: "none" },
   { prefix: "tools", kind: "none" },
   { prefix: "bindings", kind: "none" },


### PR DESCRIPTION
## Summary
- hot-reload `models` changes as `restart-heartbeat` instead of no-op
- hot-reload `agents.defaults.model` changes as `restart-heartbeat`
- keep gateway restart behavior unchanged for unrelated config paths
- add regression test coverage in `config-reload.test.ts`

## Root cause
`buildGatewayReloadPlan` treated both `models.*` and `agents.defaults.model` as no-op.
When users switched models with `openclaw models set`, the running heartbeat loop wasn't restarted, so it kept using stale in-memory model selection from before the timeout.

## Validation
- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/config-reload.test.ts`

Closes #31705
