### PR TITLE
fix(exec): escape regex metacharacters in allowlist path matching

### DIFF
--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -90,6 +90,25 @@ describe("exec approvals allowlist matching", () => {
     });
     expect(match).toBeNull();
   });
+
+  it("handles paths with regex metacharacters (g++, clang++)", () => {
+    const gppResolution = {
+      rawExecutable: "g++",
+      resolvedPath: "/usr/bin/g++",
+      executableName: "g++",
+    };
+    const match = matchAllowlist([{ pattern: "/usr/bin/g++" }], gppResolution);
+    expect(match).not.toBeNull();
+    expect(match?.pattern).toBe("/usr/bin/g++");
+
+    const clangResolution = {
+      rawExecutable: "clang++",
+      resolvedPath: "/usr/local/bin/clang++",
+      executableName: "clang++",
+    };
+    const clangMatch = matchAllowlist([{ pattern: "/usr/local/bin/clang++" }], clangResolution);
+    expect(clangMatch).not.toBeNull();
+  });
 });
 
 describe("mergeExecApprovalsSocketDefaults", () => {

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { escapeRegExp } from "../utils.js";
 import type { ExecAllowlistEntry } from "./exec-approvals.js";
 import { resolveDispatchWrapperExecutionPlan } from "./exec-wrapper-resolution.js";
 import { resolveExecutablePath as resolveExecutableCandidatePath } from "./executable-path.js";
@@ -132,7 +133,7 @@ function globToRegExp(pattern: string): RegExp {
       i += 1;
       continue;
     }
-    regex += ch.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&");
+    regex += escapeRegExp(ch);
     i += 1;
   }
   regex += "$";


### PR DESCRIPTION
## Summary

- `globToRegExp()` in `exec-command-resolution.ts` had a broken inline regex character class (`/[.*+?^${}()|[\\]\\\\]/g`) that silently failed to escape **any** metacharacters
- Paths containing `+` (e.g. `/usr/bin/g++`, `/usr/local/bin/clang++`) produced invalid regex `^/usr/bin/g++$`, crashing with `"Nothing to repeat"`
- This blocked **all** exec operations for affected users — the agent exec bridge became completely unusable
- Fix: replace the broken inline regex with the existing `escapeRegExp()` utility from `utils.ts`, which correctly handles all metacharacters

Closes #32145

## Root cause

The character class `[.*+?^${}()|[\\]\\\\]` is mis-parsed by the JS regex engine:
- `[\\]` inside the class matches `\` then `]`, **closing the class prematurely**
- The remaining `\\\\]` becomes stray syntax outside the class
- Result: no characters are actually escaped, so `+`, `.`, `(`, etc. all pass through raw

The `escapeRegExp()` in `utils.ts` has the correct version (`/[.*+?^${}()|[\]\\]/g`) which properly escapes `]` inside the class.

## Test plan

- [x] Added regression test for `/usr/bin/g++` and `/usr/local/bin/clang++` paths
- [x] All 40 exec-approvals tests pass
- [x] `pnpm build` succeeds
- [x] End-to-end verification: `matchAllowlist([{pattern: '/usr/bin/g++'}], {resolvedPath: '/usr/bin/g++'})` returns match instead of crashing


🤖 Generated with [Claude Code](https://claude.com/claude-code)