### PR TITLE
fix: prevent reasoning text leak through handleMessageEnd fallback

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -288,7 +288,7 @@ export function handleMessageEnd(
   let mediaUrls = parsedText?.mediaUrls;
   let hasMedia = Boolean(mediaUrls && mediaUrls.length > 0);
 
-  if (!cleanedText && !hasMedia) {
+  if (!cleanedText && !hasMedia && !ctx.params.enforceFinalTag) {
     const rawTrimmed = rawText.trim();
     const rawStrippedFinal = rawTrimmed.replace(/<\s*\/?\s*final\s*>/gi, "").trim();
     const rawCandidate = rawStrippedFinal || rawTrimmed;

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
@@ -4,7 +4,7 @@ import {
   createStubSessionHarness,
   emitAssistantTextDelta,
   emitMessageStartAndEndForAssistantText,
-  expectSingleAgentEventText,
+  extractAgentEventPayloads,
 } from "./pi-embedded-subscribe.e2e-harness.js";
 import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
 
@@ -37,7 +37,7 @@ describe("subscribeEmbeddedPiSession", () => {
 
     expect(onPartialReply).not.toHaveBeenCalled();
   });
-  it("emits agent events on message_end even without <final> tags", () => {
+  it("suppresses agent events on message_end without <final> tags when enforced", () => {
     const { session, emit } = createStubSessionHarness();
 
     const onAgentEvent = vi.fn();
@@ -49,7 +49,34 @@ describe("subscribeEmbeddedPiSession", () => {
       onAgentEvent,
     });
     emitMessageStartAndEndForAssistantText({ emit, text: "Hello world" });
-    expectSingleAgentEventText(onAgentEvent.mock.calls, "Hello world");
+    // With enforceFinalTag, text without <final> tags is treated as leaked
+    // reasoning and should NOT be recovered by the message_end fallback.
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(0);
+  });
+  it("emits via streaming when <final> tags are present and enforcement is on", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onPartialReply = vi.fn();
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onPartialReply,
+      onAgentEvent,
+    });
+
+    // With enforceFinalTag, content is emitted via streaming (text_delta path),
+    // NOT recovered from message_end fallback. extractAssistantText strips
+    // <final> tags, so message_end would see plain text with no <final> markers
+    // and correctly suppress it (treated as reasoning leak).
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "<final>Hello world</final>" });
+
+    expect(onPartialReply).toHaveBeenCalled();
+    expect(onPartialReply.mock.calls[0][0].text).toBe("Hello world");
   });
   it("does not require <final> when enforcement is off", () => {
     const { session, emit } = createStubSessionHarness();

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -62,6 +62,12 @@ describe("stripSilentToken", () => {
     expect(stripSilentToken("  NO_REPLY  ")).toBe("");
   });
 
+  it("strips token preceded by bold markdown formatting", () => {
+    expect(stripSilentToken("**NO_REPLY")).toBe("");
+    expect(stripSilentToken("some text **NO_REPLY")).toBe("some text");
+    expect(stripSilentToken("reasoning**NO_REPLY")).toBe("reasoning");
+  });
+
   it("works with custom token", () => {
     expect(stripSilentToken("done HEARTBEAT_OK", "HEARTBEAT_OK")).toBe("done");
   });

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -24,7 +24,7 @@ export function isSilentReplyText(
  */
 export function stripSilentToken(text: string, token: string = SILENT_REPLY_TOKEN): string {
   const escaped = escapeRegExp(token);
-  return text.replace(new RegExp(`(?:^|\\s+)${escaped}\\s*$`), "").trim();
+  return text.replace(new RegExp(`(?:^|\\s+|\\*+)${escaped}\\s*$`), "").trim();
 }
 
 export function isSilentReplyPrefixText(


### PR DESCRIPTION
## Summary

- Guard `handleMessageEnd` raw text fallback with `enforceFinalTag` check — when `enforceFinalTag` is active (Google providers), `stripBlockTags` returning empty means no `<final>` tag was seen, and the text should be treated as leaked reasoning, not recovered by the fallback
- Harden `stripSilentToken` regex to allow bold markdown (`**`) as separator before `NO_REPLY`, matching the pattern Gemini Flash Lite produces (e.g. `**Applying single-bot mention rule**NO_REPLY`)

Fixes reasoning text leaking into Discord messages when Codex rate limit cooldown causes fallback to Gemini Flash Lite, which doesn't reliably use `<think>/<final>` tags and embeds reasoning as bold-text prefixes.

### Root cause chain

1. Cron jobs drain model rate limit budget
2. Model enters cooldown → Discord messages fall back to smaller model (Gemini Flash Lite in my case)
3. Gemini Flash Lite leaks reasoning as bold-text prefixes (e.g. `**Applying single-bot mention rule**NO_REPLY`)
4. `enforceFinalTag`'s `stripBlockTags` correctly returns empty (no `<final>` tag seen), but the `handleMessageEnd` fallback at line 291 recovers raw text, defeating the protection

### Why the fallback guard is safe

When `enforceFinalTag` is true, `<final>`-tagged content is always emitted via the streaming path (`text_delta` events, which set `emittedAssistantUpdate = true`). The `handleMessageEnd` fallback only triggers when `emittedAssistantUpdate` is false (no streaming happened) — meaning the model's response came without `<final>` tags and should be treated as leaked reasoning.

Note: `extractAssistantText` already strips `<final>` tags via `stripReasoningTagsFromText`, so by the time `handleMessageEnd`'s `stripBlockTags` runs, there are never `<final>` tags in rawText. The comment at line 431 of `pi-embedded-subscribe.ts` explicitly anticipated this suppression pattern.

## Test plan

- [x] `stripSilentToken` correctly strips `**NO_REPLY` (bold markdown before token)
- [x] `handleMessageEnd` suppresses agent events when `enforceFinalTag` is true and no `<final>` tags are present
- [x] Streaming path still correctly emits `<final>`-tagged content when enforcement is on
- [x] No regression on existing `enforceFinalTag` streaming tests
- [x] No regression on `stripSilentToken` existing tests