### PR TITLE
fix(security): enforce ACP sandbox inheritance for cross-agent spawns

### DIFF
--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -53,6 +53,10 @@ export type SpawnAcpContext = {
   agentAccountId?: string;
   agentTo?: string;
   agentThreadId?: string | number;
+  /** Override the requester agent ID for sandbox checks in cron/hook contexts where
+   *  agentSessionKey is not agent-scoped and would otherwise fall back to the default agent.
+   *  Mirrors requesterAgentIdOverride in SpawnSubagentContext. */
+  requesterAgentIdOverride?: string;
 };
 
 export type SpawnAcpResult = {
@@ -267,9 +271,15 @@ export async function spawnAcpDirect(
   // Sandbox inheritance guard: mirror the subagent spawn check so sandboxed
   // sessions cannot escape their isolation boundary via the ACP runtime path.
   const sandboxMode = params.sandbox === "require" ? "require" : "inherit";
+  // When the requester session key is non-agent-scoped (cron/hook contexts), agentId resolution
+  // falls back to the config default agent which may be wrong.  Use requesterAgentIdOverride to
+  // construct a proper agent-scoped key so sandbox config is looked up for the correct agent.
+  const requesterKeyForSandbox = ctx.requesterAgentIdOverride
+    ? `agent:${normalizeAgentId(ctx.requesterAgentIdOverride)}:main:0`
+    : ctx.agentSessionKey;
   const requesterRuntime = resolveSandboxRuntimeStatus({
     cfg,
-    sessionKey: ctx.agentSessionKey,
+    sessionKey: requesterKeyForSandbox,
   });
   const childRuntime = resolveSandboxRuntimeStatus({
     cfg,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -32,6 +32,7 @@ import {
 } from "../infra/outbound/session-binding-service.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
+import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 
 export const ACP_SPAWN_MODES = ["run", "session"] as const;
 export type SpawnAcpMode = (typeof ACP_SPAWN_MODES)[number];
@@ -43,6 +44,7 @@ export type SpawnAcpParams = {
   cwd?: string;
   mode?: SpawnAcpMode;
   thread?: boolean;
+  sandbox?: "inherit" | "require";
 };
 
 export type SpawnAcpContext = {
@@ -261,6 +263,33 @@ export async function spawnAcpDirect(
   }
 
   const sessionKey = `agent:${targetAgentId}:acp:${crypto.randomUUID()}`;
+
+  // Sandbox inheritance guard: mirror the subagent spawn check so sandboxed
+  // sessions cannot escape their isolation boundary via the ACP runtime path.
+  const sandboxMode = params.sandbox === "require" ? "require" : "inherit";
+  const requesterRuntime = resolveSandboxRuntimeStatus({
+    cfg,
+    sessionKey: ctx.agentSessionKey,
+  });
+  const childRuntime = resolveSandboxRuntimeStatus({
+    cfg,
+    sessionKey,
+  });
+  if (!childRuntime.sandboxed && (requesterRuntime.sandboxed || sandboxMode === "require")) {
+    if (requesterRuntime.sandboxed) {
+      return {
+        status: "forbidden",
+        error:
+          "Sandboxed sessions cannot spawn unsandboxed ACP sessions. Set a sandboxed target agent or use the same agent runtime.",
+      };
+    }
+    return {
+      status: "forbidden",
+      error:
+        'sessions_spawn sandbox="require" needs a sandboxed target runtime. Pick a sandboxed agentId or use sandbox="inherit".',
+    };
+  }
+
   const runtimeMode = resolveAcpSessionMode(spawnMode);
 
   let preparedBinding: PreparedAcpThreadBinding | null = null;

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -246,6 +246,10 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
           },
         },
         list: [
+          // "main" must be listed explicitly so resolveDefaultAgentId returns "main"
+          // rather than "research"; otherwise the requester sandbox check uses research's
+          // mode:"off" config and never fires the sandboxed-requester guard.
+          { id: "main" },
           {
             id: "research",
             sandbox: {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -223,4 +223,70 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     expect(details.error).toContain('sandbox="require"');
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
+
+  // ACP sandbox inheritance guard (GHSA-p7gr-f84w-hqg5)
+  async function executeAcpSpawn(callId: string, agentId: string, sandbox?: "inherit" | "require") {
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "main",
+      agentChannel: "whatsapp",
+    });
+    return tool.execute(callId, { task: "do thing", agentId, runtime: "acp", sandbox });
+  }
+
+  it("forbids sandboxed session from spawning unsandboxed ACP session (GHSA-p7gr-f84w-hqg5)", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+          },
+        },
+        list: [
+          {
+            id: "research",
+            sandbox: {
+              mode: "off",
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await executeAcpSpawn("call13", "research");
+    const details = result.details as { status?: string; error?: string };
+
+    expect(details.status).toBe("forbidden");
+    expect(details.error).toContain("Sandboxed sessions cannot spawn unsandboxed ACP sessions.");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it('forbids ACP sandbox="require" when target ACP agent is unsandboxed', async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        list: [
+          {
+            id: "research",
+            sandbox: {
+              mode: "off",
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await executeAcpSpawn("call14", "research", "require");
+    const details = result.details as { status?: string; error?: string };
+
+    expect(details.status).toBe("forbidden");
+    expect(details.error).toContain('sandbox="require"');
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -142,6 +142,7 @@ export function createSessionsSpawnTool(opts?: {
             agentAccountId: opts?.agentAccountId,
             agentTo: opts?.agentTo,
             agentThreadId: opts?.agentThreadId,
+            requesterAgentIdOverride: opts?.requesterAgentIdOverride,
           },
         );
         return jsonResult(result);

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -134,6 +134,7 @@ export function createSessionsSpawnTool(opts?: {
             cwd,
             mode: mode && ACP_SPAWN_MODES.includes(mode) ? mode : undefined,
             thread,
+            sandbox,
           },
           {
             agentSessionKey: opts?.agentSessionKey,

--- a/src/browser/server.auth-fail-closed.test.ts
+++ b/src/browser/server.auth-fail-closed.test.ts
@@ -12,13 +12,12 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/config.js")>();
-  const browserConfig = {
-    enabled: true,
-  };
   return {
     ...actual,
     loadConfig: () => ({
-      browser: browserConfig,
+      browser: {
+        enabled: true,
+      },
     }),
   };
 });


### PR DESCRIPTION
## Summary
- enforce sandbox inheritance in ACP runtime spawn so cross-agent spawns cannot elevate beyond parent constraints
- add follow-up hardening from codex review
- fail closed when browser auth bootstrap cannot establish safe defaults

## Context
- addresses GHSA-p7gr-f84w-hqg5
- replaces orphaned closed PR #32066

## Testing
- existing security and ACP test suites on this branch
