### PR TITLE
fix(bluebubbles): gracefully fallback on unsupported tapback emoji

### DIFF
--- a/extensions/bluebubbles/src/reactions.test.ts
+++ b/extensions/bluebubbles/src/reactions.test.ts
@@ -106,18 +106,14 @@ describe("reactions", () => {
       ).rejects.toThrow("password is required");
     });
 
-    it("throws for unsupported reaction type", async () => {
-      await expect(
-        sendBlueBubblesReaction({
-          chatGuid: "chat-123",
-          messageGuid: "msg-123",
-          emoji: "unsupported",
-          opts: {
-            serverUrl: "http://localhost:1234",
-            password: "test",
-          },
-        }),
-      ).rejects.toThrow("Unsupported BlueBubbles reaction");
+    it("falls back to 'like' for unsupported reaction type", async () => {
+      // Unsupported emoji now gracefully fallback to 'like' instead of throwing
+      const result = normalizeBlueBubblesReactionInput("unsupported");
+      expect(result).toBe("like");
+      
+      // Also test with remove flag
+      const resultRemove = normalizeBlueBubblesReactionInput("unsupported", true);
+      expect(resultRemove).toBe("-like");
     });
 
     describe("reaction type normalization", () => {

--- a/extensions/bluebubbles/src/reactions.ts
+++ b/extensions/bluebubbles/src/reactions.ts
@@ -127,7 +127,8 @@ export function normalizeBlueBubblesReactionInput(emoji: string, remove?: boolea
   const aliased = REACTION_ALIASES.get(raw) ?? raw;
   const mapped = REACTION_EMOJIS.get(trimmed) ?? REACTION_EMOJIS.get(raw) ?? aliased;
   if (!REACTION_TYPES.has(mapped)) {
-    throw new Error(`Unsupported BlueBubbles reaction: ${trimmed}`);
+    // Fallback: map unsupported emoji to the closest iMessage tapback.
+    return remove ? "-like" : "like";
   }
   return remove ? `-${mapped}` : mapped;
 }
@@ -180,3 +181,4 @@ export async function sendBlueBubblesReaction(params: {
     throw new Error(`BlueBubbles reaction failed (${res.status}): ${errorText || "unknown"}`);
   }
 }
+


### PR DESCRIPTION
Fixes #31813

## Summary
Replace throw with graceful fallback to 'like' for unsupported BlueBubbles tapback emojis.

## Changes
- Modify 
ormalizeBlueBubblesReactionInput() to return fallback instead of throwing
- Update test to expect fallback behavior