### PR TITLE
fix(agent): substitute YYYY-MM-DD in post-compaction context & inject timestamp on /new

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -666,7 +666,8 @@ export async function runReplyAgent(params: {
       // Inject post-compaction workspace context for the next agent turn
       if (sessionKey) {
         const workspaceDir = process.cwd();
-        readPostCompactionContext(workspaceDir)
+        const userTimezone = cfg.agents?.defaults?.userTimezone;
+        readPostCompactionContext(workspaceDir, userTimezone)
           .then((contextContent) => {
             if (contextContent) {
               enqueueSystemEvent(contextContent, { sessionKey });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { lookupContextTokens } from "../../agents/context.js";
+import { resolveUserTimezone } from "../../agents/date-time.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
@@ -666,7 +667,7 @@ export async function runReplyAgent(params: {
       // Inject post-compaction workspace context for the next agent turn
       if (sessionKey) {
         const workspaceDir = process.cwd();
-        const userTimezone = cfg.agents?.defaults?.userTimezone;
+        const userTimezone = resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
         readPostCompactionContext(workspaceDir, userTimezone)
           .then((contextContent) => {
             if (contextContent) {

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -167,6 +167,36 @@ Never do Y.
     expect(result).not.toContain("Other Section");
   });
 
+  it("substitutes literal YYYY-MM-DD with the current date", async () => {
+    const content = `# Rules
+
+## Session Startup
+
+Read memory/YYYY-MM-DD.md before responding.
+
+## Other
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    // Should NOT contain the literal placeholder
+    expect(result).not.toContain("YYYY-MM-DD");
+    // Should contain an actual date like 2026-03-02
+    expect(result).toMatch(/memory\/\d{4}-\d{2}-\d{2}\.md/);
+  });
+
+  it("substitutes YYYY-MM-DD using the provided timezone", async () => {
+    const content = `## Session Startup
+
+Today is YYYY-MM-DD.
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir, "America/New_York");
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("YYYY-MM-DD");
+    expect(result).toMatch(/Today is \d{4}-\d{2}-\d{2}/);
+  });
+
   it.runIf(process.platform !== "win32")(
     "returns null when AGENTS.md is a symlink escaping workspace",
     async () => {

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -5,10 +5,40 @@ import { openBoundaryFile } from "../../infra/boundary-file-read.js";
 const MAX_CONTEXT_CHARS = 3000;
 
 /**
+ * Format the current date as YYYY-MM-DD in the given timezone (UTC fallback).
+ * Matches the pattern used in memory-flush.ts for consistency.
+ */
+function formatCurrentDateStamp(timezone?: string): string {
+  const now = new Date();
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone || "UTC",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(now);
+    const year = parts.find((p) => p.type === "year")?.value;
+    const month = parts.find((p) => p.type === "month")?.value;
+    const day = parts.find((p) => p.type === "day")?.value;
+    if (year && month && day) {
+      return `${year}-${month}-${day}`;
+    }
+  } catch {
+    // Fall through to ISO fallback
+  }
+  return now.toISOString().slice(0, 10);
+}
+
+/**
  * Read critical sections from workspace AGENTS.md for post-compaction injection.
  * Returns formatted system event text, or null if no AGENTS.md or no relevant sections.
+ *
+ * @param timezone - Optional user timezone for YYYY-MM-DD substitution (defaults to UTC).
  */
-export async function readPostCompactionContext(workspaceDir: string): Promise<string | null> {
+export async function readPostCompactionContext(
+  workspaceDir: string,
+  timezone?: string,
+): Promise<string | null> {
   const agentsPath = path.join(workspaceDir, "AGENTS.md");
 
   try {
@@ -36,7 +66,11 @@ export async function readPostCompactionContext(workspaceDir: string): Promise<s
       return null;
     }
 
-    const combined = sections.join("\n\n");
+    // Substitute literal YYYY-MM-DD placeholders with the actual date so agents
+    // can resolve date-based file paths (e.g. memory/YYYY-MM-DD.md) after compaction.
+    // This mirrors the substitution already performed in memory-flush.ts.
+    const dateStamp = formatCurrentDateStamp(timezone);
+    const combined = sections.join("\n\n").replaceAll("YYYY-MM-DD", dateStamp);
     const safeContent =
       combined.length > MAX_CONTEXT_CHARS
         ? combined.slice(0, MAX_CONTEXT_CHARS) + "\n...[truncated]..."

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -326,8 +326,6 @@ export const agentHandlers: GatewayRequestHandlers = {
     let bestEffortDeliver = requestedBestEffortDeliver ?? false;
     let cfgForAgent: ReturnType<typeof loadConfig> | undefined;
     let resolvedSessionKey = requestedSessionKey;
-    let skipTimestampInjection = false;
-
     const resetCommandMatch = message.match(RESET_COMMAND_RE);
     if (resetCommandMatch && requestedSessionKey) {
       const resetReason = resetCommandMatch[1]?.toLowerCase() === "new" ? "new" : "reset";
@@ -351,8 +349,10 @@ export const agentHandlers: GatewayRequestHandlers = {
       } else {
         // Keep bare /new and /reset behavior aligned with chat.send:
         // reset first, then run a fresh-session greeting prompt in-place.
+        // Do NOT skip timestamp injection — the agent needs the current date
+        // to resolve date-based paths (e.g. memory/YYYY-MM-DD.md) in its
+        // Session Startup sequence.  See: #32363
         message = BARE_SESSION_RESET_PROMPT;
-        skipTimestampInjection = true;
       }
     }
 
@@ -360,9 +360,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     // Channel messages (Discord, Telegram, etc.) get timestamps via envelope
     // formatting in a separate code path — they never reach this handler.
     // See: https://github.com/moltbot/moltbot/issues/3658
-    if (!skipTimestampInjection) {
-      message = injectTimestamp(message, timestampOptsFromConfig(cfg));
-    }
+    message = injectTimestamp(message, timestampOptsFromConfig(cfg));
 
     if (requestedSessionKey) {
       const { cfg, storePath, entry, canonicalKey } = loadSessionEntry(requestedSessionKey);


### PR DESCRIPTION
## Summary

Fixes #32363 — Agents don't know the current date after session compaction or on bare `/new`/`/reset`.

**Root cause (two separate paths):**

1. **Post-compaction context**: After session compaction, `readPostCompactionContext()` extracts `## Session Startup` and `## Red Lines` sections from AGENTS.md and injects them as system events. Literal `YYYY-MM-DD` placeholders were passed through unsubstituted, so agents couldn't resolve date-based file paths (e.g. `memory/YYYY-MM-DD.md`). The same substitution was already performed in `memory-flush.ts` but was missing here.

2. **Bare `/new` and `/reset`**: The gateway agent handler set `skipTimestampInjection = true` for bare `/new`/`/reset` commands, preventing the agent from receiving the current date in the timestamp that's normally injected into every message. The agent needs the date to execute its Session Startup sequence correctly.

**Changes:**

- Add `formatCurrentDateStamp()` to `post-compaction-context.ts` and substitute `YYYY-MM-DD` with the actual date before injection (mirrors the existing pattern in `memory-flush.ts`)
- Pass `userTimezone` from config to `readPostCompactionContext()` for timezone-aware formatting
- Remove `skipTimestampInjection` variable and guard so bare `/new`/`/reset` always get the current date via `injectTimestamp()`
- Add two tests for YYYY-MM-DD substitution (default UTC and explicit timezone)

## Test plan

- [x] All 14 `post-compaction-context.test.ts` tests pass (12 existing + 2 new)
- [x] Gateway agent tests: same pass/fail profile as main (pre-existing mock issue unrelated to this change)
- [ ] Manual: Create an AGENTS.md with `## Session Startup` referencing `memory/YYYY-MM-DD.md`, trigger compaction, verify the date is substituted
- [ ] Manual: Send bare `/new`, verify the agent receives a timestamp with today's date

🤖 Generated with [Claude Code](https://claude.com/claude-code)