### PR TITLE
fix(cli): bootstrap missing dist for npx github source installs

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
+import { spawnSync } from "node:child_process";
+import { access } from "node:fs/promises";
 import module from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 // https://nodejs.org/api/module.html#module-compile-cache
 if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
@@ -13,6 +17,96 @@ if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
 
 const isModuleNotFoundError = (err) =>
   err && typeof err === "object" && "code" in err && err.code === "ERR_MODULE_NOT_FOUND";
+
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
+const entryCandidates = ["dist/entry.js", "dist/entry.mjs"];
+
+const exists = async (relativePath) => {
+  try {
+    await access(path.join(rootDir, relativePath));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const hasAnyEntryBuild = async () => {
+  for (const candidate of entryCandidates) {
+    if (await exists(candidate)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const hasCommand = (command, args = ["--version"]) => {
+  const result = spawnSync(command, args, { stdio: "ignore", shell: false });
+  return !result.error;
+};
+
+const resolvePnpmRunner = () => {
+  if (hasCommand("pnpm")) {
+    return {
+      displayName: "pnpm",
+      run: (args) => spawnSync("pnpm", args, { cwd: rootDir, stdio: "inherit", shell: false }),
+    };
+  }
+
+  if (hasCommand("corepack")) {
+    return {
+      displayName: "corepack pnpm",
+      run: (args) =>
+        spawnSync("corepack", ["pnpm", ...args], { cwd: rootDir, stdio: "inherit", shell: false }),
+    };
+  }
+
+  return null;
+};
+
+const runOrThrow = (runner, args, failureHelp) => {
+  const result = runner.run(args);
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(
+      `openclaw: ${failureHelp}\n` +
+        `Try running manually:\n` +
+        `  ${runner.displayName} ${args.join(" ")}`,
+    );
+  }
+};
+
+const ensureDistBuild = async () => {
+  if (await hasAnyEntryBuild()) {
+    return;
+  }
+
+  process.stderr.write("openclaw: missing dist build output; bootstrapping...\n");
+
+  const runner = resolvePnpmRunner();
+  if (!runner) {
+    throw new Error(
+      "openclaw: dist build output is missing and no package manager was found.\n" +
+        "Install pnpm (https://pnpm.io/installation) or enable Corepack, then run:\n" +
+        "  corepack enable\n" +
+        "  corepack pnpm install --frozen-lockfile\n" +
+        "  corepack pnpm exec tsdown --no-clean",
+    );
+  }
+
+  if (!(await exists("node_modules"))) {
+    runOrThrow(runner, ["install", "--frozen-lockfile"], "dependency installation failed.");
+  }
+
+  runOrThrow(runner, ["exec", "tsdown", "--no-clean"], "build failed.");
+
+  if (!(await hasAnyEntryBuild())) {
+    throw new Error(
+      "openclaw: bootstrap completed but dist/entry.(m)js is still missing.\n" +
+        "Try a clean build manually and rerun:\n" +
+        `  ${runner.displayName} install --frozen-lockfile\n` +
+        `  ${runner.displayName} exec tsdown --no-clean`,
+    );
+  }
+};
 
 const installProcessWarningFilter = async () => {
   // Keep bootstrap warnings consistent with the TypeScript runtime.
@@ -32,6 +126,7 @@ const installProcessWarningFilter = async () => {
   }
 };
 
+await ensureDistBuild();
 await installProcessWarningFilter();
 
 const tryImport = async (specifier) => {

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -39,6 +39,9 @@ const hasAnyEntryBuild = async () => {
   return false;
 };
 
+const hasTsdownBuildTool = async () =>
+  (await exists("node_modules/.bin/tsdown")) || (await exists("node_modules/.bin/tsdown.cmd"));
+
 const hasCommand = (command, args = ["--version"]) => {
   const result = spawnSync(command, args, { stdio: "ignore", shell: false });
   return !result.error;
@@ -92,8 +95,20 @@ const ensureDistBuild = async () => {
     );
   }
 
-  if (!(await exists("node_modules"))) {
-    runOrThrow(runner, ["install", "--frozen-lockfile"], "dependency installation failed.");
+  if (!(await exists("node_modules")) || !(await hasTsdownBuildTool())) {
+    runOrThrow(
+      runner,
+      ["install", "--frozen-lockfile", "--prod=false"],
+      "dependency installation failed.",
+    );
+  }
+
+  if (!(await hasTsdownBuildTool())) {
+    throw new Error(
+      'openclaw: build tool "tsdown" is unavailable after dependency install.\n' +
+        "Try running manually:\n" +
+        `  ${runner.displayName} install --frozen-lockfile --prod=false`,
+    );
   }
 
   runOrThrow(runner, ["exec", "tsdown", "--no-clean"], "build failed.");

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -90,8 +90,8 @@ const ensureDistBuild = async () => {
       "openclaw: dist build output is missing and no package manager was found.\n" +
         "Install pnpm (https://pnpm.io/installation) or enable Corepack, then run:\n" +
         "  corepack enable\n" +
-        "  corepack pnpm install --frozen-lockfile\n" +
-        "  corepack pnpm exec tsdown --no-clean",
+        "  corepack pnpm install --frozen-lockfile --prod=false\n" +
+        "  corepack pnpm build",
     );
   }
 
@@ -111,14 +111,14 @@ const ensureDistBuild = async () => {
     );
   }
 
-  runOrThrow(runner, ["exec", "tsdown", "--no-clean"], "build failed.");
+  runOrThrow(runner, ["build"], "build failed.");
 
   if (!(await hasAnyEntryBuild())) {
     throw new Error(
       "openclaw: bootstrap completed but dist/entry.(m)js is still missing.\n" +
         "Try a clean build manually and rerun:\n" +
-        `  ${runner.displayName} install --frozen-lockfile\n` +
-        `  ${runner.displayName} exec tsdown --no-clean`,
+        `  ${runner.displayName} install --frozen-lockfile --prod=false\n` +
+        `  ${runner.displayName} build`,
     );
   }
 };


### PR DESCRIPTION
## Summary

- Problem: `npx github:openclaw/openclaw onboard` fails when GitHub source tarballs do not include prebuilt `dist/entry.(m)js`.
- Impact: Fresh-machine `npx` runs require a manual install/build step.
- Fix: `openclaw.mjs` now bootstraps and builds `dist` before importing the runtime entry when it is missing.
- Scope boundary: No changes to publish/release/docs flow, and no onboarding behavior changes beyond startup bootstrap.

## Detail

Bootstrap missing build output at runtime so OpenClaw can run from `npx` without a global install.

- Detect missing `dist/entry.js` and `dist/entry.mjs`
- Bootstrap with `pnpm`, falling back to `corepack pnpm`
- Install dependencies only when `node_modules` is missing
- Run full pnpm build (or corepack pnpm build)
- Preserve existing compile-cache and warning-filter behavior
- Surface explicit manual recovery commands when bootstrap cannot proceed

Perfect. Use that instead of opening a new issue.

Fixes #32284 

