### PR TITLE
fix(exec): escape regex metacharacters in binary paths (#32145)

### DIFF
--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -82,6 +82,83 @@ describe("exec approvals allowlist matching", () => {
     expect(match?.pattern).toBe("*");
   });
 
+  it("matches paths with regex metacharacters (+, ., (, ), [, ], {, }, ?, |)", () => {
+    // Regression test for #32145 - binary paths containing + (g++, clang++)
+    // should not break regex compilation
+    const gppResolution = {
+      rawExecutable: "g++",
+      resolvedPath: "/usr/bin/g++",
+      executableName: "g++",
+    };
+    const clangppResolution = {
+      rawExecutable: "clang++",
+      resolvedPath: "/usr/local/bin/clang++",
+      executableName: "clang++",
+    };
+
+    // Test exact path matching with +
+    const gppMatch = matchAllowlist([{ pattern: "/usr/bin/g++" }], gppResolution);
+    expect(gppMatch).not.toBeNull();
+    expect(gppMatch?.pattern).toBe("/usr/bin/g++");
+
+    // Test wildcard matching with +
+    const wildcardMatch = matchAllowlist([{ pattern: "/usr/bin/g++" }], {
+      rawExecutable: "g++",
+      resolvedPath: "/usr/bin/g++-14",
+      executableName: "g++-14",
+    });
+    expect(wildcardMatch).toBeNull();
+
+    // Test clang++ path
+    const clangMatch = matchAllowlist([{ pattern: "/usr/local/bin/clang++" }], clangppResolution);
+    expect(clangMatch).not.toBeNull();
+    expect(clangMatch?.pattern).toBe("/usr/local/bin/clang++");
+  });
+
+  it("handles paths with various regex metacharacters (. () [] { } ? |)", () => {
+    // Additional regression tests for paths containing other regex metacharacters
+    const testCases = [
+      // Paths with parentheses
+      {
+        pattern: "/opt/tools/(custom)/bin/node",
+        resolvedPath: "/opt/tools/(custom)/bin/node",
+        shouldMatch: true,
+      },
+      {
+        pattern: "/opt/tools/(custom)/bin/*",
+        resolvedPath: "/opt/tools/(custom)/bin/node",
+        shouldMatch: true,
+      },
+      // Paths with square brackets
+      {
+        pattern: "/usr/local/bin/app[64]",
+        resolvedPath: "/usr/local/bin/app[64]",
+        shouldMatch: true,
+      },
+      // Paths with curly braces
+      { pattern: "/usr/bin/{gcc,g++}", resolvedPath: "/usr/bin/g++", shouldMatch: false }, // curly brace glob not supported
+      // Paths with pipe (escaped in regex)
+      { pattern: "/usr/bin/cmd|a", resolvedPath: "/usr/bin/cmd|a", shouldMatch: true },
+      // Paths with question mark
+      { pattern: "/usr/bin/file?.txt", resolvedPath: "/usr/bin/file1.txt", shouldMatch: true },
+    ];
+
+    for (const tc of testCases) {
+      const resolution = {
+        rawExecutable: tc.resolvedPath.split("/").pop() || "",
+        resolvedPath: tc.resolvedPath,
+        executableName: tc.resolvedPath.split("/").pop() || "",
+      };
+      const match = matchAllowlist([{ pattern: tc.pattern }], resolution);
+      if (tc.shouldMatch) {
+        expect(match).not.toBeNull();
+      } else {
+        // Some patterns may not match as expected due to glob vs regex differences
+        // Just verify no exception is thrown
+      }
+    }
+  });
+
   it("requires a resolved path", () => {
     const match = matchAllowlist([{ pattern: "bin/rg" }], {
       rawExecutable: "bin/rg",

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { escapeRegExp } from "../utils.js";
 import type { ExecAllowlistEntry } from "./exec-approvals.js";
 import { resolveDispatchWrapperExecutionPlan } from "./exec-wrapper-resolution.js";
 import { resolveExecutablePath as resolveExecutableCandidatePath } from "./executable-path.js";
@@ -132,7 +133,7 @@ function globToRegExp(pattern: string): RegExp {
       i += 1;
       continue;
     }
-    regex += ch.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&");
+    regex += escapeRegExp(ch);
     i += 1;
   }
   regex += "$";


### PR DESCRIPTION
Fixes #32145