### PR TITLE
fix(cron): let resolveOutboundTarget handle missing delivery target fallback

### DIFF
--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -228,7 +228,9 @@ describe("resolveDeliveryTarget", () => {
     if (result.ok) {
       throw new Error("expected unresolved delivery target");
     }
-    expect(result.error.message).toContain('No delivery target resolved for channel "telegram"');
+    // resolveOutboundTarget provides the standard missing-target error when
+    // no explicit target, no session lastTo, and no plugin resolveDefaultTo.
+    expect(result.error.message).toContain("requires target");
   });
 
   it("returns an error when channel selection is ambiguous", async () => {

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -148,20 +148,6 @@ export async function resolveDeliveryTarget(
     };
   }
 
-  if (!toCandidate) {
-    return {
-      ok: false,
-      channel,
-      to: undefined,
-      accountId,
-      threadId,
-      mode,
-      error:
-        channelResolutionError ??
-        new Error(`No delivery target resolved for channel "${channel}". Set delivery.to.`),
-    };
-  }
-
   let allowFromOverride: string[] | undefined;
   if (channel === "whatsapp") {
     const resolvedAccountId = normalizeAccountId(accountId);
@@ -177,7 +163,7 @@ export async function resolveDeliveryTarget(
       .filter((entry): entry is string => Boolean(entry));
     allowFromOverride = [...new Set([...configuredAllowFrom, ...storeAllowFrom])];
 
-    if (mode === "implicit" && allowFromOverride.length > 0) {
+    if (toCandidate && mode === "implicit" && allowFromOverride.length > 0) {
       const normalizedCurrentTarget = normalizeWhatsAppTarget(toCandidate);
       if (!normalizedCurrentTarget || !allowFromOverride.includes(normalizedCurrentTarget)) {
         toCandidate = allowFromOverride[0];


### PR DESCRIPTION
## Summary

Fixes #32355 — Cron delivery path doesn't call `plugin.config.resolveDefaultTo()`, so `--channel` without `--to` always fails even when the plugin can auto-resolve the target.

**Root cause**: `delivery-target.ts:151` short-circuits with an error when `toCandidate` is falsy, before reaching `resolveOutboundTarget()` at line 188. The direct send path in `targets.ts:208-216` correctly falls back to `plugin.config.resolveDefaultTo()`, but the cron delivery path never reaches it.

**Fix**: Remove the early `!toCandidate` exit so `resolveOutboundTarget()` can attempt the plugin-provided default. Guard the WhatsApp `allowFrom` override (line 180) against falsy `toCandidate`.

## Changes

| File | Change |
|------|--------|
| `src/cron/isolated-agent/delivery-target.ts` | Remove early `!toCandidate` exit, guard WhatsApp allowFrom check (-14/+1) |
| `src/cron/isolated-agent/delivery-target.test.ts` | Update error message assertion to match `resolveOutboundTarget` output (+3/-1) |

## Test plan

- [x] `vitest run src/cron/isolated-agent/delivery-target.test.ts`: 15/15 pass
- [x] Lint: 0 warnings (oxlint)
- [x] Format: PASS (oxfmt)

lobster-biscuit