### PR TITLE
fix(slack): fail fast on non-recoverable auth errors instead of retry loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Sessions/idle reset correctness: preserve existing `updatedAt` during inbound metadata-only writes so idle-reset boundaries are not unintentionally refreshed before actual user turns. (#32379) Thanks @romeodiaz.
+- Slack/socket auth failure handling: fail fast on non-recoverable auth errors (`account_inactive`, `invalid_auth`, etc.) during startup and reconnect instead of retry-looping indefinitely, including `unable_to_socket_mode_start` error payload propagation. (#32377) Thanks @scoootscooob.
 - Gateway/message tool reliability: avoid false `Unknown channel` failures when `message.*` actions receive platform-specific channel ids by falling back to `toolContext.currentChannelProvider`, and prevent health-monitor restart thrash for channels that just (re)started by adding a per-channel startup-connect grace window. (from #32367) Thanks @MunemHashmi.
 - Discord/lifecycle startup status: push an immediate `connected` status snapshot when the gateway is already connected before lifecycle debug listeners attach, with abort-guarding to avoid contradictory status flips during pre-aborted startup. (#32336) Thanks @mitchmcalister.
 - Cron/isolated delivery target fallback: remove early unresolved-target return so cron delivery can flow through shared outbound target resolution (including per-channel `resolveDefaultTo` fallback) when `delivery.to` is omitted. (#32364) Thanks @hclsys.

--- a/src/slack/monitor/provider.auth-errors.test.ts
+++ b/src/slack/monitor/provider.auth-errors.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { isNonRecoverableSlackAuthError } from "./provider.js";
+
+describe("isNonRecoverableSlackAuthError", () => {
+  it.each([
+    "An API error occurred: account_inactive",
+    "An API error occurred: invalid_auth",
+    "An API error occurred: token_revoked",
+    "An API error occurred: token_expired",
+    "An API error occurred: not_authed",
+    "An API error occurred: org_login_required",
+    "An API error occurred: team_access_not_granted",
+    "An API error occurred: missing_scope",
+    "An API error occurred: cannot_find_service",
+    "An API error occurred: invalid_token",
+  ])("returns true for non-recoverable error: %s", (msg) => {
+    expect(isNonRecoverableSlackAuthError(new Error(msg))).toBe(true);
+  });
+
+  it("returns true when error is a plain string", () => {
+    expect(isNonRecoverableSlackAuthError("account_inactive")).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(isNonRecoverableSlackAuthError(new Error("ACCOUNT_INACTIVE"))).toBe(true);
+    expect(isNonRecoverableSlackAuthError(new Error("Invalid_Auth"))).toBe(true);
+  });
+
+  it.each([
+    "Connection timed out",
+    "ECONNRESET",
+    "Network request failed",
+    "socket hang up",
+    "ETIMEDOUT",
+    "rate_limited",
+  ])("returns false for recoverable/transient error: %s", (msg) => {
+    expect(isNonRecoverableSlackAuthError(new Error(msg))).toBe(false);
+  });
+
+  it("returns false for non-error values", () => {
+    expect(isNonRecoverableSlackAuthError(null)).toBe(false);
+    expect(isNonRecoverableSlackAuthError(undefined)).toBe(false);
+    expect(isNonRecoverableSlackAuthError(42)).toBe(false);
+    expect(isNonRecoverableSlackAuthError({})).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isNonRecoverableSlackAuthError("")).toBe(false);
+    expect(isNonRecoverableSlackAuthError(new Error(""))).toBe(false);
+  });
+});

--- a/src/slack/monitor/provider.reconnect.test.ts
+++ b/src/slack/monitor/provider.reconnect.test.ts
@@ -42,4 +42,18 @@ describe("slack socket reconnect helpers", () => {
 
     await expect(waiter).resolves.toEqual({ event: "error", error: err });
   });
+
+  it("preserves error payload from unable_to_socket_mode_start event", async () => {
+    const client = new FakeEmitter();
+    const app = { receiver: { client } };
+    const err = new Error("invalid_auth");
+
+    const waiter = __testing.waitForSlackSocketDisconnect(app as never);
+    client.emit("unable_to_socket_mode_start", err);
+
+    await expect(waiter).resolves.toEqual({
+      event: "unable_to_socket_mode_start",
+      error: err,
+    });
+  });
 });

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -105,7 +105,8 @@ function waitForSlackSocketDisconnect(
     }
 
     const disconnectListener = () => resolveOnce({ event: "disconnect" });
-    const startFailListener = () => resolveOnce({ event: "unable_to_socket_mode_start" });
+    const startFailListener = (error?: unknown) =>
+      resolveOnce({ event: "unable_to_socket_mode_start", error });
     const errorListener = (error: unknown) => resolveOnce({ event: "error", error });
     const abortListener = () => resolveOnce({ event: "disconnect" });
 

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -128,6 +128,18 @@ function waitForSlackSocketDisconnect(
   });
 }
 
