### PR TITLE
fix(sandbox): honour alsoAllow in tools.sandbox.tools policy

### DIFF
--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -296,6 +296,8 @@ export type AgentToolsConfig = {
   sandbox?: {
     tools?: {
       allow?: string[];
+      /** Additional allowlist entries merged into the sandbox allow list. */
+      alsoAllow?: string[];
       deny?: string[];
     };
   };
@@ -586,6 +588,8 @@ export type ToolsConfig = {
   sandbox?: {
     tools?: {
       allow?: string[];
+      /** Additional allowlist entries merged into the sandbox allow list. */
+      alsoAllow?: string[];
       deny?: string[];
     };
   };


### PR DESCRIPTION
## Summary

`tools.sandbox.tools.alsoAllow` (both agent-level and global) was being ignored — the field was defined in `types.tools.ts` but never read in `resolveSandboxToolPolicyForAgent`. The resolved allow list was built only from `allow`, so `alsoAllow` entries had no effect.

## Fix

Read `agentAlsoAllow` and `globalAlsoAllow`, then merge them into the base allow list (agent-level `alsoAllow` takes precedence over global), deduplicating with `Set`.

This mirrors the existing `alsoAllow` behaviour at the top-level tool policy layer.

## Test plan

- [ ] Agent with `tools.sandbox.tools.alsoAllow: ["message"]` — `message` tool available in sandbox
- [ ] Global `tools.sandbox.tools.alsoAllow` — applies when no agent override
- [ ] Agent `tools.sandbox.tools.allow` explicit list — `alsoAllow` still extends it
- [ ] No `alsoAllow` set — behaviour unchanged from before