### PR TITLE
fix: classify overloaded errors separately to enable cross-provider fallback

### DIFF
--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -40,6 +40,7 @@ export type AuthProfileFailureReason =
   | "auth_permanent"
   | "format"
   | "rate_limit"
+  | "overloaded"
   | "billing"
   | "timeout"
   | "model_not_found"

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -7,6 +7,7 @@ const FAILURE_REASON_PRIORITY: AuthProfileFailureReason[] = [
   "auth_permanent",
   "auth",
   "billing",
+  "overloaded",
   "format",
   "model_not_found",
   "timeout",

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -18,8 +18,8 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");
-    // Anthropic 529 (overloaded) should trigger failover as rate_limit.
-    expect(resolveFailoverReasonFromError({ status: 529 })).toBe("rate_limit");
+    // Anthropic 529 (overloaded) should trigger failover as overloaded.
+    expect(resolveFailoverReasonFromError({ status: 529 })).toBe("overloaded");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -49,6 +49,8 @@ export function resolveFailoverStatus(reason: FailoverReason): number | undefine
       return 402;
     case "rate_limit":
       return 429;
+    case "overloaded":
+      return 529;
     case "auth":
       return 401;
     case "auth_permanent":
@@ -172,7 +174,7 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
     return "timeout";
   }
   if (status === 529) {
-    return "rate_limit";
+    return "overloaded";
   }
   if (status === 400) {
     return "format";

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -509,6 +509,18 @@ describe("runWithModelFallback", () => {
     });
   });
 
