### PR TITLE
fix(messages): resolve responsePrefix {model} from actual response model (#30482)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -602,6 +602,14 @@ export async function runAgentTurnWithFallback(params: {
     };
   }
 
+  // Refresh model selection from run metadata so responsePrefix templates use
+  // the actual provider/model that produced this response.
+  params.opts?.onModelSelected?.({
+    provider: runResult.meta?.agentMeta?.provider ?? fallbackProvider,
+    model: runResult.meta?.agentMeta?.model ?? fallbackModel,
+    thinkLevel: params.followupRun.run.thinkLevel,
+  });
+
   return {
     kind: "success",
     runId,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -217,6 +217,84 @@ describe("runReplyAgent onAgentRunStart", () => {
   });
 });
 
+describe("runReplyAgent onModelSelected", () => {
+  it("refreshes model selection from the actual response model", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude-opus-4-6-20260205",
+        },
+      },
+    });
+    const onModelSelected = vi.fn();
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "webchat",
+      OriginatingTo: "session:1",
+      AccountId: "primary",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        sessionId: "session",
+        sessionKey: "main",
+        messageProvider: "webchat",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      opts: { onModelSelected },
+      typing,
+      sessionCtx,
+      defaultModel: "anthropic/claude-opus-4-5",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toMatchObject({ text: "ok" });
+    expect(onModelSelected).toHaveBeenCalled();
+    expect(onModelSelected).toHaveBeenLastCalledWith({
+      provider: "anthropic",
+      model: "claude-opus-4-6-20260205",
+      thinkLevel: "low",
+    });
+  });
+});
+
 describe("runReplyAgent authProfileId fallback scoping", () => {
   it("drops authProfileId when provider changes during fallback", async () => {
     runWithModelFallbackMock.mockImplementationOnce(


### PR DESCRIPTION
## Summary

Fixes #30482 — `responsePrefix` template variable `{model}` now renders the actual model that generated the response, not the stale session default.

## Root Cause

`onModelSelected` was only called before the LLM run, setting the initial model. After fallback or model switching, the response metadata contained the real model but it was never propagated back to the responsePrefix template context.

## Fix

After the agent run completes, call `onModelSelected` again with the actual `provider`/`model` from `runResult.meta.agentMeta`.

## Changes

- `src/auto-reply/reply/agent-runner-execution.ts`: Added post-run `onModelSelected` refresh
- `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`: Test verifying model refresh

2 files, 86 insertions.