### PR TITLE
feat(sessions): default group/thread sessions to idle reset instead of daily

### DIFF
--- a/src/config/sessions/reset.ts
+++ b/src/config/sessions/reset.ts
@@ -20,6 +20,15 @@ export type SessionFreshness = {
 export const DEFAULT_RESET_MODE: SessionResetMode = "daily";
 export const DEFAULT_RESET_AT_HOUR = 4;
 
+/**
+ * Type-aware default reset mode.  Direct/DM sessions reset daily (fresh
+ * start each day), while group and thread sessions default to idle-based
+ * reset so ongoing conversations retain context across days.
+ */
+function defaultResetModeForType(resetType: SessionResetType): SessionResetMode {
+  return resetType === "direct" ? "daily" : "idle";
+}
+
 const THREAD_SESSION_MARKERS = [":thread:", ":topic:"];
 const GROUP_SESSION_MARKERS = [":group:", ":channel:"];
 
@@ -100,7 +109,9 @@ export function resolveSessionResetPolicy(params: {
   const mode =
     typeReset?.mode ??
     baseReset?.mode ??
-    (!hasExplicitReset && legacyIdleMinutes != null ? "idle" : DEFAULT_RESET_MODE);
+    (!hasExplicitReset && legacyIdleMinutes != null
+      ? "idle"
+      : defaultResetModeForType(params.resetType));
   const atHour = normalizeResetAtHour(
     typeReset?.atHour ?? baseReset?.atHour ?? DEFAULT_RESET_AT_HOUR,
   );

--- a/src/config/sessions/reset.ts
+++ b/src/config/sessions/reset.ts
@@ -106,9 +106,15 @@ export function resolveSessionResetPolicy(params: {
         : undefined));
   const hasExplicitReset = Boolean(baseReset || sessionCfg?.resetByType);
   const legacyIdleMinutes = params.resetOverride ? undefined : sessionCfg?.idleMinutes;
+  // When a channel override is present but omits `mode`, fall through to the
+  // global `session.reset.mode` before using the type-aware default, so that
+  // e.g. `reset.mode: "daily"` + `resetByChannel.discord: { atHour: 8 }`
+  // preserves daily resets instead of silently switching to idle.
+  const globalMode = params.resetOverride ? sessionCfg?.reset?.mode : undefined;
   const mode =
     typeReset?.mode ??
     baseReset?.mode ??
+    globalMode ??
     (!hasExplicitReset && legacyIdleMinutes != null
       ? "idle"
       : defaultResetModeForType(params.resetType));

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -141,6 +141,53 @@ describe("resolveSessionResetPolicy", () => {
         resetType: "group",
       });
 
+      // Group sessions default to idle (not daily), but dm config does not bleed into group.
+      expect(groupPolicy.mode).toBe("idle");
+    });
+  });
+
+  describe("type-aware defaults", () => {
+    it("defaults direct sessions to daily reset", () => {
+      const policy = resolveSessionResetPolicy({ resetType: "direct" });
+      expect(policy.mode).toBe("daily");
+      expect(policy.atHour).toBe(4);
+    });
+
+    it("defaults group sessions to idle reset", () => {
+      const policy = resolveSessionResetPolicy({ resetType: "group" });
+      expect(policy.mode).toBe("idle");
+      expect(policy.idleMinutes).toBe(60);
+    });
+
+    it("defaults thread sessions to idle reset", () => {
+      const policy = resolveSessionResetPolicy({ resetType: "thread" });
+      expect(policy.mode).toBe("idle");
+      expect(policy.idleMinutes).toBe(60);
+    });
+
+    it("respects explicit daily mode for group sessions", () => {
+      const sessionCfg = {
+        resetByType: {
+          group: { mode: "daily" as const },
+        },
+      } as unknown as SessionConfig;
+
+      const policy = resolveSessionResetPolicy({
+        sessionCfg,
+        resetType: "group",
+      });
+      expect(policy.mode).toBe("daily");
+    });
+
+    it("respects explicit base reset mode for all types", () => {
+      const sessionCfg = {
+        reset: { mode: "daily" as const },
+      } as unknown as SessionConfig;
+
+      const groupPolicy = resolveSessionResetPolicy({
+        sessionCfg,
+        resetType: "group",
+      });
       expect(groupPolicy.mode).toBe("daily");
     });
   });

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -190,6 +190,23 @@ describe("resolveSessionResetPolicy", () => {
       });
       expect(groupPolicy.mode).toBe("daily");
     });
+
+    it("preserves global daily mode when channel override omits mode", () => {
+      // session.reset.mode: "daily" + resetByChannel.discord: { atHour: 8 }
+      // The channel override provides only atHour; the global mode should
+      // still be honored instead of falling through to the type default.
+      const sessionCfg = {
+        reset: { mode: "daily" as const },
+      } as unknown as SessionConfig;
+
+      const policy = resolveSessionResetPolicy({
+        sessionCfg,
+        resetType: "group",
+        resetOverride: { atHour: 8 },
+      });
+      expect(policy.mode).toBe("daily");
+      expect(policy.atHour).toBe(8);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Group and thread sessions now default to `idle` reset mode (60-minute inactivity timeout) instead of `daily` (4 AM reset). This preserves conversation context across days as long as there is activity.
- Direct/DM sessions are unchanged — still default to daily reset at 4 AM.
- Users who prefer the old daily reset for group/thread can explicitly configure `session.resetByType.group.mode: "daily"` and `session.resetByType.thread.mode: "daily"`.

Closes #32109

## Test plan

- [x] Updated existing test to match new group default behavior
- [x] New test: direct sessions default to daily
- [x] New test: group sessions default to idle with 60m timeout
- [x] New test: thread sessions default to idle with 60m timeout
- [x] New test: explicit daily override for group sessions works
- [x] New test: explicit base reset mode applies to all types
- [x] All 60 session-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)