### PR TITLE
fix(hooks): emit message:sent for agent replies, not just tool sends (#31293)

### DIFF
--- a/ISSUE.md
+++ b/ISSUE.md
@@ -1,0 +1,87 @@
+### Bug type
+
+Behavior bug (incorrect output/state without crash)
+
+### Summary
+
+Internal hooks registered for `message:sent` via HOOK.md never fire for normal agent replies on any channel (Telegram, Discord, Signal, Slack, iMessage). They only fire for `message` tool sends (`action=send`). Each channel's delivery path bypasses `deliverOutboundPayloads` / `emitMessageSent` entirely.
+
+### Steps to reproduce
+
+1. Create a HOOK.md in workspace with `events: ["message:sent"]`
+2. Create handler.ts that logs when event fires:
+   console.log(`[hook] message:sent fired: ${event.context?.content?.slice(0, 50)}`);
+3. Restart gateway — hook registers successfully in logs
+4. Send a message to the agent via Telegram (or any channel)
+5. Agent replies normally
+6. Check gateway logs — no hook log lines appear
+7. Use `message` tool (action=send) to send a message — hook DOES fire
+
+### Expected behavior
+
+`message:sent` hook should fire after every successful outbound message, including normal agent replies — not just `message` tool sends. The docs describe this event as firing for outbound messages generally.
+
+### Actual behavior
+
+Hook is registered at startup (`Registered hook: nmem-reply-save -> message:sent`) but zero events are emitted for agent replies. The `emitMessageSent` function exists in `deliverOutboundPayloads` but is never called from channel-specific delivery paths:
+
+- Telegram: `deliverReplies` → `bot.api.sendMessage` (bypasses deliverOutboundPayloads)
+- Discord: `deliverDiscordInteractionReply` (bypasses deliverOutboundPayloads)
+- Signal: `deps.deliverReplies` (bypasses deliverOutboundPayloads)
+- Slack: `ctx.app.client.chat.update` (bypasses deliverOutboundPayloads)
+
+Only the `message` tool path (`action=send`) goes through `deliverOutboundPayloads` → `emitMessageSent` → hook fires.
+
+Meanwhile, `message:received` fires correctly for every inbound message.
+
+### OpenClaw version
+
+2026.2.26
+
+### Operating system
+
+MacOS Tahoe 26.3
+
+### Install method
+
+npm global
+
+### Logs, screenshots, and evidence
+
+```shell
+Gateway startup log shows hook registered:
+  "Registered hook: nmem-reply-save -> message:sent"
+  "nmem-reply-save: handler loaded, listening for message:sent"
+
+Debug logging added to handler — zero log lines appear despite many agent replies.
+
+Comparison: `message:received` hook (nmem-autosave) fires correctly for every inbound message.
+
+Code trace in deliver-DzVpHq63.js:
+- emitMessageSent() is defined inside deliverOutboundPayloads() (line ~1138)
+- It correctly calls both hookRunner.runMessageSent AND triggerInternalHook
+- BUT deliverOutboundPayloads is only called from the `message` tool send path
+- Channel-specific agent reply delivery (Telegram/Discord/Signal/Slack/iMessage) all use their own direct delivery functions that never call emitMessageSent
+```
+
+### Impact and severity
+
+Affected: All users using `message:sent` hooks via HOOK.md on any channel
+Severity: Medium (hooks silently non-functional for primary use case)
+Frequency: 100% repro — agent replies never trigger message:sent hooks
+Consequence: Cannot capture outbound agent replies via hooks. Breaks use cases like conversation logging, memory sync, analytics. Users may not realize hooks aren't firing since registration succeeds without error.
+
+### Additional information
+
+Suggested fix: Add hook emission to createReplyDispatcher / createReplyDispatcherWithTyping (single change point). After the `deliver` callback succeeds, call emitMessageSent with the payload content. This way all channels benefit without per-channel modifications:
+
+// In createReplyDispatcher, wrap the deliver callback:
+sendChain = sendChain.then(async () => {
+await options.deliver(normalized, { kind });
+// Fire message:sent hook after successful delivery
+if (options.onDelivered) options.onDelivered(normalized);
+});
+
+Workaround: Using a cron job (every 30 min, Gemini Flash) to extract replies from daily notes and sync to NeuralMemory.
+
+Channel: Telegram (tested), but code analysis shows all channels are affected.

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -1,6 +1,10 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
+import {
+  deriveReplyDispatchHookContext,
+  runWithReplyDispatchHookContext,
+} from "./reply/dispatch-hook-context.js";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
 import {
   createReplyDispatcher,
@@ -40,17 +44,20 @@ export async function dispatchInboundMessage(params: {
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
   const finalized = finalizeInboundContext(params.ctx);
-  return await withReplyDispatcher({
-    dispatcher: params.dispatcher,
-    run: () =>
-      dispatchReplyFromConfig({
-        ctx: finalized,
-        cfg: params.cfg,
-        dispatcher: params.dispatcher,
-        replyOptions: params.replyOptions,
-        replyResolver: params.replyResolver,
-      }),
-  });
+  const hookContext = deriveReplyDispatchHookContext(finalized);
+  return await runWithReplyDispatchHookContext(hookContext, async () =>
+    withReplyDispatcher({
+      dispatcher: params.dispatcher,
+      run: () =>
+        dispatchReplyFromConfig({
+          ctx: finalized,
+          cfg: params.cfg,
+          dispatcher: params.dispatcher,
+          replyOptions: params.replyOptions,
+          replyResolver: params.replyResolver,
+        }),
+    }),
+  );
 }
 
 export async function dispatchInboundMessageWithBufferedDispatcher(params: {

--- a/src/auto-reply/reply/dispatch-hook-context.ts
+++ b/src/auto-reply/reply/dispatch-hook-context.ts
@@ -1,0 +1,52 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { FinalizedMsgContext } from "../templating.js";
+import { normalizeMessageChannel } from "../../utils/message-channel.js";
+
+export type ReplyDispatchHookContext = {
+  sessionKey: string;
+  channelId: string;
+  to: string;
+  accountId?: string;
+  isGroup?: boolean;
+  groupId?: string;
+};
+
+const replyDispatchHookContextStorage = new AsyncLocalStorage<ReplyDispatchHookContext | undefined>();
+
+export function runWithReplyDispatchHookContext<T>(
+  context: ReplyDispatchHookContext | undefined,
+  run: () => Promise<T>,
+): Promise<T> {
+  return replyDispatchHookContextStorage.run(context, run);
+}
+
+export function getReplyDispatchHookContext(): ReplyDispatchHookContext | undefined {
+  return replyDispatchHookContextStorage.getStore();
+}
+
+export function deriveReplyDispatchHookContext(
+  ctx: FinalizedMsgContext,
+): ReplyDispatchHookContext | undefined {
+  const sessionKey = typeof ctx.SessionKey === "string" ? ctx.SessionKey.trim() : "";
+  const channelId = normalizeMessageChannel(ctx.OriginatingChannel ?? ctx.Provider ?? ctx.Surface);
+  const toCandidate =
+    typeof ctx.OriginatingTo === "string"
+      ? ctx.OriginatingTo
+      : typeof ctx.To === "string"
+        ? ctx.To
+        : typeof ctx.From === "string"
+          ? ctx.From
+          : "";
+  const to = toCandidate.trim();
+  if (!sessionKey || !channelId || !to) {
+    return undefined;
+  }
+  const isGroup = Boolean(ctx.GroupSubject || ctx.GroupChannel);
+  return {
+    sessionKey,
+    channelId,
+    to,
+    ...(ctx.AccountId ? { accountId: ctx.AccountId } : {}),
+    ...(isGroup ? { isGroup: true, groupId: to } : {}),
+  };
+}

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,7 +1,14 @@
 import type { TypingCallbacks } from "../../channels/typing.js";
 import type { HumanDelayConfig } from "../../config/types.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import {
+  buildCanonicalSentMessageHookContext,
+  toInternalMessageSentContext,
+} from "../../hooks/message-hook-mappers.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { sleep } from "../../utils.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import { getReplyDispatchHookContext } from "./dispatch-hook-context.js";
 import { registerDispatcher } from "./dispatcher-registry.js";
 import { normalizeReplyPayload, type NormalizeReplySkipReason } from "./normalize-reply.js";
 import type { ResponsePrefixContext } from "./response-prefix-template.js";
@@ -23,6 +30,7 @@ type ReplyDispatchDeliverer = (
 
 const DEFAULT_HUMAN_DELAY_MIN_MS = 800;
 const DEFAULT_HUMAN_DELAY_MAX_MS = 2500;
+const log = createSubsystemLogger("reply-dispatcher");
 
 /** Generate a random delay within the configured range. */
 function getHumanDelay(config: HumanDelayConfig | undefined): number {
@@ -104,6 +112,37 @@ function normalizeReplyPayloadInternal(
   });
 }
 
+function emitAgentReplyMessageSent(params: { payload: ReplyPayload; success: boolean; error?: string }): void {
+  if (params.payload.isReasoning) {
+    return;
+  }
+  const hookContext = getReplyDispatchHookContext();
+  if (!hookContext) {
+    return;
+  }
+  const canonical = buildCanonicalSentMessageHookContext({
+    to: hookContext.to,
+    content: params.payload.text ?? "",
+    success: params.success,
+    error: params.error,
+    channelId: hookContext.channelId,
+    accountId: hookContext.accountId,
+    conversationId: hookContext.to,
+    isGroup: hookContext.isGroup,
+    groupId: hookContext.groupId,
+  });
+  void triggerInternalHook(
+    createInternalHookEvent(
+      "message",
+      "sent",
+      hookContext.sessionKey,
+      toInternalMessageSentContext(canonical),
+    ),
+  ).catch((err) => {
+    log.warn(`reply-dispatcher: message:sent internal hook failed: ${String(err)}`);
+  });
+}
+
 export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDispatcher {
   let sendChain: Promise<void> = Promise.resolve();
   // Track in-flight deliveries so we can emit a reliable "idle" signal.
@@ -158,8 +197,14 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         // Safe: deliver is called inside an async .then() callback, so even a synchronous
         // throw becomes a rejection that flows through .catch()/.finally(), ensuring cleanup.
         await options.deliver(normalized, { kind });
+        emitAgentReplyMessageSent({ payload: normalized, success: true });
       })
       .catch((err) => {
+        emitAgentReplyMessageSent({
+          payload: normalized,
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
         options.onError?.(err, { kind });
       })
       .finally(() => {

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1,9 +1,15 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { expectInboundContextContract } from "../../../test/helpers/inbound-contract.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import {
+  clearInternalHooks,
+  registerInternalHook,
+  type InternalHookEvent,
+} from "../../hooks/internal-hooks.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { MsgContext } from "../templating.js";
 import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN } from "../tokens.js";
+import { runWithReplyDispatchHookContext } from "./dispatch-hook-context.js";
 import { finalizeInboundContext } from "./inbound-context.js";
 import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { parseLineDirectives, hasLineDirectives } from "./line-directives.js";
@@ -1388,6 +1394,42 @@ describe("createReplyDispatcher", () => {
     expect(deliver).toHaveBeenCalledTimes(2);
 
     vi.useRealTimers();
+  });
+
+  it("emits message:sent internal hook for delivered agent replies", async () => {
+    clearInternalHooks();
+    const handler = vi.fn();
+    registerInternalHook("message:sent", handler);
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createReplyDispatcher({ deliver });
+
+    await runWithReplyDispatchHookContext(
+      {
+        sessionKey: "agent:main:discord:session-1",
+        channelId: "discord",
+        to: "channel:C123",
+      },
+      async () => {
+        dispatcher.sendFinalReply({ text: "reply from agent" });
+        dispatcher.markComplete();
+        await dispatcher.waitForIdle();
+      },
+    );
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const event = handler.mock.calls[0][0] as InternalHookEvent;
+    expect(event.type).toBe("message");
+    expect(event.action).toBe("sent");
+    expect(event.sessionKey).toBe("agent:main:discord:session-1");
+    expect(event.context).toMatchObject({
+      content: "reply from agent",
+      success: true,
+      channelId: "discord",
+      to: "channel:C123",
+      conversationId: "channel:C123",
+    });
+
+    clearInternalHooks();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #31293 — `message:sent` internal hooks now fire for normal agent replies on all channels, not just for `message` tool sends.

## Root Cause

The reply dispatcher delivered agent messages to channels without emitting the `message:sent` hook. Only the `message` tool path (`action=send`) called `emitMessageSent`.

## Fix

- Created `dispatch-hook-context.ts` using `AsyncLocalStorage` to carry session/channel context through the reply dispatch chain
- In `dispatch.ts`, derive and propagate hook context from the finalized inbound context
- In `reply-dispatcher.ts`, emit `message:sent` after successful delivery (and on failure with error)
- Reasoning payloads are excluded from hook emission

## Changes

- `src/auto-reply/reply/dispatch-hook-context.ts` (new): AsyncLocalStorage-based context carrier
- `src/auto-reply/dispatch.ts`: Wrap dispatch in hook context
- `src/auto-reply/reply/reply-dispatcher.ts`: Emit hook after delivery
- `src/auto-reply/reply/reply-flow.test.ts`: Integration test verifying hook fires

4 files, 156 insertions, 10 deletions.