### PR TITLE
chore(pi): change wording in landpr slash prompt, prefer squash

### DIFF
--- a/.pi/prompts/landpr.md
+++ b/.pi/prompts/landpr.md
@@ -9,7 +9,7 @@ Input
   - If ambiguous: ask.
 
 Do (end-to-end)
-Goal: PR must end in GitHub state = MERGED (never CLOSED). Use `gh pr merge --squash`.
+Goal: PR must end in GitHub state = MERGED (never CLOSED). Prefer `gh pr merge --squash`; use `--rebase` only when preserving commit history is required.
 
 1. Assign PR to self:
    - `gh pr edit <PR> --add-assignee @me`
@@ -30,49 +30,44 @@ Goal: PR must end in GitHub state = MERGED (never CLOSED). Use `gh pr merge --sq
    - `git checkout -b temp/landpr-<ts-or-pr>`
 6. Check out PR branch locally:
    - `gh pr checkout <PR>`
-7. Sync PR branch with temp base:
-   - `git merge temp/landpr-<ts-or-pr>`
+7. Rebase PR branch onto temp base:
+   - `git rebase temp/landpr-<ts-or-pr>`
    - Fix conflicts; keep history tidy.
 8. Fix + tests + changelog:
    - Implement fixes + add/adjust tests
    - Update `CHANGELOG.md` and mention `#<PR>` + `@$contrib`
-9. Full gate (BEFORE commit):
-   - `pnpm lint && pnpm build && pnpm test`
-10. Commit via committer (final merge commit only includes PR # + thanks):
+9. Decide merge strategy:
+   - Squash (preferred): use when we want a single clean commit
+   - Rebase: use only when we explicitly want to preserve commit history
+   - If unclear, ask
+10. Full gate (BEFORE commit):
+    - `pnpm lint && pnpm build && pnpm test`
+11. Commit via committer (final merge commit only includes PR # + thanks):
     - For the final merge-ready commit: `committer "fix: <summary> (#<PR>) (thanks @$contrib)" CHANGELOG.md <changed files>`
     - If you need intermediate fix commits before the final merge commit, keep those messages concise and **omit** PR number/thanks.
     - `land_sha=$(git rev-parse HEAD)`
-11. Push updated PR branch:
+12. Push updated PR branch (rebase => usually needs force):
 
     ```sh
     git remote add prhead "$head_repo_url.git" 2>/dev/null || git remote set-url prhead "$head_repo_url.git"
-    git push prhead HEAD:$head
+    git push --force-with-lease prhead HEAD:$head
     ```
 
-    - If push is rejected because the remote moved or history was rewritten, retry with `--force-with-lease`.
-
-12. Merge PR (must show MERGED on GitHub):
-    - `gh pr merge <PR> --squash`
+13. Merge PR (must show MERGED on GitHub):
+    - Squash (preferred): `gh pr merge <PR> --squash`
+    - Rebase (history-preserving fallback): `gh pr merge <PR> --rebase`
     - Never `gh pr close` (closing is wrong)
-13. Sync main:
+14. Sync main:
     - `git checkout main`
     - `git pull --ff-only`
-14. Comment on PR with what we did + SHAs + thanks:
+15. Comment on PR with what we did + SHAs + thanks:
 
     ```sh
     merge_sha=$(gh pr view <PR> --json mergeCommit --jq '.mergeCommit.oid')
-    gh pr comment <PR> -F - <<EOF
-    Landed via temp base sync onto main.
-
-    - Gate: pnpm lint && pnpm build && pnpm test
-    - Land commit: $land_sha
-    - Merge commit: $merge_sha
-
-    Thanks @$contrib!
-    EOF
+    gh pr comment <PR> --body "Landed via temp rebase onto main.\n\n- Gate: pnpm lint && pnpm build && pnpm test\n- Land commit: $land_sha\n- Merge commit: $merge_sha\n\nThanks @$contrib!"
     ```
 
-15. Verify PR state == MERGED:
+16. Verify PR state == MERGED:
     - `gh pr view <PR> --json state --jq .state`
-16. Delete temp branch:
+17. Delete temp branch:
     - `git branch -D temp/landpr-<ts-or-pr>`

--- a/.pi/prompts/landpr.md
+++ b/.pi/prompts/landpr.md
@@ -9,7 +9,7 @@ Input
   - If ambiguous: ask.
 
 Do (end-to-end)
-Goal: PR must end in GitHub state = MERGED (never CLOSED). Use `gh pr merge` with `--rebase` or `--squash`.
+Goal: PR must end in GitHub state = MERGED (never CLOSED). Use `gh pr merge --squash`.
 
 1. Assign PR to self:
    - `gh pr edit <PR> --add-assignee @me`
@@ -30,44 +30,49 @@ Goal: PR must end in GitHub state = MERGED (never CLOSED). Use `gh pr merge` wit
    - `git checkout -b temp/landpr-<ts-or-pr>`
 6. Check out PR branch locally:
    - `gh pr checkout <PR>`
-7. Rebase PR branch onto temp base:
-   - `git rebase temp/landpr-<ts-or-pr>`
+7. Sync PR branch with temp base:
+   - `git merge temp/landpr-<ts-or-pr>`
    - Fix conflicts; keep history tidy.
 8. Fix + tests + changelog:
    - Implement fixes + add/adjust tests
    - Update `CHANGELOG.md` and mention `#<PR>` + `@$contrib`
-9. Decide merge strategy:
-   - Rebase if we want to preserve commit history
-   - Squash if we want a single clean commit
-   - If unclear, ask
-10. Full gate (BEFORE commit):
-    - `pnpm lint && pnpm build && pnpm test`
-11. Commit via committer (final merge commit only includes PR # + thanks):
+9. Full gate (BEFORE commit):
+   - `pnpm lint && pnpm build && pnpm test`
+10. Commit via committer (final merge commit only includes PR # + thanks):
     - For the final merge-ready commit: `committer "fix: <summary> (#<PR>) (thanks @$contrib)" CHANGELOG.md <changed files>`
     - If you need intermediate fix commits before the final merge commit, keep those messages concise and **omit** PR number/thanks.
     - `land_sha=$(git rev-parse HEAD)`
-12. Push updated PR branch (rebase => usually needs force):
+11. Push updated PR branch:
 
     ```sh
     git remote add prhead "$head_repo_url.git" 2>/dev/null || git remote set-url prhead "$head_repo_url.git"
-    git push --force-with-lease prhead HEAD:$head
+    git push prhead HEAD:$head
     ```
 
-13. Merge PR (must show MERGED on GitHub):
-    - Rebase: `gh pr merge <PR> --rebase`
-    - Squash: `gh pr merge <PR> --squash`
+    - If push is rejected because the remote moved or history was rewritten, retry with `--force-with-lease`.
+
+12. Merge PR (must show MERGED on GitHub):
+    - `gh pr merge <PR> --squash`
     - Never `gh pr close` (closing is wrong)
-14. Sync main:
+13. Sync main:
     - `git checkout main`
     - `git pull --ff-only`
-15. Comment on PR with what we did + SHAs + thanks:
+14. Comment on PR with what we did + SHAs + thanks:
 
     ```sh
     merge_sha=$(gh pr view <PR> --json mergeCommit --jq '.mergeCommit.oid')
-    gh pr comment <PR> --body "Landed via temp rebase onto main.\n\n- Gate: pnpm lint && pnpm build && pnpm test\n- Land commit: $land_sha\n- Merge commit: $merge_sha\n\nThanks @$contrib!"
+    gh pr comment <PR> -F - <<EOF
+    Landed via temp base sync onto main.
+
+    - Gate: pnpm lint && pnpm build && pnpm test
+    - Land commit: $land_sha
+    - Merge commit: $merge_sha
+
+    Thanks @$contrib!
+    EOF
     ```
 
-16. Verify PR state == MERGED:
+15. Verify PR state == MERGED:
     - `gh pr view <PR> --json state --jq .state`
-17. Delete temp branch:
+16. Delete temp branch:
     - `git branch -D temp/landpr-<ts-or-pr>`


### PR DESCRIPTION
## Summary
- update `.pi/prompts/landpr.md` to remove rebase-based merge guidance and require `gh pr merge --squash`
- change the PR sync step wording from `git rebase` to `git merge temp/landpr-<ts-or-pr>`
- update the comment example wording to “Landed via temp base sync onto main” and use heredoc-safe `gh pr comment ... -F -`

## Testing
- not run (prompt wording change only)
