### PR TITLE
fix(telegram): prevent duplicate messages in DM draft streaming mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
 - Exec heartbeat routing: scope exec-triggered heartbeat wakes to agent session keys so unrelated agents are no longer awakened by exec events, while preserving legacy unscoped behavior for non-canonical session keys. (#32724) thanks @altaywtf
 - macOS/Tailscale remote gateway discovery: add a Tailscale Serve fallback peer probe path (`wss://<peer>.ts.net`) when Bonjour and wide-area DNS-SD discovery return no gateways, and refresh both discovery paths from macOS onboarding. (#32860) Thanks @ngutman.
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -225,6 +225,7 @@ export const dispatchTelegramMessage = async ({
       stream,
       lastPartialText: "",
       hasStreamedMessage: false,
+      previewRevisionBaseline: stream?.previewRevision?.() ?? 0,
     };
   };
   const lanes: Record<LaneName, DraftLaneState> = {
@@ -259,6 +260,7 @@ export const dispatchTelegramMessage = async ({
   const resetDraftLaneState = (lane: DraftLaneState) => {
     lane.lastPartialText = "";
     lane.hasStreamedMessage = false;
+    lane.previewRevisionBaseline = lane.stream?.previewRevision?.() ?? lane.previewRevisionBaseline;
   };
   const updateDraftFromPartial = (lane: DraftLaneState, text: string | undefined) => {
     const laneStream = lane.stream;

--- a/src/telegram/draft-stream.test-helpers.ts
+++ b/src/telegram/draft-stream.test-helpers.ts
@@ -8,6 +8,7 @@ export type TestDraftStream = {
   messageId: ReturnType<typeof vi.fn<() => number | undefined>>;
   previewMode: ReturnType<typeof vi.fn<() => DraftPreviewMode>>;
   previewRevision: ReturnType<typeof vi.fn<() => number>>;
+  lastDeliveredText: ReturnType<typeof vi.fn<() => string>>;
   clear: ReturnType<typeof vi.fn<() => Promise<void>>>;
   stop: ReturnType<typeof vi.fn<() => Promise<void>>>;
   forceNewMessage: ReturnType<typeof vi.fn<() => void>>;
@@ -23,15 +24,18 @@ export function createTestDraftStream(params?: {
 }): TestDraftStream {
   let messageId = params?.messageId;
   let previewRevision = 0;
+  let lastDeliveredText = "";
   return {
     update: vi.fn().mockImplementation((text: string) => {
       previewRevision += 1;
+      lastDeliveredText = text.trimEnd();
       params?.onUpdate?.(text);
     }),
     flush: vi.fn().mockResolvedValue(undefined),
     messageId: vi.fn().mockImplementation(() => messageId),
     previewMode: vi.fn().mockReturnValue(params?.previewMode ?? "message"),
     previewRevision: vi.fn().mockImplementation(() => previewRevision),
+    lastDeliveredText: vi.fn().mockImplementation(() => lastDeliveredText),
     clear: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn().mockImplementation(async () => {
       await params?.onStop?.();
@@ -51,17 +55,20 @@ export function createSequencedTestDraftStream(startMessageId = 1001): TestDraft
   let activeMessageId: number | undefined;
   let nextMessageId = startMessageId;
   let previewRevision = 0;
+  let lastDeliveredText = "";
   return {
-    update: vi.fn().mockImplementation(() => {
+    update: vi.fn().mockImplementation((text: string) => {
       if (activeMessageId == null) {
         activeMessageId = nextMessageId++;
       }
       previewRevision += 1;
+      lastDeliveredText = text.trimEnd();
     }),
     flush: vi.fn().mockResolvedValue(undefined),
     messageId: vi.fn().mockImplementation(() => activeMessageId),
     previewMode: vi.fn().mockReturnValue("message"),
     previewRevision: vi.fn().mockImplementation(() => previewRevision),
+    lastDeliveredText: vi.fn().mockImplementation(() => lastDeliveredText),
     clear: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn().mockResolvedValue(undefined),
     forceNewMessage: vi.fn().mockImplementation(() => {

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -59,6 +59,7 @@ export type TelegramDraftStream = {
   messageId: () => number | undefined;
   previewMode?: () => "message" | "draft";
   previewRevision?: () => number;
+  lastDeliveredText?: () => string;
   clear: () => Promise<void>;
   stop: () => Promise<void>;
   /** Reset internal state so the next update creates a new message instead of editing. */
@@ -127,6 +128,7 @@ export function createTelegramDraftStream(params: {
   let streamDraftId = usesDraftTransport ? allocateTelegramDraftId() : undefined;
   let previewTransport: "message" | "draft" = usesDraftTransport ? "draft" : "message";
   let lastSentText = "";
+  let lastDeliveredText = "";
   let lastSentParseMode: "HTML" | undefined;
   let previewRevision = 0;
   let generation = 0;
@@ -289,6 +291,7 @@ export function createTelegramDraftStream(params: {
       }
       if (sent) {
         previewRevision += 1;
+        lastDeliveredText = trimmed;
       }
       return sent;
     } catch (err) {
@@ -340,6 +343,7 @@ export function createTelegramDraftStream(params: {
     messageId: () => streamMessageId,
     previewMode: () => previewTransport,
     previewRevision: () => previewRevision,
+    lastDeliveredText: () => lastDeliveredText,
     clear,
     stop,
     forceNewMessage,

--- a/src/telegram/lane-delivery.test.ts
+++ b/src/telegram/lane-delivery.test.ts
@@ -12,7 +12,8 @@ function createHarness(params?: {
   answerLastPartialText?: string;
   answerPreviewRevisionBaseline?: number;
 }) {
-  const answer = params?.answerStream ?? createTestDraftStream({ messageId: params?.answerMessageId });
+  const answer =
+    params?.answerStream ?? createTestDraftStream({ messageId: params?.answerMessageId });
   const reasoning = createTestDraftStream();
   const lanes: Record<LaneName, DraftLaneState> = {
     answer: {
@@ -214,6 +215,7 @@ describe("createLaneTextDeliverer", () => {
   it("treats unchanged DM draft final text as already finalized", async () => {
     const answerStream = createTestDraftStream({ previewMode: "draft" });
     answerStream.previewRevision.mockReturnValue(7);
+    answerStream.lastDeliveredText.mockReturnValue("Hello final");
     answerStream.update.mockImplementation(() => {});
     const harness = createHarness({
       answerStream: answerStream as DraftLaneState["stream"],
@@ -260,7 +262,7 @@ describe("createLaneTextDeliverer", () => {
     );
     expect(harness.markDelivered).not.toHaveBeenCalled();
     expect(harness.log).toHaveBeenCalledWith(
-      expect.stringContaining("draft finalization not emitted"),
+      expect.stringContaining("draft final text not emitted"),
     );
   });
 
@@ -289,7 +291,39 @@ describe("createLaneTextDeliverer", () => {
     );
     expect(harness.markDelivered).not.toHaveBeenCalled();
     expect(harness.log).toHaveBeenCalledWith(
-      expect.stringContaining("draft finalization not emitted"),
+      expect.stringContaining("draft final text not emitted"),
+    );
+  });
+
+  it("falls back when revision advances but final text was not emitted", async () => {
+    let previewRevision = 7;
+    const answerStream = createTestDraftStream({ previewMode: "draft" });
+    answerStream.previewRevision.mockImplementation(() => previewRevision);
+    answerStream.lastDeliveredText.mockReturnValue("Older partial");
+    answerStream.update.mockImplementation(() => {});
+    answerStream.flush.mockImplementation(async () => {
+      previewRevision += 1;
+    });
+    const harness = createHarness({
+      answerStream: answerStream as DraftLaneState["stream"],
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "Final answer",
+    });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Final answer",
+      payload: { text: "Final answer" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("sent");
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Final answer" }),
+    );
+    expect(harness.markDelivered).not.toHaveBeenCalled();
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("draft final text not emitted"),
     );
   });
 

--- a/src/telegram/lane-delivery.test.ts
+++ b/src/telegram/lane-delivery.test.ts
@@ -7,19 +7,25 @@ function createHarness(params?: {
   answerMessageId?: number;
   draftMaxChars?: number;
   answerMessageIdAfterStop?: number;
+  answerStream?: DraftLaneState["stream"];
+  answerHasStreamedMessage?: boolean;
+  answerLastPartialText?: string;
+  answerPreviewRevisionBaseline?: number;
 }) {
-  const answer = createTestDraftStream({ messageId: params?.answerMessageId });
+  const answer = params?.answerStream ?? createTestDraftStream({ messageId: params?.answerMessageId });
   const reasoning = createTestDraftStream();
   const lanes: Record<LaneName, DraftLaneState> = {
     answer: {
-      stream: answer as DraftLaneState["stream"],
-      lastPartialText: "",
-      hasStreamedMessage: false,
+      stream: answer,
+      lastPartialText: params?.answerLastPartialText ?? "",
+      hasStreamedMessage: params?.answerHasStreamedMessage ?? false,
+      previewRevisionBaseline: params?.answerPreviewRevisionBaseline ?? 0,
     },
     reasoning: {
       stream: reasoning as DraftLaneState["stream"],
       lastPartialText: "",
       hasStreamedMessage: false,
+      previewRevisionBaseline: 0,
     },
   };
   const sendPayload = vi.fn().mockResolvedValue(true);
@@ -28,7 +34,9 @@ function createHarness(params?: {
   });
   const stopDraftLane = vi.fn().mockImplementation(async (lane: DraftLaneState) => {
     if (lane === lanes.answer && params?.answerMessageIdAfterStop !== undefined) {
-      answer.setMessageId(params.answerMessageIdAfterStop);
+      (answer as { setMessageId?: (value: number | undefined) => void }).setMessageId?.(
+        params.answerMessageIdAfterStop,
+      );
     }
     await lane.stream?.stop();
   });
@@ -59,7 +67,7 @@ function createHarness(params?: {
     lanes,
     answer: {
       stream: answer,
-      setMessageId: answer.setMessageId,
+      setMessageId: (answer as { setMessageId?: (value: number | undefined) => void }).setMessageId,
     },
     sendPayload,
     flushDraftLane,
@@ -106,7 +114,7 @@ describe("createLaneTextDeliverer", () => {
     });
 
     expect(result).toBe("preview-finalized");
-    expect(harness.answer.stream.update).toHaveBeenCalledWith("no problem");
+    expect(harness.answer.stream?.update).toHaveBeenCalledWith("no problem");
     expect(harness.editPreview).toHaveBeenCalledWith(
       expect.objectContaining({
         laneName: "answer",
@@ -201,5 +209,132 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.editPreview).not.toHaveBeenCalled();
     expect(harness.sendPayload).toHaveBeenCalledWith(expect.objectContaining({ text: longText }));
     expect(harness.log).toHaveBeenCalledWith(expect.stringContaining("preview final too long"));
+  });
+
+  it("treats unchanged DM draft final text as already finalized", async () => {
+    const answerStream = createTestDraftStream({ previewMode: "draft" });
+    answerStream.previewRevision.mockReturnValue(7);
+    answerStream.update.mockImplementation(() => {});
+    const harness = createHarness({
+      answerStream: answerStream as DraftLaneState["stream"],
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "Hello final",
+    });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-finalized");
+    expect(harness.flushDraftLane).toHaveBeenCalledTimes(1);
+    expect(harness.stopDraftLane).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back once when DM draft finalization emits no update", async () => {
+    const answerStream = createTestDraftStream({ previewMode: "draft" });
+    answerStream.previewRevision.mockReturnValue(3);
+    answerStream.update.mockImplementation(() => {});
+    const harness = createHarness({
+      answerStream: answerStream as DraftLaneState["stream"],
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "Partial",
+    });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Final answer",
+      payload: { text: "Final answer" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("sent");
+    expect(harness.flushDraftLane).toHaveBeenCalledTimes(1);
+    expect(harness.stopDraftLane).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Final answer" }),
+    );
+    expect(harness.markDelivered).not.toHaveBeenCalled();
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("draft finalization not emitted"),
+    );
+  });
+
+  it("falls back when unchanged final text has no emitted draft preview in current lane", async () => {
+    const answerStream = createTestDraftStream({ previewMode: "draft" });
+    answerStream.previewRevision.mockReturnValue(7);
+    answerStream.update.mockImplementation(() => {});
+    const harness = createHarness({
+      answerStream: answerStream as DraftLaneState["stream"],
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "Hello final",
+      answerPreviewRevisionBaseline: 7,
+    });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("sent");
+    expect(harness.stopDraftLane).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Hello final" }),
+    );
+    expect(harness.markDelivered).not.toHaveBeenCalled();
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("draft finalization not emitted"),
+    );
+  });
+
+  it("does not use DM draft final shortcut for media payloads", async () => {
+    const answerStream = createTestDraftStream({ previewMode: "draft" });
+    const harness = createHarness({
+      answerStream: answerStream as DraftLaneState["stream"],
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "Image incoming",
+    });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Image incoming",
+      payload: { text: "Image incoming", mediaUrl: "file:///tmp/example.png" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("sent");
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Image incoming", mediaUrl: "file:///tmp/example.png" }),
+    );
+    expect(harness.markDelivered).not.toHaveBeenCalled();
+  });
+
+  it("does not use DM draft final shortcut when inline buttons are present", async () => {
+    const answerStream = createTestDraftStream({ previewMode: "draft" });
+    const harness = createHarness({
+      answerStream: answerStream as DraftLaneState["stream"],
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "Choose one",
+    });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Choose one",
+      payload: { text: "Choose one" },
+      previewButtons: [[{ text: "OK", callback_data: "ok" }]],
+      infoKind: "final",
+    });
+
+    expect(result).toBe("sent");
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Choose one" }),
+    );
+    expect(harness.markDelivered).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -338,22 +338,31 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       let draftPreviewStopped = false;
       if (canFinalizeDraftPreviewDirectly) {
         const previewRevisionBeforeFlush = lane.stream?.previewRevision?.() ?? 0;
+        const finalTextSnapshot = text.trimEnd();
         const hasEmittedPreviewInCurrentLane =
           previewRevisionBeforeFlush > lane.previewRevisionBaseline;
-        const alreadyAtFinalText = text === lane.lastPartialText && hasEmittedPreviewInCurrentLane;
+        const deliveredPreviewTextBeforeFinal = lane.stream?.lastDeliveredText?.() ?? "";
+        const finalTextAlreadyDelivered =
+          deliveredPreviewTextBeforeFinal === finalTextSnapshot && hasEmittedPreviewInCurrentLane;
+        const unchangedFinalText = text === lane.lastPartialText;
         lane.stream?.update(text);
         await params.flushDraftLane(lane);
         await params.stopDraftLane(lane);
         draftPreviewStopped = true;
         const previewUpdated = (lane.stream?.previewRevision?.() ?? 0) > previewRevisionBeforeFlush;
-        if (previewUpdated || alreadyAtFinalText) {
+        const deliveredPreviewTextAfterFinal =
+          lane.stream?.lastDeliveredText?.() ?? deliveredPreviewTextBeforeFinal;
+        if (
+          (previewUpdated && deliveredPreviewTextAfterFinal === finalTextSnapshot) ||
+          (unchangedFinalText && finalTextAlreadyDelivered)
+        ) {
           lane.lastPartialText = text;
           params.finalizedPreviewByLane[laneName] = true;
           params.markDelivered();
           return "preview-finalized";
         }
         params.log(
-          `telegram: ${laneName} draft finalization not emitted; falling back to standard send`,
+          `telegram: ${laneName} draft final text not emitted; falling back to standard send`,
         );
       }
 

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -328,17 +328,30 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       !hasMedia && text.length > 0 && text.length <= params.draftMaxChars && !payload.isError;
 
     if (infoKind === "final") {
-      // For DM draft mode (sendMessageDraft), the draft bubble auto-converts to final message.
-      // We only need to flush the draft and mark as delivered, no separate sendPayload needed.
-      // Check if we're in draft preview mode and have already streamed content.
-      if (isDraftPreviewLane(lane) && lane.hasStreamedMessage) {
-        // Flush any pending draft updates and stop the stream.
+      const hasPreviewButtons = Boolean(previewButtons?.some((row) => row.length > 0));
+      const canFinalizeDraftPreviewDirectly =
+        isDraftPreviewLane(lane) &&
+        lane.hasStreamedMessage &&
+        canEditViaPreview &&
+        !hasPreviewButtons;
+      let draftPreviewStopped = false;
+      if (canFinalizeDraftPreviewDirectly) {
+        const previewRevisionBeforeFlush = lane.stream?.previewRevision?.() ?? 0;
+        const alreadyAtFinalText = text === lane.lastPartialText;
         lane.stream?.update(text);
         await params.flushDraftLane(lane);
         await params.stopDraftLane(lane);
-        lane.lastPartialText = text;
-        params.markDelivered();
-        return "preview-finalized";
+        draftPreviewStopped = true;
+        const previewUpdated = (lane.stream?.previewRevision?.() ?? 0) > previewRevisionBeforeFlush;
+        if (previewUpdated || alreadyAtFinalText) {
+          lane.lastPartialText = text;
+          params.finalizedPreviewByLane[laneName] = true;
+          params.markDelivered();
+          return "preview-finalized";
+        }
+        params.log(
+          `telegram: ${laneName} draft finalization not emitted; falling back to standard send`,
+        );
       }
 
       if (laneName === "answer") {
@@ -353,7 +366,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           return archivedResult;
         }
       }
-      if (canEditViaPreview && !params.finalizedPreviewByLane[laneName]) {
+      if (canEditViaPreview && !params.finalizedPreviewByLane[laneName] && !draftPreviewStopped) {
         await params.flushDraftLane(lane);
         if (laneName === "answer") {
           const archivedResultAfterFlush = await consumeArchivedAnswerPreviewForFinal({
@@ -385,7 +398,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           `telegram: preview final too long for edit (${text.length} > ${params.draftMaxChars}); falling back to standard send`,
         );
       }
-      await params.stopDraftLane(lane);
+      if (!draftPreviewStopped) {
+        await params.stopDraftLane(lane);
+      }
       const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
       return delivered ? "sent" : "skipped";
     }

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -8,6 +8,7 @@ export type DraftLaneState = {
   stream: TelegramDraftStream | undefined;
   lastPartialText: string;
   hasStreamedMessage: boolean;
+  previewRevisionBaseline: number;
 };
 
 export type ArchivedPreview = {
@@ -337,7 +338,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       let draftPreviewStopped = false;
       if (canFinalizeDraftPreviewDirectly) {
         const previewRevisionBeforeFlush = lane.stream?.previewRevision?.() ?? 0;
-        const alreadyAtFinalText = text === lane.lastPartialText;
+        const hasEmittedPreviewInCurrentLane =
+          previewRevisionBeforeFlush > lane.previewRevisionBaseline;
+        const alreadyAtFinalText = text === lane.lastPartialText && hasEmittedPreviewInCurrentLane;
         lane.stream?.update(text);
         await params.flushDraftLane(lane);
         await params.stopDraftLane(lane);

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -328,6 +328,19 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       !hasMedia && text.length > 0 && text.length <= params.draftMaxChars && !payload.isError;
 
     if (infoKind === "final") {
+      // For DM draft mode (sendMessageDraft), the draft bubble auto-converts to final message.
+      // We only need to flush the draft and mark as delivered, no separate sendPayload needed.
+      // Check if we're in draft preview mode and have already streamed content.
+      if (isDraftPreviewLane(lane) && lane.hasStreamedMessage) {
+        // Flush any pending draft updates and stop the stream.
+        lane.stream?.update(text);
+        await params.flushDraftLane(lane);
+        await params.stopDraftLane(lane);
+        lane.lastPartialText = text;
+        params.markDelivered();
+        return "preview-finalized";
+      }
+
       if (laneName === "answer") {
         const archivedResult = await consumeArchivedAnswerPreviewForFinal({
           lane,


### PR DESCRIPTION
## Problem

When using `sendMessageDraft` for DM streaming (`streaming: 'partial'`), users receive **duplicate messages**:
1. First message: streaming draft bubble (correct)
2. Second message: complete message sent via `sendMessage` (incorrect - should not be sent)

The draft bubble from `sendMessageDraft` auto-converts to the final message, so no separate `sendMessage` call is needed.

## Root Cause

In `src/telegram/lane-delivery.ts`, the final message handling logic did not properly handle the DM draft flow. When `infoKind === "final"`, the code always fell through to `sendPayload()` after the draft was finalized, causing the duplicate.

## Solution

Check if we're in draft preview mode (`isDraftPreviewLane(lane)`) before processing the final message:
- If draft mode: flush the draft, verify it was updated, and return `"preview-finalized"` without calling `sendPayload()`
- If not draft mode: continue with existing logic (edit preview message or send new message)

## Testing

- Tested with `streaming: "partial"` in DM chats
- Verified only one message appears (the streaming draft that auto-converts to final)
- No duplicate messages

## Related

- Telegram Bot API 9.3 introduced `sendMessageDraft` for streaming partial messages
- Telegram Bot API 9.5 allowed all bots to use this method