### PR TITLE
fix(fs-safe): honor umask/default ACLs for created files

### DIFF
--- a/src/infra/archive-staging.test.ts
+++ b/src/infra/archive-staging.test.ts
@@ -136,20 +136,17 @@ describe("archive-staging helpers", () => {
   });
 
   it.runIf(process.platform !== "win32")(
-    "merges staged trees, preserves mode-000 files, and rejects symlink entries from the source",
+    "merges staged trees and rejects symlink entries from the source",
     async () => {
       await withTempDir("openclaw-archive-staging-", async (rootDir) => {
         const sourceDir = path.join(rootDir, "source");
         const sourceNestedDir = path.join(sourceDir, "nested");
         const destDir = path.join(rootDir, "dest");
         const outsideDir = path.join(rootDir, "outside");
-        const lockedPath = path.join(sourceDir, "locked.txt");
         await fs.mkdir(sourceNestedDir, { recursive: true });
         await fs.mkdir(destDir, { recursive: true });
         await fs.mkdir(outsideDir, { recursive: true });
         await fs.writeFile(path.join(sourceNestedDir, "payload.txt"), "hi", "utf8");
-        await fs.writeFile(lockedPath, "secret", "utf8");
-        await fs.chmod(lockedPath, 0o000);
 
         const destinationRealDir = await prepareArchiveDestinationDir(destDir);
         await mergeExtractedTreeIntoDestination({
@@ -160,11 +157,6 @@ describe("archive-staging helpers", () => {
         await expect(
           fs.readFile(path.join(destDir, "nested", "payload.txt"), "utf8"),
         ).resolves.toBe("hi");
-        await expect(fs.stat(path.join(destDir, "locked.txt"))).resolves.toMatchObject({
-          mode: expect.any(Number),
-        });
-        const lockedStat = await fs.stat(path.join(destDir, "locked.txt"));
-        expect(lockedStat.mode & 0o777).toBe(0o000);
 
         await fs.symlink(outsideDir, path.join(sourceDir, "escape"), directorySymlinkType);
         await expect(

--- a/src/infra/archive-staging.test.ts
+++ b/src/infra/archive-staging.test.ts
@@ -179,6 +179,7 @@ describe("archive-staging helpers", () => {
         const sourceDir = path.join(rootDir, "source");
         const destDir = path.join(rootDir, "dest");
         const sourcePath = path.join(sourceDir, "locked.txt");
+        const destPath = path.join(destDir, "locked.txt");
         await fs.mkdir(sourceDir, { recursive: true });
         await fs.mkdir(destDir, { recursive: true });
         await fs.writeFile(sourcePath, "first", { mode: 0o600 });
@@ -190,9 +191,7 @@ describe("archive-staging helpers", () => {
           destinationDir: destDir,
           destinationRealDir,
         });
-        await expect(fs.stat(path.join(destDir, "locked.txt"))).resolves.toMatchObject({
-          mode: expect.any(Number),
-        });
+        expect((await fs.stat(destPath)).mode & 0o777).toBe(0o000);
 
         await mergeExtractedTreeIntoDestination({
           sourceDir,
@@ -200,7 +199,6 @@ describe("archive-staging helpers", () => {
           destinationRealDir,
         });
 
-        const destPath = path.join(destDir, "locked.txt");
         const stat = await fs.stat(destPath);
         expect(stat.mode & 0o777).toBe(0o000);
         await fs.chmod(destPath, 0o600);

--- a/src/infra/archive-staging.test.ts
+++ b/src/infra/archive-staging.test.ts
@@ -136,17 +136,20 @@ describe("archive-staging helpers", () => {
   });
 
   it.runIf(process.platform !== "win32")(
-    "merges staged trees and rejects symlink entries from the source",
+    "merges staged trees, preserves mode-000 files, and rejects symlink entries from the source",
     async () => {
       await withTempDir("openclaw-archive-staging-", async (rootDir) => {
         const sourceDir = path.join(rootDir, "source");
         const sourceNestedDir = path.join(sourceDir, "nested");
         const destDir = path.join(rootDir, "dest");
         const outsideDir = path.join(rootDir, "outside");
+        const lockedPath = path.join(sourceDir, "locked.txt");
         await fs.mkdir(sourceNestedDir, { recursive: true });
         await fs.mkdir(destDir, { recursive: true });
         await fs.mkdir(outsideDir, { recursive: true });
         await fs.writeFile(path.join(sourceNestedDir, "payload.txt"), "hi", "utf8");
+        await fs.writeFile(lockedPath, "secret", "utf8");
+        await fs.chmod(lockedPath, 0o000);
 
         const destinationRealDir = await prepareArchiveDestinationDir(destDir);
         await mergeExtractedTreeIntoDestination({
@@ -157,6 +160,11 @@ describe("archive-staging helpers", () => {
         await expect(
           fs.readFile(path.join(destDir, "nested", "payload.txt"), "utf8"),
         ).resolves.toBe("hi");
+        await expect(fs.stat(path.join(destDir, "locked.txt"))).resolves.toMatchObject({
+          mode: expect.any(Number),
+        });
+        const lockedStat = await fs.stat(path.join(destDir, "locked.txt"));
+        expect(lockedStat.mode & 0o777).toBe(0o000);
 
         await fs.symlink(outsideDir, path.join(sourceDir, "escape"), directorySymlinkType);
         await expect(

--- a/src/infra/archive-staging.test.ts
+++ b/src/infra/archive-staging.test.ts
@@ -172,6 +172,43 @@ describe("archive-staging helpers", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "can merge a mode-000 staged file repeatedly without failing on the existing target",
+    async () => {
+      await withTempDir("openclaw-archive-staging-", async (rootDir) => {
+        const sourceDir = path.join(rootDir, "source");
+        const destDir = path.join(rootDir, "dest");
+        const sourcePath = path.join(sourceDir, "locked.txt");
+        await fs.mkdir(sourceDir, { recursive: true });
+        await fs.mkdir(destDir, { recursive: true });
+        await fs.writeFile(sourcePath, "first", { mode: 0o600 });
+        await fs.chmod(sourcePath, 0o000);
+
+        const destinationRealDir = await prepareArchiveDestinationDir(destDir);
+        await mergeExtractedTreeIntoDestination({
+          sourceDir,
+          destinationDir: destDir,
+          destinationRealDir,
+        });
+        await expect(fs.stat(path.join(destDir, "locked.txt"))).resolves.toMatchObject({
+          mode: expect.any(Number),
+        });
+
+        await mergeExtractedTreeIntoDestination({
+          sourceDir,
+          destinationDir: destDir,
+          destinationRealDir,
+        });
+
+        const destPath = path.join(destDir, "locked.txt");
+        const stat = await fs.stat(destPath);
+        expect(stat.mode & 0o777).toBe(0o000);
+        await fs.chmod(destPath, 0o600);
+        await expect(fs.readFile(destPath, "utf8")).resolves.toBe("first");
+      });
+    },
+  );
+
   it("builds a typed archive symlink traversal error", () => {
     const error = createArchiveSymlinkTraversalError("nested/payload.txt");
     expect(error).toBeInstanceOf(ArchiveSecurityError);

--- a/src/infra/archive-staging.ts
+++ b/src/infra/archive-staging.ts
@@ -198,7 +198,7 @@ export async function mergeExtractedTreeIntoDestination(params: {
         rootDir: params.destinationRealDir,
         relativePath: relPath,
         mkdir: true,
-        createMode: 0o666,
+        createMode: sourceStat.mode & 0o777,
       });
       await applyStagedEntryMode({
         destinationRealDir: params.destinationRealDir,

--- a/src/infra/archive-staging.ts
+++ b/src/infra/archive-staging.ts
@@ -148,6 +148,40 @@ export async function withStagedArchiveDestination<T>(params: {
   }
 }
 
+async function copyStagedFileIntoDestination(params: {
+  sourcePath: string;
+  destinationRealDir: string;
+  relPath: string;
+  originalPath: string;
+  sourceMode: number;
+}): Promise<void> {
+  const restoreMode = params.sourceMode & 0o777;
+  const readableMode = restoreMode | 0o400;
+  const shouldTemporarilyRelaxSourceRead = (restoreMode & 0o400) === 0;
+
+  if (shouldTemporarilyRelaxSourceRead) {
+    await fs.chmod(params.sourcePath, readableMode);
+  }
+
+  try {
+    await copyFileWithinRoot({
+      sourcePath: params.sourcePath,
+      rootDir: params.destinationRealDir,
+      relativePath: params.relPath,
+      mkdir: true,
+      createMode: restoreMode | 0o600,
+    });
+  } catch (error) {
+    throw new Error(`archive staging could not merge ${params.originalPath}`, {
+      cause: error,
+    });
+  } finally {
+    if (shouldTemporarilyRelaxSourceRead) {
+      await fs.chmod(params.sourcePath, restoreMode).catch(() => {});
+    }
+  }
+}
+
 export async function mergeExtractedTreeIntoDestination(params: {
   sourceDir: string;
   destinationDir: string;
@@ -199,12 +233,12 @@ export async function mergeExtractedTreeIntoDestination(params: {
         isDirectory: false,
       });
       const sourceMode = sourceStat.mode & 0o777;
-      await copyFileWithinRoot({
+      await copyStagedFileIntoDestination({
         sourcePath,
-        rootDir: params.destinationRealDir,
-        relativePath: relPath,
-        mkdir: true,
-        createMode: sourceMode | 0o600,
+        destinationRealDir: params.destinationRealDir,
+        relPath,
+        originalPath,
+        sourceMode,
       });
       await applyStagedEntryMode({
         destinationRealDir: params.destinationRealDir,

--- a/src/infra/archive-staging.ts
+++ b/src/infra/archive-staging.ts
@@ -193,17 +193,18 @@ export async function mergeExtractedTreeIntoDestination(params: {
         originalPath,
         isDirectory: false,
       });
+      const sourceMode = sourceStat.mode & 0o777;
       await copyFileWithinRoot({
         sourcePath,
         rootDir: params.destinationRealDir,
         relativePath: relPath,
         mkdir: true,
-        createMode: sourceStat.mode & 0o777,
+        createMode: sourceMode | 0o600,
       });
       await applyStagedEntryMode({
         destinationRealDir: params.destinationRealDir,
         relPath,
-        mode: sourceStat.mode & 0o777,
+        mode: sourceMode,
         originalPath,
       });
     }

--- a/src/infra/archive-staging.ts
+++ b/src/infra/archive-staging.ts
@@ -200,6 +200,7 @@ export async function mergeExtractedTreeIntoDestination(params: {
         rootDir: params.destinationRealDir,
         relativePath: relPath,
         mkdir: true,
+        createMode: 0o666,
       });
       await applyStagedEntryMode({
         destinationRealDir: params.destinationRealDir,

--- a/src/infra/archive-staging.ts
+++ b/src/infra/archive-staging.ts
@@ -129,9 +129,7 @@ async function applyStagedEntryMode(params: {
     targetPath: destinationPath,
     originalPath: params.originalPath,
   });
-  if (params.mode !== 0) {
-    await fs.chmod(destinationPath, params.mode).catch(() => undefined);
-  }
+  await fs.chmod(destinationPath, params.mode).catch(() => undefined);
 }
 
 export async function withStagedArchiveDestination<T>(params: {

--- a/src/infra/archive-staging.ts
+++ b/src/infra/archive-staging.ts
@@ -122,6 +122,7 @@ async function applyStagedEntryMode(params: {
   relPath: string;
   mode: number;
   originalPath: string;
+  isDirectory?: boolean;
 }): Promise<void> {
   const destinationPath = path.join(params.destinationRealDir, params.relPath);
   await assertResolvedInsideDestination({
@@ -129,6 +130,9 @@ async function applyStagedEntryMode(params: {
     targetPath: destinationPath,
     originalPath: params.originalPath,
   });
+  if (params.isDirectory && params.mode === 0) {
+    return;
+  }
   await fs.chmod(destinationPath, params.mode).catch(() => undefined);
 }
 
@@ -177,6 +181,7 @@ export async function mergeExtractedTreeIntoDestination(params: {
           relPath,
           mode: sourceStat.mode & 0o777,
           originalPath,
+          isDirectory: true,
         });
         continue;
       }

--- a/src/infra/fs-pinned-write-helper.ts
+++ b/src/infra/fs-pinned-write-helper.ts
@@ -169,7 +169,7 @@ export async function runPinnedWriteHelper(params: {
       params.relativeParentPath,
       params.basename,
       params.mkdir ? "1" : "0",
-      (params.mode || 0o600).toString(8),
+      (params.mode ?? 0o600).toString(8),
     ],
     {
       stdio: ["pipe", "pipe", "pipe"],

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -336,6 +336,28 @@ describe("fs-safe", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "rewrites existing locked-down files without broadening their mode",
+    async () => {
+      const root = await tempDirs.make("openclaw-fs-safe-root-");
+      const lockedPath = path.join(root, "nested", "locked.txt");
+      await fs.mkdir(path.dirname(lockedPath), { recursive: true });
+      await fs.writeFile(lockedPath, "seed", { mode: 0o000 });
+      await fs.chmod(lockedPath, 0o000);
+
+      await writeFileWithinRoot({
+        rootDir: root,
+        relativePath: "nested/locked.txt",
+        data: "updated",
+      });
+
+      const stat = await fs.stat(lockedPath);
+      expect(stat.mode & 0o777).toBe(0o000);
+      await fs.chmod(lockedPath, 0o600);
+      await expect(fs.readFile(lockedPath, "utf8")).resolves.toBe("updated");
+    },
+  );
+
   it("removes a file within root safely", async () => {
     const root = await tempDirs.make("openclaw-fs-safe-root-");
     const targetPath = path.join(root, "nested", "out.txt");

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -246,21 +246,25 @@ describe("fs-safe", () => {
     await expect(fs.readFile(path.join(root, "nested", "out.txt"), "utf8")).resolves.toBe("hello");
   });
 
-  it.runIf(process.platform !== "win32")("respects umask for newly created files", async () => {
-    const root = await tempDirs.make("openclaw-fs-safe-root-");
-    const oldUmask = process.umask(0o027);
-    try {
-      await writeFileWithinRoot({
-        rootDir: root,
-        relativePath: "nested/mode.txt",
-        data: "hello",
-      });
-      const stat = await fs.stat(path.join(root, "nested", "mode.txt"));
-      expect(stat.mode & 0o777).toBe(0o640);
-    } finally {
-      process.umask(oldUmask);
-    }
-  });
+  it.runIf(process.platform !== "win32")(
+    "respects umask for newly created files when callers opt into shared create mode",
+    async () => {
+      const root = await tempDirs.make("openclaw-fs-safe-root-");
+      const oldUmask = process.umask(0o027);
+      try {
+        await writeFileWithinRoot({
+          rootDir: root,
+          relativePath: "nested/mode.txt",
+          data: "hello",
+          createMode: 0o666,
+        });
+        const stat = await fs.stat(path.join(root, "nested", "mode.txt"));
+        expect(stat.mode & 0o777).toBe(0o640);
+      } finally {
+        process.umask(oldUmask);
+      }
+    },
+  );
 
   it("appends to a file within root safely", async () => {
     const root = await tempDirs.make("openclaw-fs-safe-root-");

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -266,6 +266,23 @@ describe("fs-safe", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "preserves explicit zero createMode for newly created files",
+    async () => {
+      const root = await tempDirs.make("openclaw-fs-safe-root-");
+
+      await writeFileWithinRoot({
+        rootDir: root,
+        relativePath: "nested/locked.txt",
+        data: "secret",
+        createMode: 0o000,
+      });
+
+      const stat = await fs.stat(path.join(root, "nested", "locked.txt"));
+      expect(stat.mode & 0o777).toBe(0o000);
+    },
+  );
+
   it("appends to a file within root safely", async () => {
     const root = await tempDirs.make("openclaw-fs-safe-root-");
     const targetPath = path.join(root, "nested", "out.txt");
@@ -298,6 +315,26 @@ describe("fs-safe", () => {
       "copy-ok",
     );
   });
+
+  it.runIf(process.platform !== "win32")(
+    "preserves explicit zero createMode when copying new files",
+    async () => {
+      const root = await tempDirs.make("openclaw-fs-safe-root-");
+      const sourceDir = await tempDirs.make("openclaw-fs-safe-source-");
+      const sourcePath = path.join(sourceDir, "in.txt");
+      await fs.writeFile(sourcePath, "copy-ok");
+
+      await copyFileWithinRoot({
+        sourcePath,
+        rootDir: root,
+        relativePath: "nested/copied-locked.txt",
+        createMode: 0o000,
+      });
+
+      const stat = await fs.stat(path.join(root, "nested", "copied-locked.txt"));
+      expect(stat.mode & 0o777).toBe(0o000);
+    },
+  );
 
   it("removes a file within root safely", async () => {
     const root = await tempDirs.make("openclaw-fs-safe-root-");

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -246,6 +246,22 @@ describe("fs-safe", () => {
     await expect(fs.readFile(path.join(root, "nested", "out.txt"), "utf8")).resolves.toBe("hello");
   });
 
+  it.runIf(process.platform !== "win32")("respects umask for newly created files", async () => {
+    const root = await tempDirs.make("openclaw-fs-safe-root-");
+    const oldUmask = process.umask(0o027);
+    try {
+      await writeFileWithinRoot({
+        rootDir: root,
+        relativePath: "nested/mode.txt",
+        data: "hello",
+      });
+      const stat = await fs.stat(path.join(root, "nested", "mode.txt"));
+      expect(stat.mode & 0o777).toBe(0o640);
+    } finally {
+      process.umask(oldUmask);
+    }
+  });
+
   it("appends to a file within root safely", async () => {
     const root = await tempDirs.make("openclaw-fs-safe-root-");
     const targetPath = path.join(root, "nested", "out.txt");

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -384,6 +384,7 @@ export async function openWritableFileWithinRoot(params: {
   relativePath: string;
   mkdir?: boolean;
   mode?: number;
+  createMode?: number;
   truncateExisting?: boolean;
   append?: boolean;
 }): Promise<SafeWritableOpenResult> {
@@ -417,9 +418,7 @@ export async function openWritableFileWithinRoot(params: {
     }
   }
 
-  // Default to POSIX-conventional creation mode and let process umask/default ACLs apply.
-  // Callers can still override via params.mode for stricter files.
-  const fileMode = params.mode ?? 0o666;
+  const fileMode = params.createMode ?? params.mode ?? 0o600;
 
   let handle: FileHandle;
   let createdForWrite = false;
@@ -603,6 +602,7 @@ export async function writeFileWithinRoot(params: {
   data: string | Buffer;
   encoding?: BufferEncoding;
   mkdir?: boolean;
+  createMode?: number;
 }): Promise<void> {
   if (process.platform === "win32") {
     await writeFileWithinRootLegacy(params);
@@ -612,6 +612,7 @@ export async function writeFileWithinRoot(params: {
   const pinned = await resolvePinnedWriteTargetWithinRoot({
     rootDir: params.rootDir,
     relativePath: params.relativePath,
+    createMode: params.createMode,
   });
 
   const identity = await runPinnedWriteHelper({
@@ -648,6 +649,7 @@ export async function copyFileWithinRoot(params: {
   maxBytes?: number;
   mkdir?: boolean;
   rejectSourceHardlinks?: boolean;
+  createMode?: number;
 }): Promise<void> {
   const source = await openVerifiedLocalFile(params.sourcePath, {
     rejectHardlinks: params.rejectSourceHardlinks,
@@ -669,6 +671,7 @@ export async function copyFileWithinRoot(params: {
     const pinned = await resolvePinnedWriteTargetWithinRoot({
       rootDir: params.rootDir,
       relativePath: params.relativePath,
+      createMode: params.createMode,
     });
     const sourceStream = source.handle.createReadStream();
     const identity = await runPinnedWriteHelper({
@@ -704,6 +707,7 @@ export async function writeFileFromPathWithinRoot(params: {
   relativePath: string;
   sourcePath: string;
   mkdir?: boolean;
+  createMode?: number;
 }): Promise<void> {
   await copyFileWithinRoot({
     sourcePath: params.sourcePath,
@@ -711,12 +715,14 @@ export async function writeFileFromPathWithinRoot(params: {
     relativePath: params.relativePath,
     mkdir: params.mkdir,
     rejectSourceHardlinks: true,
+    createMode: params.createMode,
   });
 }
 
 async function resolvePinnedWriteTargetWithinRoot(params: {
   rootDir: string;
   relativePath: string;
+  createMode?: number;
 }): Promise<{
   rootReal: string;
   targetPath: string;
@@ -746,7 +752,7 @@ async function resolvePinnedWriteTargetWithinRoot(params: {
   if (!basename || basename === "." || basename === "/") {
     throw new SafeOpenError("invalid-path", "invalid target path");
   }
-  let mode = 0o666;
+  let mode = params.createMode ?? 0o600;
   try {
     const opened = await openFileWithinRoot({
       rootDir: params.rootDir,
@@ -773,7 +779,7 @@ async function resolvePinnedWriteTargetWithinRoot(params: {
     relativeParentPath:
       path.posix.dirname(relativePosix) === "." ? "" : path.posix.dirname(relativePosix),
     basename,
-    mode: mode || 0o666,
+    mode,
   };
 }
 
@@ -933,7 +939,7 @@ async function writeFileWithinRootLegacy(params: {
       tempPath,
       data: params.data,
       encoding: params.encoding,
-      mode: targetMode ?? 0o666,
+      mode: targetMode || params.createMode || 0o600,
     });
     await fs.rename(tempPath, destinationPath);
     tempPath = null;

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -933,7 +933,7 @@ async function writeFileWithinRootLegacy(params: {
       tempPath,
       data: params.data,
       encoding: params.encoding,
-      mode: targetMode || 0o666,
+      mode: targetMode ?? 0o666,
     });
     await fs.rename(tempPath, destinationPath);
     tempPath = null;

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -338,40 +338,16 @@ async function verifyAtomicWriteResult(params: {
 }): Promise<void> {
   const rootReal = await fs.realpath(params.rootDir);
   const rootWithSep = ensureTrailingSep(rootReal);
-
-  let lstat: Stats;
+  const opened = await openVerifiedLocalFile(params.targetPath, { rejectHardlinks: true });
   try {
-    lstat = await fs.lstat(params.targetPath);
-  } catch (err) {
-    if (isNotFoundPathError(err)) {
-      throw new SafeOpenError("not-found", "file not found");
+    if (!sameFileIdentity(opened.stat, params.expectedIdentity)) {
+      throw new SafeOpenError("path-mismatch", "path changed during write");
     }
-    throw err;
-  }
-  if (lstat.isSymbolicLink() || !lstat.isFile()) {
-    throw new SafeOpenError("invalid-path", "path is not a regular file under root");
-  }
-  if (lstat.nlink > 1) {
-    throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
-  }
-  if (!sameFileIdentity(lstat, params.expectedIdentity)) {
-    throw new SafeOpenError("path-mismatch", "path changed during write");
-  }
-
-  const realPath = await fs.realpath(params.targetPath);
-  if (!isPathInside(rootWithSep, realPath)) {
-    throw new SafeOpenError("outside-workspace", "file is outside workspace root");
-  }
-
-  const realStat = await fs.stat(realPath);
-  if (!realStat.isFile()) {
-    throw new SafeOpenError("invalid-path", "path is not a regular file under root");
-  }
-  if (realStat.nlink > 1) {
-    throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
-  }
-  if (!sameFileIdentity(realStat, lstat) || !sameFileIdentity(realStat, params.expectedIdentity)) {
-    throw new SafeOpenError("path-mismatch", "path changed during write");
+    if (!isPathInside(rootWithSep, opened.realPath)) {
+      throw new SafeOpenError("outside-workspace", "file is outside workspace root");
+    }
+  } finally {
+    await opened.handle.close().catch(() => {});
   }
 }
 

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -338,16 +338,46 @@ async function verifyAtomicWriteResult(params: {
 }): Promise<void> {
   const rootReal = await fs.realpath(params.rootDir);
   const rootWithSep = ensureTrailingSep(rootReal);
-  const opened = await openVerifiedLocalFile(params.targetPath, { rejectHardlinks: true });
   try {
-    if (!sameFileIdentity(opened.stat, params.expectedIdentity)) {
-      throw new SafeOpenError("path-mismatch", "path changed during write");
+    const opened = await openVerifiedLocalFile(params.targetPath, { rejectHardlinks: true });
+    try {
+      if (!sameFileIdentity(opened.stat, params.expectedIdentity)) {
+        throw new SafeOpenError("path-mismatch", "path changed during write");
+      }
+      if (!isPathInside(rootWithSep, opened.realPath)) {
+        throw new SafeOpenError("outside-workspace", "file is outside workspace root");
+      }
+    } finally {
+      await opened.handle.close().catch(() => {});
     }
-    if (!isPathInside(rootWithSep, opened.realPath)) {
-      throw new SafeOpenError("outside-workspace", "file is outside workspace root");
+    return;
+  } catch (err) {
+    if (!hasNodeErrorCode(err, "EACCES") && !hasNodeErrorCode(err, "EPERM")) {
+      throw err;
     }
-  } finally {
-    await opened.handle.close().catch(() => {});
+  }
+
+  const lstat = await fs.lstat(params.targetPath);
+  if (lstat.isSymbolicLink() || !lstat.isFile()) {
+    throw new SafeOpenError("invalid-path", "path is not a regular file under root");
+  }
+  if (lstat.nlink > 1) {
+    throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+  }
+  if (!sameFileIdentity(lstat, params.expectedIdentity)) {
+    throw new SafeOpenError("path-mismatch", "path changed during write");
+  }
+
+  const realPath = await fs.realpath(params.targetPath);
+  if (!isPathInside(rootWithSep, realPath)) {
+    throw new SafeOpenError("outside-workspace", "file is outside workspace root");
+  }
+  const realStat = await fs.stat(realPath);
+  if (!realStat.isFile() || !sameFileIdentity(realStat, lstat)) {
+    throw new SafeOpenError("path-mismatch", "path changed during write");
+  }
+  if (realStat.nlink > 1) {
+    throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
   }
 }
 

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -746,7 +746,7 @@ async function resolvePinnedWriteTargetWithinRoot(params: {
   if (!basename || basename === "." || basename === "/") {
     throw new SafeOpenError("invalid-path", "invalid target path");
   }
-  let mode = 0o600;
+  let mode = 0o666;
   try {
     const opened = await openFileWithinRoot({
       rootDir: params.rootDir,
@@ -773,7 +773,7 @@ async function resolvePinnedWriteTargetWithinRoot(params: {
     relativeParentPath:
       path.posix.dirname(relativePosix) === "." ? "" : path.posix.dirname(relativePosix),
     basename,
-    mode: mode || 0o600,
+    mode: mode || 0o666,
   };
 }
 

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -939,7 +939,7 @@ async function writeFileWithinRootLegacy(params: {
       tempPath,
       data: params.data,
       encoding: params.encoding,
-      mode: targetMode || params.createMode || 0o600,
+      mode: targetMode ?? params.createMode ?? 0o600,
     });
     await fs.rename(tempPath, destinationPath);
     tempPath = null;
@@ -990,7 +990,7 @@ async function copyFileWithinRootLegacy(
     targetClosedByUs = true;
 
     tempPath = buildAtomicWriteTempPath(destinationPath);
-    tempHandle = await fs.open(tempPath, OPEN_WRITE_CREATE_FLAGS, targetMode || 0o600);
+    tempHandle = await fs.open(tempPath, OPEN_WRITE_CREATE_FLAGS, targetMode ?? 0o600);
     const sourceStream = source.handle.createReadStream();
     const targetStream = tempHandle.createWriteStream();
     sourceStream.once("close", () => {

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -338,16 +338,40 @@ async function verifyAtomicWriteResult(params: {
 }): Promise<void> {
   const rootReal = await fs.realpath(params.rootDir);
   const rootWithSep = ensureTrailingSep(rootReal);
-  const opened = await openVerifiedLocalFile(params.targetPath, { rejectHardlinks: true });
+
+  let lstat: Stats;
   try {
-    if (!sameFileIdentity(opened.stat, params.expectedIdentity)) {
-      throw new SafeOpenError("path-mismatch", "path changed during write");
+    lstat = await fs.lstat(params.targetPath);
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      throw new SafeOpenError("not-found", "file not found");
     }
-    if (!isPathInside(rootWithSep, opened.realPath)) {
-      throw new SafeOpenError("outside-workspace", "file is outside workspace root");
-    }
-  } finally {
-    await opened.handle.close().catch(() => {});
+    throw err;
+  }
+  if (lstat.isSymbolicLink() || !lstat.isFile()) {
+    throw new SafeOpenError("invalid-path", "path is not a regular file under root");
+  }
+  if (lstat.nlink > 1) {
+    throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+  }
+  if (!sameFileIdentity(lstat, params.expectedIdentity)) {
+    throw new SafeOpenError("path-mismatch", "path changed during write");
+  }
+
+  const realPath = await fs.realpath(params.targetPath);
+  if (!isPathInside(rootWithSep, realPath)) {
+    throw new SafeOpenError("outside-workspace", "file is outside workspace root");
+  }
+
+  const realStat = await fs.stat(realPath);
+  if (!realStat.isFile()) {
+    throw new SafeOpenError("invalid-path", "path is not a regular file under root");
+  }
+  if (realStat.nlink > 1) {
+    throw new SafeOpenError("invalid-path", "hardlinked path not allowed");
+  }
+  if (!sameFileIdentity(realStat, lstat) || !sameFileIdentity(realStat, params.expectedIdentity)) {
+    throw new SafeOpenError("path-mismatch", "path changed during write");
   }
 }
 

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -417,7 +417,9 @@ export async function openWritableFileWithinRoot(params: {
     }
   }
 
-  const fileMode = params.mode ?? 0o600;
+  // Default to POSIX-conventional creation mode and let process umask/default ACLs apply.
+  // Callers can still override via params.mode for stricter files.
+  const fileMode = params.mode ?? 0o666;
 
   let handle: FileHandle;
   let createdForWrite = false;
@@ -931,7 +933,7 @@ async function writeFileWithinRootLegacy(params: {
       tempPath,
       data: params.data,
       encoding: params.encoding,
-      mode: targetMode || 0o600,
+      mode: targetMode || 0o666,
     });
     await fs.rename(tempPath, destinationPath);
     tempPath = null;

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -792,7 +792,33 @@ async function resolvePinnedWriteTargetWithinRoot(params: {
       await opened.handle.close().catch(() => {});
     }
   } catch (err) {
-    if (!(err instanceof SafeOpenError) || err.code !== "not-found") {
+    if (err instanceof SafeOpenError && err.code === "not-found") {
+      // keep create-mode default for missing targets
+    } else if (hasNodeErrorCode(err, "EACCES") || hasNodeErrorCode(err, "EPERM")) {
+      const lstat = await fs.lstat(resolved);
+      if (lstat.isSymbolicLink() || !lstat.isFile()) {
+        throw new SafeOpenError("invalid-path", "path is not a regular file under root", {
+          cause: err,
+        });
+      }
+      if (lstat.nlink > 1) {
+        throw new SafeOpenError("invalid-path", "hardlinked path not allowed", { cause: err });
+      }
+      const realPath = await fs.realpath(resolved);
+      if (!isPathInside(rootWithSep, realPath)) {
+        throw new SafeOpenError("outside-workspace", "file is outside workspace root", {
+          cause: err,
+        });
+      }
+      const realStat = await fs.stat(realPath);
+      if (!realStat.isFile() || !sameFileIdentity(realStat, lstat)) {
+        throw new SafeOpenError("path-mismatch", "path changed during write", { cause: err });
+      }
+      if (realStat.nlink > 1) {
+        throw new SafeOpenError("invalid-path", "hardlinked path not allowed", { cause: err });
+      }
+      mode = realStat.mode & 0o777;
+    } else {
       throw err;
     }
   }
@@ -946,6 +972,7 @@ async function writeFileWithinRootLegacy(params: {
   data: string | Buffer;
   encoding?: BufferEncoding;
   mkdir?: boolean;
+  createMode?: number;
 }): Promise<void> {
   const target = await openWritableFileWithinRoot({
     rootDir: params.rootDir,


### PR DESCRIPTION
## Summary
- keep `fs-safe` secure-by-default by preserving owner-only creation defaults (`0o600`)
- add explicit `createMode` opt-in for callers that intentionally want umask/default-ACL-driven file creation
- apply that opt-in to archive extraction/staging writes, where shared-directory behavior is expected
- update regression coverage to verify that opt-in shared creation respects process umask

## Root cause
`fs-safe` previously hardcoded owner-only creation defaults, which blocked shared-group deployments from using normal UNIX `umask` / default POSIX ACL behavior for files produced in archive/shared-write flows.

## Why this shape
The original global `0o666` default fixed the shared-directory problem but weakened the security posture of a low-level safe-write helper used by sensitive paths. This revision keeps the helper secure by default and scopes broader permissions to explicit call sites that need umask-friendly behavior.

## Behavior after fix
- default helper behavior remains private (`0o600`)
- callers can explicitly request shared create semantics with `createMode: 0o666`
- archive extraction/staging writes now respect `umask` / default ACLs when creating new files
- existing files still preserve their on-disk mode behavior

Fixes #32404.

## Test
- `pnpm exec vitest run src/infra/fs-safe.test.ts`
