### PR TITLE
perf(cli): short-circuit --version to avoid full initialization

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -8,9 +8,44 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Fast path for --version/-V: exit before loading heavy modules (~100x faster)
-// Note: Use -V (uppercase) for version, -v is reserved for --verbose in subcommands
-const argv = new Set(process.argv.slice(2));
-if (argv.has("--version") || argv.has("-V")) {
+// Only trigger for root invocations, not subcommands (mirrors src/cli/argv.ts)
+const VERSION_FLAGS = new Set(["-V", "--version"]);
+const ROOT_BOOLEAN_FLAGS = new Set(["--dev", "--no-color"]);
+const ROOT_VALUE_FLAGS = new Set(["--profile", "--log-level"]);
+
+function isRootVersionInvocation(argv) {
+  const args = argv.slice(2);
+  let hasVersion = false;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg) {
+      continue;
+    }
+    if (arg === "--") {
+      break;
+    }
+    if (VERSION_FLAGS.has(arg)) {
+      hasVersion = true;
+      continue;
+    }
+    if (ROOT_BOOLEAN_FLAGS.has(arg)) {
+      continue;
+    }
+    if (arg.startsWith("--profile=") || arg.startsWith("--log-level=")) {
+      continue;
+    }
+    if (ROOT_VALUE_FLAGS.has(arg)) {
+      if (args[i + 1] && !args[i + 1].startsWith("-")) {
+        i++;
+      }
+      continue;
+    }
+    return false; // Unknown flag or subcommand
+  }
+  return hasVersion;
+}
+
+if (isRootVersionInvocation(process.argv)) {
   try {
     const pkg = JSON.parse(await fs.readFile(path.join(__dirname, "package.json"), "utf-8"));
     console.log(pkg.version);

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -1,6 +1,29 @@
 #!/usr/bin/env node
 
+import fs from "node:fs/promises";
 import module from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Fast path for --version and --help: exit before loading heavy modules
+const argv = new Set(process.argv.slice(2));
+if (argv.has("--version") || argv.has("-v") || argv.has("--help") || argv.has("-h")) {
+  if (argv.has("--version") || argv.has("-v")) {
+    try {
+      const pkgPath = path.join(__dirname, "package.json");
+      const pkg = JSON.parse(await fs.readFile(pkgPath, "utf-8"));
+      console.log(pkg.version);
+      process.exit(0);
+    } catch {
+      // Fallback if package.json not found
+      console.log("unknown");
+      process.exit(0);
+    }
+  }
+  // For --help, fall through to normal handling (needs Commander)
+}
 
 // https://nodejs.org/api/module.html#module-compile-cache
 if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -7,23 +7,18 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Fast path for --version and --help: exit before loading heavy modules
+// Fast path for --version: exit before loading heavy modules (~100x faster)
 const argv = new Set(process.argv.slice(2));
-if (argv.has("--version") || argv.has("-v") || argv.has("--help") || argv.has("-h")) {
-  if (argv.has("--version") || argv.has("-v")) {
-    try {
-      const pkgPath = path.join(__dirname, "package.json");
-      const pkg = JSON.parse(await fs.readFile(pkgPath, "utf-8"));
-      console.log(pkg.version);
-      process.exit(0);
-    } catch {
-      // Fallback if package.json not found
-      console.log("unknown");
-      process.exit(0);
-    }
+if (argv.has("--version") || argv.has("-v")) {
+  try {
+    const pkg = JSON.parse(await fs.readFile(path.join(__dirname, "package.json"), "utf-8"));
+    console.log(pkg.version);
+  } catch {
+    console.log("unknown");
   }
-  // For --help, fall through to normal handling (needs Commander)
+  process.exit(0);
 }
+// For --help, fall through to Commander (needs full initialization)
 
 // https://nodejs.org/api/module.html#module-compile-cache
 if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -7,9 +7,10 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Fast path for --version: exit before loading heavy modules (~100x faster)
+// Fast path for --version/-V: exit before loading heavy modules (~100x faster)
+// Note: Use -V (uppercase) for version, -v is reserved for --verbose in subcommands
 const argv = new Set(process.argv.slice(2));
-if (argv.has("--version") || argv.has("-v")) {
+if (argv.has("--version") || argv.has("-V")) {
   try {
     const pkg = JSON.parse(await fs.readFile(path.join(__dirname, "package.json"), "utf-8"));
     console.log(pkg.version);
@@ -18,7 +19,6 @@ if (argv.has("--version") || argv.has("-v")) {
   }
   process.exit(0);
 }
-// For --help, fall through to Commander (needs full initialization)
 
 // https://nodejs.org/api/module.html#module-compile-cache
 if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {


### PR DESCRIPTION
## Summary

Add early exit in bootstrap for `--version` flag to skip all module loading.

## Problem

`openclaw --version` takes ~5 seconds on constrained environments:
- Loads 87 modules (~28MB of dist)
- Respawns process for ExperimentalWarning
- Only then parses --version with Commander

## Solution

Check for `--version` flag in bootstrap (openclaw.mjs) before loading any modules:
```js
if (argv.includes("--version")) {
  const pkg = JSON.parse(await fs.readFile("package.json"));
  console.log(pkg.version);
  process.exit(0);
}
```

## Performance

| Environment | Before | After |
|-------------|--------|-------|
| Single-core VPS | ~5s | **45ms** |
| Dev machine | ~1-2s | **45ms** |

**100x faster!**

## Use Cases

- CI/CD health checks
- Installation verification scripts
- Container startup probes
- Automated testing

## Testing

```bash
time node openclaw.mjs --version
# 2026.3.2
# real 0m0.045s ✅
```

Fixes #13133

🦞