### PR TITLE
fix(acp): use publishable acpx install hint

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -313,7 +313,7 @@ See [Configuration Reference](/gateway/configuration-reference).
 Install and enable plugin:
 
 ```bash
-openclaw plugins install @openclaw/acpx
+openclaw plugins install acpx
 openclaw config set plugins.entries.acpx.enabled true
 ```
 

--- a/src/auto-reply/reply/commands-acp/shared.ts
+++ b/src/auto-reply/reply/commands-acp/shared.ts
@@ -419,7 +419,7 @@ export function resolveAcpInstallCommandHint(cfg: OpenClawConfig): string {
     if (existsSync(localPath)) {
       return `openclaw plugins install ${localPath}`;
     }
-    return "openclaw plugins install @openclaw/acpx";
+    return "openclaw plugins install acpx";
   }
   return `Install and enable the plugin that provides ACP backend "${backendId}".`;
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: ACP install fallback suggested `openclaw plugins install @openclaw/acpx`, but that npm spec is not published and leads to E404.
- Why it matters: users following `/acp install` guidance can hit a dead-end install flow.
- What changed: fallback install hint and docs example were updated to use `openclaw plugins install acpx`.
- What did NOT change (scope boundary): no ACP runtime execution path or backend protocol logic changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32380
- Related #

## User-visible / Behavior Changes

- `/acp install` guidance now points to a publishable package spec (`acpx`) when local plugin path is unavailable.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime/container: local Node runtime
- Model/provider: N/A
- Integration/channel (if any): ACP command surface
- Relevant config (redacted): default

### Steps

1. Run `/acp install` or resolve ACP install hint when local `extensions/acpx` path is absent.
2. Confirm emitted install command uses `openclaw plugins install acpx`.
3. Confirm docs command example matches runtime hint.

### Expected

- Install guidance points to a valid, publishable npm spec.

### Actual

- Matches expected after patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: executed `commands-acp` tests and full `pnpm check`; inspected generated `/acp install` guidance.
- Edge cases checked: fallback path when local `extensions/acpx` is not present.
- What you did **not** verify: end-to-end install flow across all OS targets.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert PR commit.
- Files/config to restore: `src/auto-reply/reply/commands-acp/shared.ts`, `docs/tools/acp-agents.md`
- Known bad symptoms reviewers should watch for: ACP install hint regressing back to non-published scoped package.

## Risks and Mitigations

- Risk: users with custom private package mirrors may expect the old scoped name.
  - Mitigation: fallback remains configurable via `acp.runtime.installCommand`; revert is trivial if needed.
