### PR TITLE
feat(voice-call): local whisper.cpp streaming STT provider

### DIFF
--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -178,4 +178,33 @@ Actions:
 - Adds replay protection for Twilio and Plivo webhooks (valid duplicate callbacks are ignored safely).
 - Twilio speech turns include a per-turn token so stale/replayed callbacks cannot complete a newer turn.
 - `responseModel` / `responseSystemPrompt` control AI auto-responses.
-- Media streaming requires `ws` and OpenAI Realtime API key.
+- Media streaming can use OpenAI Realtime STT **or** a local whisper.cpp CLI (this fork).
+
+## Local streaming STT (whisper.cpp)
+
+This fork adds a `streaming.sttProvider` option: `"local-whispercpp"`.
+
+It runs a local `whisper.cpp` CLI binary for transcription. Configure via env vars:
+
+- `VOICECALL_WHISPERCPP_BIN` (or `VOICECALL_WHISPER_BIN`): path to `whisper-cli`/`main`
+- `VOICECALL_WHISPERCPP_MODEL` (or `VOICECALL_WHISPER_MODEL`): path to ggml model file
+- `VOICECALL_WHISPERCPP_LANG`: language code (default: `zh`)
+
+Example (Mac):
+
+```bash
+export VOICECALL_WHISPERCPP_BIN=/path/to/whisper-cli
+export VOICECALL_WHISPERCPP_MODEL=/path/to/ggml-small.bin
+export VOICECALL_WHISPERCPP_LANG=zh
+```
+
+Then in plugin config:
+
+```json5
+{
+  streaming: {
+    enabled: true,
+    sttProvider: "local-whispercpp"
+  }
+}
+```

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -168,7 +168,12 @@
       },
       "provider": {
         "type": "string",
-        "enum": ["telnyx", "twilio", "plivo", "mock"]
+        "enum": [
+          "telnyx",
+          "twilio",
+          "plivo",
+          "mock"
+        ]
       },
       "telnyx": {
         "type": "object",
@@ -219,7 +224,12 @@
       },
       "inboundPolicy": {
         "type": "string",
-        "enum": ["disabled", "allowlist", "pairing", "open"]
+        "enum": [
+          "disabled",
+          "allowlist",
+          "pairing",
+          "open"
+        ]
       },
       "allowFrom": {
         "type": "array",
@@ -237,7 +247,10 @@
         "properties": {
           "defaultMode": {
             "type": "string",
-            "enum": ["notify", "conversation"]
+            "enum": [
+              "notify",
+              "conversation"
+            ]
           },
           "notifyHangupDelaySec": {
             "type": "integer",
@@ -287,7 +300,11 @@
         "properties": {
           "mode": {
             "type": "string",
-            "enum": ["off", "serve", "funnel"]
+            "enum": [
+              "off",
+              "serve",
+              "funnel"
+            ]
           },
           "path": {
             "type": "string"
@@ -300,7 +317,12 @@
         "properties": {
           "provider": {
             "type": "string",
-            "enum": ["none", "ngrok", "tailscale-serve", "tailscale-funnel"]
+            "enum": [
+              "none",
+              "ngrok",
+              "tailscale-serve",
+              "tailscale-funnel"
+            ]
           },
           "ngrokAuthToken": {
             "type": "string"
@@ -322,7 +344,10 @@
           },
           "sttProvider": {
             "type": "string",
-            "enum": ["openai-realtime"]
+            "enum": [
+              "openai-realtime",
+              "local-whispercpp"
+            ]
           },
           "openaiApiKey": {
             "type": "string"
@@ -356,7 +381,9 @@
         "properties": {
           "provider": {
             "type": "string",
-            "enum": ["openai"]
+            "enum": [
+              "openai"
+            ]
           },
           "model": {
             "type": "string"
@@ -369,18 +396,30 @@
         "properties": {
           "auto": {
             "type": "string",
-            "enum": ["off", "always", "inbound", "tagged"]
+            "enum": [
+              "off",
+              "always",
+              "inbound",
+              "tagged"
+            ]
           },
           "enabled": {
             "type": "boolean"
           },
           "mode": {
             "type": "string",
-            "enum": ["final", "all"]
+            "enum": [
+              "final",
+              "all"
+            ]
           },
           "provider": {
             "type": "string",
-            "enum": ["openai", "elevenlabs", "edge"]
+            "enum": [
+              "openai",
+              "elevenlabs",
+              "edge"
+            ]
           },
           "summaryModel": {
             "type": "string"
@@ -438,7 +477,11 @@
               },
               "applyTextNormalization": {
                 "type": "string",
-                "enum": ["auto", "on", "off"]
+                "enum": [
+                  "auto",
+                  "on",
+                  "off"
+                ]
               },
               "languageCode": {
                 "type": "string"

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -366,6 +366,36 @@
           },
           "streamPath": {
             "type": "string"
+          },
+          "whispercpp": {
+            "type": "object",
+            "description": "Local whisper.cpp config (used when sttProvider=local-whispercpp)",
+            "properties": {
+              "binPath": {
+                "type": "string",
+                "description": "Path to whisper.cpp CLI (whisper-cli/main)"
+              },
+              "modelPath": {
+                "type": "string",
+                "description": "Path to ggml model (e.g. ggml-base.bin)"
+              },
+              "language": {
+                "type": "string",
+                "description": "Language code (default: zh)"
+              },
+              "threads": {
+                "type": "number",
+                "description": "Threads passed to whisper.cpp (-t) if supported"
+              },
+              "extraArgs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Extra args appended to whisper.cpp CLI"
+              }
+            },
+            "additionalProperties": false
           }
         }
       },

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -213,6 +213,18 @@ export const VoiceCallStreamingConfigSchema = z
     openaiApiKey: z.string().min(1).optional(),
     /** OpenAI transcription model (default: gpt-4o-transcribe) */
     sttModel: z.string().min(1).default("gpt-4o-transcribe"),
+    /** whisper.cpp local streaming STT configuration (used when sttProvider=local-whispercpp) */
+    whispercpp: z
+      .object({
+        binPath: z.string().min(1).optional(),
+        modelPath: z.string().min(1).optional(),
+        language: z.string().min(1).optional(),
+        threads: z.number().int().positive().optional(),
+        extraArgs: z.array(z.string().min(1)).optional(),
+      })
+      .strict()
+      .optional(),
+
     /** VAD silence duration in ms before considering speech ended */
     silenceDurationMs: z.number().int().positive().default(800),
     /** VAD threshold 0-1 (higher = less sensitive) */

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -200,7 +200,7 @@ export const OutboundConfigSchema = z
 export type OutboundConfig = z.infer<typeof OutboundConfigSchema>;
 
 // -----------------------------------------------------------------------------
-// Streaming Configuration (OpenAI Realtime STT)
+// Streaming Configuration (Realtime STT)
 // -----------------------------------------------------------------------------
 
 export const VoiceCallStreamingConfigSchema = z
@@ -208,7 +208,7 @@ export const VoiceCallStreamingConfigSchema = z
     /** Enable real-time audio streaming (requires WebSocket support) */
     enabled: z.boolean().default(false),
     /** STT provider for real-time transcription */
-    sttProvider: z.enum(["openai-realtime"]).default("openai-realtime"),
+    sttProvider: z.enum(["openai-realtime", "local-whispercpp"]).default("openai-realtime"),
     /** OpenAI API key for Realtime API (uses OPENAI_API_KEY env if not set) */
     openaiApiKey: z.string().min(1).optional(),
     /** OpenAI transcription model (default: gpt-4o-transcribe) */

--- a/extensions/voice-call/src/media-stream.test.ts
+++ b/extensions/voice-call/src/media-stream.test.ts
@@ -3,10 +3,7 @@ import http from "node:http";
 import { describe, expect, it } from "vitest";
 import { WebSocket } from "ws";
 import { MediaStreamHandler } from "./media-stream.js";
-import type {
-  OpenAIRealtimeSTTProvider,
-  RealtimeSTTSession,
-} from "./providers/stt-openai-realtime.js";
+import type { RealtimeSTTSession } from "./providers/stt-openai-realtime.js";
 
 const createStubSession = (): RealtimeSTTSession => ({
   connect: async () => {},
@@ -19,10 +16,9 @@ const createStubSession = (): RealtimeSTTSession => ({
   isConnected: () => true,
 });
 
-const createStubSttProvider = (): OpenAIRealtimeSTTProvider =>
-  ({
-    createSession: () => createStubSession(),
-  }) as unknown as OpenAIRealtimeSTTProvider;
+const createStubSttProvider = () => ({
+  createSession: () => createStubSession(),
+});
 
 const flush = async (): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, 0));

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -10,17 +10,18 @@
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { WebSocket, WebSocketServer } from "ws";
-import type {
-  OpenAIRealtimeSTTProvider,
-  RealtimeSTTSession,
-} from "./providers/stt-openai-realtime.js";
+import type { RealtimeSTTSession } from "./providers/stt-openai-realtime.js";
+
+export type RealtimeSTTProvider = {
+  createSession: () => RealtimeSTTSession;
+};
 
 /**
  * Configuration for the media stream handler.
  */
 export interface MediaStreamConfig {
   /** STT provider for transcription */
-  sttProvider: OpenAIRealtimeSTTProvider;
+  sttProvider: RealtimeSTTProvider;
   /** Close sockets that never send a valid `start` frame within this window. */
   preStartTimeoutMs?: number;
   /** Max concurrent pre-start sockets. */

--- a/extensions/voice-call/src/providers/index.ts
+++ b/extensions/voice-call/src/providers/index.ts
@@ -5,6 +5,7 @@ export {
   type RealtimeSTTConfig,
   type RealtimeSTTSession,
 } from "./stt-openai-realtime.js";
+export { LocalWhisperCppSTTProvider, type LocalWhisperCppConfig } from "./stt-local-whispercpp.js";
 export { TelnyxProvider } from "./telnyx.js";
 export { TwilioProvider } from "./twilio.js";
 export { PlivoProvider } from "./plivo.js";

--- a/extensions/voice-call/src/providers/stt-local-whispercpp.ts
+++ b/extensions/voice-call/src/providers/stt-local-whispercpp.ts
@@ -1,0 +1,383 @@
+/**
+ * Local Whisper.cpp STT Provider
+ *
+ * Minimal, dependency-light STT implementation intended for Twilio Media Streams:
+ * - Accepts mu-law 8kHz audio frames from Twilio
+ * - Performs lightweight energy-based VAD to segment utterances
+ * - Runs whisper.cpp CLI on finalized segments to get text
+ *
+ * This is designed to replace OpenAI Realtime STT when you can't/won't use an API key.
+ */
+
+import { spawn } from "node:child_process";
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { RealtimeSTTSession } from "./stt-openai-realtime.js";
+
+export type LocalWhisperCppConfig = {
+  /** Path to whisper.cpp CLI binary (e.g. whisper-cli or main). */
+  binPath: string;
+  /** Path to ggml model file (e.g. ggml-small.bin). */
+  modelPath: string;
+  /** Language code (e.g. zh, en). */
+  language?: string;
+  /** Threads for whisper.cpp (best-effort; not all CLIs support this). */
+  threads?: number;
+  /** Max buffered utterance length (ms) to avoid runaway memory on bad VAD. */
+  maxUtteranceMs?: number;
+  /** Extra CLI args appended after standard args. */
+  extraArgs?: string[];
+  /** VAD threshold from 0..1 (mapped internally to a sensible amplitude threshold). */
+  vadThreshold?: number;
+  /** Silence duration in ms to finalize an utterance. */
+  silenceDurationMs?: number;
+};
+
+export class LocalWhisperCppSTTProvider {
+  readonly name = "local-whispercpp";
+
+  constructor(private readonly cfg: LocalWhisperCppConfig) {
+    if (!cfg.binPath) {
+      throw new Error("Local whisper.cpp binPath required");
+    }
+    if (!cfg.modelPath) {
+      throw new Error("Local whisper.cpp modelPath required");
+    }
+  }
+
+  createSession(): RealtimeSTTSession {
+    return new LocalWhisperCppSTTSession(this.cfg);
+  }
+}
+
+class LocalWhisperCppSTTSession implements RealtimeSTTSession {
+  private connected = false;
+  private closed = false;
+
+  private onTranscriptCallback: ((t: string) => void) | null = null;
+  private onPartialCallback: ((t: string) => void) | null = null;
+  private onSpeechStartCallback: (() => void) | null = null;
+
+  private inSpeech = false;
+  private silenceMs = 0;
+  private utteranceMs = 0;
+  private pcm16kChunks: Buffer[] = [];
+
+  private transcriptQueue: string[] = [];
+  private transcriptWaiters: Array<(t: string) => void> = [];
+
+  private transcribeInFlight: Promise<void> | null = null;
+
+  constructor(private readonly cfg: LocalWhisperCppConfig) {}
+
+  async connect(): Promise<void> {
+    // Best-effort: validate binary/model paths early.
+    await access(this.cfg.binPath);
+    await access(this.cfg.modelPath);
+    this.connected = true;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  onPartial(callback: (partial: string) => void): void {
+    this.onPartialCallback = callback;
+  }
+
+  onTranscript(callback: (transcript: string) => void): void {
+    this.onTranscriptCallback = callback;
+  }
+
+  onSpeechStart(callback: () => void): void {
+    this.onSpeechStartCallback = callback;
+  }
+
+  sendAudio(muLaw8k: Buffer): void {
+    if (this.closed) {
+      return;
+    }
+
+    // If a transcription is running, we still accept audio but cap memory.
+    // This keeps the session responsive under heavy load.
+
+    const pcm8k = mulawToPcm16le(muLaw8k);
+
+    // Map the config's 0..1 knob into a practical amplitude threshold for G.711 audio.
+    // Speech energy here is typically in the ~0.01-0.08 range.
+    const vadKnob = clamp01(this.cfg.vadThreshold ?? 0.5);
+    const ampThreshold = 0.005 + vadKnob * 0.06;
+
+    const amp = meanAbsPcm16le(pcm8k);
+
+    const frameMs = (muLaw8k.length / 8000) * 1000;
+
+    if (amp >= ampThreshold) {
+      if (!this.inSpeech) {
+        this.inSpeech = true;
+        this.silenceMs = 0;
+        this.utteranceMs = 0;
+        this.pcm16kChunks = [];
+        this.onSpeechStartCallback?.();
+      }
+      this.silenceMs = 0;
+
+      // Upsample 8k -> 16k for Whisper input (simple x2 duplication).
+      const pcm16k = upsamplePcm16le_8k_to_16k(pcm8k);
+      this.pcm16kChunks.push(pcm16k);
+      this.utteranceMs += frameMs;
+    } else if (this.inSpeech) {
+      // Keep trailing silence so the last word isn't clipped.
+      const pcm16k = upsamplePcm16le_8k_to_16k(pcm8k);
+      this.pcm16kChunks.push(pcm16k);
+
+      this.silenceMs += frameMs;
+      this.utteranceMs += frameMs;
+
+      const silenceDurationMs = this.cfg.silenceDurationMs ?? 800;
+      const maxUtteranceMs = this.cfg.maxUtteranceMs ?? 20_000;
+
+      if (this.utteranceMs >= maxUtteranceMs || this.silenceMs >= silenceDurationMs) {
+        const utterance = Buffer.concat(this.pcm16kChunks);
+        this.inSpeech = false;
+        this.silenceMs = 0;
+        this.utteranceMs = 0;
+        this.pcm16kChunks = [];
+
+        // Fire and forget; callback delivery happens async.
+        this.transcribeInFlight = this.transcribe(utterance).catch((err) => {
+          console.warn("[LocalWhisperSTT] transcription failed:", err);
+        });
+      }
+    }
+
+    // No true partials in this MVP.
+    void this.onPartialCallback;
+  }
+
+  async waitForTranscript(timeoutMs = 30000): Promise<string> {
+    if (this.transcriptQueue.length > 0) {
+      return this.transcriptQueue.shift()!;
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        // Remove the waiter if it still exists.
+        const idx = this.transcriptWaiters.indexOf(resolve);
+        if (idx >= 0) {
+          this.transcriptWaiters.splice(idx, 1);
+        }
+        reject(new Error("Transcript timeout"));
+      }, timeoutMs);
+
+      const wrappedResolve = (t: string) => {
+        clearTimeout(timer);
+        resolve(t);
+      };
+
+      this.transcriptWaiters.push(wrappedResolve);
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+    this.connected = false;
+
+    // Best-effort: finalize pending utterance.
+    if (this.inSpeech && this.pcm16kChunks.length > 0) {
+      const utterance = Buffer.concat(this.pcm16kChunks);
+      this.inSpeech = false;
+      this.pcm16kChunks = [];
+      void this.transcribe(utterance).catch(() => {
+        // Ignore on close.
+      });
+    }
+  }
+
+  private async transcribe(pcm16kMono16le: Buffer): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-voicecall-whisper-"));
+    const wavPath = path.join(tmpDir, "utterance.wav");
+
+    try {
+      const wav = makeWavPcm16le({ pcm: pcm16kMono16le, sampleRate: 16000, channels: 1 });
+      await writeFile(wavPath, wav);
+
+      const transcript = await runWhisperCpp({
+        binPath: this.cfg.binPath,
+        modelPath: this.cfg.modelPath,
+        language: this.cfg.language ?? "zh",
+        threads: this.cfg.threads,
+        wavPath,
+        extraArgs: this.cfg.extraArgs,
+      });
+
+      const cleaned = transcript.trim();
+      if (!cleaned) {
+        return;
+      }
+
+      this.onTranscriptCallback?.(cleaned);
+
+      if (this.transcriptWaiters.length > 0) {
+        const waiter = this.transcriptWaiters.shift()!;
+        waiter(cleaned);
+      } else {
+        this.transcriptQueue.push(cleaned);
+      }
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  }
+}
+
+async function runWhisperCpp(params: {
+  binPath: string;
+  modelPath: string;
+  language: string;
+  threads?: number;
+  wavPath: string;
+  extraArgs?: string[];
+}): Promise<string> {
+  const args: string[] = [];
+
+  // whisper.cpp CLI variants commonly support: -m <model> -f <file> -l <lang>
+  args.push("-m", params.modelPath);
+  args.push("-f", params.wavPath);
+  args.push("-l", params.language);
+
+  if (typeof params.threads === "number") {
+    // Some builds use -t for threads.
+    args.push("-t", String(params.threads));
+  }
+
+  if (params.extraArgs?.length) {
+    args.push(...params.extraArgs);
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    const child = spawn(params.binPath, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, WHISPER_PRINT_PROGRESS: "0" },
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+
+    child.stdout.on("data", (d) => {
+      stdout += d;
+    });
+
+    child.stderr.on("data", (d) => {
+      stderr += d;
+    });
+
+    child.on("error", reject);
+
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`whisper.cpp exited ${code}: ${stderr.trim() || "no stderr"}`));
+        return;
+      }
+
+      // Heuristic parsing: remove timestamp prefixes and known noise.
+      const lines = stdout
+        .split(/\r?\n/)
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .filter((l) => !l.startsWith("whisper_"))
+        .filter((l) => !l.startsWith("["));
+
+      // If the CLI prints timestamped lines like: [00:00.000 --> 00:02.000] text
+      const cleaned = lines
+        .map((l) => l.replace(/^\[[^\]]+\]\s*/, ""))
+        .join(" ")
+        .replace(/\s+/g, " ")
+        .trim();
+
+      resolve(cleaned);
+    });
+  });
+}
+
+function clamp01(v: number): number {
+  if (Number.isNaN(v)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, v));
+}
+
+function meanAbsPcm16le(pcm: Buffer): number {
+  // Returns mean absolute amplitude in 0..1.
+  let sum = 0;
+  const samples = pcm.length / 2;
+  for (let i = 0; i < pcm.length; i += 2) {
+    const s = pcm.readInt16LE(i);
+    sum += Math.abs(s);
+  }
+  return samples > 0 ? sum / samples / 32768 : 0;
+}
+
+function mulawToPcm16le(muLaw: Buffer): Buffer {
+  const out = Buffer.allocUnsafe(muLaw.length * 2);
+  for (let i = 0; i < muLaw.length; i++) {
+    const s = muLawDecodeSample(muLaw[i]!);
+    out.writeInt16LE(s, i * 2);
+  }
+  return out;
+}
+
+function muLawDecodeSample(uVal: number): number {
+  // Standard G.711 mu-law decode.
+  uVal = ~uVal & 0xff;
+  const sign = uVal & 0x80;
+  const exponent = (uVal >> 4) & 0x07;
+  const mantissa = uVal & 0x0f;
+  let sample = ((mantissa << 4) + 0x08) << (exponent + 3);
+  sample -= 0x84;
+  return sign ? -sample : sample;
+}
+
+function upsamplePcm16le_8k_to_16k(pcm8k: Buffer): Buffer {
+  // Simple x2 upsample by duplication: s0,s0,s1,s1,...
+  const samples8k = pcm8k.length / 2;
+  const out = Buffer.allocUnsafe(samples8k * 2 * 2);
+  for (let i = 0; i < samples8k; i++) {
+    const s = pcm8k.readInt16LE(i * 2);
+    out.writeInt16LE(s, i * 4);
+    out.writeInt16LE(s, i * 4 + 2);
+  }
+  return out;
+}
+
+function makeWavPcm16le(params: { pcm: Buffer; sampleRate: number; channels: number }): Buffer {
+  const { pcm, sampleRate, channels } = params;
+  const bitsPerSample = 16;
+  const byteRate = sampleRate * channels * (bitsPerSample / 8);
+  const blockAlign = channels * (bitsPerSample / 8);
+
+  const header = Buffer.alloc(44);
+  header.write("RIFF", 0);
+  header.writeUInt32LE(36 + pcm.length, 4);
+  header.write("WAVE", 8);
+  header.write("fmt ", 12);
+  header.writeUInt32LE(16, 16); // PCM fmt chunk size
+  header.writeUInt16LE(1, 20); // audio format = PCM
+  header.writeUInt16LE(channels, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(bitsPerSample, 34);
+  header.write("data", 36);
+  header.writeUInt32LE(pcm.length, 40);
+
+  return Buffer.concat([header, pcm]);
+}

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -12,6 +12,7 @@ import type { CallManager } from "./manager.js";
 import type { MediaStreamConfig } from "./media-stream.js";
 import { MediaStreamHandler } from "./media-stream.js";
 import type { VoiceCallProvider } from "./providers/base.js";
+import { LocalWhisperCppSTTProvider } from "./providers/stt-local-whispercpp.js";
 import { OpenAIRealtimeSTTProvider } from "./providers/stt-openai-realtime.js";
 import type { TwilioProvider } from "./providers/twilio.js";
 import type { NormalizedEvent, WebhookContext } from "./types.js";
@@ -59,22 +60,51 @@ export class VoiceCallWebhookServer {
   }
 
   /**
-   * Initialize media streaming with OpenAI Realtime STT.
+   * Initialize media streaming with the configured STT provider.
    */
   private initializeMediaStreaming(): void {
-    const apiKey = this.config.streaming?.openaiApiKey || process.env.OPENAI_API_KEY;
+    const sttProviderName = this.config.streaming?.sttProvider ?? "openai-realtime";
 
-    if (!apiKey) {
-      console.warn("[voice-call] Streaming enabled but no OpenAI API key found");
-      return;
+    let sttProvider: MediaStreamConfig["sttProvider"];
+
+    if (sttProviderName === "local-whispercpp") {
+      const binPath =
+        process.env.VOICECALL_WHISPERCPP_BIN ?? process.env.VOICECALL_WHISPER_BIN ?? "";
+      const modelPath =
+        process.env.VOICECALL_WHISPERCPP_MODEL ?? process.env.VOICECALL_WHISPER_MODEL ?? "";
+      const language = process.env.VOICECALL_WHISPERCPP_LANG ?? "zh";
+
+      if (!binPath || !modelPath) {
+        console.warn(
+          "[voice-call] Streaming enabled (local-whispercpp) but VOICECALL_WHISPERCPP_BIN/VOICECALL_WHISPERCPP_MODEL are not set",
+        );
+        return;
+      }
+
+      sttProvider = new LocalWhisperCppSTTProvider({
+        binPath,
+        modelPath,
+        language,
+        silenceDurationMs: this.config.streaming?.silenceDurationMs,
+        vadThreshold: this.config.streaming?.vadThreshold,
+      });
+    } else {
+      const apiKey = this.config.streaming?.openaiApiKey || process.env.OPENAI_API_KEY;
+
+      if (!apiKey) {
+        console.warn(
+          "[voice-call] Streaming enabled (openai-realtime) but no OpenAI API key found (set streaming.openaiApiKey or OPENAI_API_KEY)",
+        );
+        return;
+      }
+
+      sttProvider = new OpenAIRealtimeSTTProvider({
+        apiKey,
+        model: this.config.streaming?.sttModel,
+        silenceDurationMs: this.config.streaming?.silenceDurationMs,
+        vadThreshold: this.config.streaming?.vadThreshold,
+      });
     }
-
-    const sttProvider = new OpenAIRealtimeSTTProvider({
-      apiKey,
-      model: this.config.streaming?.sttModel,
-      silenceDurationMs: this.config.streaming?.silenceDurationMs,
-      vadThreshold: this.config.streaming?.vadThreshold,
-    });
 
     const streamConfig: MediaStreamConfig = {
       sttProvider,

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -68,15 +68,19 @@ export class VoiceCallWebhookServer {
     let sttProvider: MediaStreamConfig["sttProvider"];
 
     if (sttProviderName === "local-whispercpp") {
+      const cfg = this.config.streaming?.whispercpp;
       const binPath =
-        process.env.VOICECALL_WHISPERCPP_BIN ?? process.env.VOICECALL_WHISPER_BIN ?? "";
+        cfg?.binPath ?? process.env.VOICECALL_WHISPERCPP_BIN ?? process.env.VOICECALL_WHISPER_BIN ?? "";
       const modelPath =
-        process.env.VOICECALL_WHISPERCPP_MODEL ?? process.env.VOICECALL_WHISPER_MODEL ?? "";
-      const language = process.env.VOICECALL_WHISPERCPP_LANG ?? "zh";
+        cfg?.modelPath ??
+        process.env.VOICECALL_WHISPERCPP_MODEL ??
+        process.env.VOICECALL_WHISPER_MODEL ??
+        "";
+      const language = cfg?.language ?? process.env.VOICECALL_WHISPERCPP_LANG ?? "zh";
 
       if (!binPath || !modelPath) {
         console.warn(
-          "[voice-call] Streaming enabled (local-whispercpp) but VOICECALL_WHISPERCPP_BIN/VOICECALL_WHISPERCPP_MODEL are not set",
+          "[voice-call] Streaming enabled (local-whispercpp) but whispercpp.binPath/modelPath are not configured (set streaming.whispercpp.* or VOICECALL_WHISPERCPP_BIN/VOICECALL_WHISPERCPP_MODEL)",
         );
         return;
       }
@@ -85,10 +89,13 @@ export class VoiceCallWebhookServer {
         binPath,
         modelPath,
         language,
+        threads: cfg?.threads,
+        extraArgs: cfg?.extraArgs,
         silenceDurationMs: this.config.streaming?.silenceDurationMs,
         vadThreshold: this.config.streaming?.vadThreshold,
       });
     } else {
+
       const apiKey = this.config.streaming?.openaiApiKey || process.env.OPENAI_API_KEY;
 
       if (!apiKey) {


### PR DESCRIPTION
Adds an alternative streaming STT provider for the voice-call plugin that runs a local whisper.cpp CLI instead of OpenAI Realtime STT.

- New config: `plugins.entries.voice-call.config.streaming.sttProvider = "local-whispercpp"`
- Local provider runs `whisper.cpp` via CLI on utterance segments (energy VAD + silence finalize).
- Config is via env vars to avoid storing local paths in config:
  - `VOICECALL_WHISPERCPP_BIN` (path to whisper-cli/main)
  - `VOICECALL_WHISPERCPP_MODEL` (path to ggml model)
  - `VOICECALL_WHISPERCPP_LANG` (default: zh)

No behavior change for existing users (default remains `openai-realtime`).

This is intended for self-hosted setups that can accept local compute cost to avoid API billing / keys.