### PR TITLE
fix(browser): fail closed browser auth bootstrap (GHSA-vpj2-69hf-rppw)

### DIFF
--- a/src/browser/server.auth-fail-closed.test.ts
+++ b/src/browser/server.auth-fail-closed.test.ts
@@ -12,13 +12,12 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/config.js")>();
-  const browserConfig = {
-    enabled: true,
-  };
   return {
     ...actual,
     loadConfig: () => ({
-      browser: browserConfig,
+      browser: {
+        enabled: true,
+      },
     }),
   };
 });


### PR DESCRIPTION
## Summary

Addresses GHSA-vpj2-69hf-rppw: browser control startup could continue unauthenticated after auth bootstrap failure.

- Refactors test config setup to inline `browser: { enabled: true }` directly rather than via a variable (minor cleanup in the regression test for the fail-closed fix)

The `server.ts` fail-closed guard (`browserAuthBootstrapFailed`) is already present; this cleans up the accompanying test.

## Test plan

- [ ] `src/browser/server.auth-fail-closed.test.ts` passes — confirms startup aborts when auth bootstrap fails with no fallback credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)