### PR TITLE
fix(discord): add missing accountId to DiscordReactionRoutingParams

### DIFF
--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -49,6 +49,7 @@ type DiscordReactionListenerParams = {
 } & DiscordReactionRoutingParams;
 
 type DiscordReactionRoutingParams = {
+  accountId: string;
   botUserId?: string;
   dmEnabled: boolean;
   groupDmEnabled: boolean;


### PR DESCRIPTION
## Summary

- `accountId` was passed at construction time (`provider.ts:569`) and used inside `handleDiscordReactionEvent` (lines 210, 369, 424) but was missing from the `DiscordReactionRoutingParams` type definition
- This caused 4 TypeScript errors during the `build:plugin-sdk:dts` step (`tsconfig.plugin-sdk.dts.json`), breaking Docker builds
- Fix: add `accountId: string` to `DiscordReactionRoutingParams`

Closes #32204

## Test plan

- [x] `npx tsc -p tsconfig.plugin-sdk.dts.json --noEmit` passes (previously 4 errors)
- [x] All 262 Discord monitor tests pass (30 test files)
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)