### PR TITLE
fix(auto-reply): preserve newlines in stripInlineStatus and extractInlineSimpleCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/inline command cleanup: preserve newline structure when stripping inline `/status` and extracting inline slash commands by collapsing only horizontal whitespace, preventing paragraph flattening in multi-line replies. (#32224) Thanks @scoootscooob.
 - macOS/LaunchAgent security defaults: write `Umask=63` (octal `077`) into generated gateway launchd plists so post-update service reinstalls keep owner-only file permissions by default instead of falling back to system `022`. (#32022) Fixes #31905. Thanks @liuxiaopai-ai.
 - Plugin SDK/runtime hardening: add package export verification in CI/release checks to catch missing runtime exports before publish-time regressions. (#28575) Thanks @Glucksberg.
 - Media understanding/provider HTTP proxy routing: pass a proxy-aware fetch function from `HTTPS_PROXY`/`HTTP_PROXY` env vars into audio/video provider calls (with graceful malformed-proxy fallback) so transcription/video requests honor configured outbound proxies. (#27093) Thanks @mcaxtr.

--- a/src/auto-reply/reply/reply-inline.test.ts
+++ b/src/auto-reply/reply/reply-inline.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { extractInlineSimpleCommand, stripInlineStatus } from "./reply-inline.js";
+
+describe("stripInlineStatus", () => {
+  it("strips /status directive from message", () => {
+    const result = stripInlineStatus("/status hello world");
+    expect(result.cleaned).toBe("hello world");
+    expect(result.didStrip).toBe(true);
+  });
+
+  it("preserves newlines in multi-line messages", () => {
+    const result = stripInlineStatus("first line\nsecond line\nthird line");
+    expect(result.cleaned).toBe("first line\nsecond line\nthird line");
+    expect(result.didStrip).toBe(false);
+  });
+
+  it("preserves newlines when stripping /status", () => {
+    const result = stripInlineStatus("/status\nfirst paragraph\n\nsecond paragraph");
+    expect(result.cleaned).toBe("first paragraph\n\nsecond paragraph");
+    expect(result.didStrip).toBe(true);
+  });
+
+  it("collapses horizontal whitespace but keeps newlines", () => {
+    const result = stripInlineStatus("hello   world\n  indented  line");
+    expect(result.cleaned).toBe("hello world\n indented line");
+    // didStrip is true because whitespace normalization changed the string
+    expect(result.didStrip).toBe(true);
+  });
+
+  it("returns empty string for whitespace-only input", () => {
+    const result = stripInlineStatus("   ");
+    expect(result.cleaned).toBe("");
+    expect(result.didStrip).toBe(false);
+  });
+});
+
+describe("extractInlineSimpleCommand", () => {
+  it("extracts /help command", () => {
+    const result = extractInlineSimpleCommand("/help some question");
+    expect(result?.command).toBe("/help");
+    expect(result?.cleaned).toBe("some question");
+  });
+
+  it("preserves newlines after extracting command", () => {
+    const result = extractInlineSimpleCommand("/help first line\nsecond line");
+    expect(result?.command).toBe("/help");
+    expect(result?.cleaned).toBe("first line\nsecond line");
+  });
+
+  it("returns null for empty body", () => {
+    expect(extractInlineSimpleCommand("")).toBeNull();
+    expect(extractInlineSimpleCommand(undefined)).toBeNull();
+  });
+});

--- a/src/auto-reply/reply/reply-inline.ts
+++ b/src/auto-reply/reply/reply-inline.ts
@@ -24,7 +24,10 @@ export function extractInlineSimpleCommand(body?: string): {
   if (!command) {
     return null;
   }
-  const cleaned = body.replace(match[0], " ").replace(/\s+/g, " ").trim();
+  const cleaned = body
+    .replace(match[0], " ")
+    .replace(/[^\S\n]+/g, " ")
+    .trim();
   return { command, cleaned };
 }
 
@@ -36,6 +39,11 @@ export function stripInlineStatus(body: string): {
   if (!trimmed) {
     return { cleaned: "", didStrip: false };
   }
-  const cleaned = trimmed.replace(INLINE_STATUS_RE, " ").replace(/\s+/g, " ").trim();
+  // Use [^\S\n]+ instead of \s+ to only collapse horizontal whitespace,
+  // preserving newlines so multi-line messages keep their paragraph structure.
+  const cleaned = trimmed
+    .replace(INLINE_STATUS_RE, " ")
+    .replace(/[^\S\n]+/g, " ")
+    .trim();
   return { cleaned, didStrip: cleaned !== trimmed };
 }


### PR DESCRIPTION
## Summary

- `stripInlineStatus()` and `extractInlineSimpleCommand()` used `/\s+/g` to normalize whitespace, which collapsed newlines along with spaces/tabs. This destroyed paragraph structure in multi-line messages from Discord (Shift+Enter) and other channels.
- Replaced with `/[^\S\n]+/g` to only collapse horizontal whitespace while preserving line breaks.

Closes #32216

## Test plan

- [x] New test suite with 8 tests covering both functions
- [x] Verified newlines preserved in multi-line messages (no `/status`)
- [x] Verified newlines preserved when stripping `/status` directive
- [x] Verified horizontal whitespace still collapsed correctly
- [x] Verified `/help` command extraction preserves newlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)