### PR TITLE
Feat/grok imagine skill

### DIFF
--- a/skills/grok-imagine/SKILL.md
+++ b/skills/grok-imagine/SKILL.md
@@ -81,3 +81,52 @@ Notes
 - The script prints a `MEDIA:` line for OpenClaw to auto-attach on supported chat providers.
 - Do not read the image back; report the saved path only.
 - URL responses from the API expire quickly; the script uses base64 to avoid this.
+
+---
+
+# Video Generation
+
+Generate videos from text, animate images, or edit existing videos.
+
+Generate (text-to-video)
+
+```bash
+uv run {baseDir}/scripts/generate_video.py --prompt "a cat lounging on a sunny windowsill" --filename "cat.mp4"
+```
+
+Image-to-video (animate an image)
+
+```bash
+uv run {baseDir}/scripts/generate_video.py --prompt "the dog starts running" --filename "dog-run.mp4" -i photo.png
+```
+
+Video edit
+
+```bash
+uv run {baseDir}/scripts/generate_video.py --prompt "make it nighttime" --filename "night.mp4" --video daytime.mp4
+```
+
+Custom duration and resolution
+
+```bash
+uv run {baseDir}/scripts/generate_video.py --prompt "ocean waves crashing" --filename "waves.mp4" --duration 10 --resolution 720p --aspect-ratio 16:9
+```
+
+## Video Model
+
+| Model | Cost | Rate limit |
+| ----- | ---- | ---------- |
+| `grok-imagine-video` (default) | $0.05/second | 60 RPM |
+
+## Video Parameters
+
+- Duration: 1–15 seconds.
+- Resolution: `480p` (default), `720p`.
+- Aspect ratio: `16:9`, `1:1`, `9:16`, etc.
+- Input videos for editing must be ≤ 8.7 seconds, MP4 (H.264/H.265/AV1).
+
+Video Notes
+
+- Video generation is **asynchronous**: the script submits, polls for completion, then downloads the MP4.
+- The script prints a `MEDIA:` line for OpenClaw to auto-attach on supported chat providers.
+- Do not read the video back; report the saved path only.

--- a/skills/grok-imagine/SKILL.md
+++ b/skills/grok-imagine/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: grok-imagine
+description: Generate or edit images via xAI's Grok Imagine API.
+homepage: https://docs.x.ai/developers/model-capabilities/images/generation
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🎆",
+        "requires": { "bins": ["uv"], "env": ["XAI_API_KEY"] },
+        "primaryEnv": "XAI_API_KEY",
+        "install":
+          [
+            {
+              "id": "uv-brew",
+              "kind": "brew",
+              "formula": "uv",
+              "bins": ["uv"],
+              "label": "Install uv (brew)",
+            },
+          ],
+      },
+  }
+---
+
+# Grok Imagine (xAI Image Generation)
+
+Use the bundled script to generate or edit images via xAI's Grok Imagine API.
+
+Generate
+
+```bash
+uv run {baseDir}/scripts/generate_image.py --prompt "your image description" --filename "output.png"
+```
+
+Edit (single image)
+
+```bash
+uv run {baseDir}/scripts/generate_image.py --prompt "add a hat to this cat" --filename "output.png" -i "/path/in.png"
+```
+
+Multi-image composition
+
+```bash
+uv run {baseDir}/scripts/generate_image.py --prompt "combine these into one scene" --filename "output.png" -i img1.png -i img2.png
+```
+
+Generate multiple images
+
+```bash
+uv run {baseDir}/scripts/generate_image.py --prompt "a futuristic cityscape" --filename "city.png" --count 4
+```
+
+Use the pro model
+
+```bash
+uv run {baseDir}/scripts/generate_image.py --prompt "detailed portrait" --filename "portrait.png" --model grok-imagine-image-pro
+```
+
+API key
+
+- `XAI_API_KEY` env var
+- Or set `skills."grok-imagine".apiKey` / `skills."grok-imagine".env.XAI_API_KEY` in `~/.openclaw/openclaw.json`
+
+## Models
+
+| Model | Quality | Cost | Rate limit |
+| ----- | ------- | ---- | ---------- |
+| `grok-imagine-image` (default) | Standard | $0.02/image | 300 RPM |
+| `grok-imagine-image-pro` | High | $0.07/image | 30 RPM |
+
+## Parameters
+
+- Resolution: `1k` (default), `2k`.
+- Aspect ratio: `1:1` (default), `16:9`, `9:16`, `4:3`, `3:4`, etc.
+- Count: 1–10 images per request.
+
+Notes
+
+- Use timestamps in filenames: `yyyy-mm-dd-hh-mm-ss-name.png`.
+- The script prints a `MEDIA:` line for OpenClaw to auto-attach on supported chat providers.
+- Do not read the image back; report the saved path only.
+- URL responses from the API expire quickly; the script uses base64 to avoid this.

