### PR TITLE
fix: wire BoundDeliveryRouter into ACP delivery path for thread-bound sessions

### DIFF
--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BoundDeliveryRouter } from "../../infra/outbound/bound-delivery-router.js";
+import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
 import { createAcpDispatchDeliveryCoordinator } from "./dispatch-acp-delivery.js";
 import type { ReplyDispatcher } from "./reply-dispatcher.js";
 import { buildTestCtx } from "./test-ctx.js";
@@ -11,8 +13,16 @@ const ttsMocks = vi.hoisted(() => ({
   }),
 }));
 
+const routeMocks = vi.hoisted(() => ({
+  routeReply: vi.fn(async (_params: unknown) => ({ ok: true, messageId: "mock" })),
+}));
+
 vi.mock("../../tts/tts.js", () => ({
   maybeApplyTtsToPayload: (params: unknown) => ttsMocks.maybeApplyTtsToPayload(params),
+}));
+
+vi.mock("./route-reply.js", () => ({
+  routeReply: (params: unknown) => routeMocks.routeReply(params),
 }));
 
 function createDispatcher(): ReplyDispatcher {
@@ -71,5 +81,193 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     await coordinator.deliver("final", {});
 
     expect(onReplyStart).not.toHaveBeenCalled();
+  });
+});
+
+function createMockBinding(overrides?: Partial<SessionBindingRecord>): SessionBindingRecord {
+  return {
+    bindingId: "bind-1",
+    targetSessionKey: "agent:codex-acp:session-1",
+    targetKind: "subagent",
+    conversation: {
+      channel: "discord",
+      accountId: "acct-discord-1",
+      conversationId: "thread-12345",
+    },
+    status: "active",
+    boundAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function createMockBoundDeliveryRouter(
+  result: ReturnType<BoundDeliveryRouter["resolveDestination"]>,
+): BoundDeliveryRouter {
+  return {
+    resolveDestination: vi.fn(() => result),
+  };
+}
+
+describe("createAcpDispatchDeliveryCoordinator — binding resolution", () => {
+  beforeEach(() => {
+    routeMocks.routeReply.mockReset();
+    routeMocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
+  });
+
+  it("routes to Discord thread when binding is found", async () => {
+    const binding = createMockBinding();
+    const router = createMockBoundDeliveryRouter({
+      binding,
+      mode: "bound",
+      reason: "requester-match",
+    });
+
+    const coordinator = createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "discord",
+        Surface: "discord",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher: createDispatcher(),
+      inboundAudio: false,
+      shouldRouteToOriginating: false,
+      boundDeliveryRouter: router,
+    });
+
+    await coordinator.deliver("block", { text: "hello from ACP" });
+
+    expect(routeMocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        to: "thread-12345",
+      }),
+    );
+    expect(coordinator.getRoutedCounts().block).toBe(1);
+  });
+
+  it("falls through to dispatcher when no binding exists", async () => {
+    const router = createMockBoundDeliveryRouter({
+      binding: null,
+      mode: "fallback",
+      reason: "no-active-binding",
+    });
+
+    const dispatcher = createDispatcher();
+    const coordinator = createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "discord",
+        Surface: "discord",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher,
+      inboundAudio: false,
+      shouldRouteToOriginating: false,
+      boundDeliveryRouter: router,
+    });
+
+    await coordinator.deliver("block", { text: "hello" });
+
+    expect(routeMocks.routeReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).toHaveBeenCalled();
+  });
+
+  it("throws on stale/ambiguous binding (fail closed)", async () => {
+    const router = createMockBoundDeliveryRouter({
+      binding: null,
+      mode: "fallback",
+      reason: "ambiguous-without-requester",
+    });
+
+    const dispatcher = createDispatcher();
+    const coordinator = createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "discord",
+        Surface: "discord",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher,
+      inboundAudio: false,
+      shouldRouteToOriginating: false,
+      boundDeliveryRouter: router,
+    });
+
+    await expect(coordinator.deliver("block", { text: "hello" })).rejects.toThrow(
+      /binding resolution failed closed/,
+    );
+    expect(routeMocks.routeReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("skips binding resolution when originating context is already set", async () => {
+    const router = createMockBoundDeliveryRouter({
+      binding: createMockBinding(),
+      mode: "bound",
+      reason: "requester-match",
+    });
+
+    const coordinator = createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "discord",
+        Surface: "discord",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher: createDispatcher(),
+      inboundAudio: false,
+      shouldRouteToOriginating: true,
+      originatingChannel: "telegram",
+      originatingTo: "telegram:chat-99",
+      boundDeliveryRouter: router,
+    });
+
+    await coordinator.deliver("block", { text: "hello" });
+
+    // Router should not be called since originating was already set
+    expect(router.resolveDestination).not.toHaveBeenCalled();
+    expect(routeMocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "telegram:chat-99",
+      }),
+    );
+  });
+
+  it("passes requester to disambiguate multiple bindings", async () => {
+    const router = createMockBoundDeliveryRouter({
+      binding: createMockBinding(),
+      mode: "bound",
+      reason: "requester-match",
+    });
+
+    const requester = {
+      channel: "discord",
+      accountId: "acct-discord-1",
+      conversationId: "thread-12345",
+    };
+
+    createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "discord",
+        Surface: "discord",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher: createDispatcher(),
+      inboundAudio: false,
+      shouldRouteToOriginating: false,
+      boundDeliveryRouter: router,
+      requester,
+    });
+
+    expect(router.resolveDestination).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requester,
+        targetSessionKey: "agent:codex-acp:session-1",
+        failClosed: true,
+      }),
+    );
   });
 });

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -1,7 +1,9 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
+import type { BoundDeliveryRouter } from "../../infra/outbound/bound-delivery-router.js";
 import { runMessageAction } from "../../infra/outbound/message-action-runner.js";
