### PR TITLE
Tests: isolate workspace skill prompt fixtures from bundled skills

### DIFF
--- a/src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.test.ts
+++ b/src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.test.ts
@@ -91,9 +91,11 @@ describe("buildWorkspaceSkillsPrompt", () => {
     });
 
     const managedSkillsDir = path.join(workspaceDir, ".managed");
+    const bundledSkillsDir = path.join(workspaceDir, ".bundled");
     const defaultPrompt = withEnv({ HOME: workspaceDir, PATH: "" }, () =>
       buildWorkspaceSkillsPrompt(workspaceDir, {
         managedSkillsDir,
+        bundledSkillsDir,
         eligibility: {
           remote: {
             platforms: ["linux"],
@@ -113,6 +115,7 @@ describe("buildWorkspaceSkillsPrompt", () => {
     const gatedPrompt = withEnv({ HOME: workspaceDir, PATH: "" }, () =>
       buildWorkspaceSkillsPrompt(workspaceDir, {
         managedSkillsDir,
+        bundledSkillsDir,
         config: {
           browser: { enabled: false },
           skills: { entries: { "env-skill": { apiKey: "ok" } } },
@@ -146,6 +149,7 @@ describe("buildWorkspaceSkillsPrompt", () => {
     const prompt = withEnv({ HOME: workspaceDir, PATH: "" }, () =>
       buildWorkspaceSkillsPrompt(workspaceDir, {
         managedSkillsDir: path.join(workspaceDir, ".managed"),
+        bundledSkillsDir: path.join(workspaceDir, ".bundled"),
         config: { skills: { entries: { alias: { enabled: false } } } },
       }),
     );

--- a/src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts
+++ b/src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts
@@ -59,7 +59,13 @@ describe("buildWorkspaceSkillsPrompt", () => {
     workspaceDir: string,
     opts?: Parameters<typeof buildWorkspaceSkillsPrompt>[1],
   ) =>
-    withEnv({ HOME: workspaceDir, PATH: "" }, () => buildWorkspaceSkillsPrompt(workspaceDir, opts));
+    withEnv({ HOME: workspaceDir, PATH: "" }, () =>
+      buildWorkspaceSkillsPrompt(workspaceDir, {
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+        bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+        ...opts,
+      }),
+    );
 
   const cloneSourceTemplate = async () => {
     const sourceWorkspace = await createCaseDir("source");


### PR DESCRIPTION
## Summary
- split from #26712 into a focused test-only PR
- isolate workspace skill prompt fixtures from bundled/default skills
- reduce cross-test coupling when validating merged workspace skill prompts

## Validation
- `pnpm exec vitest run src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.test.ts src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts`

## Context
This PR is one focused slice extracted from:
- https://github.com/openclaw/openclaw/pull/26712
