### PR TITLE
fix(webchat): suppress partial NO_REPLY tokens during streaming

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1,6 +1,10 @@
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../auto-reply/heartbeat.js";
 import { normalizeVerboseLevel } from "../auto-reply/thinking.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import {
+  isSilentReplyPrefixText,
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+} from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
@@ -289,6 +293,10 @@ export function createAgentEventHandler({
       return;
     }
     if (isSilentReplyText(cleaned, SILENT_REPLY_TOKEN)) {
+      return;
+    }
+    // Suppress partial NO_REPLY tokens during streaming (e.g. "NO" before full "NO_REPLY" arrives)
+    if (isSilentReplyPrefixText(cleaned, SILENT_REPLY_TOKEN)) {
       return;
     }
     chatRunState.buffers.set(clientRunId, cleaned);


### PR DESCRIPTION
Closes #32015

## Problem
During streaming in webchat, the delta handler only checks for the **full** `NO_REPLY` token via `isSilentReplyText`. When tokens arrive incrementally (e.g. `"NO"` → `"NO_R"` → `"NO_REPLY"`), the partial text passes the check and gets rendered as a visible "NO" bubble.

## Fix
Add `isSilentReplyPrefixText` check in `emitChatDelta` to suppress partial silent token prefixes during streaming. The existing `isSilentReplyPrefixText` function already handles this exact case (checks if text looks like a prefix of the silent token).

## Tests
`pnpm test -- src/gateway/server-chat` (15 tests pass)