--- a/skills/grok-imagine/scripts/generate_image.py
+++ b/skills/grok-imagine/scripts/generate_image.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "httpx>=0.27.0",
+#     "pillow>=10.0.0",
+# ]
+# ///
+"""
+Generate or edit images using xAI's Grok Imagine API.
+
+Usage:
+    uv run generate_image.py --prompt "your image description" --filename "output.png"
+
+Edit (single image):
+    uv run generate_image.py --prompt "add a hat" --filename "output.png" -i photo.png
+
+Multi-image composition:
+    uv run generate_image.py --prompt "combine these" --filename "output.png" -i a.png -i b.png
+"""
+
+import argparse
+import base64
+import mimetypes
+import os
+import sys
+from pathlib import Path
+
+API_BASE = "https://api.x.ai/v1"
+
+ALL_MODELS = {"grok-imagine-image", "grok-imagine-image-pro"}
+DEFAULT_MODEL = "grok-imagine-image"
+
+
+def get_api_key(provided_key: str | None) -> str | None:
+    """Get API key from argument first, then environment."""
+    if provided_key:
+        return provided_key
+    return os.environ.get("XAI_API_KEY")
+
+
+def encode_image_to_data_uri(image_path: str) -> str:
+    """Read a local image and return a base64 data URI."""
+    path = Path(image_path)
+    if not path.exists():
+        print(f"Error: Input image not found: {image_path}", file=sys.stderr)
+        sys.exit(1)
+
+    mime_type, _ = mimetypes.guess_type(str(path))
+    if not mime_type or not mime_type.startswith("image/"):
+        mime_type = "image/png"
+
+    data = path.read_bytes()
+    b64 = base64.b64encode(data).decode("ascii")
+    return f"data:{mime_type};base64,{b64}"
+
+
+def save_image(b64_data: str, output_path: Path, index: int | None = None) -> Path:
+    """Decode base64 image data and save as PNG."""
+    from io import BytesIO
+    from PIL import Image as PILImage
+
+    if index is not None:
+        stem = output_path.stem
+        suffix = output_path.suffix or ".png"
+        dest = output_path.parent / f"{stem}-{index}{suffix}"
+    else:
+        dest = output_path
+
+    # Strip whitespace and ensure proper base64 padding (API may omit trailing '=')
+    cleaned = b64_data.translate(str.maketrans("", "", " \t\n\r"))
+    padded = cleaned + "=" * (-len(cleaned) % 4)
+    raw = base64.b64decode(padded)
+
+    # Convert to PNG regardless of what format the API returned
+    image = PILImage.open(BytesIO(raw))
+    if image.mode == "RGBA":
+        rgb = PILImage.new("RGB", image.size, (255, 255, 255))
+        rgb.paste(image, mask=image.split()[3])
+        rgb.save(str(dest), "PNG")
+    elif image.mode == "RGB":
+        image.save(str(dest), "PNG")
+    else:
+        image.convert("RGB").save(str(dest), "PNG")
+
+    return dest
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate or edit images using xAI Grok Imagine"
+    )
+    parser.add_argument(
+        "--prompt", "-p",
+        required=True,
+        help="Image description or edit instruction",
+    )
+    parser.add_argument(
+        "--filename", "-f",
+        required=True,
+        help="Output filename (e.g., sunset-mountains.png)",
+    )
+    parser.add_argument(
+        "--input-image", "-i",
+        action="append",
+        dest="input_images",
+        metavar="IMAGE",
+        help="Input image path(s) for editing. Can be specified multiple times.",
+    )
+    parser.add_argument(
+        "--model", "-m",
+        default=DEFAULT_MODEL,
+        help=f"Model to use (default: {DEFAULT_MODEL}). Options: {', '.join(sorted(ALL_MODELS))}",
+    )
+    parser.add_argument(
+        "--resolution", "-r",
+        choices=["1k", "2k"],
+        default=None,
+        help="Output resolution: 1k or 2k",
+    )
+    parser.add_argument(
+        "--aspect-ratio", "-a",
+        default=None,
+        help="Aspect ratio (e.g., 16:9, 1:1, 9:16, 4:3)",
+    )
+    parser.add_argument(
+        "--count", "-n",
+        type=int,
+        default=1,
+        help="Number of images to generate (1-10, default: 1)",
+    )
+    parser.add_argument(
+        "--api-key", "-k",
+        help="xAI API key (overrides XAI_API_KEY env var)",
+    )
+
+    args = parser.parse_args()
+
+    # Validate API key
+    api_key = get_api_key(args.api_key)
+    if not api_key:
+        print("Error: No API key provided.", file=sys.stderr)
+        print("Please either:", file=sys.stderr)
+        print("  1. Provide --api-key argument", file=sys.stderr)
+        print("  2. Set XAI_API_KEY environment variable", file=sys.stderr)
+        sys.exit(1)
+
+    # Validate count
+    if args.count < 1 or args.count > 10:
+        print("Error: --count must be between 1 and 10.", file=sys.stderr)
+        sys.exit(1)
+
+    # Import httpx here to avoid slow import on early errors
+    import httpx
+
+    # Set up output path
+    output_path = Path(args.filename)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    is_edit = bool(args.input_images)
+
+    # Build request body
+    body: dict = {
+        "model": args.model,
+        "prompt": args.prompt,
+        "n": args.count,
+        "response_format": "b64_json",
+    }
+
+    if args.resolution:
+        body["resolution"] = args.resolution
+    if args.aspect_ratio:
+        body["aspect_ratio"] = args.aspect_ratio
+
+    if is_edit:
+        # Edit mode: encode input images as data URIs
+        endpoint = f"{API_BASE}/images/edits"
+        images = args.input_images or []
+
+        if len(images) == 1:
+            data_uri = encode_image_to_data_uri(images[0])
+            body["image"] = {"url": data_uri, "type": "image_url"}
+            print(f"Loaded input image: {images[0]}")
+        else:
+            body["images"] = []
+            for img_path in images:
+                data_uri = encode_image_to_data_uri(img_path)
+                body["images"].append({"url": data_uri, "type": "image_url"})
+                print(f"Loaded input image: {img_path}")
+
+        img_count = len(images)
+        print(f"Editing {img_count} image{'s' if img_count > 1 else ''} with {args.model}...")
+    else:
+        # Generation mode
+        endpoint = f"{API_BASE}/images/generations"
+        print(f"Generating {args.count} image{'s' if args.count > 1 else ''} with {args.model}...")
+
+    try:
+        with httpx.Client(timeout=120.0) as client:
+            response = client.post(endpoint, headers=headers, json=body)
+
+        if response.status_code != 200:
+            error_detail = response.text
+            try:
+                error_json = response.json()
+                error_detail = error_json.get("error", {}).get("message", response.text)
+            except Exception:
+                pass
+            print(f"Error: API returned {response.status_code}: {error_detail}", file=sys.stderr)
+            sys.exit(1)
+
+        result = response.json()
+        data = result.get("data", [])
+
+        if not data:
+            print("Error: No images returned in the response.", file=sys.stderr)
+            sys.exit(1)
+
+        saved_paths: list[Path] = []
+        for idx, item in enumerate(data):
+            b64 = item.get("b64_json")
+            if not b64:
+                print(f"Warning: Image {idx + 1} has no b64_json data, skipping.", file=sys.stderr)
+                continue
+
+            if len(data) == 1:
+                dest = save_image(b64, output_path)
+            else:
+                dest = save_image(b64, output_path, index=idx + 1)
+
+            saved_paths.append(dest)
+
+            revised = item.get("revised_prompt")
+            if revised:
+                print(f"Revised prompt ({idx + 1}): {revised}")
+
+        if not saved_paths:
+            print("Error: No images could be saved.", file=sys.stderr)
+            sys.exit(1)
+
+        for dest in saved_paths:
+            full_path = dest.resolve()
+            print(f"\nImage saved: {full_path}")
+            # OpenClaw parses MEDIA tokens and will attach the file on supported providers.
+            print(f"MEDIA: {full_path}")
+
+    except httpx.TimeoutException:
+        print("Error: Request timed out. Try again or use a simpler prompt.", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error generating image: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/grok-imagine/scripts/generate_video.py
+++ b/skills/grok-imagine/scripts/generate_video.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "httpx>=0.27.0",
+# ]
+# ///
+"""
+Generate videos using xAI's Grok Imagine Video API.
+
+Usage (text-to-video):
+    uv run generate_video.py --prompt "a cat on a sunny windowsill" --filename "cat.mp4"
+
+Image-to-video:
+    uv run generate_video.py --prompt "animate this scene" --filename "out.mp4" -i photo.png
+
+Video edit:
+    uv run generate_video.py --prompt "make it night time" --filename "out.mp4" --video input.mp4
+"""
+
+import argparse
+import base64
+import mimetypes
+import os
+import sys
+import time
+from pathlib import Path
+
+API_BASE = "https://api.x.ai/v1"
+DEFAULT_MODEL = "grok-imagine-video"
+DEFAULT_POLL_INTERVAL = 5
+MAX_POLL_ATTEMPTS = 120  # 10 minutes at 5s intervals
+
+
+def get_api_key(provided_key: str | None) -> str | None:
+    """Get API key from argument first, then environment."""
+    if provided_key:
+        return provided_key
+    return os.environ.get("XAI_API_KEY")
+
+
+def encode_image_to_data_uri(image_path: str) -> str:
+    """Read a local image and return a base64 data URI."""
+    path = Path(image_path)
+    if not path.exists():
+        print(f"Error: Input image not found: {image_path}", file=sys.stderr)
+        sys.exit(1)
+
+    mime_type, _ = mimetypes.guess_type(str(path))
+    if not mime_type or not mime_type.startswith("image/"):
+        mime_type = "image/png"
+
+    data = path.read_bytes()
+    b64 = base64.b64encode(data).decode("ascii")
+    return f"data:{mime_type};base64,{b64}"
+
+
+def encode_video_to_data_uri(video_path: str) -> str:
+    """Read a local video and return a base64 data URI."""
+    path = Path(video_path)
+    if not path.exists():
+        print(f"Error: Input video not found: {video_path}", file=sys.stderr)
+        sys.exit(1)
+
+    mime_type, _ = mimetypes.guess_type(str(path))
+    if not mime_type or not mime_type.startswith("video/"):
+        mime_type = "video/mp4"
+
+    data = path.read_bytes()
+    b64 = base64.b64encode(data).decode("ascii")
+    return f"data:{mime_type};base64,{b64}"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate videos using xAI Grok Imagine Video"
+    )
+    parser.add_argument(
+        "--prompt", "-p",
+        required=True,
+        help="Video description or edit instruction",
+    )
+    parser.add_argument(
+        "--filename", "-f",
+        required=True,
+        help="Output filename (e.g., output.mp4)",
+    )
+    parser.add_argument(
+        "--input-image", "-i",
+        dest="input_image",
+        metavar="IMAGE",
+        help="Input image path for image-to-video generation.",
+    )
+    parser.add_argument(
+        "--video", "-v",
+        dest="input_video",
+        metavar="VIDEO",
+        help="Input video path for video editing.",
+    )
+    parser.add_argument(
+        "--model", "-m",
+        default=DEFAULT_MODEL,
+        help=f"Model to use (default: {DEFAULT_MODEL})",
+    )
+    parser.add_argument(
+        "--duration", "-d",
+        type=int,
+        default=None,
+        help="Video duration in seconds (1-15)",
+    )
+    parser.add_argument(
+        "--resolution", "-r",
+        choices=["480p", "720p"],
+        default=None,
+        help="Output resolution: 480p (default) or 720p",
+    )
+    parser.add_argument(
+        "--aspect-ratio", "-a",
+        default=None,
+        help="Aspect ratio (e.g., 16:9, 1:1, 9:16)",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=DEFAULT_POLL_INTERVAL,
+        help=f"Seconds between poll attempts (default: {DEFAULT_POLL_INTERVAL})",
+    )
+    parser.add_argument(
+        "--api-key", "-k",
+        help="xAI API key (overrides XAI_API_KEY env var)",
+    )
+
+    args = parser.parse_args()
+
+    # Validate API key
+    api_key = get_api_key(args.api_key)
+    if not api_key:
+        print("Error: No API key provided.", file=sys.stderr)
+        print("Please either:", file=sys.stderr)
+        print("  1. Provide --api-key argument", file=sys.stderr)
+        print("  2. Set XAI_API_KEY environment variable", file=sys.stderr)
+        sys.exit(1)
+
+    # Validate duration
+    if args.duration is not None and (args.duration < 1 or args.duration > 15):
+        print("Error: --duration must be between 1 and 15.", file=sys.stderr)
+        sys.exit(1)
+
+    # Import httpx here to avoid slow import on early errors
+    import httpx
+
+    # Set up output path
+    output_path = Path(args.filename)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    is_edit = bool(args.input_video)
+
+    # Build request body
+    body: dict = {
+        "model": args.model,
+        "prompt": args.prompt,
+    }
+
+    if args.duration is not None:
+        body["duration"] = args.duration
+    if args.resolution:
+        body["resolution"] = args.resolution
+    if args.aspect_ratio:
+        body["aspect_ratio"] = args.aspect_ratio
+
+    if args.input_image:
+        data_uri = encode_image_to_data_uri(args.input_image)
+        body["image"] = {"url": data_uri, "type": "image_url"}
+        print(f"Loaded input image: {args.input_image}")
+
+    if is_edit:
+        endpoint = f"{API_BASE}/videos/edits"
+        data_uri = encode_video_to_data_uri(args.input_video)
+        body["video"] = {"url": data_uri, "type": "video_url"}
+        print(f"Loaded input video: {args.input_video}")
+        print(f"Editing video with {args.model}...")
+    else:
+        endpoint = f"{API_BASE}/videos/generations"
+        mode = "image-to-video" if args.input_image else "text-to-video"
+        print(f"Generating video ({mode}) with {args.model}...")
+
+    try:
+        # Single client for submit + poll — reuses TCP + TLS connection
+        with httpx.Client(
+            timeout=30.0,
+            follow_redirects=True,
+            headers={"Authorization": f"Bearer {api_key}"},
+        ) as client:
+            # Step 1: Submit the generation request
+            response = client.post(endpoint, json=body, timeout=60.0)
+
+            if response.status_code != 200:
+                error_detail = response.text
+                try:
+                    error_json = response.json()
+                    error_detail = error_json.get("error", {}).get("message", response.text)
+                except Exception:
+                    pass
+                print(f"Error: API returned {response.status_code}: {error_detail}", file=sys.stderr)
+                sys.exit(1)
+
+            result = response.json()
+            request_id = result.get("request_id")
+            if not request_id:
+                print(f"Error: No request_id in response: {result}", file=sys.stderr)
+                sys.exit(1)
+
+            print(f"Request submitted: {request_id}")
+            print(f"Polling for completion (every {args.poll_interval}s)...", flush=True)
+
+            # Step 2: Poll until done
+            poll_url = f"{API_BASE}/videos/{request_id}"
+            video_url = None
+            consecutive_errors = 0
+            max_consecutive_errors = 10
+
+            for attempt in range(1, MAX_POLL_ATTEMPTS + 1):
+                # Check immediately on first attempt, sleep between subsequent polls
+                if attempt > 1:
+                    time.sleep(args.poll_interval)
+
+                try:
+                    poll_response = client.get(poll_url)
+                except httpx.TransportError as poll_err:
+                    consecutive_errors += 1
+                    print(f"  Poll {attempt}: network error ({poll_err}), retrying...", file=sys.stderr, flush=True)
+                    continue
+
+                if poll_response.status_code not in (200, 202):
+                    consecutive_errors += 1
+                    print(f"  Poll {attempt}: HTTP {poll_response.status_code}", file=sys.stderr, flush=True)
+                    if consecutive_errors >= max_consecutive_errors:
+                        print(f"Error: {consecutive_errors} consecutive poll failures, giving up.", file=sys.stderr)
+                        sys.exit(1)
+                    continue
+
+                # Successful poll — reset error counter
+                consecutive_errors = 0
+
+                poll_result = poll_response.json()
+                status = poll_result.get("status", "pending")
+
+                if status == "done":
+                    video_data = poll_result.get("video", {})
+                    video_url = video_data.get("url")
+                    duration = video_data.get("duration")
+                    print(f"  Poll {attempt}: done! Duration: {duration}s", flush=True)
+                    break
+                elif status == "expired":
+                    print("Error: Video generation expired.", file=sys.stderr)
+                    sys.exit(1)
+                else:
+                    print(f"  Poll {attempt}: {status}...", flush=True)
+
+            if not video_url:
+                print("Error: Timed out waiting for video generation.", file=sys.stderr)
+                sys.exit(1)
+
+        # Step 3: Download the video (separate client — don't send auth to CDN)
+        print("Downloading video...", flush=True)
+        with httpx.Client(timeout=120.0, follow_redirects=True) as dl_client:
+            dl_response = dl_client.get(video_url)
+
+            if dl_response.status_code != 200:
+                print(f"Error: Failed to download video: HTTP {dl_response.status_code}", file=sys.stderr)
+                sys.exit(1)
+
+            output_path.write_bytes(dl_response.content)
+            full_path = output_path.resolve()
+            size_mb = len(dl_response.content) / (1024 * 1024)
+            print(f"\nVideo saved: {full_path} ({size_mb:.1f} MB)")
+            # OpenClaw parses MEDIA tokens and will attach the file on supported providers.
+            print(f"MEDIA: {full_path}")
+
+    except httpx.TimeoutException:
+        print("Error: Request timed out.", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error generating video: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: No support for xAI Grok Imagine image or video generation in openclaw skills
- Why it matters: Grok image and video models are fast and cheap — great for on-the-fly media generation across chat channels
- What changed: Added `grok-imagine` skill with two standalone Python scripts (`generate_image.py` for image gen/edit with Pillow PNG conversion, `generate_video.py` for async video gen/edit with status polling) and `SKILL.md` with usage docs. Image script converts all API responses to PNG via Pillow (matching nano-banana-pro pattern) regardless of what format the API returns. Video script polls `GET /v1/videos/{request_id}`, reuses a single `httpx.Client` for submit+poll, uses a separate unauthenticated client for CDN download, and bails out after 10 consecutive poll failures.
- What did NOT change (scope boundary): No changes to openclaw core, gateway, routing, or any other skill. Both scripts are self-contained — they run via `uv run` and only depend on `httpx` + `pillow`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- New `grok-imagine` skill available for image generation, image editing, multi-image composition, text-to-video, image-to-video, and video editing
- Requires `uv` binary and `XAI_API_KEY` env var (or config at `skills."grok-imagine".env.XAI_API_KEY`)
- Scripts output `MEDIA:` tokens for auto-attach on supported chat providers
- Image models: `grok-imagine-image` (default, $0.02/image), `grok-imagine-image-pro` ($0.07/image)
- Video model: `grok-imagine-video` ($0.05/second), 1–15s duration, 480p/720p
- All images saved as PNG regardless of API response format (consistent with nano-banana-pro)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` — reads `XAI_API_KEY` from env, passes as Bearer token to `api.x.ai` only
- New/changed network calls? `Yes` — `POST /v1/images/generations`, `POST /v1/images/edits`, `POST /v1/videos/generations`, `POST /v1/videos/edits`, `GET /v1/videos/{request_id}` (all to `api.x.ai`), and `GET vidgen.x.ai/...` (CDN download, no auth)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: All API calls go to xAI's own endpoints (`api.x.ai`). Bearer token is scoped to `api.x.ai` — the video download uses a separate unauthenticated client so the token is never sent to the CDN (`vidgen.x.ai`).

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Python 3.10+ via `uv 0.9.17`
- Model/provider: xAI Grok Imagine (`grok-imagine-image`, `grok-imagine-image-pro`, `grok-imagine-video`)
- Integration/channel (if any): N/A (standalone scripts)
- Relevant config (redacted): `XAI_API_KEY=xai-...`

### Steps

1. `export XAI_API_KEY=xai-...`
2. `uv run skills/grok-imagine/scripts/generate_image.py --prompt "a cabin in snow" --filename "cabin.png"`
3. `uv run skills/grok-imagine/scripts/generate_video.py --prompt "a cat stretching" --filename "cat.mp4" --duration 3`

### Expected

- Image script saves a valid PNG in ~5–20s
- Video script submits, polls every 5s, detects `status: "done"` at poll 2–4, downloads and saves a valid MP4 in ~10–40s

### Actual

- Both complete as expected. All output files verified with `file` and `ffprobe`.

## Evidence

- [x] Trace/log snippets

```
Generating video (text-to-video) with grok-imagine-video...
Request submitted: Redacted
Polling for completion (every 5s)...
  Poll 1: pending...
  Poll 2: pending...
  Poll 3: pending...
  Poll 4: done! Duration: 3s
Downloading video...

Video saved: /Users/REDACTED/grok-imagine-tests/cat.mp4 (0.8 MB)
MEDIA: /Users/REDACED/grok-imagine-tests/cat.mp4
```

https://github.com/user-attachments/assets/3b411d3c-b6df-41c4-91e6-bf0c945fe689



- [x] Full test matrix (15 permutations, all passed):
  - 7 video: text-to-video (480p, 720p, 9:16, 1:1, 10s long), image-to-video, video edit
  - 8 image: default model, pro 2k, 9:16, 16:9, 1:1, batch×3, single edit, multi-image composition
  - 2 error paths: missing API key (exit 1), missing input file (exit 1)
  - All output verified with `ffprobe` (resolution, codec, duration, fps) and `file` (format, dimensions)
  - Image format fix verified: default model output (previously JPEG-in-a-PNG) now saves as real PNG

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: All 7 video modes (text-to-video at 4 aspect ratios/resolutions, long 10s duration, image-to-video, video edit), all 8 image modes (2 models, 4 aspect ratios, batch generation, single edit, multi-image composition), both error paths. Output files verified with `ffprobe` and `file`. Images visually inspected.
- Edge cases checked: Persistent HTTP 500 on poll (bails out after 10 consecutive errors), network error retry in poll loop, immediate first poll (no wasted sleep), Pillow PNG conversion for both default model (returns JPEG) and pro model (returns PNG)
- What you did **not** verify: Rate limiting (429), expired video generation, large input files near the 8.7s video edit limit, running through openclaw gateway (tested scripts directly only)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` — new skill only, uses standard `XAI_API_KEY` env var
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `skills/grok-imagine/` directory entirely
- Files/config to restore: N/A — additive only, no existing files modified
- Known bad symptoms reviewers should watch for: Video download URL from the CDN is temporary — if network stalls between poll completion and download, the URL could expire and the user would need to re-run from scratch

## Risks and Mitigations

- Risk: None — additive feature, self-contained scripts, no core changes
