### PR TITLE
fix: skip non-existent directories in doctor --fix service PATH

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -1,6 +1,7 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveGatewayStateDir } from "./paths.js";
 import {
   buildMinimalServicePath,
@@ -8,9 +9,19 @@ import {
   buildServiceEnvironment,
   getMinimalServicePathParts,
   getMinimalServicePathPartsFromEnv,
+  resolveDarwinUserBinDirs,
+  resolveLinuxUserBinDirs,
 } from "./service-env.js";
 
 describe("getMinimalServicePathParts - Linux user directories", () => {
+  beforeEach(() => {
+    // Mock existsSync so candidate user dirs from fake HOME paths are treated as present.
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("includes user bin directories when HOME is set on Linux", () => {
     const result = getMinimalServicePathParts({
       platform: "linux",
@@ -170,7 +181,95 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
   });
 });
 
+describe("getMinimalServicePathParts - filters non-existent user dirs (#32448)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("excludes user bin directories that do not exist on disk", () => {
+    // Only allow system dirs and ~/.local/bin to "exist".
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+      const s = String(p);
+      return s === "/home/testuser/.local/bin" || s.startsWith("/usr") || s === "/bin";
+    });
+
+    const result = getMinimalServicePathParts({
+      platform: "linux",
+      home: "/home/testuser",
+    });
+
+    // Existing dir should be included.
+    expect(result).toContain("/home/testuser/.local/bin");
+    // Non-existent dirs should be excluded.
+    expect(result).not.toContain("/home/testuser/.npm-global/bin");
+    expect(result).not.toContain("/home/testuser/.nvm/current/bin");
+    expect(result).not.toContain("/home/testuser/.fnm/current/bin");
+    // System dirs are never filtered.
+    expect(result).toContain("/usr/local/bin");
+    expect(result).toContain("/usr/bin");
+    expect(result).toContain("/bin");
+  });
+
+  it("excludes non-existent macOS user directories", () => {
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+      const s = String(p);
+      return (
+        s === "/Users/testuser/.local/bin" ||
+        s.startsWith("/opt") ||
+        s.startsWith("/usr") ||
+        s === "/bin"
+      );
+    });
+
+    const result = getMinimalServicePathParts({
+      platform: "darwin",
+      home: "/Users/testuser",
+    });
+
+    expect(result).toContain("/Users/testuser/.local/bin");
+    expect(result).not.toContain("/Users/testuser/.npm-global/bin");
+    expect(result).not.toContain("/Users/testuser/.volta/bin");
+    expect(result).toContain("/opt/homebrew/bin");
+  });
+
+  it("still includes extraDirs even if they do not exist", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+
+    const result = getMinimalServicePathParts({
+      platform: "linux",
+      home: "/home/testuser",
+      extraDirs: ["/custom/bin"],
+    });
+
+    // Extra dirs are not filtered — only user candidate dirs are.
+    expect(result).toContain("/custom/bin");
+    // All user dirs should be excluded since existsSync returns false.
+    expect(result).not.toContain("/home/testuser/.local/bin");
+    expect(result).not.toContain("/home/testuser/.npm-global/bin");
+  });
+
+  it("resolution functions still return all candidates regardless of existence", () => {
+    // The resolution functions are pure: they don't check the filesystem.
+    const linuxDirs = resolveLinuxUserBinDirs("/home/testuser");
+    expect(linuxDirs).toContain("/home/testuser/.npm-global/bin");
+    expect(linuxDirs).toContain("/home/testuser/.nvm/current/bin");
+
+    const darwinDirs = resolveDarwinUserBinDirs("/Users/testuser");
+    expect(darwinDirs).toContain("/Users/testuser/.npm-global/bin");
+    expect(darwinDirs).toContain(
+      "/Users/testuser/Library/Application Support/fnm/aliases/default/bin",
+    );
+  });
+});
+
 describe("buildMinimalServicePath", () => {
+  beforeEach(() => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   const splitPath = (value: string, platform: NodeJS.Platform) =>
     value.split(platform === "win32" ? path.win32.delimiter : path.posix.delimiter);
 

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { VERSION } from "../version.js";
@@ -192,12 +193,17 @@ export function getMinimalServicePathParts(options: MinimalServicePathOptions = 
   const systemDirs = resolveSystemPathDirs(platform);
 
   // Add user bin directories for version managers (npm global, nvm, fnm, volta, etc.)
-  const userDirs =
+  // Filter out candidates that don't actually exist on the filesystem.  Hardcoded
+  // paths (e.g. ~/.npm-global/bin, ~/.nvm/current/bin) are speculative — including
+  // them when they don't exist adds stale entries to the service PATH and can mask
+  // "command not found" errors.  (#32448)
+  const userDirs = (
     platform === "linux"
       ? resolveLinuxUserBinDirs(options.home, options.env)
       : platform === "darwin"
         ? resolveDarwinUserBinDirs(options.home, options.env)
-        : [];
+        : []
+  ).filter((dir) => fs.existsSync(dir));
 
   const add = (dir: string) => {
     if (!dir) {


### PR DESCRIPTION
## Summary
- Filter user-candidate directories through `fs.existsSync` in `getMinimalServicePathParts` so only paths that actually exist at `doctor --fix` time are written to the systemd/launchd service file
- Prevents stale `~/.npm-global/bin` entries and missing `~/.nvm/current/bin` symlinks from breaking node resolution
- Resolution functions (`resolveLinuxUserBinDirs`, `resolveDarwinUserBinDirs`) remain pure — filtering is applied at the assembly layer

Closes #32448

## Test plan
- [x] Existing 47 service-env tests pass with `fs.existsSync` mocked to `true`
- [x] 4 new tests verify non-existent dirs are excluded while system dirs and extraDirs are preserved
- [x] New test verifies resolution functions still return all candidates (no filesystem coupling)
- [x] All 179 daemon tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)