### PR TITLE
fix(memory): dispose GGML Metal contexts on shutdown to prevent assertion crash

### DIFF
--- a/src/memory/embeddings.test.ts
+++ b/src/memory/embeddings.test.ts
@@ -436,6 +436,100 @@ describe("local embedding normalization", () => {
     expect(embedding.every((value) => Number.isFinite(value))).toBe(true);
   });
 
+  it("dispose() releases embeddingContext, model, and llama in order", async () => {
+    const disposeContext = vi.fn().mockResolvedValue(undefined);
+    const disposeModel = vi.fn().mockResolvedValue(undefined);
+    const disposeLlama = vi.fn().mockResolvedValue(undefined);
+    const callOrder: string[] = [];
+
+    importNodeLlamaCppMock.mockResolvedValue({
+      getLlama: async () => ({
+        dispose: () => {
+          callOrder.push("llama");
+          return disposeLlama();
+        },
+        loadModel: vi.fn().mockResolvedValue({
+          dispose: () => {
+            callOrder.push("model");
+            return disposeModel();
+          },
+          createEmbeddingContext: vi.fn().mockResolvedValue({
+            dispose: () => {
+              callOrder.push("context");
+              return disposeContext();
+            },
+            getEmbeddingFor: vi.fn().mockResolvedValue({ vector: new Float32Array([1, 0, 0]) }),
+          }),
+        }),
+      }),
+      resolveModelFile: async () => "/fake/model.gguf",
+      LlamaLogLevel: { error: 0 },
+    });
+
+    const result = await createLocalProviderForTest();
+    const provider = requireProvider(result);
+
+    // Trigger lazy init so resources are allocated.
+    await provider.embedQuery("warm-up");
+
+    expect(provider.dispose).toBeDefined();
+    await provider.dispose!();
+
+    expect(callOrder).toEqual(["context", "model", "llama"]);
+    expect(disposeContext).toHaveBeenCalledOnce();
+    expect(disposeModel).toHaveBeenCalledOnce();
+    expect(disposeLlama).toHaveBeenCalledOnce();
+  });
+
+  it("dispose() is a no-op when called before any embedding is generated", async () => {
+    importNodeLlamaCppMock.mockResolvedValue({
+      getLlama: async () => ({
+        dispose: vi.fn(),
+        loadModel: vi.fn(),
+      }),
+      resolveModelFile: async () => "/fake/model.gguf",
+      LlamaLogLevel: { error: 0 },
+    });
+
+    const result = await createLocalProviderForTest();
+    const provider = requireProvider(result);
+
+    // No embedQuery call — resources were never initialised.
+    await expect(provider.dispose!()).resolves.toBeUndefined();
+  });
+
+  it("dispose() is idempotent — second call does not re-dispose", async () => {
+    const disposeContext = vi.fn().mockResolvedValue(undefined);
+    const disposeModel = vi.fn().mockResolvedValue(undefined);
+    const disposeLlama = vi.fn().mockResolvedValue(undefined);
+
+    importNodeLlamaCppMock.mockResolvedValue({
+      getLlama: async () => ({
+        dispose: disposeLlama,
+        loadModel: vi.fn().mockResolvedValue({
+          dispose: disposeModel,
+          createEmbeddingContext: vi.fn().mockResolvedValue({
+            dispose: disposeContext,
+            getEmbeddingFor: vi.fn().mockResolvedValue({ vector: new Float32Array([1, 0, 0]) }),
+          }),
+        }),
+      }),
+      resolveModelFile: async () => "/fake/model.gguf",
+      LlamaLogLevel: { error: 0 },
+    });
+
+    const result = await createLocalProviderForTest();
+    const provider = requireProvider(result);
+    await provider.embedQuery("warm-up");
+
+    await provider.dispose!();
+    await provider.dispose!(); // second call — should be a no-op
+
+    expect(disposeContext).toHaveBeenCalledOnce();
+    expect(disposeModel).toHaveBeenCalledOnce();
+    expect(disposeLlama).toHaveBeenCalledOnce();
+  });
+
   it("normalizes batch embeddings to magnitude ~1.0", async () => {
     const unnormalizedVectors = [
       [2.35, 3.45, 0.63, 4.3],

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -34,6 +34,8 @@ export type EmbeddingProvider = {
   maxInputTokens?: number;
   embedQuery: (text: string) => Promise<number[]>;
   embedBatch: (texts: string[]) => Promise<number[][]>;
+  /** Release native resources (e.g. GGML Metal contexts). Safe to call multiple times. */
+  dispose?: () => Promise<void>;
 };
 
 export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama";
@@ -143,6 +145,27 @@ async function createLocalEmbeddingProvider(
         }),
       );
       return embeddings;
+    },
+    // Dispose native GGML/Metal resources in reverse-creation order to prevent
+    // the Metal assertion crash (rsets->data count != 0) on process exit.
+    // Refs are nulled before awaiting so idempotency holds even if a step throws.
+    dispose: async () => {
+      const ctx = embeddingContext;
+      embeddingContext = null;
+      const model = embeddingModel;
+      embeddingModel = null;
+      const inst = llama;
+      llama = null;
+
+      if (ctx) {
+        await ctx.dispose();
+      }
+      if (model) {
+        await model.dispose();
+      }
+      if (inst) {
+        await inst.dispose();
+      }
     },
   };
 }

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -780,6 +780,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         await pendingSync;
       } catch {}
     }
