### PR TITLE
fix(agents): set preserveSignatures to isAnthropic in resolveTranscriptPolicy

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -76,6 +76,33 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.sanitizeMode).toBe("full");
   });
 
+  it("preserves thinking block signatures for Anthropic providers", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "anthropic",
+      modelId: "claude-opus-4-5",
+      modelApi: "anthropic-messages",
+    });
+    expect(policy.preserveSignatures).toBe(true);
+  });
+
+  it("preserves thinking block signatures for Bedrock Anthropic models", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "amazon-bedrock",
+      modelId: "us.anthropic.claude-opus-4-6-v1",
+      modelApi: "bedrock-converse-stream",
+    });
+    expect(policy.preserveSignatures).toBe(true);
+  });
+
+  it("strips thinking block signatures for non-Anthropic providers", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-4o",
+      modelApi: "openai",
+    });
+    expect(policy.preserveSignatures).toBe(false);
+  });
+
   it("keeps OpenRouter on its existing turn-validation path", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openrouter",

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -103,6 +103,18 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.preserveSignatures).toBe(false);
   });
 
+  it("strips thinking block signatures for non-Claude Bedrock models (e.g. amazon.nova-*)", () => {
+    // amazon.nova-* and other non-Anthropic Bedrock models do not produce thinking blocks.
+    // Preserving signatures for them would leak Claude-specific payload fields into
+    // cross-model replays, so preserveSignatures must be false.
+    const policy = resolveTranscriptPolicy({
+      provider: "amazon-bedrock",
+      modelId: "amazon.nova-pro-v1:0",
+      modelApi: "bedrock-converse-stream",
+    });
+    expect(policy.preserveSignatures).toBe(false);
+  });
+
   it("keeps OpenRouter on its existing turn-validation path", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openrouter",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -123,7 +123,14 @@ export function resolveTranscriptPolicy(params: {
       (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
     toolCallIdMode,
     repairToolUseResultPairing,
-    preserveSignatures: isAnthropic,
+    // Preserve thought_signature fields only for native Anthropic API or Anthropic Claude
+    // models on Bedrock (e.g. anthropic.claude-*). Other Bedrock models such as
+    // amazon.nova-* do not produce thinking blocks, so stripping is safe and avoids
+    // leaking provider-specific payload fields into cross-model replays.
+    preserveSignatures:
+      params.modelApi === "anthropic-messages" ||
+      provider === "anthropic" ||
+      (isAnthropic && /anthropic[./]claude/i.test(modelId)),
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks,

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -123,7 +123,7 @@ export function resolveTranscriptPolicy(params: {
       (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
     toolCallIdMode,
     repairToolUseResultPairing,
-    preserveSignatures: false,
+    preserveSignatures: isAnthropic,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks,


### PR DESCRIPTION
## Summary

Fixes #32526

`resolveTranscriptPolicy` was hardcoding `preserveSignatures: false` for all providers. This caused `stripThoughtSignatures` to remove `msg_`-prefixed `thought_signature` fields from Anthropic thinking blocks, breaking the Anthropic API contract:

```
messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified.
```

## Fix

One-line change — `isAnthropic` is already in scope:

```diff
- preserveSignatures: false,
+ preserveSignatures: isAnthropic,
```

Signatures are preserved for Anthropic and Bedrock providers (where thinking blocks are native), and still stripped for non-Anthropic providers during cross-provider transcript replay.

## Tests

3 new test cases in `transcript-policy.test.ts`:
- ✅ `preserveSignatures: true` for `anthropic-messages` API
- ✅ `preserveSignatures: true` for `bedrock-converse-stream` API (Anthropic on Bedrock)
- ✅ `preserveSignatures: false` for non-Anthropic providers (OpenAI)