### PR TITLE
feat(edit): return current file content on mismatch

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -1,6 +1,23 @@
 #!/usr/bin/env node
 
+import fs from "node:fs/promises";
 import module from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Fast path for --version: exit before loading heavy modules (~100x faster)
+const argv = new Set(process.argv.slice(2));
+if (argv.has("--version") || argv.has("-v")) {
+  try {
+    const pkg = JSON.parse(await fs.readFile(path.join(__dirname, "package.json"), "utf-8"));
+    console.log(pkg.version);
+  } catch {
+    console.log("unknown");
+  }
+  process.exit(0);
+}
 
 // https://nodejs.org/api/module.html#module-compile-cache
 if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -1,23 +1,6 @@
 #!/usr/bin/env node
 
-import fs from "node:fs/promises";
 import module from "node:module";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-// Fast path for --version: exit before loading heavy modules (~100x faster)
-const argv = new Set(process.argv.slice(2));
-if (argv.has("--version") || argv.has("-v")) {
-  try {
-    const pkg = JSON.parse(await fs.readFile(path.join(__dirname, "package.json"), "utf-8"));
-    console.log(pkg.version);
-  } catch {
-    console.log("unknown");
-  }
-  process.exit(0);
-}
 
 // https://nodejs.org/api/module.html#module-compile-cache
 if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {

--- a/src/agents/pi-tools.edit-return-content.test.ts
+++ b/src/agents/pi-tools.edit-return-content.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { createHostWorkspaceEditTool } from './pi-tools.read.js';
+
+describe('Edit tool returns current content on mismatch', () => {
+  let tempDir: string;
+  let testFile: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'edit-tool-test-'));
+    testFile = path.join(tempDir, 'test.txt');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('should return current file content when oldText does not match', async () => {
+    // Create test file
+    const originalContent = 'Hello World\nLine 2\nLine 3';
+    await fs.writeFile(testFile, originalContent);
+
+    // Create edit tool
+    const editTool = createHostWorkspaceEditTool(tempDir);
+
+    // Try to edit with wrong oldText
+    const result = await editTool.execute(
+      'test-call-id',
+      {
+        file_path: testFile,
+        oldText: 'Wrong text that does not exist',
+        newText: 'Replacement text',
+      },
+      undefined
+    );
+
+    // Should be an error
+    expect(result.isError).toBe(true);
+
+    // Should include current file content
+    const textContent = result.content
+      .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+      .map(block => block.text)
+      .join('\n');
+
+    expect(textContent).toContain('Current file content');
+    expect(textContent).toContain('Hello World');
+    expect(textContent).toContain('Line 2');
+    expect(textContent).toContain('Line 3');
+  });
+
+  it('should successfully edit when oldText matches', async () => {
+    // Create test file
+    const originalContent = 'Hello World\nLine 2\nLine 3';
+    await fs.writeFile(testFile, originalContent);
+
+    // Create edit tool
+    const editTool = createHostWorkspaceEditTool(tempDir);
+
+    // Edit with correct oldText
+    const result = await editTool.execute(
+      'test-call-id',
+      {
+        file_path: testFile,
+        oldText: 'Hello World',
+        newText: 'Hello OpenClaw',
+      },
+      undefined
+    );
+
+    // Should succeed
+    expect(result.isError).toBeUndefined();
+
+    // File should be updated
+    const updatedContent = await fs.readFile(testFile, 'utf-8');
+    expect(updatedContent).toBe('Hello OpenClaw\nLine 2\nLine 3');
+  });
+
+  it('should handle file not found gracefully', async () => {
+    // Create edit tool
+    const editTool = createHostWorkspaceEditTool(tempDir);
+
+    // Try to edit non-existent file
+    const result = await editTool.execute(
+      'test-call-id',
+      {
+        file_path: path.join(tempDir, 'nonexistent.txt'),
+        oldText: 'Some text',
+        newText: 'New text',
+      },
+      undefined
+    );
+
+    // Should be an error
+    expect(result.isError).toBe(true);
+
+    // Should NOT include current content section (file doesn't exist)
+    const textContent = result.content
+      .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+      .map(block => block.text)
+      .join('\n');
+
+    expect(textContent).not.toContain('Current file content');
+  });
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -684,35 +684,36 @@ function wrapEditToolWithCurrentContent(tool: AnyAgentTool, bridge: SandboxFsBri
     ...wrapped,
     execute: async (toolCallId, params, signal, onUpdate) => {
       const result = await wrapped.execute(toolCallId, params, signal, onUpdate);
-      
-      // Check if edit failed due to mismatch
-      if (result.isError && result.content.some(block => {
-        if (block.type === 'text') {
-          const text = block.text.toLowerCase();
-          return text.includes('mismatch') || 
-                 text.includes('not found') || 
-                 text.includes('no exact match') ||
-                 text.includes('could not find') ||
-                 text.includes('does not match');
-        }
-        return false;
-      })) {
+
+      // Check if edit failed due to oldText mismatch (specific error from pi-coding-agent)
+      if (
+        result.isError &&
+        result.content.some((block) => {
+          if (block.type === "text") {
+            const text = block.text.toLowerCase();
+            // Only match specific oldText mismatch errors from createEditTool
+            return text.includes("oldtext") && text.includes("not found");
+          }
+          return false;
+        })
+      ) {
         // Try to read current file content and append it to the error
         const record = params as Record<string, unknown>;
         const filePath = record?.file_path || record?.path;
-        
-        if (typeof filePath === 'string') {
+
+        if (typeof filePath === "string") {
           try {
-            const content = await bridge.readFile({ filePath, cwd: '', encoding: 'utf-8' });
-            const currentContent = typeof content === 'string' ? content : Buffer.from(content).toString('utf-8');
-            
+            // bridge.readFile returns Buffer, no encoding parameter
+            const content = await bridge.readFile({ filePath, cwd: "" });
+            const currentContent = Buffer.from(content).toString("utf-8");
+
             // Append current content to error message
             return {
               ...result,
               content: [
                 ...result.content,
                 {
-                  type: 'text' as const,
+                  type: "text" as const,
                   text: `\n\n--- Current file content ---\n${currentContent}\n--- End of current content ---`,
                 },
               ],
@@ -723,7 +724,7 @@ function wrapEditToolWithCurrentContent(tool: AnyAgentTool, bridge: SandboxFsBri
           }
         }
       }
-      
+
       return result;
     },
   };
@@ -740,51 +741,53 @@ export function createHostWorkspaceEditTool(root: string, options?: { workspaceO
   const base = createEditTool(root, {
     operations: createHostEditOperations(root, options),
   }) as unknown as AnyAgentTool;
-  return wrapHostEditToolWithCurrentContent(base, root, options);
+  return wrapHostEditToolWithCurrentContent(base, root);
 }
 
 /**
  * Wraps the host edit tool to return the current file content on mismatch.
  * Implements Option 1 from https://github.com/openclaw/openclaw/issues/18132
  */
-function wrapHostEditToolWithCurrentContent(
-  tool: AnyAgentTool, 
-  root: string, 
-  options?: { workspaceOnly?: boolean }
-): AnyAgentTool {
+function wrapHostEditToolWithCurrentContent(tool: AnyAgentTool, root: string): AnyAgentTool {
   const wrapped = wrapToolParamNormalization(tool, CLAUDE_PARAM_GROUPS.edit);
   return {
     ...wrapped,
     execute: async (toolCallId, params, signal, onUpdate) => {
       const result = await wrapped.execute(toolCallId, params, signal, onUpdate);
-      
-      // Check if edit failed due to mismatch
-      if (result.isError && result.content.some(block => {
-        if (block.type === 'text') {
-          const text = block.text.toLowerCase();
-          return text.includes('mismatch') || 
-                 text.includes('not found') || 
-                 text.includes('no exact match') ||
-                 text.includes('could not find') ||
-                 text.includes('does not match');
-        }
-        return false;
-      })) {
+
+      // Check if edit failed due to oldText mismatch (specific error from pi-coding-agent)
+      if (
+        result.isError &&
+        result.content.some((block) => {
+          if (block.type === "text") {
+            const text = block.text.toLowerCase();
+            // Only match specific oldText mismatch errors from createEditTool
+            return text.includes("oldtext") && text.includes("not found");
+          }
+          return false;
+        })
+      ) {
         // Try to read current file content and append it to the error
         const record = params as Record<string, unknown>;
         const filePath = record?.file_path || record?.path;
-        
-        if (typeof filePath === 'string') {
+
+        if (typeof filePath === "string") {
           try {
-            const content = await fs.readFile(filePath, 'utf-8');
-            
+            // Use readFileWithinRoot to enforce workspace boundary
+            const relative = toRelativeWorkspacePath(root, filePath);
+            const safeRead = await readFileWithinRoot({
+              rootDir: root,
+              relativePath: relative,
+            });
+            const content = safeRead.buffer.toString("utf-8");
+
             // Append current content to error message
             return {
               ...result,
               content: [
                 ...result.content,
                 {
-                  type: 'text' as const,
+                  type: "text" as const,
                   text: `\n\n--- Current file content ---\n${content}\n--- End of current content ---`,
                 },
               ],
@@ -795,7 +798,7 @@ function wrapHostEditToolWithCurrentContent(
           }
         }
       }
-      
+
       return result;
     },
   };

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -670,7 +670,63 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
   const base = createEditTool(params.root, {
     operations: createSandboxEditOperations(params),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
+  return wrapEditToolWithCurrentContent(base, params.bridge);
+}
+
+/**
+ * Wraps the edit tool to return the current file content on mismatch.
+ * This allows the agent to retry immediately without a separate Read call.
+ * Implements Option 1 from https://github.com/openclaw/openclaw/issues/18132
+ */
+function wrapEditToolWithCurrentContent(tool: AnyAgentTool, bridge: SandboxFsBridge): AnyAgentTool {
+  const wrapped = wrapToolParamNormalization(tool, CLAUDE_PARAM_GROUPS.edit);
+  return {
+    ...wrapped,
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      const result = await wrapped.execute(toolCallId, params, signal, onUpdate);
+      
+      // Check if edit failed due to mismatch
+      if (result.isError && result.content.some(block => {
+        if (block.type === 'text') {
+          const text = block.text.toLowerCase();
+          return text.includes('mismatch') || 
+                 text.includes('not found') || 
+                 text.includes('no exact match') ||
+                 text.includes('could not find') ||
+                 text.includes('does not match');
+        }
+        return false;
+      })) {
+        // Try to read current file content and append it to the error
+        const record = params as Record<string, unknown>;
+        const filePath = record?.file_path || record?.path;
+        
+        if (typeof filePath === 'string') {
+          try {
+            const content = await bridge.readFile({ filePath, cwd: '', encoding: 'utf-8' });
+            const currentContent = typeof content === 'string' ? content : Buffer.from(content).toString('utf-8');
+            
+            // Append current content to error message
+            return {
+              ...result,
+              content: [
+                ...result.content,
+                {
+                  type: 'text' as const,
+                  text: `\n\n--- Current file content ---\n${currentContent}\n--- End of current content ---`,
+                },
+              ],
+            };
+          } catch {
+            // If we can't read the file, just return the original error
+            return result;
+          }
+        }
+      }
+      
+      return result;
+    },
+  };
 }
 
 export function createHostWorkspaceWriteTool(root: string, options?: { workspaceOnly?: boolean }) {
@@ -684,7 +740,65 @@ export function createHostWorkspaceEditTool(root: string, options?: { workspaceO
   const base = createEditTool(root, {
     operations: createHostEditOperations(root, options),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
+  return wrapHostEditToolWithCurrentContent(base, root, options);
+}
+
+/**
+ * Wraps the host edit tool to return the current file content on mismatch.
+ * Implements Option 1 from https://github.com/openclaw/openclaw/issues/18132
+ */
+function wrapHostEditToolWithCurrentContent(
+  tool: AnyAgentTool, 
+  root: string, 
+  options?: { workspaceOnly?: boolean }
+): AnyAgentTool {
+  const wrapped = wrapToolParamNormalization(tool, CLAUDE_PARAM_GROUPS.edit);
+  return {
+    ...wrapped,
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      const result = await wrapped.execute(toolCallId, params, signal, onUpdate);
+      
+      // Check if edit failed due to mismatch
+      if (result.isError && result.content.some(block => {
+        if (block.type === 'text') {
+          const text = block.text.toLowerCase();
+          return text.includes('mismatch') || 
+                 text.includes('not found') || 
+                 text.includes('no exact match') ||
+                 text.includes('could not find') ||
+                 text.includes('does not match');
+        }
+        return false;
+      })) {
+        // Try to read current file content and append it to the error
+        const record = params as Record<string, unknown>;
+        const filePath = record?.file_path || record?.path;
+        
+        if (typeof filePath === 'string') {
+          try {
+            const content = await fs.readFile(filePath, 'utf-8');
+            
+            // Append current content to error message
+            return {
+              ...result,
+              content: [
+                ...result.content,
+                {
+                  type: 'text' as const,
+                  text: `\n\n--- Current file content ---\n${content}\n--- End of current content ---`,
+                },
+              ],
+            };
+          } catch {
+            // If we can't read the file, just return the original error
+            return result;
+          }
+        }
+      }
+      
+      return result;
+    },
+  };
 }
 
 export function createOpenClawReadTool(


### PR DESCRIPTION
## Summary

Implements **Option 1** from #18132: Return current file content on edit mismatch.

## Problem

When `oldText` doesn't match (due to file changes between read and edit), the agent must:
1. Realize the edit failed
2. Make a separate `Read` call
3. Re-compute the edit
4. Retry

This wastes tokens and time.

## Solution

On edit mismatch, automatically append the current file content to the error response:

```diff
- Error: oldText not found in file
+ Error: oldText not found in file
+ 
+ --- Current file content ---
+ [full file content here]
+ --- End of current content ---
```

## Changes

- `wrapEditToolWithCurrentContent()` - Wraps sandboxed edit tool
- `wrapHostEditToolWithCurrentContent()` - Wraps host edit tool
- Both detect mismatch errors and append current file content
- Unit tests included

## Benefits

- ✅ Saves tokens (no separate Read call)
- ✅ Faster recovery from edit failures  
- ✅ Better agent experience
- ✅ Backwards compatible

## Testing

```bash
npm test src/agents/pi-tools.edit-return-content.test.ts
```

## Related

- Issue: #18132
- Alternative: Option 2 (line-based editing), Option 3 (auto-retry), Option 4 (fuzzy match)

🦞