### PR TITLE
fix(skills): pass per-agent skillFilter in listSkillCommandsForAgents

### DIFF
--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -1,5 +1,9 @@
 import fs from "node:fs";
-import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import {
+  listAgentIds,
+  resolveAgentSkillsFilter,
+  resolveAgentWorkspaceDir,
+} from "../agents/agent-scope.js";
 import { buildWorkspaceSkillCommandSpecs, type SkillCommandSpec } from "../agents/skills.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
@@ -64,6 +68,7 @@ export function listSkillCommandsForAgents(params: {
     visitedDirs.add(canonicalDir);
     const commands = buildWorkspaceSkillCommandSpecs(workspaceDir, {
       config: params.cfg,
+      skillFilter: resolveAgentSkillsFilter(params.cfg, agentId),
       eligibility: { remote: getRemoteSkillEligibility() },
       reservedNames: used,
     });


### PR DESCRIPTION
## Summary

`listSkillCommandsForAgents` was calling `buildWorkspaceSkillCommandSpecs` without a `skillFilter`, so every agent's skill commands were built from all skills in the workspace directory — ignoring the per-agent `skills` list in config.

## Fix

Pass `skillFilter: resolveAgentSkillsFilter(cfg, agentId)` so that each agent's skill command list is filtered to only the skills explicitly assigned to that agent.

## Test plan

- [ ] Agent with `skills: ["bird"]` — only bird skill commands listed for that agent
- [ ] Agent with no `skills` list — all workspace skills listed (existing behaviour)
- [ ] Multiple agents with different skill lists — each gets its own filtered set