### PR TITLE
fix(browser): use ws RawData type to avoid TS2702 in chrome CDP health check

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -2,6 +2,7 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { RawData } from "ws";
 import { ensurePortAvailable } from "../infra/ports.js";
 import { rawDataToString } from "../infra/ws.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -134,7 +135,7 @@ async function canRunCdpHealthCommand(
       handshakeTimeoutMs: timeoutMs,
     });
     let settled = false;
-    const onMessage = (raw: WebSocket.RawData) => {
+    const onMessage = (raw: RawData) => {
       if (settled) {
         return;
       }


### PR DESCRIPTION
## Problem
CI `pnpm tsgo` fails with:
`src/browser/chrome.ts(137,29): error TS2702: WebSocket only refers to a type, but is being used as a namespace here.`

The module uses `WebSocket.RawData`, but `WebSocket` resolves to the DOM type in this file.

## Fix
Import `RawData` from `ws` and type the handler as `(raw: RawData)`.

## Notes
This unblocks `pnpm check` and docker install-smoke builds that compile `tsconfig.plugin-sdk.dts.json`.
