### PR TITLE
chore(gitignore): add .claude folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,7 @@ USER.md
 !.agent/workflows/
 /local/
 package-lock.json
-.claude/settings.local.json
+.claude/
 .agents/
 .agents
 .agent/


### PR DESCRIPTION
## Summary

- **Problem:** Only `.claude/settings.local.json` was gitignored, leaving other `.claude/` contents (e.g. memory files, local config) unignored and at risk of accidental commits.
- **What changed:** Broadened the `.gitignore` entry from `.claude/settings.local.json` to `.claude/` so the entire directory is ignored.
- **What did NOT change:** No other gitignore rules or project files were modified.

## Change Type

- [x] Chore/infra

## Verification

```sh
echo "test" > .claude/test-file
git status  # .claude/test-file should not appear
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)