### PR TITLE
fix(auth): complete coding-plan auth normalization in auth order

### DIFF
--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveAuthProfileOrder } from "./order.js";
+import type { AuthProfileStore } from "./types.js";
+
+describe("resolveAuthProfileOrder", () => {
+  it("accepts base-provider credentials for volcengine-plan auth lookup", () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "volcengine:default": {
+          type: "api_key",
+          provider: "volcengine",
+          key: "sk-test",
+        },
+      },
+    };
+
+    const order = resolveAuthProfileOrder({
+      store,
+      provider: "volcengine-plan",
+    });
+
+    expect(order).toEqual(["volcengine:default"]);
+  });
+});

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -1,5 +1,9 @@
 import type { OpenClawConfig } from "../../config/config.js";
-import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
+import {
+  findNormalizedProviderValue,
+  normalizeProviderId,
+  normalizeProviderIdForAuth,
+} from "../model-selection.js";
 import { dedupeProfileIds, listProfilesForProvider } from "./profiles.js";
 import type { AuthProfileStore } from "./types.js";
 import {
@@ -16,6 +20,7 @@ export function resolveAuthProfileOrder(params: {
 }): string[] {
   const { cfg, store, provider, preferredProfile } = params;
   const providerKey = normalizeProviderId(provider);
+  const providerAuthKey = normalizeProviderIdForAuth(provider);
   const now = Date.now();
 
   // Clear any cooldowns that have expired since the last check so profiles
@@ -27,12 +32,12 @@ export function resolveAuthProfileOrder(params: {
   const explicitOrder = storedOrder ?? configuredOrder;
   const explicitProfiles = cfg?.auth?.profiles
     ? Object.entries(cfg.auth.profiles)
-        .filter(([, profile]) => normalizeProviderId(profile.provider) === providerKey)
+        .filter(([, profile]) => normalizeProviderIdForAuth(profile.provider) === providerAuthKey)
         .map(([profileId]) => profileId)
     : [];
   const baseOrder =
     explicitOrder ??
-    (explicitProfiles.length > 0 ? explicitProfiles : listProfilesForProvider(store, providerKey));
+    (explicitProfiles.length > 0 ? explicitProfiles : listProfilesForProvider(store, provider));
   if (baseOrder.length === 0) {
     return [];
   }
@@ -42,12 +47,12 @@ export function resolveAuthProfileOrder(params: {
     if (!cred) {
       return false;
     }
-    if (normalizeProviderId(cred.provider) !== providerKey) {
+    if (normalizeProviderIdForAuth(cred.provider) !== providerAuthKey) {
       return false;
     }
     const profileConfig = cfg?.auth?.profiles?.[profileId];
     if (profileConfig) {
-      if (normalizeProviderId(profileConfig.provider) !== providerKey) {
+      if (normalizeProviderIdForAuth(profileConfig.provider) !== providerAuthKey) {
         return false;
       }
       if (profileConfig.mode !== cred.type) {
@@ -86,7 +91,7 @@ export function resolveAuthProfileOrder(params: {
   // provider's stored credentials and use any valid entries.
   const allBaseProfilesMissing = baseOrder.every((profileId) => !store.profiles[profileId]);
   if (filtered.length === 0 && explicitProfiles.length > 0 && allBaseProfilesMissing) {
-    const storeProfiles = listProfilesForProvider(store, providerKey);
+    const storeProfiles = listProfilesForProvider(store, provider);
     filtered = storeProfiles.filter(isValidProfile);
   }
 


### PR DESCRIPTION
## Summary
- Follow-up for #31821: normalize provider IDs in `resolveAuthProfileOrder` using `normalizeProviderIdForAuth` for credential/profile matching paths.
- Keep routing semantics unchanged (`normalizeProviderId` still used for provider/order key lookup).
- Add regression test proving `volcengine-plan` resolves `volcengine` stored credentials.

## Why
`#31821` added auth normalization in `listProfilesForProvider`, but `resolveAuthProfileOrder` still validated credentials with routing normalization, which filtered out base-provider credentials for `*-plan` providers.

## Tests
- `pnpm exec vitest run src/agents/model-selection.test.ts src/agents/auth-profiles/order.test.ts`
