### PR TITLE
fix(config): prevent SecretRef structural fields from corrupting raw editor

### DIFF
--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -254,6 +254,29 @@ describe("redactConfigSnapshot", () => {
     expect(result.raw).toContain(REDACTED_SENTINEL);
   });
 
+  it("does not corrupt raw text when secret ref structural fields appear elsewhere", () => {
+    const config = {
+      models: {
+        providers: {
+          default: {
+            apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+            baseUrl: "https://api.openai.com",
+          },
+        },
+      },
+    };
+    const raw = JSON.stringify(config, null, 2);
+    const snapshot = makeSnapshot(config, raw);
+    const result = redactConfigSnapshot(snapshot, mainSchemaHints);
+    // The secret ref id should be redacted in the raw text
+    expect(result.raw).not.toContain("OPENAI_API_KEY");
+    // Structural fields like "default" and "env" must survive — they appear
+    // as provider names and source discriminators throughout the config.
+    expect(result.raw).toContain('"default"');
+    expect(result.raw).toContain('"env"');
+    expect(result.raw).toContain("https://api.openai.com");
+  });
+
   it("redacts parsed and resolved objects", () => {
     const snapshot = makeSnapshot({
       channels: { discord: { token: "MTIzNDU2Nzg5MDEyMzQ1Njc4.GaBcDe.FgH" } },

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -22,6 +22,16 @@ function isWholeObjectSensitivePath(path: string): boolean {
   return lowered.endsWith("serviceaccount") || lowered.endsWith("serviceaccountref");
 }
 
+/**
+ * Detect a SecretRef-shaped object (has `source` discriminator + `id`).
+ * These objects carry structural fields ("env", "default", "file") that
+ * must NOT be treated as secret values to avoid corrupting the raw config
+ * text during global string replacement.
+ */
+function isSecretRefShape(value: Record<string, unknown>): boolean {
+  return typeof value.source === "string" && typeof value.id === "string";
+}
+
 function collectSensitiveStrings(value: unknown, values: string[]): void {
   if (typeof value === "string") {
     if (!isEnvVarPlaceholder(value)) {
@@ -36,7 +46,18 @@ function collectSensitiveStrings(value: unknown, values: string[]): void {
     return;
   }
   if (value && typeof value === "object") {
-    for (const item of Object.values(value as Record<string, unknown>)) {
+    const obj = value as Record<string, unknown>;
+    // Secret refs carry structural fields (source, provider) whose values
+    // ("env", "default", "file") appear elsewhere in the config.  Collecting
+    // them causes global text replacement to corrupt unrelated fields.
+    // Only collect the `id` value — the actual secret reference.
+    if (isSecretRefShape(obj)) {
+      if (typeof obj.id === "string" && !isEnvVarPlaceholder(obj.id)) {
+        values.push(obj.id);
+      }
+      return;
+    }
+    for (const item of Object.values(obj)) {
       collectSensitiveStrings(item, values);
     }
   }


### PR DESCRIPTION
## Problem

After implementing the secrets ref schema, editing config in raw mode is broken. When a `SecretInputSchema` field contains a `SecretRefSchema` object (e.g. `{ source: "env", provider: "default", id: "OPENAI_API_KEY" }`), `collectSensitiveStrings()` recursively collects **all** string values — including structural fields like `"env"` and `"default"`.

`redactRawText()` then performs global string replacement, corrupting every occurrence of `"default"` and `"env"` throughout the raw JSON5 config. This makes the raw editor unusable and the file unsavable (schema validation fails on the mangled output).

## Root Cause

`collectSensitiveStrings()` treats all string values inside objects at sensitive paths as secret material. It doesn't distinguish between:
- **Structural fields** (`source: "env"`, `provider: "default"`) — common strings that appear everywhere in config
- **The actual secret reference** (`id: "OPENAI_API_KEY"`) — the only truly sensitive value

## Fix

Add `isSecretRefShape()` detection: when a sensitive-path object has both `source` and `id` string fields (the SecretRefSchema discriminator pattern), only collect the `id` value. The `source` and `provider` fields are structural metadata, not secrets.

**2 files changed, +45 lines** — minimal and backward compatible.

## Test plan

- [x] New test: raw text with SecretRef preserves `"default"` and `"env"` while redacting `"OPENAI_API_KEY"`
- [x] All 38 existing redaction tests pass (including the existing SecretRef object-level redaction test)
- [x] `tsgo --noEmit` clean

Closes #32164

🤖 Generated with [Claude Code](https://claude.com/claude-code)