### PR TITLE
ui: prevent final payload truncation from overwriting streamed reply

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -258,6 +258,31 @@ describe("handleChatEvent", () => {
     expect(state.chatRunId).toBe(null);
   });
 
+  it("keeps final payload when a multi-line suffix is intentional", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Intro line 1\nIntro line 2\nAnswer line 1\nAnswer line 2",
+      chatStreamStartedAt: 100,
+    });
+    const finalMsg = {
+      role: "assistant",
+      content: [{ type: "text", text: "Answer line 1\nAnswer line 2" }],
+      timestamp: 101,
+    };
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: finalMsg,
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([finalMsg]);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatRunId).toBe(null);
+  });
+
   it("appends final payload message from own run before clearing stream state", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -233,6 +233,31 @@ describe("handleChatEvent", () => {
     expect(state.chatRunId).toBe(null);
   });
 
+  it("keeps final payload when it is an intentional concise suffix", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Long draft intro\nConcise final answer",
+      chatStreamStartedAt: 100,
+    });
+    const finalMsg = {
+      role: "assistant",
+      content: [{ type: "text", text: "Concise final answer" }],
+      timestamp: 101,
+    };
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: finalMsg,
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([finalMsg]);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatRunId).toBe(null);
+  });
+
   it("appends final payload message from own run before clearing stream state", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -181,6 +181,33 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe(null);
   });
 
+  it("keeps streamed text when final payload appears truncated", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Part A\nPart B\nPart C",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Part C" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toHaveLength(1);
+    expect(state.chatMessages[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Part A\nPart B\nPart C" }],
+    });
+    expect(state.chatStream).toBe(null);
+    expect(state.chatRunId).toBe(null);
+  });
+
   it("appends final payload message from own run before clearing stream state", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -208,6 +208,31 @@ describe("handleChatEvent", () => {
     expect(state.chatRunId).toBe(null);
   });
 
+  it("keeps final payload when it is only a non-suffix substring of stream", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Draft that includes concise answer then keeps going",
+      chatStreamStartedAt: 100,
+    });
+    const finalMsg = {
+      role: "assistant",
+      content: [{ type: "text", text: "concise answer" }],
+      timestamp: 101,
+    };
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: finalMsg,
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([finalMsg]);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatRunId).toBe(null);
+  });
+
   it("appends final payload message from own run before clearing stream state", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -142,6 +142,13 @@ function shouldPreferStreamedText(
   if (!prefix.trim()) {
     return false;
   }
+  const finalLines = normalizedFinal
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (finalLines.length !== 1) {
+    return false;
+  }
   // Treat suffix-only finals as truncated only when earlier sections were already streamed.
   const prefixLines = prefix
     .split(/\r?\n/)

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -134,7 +134,20 @@ function shouldPreferStreamedText(
   if (streamed.length <= normalizedFinal.length) {
     return false;
   }
-  return streamed.endsWith(normalizedFinal);
+  if (!streamed.endsWith(normalizedFinal)) {
+    return false;
+  }
+  const suffixStart = streamed.length - normalizedFinal.length;
+  const prefix = streamed.slice(0, suffixStart);
+  if (!prefix.trim()) {
+    return false;
+  }
+  // Treat suffix-only finals as truncated only when earlier sections were already streamed.
+  const prefixLines = prefix
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  return prefixLines.length >= 2;
 }
 
 export async function sendChatMessage(

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -107,6 +107,36 @@ function normalizeFinalAssistantMessage(message: unknown): Record<string, unknow
   });
 }
 
