### PR TITLE
fix(discord): destructure DiscordReactionRoutingParams to fix TS2339 build errors

### DIFF
--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -328,7 +328,22 @@ async function handleDiscordReactionEvent(
   } & DiscordReactionRoutingParams,
 ) {
   try {
-    const { data, client, action, botUserId, guildEntries } = params;
+    const {
+      data,
+      client,
+      action,
+      botUserId,
+      guildEntries,
+      accountId,
+      cfg,
+      dmEnabled,
+      groupDmEnabled,
+      groupDmChannels,
+      dmPolicy,
+      allowFrom,
+      groupPolicy,
+      allowNameMatching,
+    } = params;
     if (!("user" in data)) {
       return;
     }
@@ -367,7 +382,7 @@ async function handleDiscordReactionEvent(
       channelType === ChannelType.PrivateThread ||
       channelType === ChannelType.AnnouncementThread;
     const reactionIngressBase: Omit<DiscordReactionIngressAuthorizationParams, "channelConfig"> = {
-      accountId: params.accountId,
+      accountId,
       user,
       isDirectMessage,
       isGroupDm,
@@ -375,13 +390,13 @@ async function handleDiscordReactionEvent(
       channelId: data.channel_id,
       channelName,
       channelSlug,
-      dmEnabled: params.dmEnabled,
-      groupDmEnabled: params.groupDmEnabled,
-      groupDmChannels: params.groupDmChannels,
-      dmPolicy: params.dmPolicy,
-      allowFrom: params.allowFrom,
-      groupPolicy: params.groupPolicy,
-      allowNameMatching: params.allowNameMatching,
+      dmEnabled,
+      groupDmEnabled,
+      groupDmChannels,
+      dmPolicy,
+      allowFrom,
+      groupPolicy,
+      allowNameMatching,
       guildInfo,
     };
     const ingressAccess = await authorizeDiscordReactionIngress(reactionIngressBase);
@@ -420,9 +435,9 @@ async function handleDiscordReactionEvent(
     const emitReaction = (text: string, parentPeerId?: string) => {
       const { contextKey } = resolveReactionBase();
       const route = resolveAgentRoute({
-        cfg: params.cfg,
+        cfg,
         channel: "discord",
-        accountId: params.accountId,
+        accountId,
         guildId: data.guild_id ?? undefined,
         memberRoleIds,
         peer: {
@@ -448,7 +463,7 @@ async function handleDiscordReactionEvent(
         userName: user.username,
         userTag: formatDiscordUserTag(user),
         allowlist: guildInfo?.users,
-        allowNameMatching: params.allowNameMatching,
+        allowNameMatching,
       });
     const emitReactionWithAuthor = (message: { author?: User } | null) => {
       const { baseText } = resolveReactionBase();


### PR DESCRIPTION
## Summary

Fixes #32344 — build fails on main due to missing `accountId` type in Discord listeners.

## Problem

`handleDiscordReactionEvent` accesses properties from the `DiscordReactionRoutingParams` intersection type via `params.xxx`, but TypeScript strict mode doesn't resolve these properly through the inline intersection, producing four TS2339/TS2353 errors:

```
src/discord/monitor/listeners.ts:210:9 - error TS2353: 'accountId' does not exist in type '...'
src/discord/monitor/listeners.ts:210:41 - error TS2339: Property 'accountId' does not exist on type 'DiscordReactionListenerParams'
src/discord/monitor/listeners.ts:369:25 - error TS2339: Property 'accountId' does not exist on type '...'
src/discord/monitor/listeners.ts:424:27 - error TS2339: Property 'accountId' does not exist on type '...'
```

## Fix

Destructure `accountId`, `cfg`, `dmEnabled`, `groupDmEnabled`, `groupDmChannels`, `dmPolicy`, `allowFrom`, `groupPolicy`, and `allowNameMatching` from `params` alongside the existing destructured variables (`data`, `client`, `action`, `botUserId`, `guildEntries`), and use the destructured names directly instead of `params.xxx`.

`params.logger` is kept in the `catch` block since the destructured `logger` would be scoped to the `try` block.

## Verification

- `pnpm build` ✅ (exit 0)
- `pnpm tsgo` ✅ (no listeners.ts errors; only pre-existing TS2550 in test files)
- `oxlint` ✅ (0 errors, 0 warnings)
