### PR TITLE
test(gateway): guard JSON BlueBubbles webhook passthrough

### DIFF
--- a/src/gateway/hooks-test-helpers.ts
+++ b/src/gateway/hooks-test-helpers.ts
@@ -26,12 +26,18 @@ export function createGatewayRequest(params: {
   method?: string;
   remoteAddress?: string;
   host?: string;
+  headers?: Record<string, string>;
 }): IncomingMessage {
   const headers: Record<string, string> = {
     host: params.host ?? "localhost:18789",
   };
   if (params.authorization) {
     headers.authorization = params.authorization;
+  }
+  if (params.headers) {
+    for (const [key, value] of Object.entries(params.headers)) {
+      headers[key] = value;
+    }
   }
   return {
     method: params.method ?? "GET",

--- a/src/gateway/server-http.test-harness.ts
+++ b/src/gateway/server-http.test-harness.ts
@@ -28,11 +28,13 @@ export function createRequest(params: {
   path: string;
   authorization?: string;
   method?: string;
+  headers?: Record<string, string>;
 }): IncomingMessage {
   return createGatewayRequest({
     path: params.path,
     authorization: params.authorization,
     method: params.method,
+    headers: params.headers,
   });
 }
 
@@ -127,6 +129,7 @@ export async function sendRequest(
     path: string;
     authorization?: string;
     method?: string;
+    headers?: Record<string, string>;
   },
 ): Promise<ReturnType<typeof createResponse>> {
   const response = createResponse();

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -453,6 +453,48 @@ describe("gateway plugin HTTP auth boundary", () => {
     });
   });
 
+  test("passes JSON POST webhook routes with query params through root-mounted control ui to plugins", async () => {
+    const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+      const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+      const contentType = req.headers["content-type"];
+      if (
+        req.method !== "POST" ||
+        pathname !== "/bluebubbles-webhook" ||
+        contentType !== "application/json"
+      ) {
+        return false;
+      }
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end("plugin-webhook-json");
+      return true;
+    });
+
+    await withGatewayServer({
+      prefix: "openclaw-plugin-http-control-ui-webhook-post-json-test-",
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        controlUiEnabled: true,
+        controlUiBasePath: "",
+        controlUiRoot: { kind: "missing" },
+        handlePluginRequest,
+      },
+      run: async (server) => {
+        const response = await sendRequest(server, {
+          path: "/bluebubbles-webhook?password=test-password",
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+        });
+
+        expect(response.res.statusCode).toBe(200);
+        expect(response.getBody()).toBe("plugin-webhook-json");
+        expect(handlePluginRequest).toHaveBeenCalledTimes(1);
+      },
+    });
+  });
+
   test("plugin routes take priority over control ui catch-all", async () => {
     const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
       const pathname = new URL(req.url ?? "/", "http://localhost").pathname;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: BlueBubbles users reported `POST /bluebubbles-webhook` returning `405` when Control UI is root-mounted (`basePath=""`) and payloads are standard JSON with query auth.
- Why it matters: this is a complete inbound webhook outage for BlueBubbles, and regressions can silently reappear if routing precedence changes.
- What changed: added a gateway regression test that asserts JSON `POST` webhook requests with query params pass through Control UI routing to plugin handlers.
- What did NOT change (scope boundary): no runtime routing/auth logic changed in this PR; this is guardrail test coverage only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #32304

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): BlueBubbles webhook path handling in gateway/plugin routing
- Relevant config (redacted): root-mounted Control UI (`gateway.controlUi.basePath=""`)

### Steps

1. Configure gateway test harness with Control UI enabled at root (`basePath=""`) and a plugin handler for `/bluebubbles-webhook`.
2. Send `POST /bluebubbles-webhook?password=test-password` with `Content-Type: application/json`.
3. Assert request is handled by plugin handler (not Control UI fallback) and returns plugin response.

### Expected

- JSON `POST` webhook route passes through to plugin handler.

### Actual

- Added test now enforces this behavior; suite passes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran `pnpm test -- src/gateway/server.plugin-http-auth.test.ts`; new JSON webhook passthrough case passes.
- Edge cases checked: Existing non-JSON POST passthrough case and auth-boundary tests still pass.
- What you did **not** verify: live BlueBubbles end-to-end with a running gateway instance.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this single commit.
- Files/config to restore: `src/gateway/server.plugin-http-auth.test.ts`, `src/gateway/server-http.test-harness.ts`, `src/gateway/hooks-test-helpers.ts`
- Known bad symptoms reviewers should watch for: test harness request helper header behavior drift.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: test harness helper now supports arbitrary headers and could affect existing tests if misused.
  - Mitigation: existing gateway auth suite was re-run; behavior remains unchanged.
