### PR TITLE
fix: cron announce delivery for named agents (#32432)

### DIFF
--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -393,7 +393,7 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
-  it("returns ok when announce delivery reports false and best-effort is disabled", async () => {
+  it("falls back to direct delivery when announce reports false and best-effort is disabled", async () => {
     await withTempHome(async (home) => {
       const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
       const deps = createCliDeps();
@@ -412,13 +412,12 @@ describe("runCronIsolatedAgentTurn", () => {
         },
       });
 
-      // Announce delivery failure should not mark a successful agent execution
-      // as error. The execution succeeded; only delivery failed.
+      // When announce delivery fails, the direct-delivery fallback fires
+      // so the message still reaches the target channel.
       expect(res.status).toBe("ok");
-      expect(res.delivered).toBe(false);
+      expect(res.delivered).toBe(true);
       expect(res.deliveryAttempted).toBe(true);
-      expect(res.error).toBe("cron announce delivery failed");
-      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -431,7 +430,7 @@ describe("runCronIsolatedAgentTurn", () => {
     expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
   });
 
-  it("returns ok when announce flow throws and best-effort is disabled", async () => {
+  it("falls back to direct delivery when announce flow throws and best-effort is disabled", async () => {
     await withTempHome(async (home) => {
       const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
       const deps = createCliDeps();
@@ -452,13 +451,12 @@ describe("runCronIsolatedAgentTurn", () => {
         },
       });
 
-      // Even when announce throws (e.g. "pairing required"), the agent
-      // execution succeeded so the job status should be ok.
+      // When announce throws (e.g. "pairing required"), the direct-delivery
+      // fallback fires so the message still reaches the target channel.
       expect(res.status).toBe("ok");
-      expect(res.delivered).toBe(false);
+      expect(res.delivered).toBe(true);
       expect(res.deliveryAttempted).toBe(true);
-      expect(res.error).toContain("pairing required");
-      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { matchesMessagingToolDeliveryTarget } from "./delivery-dispatch.js";
+
+// Mock the announce flow dependencies to test the fallback behavior.
+vi.mock("../../agents/subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: vi.fn(),
+}));
+vi.mock("../../agents/subagent-registry.js", () => ({
+  countActiveDescendantRuns: vi.fn().mockReturnValue(0),
+}));
+
+describe("matchesMessagingToolDeliveryTarget", () => {
+  it("matches when channel and to agree", () => {
+    expect(
+      matchesMessagingToolDeliveryTarget(
+        { provider: "telegram", to: "123456" },
+        { channel: "telegram", to: "123456" },
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects when channel differs", () => {
+    expect(
+      matchesMessagingToolDeliveryTarget(
+        { provider: "whatsapp", to: "123456" },
+        { channel: "telegram", to: "123456" },
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects when to is missing from delivery", () => {
+    expect(
+      matchesMessagingToolDeliveryTarget(
+        { provider: "telegram", to: "123456" },
+        { channel: "telegram", to: undefined },
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects when channel is missing from delivery", () => {
+    expect(
+      matchesMessagingToolDeliveryTarget(
+        { provider: "telegram", to: "123456" },
+        { channel: undefined, to: "123456" },
+      ),
+    ).toBe(false);
+  });
+
+  it("strips :topic:NNN suffix from target.to before comparing", () => {
+    expect(
+      matchesMessagingToolDeliveryTarget(
+        { provider: "telegram", to: "-1003597428309:topic:462" },
+        { channel: "telegram", to: "-1003597428309" },
+      ),
+    ).toBe(true);
+  });
+
+  it("matches when provider is 'message' (generic)", () => {
+    expect(
+      matchesMessagingToolDeliveryTarget(
+        { provider: "message", to: "123456" },
+        { channel: "telegram", to: "123456" },
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects when accountIds differ", () => {
+    expect(
+      matchesMessagingToolDeliveryTarget(
+        { provider: "telegram", to: "123456", accountId: "bot-a" },
+        { channel: "telegram", to: "123456", accountId: "bot-b" },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("resolveCronDeliveryBestEffort", () => {
+  // Import dynamically to avoid top-level side effects
+  it("returns false by default (no bestEffort set)", async () => {
+    const { resolveCronDeliveryBestEffort } = await import("./delivery-dispatch.js");
+    const job = { delivery: {}, payload: { kind: "agentTurn" } } as never;
+    expect(resolveCronDeliveryBestEffort(job)).toBe(false);
+  });
+
+  it("returns true when delivery.bestEffort is true", async () => {
+    const { resolveCronDeliveryBestEffort } = await import("./delivery-dispatch.js");
+    const job = { delivery: { bestEffort: true }, payload: { kind: "agentTurn" } } as never;
+    expect(resolveCronDeliveryBestEffort(job)).toBe(true);
+  });
+
+  it("returns true when payload.bestEffortDeliver is true and no delivery.bestEffort", async () => {
+    const { resolveCronDeliveryBestEffort } = await import("./delivery-dispatch.js");
+    const job = {
+      delivery: {},
+      payload: { kind: "agentTurn", bestEffortDeliver: true },
+    } as never;
+    expect(resolveCronDeliveryBestEffort(job)).toBe(true);
+  });
+});

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -86,17 +86,15 @@ async function resolveCronAnnounceSessionKey(params: {
       // can look up channel metadata (lastChannel, to, sessionId).  Named agents
       // may not have a session entry for this target yet, causing announce
       // delivery to silently fail (#32432).
-      if (route) {
-        await ensureOutboundSessionEntry({
-          cfg: params.cfg,
-          agentId: params.agentId,
-          channel: params.delivery.channel,
-          accountId: params.delivery.accountId,
-          route,
-        }).catch(() => {
-          // Best-effort: don't block delivery on session entry creation.
-        });
-      }
+      await ensureOutboundSessionEntry({
+        cfg: params.cfg,
+        agentId: params.agentId,
+        channel: params.delivery.channel,
+        accountId: params.delivery.accountId,
+        route,
+      }).catch(() => {
+        // Best-effort: don't block delivery on session entry creation.
+      });
       return resolved;
     }
   } catch {
@@ -159,6 +157,12 @@ export async function dispatchCronDelivery(
   // Keep this strict so timer fallback can safely decide whether to wake main.
   let delivered = params.skipMessagingToolDelivery;
   let deliveryAttempted = params.skipMessagingToolDelivery;
+  // Tracks whether `runSubagentAnnounceFlow` was actually called.  Early
+  // returns from `deliverViaAnnounce` (active subagents, interim suppression,
+  // SILENT_REPLY_TOKEN) are intentional suppressions — not delivery failures —
+  // so the direct-delivery fallback must only fire when the announce send was
+  // actually attempted and failed.
+  let announceDeliveryWasAttempted = false;
   const failDeliveryTarget = (error: string) =>
     params.withRunSession({
       status: "error",
@@ -316,6 +320,7 @@ export async function dispatchCronDelivery(
         });
       }
       deliveryAttempted = true;
+      announceDeliveryWasAttempted = true;
       const didAnnounce = await runSubagentAnnounceFlow({
         childSessionKey: params.agentSessionKey,
         childRunId: `${params.job.id}:${params.runSessionId}:${params.runStartedAt}`,
@@ -446,11 +451,13 @@ export async function dispatchCronDelivery(
     } else {
       const announceResult = await deliverViaAnnounce(params.resolvedDelivery);
       if (announceResult) {
-        // If announce delivery failed (delivered=false), fall back to direct
-        // delivery.  Named agents may not have an active session for the
-        // announce flow to inject into, so sending directly to the channel
-        // is the only reliable alternative (#32432).
-        if (!delivered && !params.isAborted()) {
+        // Fall back to direct delivery only when the announce send was
+        // actually attempted and failed.  Early returns from
+        // deliverViaAnnounce (active subagents, interim suppression,
+        // SILENT_REPLY_TOKEN) are intentional suppressions that must NOT
+        // trigger direct delivery — doing so would bypass the suppression
+        // guard and leak partial/stale content to the channel.  (#32432)
+        if (announceDeliveryWasAttempted && !delivered && !params.isAborted()) {
           const directFallback = await deliverViaDirect(params.resolvedDelivery);
           if (directFallback) {
             return {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -7,7 +7,10 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { resolveAgentMainSessionKey } from "../../config/sessions.js";
 import { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
 import { resolveAgentOutboundIdentity } from "../../infra/outbound/identity.js";
-import { resolveOutboundSessionRoute } from "../../infra/outbound/outbound-session.js";
+import {
+  ensureOutboundSessionEntry,
+  resolveOutboundSessionRoute,
+} from "../../infra/outbound/outbound-session.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
 import { logWarn } from "../../logger.js";
 import type { CronJob, CronRunTelemetry } from "../types.js";
@@ -79,6 +82,21 @@ async function resolveCronAnnounceSessionKey(params: {
     });
     const resolved = route?.sessionKey?.trim();
     if (resolved) {
+      // Ensure the session entry exists so downstream announce / queue delivery
+      // can look up channel metadata (lastChannel, to, sessionId).  Named agents
+      // may not have a session entry for this target yet, causing announce
+      // delivery to silently fail (#32432).
+      if (route) {
+        await ensureOutboundSessionEntry({
+          cfg: params.cfg,
+          agentId: params.agentId,
+          channel: params.delivery.channel,
+          accountId: params.delivery.accountId,
+          route,
+        }).catch(() => {
+          // Best-effort: don't block delivery on session entry creation.
+        });
+      }
       return resolved;
     }
   } catch {
@@ -428,6 +446,36 @@ export async function dispatchCronDelivery(
     } else {
       const announceResult = await deliverViaAnnounce(params.resolvedDelivery);
       if (announceResult) {
+        // If announce delivery failed (delivered=false), fall back to direct
+        // delivery.  Named agents may not have an active session for the
+        // announce flow to inject into, so sending directly to the channel
+        // is the only reliable alternative (#32432).
+        if (!delivered && !params.isAborted()) {
+          const directFallback = await deliverViaDirect(params.resolvedDelivery);
+          if (directFallback) {
+            return {
+              result: directFallback,
+              delivered,
+              deliveryAttempted,
+              summary,
+              outputText,
+              synthesizedText,
+              deliveryPayloads,
+            };
+          }
+          // If direct delivery succeeded (returned null without error),
+          // `delivered` has been set to true by deliverViaDirect.
+          if (delivered) {
+            return {
+              delivered,
+              deliveryAttempted,
+              summary,
+              outputText,
+              synthesizedText,
+              deliveryPayloads,
+            };
+          }
+        }
         return {
           result: announceResult,
           delivered,


### PR DESCRIPTION
## Summary
- Ensure outbound session entry exists when resolving cron announce session key — named agents may not have a session entry for the delivery target, causing the announce flow to silently fail with `delivered: false`
- Fall back to direct outbound delivery (`deliverViaDirect`) when announce delivery fails, so cron output still reaches the target channel even when no active agent session exists for the named agent
- Add unit tests for `matchesMessagingToolDeliveryTarget` and `resolveCronDeliveryBestEffort`

## Root Cause
When a cron job runs with `--agent <named-agent>`, `resolveCronAnnounceSessionKey()` derives an outbound session key (e.g. `agent:my-agent:telegram:direct:123456`) but the session store has no entry for it — unlike the default agent which accumulates session entries from prior conversations. The downstream announce flow (`runSubagentAnnounceFlow`) then fails to find channel metadata for the resolved key, causing delivery to silently return `false`.

## Fix
1. **`resolveCronAnnounceSessionKey`**: After successfully resolving an outbound route, call `ensureOutboundSessionEntry` (best-effort) to create the session metadata entry. This mirrors the same pattern used in the gateway's `send` handler when deriving routes.
2. **`dispatchCronDelivery`**: When announce delivery returns with `delivered=false` (and the run isn't aborted), attempt `deliverViaDirect` as a fallback. This ensures cron output reaches the channel even when the announce injection path is unavailable.

## Test plan
- [x] All 10 new unit tests pass (`delivery-dispatch.named-agent.test.ts`)
- [ ] Manual: run `openclaw cron add --agent <named> --at +2m --channel telegram --to <id> --announce --message "test"` and verify delivery succeeds
- [ ] Verify default agent cron delivery is unaffected (no regression)

Closes #32432

🤖 Generated with [Claude Code](https://claude.com/claude-code)