### PR TITLE
fix: add @tloncorp/api to pnpm onlyBuiltDependencies allowlist

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ onlyBuiltDependencies:
   - "@lydell/node-pty"
   - "@matrix-org/matrix-sdk-crypto-nodejs"
   - "@napi-rs/canvas"
+  - "@tloncorp/api"
   - "@whiskeysockets/baileys"
   - authenticate-pam
   - esbuild


### PR DESCRIPTION
## Summary

- Adds `@tloncorp/api` to the `onlyBuiltDependencies` list in `pnpm-workspace.yaml`, fixing `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` during git-method installs.

Fixes #32439

## Test plan

- [ ] Run `pnpm install` from a clean state and confirm `@tloncorp/api` installs without error
- [ ] Verify `extensions/tlon` builds successfully


Made with [Cursor](https://cursor.com)