### PR TITLE
fix(gateway): let non-GET requests fall through controlUi routing when basePath is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Control UI basePath webhook passthrough: let non-read methods under configured `controlUiBasePath` fall through to plugin routes (instead of returning Control UI 405), restoring webhook handlers behind basePath mounts. (#32311) Thanks @ademczuk.
 - Voice-call/Twilio signature verification: retry signature validation across deterministic URL port variants (with/without port) to handle mixed Twilio signing behavior behind reverse proxies and non-standard ports. (#25140) Thanks @drvoss.
 - Voice-call/Twilio external outbound: auto-register webhook-first `outbound-api` calls (initiated outside OpenClaw) so media streams are accepted and call direction metadata stays accurate. (#31181) Thanks @scoootscooob.
 - Voice-call/Twilio inbound greeting: run answered-call initial notify greeting for Twilio instead of skipping the manager speak path, with regression coverage for both Twilio and Plivo notify flows. (#29121) Thanks @xinhuagu.

--- a/src/gateway/control-ui-http-utils.ts
+++ b/src/gateway/control-ui-http-utils.ts
@@ -13,7 +13,3 @@ export function respondPlainText(res: ServerResponse, statusCode: number, body: 
 export function respondNotFound(res: ServerResponse): void {
   respondPlainText(res, 404, "Not Found");
 }
-
-export function respondMethodNotAllowed(res: ServerResponse): void {
-  respondPlainText(res, 405, "Method Not Allowed");
-}

--- a/src/gateway/control-ui-routing.test.ts
+++ b/src/gateway/control-ui-routing.test.ts
@@ -22,14 +22,26 @@ describe("classifyControlUiRequest", () => {
     expect(classified).toEqual({ kind: "not-found" });
   });
 
-  it("returns method-not-allowed for basePath non-read methods", () => {
+  it("falls through basePath non-read methods for plugin webhooks", () => {
     const classified = classifyControlUiRequest({
       basePath: "/openclaw",
       pathname: "/openclaw",
       search: "",
       method: "POST",
     });
-    expect(classified).toEqual({ kind: "method-not-allowed" });
+    expect(classified).toEqual({ kind: "not-control-ui" });
+  });
+
+  it("falls through PUT/DELETE/PATCH/OPTIONS under basePath for plugin handlers", () => {
+    for (const method of ["PUT", "DELETE", "PATCH", "OPTIONS"]) {
+      const classified = classifyControlUiRequest({
+        basePath: "/openclaw",
+        pathname: "/openclaw/webhook",
+        search: "",
+        method,
+      });
+      expect(classified, `${method} should fall through`).toEqual({ kind: "not-control-ui" });
+    }
   });
 
   it("returns redirect for basePath entrypoint GET", () => {

--- a/src/gateway/control-ui-routing.ts
+++ b/src/gateway/control-ui-routing.ts
@@ -3,7 +3,6 @@ import { isReadHttpMethod } from "./control-ui-http-utils.js";
 export type ControlUiRequestClassification =
   | { kind: "not-control-ui" }
   | { kind: "not-found" }
-  | { kind: "method-not-allowed" }
   | { kind: "redirect"; location: string }
   | { kind: "serve" };
 
@@ -36,7 +35,7 @@ export function classifyControlUiRequest(params: {
     return { kind: "not-control-ui" };
   }
   if (!isReadHttpMethod(method)) {
-    return { kind: "method-not-allowed" };
+    return { kind: "not-control-ui" };
   }
   if (pathname === basePath) {
     return { kind: "redirect", location: `${basePath}/${search}` };

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -402,19 +402,18 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
-  it("returns 405 for POST requests under configured basePath", async () => {
+  it("falls through POST requests under configured basePath (plugin webhook passthrough)", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
         for (const route of ["/openclaw", "/openclaw/", "/openclaw/some-page"]) {
-          const { handled, res, end } = runControlUiRequest({
+          const { handled, end } = runControlUiRequest({
             url: route,
             method: "POST",
             rootPath: tmp,
             basePath: "/openclaw",
           });
-          expect(handled, `expected ${route} to be handled`).toBe(true);
-          expect(res.statusCode, `expected ${route} status`).toBe(405);
-          expect(end, `expected ${route} body`).toHaveBeenCalledWith("Method Not Allowed");
+          expect(handled, `POST to ${route} should pass through to plugin handlers`).toBe(false);
+          expect(end, `POST to ${route} should not write a response`).not.toHaveBeenCalled();
         }
       },
     });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -15,7 +15,6 @@ import {
 import { buildControlUiCspHeader } from "./control-ui-csp.js";
 import {
   isReadHttpMethod,
-  respondMethodNotAllowed,
   respondNotFound as respondControlUiNotFound,
   respondPlainText,
 } from "./control-ui-http-utils.js";
@@ -291,10 +290,6 @@ export function handleControlUiHttpRequest(
   if (route.kind === "not-found") {
     applyControlUiSecurityHeaders(res);
     respondControlUiNotFound(res);
-    return true;
-  }
-  if (route.kind === "method-not-allowed") {
-    respondMethodNotAllowed(res);
     return true;
   }
   if (route.kind === "redirect") {


### PR DESCRIPTION
## Summary
- Fix 2026.3.1 regression where ALL webhook POST requests return 405 when `controlUiBasePath` is set (#31983, #32275)
- Root cause: `classifyControlUiRequest` returns `method-not-allowed` for non-GET/HEAD methods under basePath, blocking plugin webhook handlers (BlueBubbles, Mattermost, etc.)
- Fix: return `not-control-ui` instead (matching the empty-basePath behavior), so requests fall through to plugin HTTP handlers
- Remove now-dead `method-not-allowed` type variant, handler branch, and `respondMethodNotAllowed` utility
- Add test coverage for PUT/DELETE/PATCH/OPTIONS methods under basePath
- Closes #31983
- Closes #32275

## Test plan
- [x] `pnpm vitest run src/gateway/control-ui-routing.test.ts` — 6 tests pass (updated + new)
- [x] `pnpm vitest run src/gateway/control-ui.http.test.ts` — 18 tests pass (updated)
- [x] `pnpm vitest run src/gateway/gateway-misc.test.ts` — 21 tests pass (regression)
- [x] `pnpm tsgo` — zero errors
- [x] `pnpm check` — passes (no format issues in changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)