### PR TITLE
fix(slack): prevent duplicate DM processing from app_mention events

### DIFF
--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -104,6 +104,14 @@ export function registerSlackMessageEvents(params: {
       }
 
       const mention = event as SlackAppMentionEvent;
+
+      // Skip app_mention for DMs - they're already handled by message.im event
+      // This prevents duplicate processing when both message and app_mention fire for DMs
+      const channelType = mention.channel_type;
+      if (channelType === "im" || channelType === "mpim") {
+        return;
+      }
+
       await handleSlackMessage(mention as unknown as SlackMessageEvent, {
         source: "app_mention",
         wasMentioned: true,


### PR DESCRIPTION
## Summary
- **Problem:** Slack DMs are processed twice for every message because both `message.im` and `app_mention` events fire for the same DM.
- **Why it matters:** Users are charged 2x tokens/credits per DM message, wasting 50% of API costs and generating duplicate responses.
- **What changed:** Added `channel_type` check in `app_mention` handler to skip DM events (`im`/`mpim`) since they're already handled by `message.im`.
- **What did NOT change:** Channel @mention handling unchanged — this fix only affects DMs.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #(if there's an existing issue)
- Related #(if any)

## User-visible / Behavior Changes
- DM messages now process only once instead of twice.
- 50% reduction in API costs for Slack DM users.
- No change to channel @mention behavior.

## Security Impact (required)
- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment
- OS: macOS (Darwin 25.3.0)
- Runtime/container: Node.js v22.22.0
- Model/provider: Anthropic Claude (tested with both OAuth and API key)
- Integration/channel: Slack (socket mode)
- Relevant config: Standard Slack app with both `message.im` and `app_mention` events subscribed

### Steps
1. Send a DM to the OpenClaw bot in Slack.
2. Check logs for `"embedded run start"` entries.
3. Observe the same `runId` appears twice within 200–400ms.

### Expected
- One message should trigger one agent invocation with one unique `runId`.

### Actual (before fix)
- One message triggered two agent invocations with the same `runId`.

## Evidence
- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Before fix (logs from production):**
```json
// Message: "are you alive?"
{"subsystem":"agent/embedded","message":"embedded run start: runId=13cd482c-68a9-479e-81a8-20404944b14f ...","date":"2026-03-02T20:32:42.699Z"}
{"subsystem":"agent/embedded","message":"embedded run start: runId=13cd482c-68a9-479e-81a8-20404944b14f ...","date":"2026-03-02T20:32:42.954Z"}
// ^^^ SAME runId fired TWICE (255ms apart)

// After fix:
// Message: "hello"
{"subsystem":"agent/embedded","message":"embedded run start: runId=58471062-8e48-44e6-bf89-0a01837565fe ...","date":"2026-03-02T21:13:07.148Z"}
// ^^^ ONLY ONE invocation
```

## Human Verification (required)

### Verified scenarios
- DM messages to bot process only once.
- Channel @mentions still work correctly (not affected by this change).
- Group DMs (`mpim`) are also deduplicated.

### Edge cases checked
- DMs with attachments.
- DMs with mentions.
- Rapid message bursts.

### What I did NOT verify
- Thread replies in DMs (assumed to work based on `channel_type` logic).
- DMs from bots (if `allowBots: true`).

## Compatibility / Migration
- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery (if this breaks)
- How to disable/revert: Revert commit or remove the `channel_type` check from `src/slack/monitor/events/messages.ts` lines 107–113.
- Files/config to restore: Only `src/slack/monitor/events/messages.ts`.
- Known bad symptoms: If DMs stop working entirely, check for errors in gateway logs related to `channel_type` being undefined.

## Risks and Mitigations
- **Risk:** If Slack’s `channel_type` field is missing or undefined in some edge case, DMs might process twice again.
  - Mitigation: The existing `markMessageSeen()` dedupe cache still provides fallback protection.
- **Risk:** If `app_mention` is needed for some DM scenario we haven’t tested.
  - Mitigation: Easy to revert (single 6-line change). Monitor production logs after deployment.

## References