+  it("skips overloaded providers and escalates to fallback", async () => {
+    const now = Date.now();
+    await expectSkippedUnavailableProvider({
+      providerPrefix: "overloaded-test",
+      usageStat: {
+        cooldownUntil: now + 5 * 60_000,
+        failureCounts: { overloaded: 2 },
+      },
+      expectedReason: "overloaded",
+    });
+  });
+
   it("does not skip when any profile is available", async () => {
     const provider = `cooldown-mixed-${crypto.randomUUID()}`;
     const profileA = `${provider}:a`;

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -402,7 +402,8 @@ function resolveCooldownDecision(params: {
   const isPersistentIssue =
     inferredReason === "auth" ||
     inferredReason === "auth_permanent" ||
-    inferredReason === "billing";
+    inferredReason === "billing" ||
+    inferredReason === "overloaded";
   if (isPersistentIssue) {
     return {
       type: "skip",

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -490,7 +490,7 @@ describe("classifyFailoverReason", () => {
       classifyFailoverReason(
         '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
       ),
-    ).toBe("rate_limit");
+    ).toBe("overloaded");
     expect(classifyFailoverReason("invalid request format")).toBe("format");
     expect(classifyFailoverReason("credit balance too low")).toBe("billing");
     expect(classifyFailoverReason("deadline exceeded")).toBe("timeout");
@@ -521,18 +521,18 @@ describe("classifyFailoverReason", () => {
       "rate_limit",
     );
   });
-  it("classifies provider high-demand / service-unavailable messages as rate_limit", () => {
+  it("classifies provider high-demand / service-unavailable messages as overloaded", () => {
     expect(
       classifyFailoverReason(
         "This model is currently experiencing high demand. Please try again later.",
       ),
-    ).toBe("rate_limit");
-    expect(classifyFailoverReason("LLM error: service unavailable")).toBe("rate_limit");
+    ).toBe("overloaded");
+    expect(classifyFailoverReason("LLM error: service unavailable")).toBe("overloaded");
     expect(
       classifyFailoverReason(
         '{"error":{"code":503,"message":"The model is overloaded. Please try later","status":"UNAVAILABLE"}}',
       ),
-    ).toBe("rate_limit");
+    ).toBe("overloaded");
   });
   it("classifies permanent auth errors as auth_permanent", () => {
     expect(classifyFailoverReason("invalid_api_key")).toBe("auth_permanent");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -801,7 +801,7 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
     return "rate_limit";
   }
   if (isOverloadedErrorMessage(raw)) {
-    return "rate_limit";
+    return "overloaded";
   }
   if (isCloudCodeAssistFormatError(raw)) {
     return "format";

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -5,6 +5,7 @@ export type FailoverReason =
   | "auth_permanent"
   | "format"
   | "rate_limit"
+  | "overloaded"
   | "billing"
   | "timeout"
   | "model_not_found"

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1055,9 +1055,12 @@ export async function runEmbeddedPiAgent(
               profileId: lastProfileId,
               reason: promptFailoverReason,
             });
+            // Overloaded errors are provider-wide (not profile-specific); skip
+            // profile rotation and escalate to fallback providers immediately.
             if (
               isFailoverErrorMessage(errorText) &&
               promptFailoverReason !== "timeout" &&
+              promptFailoverReason !== "overloaded" &&
               (await advanceAuthProfile())
             ) {
               continue;
@@ -1164,9 +1167,13 @@ export async function runEmbeddedPiAgent(
               }
             }
 
-            const rotated = await advanceAuthProfile();
-            if (rotated) {
-              continue;
+            // Overloaded errors are provider-wide; skip profile rotation and
+            // escalate to fallback providers immediately.
+            if (assistantFailoverReason !== "overloaded") {
+              const rotated = await advanceAuthProfile();
+              if (rotated) {
+                continue;
+              }
             }
 
             if (fallbackConfigured) {

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -91,7 +91,7 @@ export function mapFailoverReasonToProbeStatus(reason?: string | null): AuthProb
     // surface in the auth bucket instead of showing as unknown.
     return "auth";
   }
-  if (reason === "rate_limit") {
+  if (reason === "rate_limit" || reason === "overloaded") {
     return "rate_limit";
   }
   if (reason === "billing") {


### PR DESCRIPTION
## Summary
- Introduces a new `"overloaded"` failure reason (distinct from `"rate_limit"`) for provider overload errors (HTTP 529, "service unavailable", "high demand")
- Skips profile rotation in the inner runner for overloaded errors since they are provider-wide, not profile-specific
- Treats overloaded providers as persistently unavailable in the fallback loop, causing immediate escalation to the next configured fallback provider

## Problem
When the primary provider returned overloaded errors, the failover system classified them as `"rate_limit"` and retried alternate auth profiles of the **same** provider instead of escalating to configured **fallback providers**. During the Anthropic outage on 2026-03-02, this meant all requests failed for ~2 hours despite operational Google and OpenAI fallbacks being configured.

## Root Cause
`classifyFailoverReason()` mapped `isOverloadedErrorMessage()` → `"rate_limit"`, which:
1. Caused the inner runner to rotate through all profiles of the same provider (wasting time on a provider-wide issue)
2. Caused `resolveCooldownDecision()` to allow same-provider sibling models (rate_limit is model-scoped) instead of skipping the provider

## Changes
| File | Change |
|------|--------|
| `pi-embedded-helpers/types.ts` | Add `"overloaded"` to `FailoverReason` |
| `auth-profiles/types.ts` | Add `"overloaded"` to `AuthProfileFailureReason` |
| `pi-embedded-helpers/errors.ts` | Map overloaded → `"overloaded"` instead of `"rate_limit"` |
| `failover-error.ts` | Map `"overloaded"` → HTTP 529; map HTTP 529 → `"overloaded"` |
| `auth-profiles/usage.ts` | Add `"overloaded"` to failure reason priority list |
| `model-fallback.ts` | Add `"overloaded"` to `isPersistentIssue` (skip entire provider) |
| `pi-embedded-runner/run.ts` | Skip profile rotation for overloaded errors in both prompt and assistant error paths |
| `commands/models/list.probe.ts` | Map `"overloaded"` to `"rate_limit"` probe status for display |

## Test plan
- [x] Updated `classifyFailoverReason` test: overloaded JSON → `"overloaded"`
- [x] Updated `classifyFailoverReason` test: high-demand/service-unavailable → `"overloaded"`
- [x] Updated `resolveFailoverReasonFromError` test: HTTP 529 → `"overloaded"`
- [x] Added model-fallback test: overloaded provider skipped, fallback provider used
- [x] All 165 tests pass across 6 affected test files
- [x] TypeScript compiles cleanly (no new errors)

Closes #32533

🤖 Generated with [Claude Code](https://claude.com/claude-code)