### PR TITLE
Docs: align README Node runtime requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Model note: while many providers/models are supported, for the best experience a
 
 ## Install (recommended)
 
-Runtime: **Node ≥22**.
+Runtime: **Node >=22.12.0**.
 
 ```bash
 npm install -g openclaw@latest
@@ -62,7 +62,7 @@ The wizard installs the Gateway daemon (launchd/systemd user service) so it stay
 
 ## Quick start (TL;DR)
 
-Runtime: **Node ≥22**.
+Runtime: **Node >=22.12.0**.
 
 Full beginner guide (auth, pairing, channels): [Getting started](https://docs.openclaw.ai/start/getting-started)
 


### PR DESCRIPTION
## Summary
- Updates README runtime wording to match the project’s enforced Node baseline.
- Replaces `Node ≥22` with `Node >=22.12.0` in both install and quick-start sections.

## Why
- The repo currently enforces Node `>=22.12.0` in `package.json` and documents the same security baseline in `SECURITY.md`.
- README previously stated a broader requirement (`>=22`), which can mislead users onto unsupported patch versions and create avoidable setup/support issues.

## Files changed
- `README.md`

## Validation
- `pnpm check:docs`
  - `pnpm format:docs:check`
  - `pnpm lint:docs`
  - `pnpm docs:check-links`

## Impact
- Docs-only change; no runtime behavior changes.
