### PR TITLE
fix(tools): handle abort-after-commit false failures for host write/edit

### DIFF
--- a/src/agents/pi-tools.abort-recovery.test.ts
+++ b/src/agents/pi-tools.abort-recovery.test.ts
@@ -26,7 +26,8 @@ vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
   };
 });
 
-const { createHostWorkspaceWriteTool, createHostWorkspaceEditTool } = await import("./pi-tools.read.js");
+const { createHostWorkspaceWriteTool, createHostWorkspaceEditTool } =
+  await import("./pi-tools.read.js");
 
 describe("host tool abort-after-commit recovery", () => {
   let tmpDir = "";
@@ -67,6 +68,23 @@ describe("host tool abort-after-commit recovery", () => {
     expect(text).toContain("Successfully replaced text");
   });
 
+  it("recovers committed edit when newText contains oldText", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-abort-embed-"));
+    const file = path.join(tmpDir, "note.txt");
+    // Simulate post-commit state for oldText="foo" -> newText="foobar"
+    await fs.writeFile(file, "foobar\n", "utf8");
+
+    const tool = createHostWorkspaceEditTool(tmpDir, { workspaceOnly: false });
+    const result = await tool.execute(
+      "tc-3",
+      { path: file, oldText: "foo", newText: "foobar" },
+      undefined,
+      undefined,
+    );
+    const text = (result.content?.[0] as { text?: string })?.text ?? "";
+    expect(text).toContain("Successfully replaced text");
+  });
+
   it("keeps edit aborted error when oldText still exists (no committed replacement)", async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-abort-fail-"));
     const file = path.join(tmpDir, "note.txt");
@@ -76,11 +94,22 @@ describe("host tool abort-after-commit recovery", () => {
     const tool = createHostWorkspaceEditTool(tmpDir, { workspaceOnly: false });
     await expect(
       tool.execute(
-        "tc-3",
+        "tc-4",
         { path: file, oldText: "before", newText: "after" },
         undefined,
         undefined,
       ),
+    ).rejects.toThrow("Operation aborted");
+  });
+
+  it("keeps edit aborted error for empty newText to avoid false positives", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-abort-empty-new-"));
+    const file = path.join(tmpDir, "note.txt");
+    await fs.writeFile(file, "something else\n", "utf8");
+
+    const tool = createHostWorkspaceEditTool(tmpDir, { workspaceOnly: false });
+    await expect(
+      tool.execute("tc-5", { path: file, oldText: "before", newText: "" }, undefined, undefined),
     ).rejects.toThrow("Operation aborted");
   });
 });

--- a/src/agents/pi-tools.abort-recovery.test.ts
+++ b/src/agents/pi-tools.abort-recovery.test.ts
@@ -3,6 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const mockState = vi.hoisted(() => ({
+  writeMode: "commitThenAbort" as "commitThenAbort" | "abortOnly",
+  editMode: "commitThenAbort" as "commitThenAbort" | "abortOnly",
+}));
+
 vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@mariozechner/pi-coding-agent")>();
   return {
@@ -11,7 +16,11 @@ vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
       name: "write",
       description: "test write tool",
       parameters: { type: "object", properties: {} },
-      execute: async () => {
+      execute: async (_toolCallId: string, args: { path: string; content: string }) => {
+        if (mockState.writeMode === "commitThenAbort") {
+          await fs.mkdir(path.dirname(args.path), { recursive: true });
+          await fs.writeFile(args.path, args.content, "utf8");
+        }
         throw new Error("Operation aborted");
       },
     }),
@@ -19,7 +28,14 @@ vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
       name: "edit",
       description: "test edit tool",
       parameters: { type: "object", properties: {} },
-      execute: async () => {
+      execute: async (
+        _toolCallId: string,
+        args: { path: string; oldText: string; newText: string },
+      ) => {
+        if (mockState.editMode === "commitThenAbort") {
+          const current = await fs.readFile(args.path, "utf8");
+          await fs.writeFile(args.path, current.replace(args.oldText, args.newText), "utf8");
+        }
         throw new Error("Operation aborted");
       },
     }),
