### PR TITLE
fix(providers): deduplicate tool names before API call (#14749)

### DIFF
--- a/src/agents/workspace-run.test.ts
+++ b/src/agents/workspace-run.test.ts
@@ -18,12 +18,32 @@ describe("resolveRunWorkspaceDir", () => {
     expect(result.workspaceDir).toBe(path.resolve(explicit));
   });
 
-  it("falls back to configured per-agent workspace when input is missing", () => {
+  it("prefers defaults workspace for subagent sessions when input is missing", () => {
     const defaultWorkspace = path.join(process.cwd(), "tmp", "workspace-default-main");
     const researchWorkspace = path.join(process.cwd(), "tmp", "workspace-research");
     const cfg = {
       agents: {
         defaults: { workspace: defaultWorkspace },
+        list: [{ id: "research", workspace: researchWorkspace }],
+      },
+    } satisfies OpenClawConfig;
+
+    const result = resolveRunWorkspaceDir({
+      workspaceDir: undefined,
+      sessionKey: "agent:research:subagent:test",
+      config: cfg,
+    });
+
+    expect(result.usedFallback).toBe(true);
+    expect(result.fallbackReason).toBe("missing");
+    expect(result.agentId).toBe("research");
+    expect(result.workspaceDir).toBe(path.resolve(defaultWorkspace));
+  });
+
+  it("falls back to parent workspace for subagent sessions when defaults workspace is missing", () => {
+    const researchWorkspace = path.join(process.cwd(), "tmp", "workspace-research");
+    const cfg = {
+      agents: {
         list: [{ id: "research", workspace: researchWorkspace }],
       },
     } satisfies OpenClawConfig;

--- a/src/agents/workspace-run.ts
+++ b/src/agents/workspace-run.ts
@@ -4,6 +4,7 @@ import { redactIdentifier } from "../logging/redact-identifier.js";
 import {
   classifySessionKeyShape,
   DEFAULT_AGENT_ID,
+  isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
@@ -101,7 +102,13 @@ export function resolveRunWorkspaceDir(params: {
 
   const fallbackReason: WorkspaceFallbackReason =
     requested == null ? "missing" : typeof requested === "string" ? "blank" : "invalid_type";
-  const fallbackWorkspace = resolveAgentWorkspaceDir(params.config ?? {}, agentId);
+  const configuredDefaultWorkspace = params.config?.agents?.defaults?.workspace?.trim();
+  const shouldPreferDefaultWorkspace =
+    !params.agentId?.trim() && isSubagentSessionKey(params.sessionKey);
+  const fallbackWorkspace =
+    shouldPreferDefaultWorkspace && configuredDefaultWorkspace
+      ? resolveUserPath(configuredDefaultWorkspace)
+      : resolveAgentWorkspaceDir(params.config ?? {}, agentId);
   const sanitizedFallback = sanitizeForPromptLiteral(fallbackWorkspace);
   if (sanitizedFallback !== fallbackWorkspace) {
     logWarn("Control/format characters stripped from fallback workspaceDir (OC-19 hardening).");


### PR DESCRIPTION
## Summary

Fixes #14749 — Grok via OpenRouter no longer fails with `400 Duplicate tool names: web_search`.

## Root Cause

Grok 4.1 has native tool support including `web_search`. OpenClaw also defines a `web_search` tool. When both are sent in the tools array, the xAI API rejects it as duplicate.

## Fix

Added deduplication logic that filters out duplicate tool names before sending to the LLM API, keeping the first occurrence.

## Changes

- `src/agents/pi-embedded-runner/run/attempt.ts`: Added dedup filter before API call
- `src/agents/pi-embedded-runner/run/attempt.test.ts`: Test verifying duplicates are removed

2 files, 56 insertions, 1 deletion.