### PR TITLE
fix(heartbeat): route exec and cron events back to originating channel

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -264,7 +264,7 @@ export function emitExecSystemEvent(
     return;
   }
   enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
-  requestHeartbeatNow({ reason: "exec-event" });
+  requestHeartbeatNow({ reason: "exec-event", sessionKey });
 }
 
 export async function runExecProcess(opts: {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1087,10 +1087,24 @@ function buildAnnounceReplyInstruction(params: {
   if (params.requesterIsSubagent) {
     return `Convert this completion into a concise internal orchestration update for your parent agent in your own words. Keep this internal context private (don't mention system/log/stats/session details or announce type). If this result is duplicate or no update is needed, reply ONLY: ${SILENT_REPLY_TOKEN}.`;
   }
+  // After delivering to the user, check the project plan and continue or gate.
+  const continuationInstruction =
+    ` After delivering, check if your active project workspace contains a PROJECT-PLAN.md.` +
+    ` If it does, read the Active Workstreams section to identify the next step.` +
+    ` If the next step is marked [GATE]: append a gate entry to GATE_CHECKPOINTS.md, tell the user you are waiting for their go-ahead before proceeding, and stop.` +
+    ` If the next step has no [GATE] marker: tell the user you are proceeding to it and start it now.` +
+    ` If there is no PROJECT-PLAN.md or no clear next action in Active Workstreams: stop normally.` +
+    ` When a milestone stage changes, update WORKBOARD.md.`;
   if (params.expectsCompletionMessage) {
-    return `A completed ${params.announceType} is ready for user delivery. Convert the result above into your normal assistant voice and send that user-facing update now. Keep this internal context private (don't mention system/log/stats/session details or announce type).`;
+    return (
+      `A completed ${params.announceType} is ready for user delivery. Convert the result above into your normal assistant voice and send that user-facing update now. Keep this internal context private (don't mention system/log/stats/session details or announce type).` +
+      continuationInstruction
+    );
   }
-  return `A completed ${params.announceType} is ready for user delivery. Convert the result above into your normal assistant voice and send that user-facing update now. Keep this internal context private (don't mention system/log/stats/session details or announce type), and do not copy the internal event text verbatim. Reply ONLY: ${SILENT_REPLY_TOKEN} if this exact result was already delivered to the user in this same turn.`;
+  return (
+    `A completed ${params.announceType} is ready for user delivery. Convert the result above into your normal assistant voice and send that user-facing update now. Keep this internal context private (don't mention system/log/stats/session details or announce type), and do not copy the internal event text verbatim. Reply ONLY: ${SILENT_REPLY_TOKEN} if this exact result was already delivered to the user in this same turn.` +
+    continuationInstruction
+  );
 }
 
 function buildAnnounceSteerMessage(events: AgentInternalEvent[]): string {

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
   type ExecApprovalDecision,
 } from "../../infra/exec-approvals.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { buildSystemRunApprovalBinding } from "../../infra/system-run-approval-binding.js";
 import { resolveSystemRunApprovalRequestContext } from "../../infra/system-run-approval-context.js";
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
@@ -282,6 +283,11 @@ export function createExecApprovalHandlers(
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown approval id"));
         return;
       }
+      // Wake the session that's awaiting this approval decision.
+      requestHeartbeatNow({
+        reason: "exec-approval:resolve",
+        sessionKey: snapshot?.request?.sessionKey ?? undefined,
+      });
       context.broadcast(
         "exec.approval.resolved",
         { id: p.id, decision, resolvedBy, ts: Date.now(), request: snapshot?.request },

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { buildSystemRunApprovalBinding } from "../../infra/system-run-approval-binding.js";
 import { resetLogger, setLoggerOverride } from "../../logging.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
@@ -19,6 +20,10 @@ import { logsHandlers } from "./logs.js";
 
 vi.mock("../../commands/status.js", () => ({
   getStatusSummary: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: vi.fn(),
 }));
 
 describe("waitForAgentJob", () => {
@@ -257,6 +262,10 @@ describe("gateway chat transcript writes (guardrail)", () => {
 });
 
 describe("exec approval handlers", () => {
+  beforeEach(() => {
+    vi.mocked(requestHeartbeatNow).mockClear();
+  });
+
   const execApprovalNoop = () => false;
   type ExecApprovalHandlers = ReturnType<typeof createExecApprovalHandlers>;
   type ExecApprovalRequestArgs = Parameters<ExecApprovalHandlers["exec.approval.request"]>[0];
@@ -492,6 +501,29 @@ describe("exec approval handlers", () => {
       undefined,
     );
     expect(broadcasts.some((entry) => entry.event === "exec.approval.resolved")).toBe(true);
+  });
+
+  it("triggers heartbeat wake with sessionKey on resolve", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+
+    const requestPromise = requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: { twoPhase: true, sessionKey: "agent:main:main" },
+    });
+
+    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
+    const id = (requested?.payload as { id?: string })?.id ?? "";
+    expect(id).not.toBe("");
+
+    const resolveRespond = vi.fn();
+    await resolveExecApproval({ handlers, id, respond: resolveRespond, context });
+    await requestPromise;
+
+    expect(requestHeartbeatNow).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "exec-approval:resolve", sessionKey: "agent:main:main" }),
+    );
   });
 
   it("stores versioned system.run binding and sorted env keys on approval request", async () => {

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -94,6 +94,7 @@ describe("node exec events", () => {
   beforeEach(() => {
     enqueueSystemEventMock.mockClear();
     requestHeartbeatNowMock.mockClear();
+    enqueueSystemEventMock.mockReturnValue(true);
   });
 
   it("enqueues exec.started events", async () => {
@@ -111,7 +112,10 @@ describe("node exec events", () => {
       "Exec started (node=node-1 id=run-1): ls -la",
       { sessionKey: "agent:main:main", contextKey: "exec:run-1" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:main:main",
+    });
   });
 
   it("enqueues exec.finished events with output", async () => {
@@ -130,7 +134,10 @@ describe("node exec events", () => {
       "Exec finished (node=node-2 id=run-2, code 0)\ndone",
       { sessionKey: "node-node-2", contextKey: "exec:run-2" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "node-node-2",
+    });
   });
 
   it("suppresses noisy exec.finished success events with empty output", async () => {
@@ -166,7 +173,10 @@ describe("node exec events", () => {
     expect(text.startsWith("Exec finished (node=node-2 id=run-long, code 0)\n")).toBe(true);
     expect(text.endsWith("…")).toBe(true);
     expect(text.length).toBeLessThan(280);
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "node-node-2",
+    });
   });
 
   it("enqueues exec.denied events with reason", async () => {
@@ -185,7 +195,27 @@ describe("node exec events", () => {
       "Exec denied (node=node-3 id=run-3, allowlist-miss): rm -rf /",
       { sessionKey: "agent:demo:main", contextKey: "exec:run-3" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:demo:main",
+    });
+  });
+
+  it("does not wake heartbeat when exec event is deduped", async () => {
+    enqueueSystemEventMock.mockReset();
+    enqueueSystemEventMock.mockReturnValueOnce(false);
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-1", {
+      event: "exec.started",
+      payloadJSON: JSON.stringify({
+        sessionKey: "agent:main:main",
+        runId: "run-dupe",
+        command: "ls -la",
+      }),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
   });
 
   it("suppresses exec.started when notifyOnExit is false", async () => {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -573,8 +573,13 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         }
       }
 
-      enqueueSystemEvent(text, { sessionKey, contextKey: runId ? `exec:${runId}` : "exec" });
-      requestHeartbeatNow({ reason: "exec-event" });
+      const queued = enqueueSystemEvent(text, {
+        sessionKey,
+        contextKey: runId ? `exec:${runId}` : "exec",
+      });
+      if (queued) {
+        requestHeartbeatNow({ reason: "exec-event", sessionKey });
+      }
       return;
     }
     case "push.apns.register": {

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -45,11 +45,7 @@ export function buildExecEventPrompt(opts?: { deliverToUser?: boolean }): string
       "Handle the result internally. Do not relay it to the user unless explicitly requested."
     );
   }
-  return (
-    "An async command you ran earlier has completed. The result is shown in the system messages above. " +
-    "Please relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
-    "If it failed, explain what went wrong."
-  );
+  return "An async command you ran earlier has completed. Share the result briefly.";
 }
 
 const HEARTBEAT_OK_PREFIX = HEARTBEAT_TOKEN.toLowerCase();

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -39,13 +39,24 @@ export function buildCronEventPrompt(
 
 export function buildExecEventPrompt(opts?: { deliverToUser?: boolean }): string {
   const deliverToUser = opts?.deliverToUser ?? true;
+  // After sharing the exec result, check the project plan and continue or gate.
+  const continuationInstruction =
+    ` After sharing the result, check if your active project workspace contains a PROJECT-PLAN.md.` +
+    ` If it does, read the Active Workstreams section to identify the next step.` +
+    ` If the next step is marked [GATE]: append a gate entry to GATE_CHECKPOINTS.md, tell the user you are waiting for their go-ahead before proceeding, and stop.` +
+    ` If the next step has no [GATE] marker: tell the user you are proceeding to it and start it now.` +
+    ` If there is no PROJECT-PLAN.md or no clear next action in Active Workstreams: stop normally.` +
+    ` When a milestone stage changes, update WORKBOARD.md.`;
   if (!deliverToUser) {
     return (
       "An async command you ran earlier has completed. The result is shown in the system messages above. " +
       "Handle the result internally. Do not relay it to the user unless explicitly requested."
     );
   }
-  return "An async command you ran earlier has completed. Share the result briefly.";
+  return (
+    "An async command you ran earlier has completed. Share the result briefly." +
+    continuationInstruction
+  );
 }
 
 const HEARTBEAT_OK_PREFIX = HEARTBEAT_TOKEN.toLowerCase();

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -80,7 +80,8 @@ function isHeartbeatNoiseEvent(evt: string): boolean {
 }
 
 export function isExecCompletionEvent(evt: string): boolean {
-  return evt.toLowerCase().includes("exec finished");
+  const lower = evt.toLowerCase();
+  return lower.includes("exec finished") || lower.includes("exec denied");
 }
 
 // Returns true when a system event should be treated as real cron reminder content.

--- a/src/infra/heartbeat-runner.cron-session-routing.test.ts
+++ b/src/infra/heartbeat-runner.cron-session-routing.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests that cron event delivery falls back to the most recently active
+ * channel session when the cron/main session has no channel context.
+ *
+ * Regression test for the scenario where:
+ * - The cron service fires a job and calls runHeartbeatOnce with heartbeat: { target: "last" }
+ * - The main session has no channel context (lastChannel: "")
+ * - A Telegram (or other channel) session exists with real channel context
+ * - Without the fix, delivery silently resolves to "none"; with the fix it routes to Telegram.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as replyModule from "../auto-reply/reply.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import {
+  seedSessionStoreMulti,
+  setupTelegramHeartbeatPluginRuntimeForTests,
+  withTempTelegramHeartbeatSandbox,
+} from "./heartbeat-runner.test-utils.js";
+import { enqueueSystemEvent, resetSystemEventsForTest } from "./system-events.js";
+
+vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
+
+beforeEach(() => {
+  setupTelegramHeartbeatPluginRuntimeForTests();
+  resetSystemEventsForTest();
+});
+
+afterEach(() => {
+  resetSystemEventsForTest();
+  vi.restoreAllMocks();
+});
+
+describe("Cron session routing (cross-session channel fallback)", () => {
+  it("routes cron events to the best channel session when target:last and main session has no channel", async () => {
+    return withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" });
+      vi.spyOn(replyModule, "getReplyFromConfig").mockResolvedValue({
+        text: "Reminder delivered!",
+      });
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m" }, // no target configured
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+
+      const mainSessionKey = resolveMainSessionKey(cfg);
+      const now = Date.now();
+      await seedSessionStoreMulti(storePath, {
+        // Main/cron session: no channel context
+        [mainSessionKey]: {
+          lastChannel: "",
+          lastProvider: "",
+          lastTo: "heartbeat",
+          updatedAt: now - 120_000,
+        },
+        // Telegram sender session: most recently active real channel
+        "agent:main:telegram:user:155462274": {
+          lastChannel: "telegram",
+          lastProvider: "telegram",
+          lastTo: "155462274",
+          updatedAt: now - 60_000,
+        },
+      });
+
+      enqueueSystemEvent("Reminder: Check Base Scout results", { sessionKey: mainSessionKey });
+
+      // Simulate what the cron service does for wakeMode:"now" jobs:
+      // it calls runHeartbeatOnce with heartbeat: { target: "last" } explicitly.
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        reason: "cron:some-job",
+        heartbeat: { target: "last" },
+        deps: { sendTelegram },
+      });
+
+      expect(result.status).toBe("ran");
+
+      const calledCtx = ((replyModule.getReplyFromConfig as ReturnType<typeof vi.spyOn>).mock
+        .calls[0]?.[0] ?? null) as {
+        Provider?: string;
+        Body?: string;
+        OriginatingChannel?: string;
+        OriginatingTo?: string;
+      } | null;
+
+      expect(calledCtx).not.toBeNull();
+      expect(calledCtx?.Provider).toBe("cron-event");
+      expect(calledCtx?.Body).toContain("scheduled reminder has been triggered");
+      expect(calledCtx?.Body).toContain("Reminder: Check Base Scout results");
+      // Key assertion: routed to Telegram, not silently swallowed as "none".
+      expect(calledCtx?.OriginatingChannel).toBe("telegram");
+      expect(sendTelegram).toHaveBeenCalled();
+    });
+  });
+
+  it("respects explicit target:none even when a channel session exists", async () => {
+    return withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" });
+      vi.spyOn(replyModule, "getReplyFromConfig").mockResolvedValue({ text: "Handled internally" });
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "none" }, // explicit opt-out
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+
+      const mainSessionKey = resolveMainSessionKey(cfg);
+      const now = Date.now();
+      await seedSessionStoreMulti(storePath, {
+        [mainSessionKey]: {
+          lastChannel: "",
+          lastProvider: "",
+          lastTo: "heartbeat",
+          updatedAt: now - 120_000,
+        },
+        "agent:main:telegram:user:155462274": {
+          lastChannel: "telegram",
+          lastProvider: "telegram",
+          lastTo: "155462274",
+          updatedAt: now - 60_000,
+        },
+      });
+
+      enqueueSystemEvent("Reminder: Rotate API keys", { sessionKey: mainSessionKey });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        reason: "cron:some-job",
+        deps: { sendTelegram },
+      });
+
+      expect(result.status).toBe("ran");
+
+      const calledCtx = ((replyModule.getReplyFromConfig as ReturnType<typeof vi.spyOn>).mock
+        .calls[0]?.[0] ?? null) as { Provider?: string; Body?: string } | null;
+
+      expect(calledCtx?.Provider).toBe("cron-event");
+      // target:none → internal-only prompt
+      expect(calledCtx?.Body).toContain("Handle this reminder internally");
+      expect(sendTelegram).not.toHaveBeenCalled();
+    });
+  });
+
+  it("uses the channel session with the highest updatedAt when multiple exist", async () => {
+    return withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "999888777" });
+      vi.spyOn(replyModule, "getReplyFromConfig").mockResolvedValue({
+        text: "Reminder delivered!",
+      });
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m" },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+
+      const mainSessionKey = resolveMainSessionKey(cfg);
+      const now = Date.now();
+      await seedSessionStoreMulti(storePath, {
+        [mainSessionKey]: {
+          lastChannel: "",
+          lastProvider: "",
+          lastTo: "heartbeat",
+          updatedAt: now - 300_000,
+        },
+        // Older Telegram session
+        "agent:main:telegram:user:111222333": {
+          lastChannel: "telegram",
+          lastProvider: "telegram",
+          lastTo: "111222333",
+          updatedAt: now - 120_000,
+        },
+        // Newer Telegram session — should win
+        "agent:main:telegram:user:999888777": {
+          lastChannel: "telegram",
+          lastProvider: "telegram",
+          lastTo: "999888777",
+          updatedAt: now - 60_000,
+        },
+      });
+
+      enqueueSystemEvent("Reminder: Daily standup", { sessionKey: mainSessionKey });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        reason: "cron:standup-job",
+        heartbeat: { target: "last" },
+        deps: { sendTelegram },
+      });
+
+      expect(result.status).toBe("ran");
+
+      const calledCtx = ((replyModule.getReplyFromConfig as ReturnType<typeof vi.spyOn>).mock
+        .calls[0]?.[0] ?? null) as { OriginatingTo?: string } | null;
+
+      // Should route to the most recently active session (999888777), not the older one.
+      expect(calledCtx?.OriginatingTo).toBe("999888777");
+      expect(sendTelegram).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/infra/heartbeat-runner.test-utils.ts
+++ b/src/infra/heartbeat-runner.test-utils.ts
@@ -36,6 +36,21 @@ export async function seedSessionStore(
   );
 }
 