+import type { ConversationRef } from "../../infra/outbound/session-binding-service.js";
 import { maybeApplyTtsToPayload } from "../../tts/tts.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
@@ -53,7 +55,40 @@ export function createAcpDispatchDeliveryCoordinator(params: {
   originatingChannel?: string;
   originatingTo?: string;
   onReplyStart?: () => Promise<void> | void;
+  requester?: ConversationRef;
+  boundDeliveryRouter?: BoundDeliveryRouter;
 }): AcpDispatchDeliveryCoordinator {
+  // Resolve thread binding for ACP sessions spawned from external channels
+  let shouldRouteToOriginating = params.shouldRouteToOriginating;
+  let originatingChannel = params.originatingChannel;
+  let originatingTo = params.originatingTo;
+  let bindingFailedClosed = false;
+  let bindingFailReason = "";
+
+  if (params.boundDeliveryRouter && !shouldRouteToOriginating) {
+    const sessionKey = params.ctx.SessionKey?.trim();
+    if (sessionKey) {
+      const resolution = params.boundDeliveryRouter.resolveDestination({
+        eventKind: "task_completion",
+        targetSessionKey: sessionKey,
+        requester: params.requester,
+        failClosed: true,
+      });
+      if (resolution.mode === "bound" && resolution.binding) {
+        shouldRouteToOriginating = true;
+        originatingChannel = resolution.binding.conversation.channel;
+        originatingTo = resolution.binding.conversation.conversationId;
+        logVerbose(
+          `dispatch-acp: binding resolved to ${originatingChannel}:${originatingTo} (${resolution.reason})`,
+        );
+      } else if (resolution.reason !== "no-active-binding") {
+        bindingFailedClosed = true;
+        bindingFailReason = resolution.reason;
+        logVerbose(`dispatch-acp: binding resolution failed closed: ${resolution.reason}`);
+      }
+    }
+  }
+
   const state: AcpDispatchDeliveryState = {
     startedReplyLifecycle: false,
     accumulatedBlockText: "",
@@ -78,7 +113,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     payload: ReplyPayload,
     toolCallId: string,
   ): Promise<boolean> => {
-    if (!params.shouldRouteToOriginating || !params.originatingChannel || !params.originatingTo) {
+    if (!shouldRouteToOriginating || !originatingChannel || !originatingTo) {
       return false;
     }
     const handle = state.toolMessageByCallId.get(toolCallId);
@@ -140,7 +175,13 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       ttsAuto: params.sessionTtsAuto,
     });
 
-    if (params.shouldRouteToOriginating && params.originatingChannel && params.originatingTo) {
+    if (bindingFailedClosed) {
+      throw new Error(
+        `ACP delivery blocked: binding resolution failed closed (${bindingFailReason})`,
+      );
+    }
+
+    if (shouldRouteToOriginating && originatingChannel && originatingTo) {
       const toolCallId = meta?.toolCallId?.trim();
       if (kind === "tool" && meta?.allowEdit === true && toolCallId) {
         const edited = await tryEditToolMessage(ttsPayload, toolCallId);
@@ -151,8 +192,8 @@ export function createAcpDispatchDeliveryCoordinator(params: {
 
       const result = await routeReply({
         payload: ttsPayload,
-        channel: params.originatingChannel,
-        to: params.originatingTo,
+        channel: originatingChannel,
+        to: originatingTo,
         sessionKey: params.ctx.SessionKey,
         accountId: params.ctx.AccountId,
         threadId: params.ctx.MessageThreadId,
@@ -166,9 +207,9 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       }
       if (kind === "tool" && meta?.toolCallId && result.messageId) {
         state.toolMessageByCallId.set(meta.toolCallId, {
-          channel: params.originatingChannel,
+          channel: originatingChannel,
           accountId: params.ctx.AccountId,
-          to: params.originatingTo,
+          to: originatingTo,
           ...(params.ctx.MessageThreadId != null ? { threadId: params.ctx.MessageThreadId } : {}),
           messageId: result.messageId,
         });

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -49,6 +49,18 @@ const bindingServiceMocks = vi.hoisted(() => ({
   listBySession: vi.fn<(sessionKey: string) => SessionBindingRecord[]>(() => []),
 }));
 
+const boundDeliveryRouterMocks = vi.hoisted(() => ({
+  resolveDestination: vi.fn(
+    (
+      _input: unknown,
+    ): { binding: SessionBindingRecord | null; mode: "bound" | "fallback"; reason: string } => ({
+      binding: null,
+      mode: "fallback",
+      reason: "no-active-binding",
+    }),
+  ),
+}));
+
 vi.mock("../../acp/control-plane/manager.js", () => ({
   getAcpSessionManager: () => managerMocks,
 }));
@@ -81,6 +93,12 @@ vi.mock("../../acp/runtime/session-meta.js", () => ({
 vi.mock("../../infra/outbound/session-binding-service.js", () => ({
   getSessionBindingService: () => ({
     listBySession: (sessionKey: string) => bindingServiceMocks.listBySession(sessionKey),
+  }),
+}));
+
+vi.mock("../../infra/outbound/bound-delivery-router.js", () => ({
+  createBoundDeliveryRouter: () => ({
+    resolveDestination: (input: unknown) => boundDeliveryRouterMocks.resolveDestination(input),
   }),
 }));
 
@@ -227,6 +245,12 @@ describe("tryDispatchAcpReply", () => {
     sessionMetaMocks.readAcpSessionEntry.mockReturnValue(null);
     bindingServiceMocks.listBySession.mockReset();
     bindingServiceMocks.listBySession.mockReturnValue([]);
+    boundDeliveryRouterMocks.resolveDestination.mockReset();
+    boundDeliveryRouterMocks.resolveDestination.mockReturnValue({
+      binding: null,
+      mode: "fallback" as const,
+      reason: "no-active-binding",
+    });
   });
 
   it("routes ACP block output to originating channel", async () => {
@@ -371,5 +395,73 @@ describe("tryDispatchAcpReply", () => {
         text: expect.stringContaining("ACP_DISPATCH_DISABLED"),
       }),
     );
+  });
+
+  it("routes ACP output to Discord thread via binding resolution", async () => {
+    setReadyAcpResolution();
+    boundDeliveryRouterMocks.resolveDestination.mockReturnValue({
+      binding: {
+        bindingId: "bind-1",
+        targetSessionKey: sessionKey,
+        targetKind: "subagent",
+        conversation: {
+          channel: "discord",
+          accountId: "acct-discord-1",
+          conversationId: "thread-99999",
+        },
+        status: "active",
+        boundAt: Date.now(),
+      },
+      mode: "bound" as const,
+      reason: "single-active-binding",
+    });
+    managerMocks.runTurn.mockImplementation(
+      async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
+        await onEvent({ type: "text_delta", text: "routed to thread", tag: "agent_message_chunk" });
+        await onEvent({ type: "done" });
+      },
+    );
+
+    const { dispatcher } = createDispatcher();
+    const result = await runDispatch({
+      bodyForAgent: "test binding",
+      dispatcher,
+      shouldRouteToOriginating: false,
+    });
+
+    expect(result?.counts.block).toBe(1);
+    expect(routeMocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        to: "thread-99999",
+      }),
+    );
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("falls through to dispatcher when no binding exists", async () => {
+    setReadyAcpResolution();
+    boundDeliveryRouterMocks.resolveDestination.mockReturnValue({
+      binding: null,
+      mode: "fallback" as const,
+      reason: "no-active-binding",
+    });
+    managerMocks.runTurn.mockImplementation(
+      async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
+        await onEvent({ type: "text_delta", text: "no binding", tag: "agent_message_chunk" });
+        await onEvent({ type: "done" });
+      },
+    );
+
+    const { dispatcher } = createDispatcher();
+    const result = await runDispatch({
+      bodyForAgent: "test no binding",
+      dispatcher,
+      shouldRouteToOriginating: false,
+    });
+
+    expect(routeMocks.routeReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).toHaveBeenCalled();
+    expect(result).not.toBeNull();
   });
 });

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -11,7 +11,11 @@ import { readAcpSessionEntry } from "../../acp/runtime/session-meta.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
-import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
+import { createBoundDeliveryRouter } from "../../infra/outbound/bound-delivery-router.js";
+import {
+  getSessionBindingService,
+  type ConversationRef,
+} from "../../infra/outbound/session-binding-service.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { prefixSystemMessage } from "../../infra/system-message.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
@@ -175,6 +179,19 @@ export async function tryDispatchAcpReply(params: {
   }
 
   let queuedFinal = false;
+
+  // Build requester context for binding disambiguation
+  const requester: ConversationRef | undefined = (() => {
+    const channel = String(params.ctx.Surface ?? params.ctx.Provider ?? "").trim();
+    const accountId = String(params.ctx.AccountId ?? "").trim();
+    const threadId =
+      params.ctx.MessageThreadId != null ? String(params.ctx.MessageThreadId).trim() : "";
+    if (!channel || !accountId || !threadId) {
+      return undefined;
+    }
+    return { channel, accountId, conversationId: threadId };
+  })();
+
   const delivery = createAcpDispatchDeliveryCoordinator({
     cfg: params.cfg,
     ctx: params.ctx,
@@ -186,6 +203,8 @@ export async function tryDispatchAcpReply(params: {
     originatingChannel: params.originatingChannel,
     originatingTo: params.originatingTo,
     onReplyStart: params.onReplyStart,
+    requester,
+    boundDeliveryRouter: createBoundDeliveryRouter(),
   });
 
   const promptText = resolveAcpPromptText(params.ctx);


### PR DESCRIPTION
## Summary

- Wire `BoundDeliveryRouter.resolveDestination()` into `createAcpDispatchDeliveryCoordinator()` so ACP sessions spawned from Discord threads route output to the originating thread instead of webchat
- Build and pass `ConversationRef` requester context from `tryDispatchAcpReply()` for binding disambiguation when multiple bindings exist
- Fail closed on stale/ambiguous bindings (throw instead of falling back to webchat)

## Changes

- **`src/auto-reply/reply/dispatch-acp-delivery.ts`** — Add `requester?` and `boundDeliveryRouter?` params; resolve binding before delivery with fail-closed semantics
- **`src/auto-reply/reply/dispatch-acp.ts`** — Build `ConversationRef` from `FinalizedMsgContext` and pass it + `createBoundDeliveryRouter()` to the coordinator
- **`src/auto-reply/reply/dispatch-acp-delivery.test.ts`** — 5 new unit tests for binding resolution (found → routes, no binding → fallback, stale → throw, originating set → skip, requester disambiguation)
- **`src/auto-reply/reply/dispatch-acp.test.ts`** — 2 new integration tests (end-to-end with binding → Discord delivery, end-to-end without binding → dispatcher default)

Ref: `docs/experiments/plans/acp-thread-bound-agents.md` lines 237-241, 547-551

## Test plan

- [x] `pnpm test src/auto-reply/reply/dispatch-acp-delivery.test.ts` — 8 tests pass (3 existing + 5 new)
- [x] `pnpm test src/auto-reply/reply/dispatch-acp.test.ts` — 9 tests pass (7 existing + 2 new)
- [x] `pnpm test src/infra/outbound/bound-delivery-router.test.ts` — 5 existing tests unbroken
- [x] `pnpm test src/agents/acp-binding-architecture.guardrail.test.ts` — guardrail passes
- [ ] Manual: spawn ACP session from Discord thread, confirm output streams to thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)