### PR TITLE
Gateway: refresh service env after update.run

### DIFF
--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -1,5 +1,7 @@
+import path from "node:path";
 import { loadConfig } from "../../config/config.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
+import { resolveGatewayService } from "../../daemon/service.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import {
   formatDoctorNonInteractiveHint,
@@ -9,11 +11,88 @@ import {
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { normalizeUpdateChannel } from "../../infra/update-channels.js";
 import { runGatewayUpdate } from "../../infra/update-runner.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
+import { pathExists } from "../../utils.js";
 import { formatControlPlaneActor, resolveControlPlaneActor } from "../control-plane-audit.js";
 import { validateUpdateRunParams } from "../protocol/index.js";
 import { parseRestartRequestParams } from "./restart-request.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
+
+const SERVICE_REFRESH_TIMEOUT_MS = 60_000;
+const SERVICE_REFRESH_ARGS = ["gateway", "install", "--force", "--json"] as const;
+
+function resolveNodeRunner(): string {
+  const base = path.basename(process.execPath).toLowerCase();
+  if (base === "node" || base === "node.exe") {
+    return process.execPath;
+  }
+  return "node";
+}
+
+function resolveGatewayInstallEntrypointCandidates(root?: string): string[] {
+  const dedup = new Set<string>();
+  const add = (value?: string) => {
+    const trimmed = value?.trim();
+    if (!trimmed) {
+      return;
+    }
+    dedup.add(path.resolve(trimmed));
+  };
+  add(root ? path.join(root, "openclaw.mjs") : undefined);
+  add(path.join(process.cwd(), "openclaw.mjs"));
+  const argvDir = process.argv[1] ? path.dirname(path.resolve(process.argv[1])) : undefined;
+  if (argvDir) {
+    add(path.join(argvDir, "openclaw.mjs"));
+    add(path.join(argvDir, "..", "openclaw.mjs"));
+  }
+  return [...dedup];
+}
+
+async function refreshGatewayServiceEnvFromUpdatedInstall(root?: string): Promise<{
+  attempted: boolean;
+  ok: boolean;
+  reason?: string;
+}> {
+  const service = resolveGatewayService();
+  let loaded = false;
+  try {
+    loaded = await service.isLoaded({ env: process.env });
+  } catch (err) {
+    return {
+      attempted: false,
+      ok: false,
+      reason: `service check failed: ${String(err)}`,
+    };
+  }
+  if (!loaded) {
+    return { attempted: false, ok: true, reason: "service not installed" };
+  }
+
+  const nodeRunner = resolveNodeRunner();
+  for (const candidate of resolveGatewayInstallEntrypointCandidates(root)) {
+    if (!(await pathExists(candidate))) {
+      continue;
+    }
+    const res = await runCommandWithTimeout([nodeRunner, candidate, ...SERVICE_REFRESH_ARGS], {
+      timeoutMs: SERVICE_REFRESH_TIMEOUT_MS,
+    });
+    if (res.code === 0) {
+      return { attempted: true, ok: true };
+    }
+    return {
+      attempted: true,
+      ok: false,
+      reason: `refresh failed (${candidate}): exit=${res.code}`,
+    };
+  }
+
+  return {
+    attempted: false,
+    ok: false,
+    reason: "updated openclaw.mjs not found",
+  };
+}
 
 export const updateHandlers: GatewayRequestHandlers = {
   "update.run": async ({ params, respond, client, context }) => {
@@ -30,6 +109,7 @@ export const updateHandlers: GatewayRequestHandlers = {
         : undefined;
 
     let result: Awaited<ReturnType<typeof runGatewayUpdate>>;
+    let resolvedRoot: string | undefined;
     try {
       const config = loadConfig();
       const configChannel = normalizeUpdateChannel(config.update?.channel);
@@ -39,6 +119,7 @@ export const updateHandlers: GatewayRequestHandlers = {
           argv1: process.argv[1],
           cwd: process.cwd(),
         })) ?? process.cwd();
+      resolvedRoot = root;
       result = await runGatewayUpdate({
         timeoutMs,
         cwd: root,
@@ -53,6 +134,17 @@ export const updateHandlers: GatewayRequestHandlers = {
         steps: [],
         durationMs: 0,
       };
+    }
+
+    if (result.status === "ok") {
+      const refreshResult = await refreshGatewayServiceEnvFromUpdatedInstall(
+        result.root ?? resolvedRoot,
+      );
+      if (!refreshResult.ok) {
+        context?.logGateway?.warn(
+          `update.run service env refresh skipped ${formatControlPlaneActor(actor)} reason=${refreshResult.reason ?? "unknown"}`,
+        );
+      }
     }
 
     const payload: RestartSentinelPayload = {


### PR DESCRIPTION
## Summary
- split from #26712 into a focused gateway update PR
- refresh gateway service env after `update.run` so post-update runtime reads the latest env values
- add tests for env refresh behavior in update server methods

## Validation
- `pnpm exec vitest run src/gateway/server-methods/update.test.ts`

## Context
This PR is one focused slice extracted from:
- https://github.com/openclaw/openclaw/pull/26712
