### PR TITLE
fix(skill): use ESM imports in sherpa-onnx-tts script

### DIFF
--- a/skills/sherpa-onnx-tts/bin/sherpa-onnx-tts
+++ b/skills/sherpa-onnx-tts/bin/sherpa-onnx-tts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const fs = require("node:fs");
-const path = require("node:path");
-const { spawnSync } = require("node:child_process");
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
 
 function usage(message) {
   if (message) {


### PR DESCRIPTION
## 问题

根据 issue #31956，sherpa-onnx-tts skill 的 bin 脚本使用 CommonJS `require()` 语法，但项目是 ESM 模块，导致 Node.js v22 报错：

```
ReferenceError: require is not defined in ES module scope
```

## 修复

将 CommonJS 语法改为 ESM import：

```javascript
// 修改前
const fs = require("node:fs");
const path = require("node:path");
const { spawnSync } = require("node:child_process");

// 修改后
import fs from "node:fs";
import path from "node:path";
import { spawnSync } from "node:child_process";
```

## 验证

用户提供的修复方案已验证可行，脚本可以正常运行并生成 WAV 文件。

Fixes #31956