+function createAssistantTextMessage(text: string, timestamp?: unknown): Record<string, unknown> {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    timestamp: typeof timestamp === "number" ? timestamp : Date.now(),
+  };
+}
+
+function shouldPreferStreamedText(
+  streamedText: string | null,
+  finalMessage: Record<string, unknown>,
+): boolean {
+  const streamed = streamedText?.trim();
+  if (!streamed) {
+    return false;
+  }
+  const finalText = extractText(finalMessage);
+  if (typeof finalText !== "string") {
+    return false;
+  }
+  const normalizedFinal = finalText.trim();
+  if (!normalizedFinal) {
+    return true;
+  }
+  if (streamed.length <= normalizedFinal.length) {
+    return false;
+  }
+  return streamed.includes(normalizedFinal);
+}
+
 export async function sendChatMessage(
   state: ChatState,
   message: string,
@@ -250,16 +280,16 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
     if (finalMessage) {
-      state.chatMessages = [...state.chatMessages, finalMessage];
+      if (shouldPreferStreamedText(state.chatStream, finalMessage)) {
+        state.chatMessages = [
+          ...state.chatMessages,
+          createAssistantTextMessage(state.chatStream ?? "", finalMessage.timestamp),
+        ];
+      } else {
+        state.chatMessages = [...state.chatMessages, finalMessage];
+      }
     } else if (state.chatStream?.trim()) {
-      state.chatMessages = [
-        ...state.chatMessages,
-        {
-          role: "assistant",
-          content: [{ type: "text", text: state.chatStream }],
-          timestamp: Date.now(),
-        },
-      ];
+      state.chatMessages = [...state.chatMessages, createAssistantTextMessage(state.chatStream)];
     }
     state.chatStream = null;
     state.chatRunId = null;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -134,7 +134,7 @@ function shouldPreferStreamedText(
   if (streamed.length <= normalizedFinal.length) {
     return false;
   }
-  return streamed.includes(normalizedFinal);
+  return streamed.endsWith(normalizedFinal);
 }
 
 export async function sendChatMessage(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: in webchat, streamed assistant output can be longer than the final event payload, but the controller always trusts the final payload when present.
- Why it matters: earlier rendered sections can disappear at completion, matching reports where only the last section remains visible.
- What changed: added a conservative guard in `handleChatEvent` to keep streamed text when final text is clearly truncated (stream is longer and contains the final text, or final text is empty).
- What did NOT change (scope boundary): delta accumulation, abort handling, history loading, and normal final-message preference when final is complete.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32149
- Related #32062

## User-visible / Behavior Changes

- Webchat no longer drops earlier streamed content when a shorter final assistant payload arrives.
- Users now keep the full streamed assistant reply in truncation cases instead of seeing only a tail section.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): Control UI webchat controller
- Relevant config (redacted): N/A

### Steps

1. Start with chat state where `chatStream` contains a longer assistant response (e.g. `Part A\nPart B\nPart C`).
2. Dispatch a `final` chat event for the same run with assistant text containing only a shorter tail (e.g. `Part C`).
3. Observe `chatMessages` after `handleChatEvent`.

### Expected

- The UI keeps the complete streamed assistant text and does not overwrite it with a truncated final payload.

### Actual

- Before fix, the UI appended only the shorter final payload and dropped earlier streamed sections.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run:

```bash
pnpm vitest run ui/src/ui/controllers/chat.test.ts -t "keeps streamed text when final payload appears truncated"
pnpm vitest run ui/src/ui/controllers/chat.test.ts
pnpm check
```

`pnpm check` result in this branch: fails due pre-existing upstream `main` TypeScript error in `src/discord/monitor/agent-components.ts` (TS7053), unrelated to files touched in this PR.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced overwrite using a new regression test where final text is a truncated tail of streamed text.
  - Confirmed fix keeps streamed text in that case.
  - Confirmed existing behavior still prefers final payload when final text is complete (`prefers final payload message over streamed text` test still passes).
- Edge cases checked:
  - Final with no message still falls back to stream.
  - Aborted handling unchanged and still green.
- What you did **not** verify:
  - End-to-end browser session replay against live gateway events.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `ui/src/ui/controllers/chat.ts`
  - `ui/src/ui/controllers/chat.test.ts`
- Known bad symptoms reviewers should watch for:
  - Legitimate short final replies incorrectly replaced by stream content.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Heuristic could keep stream in edge cases where final intentionally differs.
  - Mitigation:
    - Guard is strict: stream must be longer and include final text (or final text empty), limiting activation to clear truncation patterns.
