### PR TITLE
fix(matrix): wire asVoice from message tool to voice message send

### DIFF
--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -69,6 +69,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
       const mediaUrl = readStringParam(params, "media", { trim: false });
       const replyTo = readStringParam(params, "replyTo");
       const threadId = readStringParam(params, "threadId");
+      const audioAsVoice = params.asVoice === true;
       return await handleMatrixAction(
         {
           action: "sendMessage",
@@ -77,6 +78,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyTo ?? undefined,
           threadId: threadId ?? undefined,
+          audioAsVoice,
         },
         cfg as CoreConfig,
       );

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -19,12 +19,14 @@ export async function sendMatrixMessage(
     mediaUrl?: string;
     replyToId?: string;
     threadId?: string;
+    audioAsVoice?: boolean;
   } = {},
 ) {
   return await sendMessageMatrix(to, content, {
     mediaUrl: opts.mediaUrl,
     replyToId: opts.replyToId,
     threadId: opts.threadId,
+    audioAsVoice: opts.audioAsVoice,
     client: opts.client,
     timeoutMs: opts.timeoutMs,
   });

--- a/extensions/matrix/src/tool-actions.test.ts
+++ b/extensions/matrix/src/tool-actions.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock the matrix actions module so we can inspect `sendMatrixMessage` calls
+// without requiring a real Matrix client.
+vi.mock("./matrix/actions.js", () => ({
+  sendMatrixMessage: vi.fn().mockResolvedValue({ messageId: "evt-1", roomId: "!room:test" }),
+  editMatrixMessage: vi.fn(),
+  deleteMatrixMessage: vi.fn(),
+  readMatrixMessages: vi.fn(),
+  getMatrixMemberInfo: vi.fn(),
+  getMatrixRoomInfo: vi.fn(),
+  listMatrixPins: vi.fn(),
+  listMatrixReactions: vi.fn(),
+  pinMatrixMessage: vi.fn(),
+  removeMatrixReactions: vi.fn(),
+  unpinMatrixMessage: vi.fn(),
+}));
+
+vi.mock("./matrix/send.js", () => ({
+  reactMatrixMessage: vi.fn(),
+}));
+
+import { sendMatrixMessage } from "./matrix/actions.js";
+import { handleMatrixAction } from "./tool-actions.js";
+import type { CoreConfig } from "./types.js";
+
+const baseCfg = { channels: { matrix: { actions: {} } } } as unknown as CoreConfig;
+
+describe("handleMatrixAction – sendMessage", () => {
+  it("forwards audioAsVoice to sendMatrixMessage", async () => {
+    await handleMatrixAction(
+      {
+        action: "sendMessage",
+        to: "!room:example.org",
+        content: "",
+        mediaUrl: "https://example.com/voice.ogg",
+        audioAsVoice: true,
+      },
+      baseCfg,
+    );
+
+    expect(sendMatrixMessage).toHaveBeenCalledTimes(1);
+    expect(sendMatrixMessage).toHaveBeenCalledWith(
+      "!room:example.org",
+      "",
+      expect.objectContaining({ audioAsVoice: true }),
+    );
+  });
+
+  it("defaults audioAsVoice to false when not provided", async () => {
+    vi.mocked(sendMatrixMessage).mockClear();
+
+    await handleMatrixAction(
+      {
+        action: "sendMessage",
+        to: "!room:example.org",
+        content: "hello",
+      },
+      baseCfg,
+    );
+
+    expect(sendMatrixMessage).toHaveBeenCalledTimes(1);
+    expect(sendMatrixMessage).toHaveBeenCalledWith(
+      "!room:example.org",
+      "hello",
+      expect.objectContaining({ audioAsVoice: false }),
+    );
+  });
+});

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -82,10 +82,12 @@ export async function handleMatrixAction(
         const replyToId =
           readStringParam(params, "replyToId") ?? readStringParam(params, "replyTo");
         const threadId = readStringParam(params, "threadId");
+        const audioAsVoice = params.audioAsVoice === true;
         const result = await sendMatrixMessage(to, content, {
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyToId ?? undefined,
           threadId: threadId ?? undefined,
+          audioAsVoice,
         });
         return jsonResult({ ok: true, result });
       }


### PR DESCRIPTION
## Summary
- The Matrix plugin already supports `audioAsVoice` in `sendMessageMatrix` and correctly produces MSC3245 voice messages, but the `message` tool action handler never extracted or forwarded the parameter
- Wires `asVoice` through three layers: `actions.ts` → `tool-actions.ts` → `actions/messages.ts` → `send.ts`
- Adds unit tests for the `handleMatrixAction` layer verifying the parameter is forwarded

## Test plan
- [x] `tsc --noEmit` passes (no new type errors)
- [x] All 5 Matrix send tests pass (includes existing `audioAsVoice` tests)
- [x] All 102 Matrix extension tests pass (28 test files)
- [x] New `tool-actions.test.ts` — 2 tests verifying `audioAsVoice` forwarding
- [x] All 38 core channel action tests pass
- [x] Pre-commit lint passes

Closes #32489

🤖 Generated with [Claude Code](https://claude.com/claude-code)