### PR TITLE
agents: preserve explicit provider fallbacks

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -190,6 +190,35 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledWith("openai", "gpt-5.3-codex");
   });
 
+  it("preserves an explicit openai fallback for gpt-5.3-codex", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.3-codex",
+            fallbacks: ["openai/gpt-5.3-codex"],
+          },
+        },
+      },
+    });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("rate limited"))
+      .mockResolvedValueOnce("fallback success");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai-codex",
+      model: "gpt-5.3-codex",
+      run,
+    });
+
+    expect(result.result).toBe("fallback success");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run).toHaveBeenNthCalledWith(1, "openai-codex", "gpt-5.3-codex");
+    expect(run).toHaveBeenNthCalledWith(2, "openai", "gpt-5.3-codex");
+  });
+
   it("falls back on unrecognized errors when candidates remain", async () => {
     const cfg = makeCfg();
     const run = vi.fn().mockRejectedValueOnce(new Error("bad request")).mockResolvedValueOnce("ok");

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -22,6 +22,7 @@ import {
   buildModelAliasIndex,
   modelKey,
   normalizeModelRef,
+  normalizeProviderId,
   resolveConfiguredModelRef,
   resolveModelRefFromString,
 } from "./model-selection.js";
@@ -241,6 +242,30 @@ function resolveImageFallbackCandidates(params: {
   return candidates;
 }
 
+function resolveExplicitFallbackRef(params: {
+  raw: string;
+  defaultProvider: string;
+  aliasIndex: ReturnType<typeof buildModelAliasIndex>;
+}): ModelCandidate | null {
+  const resolved = resolveModelRefFromString({
+    raw: params.raw,
+    defaultProvider: params.defaultProvider,
+    aliasIndex: params.aliasIndex,
+  });
+  if (!resolved) {
+    return null;
+  }
+  const slash = params.raw.indexOf("/");
+  if (slash === -1) {
+    return resolved.ref;
+  }
+  const explicitProvider = normalizeProviderId(params.raw.slice(0, slash).trim());
+  if (explicitProvider === "openai" && resolved.ref.provider === "openai-codex") {
+    return { provider: explicitProvider, model: resolved.ref.model };
+  }
+  return resolved.ref;
+}
+
 function resolveFallbackCandidates(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
@@ -298,7 +323,7 @@ function resolveFallbackCandidates(params: {
   })();
 
   for (const raw of modelFallbacks) {
-    const resolved = resolveModelRefFromString({
+    const resolved = resolveExplicitFallbackRef({
       raw: String(raw ?? ""),
       defaultProvider,
       aliasIndex,
@@ -308,7 +333,7 @@ function resolveFallbackCandidates(params: {
     }
     // Fallbacks are explicit user intent; do not silently filter them by the
     // model allowlist.
-    addExplicitCandidate(resolved.ref);
+    addExplicitCandidate(resolved);
   }
 
   if (params.fallbacksOverride === undefined && primary?.provider && primary.model) {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -260,7 +260,7 @@ function resolveExplicitFallbackRef(params: {
     return resolved.ref;
   }
   const explicitProvider = normalizeProviderId(params.raw.slice(0, slash).trim());
-  if (explicitProvider === "openai" && resolved.ref.provider === "openai-codex") {
+  if (explicitProvider && explicitProvider !== resolved.ref.provider) {
     return { provider: explicitProvider, model: resolved.ref.model };
   }
   return resolved.ref;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: explicit fallback entries like `openai/gpt-5.3-codex` can be normalized back to `openai-codex` during fallback resolution.
- Why it matters: this can keep retries on the same provider instead of honoring an explicit cross-provider fallback sequence.
- What changed: fallback parsing now preserves explicitly specified provider ids when the fallback string includes a provider prefix.
- What did NOT change (scope boundary): no changes to fallback cooldown behavior, retry ordering, or provider auth/config resolution.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Explicit fallback entries that include a provider prefix now keep that provider intent during fallback selection.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: openai-codex primary with explicit openai fallback
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.model = { primary: "openai-codex/gpt-5.3-codex", fallbacks: ["openai/gpt-5.3-codex"] }`

### Steps

1. Configure a primary model on `openai-codex` and an explicit fallback on `openai` for the same model id.
2. Trigger a primary failure (e.g. first run throws).
3. Observe the fallback provider selected on retry.

### Expected

- Retry uses the explicit fallback provider (`openai`) from config.

### Actual

- Before this fix, explicit provider could be canonicalized back to `openai-codex` in fallback parsing.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm -s vitest run src/agents/model-fallback.test.ts` (49/49 passing), including the new explicit-provider fallback case.
- Edge cases checked: explicit provider-prefixed fallback entries continue to bypass allowlist filtering as explicit user intent.
- What you did **not** verify: full integration with live provider credentials.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/model-fallback.ts`, `src/agents/model-fallback.test.ts`
- Known bad symptoms reviewers should watch for: fallback choosing the wrong provider for explicitly prefixed entries.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: provider alias parsing regressions for other explicit fallback formats.
  - Mitigation: targeted unit coverage added for explicit-provider parsing behavior.
