### PR TITLE
docs(telegram): warn when using accounts without accounts.default

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -72,6 +72,14 @@ openclaw pairing approve telegram <CODE>
 Token resolution order is account-aware. In practice, config values win over env fallback, and `TELEGRAM_BOT_TOKEN` only applies to the default account.
 </Note>
 
+<Warning>
+If you configure `channels.telegram.accounts` (multi-account), **always** define `channels.telegram.accounts.default` explicitly.
+
+If you only add a named account (for example `accounts.news`) without a `default` account, default inbound/outbound routing can become confusing.
+
+Recommendation: align `channels.telegram.botToken` with `channels.telegram.accounts.default.botToken` for clarity.
+</Warning>
+
 ## Telegram side settings
 
 <AccordionGroup>

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -102,6 +102,11 @@ When validation fails:
     }
     ```
 
+    <Warning>
+    Multi-account note: if you use `channels.telegram.accounts`, define `channels.telegram.accounts.default` explicitly.
+    If you only add a named account (for example `accounts.news`) without a default, routing can be surprising.
+    </Warning>
+
   </Accordion>
 
   <Accordion title="Choose and configure models">


### PR DESCRIPTION
Adds explicit warnings in Telegram docs + gateway config docs: if `channels.telegram.accounts` is used, define `channels.telegram.accounts.default` explicitly.

Rationale: in real setups, configuring only a named account (e.g. `accounts.news`) without `default` can lead to confusing default routing/identity behavior.

Fixes: openclaw/openclaw#32138
