### PR TITLE
fix(slack): print manifest JSON outside note box for clean copy-paste

### DIFF
--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -111,10 +111,11 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
     ].join("\n"),
     "Slack socket mode tokens",
   );
-  // Print the manifest JSON directly (without box framing) so it can be copied cleanly.
-  console.log("\nManifest (JSON):\n");
-  console.log(manifest);
-  console.log();
+  // Print the manifest JSON via prompter.log (not console.log) so the output stays
+  // within the WizardPrompter abstraction and can be captured in tests or non-TTY contexts.
+  await prompter.log("\nManifest (JSON):\n");
+  await prompter.log(manifest);
+  await prompter.log("");
 }
 
 function setSlackChannelAllowlist(

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -108,12 +108,13 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
       "5) App Home → enable the Messages tab for DMs",
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
       `Docs: ${formatDocsLink("/slack", "slack")}`,
-      "",
-      "Manifest (JSON):",
-      manifest,
     ].join("\n"),
     "Slack socket mode tokens",
   );
+  // Print the manifest JSON directly (without box framing) so it can be copied cleanly.
+  console.log("\nManifest (JSON):\n");
+  console.log(manifest);
+  console.log();
 }
 
 function setSlackChannelAllowlist(

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -62,6 +62,11 @@ export function createClackPrompter(): WizardPrompter {
     note: async (message, title) => {
       emitNote(message, title);
     },
+    log: async (message) => {
+      // Plain undecorated output — respects the prompter abstraction so callers
+      // (e.g. tests) can swap the writer rather than relying on process.stdout.
+      process.stdout.write(message + "\n");
+    },
     select: async (params) =>
       guardCancel(
         await select({

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -38,6 +38,8 @@ export type WizardPrompter = {
   intro: (title: string) => Promise<void>;
   outro: (message: string) => Promise<void>;
   note: (message: string, title?: string) => Promise<void>;
+  /** Print a plain undecorated line — use instead of console.log to stay within the prompter abstraction. */
+  log: (message: string) => Promise<void>;
   select: <T>(params: WizardSelectParams<T>) => Promise<T>;
   multiselect: <T>(params: WizardMultiSelectParams<T>) => Promise<T[]>;
   text: (params: WizardTextParams) => Promise<string>;


### PR DESCRIPTION
## Summary

Fixes #32493

The Slack JSON manifest was embedded inside a `prompter.note()` call (backed by clack's `note()`), which wraps every line in box-drawing characters (`│`). This makes the output invalid JSON and forces users to manually strip the pipes before they can use it.

## Fix

Move the manifest output to a plain `console.log()` call after the note box, so users can copy it directly as valid JSON.

## Before
```
╭─ Slack socket mode tokens ──────────────────╮
│ 1) Slack API → Create App → From manifest   │
│ ...                                          │
│ Manifest (JSON):                             │
│ {                                            │
│   "display_information": {                  │
│     "name": "MyBot"                         │
│   }                                          │
│ }                                            │
╰─────────────────────────────────────────────╯
```

## After
```
╭─ Slack socket mode tokens ──────────────────╮
│ 1) Slack API → Create App → From manifest   │
│ ...                                          │
╰─────────────────────────────────────────────╯

Manifest (JSON):

{
  "display_information": {
    "name": "MyBot"
  }
}
```