### PR TITLE
fix(slack): preserve session continuity for top-level channel messages

### DIFF
--- a/src/slack/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/src/slack/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -23,7 +23,7 @@ function buildCtx(overrides?: { replyToMode?: "all" | "first" | "off" }) {
 const account: ResolvedSlackAccount = createSlackTestAccount();
 
 describe("thread-level session keys", () => {
-  it("uses thread-level session key for channel messages", async () => {
+  it("uses base session key for top-level channel messages", async () => {
     const ctx = buildCtx();
     ctx.resolveUserName = async () => ({ name: "Alice" });
 
@@ -43,11 +43,10 @@ describe("thread-level session keys", () => {
     });
 
     expect(prepared).toBeTruthy();
-    // Channel messages should get thread-level session key with :thread: suffix
-    // The resolved session key is in ctxPayload.SessionKey, not route.sessionKey
+    // Top-level channel messages should share the base session key so
+    // conversation context is preserved across messages (#32103).
     const sessionKey = prepared!.ctxPayload.SessionKey as string;
-    expect(sessionKey).toContain(":thread:");
-    expect(sessionKey).toContain("1770408518.451689");
+    expect(sessionKey).not.toContain(":thread:");
   });
 
   it("uses parent thread_ts for thread replies", async () => {

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -219,7 +219,7 @@ export async function prepareSlackMessage(params: {
       ? threadContext.messageTs
       : undefined;
   const canonicalThreadId = isRoomish
-    ? (threadContext.incomingThreadTs ?? message.ts)
+    ? threadContext.incomingThreadTs
     : isThreadReply
       ? threadTs
       : autoThreadId;


### PR DESCRIPTION

The thread-level session isolation introduced in #10686 used message.ts
  as a fallback canonicalThreadId for top-level channel messages. Since
  each message has a unique ts, every top-level message created a new
  session key (e.g. :thread:1770408518.451689), destroying conversation
  context.

  Remove the ?? message.ts fallback so top-level channel messages get
  an undefined canonicalThreadId, which resolveThreadSessionKeys() maps
  back to the shared base channel session key. Thread replies still
  receive proper thread-scoped keys via incomingThreadTs.

  Fixes #32103

  Summary

  - Top-level Slack channel messages each created a unique session key via ?? message.ts fallback, destroying
  conversation continuity
  - Removed the fallback so top-level messages share the base channel session key
  - Thread replies still get isolated session keys via incomingThreadTs

  Test plan

  - Updated test: top-level channel messages assert no :thread: suffix
  - Thread reply test unchanged: asserts :thread:<parent_ts>
  - DM test unchanged: asserts no :thread: