### PR TITLE
fix(slack): skip thread history fetch for existing sessions (#32121)

### DIFF
--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -516,7 +516,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(replies).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps loading thread history when thread session already exists in store", async () => {
+  it("skips thread history when thread session already exists in store", async () => {
     const { storePath } = makeTmpStorePath();
     const cfg = {
       session: { store: storePath },
@@ -538,19 +538,13 @@ describe("slack prepareSlackMessage inbound contract", () => {
       JSON.stringify({ [threadKeys.sessionKey]: { updatedAt: Date.now() } }, null, 2),
     );
 
-    const replies = vi
-      .fn()
-      .mockResolvedValueOnce({
-        messages: [{ text: "starter", user: "U2", ts: "200.000" }],
-      })
-      .mockResolvedValueOnce({
-        messages: [
-          { text: "starter", user: "U2", ts: "200.000" },
-          { text: "assistant follow-up", bot_id: "B1", ts: "200.500" },
-          { text: "user follow-up", user: "U1", ts: "200.800" },
-          { text: "current message", user: "U1", ts: "201.000" },
-        ],
-      });
+    // Only the thread-starter lookup (first replies call) should happen.
+    // The history fetch (second replies call) must be skipped for existing sessions
+    // because the session transcript already contains prior context — re-injecting
+    // history on every subsequent turn wastes tokens unnecessarily.
+    const replies = vi.fn().mockResolvedValueOnce({
+      messages: [{ text: "starter", user: "U2", ts: "200.000" }],
+    });
     const slackCtx = createThreadSlackCtx({ cfg, replies });
     slackCtx.resolveUserName = async () => ({ name: "Alice" });
     slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
@@ -563,10 +557,10 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
     expect(prepared).toBeTruthy();
     expect(prepared!.ctxPayload.IsFirstThreadTurn).toBeUndefined();
-    expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("assistant follow-up");
-    expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("user follow-up");
-    expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("current message");
-    expect(replies).toHaveBeenCalledTimes(2);
+    // ThreadHistoryBody must be absent — the session already has context
+    expect(prepared!.ctxPayload.ThreadHistoryBody).toBeFalsy();
+    // Only one Slack API call: thread starter lookup; no history fetch
+    expect(replies).toHaveBeenCalledTimes(1);
   });
 
   it("includes thread_ts and parent_user_id metadata in thread replies", async () => {

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -544,15 +544,17 @@ export async function prepareSlackMessage(params: {
       threadLabel = `Slack thread ${roomLabel}`;
     }
 
-    // Fetch full thread history for new thread sessions
-    // This provides context of previous messages (including bot replies) in the thread
-    // Use the thread session key (not base session key) to determine if this is a new session
+    // Fetch full thread history for new thread sessions only.
+    // Once a session exists (threadSessionPreviousTimestamp is set) its transcript
+    // already contains the prior turns, so re-injecting history on every message
+    // would bloat every subsequent request with redundant context tokens.
+    // Use the thread session key (not base session key) to determine if this is a new session.
     const threadInitialHistoryLimit = account.config?.thread?.initialHistoryLimit ?? 20;
     threadSessionPreviousTimestamp = readSessionUpdatedAt({
       storePath,
       sessionKey, // Thread-specific session key
     });
-    if (threadInitialHistoryLimit > 0) {
+    if (threadInitialHistoryLimit > 0 && !threadSessionPreviousTimestamp) {
       const threadHistory = await resolveSlackThreadHistory({
         channelId: message.channel,
         threadTs,


### PR DESCRIPTION
## Summary

Fixes #32121

Thread history was fetched and injected into the context on **every** message in a Slack thread, even when the session already had the prior turns in its transcript. This caused redundant token usage on every subsequent reply in a long-running thread.

## Root Cause

In `prepare.ts`, the `resolveSlackThreadHistory` call was gated only on `threadInitialHistoryLimit > 0`. The `threadSessionPreviousTimestamp` value was computed immediately before but never used to gate the history fetch.

## Fix

Add `&& !threadSessionPreviousTimestamp` to the history-fetch condition so that thread history is only injected on the **first turn** of a new session. For subsequent turns the session transcript already contains full context, making re-injection redundant.

```diff
-    if (threadInitialHistoryLimit > 0) {
+    if (threadInitialHistoryLimit > 0 && !threadSessionPreviousTimestamp) {
```

## Tests

Updated the `prepareSlackMessage` test that was asserting the old (redundant) behaviour. The test now verifies:
- Only **one** Slack API call occurs for existing thread sessions (thread-starter lookup only, no history fetch)
- `ThreadHistoryBody` is absent for subsequent turns in existing sessions
- New-session behaviour is unchanged (history still fetched on first turn)

All 21 existing tests pass.