### PR TITLE
fix(gemini-cli-auth): use PLATFORM_UNSPECIFIED for Linux in loadCodeAssist

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -239,7 +239,7 @@ describe("loginGeminiCliOAuth", () => {
     "GOOGLE_CLOUD_PROJECT_ID",
   ] as const;
 
-  function getExpectedPlatform(): "WINDOWS" | "MACOS" | "LINUX" | "PLATFORM_UNSPECIFIED" {
+  function getExpectedPlatform(): "WINDOWS" | "MACOS" | "PLATFORM_UNSPECIFIED" {
     if (process.platform === "win32") {
       return "WINDOWS";
     }

--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -239,14 +239,15 @@ describe("loginGeminiCliOAuth", () => {
     "GOOGLE_CLOUD_PROJECT_ID",
   ] as const;
 
-  function getExpectedPlatform(): "WINDOWS" | "MACOS" | "LINUX" {
+  function getExpectedPlatform(): "WINDOWS" | "MACOS" | "LINUX" | "PLATFORM_UNSPECIFIED" {
     if (process.platform === "win32") {
       return "WINDOWS";
     }
-    if (process.platform === "linux") {
-      return "LINUX";
+    if (process.platform === "darwin") {
+      return "MACOS";
     }
-    return "MACOS";
+    // Matches updated resolvePlatform() which uses PLATFORM_UNSPECIFIED for Linux
+    return "PLATFORM_UNSPECIFIED";
   }
 
   function getRequestUrl(input: string | URL | Request): string {

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -224,14 +224,16 @@ function generatePkce(): { verifier: string; challenge: string } {
   return { verifier, challenge };
 }
 
-function resolvePlatform(): "WINDOWS" | "MACOS" | "LINUX" {
+function resolvePlatform(): "WINDOWS" | "MACOS" | "LINUX" | "PLATFORM_UNSPECIFIED" {
   if (process.platform === "win32") {
     return "WINDOWS";
   }
-  if (process.platform === "linux") {
-    return "LINUX";
+  if (process.platform === "darwin") {
+    return "MACOS";
   }
-  return "MACOS";
+  // Google's loadCodeAssist API rejects "LINUX" as an invalid Platform enum value.
+  // Use "PLATFORM_UNSPECIFIED" for Linux and other platforms to match the pi-ai runtime.
+  return "PLATFORM_UNSPECIFIED";
 }
 
 async function fetchWithTimeout(

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -224,7 +224,7 @@ function generatePkce(): { verifier: string; challenge: string } {
   return { verifier, challenge };
 }
 
-function resolvePlatform(): "WINDOWS" | "MACOS" | "LINUX" | "PLATFORM_UNSPECIFIED" {
+function resolvePlatform(): "WINDOWS" | "MACOS" | "PLATFORM_UNSPECIFIED" {
   if (process.platform === "win32") {
     return "WINDOWS";
   }


### PR DESCRIPTION
## Summary

- Google's `loadCodeAssist` API rejects `"LINUX"` as an invalid `Platform` enum value, causing Gemini CLI OAuth setup to fail with `400 Bad Request` on all Linux systems
- Changed `resolvePlatform()` to return `"PLATFORM_UNSPECIFIED"` for Linux (and other non-Windows/macOS platforms), matching the approach already used by the `pi-ai` runtime (`@mariozechner/pi-ai/dist/utils/oauth/google-gemini-cli.js`)
- Also fixed the original logic which incorrectly used `process.platform === "linux"` check before a `"MACOS"` fallback, instead of explicitly checking for `"darwin"`

## Error reproduced

```
Error: loadCodeAssist failed: 400 Bad Request
  Invalid value at 'metadata.platform' (type.googleapis.com/google.internal.cloud.code.v1internal.ClientMetadata.Platform), "LINUX"
```

## Test plan

- [x] Updated `oauth.test.ts` to match new `resolvePlatform()` behavior
- [ ] Verify OAuth login works on Linux after the fix
- [ ] Verify OAuth login still works on macOS and Windows (no behavior change for those platforms)