### PR TITLE
fix(daemon): default NODE_USE_SYSTEM_CA=1 on macOS for enterprise TLS

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -354,6 +354,33 @@ describe("buildServiceEnvironment", () => {
     });
     expect(env.NODE_EXTRA_CA_CERTS).toBe("/custom/certs/ca.pem");
   });
+
+  it("defaults NODE_USE_SYSTEM_CA=1 on macOS", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user" },
+      port: 18789,
+      platform: "darwin",
+    });
+    expect(env.NODE_USE_SYSTEM_CA).toBe("1");
+  });
+
+  it("does not default NODE_USE_SYSTEM_CA on non-macOS", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user" },
+      port: 18789,
+      platform: "linux",
+    });
+    expect(env.NODE_USE_SYSTEM_CA).toBeUndefined();
+  });
+
+  it("respects user-provided NODE_USE_SYSTEM_CA over the default", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user", NODE_USE_SYSTEM_CA: "0" },
+      port: 18789,
+      platform: "darwin",
+    });
+    expect(env.NODE_USE_SYSTEM_CA).toBe("0");
+  });
 });
 
 describe("buildNodeServiceEnvironment", () => {
@@ -448,6 +475,30 @@ describe("buildNodeServiceEnvironment", () => {
       env: { HOME: "/home/user", NODE_EXTRA_CA_CERTS: "/custom/certs/ca.pem" },
     });
     expect(env.NODE_EXTRA_CA_CERTS).toBe("/custom/certs/ca.pem");
+  });
+
+  it("defaults NODE_USE_SYSTEM_CA=1 on macOS for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user" },
+      platform: "darwin",
+    });
+    expect(env.NODE_USE_SYSTEM_CA).toBe("1");
+  });
+
+  it("does not default NODE_USE_SYSTEM_CA on non-macOS for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user" },
+      platform: "linux",
+    });
+    expect(env.NODE_USE_SYSTEM_CA).toBeUndefined();
+  });
+
+  it("respects user-provided NODE_USE_SYSTEM_CA for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user", NODE_USE_SYSTEM_CA: "0" },
+      platform: "darwin",
+    });
+    expect(env.NODE_USE_SYSTEM_CA).toBe("0");
   });
 });
 

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -251,6 +251,7 @@ export function buildServiceEnvironment(params: {
     PATH: sharedEnv.minimalPath,
     ...sharedEnv.proxyEnv,
     NODE_EXTRA_CA_CERTS: sharedEnv.nodeCaCerts,
+    NODE_USE_SYSTEM_CA: sharedEnv.nodeUseSystemCa,
     OPENCLAW_PROFILE: profile,
     OPENCLAW_STATE_DIR: sharedEnv.stateDir,
     OPENCLAW_CONFIG_PATH: sharedEnv.configPath,
@@ -279,6 +280,7 @@ export function buildNodeServiceEnvironment(params: {
     PATH: sharedEnv.minimalPath,
     ...sharedEnv.proxyEnv,
     NODE_EXTRA_CA_CERTS: sharedEnv.nodeCaCerts,
+    NODE_USE_SYSTEM_CA: sharedEnv.nodeUseSystemCa,
     OPENCLAW_STATE_DIR: sharedEnv.stateDir,
     OPENCLAW_CONFIG_PATH: sharedEnv.configPath,
     OPENCLAW_GATEWAY_TOKEN: gatewayToken,
@@ -303,6 +305,7 @@ function resolveSharedServiceEnvironmentFields(
   minimalPath: string;
   proxyEnv: Record<string, string | undefined>;
   nodeCaCerts: string | undefined;
+  nodeUseSystemCa: string | undefined;
 } {
   const stateDir = env.OPENCLAW_STATE_DIR;
   const configPath = env.OPENCLAW_CONFIG_PATH;
@@ -314,6 +317,7 @@ function resolveSharedServiceEnvironmentFields(
   // works correctly when running as a LaunchAgent without extra user configuration.
   const nodeCaCerts =
     env.NODE_EXTRA_CA_CERTS ?? (platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
+  const nodeUseSystemCa = env.NODE_USE_SYSTEM_CA ?? (platform === "darwin" ? "1" : undefined);
   return {
     stateDir,
     configPath,
@@ -321,5 +325,6 @@ function resolveSharedServiceEnvironmentFields(
     minimalPath: buildMinimalServicePath({ env }),
     proxyEnv,
     nodeCaCerts,
+    nodeUseSystemCa,
   };
 }


### PR DESCRIPTION
### Problem
On macOS, supervised services (launchd) often do not inherit a shell environment. For enterprise setups that install a corporate root CA into the System Keychain, Node should be able to trust the system certificate store so TLS works without extra manual configuration.

### Fix
- Default `NODE_USE_SYSTEM_CA=1` on macOS (darwin) for daemon-managed gateway/node services when not already set in the environment.
- Forward `NODE_USE_SYSTEM_CA` through both `buildServiceEnvironment` and `buildNodeServiceEnvironment`.

This is complementary to the existing `NODE_EXTRA_CA_CERTS` macOS fallback (see #27915).

### Node version behavior
`NODE_USE_SYSTEM_CA` is supported in Node.js **v22.19.0+** and **v24.6.0+** (ignored on older versions).

### Tests
- Adds unit coverage for:
  - macOS default to `"1"`
  - env value precedence (e.g. `"0"`)
  - non-macOS remains `undefined`
  - included in both service env builders

### AI-assisted contribution

This PR was **AI-assisted** (OpenClaw agent + LLM) for drafting/iteration, with human review.

**Testing:** lightly tested  
- Unit tests added/updated and run locally (vitest unit tests).

**What it does (author understands the change):**  
Defaults `NODE_USE_SYSTEM_CA=1` on macOS for daemon-supervised services so Node trusts the macOS system certificate store (useful for enterprise CA installs). Also forwards user-provided `NODE_USE_SYSTEM_CA` through service env builders.

**Prompts/logs:** not included (happy to provide additional context if helpful).
