### PR TITLE
fix(slack): exclude thread starter from thread history to avoid token duplication

### DIFF
--- a/src/slack/monitor/media.test.ts
+++ b/src/slack/monitor/media.test.ts
@@ -739,9 +739,10 @@ describe("resolveSlackThreadHistory", () => {
       limit: 10,
     });
 
-    expect(result).toHaveLength(2);
-    expect(result[0]?.text).toBe("[attached: screenshot.png]");
-    expect(result[1]?.text).toBe("hello");
+    // Thread starter (ts === threadTs "1.000") is now excluded — it is
+    // provided separately via ThreadStarterBody to avoid duplication.
+    expect(result).toHaveLength(1);
+    expect(result[0]?.text).toBe("hello");
   });
 
   it("returns empty when limit is zero without calling Slack API", async () => {

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -493,6 +493,11 @@ export async function resolveSlackThreadHistory(params: {
         if (params.currentMessageTs && msg.ts === params.currentMessageTs) {
           continue;
         }
+        // Skip the thread starter — it is provided separately via ThreadStarterBody
+        // to avoid duplicating it in the context window.
+        if (msg.ts === params.threadTs) {
+          continue;
+        }
         retained.push(msg);
         if (retained.length > maxMessages) {
           retained.shift();


### PR DESCRIPTION
## Summary

Fixes #32121 — thread starter message duplicated in context window causing unnecessary token consumption.

**Root cause:** `resolveSlackThreadHistory` calls `conversations.replies` with `inclusive: true`, which returns the thread root message as the first item. The code skips `currentMessageTs` but never filters out the thread starter (`threadTs`). This causes the same content to appear in both `ThreadStarterBody` and `ThreadHistoryBody`, consuming extra tokens on every thread turn.

**Fix:** Added a check to skip messages where `msg.ts === params.threadTs` in the history collection loop, matching the existing `currentMessageTs` exclusion pattern. The thread starter content remains available via `ThreadStarterBody`.

## Test plan

- [x] `vitest run src/slack/monitor/media` — 28 tests pass (updated expectation for dedup)
- [x] `vitest run src/slack/monitor/message-handler/prepare` — 24 tests pass
- [x] `oxfmt --check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)