### PR TITLE
telegram: isolate DM sessions by sender id when chat.id differs

### DIFF
--- a/src/telegram/bot-message-context.dm-threads.test.ts
+++ b/src/telegram/bot-message-context.dm-threads.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
 import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
 
 describe("buildTelegramMessageContext dm thread sessions", () => {
@@ -102,5 +103,47 @@ describe("buildTelegramMessageContext group sessions without forum", () => {
     // Session key SHOULD include :topic:99 for forums
     expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:telegram:group:-1001234567890:topic:99");
     expect(ctx?.ctxPayload?.MessageThreadId).toBe(99);
+  });
+});
+
+describe("buildTelegramMessageContext direct peer routing", () => {
+  afterEach(() => {
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("isolates dm sessions by sender id when chat id differs", async () => {
+    const runtimeCfg = {
+      agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+      channels: { telegram: {} },
+      messages: { groupChat: { mentionPatterns: [] } },
+      session: { dmScope: "per-channel-peer" as const },
+    };
+    setRuntimeConfigSnapshot(runtimeCfg);
+
+    const baseMessage = {
+      chat: { id: 777777777, type: "private" as const },
+      date: 1700000000,
+      text: "hello",
+    };
+
+    const first = await buildTelegramMessageContextForTest({
+      cfg: runtimeCfg,
+      message: {
+        ...baseMessage,
+        message_id: 1,
+        from: { id: 123456789, first_name: "Alice" },
+      },
+    });
+    const second = await buildTelegramMessageContextForTest({
+      cfg: runtimeCfg,
+      message: {
+        ...baseMessage,
+        message_id: 2,
+        from: { id: 987654321, first_name: "Bob" },
+      },
+    });
+
+    expect(first?.ctxPayload?.SessionKey).toBe("agent:main:telegram:direct:123456789");
+    expect(second?.ctxPayload?.SessionKey).toBe("agent:main:telegram:direct:987654321");
   });
 });

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -52,6 +52,7 @@ import {
   buildGroupLabel,
   buildSenderLabel,
   buildSenderName,
+  resolveTelegramDirectPeerId,
   buildTelegramGroupFrom,
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
@@ -174,6 +175,7 @@ export const buildTelegramMessageContext = async ({
   const msg = primaryCtx.message;
   const chatId = msg.chat.id;
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
+  const senderId = msg.from?.id ? String(msg.from.id) : "";
   const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
   const isForum = (msg.chat as { is_forum?: boolean }).is_forum === true;
   const threadSpec = resolveTelegramThreadSpec({
@@ -191,7 +193,9 @@ export const buildTelegramMessageContext = async ({
     !isGroup && groupConfig && "dmPolicy" in groupConfig
       ? (groupConfig.dmPolicy ?? dmPolicy)
       : dmPolicy;
-  const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
+  const peerId = isGroup
+    ? buildTelegramGroupPeerId(chatId, resolvedThreadId)
+    : resolveTelegramDirectPeerId({ chatId, senderId });
   const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
   // Fresh config for bindings lookup; other routing inputs are payload-derived.
   const route = resolveAgentRoute({
@@ -235,7 +239,6 @@ export const buildTelegramMessageContext = async ({
   // Group sender checks are explicit and must not inherit DM pairing-store entries.
   const effectiveGroupAllow = normalizeAllowFrom(groupAllowOverride ?? groupAllowFrom);
   const hasGroupAllowOverride = typeof groupAllowOverride !== "undefined";
-  const senderId = msg.from?.id ? String(msg.from.id) : "";
   const senderUsername = msg.from?.username ?? "";
   const baseAccess = evaluateTelegramGroupBaseAccess({
     isGroup,

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   describeReplyTarget,
   expandTextLinks,
   normalizeForwardedContext,
+  resolveTelegramDirectPeerId,
   resolveTelegramForumThreadId,
 } from "./helpers.js";
 
@@ -50,6 +51,20 @@ describe("buildTypingThreadParams", () => {
     { input: 1, expected: { message_thread_id: 1 } },
   ])("builds typing params", ({ input, expected }) => {
     expect(buildTypingThreadParams(input)).toEqual(expected);
+  });
+});
+
+describe("resolveTelegramDirectPeerId", () => {
+  it("prefers sender id when available", () => {
+    expect(resolveTelegramDirectPeerId({ chatId: 777777777, senderId: 123456789 })).toBe(
+      "123456789",
+    );
+  });
+
+  it("falls back to chat id when sender id is missing", () => {
+    expect(resolveTelegramDirectPeerId({ chatId: 777777777, senderId: undefined })).toBe(
+      "777777777",
+    );
   });
 });
 

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -175,6 +175,24 @@ export function buildTelegramGroupPeerId(chatId: number | string, messageThreadI
   return messageThreadId != null ? `${chatId}:topic:${messageThreadId}` : String(chatId);
 }
 
+/**
+ * Resolve the direct-message peer identifier for Telegram routing/session keys.
+ *
+ * In some Telegram DM deliveries (for example certain business/chat bridge flows),
+ * `chat.id` can differ from the actual sender user id. Prefer sender id when present
+ * so per-peer DM scopes isolate users correctly.
+ */
+export function resolveTelegramDirectPeerId(params: {
+  chatId: number | string;
+  senderId?: number | string | null;
+}) {
+  const senderId = params.senderId != null ? String(params.senderId).trim() : "";
+  if (senderId) {
+    return senderId;
+  }
+  return String(params.chatId);
+}
+
 export function buildTelegramGroupFrom(chatId: number | string, messageThreadId?: number) {
   return `telegram:group:${buildTelegramGroupPeerId(chatId, messageThreadId)}`;
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram DM routing keyed direct peers by `chat.id`, which can differ from the actual sender id in some private-chat deliveries.
- Why it matters: With `session.dmScope=per-channel-peer`, different users can collapse into the same DM session key, mixing context/history.
- What changed: DM peer routing now prefers sender id (when present) and falls back to `chat.id`; added regression coverage for this routing path.
- What did NOT change (scope boundary): No changes to group/forum routing, message delivery behavior, command handling semantics, or non-Telegram channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31984
- Related #32103

## User-visible / Behavior Changes

- Telegram DMs now isolate session keys by sender id when sender id and chat id differ.
- For DMs where sender id is absent, behavior remains unchanged (falls back to `chat.id`).

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - Risk: Session-key selection in Telegram DMs changes for the sender-id-differs edge case.
  - Mitigation: Fallback to previous `chat.id` behavior when sender id is missing; regression test added for both preferred and fallback paths.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A (routing layer)
- Integration/channel (if any): Telegram
- Relevant config (redacted): `session.dmScope: "per-channel-peer"`

### Steps

1. Configure runtime config with `session.dmScope="per-channel-peer"`.
2. Build two Telegram DM inbound contexts with identical `chat.id` and different `from.id`.
3. Inspect `ctxPayload.SessionKey` for each message.

### Expected

- Distinct DM session keys per sender.

### Actual

- Before fix: both messages resolved to `agent:main:telegram:direct:<chat.id>`.
- After fix: messages resolve to `agent:main:telegram:direct:<sender.id>`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced collision locally with a direct script using two DM senders on one `chat.id`.
  - Confirmed new regression test passes with distinct session keys.
- Edge cases checked:
  - Sender id present: sender id wins.
  - Sender id missing: fallback remains `chat.id`.
- What you did **not** verify:
  - Live Telegram traffic against real bot tokens.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `8dbc9bd85b793d92ee3b17aed4f5006d31838fed`.
- Files/config to restore:
  - `src/telegram/bot/helpers.ts`
  - `src/telegram/bot-message-context.ts`
  - `src/telegram/bot/helpers.test.ts`
  - `src/telegram/bot-message-context.dm-threads.test.ts`
- Known bad symptoms reviewers should watch for:
  - DM sessions unexpectedly collapsing for sender-id-differs Telegram messages.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Existing installs depending on `chat.id`-based DM grouping for sender-id-differs traffic may observe split sessions.
  - Mitigation: Change is limited to direct peer id selection; fallback behavior is preserved when sender id is unavailable; regression coverage added.
