### PR TITLE
fix(exec): suggest increasing timeout on timeouts (#15741)

### DIFF
--- a/skills/openai-image-gen/SKILL.md
+++ b/skills/openai-image-gen/SKILL.md
@@ -29,6 +29,9 @@ Generate a handful of “random but structured” prompts and render them via th
 
 ## Run
 
+Note: Image generation can take longer than common exec timeouts (for example 30 seconds).
+When invoking this skill via OpenClaw’s exec tool, set a higher timeout to avoid premature termination/retries (e.g., exec timeout=300).
+
 ```bash
 python3 {baseDir}/scripts/gen.py
 open ~/Projects/tmp/openai-image-gen-*/index.html  # if ~/Projects/tmp exists; else ./tmp/...

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -535,8 +535,8 @@ export async function runExecProcess(opts: {
           : "Command not executable (permission denied)"
         : exit.reason === "overall-timeout"
           ? typeof opts.timeoutSec === "number" && opts.timeoutSec > 0
-            ? `Command timed out after ${opts.timeoutSec} seconds`
-            : "Command timed out"
+            ? `Command timed out after ${opts.timeoutSec} seconds. If this command is expected to take longer, re-run with a higher timeout (e.g., exec timeout=300).`
+            : "Command timed out. If this command is expected to take longer, re-run with a higher timeout (e.g., exec timeout=300)."
           : exit.reason === "no-output-timeout"
             ? "Command timed out waiting for output"
             : exit.exitSignal != null

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -458,6 +458,9 @@ describe("exec tool backgrounding", () => {
       allowBackground: false,
     });
     await expect(executeExecCommand(customBash, longDelayCmd)).rejects.toThrow(/timed out/i);
+    await expect(executeExecCommand(customBash, longDelayCmd)).rejects.toThrow(
+      /re-run with a higher timeout/i,
+    );
   });
 
   it.each<DisallowedElevationCase>(DISALLOWED_ELEVATION_CASES)(


### PR DESCRIPTION
## **Summary**

- Problem: openai-image-gen can take longer than common exec timeouts; when the command times out, the error is not actionable, and the agent can end up retrying the same command repeatedly.
- Why it matters: This makes the openai-image-gen skill unreliable and can waste time/compute due to repeated restarts.
- What changed: Exec timeout failures now include a clear suggestion to re-run with a higher timeout; the openai-image-gen skill docs also call out the need for a longer timeout; added/updated a regression assertion in the exec tool test.
- What did NOT change (scope boundary): No changes to exec timeout semantics or defaults; only user-facing messaging + skill guidance.

## **Change Type (select all)**

- [x]  Bug fix
- [ ]  Feature
- [ ]  Refactor
- [x]  Docs
- [ ]  Security hardening
- [ ]  Chore/infra

## **Scope (select all touched areas)**

- [ ]  Gateway / orchestration
- [x]  Skills / tool execution
- [ ]  Auth / tokens
- [ ]  Memory / storage
- [ ]  Integrations
- [ ]  API / contracts
- [ ]  UI / DX
- [ ]  CI/CD / infra

## **Linked Issue/PR**

- Closes #15741

## **User-visible / Behavior Changes**

- When exec times out, the failure message now suggests re-running with a higher timeout (e.g., timeout=300), reducing “retry loops” for long-running commands (like image generation).
- openai-image-gen docs now explicitly warn that image generation can exceed short timeouts.

## **Security Impact (required)**

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation:

## **Repro + Verification**

### **Environment**

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### **Steps**

1. Run pnpm test src/agents/bash-tools.test.ts -t "uses default timeout when timeout is omitted".
2. Run pnpm check.

### **Expected**

- Tests pass; exec timeout errors include guidance to increase timeout.

### **Actual**

- Previously: timeout errors were generic and not actionable for long-running commands.

## **Evidence**

- [x]  Passing after: targeted test + pnpm check

## **Human Verification (required)**

- Verified scenarios: targeted exec timeout test; pnpm check
- Edge cases checked: N/A
- What you did **not** verify: end-to-end image generation against the OpenAI Images API

## **Compatibility / Migration**

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## **Failure Recovery (if this breaks)**

- Revert this commit.

## **Risks and Mitigations**

None.