### PR TITLE
fix(browser): wait for extension tabs after relay drop (#32331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - ACP/session history: persist transcripts for successful ACP child runs, preserve exact transcript text, record ACP spawned-session lineage, and keep spawn-time transcript-path persistence best-effort so history storage failures do not block execution. (#40137) thanks @mbelinky.
 - Browser/CDP: normalize loopback direct WebSocket CDP URLs back to HTTP(S) for `/json/*` tab operations so local `ws://` / `wss://` profiles can still list, focus, open, and close tabs after the new direct-WS support lands. (#31085) Thanks @shrey150.
 - Browser/CDP: rewrite wildcard `ws://0.0.0.0` and `ws://[::]` debugger URLs from remote `/json/version` responses back to the external CDP host/port, fixing Browserless-style container endpoints. (#17760) Thanks @joeharouni.
+- Browser/extension relay: wait briefly for a previously attached Chrome tab to reappear after transient relay drops before failing with `tab not found`, reducing noisy reconnect flakes. (#32461) Thanks @AaronWander.
 - Context engine registry/bundled builds: share the registry state through a `globalThis` singleton so duplicated bundled module copies can resolve engines registered by each other at runtime, with regression coverage for duplicate-module imports. (#40115) thanks @jalehman.
 
 ## 2026.3.7

--- a/src/browser/server-context.ensure-tab-available.prefers-last-target.test.ts
+++ b/src/browser/server-context.ensure-tab-available.prefers-last-target.test.ts
@@ -151,4 +151,29 @@ describe("browser server-context ensureTabAvailable", () => {
       vi.useRealTimers();
     }
   });
+
+  it("still fails after the extension-tab grace window expires", async () => {
+    vi.useFakeTimers();
+    try {
+      const responses = [
+        [{ id: "A", type: "page", url: "https://a.example", webSocketDebuggerUrl: "ws://x/a" }],
+        [{ id: "A", type: "page", url: "https://a.example", webSocketDebuggerUrl: "ws://x/a" }],
+        ...Array.from({ length: 20 }, () => []),
+      ];
+      stubChromeJsonList(responses);
+      const state = makeBrowserState();
+
+      const ctx = createBrowserRouteContext({ getState: () => state });
+      const chrome = ctx.forProfile("chrome");
+      await chrome.ensureTabAvailable();
+
+      const pending = expect(chrome.ensureTabAvailable()).rejects.toThrow(
+        /no attached Chrome tabs/i,
+      );
+      await vi.advanceTimersByTimeAsync(3_500);
+      await pending;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/browser/server-context.ensure-tab-available.prefers-last-target.test.ts
+++ b/src/browser/server-context.ensure-tab-available.prefers-last-target.test.ts
@@ -122,4 +122,33 @@ describe("browser server-context ensureTabAvailable", () => {
     const chrome = ctx.forProfile("chrome");
     await expect(chrome.ensureTabAvailable()).rejects.toThrow(/no attached Chrome tabs/i);
   });
+
+  it("waits briefly for extension tabs to reappear when a previous target exists", async () => {
+    vi.useFakeTimers();
+    try {
+      const responses = [
+        // First call: select tab A and store lastTargetId.
+        [{ id: "A", type: "page", url: "https://a.example", webSocketDebuggerUrl: "ws://x/a" }],
+        [{ id: "A", type: "page", url: "https://a.example", webSocketDebuggerUrl: "ws://x/a" }],
+        // Second call: transient drop, then the extension re-announces attached tab A.
+        [],
+        [{ id: "A", type: "page", url: "https://a.example", webSocketDebuggerUrl: "ws://x/a" }],
+        [{ id: "A", type: "page", url: "https://a.example", webSocketDebuggerUrl: "ws://x/a" }],
+      ];
+      stubChromeJsonList(responses);
+      const state = makeBrowserState();
+
+      const ctx = createBrowserRouteContext({ getState: () => state });
+      const chrome = ctx.forProfile("chrome");
+      const first = await chrome.ensureTabAvailable();
+      expect(first.targetId).toBe("A");
+
+      const secondPromise = chrome.ensureTabAvailable();
+      await vi.advanceTimersByTimeAsync(250);
+      const second = await secondPromise;
+      expect(second.targetId).toBe("A");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/browser/server-context.selection.ts
+++ b/src/browser/server-context.selection.ts
@@ -32,15 +32,28 @@ export function createProfileSelectionOps({
   const ensureTabAvailable = async (targetId?: string): Promise<BrowserTab> => {
     await ensureBrowserAvailable();
     const profileState = getProfileState();
-    const tabs1 = await listTabs();
+    let tabs1 = await listTabs();
     if (tabs1.length === 0) {
       if (profile.driver === "extension") {
-        throw new Error(
-          `tab not found (no attached Chrome tabs for profile "${profile.name}"). ` +
-            "Click the OpenClaw Browser Relay toolbar icon on the tab you want to control (badge ON).",
-        );
+        // Chrome extension relay can briefly drop its WebSocket connection (MV3 service worker
+        // lifecycle, relay restart). If we previously had a target selected, wait briefly for
+        // the extension to reconnect and re-announce its attached tabs before failing.
+        if (profileState.lastTargetId?.trim()) {
+          const deadlineAt = Date.now() + 3_000;
+          while (tabs1.length === 0 && Date.now() < deadlineAt) {
+            await new Promise((resolve) => setTimeout(resolve, 200));
+            tabs1 = await listTabs();
+          }
+        }
+        if (tabs1.length === 0) {
+          throw new Error(
+            `tab not found (no attached Chrome tabs for profile "${profile.name}"). ` +
+              "Click the OpenClaw Browser Relay toolbar icon on the tab you want to control (badge ON).",
+          );
+        }
+      } else {
+        await openTab("about:blank");
       }
-      await openTab("about:blank");
     }
 
     const tabs = await listTabs();

--- a/src/infra/git-commit.test.ts
+++ b/src/infra/git-commit.test.ts
@@ -65,7 +65,9 @@ describe("git commit resolution", () => {
     const repoHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
       cwd: repoRoot,
       encoding: "utf-8",
-    }).trim();
+    })
+      .trim()
+      .slice(0, 7);
 
     const temp = await makeTempDir("git-commit-cwd");
     const otherRepo = path.join(temp, "other");
@@ -81,7 +83,9 @@ describe("git commit resolution", () => {
     const otherHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
       cwd: otherRepo,
       encoding: "utf-8",
-    }).trim();
+    })
+      .trim()
+      .slice(0, 7);
 
     process.chdir(otherRepo);
     const { resolveCommitHash } = await import("./git-commit.js");
@@ -95,7 +99,9 @@ describe("git commit resolution", () => {
     const repoHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
       cwd: repoRoot,
       encoding: "utf-8",
-    }).trim();
+    })
+      .trim()
+      .slice(0, 7);
 
     const { resolveCommitHash } = await import("./git-commit.js");
     const entryModuleUrl = pathToFileURL(path.join(repoRoot, "src", "entry.ts")).href;
@@ -161,7 +167,9 @@ describe("git commit resolution", () => {
     const repoHead = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
       cwd: repoRoot,
       encoding: "utf-8",
-    }).trim();
+    })
+      .trim()
+      .slice(0, 7);
 
     const { resolveCommitHash } = await import("./git-commit.js");
 


### PR DESCRIPTION
## **Summary**

- Problem: Chrome extension relay profiles can briefly return an empty /json/list during transient relay/extension reconnects, causing the browser tool to immediately fail with “no attached Chrome tabs” and repeatedly prompt the user to re-attach.
- Why it matters: This adds frequent manual intervention and breaks otherwise recoverable browser tool flows.
- What changed: When using an extension-driven profile and a previous target exists (lastTargetId), tab selection waits briefly (up to 3s) for tabs to reappear before failing; added a regression test covering the transient-empty case.
- What did NOT change (scope boundary): No new relay protocol/extension changes; no new config knobs; initial “never attached” cases still fail fast with the same guidance.

## **Change Type (select all)**

- [x]  Bug fix
- [ ]  Feature
- [ ]  Refactor
- [ ]  Docs
- [ ]  Security hardening
- [ ]  Chore/infra

## **Scope (select all touched areas)**

- [ ]  Gateway / orchestration
- [x]  Skills / tool execution
- [ ]  Auth / tokens
- [ ]  Memory / storage
- [ ]  Integrations
- [ ]  API / contracts
- [ ]  UI / DX
- [ ]  CI/CD / infra

## **Linked Issue/PR**

- Closes #32331

## **User-visible / Behavior Changes**

- Browser tool calls using the Chrome extension relay profile are less likely to get stuck prompting the user to re-attach after a transient relay/extension reconnect.

## **Security Impact (required)**

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## **Repro + Verification**

### **Environment**

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### **Steps**

1. Run pnpm test src/browser/server-context.ensure-tab-available.prefers-last-target.test.ts.
2. Run pnpm check.

### **Expected**

- Tests pass; extension tab selection tolerates a brief empty /json/list after a prior selection.

### **Actual**

- Previously: selection failed immediately and prompted manual re-attach.

## **Evidence**

- [x]  Passing after: targeted unit test + pnpm check

## **Human Verification (required)**

- Verified scenarios: targeted unit test; pnpm check
- Edge cases checked: transient empty list after prior selection
- What you did **not** verify: full end-to-end repro with a real Chrome extension drop/reconnect

## **Compatibility / Migration**

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## **Failure Recovery (if this breaks)**

- Revert this commit.

## **Risks and Mitigations**

None.