### PR TITLE
agents: recover partial streams from non-text update events

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -210,7 +210,8 @@ export function handleMessageUpdate(
             mediaUrls: hasMedia ? mediaUrls : undefined,
           },
         });
-        ctx.state.emittedAssistantUpdate = true;
+        // Keep message_end fallback enabled for snapshot-only updates so
+        // providers can still emit a final assistant payload at the end.
         if (ctx.params.onPartialReply && ctx.state.shouldEmitPartialReplies) {
           void ctx.params.onPartialReply({
             text: cleanedText,

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -204,6 +204,12 @@ export function handleMessageUpdate(
       const hasMedia = Boolean(mediaUrls && mediaUrls.length > 0);
       const hasAudio = Boolean(parsedSnapshot.audioAsVoice);
       const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
+      const previousSnapshot = ctx.state.lastStreamedAssistant?.trim();
+      const previousParsed = previousSnapshot
+        ? parseReplyDirectives(stripTrailingDirective(previousSnapshot))
+        : null;
+      const mediaChanged = !areMediaUrlsEqual(mediaUrls, previousParsed?.mediaUrls);
+      const audioChanged = hasAudio !== Boolean(previousParsed?.audioAsVoice);
 
       let shouldEmit = false;
       let deltaText = "";
@@ -213,7 +219,7 @@ export function handleMessageUpdate(
         shouldEmit = false;
       } else {
         deltaText = cleanedText.slice(previousCleaned.length);
-        shouldEmit = Boolean(deltaText || hasMedia || hasAudio);
+        shouldEmit = Boolean(deltaText || mediaChanged || audioChanged);
       }
 
       if (shouldEmit) {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -33,6 +33,20 @@ const stripTrailingDirective = (text: string): string => {
   return text.slice(0, openIndex);
 };
 
+const areMediaUrlsEqual = (left?: string[], right?: string[]): boolean => {
+  const leftList = left ?? [];
+  const rightList = right ?? [];
+  if (leftList.length !== rightList.length) {
+    return false;
+  }
+  for (let i = 0; i < leftList.length; i += 1) {
+    if (leftList[i] !== rightList[i]) {
+      return false;
+    }
+  }
+  return true;
+};
+
 function emitReasoningEnd(ctx: EmbeddedPiSubscribeContext) {
   if (!ctx.state.reasoningStreamOpen) {
     return;
@@ -186,13 +200,12 @@ export function handleMessageUpdate(
         shouldEmit = Boolean(deltaText || hasMedia || hasAudio);
       }
 
-      if (shouldEmit && cleanedText) {
-        syncSnapshotIntoTextBuffers(ctx, snapshot);
-      }
-      ctx.state.lastStreamedAssistant = snapshot;
-      ctx.state.lastStreamedAssistantCleaned = cleanedText;
-
       if (shouldEmit) {
+        if (cleanedText) {
+          syncSnapshotIntoTextBuffers(ctx, snapshot);
+        }
+        ctx.state.lastStreamedAssistant = snapshot;
+        ctx.state.lastStreamedAssistantCleaned = cleanedText;
         emitAgentEvent({
           runId: ctx.params.runId,
           stream: "assistant",
@@ -382,12 +395,14 @@ export function handleMessageEnd(
   let cleanedText = parsedText?.text ?? "";
   let mediaUrls = parsedText?.mediaUrls;
   let hasMedia = Boolean(mediaUrls && mediaUrls.length > 0);
+  let finalSnapshot = trimmedText;
 
   if (!cleanedText && !hasMedia && !ctx.params.enforceFinalTag) {
     const rawTrimmed = rawText.trim();
     const rawStrippedFinal = rawTrimmed.replace(/<\s*\/?\s*final\s*>/gi, "").trim();
     const rawCandidate = rawStrippedFinal || rawTrimmed;
     if (rawCandidate) {
+      finalSnapshot = rawCandidate;
       const parsedFallback = parseReplyDirectives(stripTrailingDirective(rawCandidate));
       cleanedText = parsedFallback.text ?? rawCandidate;
       mediaUrls = parsedFallback.mediaUrls;
@@ -395,22 +410,33 @@ export function handleMessageEnd(
     }
   }
 
-  const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
+  const previousSnapshot = ctx.state.lastStreamedAssistant?.trim();
+  const previousParsed = previousSnapshot
+    ? parseReplyDirectives(stripTrailingDirective(previousSnapshot))
+    : null;
+  const previousCleaned = previousParsed?.text ?? ctx.state.lastStreamedAssistantCleaned;
+  const previousMediaUrls = previousParsed?.mediaUrls;
+  const hasPreviousAssistantSnapshot = Boolean(
+    ctx.state.emittedAssistantUpdate ||
+    previousSnapshot ||
+    ctx.state.lastStreamedAssistantCleaned !== undefined,
+  );
+  const sameMediaUrls = areMediaUrlsEqual(mediaUrls, previousMediaUrls);
+  const sameAssistantPayload =
+    hasPreviousAssistantSnapshot && cleanedText === (previousCleaned ?? "") && sameMediaUrls;
   let shouldEmitFinalAssistant = false;
   let finalDeltaText = cleanedText;
-  if (cleanedText || hasMedia) {
-    if (!ctx.state.emittedAssistantUpdate || !previousCleaned) {
+  if ((cleanedText || hasMedia) && !sameAssistantPayload) {
+    const previousCleanedValue = previousCleaned ?? "";
+    if (!ctx.state.emittedAssistantUpdate || !hasPreviousAssistantSnapshot) {
       shouldEmitFinalAssistant = true;
       finalDeltaText = cleanedText;
-    } else if (cleanedText.startsWith(previousCleaned)) {
-      finalDeltaText = cleanedText.slice(previousCleaned.length);
-      shouldEmitFinalAssistant = Boolean(finalDeltaText || hasMedia);
-    } else if (cleanedText !== previousCleaned) {
+    } else if (cleanedText.startsWith(previousCleanedValue)) {
+      finalDeltaText = cleanedText.slice(previousCleanedValue.length);
+      shouldEmitFinalAssistant = Boolean(finalDeltaText || (hasMedia && !sameMediaUrls));
+    } else if (cleanedText !== previousCleanedValue) {
       // When providers rewrite earlier text, emit the full reconciled text.
       finalDeltaText = cleanedText;
-      shouldEmitFinalAssistant = true;
-    } else if (hasMedia) {
-      finalDeltaText = "";
       shouldEmitFinalAssistant = true;
     }
   }
@@ -434,7 +460,7 @@ export function handleMessageEnd(
       },
     });
     ctx.state.emittedAssistantUpdate = true;
-    ctx.state.lastStreamedAssistant = cleanedText;
+    ctx.state.lastStreamedAssistant = finalSnapshot || cleanedText;
     ctx.state.lastStreamedAssistantCleaned = cleanedText;
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -3,6 +3,7 @@ import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
+import { extractTextFromChatContent } from "../shared/chat-content.js";
 import {
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
@@ -16,6 +17,9 @@ import {
   extractThinkingFromTaggedText,
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
+  stripDowngradedToolCallText,
+  stripMinimaxToolCallXml,
+  stripThinkingTagsFromText,
 } from "./pi-embedded-utils.js";
 
 const stripTrailingDirective = (text: string): string => {
@@ -98,6 +102,18 @@ function syncSnapshotIntoTextBuffers(ctx: EmbeddedPiSubscribeContext, snapshot: 
   }
 }
 
+function extractAssistantRawSnapshotText(msg: AgentMessage): string {
+  const content = (msg as { content?: unknown }).content;
+  return (
+    extractTextFromChatContent(content, {
+      sanitizeText: (text) =>
+        stripThinkingTagsFromText(stripDowngradedToolCallText(stripMinimaxToolCallXml(text))),
+      joinWith: "\n",
+      normalizeText: (text) => text,
+    }) ?? ""
+  );
+}
+
 export function handleMessageStart(
   ctx: EmbeddedPiSubscribeContext,
   evt: AgentEvent & { message: AgentMessage },
@@ -171,13 +187,13 @@ export function handleMessageUpdate(
     // Fall back to diffing the current assistant snapshot so channel preview
     // streaming continues to receive incremental updates.
     if (evtType) {
-      const snapshot = ctx
-        .stripBlockTags(extractAssistantText(msg), {
-          thinking: false,
-          final: false,
-          inlineCode: createInlineCodeState(),
-        })
-        .trim();
+      const rawAssistantText = extractAssistantRawSnapshotText(msg);
+      const snapshotRaw = ctx.stripBlockTags(rawAssistantText, {
+        thinking: false,
+        final: false,
+        inlineCode: createInlineCodeState(),
+      });
+      const snapshot = snapshotRaw.trim();
       if (!snapshot) {
         return;
       }
@@ -202,9 +218,9 @@ export function handleMessageUpdate(
 
       if (shouldEmit) {
         if (cleanedText) {
-          syncSnapshotIntoTextBuffers(ctx, snapshot);
+          syncSnapshotIntoTextBuffers(ctx, snapshotRaw);
         }
-        ctx.state.lastStreamedAssistant = snapshot;
+        ctx.state.lastStreamedAssistant = snapshotRaw;
         ctx.state.lastStreamedAssistantCleaned = cleanedText;
         emitAgentEvent({
           runId: ctx.params.runId,

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -19,7 +19,6 @@ import {
   promoteThinkingTagsToBlocks,
   stripDowngradedToolCallText,
   stripMinimaxToolCallXml,
-  stripThinkingTagsFromText,
 } from "./pi-embedded-utils.js";
 
 const stripTrailingDirective = (text: string): string => {
@@ -106,8 +105,7 @@ function extractAssistantRawSnapshotText(msg: AgentMessage): string {
   const content = (msg as { content?: unknown }).content;
   return (
     extractTextFromChatContent(content, {
-      sanitizeText: (text) =>
-        stripThinkingTagsFromText(stripDowngradedToolCallText(stripMinimaxToolCallXml(text))),
+      sanitizeText: (text) => stripDowngradedToolCallText(stripMinimaxToolCallXml(text)),
       joinWith: "\n",
       normalizeText: (text) => text,
     }) ?? ""
@@ -224,7 +222,10 @@ export function handleMessageUpdate(
 
       if (shouldEmit) {
         if (cleanedText) {
-          syncSnapshotIntoTextBuffers(ctx, snapshotRaw);
+          // In strict final-tag mode, keep <final> markers in buffers so later
+          // text_delta updates continue parsing inside the same final block.
+          const snapshotBuffer = ctx.params.enforceFinalTag ? rawAssistantText : snapshotRaw;
+          syncSnapshotIntoTextBuffers(ctx, snapshotBuffer);
         }
         ctx.state.lastStreamedAssistant = snapshotRaw;
         ctx.state.lastStreamedAssistantCleaned = cleanedText;

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -56,6 +56,34 @@ export function resolveSilentReplyFallbackText(params: {
   return fallback;
 }
 
+function syncSnapshotIntoTextBuffers(ctx: EmbeddedPiSubscribeContext, snapshot: string) {
+  if (!snapshot || snapshot === ctx.state.deltaBuffer) {
+    return;
+  }
+
+  if (snapshot.startsWith(ctx.state.deltaBuffer)) {
+    const missing = snapshot.slice(ctx.state.deltaBuffer.length);
+    if (!missing) {
+      return;
+    }
+    ctx.state.deltaBuffer += missing;
+    if (ctx.blockChunker) {
+      ctx.blockChunker.append(missing);
+    } else {
+      ctx.state.blockBuffer += missing;
+    }
+    return;
+  }
+
+  ctx.state.deltaBuffer = snapshot;
+  if (ctx.blockChunker) {
+    ctx.blockChunker.reset();
+    ctx.blockChunker.append(snapshot);
+  } else {
+    ctx.state.blockBuffer = snapshot;
+  }
+}
+
 export function handleMessageStart(
   ctx: EmbeddedPiSubscribeContext,
   evt: AgentEvent & { message: AgentMessage },
@@ -144,19 +172,23 @@ export function handleMessageUpdate(
       const cleanedText = parsedSnapshot.text;
       const mediaUrls = parsedSnapshot.mediaUrls;
       const hasMedia = Boolean(mediaUrls && mediaUrls.length > 0);
+      const hasAudio = Boolean(parsedSnapshot.audioAsVoice);
       const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
 
       let shouldEmit = false;
       let deltaText = "";
-      if (!cleanedText && !hasMedia) {
+      if (!cleanedText && !hasMedia && !hasAudio) {
         shouldEmit = false;
       } else if (previousCleaned && !cleanedText.startsWith(previousCleaned)) {
         shouldEmit = false;
       } else {
         deltaText = cleanedText.slice(previousCleaned.length);
-        shouldEmit = Boolean(deltaText || hasMedia);
+        shouldEmit = Boolean(deltaText || hasMedia || hasAudio);
       }
 
+      if (shouldEmit && cleanedText) {
+        syncSnapshotIntoTextBuffers(ctx, snapshot);
+      }
       ctx.state.lastStreamedAssistant = snapshot;
       ctx.state.lastStreamedAssistantCleaned = cleanedText;
 

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -124,6 +124,69 @@ export function handleMessageUpdate(
   }
 
   if (evtType !== "text_delta" && evtType !== "text_start" && evtType !== "text_end") {
+    // Some providers emit non-text assistant update events (for example
+    // toolcall/start markers) while still mutating the partial assistant text.
+    // Fall back to diffing the current assistant snapshot so channel preview
+    // streaming continues to receive incremental updates.
+    if (evtType) {
+      const snapshot = ctx
+        .stripBlockTags(extractAssistantText(msg), {
+          thinking: false,
+          final: false,
+          inlineCode: createInlineCodeState(),
+        })
+        .trim();
+      if (!snapshot) {
+        return;
+      }
+
+      const parsedSnapshot = parseReplyDirectives(stripTrailingDirective(snapshot));
+      const cleanedText = parsedSnapshot.text;
+      const mediaUrls = parsedSnapshot.mediaUrls;
+      const hasMedia = Boolean(mediaUrls && mediaUrls.length > 0);
+      const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
+
+      let shouldEmit = false;
+      let deltaText = "";
+      if (!cleanedText && !hasMedia) {
+        shouldEmit = false;
+      } else if (previousCleaned && !cleanedText.startsWith(previousCleaned)) {
+        shouldEmit = false;
+      } else {
+        deltaText = cleanedText.slice(previousCleaned.length);
+        shouldEmit = Boolean(deltaText || hasMedia);
+      }
+
+      ctx.state.lastStreamedAssistant = snapshot;
+      ctx.state.lastStreamedAssistantCleaned = cleanedText;
+
+      if (shouldEmit) {
+        emitAgentEvent({
+          runId: ctx.params.runId,
+          stream: "assistant",
+          data: {
+            text: cleanedText,
+            delta: deltaText,
+            mediaUrls: hasMedia ? mediaUrls : undefined,
+          },
+        });
+        void ctx.params.onAgentEvent?.({
+          stream: "assistant",
+          data: {
+            text: cleanedText,
+            delta: deltaText,
+            mediaUrls: hasMedia ? mediaUrls : undefined,
+          },
+        });
+        ctx.state.emittedAssistantUpdate = true;
+        if (ctx.params.onPartialReply && ctx.state.shouldEmitPartialReplies) {
+          void ctx.params.onPartialReply({
+            text: cleanedText,
+            mediaUrls: hasMedia ? mediaUrls : undefined,
+          });
+        }
+      }
+    }
     return;
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -210,8 +210,7 @@ export function handleMessageUpdate(
             mediaUrls: hasMedia ? mediaUrls : undefined,
           },
         });
-        // Keep message_end fallback enabled for snapshot-only updates so
-        // providers can still emit a final assistant payload at the end.
+        ctx.state.emittedAssistantUpdate = true;
         if (ctx.params.onPartialReply && ctx.state.shouldEmitPartialReplies) {
           void ctx.params.onPartialReply({
             text: cleanedText,
@@ -396,13 +395,33 @@ export function handleMessageEnd(
     }
   }
 
-  if (!ctx.state.emittedAssistantUpdate && (cleanedText || hasMedia)) {
+  const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
+  let shouldEmitFinalAssistant = false;
+  let finalDeltaText = cleanedText;
+  if (cleanedText || hasMedia) {
+    if (!ctx.state.emittedAssistantUpdate || !previousCleaned) {
+      shouldEmitFinalAssistant = true;
+      finalDeltaText = cleanedText;
+    } else if (cleanedText.startsWith(previousCleaned)) {
+      finalDeltaText = cleanedText.slice(previousCleaned.length);
+      shouldEmitFinalAssistant = Boolean(finalDeltaText || hasMedia);
+    } else if (cleanedText !== previousCleaned) {
+      // When providers rewrite earlier text, emit the full reconciled text.
+      finalDeltaText = cleanedText;
+      shouldEmitFinalAssistant = true;
+    } else if (hasMedia) {
+      finalDeltaText = "";
+      shouldEmitFinalAssistant = true;
+    }
+  }
+
+  if (shouldEmitFinalAssistant) {
     emitAgentEvent({
       runId: ctx.params.runId,
       stream: "assistant",
       data: {
         text: cleanedText,
-        delta: cleanedText,
+        delta: finalDeltaText,
         mediaUrls: hasMedia ? mediaUrls : undefined,
       },
     });
@@ -410,11 +429,13 @@ export function handleMessageEnd(
       stream: "assistant",
       data: {
         text: cleanedText,
-        delta: cleanedText,
+        delta: finalDeltaText,
         mediaUrls: hasMedia ? mediaUrls : undefined,
       },
     });
     ctx.state.emittedAssistantUpdate = true;
+    ctx.state.lastStreamedAssistant = cleanedText;
+    ctx.state.lastStreamedAssistantCleaned = cleanedText;
   }
 
   const addedDuringMessage = ctx.state.assistantTexts.length > ctx.state.assistantTextBaseline;
@@ -514,7 +535,7 @@ export function handleMessageEnd(
   ctx.state.blockState.thinking = false;
   ctx.state.blockState.final = false;
   ctx.state.blockState.inlineCode = createInlineCodeState();
-  ctx.state.lastStreamedAssistant = undefined;
-  ctx.state.lastStreamedAssistantCleaned = undefined;
+  // Keep last streamed assistant snapshots until the next message_start reset so
+  // duplicate/late message_end events can still be reconciled safely.
   ctx.state.reasoningStreamOpen = false;
 }

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -444,18 +444,19 @@ export function handleMessageEnd(
     ctx.state.lastStreamedAssistantCleaned !== undefined,
   );
   const sameMediaUrls = areMediaUrlsEqual(mediaUrls, previousMediaUrls);
+  const mediaChanged = !sameMediaUrls;
   const sameAssistantPayload =
     hasPreviousAssistantSnapshot && cleanedText === (previousCleaned ?? "") && sameMediaUrls;
   let shouldEmitFinalAssistant = false;
   let finalDeltaText = cleanedText;
-  if ((cleanedText || hasMedia) && !sameAssistantPayload) {
+  if ((cleanedText || hasMedia || mediaChanged) && !sameAssistantPayload) {
     const previousCleanedValue = previousCleaned ?? "";
     if (!ctx.state.emittedAssistantUpdate || !hasPreviousAssistantSnapshot) {
       shouldEmitFinalAssistant = true;
       finalDeltaText = cleanedText;
     } else if (cleanedText.startsWith(previousCleanedValue)) {
       finalDeltaText = cleanedText.slice(previousCleanedValue.length);
-      shouldEmitFinalAssistant = Boolean(finalDeltaText || (hasMedia && !sameMediaUrls));
+      shouldEmitFinalAssistant = Boolean(finalDeltaText || mediaChanged);
     } else if (cleanedText !== previousCleanedValue) {
       // When providers rewrite earlier text, emit the full reconciled text.
       finalDeltaText = cleanedText;

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
@@ -78,6 +78,38 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(onPartialReply).toHaveBeenCalled();
     expect(onPartialReply.mock.calls[0][0].text).toBe("Hello world");
   });
+  it("continues streaming after non-text snapshot updates in enforce-final mode", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onAgentEvent,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "<final>Hello" }],
+      },
+      assistantMessageEvent: { type: "start" },
+    });
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_delta", delta: " world</final>" },
+    });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]).toMatchObject({ text: "Hello", delta: "Hello" });
+    expect(payloads[1]).toMatchObject({ text: "Hello world", delta: " world" });
+  });
   it("does not require <final> when enforcement is off", () => {
     const { session, emit } = createStubSessionHarness();
 

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -325,6 +325,73 @@ describe("subscribeEmbeddedPiSession", () => {
     });
   });
 
+  it("keeps text_delta updates monotonic after a non-text snapshot update", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+      },
+      assistantMessageEvent: { type: "start" },
+    });
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_delta", delta: " world" },
+    });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads[0]?.text).toBe("Hello");
+    expect(payloads[0]?.delta).toBe("Hello");
+    expect(payloads[1]?.text).toBe("Hello world");
+    expect(payloads[1]?.delta).toBe(" world");
+  });
+
+  it("emits non-text partial updates when only audio_as_voice is present", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+      onPartialReply,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "[[audio_as_voice]]" }],
+      },
+      assistantMessageEvent: { type: "toolcall_delta", delta: '{"tool":"say"}' },
+    });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("");
+    expect(payloads[0]?.delta).toBe("");
+    expect(payloads[0]?.mediaUrls).toBeUndefined();
+
+    expect(onPartialReply).toHaveBeenCalledTimes(1);
+    expect(onPartialReply).toHaveBeenCalledWith({
+      text: "",
+      mediaUrls: undefined,
+    });
+  });
+
   it("emits agent events on message_end for non-streaming assistant text", () => {
     const { session, emit } = createStubSessionHarness();
 

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -358,6 +358,40 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(payloads[1]?.delta).toBe(" world");
   });
 
+  it("emits final assistant payload on message_end after snapshot-only updates", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+      },
+      assistantMessageEvent: { type: "start" },
+    });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+      },
+    });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]?.text).toBe("Hello");
+    expect(payloads[1]?.text).toBe("Hello world");
+    expect(payloads[1]?.delta).toBe("Hello world");
+  });
+
   it("emits non-text partial updates when only audio_as_voice is present", () => {
     const { session, emit } = createStubSessionHarness();
     const onAgentEvent = vi.fn();

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -531,6 +531,42 @@ describe("subscribeEmbeddedPiSession", () => {
     });
   });
 
