### PR TITLE
fix(agents): pass frequency_penalty and presence_penalty to API payload

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -317,6 +317,38 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]).toEqual({ reasoning: { max_tokens: 256 } });
   });
 
+  it("does not inject reasoning.effort for x-ai/grok models on OpenRouter (#32039)", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {};
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "openrouter",
+      "x-ai/grok-4.1-fast",
+      undefined,
+      "medium",
+    );
+
+    const model = {
+      api: "openai-completions",
+      provider: "openrouter",
+      id: "x-ai/grok-4.1-fast",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).not.toHaveProperty("reasoning");
+    expect(payloads[0]).not.toHaveProperty("reasoning_effort");
+  });
+
   it("normalizes thinking=off to null for SiliconFlow Pro models", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
@@ -331,7 +363,7 @@ describe("applyExtraParamsToAgent", () => {
       agent,
       undefined,
       "siliconflow",
-      "Pro/MiniMaxAI/MiniMax-M2.1",
+      "Pro/MiniMaxAI/MiniMax-M2.5",
       undefined,
       "off",
     );
@@ -339,7 +371,7 @@ describe("applyExtraParamsToAgent", () => {
     const model = {
       api: "openai-completions",
       provider: "siliconflow",
-      id: "Pro/MiniMaxAI/MiniMax-M2.1",
+      id: "Pro/MiniMaxAI/MiniMax-M2.5",
     } as Model<"openai-completions">;
     const context: Context = { messages: [] };
     void agent.streamFn?.(model, context, {});
@@ -377,6 +409,92 @@ describe("applyExtraParamsToAgent", () => {
 
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.thinking).toBe("off");
+  });
+
+  it("maps thinkingLevel=off to Moonshot thinking.type=disabled", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {};
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "moonshot", "kimi-k2.5", undefined, "off");
+
+    const model = {
+      api: "openai-completions",
+      provider: "moonshot",
+      id: "kimi-k2.5",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
+  });
+
+  it("maps non-off thinking levels to Moonshot thinking.type=enabled and normalizes tool_choice", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { tool_choice: "required" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "moonshot", "kimi-k2.5", undefined, "low");
+
+    const model = {
+      api: "openai-completions",
+      provider: "moonshot",
+      id: "kimi-k2.5",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.thinking).toEqual({ type: "enabled" });
+    expect(payloads[0]?.tool_choice).toBe("auto");
+  });
+
+  it("respects explicit Moonshot thinking param from model config", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {};
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "moonshot/kimi-k2.5": {
+              params: {
+                thinking: { type: "disabled" },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "moonshot", "kimi-k2.5", undefined, "high");
+
+    const model = {
+      api: "openai-completions",
+      provider: "moonshot",
+      id: "kimi-k2.5",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
   });
 
   it("removes invalid negative Google thinkingBudget and maps Gemini 3.1 to thinkingLevel", () => {
@@ -1124,4 +1242,166 @@ describe("applyExtraParamsToAgent", () => {
       expect(run().store).toBe(false);
     },
   );
+
+  it("passes frequency_penalty and presence_penalty to API payload via onPayload", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {};
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "zai/glm-5": {
+              params: {
+                temperature: 0.7,
+                frequency_penalty: 0.5,
+                presence_penalty: 0.3,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "zai", "glm-5");
+
+    const model = {
+      api: "openai-completions",
+      provider: "zai",
+      id: "glm-5",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.frequency_penalty).toBe(0.5);
+    expect(payloads[0]?.presence_penalty).toBe(0.3);
+  });
+
+  it("passes top_p and repetition_penalty to API payload via onPayload", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {};
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "ollama/llama3": {
+              params: {
+                top_p: 0.9,
+                repetition_penalty: 1.1,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "ollama", "llama3");
+
+    const model = {
+      api: "openai-completions",
+      provider: "ollama",
+      id: "llama3",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.top_p).toBe(0.9);
+    expect(payloads[0]?.repetition_penalty).toBe(1.1);
+  });
+
+  it("ignores non-numeric penalty values", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {};
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-4": {
+              params: {
+                temperature: 0.8,
+                frequency_penalty: "high",
+                presence_penalty: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "openai", "gpt-4");
+
+    const model = {
+      api: "openai-completions",
+      provider: "openai",
+      id: "gpt-4",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).not.toHaveProperty("frequency_penalty");
+    expect(payloads[0]).not.toHaveProperty("presence_penalty");
+  });
+
+  it("chains onPayload with caller-provided onPayload", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const callerPayloads: unknown[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { model: "glm-5" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "zai/glm-5": {
+              params: {
+                frequency_penalty: 0.5,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "zai", "glm-5");
+
+    const model = {
+      api: "openai-completions",
+      provider: "zai",
+      id: "glm-5",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {
+      onPayload: (payload) => callerPayloads.push(structuredClone(payload)),
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.frequency_penalty).toBe(0.5);
+    // Caller's onPayload should also have been called with the modified payload
+    expect(callerPayloads).toHaveLength(1);
+    expect((callerPayloads[0] as Record<string, unknown>).frequency_penalty).toBe(0.5);
+  });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -133,6 +133,24 @@ function createStreamFnWithExtraParams(
     streamParams.cacheRetention = cacheRetention;
   }
 
+  // Collect API-level generation params that are not part of StreamOptions.
+  // These are injected directly into the raw API payload via onPayload so
+  // providers that support them (OpenAI, Azure, Ollama, GLM, etc.) can use them.
+  const payloadParams: Record<string, number> = {};
+  if (typeof extraParams.frequency_penalty === "number") {
+    payloadParams.frequency_penalty = extraParams.frequency_penalty;
+  }
+  if (typeof extraParams.presence_penalty === "number") {
+    payloadParams.presence_penalty = extraParams.presence_penalty;
+  }
+  if (typeof extraParams.top_p === "number") {
+    payloadParams.top_p = extraParams.top_p;
+  }
+  if (typeof extraParams.repetition_penalty === "number") {
+    payloadParams.repetition_penalty = extraParams.repetition_penalty;
+  }
+  const hasPayloadParams = Object.keys(payloadParams).length > 0;
+
   // Extract OpenRouter provider routing preferences from extraParams.provider.
   // Injected into model.compat.openRouterRouting so pi-ai's buildParams sets
   // params.provider in the API request body (openai-completions.js L359-362).
@@ -146,11 +164,14 @@ function createStreamFnWithExtraParams(
       ? (extraParams.provider as Record<string, unknown>)
       : undefined;
 
-  if (Object.keys(streamParams).length === 0 && !providerRouting) {
+  if (Object.keys(streamParams).length === 0 && !providerRouting && !hasPayloadParams) {
     return undefined;
   }
 
   log.debug(`creating streamFn wrapper with params: ${JSON.stringify(streamParams)}`);
+  if (hasPayloadParams) {
+    log.debug(`payload generation params: ${JSON.stringify(payloadParams)}`);
+  }
   if (providerRouting) {
     log.debug(`OpenRouter provider routing: ${JSON.stringify(providerRouting)}`);
   }
@@ -165,9 +186,18 @@ function createStreamFnWithExtraParams(
           compat: { ...model.compat, openRouterRouting: providerRouting },
         } as unknown as typeof model)
       : model;
+    const onPayload = hasPayloadParams
+      ? (payload: unknown) => {
+          if (payload && typeof payload === "object") {
+            Object.assign(payload, payloadParams);
+          }
+          options?.onPayload?.(payload);
+        }
+      : options?.onPayload;
     return underlying(effectiveModel, context, {
       ...streamParams,
       ...options,
+      ...(onPayload ? { onPayload } : {}),
     });
   };
 
@@ -560,6 +590,107 @@ function createSiliconFlowThinkingWrapper(baseStreamFn: StreamFn | undefined): S
   };
 }
 
+type MoonshotThinkingType = "enabled" | "disabled";
+
+function normalizeMoonshotThinkingType(value: unknown): MoonshotThinkingType | undefined {
+  if (typeof value === "boolean") {
+    return value ? "enabled" : "disabled";
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (
+      normalized === "enabled" ||
+      normalized === "enable" ||
+      normalized === "on" ||
+      normalized === "true"
+    ) {
+      return "enabled";
+    }
+    if (
+      normalized === "disabled" ||
+      normalized === "disable" ||
+      normalized === "off" ||
+      normalized === "false"
+    ) {
+      return "disabled";
+    }
+    return undefined;
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const typeValue = (value as Record<string, unknown>).type;
+    return normalizeMoonshotThinkingType(typeValue);
+  }
+  return undefined;
+}
+
+function resolveMoonshotThinkingType(params: {
+  configuredThinking: unknown;
+  thinkingLevel?: ThinkLevel;
+}): MoonshotThinkingType | undefined {
+  const configured = normalizeMoonshotThinkingType(params.configuredThinking);
+  if (configured) {
+    return configured;
+  }
+  if (!params.thinkingLevel) {
+    return undefined;
+  }
+  return params.thinkingLevel === "off" ? "disabled" : "enabled";
+}
+
+function isMoonshotToolChoiceCompatible(toolChoice: unknown): boolean {
+  if (toolChoice == null) {
+    return true;
+  }
+  if (toolChoice === "auto" || toolChoice === "none") {
+    return true;
+  }
+  if (typeof toolChoice === "object" && !Array.isArray(toolChoice)) {
+    const typeValue = (toolChoice as Record<string, unknown>).type;
+    return typeValue === "auto" || typeValue === "none";
+  }
+  return false;
+}
+
+/**
+ * Moonshot Kimi supports native binary thinking mode:
+ * - { thinking: { type: "enabled" } }
+ * - { thinking: { type: "disabled" } }
+ *
+ * When thinking is enabled, Moonshot only accepts tool_choice auto|none.
+ * Normalize incompatible values to auto instead of failing the request.
+ */
+function createMoonshotThinkingWrapper(
+  baseStreamFn: StreamFn | undefined,
+  thinkingType?: MoonshotThinkingType,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          const payloadObj = payload as Record<string, unknown>;
+          let effectiveThinkingType = normalizeMoonshotThinkingType(payloadObj.thinking);
+
+          if (thinkingType) {
+            payloadObj.thinking = { type: thinkingType };
+            effectiveThinkingType = thinkingType;
+          }
+
+          if (
+            effectiveThinkingType === "enabled" &&
+            !isMoonshotToolChoiceCompatible(payloadObj.tool_choice)
+          ) {
+            payloadObj.tool_choice = "auto";
+          }
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
 /**
  * Create a streamFn wrapper that adds OpenRouter app attribution headers
  * and injects reasoning.effort based on the configured thinking level.
@@ -618,6 +749,15 @@ function createOpenRouterWrapper(
       },
     });
   };
+}
+
+/**
+ * Models on OpenRouter that do not support the `reasoning.effort` parameter.
+ * Injecting it causes "Invalid arguments passed to the model" errors.
+ */
+function isOpenRouterReasoningUnsupported(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  return id.startsWith("x-ai/");
 }
 
 function isGemini31Model(modelId: string): boolean {
@@ -799,6 +939,19 @@ export function applyExtraParamsToAgent(
     agent.streamFn = createSiliconFlowThinkingWrapper(agent.streamFn);
   }
 
+  if (provider === "moonshot") {
+    const moonshotThinkingType = resolveMoonshotThinkingType({
+      configuredThinking: merged?.thinking,
+      thinkingLevel,
+    });
+    if (moonshotThinkingType) {
+      log.debug(
+        `applying Moonshot thinking=${moonshotThinkingType} payload wrapper for ${provider}/${modelId}`,
+      );
+    }
+    agent.streamFn = createMoonshotThinkingWrapper(agent.streamFn, moonshotThinkingType);
+  }
+
   if (provider === "openrouter") {
     log.debug(`applying OpenRouter app attribution headers for ${provider}/${modelId}`);
     // "auto" is a dynamic routing model — we don't know which underlying model
@@ -807,7 +960,13 @@ export function applyExtraParamsToAgent(
     // which would cause a 400 on models where reasoning is mandatory.
     // Users who need reasoning control should target a specific model ID.
     // See: openclaw/openclaw#24851
-    const openRouterThinkingLevel = modelId === "auto" ? undefined : thinkingLevel;
+    //
+    // x-ai/grok models do not support OpenRouter's reasoning.effort parameter
+    // and reject payloads containing it with "Invalid arguments passed to the
+    // model." Skip reasoning injection for these models.
+    // See: openclaw/openclaw#32039
+    const skipReasoningInjection = modelId === "auto" || isOpenRouterReasoningUnsupported(modelId);
+    const openRouterThinkingLevel = skipReasoningInjection ? undefined : thinkingLevel;
     agent.streamFn = createOpenRouterWrapper(agent.streamFn, openRouterThinkingLevel);
     agent.streamFn = createOpenRouterSystemCacheWrapper(agent.streamFn);
   }


### PR DESCRIPTION
## Summary
- Wire `frequency_penalty`, `presence_penalty`, `top_p`, and `repetition_penalty` from model params config to the raw API payload via `onPayload`
- These OpenAI-compatible generation parameters were silently ignored when configured in `openclaw.json` under `agents.defaults.models.<provider/model>.params`
- Uses the established `onPayload` pattern (same as Z.AI `tool_stream`, OpenRouter `reasoning`, etc.) to inject params into the provider request body

## Details

`createStreamFnWithExtraParams` in `extra-params.ts` currently only forwards `temperature`, `maxTokens`, `transport`, `openaiWsWarmup`, and `cacheRetention` to the stream options. Parameters like `frequency_penalty` and `presence_penalty` are not part of pi-ai's `StreamOptions` interface, so they need to be injected via the `onPayload` hook directly into the raw API request payload.

This fix collects numeric penalty/sampling params from `extraParams` and uses `onPayload` to `Object.assign` them into the outgoing payload, chaining with any existing `onPayload` callback.

### Supported params
| Parameter | Type | Providers |
|-----------|------|-----------|
| `frequency_penalty` | number | OpenAI, Azure, GLM, Ollama |
| `presence_penalty` | number | OpenAI, Azure, GLM, Ollama |
| `top_p` | number | OpenAI, Azure, GLM, Ollama |
| `repetition_penalty` | number | Ollama, some local models |

Non-numeric values are silently ignored (same guard pattern as `temperature`).

Fixes #32496

## Test plan
- [x] 4 new test cases added covering all params, non-numeric rejection, and onPayload chaining
- [x] All 51 existing extra-params tests pass
- [x] All 14 related extra-params tests pass (cache-retention, openrouter-cache-control, zai-tool-stream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)