### PR TITLE
fix: add cooldown to prevent pre-compaction memory flush loop

### DIFF
--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { resolveMemoryFlushPromptForRun } from "./memory-flush.js";
+import { resolveMemoryFlushPromptForRun, shouldRunMemoryFlush } from "./memory-flush.js";
 
 describe("resolveMemoryFlushPromptForRun", () => {
   const cfg = {
@@ -33,5 +33,27 @@ describe("resolveMemoryFlushPromptForRun", () => {
 
     expect(prompt).toContain("Current time: already present");
     expect((prompt.match(/Current time:/g) ?? []).length).toBe(1);
+  });
+});
+
+describe("shouldRunMemoryFlush", () => {
+  it("skips during the memory flush cooldown window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-03T10:00:00.000Z"));
+
+    expect(
+      shouldRunMemoryFlush({
+        entry: {
+          totalTokens: 96_000,
+          compactionCount: 1,
+          memoryFlushAt: Date.now() - 60_000,
+        },
+        contextWindowTokens: 100_000,
+        reserveTokensFloor: 2_000,
+        softThresholdTokens: 1_000,
+      }),
+    ).toBe(false);
+
+    vi.useRealTimers();
   });
 });

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -124,7 +124,11 @@ export function resolveMemoryFlushContextWindowTokens(params: {
 export function shouldRunMemoryFlush(params: {
   entry?: Pick<
     SessionEntry,
-    "totalTokens" | "totalTokensFresh" | "compactionCount" | "memoryFlushCompactionCount"
+    | "totalTokens"
+    | "totalTokensFresh"
+    | "compactionCount"
+    | "memoryFlushAt"
+    | "memoryFlushCompactionCount"
   >;
   /**
    * Optional token count override for flush gating. When provided, this value is
@@ -158,6 +162,12 @@ export function shouldRunMemoryFlush(params: {
     return false;
   }
   if (totalTokens < threshold) {
+    return false;
+  }
+
+  // Time-based cooldown to prevent flush loops (#8723, #30115).
+  const memoryFlushAt = params.entry.memoryFlushAt;
+  if (typeof memoryFlushAt === "number" && Date.now() - memoryFlushAt < 5 * 60 * 1000) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

Hit an issue where the memory flush kept re-triggering on every message, locking out user responses indefinitely (#8723, #30115). The existing `memoryFlushCompactionCount` guard doesn't catch all cases due to stale session state.

Added a 5-minute cooldown to `shouldRunMemoryFlush()` — if a flush already ran recently, skip it. Simple, minimal, breaks the loop.

Fixes #8723
Fixes #30115

## Tests

- Added cooldown test in `memory-flush.test.ts`
- `pnpm test` + `tsc --noEmit` pass