### PR TITLE
test(security): fix flake in skill scanner cache invalidation test

### DIFF
--- a/src/security/skill-scanner.test.ts
+++ b/src/security/skill-scanner.test.ts
@@ -358,7 +358,7 @@ describe("scanDirectoryWithSummary", () => {
     expect(second.critical).toBe(first.critical);
     expect(readSpy).toHaveBeenCalledTimes(1);
 
-    await fs.writeFile(filePath, `const x = eval("2+2");`, "utf-8");
+    await fs.writeFile(filePath, `const x = eval("2+2"); // changed size`, "utf-8");
     const third = await scanDirectoryWithSummary(root);
 
     expect(third.critical).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
This PR fixes a CI flake in `src/security/skill-scanner.test.ts` where the cache invalidation test could fail if the filesystem `mtime` resolution was too low.

## Problem
The test `reuses cached findings for unchanged files and invalidates on file updates` was updating a file with content of the exact same size:
```typescript
fsSync.writeFileSync(filePath, `const x = eval("1+1");`); // 22 bytes
// ...
await fs.writeFile(filePath, `const x = eval("2+2");`, "utf-8"); // 22 bytes
```
Since the skill scanner cache uses both `size` and `mtimeMs` for invalidation, if the `writeFile` occurred within the same millisecond (or second, depending on FS resolution) as the first write, the scanner would incorrectly hit the cache, causing the `readSpy` to only be called once instead of twice.

## Solution
Change the second write to have a different file size. This ensures the cache is invalidated even if `mtimeMs` remains the same.

## Verification
- [x] **Reproduction**: Confirmed that when file size and mtime are forced to be identical, the test fails.
- [x] **Verified**: Verified that changing the file size fixes the potential flake.
- [x] **CI Checks**: `pnpm check` and `pnpm test src/security/skill-scanner.test.ts` pass locally.