### PR TITLE
fix(memory): Don't fallback to builtin when QMD is explicitly configured

### DIFF
--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -37,13 +37,6 @@ const qmdManagerStatus = createManagerStatus({
   withMemorySourceCounts: true,
 });
 
-const fallbackManagerStatus = createManagerStatus({
-  backend: "builtin",
-  provider: "openai",
-  model: "text-embedding-3-small",
-  requestedProvider: "openai",
-});
-
 const mockPrimary = {
   search: vi.fn(async () => []),
   readFile: vi.fn(async () => ({ text: "", path: "MEMORY.md" })),
@@ -54,28 +47,7 @@ const mockPrimary = {
   close: vi.fn(async () => {}),
 };
 
-const fallbackSearch = vi.fn(async () => [
-  {
-    path: "MEMORY.md",
-    startLine: 1,
-    endLine: 1,
-    score: 1,
-    snippet: "fallback",
-    source: "memory" as const,
-  },
-]);
-
-const fallbackManager = {
-  search: fallbackSearch,
-  readFile: vi.fn(async () => ({ text: "", path: "MEMORY.md" })),
-  status: vi.fn(() => fallbackManagerStatus),
-  sync: vi.fn(async () => {}),
-  probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
-  probeVectorAvailability: vi.fn(async () => true),
-  close: vi.fn(async () => {}),
-};
-
-const mockMemoryIndexGet = vi.fn(async () => fallbackManager);
+const mockMemoryIndexGet = vi.fn();
 
 vi.mock("./qmd-manager.js", () => ({
   QmdMemoryManager: {
@@ -95,7 +67,6 @@ import { getMemorySearchManager } from "./search-manager.js";
 const createQmdManagerMock = vi.mocked(QmdMemoryManager.create);
 
 type SearchManagerResult = Awaited<ReturnType<typeof getMemorySearchManager>>;
-type SearchManager = NonNullable<SearchManagerResult["manager"]>;
 
 function createQmdCfg(agentId: string): OpenClawConfig {
   return {
@@ -104,19 +75,12 @@ function createQmdCfg(agentId: string): OpenClawConfig {
   };
 }
 
-function requireManager(result: SearchManagerResult): SearchManager {
+function requireManager(result: SearchManagerResult): NonNullable<SearchManagerResult["manager"]> {
   expect(result.manager).toBeTruthy();
   if (!result.manager) {
     throw new Error("manager missing");
   }
   return result.manager;
-}
-
-async function createFailedQmdSearchHarness(params: { agentId: string; errorMessage: string }) {
-  const cfg = createQmdCfg(params.agentId);
-  mockPrimary.search.mockRejectedValueOnce(new Error(params.errorMessage));
-  const first = await getMemorySearchManager({ cfg, agentId: params.agentId });
-  return { cfg, manager: requireManager(first), firstResult: first };
 }
 
 beforeEach(() => {
@@ -127,16 +91,9 @@ beforeEach(() => {
   mockPrimary.probeEmbeddingAvailability.mockClear();
   mockPrimary.probeVectorAvailability.mockClear();
   mockPrimary.close.mockClear();
-  fallbackSearch.mockClear();
-  fallbackManager.readFile.mockClear();
-  fallbackManager.status.mockClear();
-  fallbackManager.sync.mockClear();
-  fallbackManager.probeEmbeddingAvailability.mockClear();
-  fallbackManager.probeVectorAvailability.mockClear();
-  fallbackManager.close.mockClear();
   mockMemoryIndexGet.mockClear();
-  mockMemoryIndexGet.mockResolvedValue(fallbackManager);
   createQmdManagerMock.mockClear();
+  createQmdManagerMock.mockResolvedValue(mockPrimary as unknown as QmdMemoryManager);
 });
 
 describe("getMemorySearchManager caching", () => {
@@ -149,28 +106,6 @@ describe("getMemorySearchManager caching", () => {
     expect(first.manager).toBe(second.manager);
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("evicts failed qmd wrapper so next call retries qmd", async () => {
-    const retryAgentId = "retry-agent";
-    const {
-      cfg,
-      manager: firstManager,
-      firstResult: first,
-    } = await createFailedQmdSearchHarness({
-      agentId: retryAgentId,
-      errorMessage: "qmd query failed",
-    });
-
-    const fallbackResults = await firstManager.search("hello");
-    expect(fallbackResults).toHaveLength(1);
-    expect(fallbackResults[0]?.path).toBe("MEMORY.md");
-
-    const second = await getMemorySearchManager({ cfg, agentId: retryAgentId });
-    requireManager(second);
-    expect(second.manager).not.toBe(first.manager);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
   });
 
   it("does not cache status-only qmd managers", async () => {
@@ -195,52 +130,72 @@ describe("getMemorySearchManager caching", () => {
       expect.objectContaining({ agentId, mode: "status" }),
     );
   });
+});
 
-  it("does not evict a newer cached wrapper when closing an older failed wrapper", async () => {
-    const retryAgentId = "retry-agent-close";
-    const {
-      cfg,
-      manager: firstManager,
-      firstResult: first,
-    } = await createFailedQmdSearchHarness({
-      agentId: retryAgentId,
-      errorMessage: "qmd query failed",
-    });
-    await firstManager.search("hello");
+describe("getMemorySearchManager QMD behavior", () => {
+  it("returns manager when QMD is configured and succeeds", async () => {
+    const cfg = createQmdCfg("success-agent");
 
-    const second = await getMemorySearchManager({ cfg, agentId: retryAgentId });
-    const secondManager = requireManager(second);
-    expect(second.manager).not.toBe(first.manager);
+    const result = await getMemorySearchManager({ cfg, agentId: "success-agent" });
 
-    await firstManager.close?.();
-
-    const third = await getMemorySearchManager({ cfg, agentId: retryAgentId });
-    expect(third.manager).toBe(secondManager);
+    expect(result.manager).toBeTruthy();
+    expect(result.error).toBeUndefined();
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to builtin search when qmd fails with sqlite busy", async () => {
-    const retryAgentId = "retry-agent-busy";
-    const { manager: firstManager } = await createFailedQmdSearchHarness({
-      agentId: retryAgentId,
-      errorMessage: "qmd index busy while reading results: SQLITE_BUSY: database is locked",
-    });
+  it("returns null manager with error when QMD throws", async () => {
+    const cfg = createQmdCfg("error-agent");
+    createQmdManagerMock.mockRejectedValueOnce(new Error("qmd not found in PATH"));
 
-    const results = await firstManager.search("hello");
-    expect(results).toHaveLength(1);
-    expect(results[0]?.path).toBe("MEMORY.md");
-    expect(fallbackSearch).toHaveBeenCalledTimes(1);
+    const result = await getMemorySearchManager({ cfg, agentId: "error-agent" });
+
+    expect(result.manager).toBeNull();
+    expect(result.error).toContain("QMD backend error");
+    expect(result.error).toContain("qmd not found in PATH");
+    // Should not fall back to builtin
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockMemoryIndexGet).not.toHaveBeenCalled();
   });
 
-  it("keeps original qmd error when fallback manager initialization fails", async () => {
-    const retryAgentId = "retry-agent-no-fallback-auth";
-    const { manager: firstManager } = await createFailedQmdSearchHarness({
-      agentId: retryAgentId,
-      errorMessage: "qmd query failed",
-    });
-    mockMemoryIndexGet.mockRejectedValueOnce(new Error("No API key found for provider openai"));
+  it("returns null manager with error when QMD returns null", async () => {
+    const cfg = createQmdCfg("null-agent");
+    createQmdManagerMock.mockResolvedValueOnce(null as unknown as QmdMemoryManager);
 
-    await expect(firstManager.search("hello")).rejects.toThrow("qmd query failed");
+    const result = await getMemorySearchManager({ cfg, agentId: "null-agent" });
+
+    expect(result.manager).toBeNull();
+    expect(result.error).toContain("QMD backend returned null");
+    // Should not fall back to builtin
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockMemoryIndexGet).not.toHaveBeenCalled();
+  });
+});
+
+describe("getMemorySearchManager builtin fallback", () => {
+  it("uses builtin manager when memory.backend is not set to qmd", async () => {
+    const cfg: OpenClawConfig = {
+      memory: { backend: "builtin" },
+      agents: { list: [{ id: "builtin-agent", default: true, workspace: "/tmp/workspace" }] },
+    };
+    const fallbackManager = {
+      search: vi.fn(async () => []),
+      readFile: vi.fn(async () => ({ text: "", path: "MEMORY.md" })),
+      status: vi.fn(() => qmdManagerStatus),
+      sync: vi.fn(async () => {}),
+      probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
+      probeVectorAvailability: vi.fn(async () => true),
+      close: vi.fn(async () => {}),
+    };
+    mockMemoryIndexGet.mockResolvedValueOnce(fallbackManager);
+
+    const result = await getMemorySearchManager({ cfg, agentId: "builtin-agent" });
+
+    expect(result.manager).toBe(fallbackManager);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockMemoryIndexGet).toHaveBeenCalledTimes(1);
+    // Should not try to create QMD manager
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(createQmdManagerMock).not.toHaveBeenCalled();
   });
 });

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -2,11 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ResolvedQmdConfig } from "./backend-config.js";
 import { resolveMemoryBackendConfig } from "./backend-config.js";
-import type {
-  MemoryEmbeddingProbeResult,
-  MemorySearchManager,
-  MemorySyncProgressUpdate,
-} from "./types.js";
+import type { MemorySearchManager } from "./types.js";
 
 const log = createSubsystemLogger("memory");
 const QMD_MANAGER_CACHE = new Map<string, MemorySearchManager>();
@@ -44,28 +40,24 @@ export async function getMemorySearchManager(params: {
         if (statusOnly) {
           return { manager: primary };
         }
-        const wrapper = new FallbackMemoryManager(
-          {
-            primary,
-            fallbackFactory: async () => {
-              const { MemoryIndexManager } = await import("./manager.js");
-              return await MemoryIndexManager.get(params);
-            },
-          },
-          () => {
-            if (cacheKey) {
-              QMD_MANAGER_CACHE.delete(cacheKey);
-            }
-          },
-        );
+        // When QMD is explicitly configured, we use QMD directly without fallback.
+        // Users choose QMD specifically to avoid cloud embedding dependencies.
+        // Falling back to builtin (which requires cloud providers) breaks that expectation.
+        // See: https://github.com/openclaw/openclaw/issues/12021
         if (cacheKey) {
-          QMD_MANAGER_CACHE.set(cacheKey, wrapper);
+          QMD_MANAGER_CACHE.set(cacheKey, primary);
         }
-        return { manager: wrapper };
+        return { manager: primary };
       }
+      // QMD was explicitly configured but returned null - don't fall back to builtin
+      log.error(`QMD memory backend returned null (not falling back to builtin as QMD is explicitly configured)`);
+      return { manager: null, error: `QMD backend returned null` };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      log.warn(`qmd memory unavailable; falling back to builtin: ${message}`);
+      // When QMD is explicitly configured, don't silently fall back to builtin.
+      // Return the actual QMD error so users know their chosen backend failed.
+      log.error(`QMD memory backend failed (not falling back to builtin as QMD is explicitly configured): ${message}`);
+      return { manager: null, error: `QMD backend error: ${message}` };
     }
   }
 
@@ -76,150 +68,6 @@ export async function getMemorySearchManager(params: {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { manager: null, error: message };
-  }
-}
-
-class FallbackMemoryManager implements MemorySearchManager {
-  private fallback: MemorySearchManager | null = null;
-  private primaryFailed = false;
-  private lastError?: string;
-  private cacheEvicted = false;
-
-  constructor(
-    private readonly deps: {
-      primary: MemorySearchManager;
-      fallbackFactory: () => Promise<MemorySearchManager | null>;
-    },
-    private readonly onClose?: () => void,
-  ) {}
-
-  async search(
-    query: string,
-    opts?: { maxResults?: number; minScore?: number; sessionKey?: string },
-  ) {
-    if (!this.primaryFailed) {
-      try {
-        return await this.deps.primary.search(query, opts);
-      } catch (err) {
-        this.primaryFailed = true;
-        this.lastError = err instanceof Error ? err.message : String(err);
-        log.warn(`qmd memory failed; switching to builtin index: ${this.lastError}`);
-        await this.deps.primary.close?.().catch(() => {});
-        // Evict the failed wrapper so the next request can retry QMD with a fresh manager.
-        this.evictCacheEntry();
-      }
-    }
-    const fallback = await this.ensureFallback();
-    if (fallback) {
-      return await fallback.search(query, opts);
-    }
-    throw new Error(this.lastError ?? "memory search unavailable");
-  }
-
-  async readFile(params: { relPath: string; from?: number; lines?: number }) {
-    if (!this.primaryFailed) {
-      return await this.deps.primary.readFile(params);
-    }
-    const fallback = await this.ensureFallback();
-    if (fallback) {
-      return await fallback.readFile(params);
-    }
-    throw new Error(this.lastError ?? "memory read unavailable");
-  }
-
-  status() {
-    if (!this.primaryFailed) {
-      return this.deps.primary.status();
-    }
-    const fallbackStatus = this.fallback?.status();
-    const fallbackInfo = { from: "qmd", reason: this.lastError ?? "unknown" };
-    if (fallbackStatus) {
-      const custom = fallbackStatus.custom ?? {};
-      return {
-        ...fallbackStatus,
-        fallback: fallbackInfo,
-        custom: {
-          ...custom,
-          fallback: { disabled: true, reason: this.lastError ?? "unknown" },
-        },
-      };
-    }
-    const primaryStatus = this.deps.primary.status();
-    const custom = primaryStatus.custom ?? {};
-    return {
-      ...primaryStatus,
-      fallback: fallbackInfo,
-      custom: {
-        ...custom,
-        fallback: { disabled: true, reason: this.lastError ?? "unknown" },
-      },
-    };
-  }
-
-  async sync(params?: {
-    reason?: string;
-    force?: boolean;
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }) {
-    if (!this.primaryFailed) {
-      await this.deps.primary.sync?.(params);
-      return;
-    }
-    const fallback = await this.ensureFallback();
-    await fallback?.sync?.(params);
-  }
-
-  async probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult> {
-    if (!this.primaryFailed) {
-      return await this.deps.primary.probeEmbeddingAvailability();
-    }
-    const fallback = await this.ensureFallback();
-    if (fallback) {
-      return await fallback.probeEmbeddingAvailability();
-    }
-    return { ok: false, error: this.lastError ?? "memory embeddings unavailable" };
-  }
-
-  async probeVectorAvailability() {
-    if (!this.primaryFailed) {
-      return await this.deps.primary.probeVectorAvailability();
-    }
-    const fallback = await this.ensureFallback();
-    return (await fallback?.probeVectorAvailability()) ?? false;
-  }
-
-  async close() {
-    await this.deps.primary.close?.();
-    await this.fallback?.close?.();
-    this.evictCacheEntry();
-  }
-
-  private async ensureFallback(): Promise<MemorySearchManager | null> {
-    if (this.fallback) {
-      return this.fallback;
-    }
-    let fallback: MemorySearchManager | null;
-    try {
-      fallback = await this.deps.fallbackFactory();
-      if (!fallback) {
-        log.warn("memory fallback requested but builtin index is unavailable");
-        return null;
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.warn(`memory fallback unavailable: ${message}`);
-      return null;
-    }
-    this.fallback = fallback;
-    return this.fallback;
-  }
-
-  private evictCacheEntry(): void {
-    if (this.cacheEvicted) {
-      return;
-    }
-    this.cacheEvicted = true;
-    this.onClose?.();
   }
 }
 


### PR DESCRIPTION
## Summary
When users explicitly configure `memory.backend: "qmd"`, they do so to avoid cloud embedding dependencies. The previous behavior of silently falling back to the builtin backend (which requires OpenAI/Google/etc. API keys) broke this expectation and caused confusing 'quota exceeded' errors.

Fixes #12021

## Changes
- Removes `FallbackMemoryManager` wrapping when QMD is explicitly configured
- Returns actual QMD errors instead of falling back to builtin
- Logs at error level for visibility

## Behavior Change
**BREAKING CHANGE**: Users relying on QMD→builtin fallback will now see errors instead of silent fallback. To restore fallback behavior, remove `memory.backend: "qmd"` from config (which defaults to builtin with fallback).

## Why This is the Right Fix
Users choose QMD specifically for:
1. Privacy (no data sent to cloud)
2. Cost (no API fees)
3. Offline operation

Silently falling back to cloud embeddings when QMD fails violates all three expectations. This change ensures the system honors the user's explicit backend choice.

## Testing
- [ ] Verify QMD works normally when configured
- [ ] Verify proper error messages when QMD fails
- [ ] Verify no fallback to builtin occurs

## Related
- Issue #12021: memory_search tool ignores memory.backend: 'qmd' config, tries cloud providers
