### PR TITLE
TTS: resolve core channel ids without plugin registry

### DIFF
--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -52,6 +52,7 @@ const {
   resolveModelOverridePolicy,
   summarizeText,
   resolveOutputFormat,
+  resolveChannelId,
   resolveEdgeOutputFormat,
 } = _test;
 
@@ -199,6 +200,24 @@ describe("tts", () => {
         expect(output.elevenlabs, testCase.channel).toBe(testCase.expected.elevenlabs);
         expect(output.extension, testCase.channel).toBe(testCase.expected.extension);
         expect(output.voiceCompatible, testCase.channel).toBe(testCase.expected.voiceCompatible);
+      }
+    });
+  });
+
+  describe("resolveChannelId", () => {
+    it("normalizes core and voice-bubble channels without requiring plugin registry state", () => {
+      const cases = [
+        { input: "whatsapp", expected: "whatsapp" },
+        { input: "Telegram", expected: "telegram" },
+        { input: "feishu", expected: "feishu" },
+        { input: "lark", expected: "feishu" },
+        { input: "discord", expected: "discord" },
+        { input: "   ", expected: null },
+        { input: undefined, expected: null },
+      ] as const;
+
+      for (const testCase of cases) {
+        expect(resolveChannelId(testCase.input), String(testCase.input)).toBe(testCase.expected);
       }
     });
   });

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -11,8 +11,9 @@ import {
 } from "node:fs";
 import path from "node:path";
 import type { ReplyPayload } from "../auto-reply/types.js";
-import { normalizeChannelId } from "../channels/plugins/index.js";
+import { normalizeChannelId as normalizePluginChannelId } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
+import { normalizeChannelId as normalizeCoreChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { normalizeResolvedSecretInputString } from "../config/types.secrets.js";
 import type {
@@ -498,7 +499,25 @@ function resolveOutputFormat(channelId?: string | null) {
 }
 
 function resolveChannelId(channel: string | undefined): ChannelId | null {
-  return channel ? normalizeChannelId(channel) : null;
+  const normalized = channel?.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  // TTS runs in contexts where plugin registry boot may lag behind channel dispatch.
+  // Keep core/voice-bubble channels resolvable without plugin registry data.
+  if (normalized === "lark") {
+    return "feishu";
+  }
+  if (VOICE_BUBBLE_CHANNELS.has(normalized)) {
+    return normalized;
+  }
+
+  const coreChannelId = normalizeCoreChannelId(normalized);
+  if (coreChannelId) {
+    return coreChannelId;
+  }
+  return normalizePluginChannelId(normalized);
 }
 
 function resolveEdgeOutputFormat(config: ResolvedTtsConfig): string {
@@ -955,5 +974,6 @@ export const _test = {
   resolveModelOverridePolicy,
   summarizeText,
   resolveOutputFormat,
+  resolveChannelId,
   resolveEdgeOutputFormat,
 };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: TTS channel resolution depended on plugin-registry lookup only, which can be empty before plugin boot in some execution contexts.
- Why it matters: When `channel` resolves to `null`, TTS falls back to default MP3 output instead of Opus voice-note output for WhatsApp/Telegram/Feishu.
- What changed: `resolveChannelId` now resolves core/voice-bubble channels directly first (`whatsapp`, `telegram`, `feishu`, plus alias `lark`) and only then falls back to plugin normalization.
- What did NOT change (scope boundary): No changes to provider APIs, TTS synthesis logic, or non-channel output format defaults.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #4156
- Related #31704

## User-visible / Behavior Changes

In contexts where channel plugins are not fully initialized yet, TTS now still recognizes WhatsApp/Telegram/Feishu channel ids and keeps Opus voice-note output instead of unintentionally falling back to MP3.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.7.4
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A (channel-id routing)
- Integration/channel (if any): TTS pipeline
- Relevant config (redacted): default TTS config, channel set to WhatsApp/Telegram/Feishu

### Steps

1. Resolve TTS channel id before plugin registry has full channel entries.
2. Request TTS payload for `whatsapp`, `telegram`, `feishu`, and alias `lark`.
3. Verify resolved channel id stays non-null and output format path remains Opus for voice-bubble channels.

### Expected

- Core/voice-bubble channel ids resolve without plugin-registry dependency.
- Opus format remains selected for WhatsApp/Telegram/Feishu.

### Actual

- Before this patch, plugin-only lookup could resolve `null`, causing default MP3 output selection.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/tts/tts.test.ts`
- Edge cases checked:
  - channel alias `lark` maps to `feishu`
  - blank/undefined channel remains `null`
- What you did **not** verify:
  - End-to-end live WhatsApp send on a real device

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/tts/tts.ts`
- Known bad symptoms reviewers should watch for: unexpected channel-id mismatch in TTS output path selection.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Manual `lark` alias mapping could diverge from future plugin alias metadata.
  - Mitigation: fallback to plugin normalization remains in place for non-core/extended cases.
