### PR TITLE
fix(webui): prevent inline code from breaking mid-token on copy/paste

### DIFF
--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -60,6 +60,8 @@
   background: rgba(0, 0, 0, 0.15);
   padding: 0.15em 0.4em;
   border-radius: 4px;
+  overflow-wrap: normal;
+  word-break: keep-all;
 }
 
 .chat-text :where(pre) {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1895,6 +1895,8 @@
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--secondary);
+  overflow-wrap: normal;
+  word-break: keep-all;
 }
 
 :root[data-theme="light"] .chat-text :where(:not(pre) > code) {


### PR DESCRIPTION
## Summary

Fixes #32230 — Copying inline `<code>` text (UUIDs, hashes, long tokens) from webchat injects spaces at line-break points.

**Root cause**: `.chat-text` applies `overflow-wrap: anywhere; word-break: break-word;` which forces long uninterrupted strings inside inline `<code>` to break across visual lines. When the user selects and copies, the browser clipboard captures implied line breaks as spaces — corrupting the pasted value.

**Fix**: Override with `overflow-wrap: normal; word-break: keep-all;` on inline `<code>` selectors (`.chat-text :where(:not(pre) > code)`) so tokens stay intact when copied. Pre-formatted code blocks (`<pre>`) already use `overflow-x: auto` and are unaffected.

## Changes

| File | Change |
|------|--------|
| `ui/src/styles/chat/text.css` | Add `overflow-wrap: normal; word-break: keep-all;` to inline code (+2) |
| `ui/src/styles/components.css` | Same override on the duplicate inline code selector (+2) |

## Test plan

- [x] CSS-only change — no runtime logic affected
- [x] `<pre>` code blocks unaffected (already use `overflow-x: auto`)
- [x] Verified both light and dark theme selectors are covered
- [x] oxlint: 0 warnings

lobster-biscuit