### PR TITLE
imessage: normalize echo scope keys for sender format variants

### DIFF
--- a/src/imessage/monitor/deliver.test.ts
+++ b/src/imessage/monitor/deliver.test.ts
@@ -149,4 +149,25 @@ describe("deliverReplies", () => {
       messageId: "imsg-1",
     });
   });
+
+  it("normalizes handle targets for sent-message cache scope", async () => {
+    const remember = vi.fn();
+
+    await deliverReplies({
+      replies: [{ text: "hello" }],
+      target: "imessage:+1 (555) 555-0123",
+      client,
+      accountId: "acct-4",
+      runtime,
+      maxBytes: 2048,
+      textLimit: 4000,
+      sentMessageCache: { remember },
+    });
+
+    expect(remember).toHaveBeenCalledWith("acct-4:imessage:+15555550123", { text: "hello" });
+    expect(remember).toHaveBeenCalledWith("acct-4:imessage:+15555550123", {
+      text: "hello",
+      messageId: "imsg-1",
+    });
+  });
 });

--- a/src/imessage/monitor/deliver.ts
+++ b/src/imessage/monitor/deliver.ts
@@ -6,7 +6,22 @@ import { convertMarkdownTables } from "../../markdown/tables.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { createIMessageRpcClient } from "../client.js";
 import { sendMessageIMessage } from "../send.js";
+import { normalizeIMessageHandle, parseIMessageTarget } from "../targets.js";
 import type { SentMessageCache } from "./echo-cache.js";
+
+function buildSentMessageScope(accountId: string | undefined, target: string): string {
+  const parsedTarget = parseIMessageTarget(target);
+  if (parsedTarget.kind === "chat_id") {
+    return `${accountId ?? ""}:chat_id:${parsedTarget.chatId}`;
+  }
+  if (parsedTarget.kind === "chat_guid") {
+    return `${accountId ?? ""}:chat_guid:${parsedTarget.chatGuid}`;
+  }
+  if (parsedTarget.kind === "chat_identifier") {
+    return `${accountId ?? ""}:chat_identifier:${parsedTarget.chatIdentifier}`;
+  }
+  return `${accountId ?? ""}:imessage:${normalizeIMessageHandle(parsedTarget.to)}`;
+}
 
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
@@ -20,7 +35,7 @@ export async function deliverReplies(params: {
 }) {
   const { replies, target, client, runtime, maxBytes, textLimit, accountId, sentMessageCache } =
     params;
-  const scope = `${accountId ?? ""}:${target}`;
+  const scope = buildSentMessageScope(accountId, target);
   const cfg = loadConfig();
   const tableMode = resolveMarkdownTableMode({
     cfg,

--- a/src/imessage/monitor/inbound-processing.test.ts
+++ b/src/imessage/monitor/inbound-processing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { createSentMessageCache } from "./echo-cache.js";
 import {
   describeIMessageEchoDropLog,
   resolveIMessageInboundDecision,
@@ -45,6 +46,37 @@ describe("resolveIMessageInboundDecision echo detection", () => {
         messageId: "42",
       }),
     );
+  });
+
+  it("drops inbound echoes when sender format differs but normalized handle matches", () => {
+    const cache = createSentMessageCache();
+    cache.remember("default:imessage:+15555550123", { text: "Reasoning:\n_step_" });
+
+    const decision = resolveIMessageInboundDecision({
+      cfg,
+      accountId: "default",
+      message: {
+        id: 99,
+        sender: "+1 (555) 555-0123",
+        text: "Reasoning:\n_step_",
+        is_from_me: false,
+        is_group: false,
+      },
+      opts: undefined,
+      messageText: "Reasoning:\n_step_",
+      bodyText: "Reasoning:\n_step_",
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+      echoCache: cache,
+      logVerbose: undefined,
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "echo" });
   });
 });
 

--- a/src/imessage/monitor/inbound-processing.ts
+++ b/src/imessage/monitor/inbound-processing.ts
@@ -477,7 +477,11 @@ export function buildIMessageEchoScope(params: {
   chatId?: number;
   sender: string;
 }): string {
-  return `${params.accountId}:${params.isGroup ? formatIMessageChatTarget(params.chatId) : `imessage:${params.sender}`}`;
+  return `${params.accountId}:${
+    params.isGroup
+      ? formatIMessageChatTarget(params.chatId)
+      : `imessage:${normalizeIMessageHandle(params.sender)}`
+  }`;
 }
 
 export function describeIMessageEchoDropLog(params: {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: iMessage echo-dedupe scope used raw sender text for direct messages, so format variants of the same sender (e.g. `+1555...` vs `+1 (555) ...`) produced different cache keys.
- Why it matters: self-chat duplicate deliveries can bypass echo suppression and trigger duplicate/looped inbound processing.
- What changed: normalize sender handles in `buildIMessageEchoScope` before building the direct-message scope key.
- What did NOT change (scope boundary): dedupe TTLs, message-id matching, and group scope behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Integrations
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32166
- Related #32030

## User-visible / Behavior Changes

- iMessage self-chat duplicate notifications are more reliably suppressed when sender formatting differs across events.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): iMessage monitor
- Relevant config (redacted): `channels.imessage.dmPolicy: open`

### Steps

1. Remember an outbound echo key under scope `default:imessage:+15555550123` with text `Reasoning:\n_step_`.
2. Process inbound direct iMessage from sender `+1 (555) 555-0123` with same text.
3. Observe decision from `resolveIMessageInboundDecision(...)`.

### Expected

- Decision is `{ kind: "drop", reason: "echo" }`.

### Actual

- Before fix, decision was `dispatch` because echo scope keys did not match due sender formatting differences.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Local repro script showed dispatch instead of echo-drop with format-mismatched sender.
  - Added regression test `drops inbound echoes when sender format differs but normalized handle matches`.
  - Ran `pnpm vitest run src/imessage/monitor/inbound-processing.test.ts --config vitest.unit.config.ts`.
  - Ran `pnpm check`.
- Edge cases checked:
  - Existing echo test using message ID still passes.
- What you did **not** verify:
  - Live `imsg` runtime against physical iMessage account was not executed in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/imessage/monitor/inbound-processing.ts`
  - `src/imessage/monitor/inbound-processing.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected change in echo suppression behavior for iMessage direct messages.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Sender normalization may collapse distinct sender representations that previously produced separate scopes.
  - Mitigation:
    - Scope remains account-bound and only applies to direct-message sender segment; dedupe still requires text/message-id match and TTL windows.
