### PR TITLE
telegram: keep default account in polling list

### DIFF
--- a/src/telegram/accounts.test.ts
+++ b/src/telegram/accounts.test.ts
@@ -102,6 +102,35 @@ describe("resolveTelegramAccount", () => {
     expect(lines).toContain("listTelegramAccountIds [ 'work' ]");
     expect(lines).toContain("resolve { accountId: 'work', enabled: true, tokenSource: 'config' }");
   });
+
+  it("keeps the default account in the polling list when a top-level bot token is configured", () => {
+    withEnv({ TELEGRAM_BOT_TOKEN: "" }, () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          telegram: {
+            botToken: "tok-default",
+            accounts: { alerts: { botToken: "tok-alerts" } },
+          },
+        },
+      };
+
+      expect(listTelegramAccountIds(cfg)).toEqual(["alerts", "default"]);
+    });
+  });
+
+  it("keeps the default account in the polling list when TELEGRAM_BOT_TOKEN is set", () => {
+    withEnv({ TELEGRAM_BOT_TOKEN: "tok-env" }, () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          telegram: {
+            accounts: { alerts: { botToken: "tok-alerts" } },
+          },
+        },
+      };
+
+      expect(listTelegramAccountIds(cfg)).toEqual(["alerts", "default"]);
+    });
+  });
 });
 
 describe("resolveDefaultTelegramAccountId", () => {

--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -46,10 +46,16 @@ export type ResolvedTelegramAccount = {
 };
 
 function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
-  return listConfiguredAccountIdsFromSection({
-    accounts: cfg.channels?.telegram?.accounts,
-    normalizeAccountId,
-  });
+  const ids = new Set(
+    listConfiguredAccountIdsFromSection({
+      accounts: cfg.channels?.telegram?.accounts,
+      normalizeAccountId,
+    }),
+  );
+  if (resolveTelegramToken(cfg, { accountId: DEFAULT_ACCOUNT_ID }).source !== "none") {
+    ids.add(DEFAULT_ACCOUNT_ID);
+  }
+  return [...ids];
 }
 
 export function listTelegramAccountIds(cfg: OpenClawConfig): string[] {


### PR DESCRIPTION
## Summary

- Problem: Telegram default account token could be omitted from account id listing when explicit account map exists.
- Why it matters: polling can skip the default account even when a valid default token is configured.
- What changed: account-id collection now always includes default when default token source is present, plus regression tests.
- What did NOT change: no changes to non-Telegram account routing behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Telegram polling now keeps the default account active when default token credentials are configured alongside named accounts.

## Security Impact (required)

- New permissions/capabilities? (Yes/No) No
- Secrets/tokens handling changed? (Yes/No) No
- New/changed network calls? (Yes/No) No
- Command/tool execution surface changed? (Yes/No) No
- Data access scope changed? (Yes/No) No

## Repro + Verification

### Steps

1. Configure Telegram with named accounts and also a valid default token (config or env).
2. List/resolve Telegram account ids for polling.
3. Verify default remains in the polling set.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: pnpm -s vitest run src/telegram/accounts.test.ts
- Edge cases checked: default token from config and environment.
- What you did not verify: live Telegram network polling.

## Compatibility / Migration

- Backward compatible? (Yes/No) Yes
- Config/env changes? (Yes/No) No
- Migration needed? (Yes/No) No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: src/telegram/accounts.ts, src/telegram/accounts.test.ts
- Known bad symptoms reviewers should watch for: default account missing from Telegram polling list.

## Risks and Mitigations

- Risk: account list ordering assumptions in external scripts.
  - Mitigation: deterministic sorted output maintained with existing list behavior.