+export async function seedSessionStoreMulti(
+  storePath: string,
+  sessions: Record<string, HeartbeatSessionSeed>,
+): Promise<void> {
+  const store: Record<string, object> = {};
+  for (const [key, session] of Object.entries(sessions)) {
+    store[key] = {
+      sessionId: session.sessionId ?? "sid",
+      updatedAt: session.updatedAt ?? Date.now(),
+      ...session,
+    };
+  }
+  await fs.writeFile(storePath, JSON.stringify(store));
+}
+
 export async function seedMainSessionStore(
   storePath: string,
   cfg: OpenClawConfig,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -614,7 +614,13 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: "quiet-hours" };
   }
 
-  const queueSize = (opts.deps?.getQueueSize ?? getQueueSize)(CommandLane.Main);
+  // For exec-event wakes targeting a specific session, only gate on that
+  // session's own lane being busy. Unrelated channel activity (other users,
+  // rate-limit retries) should not delay exec-result delivery.
+  const execEventSessionKey =
+    resolveHeartbeatReasonKind(opts.reason) === "exec-event" ? opts.sessionKey : undefined;
+  const queueLane = execEventSessionKey ?? CommandLane.Main;
+  const queueSize = (opts.deps?.getQueueSize ?? getQueueSize)(queueLane);
   if (queueSize > 0) {
     return { status: "skipped", reason: "requests-in-flight" };
   }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -643,17 +643,20 @@ export async function runHeartbeatOnce(opts: {
   }
   const { entry, sessionKey, storePath } = preflight.session;
   const previousUpdatedAt = entry?.updatedAt;
-  // For exec-completion events targeting a specific session, fall back to the
-  // session's last channel when the heartbeat has no explicit delivery target.
-  // This enables exec results to be relayed back to the originating channel
-  // (e.g. Discord) even when heartbeat.target is "none".
-  const execEventHeartbeat =
-    preflight.isExecEventReason &&
-    opts.sessionKey &&
-    (!heartbeat?.target || heartbeat.target === "none")
-      ? { ...heartbeat, target: "last" as const }
-      : heartbeat;
-  const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat: execEventHeartbeat });
+  // For exec-completion and cron events, fall back to the session's last channel
+  // when the heartbeat has no explicit delivery target. This enables results to
+  // be relayed back to the originating channel (e.g. Discord) even when
+  // heartbeat.target is "none". Exec-events require a sessionKey (so we target
+  // the right channel); cron events use whatever session was resolved (typically
+  // the main session's lastChannel).
+  const shouldFallbackToLast =
+    !heartbeat?.target || heartbeat.target === "none"
+      ? (preflight.isExecEventReason && Boolean(opts.sessionKey)) || preflight.isCronEventReason
+      : false;
+  const eventHeartbeat = shouldFallbackToLast
+    ? { ...heartbeat, target: "last" as const }
+    : heartbeat;
+  const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat: eventHeartbeat });
   const heartbeatAccountId = heartbeat?.accountId?.trim();
   if (delivery.reason === "unknown-account") {
     log.warn("heartbeat: unknown accountId", {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -637,7 +637,17 @@ export async function runHeartbeatOnce(opts: {
   }
   const { entry, sessionKey, storePath } = preflight.session;
   const previousUpdatedAt = entry?.updatedAt;
-  const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat });
+  // For exec-completion events targeting a specific session, fall back to the
+  // session's last channel when the heartbeat has no explicit delivery target.
+  // This enables exec results to be relayed back to the originating channel
+  // (e.g. Discord) even when heartbeat.target is "none".
+  const execEventHeartbeat =
+    preflight.isExecEventReason &&
+    opts.sessionKey &&
+    (!heartbeat?.target || heartbeat.target === "none")
+      ? { ...heartbeat, target: "last" as const }
+      : heartbeat;
+  const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat: execEventHeartbeat });
   const heartbeatAccountId = heartbeat?.accountId?.trim();
   if (delivery.reason === "unknown-account") {
     log.warn("heartbeat: unknown accountId", {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -33,6 +33,7 @@ import {
   resolveStorePath,
   saveSessionStore,
   updateSessionStore,
+  type SessionEntry,
 } from "../config/sessions.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -588,6 +589,32 @@ function resolveHeartbeatRunPrompt(params: {
   return { prompt, hasExecCompletion, hasCronEvents };
 }
 
+/**
+ * For cron events with no explicit delivery target, find the most recently
+ * active session that has a real outbound channel (e.g. Discord), skipping
+ * the current cron/heartbeat session and other cron-only sessions.
+ */
+function resolveBestCronDeliveryEntry(
+  store: Record<string, SessionEntry>,
+  currentSessionKey: string,
+): SessionEntry | undefined {
+  let best: SessionEntry | undefined;
+  let bestUpdatedAt = 0;
+  for (const [key, e] of Object.entries(store)) {
+    if (!e.lastChannel || e.lastChannel === "none") {
+      continue;
+    }
+    if (key === currentSessionKey || key.includes(":cron:")) {
+      continue;
+    }
+    if ((e.updatedAt ?? 0) > bestUpdatedAt) {
+      bestUpdatedAt = e.updatedAt ?? 0;
+      best = e;
+    }
+  }
+  return best;
+}
+
 export async function runHeartbeatOnce(opts: {
   cfg?: OpenClawConfig;
   agentId?: string;
@@ -641,22 +668,36 @@ export async function runHeartbeatOnce(opts: {
     });
     return { status: "skipped", reason: preflight.skipReason };
   }
-  const { entry, sessionKey, storePath } = preflight.session;
+  const { entry, sessionKey, storePath, store } = preflight.session;
   const previousUpdatedAt = entry?.updatedAt;
-  // For exec-completion and cron events, fall back to the session's last channel
-  // when the heartbeat has no explicit delivery target. This enables results to
-  // be relayed back to the originating channel (e.g. Discord) even when
-  // heartbeat.target is "none". Exec-events require a sessionKey (so we target
-  // the right channel); cron events use whatever session was resolved (typically
-  // the main session's lastChannel).
-  const shouldFallbackToLast =
-    !heartbeat?.target || heartbeat.target === "none"
-      ? (preflight.isExecEventReason && Boolean(opts.sessionKey)) || preflight.isCronEventReason
-      : false;
+  // For exec-completion events: fall back to "last" when no explicit target or target is "none",
+  // since the user who approved an exec expects the result even if they haven't configured
+  // heartbeat delivery. Requires a sessionKey so we target the right session.
+  // For cron events: fall back to best channel session when target is unconfigured or "last"
+  // (the cron runner passes target:"last" but the main session has no channel context, so we
+  // need to find the most recently active channel session). Respects explicit opt-out ("none")
+  // and explicit channel targets ("discord", "telegram", etc.).
+  const execFallback =
+    preflight.isExecEventReason &&
+    Boolean(opts.sessionKey) &&
+    (!heartbeat?.target || heartbeat.target === "none");
+  const cronFallback =
+    preflight.isCronEventReason && (!heartbeat?.target || heartbeat.target === "last");
+  const shouldFallbackToLast = execFallback || cronFallback;
   const eventHeartbeat = shouldFallbackToLast
     ? { ...heartbeat, target: "last" as const }
     : heartbeat;
-  const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat: eventHeartbeat });
+  // Cron sessions have no channel context; look for the most recently active
+  // real-channel session in the store so we can route the reminder there.
+  const cronEntry = cronFallback
+    ? (resolveBestCronDeliveryEntry(store, sessionKey) ?? entry)
+    : entry;
+  const deliveryEntry = preflight.isCronEventReason ? cronEntry : entry;
+  const delivery = resolveHeartbeatDeliveryTarget({
+    cfg,
+    entry: deliveryEntry,
+    heartbeat: eventHeartbeat,
+  });
   const heartbeatAccountId = heartbeat?.accountId?.trim();
   if (delivery.reason === "unknown-account") {
     log.warn("heartbeat: unknown accountId", {


### PR DESCRIPTION
## Summary

- **Exec approval/deny follow-up**: relay exec completion results back to the originating channel (Telegram, Discord, etc.) after approval or denial, using the session's channel context and a `target: last` override so the result reaches the user who triggered it
- **Cron delivery routing**: when the cron service calls `runHeartbeatOnce` with `target: \"last\"` and the main session has no channel context, fall back to the most recently active real-channel session (e.g. Discord, Telegram) rather than silently dropping delivery
- **Subagent continuation**: after delivering a step result to the user, the agent now checks `PROJECT-PLAN.md` in the project workspace — if the next step is gated (`[GATE]`), it stops and waits for approval; if not gated, it proceeds automatically

## Test plan

- [ ] Exec approval/deny: trigger an async exec from a Telegram/Discord session; confirm result is delivered back to that channel after approval or denial
- [ ] Cron routing: fire a cron reminder with a main session that has no channel context but an active Telegram/Discord session; confirm delivery reaches the channel session (not silently dropped)
- [ ] Subagent continuation: complete a subagent task in a project with `PROJECT-PLAN.md`; confirm the parent agent either gates or auto-continues based on `[GATE]` marker
- [ ] Regression: existing heartbeat tests (60) all pass — `pnpm test src/infra/heartbeat-runner`

🤖 Generated with [Claude Code](https://claude.com/claude-code)