+  it("does not emit duplicate non-text snapshot events when payload is unchanged", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+    });
+
+    const mediaOnlyMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "MEDIA: https://example.com/a.png" }],
+    };
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: mediaOnlyMessage,
+      assistantMessageEvent: { type: "start" },
+    });
+    emit({
+      type: "message_update",
+      message: mediaOnlyMessage,
+      assistantMessageEvent: { type: "toolcall_delta", delta: '{"tool":"noop"}' },
+    });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({
+      text: "",
+      delta: "",
+      mediaUrls: ["https://example.com/a.png"],
+    });
+  });
+
   it("emits non-text partial updates when only audio_as_voice is present", () => {
     const { session, emit } = createStubSessionHarness();
     const onAgentEvent = vi.fn();

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -425,6 +425,80 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(payloads[0]?.delta).toBe("Hello");
   });
 
+  it("reconciles rewritten non-text snapshots at message_end", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "abc" }],
+      },
+      assistantMessageEvent: { type: "start" },
+    });
+    emit({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "axc" }],
+      },
+      assistantMessageEvent: { type: "toolcall_delta", delta: '{"tool":"rewrite"}' },
+    });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "axc" }],
+      },
+    });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]).toMatchObject({ text: "abc", delta: "abc" });
+    expect(payloads[1]).toMatchObject({ text: "axc", delta: "axc" });
+  });
+
+  it("does not re-emit media-only snapshots on message_end", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+    });
+
+    const mediaOnlyMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "MEDIA: https://example.com/a.png" }],
+    };
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: mediaOnlyMessage,
+      assistantMessageEvent: { type: "start" },
+    });
+    emit({ type: "message_end", message: mediaOnlyMessage });
+    emit({ type: "message_end", message: mediaOnlyMessage });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({
+      text: "",
+      delta: "",
+      mediaUrls: ["https://example.com/a.png"],
+    });
+  });
+
   it("emits non-text partial updates when only audio_as_voice is present", () => {
     const { session, emit } = createStubSessionHarness();
     const onAgentEvent = vi.fn();

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -344,6 +344,7 @@ describe("subscribeEmbeddedPiSession", () => {
       },
       assistantMessageEvent: { type: "start" },
     });
+    // Non-text snapshot fallback should not break later text_delta append behavior.
     emit({
       type: "message_update",
       message: { role: "assistant" },

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -358,6 +358,38 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(payloads[1]?.delta).toBe(" world");
   });
 
+  it("preserves snapshot trailing whitespace for subsequent text_delta composition", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello " }],
+      },
+      assistantMessageEvent: { type: "start" },
+    });
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_delta", delta: "world" },
+    });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads[0]?.text).toBe("Hello");
+    expect(payloads[0]?.delta).toBe("Hello");
+    expect(payloads[1]?.text).toBe("Hello world");
+    expect(payloads[1]?.delta).toBe(" world");
+  });
+
   it("emits final assistant payload on message_end after snapshot-only updates", () => {
     const { session, emit } = createStubSessionHarness();
     const onAgentEvent = vi.fn();

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -531,6 +531,47 @@ describe("subscribeEmbeddedPiSession", () => {
     });
   });
 
