### PR TITLE
feat(discord): route GUILD_MEMBER_ADD events to agents with optional welcome trigger

### DIFF
--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -86,6 +86,8 @@ export type DiscordGuildEntry = {
   reactionNotifications?: DiscordReactionNotificationMode;
   /** Member join notification mode (off|on). Requires intents.guildMembers=true. Default: off. */
   memberJoinNotifications?: DiscordMemberJoinNotificationMode;
+  /** Discord channel ID to post welcome messages to when a member joins. Falls back to guild systemChannelId. */
+  memberJoinChannel?: string;
   /** Optional allowlist for guild senders (ids or names). */
   users?: string[];
   /** Optional allowlist for guild senders by role ID. */

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -69,6 +69,8 @@ export type DiscordGuildChannelConfig = {
 
 export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist";
 
+export type DiscordMemberJoinNotificationMode = "off" | "on";
+
 export type DiscordGuildEntry = {
   slug?: string;
   requireMention?: boolean;
@@ -82,6 +84,8 @@ export type DiscordGuildEntry = {
   toolsBySender?: GroupToolPolicyBySenderConfig;
   /** Reaction notification mode (off|own|all|allowlist). Default: own. */
   reactionNotifications?: DiscordReactionNotificationMode;
+  /** Member join notification mode (off|on). Requires intents.guildMembers=true. Default: off. */
+  memberJoinNotifications?: DiscordMemberJoinNotificationMode;
   /** Optional allowlist for guild senders (ids or names). */
   users?: string[];
   /** Optional allowlist for guild senders by role ID. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -438,6 +438,7 @@ export const DiscordGuildSchema = z
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
+    memberJoinNotifications: z.enum(["off", "on"]).optional(),
     users: DiscordIdListSchema.optional(),
     roles: DiscordIdListSchema.optional(),
     channels: z.record(z.string(), DiscordGuildChannelSchema.optional()).optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -439,6 +439,7 @@ export const DiscordGuildSchema = z
     toolsBySender: ToolPolicyBySenderSchema,
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     memberJoinNotifications: z.enum(["off", "on"]).optional(),
+    memberJoinChannel: z.string().optional(),
     users: DiscordIdListSchema.optional(),
     roles: DiscordIdListSchema.optional(),
     channels: z.record(z.string(), DiscordGuildChannelSchema.optional()).optional(),

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -1,0 +1,605 @@
+export * from "../../../extensions/discord/src/monitor/allow-list.js";
+import type { Guild, User } from "@buape/carbon";
+import type { AllowlistMatch } from "../../channels/allowlist-match.js";
+import {
+  buildChannelKeyCandidates,
+  resolveChannelEntryMatchWithFallback,
+  resolveChannelMatchConfig,
+  type ChannelMatchSource,
+} from "../../channels/channel-config.js";
+import { evaluateGroupRouteAccessForPolicy } from "../../plugin-sdk/group-access.js";
+import { formatDiscordUserTag } from "./format.js";
+
+export type DiscordAllowList = {
+  allowAll: boolean;
+  ids: Set<string>;
+  names: Set<string>;
+};
+
+export type DiscordAllowListMatch = AllowlistMatch<"wildcard" | "id" | "name" | "tag">;
+
+const DISCORD_OWNER_ALLOWLIST_PREFIXES = ["discord:", "user:", "pk:"];
+
+export type DiscordGuildEntryResolved = {
+  id?: string;
+  slug?: string;
+  requireMention?: boolean;
+  ignoreOtherMentions?: boolean;
+  reactionNotifications?: "off" | "own" | "all" | "allowlist";
+  memberJoinNotifications?: "off" | "on";
+  users?: string[];
+  roles?: string[];
+  channels?: Record<
+    string,
+    {
+      allow?: boolean;
+      requireMention?: boolean;
+      ignoreOtherMentions?: boolean;
+      skills?: string[];
+      enabled?: boolean;
+      users?: string[];
+      roles?: string[];
+      systemPrompt?: string;
+      includeThreadStarter?: boolean;
+      autoThread?: boolean;
+      autoArchiveDuration?: "60" | "1440" | "4320" | "10080" | 60 | 1440 | 4320 | 10080;
+    }
+  >;
+};
+
+export type DiscordChannelConfigResolved = {
+  allowed: boolean;
+  requireMention?: boolean;
+  ignoreOtherMentions?: boolean;
+  skills?: string[];
+  enabled?: boolean;
+  users?: string[];
+  roles?: string[];
+  systemPrompt?: string;
+  includeThreadStarter?: boolean;
+  autoThread?: boolean;
+  autoArchiveDuration?: "60" | "1440" | "4320" | "10080" | 60 | 1440 | 4320 | 10080;
+  matchKey?: string;
+  matchSource?: ChannelMatchSource;
+};
+
+export function normalizeDiscordAllowList(raw: string[] | undefined, prefixes: string[]) {
+  if (!raw || raw.length === 0) {
+    return null;
+  }
+  const ids = new Set<string>();
+  const names = new Set<string>();
+  const allowAll = raw.some((entry) => String(entry).trim() === "*");
+  for (const entry of raw) {
+    const text = String(entry).trim();
+    if (!text || text === "*") {
+      continue;
+    }
+    const normalized = normalizeDiscordSlug(text);
+    const maybeId = text.replace(/^<@!?/, "").replace(/>$/, "");
+    if (/^\d+$/.test(maybeId)) {
+      ids.add(maybeId);
+      continue;
+    }
+    const prefix = prefixes.find((entry) => text.startsWith(entry));
+    if (prefix) {
+      const candidate = text.slice(prefix.length);
+      if (candidate) {
+        ids.add(candidate);
+      }
+      continue;
+    }
+    if (normalized) {
+      names.add(normalized);
+    }
+  }
+  return { allowAll, ids, names } satisfies DiscordAllowList;
+}
+
+export function normalizeDiscordSlug(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^#/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function resolveDiscordAllowListNameMatch(
+  list: DiscordAllowList,
+  candidate: { name?: string; tag?: string },
+): { matchKey: string; matchSource: "name" | "tag" } | null {
+  const nameSlug = candidate.name ? normalizeDiscordSlug(candidate.name) : "";
+  if (nameSlug && list.names.has(nameSlug)) {
+    return { matchKey: nameSlug, matchSource: "name" };
+  }
+  const tagSlug = candidate.tag ? normalizeDiscordSlug(candidate.tag) : "";
+  if (tagSlug && list.names.has(tagSlug)) {
+    return { matchKey: tagSlug, matchSource: "tag" };
+  }
+  return null;
+}
+
+export function allowListMatches(
+  list: DiscordAllowList,
+  candidate: { id?: string; name?: string; tag?: string },
+  params?: { allowNameMatching?: boolean },
+) {
+  if (list.allowAll) {
+    return true;
+  }
+  if (candidate.id && list.ids.has(candidate.id)) {
+    return true;
+  }
+  if (params?.allowNameMatching === true) {
+    if (resolveDiscordAllowListNameMatch(list, candidate)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function resolveDiscordAllowListMatch(params: {
+  allowList: DiscordAllowList;
+  candidate: { id?: string; name?: string; tag?: string };
+  allowNameMatching?: boolean;
+}): DiscordAllowListMatch {
+  const { allowList, candidate } = params;
+  if (allowList.allowAll) {
+    return { allowed: true, matchKey: "*", matchSource: "wildcard" };
+  }
+  if (candidate.id && allowList.ids.has(candidate.id)) {
+    return { allowed: true, matchKey: candidate.id, matchSource: "id" };
+  }
+  if (params.allowNameMatching === true) {
+    const namedMatch = resolveDiscordAllowListNameMatch(allowList, candidate);
+    if (namedMatch) {
+      return { allowed: true, ...namedMatch };
+    }
+  }
+  return { allowed: false };
+}
+
+export function resolveDiscordUserAllowed(params: {
+  allowList?: string[];
+  userId: string;
+  userName?: string;
+  userTag?: string;
+  allowNameMatching?: boolean;
+}) {
+  const allowList = normalizeDiscordAllowList(params.allowList, ["discord:", "user:", "pk:"]);
+  if (!allowList) {
+    return true;
+  }
+  return allowListMatches(
+    allowList,
+    {
+      id: params.userId,
+      name: params.userName,
+      tag: params.userTag,
+    },
+    { allowNameMatching: params.allowNameMatching },
+  );
+}
+
+export function resolveDiscordRoleAllowed(params: {
+  allowList?: string[];
+  memberRoleIds: string[];
+}) {
+  // Role allowlists accept role IDs only. Names are ignored.
+  const allowList = normalizeDiscordAllowList(params.allowList, ["role:"]);
+  if (!allowList) {
+    return true;
+  }
+  if (allowList.allowAll) {
+    return true;
+  }
+  return params.memberRoleIds.some((roleId) => allowList.ids.has(roleId));
+}
+
+export function resolveDiscordMemberAllowed(params: {
+  userAllowList?: string[];
+  roleAllowList?: string[];
+  memberRoleIds: string[];
+  userId: string;
+  userName?: string;
+  userTag?: string;
+  allowNameMatching?: boolean;
+}) {
+  const hasUserRestriction = Array.isArray(params.userAllowList) && params.userAllowList.length > 0;
+  const hasRoleRestriction = Array.isArray(params.roleAllowList) && params.roleAllowList.length > 0;
+  if (!hasUserRestriction && !hasRoleRestriction) {
+    return true;
+  }
+  const userOk = hasUserRestriction
+    ? resolveDiscordUserAllowed({
+        allowList: params.userAllowList,
+        userId: params.userId,
+        userName: params.userName,
+        userTag: params.userTag,
+        allowNameMatching: params.allowNameMatching,
+      })
+    : false;
+  const roleOk = hasRoleRestriction
+    ? resolveDiscordRoleAllowed({
+        allowList: params.roleAllowList,
+        memberRoleIds: params.memberRoleIds,
+      })
+    : false;
+  return userOk || roleOk;
+}
+
+export function resolveDiscordMemberAccessState(params: {
+  channelConfig?: DiscordChannelConfigResolved | null;
+  guildInfo?: DiscordGuildEntryResolved | null;
+  memberRoleIds: string[];
+  sender: { id: string; name?: string; tag?: string };
+  allowNameMatching?: boolean;
+}) {
+  const channelUsers = params.channelConfig?.users ?? params.guildInfo?.users;
+  const channelRoles = params.channelConfig?.roles ?? params.guildInfo?.roles;
+  const hasAccessRestrictions =
+    (Array.isArray(channelUsers) && channelUsers.length > 0) ||
+    (Array.isArray(channelRoles) && channelRoles.length > 0);
+  const memberAllowed = resolveDiscordMemberAllowed({
+    userAllowList: channelUsers,
+    roleAllowList: channelRoles,
+    memberRoleIds: params.memberRoleIds,
+    userId: params.sender.id,
+    userName: params.sender.name,
+    userTag: params.sender.tag,
+    allowNameMatching: params.allowNameMatching,
+  });
+  return { channelUsers, channelRoles, hasAccessRestrictions, memberAllowed } as const;
+}
+
+export function resolveDiscordOwnerAllowFrom(params: {
+  channelConfig?: DiscordChannelConfigResolved | null;
+  guildInfo?: DiscordGuildEntryResolved | null;
+  sender: { id: string; name?: string; tag?: string };
+  allowNameMatching?: boolean;
+}): string[] | undefined {
+  const rawAllowList = params.channelConfig?.users ?? params.guildInfo?.users;
+  if (!Array.isArray(rawAllowList) || rawAllowList.length === 0) {
+    return undefined;
+  }
+  const allowList = normalizeDiscordAllowList(rawAllowList, ["discord:", "user:", "pk:"]);
+  if (!allowList) {
+    return undefined;
+  }
+  const match = resolveDiscordAllowListMatch({
+    allowList,
+    candidate: {
+      id: params.sender.id,
+      name: params.sender.name,
+      tag: params.sender.tag,
+    },
+    allowNameMatching: params.allowNameMatching,
+  });
+  if (!match.allowed || !match.matchKey || match.matchKey === "*") {
+    return undefined;
+  }
+  return [match.matchKey];
+}
+
+export function resolveDiscordOwnerAccess(params: {
+  allowFrom?: string[];
+  sender: { id: string; name?: string; tag?: string };
+  allowNameMatching?: boolean;
+}): {
+  ownerAllowList: DiscordAllowList | null;
+  ownerAllowed: boolean;
+} {
+  const ownerAllowList = normalizeDiscordAllowList(
+    params.allowFrom,
+    DISCORD_OWNER_ALLOWLIST_PREFIXES,
+  );
+  const ownerAllowed = ownerAllowList
+    ? allowListMatches(
+        ownerAllowList,
+        {
+          id: params.sender.id,
+          name: params.sender.name,
+          tag: params.sender.tag,
+        },
+        { allowNameMatching: params.allowNameMatching },
+      )
+    : false;
+  return { ownerAllowList, ownerAllowed };
+}
+
+export function resolveDiscordCommandAuthorized(params: {
+  isDirectMessage: boolean;
+  allowFrom?: string[];
+  guildInfo?: DiscordGuildEntryResolved | null;
+  author: User;
+  allowNameMatching?: boolean;
+}) {
+  if (!params.isDirectMessage) {
+    return true;
+  }
+  const allowList = normalizeDiscordAllowList(params.allowFrom, ["discord:", "user:", "pk:"]);
+  if (!allowList) {
+    return true;
+  }
+  return allowListMatches(
+    allowList,
+    {
+      id: params.author.id,
+      name: params.author.username,
+      tag: formatDiscordUserTag(params.author),
+    },
+    { allowNameMatching: params.allowNameMatching },
+  );
+}
+
+export function resolveDiscordGuildEntry(params: {
+  guild?: Guild<true> | Guild | null;
+  guildEntries?: Record<string, DiscordGuildEntryResolved>;
+}): DiscordGuildEntryResolved | null {
+  const guild = params.guild;
+  const entries = params.guildEntries;
+  if (!guild || !entries) {
+    return null;
+  }
+  const byId = entries[guild.id];
+  if (byId) {
+    return { ...byId, id: guild.id };
+  }
+  const slug = normalizeDiscordSlug(guild.name ?? "");
+  const bySlug = entries[slug];
+  if (bySlug) {
+    return { ...bySlug, id: guild.id, slug: slug || bySlug.slug };
+  }
+  const wildcard = entries["*"];
+  if (wildcard) {
+    return { ...wildcard, id: guild.id, slug: slug || wildcard.slug };
+  }
+  return null;
+}
+
+type DiscordChannelEntry = NonNullable<DiscordGuildEntryResolved["channels"]>[string];
+type DiscordChannelLookup = {
+  id: string;
+  name?: string;
+  slug?: string;
+};
+type DiscordChannelScope = "channel" | "thread";
+
+function buildDiscordChannelKeys(
+  params: DiscordChannelLookup & { allowNameMatch?: boolean },
+): string[] {
+  const allowNameMatch = params.allowNameMatch !== false;
+  return buildChannelKeyCandidates(
+    params.id,
+    allowNameMatch ? params.slug : undefined,
+    allowNameMatch ? params.name : undefined,
+  );
+}
+
+function resolveDiscordChannelEntryMatch(
+  channels: NonNullable<DiscordGuildEntryResolved["channels"]>,
+  params: DiscordChannelLookup & { allowNameMatch?: boolean },
+  parentParams?: DiscordChannelLookup,
+) {
+  const keys = buildDiscordChannelKeys(params);
+  const parentKeys = parentParams ? buildDiscordChannelKeys(parentParams) : undefined;
+  return resolveChannelEntryMatchWithFallback({
+    entries: channels,
+    keys,
+    parentKeys,
+    wildcardKey: "*",
+  });
+}
+
+function hasConfiguredDiscordChannels(
+  channels: DiscordGuildEntryResolved["channels"] | undefined,
+): channels is NonNullable<DiscordGuildEntryResolved["channels"]> {
+  return Boolean(channels && Object.keys(channels).length > 0);
+}
+
+function resolveDiscordChannelConfigEntry(
+  entry: DiscordChannelEntry,
+): DiscordChannelConfigResolved {
+  const resolved: DiscordChannelConfigResolved = {
+    allowed: entry.allow !== false,
+    requireMention: entry.requireMention,
+    ignoreOtherMentions: entry.ignoreOtherMentions,
+    skills: entry.skills,
+    enabled: entry.enabled,
+    users: entry.users,
+    roles: entry.roles,
+    systemPrompt: entry.systemPrompt,
+    includeThreadStarter: entry.includeThreadStarter,
+    autoThread: entry.autoThread,
+    autoArchiveDuration: entry.autoArchiveDuration,
+  };
+  return resolved;
+}
+
+export function resolveDiscordChannelConfig(params: {
+  guildInfo?: DiscordGuildEntryResolved | null;
+  channelId: string;
+  channelName?: string;
+  channelSlug: string;
+}): DiscordChannelConfigResolved | null {
+  const { guildInfo, channelId, channelName, channelSlug } = params;
+  const channels = guildInfo?.channels;
+  if (!hasConfiguredDiscordChannels(channels)) {
+    return null;
+  }
+  const match = resolveDiscordChannelEntryMatch(channels, {
+    id: channelId,
+    name: channelName,
+    slug: channelSlug,
+  });
+  const resolved = resolveChannelMatchConfig(match, resolveDiscordChannelConfigEntry);
+  return resolved ?? { allowed: false };
+}
+
+export function resolveDiscordChannelConfigWithFallback(params: {
+  guildInfo?: DiscordGuildEntryResolved | null;
+  channelId: string;
+  channelName?: string;
+  channelSlug: string;
+  parentId?: string;
+  parentName?: string;
+  parentSlug?: string;
+  scope?: DiscordChannelScope;
+}): DiscordChannelConfigResolved | null {
+  const {
+    guildInfo,
+    channelId,
+    channelName,
+    channelSlug,
+    parentId,
+    parentName,
+    parentSlug,
+    scope,
+  } = params;
+  const channels = guildInfo?.channels;
+  if (!hasConfiguredDiscordChannels(channels)) {
+    return null;
+  }
+  const resolvedParentSlug = parentSlug ?? (parentName ? normalizeDiscordSlug(parentName) : "");
+  const match = resolveDiscordChannelEntryMatch(
+    channels,
+    {
+      id: channelId,
+      name: channelName,
+      slug: channelSlug,
+      allowNameMatch: scope !== "thread",
+    },
+    parentId || parentName || parentSlug
+      ? {
+          id: parentId ?? "",
+          name: parentName,
+          slug: resolvedParentSlug,
+        }
+      : undefined,
+  );
+  return resolveChannelMatchConfig(match, resolveDiscordChannelConfigEntry) ?? { allowed: false };
+}
+
+export function resolveDiscordShouldRequireMention(params: {
+  isGuildMessage: boolean;
+  isThread: boolean;
+  botId?: string | null;
+  threadOwnerId?: string | null;
+  channelConfig?: DiscordChannelConfigResolved | null;
+  guildInfo?: DiscordGuildEntryResolved | null;
+  /** Pass pre-computed value to avoid redundant checks. */
+  isAutoThreadOwnedByBot?: boolean;
+}): boolean {
+  if (!params.isGuildMessage) {
+    return false;
+  }
+  // Only skip mention requirement in threads created by the bot (when autoThread is enabled).
+  const isBotThread = params.isAutoThreadOwnedByBot ?? isDiscordAutoThreadOwnedByBot(params);
+  if (isBotThread) {
+    return false;
+  }
+  return params.channelConfig?.requireMention ?? params.guildInfo?.requireMention ?? true;
+}
+
+export function isDiscordAutoThreadOwnedByBot(params: {
+  isThread: boolean;
+  channelConfig?: DiscordChannelConfigResolved | null;
+  botId?: string | null;
+  threadOwnerId?: string | null;
+}): boolean {
+  if (!params.isThread) {
+    return false;
+  }
+  if (!params.channelConfig?.autoThread) {
+    return false;
+  }
+  const botId = params.botId?.trim();
+  const threadOwnerId = params.threadOwnerId?.trim();
+  return Boolean(botId && threadOwnerId && botId === threadOwnerId);
+}
+
+export function isDiscordGroupAllowedByPolicy(params: {
+  groupPolicy: "open" | "disabled" | "allowlist";
+  guildAllowlisted: boolean;
+  channelAllowlistConfigured: boolean;
+  channelAllowed: boolean;
+}): boolean {
+  if (params.groupPolicy === "allowlist" && !params.guildAllowlisted) {
+    return false;
+  }
+
+  return evaluateGroupRouteAccessForPolicy({
+    groupPolicy:
+      params.groupPolicy === "allowlist" && !params.channelAllowlistConfigured
+        ? "open"
+        : params.groupPolicy,
+    routeAllowlistConfigured: params.channelAllowlistConfigured,
+    routeMatched: params.channelAllowed,
+  }).allowed;
+}
+
+export function resolveGroupDmAllow(params: {
+  channels?: string[];
+  channelId: string;
+  channelName?: string;
+  channelSlug: string;
+}) {
+  const { channels, channelId, channelName, channelSlug } = params;
+  if (!channels || channels.length === 0) {
+    return true;
+  }
+  const allowList = new Set(channels.map((entry) => normalizeDiscordSlug(String(entry))));
+  const candidates = [
+    normalizeDiscordSlug(channelId),
+    channelSlug,
+    channelName ? normalizeDiscordSlug(channelName) : "",
+  ].filter(Boolean);
+  return allowList.has("*") || candidates.some((candidate) => allowList.has(candidate));
+}
+
+export function shouldEmitDiscordReactionNotification(params: {
+  mode?: "off" | "own" | "all" | "allowlist";
+  botId?: string;
+  messageAuthorId?: string;
+  userId: string;
+  userName?: string;
+  userTag?: string;
+  channelConfig?: DiscordChannelConfigResolved | null;
+  guildInfo?: DiscordGuildEntryResolved | null;
+  memberRoleIds?: string[];
+  allowlist?: string[];
+  allowNameMatching?: boolean;
+}) {
+  const mode = params.mode ?? "own";
+  if (mode === "off") {
+    return false;
+  }
+  const accessGuildInfo =
+    params.guildInfo ??
+    (params.allowlist ? ({ users: params.allowlist } satisfies DiscordGuildEntryResolved) : null);
+  const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
+    channelConfig: params.channelConfig,
+    guildInfo: accessGuildInfo,
+    memberRoleIds: params.memberRoleIds ?? [],
+    sender: {
+      id: params.userId,
+      name: params.userName,
+      tag: params.userTag,
+    },
+    allowNameMatching: params.allowNameMatching,
+  });
+  if (mode === "allowlist") {
+    return hasAccessRestrictions && memberAllowed;
+  }
+  if (hasAccessRestrictions && !memberAllowed) {
+    return false;
+  }
+  if (mode === "all") {
+    return true;
+  }
+  if (mode === "own") {
+    return Boolean(params.botId && params.messageAuthorId === params.botId);
+  }
+  return false;
+}

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -27,6 +27,7 @@ export type DiscordGuildEntryResolved = {
   ignoreOtherMentions?: boolean;
   reactionNotifications?: "off" | "own" | "all" | "allowlist";
   memberJoinNotifications?: "off" | "on";
+  memberJoinChannel?: string;
   users?: string[];
   roles?: string[];
   channels?: Record<

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -11,6 +11,7 @@ import {
   type User,
 } from "@buape/carbon";
 import type { OpenClawConfig } from "../../config/config.js";
+import { callGatewayLeastPrivilege } from "../../gateway/call.js";
 import { danger, logVerbose } from "../../globals.js";
 import { formatDurationSeconds } from "../../infra/format-time/format-duration.ts";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
@@ -773,6 +774,35 @@ async function handleDiscordMemberAddEvent(params: {
     });
 
     enqueueSystemEvent(text, { sessionKey: route.sessionKey, contextKey });
+
+    // Resolve welcome channel: explicit config > Discord system channel
+    const welcomeChannelId =
+      guildInfo?.memberJoinChannel?.trim() ||
+      (typeof data.guild.systemChannelId === "string" ? data.guild.systemChannelId.trim() : null) ||
+      null;
+
+    if (welcomeChannelId) {
+      void callGatewayLeastPrivilege({
+        method: "agent",
+        params: {
+          sessionKey: route.sessionKey,
+          message: `Discord member joined: ${userTag} joined ${guildSlug}. Welcome them.`,
+          channel: "discord",
+          accountId: params.accountId,
+          to: `channel:${welcomeChannelId}`,
+          deliver: true,
+          idempotencyKey: contextKey,
+        },
+      }).catch((err: unknown) => {
+        params.logger.error(
+          danger(`discord member-add: failed to trigger welcome agent: ${String(err)}`),
+        );
+      });
+    } else {
+      params.logger.debug(
+        "discord member-add: no welcome channel configured, skipping agent trigger",
+      );
+    }
   } catch (err) {
     params.logger.error(danger(`discord member-add handler failed: ${String(err)}`));
   }

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -1,0 +1,858 @@
+export * from "../../../extensions/discord/src/monitor/listeners.js";
+import {
+  ChannelType,
+  type Client,
+  GuildMemberAddListener,
+  MessageCreateListener,
+  MessageReactionAddListener,
+  MessageReactionRemoveListener,
+  PresenceUpdateListener,
+  ThreadUpdateListener,
+  type User,
+} from "@buape/carbon";
+import type { OpenClawConfig } from "../../config/config.js";
+import { danger, logVerbose } from "../../globals.js";
+import { formatDurationSeconds } from "../../infra/format-time/format-duration.ts";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveAgentRoute } from "../../routing/resolve-route.js";
+import {
+  readStoreAllowFromForDmPolicy,
+  resolveDmGroupAccessWithLists,
+} from "../../security/dm-policy-shared.js";
+import {
+  isDiscordGroupAllowedByPolicy,
+  normalizeDiscordAllowList,
+  normalizeDiscordSlug,
+  resolveDiscordAllowListMatch,
+  resolveDiscordChannelConfigWithFallback,
+  resolveDiscordMemberAccessState,
+  resolveGroupDmAllow,
+  resolveDiscordGuildEntry,
+  shouldEmitDiscordReactionNotification,
+} from "./allow-list.js";
+import { formatDiscordReactionEmoji, formatDiscordUserTag } from "./format.js";
+import { resolveDiscordChannelInfo } from "./message-utils.js";
+import { setPresence } from "./presence-cache.js";
+import { isThreadArchived } from "./thread-bindings.discord-api.js";
+import { closeDiscordThreadSessions } from "./thread-session-close.js";
+import { normalizeDiscordListenerTimeoutMs, runDiscordTaskWithTimeout } from "./timeouts.js";
+
+type LoadedConfig = ReturnType<typeof import("../../config/config.js").loadConfig>;
+type RuntimeEnv = import("../../runtime.js").RuntimeEnv;
+type Logger = ReturnType<typeof import("../../logging/subsystem.js").createSubsystemLogger>;
+
+export type DiscordMessageEvent = Parameters<MessageCreateListener["handle"]>[0];
+
+export type DiscordMessageHandler = (
+  data: DiscordMessageEvent,
+  client: Client,
+  options?: { abortSignal?: AbortSignal },
+) => Promise<void>;
+
+type DiscordReactionEvent = Parameters<MessageReactionAddListener["handle"]>[0];
+
+type DiscordMemberAddEvent = Parameters<GuildMemberAddListener["handle"]>[0];
+
+type DiscordMemberAddListenerParams = {
+  cfg: LoadedConfig;
+  accountId: string;
+  botUserId?: string;
+  guildEntries?: Record<string, import("./allow-list.js").DiscordGuildEntryResolved>;
+  logger: Logger;
+};
+
+type DiscordReactionListenerParams = {
+  cfg: LoadedConfig;
+  runtime: RuntimeEnv;
+  logger: Logger;
+  onEvent?: () => void;
+} & DiscordReactionRoutingParams;
+
+type DiscordReactionRoutingParams = {
+  accountId: string;
+  botUserId?: string;
+  dmEnabled: boolean;
+  groupDmEnabled: boolean;
+  groupDmChannels: string[];
+  dmPolicy: "open" | "pairing" | "allowlist" | "disabled";
+  allowFrom: string[];
+  groupPolicy: "open" | "allowlist" | "disabled";
+  allowNameMatching: boolean;
+  guildEntries?: Record<string, import("./allow-list.js").DiscordGuildEntryResolved>;
+};
+
+const DISCORD_SLOW_LISTENER_THRESHOLD_MS = 30_000;
+const discordEventQueueLog = createSubsystemLogger("discord/event-queue");
+
+function formatListenerContextValue(value: unknown): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  return null;
+}
+
+function formatListenerContextSuffix(context?: Record<string, unknown>): string {
+  if (!context) {
+    return "";
+  }
+  const entries = Object.entries(context).flatMap(([key, value]) => {
+    const formatted = formatListenerContextValue(value);
+    return formatted ? [`${key}=${formatted}`] : [];
+  });
+  if (entries.length === 0) {
+    return "";
+  }
+  return ` (${entries.join(" ")})`;
+}
+
+function logSlowDiscordListener(params: {
+  logger: Logger | undefined;
+  listener: string;
+  event: string;
+  durationMs: number;
+  context?: Record<string, unknown>;
+}) {
+  if (params.durationMs < DISCORD_SLOW_LISTENER_THRESHOLD_MS) {
+    return;
+  }
+  const duration = formatDurationSeconds(params.durationMs, {
+    decimals: 1,
+    unit: "seconds",
+  });
+  const message = `Slow listener detected: ${params.listener} took ${duration} for event ${params.event}`;
+  const logger = params.logger ?? discordEventQueueLog;
+  logger.warn("Slow listener detected", {
+    listener: params.listener,
+    event: params.event,
+    durationMs: params.durationMs,
+    duration,
+    ...params.context,
+    consoleMessage: `${message}${formatListenerContextSuffix(params.context)}`,
+  });
+}
+
+async function runDiscordListenerWithSlowLog(params: {
+  logger: Logger | undefined;
+  listener: string;
+  event: string;
+  run: (abortSignal: AbortSignal | undefined) => Promise<void>;
+  timeoutMs?: number;
+  context?: Record<string, unknown>;
+  onError?: (err: unknown) => void;
+}) {
+  const startedAt = Date.now();
+  const timeoutMs = normalizeDiscordListenerTimeoutMs(params.timeoutMs);
+  const logger = params.logger ?? discordEventQueueLog;
+  let timedOut = false;
+
+  try {
+    timedOut = await runDiscordTaskWithTimeout({
+      run: params.run,
+      timeoutMs,
+      onTimeout: (resolvedTimeoutMs) => {
+        logger.error(
+          danger(
+            `discord handler timed out after ${formatDurationSeconds(resolvedTimeoutMs, {
+              decimals: 1,
+              unit: "seconds",
+            })}${formatListenerContextSuffix(params.context)}`,
+          ),
+        );
+      },
+      onAbortAfterTimeout: () => {
+        logger.warn(
+          `discord handler canceled after timeout${formatListenerContextSuffix(params.context)}`,
+        );
+      },
+      onErrorAfterTimeout: (err) => {
+        logger.error(
+          danger(
+            `discord handler failed after timeout: ${String(err)}${formatListenerContextSuffix(params.context)}`,
+          ),
+        );
+      },
+    });
+    if (timedOut) {
+      return;
+    }
+  } catch (err) {
+    if (params.onError) {
+      params.onError(err);
+      return;
+    }
+    throw err;
+  } finally {
+    if (!timedOut) {
+      logSlowDiscordListener({
+        logger: params.logger,
+        listener: params.listener,
+        event: params.event,
+        durationMs: Date.now() - startedAt,
+        context: params.context,
+      });
+    }
+  }
+}
+
+export function registerDiscordListener(listeners: Array<object>, listener: object) {
+  if (listeners.some((existing) => existing.constructor === listener.constructor)) {
+    return false;
+  }
+  listeners.push(listener);
+  return true;
+}
+
+export class DiscordMessageListener extends MessageCreateListener {
+  constructor(
+    private handler: DiscordMessageHandler,
+    private logger?: Logger,
+    private onEvent?: () => void,
+    _options?: { timeoutMs?: number },
+  ) {
+    super();
+  }
+
+  async handle(data: DiscordMessageEvent, client: Client) {
+    this.onEvent?.();
+    // Fire-and-forget: hand off to the handler without blocking the
+    // Carbon listener.  Per-session ordering and run timeouts are owned
+    // by the inbound worker queue, so the listener no longer serializes
+    // or applies its own timeout.
+    void Promise.resolve()
+      .then(() => this.handler(data, client))
+      .catch((err) => {
+        const logger = this.logger ?? discordEventQueueLog;
+        logger.error(danger(`discord handler failed: ${String(err)}`));
+      });
+  }
+}
+
+export class DiscordReactionListener extends MessageReactionAddListener {
+  constructor(private params: DiscordReactionListenerParams) {
+    super();
+  }
+
+  async handle(data: DiscordReactionEvent, client: Client) {
+    this.params.onEvent?.();
+    await runDiscordReactionHandler({
+      data,
+      client,
+      action: "added",
+      handlerParams: this.params,
+      listener: this.constructor.name,
+      event: this.type,
+    });
+  }
+}
+
+export class DiscordReactionRemoveListener extends MessageReactionRemoveListener {
+  constructor(private params: DiscordReactionListenerParams) {
+    super();
+  }
+
+  async handle(data: DiscordReactionEvent, client: Client) {
+    this.params.onEvent?.();
+    await runDiscordReactionHandler({
+      data,
+      client,
+      action: "removed",
+      handlerParams: this.params,
+      listener: this.constructor.name,
+      event: this.type,
+    });
+  }
+}
+
+async function runDiscordReactionHandler(params: {
+  data: DiscordReactionEvent;
+  client: Client;
+  action: "added" | "removed";
+  handlerParams: DiscordReactionListenerParams;
+  listener: string;
+  event: string;
+}): Promise<void> {
+  await runDiscordListenerWithSlowLog({
+    logger: params.handlerParams.logger,
+    listener: params.listener,
+    event: params.event,
+    run: async () =>
+      handleDiscordReactionEvent({
+        data: params.data,
+        client: params.client,
+        action: params.action,
+        cfg: params.handlerParams.cfg,
+        accountId: params.handlerParams.accountId,
+        botUserId: params.handlerParams.botUserId,
+        dmEnabled: params.handlerParams.dmEnabled,
+        groupDmEnabled: params.handlerParams.groupDmEnabled,
+        groupDmChannels: params.handlerParams.groupDmChannels,
+        dmPolicy: params.handlerParams.dmPolicy,
+        allowFrom: params.handlerParams.allowFrom,
+        groupPolicy: params.handlerParams.groupPolicy,
+        allowNameMatching: params.handlerParams.allowNameMatching,
+        guildEntries: params.handlerParams.guildEntries,
+        logger: params.handlerParams.logger,
+      }),
+  });
+}
+
+type DiscordReactionIngressAuthorizationParams = {
+  accountId: string;
+  user: User;
+  memberRoleIds: string[];
+  isDirectMessage: boolean;
+  isGroupDm: boolean;
+  isGuildMessage: boolean;
+  channelId: string;
+  channelName?: string;
+  channelSlug: string;
+  dmEnabled: boolean;
+  groupDmEnabled: boolean;
+  groupDmChannels: string[];
+  dmPolicy: "open" | "pairing" | "allowlist" | "disabled";
+  allowFrom: string[];
+  groupPolicy: "open" | "allowlist" | "disabled";
+  allowNameMatching: boolean;
+  guildInfo: import("./allow-list.js").DiscordGuildEntryResolved | null;
+  channelConfig?: import("./allow-list.js").DiscordChannelConfigResolved | null;
+};
+
+async function authorizeDiscordReactionIngress(
+  params: DiscordReactionIngressAuthorizationParams,
+): Promise<{ allowed: true } | { allowed: false; reason: string }> {
+  if (params.isDirectMessage && !params.dmEnabled) {
+    return { allowed: false, reason: "dm-disabled" };
+  }
+  if (params.isGroupDm && !params.groupDmEnabled) {
+    return { allowed: false, reason: "group-dm-disabled" };
+  }
+  if (params.isDirectMessage) {
+    const storeAllowFrom = await readStoreAllowFromForDmPolicy({
+      provider: "discord",
+      accountId: params.accountId,
+      dmPolicy: params.dmPolicy,
+    });
+    const access = resolveDmGroupAccessWithLists({
+      isGroup: false,
+      dmPolicy: params.dmPolicy,
+      groupPolicy: params.groupPolicy,
+      allowFrom: params.allowFrom,
+      groupAllowFrom: [],
+      storeAllowFrom,
+      isSenderAllowed: (allowEntries) => {
+        const allowList = normalizeDiscordAllowList(allowEntries, ["discord:", "user:", "pk:"]);
+        const allowMatch = allowList
+          ? resolveDiscordAllowListMatch({
+              allowList,
+              candidate: {
+                id: params.user.id,
+                name: params.user.username,
+                tag: formatDiscordUserTag(params.user),
+              },
+              allowNameMatching: params.allowNameMatching,
+            })
+          : { allowed: false };
+        return allowMatch.allowed;
+      },
+    });
+    if (access.decision !== "allow") {
+      return { allowed: false, reason: access.reason };
+    }
+  }
+  if (
+    params.isGroupDm &&
+    !resolveGroupDmAllow({
+      channels: params.groupDmChannels,
+      channelId: params.channelId,
+      channelName: params.channelName,
+      channelSlug: params.channelSlug,
+    })
+  ) {
+    return { allowed: false, reason: "group-dm-not-allowlisted" };
+  }
+  if (!params.isGuildMessage) {
+    return { allowed: true };
+  }
+  const channelAllowlistConfigured =
+    Boolean(params.guildInfo?.channels) && Object.keys(params.guildInfo?.channels ?? {}).length > 0;
+  const channelAllowed = params.channelConfig?.allowed !== false;
+  if (
+    !isDiscordGroupAllowedByPolicy({
+      groupPolicy: params.groupPolicy,
+      guildAllowlisted: Boolean(params.guildInfo),
+      channelAllowlistConfigured,
+      channelAllowed,
+    })
+  ) {
+    return { allowed: false, reason: "guild-policy" };
+  }
+  if (params.channelConfig?.allowed === false) {
+    return { allowed: false, reason: "guild-channel-denied" };
+  }
+  const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
+    channelConfig: params.channelConfig,
+    guildInfo: params.guildInfo,
+    memberRoleIds: params.memberRoleIds,
+    sender: {
+      id: params.user.id,
+      name: params.user.username,
+      tag: formatDiscordUserTag(params.user),
+    },
+    allowNameMatching: params.allowNameMatching,
+  });
+  if (hasAccessRestrictions && !memberAllowed) {
+    return { allowed: false, reason: "guild-member-denied" };
+  }
+  return { allowed: true };
+}
+
+async function handleDiscordReactionEvent(
+  params: {
+    data: DiscordReactionEvent;
+    client: Client;
+    action: "added" | "removed";
+    cfg: LoadedConfig;
+    logger: Logger;
+  } & DiscordReactionRoutingParams,
+) {
+  try {
+    const { data, client, action, botUserId, guildEntries } = params;
+    if (!("user" in data)) {
+      return;
+    }
+    const user = data.user;
+    if (!user || user.bot) {
+      return;
+    }
+
+    // Early exit: skip bot's own reactions before expensive network calls
+    if (botUserId && user.id === botUserId) {
+      return;
+    }
+
+    const isGuildMessage = Boolean(data.guild_id);
+    const guildInfo = isGuildMessage
+      ? resolveDiscordGuildEntry({
+          guild: data.guild ?? undefined,
+          guildEntries,
+        })
+      : null;
+    if (isGuildMessage && guildEntries && Object.keys(guildEntries).length > 0 && !guildInfo) {
+      return;
+    }
+
+    const channel = await client.fetchChannel(data.channel_id);
+    if (!channel) {
+      return;
+    }
+    const channelName = "name" in channel ? (channel.name ?? undefined) : undefined;
+    const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
+    const channelType = "type" in channel ? channel.type : undefined;
+    const isDirectMessage = channelType === ChannelType.DM;
+    const isGroupDm = channelType === ChannelType.GroupDM;
+    const isThreadChannel =
+      channelType === ChannelType.PublicThread ||
+      channelType === ChannelType.PrivateThread ||
+      channelType === ChannelType.AnnouncementThread;
+    const memberRoleIds = Array.isArray(data.rawMember?.roles)
+      ? data.rawMember.roles.map((roleId: string) => String(roleId))
+      : [];
+    const reactionIngressBase: Omit<DiscordReactionIngressAuthorizationParams, "channelConfig"> = {
+      accountId: params.accountId,
+      user,
+      memberRoleIds,
+      isDirectMessage,
+      isGroupDm,
+      isGuildMessage,
+      channelId: data.channel_id,
+      channelName,
+      channelSlug,
+      dmEnabled: params.dmEnabled,
+      groupDmEnabled: params.groupDmEnabled,
+      groupDmChannels: params.groupDmChannels,
+      dmPolicy: params.dmPolicy,
+      allowFrom: params.allowFrom,
+      groupPolicy: params.groupPolicy,
+      allowNameMatching: params.allowNameMatching,
+      guildInfo,
+    };
+    // Guild reactions need resolved channel/thread config before member access
+    // can mirror the normal message preflight path.
+    if (!isGuildMessage) {
+      const ingressAccess = await authorizeDiscordReactionIngress(reactionIngressBase);
+      if (!ingressAccess.allowed) {
+        logVerbose(`discord reaction blocked sender=${user.id} (reason=${ingressAccess.reason})`);
+        return;
+      }
+    }
+    let parentId = "parentId" in channel ? (channel.parentId ?? undefined) : undefined;
+    let parentName: string | undefined;
+    let parentSlug = "";
+    let reactionBase: { baseText: string; contextKey: string } | null = null;
+    const resolveReactionBase = () => {
+      if (reactionBase) {
+        return reactionBase;
+      }
+      const emojiLabel = formatDiscordReactionEmoji(data.emoji);
+      const actorLabel = formatDiscordUserTag(user);
+      const guildSlug =
+        guildInfo?.slug ||
+        (data.guild?.name
+          ? normalizeDiscordSlug(data.guild.name)
+          : (data.guild_id ?? (isGroupDm ? "group-dm" : "dm")));
+      const channelLabel = channelSlug
+        ? `#${channelSlug}`
+        : channelName
+          ? `#${normalizeDiscordSlug(channelName)}`
+          : `#${data.channel_id}`;
+      const baseText = `Discord reaction ${action}: ${emojiLabel} by ${actorLabel} on ${guildSlug} ${channelLabel} msg ${data.message_id}`;
+      const contextKey = `discord:reaction:${action}:${data.message_id}:${user.id}:${emojiLabel}`;
+      reactionBase = { baseText, contextKey };
+      return reactionBase;
+    };
+    const emitReaction = (text: string, parentPeerId?: string) => {
+      const { contextKey } = resolveReactionBase();
+      const route = resolveAgentRoute({
+        cfg: params.cfg,
+        channel: "discord",
+        accountId: params.accountId,
+        guildId: data.guild_id ?? undefined,
+        memberRoleIds,
+        peer: {
+          kind: isDirectMessage ? "direct" : isGroupDm ? "group" : "channel",
+          id: isDirectMessage ? user.id : data.channel_id,
+        },
+        parentPeer: parentPeerId ? { kind: "channel", id: parentPeerId } : undefined,
+      });
+      enqueueSystemEvent(text, {
+        sessionKey: route.sessionKey,
+        contextKey,
+      });
+    };
+    const shouldNotifyReaction = (options: {
+      mode: "off" | "own" | "all" | "allowlist";
+      messageAuthorId?: string;
+      channelConfig?: ReturnType<typeof resolveDiscordChannelConfigWithFallback>;
+    }) =>
+      shouldEmitDiscordReactionNotification({
+        mode: options.mode,
+        botId: botUserId,
+        messageAuthorId: options.messageAuthorId,
+        userId: user.id,
+        userName: user.username,
+        userTag: formatDiscordUserTag(user),
+        channelConfig: options.channelConfig,
+        guildInfo,
+        memberRoleIds,
+        allowNameMatching: params.allowNameMatching,
+      });
+    const emitReactionWithAuthor = (message: { author?: User } | null) => {
+      const { baseText } = resolveReactionBase();
+      const authorLabel = message?.author ? formatDiscordUserTag(message.author) : undefined;
+      const text = authorLabel ? `${baseText} from ${authorLabel}` : baseText;
+      emitReaction(text, parentId);
+    };
+    const loadThreadParentInfo = async () => {
+      if (!parentId) {
+        return;
+      }
+      const parentInfo = await resolveDiscordChannelInfo(client, parentId);
+      parentName = parentInfo?.name;
+      parentSlug = parentName ? normalizeDiscordSlug(parentName) : "";
+    };
+    const resolveThreadChannelConfig = () =>
+      resolveDiscordChannelConfigWithFallback({
+        guildInfo,
+        channelId: data.channel_id,
+        channelName,
+        channelSlug,
+        parentId,
+        parentName,
+        parentSlug,
+        scope: "thread",
+      });
+    const authorizeReactionIngressForChannel = async (
+      channelConfig: ReturnType<typeof resolveDiscordChannelConfigWithFallback>,
+    ) =>
+      await authorizeDiscordReactionIngress({
+        ...reactionIngressBase,
+        channelConfig,
+      });
+    const resolveThreadChannelAccess = async (channelInfo: { parentId?: string } | null) => {
+      parentId = channelInfo?.parentId;
+      await loadThreadParentInfo();
+      const channelConfig = resolveThreadChannelConfig();
+      const access = await authorizeReactionIngressForChannel(channelConfig);
+      return { access, channelConfig };
+    };
+
+    // Parallelize async operations for thread channels
+    if (isThreadChannel) {
+      const reactionMode = guildInfo?.reactionNotifications ?? "own";
+
+      // Early exit: skip fetching message if notifications are off
+      if (reactionMode === "off") {
+        return;
+      }
+
+      const channelInfoPromise = parentId
+        ? Promise.resolve({ parentId })
+        : resolveDiscordChannelInfo(client, data.channel_id);
+
+      // Fast path: for "all" and "allowlist" modes, we don't need to fetch the message
+      if (reactionMode === "all" || reactionMode === "allowlist") {
+        const channelInfo = await channelInfoPromise;
+        const { access: threadAccess, channelConfig: threadChannelConfig } =
+          await resolveThreadChannelAccess(channelInfo);
+        if (!threadAccess.allowed) {
+          return;
+        }
+        if (
+          !shouldNotifyReaction({
+            mode: reactionMode,
+            channelConfig: threadChannelConfig,
+          })
+        ) {
+          return;
+        }
+
+        const { baseText } = resolveReactionBase();
+        emitReaction(baseText, parentId);
+        return;
+      }
+
+      // For "own" mode, we need to fetch the message to check the author
+      const messagePromise = data.message.fetch().catch(() => null);
+
+      const [channelInfo, message] = await Promise.all([channelInfoPromise, messagePromise]);
+      const { access: threadAccess, channelConfig: threadChannelConfig } =
+        await resolveThreadChannelAccess(channelInfo);
+      if (!threadAccess.allowed) {
+        return;
+      }
+
+      const messageAuthorId = message?.author?.id ?? undefined;
+      if (
+        !shouldNotifyReaction({
+          mode: reactionMode,
+          messageAuthorId,
+          channelConfig: threadChannelConfig,
+        })
+      ) {
+        return;
+      }
+
+      emitReactionWithAuthor(message);
+      return;
+    }
+
+    // Non-thread channel path
+    const channelConfig = resolveDiscordChannelConfigWithFallback({
+      guildInfo,
+      channelId: data.channel_id,
+      channelName,
+      channelSlug,
+      parentId,
+      parentName,
+      parentSlug,
+      scope: "channel",
+    });
+    if (isGuildMessage) {
+      const channelAccess = await authorizeReactionIngressForChannel(channelConfig);
+      if (!channelAccess.allowed) {
+        return;
+      }
+    }
+
+    const reactionMode = guildInfo?.reactionNotifications ?? "own";
+
+    // Early exit: skip fetching message if notifications are off
+    if (reactionMode === "off") {
+      return;
+    }
+
+    // Fast path: for "all" and "allowlist" modes, we don't need to fetch the message
+    if (reactionMode === "all" || reactionMode === "allowlist") {
+      if (!shouldNotifyReaction({ mode: reactionMode, channelConfig })) {
+        return;
+      }
+
+      const { baseText } = resolveReactionBase();
+      emitReaction(baseText, parentId);
+      return;
+    }
+
+    // For "own" mode, we need to fetch the message to check the author
+    const message = await data.message.fetch().catch(() => null);
+    const messageAuthorId = message?.author?.id ?? undefined;
+    if (!shouldNotifyReaction({ mode: reactionMode, messageAuthorId, channelConfig })) {
+      return;
+    }
+
+    emitReactionWithAuthor(message);
+  } catch (err) {
+    params.logger.error(danger(`discord reaction handler failed: ${String(err)}`));
+  }
+}
+
+export class DiscordMemberAddListener extends GuildMemberAddListener {
+  constructor(private params: DiscordMemberAddListenerParams) {
+    super();
+  }
+
+  async handle(data: DiscordMemberAddEvent) {
+    const startedAt = Date.now();
+    try {
+      await handleDiscordMemberAddEvent({ data, ...this.params });
+    } finally {
+      logSlowDiscordListener({
+        logger: this.params.logger,
+        listener: this.constructor.name,
+        event: this.type,
+        durationMs: Date.now() - startedAt,
+      });
+    }
+  }
+}
+
+async function handleDiscordMemberAddEvent(params: {
+  data: DiscordMemberAddEvent;
+  cfg: LoadedConfig;
+  accountId: string;
+  botUserId?: string;
+  guildEntries?: Record<string, import("./allow-list.js").DiscordGuildEntryResolved>;
+  logger: Logger;
+}) {
+  try {
+    const { data, botUserId, guildEntries } = params;
+
+    // Skip bots
+    const user = data.member?.user;
+    if (!user || user.bot) {
+      return;
+    }
+    if (botUserId && user.id === botUserId) {
+      return;
+    }
+
+    const guildInfo = resolveDiscordGuildEntry({ guild: data.guild, guildEntries });
+
+    // Default is off — must be explicitly enabled per guild
+    const mode = guildInfo?.memberJoinNotifications ?? "off";
+    if (mode === "off") {
+      return;
+    }
+
+    const guildSlug =
+      guildInfo?.slug ||
+      (data.guild?.name ? normalizeDiscordSlug(data.guild.name) : (data.guild?.id ?? "unknown"));
+
+    const memberRoleIds = Array.isArray(data.member.rawData?.roles)
+      ? data.member.rawData.roles.map((id: string) => String(id))
+      : [];
+
+    const userTag = formatDiscordUserTag(user);
+    const text = `Discord member joined: ${userTag} joined ${guildSlug}`;
+    const contextKey = `discord:member-add:${data.guild?.id}:${user.id}`;
+
+    const route = resolveAgentRoute({
+      cfg: params.cfg,
+      channel: "discord",
+      accountId: params.accountId,
+      guildId: data.guild?.id,
+      memberRoleIds,
+      peer: null,
+    });
+
+    enqueueSystemEvent(text, { sessionKey: route.sessionKey, contextKey });
+  } catch (err) {
+    params.logger.error(danger(`discord member-add handler failed: ${String(err)}`));
+  }
+}
+
+type PresenceUpdateEvent = Parameters<PresenceUpdateListener["handle"]>[0];
+
+export class DiscordPresenceListener extends PresenceUpdateListener {
+  private logger?: Logger;
+  private accountId?: string;
+
+  constructor(params: { logger?: Logger; accountId?: string }) {
+    super();
+    this.logger = params.logger;
+    this.accountId = params.accountId;
+  }
+
+  async handle(data: PresenceUpdateEvent) {
+    try {
+      const userId =
+        "user" in data && data.user && typeof data.user === "object" && "id" in data.user
+          ? String(data.user.id)
+          : undefined;
+      if (!userId) {
+        return;
+      }
+      setPresence(
+        this.accountId,
+        userId,
+        data as import("discord-api-types/v10").GatewayPresenceUpdate,
+      );
+    } catch (err) {
+      const logger = this.logger ?? discordEventQueueLog;
+      logger.error(danger(`discord presence handler failed: ${String(err)}`));
+    }
+  }
+}
+
+type ThreadUpdateEvent = Parameters<ThreadUpdateListener["handle"]>[0];
+
+export class DiscordThreadUpdateListener extends ThreadUpdateListener {
+  constructor(
+    private cfg: OpenClawConfig,
+    private accountId: string,
+    private logger?: Logger,
+  ) {
+    super();
+  }
+
+  async handle(data: ThreadUpdateEvent) {
+    await runDiscordListenerWithSlowLog({
+      logger: this.logger,
+      listener: this.constructor.name,
+      event: this.type,
+      run: async () => {
+        // Discord only fires THREAD_UPDATE when a field actually changes, so
+        // `thread_metadata.archived === true` in this payload means the thread
+        // just transitioned to the archived state.
+        if (!isThreadArchived(data)) {
+          return;
+        }
+        const threadId = "id" in data && typeof data.id === "string" ? data.id : undefined;
+        if (!threadId) {
+          return;
+        }
+        const logger = this.logger ?? discordEventQueueLog;
+        logger.info("Discord thread archived — resetting session", { threadId });
+        const count = await closeDiscordThreadSessions({
+          cfg: this.cfg,
+          accountId: this.accountId,
+          threadId,
+        });
+        if (count > 0) {
+          logger.info("Discord thread sessions reset after archival", { threadId, count });
+        }
+      },
+      onError: (err) => {
+        const logger = this.logger ?? discordEventQueueLog;
+        logger.error(danger(`discord thread-update handler failed: ${String(err)}`));
+      },
+    });
+  }
+}

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -1,0 +1,831 @@
+export * from "../../../extensions/discord/src/monitor/provider.js";
+import { inspect } from "node:util";
+import {
+  Client,
+  ReadyListener,
+  type BaseCommand,
+  type BaseMessageInteractiveComponent,
+  type Modal,
+  type Plugin,
+} from "@buape/carbon";
+import { GatewayCloseCodes, type GatewayPlugin } from "@buape/carbon/gateway";
+import { VoicePlugin } from "@buape/carbon/voice";
+import { Routes } from "discord-api-types/v10";
+import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
+import { isAcpRuntimeError } from "../../acp/runtime/errors.js";
+import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
+import type { NativeCommandSpec } from "../../auto-reply/commands-registry.js";
+import { listNativeCommandSpecsForConfig } from "../../auto-reply/commands-registry.js";
+import type { HistoryEntry } from "../../auto-reply/reply/history.js";
+import { listSkillCommandsForAgents } from "../../auto-reply/skill-commands.js";
+import {
+  resolveThreadBindingIdleTimeoutMs,
+  resolveThreadBindingMaxAgeMs,
+  resolveThreadBindingsEnabled,
+} from "../../channels/thread-bindings-policy.js";
+import {
+  isNativeCommandsExplicitlyDisabled,
+  resolveNativeCommandsEnabled,
+  resolveNativeSkillsEnabled,
+} from "../../config/commands.js";
+import type { OpenClawConfig, ReplyToMode } from "../../config/config.js";
+import { loadConfig } from "../../config/config.js";
+import { isDangerousNameMatchingEnabled } from "../../config/dangerous-name-matching.js";
+import {
+  GROUP_POLICY_BLOCKED_LABEL,
+  resolveOpenProviderRuntimeGroupPolicy,
+  resolveDefaultGroupPolicy,
+  warnMissingProviderGroupPolicyFallbackOnce,
+} from "../../config/runtime-group-policy.js";
+import { createConnectedChannelStatusPatch } from "../../gateway/channel-status-patches.js";
+import { danger, logVerbose, shouldLogVerbose, warn } from "../../globals.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { createDiscordRetryRunner } from "../../infra/retry-policy.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { getPluginCommandSpecs } from "../../plugins/commands.js";
+import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
+import { summarizeStringEntries } from "../../shared/string-sample.js";
+import { resolveDiscordAccount } from "../accounts.js";
+import { fetchDiscordApplicationId } from "../probe.js";
+import { normalizeDiscordToken } from "../token.js";
+import { createDiscordVoiceCommand } from "../voice/command.js";
+import {
+  createAgentComponentButton,
+  createAgentSelectMenu,
+  createDiscordComponentButton,
+  createDiscordComponentChannelSelect,
+  createDiscordComponentMentionableSelect,
+  createDiscordComponentModal,
+  createDiscordComponentRoleSelect,
+  createDiscordComponentStringSelect,
+  createDiscordComponentUserSelect,
+} from "./agent-components.js";
+import { createDiscordAutoPresenceController } from "./auto-presence.js";
+import { resolveDiscordSlashCommandConfig } from "./commands.js";
+import { createExecApprovalButton, DiscordExecApprovalHandler } from "./exec-approvals.js";
+import { attachEarlyGatewayErrorGuard } from "./gateway-error-guard.js";
+import { createDiscordGatewayPlugin } from "./gateway-plugin.js";
+import {
+  DiscordMemberAddListener,
+  DiscordMessageListener,
+  DiscordPresenceListener,
+  DiscordReactionListener,
+  DiscordReactionRemoveListener,
+  DiscordThreadUpdateListener,
+  registerDiscordListener,
+} from "./listeners.js";
+import { createDiscordMessageHandler } from "./message-handler.js";
+import {
+  createDiscordCommandArgFallbackButton,
+  createDiscordModelPickerFallbackButton,
+  createDiscordModelPickerFallbackSelect,
+  createDiscordNativeCommand,
+} from "./native-command.js";
+import { resolveDiscordPresenceUpdate } from "./presence.js";
+import { resolveDiscordAllowlistConfig } from "./provider.allowlist.js";
+import { runDiscordGatewayLifecycle } from "./provider.lifecycle.js";
+import { resolveDiscordRestFetch } from "./rest-fetch.js";
+import type { DiscordMonitorStatusSink } from "./status.js";
+import {
+  createNoopThreadBindingManager,
+  createThreadBindingManager,
+  reconcileAcpThreadBindingsOnStartup,
+} from "./thread-bindings.js";
+import { formatThreadBindingDurationLabel } from "./thread-bindings.messages.js";
+
+export type MonitorDiscordOpts = {
+  token?: string;
+  accountId?: string;
+  config?: OpenClawConfig;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  mediaMaxMb?: number;
+  historyLimit?: number;
+  replyToMode?: ReplyToMode;
+  setStatus?: DiscordMonitorStatusSink;
+};
+
+type DiscordVoiceManager = import("../voice/manager.js").DiscordVoiceManager;
+
+type DiscordVoiceRuntimeModule = typeof import("../voice/manager.runtime.js");
+
+let discordVoiceRuntimePromise: Promise<DiscordVoiceRuntimeModule> | undefined;
+
+async function loadDiscordVoiceRuntime(): Promise<DiscordVoiceRuntimeModule> {
+  discordVoiceRuntimePromise ??= import("../voice/manager.runtime.js");
+  return await discordVoiceRuntimePromise;
+}
+
+function formatThreadBindingDurationForConfigLabel(durationMs: number): string {
+  const label = formatThreadBindingDurationLabel(durationMs);
+  return label === "disabled" ? "off" : label;
+}
+
+function appendPluginCommandSpecs(params: {
+  commandSpecs: NativeCommandSpec[];
+  runtime: RuntimeEnv;
+}): NativeCommandSpec[] {
+  const merged = [...params.commandSpecs];
+  const existingNames = new Set(
+    merged.map((spec) => spec.name.trim().toLowerCase()).filter(Boolean),
+  );
+  for (const pluginCommand of getPluginCommandSpecs("discord")) {
+    const normalizedName = pluginCommand.name.trim().toLowerCase();
+    if (!normalizedName) {
+      continue;
+    }
+    if (existingNames.has(normalizedName)) {
+      params.runtime.error?.(
+        danger(
+          `discord: plugin command "/${normalizedName}" duplicates an existing native command. Skipping.`,
+        ),
+      );
+      continue;
+    }
+    existingNames.add(normalizedName);
+    merged.push({
+      name: pluginCommand.name,
+      description: pluginCommand.description,
+      acceptsArgs: pluginCommand.acceptsArgs,
+    });
+  }
+  return merged;
+}
+
+const DISCORD_ACP_STATUS_PROBE_TIMEOUT_MS = 8_000;
+const DISCORD_ACP_STALE_RUNNING_ACTIVITY_MS = 2 * 60 * 1000;
+
+function isLegacyMissingSessionError(message: string): boolean {
+  return (
+    message.includes("Session is not ACP-enabled") ||
+    message.includes("ACP session metadata missing")
+  );
+}
+
+function classifyAcpStatusProbeError(params: { error: unknown; isStaleRunning: boolean }): {
+  status: "stale" | "uncertain";
+  reason: string;
+} {
+  if (isAcpRuntimeError(params.error) && params.error.code === "ACP_SESSION_INIT_FAILED") {
+    return { status: "stale", reason: "session-init-failed" };
+  }
+
+  const message = params.error instanceof Error ? params.error.message : String(params.error);
+  if (isLegacyMissingSessionError(message)) {
+    return { status: "stale", reason: "session-missing" };
+  }
+
+  return params.isStaleRunning
+    ? { status: "stale", reason: "status-error-running-stale" }
+    : { status: "uncertain", reason: "status-error" };
+}
+
+async function probeDiscordAcpBindingHealth(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  storedState?: "idle" | "running" | "error";
+  lastActivityAt?: number;
+}): Promise<{ status: "healthy" | "stale" | "uncertain"; reason?: string }> {
+  const manager = getAcpSessionManager();
+  const statusProbeAbortController = new AbortController();
+  const statusPromise = manager
+    .getSessionStatus({
+      cfg: params.cfg,
+      sessionKey: params.sessionKey,
+      signal: statusProbeAbortController.signal,
+    })
+    .then((status) => ({ kind: "status" as const, status }))
+    .catch((error: unknown) => ({ kind: "error" as const, error }));
+
+  let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<{ kind: "timeout" }>((resolve) => {
+    timeoutTimer = setTimeout(
+      () => resolve({ kind: "timeout" }),
+      DISCORD_ACP_STATUS_PROBE_TIMEOUT_MS,
+    );
+    timeoutTimer.unref?.();
+  });
+  const result = await Promise.race([statusPromise, timeoutPromise]);
+  if (timeoutTimer) {
+    clearTimeout(timeoutTimer);
+  }
+  if (result.kind === "timeout") {
+    statusProbeAbortController.abort();
+  }
+  const runningForMs =
+    params.storedState === "running" && Number.isFinite(params.lastActivityAt)
+      ? Date.now() - Math.max(0, Math.floor(params.lastActivityAt ?? 0))
+      : 0;
+  const isStaleRunning =
+    params.storedState === "running" && runningForMs >= DISCORD_ACP_STALE_RUNNING_ACTIVITY_MS;
+
+  if (result.kind === "timeout") {
+    return isStaleRunning
+      ? { status: "stale", reason: "status-timeout-running-stale" }
+      : { status: "uncertain", reason: "status-timeout" };
+  }
+  if (result.kind === "error") {
+    return classifyAcpStatusProbeError({
+      error: result.error,
+      isStaleRunning,
+    });
+  }
+  if (result.status.state === "error") {
+    // ACP error state is recoverable (next turn can clear it), so keep the
+    // binding unless stronger stale signals exist.
+    return { status: "uncertain", reason: "status-error-state" };
+  }
+  return { status: "healthy" };
+}
+
+async function deployDiscordCommands(params: {
+  client: Client;
+  runtime: RuntimeEnv;
+  enabled: boolean;
+}) {
+  if (!params.enabled) {
+    return;
+  }
+  const runWithRetry = createDiscordRetryRunner({ verbose: shouldLogVerbose() });
+  try {
+    await runWithRetry(() => params.client.handleDeployRequest(), "command deploy");
+  } catch (err) {
+    const details = formatDiscordDeployErrorDetails(err);
+    params.runtime.error?.(
+      danger(`discord: failed to deploy native commands: ${formatErrorMessage(err)}${details}`),
+    );
+  }
+}
+
+function formatDiscordDeployErrorDetails(err: unknown): string {
+  if (!err || typeof err !== "object") {
+    return "";
+  }
+  const status = (err as { status?: unknown }).status;
+  const discordCode = (err as { discordCode?: unknown }).discordCode;
+  const rawBody = (err as { rawBody?: unknown }).rawBody;
+  const details: string[] = [];
+  if (typeof status === "number") {
+    details.push(`status=${status}`);
+  }
+  if (typeof discordCode === "number" || typeof discordCode === "string") {
+    details.push(`code=${discordCode}`);
+  }
+  if (rawBody !== undefined) {
+    let bodyText = "";
+    try {
+      bodyText = JSON.stringify(rawBody);
+    } catch {
+      bodyText =
+        typeof rawBody === "string" ? rawBody : inspect(rawBody, { depth: 3, breakLength: 120 });
+    }
+    if (bodyText) {
+      const maxLen = 800;
+      const trimmed = bodyText.length > maxLen ? `${bodyText.slice(0, maxLen)}...` : bodyText;
+      details.push(`body=${trimmed}`);
+    }
+  }
+  return details.length > 0 ? ` (${details.join(", ")})` : "";
+}
+
+const DISCORD_DISALLOWED_INTENTS_CODE = GatewayCloseCodes.DisallowedIntents;
+
+function isDiscordDisallowedIntentsError(err: unknown): boolean {
+  if (!err) {
+    return false;
+  }
+  const message = formatErrorMessage(err);
+  return message.includes(String(DISCORD_DISALLOWED_INTENTS_CODE));
+}
+
+export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
+  const cfg = opts.config ?? loadConfig();
+  const account = resolveDiscordAccount({
+    cfg,
+    accountId: opts.accountId,
+  });
+  const token =
+    normalizeDiscordToken(opts.token ?? undefined, "channels.discord.token") ?? account.token;
+  if (!token) {
+    throw new Error(
+      `Discord bot token missing for account "${account.accountId}" (set discord.accounts.${account.accountId}.token or DISCORD_BOT_TOKEN for default).`,
+    );
+  }
+
+  const runtime: RuntimeEnv = opts.runtime ?? createNonExitingRuntime();
+
+  const rawDiscordCfg = account.config;
+  const discordRootThreadBindings = cfg.channels?.discord?.threadBindings;
+  const discordAccountThreadBindings =
+    cfg.channels?.discord?.accounts?.[account.accountId]?.threadBindings;
+  const discordRestFetch = resolveDiscordRestFetch(rawDiscordCfg.proxy, runtime);
+  const dmConfig = rawDiscordCfg.dm;
+  let guildEntries = rawDiscordCfg.guilds;
+  const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
+  const providerConfigPresent = cfg.channels?.discord !== undefined;
+  const { groupPolicy, providerMissingFallbackApplied } = resolveOpenProviderRuntimeGroupPolicy({
+    providerConfigPresent,
+    groupPolicy: rawDiscordCfg.groupPolicy,
+    defaultGroupPolicy,
+  });
+  const discordCfg =
+    rawDiscordCfg.groupPolicy === groupPolicy ? rawDiscordCfg : { ...rawDiscordCfg, groupPolicy };
+  warnMissingProviderGroupPolicyFallbackOnce({
+    providerMissingFallbackApplied,
+    providerKey: "discord",
+    accountId: account.accountId,
+    blockedLabel: GROUP_POLICY_BLOCKED_LABEL.guild,
+    log: (message) => runtime.log?.(warn(message)),
+  });
+  let allowFrom = discordCfg.allowFrom ?? dmConfig?.allowFrom;
+  const mediaMaxBytes = (opts.mediaMaxMb ?? discordCfg.mediaMaxMb ?? 8) * 1024 * 1024;
+  const textLimit = resolveTextChunkLimit(cfg, "discord", account.accountId, {
+    fallbackLimit: 2000,
+  });
+  const historyLimit = Math.max(
+    0,
+    opts.historyLimit ?? discordCfg.historyLimit ?? cfg.messages?.groupChat?.historyLimit ?? 20,
+  );
+  const replyToMode = opts.replyToMode ?? discordCfg.replyToMode ?? "off";
+  const dmEnabled = dmConfig?.enabled ?? true;
+  const dmPolicy = discordCfg.dmPolicy ?? dmConfig?.policy ?? "pairing";
+  const threadBindingIdleTimeoutMs = resolveThreadBindingIdleTimeoutMs({
+    channelIdleHoursRaw:
+      discordAccountThreadBindings?.idleHours ?? discordRootThreadBindings?.idleHours,
+    sessionIdleHoursRaw: cfg.session?.threadBindings?.idleHours,
+  });
+  const threadBindingMaxAgeMs = resolveThreadBindingMaxAgeMs({
+    channelMaxAgeHoursRaw:
+      discordAccountThreadBindings?.maxAgeHours ?? discordRootThreadBindings?.maxAgeHours,
+    sessionMaxAgeHoursRaw: cfg.session?.threadBindings?.maxAgeHours,
+  });
+  const threadBindingsEnabled = resolveThreadBindingsEnabled({
+    channelEnabledRaw: discordAccountThreadBindings?.enabled ?? discordRootThreadBindings?.enabled,
+    sessionEnabledRaw: cfg.session?.threadBindings?.enabled,
+  });
+  const groupDmEnabled = dmConfig?.groupEnabled ?? false;
+  const groupDmChannels = dmConfig?.groupChannels;
+  const nativeEnabled = resolveNativeCommandsEnabled({
+    providerId: "discord",
+    providerSetting: discordCfg.commands?.native,
+    globalSetting: cfg.commands?.native,
+  });
+  const nativeSkillsEnabled = resolveNativeSkillsEnabled({
+    providerId: "discord",
+    providerSetting: discordCfg.commands?.nativeSkills,
+    globalSetting: cfg.commands?.nativeSkills,
+  });
+  const nativeDisabledExplicit = isNativeCommandsExplicitlyDisabled({
+    providerSetting: discordCfg.commands?.native,
+    globalSetting: cfg.commands?.native,
+  });
+  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+  const slashCommand = resolveDiscordSlashCommandConfig(discordCfg.slashCommand);
+  const sessionPrefix = "discord:slash";
+  const ephemeralDefault = slashCommand.ephemeral;
+  const voiceEnabled = discordCfg.voice?.enabled !== false;
+
+  const allowlistResolved = await resolveDiscordAllowlistConfig({
+    token,
+    guildEntries,
+    allowFrom,
+    fetcher: discordRestFetch,
+    runtime,
+  });
+  guildEntries = allowlistResolved.guildEntries;
+  allowFrom = allowlistResolved.allowFrom;
+
+  if (shouldLogVerbose()) {
+    const allowFromSummary = summarizeStringEntries({
+      entries: allowFrom ?? [],
+      limit: 4,
+      emptyText: "any",
+    });
+    const groupDmChannelSummary = summarizeStringEntries({
+      entries: groupDmChannels ?? [],
+      limit: 4,
+      emptyText: "any",
+    });
+    const guildSummary = summarizeStringEntries({
+      entries: Object.keys(guildEntries ?? {}),
+      limit: 4,
+      emptyText: "any",
+    });
+    logVerbose(
+      `discord: config dm=${dmEnabled ? "on" : "off"} dmPolicy=${dmPolicy} allowFrom=${allowFromSummary} groupDm=${groupDmEnabled ? "on" : "off"} groupDmChannels=${groupDmChannelSummary} groupPolicy=${groupPolicy} guilds=${guildSummary} historyLimit=${historyLimit} mediaMaxMb=${Math.round(mediaMaxBytes / (1024 * 1024))} native=${nativeEnabled ? "on" : "off"} nativeSkills=${nativeSkillsEnabled ? "on" : "off"} accessGroups=${useAccessGroups ? "on" : "off"} threadBindings=${threadBindingsEnabled ? "on" : "off"} threadIdleTimeout=${formatThreadBindingDurationForConfigLabel(threadBindingIdleTimeoutMs)} threadMaxAge=${formatThreadBindingDurationForConfigLabel(threadBindingMaxAgeMs)}`,
+    );
+  }
+
+  const applicationId = await fetchDiscordApplicationId(token, 4000, discordRestFetch);
+  if (!applicationId) {
+    throw new Error("Failed to resolve Discord application id");
+  }
+
+  const maxDiscordCommands = 100;
+  let skillCommands =
+    nativeEnabled && nativeSkillsEnabled ? listSkillCommandsForAgents({ cfg }) : [];
+  let commandSpecs = nativeEnabled
+    ? listNativeCommandSpecsForConfig(cfg, { skillCommands, provider: "discord" })
+    : [];
+  if (nativeEnabled) {
+    commandSpecs = appendPluginCommandSpecs({ commandSpecs, runtime });
+  }
+  const initialCommandCount = commandSpecs.length;
+  if (nativeEnabled && nativeSkillsEnabled && commandSpecs.length > maxDiscordCommands) {
+    skillCommands = [];
+    commandSpecs = listNativeCommandSpecsForConfig(cfg, { skillCommands: [], provider: "discord" });
+    commandSpecs = appendPluginCommandSpecs({ commandSpecs, runtime });
+    runtime.log?.(
+      warn(
+        `discord: ${initialCommandCount} commands exceeds limit; removing per-skill commands and keeping /skill.`,
+      ),
+    );
+  }
+  if (nativeEnabled && commandSpecs.length > maxDiscordCommands) {
+    runtime.log?.(
+      warn(
+        `discord: ${commandSpecs.length} commands exceeds limit; some commands may fail to deploy.`,
+      ),
+    );
+  }
+  const voiceManagerRef: { current: DiscordVoiceManager | null } = { current: null };
+  const threadBindings = threadBindingsEnabled
+    ? createThreadBindingManager({
+        accountId: account.accountId,
+        token,
+        cfg,
+        idleTimeoutMs: threadBindingIdleTimeoutMs,
+        maxAgeMs: threadBindingMaxAgeMs,
+      })
+    : createNoopThreadBindingManager(account.accountId);
+  if (threadBindingsEnabled) {
+    const uncertainProbeKeys = new Set<string>();
+    const reconciliation = await reconcileAcpThreadBindingsOnStartup({
+      cfg,
+      accountId: account.accountId,
+      sendFarewell: false,
+      healthProbe: async ({ sessionKey, session }) => {
+        const probe = await probeDiscordAcpBindingHealth({
+          cfg,
+          sessionKey,
+          storedState: session.acp?.state,
+          lastActivityAt: session.acp?.lastActivityAt,
+        });
+        if (probe.status === "uncertain") {
+          uncertainProbeKeys.add(`${sessionKey}${probe.reason ? ` (${probe.reason})` : ""}`);
+        }
+        return probe;
+      },
+    });
+    if (reconciliation.removed > 0) {
+      logVerbose(
+        `discord: removed ${reconciliation.removed}/${reconciliation.checked} stale ACP thread bindings on startup for account ${account.accountId}: ${reconciliation.staleSessionKeys.join(", ")}`,
+      );
+    }
+    if (uncertainProbeKeys.size > 0) {
+      logVerbose(
+        `discord: ACP thread-binding health probe uncertain for account ${account.accountId}: ${[...uncertainProbeKeys].join(", ")}`,
+      );
+    }
+  }
+  let lifecycleStarted = false;
+  let releaseEarlyGatewayErrorGuard = () => {};
+  let deactivateMessageHandler: (() => void) | undefined;
+  let autoPresenceController: ReturnType<typeof createDiscordAutoPresenceController> | null = null;
+  try {
+    const commands: BaseCommand[] = commandSpecs.map((spec) =>
+      createDiscordNativeCommand({
+        command: spec,
+        cfg,
+        discordConfig: discordCfg,
+        accountId: account.accountId,
+        sessionPrefix,
+        ephemeralDefault,
+        threadBindings,
+      }),
+    );
+    if (nativeEnabled && voiceEnabled) {
+      commands.push(
+        createDiscordVoiceCommand({
+          cfg,
+          discordConfig: discordCfg,
+          accountId: account.accountId,
+          groupPolicy,
+          useAccessGroups,
+          getManager: () => voiceManagerRef.current,
+          ephemeralDefault,
+        }),
+      );
+    }
+
+    // Initialize exec approvals handler if enabled
+    const execApprovalsConfig = discordCfg.execApprovals ?? {};
+    const execApprovalsHandler = execApprovalsConfig.enabled
+      ? new DiscordExecApprovalHandler({
+          token,
+          accountId: account.accountId,
+          config: execApprovalsConfig,
+          cfg,
+          runtime,
+        })
+      : null;
+
+    const agentComponentsConfig = discordCfg.agentComponents ?? {};
+    const agentComponentsEnabled = agentComponentsConfig.enabled ?? true;
+
+    const components: BaseMessageInteractiveComponent[] = [
+      createDiscordCommandArgFallbackButton({
+        cfg,
+        discordConfig: discordCfg,
+        accountId: account.accountId,
+        sessionPrefix,
+        threadBindings,
+      }),
+      createDiscordModelPickerFallbackButton({
+        cfg,
+        discordConfig: discordCfg,
+        accountId: account.accountId,
+        sessionPrefix,
+        threadBindings,
+      }),
+      createDiscordModelPickerFallbackSelect({
+        cfg,
+        discordConfig: discordCfg,
+        accountId: account.accountId,
+        sessionPrefix,
+        threadBindings,
+      }),
+    ];
+    const modals: Modal[] = [];
+
+    if (execApprovalsHandler) {
+      components.push(createExecApprovalButton({ handler: execApprovalsHandler }));
+    }
+
+    if (agentComponentsEnabled) {
+      const componentContext = {
+        cfg,
+        discordConfig: discordCfg,
+        accountId: account.accountId,
+        guildEntries,
+        allowFrom,
+        dmPolicy,
+        runtime,
+        token,
+      };
+      components.push(createAgentComponentButton(componentContext));
+      components.push(createAgentSelectMenu(componentContext));
+      components.push(createDiscordComponentButton(componentContext));
+      components.push(createDiscordComponentStringSelect(componentContext));
+      components.push(createDiscordComponentUserSelect(componentContext));
+      components.push(createDiscordComponentRoleSelect(componentContext));
+      components.push(createDiscordComponentMentionableSelect(componentContext));
+      components.push(createDiscordComponentChannelSelect(componentContext));
+      modals.push(createDiscordComponentModal(componentContext));
+    }
+
+    class DiscordStatusReadyListener extends ReadyListener {
+      async handle(_data: unknown, client: Client) {
+        if (autoPresenceController?.enabled) {
+          autoPresenceController.refresh();
+          return;
+        }
+
+        const gateway = client.getPlugin<GatewayPlugin>("gateway");
+        if (!gateway) {
+          return;
+        }
+
+        const presence = resolveDiscordPresenceUpdate(discordCfg);
+        if (!presence) {
+          return;
+        }
+
+        gateway.updatePresence(presence);
+      }
+    }
+
+    const clientPlugins: Plugin[] = [
+      createDiscordGatewayPlugin({ discordConfig: discordCfg, runtime }),
+    ];
+    if (voiceEnabled) {
+      clientPlugins.push(new VoicePlugin());
+    }
+    // Pass eventQueue config to Carbon so the gateway listener budget can be tuned.
+    // Default listenerTimeout is 120s (Carbon defaults to 30s, which is too short for some
+    // Discord normalization/enqueue work).
+    const eventQueueOpts = {
+      listenerTimeout: 120_000,
+      ...discordCfg.eventQueue,
+    };
+    const client = new Client(
+      {
+        baseUrl: "http://localhost",
+        deploySecret: "a",
+        clientId: applicationId,
+        publicKey: "a",
+        token,
+        autoDeploy: false,
+        eventQueue: eventQueueOpts,
+      },
+      {
+        commands,
+        listeners: [new DiscordStatusReadyListener()],
+        components,
+        modals,
+      },
+      clientPlugins,
+    );
+    const earlyGatewayErrorGuard = attachEarlyGatewayErrorGuard(client);
+    releaseEarlyGatewayErrorGuard = earlyGatewayErrorGuard.release;
+
+    const lifecycleGateway = client.getPlugin<GatewayPlugin>("gateway");
+    if (lifecycleGateway) {
+      autoPresenceController = createDiscordAutoPresenceController({
+        accountId: account.accountId,
+        discordConfig: discordCfg,
+        gateway: lifecycleGateway,
+        log: (message) => runtime.log?.(message),
+      });
+      autoPresenceController.start();
+    }
+
+    await deployDiscordCommands({ client, runtime, enabled: nativeEnabled });
+
+    const logger = createSubsystemLogger("discord/monitor");
+    const guildHistories = new Map<string, HistoryEntry[]>();
+    let botUserId: string | undefined;
+    let botUserName: string | undefined;
+    let voiceManager: DiscordVoiceManager | null = null;
+
+    if (nativeDisabledExplicit) {
+      await clearDiscordNativeCommands({
+        client,
+        applicationId,
+        runtime,
+      });
+    }
+
+    try {
+      const botUser = await client.fetchUser("@me");
+      botUserId = botUser?.id;
+      botUserName = botUser?.username?.trim() || botUser?.globalName?.trim() || undefined;
+    } catch (err) {
+      runtime.error?.(danger(`discord: failed to fetch bot identity: ${String(err)}`));
+    }
+
+    if (voiceEnabled) {
+      const { DiscordVoiceManager, DiscordVoiceReadyListener } = await loadDiscordVoiceRuntime();
+      voiceManager = new DiscordVoiceManager({
+        client,
+        cfg,
+        discordConfig: discordCfg,
+        accountId: account.accountId,
+        runtime,
+        botUserId,
+      });
+      voiceManagerRef.current = voiceManager;
+      registerDiscordListener(client.listeners, new DiscordVoiceReadyListener(voiceManager));
+    }
+
+    const messageHandler = createDiscordMessageHandler({
+      cfg,
+      discordConfig: discordCfg,
+      accountId: account.accountId,
+      token,
+      runtime,
+      setStatus: opts.setStatus,
+      abortSignal: opts.abortSignal,
+      workerRunTimeoutMs: discordCfg.inboundWorker?.runTimeoutMs,
+      botUserId,
+      guildHistories,
+      historyLimit,
+      mediaMaxBytes,
+      textLimit,
+      replyToMode,
+      dmEnabled,
+      groupDmEnabled,
+      groupDmChannels,
+      allowFrom,
+      guildEntries,
+      threadBindings,
+      discordRestFetch,
+    });
+    deactivateMessageHandler = messageHandler.deactivate;
+    const trackInboundEvent = opts.setStatus
+      ? () => {
+          const at = Date.now();
+          opts.setStatus?.({ lastEventAt: at, lastInboundAt: at });
+        }
+      : undefined;
+
+    registerDiscordListener(
+      client.listeners,
+      new DiscordMessageListener(messageHandler, logger, trackInboundEvent, {
+        timeoutMs: eventQueueOpts.listenerTimeout,
+      }),
+    );
+    const reactionListenerOptions = {
+      cfg,
+      accountId: account.accountId,
+      runtime,
+      botUserId,
+      dmEnabled,
+      groupDmEnabled,
+      groupDmChannels: groupDmChannels ?? [],
+      dmPolicy,
+      allowFrom: allowFrom ?? [],
+      groupPolicy,
+      allowNameMatching: isDangerousNameMatchingEnabled(discordCfg),
+      guildEntries,
+      logger,
+      onEvent: trackInboundEvent,
+    };
+    registerDiscordListener(client.listeners, new DiscordReactionListener(reactionListenerOptions));
+    registerDiscordListener(
+      client.listeners,
+      new DiscordReactionRemoveListener(reactionListenerOptions),
+    );
+
+    registerDiscordListener(
+      client.listeners,
+      new DiscordThreadUpdateListener(cfg, account.accountId, logger),
+    );
+
+    if (discordCfg.intents?.presence) {
+      registerDiscordListener(
+        client.listeners,
+        new DiscordPresenceListener({ logger, accountId: account.accountId }),
+      );
+      runtime.log?.("discord: GuildPresences intent enabled — presence listener registered");
+    }
+
+    if (discordCfg.intents?.guildMembers) {
+      registerDiscordListener(
+        client.listeners,
+        new DiscordMemberAddListener({
+          cfg,
+          accountId: account.accountId,
+          botUserId,
+          guildEntries,
+          logger,
+        }),
+      );
+      runtime.log?.("discord: GuildMembers intent enabled — member-add listener registered");
+    }
+
+    const botIdentity =
+      botUserId && botUserName ? `${botUserId} (${botUserName})` : (botUserId ?? botUserName ?? "");
+    runtime.log?.(`logged in to discord${botIdentity ? ` as ${botIdentity}` : ""}`);
+    if (lifecycleGateway?.isConnected) {
+      opts.setStatus?.(createConnectedChannelStatusPatch());
+    }
+
+    lifecycleStarted = true;
+    await runDiscordGatewayLifecycle({
+      accountId: account.accountId,
+      client,
+      runtime,
+      abortSignal: opts.abortSignal,
+      statusSink: opts.setStatus,
+      isDisallowedIntentsError: isDiscordDisallowedIntentsError,
+      voiceManager,
+      voiceManagerRef,
+      execApprovalsHandler,
+      threadBindings,
+      pendingGatewayErrors: earlyGatewayErrorGuard.pendingErrors,
+      releaseEarlyGatewayErrorGuard,
+    });
+  } finally {
+    deactivateMessageHandler?.();
+    autoPresenceController?.stop();
+    opts.setStatus?.({ connected: false });
+    releaseEarlyGatewayErrorGuard();
+    if (!lifecycleStarted) {
+      threadBindings.stop();
+    }
+  }
+}
+
+async function clearDiscordNativeCommands(params: {
+  client: Client;
+  applicationId: string;
+  runtime: RuntimeEnv;
+}) {
+  try {
+    await params.client.rest.put(Routes.applicationCommands(params.applicationId), {
+      body: [],
+    });
+    logVerbose("discord: cleared native commands (commands.native=false)");
+  } catch (err) {
+    params.runtime.error?.(danger(`discord: failed to clear native commands: ${String(err)}`));
+  }
+}
+
+export const __testing = {
+  createDiscordGatewayPlugin,
+  resolveDiscordRuntimeGroupPolicy: resolveOpenProviderRuntimeGroupPolicy,
+  resolveDefaultGroupPolicy,
+  resolveDiscordRestFetch,
+  resolveThreadBindingsEnabled,
+};


### PR DESCRIPTION
Closes #23978

## Summary

- Adds `DiscordMemberAddListener` that fires when a user joins a Discord guild and delivers a system event to the matched agent session.
- Gated on `intents.guildMembers: true` (existing privileged intent flag — must also be enabled in the Discord Developer Portal).
- Opt-in per guild via `memberJoinNotifications: "on"` (default: `"off"` to avoid floods on existing deployments).
- Optional `memberJoinChannel` per guild: if set, triggers a gateway agent call to post a welcome message to that channel. Falls back to Discord's `systemChannelId` if no explicit channel is configured.

## Config example

```json
"guilds": {
  "123456789": {
    "memberJoinNotifications": "on",
    "memberJoinChannel": "987654321"
  }
}
```

## Test plan

- [ ] Join a guild with `memberJoinNotifications: "off"` (default) — no event fired
- [ ] Join a guild with `memberJoinNotifications: "on"` — system event delivered to matched agent
- [ ] Join with `memberJoinChannel` set — agent posts welcome to that channel
- [ ] Join with no `memberJoinChannel` but Discord `systemChannelId` set — falls back correctly
- [ ] Bot join events are skipped