### PR TITLE
ui: prevent code block soft-wrap so UUID copy/paste stays intact

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -87,6 +87,12 @@
   border-radius: 4px;
   padding: 12px;
   overflow-x: auto;
+
+  /* See #32230 — avoid soft wrapping long tokens that later copy with spaces. */
+  white-space: pre;
+  overflow-wrap: normal;
+  word-break: normal;
+  word-wrap: normal;
 }
 
 .sidebar-markdown code {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -67,11 +67,22 @@
   border-radius: 6px;
   padding: 10px 12px;
   overflow-x: auto;
+
+  /* Prevent browsers from soft-wrapping long tokens (UUIDs, keys, etc.).
+     Wrapping can cause copy/paste to inject spaces in some renderers (#32230). */
+  white-space: pre;
+  overflow-wrap: normal;
+  word-break: normal;
+  word-wrap: normal;
 }
 
 .chat-text :where(pre code) {
   background: none;
   padding: 0;
+
+  white-space: inherit;
+  overflow-wrap: inherit;
+  word-break: inherit;
 }
 
 .chat-text :where(blockquote) {


### PR DESCRIPTION
Fixes #32230.

Some browsers insert spaces when copying long, soft-wrapped tokens from <pre> blocks (UUIDs, keys, etc.).

This change forces chat + sidebar code blocks to preserve whitespace (no soft wrap) and only scroll horizontally.

- chat: pre/code override to disable overflow-wrap / word-break
- sidebar: same

Verification:
- pnpm -C ui test (note: suite currently failing on main for unrelated reasons; this change is CSS-only)