### PR TITLE
fix(matrix): pass mediaLocalRoots through all send paths

### DIFF
--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -54,7 +54,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
     return { to };
   },
   handleAction: async (ctx: ChannelMessageActionContext) => {
-    const { action, params, cfg } = ctx;
+    const { action, params, cfg, mediaLocalRoots } = ctx;
     const resolveRoomId = () =>
       readStringParam(params, "roomId") ??
       readStringParam(params, "channelId") ??
@@ -79,6 +79,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           threadId: threadId ?? undefined,
         },
         cfg as CoreConfig,
+        { mediaLocalRoots },
       );
     }
 

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -19,6 +19,7 @@ export async function sendMatrixMessage(
     mediaUrl?: string;
     replyToId?: string;
     threadId?: string;
+    mediaLocalRoots?: readonly string[];
   } = {},
 ) {
   return await sendMessageMatrix(to, content, {
@@ -27,6 +28,7 @@ export async function sendMatrixMessage(
     threadId: opts.threadId,
     client: opts.client,
     timeoutMs: opts.timeoutMs,
+    mediaLocalRoots: opts.mediaLocalRoots,
   });
 }
 

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -1,5 +1,6 @@
 import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import type { PollInput } from "openclaw/plugin-sdk";
+import { loadOutboundMediaFromUrl } from "openclaw/plugin-sdk";
 import { getMatrixRuntime } from "../runtime.js";
 import { buildPollStartContent, M_POLL_START } from "./poll-types.js";
 import { enqueueSend } from "./send-queue.js";
@@ -82,7 +83,10 @@ export async function sendMessageMatrix(
       let lastMessageId = "";
       if (opts.mediaUrl) {
         const maxBytes = resolveMediaMaxBytes(opts.accountId);
-        const media = await getCore().media.loadWebMedia(opts.mediaUrl, maxBytes);
+        const media = await loadOutboundMediaFromUrl(opts.mediaUrl, {
+          maxBytes,
+          mediaLocalRoots: opts.mediaLocalRoots,
+        });
         const uploaded = await uploadMediaMaybeEncrypted(client, roomId, media.buffer, {
           contentType: media.contentType,
           filename: media.fileName,

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -87,6 +87,7 @@ export type MatrixSendResult = {
 export type MatrixSendOpts = {
   client?: import("@vector-im/matrix-bot-sdk").MatrixClient;
   mediaUrl?: string;
+  mediaLocalRoots?: readonly string[];
   accountId?: string;
   replyToId?: string;
   threadId?: string | number | null;

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -22,7 +22,16 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       roomId: result.roomId,
     };
   },
-  sendMedia: async ({ to, text, mediaUrl, mediaLocalRoots, deps, replyToId, threadId, accountId }) => {
+  sendMedia: async ({
+    to,
+    text,
+    mediaUrl,
+    mediaLocalRoots,
+    deps,
+    replyToId,
+    threadId,
+    accountId,
+  }) => {
     const send = deps?.sendMatrix ?? sendMessageMatrix;
     const resolvedThreadId =
       threadId !== undefined && threadId !== null ? String(threadId) : undefined;

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -22,12 +22,13 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       roomId: result.roomId,
     };
   },
-  sendMedia: async ({ to, text, mediaUrl, deps, replyToId, threadId, accountId }) => {
+  sendMedia: async ({ to, text, mediaUrl, mediaLocalRoots, deps, replyToId, threadId, accountId }) => {
     const send = deps?.sendMatrix ?? sendMessageMatrix;
     const resolvedThreadId =
       threadId !== undefined && threadId !== null ? String(threadId) : undefined;
     const result = await send(to, text, {
       mediaUrl,
+      mediaLocalRoots,
       replyToId: replyToId ?? undefined,
       threadId: resolvedThreadId,
       accountId: accountId ?? undefined,

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -40,6 +40,7 @@ function readRoomId(params: Record<string, unknown>, required = true): string {
 export async function handleMatrixAction(
   params: Record<string, unknown>,
   cfg: CoreConfig,
+  opts?: { mediaLocalRoots?: readonly string[] },
 ): Promise<AgentToolResult<unknown>> {
   const action = readStringParam(params, "action", { required: true });
   const isActionEnabled = createActionGate(cfg.channels?.matrix?.actions);
@@ -86,6 +87,7 @@ export async function handleMatrixAction(
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyToId ?? undefined,
           threadId: threadId ?? undefined,
+          mediaLocalRoots: opts?.mediaLocalRoots,
         });
         return jsonResult({ ok: true, result });
       }


### PR DESCRIPTION
## Summary

- **Outbound adapter path** (`deliver.ts` → `matrixOutbound.sendMedia`): `mediaLocalRoots` was not forwarded to `loadOutboundMediaFromUrl`, causing agents to fail when attaching files from their configured workspace directory (e.g. `agents.main.workspace`).
- **Actions dispatch path** (`dispatchChannelMessageAction` → `handleAction` → `handleMatrixAction` → `sendMatrixMessage`): `ctx.mediaLocalRoots` from `ChannelMessageActionContext` was destructured but never threaded through — this is the path taken by the `message` tool and is the root cause of the `[tools] message failed: Local media path is not under an allowed directory` error reported in the field.

Both paths are now fixed. All new parameters are optional so existing behaviour (falling back to `getDefaultLocalRoots()`) is preserved when `mediaLocalRoots` is not provided.

Analogous fix for Mattermost was already merged in #31272 (commit `c0bf42f2a`).

## Changes

**Commit 1** — outbound adapter path:
- `extensions/matrix/src/matrix/send/types.ts`: add `mediaLocalRoots` to `MatrixSendOpts`
- `extensions/matrix/src/matrix/send.ts`: pass `mediaLocalRoots` to `loadOutboundMediaFromUrl`
- `extensions/matrix/src/outbound.ts`: destructure and forward `mediaLocalRoots` from `sendMedia` context

**Commit 2** — actions dispatch path:
- `extensions/matrix/src/actions.ts`: destructure `mediaLocalRoots` from `ChannelMessageActionContext`, pass as `opts` to `handleMatrixAction`
- `extensions/matrix/src/tool-actions.ts`: add optional `opts` parameter to `handleMatrixAction`, forward to `sendMatrixMessage`
- `extensions/matrix/src/matrix/actions/messages.ts`: add `mediaLocalRoots` to `sendMatrixMessage` opts, forward to `sendMessageMatrix`

## Test plan

- [x] Docker container rebuilt with `--no-cache`
- [x] Agent attaches file from `agents.main.workspace` via `message` tool to Matrix room — succeeds
- [x] Mattermost attachment (upstream fix) continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)