### PR TITLE
fix(discord): push connected status when gateway already connected at lifecycle start

### DIFF
--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -408,4 +408,40 @@ describe("runDiscordGatewayLifecycle", () => {
       vi.useRealTimers();
     }
   });
+
+  it("does not push connected: true when abortSignal is already aborted", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const emitter = new EventEmitter();
+    const gateway = {
+      isConnected: true,
+      options: { reconnect: { maxAttempts: 3 } },
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      emitter,
+    };
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const statusUpdates: Array<Record<string, unknown>> = [];
+    const statusSink = (patch: Record<string, unknown>) => {
+      statusUpdates.push({ ...patch });
+    };
+
+    const { lifecycleParams } = createLifecycleHarness({ gateway });
+    lifecycleParams.abortSignal = abortController.signal;
+    (lifecycleParams as Record<string, unknown>).statusSink = statusSink;
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+    // onAbort should have pushed connected: false
+    const connectedFalse = statusUpdates.find((s) => s.connected === false);
+    expect(connectedFalse).toBeDefined();
+
+    // No connected: true should appear — the isConnected check must be
+    // guarded by !lifecycleStopping to avoid contradicting the abort.
+    const connectedTrue = statusUpdates.find((s) => s.connected === true);
+    expect(connectedTrue).toBeUndefined();
+  });
 });

--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -77,6 +77,7 @@ describe("runDiscordGatewayLifecycle", () => {
     const runtimeError = vi.fn();
     const runtimeExit = vi.fn();
     const releaseEarlyGatewayErrorGuard = vi.fn();
+    const statusSink = vi.fn();
     const runtime: RuntimeEnv = {
       log: runtimeLog,
       error: runtimeError,
@@ -89,6 +90,7 @@ describe("runDiscordGatewayLifecycle", () => {
       runtimeLog,
       runtimeError,
       releaseEarlyGatewayErrorGuard,
+      statusSink,
       lifecycleParams: {
         accountId: params?.accountId ?? "default",
         client: {
@@ -102,6 +104,7 @@ describe("runDiscordGatewayLifecycle", () => {
         threadBindings: { stop: threadStop },
         pendingGatewayErrors: params?.pendingGatewayErrors,
         releaseEarlyGatewayErrorGuard,
+        statusSink,
       },
     };
   };
@@ -201,6 +204,26 @@ describe("runDiscordGatewayLifecycle", () => {
       waitCalls: 1,
       releaseEarlyGatewayErrorGuard,
     });
+  });
+
+  it("pushes connected status when gateway is already connected at lifecycle start", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const { emitter, gateway } = createGatewayHarness();
+    gateway.isConnected = true;
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    const { lifecycleParams, statusSink } = createLifecycleHarness({ gateway });
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+    const connectedCall = statusSink.mock.calls.find(
+      ([patch]: [Record<string, unknown>]) => patch.connected === true,
+    );
+    expect(connectedCall).toBeDefined();
+    expect(connectedCall![0]).toMatchObject({
+      connected: true,
+      lastDisconnect: null,
+    });
+    expect(connectedCall![0].lastConnectedAt).toBeTypeOf("number");
   });
 
   it("handles queued disallowed intents errors without waiting for gateway events", async () => {

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -244,6 +244,19 @@ export async function runDiscordGatewayLifecycle(params: {
   };
   gatewayEmitter?.on("debug", onGatewayDebug);
 
+  // If the gateway is already connected when the lifecycle starts (the
+  // "WebSocket connection opened" debug event was emitted before we
+  // registered the listener above), push the initial connected status now.
+  if (gateway?.isConnected) {
+    const at = Date.now();
+    pushStatus({
+      connected: true,
+      lastEventAt: at,
+      lastConnectedAt: at,
+      lastDisconnect: null,
+    });
+  }
+
   let sawDisallowedIntents = false;
   const logGatewayError = (err: unknown) => {
     if (params.isDisallowedIntentsError(err)) {

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -247,7 +247,10 @@ export async function runDiscordGatewayLifecycle(params: {
   // If the gateway is already connected when the lifecycle starts (the
   // "WebSocket connection opened" debug event was emitted before we
   // registered the listener above), push the initial connected status now.
-  if (gateway?.isConnected) {
+  // Guard against lifecycleStopping: if the abortSignal was already aborted,
+  // onAbort() ran synchronously above and pushed connected: false — don't
+  // contradict it with a spurious connected: true.
+  if (gateway?.isConnected && !lifecycleStopping) {
     const at = Date.now();
     pushStatus({
       connected: true,


### PR DESCRIPTION
## Summary

- When `runDiscordGatewayLifecycle` starts, it registers a debug event listener to track `"WebSocket connection opened"` events and push `connected: true` to the channel status sink.
- If the gateway completes its READY handshake *before* the lifecycle registers the listener (a race window of ~30ms observed in production), the initial event is missed and `connected` stays `undefined`.
- The health monitor (`channel-health-monitor.ts`) treats `connected === false` (or undefined, which is falsy) as unhealthy and triggers a restart every check cycle, creating a restart loop.
- This adds a `gateway.isConnected` check immediately after listener registration to catch the already-connected case.

## Reproduction

1. Discord gateway connects and emits READY before `runDiscordGatewayLifecycle` registers its debug listener
2. `connected` is never set to `true` in channel runtime
3. Health monitor detects `running: true, connected: false` → restarts channel as "stuck"
4. Restart reconnects, same race happens again → infinite restart loop every ~10 minutes

## Test plan

- [x] Added test: `pushes connected status when gateway is already connected at lifecycle start`
- [x] Existing lifecycle tests pass (10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)