### PR TITLE
fix(sandbox): make /workspace bind mount read-only when workspaceAccess is not rw

### DIFF
--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -452,8 +452,7 @@ async function createSandboxContainer(params: {
     bindSourceRoots: [workspaceDir, params.agentWorkspaceDir],
   });
   args.push("--workdir", cfg.workdir);
-  const mainMountSuffix =
-    params.workspaceAccess === "ro" && workspaceDir === params.agentWorkspaceDir ? ":ro" : "";
+  const mainMountSuffix = params.workspaceAccess === "rw" ? "" : ":ro";
   args.push("-v", `${workspaceDir}:${cfg.workdir}${mainMountSuffix}`);
   if (params.workspaceAccess !== "none" && workspaceDir !== params.agentWorkspaceDir) {
     const agentMountSuffix = params.workspaceAccess === "ro" ? ":ro" : "";


### PR DESCRIPTION
## Summary

This fix ensures that when `workspaceAccess` is set to `'ro'` or `'none'`, the sandbox workspace (`/workspace` inside the container) is mounted as read-only, matching the documented behavior.

## The Problem

Previously, the code had:

```typescript
const mainMountSuffix =
  params.workspaceAccess === "ro" && workspaceDir === params.agentWorkspaceDir ? ":ro" : "";
```

This condition was always `false` in `ro` mode because:
- In `ro` mode: `workspaceDir = sandboxWorkspaceDir`, not `agentWorkspaceDir`
- So `workspaceDir === agentWorkspaceDir` is always `false`
- Result: `mainMountSuffix = ""` (writable)

## The Fix

```typescript
const mainMountSuffix = params.workspaceAccess === "rw" ? "" : ":ro";
```

Now:
| workspaceAccess | /workspace mount |
|----------------|------------------|
| `rw` | writable |
| `ro` | read-only |
| `none` | read-only |

This makes the actual behavior match the documentation which states:
- `ro`: keeps the sandbox workspace at /workspace read-only
- `none`: uses ~/.openclaw/sandboxes (implicitly read-only as there's no write need)