### PR TITLE
fix(mac): default to universal binary for release builds

### DIFF
--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -29,7 +29,7 @@ Notes:
 - `APP_BUILD` maps to `CFBundleVersion`/`sparkle:version`; keep it numeric + monotonic (no `-beta`), or Sparkle compares it as equal.
 - If `APP_BUILD` is omitted, `scripts/package-mac-app.sh` derives a Sparkle-safe default from `APP_VERSION` (`YYYYMMDDNN`: stable defaults to `90`, prereleases use a suffix-derived lane) and uses the higher of that value and git commit count.
 - You can still override `APP_BUILD` explicitly when release engineering needs a specific monotonic value.
-- Defaults to the current architecture (`$(uname -m)`). For release/universal builds, set `BUILD_ARCHS="arm64 x86_64"` (or `BUILD_ARCHS=all`).
+- Release builds (`BUILD_CONFIG=release`) now default to universal binary (`arm64 x86_64`). Debug builds default to the current architecture (`$(uname -m)`). You can still override with `BUILD_ARCHS="arm64"` or `BUILD_ARCHS="x86_64"` if needed.
 - Use `scripts/package-mac-dist.sh` for release artifacts (zip + DMG + notarization). Use `scripts/package-mac-app.sh` for local/dev packaging.
 
 ```bash

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -16,7 +16,11 @@ GIT_BUILD_NUMBER=$(cd "$ROOT_DIR" && git rev-list --count HEAD 2>/dev/null || ec
 APP_VERSION="${APP_VERSION:-$PKG_VERSION}"
 APP_BUILD="${APP_BUILD:-}"
 BUILD_CONFIG="${BUILD_CONFIG:-debug}"
-BUILD_ARCHS_VALUE="${BUILD_ARCHS:-$(uname -m)}"
+if [[ "${BUILD_CONFIG}" == "release" ]]; then
+  BUILD_ARCHS_VALUE="${BUILD_ARCHS:-all}"
+else
+  BUILD_ARCHS_VALUE="${BUILD_ARCHS:-$(uname -m)}"
+fi
 if [[ "${BUILD_ARCHS_VALUE}" == "all" ]]; then
   BUILD_ARCHS_VALUE="arm64 x86_64"
 fi


### PR DESCRIPTION


  ## Summary
  - Release builds (`BUILD_CONFIG=release`) in `package-mac-app.sh` now default to `BUILD_ARCHS=all` (universal binary)
  instead of `$(uname -m)`
  - Prevents accidental arm64-only releases when building on Apple Silicon
  - Debug builds keep the fast host-arch-only default

  ## Root cause
  v2026.2.26 was built by running `package-mac-app.sh` directly on an ARM Mac. Without `BUILD_ARCHS=all`, it defaulted
  to `arm64`, producing a binary that crashes on Intel Macs.

  ## Test plan
  - [ ] On ARM Mac: `BUILD_CONFIG=release scripts/package-mac-app.sh` → verify `lipo -info` shows both arm64 and x86_64
  - [ ] On ARM Mac: `scripts/package-mac-app.sh` (debug) → verify only arm64
  - [ ] `BUILD_ARCHS=arm64 BUILD_CONFIG=release scripts/package-mac-app.sh` → verify override still works

  Fixes #28877
