### PR TITLE
fix: remove ack reaction on silent turns (NO_REPLY)

### DIFF
--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -351,8 +351,9 @@ export function createStatusReactionController(params: {
           }
         }
       } else {
-        // For platforms without removeReaction, set empty or just skip
-        // (Telegram handles this atomically on the next setReaction)
+        // Platforms without removeReaction rely on atomic replacement via setReaction.
+        // If a platform needs explicit removal (e.g. on silent turns), it should
+        // provide removeReaction in its adapter.
       }
       currentEmoji = "";
       pendingEmoji = "";

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -467,6 +467,31 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   if (!anyReplyDelivered) {
     await draftStream.clear();
+    // Silent turn (NO_REPLY): also remove the ack reaction so the user
+    // does not see a dangling reaction on messages the agent ignored (#32294).
+    removeAckReactionAfterReply({
+      removeAfterReply: ctx.removeAckAfterReply,
+      ackReactionPromise: prepared.ackReactionPromise,
+      ackReactionValue: prepared.ackReactionValue,
+      remove: () =>
+        removeSlackReaction(
+          message.channel,
+          prepared.ackReactionMessageTs ?? "",
+          prepared.ackReactionValue,
+          {
+            token: ctx.botToken,
+            client: ctx.app.client,
+          },
+        ),
+      onError: (err) => {
+        logAckFailure({
+          log: logVerbose,
+          channel: "slack",
+          target: `${message.channel}/${message.ts}`,
+          error: err,
+        });
+      },
+    });
     if (prepared.isRoomish) {
       clearHistoryEntriesIfEnabled({
         historyMap: ctx.channelHistories,

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -584,7 +584,14 @@ export const buildTelegramMessageContext = async ({
                 ]);
               }
             },
-            // Telegram replaces atomically — no removeReaction needed
+            removeReaction: async () => {
+              if (reactionApi) {
+                // Clear all reactions by sending an empty array to the Telegram API.
+                // This is needed so that clear() actually removes dangling emojis
+                // on silent NO_REPLY turns (#32294).
+                await reactionApi(chatId, msg.message_id, []);
+              }
+            },
           },
           initialEmoji: ackReaction,
           emojis: resolvedStatusReactionEmojis,

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -691,15 +691,10 @@ export const dispatchTelegramMessage = async ({
 
   const hasFinalResponse = queuedFinal || sentFallback;
 
-  if (statusReactionController && !hasFinalResponse) {
-    void statusReactionController.setError().catch((err) => {
-      logVerbose(`telegram: status reaction error finalize failed: ${String(err)}`);
-    });
-  }
-
   if (!hasFinalResponse) {
-    // Silent turn (NO_REPLY): also remove the ack reaction so the user
-    // does not see a dangling 👀 on messages the agent chose to ignore (#32294).
+    // Silent turn (NO_REPLY): clear the status reaction or remove the ack
+    // reaction so the user doesn't see a dangling emoji on ignored messages (#32294).
+    // Do NOT call setError() here — NO_REPLY is a deliberate silent turn, not an error.
     if (statusReactionController) {
       void statusReactionController.clear().catch((err) => {
         logVerbose(`telegram: status reaction silent-clear failed: ${String(err)}`);

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -698,6 +698,31 @@ export const dispatchTelegramMessage = async ({
   }
 
   if (!hasFinalResponse) {
+    // Silent turn (NO_REPLY): also remove the ack reaction so the user
+    // does not see a dangling 👀 on messages the agent chose to ignore (#32294).
+    if (statusReactionController) {
+      void statusReactionController.clear().catch((err) => {
+        logVerbose(`telegram: status reaction silent-clear failed: ${String(err)}`);
+      });
+    } else {
+      removeAckReactionAfterReply({
+        removeAfterReply: removeAckAfterReply,
+        ackReactionPromise,
+        ackReactionValue: ackReactionPromise ? "ack" : null,
+        remove: () => reactionApi?.(chatId, msg.message_id ?? 0, []) ?? Promise.resolve(),
+        onError: (err) => {
+          if (!msg.message_id) {
+            return;
+          }
+          logAckFailure({
+            log: logVerbose,
+            channel: "telegram",
+            target: `${chatId}/${msg.message_id}`,
+            error: err,
+          });
+        },
+      });
+    }
     clearGroupHistory();
     return;
   }


### PR DESCRIPTION
## Summary

- When `removeAckAfterReply` is enabled, the ack reaction (e.g. 👀) was left dangling on messages where the agent returned `NO_REPLY`
- The removal logic only ran in the reply-delivered code path, skipping silent turns entirely
- Now both Telegram and Slack dispatchers also remove the ack reaction in the no-reply path
- Discord already handles this correctly via its status reaction controller's `finally` block

## Changes

- **Telegram** (`bot-message-dispatch.ts`): Call `removeAckReactionAfterReply()` or `statusReactionController.clear()` in the `!hasFinalResponse` branch
- **Slack** (`dispatch.ts`): Call `removeAckReactionAfterReply()` in the `!anyReplyDelivered` branch

## Test plan

- [x] All 58 Telegram dispatch tests pass
- [x] All 195 Slack monitor tests pass (21 test files)
- [x] Ack reaction unit tests pass (8 tests)

Closes #32294

🤖 Generated with [Claude Code](https://claude.com/claude-code)