### PR TITLE
feat(discord): add thread-info action to read thread metadata

### DIFF
--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -4,10 +4,10 @@ import { readDiscordComponentSpec } from "../../discord/components.js";
 import {
   createThreadDiscord,
   deleteMessageDiscord,
-  fetchThreadInfoDiscord,
   editMessageDiscord,
   fetchChannelPermissionsDiscord,
   fetchMessageDiscord,
+  fetchThreadInfoDiscord,
   fetchReactionsDiscord,
   listPinsDiscord,
   listThreadsDiscord,

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -4,6 +4,7 @@ import { readDiscordComponentSpec } from "../../discord/components.js";
 import {
   createThreadDiscord,
   deleteMessageDiscord,
+  fetchThreadInfoDiscord,
   editMessageDiscord,
   fetchChannelPermissionsDiscord,
   fetchMessageDiscord,
@@ -374,6 +375,16 @@ export async function handleDiscordMessagingAction(
       const thread = accountId
         ? await createThreadDiscord(channelId, payload, { accountId })
         : await createThreadDiscord(channelId, payload);
+      return jsonResult({ ok: true, thread });
+    }
+    case "threadInfo": {
+      if (!isActionEnabled("threads")) {
+        throw new Error("Discord threads are disabled.");
+      }
+      const threadId = readStringParam(params, "threadId", { required: true });
+      const thread = accountId
+        ? await fetchThreadInfoDiscord(threadId, { accountId })
+        : await fetchThreadInfoDiscord(threadId);
       return jsonResult({ ok: true, thread });
     }
     case "threadList": {

--- a/src/agents/tools/discord-actions.ts
+++ b/src/agents/tools/discord-actions.ts
@@ -19,6 +19,7 @@ const messagingActions = new Set([
   "editMessage",
   "deleteMessage",
   "threadCreate",
+  "threadInfo",
   "threadList",
   "threadReply",
   "pinMessage",

--- a/src/channels/plugins/actions/discord.ts
+++ b/src/channels/plugins/actions/discord.ts
@@ -42,6 +42,7 @@ export const discordMessageActions: ChannelMessageActionAdapter = {
     }
     if (isEnabled("threads")) {
       actions.add("thread-create");
+      actions.add("thread-info");
       actions.add("thread-list");
       actions.add("thread-reply");
     }

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -245,6 +245,19 @@ export async function handleDiscordMessageAction(
     );
   }
 
+  if (action === "thread-info") {
+    const threadId = readStringParam(params, "threadId") ?? resolveChannelId();
+    return await handleDiscordAction(
+      {
+        action: "threadInfo",
+        accountId: accountId ?? undefined,
+        threadId,
+      },
+      cfg,
+      actionOptions,
+    );
+  }
+
   if (action === "sticker") {
     const stickerIds =
       readStringArrayParam(params, "stickerId", {

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -21,6 +21,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "list-pins",
   "permissions",
   "thread-create",
+  "thread-info",
   "thread-list",
   "thread-reply",
   "search",

--- a/src/discord/send.creates-thread.test.ts
+++ b/src/discord/send.creates-thread.test.ts
@@ -5,6 +5,7 @@ import {
   addRoleDiscord,
   banMemberDiscord,
   createThreadDiscord,
+  fetchThreadInfoDiscord,
   listGuildEmojisDiscord,
   listThreadsDiscord,
   reactMessageDiscord,
@@ -516,5 +517,49 @@ describe("retry rate limits", () => {
 
     expect(res.messageId).toBe("msg1");
     expect(postMock).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("fetchThreadInfoDiscord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches thread metadata via GET /channels/:id", async () => {
+    const { rest, getMock } = makeDiscordRest();
+    const fakeThread = {
+      id: "thread-1",
+      type: ChannelType.PublicThread,
+      name: "my-thread",
+      parent_id: "chan-parent",
+      thread_metadata: {
+        archived: false,
+        auto_archive_duration: 1440,
+        locked: false,
+      },
+    };
+    getMock.mockResolvedValue(fakeThread);
+    const result = await fetchThreadInfoDiscord("thread-1", { rest, token: "t" });
+    expect(getMock).toHaveBeenCalledWith(Routes.channel("thread-1"));
+    expect(result).toEqual(fakeThread);
+  });
+
+  it("returns archived thread metadata", async () => {
+    const { rest, getMock } = makeDiscordRest();
+    const archivedThread = {
+      id: "thread-2",
+      type: ChannelType.PublicThread,
+      name: "closed-thread",
+      thread_metadata: {
+        archived: true,
+        auto_archive_duration: 60,
+        locked: true,
+      },
+    };
+    getMock.mockResolvedValue(archivedThread);
+    const result = await fetchThreadInfoDiscord("thread-2", { rest, token: "t" });
+    expect(result.thread_metadata).toEqual(
+      expect.objectContaining({ archived: true, locked: true }),
+    );
   });
 });

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -95,6 +95,14 @@ export async function listPinsDiscord(
   return (await rest.get(Routes.channelPins(channelId))) as APIMessage[];
 }
 
+export async function fetchThreadInfoDiscord(
+  threadId: string,
+  opts: DiscordReactOpts = {},
+): Promise<APIChannel> {
+  const rest = resolveDiscordRest(opts);
+  return (await rest.get(Routes.channel(threadId))) as APIChannel;
+}
+
 export async function createThreadDiscord(
   channelId: string,
   payload: DiscordThreadCreate,

--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -30,6 +30,7 @@ export {
   deleteMessageDiscord,
   editMessageDiscord,
   fetchMessageDiscord,
+  fetchThreadInfoDiscord,
   listPinsDiscord,
   listThreadsDiscord,
   pinMessageDiscord,


### PR DESCRIPTION
## Summary
- Adds a `thread-info` action to the Discord message tool that fetches thread/channel metadata via `GET /channels/:id`
- Returns thread metadata including `archived`, `locked`, `auto_archive_duration`, `parent_id`, and `owner_id` fields
- Enables agents to check whether a thread is archived before posting, preventing unintentional reopening of intentionally-closed threads

Closes #32343

## Changes
- `message-action-names.ts`: Register `thread-info` action name
- `actions/discord.ts`: Enable `thread-info` when `threads` feature is active
- `handle-action.ts`: Parse `threadId` param and dispatch to `threadInfo` handler
- `discord-actions.ts`: Add `threadInfo` to the `messagingActions` set
- `discord-actions-messaging.ts`: Implement `threadInfo` case calling `fetchThreadInfoDiscord`
- `send.messages.ts`: Add `fetchThreadInfoDiscord()` — simple `GET Routes.channel(threadId)`
- `send.ts`: Export the new function

## Test plan
- [x] 2 new unit tests for `fetchThreadInfoDiscord` (normal + archived thread metadata)
- [x] All 26 thread-related tests pass
- [x] All 60 Discord send tests pass
- [x] All 271 channel plugin tests pass
- [x] TypeScript compiles cleanly (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)