### PR TITLE
fix(slack): guard message.channels/groups registration against Bolt 4.6.0

### DIFF
--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -51,18 +51,24 @@ export function registerSlackMessageEvents(params: {
   });
   // Slack may dispatch channel/group message subscriptions under typed event
   // names. Register explicit handlers so both delivery styles are supported.
-  ctx.app.event(
-    "message.channels",
-    async ({ event, body }: SlackEventMiddlewareArgs<"message.channels">) => {
-      await handleIncomingMessageEvent({ event, body });
-    },
-  );
-  ctx.app.event(
-    "message.groups",
-    async ({ event, body }: SlackEventMiddlewareArgs<"message.groups">) => {
-      await handleIncomingMessageEvent({ event, body });
-    },
-  );
+  // Bolt >=4.6.0 may reject these event names; fall back to "message" only.
+  try {
+    ctx.app.event(
+      "message.channels",
+      async ({ event, body }: SlackEventMiddlewareArgs<"message.channels">) => {
+        await handleIncomingMessageEvent({ event, body });
+      },
+    );
+    ctx.app.event(
+      "message.groups",
+      async ({ event, body }: SlackEventMiddlewareArgs<"message.groups">) => {
+        await handleIncomingMessageEvent({ event, body });
+      },
+    );
+  } catch {
+    // Bolt version does not support typed message subtypes; the generic
+    // "message" handler above covers all channel/group messages.
+  }
 
   ctx.app.event("app_mention", async ({ event, body }: SlackEventMiddlewareArgs<"app_mention">) => {
     try {


### PR DESCRIPTION
## Summary

- Wraps `message.channels` and `message.groups` event handler registration in a try-catch
- Falls back to the generic `"message"` handler when Bolt rejects typed subtypes
- Fixes all Slack channels crashing on startup with `@slack/bolt@4.6.0`

Closes #32088

## Root cause

Bolt 4.6.0 throws `"message.channels" is not a valid event type` at registration time. The generic `"message"` handler already covers all channel/group messages, so the typed handlers are a nice-to-have that shouldn't crash the gateway.

## Test plan

- [x] Reproduced locally: all 9 Slack channels `stopped` with error before fix
- [x] After fix: all 9 Slack channels `running`
- [x] Verified with standalone script that Bolt 4.6.0 throws on `message.channels`/`message.groups`
- [x] `pnpm build` passes
- [x] BlueBubbles and other channels unaffected


🤖 Generated with [Claude Code](https://claude.com/claude-code)