### PR TITLE
fix: treat cron tool errors as non-fatal when run has deliverable content

### DIFF
--- a/src/cron/isolated-agent/run.cron-status-error-recovery.test.ts
+++ b/src/cron/isolated-agent/run.cron-status-error-recovery.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  makeIsolatedAgentTurnParams,
+  setupRunCronIsolatedAgentTurnSuite,
+} from "./run.suite-helpers.js";
+import { loadRunCronIsolatedAgentTurn, runWithModelFallbackMock } from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+describe("runCronIsolatedAgentTurn — error payload recovery (#32244)", () => {
+  setupRunCronIsolatedAgentTurnSuite();
+
+  it("marks run as ok when non-error payload with text follows an error payload", async () => {
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [
+          { text: "Write: to ~/file.md failed", isError: true },
+          { text: "File written successfully" },
+        ],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentTurnParams());
+    expect(result.status).toBe("ok");
+  });
+
+  it("marks run as ok when non-error payload appears BEFORE the last error payload", async () => {
+    // The model produces useful output first, then a tool error at the end.
+    // The run should still be considered successful since it has deliverable content.
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [
+          { text: "Here is the report for today." },
+          { text: "Write: to ~/file.md (6827 chars) failed", isError: true },
+        ],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentTurnParams());
+    expect(result.status).toBe("ok");
+  });
+
+  it("marks run as error when only error payloads exist (no recovery)", async () => {
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [{ text: "Connection refused", isError: true }],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentTurnParams());
+    expect(result.status).toBe("error");
+  });
+
+  it("marks run as error when run-level error exists even with non-error payloads", async () => {
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [{ text: "partial output" }, { text: "context overflow", isError: true }],
+        meta: {
+          agentMeta: { usage: { input: 10, output: 20 } },
+          error: "context length exceeded",
+        },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentTurnParams());
+    expect(result.status).toBe("error");
+  });
+});

--- a/src/cron/isolated-agent/run.cron-status-error-recovery.test.ts
+++ b/src/cron/isolated-agent/run.cron-status-error-recovery.test.ts
@@ -60,6 +60,24 @@ describe("runCronIsolatedAgentTurn — error payload recovery (#32244)", () => {
     expect(result.status).toBe("error");
   });
 
+  it("marks run as ok when non-error payload has channelData alongside an error payload", async () => {
+    // Slack Block Kit or other structured channel content should count as deliverable.
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [
+          { channelData: { slack: { blocks: [{ type: "section" }] } } },
+          { text: "Write failed", isError: true },
+        ],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentTurnParams());
+    expect(result.status).toBe("ok");
+  });
+
   it("marks run as error when run-level error exists even with non-error payloads", async () => {
     runWithModelFallbackMock.mockResolvedValue({
       result: {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -636,17 +636,22 @@ export async function runCronIsolatedAgentTurn(params: {
   const deliveryBestEffort = resolveCronDeliveryBestEffort(params.job);
   const hasErrorPayload = payloads.some((payload) => payload?.isError === true);
   const runLevelError = runResult.meta?.error;
-  const lastErrorPayloadIndex = payloads.findLastIndex((payload) => payload?.isError === true);
-  const hasSuccessfulPayloadAfterLastError =
-    !runLevelError &&
-    lastErrorPayloadIndex >= 0 &&
-    payloads
-      .slice(lastErrorPayloadIndex + 1)
-      .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
-  // Tool wrappers can emit transient/false-positive error payloads before a valid final
-  // assistant payload.  Only treat payload errors as recoverable when (a) the run itself
-  // did not report a model/context-level error and (b) a non-error payload follows.
-  const hasFatalErrorPayload = hasErrorPayload && !hasSuccessfulPayloadAfterLastError;
+  const hasNonErrorPayloadWithContent = payloads.some(
+    (payload) =>
+      payload?.isError !== true &&
+      (Boolean(payload?.text?.trim()) ||
+        Boolean(payload?.mediaUrl) ||
+        (payload?.mediaUrls?.length ?? 0) > 0),
+  );
+  // Tool wrappers can emit transient error payloads (e.g. a failed write that is retried)
+  // alongside successful payloads in the same run.  When (a) the run itself did not report
+  // a model/context-level error and (b) a non-error payload with deliverable content exists
+  // anywhere in the run, the error is considered transient — the run produced useful output
+  // and should not be marked as failed.  This avoids false-positive "error" status when the
+  // model recovers from a tool failure or when the error payload is a trailing tool output
+  // line that merely contains the word "failed" (#32244).
+  const hasFatalErrorPayload =
+    hasErrorPayload && (Boolean(runLevelError) || !hasNonErrorPayloadWithContent);
   const lastErrorPayloadText = [...payloads]
     .toReversed()
     .find((payload) => payload?.isError === true && Boolean(payload?.text?.trim()))

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -641,7 +641,8 @@ export async function runCronIsolatedAgentTurn(params: {
       payload?.isError !== true &&
       (Boolean(payload?.text?.trim()) ||
         Boolean(payload?.mediaUrl) ||
-        (payload?.mediaUrls?.length ?? 0) > 0),
+        (payload?.mediaUrls?.length ?? 0) > 0 ||
+        Object.keys(payload?.channelData ?? {}).length > 0),
   );
   // Tool wrappers can emit transient error payloads (e.g. a failed write that is retried)
   // alongside successful payloads in the same run.  When (a) the run itself did not report


### PR DESCRIPTION
## Summary

- Fixes false-positive `lastRunStatus: "error"` when a cron job produces useful output alongside transient tool errors
- Previously, error recovery required a non-error payload with text **after** the last error — trailing tool failures at the end of a run were always considered fatal
- Now checks for non-error payloads with content **anywhere** in the run (text, media, or media URLs)
- Run-level errors (model/context failures) still override and correctly report "error"

## Problem

When a cron job successfully writes a file and delivers its message, but also encounters a tool error (e.g. a transient write failure that the model retried), the run status was incorrectly set to "error" even though `lastDelivered: true` and the file was actually written. The error text like `"✦ ✍ Write: to ~/file.md (6827 chars) failed"` was treated as a fatal error because no non-error payload with text appeared after it.

## Test plan

- [x] New test: run marked "ok" when non-error payload with text follows an error payload
- [x] New test: run marked "ok" when non-error payload appears **before** the last error payload
- [x] New test: run correctly marked "error" when only error payloads exist
- [x] New test: run correctly marked "error" when run-level error exists even with non-error payloads
- [x] All 382 cron tests pass (52 test files)

Closes #32244

🤖 Generated with [Claude Code](https://claude.com/claude-code)