### PR TITLE
test(cron): avoid bun flake by asserting embedded model on last call

### DIFF
--- a/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
+++ b/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
@@ -427,7 +427,7 @@ describe("runCronIsolatedAgentTurn", () => {
       });
 
       expect(res.status).toBe("ok");
-      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0] as { prompt?: string };
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls.at(-1)?.[0] as { prompt?: string };
       expect(call?.prompt).toContain("EXTERNAL, UNTRUSTED");
       expect(call?.prompt).toContain("Hello");
     });
@@ -449,7 +449,7 @@ describe("runCronIsolatedAgentTurn", () => {
       });
 
       expect(res.status).toBe("ok");
-      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0] as { prompt?: string };
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls.at(-1)?.[0] as { prompt?: string };
       expect(call?.prompt).not.toContain("EXTERNAL, UNTRUSTED");
       expect(call?.prompt).toContain("Hello");
     });
@@ -486,7 +486,7 @@ describe("runCronIsolatedAgentTurn", () => {
       });
 
       expect(res.status).toBe("ok");
-      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0] as {
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls.at(-1)?.[0] as {
         provider?: string;
         model?: string;
       };


### PR DESCRIPTION
## Context
Bun CI intermittently fails `src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts` with:
> expected provider openai, received anthropic

In bun runs the embedded agent can be invoked multiple times (retries/fallbacks). The test currently asserts against `mock.calls[0]`, which becomes ordering-dependent.

## Fix
Assert against the **last** `runEmbeddedPiAgent` invocation via `mock.calls.at(-1)`.

## Tests
- `pnpm test -- src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts`