### PR TITLE
Daemon: prefer stable Homebrew node symlink for gateway install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/install Node path stability: normalize Homebrew Cellar runtime paths to stable `/opt/homebrew/bin/node` or `/usr/local/bin/node` when they resolve to the same binary, so launchd plists survive Homebrew Node upgrades without manual reinstall. (#32182) Thanks @timcopelandnz.
 - macOS/LaunchAgent security defaults: write `Umask=63` (octal `077`) into generated gateway launchd plists so post-update service reinstalls keep owner-only file permissions by default instead of falling back to system `022`. (#32022) Fixes #31905. Thanks @liuxiaopai-ai.
 - Plugin SDK/runtime hardening: add package export verification in CI/release checks to catch missing runtime exports before publish-time regressions. (#28575) Thanks @Glucksberg.
 - Media understanding/provider HTTP proxy routing: pass a proxy-aware fetch function from `HTTPS_PROXY`/`HTTP_PROXY` env vars into audio/video provider calls (with graceful malformed-proxy fallback) so transcription/video requests honor configured outbound proxies. (#27093) Thanks @mcaxtr.

--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -2,11 +2,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const fsMocks = vi.hoisted(() => ({
   access: vi.fn(),
+  realpath: vi.fn(async (target: string) => target),
 }));
 
 vi.mock("node:fs/promises", () => ({
-  default: { access: fsMocks.access },
+  default: { access: fsMocks.access, realpath: fsMocks.realpath },
   access: fsMocks.access,
+  realpath: fsMocks.realpath,
 }));
 
 import {
@@ -47,6 +49,30 @@ describe("resolvePreferredNodePath", () => {
 
     expect(result).toBe(fnmNode);
     expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes Homebrew Cellar execPath to stable symlink", async () => {
+    mockNodePathPresent(darwinNode);
+    const cellarNode = "/opt/homebrew/Cellar/node/25.7.0/bin/node";
+
+    fsMocks.realpath.mockImplementation(async (target: string) => {
+      if (target === cellarNode || target === darwinNode) {
+        return cellarNode;
+      }
+      return target;
+    });
+
+    const execFile = vi.fn().mockResolvedValue({ stdout: "25.7.0\n", stderr: "" });
+
+    const result = await resolvePreferredNodePath({
+      env: {},
+      runtime: "node",
+      platform: "darwin",
+      execFile,
+      execPath: cellarNode,
+    });
+
+    expect(result).toBe(darwinNode);
   });
 
   it("falls back to system node when execPath version is unsupported", async () => {

--- a/src/daemon/runtime-paths.ts
+++ b/src/daemon/runtime-paths.ts
@@ -79,6 +79,41 @@ async function resolveNodeVersion(
   }
 }
 
+async function preferStableHomebrewNodePath(params: {
+  nodePath: string;
+  env: Record<string, string | undefined>;
+  platform: NodeJS.Platform;
+}): Promise<string> {
+  if (params.platform !== "darwin") {
+    return params.nodePath;
+  }
+
+  const normalized = normalizeForCompare(params.nodePath, params.platform);
+  const cellarMarker = "/cellar/node/";
+  if (!normalized.toLowerCase().includes(cellarMarker)) {
+    return params.nodePath;
+  }
+
+  const brewSymlink = params.nodePath.startsWith("/usr/local/")
+    ? "/usr/local/bin/node"
+    : "/opt/homebrew/bin/node";
+
+  try {
+    const symlinkRealpath = await fs.realpath(brewSymlink);
+    const nodeRealpath = await fs.realpath(params.nodePath);
+    if (
+      normalizeForCompare(symlinkRealpath, params.platform) ===
+      normalizeForCompare(nodeRealpath, params.platform)
+    ) {
+      return brewSymlink;
+    }
+  } catch {
+    // Keep the original path when the stable symlink is unavailable.
+  }
+
+  return params.nodePath;
+}
+
 export type SystemNodeInfo = {
   path: string;
   version: string | null;
@@ -172,7 +207,11 @@ export async function resolvePreferredNodePath(params: {
     const execFileImpl = params.execFile ?? execFileAsync;
     const version = await resolveNodeVersion(currentExecPath, execFileImpl);
     if (isSupportedNodeVersion(version)) {
-      return currentExecPath;
+      return preferStableHomebrewNodePath({
+        nodePath: currentExecPath,
+        env: params.env ?? process.env,
+        platform,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- normalize Homebrew Cellar node executable paths to stable symlink locations when generating daemon install plans
- prefer `/opt/homebrew/bin/node` or `/usr/local/bin/node` when they resolve to the same binary as a versioned Cellar path
- add regression coverage for Cellar-to-symlink normalization

## Testing
- pnpm test src/daemon/runtime-paths.test.ts

Fixes #32182
