### PR TITLE
docs(contributing): require before/after screenshots for UI PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,6 +391,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Changes
+
+- Docs/Contributing: require before/after screenshots for UI or visual PRs in the pre-PR checklist. (#32206) Thanks @hydro13.
+
 ### Fixes
 
 - Feishu/Multi-account + reply reliability: add `channels.feishu.defaultAccount` outbound routing support with schema validation, prevent inbound preview text from leaking into prompt system events, keep quoted-message extraction text-first (post/interactive/file placeholders instead of raw JSON), route Feishu video sends as `msg_type: "file"`, and avoid websocket event blocking by using non-blocking event handling in monitor dispatch. Landed from contributor PRs #31209, #29610, #30432, #30331, and #29501. Thanks @stakeswky, @hclsys, @bmendonca3, @patrick-yingxi-pan, and @zwffff.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,7 @@ Welcome to the lobster tank! 🦞
 - Ensure CI checks pass
 - Keep PRs focused (one thing per PR; do not mix unrelated concerns)
 - Describe what & why
+- **Include screenshots** — one showing the problem/before, one showing the fix/after (for UI or visual changes)
 
 ## Control UI Decorators
 


### PR DESCRIPTION
Came up during the Weekly Claw stream tonight — reviewers asked for screenshots in PRs. Makes sense: a before/after screenshot tells you instantly whether a fix actually worked.

Added one line to the **Before You PR** checklist:

```
- Include screenshots — one showing the problem/before, one showing the fix/after (for UI or visual changes)
```