### PR TITLE
fix(slack): filter inherited parent files from thread replies

### DIFF
--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -512,8 +512,32 @@ export async function prepareSlackMessage(params: {
     return null;
   }
 
+  // When processing a thread reply, filter out files that belong to the thread
+  // starter (parent message). Slack's Events API includes the parent's `files`
+  // array in every thread reply payload, which causes ghost media attachments
+  // on text-only replies. We eagerly resolve the thread starter here (the result
+  // is cached) and exclude any file IDs that match the parent. (#32203)
+  let ownFiles = message.files;
+  if (isThreadReply && threadTs && message.files?.length) {
+    const starter = await resolveSlackThreadStarter({
+      channelId: message.channel,
+      threadTs,
+      client: ctx.app.client,
+    });
+    if (starter?.files?.length) {
+      const starterFileIds = new Set(starter.files.map((f) => f.id));
+      const filtered = message.files.filter((f) => !f.id || !starterFileIds.has(f.id));
+      if (filtered.length < message.files.length) {
+        logVerbose(
+          `slack: filtered ${message.files.length - filtered.length} inherited parent file(s) from thread reply`,
+        );
+      }
+      ownFiles = filtered.length > 0 ? filtered : undefined;
+    }
+  }
+
   const media = await resolveSlackMedia({
-    files: message.files,
+    files: ownFiles,
     token: ctx.botToken,
     maxBytes: ctx.mediaMaxBytes,
   });


### PR DESCRIPTION
## Summary

Fixes #32203 — Slack thread replies were re-attaching the parent message's files as ghost media on every text-only reply.

## Problem

Slack's Events API includes the parent message's `files` array in every thread reply event payload. OpenClaw treated these as new attachments, causing:
- Duplicate file downloads (same file re-downloaded with new UUID each time)
- AI model confusion (thinks user sent an image when they sent text only)
- Wasted disk space (~756KB × N replies for each thread with images)

## Fix

Before calling `resolveSlackMedia`, thread replies now filter `message.files` against the thread starter's file IDs. Files belonging to the parent are excluded.

Key details:
- Uses `resolveSlackThreadStarter()` which is **already cached** — no extra API calls
- Compares by Slack file ID (reliable, unique per upload)
- Files without an ID are preserved (defensive)
- Logs filtered files at verbose level for debugging
- Only 1 file changed, 25 insertions, 1 deletion

## Testing

Verified with SHA-1 comparison: 19 thread replies in a test conversation all had byte-identical files (`11a7baac...`) re-downloaded as separate UUIDs. With this fix, only the reply that actually contains the file would trigger a download.