### PR TITLE
fix(tests): align extension test mocks with updated ResolvedAgentRoute and dispatch types

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -73,8 +73,9 @@ const mockResolveGroupPolicy = vi.fn(() => "open");
 type DispatchReplyParams = Parameters<
   PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"]
 >[0];
+const EMPTY_DISPATCH_RESULT = { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
 const mockDispatchReplyWithBufferedBlockDispatcher = vi.fn(
-  async (_params: DispatchReplyParams): Promise<void> => undefined,
+  async (_params: DispatchReplyParams) => EMPTY_DISPATCH_RESULT,
 );
 const mockHasControlCommand = vi.fn(() => false);
 const mockResolveCommandAuthorizedFromAuthorizers = vi.fn(() => false);
@@ -86,16 +87,14 @@ const mockSaveMediaBuffer = vi.fn().mockResolvedValue({
 });
 const mockResolveStorePath = vi.fn(() => "/tmp/sessions.json");
 const mockReadSessionUpdatedAt = vi.fn(() => undefined);
-const mockResolveEnvelopeFormatOptions = vi.fn(() => ({
-  template: "channel+name+time",
-}));
+const mockResolveEnvelopeFormatOptions = vi.fn(() => ({}));
 const mockFormatAgentEnvelope = vi.fn((opts: { body: string }) => opts.body);
 const mockFormatInboundEnvelope = vi.fn((opts: { body: string }) => opts.body);
 const mockChunkMarkdownText = vi.fn((text: string) => [text]);
 const mockChunkByNewline = vi.fn((text: string) => (text ? [text] : []));
 const mockChunkTextWithMode = vi.fn((text: string) => (text ? [text] : []));
 const mockChunkMarkdownTextWithMode = vi.fn((text: string) => (text ? [text] : []));
-const mockResolveChunkMode = vi.fn(() => "length");
+const mockResolveChunkMode = vi.fn((): "length" | "newline" => "length");
 const mockFetchBlueBubblesHistory = vi.mocked(fetchBlueBubblesHistory);
 
 function createMockRuntime(): PluginRuntime {
@@ -1765,6 +1764,7 @@ describe("BlueBubbles webhook monitor", () => {
 
       mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
         await params.dispatcherOptions.onReplyStart?.();
+        return EMPTY_DISPATCH_RESULT;
       });
 
       const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
@@ -1815,6 +1815,7 @@ describe("BlueBubbles webhook monitor", () => {
         await params.dispatcherOptions.onReplyStart?.();
         await params.dispatcherOptions.deliver({ text: "replying now" }, { kind: "final" });
         await params.dispatcherOptions.onIdle?.();
+        return EMPTY_DISPATCH_RESULT;
       });
 
       const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
@@ -1860,7 +1861,9 @@ describe("BlueBubbles webhook monitor", () => {
         },
       };
 
-      mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async () => undefined);
+      mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(
+        async () => EMPTY_DISPATCH_RESULT,
+      );
 
       const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
       const res = createMockResponse();
@@ -1882,6 +1885,7 @@ describe("BlueBubbles webhook monitor", () => {
 
       mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
         await params.dispatcherOptions.deliver({ text: "replying now" }, { kind: "final" });
+        return EMPTY_DISPATCH_RESULT;
       });
 
       const account = createMockAccount();
@@ -1933,6 +1937,7 @@ describe("BlueBubbles webhook monitor", () => {
 
       mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
         await params.dispatcherOptions.deliver({ text: "replying now" }, { kind: "final" });
+        return EMPTY_DISPATCH_RESULT;
       });
 
       const account = createMockAccount();
@@ -2005,6 +2010,7 @@ describe("BlueBubbles webhook monitor", () => {
 
       mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
         await params.dispatcherOptions.deliver({ text: "replying now" }, { kind: "final" });
+        return EMPTY_DISPATCH_RESULT;
       });
 
       const account = createMockAccount();

--- a/extensions/bluebubbles/src/monitor.webhook-auth.test.ts
+++ b/extensions/bluebubbles/src/monitor.webhook-auth.test.ts
@@ -73,8 +73,9 @@ const mockResolveGroupPolicy = vi.fn(() => "open");
 type DispatchReplyParams = Parameters<
   PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"]
 >[0];
+const EMPTY_DISPATCH_RESULT = { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
 const mockDispatchReplyWithBufferedBlockDispatcher = vi.fn(
-  async (_params: DispatchReplyParams): Promise<void> => undefined,
+  async (_params: DispatchReplyParams) => EMPTY_DISPATCH_RESULT,
 );
 const mockHasControlCommand = vi.fn(() => false);
 const mockResolveCommandAuthorizedFromAuthorizers = vi.fn(() => false);
@@ -86,16 +87,14 @@ const mockSaveMediaBuffer = vi.fn().mockResolvedValue({
 });
 const mockResolveStorePath = vi.fn(() => "/tmp/sessions.json");
 const mockReadSessionUpdatedAt = vi.fn(() => undefined);
-const mockResolveEnvelopeFormatOptions = vi.fn(() => ({
-  template: "channel+name+time",
-}));
+const mockResolveEnvelopeFormatOptions = vi.fn(() => ({}));
 const mockFormatAgentEnvelope = vi.fn((opts: { body: string }) => opts.body);
 const mockFormatInboundEnvelope = vi.fn((opts: { body: string }) => opts.body);
 const mockChunkMarkdownText = vi.fn((text: string) => [text]);
 const mockChunkByNewline = vi.fn((text: string) => (text ? [text] : []));
 const mockChunkTextWithMode = vi.fn((text: string) => (text ? [text] : []));
 const mockChunkMarkdownTextWithMode = vi.fn((text: string) => (text ? [text] : []));
-const mockResolveChunkMode = vi.fn(() => "length");
+const mockResolveChunkMode = vi.fn((): "length" | "newline" => "length");
 const mockFetchBlueBubblesHistory = vi.mocked(fetchBlueBubblesHistory);
 
 function createMockRuntime(): PluginRuntime {
@@ -814,6 +813,7 @@ describe("BlueBubbles webhook monitor", () => {
 
       mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
         await params.dispatcherOptions.deliver({ text: "replying now" }, { kind: "final" });
+        return EMPTY_DISPATCH_RESULT;
       });
 
       const account = createMockAccount({ groupPolicy: "open" });

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -97,9 +97,10 @@ describe("buildFeishuAgentBody", () => {
 
 describe("handleFeishuMessage command authorization", () => {
   const mockFinalizeInboundContext = vi.fn((ctx: unknown) => ctx);
-  const mockDispatchReplyFromConfig = vi
-    .fn()
-    .mockResolvedValue({ queuedFinal: false, counts: { final: 1 } });
+  const mockDispatchReplyFromConfig = vi.fn().mockResolvedValue({
+    queuedFinal: false,
+    counts: { tool: 0, block: 0, final: 1 },
+  });
   const mockWithReplyDispatcher = vi.fn(
     async ({
       dispatcher,

--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -86,9 +86,10 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         convertMarkdownTables: vi.fn((text: string) => text),
       },
       reply: {
-        dispatchReplyWithBufferedBlockDispatcher: vi.fn(
-          async () => undefined,
-        ) as unknown as PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"],
+        dispatchReplyWithBufferedBlockDispatcher: vi.fn(async () => ({
+          queuedFinal: false,
+          counts: { tool: 0, block: 0, final: 0 },
+        })) as unknown as PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"],
         createReplyDispatcherWithTyping:
           vi.fn() as unknown as PluginRuntime["channel"]["reply"]["createReplyDispatcherWithTyping"],
         resolveEffectiveMessagesConfig:
@@ -118,15 +119,18 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         formatInboundEnvelope: vi.fn(
           (opts: { body: string }) => opts.body,
         ) as unknown as PluginRuntime["channel"]["reply"]["formatInboundEnvelope"],
-        resolveEnvelopeFormatOptions: vi.fn(() => ({
-          template: "channel+name+time",
-        })) as unknown as PluginRuntime["channel"]["reply"]["resolveEnvelopeFormatOptions"],
+        resolveEnvelopeFormatOptions: vi.fn(
+          () => ({}),
+        ) as unknown as PluginRuntime["channel"]["reply"]["resolveEnvelopeFormatOptions"],
       },
       routing: {
         resolveAgentRoute: vi.fn(() => ({
           agentId: "main",
+          channel: "test",
           accountId: "default",
           sessionKey: "agent:main:test:dm:peer",
+          mainSessionKey: "agent:main:main",
+          matchedBy: "default" as const,
         })) as unknown as PluginRuntime["channel"]["routing"]["resolveAgentRoute"],
       },
       pairing: {


### PR DESCRIPTION
## Summary

- Updates stale mock objects in extension test files to match the current `ResolvedAgentRoute` type (adds required `channel`, `mainSessionKey`, `matchedBy` fields)
- Fixes `mockResolveEnvelopeFormatOptions` to return valid `EnvelopeFormatOptions` instead of `{ template: ... }` which has no properties in common with the type
- Fixes `mockDispatchReplyWithBufferedBlockDispatcher` and `mockDispatchReplyFromConfig` return types to match `DispatchInboundResult` / `DispatchFromConfigResult` instead of `Promise<void>`
- Narrows `mockResolveChunkMode` return type to `ChunkMode` union

## Affected files

- `extensions/test-utils/plugin-runtime-mock.ts` — base mock updated
- `extensions/bluebubbles/src/monitor.test.ts` — mock return types fixed
- `extensions/bluebubbles/src/monitor.webhook-auth.test.ts` — mock return types fixed
- `extensions/feishu/src/bot.test.ts` — dispatch result mock fixed

## Test plan

- [x] All 105 tests pass across the 3 affected test files
- [x] `tsgo --noEmit` shows zero extension test errors (only pre-existing unrelated errors remain)


Made with [Cursor](https://cursor.com)