### PR TITLE
Cron: suppress mixed HEARTBEAT_OK announce payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/Heartbeat announce suppression: treat isolated cron outputs as heartbeat-only when any payload includes `HEARTBEAT_OK` (while still delivering media payloads), preventing multi-payload heartbeat narration from being pushed to end users. Fixes #32130.
 - Synology Chat/webhook compatibility: accept JSON and alias payload fields, allow token resolution from body/query/header sources, and ACK webhook requests with `204` to avoid persistent `Processing...` states in Synology Chat clients. (#26635) Thanks @memphislee09-source.
 - Synology Chat/webhook ingress hardening: enforce bounded body reads (size + timeout) via shared request-body guards to prevent unauthenticated slow-body hangs before token validation. (#25831) Thanks @bmendonca3.
 - Auto-reply/followup queue: avoid stale callback reuse across idle-window restarts by caching the followup runner only when a drain actually starts, preserving enqueue ordering after empty-finalize paths. (#31902) Thanks @Lanfei.

--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -101,4 +101,14 @@ describe("isHeartbeatOnlyResponse", () => {
     const payloads = [{ text: "HEARTBEAT_OK" }, { mediaUrl: "https://example.com/report.png" }];
     expect(isHeartbeatOnlyResponse(payloads, 300)).toBe(false);
   });
+
+  it("does not suppress when payload includes channelData", () => {
+    const payloads = [{ text: "HEARTBEAT_OK" }, { channelData: { buttons: [{ text: "Open" }] } }];
+    expect(isHeartbeatOnlyResponse(payloads, 300)).toBe(false);
+  });
+
+  it("does not suppress when HEARTBEAT_OK is attached to meaningful text", () => {
+    const payloads = [{ text: "ALERT: disk usage 99% HEARTBEAT_OK" }];
+    expect(isHeartbeatOnlyResponse(payloads, 300)).toBe(false);
+  });
 });

--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isHeartbeatOnlyResponse,
   pickLastDeliverablePayload,
   pickLastNonEmptyTextFromPayloads,
   pickSummaryFromPayloads,
@@ -82,5 +83,22 @@ describe("pickLastDeliverablePayload", () => {
     const normal = { text: "ok", isError: undefined };
     const error = { text: "bad", isError: true as const };
     expect(pickLastDeliverablePayload([normal, error])).toBe(normal);
+  });
+});
+
+describe("isHeartbeatOnlyResponse", () => {
+  it("suppresses mixed narration when any payload contains HEARTBEAT_OK", () => {
+    const payloads = [{ text: "Quiet hours check: no urgent activity." }, { text: "HEARTBEAT_OK" }];
+    expect(isHeartbeatOnlyResponse(payloads, 300)).toBe(true);
+  });
+
+  it("does not suppress when there is no HEARTBEAT_OK token", () => {
+    const payloads = [{ text: "Daily digest complete." }];
+    expect(isHeartbeatOnlyResponse(payloads, 300)).toBe(false);
+  });
+
+  it("does not suppress when payload includes media", () => {
+    const payloads = [{ text: "HEARTBEAT_OK" }, { mediaUrl: "https://example.com/report.png" }];
+    expect(isHeartbeatOnlyResponse(payloads, 300)).toBe(false);
   });
 });

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -97,20 +97,26 @@ export function isHeartbeatOnlyResponse(payloads: DeliveryPayload[], ackMaxChars
     return true;
   }
 
