### PR TITLE
feat(subagents): add completionDelivery config to suppress channel sends

### DIFF
--- a/src/agents/subagent-completion-delivery.ts
+++ b/src/agents/subagent-completion-delivery.ts
@@ -1,0 +1,14 @@
+/**
+ * Resolve whether a spawned subagent should send completion messages directly
+ * to the user's channel. Returns false when config completionDelivery is
+ * "internal" or when the caller explicitly opts out.
+ */
+export function resolveExpectsCompletionMessage(
+  callerParam: boolean | undefined,
+  completionDeliveryConfig: "internal" | "user" | undefined,
+): boolean {
+  if (completionDeliveryConfig === "internal") {
+    return false;
+  }
+  return callerParam !== false;
+}

--- a/src/agents/subagent-spawn.completion-delivery.test.ts
+++ b/src/agents/subagent-spawn.completion-delivery.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolveExpectsCompletionMessage } from "./subagent-completion-delivery.js";
+
+describe("resolveExpectsCompletionMessage", () => {
+  it("returns true by default (no config, no caller override)", () => {
+    expect(resolveExpectsCompletionMessage(undefined, undefined)).toBe(true);
+  });
+
+  it("returns true when config is 'user'", () => {
+    expect(resolveExpectsCompletionMessage(undefined, "user")).toBe(true);
+  });
+
+  it("returns false when config is 'internal'", () => {
+    expect(resolveExpectsCompletionMessage(undefined, "internal")).toBe(false);
+  });
+
+  it("returns false when config is 'internal' even if caller explicitly passes true", () => {
+    expect(resolveExpectsCompletionMessage(true, "internal")).toBe(false);
+  });
+
+  it("returns false when caller explicitly passes false", () => {
+    expect(resolveExpectsCompletionMessage(false, undefined)).toBe(false);
+  });
+
+  it("returns false when caller passes false and config is 'user'", () => {
+    expect(resolveExpectsCompletionMessage(false, "user")).toBe(false);
+  });
+
+  it("returns true when caller explicitly passes true and no config", () => {
+    expect(resolveExpectsCompletionMessage(true, undefined)).toBe(true);
+  });
+});

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -18,6 +18,7 @@ import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import { buildSubagentSystemPrompt } from "./subagent-announce.js";
+import { resolveExpectsCompletionMessage } from "./subagent-completion-delivery.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
 import { readStringParam } from "./tools/common.js";
@@ -281,7 +282,6 @@ export async function spawnSubagentDirect(
       : params.cleanup === "keep" || params.cleanup === "delete"
         ? params.cleanup
         : "keep";
-  const expectsCompletionMessage = params.expectsCompletionMessage !== false;
   const requesterOrigin = normalizeDeliveryContext({
     channel: ctx.agentChannel,
     accountId: ctx.agentAccountId,
@@ -290,6 +290,14 @@ export async function spawnSubagentDirect(
   });
   const hookRunner = getGlobalHookRunner();
   const cfg = loadConfig();
+
+  // Resolve completion message delivery mode.
+  // Config-level completionDelivery ("internal" suppresses direct channel send)
+  // can be overridden by an explicit expectsCompletionMessage=false from the caller.
+  const expectsCompletionMessage = resolveExpectsCompletionMessage(
+    params.expectsCompletionMessage,
+    cfg?.agents?.defaults?.subagents?.completionDelivery,
+  );
 
   // When agent omits runTimeoutSeconds, use the config default.
   // Falls back to 0 (no timeout) if config key is also unset,

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,32 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts agents.defaults.subagents.completionDelivery", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          subagents: {
+            completionDelivery: "internal",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects invalid agents.defaults.subagents.completionDelivery value", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          subagents: {
+            completionDelivery: "always" as unknown,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
 });

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -274,6 +274,12 @@ export type AgentDefaultsConfig = {
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 60000). */
     announceTimeoutMs?: number;
+    /**
+     * Completion message delivery mode for spawned sub-agents.
+     * - "user": send completion message directly to the user's channel (default).
+     * - "internal": only inject into the parent session (no external send).
+     */
+    completionDelivery?: "internal" | "user";
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -173,6 +173,7 @@ export const AgentDefaultsSchema = z
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
+        completionDelivery: z.union([z.literal("internal"), z.literal("user")]).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary
- Adds `agents.defaults.subagents.completionDelivery` config option with two modes:
  - `"user"` (default): current behavior — completion messages are sent directly to the user's chat channel
  - `"internal"`: completion messages are only injected into the parent session queue, suppressing direct channel delivery
- Extracts `resolveExpectsCompletionMessage()` as a pure, testable function in its own module
- Includes 7 unit tests covering all resolution combinations

## Test plan
- [x] 7 new unit tests pass (`resolveExpectsCompletionMessage` — default, explicit user, internal, internal+caller-true, caller-false, caller-false+user, caller-true+no-config)
- [x] Existing 9 dispatch tests pass unchanged
- [x] Lint passes
- [ ] Verify on a live instance: set `completionDelivery: "internal"` and confirm subagent completion messages no longer leak to user channels

Closes #32124

🤖 Generated with [Claude Code](https://claude.com/claude-code)