### PR TITLE
docs(mattermost): clarify chatmode and requireMention interaction

### DIFF
--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -90,6 +90,50 @@ Notes:
 - `onchar` still responds to explicit @mentions.
 - `channels.mattermost.requireMention` is honored for legacy configs but `chatmode` is preferred.
 
+### Chatmode and requireMention interaction
+
+> **Important:** `chatmode: "onmessage"` implicitly sets `requireMention: false` at the
+> account level. If you also set `requireMention: true` on the same account, the chatmode
+> value wins silently (a warning is logged). This applies to all channels the account is in,
+> unless overridden per-group.
+
+Group-level `requireMention` in `groups.<channelId>` **does** override the account-level
+value derived from chatmode. However, this interaction is non-obvious — the account-level
+setting is derived implicitly from `chatmode`, not from the explicit `requireMention` field.
+
+#### Common pattern: respond to everything in a dedicated channel, mention-only elsewhere
+
+Set `chatmode: "oncall"` on the account (which implies `requireMention: true`), then
+use a per-group override to disable mention gating only in the bot's dedicated channel:
+
+```json5
+{
+  channels: {
+    mattermost: {
+      accounts: {
+        mybot: {
+          botToken: "...",
+          baseUrl: "https://chat.example.com",
+          chatmode: "oncall", // mention-only by default
+        },
+      },
+      groups: {
+        "<dedicated-channel-id>": {
+          requireMention: false, // respond to everything here
+        },
+        "<other-channel-id>": {
+          // inherits requireMention: true from chatmode "oncall"
+        },
+      },
+    },
+  },
+}
+```
+
+> **Tip:** After changing `chatmode` or `requireMention` config, stale sessions may retain
+> the old behavior. Delete affected sessions from `agents/<agentId>/sessions/sessions.json`
+> to force a clean state.
+
 ## Access control (DMs)
 
 - Default: `channels.mattermost.dmPolicy = "pairing"` (unknown senders get a pairing code).

--- a/extensions/mattermost/src/mattermost/accounts.ts
+++ b/extensions/mattermost/src/mattermost/accounts.ts
@@ -68,11 +68,19 @@ function mergeMattermostAccountConfig(
   return { ...base, ...account };
 }
 
-function resolveMattermostRequireMention(config: MattermostAccountConfig): boolean | undefined {
+function resolveMattermostRequireMention(
+  config: MattermostAccountConfig,
+  accountId?: string,
+): boolean | undefined {
   if (config.chatmode === "oncall") {
     return true;
   }
   if (config.chatmode === "onmessage") {
+    if (config.requireMention === true) {
+      console.warn(
+        `[mattermost] account '${accountId ?? "default"}': chatmode 'onmessage' overrides explicit requireMention=true — use per-group requireMention or set chatmode to 'oncall'`,
+      );
+    }
     return false;
   }
   if (config.chatmode === "onchar") {
@@ -98,7 +106,7 @@ export function resolveMattermostAccount(params: {
   const configUrl = merged.baseUrl?.trim();
   const botToken = configToken || envToken;
   const baseUrl = normalizeMattermostBaseUrl(configUrl || envUrl);
-  const requireMention = resolveMattermostRequireMention(merged);
+  const requireMention = resolveMattermostRequireMention(merged, accountId);
 
   const botTokenSource: MattermostTokenSource = configToken ? "config" : envToken ? "env" : "none";
   const baseUrlSource: MattermostBaseUrlSource = configUrl ? "config" : envUrl ? "env" : "none";


### PR DESCRIPTION
## Problem

Users configuring `chatmode: "onmessage"` globally may not realize it implicitly sets `requireMention: false` at the account level via `resolveMattermostRequireMention()`. If they also set explicit `requireMention: true` on the same account, the chatmode value silently wins.

Group-level `requireMention` in `groups.<channelId>` does override the account-level value, but this interaction is undocumented and confusing.

## Changes

### Documentation (`docs/channels/mattermost.md`)
- Added a section explaining the chatmode → requireMention implicit coupling
- Documented that group-level `requireMention` overrides account-level (derived from chatmode)
- Added a recommended pattern: `chatmode: "oncall"` on the account + per-group `requireMention: false` for the dedicated channel
- Added a tip about deleting stale sessions after config changes

### Warning log (`extensions/mattermost/src/mattermost/accounts.ts`)
- In `resolveMattermostRequireMention()`, when `chatmode === "onmessage"` and the account also has explicit `requireMention: true`, a warning is now logged:
  `[mattermost] account 'X': chatmode 'onmessage' overrides explicit requireMention=true — use per-group requireMention or set chatmode to 'oncall'`
- This helps users notice the silent override during startup