### PR TITLE
WhatsApp: guard main DM last-route to single owner

### DIFF
--- a/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
+++ b/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
@@ -357,4 +357,76 @@ describe("web processMessage inbound contract", () => {
 
     expect(updateLastRouteMock).not.toHaveBeenCalled();
   });
+
+  it("does not update main last route for non-owner sender when main DM scope is pinned", async () => {
+    const updateLastRouteMock = vi.mocked(updateLastRouteInBackground);
+    updateLastRouteMock.mockClear();
+
+    const args = makeProcessMessageArgs({
+      routeSessionKey: "agent:main:main",
+      groupHistoryKey: "+3000",
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+1000"],
+          },
+        },
+        messages: {},
+        session: { store: sessionStorePath, dmScope: "main" },
+      } as unknown as ReturnType<typeof import("../../../config/config.js").loadConfig>,
+      msg: {
+        id: "msg-last-route-3",
+        from: "+3000",
+        to: "+2000",
+        chatType: "direct",
+        body: "hello",
+        senderE164: "+3000",
+      },
+    });
+    args.route = {
+      ...args.route,
+      sessionKey: "agent:main:main",
+      mainSessionKey: "agent:main:main",
+    };
+
+    await processMessage(args);
+
+    expect(updateLastRouteMock).not.toHaveBeenCalled();
+  });
+
+  it("updates main last route for owner sender when main DM scope is pinned", async () => {
+    const updateLastRouteMock = vi.mocked(updateLastRouteInBackground);
+    updateLastRouteMock.mockClear();
+
+    const args = makeProcessMessageArgs({
+      routeSessionKey: "agent:main:main",
+      groupHistoryKey: "+1000",
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+1000"],
+          },
+        },
+        messages: {},
+        session: { store: sessionStorePath, dmScope: "main" },
+      } as unknown as ReturnType<typeof import("../../../config/config.js").loadConfig>,
+      msg: {
+        id: "msg-last-route-4",
+        from: "+1000",
+        to: "+2000",
+        chatType: "direct",
+        body: "hello",
+        senderE164: "+1000",
+      },
+    });
+    args.route = {
+      ...args.route,
+      sessionKey: "agent:main:main",
+      mainSessionKey: "agent:main:main",
+    };
+
+    await processMessage(args);
+
+    expect(updateLastRouteMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -113,6 +113,28 @@ async function resolveWhatsAppCommandAuthorized(params: {
   return access.commandAuthorized;
 }
 
+function resolvePinnedMainDmRecipient(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  msg: WebInboundMsg;
+}): string | null {
+  if ((params.cfg.session?.dmScope ?? "main") !== "main") {
+    return null;
+  }
+  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.msg.accountId });
+  const rawAllowFrom = account.allowFrom ?? [];
+  if (rawAllowFrom.includes("*")) {
+    return null;
+  }
+  const normalizedOwners = Array.from(
+    new Set(
+      rawAllowFrom
+        .map((entry) => normalizeE164(String(entry)))
+        .filter((entry): entry is string => Boolean(entry)),
+    ),
+  );
+  return normalizedOwners.length === 1 ? normalizedOwners[0] : null;
+}
+
 export async function processMessage(params: {
   cfg: ReturnType<typeof loadConfig>;
   msg: WebInboundMsg;
@@ -329,7 +351,17 @@ export async function processMessage(params: {
   // Only update main session's lastRoute when DM actually IS the main session.
   // When dmScope="per-channel-peer", the DM uses an isolated sessionKey,
   // and updating mainSessionKey would corrupt routing for the session owner.
-  if (dmRouteTarget && params.route.sessionKey === params.route.mainSessionKey) {
+  const pinnedMainDmRecipient = resolvePinnedMainDmRecipient({
+    cfg: params.cfg,
+    msg: params.msg,
+  });
+  const shouldUpdateMainLastRoute =
+    !pinnedMainDmRecipient || pinnedMainDmRecipient === dmRouteTarget;
+  if (
+    dmRouteTarget &&
+    params.route.sessionKey === params.route.mainSessionKey &&
+    shouldUpdateMainLastRoute
+  ) {
     updateLastRouteInBackground({
       cfg: params.cfg,
       backgroundTasks: params.backgroundTasks,
@@ -341,6 +373,14 @@ export async function processMessage(params: {
       ctx: ctxPayload,
       warn: params.replyLogger.warn.bind(params.replyLogger),
     });
+  } else if (
+    dmRouteTarget &&
+    params.route.sessionKey === params.route.mainSessionKey &&
+    pinnedMainDmRecipient
+  ) {
+    logVerbose(
+      `Skipping main-session last route update for ${dmRouteTarget} (pinned owner ${pinnedMainDmRecipient})`,
+    );
   }
 
   const metaTask = recordSessionMetaFromInbound({


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: In WhatsApp `session.dmScope="main"`, inbound DMs can overwrite the main-session `lastRoute` recipient.
- Why it matters: If only one owner is configured in `channels.whatsapp.allowFrom`, a non-owner overwrite can misroute follow-up replies/tasks.
- What changed: Added a guard in `processMessage` to pin main-session lastRoute updates to the single configured owner when `allowFrom` has exactly one normalized E.164 entry.
- What did NOT change (scope boundary): No changes to session key derivation, group routing, command authorization, or delivery behavior outside this specific lastRoute update guard.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32097
- Related #31704

## User-visible / Behavior Changes

In WhatsApp direct messages with `session.dmScope="main"` and a single `channels.whatsapp.allowFrom` owner, non-owner inbound messages no longer overwrite the main session's route target.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.7.4
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A (routing behavior)
- Integration/channel (if any): WhatsApp inbound monitor
- Relevant config (redacted): `session.dmScope="main"`, `channels.whatsapp.allowFrom=["+1000"]`

### Steps

1. Configure `session.dmScope="main"` and one owner in `channels.whatsapp.allowFrom`.
2. Process a direct WhatsApp inbound from a non-owner sender.
3. Verify main-session `lastRoute` is not updated; process owner inbound and verify it updates.

### Expected

- Non-owner sender does not replace the pinned main-session route target.
- Owner sender still updates main-session route target.

### Actual

- Before this patch, non-owner sender could overwrite main-session route target.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/web/auto-reply/monitor/process-message.inbound-contract.test.ts`
  - `pnpm check`
- Edge cases checked:
  - Existing isolated DM scope behavior remains unchanged.
  - Existing main-session update path still updates for owner sender.
- What you did **not** verify:
  - Live WhatsApp runtime integration against real accounts.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/web/auto-reply/monitor/process-message.ts`
- Known bad symptoms reviewers should watch for: owner DMs no longer updating main-session lastRoute when single-owner allowFrom is configured.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Some deployments may rely on non-owner DMs updating main-session route even with single-entry `allowFrom`.
  - Mitigation: Guard only activates in narrow configuration (`dmScope=main` + exactly one normalized owner in `allowFrom`), and owner updates remain unchanged.
