### PR TITLE
models-config: apply config env vars before implicit provider discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/Control UI basePath webhook passthrough: let non-read methods under configured `controlUiBasePath` fall through to plugin routes (instead of returning Control UI 405), restoring webhook handlers behind basePath mounts. (#32311) Thanks @ademczuk.
+- Models/config env propagation: apply `config.env.vars` before implicit provider discovery in models bootstrap so config-scoped credentials are visible to implicit provider resolution paths. (#32295) Thanks @hsiaoa.
 - Voice-call/Twilio signature verification: retry signature validation across deterministic URL port variants (with/without port) to handle mixed Twilio signing behavior behind reverse proxies and non-standard ports. (#25140) Thanks @drvoss.
 - Hooks/webhook ACK compatibility: return `200` (instead of `202`) for successful `/hooks/agent` requests so providers that require `200` (for example Forward Email) accept dispatched agent hook deliveries. (#28204) Thanks @Glucksberg.
 - Voice-call/Twilio external outbound: auto-register webhook-first `outbound-api` calls (initiated outside OpenClaw) so media streams are accepted and call direction metadata stays accurate. (#31181) Thanks @scoootscooob.

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  CUSTOM_PROXY_MODELS_CONFIG,
+  installModelsConfigTestHooks,
+  unsetEnv,
+  withModelsTempHome as withTempHome,
+  withTempEnv,
+} from "./models-config.e2e-harness.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+
+installModelsConfigTestHooks();
+
+const TEST_ENV_VAR = "OPENCLAW_MODELS_CONFIG_TEST_ENV";
+
+describe("models-config", () => {
+  it("applies config env.vars entries while ensuring models.json", async () => {
+    await withTempHome(async () => {
+      await withTempEnv([TEST_ENV_VAR], async () => {
+        unsetEnv([TEST_ENV_VAR]);
+        const cfg: OpenClawConfig = {
+          ...CUSTOM_PROXY_MODELS_CONFIG,
+          env: { vars: { [TEST_ENV_VAR]: "from-config" } },
+        };
+
+        await ensureOpenClawModelsJson(cfg);
+
+        expect(process.env[TEST_ENV_VAR]).toBe("from-config");
+      });
+    });
+  });
+
+  it("does not overwrite already-set host env vars", async () => {
+    await withTempHome(async () => {
+      await withTempEnv([TEST_ENV_VAR], async () => {
+        process.env[TEST_ENV_VAR] = "from-host";
+        const cfg: OpenClawConfig = {
+          ...CUSTOM_PROXY_MODELS_CONFIG,
+          env: { vars: { [TEST_ENV_VAR]: "from-config" } },
+        };
+
+        await ensureOpenClawModelsJson(cfg);
+
+        expect(process.env[TEST_ENV_VAR]).toBe("from-host");
+      });
+    });
+  });
+});

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { type OpenClawConfig, loadConfig } from "../config/config.js";
+import { applyConfigEnvVars } from "../config/env-vars.js";
 import { isRecord } from "../utils.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
 import {
@@ -116,6 +117,12 @@ export async function ensureOpenClawModelsJson(
 ): Promise<{ agentDir: string; wrote: boolean }> {
   const cfg = config ?? loadConfig();
   const agentDir = agentDirOverride?.trim() ? agentDirOverride.trim() : resolveOpenClawAgentDir();
+
+  // Ensure config env vars (e.g. AWS_PROFILE, AWS_ACCESS_KEY_ID) are
+  // available in process.env before implicit provider discovery.  Some
+  // callers (agent runner, tools) pass config objects that haven't gone
+  // through the full loadConfig() pipeline which applies these.
+  applyConfigEnvVars(cfg);
 
   const explicitProviders = cfg.models?.providers ?? {};
   const implicitProviders = await resolveImplicitProviders({ agentDir, explicitProviders });


### PR DESCRIPTION
## Summary

Fixes #32290.

`ensureOpenClawModelsJson()` calls `resolveImplicitBedrockProvider()` which checks for AWS credentials in `process.env` (e.g. `AWS_PROFILE`, `AWS_ACCESS_KEY_ID`). However, some callers (agent runner, tools, compaction) pass config objects that haven't gone through the full `loadConfig()` pipeline — meaning config-defined env vars from `openclaw.json` `env.vars` are never applied to `process.env` before discovery runs.

This causes Bedrock discovery to silently fail or skip when AWS credentials are only configured via `openclaw.json` `env.vars` rather than being present in the host shell environment.

The fix calls `applyConfigEnvVars(cfg)` at the top of `ensureOpenClawModelsJson` before any implicit provider discovery. This is idempotent (only sets vars not already present in `process.env`) and matches the existing pattern used in `loadConfig()`.

## Test plan

- [x] All existing `models-config` tests pass (68/68)
- [x] All `config.env-vars` tests pass (6/6)
- [x] Build succeeds with no type errors
- [x] Lint/format clean
- [ ] Manual: configure `AWS_PROFILE` only in `openclaw.json` `env.vars`, verify `openclaw status` shows Bedrock models discovered