### PR TITLE
fix(discord): resample audio to 48kHz for voice messages

### DIFF
--- a/src/discord/voice-message.ts
+++ b/src/discord/voice-message.ts
@@ -182,6 +182,8 @@ export async function ensureOggOpus(filePath: string): Promise<{ path: string; c
   }
 
   // Convert to OGG/Opus
+  // Always resample to 48kHz to ensure Discord voice messages play at correct speed
+  // (Discord expects 48kHz; lower sample rates like 24kHz from some TTS providers cause 0.5x playback)
   const tempDir = resolvePreferredOpenClawTmpDir();
   const outputPath = path.join(tempDir, `voice-${crypto.randomUUID()}.ogg`);
 
@@ -189,6 +191,8 @@ export async function ensureOggOpus(filePath: string): Promise<{ path: string; c
     "-y",
     "-i",
     filePath,
+    "-ar",
+    "48000",
     "-c:a",
     "libopus",
     "-b:a",


### PR DESCRIPTION
Fixes #32293: Discord voice message plays at ~0.5x speed with 24kHz TTS source

When TTS providers (like mlx-audio Qwen3-TTS) output audio at 24kHz, Discord voice messages play at half speed because Discord expects 48kHz.

This fix adds explicit sample rate conversion to 48kHz in the ensureOggOpus function, ensuring voice messages always play at correct speed regardless of the input audio's sample rate.