### PR TITLE
fix(sessions): preserve idle reset timestamp on inbound metadata writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sessions/idle reset correctness: preserve existing `updatedAt` during inbound metadata-only writes so idle-reset boundaries are not unintentionally refreshed before actual user turns. (#32379) Thanks @romeodiaz.
 - Gateway/message tool reliability: avoid false `Unknown channel` failures when `message.*` actions receive platform-specific channel ids by falling back to `toolContext.currentChannelProvider`, and prevent health-monitor restart thrash for channels that just (re)started by adding a per-channel startup-connect grace window. (from #32367) Thanks @MunemHashmi.
 - Discord/lifecycle startup status: push an immediate `connected` status snapshot when the gateway is already connected before lifecycle debug listeners attach, with abort-guarding to avoid contradictory status flips during pre-aborted startup. (#32336) Thanks @mitchmcalister.
 - Cron/isolated delivery target fallback: remove early unresolved-target return so cron delivery can flow through shared outbound target resolution (including per-channel `resolveDefaultTo` fallback) when `delivery.to` is omitted. (#32364) Thanks @hclsys.

--- a/src/config/sessions/store.session-key-normalization.test.ts
+++ b/src/config/sessions/store.session-key-normalization.test.ts
@@ -108,4 +108,41 @@ describe("session store key normalization", () => {
     expect(store[CANONICAL_KEY]?.sessionId).toBe("legacy-session");
     expect(store[MIXED_CASE_KEY]).toBeUndefined();
   });
+
+  it("preserves updatedAt when recording inbound metadata for an existing session", async () => {
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [CANONICAL_KEY]: {
+            sessionId: "existing-session",
+            updatedAt: 1111,
+            chatType: "direct",
+            channel: "webchat",
+            origin: {
+              provider: "webchat",
+              chatType: "direct",
+              from: "WebChat:User-1",
+              to: "webchat:user-1",
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    clearSessionStoreCacheForTest();
+
+    await recordSessionMetaFromInbound({
+      storePath,
+      sessionKey: CANONICAL_KEY,
+      ctx: createInboundContext(),
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[CANONICAL_KEY]?.sessionId).toBe("existing-session");
+    expect(store[CANONICAL_KEY]?.updatedAt).toBe(1111);
+    expect(store[CANONICAL_KEY]?.origin?.provider).toBe("webchat");
+  });
 });

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { acquireSessionWriteLock } from "../../agents/session-write-lock.js";
@@ -736,7 +737,16 @@ export async function recordSessionMetaFromInbound(params: {
       if (!existing && !createIfMissing) {
         return null;
       }
-      const next = mergeSessionEntry(existing, patch);
+      const next = existing
+        ? normalizeSessionRuntimeModelFields({
+            ...existing,
+            ...patch,
+            // Inbound metadata updates must not refresh activity timestamps;
+            // idle reset evaluation relies on updatedAt from actual session turns.
+            sessionId: existing.sessionId ?? crypto.randomUUID(),
+            updatedAt: existing.updatedAt ?? Date.now(),
+          })
+        : mergeSessionEntry(existing, patch);
       store[resolved.normalizedKey] = next;
       for (const legacyKey of resolved.legacyKeys) {
         delete store[legacyKey];


### PR DESCRIPTION
## Summary
- preserve `updatedAt` in `recordSessionMetaFromInbound()` when a session entry already exists
- avoid refreshing idle activity timestamps during metadata-only writes
- add a regression test to ensure inbound metadata updates do not modify `updatedAt`

## Problem
Idle-based session resets can fail for long-running DM/thread sessions because inbound metadata writes run before session freshness evaluation and bump `updatedAt` to `Date.now()`.

That makes stale sessions appear fresh indefinitely, so new messages keep appending to the same session even after long idle gaps.

## Root Cause
`recordSessionMetaFromInbound()` used `mergeSessionEntry(existing, patch)`, and `mergeSessionEntry` always advances `updatedAt` to at least `Date.now()`.

## Fix
When an existing entry is present, merge metadata patch fields directly while preserving:
- existing `updatedAt`
- existing `sessionId` (or generate only if missing)

Creation flow for missing entries is unchanged and still uses `mergeSessionEntry`.

## Test
Added `preserves updatedAt when recording inbound metadata for an existing session` in:
- `src/config/sessions/store.session-key-normalization.test.ts`

Ran:
- `corepack pnpm -s vitest run src/config/sessions/store.session-key-normalization.test.ts`

(4 tests passed)
