### PR TITLE
CI: gate Windows checks by windows-relevant scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,7 +331,7 @@ jobs:
   checks-windows:
     needs: [docs-scope, changed-scope, build-artifacts, check]
     if: needs.docs-scope.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.changed-scope.outputs.run_windows == 'true')
-    runs-on: blacksmith-16vcpu-windows-2025
+    runs-on: blacksmith-32vcpu-windows-2025
     timeout-minutes: 45
     env:
       NODE_OPTIONS: --max-old-space-size=6144

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       run_node: ${{ steps.scope.outputs.run_node }}
       run_macos: ${{ steps.scope.outputs.run_macos }}
       run_android: ${{ steps.scope.outputs.run_android }}
+      run_windows: ${{ steps.scope.outputs.run_windows }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -329,7 +330,7 @@ jobs:
 
   checks-windows:
     needs: [docs-scope, changed-scope, build-artifacts, check]
-    if: needs.docs-scope.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.changed-scope.outputs.run_node == 'true')
+    if: needs.docs-scope.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.changed-scope.outputs.run_windows == 'true')
     runs-on: blacksmith-16vcpu-windows-2025
     timeout-minutes: 45
     env:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -43,7 +43,7 @@ Scope logic lives in `scripts/ci-changed-scope.mjs` and is covered by unit tests
 | Runner                           | Jobs                                       |
 | -------------------------------- | ------------------------------------------ |
 | `blacksmith-16vcpu-ubuntu-2404`  | Most Linux jobs, including scope detection |
-| `blacksmith-16vcpu-windows-2025` | `checks-windows`                           |
+| `blacksmith-32vcpu-windows-2025` | `checks-windows`                           |
 | `macos-latest`                   | `macos`, `ios`                             |
 
 ## Local Equivalents

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -13,20 +13,20 @@ The CI runs on every push to `main` and every pull request. It uses smart scopin
 
 ## Job Overview
 
-| Job               | Purpose                                         | When it runs                                      |
-| ----------------- | ----------------------------------------------- | ------------------------------------------------- |
-| `docs-scope`      | Detect docs-only changes                        | Always                                            |
-| `changed-scope`   | Detect which areas changed (node/macos/android) | Non-docs PRs                                      |
-| `check`           | TypeScript types, lint, format                  | Push to `main`, or PRs with Node-relevant changes |
-| `check-docs`      | Markdown lint + broken link check               | Docs changed                                      |
-| `code-analysis`   | LOC threshold check (1000 lines)                | PRs only                                          |
-| `secrets`         | Detect leaked secrets                           | Always                                            |
-| `build-artifacts` | Build dist once, share with other jobs          | Non-docs, node changes                            |
-| `release-check`   | Validate npm pack contents                      | After build                                       |
-| `checks`          | Node/Bun tests + protocol check                 | Non-docs, node changes                            |
-| `checks-windows`  | Windows-specific tests                          | Non-docs, node changes                            |
-| `macos`           | Swift lint/build/test + TS tests                | PRs with macos changes                            |
-| `android`         | Gradle build + tests                            | Non-docs, android changes                         |
+| Job               | Purpose                                                 | When it runs                                      |
+| ----------------- | ------------------------------------------------------- | ------------------------------------------------- |
+| `docs-scope`      | Detect docs-only changes                                | Always                                            |
+| `changed-scope`   | Detect which areas changed (node/macos/android/windows) | Non-docs PRs                                      |
+| `check`           | TypeScript types, lint, format                          | Push to `main`, or PRs with Node-relevant changes |
+| `check-docs`      | Markdown lint + broken link check                       | Docs changed                                      |
+| `code-analysis`   | LOC threshold check (1000 lines)                        | PRs only                                          |
+| `secrets`         | Detect leaked secrets                                   | Always                                            |
+| `build-artifacts` | Build dist once, share with other jobs                  | Non-docs, node changes                            |
+| `release-check`   | Validate npm pack contents                              | After build                                       |
+| `checks`          | Node/Bun tests + protocol check                         | Non-docs, node changes                            |
+| `checks-windows`  | Windows-specific tests                                  | Non-docs, windows-relevant changes                |
+| `macos`           | Swift lint/build/test + TS tests                        | PRs with macos changes                            |
+| `android`         | Gradle build + tests                                    | Non-docs, android changes                         |
 
 ## Fail-Fast Order
 
