### PR TITLE
fix(voice-call): clear failed runtime promise to prevent EADDRINUSE errors

### DIFF
--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -498,7 +498,13 @@ const voiceCallPlugin = {
         try {
           await ensureRuntime();
         } catch (err) {
-          // Error already logged in runtime.ts with more detail
+          // Log startup failures (runtime.ts only logs createVoiceCallRuntime errors,
+          // not validation or disabled-config errors that happen earlier in ensureRuntime)
+          api.logger.error(
+            `[voice-call] Service startup failed: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
           // Ensure cleanup on startup failure (defensive, already done in ensureRuntime catch)
           runtimePromise = null;
           runtime = null;

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -181,8 +181,14 @@ const voiceCallPlugin = {
           logger: api.logger,
         });
       }
-      runtime = await runtimePromise;
-      return runtime;
+      try {
+        runtime = await runtimePromise;
+        return runtime;
+      } catch (err) {
+        // Clear the failed promise so next call retries cleanly
+        runtimePromise = null;
+        throw err;
+      }
     };
 
     const sendError = (respond: (ok: boolean, payload?: unknown) => void, err: unknown) => {
@@ -497,6 +503,9 @@ const voiceCallPlugin = {
               err instanceof Error ? err.message : String(err)
             }`,
           );
+          // Ensure cleanup on startup failure
+          runtimePromise = null;
+          runtime = null;
         }
       },
       stop: async () => {
@@ -506,6 +515,12 @@ const voiceCallPlugin = {
         try {
           const rt = await runtimePromise;
           await rt.stop();
+        } catch (err) {
+          api.logger.warn(
+            `[voice-call] Error during runtime stop: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
         } finally {
           runtimePromise = null;
           runtime = null;

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -498,12 +498,8 @@ const voiceCallPlugin = {
         try {
           await ensureRuntime();
         } catch (err) {
-          api.logger.error(
-            `[voice-call] Failed to start runtime: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-          );
-          // Ensure cleanup on startup failure
+          // Error already logged in runtime.ts with more detail
+          // Ensure cleanup on startup failure (defensive, already done in ensureRuntime catch)
           runtimePromise = null;
           runtime = null;
         }

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -124,91 +124,133 @@ export async function createVoiceCallRuntime(params: {
   const manager = new CallManager(config);
   const webhookServer = new VoiceCallWebhookServer(config, manager, provider, coreConfig);
 
-  const localUrl = await webhookServer.start();
+  let localUrl: string;
+  try {
+    localUrl = await webhookServer.start();
+  } catch (err) {
+    log.error(
+      `[voice-call] Failed to start webhook server: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    throw err;
+  }
 
-  // Determine public URL - priority: config.publicUrl > tunnel > legacy tailscale
-  let publicUrl: string | null = config.publicUrl ?? null;
+  // Wrap remaining initialization in try/catch to clean up webhook server on failure
   let tunnelResult: TunnelResult | null = null;
+  try {
+    // Determine public URL - priority: config.publicUrl > tunnel > legacy tailscale
+    let publicUrl: string | null = config.publicUrl ?? null;
 
-  if (!publicUrl && config.tunnel?.provider && config.tunnel.provider !== "none") {
+    if (!publicUrl && config.tunnel?.provider && config.tunnel.provider !== "none") {
+      try {
+        tunnelResult = await startTunnel({
+          provider: config.tunnel.provider,
+          port: config.serve.port,
+          path: config.serve.path,
+          ngrokAuthToken: config.tunnel.ngrokAuthToken,
+          ngrokDomain: config.tunnel.ngrokDomain,
+        });
+        publicUrl = tunnelResult?.publicUrl ?? null;
+      } catch (err) {
+        log.error(
+          `[voice-call] Tunnel setup failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    if (!publicUrl && config.tailscale?.mode !== "off") {
+      publicUrl = await setupTailscaleExposure(config);
+    }
+
+    const webhookUrl = publicUrl ?? localUrl;
+
+    if (publicUrl && provider.name === "twilio") {
+      (provider as TwilioProvider).setPublicUrl(publicUrl);
+    }
+
+    if (provider.name === "twilio" && config.streaming?.enabled) {
+      const twilioProvider = provider as TwilioProvider;
+      if (ttsRuntime?.textToSpeechTelephony) {
+        try {
+          const ttsProvider = createTelephonyTtsProvider({
+            coreConfig,
+            ttsOverride: config.tts,
+            runtime: ttsRuntime,
+          });
+          twilioProvider.setTTSProvider(ttsProvider);
+          log.info("[voice-call] Telephony TTS provider configured");
+        } catch (err) {
+          log.warn(
+            `[voice-call] Failed to initialize telephony TTS: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      } else {
+        log.warn("[voice-call] Telephony TTS unavailable; streaming TTS disabled");
+      }
+
+      const mediaHandler = webhookServer.getMediaStreamHandler();
+      if (mediaHandler) {
+        twilioProvider.setMediaStreamHandler(mediaHandler);
+        log.info("[voice-call] Media stream handler wired to provider");
+      }
+    }
+
+    await manager.initialize(provider, webhookUrl);
+
+    const stop = async () => {
+      if (tunnelResult) {
+        await tunnelResult.stop();
+      }
+      await cleanupTailscaleExposure(config);
+      await webhookServer.stop();
+    };
+
+    log.info("[voice-call] Runtime initialized");
+    log.info(`[voice-call] Webhook URL: ${webhookUrl}`);
+    if (publicUrl) {
+      log.info(`[voice-call] Public URL: ${publicUrl}`);
+    }
+
+    return {
+      config,
+      provider,
+      manager,
+      webhookServer,
+      webhookUrl,
+      publicUrl,
+      stop,
+    };
+  } catch (err) {
+    // Clean up webhook server on initialization failure
+    log.error(
+      `[voice-call] Runtime initialization failed, cleaning up webhook server: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
     try {
-      tunnelResult = await startTunnel({
-        provider: config.tunnel.provider,
-        port: config.serve.port,
-        path: config.serve.path,
-        ngrokAuthToken: config.tunnel.ngrokAuthToken,
-        ngrokDomain: config.tunnel.ngrokDomain,
-      });
-      publicUrl = tunnelResult?.publicUrl ?? null;
-    } catch (err) {
-      log.error(
-        `[voice-call] Tunnel setup failed: ${err instanceof Error ? err.message : String(err)}`,
+      await webhookServer.stop();
+    } catch (stopErr) {
+      log.warn(
+        `[voice-call] Failed to stop webhook server during cleanup: ${
+          stopErr instanceof Error ? stopErr.message : String(stopErr)
+        }`,
       );
     }
-  }
-
-  if (!publicUrl && config.tailscale?.mode !== "off") {
-    publicUrl = await setupTailscaleExposure(config);
-  }
-
-  const webhookUrl = publicUrl ?? localUrl;
-
-  if (publicUrl && provider.name === "twilio") {
-    (provider as TwilioProvider).setPublicUrl(publicUrl);
-  }
-
-  if (provider.name === "twilio" && config.streaming?.enabled) {
-    const twilioProvider = provider as TwilioProvider;
-    if (ttsRuntime?.textToSpeechTelephony) {
+    // Clean up tunnel if started
+    if (tunnelResult) {
       try {
-        const ttsProvider = createTelephonyTtsProvider({
-          coreConfig,
-          ttsOverride: config.tts,
-          runtime: ttsRuntime,
-        });
-        twilioProvider.setTTSProvider(ttsProvider);
-        log.info("[voice-call] Telephony TTS provider configured");
-      } catch (err) {
+        await tunnelResult.stop();
+      } catch (tunnelErr) {
         log.warn(
-          `[voice-call] Failed to initialize telephony TTS: ${
-            err instanceof Error ? err.message : String(err)
+          `[voice-call] Failed to stop tunnel during cleanup: ${
+            tunnelErr instanceof Error ? tunnelErr.message : String(tunnelErr)
           }`,
         );
       }
-    } else {
-      log.warn("[voice-call] Telephony TTS unavailable; streaming TTS disabled");
     }
-
-    const mediaHandler = webhookServer.getMediaStreamHandler();
-    if (mediaHandler) {
-      twilioProvider.setMediaStreamHandler(mediaHandler);
-      log.info("[voice-call] Media stream handler wired to provider");
-    }
+    throw err;
   }
-
-  await manager.initialize(provider, webhookUrl);
-
-  const stop = async () => {
-    if (tunnelResult) {
-      await tunnelResult.stop();
-    }
-    await cleanupTailscaleExposure(config);
-    await webhookServer.stop();
-  };
-
-  log.info("[voice-call] Runtime initialized");
-  log.info(`[voice-call] Webhook URL: ${webhookUrl}`);
-  if (publicUrl) {
-    log.info(`[voice-call] Public URL: ${publicUrl}`);
-  }
-
-  return {
-    config,
-    provider,
-    manager,
-    webhookServer,
-    webhookUrl,
-    publicUrl,
-    stop,
-  };
 }

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -224,21 +224,13 @@ export async function createVoiceCallRuntime(params: {
       stop,
     };
   } catch (err) {
-    // Clean up webhook server on initialization failure
+    // Clean up all resources on initialization failure
     log.error(
-      `[voice-call] Runtime initialization failed, cleaning up webhook server: ${
+      `[voice-call] Runtime initialization failed, cleaning up resources: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
-    try {
-      await webhookServer.stop();
-    } catch (stopErr) {
-      log.warn(
-        `[voice-call] Failed to stop webhook server during cleanup: ${
-          stopErr instanceof Error ? stopErr.message : String(stopErr)
-        }`,
-      );
-    }
+    
     // Clean up tunnel if started
     if (tunnelResult) {
       try {
@@ -251,6 +243,29 @@ export async function createVoiceCallRuntime(params: {
         );
       }
     }
+    
+    // Clean up tailscale exposure (idempotent, safe to call even if not set up)
+    try {
+      await cleanupTailscaleExposure(config);
+    } catch (tailscaleErr) {
+      log.warn(
+        `[voice-call] Failed to cleanup tailscale during cleanup: ${
+          tailscaleErr instanceof Error ? tailscaleErr.message : String(tailscaleErr)
+        }`,
+      );
+    }
+    
+    // Clean up webhook server last
+    try {
+      await webhookServer.stop();
+    } catch (stopErr) {
+      log.warn(
+        `[voice-call] Failed to stop webhook server during cleanup: ${
+          stopErr instanceof Error ? stopErr.message : String(stopErr)
+        }`,
+      );
+    }
+    
     throw err;
   }
 }

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -230,7 +230,7 @@ export async function createVoiceCallRuntime(params: {
         err instanceof Error ? err.message : String(err)
       }`,
     );
-    
+
     // Clean up tunnel if started
     if (tunnelResult) {
       try {
@@ -243,7 +243,7 @@ export async function createVoiceCallRuntime(params: {
         );
       }
     }
-    
+
     // Clean up tailscale exposure (idempotent, safe to call even if not set up)
     try {
       await cleanupTailscaleExposure(config);
@@ -254,7 +254,7 @@ export async function createVoiceCallRuntime(params: {
         }`,
       );
     }
-    
+
     // Clean up webhook server last
     try {
       await webhookServer.stop();
@@ -265,7 +265,7 @@ export async function createVoiceCallRuntime(params: {
         }`,
       );
     }
-    
+
     throw err;
   }
 }


### PR DESCRIPTION
## Problem

Fixes #32387

When runtime initialization fails after the webhook server has started, the `runtimePromise` remains set but `runtime` stays `null`. Subsequent tool calls would try to await the failed promise again, potentially causing port conflicts (EADDRINUSE).

## Root Cause

1. Service starts → calls `ensureRuntime()` → webhook server starts successfully on port 31156
2. If any subsequent initialization step fails, the error is caught in the service start handler
3. The webhook server keeps running, but:
   - `runtime` stays `null`
   - `runtimePromise` stays set to the failed promise
4. Next tool call → `ensureRuntime()` sees `runtime` is null, but `runtimePromise` exists
5. It tries to await the same failed promise → either retries creating server (EADDRINUSE) or throws cached error

## Changes

### 1. Clear failed promise in `ensureRuntime()`
- Wrap `await runtimePromise` in try/catch
- Clear `runtimePromise = null` on failure
- This allows clean retry on next call

### 2. Add cleanup in service start error handler
- Set `runtimePromise = null` and `runtime = null` on startup failure
- Ensures clean state after failed initialization

### 3. Add error logging in service stop handler  
- Wrap `rt.stop()` in try/catch
- Log warnings instead of failing silently
- Still cleans up state in finally block

## Testing

Before fix:
```
01:31:15 info [voice-call] Webhook server listening on http://127.0.0.1:31156/voice/webhook
01:32:06 debug embedded run tool start: tool=voice_call
Error: listen EADDRINUSE: address already in use 127.0.0.1:31156
```

After fix:
- Failed initialization is cleaned up properly
- Subsequent calls retry cleanly without port conflicts
- Successful initialization reuses existing runtime

## Risk Assessment

**Low risk** - defensive error handling changes only:
- No change to happy path logic
- Only affects error recovery paths  
- Ensures proper cleanup on failure