### PR TITLE
perf(runtime): convert dynamic crypto import to static and cache Chalk instance

### DIFF
--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { parseByteSize } from "../cli/parse-bytes.js";
@@ -123,7 +124,6 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
     .map((l) => l.trim())
     .filter(Boolean);
   const kept = lines.slice(Math.max(0, lines.length - opts.keepLines));
-  const { randomBytes } = await import("node:crypto");
   const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
   await fs.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
   await fs.rename(tmp, filePath);

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -75,16 +75,23 @@ function isRichConsoleEnv(): boolean {
   return term.length > 0 && term !== "dumb";
 }
 
+let cachedChalk: ChalkInstance | null = null;
+
 function getColorForConsole(): ChalkInstance {
+  if (cachedChalk) {
+    return cachedChalk;
+  }
   const hasForceColor =
     typeof process.env.FORCE_COLOR === "string" &&
     process.env.FORCE_COLOR.trim().length > 0 &&
     process.env.FORCE_COLOR.trim() !== "0";
   if (process.env.NO_COLOR && !hasForceColor) {
-    return new Chalk({ level: 0 });
+    cachedChalk = new Chalk({ level: 0 });
+    return cachedChalk;
   }
   const hasTty = Boolean(process.stdout.isTTY || process.stderr.isTTY);
-  return hasTty || isRichConsoleEnv() ? new Chalk({ level: 1 }) : new Chalk({ level: 0 });
+  cachedChalk = hasTty || isRichConsoleEnv() ? new Chalk({ level: 1 }) : new Chalk({ level: 0 });
+  return cachedChalk;
 }
 
 const SUBSYSTEM_COLORS = ["cyan", "green", "yellow", "blue", "magenta", "red"] as const;


### PR DESCRIPTION
## Summary

Follow-up to 161611317 — extends the perf sprint with two more hot-path optimizations:

- **src/cron/run-log.ts**: convert `await import("node:crypto")` inside `pruneIfNeeded` to a top-level static import, matching the same fix already applied to `src/cron/store.ts`. Eliminates per-call module resolution overhead on the prune path.

- **src/logging/subsystem.ts**: cache the `Chalk` instance returned by `getColorForConsole()` in a module-level variable. The environment checks (`NO_COLOR`, `FORCE_COLOR`, TTY, `TERM`) do not change during a process lifetime, so the instance can be computed once and reused — avoiding repeated object allocation on every formatted console line.

## Test plan

- [x] `vitest run src/cron/run-log` — 9 tests pass
- [x] `vitest run src/logging/subsystem` — 5 tests pass
- [x] `oxfmt --check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)