### PR TITLE
gateway: hot-reload channel health monitor interval changes

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -165,6 +165,13 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toContain("gateway.remote.url");
   });
 
+  it("hot-reloads channel health monitor when channelHealthCheckMinutes changes", () => {
+    const plan = buildGatewayReloadPlan(["gateway.channelHealthCheckMinutes"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartChannelHealthMonitor).toBe(true);
+    expect(plan.hotReasons).toContain("gateway.channelHealthCheckMinutes");
+  });
+
   it("treats secrets config changes as no-op for gateway restart planning", () => {
     const plan = buildGatewayReloadPlan(["secrets.providers.default.path"]);
     expect(plan.restartGateway).toBe(false);

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -22,6 +22,7 @@ export type GatewayReloadPlan = {
   restartBrowserControl: boolean;
   restartCron: boolean;
   restartHeartbeat: boolean;
+  restartChannelHealthMonitor: boolean;
   restartChannels: Set<ChannelKind>;
   noopPaths: string[];
 };
@@ -38,6 +39,7 @@ type ReloadAction =
   | "restart-browser-control"
   | "restart-cron"
   | "restart-heartbeat"
+  | "restart-channel-health-monitor"
   | `restart-channel:${ChannelId}`;
 
 const DEFAULT_RELOAD_SETTINGS: GatewayReloadSettings = {
@@ -50,6 +52,11 @@ const MISSING_CONFIG_MAX_RETRIES = 2;
 const BASE_RELOAD_RULES: ReloadRule[] = [
   { prefix: "gateway.remote", kind: "none" },
   { prefix: "gateway.reload", kind: "none" },
+  {
+    prefix: "gateway.channelHealthCheckMinutes",
+    kind: "hot",
+    actions: ["restart-channel-health-monitor"],
+  },
   // Stuck-session warning threshold is read by the diagnostics heartbeat loop.
   { prefix: "diagnostics.stuckSessionWarnMs", kind: "none" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },
@@ -199,6 +206,7 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
     restartBrowserControl: false,
     restartCron: false,
     restartHeartbeat: false,
+    restartChannelHealthMonitor: false,
     restartChannels: new Set(),
     noopPaths: [],
   };
@@ -224,6 +232,9 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
         break;
       case "restart-heartbeat":
         plan.restartHeartbeat = true;
+        break;
+      case "restart-channel-health-monitor":
+        plan.restartChannelHealthMonitor = true;
         break;
       default:
         break;

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -16,9 +16,11 @@ import {
 } from "../infra/restart.js";
 import { setCommandLaneConcurrency, getTotalQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
+import { startChannelHealthMonitor, type ChannelHealthMonitor } from "./channel-health-monitor.js";
 import type { ChannelKind, GatewayReloadPlan } from "./config-reload.js";
 import { resolveHooksConfig } from "./hooks.js";
 import { startBrowserControlServerIfEnabled } from "./server-browser.js";
+import type { ChannelManager } from "./server-channels.js";
 import { buildGatewayCronService, type GatewayCronState } from "./server-cron.js";
 
 type GatewayHotReloadState = {
@@ -26,6 +28,7 @@ type GatewayHotReloadState = {
   heartbeatRunner: HeartbeatRunner;
   cronState: GatewayCronState;
   browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> | null;
+  channelHealthMonitor: ChannelHealthMonitor | null;
 };
 
 export function createGatewayReloadHandlers(params: {
@@ -33,6 +36,7 @@ export function createGatewayReloadHandlers(params: {
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
   getState: () => GatewayHotReloadState;
   setState: (state: GatewayHotReloadState) => void;
+  channelManager: ChannelManager;
   startChannel: (name: ChannelKind) => Promise<void>;
   stopChannel: (name: ChannelKind) => Promise<void>;
   logHooks: {
@@ -63,6 +67,18 @@ export function createGatewayReloadHandlers(params: {
 
     if (plan.restartHeartbeat) {
       nextState.heartbeatRunner.updateConfig(nextConfig);
+    }
+
+    if (plan.restartChannelHealthMonitor) {
+      state.channelHealthMonitor?.stop();
+      const healthCheckMinutes = nextConfig.gateway?.channelHealthCheckMinutes;
+      const healthCheckDisabled = healthCheckMinutes === 0;
+      nextState.channelHealthMonitor = healthCheckDisabled
+        ? null
+        : startChannelHealthMonitor({
+            channelManager: params.channelManager,
+            checkIntervalMs: (healthCheckMinutes ?? 5) * 60_000,
+          });
     }
 
     resetDirectoryCache();

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -656,7 +656,7 @@ export async function startGatewayServer(
 
   const healthCheckMinutes = cfgAtStart.gateway?.channelHealthCheckMinutes;
   const healthCheckDisabled = healthCheckMinutes === 0;
-  const channelHealthMonitor = healthCheckDisabled
+  let channelHealthMonitor = healthCheckDisabled
     ? null
     : startChannelHealthMonitor({
         channelManager,
@@ -841,6 +841,7 @@ export async function startGatewayServer(
             heartbeatRunner,
             cronState,
             browserControl,
+            channelHealthMonitor,
           }),
           setState: (nextState) => {
             hooksConfig = nextState.hooksConfig;
@@ -849,7 +850,9 @@ export async function startGatewayServer(
             cron = cronState.cron;
             cronStorePath = cronState.storePath;
             browserControl = nextState.browserControl;
+            channelHealthMonitor = nextState.channelHealthMonitor;
           },
+          channelManager,
           startChannel,
           stopChannel,
           logHooks,

--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -37,6 +37,13 @@ const hoisted = vi.hoisted(() => {
     updateConfig: heartbeatUpdateConfig,
   }));
 
+  const channelHealthMonitorStops: Array<ReturnType<typeof vi.fn>> = [];
+  const startChannelHealthMonitor = vi.fn(() => {
+    const stop = vi.fn();
+    channelHealthMonitorStops.push(stop);
+    return { stop };
+  });
+
   const startGmailWatcher = vi.fn(async () => ({ started: true }));
   const stopGmailWatcher = vi.fn(async () => {});
 
@@ -132,6 +139,8 @@ const hoisted = vi.hoisted(() => {
     heartbeatStop,
     heartbeatUpdateConfig,
     startHeartbeatRunner,
+    startChannelHealthMonitor,
+    channelHealthMonitorStops,
     startGmailWatcher,
     stopGmailWatcher,
     providerManager,
@@ -153,6 +162,10 @@ vi.mock("./server-browser.js", () => ({
 
 vi.mock("../infra/heartbeat-runner.js", () => ({
   startHeartbeatRunner: hoisted.startHeartbeatRunner,
+}));
+
+vi.mock("./channel-health-monitor.js", () => ({
+  startChannelHealthMonitor: hoisted.startChannelHealthMonitor,
 }));
 
 vi.mock("../hooks/gmail-watcher.js", () => ({
@@ -318,6 +331,7 @@ describe("gateway hot reload", () => {
           restartBrowserControl: true,
           restartCron: true,
           restartHeartbeat: true,
+          restartChannelHealthMonitor: false,
           restartChannels: new Set(["whatsapp", "telegram", "discord", "signal", "imessage"]),
           noopPaths: [],
         },
@@ -368,6 +382,7 @@ describe("gateway hot reload", () => {
           restartBrowserControl: false,
           restartCron: false,
           restartHeartbeat: false,
+          restartChannelHealthMonitor: false,
           restartChannels: new Set(),
           noopPaths: [],
         },
@@ -376,6 +391,41 @@ describe("gateway hot reload", () => {
       await Promise.resolve(restartResult);
 
       expect(signalSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("stops channel health monitor when channelHealthCheckMinutes is hot-reloaded to 0", async () => {
+    const startCallsBefore = hoisted.startChannelHealthMonitor.mock.calls.length;
+    const monitorStopsBefore = hoisted.channelHealthMonitorStops.length;
+    await withGatewayServer(async () => {
+      expect(hoisted.startChannelHealthMonitor.mock.calls.length).toBe(startCallsBefore + 1);
+      expect(hoisted.channelHealthMonitorStops.length).toBe(monitorStopsBefore + 1);
+      const currentMonitorStop = hoisted.channelHealthMonitorStops.at(-1);
+      expect(currentMonitorStop).toBeTypeOf("function");
+      expect(currentMonitorStop).not.toHaveBeenCalled();
+
+      const onHotReload = hoisted.getOnHotReload();
+      expect(onHotReload).toBeTypeOf("function");
+
+      await onHotReload?.(
+        {
+          changedPaths: ["gateway.channelHealthCheckMinutes"],
+          restartGateway: false,
+          restartReasons: [],
+          hotReasons: ["gateway.channelHealthCheckMinutes"],
+          reloadHooks: false,
+          restartGmailWatcher: false,
+          restartBrowserControl: false,
+          restartCron: false,
+          restartHeartbeat: false,
+          restartChannelHealthMonitor: true,
+          restartChannels: new Set(),
+          noopPaths: [],
+        },
+        { gateway: { channelHealthCheckMinutes: 0 } },
+      );
+
+      expect(currentMonitorStop).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -417,6 +467,7 @@ describe("gateway hot reload", () => {
         restartBrowserControl: false,
         restartCron: false,
         restartHeartbeat: false,
+        restartChannelHealthMonitor: false,
         restartChannels: new Set(),
         noopPaths: [],
       };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `gateway.channelHealthCheckMinutes` changes were not applied at hot-reload time, so setting it to `0` did not stop an already-running channel health monitor.
- Why it matters: operators using `gateway.reload.mode=hot` could disable health checks in config and still see monitor-driven restarts until a full process restart.
- What changed: added a dedicated hot-reload rule/action for `gateway.channelHealthCheckMinutes` and wired monitor lifecycle (stop/restart) into gateway hot-reload handlers.
- What did NOT change (scope boundary): no changes to monitor health logic/restart heuristics, no changes to other `gateway.*` reload behavior, and no channel-specific restart policy changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32105
- Related #28622

## User-visible / Behavior Changes

- When `gateway.reload.mode` is `hot`, changing `gateway.channelHealthCheckMinutes` now takes effect immediately:
- `0` stops the running monitor.
- non-zero (or unset) restarts the monitor with the updated interval.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22+, Vitest
- Model/provider: N/A
- Integration/channel (if any): Gateway channel health monitor
- Relevant config (redacted): `gateway.reload.mode=hot`, `gateway.channelHealthCheckMinutes` toggled to `0`

### Steps

1. Start gateway with health monitor enabled (`gateway.channelHealthCheckMinutes` unset or non-zero).
2. Trigger hot reload with config change setting `gateway.channelHealthCheckMinutes: 0`.
3. Observe monitor lifecycle in test harness.

### Expected

- Existing health monitor is stopped on hot reload when value becomes `0`.

### Actual

- Before this change, the existing monitor stayed active until full gateway restart.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Repro test failed before fix:
    - `pnpm -s vitest run src/gateway/server.reload.test.ts -t "stops channel health monitor when channelHealthCheckMinutes is hot-reloaded to 0"`
  - Targeted suites pass after fix:
    - `pnpm -s vitest run src/gateway/config-reload.test.ts src/gateway/server.reload.test.ts`
  - Full repo checks pass:
    - `pnpm check`
- Edge cases checked:
  - Reload-plan classification for `gateway.channelHealthCheckMinutes` is hot-action driven (not restart-gateway).
  - Existing restart-required behavior for other `gateway.*` keys remains intact.
- What you did **not** verify:
  - Live long-running channel behavior on real network channels outside test harness.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Set `gateway.reload.mode` to `restart` (or restart gateway after config changes) as immediate operational fallback.
- Files/config to restore:
  - Revert this PR's changes in gateway reload planning/handlers.
- Known bad symptoms reviewers should watch for:
  - Health monitor not restarting when `channelHealthCheckMinutes` changes from one non-zero value to another.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Monitor lifecycle could be restarted unnecessarily on frequent config edits touching the same key.
  - Mitigation:
    - Restart is only triggered when diff includes `gateway.channelHealthCheckMinutes`; behavior is bounded and covered by new reload-plan + hot-reload tests.
