### PR TITLE
status: report latest runtime model when selected model drifts

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -334,6 +334,31 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("(rate limit)");
   });
 
+  it("prefers latest runtime model when selected model drifts without fallback state", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "github-copilot/claude-haiku-4-5",
+        contextTokens: 32_000,
+      },
+      sessionEntry: {
+        sessionId: "runtime-drift-no-fallback",
+        updatedAt: 0,
+        modelProvider: "minimax-portal",
+        model: "MiniMax-M2.5",
+      },
+      sessionKey: "agent:main:discord:channel:123",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "oauth",
+      activeModelAuth: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Model: minimax-portal/MiniMax-M2.5");
+    expect(normalized).toContain("latest run");
+    expect(normalized).not.toContain("Fallback:");
+  });
+
   it("omits active lines when runtime matches selected model", () => {
     const text = buildStatusMessage({
       agent: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -662,7 +662,7 @@ export function buildStatusMessage(args: StatusArgs): string {
       : ""
     : selectedAuthLabel;
   const modelNoteParts: string[] = [];
-  if (channelModelNote) {
+  if (channelModelNote && !shouldPreferRuntimeModel) {
     modelNoteParts.push(channelModelNote);
   }
   if (shouldPreferRuntimeModel) {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -609,6 +609,12 @@ export function buildStatusMessage(args: StatusArgs): string {
   const costLabel = showCost && hasUsage ? formatUsd(cost) : undefined;
 
   const selectedAuthLabel = selectedAuthLabelValue ? ` · 🔑 ${selectedAuthLabelValue}` : "";
+  const hasFallbackHints = Boolean(
+    entry?.fallbackNoticeSelectedModel?.trim() || entry?.fallbackNoticeActiveModel?.trim(),
+  );
+  const hasManualModelOverride = Boolean(
+    entry?.providerOverride?.trim() || entry?.modelOverride?.trim(),
+  );
   const channelModelNote = (() => {
     if (!args.config || !entry) {
       return undefined;
@@ -647,8 +653,23 @@ export function buildStatusMessage(args: StatusArgs): string {
     }
     return "channel override";
   })();
-  const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
-  const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`;
+  const shouldPreferRuntimeModel =
+    modelRefs.activeDiffers && !hasFallbackHints && !hasManualModelOverride;
+  const displayedModelLabel = shouldPreferRuntimeModel ? activeModelLabel : selectedModelLabel;
+  const displayedAuthLabel = shouldPreferRuntimeModel
+    ? activeAuthLabelValue
+      ? ` · 🔑 ${activeAuthLabelValue}`
+      : ""
+    : selectedAuthLabel;
+  const modelNoteParts: string[] = [];
+  if (channelModelNote) {
+    modelNoteParts.push(channelModelNote);
+  }
+  if (shouldPreferRuntimeModel) {
+    modelNoteParts.push("latest run");
+  }
+  const modelNote = modelNoteParts.length > 0 ? ` · ${modelNoteParts.join(" · ")}` : "";
+  const modelLine = `🧠 Model: ${displayedModelLabel}${displayedAuthLabel}${modelNote}`;
   const showFallbackAuth = activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;
   const fallbackLine = fallbackState.active
     ? `↪️ Fallback: ${activeModelLabel}${


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `/status` can report a stale selected model even when the session's latest runtime model is different and there is no fallback state indicating a temporary failover.
- Why it matters: users can see incorrect model identity (for example reported Haiku while latest runs are MiniMax), which undermines operator trust.
- What changed: status rendering now prefers the latest runtime model for the main model line only when model drift exists and there are no fallback hints and no manual model override.
- What did NOT change (scope boundary): fallback reporting behavior, manual `/model` overrides, auth mode resolution, and run-time model selection are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32189
- Related #30482

## User-visible / Behavior Changes

- In `/status`, when selected model and latest runtime model drift without fallback/override metadata, the model line now shows the latest runtime model with `latest run` note.
- This prevents stale model labels from being shown as authoritative in steady-state runtime scenarios.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: status rendering logic only
- Integration/channel (if any): `/status` output
- Relevant config (redacted): N/A

### Steps

1. Build status with selected model `github-copilot/claude-haiku-4-5`.
2. Set session runtime model fields to `modelProvider=minimax-portal`, `model=MiniMax-M2.5`.
3. Ensure no fallback notice fields and no manual model override fields are set.

### Expected

- Model line reflects the latest runtime model (`minimax-portal/MiniMax-M2.5`) and marks it as `latest run`.

### Actual

- Before fix, status reported only selected model (`github-copilot/claude-haiku-4-5`), which can be stale.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands:

```bash
pnpm vitest run src/auto-reply/status.test.ts -t "prefers latest runtime model when selected model drifts without fallback state"
pnpm vitest run src/auto-reply/status.test.ts
pnpm check
```

`pnpm check` currently fails on upstream `main` due unrelated pre-existing TypeScript errors in `extensions/zalouser/src/monitor.ts` and `extensions/zalouser/src/zalo-js.ts`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added targeted failing test that reproduced stale model line behavior.
  - Confirmed fixed output reports runtime model with `latest run` note.
  - Confirmed full `src/auto-reply/status.test.ts` suite stays green.
- Edge cases checked:
  - Existing tests for explicit fallback state and mismatch cases remain unchanged.
  - Manual override and fallback-hint paths are excluded from new behavior.
- What you did **not** verify:
  - Live Discord end-to-end run in a real guild.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/auto-reply/status.ts`
  - `src/auto-reply/status.test.ts`
- Known bad symptoms reviewers should watch for:
  - Model line unexpectedly showing runtime model in cases with explicit override/fallback.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Runtime model fields could be stale in edge environments and become displayed as `latest run`.
  - Mitigation:
    - Behavior is gated to no-fallback/no-override drift cases only; explicit fallback/override paths are unchanged and covered by existing tests.
