### PR TITLE
fix(memoryFlush): guard transcript-size forced flush against repeated runs

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -31,6 +31,7 @@ import {
   resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
 import {
+  hasAlreadyFlushedForCurrentCompaction,
   resolveMemoryFlushContextWindowTokens,
   resolveMemoryFlushPromptForRun,
   resolveMemoryFlushSettings,
@@ -437,7 +438,9 @@ export async function runMemoryFlushIfNeeded(params: {
         reserveTokensFloor: memoryFlushSettings.reserveTokensFloor,
         softThresholdTokens: memoryFlushSettings.softThresholdTokens,
       })) ||
-    shouldForceFlushByTranscriptSize;
+    (shouldForceFlushByTranscriptSize &&
+      entry != null &&
+      !hasAlreadyFlushedForCurrentCompaction(entry));
 
   if (!shouldFlushMemory) {
     return entry ?? params.sessionEntry;

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -161,11 +161,22 @@ export function shouldRunMemoryFlush(params: {
     return false;
   }
 
-  const compactionCount = params.entry.compactionCount ?? 0;
-  const lastFlushAt = params.entry.memoryFlushCompactionCount;
-  if (typeof lastFlushAt === "number" && lastFlushAt === compactionCount) {
+  if (hasAlreadyFlushedForCurrentCompaction(params.entry)) {
     return false;
   }
 
   return true;
+}
+
+/**
+ * Returns true when a memory flush has already been performed for the current
+ * compaction cycle. This prevents repeated flush runs within the same cycle —
+ * important for both the token-based and transcript-size–based trigger paths.
+ */
+export function hasAlreadyFlushedForCurrentCompaction(
+  entry: Pick<SessionEntry, "compactionCount" | "memoryFlushCompactionCount">,
+): boolean {
+  const compactionCount = entry.compactionCount ?? 0;
+  const lastFlushAt = entry.memoryFlushCompactionCount;
+  return typeof lastFlushAt === "number" && lastFlushAt === compactionCount;
 }

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -17,6 +17,7 @@ import {
 import {
   DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES,
   DEFAULT_MEMORY_FLUSH_SOFT_TOKENS,
+  hasAlreadyFlushedForCurrentCompaction,
   resolveMemoryFlushContextWindowTokens,
   resolveMemoryFlushSettings,
   shouldRunMemoryFlush,
@@ -347,6 +348,42 @@ describe("shouldRunMemoryFlush", () => {
         softThresholdTokens: 2_000,
       }),
     ).toBe(false);
+  });
+});
+
+describe("hasAlreadyFlushedForCurrentCompaction", () => {
+  it("returns true when memoryFlushCompactionCount matches compactionCount", () => {
+    expect(
+      hasAlreadyFlushedForCurrentCompaction({
+        compactionCount: 3,
+        memoryFlushCompactionCount: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when memoryFlushCompactionCount differs", () => {
+    expect(
+      hasAlreadyFlushedForCurrentCompaction({
+        compactionCount: 3,
+        memoryFlushCompactionCount: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when memoryFlushCompactionCount is undefined", () => {
+    expect(
+      hasAlreadyFlushedForCurrentCompaction({
+        compactionCount: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats missing compactionCount as 0", () => {
+    expect(
+      hasAlreadyFlushedForCurrentCompaction({
+        memoryFlushCompactionCount: 0,
+      }),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #32317 — Pre-compaction memory flush fires on every message after v2026.3.1 upgrade.

**Root cause**: `agent-runner-memory.ts:440` — the `shouldForceFlushByTranscriptSize` path (introduced in `d729ab21`) is OR'd into the flush decision without the `memoryFlushCompactionCount` guard. The token-based path in `shouldRunMemoryFlush()` correctly checks `memoryFlushCompactionCount === compactionCount` to prevent repeated flushes within the same compaction cycle, but the transcript-size path bypasses this check.

With tool calls and heartbeats, transcript file size grows fast in bytes even at low token counts (reporter shows 49k/200k tokens). Once the 2 MB `forceFlushTranscriptBytes` default is crossed, forced flush fires on every single message.

**Fix**: Extract `hasAlreadyFlushedForCurrentCompaction()` from the inline guard and apply it to both trigger paths.

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/reply/memory-flush.ts` | Extract `hasAlreadyFlushedForCurrentCompaction()` helper (+14/-3) |
| `src/auto-reply/reply/agent-runner-memory.ts` | Apply compaction guard to transcript-size flush path (+4/-1) |
| `src/auto-reply/reply/reply-state.test.ts` | Add 4 tests for `hasAlreadyFlushedForCurrentCompaction()` (+37) |

## Test plan

- [x] `vitest run src/auto-reply/reply/reply-state.test.ts`: 27/27 pass
- [x] Build: PASS (tsc --noEmit, pre-existing upstream errors only)
- [x] Lint: 0 warnings (oxlint)
- [x] Format: PASS (oxfmt)

lobster-biscuit