### PR TITLE
fix(hooks): use globalThis singleton for handler registry to survive bundle splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/Control UI basePath webhook passthrough: let non-read methods under configured `controlUiBasePath` fall through to plugin routes (instead of returning Control UI 405), restoring webhook handlers behind basePath mounts. (#32311) Thanks @ademczuk.
 - Models/config env propagation: apply `config.env.vars` before implicit provider discovery in models bootstrap so config-scoped credentials are visible to implicit provider resolution paths. (#32295) Thanks @hsiaoa.
+- Hooks/runtime stability: keep the internal hook handler registry on a `globalThis` singleton so hook registration/dispatch remains consistent when bundling emits duplicate module copies. (#32292) Thanks @Drickon.
 - Voice-call/Twilio signature verification: retry signature validation across deterministic URL port variants (with/without port) to handle mixed Twilio signing behavior behind reverse proxies and non-standard ports. (#25140) Thanks @drvoss.
 - Hooks/webhook ACK compatibility: return `200` (instead of `202`) for successful `/hooks/agent` requests so providers that require `200` (for example Forward Email) accept dispatched agent hook deliveries. (#28204) Thanks @Glucksberg.
 - Voice-call/Twilio external outbound: auto-register webhook-first `outbound-api` calls (initiated outside OpenClaw) so media streams are accepted and call direction metadata stays accurate. (#31181) Thanks @scoootscooob.

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -142,6 +142,25 @@ describe("hooks", () => {
       const event = createInternalHookEvent("command", "new", "test-session");
       await expect(triggerInternalHook(event)).resolves.not.toThrow();
     });
+
+    it("stores handlers in the global singleton registry", async () => {
+      const globalHooks = globalThis as typeof globalThis & {
+        __openclaw_internal_hook_handlers__?: Map<string, Array<(event: unknown) => unknown>>;
+      };
+      const handler = vi.fn();
+      registerInternalHook("command:new", handler);
+
+      const event = createInternalHookEvent("command", "new", "test-session");
+      await triggerInternalHook(event);
+
+      expect(handler).toHaveBeenCalledWith(event);
+      expect(globalHooks.__openclaw_internal_hook_handlers__?.has("command:new")).toBe(true);
+
+      const injectedHandler = vi.fn();
+      globalHooks.__openclaw_internal_hook_handlers__?.set("command:new", [injectedHandler]);
+      await triggerInternalHook(event);
+      expect(injectedHandler).toHaveBeenCalledWith(event);
+    });
   });
 
   describe("createInternalHookEvent", () => {

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -213,10 +213,10 @@ export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | 
 const _g = globalThis as typeof globalThis & {
   __openclaw_internal_hook_handlers__?: Map<string, InternalHookHandler[]>;
 };
-if (!_g.__openclaw_internal_hook_handlers__) {
-  _g.__openclaw_internal_hook_handlers__ = new Map<string, InternalHookHandler[]>();
-}
-const handlers = _g.__openclaw_internal_hook_handlers__;
+const handlers = (_g.__openclaw_internal_hook_handlers__ ??= new Map<
+  string,
+  InternalHookHandler[]
+>());
 const log = createSubsystemLogger("internal-hooks");
 
 /**

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -200,8 +200,23 @@ export interface InternalHookEvent {
 
 export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | void;
 
-/** Registry of hook handlers by event key */
-const handlers = new Map<string, InternalHookHandler[]>();
+/**
+ * Registry of hook handlers by event key.
+ *
+ * Uses a globalThis singleton so that registerInternalHook and
+ * triggerInternalHook always share the same Map even when the bundler
+ * emits multiple copies of this module into separate chunks (bundle
+ * splitting). Without the singleton, handlers registered in one chunk
+ * are invisible to triggerInternalHook in another chunk, causing hooks
+ * to silently fire with zero handlers.
+ */
+const _g = globalThis as typeof globalThis & {
+  __openclaw_internal_hook_handlers__?: Map<string, InternalHookHandler[]>;
+};
+if (!_g.__openclaw_internal_hook_handlers__) {
+  _g.__openclaw_internal_hook_handlers__ = new Map<string, InternalHookHandler[]>();
+}
+const handlers = _g.__openclaw_internal_hook_handlers__;
 const log = createSubsystemLogger("internal-hooks");
 
 /**


### PR DESCRIPTION
## Problem

After PR #9859 landed, hooks registered via `registerInternalHook` were silently never firing in production. The bundler emits `internal-hooks` into multiple chunks — the loader registers handlers into one chunk's Map, while `triggerInternalHook` in `get-reply.ts` reads from a different chunk's Map. The handler list is empty; hooks run zero times.

**Reproduce:** enable any external hook via `hooks.external.entries` that listens on `message:transcribed`. Send a voice message. The handler is registered at startup but never invoked.

## Fix

Use `globalThis.__openclaw_internal_hook_handlers__` as a shared singleton. All module copies check for and reuse the same Map on first access, so registrations from one chunk are always visible to triggers in another.

## Tests

All 29 existing `internal-hooks.test.ts` tests pass. `pnpm check` clean.

Note: a unit test cannot reproduce the bundle-split scenario (tests run in a single module context). The fix was validated end-to-end by confirming external hooks fire after the change.

Follows #9859.