### PR TITLE
feat(exec): add wakeOnExit immediate session-event wake for background completions

### DIFF
--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -19,6 +19,7 @@ Key parameters:
 - `background` (bool): background immediately
 - `timeout` (seconds, default 1800): kill the process after this timeout
 - `elevated` (bool): run on host if elevated mode is enabled/allowed
+- `wakeOnExit` (bool, default false): trigger an immediate session event run after enqueueing a background exec completion event (currently supported only for `agent:` session keys)
 - Need a real TTY? Set `pty: true`.
 - `workdir`, `env`
 
@@ -46,7 +47,12 @@ Config (preferred):
 - `tools.exec.backgroundMs` (default 10000)
 - `tools.exec.timeoutSec` (default 1800)
 - `tools.exec.cleanupMs` (default 1800000)
-- `tools.exec.notifyOnExit` (default true): enqueue a system event + request heartbeat when a backgrounded exec exits.
+- `tools.exec.notifyOnExit` (default true): enqueue a system event when a backgrounded exec exits.
+  By default this also requests a heartbeat wake (legacy behavior).
+  If `wakeOnExit=true` is set on the run, completion wakes switch to immediate session-event runs instead of heartbeat.
+  Immediate wake is currently supported only for `agent:` session keys; non-agent keys fall back to the same heartbeat wake used by `wakeOnExit=false`.
+  Non-agent immediate wake support is intentionally deferred for now and open to future contributions.
+  Completion events include `session=<id>` so follow-up turns can call `process poll/log` for full output.
 - `tools.exec.notifyOnExitEmptySuccess` (default false): when true, also enqueue completion events for successful backgrounded runs that produced no output.
 
 ## process tool

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -26,6 +26,7 @@ Background sessions are scoped per agent; `process` only sees sessions from the 
 - `ask` (`off | on-miss | always`): approval prompts for `gateway`/`node`
 - `node` (string): node id/name for `host=node`
 - `elevated` (bool): request elevated mode (gateway host); `security=full` is only forced when elevated resolves to `full`
+- `wakeOnExit` (bool, default `false`): when background completion is enqueued as a system event, trigger an immediate session event run (currently supported only for `agent:` session keys)
 
 Notes:
 
@@ -50,7 +51,12 @@ Notes:
 
 ## Config
 
-- `tools.exec.notifyOnExit` (default: true): when true, backgrounded exec sessions enqueue a system event and request a heartbeat on exit.
+- `tools.exec.notifyOnExit` (default: true): when true, backgrounded exec sessions enqueue a system event on exit.
+  By default this also requests a heartbeat wake (legacy behavior).
+  When `wakeOnExit=true` on the run, the wake path switches to an immediate session event run instead of heartbeat.
+  `wakeOnExit` immediate wake is currently supported only for `agent:` session keys; non-agent keys fall back to the same heartbeat wake used by `wakeOnExit=false`.
+  Non-agent immediate wake support is intentionally deferred for now and open to future contributions.
+  Completion events include `session=<id>` so follow-up turns can fetch full output with `process poll/log`.
 - `tools.exec.approvalRunningNoticeMs` (default: 10000): emit a single “running” notice when an approval-gated exec runs longer than this (0 disables).
 - `tools.exec.host` (default: `sandbox`)
 - `tools.exec.security` (default: `deny` for sandbox, `allowlist` for gateway + node when unset)

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -30,7 +30,9 @@ export interface ProcessSession {
   command: string;
   scopeKey?: string;
   sessionKey?: string;
+  agentId?: string;
   notifyOnExit?: boolean;
+  wakeOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   exitNotified?: boolean;
   child?: ChildProcessWithoutNullStreams;

--- a/src/agents/bash-tools.exec-host-approval-wake-on-exit.test.ts
+++ b/src/agents/bash-tools.exec-host-approval-wake-on-exit.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  registerExecApprovalRequestForHostMock,
+  waitForExecApprovalDecisionMock,
+  emitExecSystemEventMock,
+  callGatewayToolMock,
+  listNodesMock,
+  resolveNodeIdFromListMock,
+} = vi.hoisted(() => ({
+  registerExecApprovalRequestForHostMock: vi.fn(async () => ({
+    expiresAtMs: Date.now() + 60_000,
+    finalDecision: undefined,
+  })),
+  waitForExecApprovalDecisionMock: vi.fn(async () => "deny"),
+  emitExecSystemEventMock: vi.fn(),
+  callGatewayToolMock: vi.fn(),
+  listNodesMock: vi.fn(async () => [
+    { nodeId: "node-1", commands: ["system.run"], platform: "darwin" },
+  ]),
+  resolveNodeIdFromListMock: vi.fn((nodes: Array<{ nodeId: string }>) => nodes[0]?.nodeId),
+}));
+
+vi.mock("./bash-tools.exec-approval-request.js", () => ({
+  buildExecApprovalRequesterContext: vi.fn(
+    (params: { agentId?: string; sessionKey?: string }) => params,
+  ),
+  buildExecApprovalTurnSourceContext: vi.fn(
+    (params: {
+      turnSourceChannel?: string;
+      turnSourceTo?: string;
+      turnSourceAccountId?: string;
+      turnSourceThreadId?: string | number;
+    }) => params,
+  ),
+  registerExecApprovalRequestForHost: registerExecApprovalRequestForHostMock,
+  registerExecApprovalRequestForHostOrThrow: registerExecApprovalRequestForHostMock,
+  waitForExecApprovalDecision: waitForExecApprovalDecisionMock,
+}));
+vi.mock("./bash-tools.exec-runtime.js", () => ({
+  DEFAULT_APPROVAL_TIMEOUT_MS: 120_000,
+  DEFAULT_NOTIFY_TAIL_CHARS: 400,
+  createApprovalSlug: vi.fn((id: string) => id.slice(0, 8)),
+  emitExecSystemEvent: emitExecSystemEventMock,
+  normalizeNotifyOutput: vi.fn((value: string) => value),
+  runExecProcess: vi.fn(),
+}));
+vi.mock("./tools/gateway.js", () => ({
+  callGatewayTool: callGatewayToolMock,
+}));
+vi.mock("./tools/nodes-utils.js", () => ({
+  listNodes: listNodesMock,
+  resolveNodeIdFromList: resolveNodeIdFromListMock,
+}));
+
+import { processGatewayAllowlist } from "./bash-tools.exec-host-gateway.js";
+import { executeNodeHostCommand } from "./bash-tools.exec-host-node.js";
+
+describe("exec host approval denied wake propagation", () => {
+  beforeEach(() => {
+    registerExecApprovalRequestForHostMock.mockReset();
+    registerExecApprovalRequestForHostMock.mockResolvedValue({
+      expiresAtMs: Date.now() + 60_000,
+      finalDecision: undefined,
+    });
+    waitForExecApprovalDecisionMock.mockReset();
+    waitForExecApprovalDecisionMock.mockResolvedValue("deny");
+    emitExecSystemEventMock.mockReset();
+    callGatewayToolMock.mockReset();
+    listNodesMock.mockReset();
+    listNodesMock.mockResolvedValue([
+      { nodeId: "node-1", commands: ["system.run"], platform: "darwin" },
+    ]);
+    resolveNodeIdFromListMock.mockReset();
+    resolveNodeIdFromListMock.mockImplementation(
+      (nodes: Array<{ nodeId: string }>) => nodes[0]?.nodeId,
+    );
+  });
+
+  it("propagates wakeOnExit for gateway approval-denied events", async () => {
+    const result = await processGatewayAllowlist({
+      command: "ls -la",
+      workdir: process.cwd(),
+      env: {},
+      pty: false,
+      defaultTimeoutSec: 30,
+      security: "full",
+      ask: "always",
+      safeBins: new Set<string>(),
+      safeBinProfiles: {},
+      warnings: [],
+      notifySessionKey: "agent:main:main",
+      wakeOnExit: true,
+      approvalRunningNoticeMs: 0,
+      maxOutput: 10_000,
+      pendingMaxOutput: 10_000,
+    });
+
+    expect(result.pendingResult?.details?.status).toBe("approval-pending");
+    await expect
+      .poll(() => emitExecSystemEventMock.mock.calls.length, { timeout: 2_000, interval: 20 })
+      .toBeGreaterThan(0);
+    expect(emitExecSystemEventMock).toHaveBeenCalledWith(
+      expect.stringContaining("Exec denied (gateway"),
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        wakeOnExit: true,
+      }),
+    );
+  });
+
+  it("propagates wakeOnExit for node approval-denied events", async () => {
+    callGatewayToolMock.mockImplementation(async (method, _opts, params) => {
+      if (
+        method === "node.invoke" &&
+        (params as { command?: string }).command === "system.run.prepare"
+      ) {
+        return {
+          payload: {
+            cmdText: "ls -la",
+            plan: {
+              argv: ["ls", "-la"],
+              cwd: process.cwd(),
+              rawCommand: "ls -la",
+              agentId: "main",
+              sessionKey: "agent:main:main",
+            },
+          },
+        };
+      }
+      return { ok: true };
+    });
+
+    const result = await executeNodeHostCommand({
+      command: "ls -la",
+      workdir: process.cwd(),
+      env: {},
+      security: "full",
+      ask: "always",
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+      notifySessionKey: "agent:main:main",
+      wakeOnExit: true,
+    });
+
+    expect(result.details?.status).toBe("approval-pending");
+    await expect
+      .poll(() => emitExecSystemEventMock.mock.calls.length, { timeout: 2_000, interval: 20 })
+      .toBeGreaterThan(0);
+    expect(emitExecSystemEventMock).toHaveBeenCalledWith(
+      expect.stringContaining("Exec denied (node="),
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        wakeOnExit: true,
+      }),
+    );
+  });
+});

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -53,6 +53,7 @@ export type ProcessGatewayAllowlistParams = {
   scopeKey?: string;
   warnings: string[];
   notifySessionKey?: string;
+  wakeOnExit?: boolean;
   approvalRunningNoticeMs: number;
   maxOutput: number;
   pendingMaxOutput: number;
@@ -177,6 +178,8 @@ export async function processGatewayAllowlist(
             {
               sessionKey: params.notifySessionKey,
               contextKey,
+              agentId: params.agentId,
+              wakeOnExit: params.wakeOnExit === true,
             },
           ),
       });
@@ -232,6 +235,8 @@ export async function processGatewayAllowlist(
           {
             sessionKey: params.notifySessionKey,
             contextKey,
+            agentId: params.agentId,
+            wakeOnExit: params.wakeOnExit === true,
           },
         );
         return;
@@ -264,6 +269,8 @@ export async function processGatewayAllowlist(
           {
             sessionKey: params.notifySessionKey,
             contextKey,
+            agentId: params.agentId,
+            wakeOnExit: params.wakeOnExit === true,
           },
         );
         return;
@@ -276,7 +283,11 @@ export async function processGatewayAllowlist(
         runningTimer = setTimeout(() => {
           emitExecSystemEvent(
             `Exec running (gateway id=${approvalId}, session=${run?.session.id}, >${noticeSeconds}s): ${params.command}`,
-            { sessionKey: params.notifySessionKey, contextKey },
+            {
+              sessionKey: params.notifySessionKey,
+              contextKey,
+              agentId: params.agentId,
+            },
           );
         }, params.approvalRunningNoticeMs);
       }