@@ -43,7 +43,7 @@ Scope logic lives in `scripts/ci-changed-scope.mjs` and is covered by unit tests
 | Runner                           | Jobs                                       |
 | -------------------------------- | ------------------------------------------ |
 | `blacksmith-16vcpu-ubuntu-2404`  | Most Linux jobs, including scope detection |
-| `blacksmith-32vcpu-windows-2025` | `checks-windows`                           |
+| `blacksmith-16vcpu-windows-2025` | `checks-windows`                           |
 | `macos-latest`                   | `macos`, `ios`                             |
 
 ## Local Equivalents

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 
-/** @typedef {{ runNode: boolean; runMacos: boolean; runAndroid: boolean }} ChangedScope */
+/** @typedef {{ runNode: boolean; runMacos: boolean; runAndroid: boolean; runWindows: boolean }} ChangedScope */
 
 const DOCS_PATH_RE = /^(docs\/|.*\.mdx?$)/;
 const MACOS_PROTOCOL_GEN_RE =
@@ -10,6 +10,8 @@ const MACOS_NATIVE_RE = /^(apps\/macos\/|apps\/ios\/|apps\/shared\/|Swabble\/)/;
 const ANDROID_NATIVE_RE = /^(apps\/android\/|apps\/shared\/)/;
 const NODE_SCOPE_RE =
   /^(src\/|test\/|extensions\/|packages\/|scripts\/|ui\/|\.github\/|openclaw\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig.*\.json$|vitest.*\.ts$|tsdown\.config\.ts$|\.oxlintrc\.json$|\.oxfmtrc\.jsonc$)/;
+const WINDOWS_SCOPE_RE =
+  /^(src\/|test\/|extensions\/|packages\/|scripts\/|ui\/|openclaw\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig.*\.json$|vitest.*\.ts$|tsdown\.config\.ts$|\.github\/workflows\/ci\.yml$|\.github\/actions\/setup-node-env\/action\.yml$|\.github\/actions\/setup-pnpm-store-cache\/action\.yml$)/;
 const NATIVE_ONLY_RE =
   /^(apps\/android\/|apps\/ios\/|apps\/macos\/|apps\/shared\/|Swabble\/|appcast\.xml$)/;
 
