### PR TITLE
fix(slack): include all native slash commands in app manifest

### DIFF
--- a/src/channels/plugins/onboarding/slack.test.ts
+++ b/src/channels/plugins/onboarding/slack.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { buildSlackManifest } from "./slack.js";
+
+describe("buildSlackManifest", () => {
+  it("includes native slash commands beyond /openclaw", () => {
+    const raw = buildSlackManifest("TestBot");
+    const manifest = JSON.parse(raw);
+    const commands: { command: string; description: string }[] = manifest.features.slash_commands;
+
+    // Should always include the primary /openclaw command
+    expect(commands.some((c) => c.command === "/openclaw")).toBe(true);
+
+    // Should include well-known native commands (with Slack overrides)
+    const names = commands.map((c) => c.command);
+    expect(names).toContain("/help");
+    expect(names).toContain("/new");
+    expect(names).toContain("/reset");
+    expect(names).toContain("/stop");
+    // Slack renames /status → /agentstatus to avoid Slack's reserved name
+    expect(names).toContain("/agentstatus");
+    expect(names).not.toContain("/status");
+
+    // Should have many more than just /openclaw
+    expect(commands.length).toBeGreaterThan(10);
+  });
+
+  it("uses the provided bot name", () => {
+    const raw = buildSlackManifest("MyBot");
+    const manifest = JSON.parse(raw);
+    expect(manifest.display_information.name).toBe("MyBot");
+    expect(manifest.features.bot_user.display_name).toBe("MyBot");
+  });
+
+  it("falls back to OpenClaw for empty names", () => {
+    const raw = buildSlackManifest("  ");
+    const manifest = JSON.parse(raw);
+    expect(manifest.display_information.name).toBe("OpenClaw");
+  });
+
+  it("every slash command has a description", () => {
+    const raw = buildSlackManifest("TestBot");
+    const manifest = JSON.parse(raw);
+    const commands: { command: string; description: string }[] = manifest.features.slash_commands;
+
+    for (const cmd of commands) {
+      expect(cmd.description).toBeTruthy();
+      expect(cmd.command.startsWith("/")).toBe(true);
+    }
+  });
+});

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -1,3 +1,4 @@
+import { listNativeCommandSpecs } from "../../../auto-reply/commands-registry.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { hasConfiguredSecretInput } from "../../../config/types.secrets.js";
 import { DEFAULT_ACCOUNT_ID } from "../../../routing/session-key.js";
@@ -28,8 +29,22 @@ import {
 
 const channel = "slack" as const;
 
-function buildSlackManifest(botName: string) {
+/** @internal Exported for testing only. */
+export function buildSlackManifest(botName: string) {
   const safeName = botName.trim() || "OpenClaw";
+  const nativeSpecs = listNativeCommandSpecs({ provider: "slack" });
+  const slashCommands = [
+    {
+      command: "/openclaw",
+      description: "Send a message to OpenClaw",
+      should_escape: false,
+    },
+    ...nativeSpecs.map((spec) => ({
+      command: `/${spec.name}`,
+      description: spec.description,
+      should_escape: false,
+    })),
+  ];
   const manifest = {
     display_information: {
       name: safeName,
@@ -44,13 +59,7 @@ function buildSlackManifest(botName: string) {
         messages_tab_enabled: true,
         messages_tab_read_only_enabled: false,
       },
-      slash_commands: [
-        {
-          command: "/openclaw",
-          description: "Send a message to OpenClaw",
-          should_escape: false,
-        },
-      ],
+      slash_commands: slashCommands,
     },
     oauth_config: {
       scopes: {


### PR DESCRIPTION
## Summary
- Populates the Slack app manifest `slash_commands` array from the native command registry instead of hardcoding only `/openclaw`
- Applies Slack-specific name overrides (e.g. `/status` → `/agentstatus` to avoid Slack's reserved name)
- All registered native commands are now included automatically

## Problem
The Slack app manifest generated by `openclaw channels add` only included the `/openclaw` slash command. Users had to manually add every other slash command to their Slack app — a tedious process with 30+ commands.

## Changes
| File | Change |
|------|--------|
| `onboarding/slack.ts` | Import `listNativeCommandSpecs` and build `slash_commands` dynamically from the command registry |
| `onboarding/slack.test.ts` | New test file verifying manifest includes native commands, applies Slack overrides, and validates structure |

## Test plan
- [x] Manifest includes `/openclaw` primary command
- [x] Manifest includes well-known commands (`/help`, `/new`, `/reset`, `/stop`)
- [x] Slack name override applied (`/status` → `/agentstatus`)
- [x] All commands have descriptions and start with `/`
- [x] 10+ native commands included (currently ~35)
- [x] Bot name and fallback behavior preserved
- [x] All 4 tests pass

Closes #32499

🤖 Generated with [Claude Code](https://claude.com/claude-code)