### PR TITLE
fix(agents): prevent subagent timeout from leaking tool results to chat

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -3103,7 +3103,7 @@ describe("subagent announce formatting", () => {
 
   describe("security: timeout does not leak tool results", () => {
     it("does not forward toolResult content when no assistant message exists (timeout scenario)", async () => {
-      const sensitiveCode = 'const API_KEY = "sk-secret-1234"; export default handler;';
+      const sensitiveCode = 'const API_KEY = "sk-secret-1234"; export default handler;'; // pragma: allowlist secret
       chatHistoryMock.mockResolvedValueOnce({
         messages: [
           { role: "user", content: "investigate the bug" },

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -394,7 +394,7 @@ describe("subagent announce formatting", () => {
     { role: "toolResult", toolOutput: "tool output line 1", childRunId: "run-tool-fallback-1" },
     { role: "tool", toolOutput: "tool output line 2", childRunId: "run-tool-fallback-2" },
   ] as const)(
-    "falls back to latest $role output when assistant reply is empty",
+    "does NOT leak $role content when assistant reply is empty (security)",
     async (testCase) => {
       chatHistoryMock.mockResolvedValueOnce({
         messages: [
@@ -421,7 +421,7 @@ describe("subagent announce formatting", () => {
 
       const call = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
       const msg = call?.params?.message as string;
-      expect(msg).toContain(testCase.toolOutput);
+      expect(msg).not.toContain(testCase.toolOutput);
     },
   );
 
@@ -1614,7 +1614,7 @@ describe("subagent announce formatting", () => {
     expect(msg).not.toContain("old tool output");
   });
 
-  it("falls back to latest tool output for completion-mode when assistant output is empty", async () => {
+  it("does not leak tool output in completion-mode when assistant output is empty (security)", async () => {
     chatHistoryMock.mockResolvedValueOnce({
       messages: [
         {
@@ -1640,11 +1640,15 @@ describe("subagent announce formatting", () => {
     });
 
     expect(didAnnounce).toBe(true);
-    expect(sendSpy).not.toHaveBeenCalled();
-    expect(agentSpy).toHaveBeenCalledTimes(1);
-    const call = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
-    const msg = call?.params?.message as string;
-    expect(msg).toContain("tool output only");
+    // Tool output must not appear in the completion message (security fix).
+    const agentCall = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
+    const agentMsg = agentCall?.params?.message ?? "";
+    expect(agentMsg).not.toContain("tool output only");
+    if (sendSpy.mock.calls.length > 0) {
+      const sendCall = sendSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
+      const sendMsg = sendCall?.params?.message ?? "";
+      expect(sendMsg).not.toContain("tool output only");
+    }
   });
 
   it("ignores user text when deriving fallback completion output", async () => {
@@ -3094,6 +3098,125 @@ describe("subagent announce formatting", () => {
       expect(childCall?.params?.message ?? "").toContain("grandchild settled output");
       const parentCall = agentSpy.mock.calls[1]?.[0] as { params?: { message?: string } };
       expect(parentCall?.params?.message ?? "").toContain("child synthesized from grandchild");
+    });
+  });
+
+  describe("security: timeout does not leak tool results", () => {
+    it("does not forward toolResult content when no assistant message exists (timeout scenario)", async () => {
+      const sensitiveCode = 'const API_KEY = "sk-secret-1234"; export default handler;';
+      chatHistoryMock.mockResolvedValueOnce({
+        messages: [
+          { role: "user", content: "investigate the bug" },
+          { role: "toolResult", content: [{ type: "text", text: sensitiveCode }] },
+        ],
+      });
+      readLatestAssistantReplyMock.mockResolvedValue("");
+      await runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:worker",
+        childRunId: "run-timeout-leak-1",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+        ...defaultOutcomeAnnounce,
+        outcome: { status: "timeout" },
+        expectsCompletionMessage: true,
+        waitForCompletion: false,
+      });
+      if (sendSpy.mock.calls.length > 0) {
+        const sendCall = sendSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
+        expect(sendCall?.params?.message ?? "").not.toContain(sensitiveCode);
+      }
+      if (agentSpy.mock.calls.length > 0) {
+        const agentCall = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
+        expect(agentCall?.params?.message ?? "").not.toContain(sensitiveCode);
+      }
+    });
+
+    it("returns only assistant content when both assistant and toolResult exist", async () => {
+      chatHistoryMock.mockResolvedValueOnce({
+        messages: [
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "full source code of secret.ts" }],
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "I found the bug in the handler" }],
+          },
+        ],
+      });
+      readLatestAssistantReplyMock.mockResolvedValue("");
+      await runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:worker",
+        childRunId: "run-timeout-leak-2",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        ...defaultOutcomeAnnounce,
+        waitForCompletion: false,
+      });
+      const call = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
+      const msg = call?.params?.message as string;
+      expect(msg).toContain("I found the bug in the handler");
+      expect(msg).not.toContain("full source code of secret.ts");
+    });
+
+    it("truncates very long findings in completion message", async () => {
+      const longContent = "A".repeat(5000);
+      readLatestAssistantReplyMock.mockResolvedValue(longContent);
+      await runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:worker",
+        childRunId: "run-long-findings",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+        ...defaultOutcomeAnnounce,
+        expectsCompletionMessage: true,
+        waitForCompletion: false,
+      });
+      const allMessages: string[] = [];
+      for (const c of sendSpy.mock.calls) {
+        const p = (c[0] as { params?: { message?: string } })?.params;
+        if (p?.message) {
+          allMessages.push(p.message);
+        }
+      }
+      for (const c of agentSpy.mock.calls) {
+        const p = (c[0] as { params?: { message?: string } })?.params;
+        if (p?.message) {
+          allMessages.push(p.message);
+        }
+      }
+      expect(allMessages.length).toBeGreaterThan(0);
+      const combined = allMessages.join("\n");
+      expect(combined).toContain("[… output truncated]");
+      expect(combined).not.toContain(longContent);
+    });
+
+    it("does not leak tool content via direct send path on timeout", async () => {
+      const rawCode = "function secretHandler() { return process.env.DB_PASSWORD; }";
+      chatHistoryMock.mockResolvedValueOnce({
+        messages: [{ role: "tool", content: [{ type: "text", text: rawCode }] }],
+      });
+      readLatestAssistantReplyMock.mockResolvedValue("");
+      await runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:worker",
+        childRunId: "run-timeout-direct-leak",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        requesterOrigin: { channel: "slack", to: "channel:C999", accountId: "acct-1" },
+        ...defaultOutcomeAnnounce,
+        outcome: { status: "timeout" },
+        expectsCompletionMessage: true,
+        waitForCompletion: false,
+      });
+      for (const c of sendSpy.mock.calls) {
+        const p = (c[0] as { params?: { message?: string } })?.params;
+        expect(p?.message ?? "").not.toContain(rawCode);
+      }
+      for (const c of agentSpy.mock.calls) {
+        const p = (c[0] as { params?: { message?: string } })?.params;
+        expect(p?.message ?? "").not.toContain(rawCode);
+      }
     });
   });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -56,6 +56,10 @@ const FAST_TEST_RETRY_INTERVAL_MS = 8;
 const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 90_000;
 const MAX_TIMER_SAFE_TIMEOUT_MS = 2_147_000_000;
 const GATEWAY_TIMEOUT_PATTERN = /gateway timeout/i;
+
+/** Hard cap on findings text forwarded in completion messages. */
+const MAX_FINDINGS_LENGTH = 2000;
+
 let subagentRegistryRuntimePromise: Promise<
   typeof import("./subagent-registry-runtime.js")
 > | null = null;
@@ -303,9 +307,19 @@ async function readLatestSubagentOutput(sessionKey: string): Promise<string | un
     method: "chat.history",
     params: { sessionKey, limit: 50 },
   });
+  // Security: only extract assistant-role messages in the fallback path.
+  // toolResult/tool content may contain raw source code, API keys, or other
+  // sensitive data that must not be forwarded to the chat channel.
   const messages = Array.isArray(history?.messages) ? history.messages : [];
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const msg = messages[i];
+    if (!msg || typeof msg !== "object") {
+      continue;
+    }
+    const role = (msg as { role?: unknown }).role;
+    if (role !== "assistant") {
+      continue;
+    }
     const text = extractSubagentOutputText(msg);
     if (text) {
       return text;
@@ -1366,7 +1380,11 @@ export async function runSubagentAnnounceFlow(params: {
 
     const taskLabel = params.label || params.task || "task";
     const announceSessionId = childSessionId || "unknown";
-    const findings = childCompletionFindings || reply || "(no output)";
+    let findings = childCompletionFindings || reply || "(no output)";
+    // Truncate overly long findings to prevent flooding the chat channel.
+    if (findings.length > MAX_FINDINGS_LENGTH) {
+      findings = findings.slice(0, MAX_FINDINGS_LENGTH) + "\n\n[… output truncated]";
+    }
 
     let requesterIsSubagent = requesterIsInternalSession();
     if (requesterIsSubagent) {


### PR DESCRIPTION
## Problem

When a subagent times out mid-tool-execution (e.g. while reading files with `read_file`), the system attempts to extract the subagent's "findings" to include in the timeout notification. If no assistant message exists yet (common — the agent was still processing tool results), `readLatestSubagentOutput()` falls back to extracting raw `toolResult` content. This content — which may contain **full source code files, API keys, database passwords, or other sensitive data** — is then sent directly to the chat channel, bypassing AI review.

**Security impact: Medium-High** — any file the subagent read before timeout gets leaked verbatim to the end-user chat.

## Root Cause

In `src/agents/subagent-announce.ts`, `readLatestSubagentOutput()` has a two-level extraction:
1. First tries `readLatestAssistantReply()` — safe, only returns assistant messages
2. Falls back to iterating **all** messages including `toolResult`/`tool` roles — **unsafe**, returns raw file contents

Combined with the direct-send path (`method: "send"`) that bypasses the main agent's AI processing, raw tool output gets forwarded verbatim to the chat channel.

## Changes

1. **`readLatestSubagentOutput()` fallback**: Now only extracts from `assistant`-role messages, skipping `toolResult`/`tool` roles entirely
2. **`buildCompletionDeliveryMessage()`**: Truncates findings exceeding 2000 characters to prevent chat flooding

## Tests

- Added test: timeout with only toolResult in history → findings should be empty (no leak)
- Added test: timeout with assistant + toolResult → should only return assistant content
- Added test: very long findings → should be truncated to 2000 chars with note
- All existing tests pass