### PR TITLE
fix: strip trailing NO_REPLY from mixed content in outbound delivery

### DIFF
--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -1157,6 +1157,54 @@ describe("normalizeOutboundPayloads", () => {
     ]);
     expect(normalized).toEqual([{ text: "final answer", mediaUrls: [] }]);
   });
+
+  describe("NO_REPLY safety net (#32403)", () => {
+    it("drops exact NO_REPLY payload", () => {
+      const normalized = normalizeOutboundPayloads([{ text: "NO_REPLY" }]);
+      expect(normalized).toEqual([]);
+    });
+
+    it("drops exact NO_REPLY with surrounding whitespace", () => {
+      const normalized = normalizeOutboundPayloads([{ text: "  NO_REPLY  " }]);
+      expect(normalized).toEqual([]);
+    });
+
+    it("strips trailing NO_REPLY from mixed content", () => {
+      const normalized = normalizeOutboundPayloads([{ text: "😄 NO_REPLY" }]);
+      expect(normalized).toEqual([{ text: "😄", mediaUrls: [] }]);
+    });
+
+    it("strips trailing NO_REPLY with leading text", () => {
+      const normalized = normalizeOutboundPayloads([
+        { text: "Got it, nothing to report NO_REPLY" },
+      ]);
+      expect(normalized).toEqual([{ text: "Got it, nothing to report", mediaUrls: [] }]);
+    });
+
+    it("drops payload when stripping NO_REPLY leaves empty text and no media", () => {
+      const normalized = normalizeOutboundPayloads([{ text: "NO_REPLY" }]);
+      expect(normalized).toEqual([]);
+    });
+
+    it("keeps media payload when text is NO_REPLY", () => {
+      const normalized = normalizeOutboundPayloads([
+        { text: "NO_REPLY", mediaUrl: "https://x.test/a.png" },
+      ]);
+      expect(normalized).toEqual([{ text: "", mediaUrls: ["https://x.test/a.png"] }]);
+    });
+
+    it("preserves valid text that does not contain NO_REPLY", () => {
+      const normalized = normalizeOutboundPayloads([{ text: "Hello, how can I help?" }]);
+      expect(normalized).toEqual([{ text: "Hello, how can I help?", mediaUrls: [] }]);
+    });
+
+    it("preserves text that contains NO_REPLY as substring of a word", () => {
+      // "NO_REPLY" only stripped at word boundaries — embedded tokens in
+      // longer words should not be touched.
+      const normalized = normalizeOutboundPayloads([{ text: "SNO_REPLY_MODE" }]);
+      expect(normalized).toEqual([{ text: "SNO_REPLY_MODE", mediaUrls: [] }]);
+    });
+  });
 });
 
 describe("formatOutboundPayloadLog", () => {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -3,6 +3,7 @@ import {
   isRenderablePayload,
   shouldSuppressReasoningPayload,
 } from "../../auto-reply/reply/reply-payloads.js";
+import { SILENT_REPLY_TOKEN, stripSilentToken } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 
 export type NormalizedOutboundPayload = {
@@ -49,6 +50,14 @@ export function normalizeReplyPayloadsForDelivery(
       continue;
     }
     const parsed = parseReplyDirectives(payload.text ?? "");
+    // Safety net: strip trailing NO_REPLY from mixed content that may have
+    // slipped through higher-level normalization.  parseReplyDirectives only
+    // handles exact-match silence; mixed content like "😄 NO_REPLY" passes
+    // through with the token still embedded.  (#32403)
+    let text = parsed.text ?? "";
+    if (text && !parsed.isSilent && text.includes(SILENT_REPLY_TOKEN)) {
+      text = stripSilentToken(text);
+    }
     const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
     const explicitMediaUrl = payload.mediaUrl ?? parsed.mediaUrl;
     const mergedMedia = mergeMediaUrls(
@@ -59,7 +68,7 @@ export function normalizeReplyPayloadsForDelivery(
     const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
     const next: ReplyPayload = {
       ...payload,
-      text: parsed.text ?? "",
+      text,
       mediaUrls: mergedMedia.length ? mergedMedia : undefined,
       mediaUrl: resolvedMediaUrl,
       replyToId: payload.replyToId ?? parsed.replyToId,


### PR DESCRIPTION
Closes #32403

## Problem

`normalizeReplyPayloadsForDelivery` (the last normalization step before channel delivery) used `parseReplyDirectives` which only checks for **exact** `NO_REPLY` match via `isSilentReplyText`. Mixed content like `"😄 NO_REPLY"` or `"Got it, nothing to report NO_REPLY"` passed through with the token still embedded, leaking it to end users.

This affects all channels that lack adapter-level `NO_REPLY` guards — which is every channel except Slack (the only one with its own `isSilentReplyText` check in `send.ts`).

The leak was most visible during memory-flush turns where the agent is instructed to reply with `NO_REPLY` if nothing to store, but sometimes emits mixed content containing the token.

## Fix

Add `stripSilentToken` as a safety net in `normalizeReplyPayloadsForDelivery` (`src/infra/outbound/payloads.ts`). After `parseReplyDirectives` handles the exact-match case, the new guard catches any remaining trailing `NO_REPLY` tokens in mixed content using the same `stripSilentToken` function that `normalizeReplyPayload` (the higher-level normalizer) already uses.

- If stripping empties the text and there's no media/channelData, the existing `isRenderablePayload` check drops the payload
- If there is media alongside the token, the text is cleaned but the payload is preserved
- Text where `NO_REPLY` appears as a substring of a longer word (e.g. `SNO_REPLY_MODE`) is correctly left untouched

## Test plan

- [x] Added 8 test cases covering: exact match, whitespace-padded, trailing mixed content, strip-to-empty, media preservation, valid text passthrough, embedded substring
- [x] All 66 outbound tests pass
- [x] All 35 deliver tests pass
- [x] All 55 tokens + dispatch tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)