### PR TITLE
fix(telegram): use retry logic for sticker getFile calls

### DIFF
--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -31,7 +31,7 @@ const MAX_MEDIA_BYTES = 10_000_000;
 const BOT_TOKEN = "tok123";
 
 function makeCtx(
-  mediaField: "voice" | "audio" | "photo" | "video" | "document" | "animation",
+  mediaField: "voice" | "audio" | "photo" | "video" | "document" | "animation" | "sticker",
   getFile: TelegramContext["getFile"],
   opts?: { file_name?: string },
 ): TelegramContext {
@@ -77,6 +77,17 @@ function makeCtx(
       width: 200,
       height: 200,
       ...(opts?.file_name && { file_name: opts.file_name }),
+    };
+  }
+  if (mediaField === "sticker") {
+    msg.sticker = {
+      file_id: "stk1",
+      file_unique_id: "ustk1",
+      type: "regular",
+      width: 512,
+      height: 512,
+      is_animated: false,
+      is_video: false,
     };
   }
   return {
@@ -242,6 +253,45 @@ describe("resolveMedia getFile retry", () => {
     const result = await expectTransientGetFileRetrySuccess();
     // Should retry transient errors.
     expect(result).not.toBeNull();
+  });
+
+  it("retries getFile for stickers on transient failure", async () => {
+    const getFile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Network request for 'getFile' failed!"))
+      .mockResolvedValueOnce({ file_path: "stickers/file_0.webp" });
+
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("sticker-data"),
+      contentType: "image/webp",
+      fileName: "file_0.webp",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_0.webp",
+      contentType: "image/webp",
+    });
+
+    const ctx = makeCtx("sticker", getFile);
+    const promise = resolveMedia(ctx, MAX_MEDIA_BYTES, BOT_TOKEN);
+    await flushRetryTimers();
+    const result = await promise;
+
+    expect(getFile).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(
+      expect.objectContaining({ path: "/tmp/file_0.webp", placeholder: "<media:sticker>" }),
+    );
+  });
+
+  it("returns null for sticker when getFile exhausts retries", async () => {
+    const getFile = vi.fn().mockRejectedValue(new Error("Network request for 'getFile' failed!"));
+
+    const ctx = makeCtx("sticker", getFile);
+    const promise = resolveMedia(ctx, MAX_MEDIA_BYTES, BOT_TOKEN);
+    await flushRetryTimers();
+    const result = await promise;
+
+    expect(getFile).toHaveBeenCalledTimes(3);
+    expect(result).toBeNull();
   });
 });
 

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -156,8 +156,8 @@ async function resolveStickerMedia(params: {
   }
 
   try {
-    const file = await ctx.getFile();
-    if (!file.file_path) {
+    const file = await resolveTelegramFileWithRetry(ctx);
+    if (!file?.file_path) {
       logVerbose("telegram: getFile returned no file_path for sticker");
       return null;
     }


### PR DESCRIPTION
## Summary

- Sticker downloads called `ctx.getFile()` directly without retry, while all other media types used `resolveTelegramFileWithRetry()` (3 attempts, 1-4s delay with jitter)
- This made stickers vulnerable to transient Telegram API failures, especially in group topics where file availability can be delayed
- Now stickers use the same retry helper as all other media types

Refs #32326

## Changes

- **`delivery.resolve-media.ts`**: Replace direct `ctx.getFile()` in `resolveStickerMedia` with `resolveTelegramFileWithRetry(ctx)`, adding null-check for the retry helper's return value
- **`delivery.resolve-media-retry.test.ts`**: Add `sticker` to `makeCtx` helper and two new tests for sticker retry behavior

## Test plan

- [x] All 18 media retry tests pass (16 existing + 2 new sticker tests)
- [x] All 77 Telegram bot tests pass (3 test files)
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)