### PR TITLE
discord: close native slash interactions on zero-payload dispatch

### DIFF
--- a/src/discord/monitor/native-command.model-picker.test.ts
+++ b/src/discord/monitor/native-command.model-picker.test.ts
@@ -14,6 +14,7 @@ import * as modelPickerPreferencesModule from "./model-picker-preferences.js";
 import * as modelPickerModule from "./model-picker.js";
 import { createModelsProviderData as createBaseModelsProviderData } from "./model-picker.test-utils.js";
 import {
+  createDiscordNativeCommand,
   createDiscordModelPickerFallbackButton,
   createDiscordModelPickerFallbackSelect,
 } from "./native-command.js";
@@ -453,5 +454,58 @@ describe("Discord model picker interactions", () => {
       String(call[0] ?? "").includes("model picker override mismatch"),
     )?.[0];
     expect(mismatchLog).toContain("session key agent:worker:subagent:bound");
+  });
+
+  it("acknowledges slash interaction when dispatch queues no final reply", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: "anthropic/claude-opus-4-5",
+          humanDelay: { mode: "off" },
+          workspace: "/tmp/openclaw",
+        },
+      },
+      session: { store: "/tmp/openclaw-sessions.json" },
+      channels: {
+        discord: { dm: { enabled: true, policy: "open" } },
+      },
+    } as unknown as OpenClawConfig;
+
+    vi.spyOn(dispatcherModule, "dispatchReplyWithDispatcher").mockResolvedValue({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+
+    const command = createDiscordNativeCommand({
+      command: {
+        name: "verbose",
+        description: "Toggle verbose mode.",
+        acceptsArgs: true,
+      },
+      cfg,
+      discordConfig: cfg.channels?.discord ?? {},
+      accountId: "default",
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager("default"),
+    });
+
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const followUp = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: "u1", username: "Ada", globalName: "Ada" },
+      channel: { type: ChannelType.DM, id: "dm-1" },
+      guild: null,
+      rawData: { id: "i-native-empty", member: { roles: [] } },
+      options: { getString: vi.fn().mockReturnValue("on") },
+      reply,
+      followUp,
+    } as unknown as Parameters<typeof command.run>[0];
+
+    await command.run(interaction);
+
+    expect(reply).toHaveBeenCalledTimes(1);
+    expect(followUp).toHaveBeenCalledTimes(0);
+    expect(reply.mock.calls[0]?.[0]?.content).toBe("✓");
   });
 });

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -1623,6 +1623,10 @@ async function dispatchDiscordCommandInteraction(params: {
       onModelSelected,
     },
   });
+
+  if (!didReply && !suppressReplies) {
+    await respond("✓", { ephemeral: true });
+  }
 }
 
 async function deliverDiscordInteractionReply(params: {


### PR DESCRIPTION
## Summary

- Problem: Discord native slash interactions can remain pending forever when a turn uses `message` tool `action: send` and the dispatcher queues no final payload.
- Why it matters: users see perpetual "Bot is responding..." despite tool-side delivery completing.
- What changed: native command handling now sends an ephemeral acknowledgement (`✓`) when dispatch completes without any final interaction reply and replies were not explicitly suppressed.
- What did NOT change (scope boundary): message tool delivery behavior, payload dedupe policy, and slash auth/routing logic are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #31246
- Related #

## User-visible / Behavior Changes

- Discord slash commands now reliably resolve even when dispatch emits no final payload (for example turns dominated by `message.send`), via an ephemeral acknowledgement.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm + Vitest
- Model/provider: N/A
- Integration/channel (if any): Discord native slash commands
- Relevant config (redacted): `channels.discord.dm.enabled=true`

### Steps

1. Create a native slash command flow where dispatch path completes with no final payload (same class as `message.send`-only delivery turns).
2. Invoke the command through Discord interaction handling.
3. Observe interaction completion behavior.

### Expected

- Interaction always resolves (reply/follow-up closes the pending state).

### Actual

- Before fix: no interaction reply is sent on zero-final dispatch path, leaving "Bot is responding..." indefinitely.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression test proving slash interaction receives a closing acknowledgement when dispatch queues no final reply.
  - Confirmed no regressions in Discord interaction monitor tests.
- Edge cases checked:
  - Acknowledgement is skipped when replies are explicitly suppressed.
- What you did **not** verify:
  - Live Discord end-to-end against production token.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/discord/monitor/native-command.ts`, `src/discord/monitor/native-command.model-picker.test.ts`
- Known bad symptoms reviewers should watch for: unexpected missing/extra interaction acknowledgements in Discord slash commands.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: emitting an acknowledgement where previous behavior was silent.
  - Mitigation: limited to zero-final-payload path and explicit `suppressReplies` guard.
