### PR TITLE
docs(signal): add block streaming and progressive delivery guide

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -212,6 +212,72 @@ Groups:
 - Use `channels.signal.ignoreAttachments` to skip downloading media.
 - Group history context uses `channels.signal.historyLimit` (or `channels.signal.accounts.*.historyLimit`), falling back to `messages.groupChat.historyLimit`. Set `0` to disable (default 50).
 
+## Streaming and progressive delivery
+
+Signal has no message-edit API, so preview streaming (partial or block-edit modes used on other platforms) cannot work — once a message is sent it cannot be updated in place.
+
+**Block streaming** solves this by sending completed chunks as separate messages while the model is still generating. Each chunk is a self-contained piece of text, so the conversation reads naturally even though the full reply is not finished yet.
+
+Block streaming is off by default for Signal. Enable it explicitly:
+
+```json5
+{
+  channels: {
+    signal: {
+      blockStreaming: true,
+    },
+  },
+}
+```
+
+### Full configuration example
+
+```json5
+{
+  agents: {
+    defaults: {
+      blockStreamingDefault: "on",
+      blockStreamingBreak: "text_end",
+      blockStreamingChunk: { minChars: 800, maxChars: 1200 },
+      blockStreamingCoalesce: { idleMs: 1000 },
+      humanDelay: { mode: "natural" },
+    },
+  },
+  channels: {
+    signal: {
+      blockStreaming: true,
+    },
+  },
+}
+```
+
+### Break modes
+
+- `blockStreamingBreak: "text_end"` — emits each chunk as soon as a text block finishes. Good for responsive, conversational replies.
+- `blockStreamingBreak: "message_end"` — waits for the full model response, then splits into chunks if the reply exceeds the chunk size. Better for long-form answers where you want coherent paragraphs.
+
+### Coalescing
+
+Signal defaults to a higher coalesce floor (`minChars: 1500`) to prevent tiny-fragment spam on mobile. If the model produces a short text block, the gateway holds it and merges it into the next chunk until the minimum is reached.
+
+Tune up for fewer, larger messages or down for faster delivery:
+
+```json5
+{
+  channels: {
+    signal: {
+      blockStreamingCoalesce: { minChars: 2000 },
+    },
+  },
+}
+```
+
+### Human delay
+
+`humanDelay: { mode: "natural" }` adds 800–2500 ms pauses between block messages, matching a natural typing cadence. Without it, chunks arrive in rapid machine-gun bursts that can feel jarring on mobile.
+
+For the full streaming architecture (preview streaming, block streaming, and how they interact across channels), see [Streaming](/concepts/streaming).
+
 ## Typing + read receipts
 
 - **Typing indicators**: OpenClaw sends typing signals via `signal-cli sendTyping` and refreshes them while a reply is running.


### PR DESCRIPTION
## Summary

- **Problem:** Signal channel docs (`docs/channels/signal.md`) never mention block streaming. Signal has no message-edit API, so preview streaming is impossible, but block streaming works and is a major UX improvement.
- **Why it matters:** Without documentation, Signal users see a typing indicator for minutes and then receive everything in a single batch. Block streaming sends completed chunks as separate messages during generation — but users have no way to discover this without reading the generic `docs/concepts/streaming.md`.
- **What changed:** Added a new "Streaming and progressive delivery" section to `docs/channels/signal.md` covering: why preview streaming does not work on Signal, how block streaming solves it, explicit opt-in config, coalescing behavior, human delay pacing, break modes, and a link to the full streaming architecture docs.
- **What did NOT change (scope boundary):** No source code changes. No changes to other channel docs. No streaming behavior changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Signal channel docs gap (no existing issue)

## User-visible / Behavior Changes

None — docs only.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js v22
- Integration/channel: Signal

### Steps

1. Read `docs/channels/signal.md`
2. Verify the new "Streaming and progressive delivery" section is between "Media + limits" and "Typing + read receipts"
3. Verify config examples use valid JSON5

### Expected

- Section clearly explains why preview streaming does not work on Signal
- Block streaming opt-in and configuration are documented
- All referenced config keys exist in source types

### Actual

- As expected

## Evidence

- [x] Manual review of rendered docs
- Config keys verified against source types:
  - `channels.signal.blockStreaming` → `types.channel-messaging-common.ts`
  - `channels.signal.blockStreamingCoalesce` → `types.channel-messaging-common.ts`
  - `agents.defaults.blockStreamingDefault` → `types.agent-defaults.ts`
  - `agents.defaults.blockStreamingBreak` → `types.agent-defaults.ts`
  - `agents.defaults.blockStreamingChunk` → `types.agent-defaults.ts` / `types.base.ts`
  - `agents.defaults.humanDelay` → `types.agent-defaults.ts` / `types.base.ts`

## Human Verification (required)

- Verified scenarios: All config keys cross-referenced with TypeScript type definitions in `src/config/types.*.ts`
- Edge cases checked: JSON5 syntax validity, heading level consistency with rest of signal.md, placement between correct sections
- What you did **not** verify: Rendered docs site appearance (no local docs build)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: `docs/channels/signal.md`
- Known bad symptoms: N/A (docs only)

## Risks and Mitigations

None.