### PR TITLE
fix(slack): remove message.channels/groups event handlers incompatible with Bolt v4.6.0

### DIFF
--- a/src/slack/monitor/events/messages.test.ts
+++ b/src/slack/monitor/events/messages.test.ts
@@ -33,8 +33,7 @@ function createMessageHandlers(overrides?: SlackSystemEventTestOverrides) {
   });
   return {
     handler: harness.getHandler("message") as MessageHandler | null,
-    channelHandler: harness.getHandler("message.channels") as MessageHandler | null,
-    groupHandler: harness.getHandler("message.groups") as MessageHandler | null,
+    appMentionHandler: harness.getHandler("app_mention") as MessageHandler | null,
     handleSlackMessage,
   };
 }
@@ -159,31 +158,37 @@ describe("registerSlackMessageEvents", () => {
     expect(messageQueueMock).not.toHaveBeenCalled();
   });
 
-  it("registers and forwards message.channels and message.groups events", async () => {
+  it("forwards channel and group messages via the generic message handler", async () => {
     messageQueueMock.mockClear();
     messageAllowMock.mockReset().mockResolvedValue([]);
-    const { channelHandler, groupHandler, handleSlackMessage } = createMessageHandlers({
+    const { handler, handleSlackMessage } = createMessageHandlers({
       dmPolicy: "open",
       channelType: "channel",
     });
 
-    expect(channelHandler).toBeTruthy();
-    expect(groupHandler).toBeTruthy();
+    expect(handler).toBeTruthy();
 
-    const channelMessage = {
-      type: "message",
-      channel: "C1",
-      channel_type: "channel",
-      user: "U1",
-      text: "hello channel",
-      ts: "123.100",
-    };
-    await channelHandler!({ event: channelMessage, body: {} });
-    await groupHandler!({
+    // Test channel message
+    await handler!({
       event: {
-        ...channelMessage,
-        channel_type: "group",
+        type: "message",
+        channel: "C1",
+        channel_type: "channel",
+        user: "U1",
+        text: "hello channel",
+        ts: "123.100",
+      },
+      body: {},
+    });
+
+    // Test group message
+    await handler!({
+      event: {
+        type: "message",
         channel: "G1",
+        channel_type: "group",
+        user: "U1",
+        text: "hello group",
         ts: "123.200",
       },
       body: {},

--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -49,20 +49,22 @@ export function registerSlackMessageEvents(params: {
   ctx.app.event("message", async ({ event, body }: SlackEventMiddlewareArgs<"message">) => {
     await handleIncomingMessageEvent({ event, body });
   });
-  // Slack may dispatch channel/group message subscriptions under typed event
-  // names. Register explicit handlers so both delivery styles are supported.
-  ctx.app.event(
-    "message.channels",
-    async ({ event, body }: SlackEventMiddlewareArgs<"message.channels">) => {
-      await handleIncomingMessageEvent({ event, body });
-    },
-  );
-  ctx.app.event(
-    "message.groups",
-    async ({ event, body }: SlackEventMiddlewareArgs<"message.groups">) => {
-      await handleIncomingMessageEvent({ event, body });
-    },
-  );
+  // Note: We intentionally do NOT register "message.channels" or "message.groups"
+  // handlers here. While these are valid event types to SUBSCRIBE TO in your Slack
+  // App's Event Subscriptions settings, @slack/bolt v4.6.0+ does not support
+  // registering handlers for these specific sub-types using app.event().
+  //
+  // Bolt v4.6.0 validates handler registration and rejects these with:
+  // "Although the document mentions 'message.channels', it is not a valid event type.
+  //  Use 'message' instead. If you want to filter message events, you can use
+  //  event.channel_type for it."
+  //
+  // The generic "message" handler above receives all message events. To distinguish
+  // between channels, groups, DMs, etc., check event.channel_type in the handler.
+  //
+  // This is a Bolt framework change, not a Slack API deprecation. The event types
+  // are still valid for subscription in Slack App settings, but Bolt only allows
+  // registering handlers for the base "message" type.
 
   ctx.app.event("app_mention", async ({ event, body }: SlackEventMiddlewareArgs<"app_mention">) => {
     try {


### PR DESCRIPTION
## Summary

- **Problem:** Slack provider crashes in a loop when starting because `message.channels` and `message.groups` event handler registrations are rejected by @slack/bolt v4.6.0
- **Why it matters:** Gateway cannot receive Slack messages/mentions at all when provider is in crash loop
- **What changed:** Removed `message.channels` and `message.groups` handler registrations; use generic `message` handler with `event.channel_type` filtering instead

## Context

The issue was introduced in commit 06306501a by @liuxiaopai-ai, which added `message.channels` and `message.groups` event handler registrations.

Commit 1fe0f848d by @Takhoffman later added TypeScript types for these handlers (PR #31758).

@slack/bolt v4.6.0 introduced stricter validation that rejects registering handlers for these event sub-types. The error occurs at handler registration time:

> "Although the document mentions 'message.channels', it is not a valid event type. Use 'message' instead."

Note: These are still valid event types to subscribe to in Slack App Event Subscriptions settings. The Bolt framework simply doesn't support registering handlers for these sub-types anymore.

Closes #32088

## Evidence

**Error logs before fix (crash loop):**
```
15:10:45.373 [default] starting provider
15:10:45.420 [default] channel exited: Although the document mentions "message.channels", it is not a valid event type...
15:10:45.429 [default] auto-restart attempt 2/10 in 11s
```

**Test results after fix:**
```
✓ src/slack/monitor/events/messages.test.ts (7 tests)
All tests passing
```