### PR TITLE
fix(gateway): hot-reload channelHealthCheckMinutes without full restart

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -159,6 +159,13 @@ describe("buildGatewayReloadPlan", () => {
     );
   });
 
+  it("hot-reloads health monitor when channelHealthCheckMinutes changes", () => {
+    const plan = buildGatewayReloadPlan(["gateway.channelHealthCheckMinutes"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartHealthMonitor).toBe(true);
+    expect(plan.hotReasons).toContain("gateway.channelHealthCheckMinutes");
+  });
+
   it("treats gateway.remote as no-op", () => {
     const plan = buildGatewayReloadPlan(["gateway.remote.url"]);
     expect(plan.restartGateway).toBe(false);

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -22,6 +22,7 @@ export type GatewayReloadPlan = {
   restartBrowserControl: boolean;
   restartCron: boolean;
   restartHeartbeat: boolean;
+  restartHealthMonitor: boolean;
   restartChannels: Set<ChannelKind>;
   noopPaths: string[];
 };
@@ -38,6 +39,7 @@ type ReloadAction =
   | "restart-browser-control"
   | "restart-cron"
   | "restart-heartbeat"
+  | "restart-health-monitor"
   | `restart-channel:${ChannelId}`;
 
 const DEFAULT_RELOAD_SETTINGS: GatewayReloadSettings = {
@@ -50,6 +52,11 @@ const MISSING_CONFIG_MAX_RETRIES = 2;
 const BASE_RELOAD_RULES: ReloadRule[] = [
   { prefix: "gateway.remote", kind: "none" },
   { prefix: "gateway.reload", kind: "none" },
+  {
+    prefix: "gateway.channelHealthCheckMinutes",
+    kind: "hot",
+    actions: ["restart-health-monitor"],
+  },
   // Stuck-session warning threshold is read by the diagnostics heartbeat loop.
   { prefix: "diagnostics.stuckSessionWarnMs", kind: "none" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },
@@ -199,6 +206,7 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
     restartBrowserControl: false,
     restartCron: false,
     restartHeartbeat: false,
+    restartHealthMonitor: false,
     restartChannels: new Set(),
     noopPaths: [],
   };
@@ -224,6 +232,9 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
         break;
       case "restart-heartbeat":
         plan.restartHeartbeat = true;
+        break;
+      case "restart-health-monitor":
+        plan.restartHealthMonitor = true;
         break;
       default:
         break;

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -16,6 +16,7 @@ import {
 } from "../infra/restart.js";
 import { setCommandLaneConcurrency, getTotalQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
+import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
 import type { ChannelKind, GatewayReloadPlan } from "./config-reload.js";
 import { resolveHooksConfig } from "./hooks.js";
 import { startBrowserControlServerIfEnabled } from "./server-browser.js";
@@ -26,6 +27,7 @@ type GatewayHotReloadState = {
   heartbeatRunner: HeartbeatRunner;
   cronState: GatewayCronState;
   browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> | null;
+  channelHealthMonitor: ChannelHealthMonitor | null;
 };
 
 export function createGatewayReloadHandlers(params: {
@@ -44,6 +46,7 @@ export function createGatewayReloadHandlers(params: {
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   logCron: { error: (msg: string) => void };
   logReload: { info: (msg: string) => void; warn: (msg: string) => void };
+  createHealthMonitor: (checkIntervalMs: number) => ChannelHealthMonitor;
 }) {
   const applyHotReload = async (
     plan: GatewayReloadPlan,
@@ -88,6 +91,13 @@ export function createGatewayReloadHandlers(params: {
       } catch (err) {
         params.logBrowser.error(`server failed to start: ${String(err)}`);
       }
+    }
+
+    if (plan.restartHealthMonitor) {
+      state.channelHealthMonitor?.stop();
+      const minutes = nextConfig.gateway?.channelHealthCheckMinutes;
+      nextState.channelHealthMonitor =
+        minutes === 0 ? null : params.createHealthMonitor((minutes ?? 5) * 60_000);
     }
 
     if (plan.restartGmailWatcher) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -656,7 +656,7 @@ export async function startGatewayServer(
 
   const healthCheckMinutes = cfgAtStart.gateway?.channelHealthCheckMinutes;
   const healthCheckDisabled = healthCheckMinutes === 0;
-  const channelHealthMonitor = healthCheckDisabled
+  let channelHealthMonitor = healthCheckDisabled
     ? null
     : startChannelHealthMonitor({
         channelManager,
@@ -841,6 +841,7 @@ export async function startGatewayServer(
             heartbeatRunner,
             cronState,
             browserControl,
+            channelHealthMonitor,
           }),
           setState: (nextState) => {
             hooksConfig = nextState.hooksConfig;
@@ -849,6 +850,7 @@ export async function startGatewayServer(
             cron = cronState.cron;
             cronStorePath = cronState.storePath;
             browserControl = nextState.browserControl;
+            channelHealthMonitor = nextState.channelHealthMonitor;
           },
           startChannel,
           stopChannel,
@@ -857,6 +859,8 @@ export async function startGatewayServer(
           logChannels,
           logCron,
           logReload,
+          createHealthMonitor: (checkIntervalMs: number) =>
+            startChannelHealthMonitor({ channelManager, checkIntervalMs }),
         });
 
         return startGatewayConfigReloader({


### PR DESCRIPTION
## Problem

Setting `gateway.channelHealthCheckMinutes: 0` via hot-reload does not stop the channel health monitor — it continues running until a full gateway restart. This is because the health monitor is created once at startup in `server.impl.ts` and `applyHotReload()` has no knowledge of it.

## Fix

1. **`config-reload.ts`** — Add a `gateway.channelHealthCheckMinutes` hot-reload rule with a new `restart-health-monitor` action, so changes to this key no longer fall through to the catch-all `gateway → restart` rule.

2. **`server-reload-handlers.ts`** — Add `channelHealthMonitor` to `GatewayHotReloadState` and handle `plan.restartHealthMonitor`: stop the old monitor and create a new one with the updated interval (or `null` when set to 0).

3. **`server.impl.ts`** — Expose `channelHealthMonitor` through getState/setState and provide a `createHealthMonitor` factory so the reload handler can instantiate new monitors without directly accessing `channelManager`.

## Test plan

- [x] New test in `config-reload.test.ts`: `gateway.channelHealthCheckMinutes` triggers hot-reload with `restartHealthMonitor: true` (not a full gateway restart)
- [x] Existing `config-reload.test.ts` tests pass (17/17)
- [x] Existing `channel-health-monitor.test.ts` tests pass (21/21)
- [x] `tsgo --noEmit` clean on changed files

Closes #32105

🤖 Generated with [Claude Code](https://claude.com/claude-code)