### PR TITLE
Telegram: allow named-account DMs through with per-account session key(#32351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/named-account DMs: fix silent message drop for named Telegram accounts (e.g. `accounts.atlas`) that have no explicit bindings — DMs were received (`raw-update` logged) but silently dropped before lane enqueue after the 2026.3.1 fail-closed routing guard. DMs now proceed with a per-account session key that preserves conversation isolation across multiple named accounts sharing the same default agent; groups still require explicit bindings. (#32351)
 - Gateway/message tool reliability: avoid false `Unknown channel` failures when `message.*` actions receive platform-specific channel ids by falling back to `toolContext.currentChannelProvider`, and prevent health-monitor restart thrash for channels that just (re)started by adding a per-channel startup-connect grace window. (from #32367) Thanks @MunemHashmi.
 - Discord/lifecycle startup status: push an immediate `connected` status snapshot when the gateway is already connected before lifecycle debug listeners attach, with abort-guarding to avoid contradictory status flips during pre-aborted startup. (#32336) Thanks @mitchmcalister.
 - Cron/isolated delivery target fallback: remove early unresolved-target return so cron delivery can flow through shared outbound target resolution (including per-channel `resolveDefaultTo` fallback) when `delivery.to` is omitted. (#32364) Thanks @hclsys.

--- a/src/telegram/bot-message-context.named-account-dm.test.ts
+++ b/src/telegram/bot-message-context.named-account-dm.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+
+/**
+ * Regression tests for issue #32351: DMs on named Telegram accounts were
+ * silently dropped when there was no explicit binding (matchedBy === "default").
+ * The fix allows DMs through with a per-account session key so each named
+ * account's conversations remain isolated even when sharing the default agent.
+ */
+describe("buildTelegramMessageContext named-account DM routing (issue #32351)", () => {
+  const namedAccountCfg = {
+    agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+    channels: { telegram: {} },
+    messages: { groupChat: { mentionPatterns: [] } },
+    // no bindings → route.matchedBy will be "default"
+  };
+
+  afterEach(() => {
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("allows DM through for named account with no explicit binding", async () => {
+    setRuntimeConfigSnapshot(namedAccountCfg);
+
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg: namedAccountCfg,
+      accountId: "atlas",
+      dmPolicy: "open",
+      message: {
+        message_id: 1,
+        chat: { id: 814912386, type: "private" },
+        date: 1700000000,
+        text: "hello",
+        from: { id: 814912386, first_name: "Alice" },
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+  });
+
+  it("uses per-account session key for named account DMs with no explicit binding", async () => {
+    setRuntimeConfigSnapshot(namedAccountCfg);
+
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg: namedAccountCfg,
+      accountId: "atlas",
+      dmPolicy: "open",
+      message: {
+        message_id: 1,
+        chat: { id: 814912386, type: "private" },
+        date: 1700000000,
+        text: "hello",
+        from: { id: 814912386, first_name: "Alice" },
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    // Key format: agent:<agentId>:telegram:<accountId>:direct:<peerId>
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:telegram:atlas:direct:814912386");
+  });
+
+  it("isolates DM sessions between two different named accounts with the same default agent", async () => {
+    setRuntimeConfigSnapshot(namedAccountCfg);
+
+    const ctxAtlas = await buildTelegramMessageContextForTest({
+      cfg: namedAccountCfg,
+      accountId: "atlas",
+      dmPolicy: "open",
+      message: {
+        message_id: 1,
+        chat: { id: 814912386, type: "private" },
+        date: 1700000000,
+        text: "hello",
+        from: { id: 814912386, first_name: "Alice" },
+      },
+    });
+
+    const ctxSkynet = await buildTelegramMessageContextForTest({
+      cfg: namedAccountCfg,
+      accountId: "skynet",
+      dmPolicy: "open",
+      message: {
+        message_id: 2,
+        chat: { id: 814912386, type: "private" },
+        date: 1700000001,
+        text: "hello",
+        from: { id: 814912386, first_name: "Alice" },
+      },
+    });
+
+    expect(ctxAtlas).not.toBeNull();
+    expect(ctxSkynet).not.toBeNull();
+    // Each named account gets a distinct session key, preventing cross-account contamination.
+    expect(ctxAtlas?.ctxPayload?.SessionKey).not.toBe(ctxSkynet?.ctxPayload?.SessionKey);
+    expect(ctxAtlas?.ctxPayload?.SessionKey).toBe("agent:main:telegram:atlas:direct:814912386");
+    expect(ctxSkynet?.ctxPayload?.SessionKey).toBe("agent:main:telegram:skynet:direct:814912386");
+  });
+
+  it("still drops group messages for named accounts with no explicit binding", async () => {
+    setRuntimeConfigSnapshot(namedAccountCfg);
+
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg: namedAccountCfg,
+      accountId: "atlas",
+      dmPolicy: "open",
+      options: { forceWasMentioned: true },
+      resolveGroupActivation: () => true,
+      message: {
+        message_id: 1,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+        date: 1700000000,
+        text: "@bot hello",
+        from: { id: 814912386, first_name: "Alice" },
+      },
+    });
+
+    // Groups require an explicit binding; named accounts without one are still dropped.
+    expect(ctx).toBeNull();
+  });
+
+  it("default account DM still uses normal session key (no regression)", async () => {
+    setRuntimeConfigSnapshot(namedAccountCfg);
+
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg: namedAccountCfg,
+      // accountId defaults to "default"
+      dmPolicy: "open",
+      message: {
+        message_id: 1,
+        chat: { id: 42, type: "private" },
+        date: 1700000000,
+        text: "hello",
+        from: { id: 42, first_name: "Alice" },
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    // Default account uses the normal dmScope="main" session key.
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:main");
+  });
+});

--- a/src/telegram/bot-message-context.test-harness.ts
+++ b/src/telegram/bot-message-context.test-harness.ts
@@ -16,6 +16,10 @@ type BuildTelegramMessageContextForTestParams = {
   allMedia?: TelegramMediaRef[];
   options?: BuildTelegramMessageContextParams["options"];
   cfg?: Record<string, unknown>;
+  accountId?: string;
+  dmPolicy?: BuildTelegramMessageContextParams["dmPolicy"];
+  allowFrom?: BuildTelegramMessageContextParams["allowFrom"];
+  storeAllowFrom?: string[];
   resolveGroupActivation?: BuildTelegramMessageContextParams["resolveGroupActivation"];
   resolveGroupRequireMention?: BuildTelegramMessageContextParams["resolveGroupRequireMention"];
   resolveTelegramGroupConfig?: BuildTelegramMessageContextParams["resolveTelegramGroupConfig"];
@@ -36,7 +40,6 @@ export async function buildTelegramMessageContextForTest(
       me: { id: 7, username: "bot" },
     } as never,
     allMedia: params.allMedia ?? [],
-    storeAllowFrom: [],
     options: params.options ?? {},
     bot: {
       api: {
@@ -45,11 +48,12 @@ export async function buildTelegramMessageContextForTest(
       },
     } as never,
     cfg: (params.cfg ?? baseTelegramMessageContextConfig) as never,
-    account: { accountId: "default" } as never,
+    account: { accountId: params.accountId ?? "default" } as never,
     historyLimit: 0,
     groupHistories: new Map(),
-    dmPolicy: "open",
-    allowFrom: [],
+    dmPolicy: params.dmPolicy ?? "open",
+    allowFrom: params.allowFrom ?? [],
+    storeAllowFrom: params.storeAllowFrom ?? [],
     groupAllowFrom: [],
     ackReactionScope: "off",
     logger: { info: vi.fn() },

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -234,6 +234,10 @@ export const buildTelegramMessageContext = async ({
         accountId: account.accountId,
         peer: { kind: "direct", id: peerId },
         dmScope: "per-account-channel-peer",
+        // Thread identity-links through to keep parity with the routed path in
+        // resolveAgentRoute, which also passes cfg.session?.identityLinks so that
+        // resolveLinkedPeerId can collapse multiple peer IDs into a canonical key.
+        identityLinks: cfg.session?.identityLinks,
       }).toLowerCase()
     : route.sessionKey;
   // DMs: use thread suffix for session isolation (works regardless of dmScope)

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -38,7 +38,7 @@ import type {
 } from "../config/types.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
-import { resolveAgentRoute } from "../routing/resolve-route.js";
+import { buildAgentSessionKey, resolveAgentRoute } from "../routing/resolve-route.js";
 import { DEFAULT_ACCOUNT_ID, resolveThreadSessionKeys } from "../routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../security/dm-policy-shared.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -209,9 +209,13 @@ export const buildTelegramMessageContext = async ({
     },
     parentPeer,
   });
-  // Fail closed for named Telegram accounts when route resolution falls back to
-  // default-agent routing. This prevents cross-account DM/session contamination.
-  if (route.accountId !== DEFAULT_ACCOUNT_ID && route.matchedBy === "default") {
+  // Named account with no matching binding: DMs are allowed through with a
+  // per-account session key so multiple named Telegram accounts sharing the
+  // same default agent get fully isolated conversation histories.  Groups still
+  // require an explicit binding to avoid routing messages to the wrong agent.
+  const isNamedAccountFallback =
+    route.accountId !== DEFAULT_ACCOUNT_ID && route.matchedBy === "default";
+  if (isNamedAccountFallback && isGroup) {
     logInboundDrop({
       log: logVerbose,
       channel: "telegram",
@@ -220,7 +224,18 @@ export const buildTelegramMessageContext = async ({
     });
     return null;
   }
-  const baseSessionKey = route.sessionKey;
+  // For DMs without an explicit binding on a named account, derive a
+  // per-account-channel-peer session key so each named account's DMs are
+  // isolated even when they share the same default agent.
+  const baseSessionKey = isNamedAccountFallback
+    ? buildAgentSessionKey({
+        agentId: route.agentId,
+        channel: "telegram",
+        accountId: account.accountId,
+        peer: { kind: "direct", id: peerId },
+        dmScope: "per-account-channel-peer",
+      }).toLowerCase()
+    : route.sessionKey;
   // DMs: use thread suffix for session isolation (works regardless of dmScope)
   const threadKeys =
     dmThreadId != null


### PR DESCRIPTION
## Summary

- **Problem:** Telegram DMs sent to a named account (e.g. `accounts.atlas`) were silently dropped after the 2026.3.1 fail-closed routing guard was introduced. The `raw-update` log confirmed the update was received, but no message ever reached the lane queue — and no drop reason was logged (verbose logging was off).
- **Root cause:** `buildTelegramMessageContext` contained an unconditional guard: when `route.accountId !== DEFAULT_ACCOUNT_ID && route.matchedBy === "default"` it returned `null` for **all** message types (DMs and groups alike). The guard was added to prevent cross-account session contamination — with the default `dmScope="main"` the session key does not include `accountId`, so two named accounts sharing the same default agent would share a session. The guard was correct in intent but too broad in scope.
- **Why `/reset` appeared to work:** `/reset` is a native command handled by `bot.command()`, which runs entirely before `buildTelegramMessageContext` and does not call `next()`. So commands bypassed the guard; only subsequent plain-text DMs hit it.
- **What changed:**
  - For **groups**: the guard is preserved — groups need an explicit binding to avoid ambiguous routing.
  - For **DMs**: instead of dropping, the message is allowed through with a `per-account-channel-peer` session key (`agent:<agentId>:telegram:<accountId>:direct:<peerId>`). This isolates each named account's conversation history without requiring an explicit binding.
- **What did NOT change:** All existing DM flows for the `default` account are unaffected. Groups still require explicit bindings. The allowlist (`dmPolicy`, `allowFrom`) still applies after the routing check.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32351
- Related #

## User-visible / Behavior Changes

- Telegram DMs to named accounts (e.g. `accounts.atlas`) that have no explicit bindings now reach the agent instead of being dropped.
- Each named account's DM history is isolated by account ID even when multiple named accounts share the same default agent.
- Group messages to named accounts without explicit bindings continue to be dropped (unchanged).

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No** — session isolation is *strengthened* (per-account key instead of shared key); no new access surface is introduced.
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+ / gateway process
- Model/provider: Any
- Integration/channel: Telegram (named account, e.g. `accounts.atlas`)
- Relevant config (redacted):
  ```yaml
  accounts:
    atlas:
      token: <redacted>
  accounts.default.enabled: false
  channels.telegram.dmPolicy: allowlist
  channels.telegram.allowFrom: [<user-id>]
  ```

### Steps

1. Configure a named Telegram account (`accounts.atlas`) with no explicit bindings.
2. Set `accounts.default.enabled=false`.
3. Start the gateway and send a `/reset` command followed by a plain-text DM from an allowed user.
4. Observe `raw-update` log lines for the plain-text DM.
5. Confirm the DM reaches the lane queue (previously it was silently dropped after step 4).

### Expected

- Both the `/reset` command and the subsequent plain-text DM are processed.
- `raw-update` log is followed by lane-enqueue logs.
- Session key in logs is `agent:main:telegram:atlas:direct:<user-id>`.

### Actual (before fix)

- `/reset` processed, subsequent DMs logged as `raw-update` then silently dropped with no lane-enqueue event.

### Actual (after fix)

- Matches expected.

## Evidence

- [x] 5 new unit tests covering: DM allowed through, correct per-account session key format, session isolation between two named accounts, group still dropped, default account not regressed — all pass.
- [x] `pnpm check` and `pnpm build` pass.

## Human Verification (required)

- **Verified scenarios:** Named account DM with no binding → allowed; named account group with no binding → dropped; two named accounts share agent → distinct session keys; default account → unaffected.
- **Edge cases checked:** `dmScope="main"` default preserved for default account; `allowFrom` / `dmPolicy` still applied after routing; `dmThreadId` suffix still appended to per-account key.
- **What you did NOT verify:** Live end-to-end with a real Telegram bot token and two simultaneous named accounts.

## Compatibility / Migration

- Backward compatible? **Yes** — default account behavior unchanged.
- Config/env changes? **No**
- Migration needed? **No**
- Note: users who had worked around the bug by adding explicit bindings will now have two possible session keys in flight. The workaround binding will continue to match (`matchedBy !== "default"`) and use the original `route.sessionKey`, so no history is lost and no migration is needed.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert <commit>`
- Files/config to restore: `src/telegram/bot-message-context.ts`
- Known bad symptoms reviewers should watch for: named-account DMs routing to the wrong agent (would indicate the `isNamedAccountFallback` guard is not activating correctly).

## Risks and Mitigations

- **Session key change for affected users:** Users who were hitting the bug (messages dropped) have no pre-existing session history under either key, so there is nothing to migrate.
- **Cross-account contamination:** Mitigated by the per-account session key; each named account always gets a distinct key scoped to `<accountId>`.
