### PR TITLE
fix: silent token prefix detection leaks partial tokens to webchat

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -68,15 +68,23 @@ describe("stripSilentToken", () => {
 });
 
 describe("isSilentReplyPrefixText", () => {
-  it("matches uppercase underscore prefixes", () => {
+  it("matches strict prefixes of the token", () => {
+    expect(isSilentReplyPrefixText("NO")).toBe(true);
     expect(isSilentReplyPrefixText("NO_")).toBe(true);
     expect(isSilentReplyPrefixText("NO_RE")).toBe(true);
-    expect(isSilentReplyPrefixText("NO_REPLY")).toBe(true);
+    expect(isSilentReplyPrefixText("NO_REPL")).toBe(true);
     expect(isSilentReplyPrefixText("  HEARTBEAT_", "HEARTBEAT_OK")).toBe(true);
+    expect(isSilentReplyPrefixText("HEART", "HEARTBEAT_OK")).toBe(true);
   });
 
-  it("rejects ambiguous natural-language prefixes", () => {
+  it("rejects the full token (not a prefix)", () => {
+    expect(isSilentReplyPrefixText("NO_REPLY")).toBe(false);
+    expect(isSilentReplyPrefixText("HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
+  });
+
+  it("rejects single characters and ambiguous input", () => {
     expect(isSilentReplyPrefixText("N")).toBe(false);
+    expect(isSilentReplyPrefixText("H", "HEARTBEAT_OK")).toBe(false);
     expect(isSilentReplyPrefixText("No")).toBe(false);
     expect(isSilentReplyPrefixText("Hello")).toBe(false);
   });
@@ -85,5 +93,7 @@ describe("isSilentReplyPrefixText", () => {
     expect(isSilentReplyPrefixText("NO_X")).toBe(false);
     expect(isSilentReplyPrefixText("NO_REPLY more")).toBe(false);
     expect(isSilentReplyPrefixText("NO-")).toBe(false);
+    expect(isSilentReplyPrefixText("NOPE")).toBe(false);
+    expect(isSilentReplyPrefixText("NOT")).toBe(false);
   });
 });

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -34,15 +34,15 @@ export function isSilentReplyPrefixText(
   if (!text) {
     return false;
   }
-  const normalized = text.trimStart().toUpperCase();
-  if (!normalized) {
+  const trimmed = text.trimStart();
+  if (!trimmed || trimmed.length < 2) {
     return false;
   }
-  if (!normalized.includes("_")) {
+  // Only match text that is already uppercase + underscores (as tokens are emitted).
+  // This prevents natural-language words like "No" or "Heart" from matching.
+  if (/[^A-Z_]/.test(trimmed)) {
     return false;
   }
-  if (/[^A-Z_]/.test(normalized)) {
-    return false;
-  }
-  return token.toUpperCase().startsWith(normalized);
+  // Must be a strict prefix (shorter than the full token).
+  return trimmed.length < token.length && token.toUpperCase().startsWith(trimmed);
 }


### PR DESCRIPTION
## Problem

During streaming, \isSilentReplyPrefixText\ is used to detect partial emission of silent tokens (\NO_REPLY\, \HEARTBEAT_OK\) before the full token is complete. However, the function required an underscore character to be present in the partial text:

\\\	s
if (!normalized.includes('_')) return false;
\\\

This means streaming chunks like \NO\ (emitted before \_REPLY\ arrives) were **not** recognized as prefixes and leaked through to users as visible messages in webchat.

## Root Cause

When a model streams \NO_REPLY\, the text may arrive in chunks: \NO\ → \_REPLY\. The prefix detector should recognize \NO\ as a potential prefix of \NO_REPLY\, but the underscore gate rejected it. Same issue affects \HEARTBEAT_OK\ — \HEART\ would also leak.

## Fix

- Remove the underscore requirement
- Add minimum length of 2 to prevent single-character false positives (\N\, \H\)
- Require strict prefix matching (\	rimmed.length < token.length\) so the full token falls through to \isSilentReplyText\ instead
- Apply the uppercase-only regex to the original trimmed text (not after \	oUpperCase()\) to prevent natural-language words like \No\ from matching

## Tests

Updated \	okens.test.ts\:
- \NO\ → now correctly detected as prefix of \NO_REPLY\ ✅
- \HEART\ → now correctly detected as prefix of \HEARTBEAT_OK\ ✅
- \NO_REPLY\ (full token) → rejected as prefix (not a strict prefix) ✅
- \No\ (mixed case) → still rejected ✅
- \N\ (single char) → still rejected ✅
- All 18 tests passing