### PR TITLE
feat(mattermost): include thread root post context in inbound messages

### DIFF
--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -138,6 +138,13 @@ export async function fetchMattermostChannel(
   return await client.request<MattermostChannel>(`/channels/${channelId}`);
 }
 
+export async function fetchMattermostPost(
+  client: MattermostClient,
+  postId: string,
+): Promise<MattermostPost> {
+  return await client.request<MattermostPost>(`/posts/${encodeURIComponent(postId)}`);
+}
+
 export async function sendMattermostTyping(
   client: MattermostClient,
   params: { channelId: string; parentId?: string },

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -32,6 +32,7 @@ import { resolveMattermostAccount } from "./accounts.js";
 import {
   createMattermostClient,
   fetchMattermostChannel,
+  fetchMattermostPost,
   fetchMattermostMe,
   fetchMattermostUser,
   normalizeMattermostBaseUrl,
@@ -613,7 +614,25 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       contextKey: `mattermost:message:${channelId}:${post.id ?? "unknown"}`,
     });
 
-    const textWithId = `${bodyText}\n[mattermost message id: ${post.id ?? "unknown"} channel: ${channelId}]`;
+    // Resolve thread root post context when this message is part of a thread
+    let threadRootContext = "";
+    if (threadRootId) {
+      try {
+        const rootPost = await fetchMattermostPost(client, threadRootId);
+        const rootBody = rootPost.message?.trim() ?? "";
+        if (rootBody) {
+          const rootUserId = rootPost.user_id?.trim();
+          const rootSenderName = rootUserId
+            ? (await resolveUserInfo(rootUserId))?.username?.trim() || `user:${rootUserId}`
+            : "unknown";
+          threadRootContext = `\n\n[Thread started by @${rootSenderName}]\n${rootBody}\n[/Thread]`;
+        }
+      } catch {
+        // Non-critical: if we can't fetch the root post, proceed without context
+      }
+    }
+
+    const textWithId = `${bodyText}${threadRootContext}\n[mattermost message id: ${post.id ?? "unknown"} channel: ${channelId}]`;
     const body = core.channel.reply.formatInboundEnvelope({
       channel: "Mattermost",
       from: fromLabel,


### PR DESCRIPTION
## Problem

When a user replies in a Mattermost thread, the agent receives the reply message but has no visibility into the root post that started the thread. This makes thread-based conversations confusing — the agent can't see what's being discussed.

## Solution

When processing an inbound Mattermost message that belongs to a thread (`root_id` is set), fetch the root post via the Mattermost API and include its content as context in the message body.

The context is formatted as:
```
[Thread started by @username]
<root post content>
[/Thread]
```

This follows the same pattern used by the Telegram channel for reply-to context (`[Replying to ...]`).

## Changes

- **`client.ts`**: Added `fetchMattermostPost()` API helper to fetch a post by ID
- **`monitor.ts`**: Added thread root context resolution before building the inbound message body. Uses existing `resolveUserInfo()` cache for sender name resolution. Failures are silently caught (non-critical path).

## Notes

- Only fetches the root post, not the entire thread history
- Uses the existing user cache so no extra API calls for known users
- Gracefully degrades: if the root post fetch fails, the message is delivered without thread context