### PR TITLE
fix(nostr): fix three bugs preventing NIP-04 DM delivery

### DIFF
--- a/extensions/nostr/src/channel.test.ts
+++ b/extensions/nostr/src/channel.test.ts
@@ -107,6 +107,14 @@ describe("nostrPlugin", () => {
     it("has reasonable text chunk limit", () => {
       expect(nostrPlugin.outbound?.textChunkLimit).toBe(4000);
     });
+
+    it("has sendText function", () => {
+      expect(nostrPlugin.outbound?.sendText).toBeTypeOf("function");
+    });
+
+    it("has sendMedia function (required by delivery framework)", () => {
+      expect(nostrPlugin.outbound?.sendMedia).toBeTypeOf("function");
+    });
   });
 
   describe("pairing", () => {

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -161,7 +161,6 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
     // as a text link (same pattern as IRC channel).
     sendMedia: async ({ to, text, mediaUrl, accountId }) => {
       const combined = mediaUrl ? `${text ?? ""}\n\nAttachment: ${mediaUrl}` : (text ?? "");
-      const core = getNostrRuntime();
       const aid = accountId ?? DEFAULT_ACCOUNT_ID;
       const bus = activeBuses.get(aid);
       if (!bus) {

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -156,6 +156,25 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
         messageId: `nostr-${Date.now()}`,
       };
     },
+    // The delivery framework requires both sendText and sendMedia.  Nostr
+    // has no native media support, so fall back to sending the media URL
+    // as a text link (same pattern as IRC channel).
+    sendMedia: async ({ to, text, mediaUrl, accountId }) => {
+      const combined = mediaUrl ? `${text ?? ""}\n\nAttachment: ${mediaUrl}` : (text ?? "");
+      const core = getNostrRuntime();
+      const aid = accountId ?? DEFAULT_ACCOUNT_ID;
+      const bus = activeBuses.get(aid);
+      if (!bus) {
+        throw new Error(`Nostr bus not running for account ${aid}`);
+      }
+      const normalizedTo = normalizePubkey(to);
+      await bus.sendDm(normalizedTo, combined);
+      return {
+        channel: "nostr" as const,
+        to: normalizedTo,
+        messageId: `nostr-${Date.now()}`,
+      };
+    },
   },
 
   status: {
@@ -274,15 +293,22 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
         `[${account.accountId}] Nostr provider started, connected to ${account.relays.length} relay(s)`,
       );
 
-      // Return cleanup function
-      return {
-        stop: () => {
-          bus.close();
-          activeBuses.delete(account.accountId);
-          metricsSnapshots.delete(account.accountId);
-          ctx.log?.info(`[${account.accountId}] Nostr provider stopped`);
-        },
-      };
+      // Keep the promise pending until abort.  Returning immediately causes
+      // the framework to treat startAccount as resolved and triggers an
+      // infinite auto-restart loop.
+      await new Promise<void>((resolve) => {
+        if (ctx.abortSignal.aborted) {
+          resolve();
+          return;
+        }
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+
+      // Cleanup when aborted
+      bus.close();
+      activeBuses.delete(account.accountId);
+      metricsSnapshots.delete(account.accountId);
+      ctx.log?.info(`[${account.accountId}] Nostr provider stopped`);
     },
   },
 };

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -160,14 +160,21 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
     // has no native media support, so fall back to sending the media URL
     // as a text link (same pattern as IRC channel).
     sendMedia: async ({ to, text, mediaUrl, accountId }) => {
+      const core = getNostrRuntime();
       const combined = mediaUrl ? `${text ?? ""}\n\nAttachment: ${mediaUrl}` : (text ?? "");
       const aid = accountId ?? DEFAULT_ACCOUNT_ID;
       const bus = activeBuses.get(aid);
       if (!bus) {
         throw new Error(`Nostr bus not running for account ${aid}`);
       }
+      const tableMode = core.channel.text.resolveMarkdownTableMode({
+        cfg: core.config.loadConfig(),
+        channel: "nostr",
+        accountId: aid,
+      });
+      const message = core.channel.text.convertMarkdownTables(combined, tableMode);
       const normalizedTo = normalizePubkey(to);
-      await bus.sendDm(normalizedTo, combined);
+      await bus.sendDm(normalizedTo, message);
       return {
         channel: "nostr" as const,
         to: normalizedTo,

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -488,9 +488,11 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
     }
   }
 
+  // subscribeMany expects a single Filter, not an array.  Wrapping it in an
+  // array produces [[{…}]] on the wire which relays reject with NOTICE.
   const sub = pool.subscribeMany(
     relays,
-    [{ kinds: [4], "#p": [pk], since }] as unknown as Parameters<typeof pool.subscribeMany>[1],
+    { kinds: [4], "#p": [pk], since } as unknown as Parameters<typeof pool.subscribeMany>[1],
     {
       onevent: handleEvent,
       oneose: () => {


### PR DESCRIPTION
## Summary

Three independent bugs prevent the Nostr channel from receiving NIP-04 DMs and sending replies:

1. **Double-nested subscription filter** — `subscribeMany` in nostr-tools 2.23.x expects a single `Filter`, not a `Filter[]`. Wrapping in an array produces `[[{…}]]` on the wire; relays reject with "bad req: provided filter is not an object"
2. **Immediate `startAccount` resolution** — returning `{ stop }` resolves the framework promise, triggering an infinite auto-restart loop. Now awaits the abort signal (same pattern as Google Chat, IRC, and other channel plugins)
3. **Missing `sendMedia`** — the delivery framework requires both `sendText` AND `sendMedia` on the outbound block (`deliver.ts:139`). Added a text-link fallback stub matching the IRC pattern

## Test plan
- [x] All 286 Nostr plugin tests pass (10 test files)
- [x] New tests: `sendText` and `sendMedia` function presence assertions
- [x] Verified `subscribeMany` type signature in nostr-tools 2.23.3: `(relays: string[], filter: Filter, params)` — single `Filter`, not array
- [ ] Manual: configure Nostr with 3 relays, send NIP-04 DM, verify inbound + outbound

Closes #32252

🤖 Generated with [Claude Code](https://claude.com/claude-code)