@@ -292,7 +303,12 @@ export async function processGatewayAllowlist(
       const summary = output
         ? `Exec finished (gateway id=${approvalId}, session=${run.session.id}, ${exitLabel})\n${output}`
         : `Exec finished (gateway id=${approvalId}, session=${run.session.id}, ${exitLabel})`;
-      emitExecSystemEvent(summary, { sessionKey: params.notifySessionKey, contextKey });
+      emitExecSystemEvent(summary, {
+        sessionKey: params.notifySessionKey,
+        contextKey,
+        agentId: params.agentId,
+        wakeOnExit: params.wakeOnExit === true,
+      });
     })();
 
     return {

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -50,6 +50,7 @@ export type ExecuteNodeHostCommandParams = {
   approvalRunningNoticeMs: number;
   warnings: string[];
   notifySessionKey?: string;
+  wakeOnExit?: boolean;
   trustedSafeBinDirs?: ReadonlySet<string>;
 };
 
@@ -189,6 +190,7 @@ export async function executeNodeHostCommand(
     approvedByAsk: boolean,
     approvalDecision: "allow-once" | "allow-always" | null,
     runId?: string,
+    opts?: { includeWakeOnExit?: boolean },
   ) =>
     ({
       nodeId,
@@ -201,6 +203,8 @@ export async function executeNodeHostCommand(
         timeoutMs: typeof params.timeoutSec === "number" ? params.timeoutSec * 1000 : undefined,
         agentId: runAgentId,
         sessionKey: runSessionKey,
+        wakeOnExit:
+          opts?.includeWakeOnExit === true && params.wakeOnExit === true ? true : undefined,
         approved: approvedByAsk,
         approvalDecision: approvalDecision ?? undefined,
         runId: runId ?? undefined,
@@ -245,7 +249,12 @@ export async function executeNodeHostCommand(
         onFailure: () =>
           emitExecSystemEvent(
             `Exec denied (node=${nodeId} id=${approvalId}, approval-request-failed): ${params.command}`,
-            { sessionKey: params.notifySessionKey, contextKey },
+            {
+              sessionKey: params.notifySessionKey,
+              contextKey,
+              agentId: params.agentId,
+              wakeOnExit: params.wakeOnExit === true,
+            },
           ),
       });
       if (decision === undefined) {
@@ -283,6 +292,8 @@ export async function executeNodeHostCommand(
           {
             sessionKey: params.notifySessionKey,
             contextKey,
+            agentId: params.agentId,
+            wakeOnExit: params.wakeOnExit === true,
           },
         );
         return;
@@ -293,7 +304,11 @@ export async function executeNodeHostCommand(
         runningTimer = setTimeout(() => {
           emitExecSystemEvent(
             `Exec running (node=${nodeId} id=${approvalId}, >${noticeSeconds}s): ${params.command}`,
-            { sessionKey: params.notifySessionKey, contextKey },
+            {
+              sessionKey: params.notifySessionKey,
+              contextKey,
+              agentId: params.agentId,
+            },
           );
         }, params.approvalRunningNoticeMs);
       }
@@ -302,7 +317,9 @@ export async function executeNodeHostCommand(
         await callGatewayTool(
           "node.invoke",
           { timeoutMs: invokeTimeoutMs },
-          buildInvokeParams(approvedByAsk, approvalDecision, approvalId),
+          buildInvokeParams(approvedByAsk, approvalDecision, approvalId, {
+            includeWakeOnExit: true,
+          }),
         );
       } catch {
         emitExecSystemEvent(
@@ -310,6 +327,8 @@ export async function executeNodeHostCommand(
           {
             sessionKey: params.notifySessionKey,
             contextKey,
+            agentId: params.agentId,
+            wakeOnExit: params.wakeOnExit === true,
           },
         );
       } finally {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -1,10 +1,14 @@
 import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
+import { loadConfig } from "../config/config.js";
+import { resolveSessionStoreKey } from "../gateway/session-utils.js";
 import type { ExecAsk, ExecHost, ExecSecurity } from "../infra/exec-approvals.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
 import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
+import { requestSessionEventRun } from "../infra/session-event-run.js";
+import { isAgentScopedSessionKey } from "../infra/session-event-target.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
@@ -135,6 +139,12 @@ export const execSchema = Type.Object({
       description: "Node id/name for host=node.",
     }),
   ),
+  wakeOnExit: Type.Optional(
+    Type.Boolean({
+      description:
+        "When true, trigger an immediate session event run after enqueueing a background exec completion event (default false). Implies notifyOnExit=true.",
+    }),
+  ),
 });
 
 export type ExecProcessOutcome = {
@@ -199,6 +209,30 @@ function compactNotifyOutput(value: string, maxChars = DEFAULT_NOTIFY_SNIPPET_CH
   return `${normalized.slice(0, safe)}…`;
 }
 
+function requestExecEventWake(opts: { sessionKey: string; agentId?: string }): boolean {
+  const rawSessionKey = opts.sessionKey.trim();
+  if (!rawSessionKey) {
+    return false;
+  }
+
+  const canonicalSessionKey = resolveSessionStoreKey({
+    cfg: loadConfig(),
+    sessionKey: rawSessionKey,
+  });
+  if (!isAgentScopedSessionKey(canonicalSessionKey)) {
+    logWarn(
+      `exec wakeOnExit: immediate wake is only supported for agent-scoped session keys; skipping session key=${rawSessionKey} canonicalKey=${canonicalSessionKey}`,
+    );
+    return false;
+  }
+  requestSessionEventRun({
+    source: "exec-event",
+    sessionKey: rawSessionKey,
+    agentId: opts.agentId,
+  });
+  return true;
+}
+
 export function applyShellPath(env: Record<string, string>, shellPath?: string | null) {
   if (!shellPath) {
     return;
@@ -235,11 +269,21 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
   if (status === "completed" && !output && session.notifyOnExitEmptySuccess !== true) {
     return;
   }
+  const sessionLabel = `session=${session.id}`;
   const summary = output
-    ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
-    : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
-  enqueueSystemEvent(summary, { sessionKey });
-  requestHeartbeatNow({ reason: `exec:${session.id}:exit` });
+    ? `Exec ${status} (${sessionLabel}, ${exitLabel}) :: ${output}`
+    : `Exec ${status} (${sessionLabel}, ${exitLabel})`;
+  const queued = enqueueSystemEvent(summary, { sessionKey });
+  if (!queued) {
+    return;
+  }
+  if (session.wakeOnExit === true) {
+    const immediateWakeTriggered = requestExecEventWake({ sessionKey, agentId: session.agentId });
+    if (immediateWakeTriggered) {
+      return;
+    }
+  }
+  requestHeartbeatNow({ reason: `exec:${session.id}:exit`, sessionKey });
 }
 
 export function createApprovalSlug(id: string) {
@@ -258,14 +302,23 @@ export function resolveApprovalRunningNoticeMs(value?: number) {
 
 export function emitExecSystemEvent(
   text: string,
-  opts: { sessionKey?: string; contextKey?: string },
+  opts: { sessionKey?: string; contextKey?: string; agentId?: string; wakeOnExit?: boolean },
 ) {
   const sessionKey = opts.sessionKey?.trim();
   if (!sessionKey) {
     return;
   }
-  enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
-  requestHeartbeatNow({ reason: "exec-event" });
+  const queued = enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
+  if (!queued) {
+    return;
+  }
+  if (opts.wakeOnExit === true) {
+    const immediateWakeTriggered = requestExecEventWake({ sessionKey, agentId: opts.agentId });
+    if (immediateWakeTriggered) {
+      return;
+    }
+  }
+  requestHeartbeatNow({ reason: "exec-event", sessionKey });
 }
 
 export async function runExecProcess(opts: {
@@ -282,9 +335,11 @@ export async function runExecProcess(opts: {
   maxOutput: number;
   pendingMaxOutput: number;
   notifyOnExit: boolean;
+  wakeOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   scopeKey?: string;
   sessionKey?: string;
+  agentId?: string;
   timeoutSec: number | null;
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
 }): Promise<ExecProcessHandle> {
@@ -302,7 +357,9 @@ export async function runExecProcess(opts: {
     command: opts.command,
     scopeKey: opts.scopeKey,
     sessionKey: opts.sessionKey,
+    agentId: opts.agentId,
     notifyOnExit: opts.notifyOnExit,
+    wakeOnExit: opts.wakeOnExit === true,
     notifyOnExitEmptySuccess: opts.notifyOnExitEmptySuccess === true,
     exitNotified: false,
     child: undefined,

--- a/src/agents/bash-tools.exec-runtime.wake-on-exit.test.ts
+++ b/src/agents/bash-tools.exec-runtime.wake-on-exit.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  enqueueSystemEventMock,
+  requestSessionEventRunMock,
+  requestHeartbeatNowMock,
+  logWarnMock,
+  loadConfigMock,
+  resolveSessionStoreKeyMock,
+} = vi.hoisted(() => ({
+  enqueueSystemEventMock: vi.fn(() => true),
+  requestSessionEventRunMock: vi.fn(),
+  requestHeartbeatNowMock: vi.fn(),
+  logWarnMock: vi.fn(),
+  loadConfigMock: vi.fn(() => ({})),
+  resolveSessionStoreKeyMock: vi.fn(({ sessionKey }: { sessionKey: string }) =>
+    sessionKey.trim().toLowerCase(),
+  ),
+}));
+
+vi.mock("../infra/system-events.js", () => ({
+  enqueueSystemEvent: enqueueSystemEventMock,
+}));
+vi.mock("../infra/session-event-run.js", () => ({
+  requestSessionEventRun: requestSessionEventRunMock,
+}));
+vi.mock("../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: requestHeartbeatNowMock,
+}));
+vi.mock("../logger.js", () => ({
+  logWarn: logWarnMock,
+}));
+vi.mock("../config/config.js", () => ({
+  loadConfig: loadConfigMock,
+}));
+vi.mock("../gateway/session-utils.js", () => ({
+  resolveSessionStoreKey: resolveSessionStoreKeyMock,
+}));
+
+import { markBackgrounded, resetProcessRegistryForTests } from "./bash-process-registry.js";
+import { emitExecSystemEvent, runExecProcess } from "./bash-tools.exec-runtime.js";
+
+const isWin = process.platform === "win32";
+const delayedCommand = isWin
+  ? "Start-Sleep -Milliseconds 20; Write-Output wake-test"
+  : "sleep 0.02; echo wake-test";
+
+function stringifyEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value === "string") {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+async function runBackgroundExec(
+  wakeOnExit: boolean,
+  sessionKey = "agent:main:main",
+): Promise<string> {
+  const run = await runExecProcess({
+    command: delayedCommand,
+    workdir: process.cwd(),
+    env: stringifyEnv(process.env),
+    usePty: false,
+    warnings: [],
+    maxOutput: 20_000,
+    pendingMaxOutput: 20_000,
+    notifyOnExit: true,
+    wakeOnExit,
+    notifyOnExitEmptySuccess: true,
+    sessionKey,
+    timeoutSec: 5,
+  });
+  markBackgrounded(run.session);
+  await run.promise;
+  return run.session.id;
+}
+
+describe("exec wakeOnExit", () => {
+  beforeEach(() => {
+    enqueueSystemEventMock.mockReset();
+    enqueueSystemEventMock.mockReturnValue(true);
+    requestSessionEventRunMock.mockReset();
+    requestHeartbeatNowMock.mockReset();
+    logWarnMock.mockReset();
+    loadConfigMock.mockReset();
+    loadConfigMock.mockReturnValue({});
+    resolveSessionStoreKeyMock.mockReset();
+    resolveSessionStoreKeyMock.mockImplementation(({ sessionKey }: { sessionKey: string }) =>
+      sessionKey.trim().toLowerCase(),
+    );
+    resetProcessRegistryForTests();
+  });
+
+  it("does not trigger a session event run for background exits when wakeOnExit is false", async () => {
+    const sessionId = await runBackgroundExec(false);
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEventMock.mock.calls[0]?.[0]).toContain(`session=${sessionId}`);
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: expect.stringMatching(/^exec:.*:exit$/),
+      sessionKey: "agent:main:main",
+    });
+  });
+
+  it("triggers a session event run for background exits when wakeOnExit is true", async () => {
+    await runBackgroundExec(true);
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "agent:main:main",
+      agentId: undefined,
+    });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+
+  it("canonicalizes alias session keys before wakeOnExit dispatch", async () => {
+    resolveSessionStoreKeyMock.mockImplementation(({ sessionKey }: { sessionKey: string }) =>
+      sessionKey === "main" ? "agent:main:main" : sessionKey.trim().toLowerCase(),
+    );
+
+    await runBackgroundExec(true, "main");
+
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "main",
+      agentId: undefined,
+    });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to heartbeat for non-agent background exits when wakeOnExit is true", async () => {
+    await runBackgroundExec(true, "global");
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: expect.stringMatching(/^exec:.*:exit$/),
+      sessionKey: "global",
+    });
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("immediate wake is only supported for agent-scoped session keys"),
+    );
+  });
+
+  it("does not trigger wake when enqueueing an exec event fails", () => {
+    enqueueSystemEventMock.mockReturnValue(false);
+
+    emitExecSystemEvent("Exec finished", {
+      sessionKey: "agent:main:main",
+      wakeOnExit: true,
+    });
+
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+
+  it("uses heartbeat by default and session wake when wakeOnExit=true", () => {
+    emitExecSystemEvent("Exec finished", {
+      sessionKey: "agent:main:main",
+      wakeOnExit: false,
+    });
+    emitExecSystemEvent("Exec finished", {
+      sessionKey: "agent:main:main",
+      wakeOnExit: true,
+    });
+
+    expect(requestHeartbeatNowMock).toHaveBeenCalledTimes(1);
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:main:main",
+    });
+    expect(requestSessionEventRunMock).toHaveBeenCalledTimes(1);
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "agent:main:main",
+      agentId: undefined,
+    });
+  });
+
+  it("falls back to heartbeat when emitExecSystemEvent uses non-agent session keys", () => {
+    emitExecSystemEvent("Exec finished", {
+      sessionKey: "global",
+      wakeOnExit: true,
+    });
+
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "global",
+    });
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("immediate wake is only supported for agent-scoped session keys"),
+    );
+  });
+
+  it("preserves alias key when emitExecSystemEvent wakes on exit", () => {
+    resolveSessionStoreKeyMock.mockImplementation(({ sessionKey }: { sessionKey: string }) =>
+      sessionKey === "main" ? "agent:main:main" : sessionKey.trim().toLowerCase(),
+    );
+
+    emitExecSystemEvent("Exec finished", {
+      sessionKey: "main",
+      wakeOnExit: true,
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith("Exec finished", {
+      sessionKey: "main",
+      contextKey: undefined,
+    });
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "main",
+      agentId: undefined,
+    });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -114,6 +114,53 @@ describe("exec approvals", () => {
         interval: 20,
       })
       .toBe(approvalId);
+    expect(
+      (invokeParams as { params?: { wakeOnExit?: boolean } } | undefined)?.params?.wakeOnExit,
+    ).toBeUndefined();
+  });
+
+  it("forwards wakeOnExit only for async approval-pending node runs", async () => {
+    let invokeParams: unknown;
+
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      if (method === "exec.approval.request") {
+        return { status: "accepted", id: (params as { id?: string })?.id };
+      }
+      if (method === "exec.approval.waitDecision") {
+        return { decision: "allow-once" };
+      }
+      if (method === "node.invoke") {
+        const invoke = params as { command?: string };
+        if (invoke.command === "system.run.prepare") {
+          return buildPreparedSystemRunPayload(params);
+        }
+        if (invoke.command === "system.run") {
+          invokeParams = params;
+          return { payload: { success: true, stdout: "ok" } };
+        }
+      }
+      return { ok: true };
+    });
+
+    const tool = createExecTool({
+      host: "node",
+      ask: "always",
+      approvalRunningNoticeMs: 0,
+    });
+
+    const result = await tool.execute("call1b", { command: "ls -la", wakeOnExit: true });
+    expect(result.details.status).toBe("approval-pending");
+
+    await expect
+      .poll(
+        () =>
+          (invokeParams as { params?: { wakeOnExit?: boolean } } | undefined)?.params?.wakeOnExit,
+        {
+          timeout: 2000,
+          interval: 20,
+        },
+      )
+      .toBe(true);
   });
 
   it("skips approval when node allowlist is satisfied", async () => {
@@ -137,6 +184,7 @@ describe("exec approvals", () => {
     };
 
     const calls: string[] = [];
+    let systemRunInvokeParams: unknown;
     vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
       calls.push(method);
       if (method === "exec.approvals.node.get") {
@@ -146,6 +194,9 @@ describe("exec approvals", () => {
         const invoke = params as { command?: string };
         if (invoke.command === "system.run.prepare") {
           return buildPreparedSystemRunPayload(params);
+        }
+        if (invoke.command === "system.run") {
+          systemRunInvokeParams = params;
         }
         return { payload: { success: true, stdout: "ok" } };
       }
@@ -161,11 +212,16 @@ describe("exec approvals", () => {
 
     const result = await tool.execute("call2", {
       command: `"${exePath}" --help`,
+      wakeOnExit: true,
     });
     expect(result.details.status).toBe("completed");
     expect(calls).toContain("exec.approvals.node.get");
     expect(calls).toContain("node.invoke");
     expect(calls).not.toContain("exec.approval.request");
+    expect(
+      (systemRunInvokeParams as { params?: { wakeOnExit?: boolean } } | undefined)?.params
+        ?.wakeOnExit,
+    ).toBeUndefined();
   });
 
   it("honors ask=off for elevated gateway exec without prompting", async () => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -190,7 +190,7 @@ export function createExecTool(
       `exec: interpreter/runtime binaries in safeBins (${unprofiledInterpreterSafeBins.join(", ")}) are unsafe without explicit hardened profiles; prefer allowlist entries`,
     );
   }
-  const notifyOnExit = defaults?.notifyOnExit !== false;
+  const defaultNotifyOnExit = defaults?.notifyOnExit !== false;
   const notifyOnExitEmptySuccess = defaults?.notifyOnExitEmptySuccess === true;
   const notifySessionKey = defaults?.sessionKey?.trim() || undefined;
   const approvalRunningNoticeMs = resolveApprovalRunningNoticeMs(defaults?.approvalRunningNoticeMs);
@@ -220,6 +220,7 @@ export function createExecTool(
         security?: string;
         ask?: string;
         node?: string;
+        wakeOnExit?: boolean;
       };
 
       if (!params.command) {
@@ -229,6 +230,15 @@ export function createExecTool(
       const maxOutput = DEFAULT_MAX_OUTPUT;
       const pendingMaxOutput = DEFAULT_PENDING_MAX_OUTPUT;
       const warnings: string[] = [];
+      const wakeOnExit = params.wakeOnExit === true;
+      let notifyOnExit = defaultNotifyOnExit;
+      if (wakeOnExit && !notifyOnExit) {
+        notifyOnExit = true;
+        const warning =
+          "Warning: wakeOnExit=true requires notifyOnExit=true; forcing notifyOnExit for this exec run.";
+        warnings.push(warning);
+        logInfo(`exec: wakeOnExit requested while notifyOnExit disabled; forcing notifyOnExit.`);
+      }
       let execCommandOverride: string | undefined;
       const backgroundRequested = params.background === true;
       const yieldRequested = typeof params.yieldMs === "number";
@@ -419,6 +429,7 @@ export function createExecTool(
           approvalRunningNoticeMs,
           warnings,
           notifySessionKey,
+          wakeOnExit,
           trustedSafeBinDirs,
         });
       }
@@ -444,6 +455,7 @@ export function createExecTool(
           scopeKey: defaults?.scopeKey,
           warnings,
           notifySessionKey,
+          wakeOnExit,
           approvalRunningNoticeMs,
           maxOutput,
           pendingMaxOutput,
@@ -480,9 +492,11 @@ export function createExecTool(
         maxOutput,
         pendingMaxOutput,
         notifyOnExit,
+        wakeOnExit,
         notifyOnExitEmptySuccess,
         scopeKey: defaults?.scopeKey,
         sessionKey: notifySessionKey,
+        agentId,
         timeoutSec: effectiveTimeout,
         onUpdate,
       });

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -192,24 +192,25 @@ const requireRunningSessionId = (result: { details: unknown }) => {
   return requireSessionId(result.details as { sessionId?: string });
 };
 
-function hasNotifyEventForPrefix(prefix: string): boolean {
-  return peekSystemEvents(DEFAULT_NOTIFY_SESSION_KEY).some((event) => event.includes(prefix));
+function hasNotifyEventForSessionId(sessionId: string): boolean {
+  return peekSystemEvents(DEFAULT_NOTIFY_SESSION_KEY).some((event) =>
+    event.includes(`session=${sessionId}`),
+  );
 }
 
 async function waitForNotifyEvent(sessionId: string) {
-  const prefix = sessionId.slice(0, 8);
   let finished = getFinishedSession(sessionId);
-  let hasEvent = hasNotifyEventForPrefix(prefix);
+  let hasEvent = hasNotifyEventForSessionId(sessionId);
   await expect
     .poll(() => {
       finished = getFinishedSession(sessionId);
-      hasEvent = hasNotifyEventForPrefix(prefix);
+      hasEvent = hasNotifyEventForSessionId(sessionId);
       return Boolean(finished && hasEvent);
     }, NOTIFY_POLL_OPTIONS)
     .toBe(true);
   return {
     finished: finished ?? getFinishedSession(sessionId),
-    hasEvent: hasEvent || hasNotifyEventForPrefix(prefix),
+    hasEvent: hasEvent || hasNotifyEventForSessionId(sessionId),
   };
 }
 
@@ -517,6 +518,22 @@ describe("exec notifyOnExit", () => {
 
     const { finished, hasEvent } = await waitForNotifyEvent(sessionId);
 
+    expect(finished).toBeTruthy();
+    expect(hasEvent).toBe(true);
+  });
+
+  it("coerces notifyOnExit to true when wakeOnExit is requested", async () => {
+    const tool = createNotifyOnExitExecTool({ notifyOnExit: false });
+    const result = await executeExecCommand(tool, echoAfterDelay("notify"), {
+      background: true,
+      wakeOnExit: true,
+    });
+    expect(readTextContent(result.content) ?? "").toContain(
+      "wakeOnExit=true requires notifyOnExit=true",
+    );
+
+    const sessionId = requireRunningSessionId(result);
+    const { finished, hasEvent } = await waitForNotifyEvent(sessionId);
     expect(finished).toBeTruthy();
     expect(hasEvent).toBe(true);
   });

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -208,6 +208,31 @@ describe("runPreparedReply media-only handling", () => {
     expect(vi.mocked(runReplyAgent)).not.toHaveBeenCalled();
   });
 
+  it("allows system-event-only runs when empty-body override is enabled", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "slack",
+        },
+        opts: {
+          allowEmptyBodyForSystemEvent: true,
+        },
+      }),
+    );
+
+    expect(result).toEqual({ text: "ok" });
+    expect(vi.mocked(runReplyAgent)).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call?.followupRun.prompt).toContain("[System event update]");
+  });
+
   it("omits auth key labels from /new and /reset confirmation messages", async () => {
     await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -308,7 +308,8 @@ export async function runPreparedReply(
   const hasMediaAttachment = Boolean(
     sessionCtx.MediaPath || (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0),
   );
-  if (!baseBodyTrimmed && !hasMediaAttachment) {
+  const allowEmptyBodyForSystemEvent = opts?.allowEmptyBodyForSystemEvent === true;
+  if (!baseBodyTrimmed && !hasMediaAttachment && !allowEmptyBodyForSystemEvent) {
     await typing.onReplyStart();
     logVerbose("Inbound body empty after normalization; skipping agent run");
     typing.cleanup();
@@ -320,7 +321,9 @@ export async function runPreparedReply(
   // run proceeds and the image/document is injected by the embedded runner.
   const effectiveBaseBody = baseBodyTrimmed
     ? baseBodyForPrompt
-    : "[User sent media without caption]";
+    : hasMediaAttachment
+      ? "[User sent media without caption]"
+      : "[System event update]";
   let prefixedBodyBase = await applySessionHints({
     baseBody: effectiveBaseBody,
     abortedLastRun,

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -44,6 +44,8 @@ export type GetReplyOptions = {
   bootstrapContextMode?: "full" | "lightweight";
   /** If true, suppress tool error warning payloads for this run. */
   suppressToolErrorWarnings?: boolean;
+  /** Allow runs with an empty inbound body when system events are queued for this session. */
+  allowEmptyBodyForSystemEvent?: boolean;
   onPartialReply?: (payload: ReplyPayload) => Promise<void> | void;
   onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when a thinking/reasoning block ends. */

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -479,7 +479,7 @@ export const FIELD_HELP: Record<string, string> = {
     "Enable known poll tool no-progress loop detection (default: true).",
   "tools.loopDetection.detectors.pingPong": "Enable ping-pong loop detection (default: true).",
   "tools.exec.notifyOnExit":
-    "When true (default), backgrounded exec sessions on exit and node exec lifecycle events enqueue a system event and request a heartbeat.",
+    "When true (default), backgrounded exec sessions on exit and node exec lifecycle events enqueue a system event and request a heartbeat (unless a run opts into wakeOnExit immediate session-event wake for agent-scoped sessions).",
   "tools.exec.notifyOnExitEmptySuccess":
     "When true, successful backgrounded exec exits with empty output still enqueue a completion system event (default: false).",
   "tools.exec.pathPrepend": "Directories to prepend to PATH for exec runs (gateway/sandbox).",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -249,7 +249,7 @@ export type ExecToolConfig = {
   approvalRunningNoticeMs?: number;
   /** How long to keep finished sessions in memory (ms). */
   cleanupMs?: number;
-  /** Emit a system event and heartbeat when a backgrounded exec exits. */
+  /** Emit a system event and heartbeat when a backgrounded exec exits (unless run-level wakeOnExit is used). */
   notifyOnExit?: boolean;
   /**
    * Also emit success exit notifications when a backgrounded exec has no output.

--- a/src/gateway/node-invoke-system-run-approval.test.ts
+++ b/src/gateway/node-invoke-system-run-approval.test.ts
@@ -240,6 +240,53 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
     expectAllowOnceForwardingResult(result);
   });
 
+  test("preserves wakeOnExit on normal forwarded system.run params", () => {
+    const result = sanitizeSystemRunParamsForForwarding({
+      rawParams: {
+        command: ["echo", "SAFE"],
+        rawCommand: "echo SAFE",
+        wakeOnExit: true,
+      },
+      nodeId: "node-1",
+      client,
+      execApprovalManager: manager(makeRecord("echo SAFE")),
+      nowMs: now,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("unreachable");
+    }
+    const params = result.params as Record<string, unknown>;
+    expect(params.wakeOnExit).toBe(true);
+    expect(params.approved).toBeUndefined();
+    expect(params.approvalDecision).toBeUndefined();
+  });
+
+  test("preserves wakeOnExit when forwarding approved allow-once params", () => {
+    const result = sanitizeSystemRunParamsForForwarding({
+      rawParams: {
+        command: ["echo", "SAFE"],
+        rawCommand: "echo SAFE",
+        runId: "approval-1",
+        approved: true,
+        approvalDecision: "allow-once",
+        wakeOnExit: true,
+      },
+      nodeId: "node-1",
+      client,
+      execApprovalManager: manager(makeRecord("echo SAFE", ["echo", "SAFE"])),
+      nowMs: now,
+    });
+
+    expectAllowOnceForwardingResult(result);
+    if (!result.ok) {
+      throw new Error("unreachable");
+    }
+    const params = result.params as Record<string, unknown>;
+    expect(params.wakeOnExit).toBe(true);
+  });
+
   test("uses systemRunPlan for forwarded command context and ignores caller tampering", () => {
     const record = makeRecord("echo SAFE", ["echo", "SAFE"]);
     record.request.systemRunPlan = {

--- a/src/gateway/node-invoke-system-run-approval.ts
+++ b/src/gateway/node-invoke-system-run-approval.ts
@@ -73,6 +73,7 @@ function pickSystemRunParams(raw: Record<string, unknown>): Record<string, unkno
     "env",
     "timeoutMs",
     "needsScreenRecording",
+    "wakeOnExit",
     "agentId",
     "sessionKey",
     "runId",

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -30,8 +30,12 @@ vi.mock("../infra/system-events.js", () => ({
 vi.mock("../infra/heartbeat-wake.js", () => ({
   requestHeartbeatNow: vi.fn(),
 }));
+vi.mock("../infra/session-event-run.js", () => ({
+  requestSessionEventRun: vi.fn(),
+}));
 vi.mock("../commands/agent.js", () => ({
   agentCommand: vi.fn(),
+  agentCommandFromIngress: vi.fn(),
 }));
 vi.mock("../config/config.js", () => ({
   loadConfig: vi.fn(() => ({ session: { mainKey: "agent:main:main" } })),
@@ -50,22 +54,25 @@ vi.mock("./session-utils.js", () => ({
 }));
 
 import type { CliDeps } from "../cli/deps.js";
-import { agentCommand } from "../commands/agent.js";
+import { agentCommandFromIngress } from "../commands/agent.js";
 import type { HealthSummary } from "../commands/health.js";
 import { loadConfig } from "../config/config.js";
 import { updateSessionStore } from "../config/sessions.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
+import { requestSessionEventRun } from "../infra/session-event-run.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import type { NodeEventContext } from "./server-node-events-types.js";
 import { handleNodeEvent } from "./server-node-events.js";
-import { loadSessionEntry } from "./session-utils.js";
+import { loadSessionEntry, resolveGatewaySessionStoreTarget } from "./session-utils.js";
 
 const enqueueSystemEventMock = vi.mocked(enqueueSystemEvent);
 const requestHeartbeatNowMock = vi.mocked(requestHeartbeatNow);
+const requestSessionEventRunMock = vi.mocked(requestSessionEventRun);
 const loadConfigMock = vi.mocked(loadConfig);
-const agentCommandMock = vi.mocked(agentCommand);
+const agentCommandMock = vi.mocked(agentCommandFromIngress);
 const updateSessionStoreMock = vi.mocked(updateSessionStore);
 const loadSessionEntryMock = vi.mocked(loadSessionEntry);
+const resolveGatewaySessionStoreTargetMock = vi.mocked(resolveGatewaySessionStoreTarget);
 
 function buildCtx(): NodeEventContext {
   return {
@@ -92,8 +99,15 @@ function buildCtx(): NodeEventContext {
 
 describe("node exec events", () => {
   beforeEach(() => {
-    enqueueSystemEventMock.mockClear();
+    enqueueSystemEventMock.mockReset();
+    enqueueSystemEventMock.mockReturnValue(true);
     requestHeartbeatNowMock.mockClear();
+    requestSessionEventRunMock.mockClear();
+    resolveGatewaySessionStoreTargetMock.mockReset();
+    resolveGatewaySessionStoreTargetMock.mockImplementation(({ key }: { key: string }) => ({
+      canonicalKey: key,
+      storeKeys: [key],
+    }));
   });
 
   it("enqueues exec.started events", async () => {
@@ -111,7 +125,11 @@ describe("node exec events", () => {
       "Exec started (node=node-1 id=run-1): ls -la",
       { sessionKey: "agent:main:main", contextKey: "exec:run-1" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:main:main",
+    });
   });
 
   it("enqueues exec.finished events with output", async () => {
@@ -119,18 +137,135 @@ describe("node exec events", () => {
     await handleNodeEvent(ctx, "node-2", {
       event: "exec.finished",
       payloadJSON: JSON.stringify({
+        sessionKey: "agent:main:main",
         runId: "run-2",
         exitCode: 0,
         timedOut: false,
         output: "done",
+        wakeOnExit: true,
       }),
     });
 
     expect(enqueueSystemEventMock).toHaveBeenCalledWith(
       "Exec finished (node=node-2 id=run-2, code 0)\ndone",
-      { sessionKey: "node-node-2", contextKey: "exec:run-2" },
+      { sessionKey: "agent:main:main", contextKey: "exec:run-2" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "agent:main:main",
+    });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps raw session keys for exec event runs", async () => {
+    resolveGatewaySessionStoreTargetMock.mockReturnValueOnce({
+      agentId: "main",
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:node-node-2",
+      storeKeys: ["agent:main:main"],
+    });
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-2", {
+      event: "exec.finished",
+      payloadJSON: JSON.stringify({
+        sessionKey: "agent:main:main",
+        runId: "run-2",
+        exitCode: 0,
+        timedOut: false,
+        output: "done",
+        wakeOnExit: true,
+      }),
+    });
+
+    expect(resolveGatewaySessionStoreTargetMock).toHaveBeenCalledWith({
+      cfg: expect.anything(),
+      key: "agent:main:main",
+      scanLegacyKeys: false,
+    });
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Exec finished (node=node-2 id=run-2, code 0)\ndone",
+      { sessionKey: "agent:main:main", contextKey: "exec:run-2" },
+    );
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "agent:main:main",
+    });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+
+  it("treats alias session keys as wake-eligible when canonicalized to agent keys", async () => {
+    resolveGatewaySessionStoreTargetMock.mockReturnValueOnce({
+      agentId: "main",
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:main",
+      storeKeys: ["main", "agent:main:main"],
+    });
+    const ctx = buildCtx();
+    const warn = vi.fn();
+    ctx.logGateway = { warn };
+    await handleNodeEvent(ctx, "node-2", {
+      event: "exec.finished",
+      payloadJSON: JSON.stringify({
+        sessionKey: "main",
+        runId: "run-main-alias",
+        exitCode: 0,
+        timedOut: false,
+        output: "done",
+        wakeOnExit: true,
+      }),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Exec finished (node=node-2 id=run-main-alias, code 0)\ndone",
+      { sessionKey: "main", contextKey: "exec:run-main-alias" },
+    );
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "main",
+    });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to heartbeat for non-agent session keys when immediate wake is unsupported", async () => {
+    resolveGatewaySessionStoreTargetMock.mockReturnValueOnce({
+      agentId: "main",
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "global",
+      storeKeys: ["global"],
+    });
+    const ctx = buildCtx();
+    const warn = vi.fn();
+    ctx.logGateway = { warn };
+    await handleNodeEvent(ctx, "node-2", {
+      event: "exec.finished",
+      payloadJSON: JSON.stringify({
+        runId: "run-global",
+        exitCode: 0,
+        timedOut: false,
+        output: "done",
+        sessionKey: "global",
+        wakeOnExit: true,
+      }),
+    });
+
+    expect(resolveGatewaySessionStoreTargetMock).toHaveBeenCalledWith({
+      cfg: expect.anything(),
+      key: "global",
+      scanLegacyKeys: false,
+    });
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Exec finished (node=node-2 id=run-global, code 0)\ndone",
+      { sessionKey: "global", contextKey: "exec:run-global" },
+    );
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "global",
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("exec wakeOnExit ignored for non-agent session key"),
+    );
   });
 
   it("suppresses noisy exec.finished success events with empty output", async () => {
@@ -147,6 +282,30 @@ describe("node exec events", () => {
 
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+  });
+
+  it("enqueues exec events without waking when wakeOnExit is false", async () => {
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-2", {
+      event: "exec.finished",
+      payloadJSON: JSON.stringify({
+        runId: "run-no-wake",
+        exitCode: 0,
+        timedOut: false,
+        output: "done",
+      }),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Exec finished (node=node-2 id=run-no-wake, code 0)\ndone",
+      { sessionKey: "node-node-2", contextKey: "exec:run-no-wake" },
+    );
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "node-node-2",
+    });
   });
 
   it("truncates long exec.finished output in system events", async () => {
@@ -154,10 +313,12 @@ describe("node exec events", () => {
     await handleNodeEvent(ctx, "node-2", {
       event: "exec.finished",
       payloadJSON: JSON.stringify({
+        sessionKey: "agent:main:main",
         runId: "run-long",
         exitCode: 0,
         timedOut: false,
         output: "x".repeat(600),
+        wakeOnExit: true,
       }),
     });
 
@@ -166,7 +327,11 @@ describe("node exec events", () => {
     expect(text.startsWith("Exec finished (node=node-2 id=run-long, code 0)\n")).toBe(true);
     expect(text.endsWith("…")).toBe(true);
     expect(text.length).toBeLessThan(280);
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "agent:main:main",
+    });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
   });
 
   it("enqueues exec.denied events with reason", async () => {
@@ -178,6 +343,7 @@ describe("node exec events", () => {
         runId: "run-3",
         command: "rm -rf /",
         reason: "allowlist-miss",
+        wakeOnExit: true,
       }),
     });
 
@@ -185,7 +351,34 @@ describe("node exec events", () => {
       "Exec denied (node=node-3 id=run-3, allowlist-miss): rm -rf /",
       { sessionKey: "agent:demo:main", contextKey: "exec:run-3" },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "agent:demo:main",
+    });
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+
+  it("heartbeats on exec.denied when wakeOnExit is false", async () => {
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-3", {
+      event: "exec.denied",
+      payloadJSON: JSON.stringify({
+        sessionKey: "agent:demo:main",
+        runId: "run-3b",
+        command: "rm -rf /",
+        reason: "allowlist-miss",
+      }),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Exec denied (node=node-3 id=run-3b, allowlist-miss): rm -rf /",
+      { sessionKey: "agent:demo:main", contextKey: "exec:run-3b" },
+    );
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:demo:main",
+    });
   });
 
   it("suppresses exec.started when notifyOnExit is false", async () => {
@@ -205,6 +398,7 @@ describe("node exec events", () => {
 
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
   });
 
   it("suppresses exec.finished when notifyOnExit is false", async () => {
@@ -224,6 +418,36 @@ describe("node exec events", () => {
     });
 
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+  });
+
+  it("allows exec.finished notifications when wakeOnExit is true even if notifyOnExit is false", async () => {
+    loadConfigMock.mockReturnValueOnce({
+      session: { mainKey: "agent:main:main" },
+      tools: { exec: { notifyOnExit: false } },
+    } as ReturnType<typeof loadConfig>);
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-2", {
+      event: "exec.finished",
+      payloadJSON: JSON.stringify({
+        sessionKey: "agent:main:main",
+        runId: "run-force-notify",
+        exitCode: 0,
+        timedOut: false,
+        output: "done",
+        wakeOnExit: true,
+      }),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Exec finished (node=node-2 id=run-force-notify, code 0)\ndone",
+      { sessionKey: "agent:main:main", contextKey: "exec:run-force-notify" },
+    );
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "agent:main:main",
+    });
     expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
   });
 
@@ -245,6 +469,68 @@ describe("node exec events", () => {
 
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+  });
+
+  it("allows exec.denied notifications when wakeOnExit is true even if notifyOnExit is false", async () => {
+    loadConfigMock.mockReturnValueOnce({
+      session: { mainKey: "agent:main:main" },
+      tools: { exec: { notifyOnExit: false } },
+    } as ReturnType<typeof loadConfig>);
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-3", {
+      event: "exec.denied",
+      payloadJSON: JSON.stringify({
+        sessionKey: "agent:demo:main",
+        runId: "run-force-denied",
+        command: "rm -rf /",
+        reason: "allowlist-miss",
+        wakeOnExit: true,
+      }),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Exec denied (node=node-3 id=run-force-denied, allowlist-miss): rm -rf /",
+      { sessionKey: "agent:demo:main", contextKey: "exec:run-force-denied" },
+    );
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    expect(requestSessionEventRunMock).toHaveBeenCalledWith({
+      source: "exec-event",
+      sessionKey: "agent:demo:main",
+    });
+  });
+
+  it("falls back to heartbeat for non-agent exec.denied session keys when immediate wake is unsupported", async () => {
+    resolveGatewaySessionStoreTargetMock.mockReturnValueOnce({
+      canonicalKey: "global",
+      storeKeys: ["global"],
+    });
+    const ctx = buildCtx();
+    const warn = vi.fn();
+    ctx.logGateway = { warn };
+    await handleNodeEvent(ctx, "node-3", {
+      event: "exec.denied",
+      payloadJSON: JSON.stringify({
+        runId: "run-global-denied",
+        sessionKey: "global",
+        command: "rm -rf /",
+        reason: "allowlist-miss",
+        wakeOnExit: true,
+      }),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Exec denied (node=node-3 id=run-global-denied, allowlist-miss): rm -rf /",
+      { sessionKey: "global", contextKey: "exec:run-global-denied" },
+    );
+    expect(requestSessionEventRunMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "global",
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("exec wakeOnExit ignored for non-agent session key"),
+    );
   });
 });
 
@@ -252,10 +538,12 @@ describe("voice transcript events", () => {
   beforeEach(() => {
     agentCommandMock.mockClear();
     updateSessionStoreMock.mockClear();
+    loadSessionEntryMock.mockReset();
     agentCommandMock.mockResolvedValue({ status: "ok" } as never);
     updateSessionStoreMock.mockImplementation(async (_storePath, update) => {
       update({});
     });
+    loadSessionEntryMock.mockImplementation((sessionKey: string) => buildSessionLookup(sessionKey));
   });
 
   it("dedupes repeated transcript payloads for the same session", async () => {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -9,6 +9,8 @@ import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { resolveOutboundTarget } from "../infra/outbound/targets.js";
 import { registerApnsToken } from "../infra/push-apns.js";
+import { requestSessionEventRun } from "../infra/session-event-run.js";
+import { isAgentScopedSessionKey } from "../infra/session-event-target.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { normalizeMainKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
@@ -525,16 +527,18 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       if (!obj) {
         return;
       }
-      const sessionKey =
+      const sessionKeyRaw =
         typeof obj.sessionKey === "string" ? obj.sessionKey.trim() : `node-${nodeId}`;
-      if (!sessionKey) {
+      if (!sessionKeyRaw) {
         return;
       }
+      const wakeOnExit = obj.wakeOnExit === true;
 
       // Respect tools.exec.notifyOnExit setting (default: true)
-      // When false, skip system event notifications for node exec events.
+      // When false, skip system event notifications for node exec events unless
+      // this run explicitly requested wakeOnExit (which implies notifyOnExit).
       const cfg = loadConfig();
-      const notifyOnExit = cfg.tools?.exec?.notifyOnExit !== false;
+      const notifyOnExit = cfg.tools?.exec?.notifyOnExit !== false || wakeOnExit;
       if (!notifyOnExit) {
         return;
       }
@@ -573,8 +577,37 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         }
       }
 
-      enqueueSystemEvent(text, { sessionKey, contextKey: runId ? `exec:${runId}` : "exec" });
-      requestHeartbeatNow({ reason: "exec-event" });
+      const queued = enqueueSystemEvent(text, {
+        sessionKey: sessionKeyRaw,
+        contextKey: runId ? `exec:${runId}` : "exec",
+      });
+      if (!queued) {
+        return;
+      }
+      const shouldImmediateWake =
+        wakeOnExit && (evt.event === "exec.finished" || evt.event === "exec.denied");
+      if (shouldImmediateWake) {
+        const wakeTarget = resolveGatewaySessionStoreTarget({
+          cfg,
+          key: sessionKeyRaw,
+          scanLegacyKeys: false,
+        });
+        if (!isAgentScopedSessionKey(wakeTarget.canonicalKey)) {
+          ctx.logGateway.warn(
+            `exec wakeOnExit ignored for non-agent session key node=${nodeId}${runId ? ` id=${runId}` : ""} sessionKey=${sessionKeyRaw} canonicalKey=${wakeTarget.canonicalKey}`,
+          );
+          requestHeartbeatNow({ reason: "exec-event", sessionKey: sessionKeyRaw });
+          return;
+        }
+        // Known limitation: runs originating from internal webchat sessions may not emit
+        // routable outbound replies because webchat is not supported by route-reply.
+        requestSessionEventRun({ source: "exec-event", sessionKey: sessionKeyRaw });
+        return;
+      }
+      if (wakeOnExit) {
+        return;
+      }
+      requestHeartbeatNow({ reason: "exec-event", sessionKey: sessionKeyRaw });
       return;
     }
     case "push.apns.register": {

--- a/src/infra/session-event-run.test.ts
+++ b/src/infra/session-event-run.test.ts
@@ -1,0 +1,558 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { loadSessionEntry as loadSessionEntryType } from "../gateway/session-utils.js";
+import type { resolveGatewaySessionStoreTarget as resolveGatewaySessionStoreTargetType } from "../gateway/session-utils.js";
+
+const {
+  dispatchInboundMessageWithDispatcherMock,
+  createReplyPrefixOptionsMock,
+  loadSessionEntryMock,
+  resolveGatewaySessionStoreTargetMock,
+  routeReplyMock,
+  hasSystemEventsMock,
+  getQueueSizeMock,
+} = vi.hoisted(() => ({
+  dispatchInboundMessageWithDispatcherMock: vi.fn(async (_params: unknown) => ({
+    queuedFinal: false,
+    counts: { tool: 0, block: 0, final: 0 },
+  })),
+  createReplyPrefixOptionsMock: vi.fn(() => ({
+    responsePrefix: undefined,
+    responsePrefixContextProvider: () => ({ identityName: "OpenClaw" }),
+    onModelSelected: vi.fn(),
+  })),
+  hasSystemEventsMock: vi.fn(() => true),
+  getQueueSizeMock: vi.fn(() => 0),
+  loadSessionEntryMock: vi.fn(
+    (sessionKey: string): ReturnType<typeof loadSessionEntryType> => ({
+      cfg: { session: { mainKey: "agent:main:main" } } as OpenClawConfig,
+      storePath: "/tmp/sessions.json",
+      store: {},
+      entry: {
+        sessionId: `sid-${sessionKey}`,
+        updatedAt: Date.now(),
+        lastChannel: "telegram",
+        lastTo: "123",
+        lastAccountId: "acct-1",
+        lastThreadId: "topic-1",
+      },
+      canonicalKey: sessionKey,
+      legacyKey: undefined,
+    }),
+  ),
+  resolveGatewaySessionStoreTargetMock: vi.fn(
+    (
+      params: Parameters<typeof resolveGatewaySessionStoreTargetType>[0],
+    ): ReturnType<typeof resolveGatewaySessionStoreTargetType> => ({
+      agentId: "main",
+      storePath: "/tmp/sessions.json",
+      canonicalKey: params.key,
+      storeKeys: [params.key],
+    }),
+  ),
+  routeReplyMock: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../auto-reply/dispatch.js", () => ({
+  dispatchInboundMessageWithDispatcher: dispatchInboundMessageWithDispatcherMock,
+}));
+vi.mock("../channels/reply-prefix.js", () => ({
+  createReplyPrefixOptions: createReplyPrefixOptionsMock,
+}));
+vi.mock("../gateway/session-utils.js", () => ({
+  loadSessionEntry: loadSessionEntryMock,
+  resolveGatewaySessionStoreTarget: resolveGatewaySessionStoreTargetMock,
+}));
+vi.mock("../auto-reply/reply/route-reply.js", () => ({
+  routeReply: routeReplyMock,
+}));
+vi.mock("./system-events.js", () => ({
+  hasSystemEvents: hasSystemEventsMock,
+}));
+vi.mock("../process/command-queue.js", () => ({
+  getQueueSize: getQueueSizeMock,
+}));
+vi.mock("../logger.js", () => ({
+  logWarn: vi.fn(),
+}));
+
+import {
+  requestSessionEventRun,
+  resetSessionEventRunStateForTests,
+  triggerSessionEventRun,
+} from "./session-event-run.js";
+
+describe("triggerSessionEventRun", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    dispatchInboundMessageWithDispatcherMock.mockClear();
+    createReplyPrefixOptionsMock.mockClear();
+    loadSessionEntryMock.mockClear();
+    hasSystemEventsMock.mockReset();
+    hasSystemEventsMock.mockReturnValue(true);
+    resolveGatewaySessionStoreTargetMock.mockReset();
+    resolveGatewaySessionStoreTargetMock.mockImplementation(
+      (
+        params: Parameters<typeof resolveGatewaySessionStoreTargetType>[0],
+      ): ReturnType<typeof resolveGatewaySessionStoreTargetType> => ({
+        agentId: "main",
+        storePath: "/tmp/sessions.json",
+        canonicalKey: params.key,
+        storeKeys: [params.key],
+      }),
+    );
+    getQueueSizeMock.mockReset();
+    getQueueSizeMock.mockReturnValue(0);
+    routeReplyMock.mockReset();
+    routeReplyMock.mockResolvedValue({ ok: true });
+    resetSessionEventRunStateForTests();
+    loadSessionEntryMock.mockImplementation(
+      (sessionKey: string): ReturnType<typeof loadSessionEntryType> => ({
+        cfg: { session: { mainKey: "agent:main:main" } } as OpenClawConfig,
+        storePath: "/tmp/sessions.json",
+        store: {},
+        entry: {
+          sessionId: `sid-${sessionKey}`,
+          updatedAt: Date.now(),
+          lastChannel: "telegram",
+          lastTo: "123",
+          lastAccountId: "acct-1",
+          lastThreadId: "topic-1",
+        },
+        canonicalKey: sessionKey,
+        legacyKey: undefined,
+      }),
+    );
+  });
+
+  it("dispatches a normal inbound run for agent sessions", async () => {
+    const triggered = await triggerSessionEventRun({
+      sessionKey: "agent:ops:main",
+      source: "exec-event",
+      agentId: "ops",
+    });
+
+    expect(triggered).toBe(true);
+    expect(dispatchInboundMessageWithDispatcherMock).toHaveBeenCalledTimes(1);
+    const [call] = dispatchInboundMessageWithDispatcherMock.mock.calls;
+    const params = call?.[0] as
+      | {
+          ctx?: Record<string, unknown>;
+          replyOptions?: Record<string, unknown>;
+        }
+      | undefined;
+    expect(params?.ctx?.SessionKey).toBe("agent:ops:main");
+    expect(params?.ctx?.Surface).toBe("webchat");
+    expect(params?.ctx?.OriginatingChannel).toBe("telegram");
+    expect(params?.ctx?.OriginatingTo).toBe("123");
+    expect(typeof params?.ctx?.MessageSid).toBe("string");
+    expect(params?.ctx?.MessageSid).toMatch(/^exec-event:/);
+    expect(params?.replyOptions).toMatchObject({
+      suppressTyping: true,
+      allowEmptyBodyForSystemEvent: true,
+    });
+  });
+
+  it("routes dispatcher deliveries to the session origin", async () => {
+    dispatchInboundMessageWithDispatcherMock.mockImplementationOnce(async (raw) => {
+      const params = raw as {
+        dispatcherOptions?: {
+          deliver?: (payload: { text?: string }, info: { kind: "final" }) => Promise<void>;
+        };
+      };
+      await params.dispatcherOptions?.deliver?.(
+        { text: "exec completion acknowledged" },
+        { kind: "final" },
+      );
+      return {
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+      };
+    });
+
+    const triggered = await triggerSessionEventRun({
+      sessionKey: "agent:ops:main",
+      source: "exec-event",
+      agentId: "ops",
+    });
+
+    expect(triggered).toBe(true);
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: "exec completion acknowledged" },
+        channel: "telegram",
+        to: "123",
+        sessionKey: "agent:ops:main",
+      }),
+    );
+  });
+
+  it("uses canonical agent keys from session lookup", async () => {
+    loadSessionEntryMock.mockImplementationOnce(
+      (_sessionKey: string): ReturnType<typeof loadSessionEntryType> => ({
+        cfg: { session: { mainKey: "agent:ops:work" } } as OpenClawConfig,
+        storePath: "/tmp/sessions.json",
+        store: {},
+        entry: {
+          sessionId: "sid-main",
+          updatedAt: Date.now(),
+          lastChannel: "discord",
+          lastTo: "C123",
+        },
+        canonicalKey: "agent:ops:work",
+        legacyKey: "main",
+      }),
+    );
+    resolveGatewaySessionStoreTargetMock.mockImplementationOnce(
+      (
+        _params: Parameters<typeof resolveGatewaySessionStoreTargetType>[0],
+      ): ReturnType<typeof resolveGatewaySessionStoreTargetType> => ({
+        agentId: "ops",
+        storePath: "/tmp/sessions.json",
+        canonicalKey: "agent:ops:work",
+        storeKeys: ["agent:ops:work", "main"],
+      }),
+    );
+
+    const triggered = await triggerSessionEventRun({
+      sessionKey: "main",
+      source: "exec-event",
+    });
+
+    expect(triggered).toBe(true);
+    const [call] = dispatchInboundMessageWithDispatcherMock.mock.calls;
+    const params = call?.[0] as { ctx?: Record<string, unknown> } | undefined;
+    expect(params?.ctx?.SessionKey).toBe("agent:ops:work");
+    expect(params?.ctx?.OriginatingChannel).toBe("discord");
+    expect(params?.ctx?.OriginatingTo).toBe("C123");
+  });
+
+  it("falls back to the requested key when only the raw key has queued events", async () => {
+    loadSessionEntryMock.mockImplementationOnce(
+      (_sessionKey: string): ReturnType<typeof loadSessionEntryType> => ({
+        cfg: { session: { mainKey: "agent:ops:work" } } as OpenClawConfig,
+        storePath: "/tmp/sessions.json",
+        store: {},
+        entry: {
+          sessionId: "sid-main",
+          updatedAt: Date.now(),
+          lastChannel: "discord",
+          lastTo: "C123",
+        },
+        canonicalKey: "agent:ops:work",
+        legacyKey: "main",
+      }),
+    );
+    resolveGatewaySessionStoreTargetMock.mockImplementationOnce(
+      (
+        _params: Parameters<typeof resolveGatewaySessionStoreTargetType>[0],
+      ): ReturnType<typeof resolveGatewaySessionStoreTargetType> => ({
+        agentId: "ops",
+        storePath: "/tmp/sessions.json",
+        canonicalKey: "agent:ops:work",
+        storeKeys: ["agent:ops:work", "main"],
+      }),
+    );
+    hasSystemEventsMock.mockImplementation((key: string) => key === "main");
+
+    const triggered = await triggerSessionEventRun({
+      sessionKey: "main",
+      source: "exec-event",
+    });
+
+    expect(triggered).toBe(true);
+    const [call] = dispatchInboundMessageWithDispatcherMock.mock.calls;
+    const params = call?.[0] as { ctx?: Record<string, unknown> } | undefined;
+    expect(params?.ctx?.SessionKey).toBe("main");
+  });
+
+  it("includes resolver alias queue keys when wake is requested with canonical key", async () => {
+    loadSessionEntryMock.mockImplementationOnce(
+      (_sessionKey: string): ReturnType<typeof loadSessionEntryType> => ({
+        cfg: { session: { mainKey: "agent:ops:work" } } as OpenClawConfig,
+        storePath: "/tmp/sessions.json",
+        store: {},
+        entry: {
+          sessionId: "sid-main",
+          updatedAt: Date.now(),
+          lastChannel: "discord",
+          lastTo: "C123",
+        },
+        canonicalKey: "agent:ops:work",
+        legacyKey: undefined,
+      }),
+    );
+    resolveGatewaySessionStoreTargetMock.mockImplementationOnce(
+      (
+        _params: Parameters<typeof resolveGatewaySessionStoreTargetType>[0],
+      ): ReturnType<typeof resolveGatewaySessionStoreTargetType> => ({
+        agentId: "ops",
+        storePath: "/tmp/sessions.json",
+        canonicalKey: "agent:ops:work",
+        storeKeys: ["agent:ops:work", "main"],
+      }),
+    );
+    hasSystemEventsMock.mockImplementation((key: string) => key === "main");
+
+    const triggered = await triggerSessionEventRun({
+      sessionKey: "agent:ops:work",
+      source: "exec-event",
+    });
+
+    expect(triggered).toBe(true);
+    const [call] = dispatchInboundMessageWithDispatcherMock.mock.calls;
+    const params = call?.[0] as { ctx?: Record<string, unknown> } | undefined;
+    expect(params?.ctx?.SessionKey).toBe("main");
+  });
+
+  it("queues a follow-up run when canonical and alias queues both have events", async () => {
+    vi.useFakeTimers();
+    loadSessionEntryMock.mockImplementation(
+      (inputKey: string): ReturnType<typeof loadSessionEntryType> => ({
+        cfg: { session: { mainKey: "agent:ops:work" } } as OpenClawConfig,
+        storePath: "/tmp/sessions.json",
+        store: {},
+        entry: {
+          sessionId: `sid-${inputKey}`,
+          updatedAt: Date.now(),
+          lastChannel: "discord",
+          lastTo: "C123",
+        },
+        canonicalKey: "agent:ops:work",
+        legacyKey: inputKey === "main" ? "main" : undefined,
+      }),
+    );
+    resolveGatewaySessionStoreTargetMock.mockImplementation(
+      (
+        _params: Parameters<typeof resolveGatewaySessionStoreTargetType>[0],
+      ): ReturnType<typeof resolveGatewaySessionStoreTargetType> => ({
+        agentId: "ops",
+        storePath: "/tmp/sessions.json",
+        canonicalKey: "agent:ops:work",
+        storeKeys: ["agent:ops:work", "main"],
+      }),
+    );
+
+    const pendingByKey = new Set(["agent:ops:work", "main"]);
+    hasSystemEventsMock.mockImplementation((key: string) => pendingByKey.has(key));
+    dispatchInboundMessageWithDispatcherMock.mockImplementation(async (raw) => {
+      const params = raw as { ctx?: { SessionKey?: string } };
+      const key = params.ctx?.SessionKey;
+      if (typeof key === "string") {
+        pendingByKey.delete(key);
+      }
+      return {
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+      };
+    });
+
+    requestSessionEventRun({
+      sessionKey: "main",
+      source: "exec-event",
+    });
+
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(250);
+
+    const dispatchedSessionKeys = dispatchInboundMessageWithDispatcherMock.mock.calls.map(
+      (call) => (call[0] as { ctx?: { SessionKey?: string } })?.ctx?.SessionKey,
+    );
+    expect(dispatchedSessionKeys).toEqual(["agent:ops:work", "main"]);
+    expect(pendingByKey.size).toBe(0);
+  });
+
+  it("skips non-agent canonical session keys", async () => {
+    loadSessionEntryMock.mockImplementationOnce(
+      (_sessionKey: string): ReturnType<typeof loadSessionEntryType> => ({
+        cfg: { session: { mainKey: "agent:main:main" } } as OpenClawConfig,
+        storePath: "/tmp/sessions.json",
+        store: {},
+        entry: {
+          sessionId: "sid-global",
+          updatedAt: Date.now(),
+        },
+        canonicalKey: "global",
+        legacyKey: undefined,
+      }),
+    );
+
+    const triggered = await triggerSessionEventRun({
+      sessionKey: "global",
+      source: "exec-event",
+    });
+
+    expect(triggered).toBe(false);
+    expect(dispatchInboundMessageWithDispatcherMock).not.toHaveBeenCalled();
+  });
+
+  it("skips dispatch when there are no queued system events", async () => {
+    hasSystemEventsMock.mockReturnValue(false);
+
+    const triggered = await triggerSessionEventRun({
+      sessionKey: "agent:ops:main",
+      source: "exec-event",
+    });
+
+    expect(triggered).toBe(false);
+    expect(dispatchInboundMessageWithDispatcherMock).not.toHaveBeenCalled();
+  });
+
+  it("skips dispatch while the main lane has requests in flight", async () => {
+    getQueueSizeMock.mockReturnValue(1);
+
+    const triggered = await triggerSessionEventRun({
+      sessionKey: "agent:ops:main",
+      source: "exec-event",
+    });
+
+    expect(triggered).toBe(false);
+    expect(dispatchInboundMessageWithDispatcherMock).not.toHaveBeenCalled();
+  });
+
+  it("coalesces duplicate wake requests and retries once the main lane clears", async () => {
+    vi.useFakeTimers();
+    getQueueSizeMock.mockReturnValueOnce(1).mockReturnValue(0);
+
+    requestSessionEventRun({
+      sessionKey: "agent:ops:main",
+      source: "exec-event",
+      agentId: "ops",
+    });
+    requestSessionEventRun({
+      sessionKey: "agent:ops:main",
+      source: "exec-event",
+      agentId: "ops",
+    });
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(dispatchInboundMessageWithDispatcherMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(dispatchInboundMessageWithDispatcherMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces duplicate wake requests for the same session even when agentId differs", async () => {
+    vi.useFakeTimers();
+
+    requestSessionEventRun({
+      sessionKey: "agent:ops:main",
+      source: "exec-event",
+      agentId: "ops",
+    });
+    requestSessionEventRun({
+      sessionKey: "agent:ops:main",
+      source: "exec-event",
+      agentId: undefined,
+    });
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(dispatchInboundMessageWithDispatcherMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry skipped non-agent session requests", async () => {
+    vi.useFakeTimers();
+    loadSessionEntryMock.mockImplementationOnce(
+      (_sessionKey: string): ReturnType<typeof loadSessionEntryType> => ({
+        cfg: { session: { mainKey: "agent:main:main" } } as OpenClawConfig,
+        storePath: "/tmp/sessions.json",
+        store: {},
+        entry: {
+          sessionId: "sid-global",
+          updatedAt: Date.now(),
+        },
+        canonicalKey: "global",
+        legacyKey: undefined,
+      }),
+    );
+
+    requestSessionEventRun({
+      sessionKey: "global",
+      source: "exec-event",
+    });
+
+    await vi.advanceTimersByTimeAsync(2500);
+    expect(dispatchInboundMessageWithDispatcherMock).not.toHaveBeenCalled();
+    expect(loadSessionEntryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues draining other sessions when one run throws, then retries the failed target", async () => {
+    vi.useFakeTimers();
+    let failedOnce = false;
+    dispatchInboundMessageWithDispatcherMock.mockImplementation(async (raw) => {
+      const params = raw as { ctx?: { SessionKey?: string } };
+      if (params.ctx?.SessionKey === "agent:ops:fail" && !failedOnce) {
+        failedOnce = true;
+        throw new Error("synthetic dispatch failure");
+      }
+      return {
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+      };
+    });
+
+    requestSessionEventRun({
+      sessionKey: "agent:ops:fail",
+      source: "exec-event",
+    });
+    requestSessionEventRun({
+      sessionKey: "agent:ops:ok",
+      source: "exec-event",
+    });
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(dispatchInboundMessageWithDispatcherMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(
+      dispatchInboundMessageWithDispatcherMock.mock.calls.some(
+        (call) =>
+          (call[0] as { ctx?: { SessionKey?: string } })?.ctx?.SessionKey === "agent:ops:ok",
+      ),
+    ).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(dispatchInboundMessageWithDispatcherMock).toHaveBeenCalledTimes(3);
+    expect(
+      dispatchInboundMessageWithDispatcherMock.mock.calls.filter(
+        (call) =>
+          (call[0] as { ctx?: { SessionKey?: string } })?.ctx?.SessionKey === "agent:ops:fail",
+      ).length,
+    ).toBe(2);
+  });
+
+  it("times out a hung dispatch and continues draining queued runs", async () => {
+    vi.useFakeTimers();
+    dispatchInboundMessageWithDispatcherMock
+      .mockImplementationOnce(
+        async (_raw) =>
+          await new Promise<never>(() => {
+            // Simulate an upstream hang that never resolves.
+          }),
+      )
+      .mockImplementation(async (_raw) => ({
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+      }));
+
+    requestSessionEventRun({
+      sessionKey: "agent:ops:hang",
+      source: "exec-event",
+    });
+    await vi.advanceTimersByTimeAsync(250);
+
+    requestSessionEventRun({
+      sessionKey: "agent:ops:next",
+      source: "exec-event",
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(1_250);
+
+    expect(dispatchInboundMessageWithDispatcherMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(
+      dispatchInboundMessageWithDispatcherMock.mock.calls.some(
+        (call) =>
+          (call[0] as { ctx?: { SessionKey?: string } })?.ctx?.SessionKey === "agent:ops:next",
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/infra/session-event-run.ts
+++ b/src/infra/session-event-run.ts
@@ -1,0 +1,348 @@
+import { randomUUID } from "node:crypto";
+import { dispatchInboundMessageWithDispatcher } from "../auto-reply/dispatch.js";
+import { routeReply } from "../auto-reply/reply/route-reply.js";
+import { normalizeChannelId } from "../channels/plugins/index.js";
+import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
+import { loadSessionEntry, resolveGatewaySessionStoreTarget } from "../gateway/session-utils.js";
+import { logWarn } from "../logger.js";
+import { getQueueSize } from "../process/command-queue.js";
+import { CommandLane } from "../process/lanes.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { deliveryContextFromSession } from "../utils/delivery-context.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
+import { isAgentScopedSessionKey } from "./session-event-target.js";
+import { hasSystemEvents } from "./system-events.js";
+
+const DEFAULT_COALESCE_MS = 250;
+const DEFAULT_RETRY_MS = 1_000;
+const DEFAULT_DISPATCH_TIMEOUT_MS = 30_000;
+
+type SessionEventRunResult =
+  | { status: "ran" }
+  | {
+      status: "skipped";
+      reason: "invalid-session" | "non-agent-session" | "no-system-events" | "requests-in-flight";
+    };
+
+type PendingSessionEventRun = {
+  sessionKey: string;
+  source: string;
+  agentId?: string;
+  requestedAt: number;
+};
+
+type WakeTimerKind = "normal" | "retry";
+
+const pendingSessionRuns = new Map<string, PendingSessionEventRun>();
+let runTimer: NodeJS.Timeout | null = null;
+let runTimerDueAt: number | null = null;
+let runTimerKind: WakeTimerKind | null = null;
+let running = false;
+
+function normalizePendingTarget(value?: string): string | undefined {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed || undefined;
+}
+
+function getPendingKey(params: { sessionKey: string }) {
+  return params.sessionKey.trim();
+}
+
+function resolveSessionEventQueueKeys(keys: Array<string | null | undefined>): string[] {
+  const visited = new Set<string>();
+  const resolved: string[] = [];
+  for (const candidate of keys) {
+    const key = normalizePendingTarget(candidate);
+    if (!key || visited.has(key)) {
+      continue;
+    }
+    visited.add(key);
+    resolved.push(key);
+  }
+  return resolved;
+}
+
+function resolveSessionEventQueueKey(keys: string[]): string | undefined {
+  for (const key of keys) {
+    if (hasSystemEvents(key)) {
+      return key;
+    }
+  }
+  return undefined;
+}
+
+async function dispatchSessionEventWithTimeout(params: {
+  cfg: ReturnType<typeof loadSessionEntry>["cfg"];
+  dispatchSessionKey: string;
+  source: string;
+  agentId: string;
+  delivery: ReturnType<typeof deliveryContextFromSession>;
+}) {
+  const normalizedOriginChannel = params.delivery?.channel
+    ? (normalizeChannelId(params.delivery.channel) ?? params.delivery.channel)
+    : undefined;
+  const normalizedOriginTo = params.delivery?.to?.trim() || undefined;
+
+  const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    channel: normalizedOriginChannel,
+    accountId: params.delivery?.accountId,
+  });
+
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      dispatchInboundMessageWithDispatcher({
+        cfg: params.cfg,
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+          BodyForAgent: "",
+          BodyForCommands: "",
+          SessionKey: params.dispatchSessionKey,
+          Provider: INTERNAL_MESSAGE_CHANNEL,
+          Surface: INTERNAL_MESSAGE_CHANNEL,
+          OriginatingChannel: normalizedOriginChannel,
+          OriginatingTo: normalizedOriginTo,
+          AccountId: params.delivery?.accountId,
+          MessageThreadId: params.delivery?.threadId,
+          MessageSid: `${params.source}:${randomUUID()}`,
+          CommandAuthorized: true,
+        },
+        dispatcherOptions: {
+          ...prefixOptions,
+          deliver: async (payload) => {
+            if (!normalizedOriginChannel || !normalizedOriginTo) {
+              return;
+            }
+            const routed = await routeReply({
+              payload,
+              channel: normalizedOriginChannel,
+              to: normalizedOriginTo,
+              sessionKey: params.dispatchSessionKey,
+              accountId: params.delivery?.accountId,
+              threadId: params.delivery?.threadId,
+              cfg: params.cfg,
+            });
+            if (!routed.ok) {
+              logWarn(`session event dispatch delivery failed: ${routed.error ?? "unknown error"}`);
+            }
+          },
+          onError: (err, info) => {
+            logWarn(`session event dispatch ${info.kind} failed: ${String(err)}`);
+          },
+        },
+        replyOptions: {
+          suppressTyping: true,
+          allowEmptyBodyForSystemEvent: true,
+          onModelSelected,
+        },
+      }),
+      new Promise<never>((_resolve, reject) => {
+        timeoutHandle = setTimeout(
+          () =>
+            reject(
+              new Error(`session event dispatch timed out (${DEFAULT_DISPATCH_TIMEOUT_MS}ms)`),
+            ),
+          DEFAULT_DISPATCH_TIMEOUT_MS,
+        );
+        timeoutHandle.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+function queuePendingSessionRun(params: {
+  sessionKey: string;
+  source: string;
+  agentId?: string;
+  requestedAt?: number;
+}) {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    return;
+  }
+  const source = params.source.trim() || "system-event";
+  const requestedAt = params.requestedAt ?? Date.now();
+  const key = getPendingKey({ sessionKey });
+  const next: PendingSessionEventRun = {
+    sessionKey,
+    source,
+    agentId: normalizePendingTarget(params.agentId),
+    requestedAt,
+  };
+  const previous = pendingSessionRuns.get(key);
+  if (!previous || next.requestedAt >= previous.requestedAt) {
+    pendingSessionRuns.set(key, next);
+  }
+}
+
+function schedulePendingSessionRuns(delayMs: number, kind: WakeTimerKind = "normal") {
+  const delay = Number.isFinite(delayMs) ? Math.max(0, delayMs) : DEFAULT_COALESCE_MS;
+  const dueAt = Date.now() + delay;
+  if (runTimer) {
+    // Keep retry cooldown as a minimum so normal coalescing cannot collapse backoff.
+    if (runTimerKind === "retry") {
+      return;
+    }
+    if (typeof runTimerDueAt === "number" && runTimerDueAt <= dueAt) {
+      return;
+    }
+    clearTimeout(runTimer);
+    runTimer = null;
+    runTimerDueAt = null;
+    runTimerKind = null;
+  }
+  runTimerDueAt = dueAt;
+  runTimerKind = kind;
+  runTimer = setTimeout(async () => {
+    runTimer = null;
+    runTimerDueAt = null;
+    runTimerKind = null;
+    if (running) {
+      schedulePendingSessionRuns(delay, kind);
+      return;
+    }
+
+    const batch = Array.from(pendingSessionRuns.values());
+    pendingSessionRuns.clear();
+    running = true;
+    try {
+      for (const pending of batch) {
+        let result: SessionEventRunResult;
+        try {
+          result = await runSessionEventOnce(pending);
+        } catch (err) {
+          // Isolate failures per session target so one bad run does not drop
+          // unrelated queued wakes from the same drain batch.
+          logWarn(
+            `session event run failed: source=${pending.source} session=${pending.sessionKey} error=${String(err)}`,
+          );
+          queuePendingSessionRun({
+            sessionKey: pending.sessionKey,
+            source: pending.source,
+            agentId: pending.agentId,
+          });
+          schedulePendingSessionRuns(DEFAULT_RETRY_MS, "retry");
+          continue;
+        }
+        if (result.status === "skipped" && result.reason === "requests-in-flight") {
+          queuePendingSessionRun({
+            sessionKey: pending.sessionKey,
+            source: pending.source,
+            agentId: pending.agentId,
+          });
+          schedulePendingSessionRuns(DEFAULT_RETRY_MS, "retry");
+        }
+      }
+    } catch (err) {
+      logWarn(`session event run failed: ${String(err)}`);
+    } finally {
+      running = false;
+      if (pendingSessionRuns.size > 0) {
+        schedulePendingSessionRuns(DEFAULT_COALESCE_MS, "normal");
+      }
+    }
+  }, delay);
+  runTimer.unref?.();
+}
+
+async function runSessionEventOnce(params: {
+  sessionKey: string;
+  source: string;
+  agentId?: string;
+}): Promise<SessionEventRunResult> {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    return { status: "skipped", reason: "invalid-session" };
+  }
+
+  const { cfg, canonicalKey, entry, legacyKey, store } = loadSessionEntry(sessionKey);
+  if (!isAgentScopedSessionKey(canonicalKey)) {
+    return { status: "skipped", reason: "non-agent-session" };
+  }
+  const { storeKeys } = resolveGatewaySessionStoreTarget({
+    cfg,
+    key: sessionKey,
+    store,
+    scanLegacyKeys: true,
+  });
+  const candidateSessionKeys = resolveSessionEventQueueKeys([
+    ...storeKeys,
+    canonicalKey,
+    sessionKey,
+    legacyKey,
+  ]);
+  const dispatchSessionKey = resolveSessionEventQueueKey(candidateSessionKeys);
+  if (!dispatchSessionKey) {
+    return { status: "skipped", reason: "no-system-events" };
+  }
+  if (getQueueSize(CommandLane.Main) > 0) {
+    return { status: "skipped", reason: "requests-in-flight" };
+  }
+
+  const delivery = deliveryContextFromSession(entry);
+  // Follow-up: internal webchat sessions are currently non-routable in route-reply,
+  // so event-driven runs may not produce outbound replies on webchat-bound sessions.
+  const resolvedAgentId = params.agentId ?? resolveAgentIdFromSessionKey(canonicalKey);
+  const source = params.source.trim() || "system-event";
+  await dispatchSessionEventWithTimeout({
+    cfg,
+    dispatchSessionKey,
+    source,
+    agentId: resolvedAgentId,
+    delivery,
+  });
+  for (const nextSessionKey of candidateSessionKeys) {
+    if (nextSessionKey === dispatchSessionKey) {
+      continue;
+    }
+    if (!hasSystemEvents(nextSessionKey)) {
+      continue;
+    }
+    // Mixed alias/canonical keys can hold separate queued system events for the
+    // same logical session. Queue a follow-up run so both queues drain.
+    queuePendingSessionRun({
+      sessionKey: nextSessionKey,
+      source,
+      agentId: params.agentId,
+    });
+  }
+
+  return { status: "ran" };
+}
+
+export async function triggerSessionEventRun(params: {
+  sessionKey: string;
+  source: string;
+  agentId?: string;
+}): Promise<boolean> {
+  const result = await runSessionEventOnce(params);
+  return result.status === "ran";
+}
+
+export function requestSessionEventRun(params: {
+  sessionKey: string;
+  source: string;
+  agentId?: string;
+}) {
+  queuePendingSessionRun(params);
+  schedulePendingSessionRuns(DEFAULT_COALESCE_MS, "normal");
+}
+
+export function resetSessionEventRunStateForTests() {
+  if (runTimer) {
+    clearTimeout(runTimer);
+  }
+  runTimer = null;
+  runTimerDueAt = null;
+  runTimerKind = null;
+  pendingSessionRuns.clear();
+  running = false;
+}

--- a/src/infra/session-event-target.ts
+++ b/src/infra/session-event-target.ts
@@ -1,0 +1,3 @@
+export function isAgentScopedSessionKey(sessionKey?: string): boolean {
+  return typeof sessionKey === "string" && sessionKey.trim().toLowerCase().startsWith("agent:");
+}

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -55,6 +55,7 @@ type SystemRunExecutionContext = {
   sessionKey: string;
   runId: string;
   cmdText: string;
+  wakeOnExit: boolean;
 };
 
 type ResolvedExecApprovals = ReturnType<typeof resolveExecApprovals>;
@@ -161,6 +162,7 @@ async function sendSystemRunDenied(
       runId: execution.runId,
       host: "node",
       command: execution.cmdText,
+      ...(execution.wakeOnExit ? { wakeOnExit: true } : {}),
       reason: params.reason,
     }),
   );
@@ -200,6 +202,7 @@ async function parseSystemRunPhase(
   const agentId = opts.params.agentId?.trim() || undefined;
   const sessionKey = opts.params.sessionKey?.trim() || "node";
   const runId = opts.params.runId?.trim() || crypto.randomUUID();
+  const wakeOnExit = opts.params.wakeOnExit === true;
   const envOverrides = sanitizeSystemRunEnvOverrides({
     overrides: opts.params.env ?? undefined,
     shellWrapper: shellCommand !== null,
@@ -211,7 +214,7 @@ async function parseSystemRunPhase(
     agentId,
     sessionKey,
     runId,
-    execution: { sessionKey, runId, cmdText },
+    execution: { sessionKey, runId, cmdText, wakeOnExit },
     approvalDecision: resolveExecApprovalDecision(opts.params.approvalDecision),
     envOverrides,
     env: opts.sanitizeEnv(envOverrides),
@@ -401,6 +404,7 @@ async function executeSystemRunPhase(
         sessionKey: phase.sessionKey,
         runId: phase.runId,
         cmdText: phase.cmdText,
+        wakeOnExit: phase.execution.wakeOnExit,
         result,
       });
       await opts.sendInvokeResult({
@@ -468,6 +472,7 @@ async function executeSystemRunPhase(
     sessionKey: phase.sessionKey,
     runId: phase.runId,
     cmdText: phase.cmdText,
+    wakeOnExit: phase.execution.wakeOnExit,
     result,
   });
 

--- a/src/node-host/invoke-types.ts
+++ b/src/node-host/invoke-types.ts
@@ -9,6 +9,7 @@ export type SystemRunParams = {
   needsScreenRecording?: boolean | null;
   agentId?: string | null;
   sessionKey?: string | null;
+  wakeOnExit?: boolean | null;
   approved?: boolean | null;
   approvalDecision?: string | null;
   runId?: string | null;
@@ -29,6 +30,7 @@ export type ExecEventPayload = {
   runId: string;
   host: string;
   command?: string;
+  wakeOnExit?: boolean;
   exitCode?: number;
   timedOut?: boolean;
   success?: boolean;
@@ -49,6 +51,7 @@ export type ExecFinishedEventParams = {
   sessionKey: string;
   runId: string;
   cmdText: string;
+  wakeOnExit: boolean;
   result: ExecFinishedResult;
 };
 

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -351,6 +351,7 @@ async function sendExecFinishedEvent(
       runId: params.runId,
       host: "node",
       command: params.cmdText,
+      ...(params.wakeOnExit ? { wakeOnExit: true } : {}),
       exitCode: params.result.exitCode ?? undefined,
       timedOut: params.result.timedOut,
       success: params.result.success,
@@ -548,8 +549,8 @@ export async function handleInvoke(
     sendInvokeResult: async (result) => {
       await sendInvokeResult(client, frame, result);
     },
-    sendExecFinishedEvent: async ({ sessionKey, runId, cmdText, result }) => {
-      await sendExecFinishedEvent({ client, sessionKey, runId, cmdText, result });
+    sendExecFinishedEvent: async ({ sessionKey, runId, cmdText, wakeOnExit, result }) => {
+      await sendExecFinishedEvent({ client, sessionKey, runId, cmdText, wakeOnExit, result });
     },
     preferMacAppExecHost,
   });


### PR DESCRIPTION
## Summary
- Add run-level wakeOnExit parameter (default false) for exec.
- When wakeOnExit=true, background exec completion events enqueue system events and trigger immediate session-event runs (agent-scoped sessions).
- Keep default behavior unchanged when wakeOnExit=false (enqueue plus heartbeat path).
- Preserve alias session key wake behavior (main and canonical agent session keys).
- Include denied-event wake parity in gateway node events when wakeOnExit=true.
- Add coverage for runtime wake behavior, session-event dispatch, and node gateway lifecycle handling.

## Validation
- bun x vitest run src/agents/bash-tools.exec-runtime.wake-on-exit.test.ts src/infra/session-event-run.test.ts src/gateway/server-node-events.test.ts

Replaces #32302 (which replaced #31981).