### PR TITLE
fix(cron): strip HEARTBEAT_OK from announce completion messages

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,3 +1,4 @@
+import { stripHeartbeatToken } from "../auto-reply/heartbeat.js";
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
@@ -1337,7 +1338,14 @@ export async function runSubagentAnnounceFlow(params: {
 
     const taskLabel = params.label || params.task || "task";
     const announceSessionId = childSessionId || "unknown";
-    const findings = childCompletionFindings || reply || "(no output)";
+    let findings = childCompletionFindings || reply || "(no output)";
+    // Strip HEARTBEAT_OK so the token never leaks to end-users (#32013).
+    if (announceType === "cron job") {
+      const { text, didStrip } = stripHeartbeatToken(findings, { mode: "message" });
+      if (didStrip) {
+        findings = text || "";
+      }
+    }
 
     let requesterIsSubagent = requesterDepth >= 1;
     if (requesterIsSubagent) {


### PR DESCRIPTION
Noticed that when cron jobs return `HEARTBEAT_OK` during an active conversation, the token can leak into user-visible messages. Pure heartbeat responses are already caught by `isHeartbeatOnlyResponse`, but mixed content like `"Summary HEARTBEAT_OK"` slips through.

This reuses the existing `stripHeartbeatToken` helper inside `buildCompletionDeliveryMessage` for the cron announce path — strips the token, keeps the rest of the content intact.

Closes #32013