@@ -33,17 +49,18 @@ describe("host tool abort-after-commit recovery", () => {
   let tmpDir = "";
 
   afterEach(async () => {
+    mockState.writeMode = "commitThenAbort";
+    mockState.editMode = "commitThenAbort";
     if (tmpDir) {
       await fs.rm(tmpDir, { recursive: true, force: true });
       tmpDir = "";
     }
   });
 
-  it("treats write as success when file already has intended content", async () => {
+  it("treats write as success when write committed before abort", async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-write-abort-"));
     const file = path.join(tmpDir, "note.txt");
     const content = "hello world";
-    await fs.writeFile(file, content, "utf8");
 
     const tool = createHostWorkspaceWriteTool(tmpDir, { workspaceOnly: false });
     const result = await tool.execute("tc-1", { path: file, content }, undefined, undefined);
@@ -51,11 +68,10 @@ describe("host tool abort-after-commit recovery", () => {
     expect(text).toContain("Successfully wrote");
   });
 
-  it("treats edit as success when file already reflects committed replacement", async () => {
+  it("treats edit as success when replacement committed before abort", async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-abort-"));
     const file = path.join(tmpDir, "note.txt");
-    // Simulate post-commit file state after replacing `before` -> `after`
-    await fs.writeFile(file, "after\n", "utf8");
+    await fs.writeFile(file, "before\n", "utf8");
 
     const tool = createHostWorkspaceEditTool(tmpDir, { workspaceOnly: false });
     const result = await tool.execute(
@@ -71,8 +87,7 @@ describe("host tool abort-after-commit recovery", () => {
   it("recovers committed edit when newText contains oldText", async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-abort-embed-"));
     const file = path.join(tmpDir, "note.txt");
-    // Simulate post-commit state for oldText="foo" -> newText="foobar"
-    await fs.writeFile(file, "foobar\n", "utf8");
+    await fs.writeFile(file, "foo\n", "utf8");
 
     const tool = createHostWorkspaceEditTool(tmpDir, { workspaceOnly: false });
     const result = await tool.execute(
@@ -85,10 +100,10 @@ describe("host tool abort-after-commit recovery", () => {
     expect(text).toContain("Successfully replaced text");
   });
 
-  it("keeps edit aborted error when oldText still exists (no committed replacement)", async () => {
+  it("keeps edit aborted error when no commit happened", async () => {
+    mockState.editMode = "abortOnly";
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-abort-fail-"));
     const file = path.join(tmpDir, "note.txt");
-    // Simulate pre-commit state where replacement did not happen
     await fs.writeFile(file, "before\nafter\n", "utf8");
 
     const tool = createHostWorkspaceEditTool(tmpDir, { workspaceOnly: false });
@@ -103,6 +118,7 @@ describe("host tool abort-after-commit recovery", () => {
   });
 
   it("keeps edit aborted error for empty newText to avoid false positives", async () => {
+    mockState.editMode = "abortOnly";
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-abort-empty-new-"));
     const file = path.join(tmpDir, "note.txt");
     await fs.writeFile(file, "something else\n", "utf8");
@@ -110,6 +126,17 @@ describe("host tool abort-after-commit recovery", () => {
     const tool = createHostWorkspaceEditTool(tmpDir, { workspaceOnly: false });
     await expect(
       tool.execute("tc-5", { path: file, oldText: "before", newText: "" }, undefined, undefined),
+    ).rejects.toThrow("Operation aborted");
+  });
+
+  it("keeps write aborted error when no write happened", async () => {
+    mockState.writeMode = "abortOnly";
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-write-abort-fail-"));
+    const file = path.join(tmpDir, "note.txt");
+
+    const tool = createHostWorkspaceWriteTool(tmpDir, { workspaceOnly: false });
+    await expect(
+      tool.execute("tc-6", { path: file, content: "hello" }, undefined, undefined),
     ).rejects.toThrow("Operation aborted");
   });
 });

--- a/src/agents/pi-tools.abort-recovery.test.ts
+++ b/src/agents/pi-tools.abort-recovery.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mariozechner/pi-coding-agent")>();
+  return {
+    ...actual,
+    createWriteTool: (_cwd: string) => ({
+      name: "write",
+      description: "test write tool",
+      parameters: { type: "object", properties: {} },
+      execute: async () => {
+        throw new Error("Operation aborted");
+      },
+    }),
+    createEditTool: (_cwd: string) => ({
+      name: "edit",
+      description: "test edit tool",
+      parameters: { type: "object", properties: {} },
+      execute: async () => {
+        throw new Error("Operation aborted");
+      },
+    }),
+  };
+});
+
+const { createHostWorkspaceWriteTool, createHostWorkspaceEditTool } = await import("./pi-tools.read.js");
+
+describe("host tool abort-after-commit recovery", () => {
+  let tmpDir = "";
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = "";
+    }
+  });
+
+  it("treats write as success when file already has intended content", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-write-abort-"));
+    const file = path.join(tmpDir, "note.txt");
+    const content = "hello world";
+    await fs.writeFile(file, content, "utf8");
+
+    const tool = createHostWorkspaceWriteTool(tmpDir, { workspaceOnly: false });
+    const result = await tool.execute("tc-1", { path: file, content }, undefined, undefined);
+    const text = (result.content?.[0] as { text?: string })?.text ?? "";
+    expect(text).toContain("Successfully wrote");
+  });
+
+  it("treats edit as success when file already contains newText", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-abort-"));
+    const file = path.join(tmpDir, "note.txt");
+    await fs.writeFile(file, "before\nafter\n", "utf8");
+
+    const tool = createHostWorkspaceEditTool(tmpDir, { workspaceOnly: false });
+    const result = await tool.execute(
+      "tc-2",
+      { path: file, oldText: "before", newText: "after" },
+      undefined,
+      undefined,
+    );
+    const text = (result.content?.[0] as { text?: string })?.text ?? "";
+    expect(text).toContain("Successfully replaced text");
+  });
+});

--- a/src/agents/pi-tools.abort-recovery.test.ts
+++ b/src/agents/pi-tools.abort-recovery.test.ts
@@ -50,10 +50,11 @@ describe("host tool abort-after-commit recovery", () => {
     expect(text).toContain("Successfully wrote");
   });
 
-  it("treats edit as success when file already contains newText", async () => {
+  it("treats edit as success when file already reflects committed replacement", async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-abort-"));
     const file = path.join(tmpDir, "note.txt");
-    await fs.writeFile(file, "before\nafter\n", "utf8");
+    // Simulate post-commit file state after replacing `before` -> `after`
+    await fs.writeFile(file, "after\n", "utf8");
 
     const tool = createHostWorkspaceEditTool(tmpDir, { workspaceOnly: false });
     const result = await tool.execute(
@@ -64,5 +65,22 @@ describe("host tool abort-after-commit recovery", () => {
     );
     const text = (result.content?.[0] as { text?: string })?.text ?? "";
     expect(text).toContain("Successfully replaced text");
+  });
+
+  it("keeps edit aborted error when oldText still exists (no committed replacement)", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-abort-fail-"));
+    const file = path.join(tmpDir, "note.txt");
+    // Simulate pre-commit state where replacement did not happen
+    await fs.writeFile(file, "before\nafter\n", "utf8");
+
+    const tool = createHostWorkspaceEditTool(tmpDir, { workspaceOnly: false });
+    await expect(
+      tool.execute(
+        "tc-3",
+        { path: file, oldText: "before", newText: "after" },
+        undefined,
+        undefined,
+      ),
+    ).rejects.toThrow("Operation aborted");
   });
 });

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -838,11 +838,19 @@ function wrapAbortAfterCommitRecovery(
 
         const oldText = typeof record?.oldText === "string" ? record.oldText : undefined;
         const newText = typeof record?.newText === "string" ? record.newText : undefined;
-        if (
-          newText !== undefined &&
+
+        const hasOldText = oldText !== undefined && oldText.length > 0;
+        const hasNewText = newText !== undefined && newText.length > 0;
+
+        const committedReplacement =
+          hasNewText &&
           current.includes(newText) &&
-          (oldText === undefined || !current.includes(oldText))
-        ) {
+          (!hasOldText || newText.includes(oldText) || !current.includes(oldText));
+
+        // For empty newText (deletion edits), post-state alone is too ambiguous:
+        // if oldText was absent before execution, we can't distinguish no-op abort
+        // from committed deletion. Avoid recovering this case to prevent false success.
+        if (committedReplacement) {
           return {
             content: [{ type: "text", text: `Successfully replaced text in ${rawPath}.` }],
             details: undefined,

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -772,6 +772,10 @@ async function writeHostFile(absolutePath: string, content: string) {
   await fs.writeFile(resolved, content, "utf-8");
 }
 
+function normalizeAtPrefixedPath(filePath: string): string {
+  return filePath.startsWith("@") ? filePath.slice(1) : filePath;
+}
+
 function expandHomePath(filePath: string): string {
   if (filePath === "~") {
     return os.homedir();
@@ -783,7 +787,8 @@ function expandHomePath(filePath: string): string {
 }
 
 function resolveToolPathForVerification(filePath: string, cwd: string): string {
-  const expanded = expandHomePath(filePath);
+  const normalized = normalizeAtPrefixedPath(filePath);
+  const expanded = expandHomePath(normalized);
   if (path.isAbsolute(expanded)) {
     return expanded;
   }
@@ -828,6 +833,9 @@ function wrapAbortAfterCommitRecovery(
             .then((stat) => ({ size: stat.size, mtimeMs: stat.mtimeMs }))
             .catch(() => undefined)
         : undefined;
+      const beforeContent = resolvedPath
+        ? await fs.readFile(resolvedPath, "utf8").catch(() => undefined)
+        : undefined;
 
       try {
         return await tool.execute(toolCallId, params, signal, onUpdate);
@@ -866,19 +874,31 @@ function wrapAbortAfterCommitRecovery(
 
         const oldText = typeof record?.oldText === "string" ? record.oldText : undefined;
         const newText = typeof record?.newText === "string" ? record.newText : undefined;
+        if (
+          typeof beforeContent !== "string" ||
+          typeof oldText !== "string" ||
+          typeof newText !== "string" ||
+          oldText.length === 0
+        ) {
+          throw error;
+        }
 
-        const hasOldText = oldText !== undefined && oldText.length > 0;
-        const hasNewText = newText !== undefined && newText.length > 0;
+        const firstIdx = beforeContent.indexOf(oldText);
+        if (firstIdx === -1) {
+          throw error;
+        }
+        const secondIdx = beforeContent.indexOf(oldText, firstIdx + oldText.length);
+        if (secondIdx !== -1) {
+          // Upstream edit requires a unique match; do not recover ambiguous pre-state.
+          throw error;
+        }
 
-        const committedReplacement =
-          hasNewText &&
-          current.includes(newText) &&
-          (!hasOldText || newText.includes(oldText) || !current.includes(oldText));
+        const expected =
+          beforeContent.slice(0, firstIdx) +
+          newText +
+          beforeContent.slice(firstIdx + oldText.length);
 
-        // For empty newText (deletion edits), post-state alone is too ambiguous:
-        // if oldText was absent before execution, we can't distinguish no-op abort
-        // from committed deletion. Avoid recovering this case to prevent false success.
-        if (committedReplacement) {
+        if (current === expected) {
           return {
             content: [{ type: "text", text: `Successfully replaced text in ${rawPath}.` }],
             details: undefined,

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
@@ -677,14 +678,16 @@ export function createHostWorkspaceWriteTool(root: string, options?: { workspace
   const base = createWriteTool(root, {
     operations: createHostWriteOperations(root, options),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.write);
+  const normalized = wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.write);
+  return wrapAbortAfterCommitRecovery(normalized, { kind: "write", cwd: root });
 }
 
 export function createHostWorkspaceEditTool(root: string, options?: { workspaceOnly?: boolean }) {
   const base = createEditTool(root, {
     operations: createHostEditOperations(root, options),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
+  const normalized = wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
+  return wrapAbortAfterCommitRecovery(normalized, { kind: "edit", cwd: root });
 }
 
 export function createOpenClawReadTool(
@@ -767,6 +770,83 @@ async function writeHostFile(absolutePath: string, content: string) {
   const resolved = path.resolve(absolutePath);
   await fs.mkdir(path.dirname(resolved), { recursive: true });
   await fs.writeFile(resolved, content, "utf-8");
+}
+
+function expandHomePath(filePath: string): string {
+  if (filePath === "~") {
+    return os.homedir();
+  }
+  if (filePath.startsWith("~/")) {
+    return path.join(os.homedir(), filePath.slice(2));
+  }
+  return filePath;
+}
+
+function resolveToolPathForVerification(filePath: string, cwd: string): string {
+  const expanded = expandHomePath(filePath);
+  if (path.isAbsolute(expanded)) {
+    return expanded;
+  }
+  return path.resolve(cwd, expanded);
+}
+
+function isOperationAbortedError(error: unknown): boolean {
+  return error instanceof Error && error.message.trim() === "Operation aborted";
+}
+
+function wrapAbortAfterCommitRecovery(
+  tool: AnyAgentTool,
+  options: { kind: "write" | "edit"; cwd: string },
+): AnyAgentTool {
+  return {
+    ...tool,
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      try {
+        return await tool.execute(toolCallId, params, signal, onUpdate);
+      } catch (error) {
+        if (!isOperationAbortedError(error)) {
+          throw error;
+        }
+        const normalized = normalizeToolParams(params);
+        const record =
+          normalized ??
+          (params && typeof params === "object" ? (params as Record<string, unknown>) : undefined);
+        const rawPath = typeof record?.path === "string" ? record.path.trim() : "";
+        if (!rawPath) {
+          throw error;
+        }
+        const resolvedPath = resolveToolPathForVerification(rawPath, options.cwd);
+        let current = "";
+        try {
+          current = await fs.readFile(resolvedPath, "utf8");
+        } catch {
+          throw error;
+        }
+
+        if (options.kind === "write") {
+          const content = typeof record?.content === "string" ? record.content : undefined;
+          if (content !== undefined && current === content) {
+            return {
+              content: [
+                { type: "text", text: `Successfully wrote ${content.length} bytes to ${rawPath}` },
+              ],
+              details: undefined,
+            };
+          }
+          throw error;
+        }
+
+        const newText = typeof record?.newText === "string" ? record.newText : undefined;
+        if (newText !== undefined && current.includes(newText)) {
+          return {
+            content: [{ type: "text", text: `Successfully replaced text in ${rawPath}.` }],
+            details: undefined,
+          };
+        }
+        throw error;
+      }
+    },
+  };
 }
 
 function createHostWriteOperations(root: string, options?: { workspaceOnly?: boolean }) {

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -833,9 +833,10 @@ function wrapAbortAfterCommitRecovery(
             .then((stat) => ({ size: stat.size, mtimeMs: stat.mtimeMs }))
             .catch(() => undefined)
         : undefined;
-      const beforeContent = resolvedPath
-        ? await fs.readFile(resolvedPath, "utf8").catch(() => undefined)
-        : undefined;
+      const beforeContent =
+        options.kind === "edit" && resolvedPath
+          ? await fs.readFile(resolvedPath, "utf8").catch(() => undefined)
+          : undefined;
 
       try {
         return await tool.execute(toolCallId, params, signal, onUpdate);

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -836,8 +836,13 @@ function wrapAbortAfterCommitRecovery(
           throw error;
         }
 
+        const oldText = typeof record?.oldText === "string" ? record.oldText : undefined;
         const newText = typeof record?.newText === "string" ? record.newText : undefined;
-        if (newText !== undefined && current.includes(newText)) {
+        if (
+          newText !== undefined &&
+          current.includes(newText) &&
+          (oldText === undefined || !current.includes(oldText))
+        ) {
           return {
             content: [{ type: "text", text: `Successfully replaced text in ${rawPath}.` }],
             details: undefined,

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -794,6 +794,19 @@ function isOperationAbortedError(error: unknown): boolean {
   return error instanceof Error && error.message.trim() === "Operation aborted";
 }
 
+function hasFileChanged(
+  before: { size: number; mtimeMs: number } | undefined,
+  after: { size: number; mtimeMs: number } | undefined,
+): boolean {
+  if (!before && after) {
+    return true;
+  }
+  if (!before || !after) {
+    return false;
+  }
+  return before.size !== after.size || before.mtimeMs !== after.mtimeMs;
+}
+
 function wrapAbortAfterCommitRecovery(
   tool: AnyAgentTool,
   options: { kind: "write" | "edit"; cwd: string },
@@ -801,21 +814,36 @@ function wrapAbortAfterCommitRecovery(
   return {
     ...tool,
     execute: async (toolCallId, params, signal, onUpdate) => {
+      const normalized = normalizeToolParams(params);
+      const record =
+        normalized ??
+        (params && typeof params === "object" ? (params as Record<string, unknown>) : undefined);
+      const rawPath = typeof record?.path === "string" ? record.path.trim() : "";
+      const resolvedPath = rawPath
+        ? resolveToolPathForVerification(rawPath, options.cwd)
+        : undefined;
+      const beforeStat = resolvedPath
+        ? await fs
+            .stat(resolvedPath)
+            .then((stat) => ({ size: stat.size, mtimeMs: stat.mtimeMs }))
+            .catch(() => undefined)
+        : undefined;
+
       try {
         return await tool.execute(toolCallId, params, signal, onUpdate);
       } catch (error) {
-        if (!isOperationAbortedError(error)) {
+        if (!isOperationAbortedError(error) || !resolvedPath || !rawPath) {
           throw error;
         }
-        const normalized = normalizeToolParams(params);
-        const record =
-          normalized ??
-          (params && typeof params === "object" ? (params as Record<string, unknown>) : undefined);
-        const rawPath = typeof record?.path === "string" ? record.path.trim() : "";
-        if (!rawPath) {
+
+        const afterStat = await fs
+          .stat(resolvedPath)
+          .then((stat) => ({ size: stat.size, mtimeMs: stat.mtimeMs }))
+          .catch(() => undefined);
+        if (!hasFileChanged(beforeStat, afterStat)) {
           throw error;
         }
-        const resolvedPath = resolveToolPathForVerification(rawPath, options.cwd);
+
         let current = "";
         try {
           current = await fs.readFile(resolvedPath, "utf8");


### PR DESCRIPTION
## Summary
- fix a race where host `write`/`edit` can report `Operation aborted` after the filesystem mutation already committed
- add host-side recovery wrapper in `pi-tools.read.ts` that verifies committed state and converts the result back to success
- add regression tests for both write and edit recovery paths

## Why
In some turns (especially isolated cron `agentTurn`), abort can arrive after write/edit has already persisted data, producing a false error while content is actually written.

This PR addresses the system-level symptom for OpenClaw host tools and covers both issue patterns:
- #32333 (`edit` reports failure but write actually happened)
- #30773 (`write` reports failure but file exists)

## Notes
- This change is scoped to host workspace write/edit wrappers in OpenClaw
- Existing access/path safety behavior is unchanged

## Test
- `pnpm exec vitest run src/agents/pi-tools.abort-recovery.test.ts src/agents/pi-tools.read.host-edit-access.test.ts`
