### PR TITLE
fix: use configured baseUrl for Moonshot provider

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -635,9 +635,9 @@ function buildMinimaxPortalProvider(): ProviderConfig {
   };
 }
 
-function buildMoonshotProvider(): ProviderConfig {
+function buildMoonshotProvider(configuredBaseUrl?: string): ProviderConfig {
   return {
-    baseUrl: MOONSHOT_BASE_URL,
+    baseUrl: configuredBaseUrl || MOONSHOT_BASE_URL,
     api: "openai-completions",
     models: [
       {
@@ -947,8 +947,12 @@ export async function resolveImplicitProviders(params: {
   const moonshotKey =
     resolveEnvApiKeyVarName("moonshot") ??
     resolveApiKeyFromProfiles({ provider: "moonshot", store: authStore });
+  const explicitMoonshot = params.explicitProviders?.moonshot;
   if (moonshotKey) {
-    providers.moonshot = { ...buildMoonshotProvider(), apiKey: moonshotKey };
+    providers.moonshot = {
+      ...buildMoonshotProvider(explicitMoonshot?.baseUrl),
+      apiKey: moonshotKey,
+    };
   }
 
   const kimiCodingKey =


### PR DESCRIPTION
## Summary

Fixed Moonshot CN users getting 401 after onboard by using the user-configured baseUrl instead of hardcoded api.moonshot.ai endpoint.

## Changes

- Modified buildMoonshotProvider() in src/agents/models-config.providers.ts to accept an optional configuredBaseUrl parameter
- Modified resolveImplicitProviders() to pass the user-configured baseUrl from explicitProviders to buildMoonshotProvider()

## Testing

- Verified the code change is syntactically correct
- Follows the same pattern as Ollama provider for handling explicit baseUrl configuration

Fixes openclaw/openclaw#32607