### PR TITLE
fix(discord): exclude '*' wildcard from unresolvedChannels audit count

### DIFF
--- a/src/discord/audit.test.ts
+++ b/src/discord/audit.test.ts
@@ -53,4 +53,55 @@ describe("discord audit", () => {
     expect(audit.channels[0]?.channelId).toBe("111");
     expect(audit.channels[0]?.missing).toContain("SendMessages");
   });
+
+  it("does not count '*' wildcard key as unresolved channel", async () => {
+    const { collectDiscordAuditChannelIds } = await import("./audit.js");
+
+    const cfg = {
+      channels: {
+        discord: {
+          enabled: true,
+          token: "t",
+          groupPolicy: "allowlist",
+          guilds: {
+            "123": {
+              channels: {
+                "111": { allow: true },
+                "*": { allow: true },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as import("../config/config.js").OpenClawConfig;
+
+    const collected = collectDiscordAuditChannelIds({ cfg, accountId: "default" });
+    expect(collected.channelIds).toEqual(["111"]);
+    expect(collected.unresolvedChannels).toBe(0);
+  });
+
+  it("handles guild with only '*' wildcard and no numeric channel ids", async () => {
+    const { collectDiscordAuditChannelIds } = await import("./audit.js");
+
+    const cfg = {
+      channels: {
+        discord: {
+          enabled: true,
+          token: "t",
+          groupPolicy: "allowlist",
+          guilds: {
+            "123": {
+              channels: {
+                "*": { allow: true },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as import("../config/config.js").OpenClawConfig;
+
+    const collected = collectDiscordAuditChannelIds({ cfg, accountId: "default" });
+    expect(collected.channelIds).toEqual([]);
+    expect(collected.unresolvedChannels).toBe(0);
+  });
 });

--- a/src/discord/audit.ts
+++ b/src/discord/audit.ts
@@ -56,6 +56,11 @@ function listConfiguredGuildChannelKeys(
       if (!channelId) {
         continue;
       }
+      // Skip wildcard keys (e.g. "*" meaning "all channels") — they are valid
+      // config but are not real channel IDs and should not be audited.
+      if (channelId === "*") {
+        continue;
+      }
       if (!shouldAuditChannelConfig(value as DiscordGuildChannelConfig | undefined)) {
         continue;
       }


### PR DESCRIPTION
## Summary

Fixes #32517

`openclaw doctor` and `channels status --probe` report a false positive warning when users configure `"*"` as a wildcard key in guild channels:

```
Some configured guild channels are not numeric IDs (unresolvedChannels=1).
```

## Root Cause

In `listConfiguredGuildChannelKeys`, every non-numeric key was included — including `"*"` — so it got counted as an unresolved channel ID in `collectDiscordAuditChannelIds`.

The `"*"` key is a valid config meaning "allow all channels in the guild" and is already handled correctly by allowlist logic elsewhere. It is not an actual Discord channel ID and should never be audited.

## Fix

Skip `"*"` in `listConfiguredGuildChannelKeys` before it enters the key set, so it's excluded from both `channelIds` and the `unresolvedChannels` count.

```ts
// Skip wildcard keys (e.g. "*" meaning "all channels") — they are valid
// config but are not real channel IDs and should not be audited.
if (channelId === "*") {
  continue;
}
```

## Tests

Added two new test cases:
- Guild with numeric IDs + `"*"` wildcard → `unresolvedChannels: 0`
- Guild with only `"*"` wildcard → `channelIds: []`, `unresolvedChannels: 0`