+  it("emits a final assistant update when message_end removes streamed media", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello\nMEDIA: https://example.com/a.png" }],
+      },
+      assistantMessageEvent: { type: "start" },
+    });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+      },
+    });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]).toMatchObject({
+      text: "Hello",
+      delta: "Hello",
+      mediaUrls: ["https://example.com/a.png"],
+    });
+    expect(payloads[1]).toMatchObject({
+      text: "Hello",
+      delta: "",
+      mediaUrls: undefined,
+    });
+  });
+
   it("does not emit duplicate non-text snapshot events when payload is unchanged", () => {
     const { session, emit } = createStubSessionHarness();
     const onAgentEvent = vi.fn();

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -279,6 +279,52 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(payloads[1]?.delta).toBe(" world");
   });
 
+  it("emits partial updates from non-text assistant update snapshots", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+      onPartialReply,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+      },
+      assistantMessageEvent: { type: "start" },
+    });
+    emit({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+      },
+      assistantMessageEvent: { type: "toolcall_delta", delta: '{"path":"README.md"}' },
+    });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads[0]?.text).toBe("Hello");
+    expect(payloads[0]?.delta).toBe("Hello");
+    expect(payloads[1]?.text).toBe("Hello world");
+    expect(payloads[1]?.delta).toBe(" world");
+
+    expect(onPartialReply).toHaveBeenNthCalledWith(1, {
+      text: "Hello",
+      mediaUrls: undefined,
+    });
+    expect(onPartialReply).toHaveBeenNthCalledWith(2, {
+      text: "Hello world",
+      mediaUrls: undefined,
+    });
+  });
+
   it("emits agent events on message_end for non-streaming assistant text", () => {
     const { session, emit } = createStubSessionHarness();
 

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -389,7 +389,40 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(payloads).toHaveLength(2);
     expect(payloads[0]?.text).toBe("Hello");
     expect(payloads[1]?.text).toBe("Hello world");
-    expect(payloads[1]?.delta).toBe("Hello world");
+    expect(payloads[1]?.delta).toBe(" world");
+  });
+
+  it("does not duplicate message_end assistant payload when snapshot already matches", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+      },
+      assistantMessageEvent: { type: "start" },
+    });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+      },
+    });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Hello");
+    expect(payloads[0]?.delta).toBe("Hello");
   });
 
   it("emits non-text partial updates when only audio_as_voice is present", () => {

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -55,6 +55,7 @@ describe("registerPluginCommand", () => {
       {
         name: "demo_cmd",
         description: "Demo command",
+        acceptsArgs: false,
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- recover assistant partial streaming when `message_update` events are non-text (`start`, `toolcall_delta`, etc.) but the assistant snapshot text has advanced
- keep monotonic/de-dup behavior by diffing against `lastStreamedAssistantCleaned`
- wire the fallback through both streamed assistant events and `onPartialReply` so Telegram can keep editing incremental previews

## Root cause
`handleMessageUpdate` previously ignored non-text, non-thinking assistant update events entirely, which dropped partial updates for providers that mutate text during those events.

## Testing
- pnpm vitest run src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts src/agents/pi-embedded-subscribe.handlers.messages.test.ts src/telegram/bot-message-dispatch.test.ts
- pnpm vitest run src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts src/agents/pi-embedded-subscribe.code-span-awareness.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.does-not-emit-duplicate-block-replies-text.test.ts

Closes #21872
