### PR TITLE
infra: escape exec allowlist regex literals for metacharacter paths

### DIFF
--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -66,6 +66,31 @@ describe("exec approvals allowlist matching", () => {
     }
   });
 
+  it("matches literal allowlist paths that include regex metacharacters", () => {
+    const cases = [
+      {
+        pattern: "/usr/bin/g++",
+        resolution: {
+          rawExecutable: "g++",
+          resolvedPath: "/usr/bin/g++",
+          executableName: "g++",
+        },
+      },
+      {
+        pattern: "/opt/tools/(custom)/bin/node",
+        resolution: {
+          rawExecutable: "node",
+          resolvedPath: "/opt/tools/(custom)/bin/node",
+          executableName: "node",
+        },
+      },
+    ];
+    for (const testCase of cases) {
+      const match = matchAllowlist([{ pattern: testCase.pattern }], testCase.resolution);
+      expect(match?.pattern).toBe(testCase.pattern);
+    }
+  });
+
   it("matches bare * wildcard pattern against any resolved path", () => {
     const match = matchAllowlist([{ pattern: "*" }], baseResolution);
     expect(match).not.toBeNull();

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -111,6 +111,12 @@ function tryRealpath(value: string): string | null {
   }
 }
 
+const REGEX_LITERAL_ESCAPE_RE = /[.*+?^${}()|[\]\\]/g;
+
+function escapeRegexLiteral(value: string): string {
+  return value.replace(REGEX_LITERAL_ESCAPE_RE, "\\$&");
+}
+
 function globToRegExp(pattern: string): RegExp {
   let regex = "^";
   let i = 0;
@@ -132,7 +138,7 @@ function globToRegExp(pattern: string): RegExp {
       i += 1;
       continue;
     }
-    regex += ch.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&");
+    regex += escapeRegexLiteral(ch);
     i += 1;
   }
   regex += "$";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: exec allowlist path matching builds a regex from each path character, but the regex-escape character class was malformed, so `+` in literal paths (for example `/usr/bin/g++`) was not escaped.
- Why it matters: compiling the matcher throws `Invalid regular expression: /^/usr/bin/g++$/i: Nothing to repeat`, which breaks `system.run` allowlist evaluation on valid binaries.
- What changed: fixed regex-literal escaping in `globToRegExp()` and added regression coverage for literal paths containing regex metacharacters (`+`, `(`, `)`).
- What did NOT change (scope boundary): no changes to wildcard semantics (`*`, `**`, `?`), command resolution, exec approval policy logic, or transport/channel behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32145
- Related #

## User-visible / Behavior Changes

- Exec allowlist matching now correctly accepts literal binary paths containing regex metacharacters (for example `/usr/bin/g++`) instead of throwing during matcher compilation.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (repro is platform-agnostic string/regex logic)
- Runtime/container: Node.js 22.22.0
- Model/provider: N/A
- Integration/channel (if any): `system.run` exec allowlist path matching
- Relevant config (redacted): N/A

### Steps

1. Run:
   `node --import tsx -e 'import { matchAllowlist } from "./src/infra/exec-command-resolution.ts"; matchAllowlist([{pattern:"/usr/bin/g++"}], {rawExecutable:"g++", resolvedPath:"/usr/bin/g++", executableName:"g++"});'`
2. Observe pre-fix failure:
   `SyntaxError: Invalid regular expression: /^/usr/bin/g++$/i: Nothing to repeat`
3. Run regression test:
   `pnpm -s vitest run src/infra/exec-approvals.test.ts -t "matches literal allowlist paths that include regex metacharacters"`

### Expected

- Literal allowlist paths with regex metacharacters are matched safely.
- No regex compilation exception.

### Actual

- Before fix, matcher creation throws on `/usr/bin/g++`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced the runtime exception directly with `matchAllowlist()` and `/usr/bin/g++`.
  - Added regression test covering `/usr/bin/g++` and `/opt/tools/(custom)/bin/node`.
  - Confirmed regression test fails pre-fix and passes post-fix.
- Edge cases checked:
  - Existing wildcard/path tests in `src/infra/exec-approvals.test.ts` remain green.
- What you did **not** verify:
  - Did not run full end-to-end remote node execution flows; validation is at the allowlist matcher boundary with targeted tests + `pnpm check`.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore:
  - `src/infra/exec-command-resolution.ts`
  - `src/infra/exec-approvals.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected allowlist non-matches for literal paths with metacharacters.

## Risks and Mitigations

- Risk: escaping logic could accidentally alter wildcard matching semantics.
  - Mitigation: only non-wildcard characters are escaped; existing wildcard tests and full `exec-approvals` test suite pass.
