### PR TITLE
fix(docker): correct awk quoting in Docker GPG fingerprint check (#32153)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN if [ -n "$OPENCLAW_INSTALL_DOCKER_CLI" ]; then \
       # Update OPENCLAW_DOCKER_GPG_FINGERPRINT when Docker rotates release keys.
       curl -fsSL https://download.docker.com/linux/debian/gpg -o /tmp/docker.gpg.asc && \
       expected_fingerprint="$(printf '%s' "$OPENCLAW_DOCKER_GPG_FINGERPRINT" | tr '[:lower:]' '[:upper:]' | tr -d '[:space:]')" && \
-      actual_fingerprint="$(gpg --batch --show-keys --with-colons /tmp/docker.gpg.asc | awk -F: '$1 == \"fpr\" { print toupper($10); exit }')" && \
+      actual_fingerprint="$(gpg --batch --show-keys --with-colons /tmp/docker.gpg.asc | awk -F: '$1 == "fpr" { print toupper($10); exit }')" && \
       if [ -z "$actual_fingerprint" ] || [ "$actual_fingerprint" != "$expected_fingerprint" ]; then \
         echo "ERROR: Docker apt key fingerprint mismatch (expected $expected_fingerprint, got ${actual_fingerprint:-<empty>})" >&2; \
         exit 1; \

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -27,4 +27,10 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain('find "$dir" -type d -exec chmod 755 {} +');
     expect(dockerfile).toContain('find "$dir" -type f -exec chmod 644 {} +');
   });
+
+  it("Docker GPG fingerprint awk uses correct quoting for OPENCLAW_SANDBOX=1 build", async () => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+    expect(dockerfile).toContain('== "fpr" {');
+    expect(dockerfile).not.toContain('\\"fpr\\"');
+  });
 });


### PR DESCRIPTION
## Summary

- **Problem:** With `OPENCLAW_SANDBOX=1`, running `./docker-setup.sh` fails during image build because the awk command used for Docker GPG fingerprint verification in the Dockerfile has incorrect escaping (`\"fpr\"`), so awk receives invalid syntax.
- **Why it matters:** Local/CI builds that enable Docker sandbox hit this code path and cannot complete the image build.
- **What changed:** Replaced `'$1 == \"fpr\"'` with `'$1 == "fpr"'` in the awk invocation (removed the stray backslashes). Added a regression test in `src/dockerfile.test.ts` that asserts the line uses correct quoting and does not contain the broken escape pattern.
- **What did NOT change (scope boundary):** No change to GPG verification logic, other Dockerfile steps, or docker-setup script behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #32153
- Related #32160 (same fix approach; this PR adds dedicated regression coverage)

## User-visible / Behavior Changes

None. Only fixes the Docker image build when `OPENCLAW_SANDBOX=1`; behavior is unchanged on non-sandbox paths.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows (local)
- Runtime/container: Node 22+, Docker available
- N/A for model/provider or channel

### Steps

1. Check out this branch and run: `pnpm vitest run src/dockerfile.test.ts`
2. (Optional) In an environment with Docker: `OPENCLAW_SANDBOX=1 ./docker-setup.sh` and confirm the build completes.

### Expected

- The above test passes; with sandbox enabled, the Docker build completes.

### Actual

- Test passes; full Docker sandbox build was not run locally.

## Evidence

- [x] Failing test/log before + passing after: New test passes after the fix and guards against reintroducing the bad escape pattern.

## Human Verification (required)

- **Verified scenarios:** Updated awk quoting in Dockerfile; added regression test in `dockerfile.test.ts` and confirmed it passes.
- **Edge cases checked:** Assertions cover both “correct pattern present” and “broken escape pattern absent”.
- **What did NOT verify:** Did not run a full `OPENCLAW_SANDBOX=1 ./docker-setup.sh` build in a real environment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this PR’s commit, or restore only `Dockerfile` and `src/dockerfile.test.ts`.
- If GPG verification or build fails, check that no other RUN steps were changed.

## Risks and Mitigations

- Risk: None; only shell quoting fix and an additional test.
- Mitigation: N/A