### PR TITLE
feat(agents): add reasoningDefault config for persistent reasoning mode

### DIFF
--- a/src/auto-reply/reply/directive-handling.levels.test.ts
+++ b/src/auto-reply/reply/directive-handling.levels.test.ts
@@ -33,4 +33,46 @@ describe("resolveCurrentDirectiveLevels", () => {
     expect(result.currentThinkLevel).toBe("minimal");
     expect(resolveDefaultThinkingLevel).not.toHaveBeenCalled();
   });
+
+  it("uses reasoningDefault from agent config when session has no override", async () => {
+    const resolveDefaultThinkingLevel = vi.fn().mockResolvedValue(undefined);
+
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: {},
+      agentCfg: {
+        reasoningDefault: "stream",
+      },
+      resolveDefaultThinkingLevel,
+    });
+
+    expect(result.currentReasoningLevel).toBe("stream");
+  });
+
+  it("prefers session reasoningLevel over reasoningDefault", async () => {
+    const resolveDefaultThinkingLevel = vi.fn().mockResolvedValue(undefined);
+
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: {
+        reasoningLevel: "on",
+      },
+      agentCfg: {
+        reasoningDefault: "stream",
+      },
+      resolveDefaultThinkingLevel,
+    });
+
+    expect(result.currentReasoningLevel).toBe("on");
+  });
+
+  it("defaults reasoning to off when no session or config override", async () => {
+    const resolveDefaultThinkingLevel = vi.fn().mockResolvedValue(undefined);
+
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: {},
+      agentCfg: {},
+      resolveDefaultThinkingLevel,
+    });
+
+    expect(result.currentReasoningLevel).toBe("off");
+  });
 });

--- a/src/auto-reply/reply/directive-handling.levels.ts
+++ b/src/auto-reply/reply/directive-handling.levels.ts
@@ -11,6 +11,7 @@ export async function resolveCurrentDirectiveLevels(params: {
     thinkingDefault?: unknown;
     verboseDefault?: unknown;
     elevatedDefault?: unknown;
+    reasoningDefault?: unknown;
   };
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel | undefined>;
 }): Promise<{
@@ -28,7 +29,9 @@ export async function resolveCurrentDirectiveLevels(params: {
     (params.sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
     (params.agentCfg?.verboseDefault as VerboseLevel | undefined);
   const currentReasoningLevel =
-    (params.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ?? "off";
+    (params.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (params.agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
+    "off";
   const currentElevatedLevel =
     (params.sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
     (params.agentCfg?.elevatedDefault as ElevatedLevel | undefined);

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,28 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts agents.defaults.reasoningDefault", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          reasoningDefault: "stream",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects invalid agents.defaults.reasoningDefault value", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          reasoningDefault: "always" as unknown,
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
 });

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -182,6 +182,8 @@ export type AgentDefaultsConfig = {
   verboseDefault?: "off" | "on" | "full";
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
+  /** Default reasoning level when no /reasoning directive is present. */
+  reasoningDefault?: "off" | "on" | "stream";
   /** Default block streaming level when no override is present. */
   blockStreamingDefault?: "off" | "on";
   /**

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -135,6 +135,7 @@ export const AgentDefaultsSchema = z
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),
+    reasoningDefault: z.union([z.literal("off"), z.literal("on"), z.literal("stream")]).optional(),
     blockStreamingDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
     blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
     blockStreamingChunk: BlockStreamingChunkSchema.optional(),


### PR DESCRIPTION
## Summary

- Adds `agents.defaults.reasoningDefault` config option (`"off"` | `"on"` | `"stream"`) so users can persist their preferred reasoning mode across sessions
- Session-level `/reasoning` directive still takes priority over the config default
- Follows the same pattern as existing `thinkingDefault`, `verboseDefault`, and `elevatedDefault`

Closes #32409

## Changes

1. **`src/config/types.agent-defaults.ts`** — Added `reasoningDefault` field to `AgentDefaultsConfig`
2. **`src/auto-reply/reply/directive-handling.levels.ts`** — Updated `resolveCurrentDirectiveLevels()` to fall back to `agentCfg.reasoningDefault` before the hard-coded `"off"` default
3. **`src/auto-reply/reply/directive-handling.levels.test.ts`** — Added three tests covering config default, session override priority, and fallback to `"off"`

## Config example

```json5
{
  agents: {
    defaults: {
      reasoningDefault: "stream"  // off | on | stream
    }
  }
}
```

## Test plan

- [x] `reasoningDefault: "stream"` is used when session has no override
- [x] Session `/reasoning on` takes priority over `reasoningDefault: "stream"`
- [x] Defaults to `"off"` when neither session nor config specifies a level
- [x] All 15 existing directive-handling tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)