### PR TITLE
fix(gateway): health check always times out when lsof is not installed

### DIFF
--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -123,6 +123,26 @@ describe("inspectGatewayRestart", () => {
     expect(snapshot.staleGatewayPids).toEqual([]);
   });
 
+  it("treats port as owned when runtime pid is known but listeners are empty (e.g. lsof missing)", async () => {
+    const service = {
+      readRuntime: vi.fn(async () => ({ status: "running", pid: 40977 })),
+    } as unknown as GatewayService;
+
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [],
+      hints: [],
+      errors: ["Error: spawn lsof ENOENT"],
+    });
+
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({ service, port: 18789 });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.staleGatewayPids).toEqual([]);
+  });
+
   it("does not treat known non-gateway listeners as stale in fallback mode", async () => {
     Object.defineProperty(process, "platform", { value: "win32", configurable: true });
     classifyPortListener.mockReturnValue("ssh");

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -74,9 +74,15 @@ export async function inspectGatewayRestart(params: {
       : [];
   const running = runtime.status === "running";
   const runtimePid = runtime.pid;
+  // When the port is busy but no listeners are available (e.g. lsof not installed),
+  // optimistically assume the running service owns the port since we cannot
+  // distinguish ownership without process enumeration tools.
   const ownsPort =
     runtimePid != null
-      ? portUsage.listeners.some((listener) => listenerOwnedByRuntimePid({ listener, runtimePid }))
+      ? portUsage.listeners.some((listener) =>
+          listenerOwnedByRuntimePid({ listener, runtimePid }),
+        ) ||
+        (portUsage.status === "busy" && portUsage.listeners.length === 0)
       : gatewayListeners.length > 0 ||
         (portUsage.status === "busy" && portUsage.listeners.length === 0);
   const healthy = running && ownsPort;


### PR DESCRIPTION
## Summary

**Severity: HIGH** — This is a critical bug that causes `openclaw gateway restart` to **always time out after 60 seconds** on any Linux system without `lsof` installed (common on minimal/container installs, Arch Linux, Alpine, etc.).

### Root Cause

In `inspectGatewayRestart()`, the `ownsPort` check when `runtimePid` is known only verifies ownership via `portUsage.listeners.some(listenerOwnedByRuntimePid)`. When `lsof` is not installed, `inspectPortUsage()` falls back to `checkPortInUse()` (which tries to bind and gets `EADDRINUSE`), returning `{ status: "busy", listeners: [] }`. Since `.some()` on an empty array always returns `false`, `ownsPort` is always `false` → `healthy` is always `false` → the health-check loop polls for 120 attempts × 500ms = **60s** then reports a timeout error, even though the gateway is running and healthy.

The `runtimePid == null` branch already had the correct fallback `(portUsage.status === "busy" && portUsage.listeners.length === 0)`, but the `runtimePid != null` branch was missing it.

### Fix

Add the same `(status === "busy" && listeners.length === 0)` fallback to the `runtimePid != null` branch, so a running service with a known PID is treated as the port owner when listener enumeration is unavailable.

### Impact

- Every `openclaw gateway restart` on a system without `lsof` was broken — always timing out after 60s
- The gateway was actually running fine; only the health check reporting was wrong
- Affects Linux distros that don't ship `lsof` by default (Arch, Alpine, minimal Debian/Ubuntu, containers)

## Test plan

- [x] Added test: `"treats port as owned when runtime pid is known but listeners are empty (e.g. lsof missing)"`
- [x] All 7 existing tests pass (no regression)
- [x] `pnpm check` passes (lint + format + typecheck)
- [x] Verified edge cases:
  - lsof installed + listener matches runtime PID → healthy ✓
  - lsof installed + listener does NOT match → unhealthy + stale PID detected ✓
  - lsof missing + runtime running + port busy → healthy ✓ (fixed)
  - lsof missing + runtime NOT running → unhealthy ✓
  - port free → unhealthy ✓