### PR TITLE
fix(whatsapp): process recent append upserts after reconnect

### DIFF
--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -42,6 +42,7 @@ export async function monitorWebInbox(options: {
   });
   await waitForWaConnection(sock);
   const connectedAtMs = Date.now();
+  const APPEND_RECENT_GRACE_MS = 60_000;
 
   let onCloseResolve: ((reason: WebListenerCloseReason) => void) | null = null;
   const onClose = new Promise<WebListenerCloseReason>((resolve) => {
@@ -411,9 +412,14 @@ export async function monitorWebInbox(options: {
 
       await maybeMarkInboundAsRead(inbound);
 
-      // If this is history/offline catch-up, mark read above but skip auto-reply.
+      // Baileys can emit fresh post-reconnect messages as "append".
+      // Keep suppressing old history sync while allowing recent append events through.
       if (upsert.type === "append") {
-        continue;
+        const messageTimestampMs =
+          typeof inbound.messageTimestampMs === "number" ? inbound.messageTimestampMs : 0;
+        if (messageTimestampMs < connectedAtMs - APPEND_RECENT_GRACE_MS) {
+          continue;
+        }
       }
 
       const enriched = await enrichInboundMessage(msg);

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -416,7 +416,10 @@ export async function monitorWebInbox(options: {
       // Keep suppressing old history sync while allowing recent append events through.
       if (upsert.type === "append") {
         const messageTimestampMs =
-          typeof inbound.messageTimestampMs === "number" ? inbound.messageTimestampMs : 0;
+          typeof inbound.messageTimestampMs === "number" &&
+          Number.isFinite(inbound.messageTimestampMs)
+            ? inbound.messageTimestampMs
+            : 0;
         if (messageTimestampMs < connectedAtMs - APPEND_RECENT_GRACE_MS) {
           continue;
         }

--- a/src/web/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
+++ b/src/web/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
@@ -331,6 +331,41 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
+  it("treats append messages with non-finite timestamps as stale", async () => {
+    const { onMessage, listener, sock } = await openInboxMonitor();
+
+    const upsert = {
+      type: "append",
+      messages: [
+        {
+          key: {
+            id: "append-nan-1",
+            fromMe: false,
+            remoteJid: "999@s.whatsapp.net",
+          },
+          message: { conversation: "nan timestamp append" },
+          messageTimestamp: "not-a-number",
+          pushName: "Edge Sender",
+        },
+      ],
+    };
+
+    sock.ev.emit("messages.upsert", upsert);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(sock.readMessages).toHaveBeenCalledWith([
+      {
+        remoteJid: "999@s.whatsapp.net",
+        id: "append-nan-1",
+        participant: undefined,
+        fromMe: false,
+      },
+    ]);
+    expect(onMessage).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+
   it("normalizes participant phone numbers to JIDs in sendReaction", async () => {
     const listener = await monitorWebInbox({
       verbose: false,

--- a/src/web/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
+++ b/src/web/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
@@ -252,7 +252,7 @@ describe("web monitor inbox", () => {
     });
   });
 
-  it("handles append messages by marking them read but skipping auto-reply", async () => {
+  it("skips stale append messages after marking them read", async () => {
     const { onMessage, listener, sock } = await openInboxMonitor();
 
     const upsert = {
@@ -265,7 +265,7 @@ describe("web monitor inbox", () => {
             remoteJid: "999@s.whatsapp.net",
           },
           message: { conversation: "old message" },
-          messageTimestamp: nowSeconds(),
+          messageTimestamp: nowSeconds(-5 * 60_000),
           pushName: "History Sender",
         },
       ],
@@ -286,6 +286,47 @@ describe("web monitor inbox", () => {
 
     // Verify it WAS NOT passed to onMessage
     expect(onMessage).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+
+  it("processes recent append messages after marking them read", async () => {
+    const { onMessage, listener, sock } = await openInboxMonitor();
+
+    const upsert = {
+      type: "append",
+      messages: [
+        {
+          key: {
+            id: "append-recent-1",
+            fromMe: false,
+            remoteJid: "999@s.whatsapp.net",
+          },
+          message: { conversation: "recent append message" },
+          messageTimestamp: nowSeconds(),
+          pushName: "Recent Sender",
+        },
+      ],
+    };
+
+    sock.ev.emit("messages.upsert", upsert);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(sock.readMessages).toHaveBeenCalledWith([
+      {
+        remoteJid: "999@s.whatsapp.net",
+        id: "append-recent-1",
+        participant: undefined,
+        fromMe: false,
+      },
+    ]);
+
+    expect(onMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: "recent append message",
+        from: "+999",
+      }),
+    );
 
     await listener.close();
   });


### PR DESCRIPTION
## Summary

- Problem: WhatsApp `messages.upsert` events with type `append` were always dropped from auto-reply, even when they were fresh post-reconnect inbound messages.
- Why it matters: after reconnect/restart, valid group/direct messages can arrive as `append`; dropping all of them can silently lose inbound turns.
- What changed: in `src/web/inbound/monitor.ts`, `append` events are now filtered by recency (`60s` grace from connection time) instead of being unconditionally skipped.
- What did NOT change (scope boundary): old history-sync `append` events are still skipped; notify-path behavior is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20952
- Related #1619

## User-visible / Behavior Changes

- Recent WhatsApp messages delivered as `append` after reconnect are now processed instead of being silently skipped.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22
- Model/provider: n/a
- Integration/channel (if any): WhatsApp (Baileys)
- Relevant config (redacted): default test harness config (`channels.whatsapp.allowFrom=["*"]`)

### Steps

1. Emit `messages.upsert` with `type: "append"` and stale timestamp.
2. Emit `messages.upsert` with `type: "append"` and current timestamp.
3. Observe read-mark + auto-reply routing behavior.

### Expected

- Stale append messages are skipped for auto-reply.
- Recent append messages are processed like valid inbound messages.

### Actual

- Matches expected in updated tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest run src/web/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts`
  - `pnpm vitest run src/web/auto-reply/web-auto-reply-monitor.test.ts`
  - `pnpm build:strict-smoke`
  - `pnpm lint:ui:no-raw-window-open`
- Edge cases checked:
  - stale append skipped
  - recent append processed
- What you did **not** verify:
  - full `pnpm check` currently fails in this environment due unrelated pre-existing TS issues under `extensions/*` (not touched by this PR)

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `1bc23607d`
- Files/config to restore: `src/web/inbound/monitor.ts`
- Known bad symptoms reviewers should watch for: unexpected replay of old history messages as fresh inbound

## Risks and Mitigations

- Risk: recent-window threshold may still include borderline old appends in clock-skewed setups.
  - Mitigation: conservative `60s` window and existing inbound dedupe + echo protection reduce duplicate reply risk.
