### PR TITLE
test(cron): isolate model precedence cases for bun stability

### DIFF
--- a/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
+++ b/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
@@ -119,6 +119,18 @@ const DEFAULT_AGENT_TURN_PAYLOAD: CronJob["payload"] = {
   deliver: false,
 };
 const GMAIL_MODEL = "openrouter/meta-llama/llama-3.3-70b:free";
+const DETERMINISTIC_MODEL_CATALOG = [
+  {
+    id: "gpt-4.1-mini",
+    name: "GPT-4.1 Mini",
+    provider: "openai",
+  },
+  {
+    id: "claude-opus-4-5",
+    name: "Claude Opus 4.5",
+    provider: "anthropic",
+  },
+];
 
 type RunCronTurnOptions = {
   cfgOverrides?: Parameters<typeof makeCfg>[2];
@@ -383,23 +395,11 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
-  it("applies model overrides with correct precedence", async () => {
+  it("prefers payload model override over default model", async () => {
     await withTempHome(async (home) => {
-      const deterministicCatalog = [
-        {
-          id: "gpt-4.1-mini",
-          name: "GPT-4.1 Mini",
-          provider: "openai",
-        },
-        {
-          id: "claude-opus-4-5",
-          name: "Claude Opus 4.5",
-          provider: "anthropic",
-        },
-      ];
-      vi.mocked(loadModelCatalog).mockResolvedValue(deterministicCatalog);
+      vi.mocked(loadModelCatalog).mockResolvedValue(DETERMINISTIC_MODEL_CATALOG);
 
-      let res = (
+      const res = (
         await runCronTurn(home, {
           jobPayload: {
             kind: "agentTurn",
@@ -410,10 +410,13 @@ describe("runCronIsolatedAgentTurn", () => {
       ).res;
       expect(res.status).toBe("ok");
       expectEmbeddedProviderModel({ provider: "openai", model: "gpt-4.1-mini" });
+    });
+  });
 
-      vi.mocked(runEmbeddedPiAgent).mockClear();
-      vi.mocked(loadModelCatalog).mockResolvedValue(deterministicCatalog);
-      res = (
+  it("applies stored session model override when payload model is absent", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(loadModelCatalog).mockResolvedValue(DETERMINISTIC_MODEL_CATALOG);
+      const res = (
         await runTurnWithStoredModelOverride(home, {
           kind: "agentTurn",
           message: DEFAULT_MESSAGE,
@@ -422,10 +425,13 @@ describe("runCronIsolatedAgentTurn", () => {
       ).res;
       expect(res.status).toBe("ok");
       expectEmbeddedProviderModel({ provider: "openai", model: "gpt-4.1-mini" });
+    });
+  });
 
-      vi.mocked(runEmbeddedPiAgent).mockClear();
-      vi.mocked(loadModelCatalog).mockResolvedValue(deterministicCatalog);
-      res = (
+  it("prefers payload model override over stored session model override", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(loadModelCatalog).mockResolvedValue(DETERMINISTIC_MODEL_CATALOG);
+      const res = (
         await runTurnWithStoredModelOverride(home, {
           kind: "agentTurn",
           message: DEFAULT_MESSAGE,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts` bundled three precedence assertions into one stateful test, and bun runs intermittently observed stale/shared state behavior (#32084).
- Why it matters: flaky unit tests create noisy CI failures and block unrelated PRs.
- What changed: split the single precedence test into three isolated tests (payload override vs default, stored session override, payload override over stored override), and use a shared deterministic catalog constant per case.
- What did NOT change (scope boundary): no runtime cron logic changes; this PR only updates test structure.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #32084
- Related #31972

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: node + bun
- Model/provider: mocked (unit test)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `bunx vitest run --config vitest.unit.config.ts src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts`
2. Run `pnpm exec vitest run src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts`
3. Stress run bun suite loop for the same file.

### Expected

- All isolated-agent precedence tests pass in node and bun.

### Actual

- Verified passing under both runners; bun stress loop also passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts`
  - `bunx vitest run --config vitest.unit.config.ts src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts`
  - 20x bun stress loop on this file
- Edge cases checked:
  - payload-only model override
  - stored session override without payload override
  - payload override taking precedence over stored override
- What you did **not** verify:
  - full repo test matrix

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts`
- Known bad symptoms reviewers should watch for: none beyond potential test instability if reverted.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: splitting test cases could miss a coupled regression previously covered in one flow.
  - Mitigation: preserved the original precedence assertions as three explicit cases with deterministic mocks.
