### PR TITLE
fix(plugins): allow hardlinks for bundled plugins (fixes #28175, #28404)

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -223,12 +223,13 @@ function shouldIgnoreScannedDirectory(dirName: string): boolean {
   return false;
 }
 
-function readPackageManifest(dir: string): PackageManifest | null {
+function readPackageManifest(dir: string, rejectHardlinks = true): PackageManifest | null {
   const manifestPath = path.join(dir, "package.json");
   const opened = openBoundaryFileSync({
     absolutePath: manifestPath,
     rootPath: dir,
     boundaryLabel: "plugin package directory",
+    rejectHardlinks,
   });
   if (!opened.ok) {
     return null;
@@ -324,12 +325,14 @@ function resolvePackageEntrySource(params: {
   entryPath: string;
   sourceLabel: string;
   diagnostics: PluginDiagnostic[];
+  rejectHardlinks?: boolean;
 }): string | null {
   const source = path.resolve(params.packageDir, params.entryPath);
   const opened = openBoundaryFileSync({
     absolutePath: source,
     rootPath: params.packageDir,
     boundaryLabel: "plugin package directory",
+    rejectHardlinks: params.rejectHardlinks ?? true,
   });
   if (!opened.ok) {
     params.diagnostics.push({
@@ -393,7 +396,8 @@ function discoverInDirectory(params: {
       continue;
     }
 
-    const manifest = readPackageManifest(fullPath);
+    const rejectHardlinks = params.origin !== "bundled";
+    const manifest = readPackageManifest(fullPath, rejectHardlinks);
     const extensions = manifest ? resolvePackageExtensions(manifest) : [];
 
     if (extensions.length > 0) {
@@ -403,6 +407,7 @@ function discoverInDirectory(params: {
           entryPath: extPath,
           sourceLabel: fullPath,
           diagnostics: params.diagnostics,
+          rejectHardlinks,
         });
         if (!resolved) {
           continue;
@@ -494,7 +499,8 @@ function discoverFromPath(params: {
   }
 
   if (stat.isDirectory()) {
-    const manifest = readPackageManifest(resolved);
+    const rejectHardlinks = params.origin !== "bundled";
+    const manifest = readPackageManifest(resolved, rejectHardlinks);
     const extensions = manifest ? resolvePackageExtensions(manifest) : [];
 
     if (extensions.length > 0) {
@@ -504,6 +510,7 @@ function discoverFromPath(params: {
           entryPath: extPath,
           sourceLabel: resolved,
           diagnostics: params.diagnostics,
+          rejectHardlinks,
         });
         if (!source) {
           continue;

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -530,9 +530,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       absolutePath: candidate.source,
       rootPath: pluginRoot,
       boundaryLabel: "plugin root",
-      // Discovery stores rootDir as realpath but source may still be a lexical alias
-      // (e.g. /var/... vs /private/var/... on macOS). Canonical boundary checks
-      // still enforce containment; skip lexical pre-check to avoid false escapes.
+      rejectHardlinks: candidate.origin !== "bundled",
       skipLexicalRootCheck: true,
     });
     if (!opened.ok) {


### PR DESCRIPTION
## Summary
This PR fixes the "unsafe plugin manifest path" error encountered when installing OpenClaw globally via `pnpm` or `bun` (#28175, #28404, #29455).

## Problem
In v2026.2.26, strict security validation was added to plugin loading which rejects any manifest file that is a hardlink (`nlink > 1`). Since `pnpm` and `bun` use hardlinks in their content-addressable stores for global installs, all bundled plugins were being rejected, causing the gateway to crash on startup.

## Solution
This PR relaxes the hardlink rejection check **only for bundled plugins**. Since bundled plugins are part of the trusted computing base, allowing them to be hardlinks is safe. Non-bundled plugins (workspace, config, global) retain the strict hardlink rejection for security.

## Verification
- [x] **Reproduction**: Reproduced the failure using a standalone script that simulates hardlinked manifests.
- [x] **Verified**: Verified that with these changes, bundled hardlinked plugins load successfully while workspace hardlinked plugins are still correctly rejected.
- [x] **Green Tests**: Ran all relevant plugin and infra tests:
  - `src/plugins/loader.test.ts` (23 passed)
  - `src/plugins/discovery.test.ts` (11 passed)
  - `src/plugins/manifest-registry.test.ts` (6 passed)
  - `src/infra/fs-safe.test.ts` (11 passed)
  - `src/infra/safe-open-sync.test.ts` (Passed)
- [x] **Checks**: `pnpm build`, `pnpm check`, and `pnpm tsgo` all pass with no errors.

Fixes #28175
Fixes #28404
Fixes #29455