### PR TITLE
fix(agents): preserve thinking block signatures for Anthropic and Bedrock Claude

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -61,6 +61,14 @@ function isAnthropicApi(modelApi?: string | null, provider?: string | null): boo
   return normalized === "anthropic";
 }
 
+function isBedrockClaude(params: { modelApi?: string | null; provider?: string | null; modelId?: string | null }): boolean {
+  const normalized = normalizeProviderId(params.provider ?? "");
+  if (normalized !== "amazon-bedrock" && params.modelApi !== "bedrock-converse-stream") {
+    return false;
+  }
+  return (params.modelId ?? "").toLowerCase().includes("claude");
+}
+
 function isMistralModel(params: { provider?: string | null; modelId?: string | null }): boolean {
   const provider = normalizeProviderId(params.provider ?? "");
   if (provider === "mistral") {
@@ -92,6 +100,7 @@ export function resolveTranscriptPolicy(params: {
     provider,
     modelId,
   });
+  const isBedrockClaudeModel = isBedrockClaude(params);
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
@@ -112,7 +121,7 @@ export function resolveTranscriptPolicy(params: {
     sanitizeToolCallIds,
     toolCallIdMode,
     repairToolUseResultPairing: !isOpenAi && repairToolUseResultPairing,
-    preserveSignatures: isAntigravityClaudeModel,
+    preserveSignatures: isAnthropic || isBedrockClaudeModel || isAntigravityClaudeModel,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     normalizeAntigravityThinkingBlocks,
     applyGoogleTurnOrdering: !isOpenAi && isGoogle,


### PR DESCRIPTION
## Summary

`resolveTranscriptPolicy` currently sets `preserveSignatures` to `isAntigravityClaudeModel`, which is effectively always `false` since Google Antigravity support was removed in v2026.2.22. This causes `stripThoughtSignatures` to remove `msg_`-prefixed `thought_signature` fields from Anthropic thinking blocks, resulting in API rejection:

```
LLM request rejected: messages.43.content.1: thinking or redacted_thinking blocks
in the latest assistant message cannot be modified.
```

### Changes

1. **Set `preserveSignatures: true` for direct Anthropic API** — `isAnthropic` now included in the condition
2. **Add `isBedrockClaude()` helper** — detects Claude models on Amazon Bedrock (provider `amazon-bedrock` or API `bedrock-converse-stream` with a model ID containing "claude")
3. **Set `preserveSignatures: true` for Bedrock Claude** — Bedrock passes through Anthropic-native thinking blocks with the same signature requirements

Final condition: `preserveSignatures: isAnthropic || isBedrockClaudeModel || isAntigravityClaudeModel`

### Why not modify `isAnthropicApi()`?

Bedrock Claude uses `bedrock-converse-stream` API, not `anthropic-messages`. Adding Bedrock to `isAnthropicApi()` would incorrectly change other policies (sanitizeMode, sanitizeToolCallIds, validateAnthropicTurns) that should remain Bedrock-specific. A separate `isBedrockClaude()` helper keeps the change surgical.

### Root cause chain

```
resolveTranscriptPolicy → preserveSignatures: false (for all providers)
  → sanitizeSessionMessagesImages calls stripThoughtSignatures
  → iterates content blocks, removes msg_-prefixed thought_signature
  → Anthropic API rejects: thinking blocks modified
```

### Testing

- Verified the fix resolves the API rejection error for direct Anthropic provider
- Confirmed Bedrock Claude detection works for provider `amazon-bedrock` and API `bedrock-converse-stream`
- Other providers (OpenAI, Google, Mistral) are unaffected — their policies remain unchanged

Fixes #32526
Related: #29618, #24612, #27504