+/**
+ * Detect non-recoverable Slack API / auth errors that should NOT be retried.
+ * These indicate permanent credential problems (revoked bot, deactivated account, etc.)
+ * and retrying will never succeed — continuing to retry blocks the entire gateway.
+ */
+export function isNonRecoverableSlackAuthError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  return /account_inactive|invalid_auth|token_revoked|token_expired|not_authed|org_login_required|team_access_not_granted|missing_scope|cannot_find_service|invalid_token/i.test(
+    msg,
+  );
+}
+
 function formatUnknownError(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
@@ -473,6 +485,14 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           reconnectAttempts = 0;
           runtime.log?.("slack socket mode connected");
         } catch (err) {
+          // Auth errors (account_inactive, invalid_auth, etc.) are permanent —
+          // retrying will never succeed and blocks the entire gateway.  Fail fast.
+          if (isNonRecoverableSlackAuthError(err)) {
+            runtime.error?.(
+              `slack socket mode failed to start due to non-recoverable auth error — skipping channel (${formatUnknownError(err)})`,
+            );
+            throw err;
+          }
           reconnectAttempts += 1;
           if (
             SLACK_SOCKET_RECONNECT_POLICY.maxAttempts > 0 &&
@@ -499,6 +519,16 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         const disconnect = await waitForSlackSocketDisconnect(app, opts.abortSignal);
         if (opts.abortSignal?.aborted) {
           break;
+        }
+
+        // Bail immediately on non-recoverable auth errors during reconnect too.
+        if (disconnect.error && isNonRecoverableSlackAuthError(disconnect.error)) {
+          runtime.error?.(
+            `slack socket mode disconnected due to non-recoverable auth error — skipping channel (${formatUnknownError(disconnect.error)})`,
+          );
+          throw disconnect.error instanceof Error
+            ? disconnect.error
+            : new Error(formatUnknownError(disconnect.error));
         }
 
         reconnectAttempts += 1;


### PR DESCRIPTION
## Summary

Fixes #32366 — When a Slack bot is removed from a workspace while still configured in OpenClaw, the gateway enters an infinite retry loop on `account_inactive`/`invalid_auth` errors, making the entire gateway unresponsive.

**Root cause:** The Slack socket mode startup catch block (line ~475) retries all errors uniformly with exponential backoff — it doesn't distinguish between recoverable network errors (timeouts, connection resets) and permanent auth failures (revoked bot, deactivated account). This is unlike the Telegram provider which already has `isRecoverableTelegramNetworkError()` to classify errors.

**Fix:** Add `isNonRecoverableSlackAuthError()` that detects permanent credential failures via error message pattern matching. The check is applied in two places:

1. **Startup catch block** — if `app.start()` throws a non-recoverable auth error, throw immediately instead of entering the retry loop
2. **Disconnect reconnect path** — if the socket disconnect event carries a non-recoverable auth error, throw immediately instead of attempting reconnection

Detected error codes: `account_inactive`, `invalid_auth`, `token_revoked`, `token_expired`, `not_authed`, `org_login_required`, `team_access_not_granted`, `missing_scope`, `cannot_find_service`, `invalid_token`

## Test plan

- [x] 20 unit tests for `isNonRecoverableSlackAuthError()` covering all known error codes, case insensitivity, string inputs, and false positives for transient errors
- [ ] Manual: configure an invalid Slack bot token, start gateway, verify it fails fast with clear error instead of retrying 12 times

🤖 Generated with [Claude Code](https://claude.com/claude-code)