@@ -19,12 +21,13 @@ const NATIVE_ONLY_RE =
  */
 export function detectChangedScope(changedPaths) {
   if (!Array.isArray(changedPaths) || changedPaths.length === 0) {
-    return { runNode: true, runMacos: true, runAndroid: true };
+    return { runNode: true, runMacos: true, runAndroid: true, runWindows: true };
   }
 
   let runNode = false;
   let runMacos = false;
   let runAndroid = false;
+  let runWindows = false;
   let hasNonDocs = false;
   let hasNonNativeNonDocs = false;
 
@@ -52,6 +55,10 @@ export function detectChangedScope(changedPaths) {
       runNode = true;
     }
 
+    if (WINDOWS_SCOPE_RE.test(path)) {
+      runWindows = true;
+    }
+
     if (!NATIVE_ONLY_RE.test(path)) {
       hasNonNativeNonDocs = true;
     }
@@ -61,7 +68,7 @@ export function detectChangedScope(changedPaths) {
     runNode = true;
   }
 
-  return { runNode, runMacos, runAndroid };
+  return { runNode, runMacos, runAndroid, runWindows };
 }
 
 /**
@@ -94,6 +101,7 @@ export function writeGitHubOutput(scope, outputPath = process.env.GITHUB_OUTPUT)
   appendFileSync(outputPath, `run_node=${scope.runNode}\n`, "utf8");
   appendFileSync(outputPath, `run_macos=${scope.runMacos}\n`, "utf8");
   appendFileSync(outputPath, `run_android=${scope.runAndroid}\n`, "utf8");
+  appendFileSync(outputPath, `run_windows=${scope.runWindows}\n`, "utf8");
 }
 
 function isDirectRun() {
@@ -123,11 +131,11 @@ if (isDirectRun()) {
   try {
     const changedPaths = listChangedPaths(args.base, args.head);
     if (changedPaths.length === 0) {
-      writeGitHubOutput({ runNode: true, runMacos: true, runAndroid: true });
+      writeGitHubOutput({ runNode: true, runMacos: true, runAndroid: true, runWindows: true });
       process.exit(0);
     }
     writeGitHubOutput(detectChangedScope(changedPaths));
   } catch {
-    writeGitHubOutput({ runNode: true, runMacos: true, runAndroid: true });
+    writeGitHubOutput({ runNode: true, runMacos: true, runAndroid: true, runWindows: true });
   }
 }

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -7,6 +7,7 @@ const { detectChangedScope } = require("../../scripts/ci-changed-scope.mjs") as 
     runNode: boolean;
     runMacos: boolean;
     runAndroid: boolean;
+    runWindows: boolean;
   };
 };
 
@@ -16,6 +17,7 @@ describe("detectChangedScope", () => {
       runNode: true,
       runMacos: true,
       runAndroid: true,
+      runWindows: true,
     });
   });
 
@@ -24,6 +26,7 @@ describe("detectChangedScope", () => {
       runNode: false,
       runMacos: false,
       runAndroid: false,
+      runWindows: false,
     });
   });
 
@@ -32,6 +35,7 @@ describe("detectChangedScope", () => {
       runNode: true,
       runMacos: false,
       runAndroid: false,
+      runWindows: true,
     });
   });
 
@@ -40,11 +44,13 @@ describe("detectChangedScope", () => {
       runNode: false,
       runMacos: true,
       runAndroid: false,
+      runWindows: false,
     });
     expect(detectChangedScope(["apps/shared/OpenClawKit/Sources/Foo.swift"])).toEqual({
       runNode: false,
       runMacos: true,
       runAndroid: true,
+      runWindows: false,
     });
   });
 
@@ -54,6 +60,7 @@ describe("detectChangedScope", () => {
         runNode: false,
         runMacos: false,
         runAndroid: false,
+        runWindows: false,
       },
     );
   });
@@ -63,12 +70,23 @@ describe("detectChangedScope", () => {
       runNode: false,
       runMacos: false,
       runAndroid: false,
+      runWindows: false,
     });
 
     expect(detectChangedScope(["assets/icon.png"])).toEqual({
       runNode: true,
       runMacos: false,
       runAndroid: false,
+      runWindows: false,
+    });
+  });
+
+  it("keeps windows lane off for non-runtime GitHub metadata files", () => {
+    expect(detectChangedScope([".github/labeler.yml"])).toEqual({
+      runNode: true,
+      runMacos: false,
+      runAndroid: false,
+      runWindows: false,
     });
   });
 });


### PR DESCRIPTION
## Summary

- Problem: `checks-windows` was triggered for all node-relevant changes, including many paths with low Windows signal.
- Why it matters: this increases Windows queue pressure and wall-clock CI time on busy periods.
- What changed:
  - Added `run_windows` output to changed-scope detection (`scripts/ci-changed-scope.mjs`).
  - Updated `checks-windows` to gate on `run_windows` instead of `run_node`.
  - Added tests covering the Windows scope behavior.
  - Updated CI docs for windows scope and corrected Windows runner label.
- What did NOT change (scope boundary):
  - No test command/runtime changes in `checks-windows`.
  - No Linux/macOS/Android scope gating changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- CI behavior change: `checks-windows` now runs on push to `main` or PRs with windows-relevant changes (`run_windows=true`).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm 10
- Model/provider: N/A
- Integration/channel (if any): GitHub Actions CI
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test src/scripts/ci-changed-scope.test.ts`.
2. Parse workflow YAML for validity.
3. Review changed-scope outputs and `checks-windows` condition.

### Expected

- Scope script emits `run_windows` and tests pass.
- `checks-windows` references `run_windows` in workflow condition.

### Actual

- Verified as expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `src/scripts/ci-changed-scope.test.ts` passes with new Windows scope expectations.
  - `.github/workflows/ci.yml` parses successfully.
- Edge cases checked:
  - docs-only and native-only path behavior remains unchanged.
  - non-runtime `.github/*` path (`.github/labeler.yml`) keeps `run_windows=false`.
- What you did **not** verify:
  - End-to-end runtime impact over multiple CI runs (left for post-merge telemetry).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR to restore previous `run_node` gate for `checks-windows`.
- Files/config to restore:
  - `.github/workflows/ci.yml`
  - `scripts/ci-changed-scope.mjs`
- Known bad symptoms reviewers should watch for:
  - Unexpectedly skipped `checks-windows` on PRs with real Windows-relevant changes.

## Risks and Mitigations

- Risk:
  - Under-scoped Windows matcher could skip needed Windows coverage.
  - Mitigation:
    - Added explicit tests and kept push-to-main behavior unchanged.
