### PR TITLE
fix(webchat): prevent copy-paste from injecting spaces into inline code tokens

### DIFF
--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -60,6 +60,12 @@
   background: rgba(0, 0, 0, 0.15);
   padding: 0.15em 0.4em;
   border-radius: 4px;
+  /* Prevent mid-word breaks inside inline code so that copy-paste does not
+     inject spaces at wrap boundaries (see #32230). The parent .chat-text
+     sets overflow-wrap: break-word which is inherited; resetting it here
+     keeps tokens like UUIDs intact when copied. */
+  overflow-wrap: normal;
+  word-break: keep-all;
 }
 
 .chat-text :where(pre) {
@@ -67,6 +73,10 @@
   border-radius: 6px;
   padding: 10px 12px;
   overflow-x: auto;
+  /* Explicit white-space: pre prevents the inherited overflow-wrap: break-word
+     from splitting long tokens at wrap boundaries during copy-paste (#32230). */
+  white-space: pre;
+  overflow-wrap: normal;
 }
 
 .chat-text :where(pre code) {


### PR DESCRIPTION
## Summary
- Resets `overflow-wrap` to `normal` on inline `<code>` elements to prevent the inherited `break-word` from `.chat-text` splitting long tokens (UUIDs, hashes, CLI arguments) at wrap boundaries
- Adds explicit `white-space: pre` and `overflow-wrap: normal` on `<pre>` blocks as belt-and-suspenders against the same inherited break-word issue in fenced code blocks
- Browsers insert a space at the visual break point when copying selected text that wraps mid-word, corrupting tokens like `e01afbad-…-f1affdb3b806` → `…f1affdb3 b806`

## Test plan
- [ ] Open webchat, have assistant produce a message with a long UUID in inline code (backticks)
- [ ] Copy the UUID from the rendered message — verify no spaces are injected
- [ ] Repeat with a fenced code block containing long tokens — verify copy is clean
- [ ] Verify inline code wraps gracefully on narrow viewports (no horizontal overflow of chat bubble)
- [ ] Verify `pnpm ui:build` succeeds (confirmed locally)

Closes #32230

🤖 Generated with [Claude Code](https://claude.com/claude-code)