### PR TITLE
fix(macos): resolve Swift build errors from pairing/dedupe refactoring

### DIFF
--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+Testing.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+Testing.swift
@@ -1,6 +1,7 @@
 #if DEBUG
 import AppKit
 import Foundation
+import OpenClawKit
 
 extension CanvasWindowController {
     static func _testSanitizeSessionKey(_ key: String) -> String {

--- a/apps/macos/Sources/OpenClaw/PairingAlertSupport.swift
+++ b/apps/macos/Sources/OpenClaw/PairingAlertSupport.swift
@@ -205,13 +205,11 @@ enum PairingAlertSupport {
             informativeText: informativeText,
             activeAlert: &state.activeAlert,
             activeRequestId: &state.activeRequestId,
-            alertHostWindow: &state.alertHostWindow)
-        { response, hostWindow in
-            Task { @MainActor in
+            alertHostWindow: &state.alertHostWindow,
+            clearActive: { hostWindow in
                 self.clearActivePairingAlert(state: state, hostWindow: hostWindow)
-                await onResponse(response, request)
-            }
-        }
+            },
+            onResponse: onResponse)
     }
 
     static func clearActivePairingAlert(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/LoopbackHost.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/LoopbackHost.swift
@@ -53,7 +53,7 @@ public enum LoopbackHost {
         return self.isLocalNetworkIPv4(ipv4)
     }
 
-    static func parseIPv4(_ host: String) -> (UInt8, UInt8, UInt8, UInt8)? {
+    public static func parseIPv4(_ host: String) -> (UInt8, UInt8, UInt8, UInt8)? {
         let parts = host.split(separator: ".", omittingEmptySubsequences: false)
         guard parts.count == 4 else { return nil }
         let bytes: [UInt8] = parts.compactMap { UInt8($0) }
@@ -61,7 +61,7 @@ public enum LoopbackHost {
         return (bytes[0], bytes[1], bytes[2], bytes[3])
     }
 
-    static func isLocalNetworkIPv4(_ ip: (UInt8, UInt8, UInt8, UInt8)) -> Bool {
+    public static func isLocalNetworkIPv4(_ ip: (UInt8, UInt8, UInt8, UInt8)) -> Bool {
         let (a, b, _, _) = ip
         // 10.0.0.0/8
         if a == 10 { return true }


### PR DESCRIPTION
### Summary

Three build errors introduced by the macOS dedupe refactoring in 87316e07d:

- `PairingAlertSupport.swift`: state-based `presentPairingAlert` overload uses trailing closure pattern that Swift can't resolve - `clearActive:` missing as named parameter. Fixed by passing both `clearActive:` and `onResponse:` explicitly.
- `CanvasWindowController+Testing.swift`: references `LoopbackHost` type (moved to `OpenClawKit` module) without importing it. Added `import OpenClawKit`.
- `LoopbackHost.swift`: `parseIPv4` and `isLocalNetworkIPv4` have `internal` access but are called from the main `OpenClaw` target across module boundary. Changed to `public`.