### PR TITLE
Agent: sanitize tool schemas across Google providers

### DIFF
--- a/src/agents/pi-embedded-runner/google.test.ts
+++ b/src/agents/pi-embedded-runner/google.test.ts
@@ -24,23 +24,26 @@ describe("sanitizeToolsForGoogle", () => {
     expect(params.properties?.foo?.format).toBeUndefined();
   };
 
-  it("strips unsupported schema keywords for Google providers", () => {
-    const tool = createTool({
-      type: "object",
-      additionalProperties: false,
-      properties: {
-        foo: {
-          type: "string",
-          format: "uuid",
+  it.each(["google", "google-gemini-cli", "google-antigravity", "google-generative-ai"] as const)(
+    "strips unsupported schema keywords for provider %s",
+    (provider) => {
+      const tool = createTool({
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          foo: {
+            type: "string",
+            format: "uuid",
+          },
         },
-      },
-    });
-    const [sanitized] = sanitizeToolsForGoogle({
-      tools: [tool],
-      provider: "google-gemini-cli",
-    });
-    expectFormatRemoved(sanitized, "additionalProperties");
-  });
+      });
+      const [sanitized] = sanitizeToolsForGoogle({
+        tools: [tool],
+        provider,
+      });
+      expectFormatRemoved(sanitized, "additionalProperties");
+    },
+  );
 
   it("returns original tools for non-google providers", () => {
     const tool = createTool({

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -54,6 +54,11 @@ const GOOGLE_SCHEMA_UNSUPPORTED_KEYWORDS = new Set([
   "maxProperties",
 ]);
 
+function isGoogleSchemaProvider(provider: string): boolean {
+  const normalized = provider.trim().toLowerCase();
+  return normalized === "google" || normalized.startsWith("google-");
+}
+
 const INTER_SESSION_PREFIX_BASE = "[Inter-session message]";
 
 function buildInterSessionPrefix(message: AgentMessage): string {
@@ -245,7 +250,7 @@ export function sanitizeToolsForGoogle<
   // AND Claude models.  This field does not support JSON Schema keywords such as
   // patternProperties, additionalProperties, $ref, etc.  We must clean schemas
   // for every provider that routes through this path.
-  if (params.provider !== "google-gemini-cli") {
+  if (!isGoogleSchemaProvider(params.provider)) {
     return params.tools;
   }
   return params.tools.map((tool) => {
@@ -262,7 +267,7 @@ export function sanitizeToolsForGoogle<
 }
 
 export function logToolSchemasForGoogle(params: { tools: AgentTool[]; provider: string }) {
-  if (params.provider !== "google-gemini-cli") {
+  if (!isGoogleSchemaProvider(params.provider)) {
     return;
   }
   const toolNames = params.tools.map((tool, index) => `${index}:${tool.name}`);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Google tool-schema sanitization in `sanitizeToolsForGoogle`/`logToolSchemasForGoogle` only ran for `google-gemini-cli`, so other Google-model provider IDs could bypass keyword cleanup and diagnostics.
- Why it matters: Unsupported schema keywords (for example `patternProperties`) can trigger Google-side 400 errors on tool declarations.
- What changed: Added shared provider gate `isGoogleSchemaProvider()` and applied it to both sanitize + logging paths; expanded unit tests to cover `google`, `google-gemini-cli`, `google-antigravity`, and `google-generative-ai`.
- What did NOT change (scope boundary): No tool behavior changes outside Google provider flows; no protocol/config/schema shape changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #22222
- Related #22187
- Related #20197

## User-visible / Behavior Changes

- Google-provider tool calls are more reliable when tool schemas contain keywords not accepted by Google’s validation subset.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: Google providers (`google`, `google-gemini-cli`, `google-antigravity`, `google-generative-ai`)
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

1. Build tool schema containing Google-unsupported keywords.
2. Run sanitize path with each Google provider id.
3. Verify unsupported keys are stripped and non-Google providers are unchanged.

### Expected

- All Google providers in this path receive schema cleanup.

### Actual

- Before fix: only `google-gemini-cli` was sanitized/logged.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm exec vitest run src/agents/pi-embedded-runner/google.test.ts` passes with expanded provider coverage.
- Edge cases checked: non-Google provider still returns original tools by reference.
- What you did **not** verify: live Google API end-to-end call.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Agent: sanitize Google tool schemas for all providers`.
- Files/config to restore: `src/agents/pi-embedded-runner/google.ts`
- Known bad symptoms reviewers should watch for: unexpected schema transformations for non-Google providers (covered by test).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Over-broad provider matching could sanitize providers unintentionally.
  - Mitigation: Gate is limited to `google` and `google-*`; non-Google passthrough is covered by tests.
