### PR TITLE
infra: escape allowlist regex literals for path matches

### DIFF
--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -82,6 +82,31 @@ describe("exec approvals allowlist matching", () => {
     }
   });
 
+  it("matches literal allowlist paths that include regex metacharacters", () => {
+    const cases = [
+      {
+        pattern: "/usr/bin/g++",
+        resolution: {
+          rawExecutable: "g++",
+          resolvedPath: "/usr/bin/g++",
+          executableName: "g++",
+        },
+      },
+      {
+        pattern: "/opt/tools/(custom)/bin/node",
+        resolution: {
+          rawExecutable: "node",
+          resolvedPath: "/opt/tools/(custom)/bin/node",
+          executableName: "node",
+        },
+      },
+    ];
+    for (const testCase of cases) {
+      const match = matchAllowlist([{ pattern: testCase.pattern }], testCase.resolution);
+      expect(match?.pattern).toBe(testCase.pattern);
+    }
+  });
+
   it("matches bare * wildcard pattern against any resolved path", () => {
     const match = matchAllowlist([{ pattern: "*" }], baseResolution);
     expect(match).not.toBeNull();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: exec allowlist path matching treats literal path characters as regex tokens during glob compilation.
- Why it matters: binaries with metacharacters in the path (for example `g++` or paths containing `(` `)` `[]`) can miss allowlist matches and trigger unexpected approval prompts.
- What changed: allowlist glob compilation now escapes literal characters via a dedicated regex-literal escape helper before assembling the matcher regex.
- What did NOT change (scope boundary): wildcard semantics (`*`, `**`, `?`), approval policy levels, and shell-analysis behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #27843

## User-visible / Behavior Changes

- Literal exec allowlist entries with regex metacharacters now match reliably.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `tools.exec.security=allowlist`, allowlist contains literal executable paths.

### Steps

1. Configure exec security to allowlist mode.
2. Add a literal executable path containing metacharacters (for example `/usr/bin/g++` or `/opt/tools/(custom)/bin/node`).
3. Execute a command using that binary and evaluate allowlist matching.

### Expected

- Literal path entries match directly and do not require unintended manual approval.

### Actual

- Before this fix, metacharacters in literal paths could alter regex matching behavior and miss the allowlist hit.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm -s vitest run src/infra/exec-approvals.test.ts` (40/40 passing), including new literal-metacharacter path cases.
- Edge cases checked: wildcard patterns like `/usr/bin/*++` still match correctly after literal escaping.
- What you did **not** verify: end-to-end interactive approval UX in a live gateway session.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/infra/exec-command-resolution.ts`, `src/infra/exec-approvals.test.ts`
- Known bad symptoms reviewers should watch for: allowlist misses for literal paths containing metacharacters.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: unintended change to glob matching behavior.
  - Mitigation: existing wildcard tests plus new metacharacter tests in `exec-approvals.test.ts`.
