### PR TITLE
fix(agents): guard gemini schema properties against null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gemini schema sanitization: coerce malformed JSON Schema `properties` values (`null`, arrays, primitives) to `{}` before provider validation, preventing downstream strict-validator crashes on invalid plugin/tool schemas. (#32332) Thanks @webdevtodayjason.
 - OpenAI/Responses WebSocket tool-call id hygiene: normalize blank/whitespace streamed tool-call ids before persistence, and block empty `function_call_output.call_id` payloads in the WS conversion path to avoid OpenAI 400 errors (`Invalid 'input[n].call_id': empty string`), with regression coverage for both inbound stream normalization and outbound payload guards.
 - Gateway/Control UI basePath webhook passthrough: let non-read methods under configured `controlUiBasePath` fall through to plugin routes (instead of returning Control UI 405), restoring webhook handlers behind basePath mounts. (#32311) Thanks @ademczuk.
 - CLI/Config validation and routing hardening: dedupe `openclaw config validate` failures to a single authoritative report, expose allowed-values metadata/hints across core Zod and plugin AJV validation (including `--json` fields), sanitize terminal-rendered validation text, and make command-path parsing root-option-aware across preaction/route/lazy registration (including routed `config get/unset` with split root options). Thanks @gumadeiras.

--- a/src/agents/schema/clean-for-gemini.test.ts
+++ b/src/agents/schema/clean-for-gemini.test.ts
@@ -21,6 +21,15 @@ describe("cleanSchemaForGemini", () => {
     expect(cleaned.properties).toEqual({});
   });
 
+  it("coerces array properties to an empty object", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: [],
+    }) as { properties?: unknown };
+
+    expect(cleaned.properties).toEqual({});
+  });
+
   it("coerces nested null properties while preserving valid siblings", () => {
     const cleaned = cleanSchemaForGemini({
       type: "object",

--- a/src/agents/schema/clean-for-gemini.test.ts
+++ b/src/agents/schema/clean-for-gemini.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { cleanSchemaForGemini } from "./clean-for-gemini.js";
+
+describe("cleanSchemaForGemini", () => {
+  it("coerces null properties to an empty object", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: null,
+    }) as { type?: unknown; properties?: unknown };
+
+    expect(cleaned.type).toBe("object");
+    expect(cleaned.properties).toEqual({});
+  });
+
+  it("coerces non-object properties to an empty object", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: "invalid",
+    }) as { properties?: unknown };
+
+    expect(cleaned.properties).toEqual({});
+  });
+
+  it("coerces nested null properties while preserving valid siblings", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: {
+        bad: {
+          type: "object",
+          properties: null,
+        },
+        good: {
+          type: "string",
+        },
+      },
+    }) as {
+      properties?: {
+        bad?: { properties?: unknown };
+        good?: { type?: unknown };
+      };
+    };
+
+    expect(cleaned.properties?.bad?.properties).toEqual({});
+    expect(cleaned.properties?.good?.type).toBe("string");
+  });
+});

--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -304,14 +304,20 @@ function cleanSchemaForGeminiWithDefs(
       continue;
     }
 
-    if (key === "properties" && value && typeof value === "object") {
-      const props = value as Record<string, unknown>;
-      cleaned[key] = Object.fromEntries(
-        Object.entries(props).map(([k, v]) => [
-          k,
-          cleanSchemaForGeminiWithDefs(v, nextDefs, refStack),
-        ]),
-      );
+    if (key === "properties") {
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        const props = value as Record<string, unknown>;
+        cleaned[key] = Object.fromEntries(
+          Object.entries(props).map(([k, v]) => [
+            k,
+            cleanSchemaForGeminiWithDefs(v, nextDefs, refStack),
+          ]),
+        );
+      } else {
+        // Guard malformed schemas (e.g. properties: null) that can trigger
+        // downstream Object.* crashes in strict provider validators.
+        cleaned[key] = {};
+      }
     } else if (key === "items" && value) {
       if (Array.isArray(value)) {
         cleaned[key] = value.map((entry) =>


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Vertex/Gemini tool-schema handling can receive malformed schemas where `properties` is `null`/non-object, which can lead to downstream `Object.*` conversion failures in strict validators.
- Why it matters: This failure mode is hard to trace from embedded-run summary logs and can abort Vertex-backed runs.
- What changed: `cleanSchemaForGemini` now coerces invalid `properties` values to `{}` and keeps recursive schema cleaning behavior.
- What did NOT change (scope boundary): No model routing/auth changes, no provider config changes, and no runtime transport changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #32245

## User-visible / Behavior Changes

- Vertex/Gemini tool-schema sanitation is more defensive: malformed `properties` values are normalized to `{}` instead of passing through.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.22.0 and Node v25.5.0
- Model/provider: Google Gemini / Vertex schema cleaning path
- Integration/channel (if any): N/A (unit tests)
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm vitest run src/agents/schema/clean-for-gemini.test.ts src/agents/schema/clean-for-xai.test.ts`.
2. Run `npx -y node@25.5.0 ./node_modules/vitest/vitest.mjs run src/agents/schema/clean-for-gemini.test.ts`.

### Expected

- Gemini schema cleaning handles malformed `properties` robustly.

### Actual

- Pass. `properties: null` and non-object `properties` are coerced to `{}`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: top-level and nested `properties: null`, and non-object `properties` values.
- Edge cases checked: behavior on Node 25.5.0.
- What you did **not** verify: live Vertex end-to-end gateway run with reporter environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `fix(agents): guard gemini tool schema properties against null`.
- Files/config to restore: `src/agents/schema/clean-for-gemini.ts`.
- Known bad symptoms reviewers should watch for: unexpected schema mutation where malformed `properties` was previously passed through.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Sanitizing malformed `properties` could hide upstream bad schema authorship.
  - Mitigation: Scope is narrow (only invalid values), and tests document exact coercion behavior.
