### PR TITLE
fix(logging): unify console timestamps via formatConsoleTimestamp for consistent output

### DIFF
--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -3,7 +3,11 @@ import type { Logger as TsLogger } from "tslog";
 import { isVerbose } from "../globals.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { clearActiveProgressLine } from "../terminal/progress-line.js";
-import { getConsoleSettings, shouldLogSubsystemToConsole } from "./console.js";
+import {
+  formatConsoleTimestamp,
+  getConsoleSettings,
+  shouldLogSubsystemToConsole,
+} from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
 import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
@@ -218,10 +222,10 @@ function formatConsoleLine(opts: {
   const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
   const time = (() => {
     if (opts.style === "pretty") {
-      return color.gray(new Date().toISOString().slice(11, 19));
+      return color.gray(formatConsoleTimestamp("pretty"));
     }
     if (loggingState.consoleTimestampPrefix) {
-      return color.gray(new Date().toISOString());
+      return color.gray(formatConsoleTimestamp("compact"));
     }
     return "";
   })();


### PR DESCRIPTION

## Summary
fix #31487 
- Problem: `formatConsoleLine` in `subsystem.ts` directly used `new Date().toISOString()` for console timestamps instead of reusing `formatConsoleTimestamp()` from `console.ts`. This caused inconsistent timestamp handling across console output paths — subsystem logger (used by `openclaw gateway`) displayed UTC, while `console.log` captures already used local time via `formatConsoleTimestamp`.
- What changed: Unified console timestamp formatting by reusing `formatConsoleTimestamp()` in `formatConsoleLine`, ensuring all console output paths go through the same function for consistent timezone and format handling.
- What did NOT change: JSON-style structured output retains `toISOString()` (UTC) per convention. File-level log timestamps and `consoleTimestampPrefix` flag logic are unaffected.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## User-visible / Behavior Changes

- `openclaw gateway` console timestamps now display in the local timezone instead of UTC, consistent with other console output.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Users who relied on UTC in console output may notice the change.
  - Mitigation: UTC was already inconsistent with `formatConsoleTimestamp`; local time is the correct default for interactive console output.