### PR TITLE
fix(slack): print manifest JSON outside note box for clean copy-paste

### DIFF
--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -108,12 +108,13 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
       "5) App Home → enable the Messages tab for DMs",
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
       `Docs: ${formatDocsLink("/slack", "slack")}`,
-      "",
-      "Manifest (JSON):",
-      manifest,
     ].join("\n"),
     "Slack socket mode tokens",
   );
+  // Print the manifest outside the note box so it can be copied as valid JSON.
+  console.log("\nManifest (JSON) — copy and paste into Slack:\n");
+  console.log(manifest);
+  console.log();
 }
 
 function setSlackChannelAllowlist(


### PR DESCRIPTION
## Summary
- The Slack onboarding wizard rendered the JSON manifest inside a `@clack/prompts` note, which wraps every line in `│` pipe borders, creating invalid JSON that can't be copy-pasted
- Moves the manifest output outside the note box via `console.log` so the JSON is printed as clean, valid text

**Before:**
```
┌  Slack socket mode tokens ──────────┐
│  1) Slack API → Create App …        │
│  …                                  │
│  Manifest (JSON):                   │
│  {                                  │
│    "display_information": { … }     │
│  }                                  │
└─────────────────────────────────────┘
```

**After:**
```
┌  Slack socket mode tokens ──────────┐
│  1) Slack API → Create App …        │
│  …                                  │
└─────────────────────────────────────┘

Manifest (JSON) — copy and paste into Slack:

{
  "display_information": { … }
}
```

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 24 wizard tests pass
- [x] All 82 onboarding plugin tests pass
- [x] Pre-commit lint passes

Closes #32493

🤖 Generated with [Claude Code](https://claude.com/claude-code)