### PR TITLE
fix(ui): ensure GFM tables render in WebChat markdown (#20410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- WebChat/markdown tables: ensure GitHub-flavored markdown table parsing is explicitly enabled at render time and add horizontal overflow handling for wide tables, with regression coverage for table-only and mixed text+table content. (#32365) Thanks @BlueBirdBack.
 - Feishu/default account resolution: always honor explicit `channels.feishu.defaultAccount` during outbound account selection (including top-level-credential setups where the preferred id is not present in `accounts`), instead of silently falling back to another account id. (#32253) Thanks @bmendonca3.
 - Gemini schema sanitization: coerce malformed JSON Schema `properties` values (`null`, arrays, primitives) to `{}` before provider validation, preventing downstream strict-validator crashes on invalid plugin/tool schemas. (#32332) Thanks @webdevtodayjason.
 - OpenAI/Responses WebSocket tool-call id hygiene: normalize blank/whitespace streamed tool-call ids before persistence, and block empty `function_call_output.call_id` payloads in the WS conversion path to avoid OpenAI 400 errors (`Invalid 'input[n].call_id': empty string`), with regression coverage for both inbound stream normalization and outbound payload guards.

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1923,7 +1923,10 @@
   margin-top: 0.75em;
   border-collapse: collapse;
   width: 100%;
+  max-width: 100%;
   font-size: 13px;
+  display: block;
+  overflow-x: auto;
 }
 
 .chat-text :where(th, td) {

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -48,4 +48,38 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).not.toContain("javascript:");
     expect(html).not.toContain("src=");
   });
+
+  it("renders GFM markdown tables (#20410)", () => {
+    const md = [
+      "| Feature | Status |",
+      "|---------|--------|",
+      "| Tables  | ✅     |",
+      "| Borders | ✅     |",
+    ].join("\n");
+    const html = toSanitizedMarkdownHtml(md);
+    expect(html).toContain("<table");
+    expect(html).toContain("<thead");
+    expect(html).toContain("<th>");
+    expect(html).toContain("Feature");
+    expect(html).toContain("Tables");
+    expect(html).not.toContain("|---------|");
+  });
+
+  it("renders GFM tables surrounded by text (#20410)", () => {
+    const md = [
+      "Text before.",
+      "",
+      "| Col1 | Col2 |",
+      "|------|------|",
+      "| A    | B    |",
+      "",
+      "Text after.",
+    ].join("\n");
+    const html = toSanitizedMarkdownHtml(md);
+    expect(html).toContain("<table");
+    expect(html).toContain("Col1");
+    expect(html).toContain("Col2");
+    // Pipes from table delimiters must not appear as raw text
+    expect(html).not.toContain("|------|");
+  });
 });

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -117,6 +117,8 @@ export function toSanitizedMarkdownHtml(markdown: string): string {
   }
   const rendered = marked.parse(`${truncated.text}${suffix}`, {
     renderer: htmlEscapeRenderer,
+    gfm: true,
+    breaks: true,
   }) as string;
   const sanitized = DOMPurify.sanitize(rendered, sanitizeOptions);
   if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -2,11 +2,6 @@ import DOMPurify from "dompurify";
 import { marked } from "marked";
 import { truncateText } from "./format.ts";
 
-marked.setOptions({
-  gfm: true,
-  breaks: true,
-});
-
 const allowedTags = [
   "a",
   "b",


### PR DESCRIPTION
## Fix: Markdown tables jammed in Gateway WebChat (#20410)

### Problem
Pipe-delimited GFM tables appear as raw text with literal pipe characters in the Gateway WebChat instead of rendering as proper HTML tables.

### Root Cause
1. `ui/src/ui/markdown.ts` — `marked.parse()` was called without explicit `gfm: true` option. In marked v17, per-call options override global setOptions without inheriting defaults.
2. `ui/src/styles/components.css` — `.chat-text table` lacked `display: block` and `overflow-x: auto`, causing wide tables to clip ("jam") against the parent container.

### Fix
- Pass `gfm: true, breaks: true` explicitly to `marked.parse()` (defense-in-depth)
- Add `display: block`, `overflow-x: auto`, `max-width: 100%` to `.chat-text table`
- Add 2 regression tests confirming `<table>/<thead>/<th>` elements are produced

### Step 6 Docker verification
`openclaw-lab:20410-fix` image built and tested. Log: `reproductions/20410/step6-verify.log`
- ✅ `gfm: true` in `marked.parse()`
- ✅ `overflow-x: auto` in `.chat-text table` CSS
- ✅ Both regression tests present
- ✅ Runtime: table markdown renders proper `<table>` HTML