### PR TITLE
fix(mattermost): chatmode onmessage does not disable mention requirement

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -562,6 +562,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         channel: "mattermost",
         accountId: account.accountId,
         groupId: channelId,
+        requireMentionOverride: account.requireMention,
       });
     const shouldBypassMention =
       isControlCommand && shouldRequireMention && !wasMentioned && commandAuthorized;


### PR DESCRIPTION
## Summary

- Forward `account.requireMention` (resolved from `chatmode: "onmessage"` → `false`) as `requireMentionOverride` to `resolveChannelGroupRequireMention`
- Without this, the SDK function defaults to `true` (require mention) because no per-group config exists for plugin channels

## Root cause

The monitor calls `core.channel.groups.resolveRequireMention` which maps to `resolveChannelGroupRequireMention` (in `src/config/group-policy.ts`). This function checks:
1. Per-group `requireMention` config → `undefined` (no groups config for Mattermost)
2. Default channel `requireMention` → `undefined`
3. `requireMentionOverride` → not passed, so skipped
4. Falls through to `return true` (always require mention)

Meanwhile, `resolveMattermostRequireMention` in `accounts.ts` correctly resolves `chatmode: "onmessage"` to `requireMention: false`, but this value was never forwarded to the group policy check.

## Fix

Pass `requireMentionOverride: account.requireMention` in the `resolveRequireMention` call (1 line added).

Closes #32075

## Test plan

- [x] Traced full code path: `accounts.ts` → `monitor.ts` → `group-policy.ts`
- [ ] With `chatmode: "onmessage"`, bot responds to channel messages without @mention
- [ ] With `chatmode: "oncall"` (default), bot still requires @mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)