### PR TITLE
fix(ios): resolve Swift build errors

### DIFF
--- a/apps/ios/Sources/Location/LocationService.swift
+++ b/apps/ios/Sources/Location/LocationService.swift
@@ -21,7 +21,7 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
         self.manager
     }
 
-    var locationRequestContinuation: CheckedContinuation<CLLocation, Error>? {
+    var locationRequestContinuation: CheckedContinuation<CLLocation, Swift.Error>? {
         get { self.locationContinuation }
         set { self.locationContinuation = newValue }
     }

--- a/apps/ios/Sources/Onboarding/GatewayOnboardingView.swift
+++ b/apps/ios/Sources/Onboarding/GatewayOnboardingView.swift
@@ -309,6 +309,7 @@ private func gatewayConnectionStatusLines(
     ConnectionStatusBox.defaultLines(appModel: appModel, gatewayController: gatewayController)
 }
 
+@MainActor
 private func resetGatewayConnectionState(
     appModel: NodeAppModel,
     connectStatusText: inout String?,

--- a/apps/ios/Sources/Screen/ScreenRecordService.swift
+++ b/apps/ios/Sources/Screen/ScreenRecordService.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import OpenClawKit
 import ReplayKit
 
 final class ScreenRecordService: @unchecked Sendable {

--- a/apps/ios/Sources/Voice/VoiceWakeManager.swift
+++ b/apps/ios/Sources/Voice/VoiceWakeManager.swift
@@ -466,7 +466,7 @@ final class VoiceWakeManager: NSObject {
         }
     }
 
-    private static func deniedByDefaultPermissionMessage(kind: String, isUndetermined: Bool) -> String {
+    private nonisolated static func deniedByDefaultPermissionMessage(kind: String, isUndetermined: Bool) -> String {
         if isUndetermined {
             return "\(kind) permission not granted"
         }


### PR DESCRIPTION
### Context

The iOS app fails to build on current `main` with 4 Swift errors across 4 files. These were introduced by recent upstream refactoring (dedupe pass, actor isolation changes, module reorganization).

### Changes

**LocationService.swift** - The `locationRequestContinuation` computed property used unqualified `Error` which resolved to `LocationService.Error` (the nested enum) instead of `Swift.Error` (what the `LocationServiceCommon` protocol requires). Qualified with `Swift.Error`.

**VoiceWakeManager.swift** - `deniedByDefaultPermissionMessage` was implicitly `@MainActor` (inherited from the class) but called from `nonisolated static func microphonePermissionMessage`. Since it's a pure function with no state access, marked it `nonisolated`.

**GatewayOnboardingView.swift** - Free function `resetGatewayConnectionState` calls `appModel.disconnectGateway()` which is `@MainActor`-isolated (via `NodeAppModel`). Added `@MainActor` annotation to the calling function.

**ScreenRecordService.swift** - Missing `import OpenClawKit` for `CaptureRateLimits` which was moved to the shared kit during the dedupe refactoring.

### Verification

Builds clean with `-configuration Release -destination "generic/platform=iOS"` on Xcode 26.2.