### PR TITLE
fix(tokens): catch pre-underscore streaming prefixes of NO_REPLY

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -81,15 +81,32 @@ describe("isSilentReplyPrefixText", () => {
     expect(isSilentReplyPrefixText("  HEARTBEAT_", "HEARTBEAT_OK")).toBe(true);
   });
 
-  it("rejects ambiguous natural-language prefixes", () => {
-    expect(isSilentReplyPrefixText("N")).toBe(false);
+  it("matches uppercase pre-underscore streaming prefixes (#32168)", () => {
+    // During streaming, the LLM may emit "NO" before the underscore arrives.
+    // These all-uppercase fragments must be caught to prevent a visible
+    // partial leak in webchat.
+    expect(isSilentReplyPrefixText("NO")).toBe(true);
+    expect(isSilentReplyPrefixText("N")).toBe(true);
+    expect(isSilentReplyPrefixText("HEARTBEAT", "HEARTBEAT_OK")).toBe(true);
+  });
+
+  it("rejects mixed-case natural-language prefixes", () => {
+    // Mixed case indicates natural language, not a streaming token prefix.
     expect(isSilentReplyPrefixText("No")).toBe(false);
     expect(isSilentReplyPrefixText("Hello")).toBe(false);
+    expect(isSilentReplyPrefixText("Heart")).toBe(false);
+    expect(isSilentReplyPrefixText("no")).toBe(false);
   });
 
   it("rejects non-prefixes and mixed characters", () => {
     expect(isSilentReplyPrefixText("NO_X")).toBe(false);
     expect(isSilentReplyPrefixText("NO_REPLY more")).toBe(false);
     expect(isSilentReplyPrefixText("NO-")).toBe(false);
+  });
+
+  it("returns false for undefined/empty", () => {
+    expect(isSilentReplyPrefixText(undefined)).toBe(false);
+    expect(isSilentReplyPrefixText("")).toBe(false);
+    expect(isSilentReplyPrefixText("   ")).toBe(false);
   });
 });

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -34,14 +34,19 @@ export function isSilentReplyPrefixText(
   if (!text) {
     return false;
   }
-  const normalized = text.trimStart().toUpperCase();
-  if (!normalized) {
+  const trimmed = text.trimStart();
+  if (!trimmed) {
     return false;
   }
-  if (!normalized.includes("_")) {
-    return false;
-  }
+  const normalized = trimmed.toUpperCase();
   if (/[^A-Z_]/.test(normalized)) {
+    return false;
+  }
+  // For fragments that don't yet contain an underscore, only match when the
+  // original text is already fully uppercase.  This avoids false positives
+  // with natural-language words like "No" or "Heart" while still catching
+  // streaming prefixes like "NO" from NO_REPLY (#32168).
+  if (!normalized.includes("_") && trimmed !== normalized) {
     return false;
   }
   return token.toUpperCase().startsWith(normalized);


### PR DESCRIPTION
## Summary

- Fixes `"NO"` partial text leaking to webchat during streaming when the agent replies with `NO_REPLY`
- Root cause: `isSilentReplyPrefixText` required an underscore in the fragment (`!normalized.includes("_")`), so `"NO"` was not recognized as a prefix of `NO_REPLY` and passed through to the typing signal
- Relaxes the guard to catch all-uppercase fragments (e.g. `"NO"`, `"HEARTBEAT"`) that are a prefix of the token
- Mixed-case input (`"No"`, `"Heart"`) is still rejected to avoid false positives with natural language

## Test plan

- [x] 20 unit tests pass in `tokens.test.ts`:
  - New test: uppercase pre-underscore prefixes `"NO"`, `"N"`, `"HEARTBEAT"` → all caught
  - Existing: mixed-case `"No"`, `"Hello"`, `"Heart"` → still rejected
  - Existing: underscore prefixes `"NO_"`, `"NO_RE"`, `"NO_REPLY"` → still caught
  - New: `undefined`/empty/whitespace → returns false
- [x] All 920 auto-reply tests pass (74 files, zero regressions)

Closes #32168

🤖 Generated with [Claude Code](https://claude.com/claude-code)