### PR TITLE
test(gateway): make request-helper auth precedence explicit

### DIFF
--- a/src/gateway/hooks-test-helpers.test.ts
+++ b/src/gateway/hooks-test-helpers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+import { createGatewayRequest } from "./hooks-test-helpers.js";
+
+describe("createGatewayRequest", () => {
+  test("preserves custom headers and applies explicit authorization last", () => {
+    const req = createGatewayRequest({
+      path: "/hooks/wake",
+      headers: {
+        authorization: "Bearer header-token",
+        "content-type": "application/json",
+      },
+      authorization: "Bearer explicit-token",
+    });
+
+    expect(req.headers.authorization).toBe("Bearer explicit-token");
+    expect(req.headers["content-type"]).toBe("application/json");
+  });
+});

--- a/src/gateway/hooks-test-helpers.ts
+++ b/src/gateway/hooks-test-helpers.ts
@@ -23,6 +23,7 @@ export function createHooksConfig(): HooksConfigResolved {
 export function createGatewayRequest(params: {
   path: string;
   authorization?: string;
+  headers?: Record<string, string>;
   method?: string;
   remoteAddress?: string;
   host?: string;
@@ -30,6 +31,11 @@ export function createGatewayRequest(params: {
   const headers: Record<string, string> = {
     host: params.host ?? "localhost:18789",
   };
+  if (params.headers) {
+    for (const [key, value] of Object.entries(params.headers)) {
+      headers[key] = value;
+    }
+  }
   if (params.authorization) {
     headers.authorization = params.authorization;
   }

--- a/src/gateway/server-http.test-harness.ts
+++ b/src/gateway/server-http.test-harness.ts
@@ -27,11 +27,13 @@ export const AUTH_TOKEN: ResolvedGatewayAuth = {
 export function createRequest(params: {
   path: string;
   authorization?: string;
+  headers?: Record<string, string>;
   method?: string;
 }): IncomingMessage {
   return createGatewayRequest({
     path: params.path,
     authorization: params.authorization,
+    headers: params.headers,
     method: params.method,
   });
 }
@@ -126,6 +128,7 @@ export async function sendRequest(
   params: {
     path: string;
     authorization?: string;
+    headers?: Record<string, string>;
     method?: string;
   },
 ): Promise<ReturnType<typeof createResponse>> {


### PR DESCRIPTION
## Summary
- allow gateway test request helpers to accept explicit raw headers
- keep `authorization` precedence unambiguous by applying the dedicated `authorization` parameter after raw header merge
- add a focused unit test proving explicit auth overrides a raw `headers.authorization` value

## Why
Some auth-boundary tests need custom headers (for example JSON content type), and header merge order should be deterministic so tests cannot accidentally shadow explicit auth input.

## Testing
- `pnpm test -- src/gateway/hooks-test-helpers.test.ts`
- `pnpm test -- src/gateway/server-http.hooks-request-timeout.test.ts`
- `pnpm check` *(fails on current repo baseline unrelated to this change: existing `extensions/tlon` + `Promise.withResolvers` tsgo errors)*
