### PR TITLE
docs(signal): add recommended DM configuration for personal assistant use

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -197,6 +197,48 @@ Groups:
 - `channels.signal.groupAllowFrom` controls who can trigger in groups when `allowlist` is set.
 - Runtime note: if `channels.signal` is completely missing, runtime falls back to `groupPolicy="allowlist"` for group checks (even if `channels.defaults.groupPolicy` is set).
 
+## Recommended configuration for personal use
+
+If you are running OpenClaw as a personal assistant and Signal is your primary channel, this configuration optimizes the DM experience.
+
+```json5
+{
+  channels: {
+    signal: {
+      enabled: true,
+      account: "+15551234567",
+      cliPath: "signal-cli",
+      dmPolicy: "allowlist",
+      allowFrom: ["+15557654321"],
+      sendReadReceipts: true,
+      chunkMode: "newline",
+      blockStreaming: true,
+      blockStreamingCoalesce: {
+        minChars: 800,
+        idleMs: 1000,
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      blockStreamingDefault: "on",
+      blockStreamingBreak: "text_end",
+      humanDelay: { mode: "natural" },
+    },
+  },
+}
+```
+
+What each setting does:
+
+- `sendReadReceipts: true` — shows blue checkmarks when the bot reads your message.
+- `chunkMode: "newline"` — splits outbound messages at paragraph boundaries instead of arbitrary character counts.
+- `blockStreaming: true` — progressive delivery: sends message blocks as they're ready instead of waiting for the full response.
+- `blockStreamingCoalesce` — merges small chunks to prevent message spam. `minChars: 800` is a good balance between responsiveness and notification noise.
+- `humanDelay: { mode: "natural" }` — adds realistic pauses between message blocks so delivery feels conversational.
+
+If you prefer receiving complete responses as a single message, increase `blockStreamingCoalesce.minChars` to a very high value (e.g. `50000`). The bot will still stream internally but coalesce everything into one delivery.
+
 ## How it works (behavior)
 
 - `signal-cli` runs as a daemon; the gateway reads events via SSE.


### PR DESCRIPTION
## Summary

- **Problem:** The Signal docs list config fields but provide no opinionated guidance for the most common use case: a single user running OpenClaw as a personal assistant over Signal DMs. Users piece together settings from multiple doc pages.
- **Why it matters:** Key features like read receipts, block streaming, paragraph chunking, and coalescing are never mentioned together. New users miss significant UX improvements.
- **What changed:** Added a "Recommended configuration for personal use" section to `docs/channels/signal.md` with a complete config example and brief explanations of each setting: `sendReadReceipts`, `chunkMode`, `blockStreaming`, `blockStreamingCoalesce`, and `humanDelay`.
- **What did NOT change (scope boundary):** No source code changes. No changes to other channel docs.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Signal docs usability (no existing issue)

## User-visible / Behavior Changes

None — docs only.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js v22
- Integration/channel: Signal

### Steps

1. Read `docs/channels/signal.md`
2. Verify the new "Recommended configuration for personal use" section is after "Access control"
3. Verify config examples use valid JSON5 and all keys exist in source types

### Expected

- Section provides a complete, opinionated DM config with clear explanations
- All referenced config keys exist in source types

### Actual

- As expected

## Evidence

- [x] Manual review of rendered docs
- Config keys verified against source types:
  - `channels.signal.sendReadReceipts` → `types.signal.ts`
  - `channels.signal.chunkMode` → `types.channel-messaging-common.ts`
  - `channels.signal.blockStreaming` → `types.channel-messaging-common.ts`
  - `channels.signal.blockStreamingCoalesce` → `types.channel-messaging-common.ts`
  - `agents.defaults.blockStreamingDefault`, `blockStreamingBreak` → `types.agent-defaults.ts`
  - `agents.defaults.humanDelay` → `types.agent-defaults.ts` / `types.base.ts`

## Human Verification (required)

- Verified scenarios: All config keys cross-referenced with TypeScript type definitions
- Edge cases checked: JSON5 syntax validity, heading level consistency, section placement
- What you did **not** verify: Rendered docs site appearance

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: `docs/channels/signal.md`
- Known bad symptoms: N/A (docs only)

## Risks and Mitigations

None.