### PR TITLE
fix(nostr): restore NIP-04 DM receive/reply delivery pipeline

### DIFF
--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -6,6 +6,7 @@ import {
   formatPairingApproveHint,
   type ChannelPlugin,
 } from "openclaw/plugin-sdk";
+import { waitForAbortSignal } from "../../../src/infra/abort-signal.js";
 import type { NostrProfile } from "./config-schema.js";
 import { NostrConfigSchema } from "./config-schema.js";
 import type { MetricEvent, MetricsSnapshot } from "./metrics.js";
@@ -156,6 +157,14 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
         messageId: `nostr-${Date.now()}`,
       };
     },
+    sendMedia: async ({ to, text, mediaUrl, accountId }) => {
+      const mergedText = [text, mediaUrl].filter(Boolean).join("\n");
+      return await nostrPlugin.outbound.sendText!({
+        to,
+        text: mergedText,
+        accountId,
+      });
+    },
   },
 
   status: {
@@ -274,15 +283,13 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
         `[${account.accountId}] Nostr provider started, connected to ${account.relays.length} relay(s)`,
       );
 
-      // Return cleanup function
-      return {
-        stop: () => {
-          bus.close();
-          activeBuses.delete(account.accountId);
-          metricsSnapshots.delete(account.accountId);
-          ctx.log?.info(`[${account.accountId}] Nostr provider stopped`);
-        },
-      };
+      // Keep provider pending for the account lifecycle.
+      await waitForAbortSignal(ctx.abortSignal);
+
+      bus.close();
+      activeBuses.delete(account.accountId);
+      metricsSnapshots.delete(account.accountId);
+      ctx.log?.info(`[${account.accountId}] Nostr provider stopped`);
     },
   },
 };

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -490,7 +490,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
 
   const sub = pool.subscribeMany(
     relays,
-    [{ kinds: [4], "#p": [pk], since }] as unknown as Parameters<typeof pool.subscribeMany>[1],
+    { kinds: [4], "#p": [pk], since } as unknown as Parameters<typeof pool.subscribeMany>[1],
     {
       onevent: handleEvent,
       oneose: () => {


### PR DESCRIPTION
## Summary
Fixes #32252 by addressing three regressions that made Nostr DM flow unusable:

1. **subscribeMany filter shape** in `nostr-bus.ts`
   - pass a single filter object instead of an array-wrapped filter to avoid `[[{...}]]` nesting
2. **gateway lifecycle in startAccount** in `channel.ts`
   - keep the task pending by awaiting `ctx.abortSignal` via `waitForAbortSignal`
   - cleanup bus/maps after abort instead of returning an immediate `{ stop }` object
3. **outbound sendMedia stub** in `channel.ts`
   - add `sendMedia` implementation so delivery framework does not skip Nostr outbound media payloads
   - fallback behavior merges `text` + `mediaUrl` and routes through `sendText`

## Validation
- `pnpm exec vitest run extensions/nostr --config vitest.extensions.config.ts`
- `pnpm exec vitest run extensions/nostr/src/channel.test.ts extensions/nostr/src/nostr-bus.test.ts --config vitest.extensions.config.ts`

All tests pass.
