### PR TITLE
fix(telegram): reuse preview message across tool-use rounds

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -620,6 +620,29 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
   });
 
+  it("immediately deletes the outgoing preview when a new assistant block starts mid-stream", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Thinking..." });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Final answer" });
+        await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    const bot = createBot();
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial", bot });
+
+    const deleteMessageCalls = (
+      bot.api as unknown as { deleteMessage: { mock: { calls: unknown[][] } } }
+    ).deleteMessage.mock.calls;
+    expect(deleteMessageCalls).toContainEqual([123, 999]);
+  });
+
   it("rotates before a late second-message partial so finalized preview is not overwritten", async () => {
     const answerDraftStream = createSequencedDraftStream(1001);
     const reasoningDraftStream = createDraftStream();

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -657,6 +657,18 @@ export const dispatchTelegramMessage = async ({
                   finalizedPreviewByLane.answer = false;
                   return;
                 }
+                if (answerLane.hasStreamedMessage) {
+                  const outgoingPreviewMessageId = answerLane.stream?.messageId();
+                  if (
+                    typeof outgoingPreviewMessageId === "number" &&
+                    !finalizedPreviewByLane.answer
+                  ) {
+                    // Eagerly remove the outgoing preview at the tool-use boundary
+                    // so users don't briefly see it as a settled intermediate
+                    // message before the next round starts streaming.
+                    bot.api.deleteMessage(chatId, outgoingPreviewMessageId).catch(() => {});
+                  }
+                }
                 await rotateAnswerLaneForNewAssistantMessage();
                 // Message-start is an explicit assistant-message boundary.
                 // Even when no forceNewMessage happened (e.g. prior answer had no


### PR DESCRIPTION
## Problem

When an LLM response involves multiple tool-use rounds, each intermediate text block between tool calls was delivered as a separate Telegram message. Users saw a flash of intermediate messages that briefly appeared and then disappeared during cleanup.

Closes #32535

## Root Cause

When onAssistantMessageStart fires for a new tool-use round, the current streaming preview is archived and forceNewMessage() is called to create a fresh preview. The cleanup loop deletes the archived previews only after the full run completes, so users briefly see the old and new previews simultaneously as visible, settled messages.

## Fix

Add a fire-and-forget deleteMessage call against the outgoing preview ID immediately inside onAssistantMessageStart, before the next round's preview starts streaming. The old preview is gone before users can see it alongside the new one.

The archive entry is preserved so consumeArchivedAnswerPreviewForFinal still picks it up during final delivery. Because the message is already deleted, the edit fails and the handler falls back to sendPayload -- multi-final delivery ordering and message count are unchanged.

No changes to forceNewMessage(), finalization flags, or cleanup paths, so text-then-media sequences and late-arriving preview IDs continue to work correctly.

## What Changed

**src/telegram/bot-message-dispatch.ts**
- Added bot.api.deleteMessage(chatId, previewMessageId).catch(() => {}) inside the onAssistantMessageStart handler, immediately before archiving and rotating the preview

**src/telegram/bot-message-dispatch.test.ts**
- Added one test: verifies bot.api.deleteMessage is called with the active preview ID when a new assistant block starts after text has streamed

## Testing

- New test confirms the outgoing preview is deleted immediately on onAssistantMessageStart
- Existing tests for forceNewMessage behaviour, multi-message archive finalization, media-only follow-up, and reasoning lane splitting are unchanged