### PR TITLE
UI: sync locale render on initial connect

### DIFF
--- a/ui/src/i18n/lib/lit-controller.ts
+++ b/ui/src/i18n/lib/lit-controller.ts
@@ -14,6 +14,8 @@ export class I18nController implements ReactiveController {
     this.unsubscribe = i18n.subscribe(() => {
       this.host.requestUpdate();
     });
+    // Locale may already be resolved before the host subscribes; force one sync update.
+    this.host.requestUpdate();
   }
 
   hostDisconnected() {

--- a/ui/src/i18n/test/lit-controller.test.ts
+++ b/ui/src/i18n/test/lit-controller.test.ts
@@ -2,6 +2,7 @@ import type { ReactiveControllerHost } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { I18nController } from "../lib/lit-controller.ts";
 import { i18n } from "../lib/translate.ts";
+import type { Locale } from "../lib/types.ts";
 
 describe("I18nController", () => {
   afterEach(() => {
@@ -9,56 +10,57 @@ describe("I18nController", () => {
   });
 
   it("requests an initial update when the host connects", () => {
-    let controller: I18nController | null = null;
+    const addController = vi.fn();
     const requestUpdate = vi.fn();
     const unsubscribe = vi.fn();
     const subscribeSpy = vi.spyOn(i18n, "subscribe").mockReturnValue(unsubscribe);
 
     const host: ReactiveControllerHost = {
-      addController(next) {
-        controller = next as I18nController;
-      },
+      addController,
       removeController() {},
       requestUpdate,
+      updateComplete: Promise.resolve(true),
     };
 
-    new I18nController(host);
-    expect(controller).not.toBeNull();
-    controller?.hostConnected();
+    const controller = new I18nController(host);
+    expect(addController).toHaveBeenCalledWith(controller);
+    controller.hostConnected();
 
     expect(subscribeSpy).toHaveBeenCalledTimes(1);
     expect(requestUpdate).toHaveBeenCalledTimes(1);
   });
 
   it("requests update on locale changes and unsubscribes when disconnected", () => {
-    let controller: I18nController | null = null;
+    const addController = vi.fn();
     const requestUpdate = vi.fn();
     const unsubscribe = vi.fn();
-    let subscriber: ((locale: never) => void) | null = null;
+    let subscriber: ((locale: Locale) => void) | undefined;
     const subscribeSpy = vi.spyOn(i18n, "subscribe").mockImplementation((next) => {
-      subscriber = next as (locale: never) => void;
+      subscriber = next as (locale: Locale) => void;
       return unsubscribe;
     });
 
     const host: ReactiveControllerHost = {
-      addController(next) {
-        controller = next as I18nController;
-      },
+      addController,
       removeController() {},
       requestUpdate,
+      updateComplete: Promise.resolve(true),
     };
 
-    new I18nController(host);
-    expect(controller).not.toBeNull();
-    controller?.hostConnected();
+    const controller = new I18nController(host);
+    expect(addController).toHaveBeenCalledWith(controller);
+    controller.hostConnected();
 
     expect(subscribeSpy).toHaveBeenCalledTimes(1);
     expect(requestUpdate).toHaveBeenCalledTimes(1);
 
-    subscriber?.("zh-CN" as never);
+    if (!subscriber) {
+      throw new Error("expected locale subscriber to be registered");
+    }
+    subscriber("zh-CN");
     expect(requestUpdate).toHaveBeenCalledTimes(2);
 
-    controller?.hostDisconnected();
+    controller.hostDisconnected();
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/src/i18n/test/lit-controller.test.ts
+++ b/ui/src/i18n/test/lit-controller.test.ts
@@ -1,0 +1,64 @@
+import type { ReactiveControllerHost } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { I18nController } from "../lib/lit-controller.ts";
+import { i18n } from "../lib/translate.ts";
+
+describe("I18nController", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("requests an initial update when the host connects", () => {
+    let controller: I18nController | null = null;
+    const requestUpdate = vi.fn();
+    const unsubscribe = vi.fn();
+    const subscribeSpy = vi.spyOn(i18n, "subscribe").mockReturnValue(unsubscribe);
+
+    const host: ReactiveControllerHost = {
+      addController(next) {
+        controller = next as I18nController;
+      },
+      removeController() {},
+      requestUpdate,
+    };
+
+    new I18nController(host);
+    expect(controller).not.toBeNull();
+    controller?.hostConnected();
+
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    expect(requestUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("requests update on locale changes and unsubscribes when disconnected", () => {
+    let controller: I18nController | null = null;
+    const requestUpdate = vi.fn();
+    const unsubscribe = vi.fn();
+    let subscriber: ((locale: never) => void) | null = null;
+    const subscribeSpy = vi.spyOn(i18n, "subscribe").mockImplementation((next) => {
+      subscriber = next as (locale: never) => void;
+      return unsubscribe;
+    });
+
+    const host: ReactiveControllerHost = {
+      addController(next) {
+        controller = next as I18nController;
+      },
+      removeController() {},
+      requestUpdate,
+    };
+
+    new I18nController(host);
+    expect(controller).not.toBeNull();
+    controller?.hostConnected();
+
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    expect(requestUpdate).toHaveBeenCalledTimes(1);
+
+    subscriber?.("zh-CN" as never);
+    expect(requestUpdate).toHaveBeenCalledTimes(2);
+
+    controller?.hostDisconnected();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Dashboard locale can persist but UI may render stale English after refresh/navigation when locale resolution completes before Lit host subscription.
- Why it matters: Users see inconsistent language application even though locale is saved.
- What changed: `I18nController.hostConnected()` now forces one initial `requestUpdate()` after subscribing; added focused tests for initial sync + subscribe/unsubscribe behavior.
- What did NOT change (scope boundary): No translation keys/locales changed; no routing/network/config behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #21567
- Related #21619

## User-visible / Behavior Changes

- Dashboard language now reliably re-renders to the persisted locale on load, even when locale initialization races with component lifecycle.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a
- Integration/channel (if any): Control UI (dashboard)
- Relevant config (redacted): n/a

### Steps

1. Persist non-English locale in dashboard.
2. Reload page / reconnect.
3. Observe UI language after initial render.

### Expected

- UI should apply persisted locale reliably after load.

### Actual

- Before fix, locale render could stay stale until another state update.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Focused unit test for i18n controller lifecycle and locale subscription flow.
- Edge cases checked: Locale already resolved before host subscription; unsubscribe on disconnect.
- What you did **not** verify: Full manual browser walkthrough across all dashboard tabs.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `UI: sync locale on controller connect`.
- Files/config to restore: `ui/src/i18n/lib/lit-controller.ts`
- Known bad symptoms reviewers should watch for: Extra initial render when control UI connects.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: One extra `requestUpdate()` on host connect.
  - Mitigation: Limited to lifecycle connect path; tiny UI-only cost; covered by focused tests.
