### PR TITLE
fix(test): resolve Feishu hoisted mock export syntax error

### DIFF
--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -1,7 +1,18 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const probeFeishuMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./probe.js", () => ({
+  probeFeishu: probeFeishuMock,
+}));
+
+vi.mock("./client.js", () => ({
+  createFeishuWSClient: vi.fn(() => ({ start: vi.fn() })),
+  createEventDispatcher: vi.fn(() => ({ register: vi.fn() })),
+}));
+
 import { monitorFeishuProvider, stopFeishuMonitor } from "./monitor.js";
-import { probeFeishuMock } from "./monitor.test-mocks.js";
 
 function buildMultiAccountWebsocketConfig(accountIds: string[]): ClawdbotConfig {
   return {

--- a/extensions/feishu/src/monitor.test-mocks.ts
+++ b/extensions/feishu/src/monitor.test-mocks.ts
@@ -1,6 +1,6 @@
 import { vi } from "vitest";
 
-export const probeFeishuMock: ReturnType<typeof vi.fn> = vi.hoisted(() => vi.fn());
+export const probeFeishuMock: ReturnType<typeof vi.fn> = vi.fn();
 
 vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,


### PR DESCRIPTION
## Summary
- Fix 2 Feishu extension test suites that crash with `SyntaxError: Cannot export hoisted variable`
- Root cause: `vi.hoisted()` result cannot be exported from a shared mock module (Vitest limitation)
- Fix: replace `vi.hoisted(() => vi.fn())` with plain `vi.fn()` in shared mock; inline `vi.hoisted()` + `vi.mock()` in startup test

## Test plan
- [x] `pnpm vitest run extensions/feishu/` — 29/29 suites pass, 230 tests pass
- [x] `pnpm tsgo` — zero errors
- [x] `pnpm format` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)