+    // Dispose native provider resources (e.g. GGML Metal contexts for local
+    // embeddings) before closing the DB so the process exits cleanly.
+    if (this.provider?.dispose) {
+      try {
+        await this.provider.dispose();
+      } catch {}
+    }
     this.db.close();
     INDEX_CACHE.delete(this.cacheKey);
   }

--- a/src/types/node-llama-cpp.d.ts
+++ b/src/types/node-llama-cpp.d.ts
@@ -7,14 +7,17 @@ declare module "node-llama-cpp" {
 
   export type LlamaEmbeddingContext = {
     getEmbeddingFor: (text: string) => Promise<LlamaEmbedding>;
+    dispose: () => Promise<void>;
   };
 
   export type LlamaModel = {
     createEmbeddingContext: () => Promise<LlamaEmbeddingContext>;
+    dispose: () => Promise<void>;
   };
 
   export type Llama = {
     loadModel: (params: { modelPath: string }) => Promise<LlamaModel>;
+    dispose: () => Promise<void>;
   };
 
   export function getLlama(params: { logLevel: LlamaLogLevel }): Promise<Llama>;


### PR DESCRIPTION
## Summary

- **Problem:** On Apple Silicon, using `provider: "local"` for memory embeddings causes a GGML Metal assertion crash (`GGML_ASSERT([rsets->data count] == 0) failed`) on process exit — including auto-update restarts. The gateway process is treated as a graceful exit, blocking the auto-update restart loop.
- **Root cause:** `createLocalEmbeddingProvider` in `src/memory/embeddings.ts` creates three native resources (`Llama`, `LlamaModel`, `LlamaEmbeddingContext`) but the returned `EmbeddingProvider` object had no `dispose()` method. `MemoryIndexManager.close()` never released these resources, leaving Metal GPU buffers allocated at process exit — triggering the assertion in `ggml-metal-device-free`.
- **What changed:** Added an optional `dispose?: () => Promise<void>` to the `EmbeddingProvider` type. `createLocalEmbeddingProvider` implements it, disposing context → model → llama in reverse-creation order (idempotent; safe to call multiple times or before any embedding is generated). `MemoryIndexManager.close()` now calls `this.provider?.dispose?.()` before closing the DB.
- **What did NOT change:** All remote embedding providers (openai, gemini, voyage, mistral) are unaffected — `dispose` is optional and they simply don't implement it.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Closes #32452

## User-visible / Behavior Changes

- On Apple Silicon, `openclaw gateway restart` and auto-update no longer crash with a GGML Metal assertion when local embeddings are in use. The gateway exits cleanly and restarts as expected.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 26.3 (Apple Silicon M-series)
- Runtime: Node 22 / npm global install
- Model/provider: `agents.defaults.memorySearch.provider: "local"` with a `.gguf` model via node-llama-cpp

### Steps

1. Configure local embeddings as described in #32452.
2. Run `openclaw gateway restart` or wait for auto-update.
3. **Before:** GGML Metal assertion crash; gateway does not restart.
4. **After:** Clean shutdown, gateway restarts normally.

### Expected

- Gateway exits without any native assertion errors.

### Actual (before fix)

- `GGML_ASSERT([rsets->data count] == 0) failed` crash in `ggml-metal-device-free` on exit.

## Evidence

- [x] 3 new tests in `src/memory/embeddings.test.ts`:
  - `dispose() releases embeddingContext, model, and llama in order` — verifies reverse-creation disposal order
  - `dispose() is a no-op when called before any embedding is generated` — verifies no crash when resources were never initialised
  - `dispose() is idempotent — second call does not re-dispose` — verifies safe repeated calls
- All 21 tests in the file pass.

## Human Verification (required)

- Verified scenarios: lint (0 warnings/errors on changed files), all 21 embedding provider tests pass.
- Edge cases checked: dispose before lazy init (no-op), double-dispose (idempotent), disposal order matches node-llama-cpp requirements (context before model before llama).
- What you did **not** verify: live end-to-end on physical Apple Silicon hardware with a real `.gguf` model.

## Compatibility / Migration

- Backward compatible? Yes — `dispose` is optional on `EmbeddingProvider`; existing providers are unaffected.
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to revert: remove the `dispose` method from `createLocalEmbeddingProvider` and the `this.provider?.dispose?.()` call from `MemoryIndexManager.close()`.
- Files: `src/memory/embeddings.ts`, `src/memory/manager.ts`.
- Known bad symptoms: if a future node-llama-cpp version changes disposal semantics, the order (context → model → llama) may need updating.

## Risks and Mitigations

- Risk: `dispose()` throws during shutdown, masking other close errors.
  - Mitigation: the call in `MemoryIndexManager.close()` is wrapped in `try/catch` so it never propagates.

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
