### PR TITLE
Tests: stabilize exec timeout default coverage

### DIFF
--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -202,7 +202,7 @@ describe("secret ref resolver", () => {
         "#!/usr/bin/env node",
         "setTimeout(() => {",
         "  process.stdout.write(JSON.stringify({ protocolVersion: 1, values: { delayed: 'ok' } }));",
-        "}, 30);",
+        "}, 2600);",
       ].join("\n"),
       0o700,
     );
@@ -217,7 +217,7 @@ describe("secret ref resolver", () => {
                 source: "exec",
                 command: scriptPath,
                 passEnv: ["PATH"],
-                timeoutMs: 500,
+                timeoutMs: 5000,
               },
             },
           },


### PR DESCRIPTION
## Summary
- Stabilizes `src/secrets/resolve.test.ts` for the exec provider default no-output-timeout case by widening timing margins.
- Changes delayed script output from `30ms` to `2600ms` and `timeoutMs` from `500` to `5000` in the regression test.
- Keeps scope test-only (no runtime behavior changes) while reducing flake risk under CI scheduler jitter.

## Validation
- `pnpm exec vitest run src/secrets/resolve.test.ts`

## Notes
- Full `pnpm check` currently reports unrelated pre-existing TypeScript test typing errors outside this PR's scope.