-  // If there's media, we should deliver regardless of text content.
+  // If there's media or structured channel payload, we should deliver.
   if (
-    payloads.some((payload) => (payload.mediaUrls?.length ?? 0) > 0 || Boolean(payload.mediaUrl))
+    payloads.some(
+      (payload) =>
+        (payload.mediaUrls?.length ?? 0) > 0 ||
+        Boolean(payload.mediaUrl) ||
+        Object.keys(payload.channelData ?? {}).length > 0,
+    )
   ) {
     return false;
   }
 
   let hasHeartbeatAck = false;
   for (const payload of payloads) {
+    // Treat only pure HEARTBEAT_OK acknowledgements as suppressors.
     const result = stripHeartbeatToken(payload.text, {
-      mode: "heartbeat",
+      mode: "message",
       maxAckChars: ackMaxChars,
     });
-    if (result.didStrip && result.shouldSkip) {
+    if (result.didStrip && result.text === "") {
       hasHeartbeatAck = true;
       break;
     }
@@ -120,13 +126,7 @@ export function isHeartbeatOnlyResponse(payloads: DeliveryPayload[], ackMaxChars
   }
 
   // Preserve existing behavior for empty/whitespace-only payload batches.
-  return payloads.every(
-    (payload) =>
-      stripHeartbeatToken(payload.text, {
-        mode: "heartbeat",
-        maxAckChars: ackMaxChars,
-      }).shouldSkip,
-  );
+  return payloads.every((payload) => !(payload.text ?? "").trim());
 }
 
 export function resolveHeartbeatAckMaxChars(agentCfg?: { heartbeat?: { ackMaxChars?: number } }) {

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -87,26 +87,46 @@ export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
 }
 
 /**
- * Check if all payloads are just heartbeat ack responses (HEARTBEAT_OK).
- * Returns true if delivery should be skipped because there's no real content.
+ * Check if payloads should be treated as heartbeat acknowledgements.
+ * Returns true when at least one payload is a heartbeat ack token and no media
+ * payloads are present. This suppresses noisy narration blocks that may appear
+ * before a final HEARTBEAT_OK.
  */
 export function isHeartbeatOnlyResponse(payloads: DeliveryPayload[], ackMaxChars: number) {
   if (payloads.length === 0) {
     return true;
   }
-  return payloads.every((payload) => {
-    // If there's media, we should deliver regardless of text content.
-    const hasMedia = (payload.mediaUrls?.length ?? 0) > 0 || Boolean(payload.mediaUrl);
-    if (hasMedia) {
-      return false;
-    }
-    // Use heartbeat mode to check if text is just HEARTBEAT_OK or short ack.
+
+  // If there's media, we should deliver regardless of text content.
+  if (
+    payloads.some((payload) => (payload.mediaUrls?.length ?? 0) > 0 || Boolean(payload.mediaUrl))
+  ) {
+    return false;
+  }
+
+  let hasHeartbeatAck = false;
+  for (const payload of payloads) {
     const result = stripHeartbeatToken(payload.text, {
       mode: "heartbeat",
       maxAckChars: ackMaxChars,
     });
-    return result.shouldSkip;
-  });
+    if (result.didStrip && result.shouldSkip) {
+      hasHeartbeatAck = true;
+      break;
+    }
+  }
+  if (hasHeartbeatAck) {
+    return true;
+  }
+
+  // Preserve existing behavior for empty/whitespace-only payload batches.
+  return payloads.every(
+    (payload) =>
+      stripHeartbeatToken(payload.text, {
+        mode: "heartbeat",
+        maxAckChars: ackMaxChars,
+      }).shouldSkip,
+  );
 }
 
 export function resolveHeartbeatAckMaxChars(agentCfg?: { heartbeat?: { ackMaxChars?: number } }) {


### PR DESCRIPTION
## Summary
- update heartbeat delivery suppression to skip announce delivery when any payload contains a stripped `HEARTBEAT_OK` token
- keep media payload behavior unchanged (media still forces delivery)
- add regression tests for mixed narration + heartbeat token, non-heartbeat text, and media precedence
- add changelog fix entry

## Testing
- `bunx oxfmt --check src/cron/isolated-agent/helpers.ts src/cron/isolated-agent/helpers.test.ts CHANGELOG.md`
- `bunx vitest run src/cron/isolated-agent/helpers.test.ts src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts --config vitest.unit.config.ts`

Fixes #32130
