### PR TITLE
feat(feishu): add comprehensive task, subtask, and tasklist tools

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -7,6 +7,7 @@ import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
 import { setFeishuRuntime } from "./src/runtime.js";
+import { registerFeishuTaskTools } from "./src/task.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
 export { monitorFeishuProvider } from "./src/monitor.js";
@@ -58,6 +59,7 @@ const plugin = {
     registerFeishuWikiTools(api);
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
+    registerFeishuTaskTools(api);
     registerFeishuBitableTools(api);
   },
 };

--- a/extensions/feishu/skills/feishu-task/SKILL.md
+++ b/extensions/feishu/skills/feishu-task/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: feishu-task
+description: |
+  Feishu Task, tasklist, subtask, comment, and attachment management. Activate when user mentions tasks, tasklists, subtasks, task comments, task attachments, or task links.
+---
+
+# Feishu Task Tools
+
+Tools:
+
+- `feishu_task_create`
+- `feishu_task_subtask_create`
+- `feishu_task_get`
+- `feishu_task_update`
+- `feishu_task_delete`
+- `feishu_task_comment_create`
+- `feishu_task_comment_list`
+- `feishu_task_comment_get`
+- `feishu_task_comment_update`
+- `feishu_task_comment_delete`
+- `feishu_task_attachment_upload`
+- `feishu_task_attachment_list`
+- `feishu_task_attachment_get`
+- `feishu_task_attachment_delete`
+- `feishu_task_add_tasklist`
+- `feishu_task_remove_tasklist`
+- `feishu_tasklist_create`
+- `feishu_tasklist_get`
+- `feishu_tasklist_get_tasks`
+- `feishu_tasklist_list`
+- `feishu_tasklist_update`
+- `feishu_tasklist_delete`
+- `feishu_tasklist_add_members`
+- `feishu_tasklist_remove_members`
+
+## Notes
+
+- `task_guid` can be taken from a task URL (guid query param) or from `feishu_task_get` output.
+- If you only have a `tasklist_guid`, use `feishu_tasklist_get_tasks` to enumerate tasks and discover each `task_guid`.
+- `comment_id` can be obtained from `feishu_task_comment_list` output.
+- `attachment_guid` can be obtained from `feishu_task_attachment_list` output.
+- `user_id_type` controls returned/accepted user identity type (`open_id`, `user_id`, `union_id`).
+- If no assignee is specified, set the assignee to the requesting user. Avoid creating unassigned tasks because the user may not be able to view them.
+- Task visibility: users can only view tasks when they are included as assignee.
+- Current limitation: the bot can only create subtasks for tasks created by itself.
+- Attachment upload supports local `file_path` and remote `file_url`. Remote URLs are fetched with runtime media safety checks and size limit (`mediaMaxMb`).
+- Keep tasklist owner as the bot. Add users as members to avoid losing bot access.
+- Use tasklist tools for tasklist membership changes; do not use `feishu_task_update` to move tasks between tasklists.
+
+## Create Task
+
+```json
+{
+  "summary": "Quarterly review",
+  "description": "Prepare review notes",
+  "due": { "timestamp": "1735689600000", "is_all_day": true },
+  "members": [{ "id": "ou_xxx", "role": "assignee", "type": "user" }],
+  "user_id_type": "open_id"
+}
+```
+
+## Create Subtask
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "summary": "Draft report outline",
+  "description": "Collect key metrics",
+  "due": { "timestamp": "1735689600000", "is_all_day": true },
+  "members": [{ "id": "ou_xxx", "role": "assignee", "type": "user" }],
+  "user_id_type": "open_id"
+}
+```
+
+## Create Comment
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "content": "Looks good to me",
+  "user_id_type": "open_id"
+}
+```
+
+## Upload Attachment (file_path)
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "file_path": "/path/to/report.pdf",
+  "user_id_type": "open_id"
+}
+```
+
+## Upload Attachment (file_url)
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "file_url": "https://oss-example.com/bucket/report.pdf",
+  "filename": "report.pdf",
+  "user_id_type": "open_id"
+}
+```
+
+## Tasklist Membership For Tasks
+
+### Add Task to Tasklist
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
+  "section_guid": "6d0f9f48-2e06-4e3d-8a0f-acde196e8c61",
+  "user_id_type": "open_id"
+}
+```
+
+### Remove Task from Tasklist
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
+  "user_id_type": "open_id"
+}
+```
+
+## Tasklists
+
+Tasklists support three roles: owner (read/edit/manage), editor (read/edit), viewer (read).
+
+### Create Tasklist
+
+```json
+{
+  "name": "Project Alpha Tasklist",
+  "members": [{ "id": "ou_xxx", "type": "user", "role": "editor" }],
+  "user_id_type": "open_id"
+}
+```
+
+### Get Tasklist
+
+```json
+{
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
+  "user_id_type": "open_id"
+}
+```
+
+### List Tasklists
+
+```json
+{
+  "page_size": 50,
+  "page_token": "aWQ9NzEwMjMzMjMxMDE=",
+  "user_id_type": "open_id"
+}
+```
+
+### Get Tasks of Tasklist
+
+```json
+{
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
+  "page_size": 100,
+  "completed": false,
+  "user_id_type": "open_id"
+}
+```
+
+### Update Tasklist
+
+```json
+{
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
+  "tasklist": {
+    "name": "Renamed Tasklist",
+    "owner": { "id": "ou_xxx", "type": "user", "role": "owner" }
+  },
+  "update_fields": ["name", "owner"],
+  "origin_owner_to_role": "editor",
+  "user_id_type": "open_id"
+}
+```
+
+### Delete Tasklist
+
+```json
+{
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004"
+}
+```
+
+### Add Tasklist Members
+
+```json
+{
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
+  "members": [{ "id": "ou_xxx", "type": "user", "role": "editor" }],
+  "user_id_type": "open_id"
+}
+```
+
+### Remove Tasklist Members
+
+```json
+{
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
+  "members": [{ "id": "ou_xxx", "type": "user", "role": "viewer" }],
+  "user_id_type": "open_id"
+}
+```

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -87,6 +87,7 @@ const FeishuToolsConfigSchema = z
     chat: z.boolean().optional(), // Chat info + member query operations (default: true)
     wiki: z.boolean().optional(), // Knowledge base operations (default: true, requires doc)
     drive: z.boolean().optional(), // Cloud storage operations (default: true)
+    task: z.boolean().optional(), // Task operations (default: true)
     perm: z.boolean().optional(), // Permission management (default: false, sensitive)
     scopes: z.boolean().optional(), // App scopes diagnostic (default: true)
   })

--- a/extensions/feishu/src/task-actions.ts
+++ b/extensions/feishu/src/task-actions.ts
@@ -1,0 +1,807 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getFeishuRuntime } from "./runtime.js";
+import {
+  TASKLIST_UPDATE_FIELD_VALUES,
+  TASK_UPDATE_FIELD_VALUES,
+  type TaskClient,
+  type AddTaskToTasklistParams,
+  type AddTasklistMembersParams,
+  type CreateTasklistParams,
+  type CreateTaskCommentParams,
+  type DeleteTaskCommentParams,
+  CreateSubtaskParams,
+  CreateTaskParams,
+  DeleteTaskAttachmentParams,
+  GetTaskAttachmentParams,
+  GetTaskParams,
+  type GetTaskCommentParams,
+  type GetTasklistParams,
+  type ListTasklistTasksParams,
+  ListTaskAttachmentsParams,
+  type ListTaskCommentsParams,
+  type ListTasklistsParams,
+  type RemoveTaskFromTasklistParams,
+  type RemoveTasklistMembersParams,
+  TaskUpdateTask,
+  type UpdateTaskCommentParams,
+  type TasklistPatchTasklist,
+  UploadTaskAttachmentParams,
+  type UpdateTasklistParams,
+  UpdateTaskParams,
+} from "./task-schema.js";
+
+const SUPPORTED_PATCH_FIELDS = new Set<string>(TASK_UPDATE_FIELD_VALUES);
+const SUPPORTED_TASKLIST_PATCH_FIELDS = new Set<string>(TASKLIST_UPDATE_FIELD_VALUES);
+const SUPPORTED_COMMENT_PATCH_FIELDS = new Set<string>(["content"]);
+
+export const BYTES_PER_MEGABYTE = 1024 * 1024;
+export const DEFAULT_TASK_MEDIA_MAX_MB = 30;
+const DEFAULT_TASK_ATTACHMENT_MAX_BYTES = DEFAULT_TASK_MEDIA_MAX_MB * BYTES_PER_MEGABYTE;
+const DEFAULT_TASK_ATTACHMENT_FILENAME = "attachment";
+const SIZE_DISPLAY_FRACTION_DIGITS = 0;
+
+type FeishuApiResponse = {
+  code?: number;
+  msg?: string;
+  log_id?: string;
+  logId?: string;
+};
+
+function ensureFeishuOk<T extends FeishuApiResponse>(context: string, response: T): T {
+  if (response.code === undefined || response.code === 0) {
+    return response;
+  }
+  const logId = response.log_id ?? response.logId;
+  if (logId) {
+    throw new Error(`${context} failed: ${response.msg}, code=${response.code}, log_id=${logId}`);
+  }
+  throw new Error(`${context} failed: ${response.msg}, code=${response.code}`);
+}
+
+async function runTaskApiCall<T extends FeishuApiResponse>(
+  context: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return ensureFeishuOk(context, await fn());
+}
+
+function omitUndefined<T extends Record<string, unknown>>(obj: T): T {
+  return Object.fromEntries(Object.entries(obj).filter(([, value]) => value !== undefined)) as T;
+}
+
+function inferUpdateFields(task: TaskUpdateTask): string[] {
+  return Object.keys(task).filter((field) => SUPPORTED_PATCH_FIELDS.has(field));
+}
+
+function ensureSupportedUpdateFields(
+  updateFields: string[],
+  supported: Set<string>,
+  resource: "task" | "tasklist" | "comment",
+) {
+  const invalid = updateFields.filter((field) => !supported.has(field));
+  if (invalid.length > 0) {
+    throw new Error(`unsupported ${resource} update_fields: ${invalid.join(", ")}`);
+  }
+}
+
+function inferCommentUpdateFields(comment: Record<string, unknown>): string[] {
+  return Object.keys(comment).filter((field) => SUPPORTED_COMMENT_PATCH_FIELDS.has(field));
+}
+
+function inferTasklistUpdateFields(tasklist: TasklistPatchTasklist): string[] {
+  return Object.keys(tasklist).filter((field) => SUPPORTED_TASKLIST_PATCH_FIELDS.has(field));
+}
+
+function formatTask(task: Record<string, unknown> | undefined) {
+  if (!task) return undefined;
+  return {
+    guid: task.guid,
+    task_id: task.task_id,
+    summary: task.summary,
+    description: task.description,
+    status: task.status,
+    url: task.url,
+    created_at: task.created_at,
+    updated_at: task.updated_at,
+    completed_at: task.completed_at,
+    due: task.due,
+    start: task.start,
+    is_milestone: task.is_milestone,
+    members: task.members,
+    tasklists: task.tasklists,
+  };
+}
+
+function formatTasklist(tasklist: Record<string, unknown> | undefined) {
+  if (!tasklist) return undefined;
+  return {
+    guid: tasklist.guid,
+    name: tasklist.name,
+    creator: tasklist.creator,
+    owner: tasklist.owner,
+    members: tasklist.members,
+    url: tasklist.url,
+    created_at: tasklist.created_at,
+    updated_at: tasklist.updated_at,
+    archive_msec: tasklist.archive_msec,
+  };
+}
+
+function formatAttachment(attachment: Record<string, unknown> | undefined) {
+  if (!attachment) return undefined;
+  return {
+    guid: attachment.guid,
+    file_token: attachment.file_token,
+    name: attachment.name,
+    size: attachment.size,
+    uploader: attachment.uploader,
+    is_cover: attachment.is_cover,
+    uploaded_at: attachment.uploaded_at,
+    url: attachment.url,
+    resource: attachment.resource,
+  };
+}
+
+function formatComment(comment: Record<string, unknown> | undefined) {
+  if (!comment) return undefined;
+  // The exact response shape can vary by endpoint; normalize common fields.
+  return {
+    comment_id: comment.comment_id ?? comment.id,
+    task_guid: comment.task_guid,
+    content: comment.content,
+    creator: comment.creator,
+    reply_to_comment_id: comment.reply_to_comment_id,
+    created_at: comment.created_at,
+    updated_at: comment.updated_at,
+  };
+}
+
+function sanitizeUploadFilename(input: string) {
+  const base = path.basename(input.trim());
+  return base.length > 0 ? base : DEFAULT_TASK_ATTACHMENT_FILENAME;
+}
+
+async function ensureUploadableLocalFile(filePath: string, maxBytes: number) {
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(filePath);
+  } catch {
+    throw new Error(`file_path not found: ${filePath}`);
+  }
+
+  if (!stat.isFile()) {
+    throw new Error(`file_path is not a regular file: ${filePath}`);
+  }
+
+  if (stat.size > maxBytes) {
+    throw new Error(
+      `file_path exceeds ${(maxBytes / BYTES_PER_MEGABYTE).toFixed(SIZE_DISPLAY_FRACTION_DIGITS)}MB limit: ${filePath}`,
+    );
+  }
+}
+
+async function saveBufferToTempFile(buffer: Buffer, fileName: string) {
+  const safeName = sanitizeUploadFilename(fileName);
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "feishu-task-attachment-"));
+  const tempPath = path.join(tempDir, safeName);
+
+  await fs.promises.writeFile(tempPath, buffer);
+
+  return {
+    tempPath,
+    cleanup: async () => {
+      await fs.promises.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+    },
+  };
+}
+
+async function downloadToTempFile(fileUrl: string, filename: string | undefined, maxBytes: number) {
+  const loaded = await getFeishuRuntime().media.loadWebMedia(fileUrl, {
+    maxBytes,
+    optimizeImages: false,
+  });
+
+  const parsedPath = (() => {
+    try {
+      return new URL(fileUrl).pathname;
+    } catch {
+      return "";
+    }
+  })();
+
+  const fallbackName = path.basename(parsedPath) || DEFAULT_TASK_ATTACHMENT_FILENAME;
+  const preferredName = filename?.trim() ? filename : (loaded.fileName ?? fallbackName);
+  return saveBufferToTempFile(loaded.buffer, preferredName);
+}
+
+export async function createTask(client: TaskClient, params: CreateTaskParams) {
+  const res = await runTaskApiCall("task.v2.task.create", () =>
+    client.task.v2.task.create({
+      data: omitUndefined({
+        summary: params.summary,
+        description: params.description,
+        due: params.due,
+        start: params.start,
+        extra: params.extra,
+        completed_at: params.completed_at,
+        members: params.members,
+        repeat_rule: params.repeat_rule,
+        tasklists: params.tasklists,
+        mode: params.mode,
+        is_milestone: params.is_milestone,
+      }),
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined),
+  };
+}
+
+export async function createSubtask(client: TaskClient, params: CreateSubtaskParams) {
+  const res = await runTaskApiCall("task.v2.taskSubtask.create", () =>
+    client.task.v2.taskSubtask.create({
+      path: { task_guid: params.task_guid },
+      data: omitUndefined({
+        summary: params.summary,
+        description: params.description,
+        due: params.due,
+        start: params.start,
+        extra: params.extra,
+        completed_at: params.completed_at,
+        members: params.members,
+        repeat_rule: params.repeat_rule,
+        tasklists: params.tasklists,
+        mode: params.mode,
+        is_milestone: params.is_milestone,
+      }),
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    subtask: formatTask((res.data?.subtask ?? undefined) as Record<string, unknown> | undefined),
+  };
+}
+
+export async function createTaskComment(client: TaskClient, params: CreateTaskCommentParams) {
+  const res = await runTaskApiCall("task.v2.comment.create", () =>
+    client.task.v2.comment.create({
+      data: omitUndefined({
+        resource_type: "task",
+        resource_id: params.task_guid,
+        content: params.content,
+        reply_to_comment_id: params.reply_to_comment_id,
+      }),
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  const data = (res.data ?? undefined) as Record<string, unknown> | undefined;
+  const comment = (data?.comment ?? data) as Record<string, unknown> | undefined;
+  return {
+    comment: formatComment(comment),
+  };
+}
+
+export async function listTaskComments(client: TaskClient, params: ListTaskCommentsParams) {
+  const res = await runTaskApiCall("task.v2.comment.list", () =>
+    client.task.v2.comment.list({
+      params: omitUndefined({
+        resource_type: "task",
+        resource_id: params.task_guid,
+        page_size: params.page_size,
+        page_token: params.page_token,
+        direction: params.direction,
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  const data = (res.data ?? undefined) as Record<string, unknown> | undefined;
+  const items = ((data?.items ?? data?.comments ?? []) as Record<string, unknown>[]).map((i) =>
+    formatComment(i),
+  );
+
+  return {
+    task_guid: params.task_guid,
+    has_more: (data?.has_more as boolean | undefined) ?? undefined,
+    page_token: (data?.page_token as string | undefined) ?? undefined,
+    items,
+  };
+}
+
+export async function getTaskComment(client: TaskClient, params: GetTaskCommentParams) {
+  const res = await runTaskApiCall("task.v2.comment.get", () =>
+    client.task.v2.comment.get({
+      path: { comment_id: params.comment_id },
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  const data = (res.data ?? undefined) as Record<string, unknown> | undefined;
+  const comment = (data?.comment ?? data) as Record<string, unknown> | undefined;
+  return {
+    comment: formatComment(comment),
+  };
+}
+
+export async function updateTaskComment(client: TaskClient, params: UpdateTaskCommentParams) {
+  const inferred = inferCommentUpdateFields(params.comment as unknown as Record<string, unknown>);
+  const updateFields = (params.update_fields ?? inferred) as string[];
+  if (updateFields.length === 0) {
+    throw new Error("update_fields is required (or provide comment fields to infer)");
+  }
+  ensureSupportedUpdateFields(updateFields, SUPPORTED_COMMENT_PATCH_FIELDS, "comment");
+
+  const res = await runTaskApiCall("task.v2.comment.patch", () =>
+    client.task.v2.comment.patch({
+      path: { comment_id: params.comment_id },
+      data: {
+        comment: params.comment,
+        update_fields: updateFields,
+      },
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  const data = (res.data ?? undefined) as Record<string, unknown> | undefined;
+  const comment = (data?.comment ?? data) as Record<string, unknown> | undefined;
+  return {
+    comment: formatComment(comment),
+  };
+}
+
+export async function deleteTaskComment(client: TaskClient, params: DeleteTaskCommentParams) {
+  await runTaskApiCall("task.v2.comment.delete", () =>
+    client.task.v2.comment.delete({
+      path: { comment_id: params.comment_id },
+    }),
+  );
+
+  return {
+    success: true,
+    comment_id: params.comment_id,
+  };
+}
+
+export async function createTasklist(client: TaskClient, params: CreateTasklistParams) {
+  const res = await runTaskApiCall("task.v2.tasklist.create", () =>
+    client.task.v2.tasklist.create({
+      data: omitUndefined({
+        name: params.name,
+        members: params.members,
+        archive_tasklist: params.archive_tasklist,
+      }),
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    tasklist: formatTasklist(
+      (res.data?.tasklist ?? undefined) as Record<string, unknown> | undefined,
+    ),
+  };
+}
+
+export async function deleteTaskAttachment(client: TaskClient, params: DeleteTaskAttachmentParams) {
+  await runTaskApiCall("task.v2.attachment.delete", () =>
+    client.task.v2.attachment.delete({
+      path: { attachment_guid: params.attachment_guid },
+    }),
+  );
+
+  return {
+    success: true,
+    attachment_guid: params.attachment_guid,
+  };
+}
+
+export async function deleteTask(client: TaskClient, taskGuid: string) {
+  await runTaskApiCall("task.v2.task.delete", () =>
+    client.task.v2.task.delete({
+      path: { task_guid: taskGuid },
+    }),
+  );
+
+  return {
+    success: true,
+    task_guid: taskGuid,
+  };
+}
+
+export async function deleteTasklist(client: TaskClient, tasklistGuid: string) {
+  await runTaskApiCall("task.v2.tasklist.delete", () =>
+    client.task.v2.tasklist.delete({
+      path: { tasklist_guid: tasklistGuid },
+    }),
+  );
+
+  return {
+    success: true,
+    tasklist_guid: tasklistGuid,
+  };
+}
+
+export async function getTask(client: TaskClient, params: GetTaskParams) {
+  const res = await runTaskApiCall("task.v2.task.get", () =>
+    client.task.v2.task.get({
+      path: { task_guid: params.task_guid },
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined),
+  };
+}
+
+export async function getTasklist(client: TaskClient, params: GetTasklistParams) {
+  const res = await runTaskApiCall("task.v2.tasklist.get", () =>
+    client.task.v2.tasklist.get({
+      path: { tasklist_guid: params.tasklist_guid },
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    tasklist: formatTasklist(
+      (res.data?.tasklist ?? undefined) as Record<string, unknown> | undefined,
+    ),
+  };
+}
+
+export async function listTasklistTasks(client: TaskClient, params: ListTasklistTasksParams) {
+  const res = await runTaskApiCall(
+    "task.v2.tasklist.tasks",
+    () =>
+      client.request({
+        method: "GET",
+        url: `/open-apis/task/v2/tasklists/${encodeURIComponent(params.tasklist_guid)}/tasks`,
+        params: omitUndefined({
+          page_size: params.page_size,
+          page_token: params.page_token,
+          completed: params.completed,
+          created_from: params.created_from,
+          created_to: params.created_to,
+          user_id_type: params.user_id_type,
+        }),
+      }) as Promise<{
+        code?: number;
+        msg?: string;
+        log_id?: string;
+        data?: {
+          items?: Record<string, unknown>[];
+          page_token?: string;
+          has_more?: boolean;
+        };
+      }>,
+  );
+
+  const items = (res.data?.items ?? []) as Record<string, unknown>[];
+
+  return {
+    tasklist_guid: params.tasklist_guid,
+    items: items.map((item) => formatTask(item)),
+    page_token: res.data?.page_token,
+    has_more: res.data?.has_more,
+  };
+}
+
+export async function listTasklists(client: TaskClient, params: ListTasklistsParams) {
+  const res = await runTaskApiCall("task.v2.tasklist.list", () =>
+    client.task.v2.tasklist.list({
+      params: omitUndefined({
+        page_size: params.page_size,
+        page_token: params.page_token,
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  const items = (res.data?.items ?? []) as Record<string, unknown>[];
+
+  return {
+    items: items.map((item) => formatTasklist(item)),
+    page_token: res.data?.page_token,
+    has_more: res.data?.has_more,
+  };
+}
+
+export async function getTaskAttachment(client: TaskClient, params: GetTaskAttachmentParams) {
+  const res = await runTaskApiCall("task.v2.attachment.get", () =>
+    client.task.v2.attachment.get({
+      path: { attachment_guid: params.attachment_guid },
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    attachment: formatAttachment(
+      (res.data?.attachment ?? undefined) as Record<string, unknown> | undefined,
+    ),
+  };
+}
+
+export async function listTaskAttachments(client: TaskClient, params: ListTaskAttachmentsParams) {
+  const res = await runTaskApiCall("task.v2.attachment.list", () =>
+    client.task.v2.attachment.list({
+      params: omitUndefined({
+        resource_type: "task",
+        resource_id: params.task_guid,
+        page_size: params.page_size,
+        page_token: params.page_token,
+        updated_mesc: params.updated_mesc,
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  const items = (res.data?.items ?? []) as Record<string, unknown>[];
+
+  return {
+    items: items.map((item) => formatAttachment(item)),
+    page_token: res.data?.page_token,
+    has_more: res.data?.has_more,
+  };
+}
+
+export async function updateTask(client: TaskClient, params: UpdateTaskParams) {
+  const task = omitUndefined(params.task as Record<string, unknown>) as TaskUpdateTask;
+  const updateFields = params.update_fields?.length
+    ? params.update_fields
+    : inferUpdateFields(task);
+  ensureSupportedUpdateFields(updateFields, SUPPORTED_PATCH_FIELDS, "task");
+
+  if (Object.keys(task).length === 0) {
+    throw new Error("task update payload is empty");
+  }
+  if (updateFields.length === 0) {
+    throw new Error("no valid update_fields provided or inferred from task payload");
+  }
+
+  const res = await runTaskApiCall("task.v2.task.patch", () =>
+    client.task.v2.task.patch({
+      path: { task_guid: params.task_guid },
+      data: {
+        task,
+        update_fields: updateFields,
+      },
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined),
+    update_fields: updateFields,
+  };
+}
+
+export async function addTaskToTasklist(client: TaskClient, params: AddTaskToTasklistParams) {
+  const res = await runTaskApiCall("task.v2.task.add_tasklist", () =>
+    client.task.v2.task.addTasklist({
+      path: { task_guid: params.task_guid },
+      data: omitUndefined({
+        tasklist_guid: params.tasklist_guid,
+        section_guid: params.section_guid,
+      }),
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined),
+  };
+}
+
+export async function removeTaskFromTasklist(
+  client: TaskClient,
+  params: RemoveTaskFromTasklistParams,
+) {
+  const res = await runTaskApiCall("task.v2.task.remove_tasklist", () =>
+    client.task.v2.task.removeTasklist({
+      path: { task_guid: params.task_guid },
+      data: omitUndefined({
+        tasklist_guid: params.tasklist_guid,
+      }),
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined),
+  };
+}
+
+export async function updateTasklist(client: TaskClient, params: UpdateTasklistParams) {
+  const tasklist = omitUndefined(
+    params.tasklist as Record<string, unknown>,
+  ) as TasklistPatchTasklist;
+  const updateFields = params.update_fields?.length
+    ? params.update_fields
+    : inferTasklistUpdateFields(tasklist);
+  ensureSupportedUpdateFields(updateFields, SUPPORTED_TASKLIST_PATCH_FIELDS, "tasklist");
+
+  if (Object.keys(tasklist).length === 0) {
+    throw new Error("tasklist update payload is empty");
+  }
+  if (updateFields.length === 0) {
+    throw new Error("no valid update_fields provided or inferred from tasklist payload");
+  }
+
+  const res = await runTaskApiCall("task.v2.tasklist.patch", () =>
+    client.task.v2.tasklist.patch({
+      path: { tasklist_guid: params.tasklist_guid },
+      data: omitUndefined({
+        tasklist,
+        update_fields: updateFields,
+        origin_owner_to_role: params.origin_owner_to_role,
+      }),
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    tasklist: formatTasklist(
+      (res.data?.tasklist ?? undefined) as Record<string, unknown> | undefined,
+    ),
+    update_fields: updateFields,
+  };
+}
+
+export async function addTasklistMembers(client: TaskClient, params: AddTasklistMembersParams) {
+  const res = await runTaskApiCall("task.v2.tasklist.addMembers", () =>
+    client.task.v2.tasklist.addMembers({
+      path: { tasklist_guid: params.tasklist_guid },
+      data: {
+        members: params.members,
+      },
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    tasklist: formatTasklist(
+      (res.data?.tasklist ?? undefined) as Record<string, unknown> | undefined,
+    ),
+  };
+}
+
+export async function removeTasklistMembers(
+  client: TaskClient,
+  params: RemoveTasklistMembersParams,
+) {
+  const res = await runTaskApiCall("task.v2.tasklist.removeMembers", () =>
+    client.task.v2.tasklist.removeMembers({
+      path: { tasklist_guid: params.tasklist_guid },
+      data: {
+        members: params.members,
+      },
+      params: omitUndefined({
+        user_id_type: params.user_id_type,
+      }),
+    }),
+  );
+
+  return {
+    tasklist: formatTasklist(
+      (res.data?.tasklist ?? undefined) as Record<string, unknown> | undefined,
+    ),
+  };
+}
+
+export async function uploadTaskAttachment(
+  client: TaskClient,
+  params: UploadTaskAttachmentParams,
+  options?: { maxBytes?: number },
+) {
+  const maxBytes =
+    typeof options?.maxBytes === "number" && options.maxBytes > 0
+      ? options.maxBytes
+      : DEFAULT_TASK_ATTACHMENT_MAX_BYTES;
+
+  let tempCleanup: (() => Promise<void>) | undefined;
+  let filePath: string;
+
+  if (params.file_path && params.file_url) {
+    throw new Error("Provide exactly one of file_path or file_url");
+  }
+
+  if (params.file_path) {
+    filePath = params.file_path;
+    await ensureUploadableLocalFile(filePath, maxBytes);
+  } else if (params.file_url) {
+    const download = await downloadToTempFile(params.file_url, params.filename, maxBytes);
+    filePath = download.tempPath;
+    tempCleanup = download.cleanup;
+  } else {
+    throw new Error("Either file_path or file_url is required");
+  }
+
+  try {
+    const res = await runTaskApiCall("task.v2.attachment.upload", async () => {
+      const uploadResponse = await client.task.v2.attachment.upload({
+        data: {
+          resource_type: "task",
+          resource_id: params.task_guid,
+          file: fs.createReadStream(filePath),
+        },
+        params: omitUndefined({
+          user_id_type: params.user_id_type,
+        }),
+      });
+
+      // Task attachment upload in the Feishu SDK returns `res.data` directly
+      // (not the usual `{ code, msg, data }` envelope). Some SDK versions may still
+      // expose `{ code, msg }` on failure, so normalize that shape.
+      const raw = uploadResponse as {
+        code?: number;
+        msg?: string;
+        log_id?: string;
+        logId?: string;
+        data?: { items?: Record<string, unknown>[] };
+        items?: Record<string, unknown>[];
+      } | null;
+
+      return {
+        code: raw?.code ?? 0,
+        msg: raw?.msg,
+        log_id: raw?.log_id ?? raw?.logId,
+        data: raw?.data ?? raw,
+      };
+    });
+
+    const responseData = res.data as
+      | {
+          items?: Record<string, unknown>[];
+          data?: { items?: Record<string, unknown>[] };
+        }
+      | undefined;
+    const items = (responseData?.items ?? responseData?.data?.items ?? []) as Record<
+      string,
+      unknown
+    >[];
+    if (items.length === 0) {
+      throw new Error("task.v2.attachment.upload failed: no attachment items returned");
+    }
+
+    return {
+      items: items.map((item) => formatAttachment(item)),
+    };
+  } finally {
+    if (tempCleanup) {
+      await tempCleanup();
+    }
+  }
+}

--- a/extensions/feishu/src/task-schema.ts
+++ b/extensions/feishu/src/task-schema.ts
@@ -1,0 +1,593 @@
+import { Type } from "@sinclair/typebox";
+import { createFeishuClient } from "./client.js";
+
+export type TaskClient = ReturnType<typeof createFeishuClient>;
+
+type TaskCreatePayload = NonNullable<Parameters<TaskClient["task"]["v2"]["task"]["create"]>[0]>;
+type TaskUpdatePayload = NonNullable<Parameters<TaskClient["task"]["v2"]["task"]["patch"]>[0]>;
+type TaskDeletePayload = NonNullable<Parameters<TaskClient["task"]["v2"]["task"]["delete"]>[0]>;
+type TaskGetPayload = NonNullable<Parameters<TaskClient["task"]["v2"]["task"]["get"]>[0]>;
+type TaskAddTasklistPayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["task"]["addTasklist"]>[0]
+>;
+type TaskRemoveTasklistPayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["task"]["removeTasklist"]>[0]
+>;
+type TaskCommentCreatePayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["comment"]["create"]>[0]
+>;
+type TaskCommentGetPayload = NonNullable<Parameters<TaskClient["task"]["v2"]["comment"]["get"]>[0]>;
+type TaskCommentListPayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["comment"]["list"]>[0]
+>;
+type TaskCommentPatchPayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["comment"]["patch"]>[0]
+>;
+type TaskCommentDeletePayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["comment"]["delete"]>[0]
+>;
+type TaskAttachmentUploadPayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["attachment"]["upload"]>[0]
+>;
+type TaskAttachmentGetPayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["attachment"]["get"]>[0]
+>;
+type TaskAttachmentListPayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["attachment"]["list"]>[0]
+>;
+type TaskAttachmentDeletePayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["attachment"]["delete"]>[0]
+>;
+type TasklistCreatePayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["tasklist"]["create"]>[0]
+>;
+type TasklistGetPayload = NonNullable<Parameters<TaskClient["task"]["v2"]["tasklist"]["get"]>[0]>;
+type TasklistListPayload = NonNullable<Parameters<TaskClient["task"]["v2"]["tasklist"]["list"]>[0]>;
+type TasklistPatchPayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["tasklist"]["patch"]>[0]
+>;
+type TasklistDeletePayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["tasklist"]["delete"]>[0]
+>;
+type TasklistAddMembersPayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["tasklist"]["addMembers"]>[0]
+>;
+type TasklistRemoveMembersPayload = NonNullable<
+  Parameters<TaskClient["task"]["v2"]["tasklist"]["removeMembers"]>[0]
+>;
+
+export type TaskCreateData = TaskCreatePayload["data"];
+export type TaskUpdateData = TaskUpdatePayload["data"];
+export type TaskUpdateTask = NonNullable<TaskUpdateData["task"]>;
+export type TaskCommentPatchData = TaskCommentPatchPayload["data"];
+export type TaskCommentPatchComment = TaskCommentPatchData["comment"];
+export type TasklistCreateData = TasklistCreatePayload["data"];
+export type TasklistPatchData = TasklistPatchPayload["data"];
+export type TasklistPatchTasklist = NonNullable<TasklistPatchData["tasklist"]>;
+export type TasklistMember = NonNullable<NonNullable<TasklistCreateData["members"]>[number]>;
+
+export const TASK_UPDATE_FIELD_VALUES = [
+  "summary",
+  "description",
+  "due",
+  "start",
+  "extra",
+  "completed_at",
+  "repeat_rule",
+  "mode",
+  "is_milestone",
+] as const;
+export const TASKLIST_UPDATE_FIELD_VALUES = ["name", "owner", "archive_tasklist"] as const;
+
+export type CreateTaskParams = {
+  summary: TaskCreateData["summary"];
+  description?: TaskCreateData["description"];
+  due?: TaskCreateData["due"];
+  start?: TaskCreateData["start"];
+  extra?: TaskCreateData["extra"];
+  completed_at?: TaskCreateData["completed_at"];
+  members?: TaskCreateData["members"];
+  repeat_rule?: TaskCreateData["repeat_rule"];
+  tasklists?: TaskCreateData["tasklists"];
+  mode?: TaskCreateData["mode"];
+  is_milestone?: TaskCreateData["is_milestone"];
+  user_id_type?: NonNullable<TaskCreatePayload["params"]>["user_id_type"];
+};
+
+export type CreateSubtaskParams = CreateTaskParams & {
+  task_guid: string;
+};
+
+export type DeleteTaskParams = {
+  task_guid: TaskDeletePayload["path"]["task_guid"];
+};
+
+export type GetTaskParams = {
+  task_guid: TaskGetPayload["path"]["task_guid"];
+  user_id_type?: NonNullable<TaskGetPayload["params"]>["user_id_type"];
+};
+
+export type UpdateTaskParams = {
+  task_guid: TaskUpdatePayload["path"]["task_guid"];
+  task: TaskUpdateTask;
+  update_fields?: TaskUpdateData["update_fields"];
+  user_id_type?: NonNullable<TaskUpdatePayload["params"]>["user_id_type"];
+};
+
+export type AddTaskToTasklistParams = {
+  task_guid: TaskAddTasklistPayload["path"]["task_guid"];
+  tasklist_guid: NonNullable<TaskAddTasklistPayload["data"]>["tasklist_guid"];
+  section_guid?: NonNullable<TaskAddTasklistPayload["data"]>["section_guid"];
+  user_id_type?: NonNullable<TaskAddTasklistPayload["params"]>["user_id_type"];
+};
+
+export type RemoveTaskFromTasklistParams = {
+  task_guid: TaskRemoveTasklistPayload["path"]["task_guid"];
+  tasklist_guid: NonNullable<TaskRemoveTasklistPayload["data"]>["tasklist_guid"];
+  user_id_type?: NonNullable<TaskRemoveTasklistPayload["params"]>["user_id_type"];
+};
+
+export type CreateTaskCommentParams = {
+  task_guid: string;
+  content: TaskCommentCreatePayload["data"]["content"];
+  reply_to_comment_id?: TaskCommentCreatePayload["data"]["reply_to_comment_id"];
+  user_id_type?: NonNullable<TaskCommentCreatePayload["params"]>["user_id_type"];
+};
+
+export type ListTaskCommentsParams = {
+  task_guid: string;
+  page_size?: NonNullable<TaskCommentListPayload["params"]>["page_size"];
+  page_token?: NonNullable<TaskCommentListPayload["params"]>["page_token"];
+  direction?: NonNullable<TaskCommentListPayload["params"]>["direction"];
+  user_id_type?: NonNullable<TaskCommentListPayload["params"]>["user_id_type"];
+};
+
+export type GetTaskCommentParams = {
+  comment_id: TaskCommentGetPayload["path"]["comment_id"];
+  user_id_type?: NonNullable<TaskCommentGetPayload["params"]>["user_id_type"];
+};
+
+export type UpdateTaskCommentParams = {
+  comment_id: TaskCommentPatchPayload["path"]["comment_id"];
+  comment: TaskCommentPatchComment;
+  update_fields?: TaskCommentPatchData["update_fields"];
+  user_id_type?: NonNullable<TaskCommentPatchPayload["params"]>["user_id_type"];
+};
+
+export type DeleteTaskCommentParams = {
+  comment_id: TaskCommentDeletePayload["path"]["comment_id"];
+};
+
+export type UploadTaskAttachmentParams = {
+  task_guid: string;
+  file_path?: string;
+  file_url?: string;
+  filename?: string;
+  user_id_type?: NonNullable<TaskAttachmentUploadPayload["params"]>["user_id_type"];
+};
+
+export type ListTaskAttachmentsParams = {
+  task_guid: NonNullable<TaskAttachmentListPayload["params"]>["resource_id"];
+  page_size?: NonNullable<TaskAttachmentListPayload["params"]>["page_size"];
+  page_token?: NonNullable<TaskAttachmentListPayload["params"]>["page_token"];
+  updated_mesc?: NonNullable<TaskAttachmentListPayload["params"]>["updated_mesc"];
+  user_id_type?: NonNullable<TaskAttachmentListPayload["params"]>["user_id_type"];
+};
+
+export type GetTaskAttachmentParams = {
+  attachment_guid: TaskAttachmentGetPayload["path"]["attachment_guid"];
+  user_id_type?: NonNullable<TaskAttachmentGetPayload["params"]>["user_id_type"];
+};
+
+export type DeleteTaskAttachmentParams = {
+  attachment_guid: NonNullable<TaskAttachmentDeletePayload["path"]>["attachment_guid"];
+};
+
+export type CreateTasklistParams = {
+  name: TasklistCreateData["name"];
+  members?: TasklistCreateData["members"];
+  archive_tasklist?: TasklistCreateData["archive_tasklist"];
+  user_id_type?: NonNullable<TasklistCreatePayload["params"]>["user_id_type"];
+};
+
+export type GetTasklistParams = {
+  tasklist_guid: NonNullable<TasklistGetPayload["path"]>["tasklist_guid"];
+  user_id_type?: NonNullable<TasklistGetPayload["params"]>["user_id_type"];
+};
+
+export type ListTasklistTasksParams = {
+  tasklist_guid: string;
+  page_size?: number;
+  page_token?: string;
+  completed?: boolean;
+  created_from?: string;
+  created_to?: string;
+  user_id_type?: string;
+};
+
+export type ListTasklistsParams = {
+  page_size?: NonNullable<TasklistListPayload["params"]>["page_size"];
+  page_token?: NonNullable<TasklistListPayload["params"]>["page_token"];
+  user_id_type?: NonNullable<TasklistListPayload["params"]>["user_id_type"];
+};
+
+export type UpdateTasklistParams = {
+  tasklist_guid: NonNullable<TasklistPatchPayload["path"]>["tasklist_guid"];
+  tasklist: TasklistPatchTasklist;
+  update_fields?: TasklistPatchData["update_fields"];
+  origin_owner_to_role?: TasklistPatchData["origin_owner_to_role"];
+  user_id_type?: NonNullable<TasklistPatchPayload["params"]>["user_id_type"];
+};
+
+export type DeleteTasklistParams = {
+  tasklist_guid: NonNullable<TasklistDeletePayload["path"]>["tasklist_guid"];
+};
+
+export type AddTasklistMembersParams = {
+  tasklist_guid: NonNullable<TasklistAddMembersPayload["path"]>["tasklist_guid"];
+  members: NonNullable<NonNullable<TasklistAddMembersPayload["data"]>["members"]>;
+  user_id_type?: NonNullable<TasklistAddMembersPayload["params"]>["user_id_type"];
+};
+
+export type RemoveTasklistMembersParams = {
+  tasklist_guid: NonNullable<TasklistRemoveMembersPayload["path"]>["tasklist_guid"];
+  members: NonNullable<NonNullable<TasklistRemoveMembersPayload["data"]>["members"]>;
+  user_id_type?: NonNullable<TasklistRemoveMembersPayload["params"]>["user_id_type"];
+};
+
+const TaskDateSchema = Type.Object({
+  timestamp: Type.Optional(
+    Type.String({
+      description: 'Unix timestamp in milliseconds (string), e.g. "1735689600000" (13-digit ms)',
+    }),
+  ),
+  is_all_day: Type.Optional(Type.Boolean({ description: "Whether this is an all-day date" })),
+});
+
+const TaskMemberSchema = Type.Object({
+  id: Type.String({ description: "Member ID (with type controlled by user_id_type)" }),
+  type: Type.Optional(Type.String({ description: 'Member type (usually "user")' })),
+  role: Type.String({ description: 'Member role, e.g. "assignee"' }),
+  name: Type.Optional(Type.String({ description: "Optional display name" })),
+});
+
+const TasklistRefSchema = Type.Object({
+  tasklist_guid: Type.Optional(Type.String({ description: "Tasklist GUID" })),
+  section_guid: Type.Optional(Type.String({ description: "Section GUID in tasklist" })),
+});
+
+const TaskUpdateFieldSchema = Type.Union(
+  TASK_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
+);
+
+const TasklistMemberRoleSchema = Type.Union(
+  [Type.Literal("owner"), Type.Literal("editor"), Type.Literal("viewer")],
+  { description: "Member role (owner/editor/viewer)" },
+);
+
+const TasklistUpdateFieldSchema = Type.Union(
+  TASKLIST_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
+);
+
+const TasklistOriginOwnerRoleSchema = Type.Union(
+  [Type.Literal("editor"), Type.Literal("viewer"), Type.Literal("none")],
+  { description: "Role for original owner after owner transfer" },
+);
+
+const TasklistMemberSchema = Type.Object({
+  id: Type.String({ description: "Member ID (with type controlled by user_id_type)" }),
+  type: Type.Optional(Type.String({ description: "Member type (user/chat/app)" })),
+  role: Type.Optional(TasklistMemberRoleSchema),
+  name: Type.Optional(Type.String({ description: "Optional display name" })),
+});
+
+export const CreateTaskSchema = Type.Object({
+  summary: Type.String({ description: "Task title/summary" }),
+  description: Type.Optional(Type.String({ description: "Task description" })),
+  due: Type.Optional(TaskDateSchema),
+  start: Type.Optional(TaskDateSchema),
+  extra: Type.Optional(Type.String({ description: "Custom opaque metadata string" })),
+  completed_at: Type.Optional(
+    Type.String({
+      description: "Completion time as Unix timestamp in milliseconds (string, 13-digit ms)",
+    }),
+  ),
+  members: Type.Optional(Type.Array(TaskMemberSchema, { description: "Initial task members" })),
+  repeat_rule: Type.Optional(Type.String({ description: "Task repeat rule" })),
+  tasklists: Type.Optional(
+    Type.Array(TasklistRefSchema, { description: "Attach the task to tasklists/sections" }),
+  ),
+  mode: Type.Optional(Type.Number({ description: "Task mode value from Feishu Task API" })),
+  is_milestone: Type.Optional(Type.Boolean({ description: "Whether task is a milestone" })),
+  user_id_type: Type.Optional(
+    Type.String({
+      description: "User ID type for member IDs, e.g. open_id/user_id/union_id",
+    }),
+  ),
+});
+
+export const CreateSubtaskSchema = Type.Object({
+  task_guid: Type.String({ description: "Parent task GUID" }),
+  ...CreateTaskSchema.properties,
+});
+
+export const DeleteTaskSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to delete" }),
+});
+
+export const GetTaskSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to retrieve" }),
+  user_id_type: Type.Optional(
+    Type.String({
+      description: "User ID type in returned members, e.g. open_id/user_id/union_id",
+    }),
+  ),
+});
+
+const TaskUpdateContentSchema = Type.Object(
+  {
+    summary: Type.Optional(Type.String({ description: "Updated summary" })),
+    description: Type.Optional(Type.String({ description: "Updated description" })),
+    due: Type.Optional(TaskDateSchema),
+    start: Type.Optional(TaskDateSchema),
+    extra: Type.Optional(Type.String({ description: "Updated extra metadata" })),
+    completed_at: Type.Optional(
+      Type.String({
+        description:
+          "Updated completion time (Unix timestamp in milliseconds, string, 13-digit ms)",
+      }),
+    ),
+    repeat_rule: Type.Optional(Type.String({ description: "Updated repeat rule" })),
+    mode: Type.Optional(Type.Number({ description: "Updated task mode" })),
+    is_milestone: Type.Optional(Type.Boolean({ description: "Updated milestone flag" })),
+  },
+  { minProperties: 1 },
+);
+
+export const UpdateTaskSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to update" }),
+  task: TaskUpdateContentSchema,
+  update_fields: Type.Optional(
+    Type.Array(TaskUpdateFieldSchema, {
+      description:
+        "Fields to update. If omitted, this tool infers from keys in task (e.g. summary, description, due, start)",
+      minItems: 1,
+      uniqueItems: true,
+    }),
+  ),
+  user_id_type: Type.Optional(
+    Type.String({
+      description: "User ID type when task body contains user-related fields",
+    }),
+  ),
+});
+
+export const CreateTaskCommentSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to comment on" }),
+  content: Type.String({ description: "Comment content" }),
+  reply_to_comment_id: Type.Optional(
+    Type.String({ description: "Reply to a specific comment ID" }),
+  ),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type when comment involves user-related fields" }),
+  ),
+});
+
+export const ListTaskCommentsSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to list comments for" }),
+  page_size: Type.Optional(
+    Type.Number({
+      description: "Page size (1-100)",
+      minimum: 1,
+      maximum: 100,
+    }),
+  ),
+  page_token: Type.Optional(Type.String({ description: "Pagination token" })),
+  direction: Type.Optional(
+    Type.Union([Type.Literal("asc"), Type.Literal("desc")], {
+      description: "Sort direction",
+    }),
+  ),
+  user_id_type: Type.Optional(Type.String({ description: "User ID type for returned creators" })),
+});
+
+export const GetTaskCommentSchema = Type.Object({
+  comment_id: Type.String({ description: "Comment ID to retrieve" }),
+  user_id_type: Type.Optional(Type.String({ description: "User ID type for returned creators" })),
+});
+
+const TaskCommentUpdateContentSchema = Type.Object(
+  {
+    content: Type.Optional(Type.String({ description: "Updated comment content" })),
+  },
+  { minProperties: 1 },
+);
+
+export const UpdateTaskCommentSchema = Type.Object({
+  comment_id: Type.String({ description: "Comment ID to update" }),
+  comment: TaskCommentUpdateContentSchema,
+  update_fields: Type.Optional(
+    Type.Array(Type.String(), {
+      description: "Fields to update. If omitted, this tool infers from keys in comment (content)",
+      minItems: 1,
+    }),
+  ),
+  user_id_type: Type.Optional(Type.String({ description: "User ID type for returned creators" })),
+});
+
+export const DeleteTaskCommentSchema = Type.Object({
+  comment_id: Type.String({ description: "Comment ID to delete" }),
+});
+
+const TasklistUpdateContentSchema = Type.Object(
+  {
+    name: Type.Optional(Type.String({ description: "Updated tasklist name" })),
+    owner: Type.Optional(TasklistMemberSchema),
+    archive_tasklist: Type.Optional(Type.Boolean({ description: "Archive/unarchive tasklist" })),
+  },
+  { minProperties: 1 },
+);
+
+export const AddTaskToTasklistSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to move" }),
+  tasklist_guid: Type.String({ description: "Tasklist GUID to add the task into" }),
+  section_guid: Type.Optional(Type.String({ description: "Tasklist section GUID" })),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type when task body contains user-related fields" }),
+  ),
+});
+
+export const RemoveTaskFromTasklistSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to move" }),
+  tasklist_guid: Type.String({ description: "Tasklist GUID to remove the task from" }),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type when task body contains user-related fields" }),
+  ),
+});
+
+export const CreateTasklistSchema = Type.Object({
+  name: Type.String({ description: "Tasklist name" }),
+  members: Type.Optional(Type.Array(TasklistMemberSchema, { description: "Initial members" })),
+  archive_tasklist: Type.Optional(
+    Type.Boolean({ description: "Whether to create as archived tasklist" }),
+  ),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type for member IDs, e.g. open_id/user_id/union_id" }),
+  ),
+});
+
+export const GetTasklistSchema = Type.Object({
+  tasklist_guid: Type.String({ description: "Tasklist GUID to retrieve" }),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type in returned members, e.g. open_id/user_id/union_id" }),
+  ),
+});
+
+export const ListTasklistsSchema = Type.Object({
+  page_size: Type.Optional(
+    Type.Number({
+      description: "Page size (1-100)",
+      minimum: 1,
+      maximum: 100,
+    }),
+  ),
+  page_token: Type.Optional(Type.String({ description: "Pagination token" })),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type in returned members, e.g. open_id/user_id/union_id" }),
+  ),
+});
+
+export const ListTasklistTasksSchema = Type.Object({
+  tasklist_guid: Type.String({ description: "Tasklist GUID to enumerate tasks from" }),
+  page_size: Type.Optional(
+    Type.Number({
+      description: "Page size for pagination",
+      minimum: 1,
+    }),
+  ),
+  page_token: Type.Optional(Type.String({ description: "Pagination token" })),
+  completed: Type.Optional(
+    Type.Boolean({ description: "Filter by completion status when supported by the API" }),
+  ),
+  created_from: Type.Optional(
+    Type.String({
+      description:
+        "Inclusive lower bound of task creation time, as Unix timestamp in milliseconds (string)",
+    }),
+  ),
+  created_to: Type.Optional(
+    Type.String({
+      description:
+        "Inclusive upper bound of task creation time, as Unix timestamp in milliseconds (string)",
+    }),
+  ),
+  user_id_type: Type.Optional(
+    Type.String({
+      description: "User ID type in returned member/user fields, e.g. open_id/user_id/union_id",
+    }),
+  ),
+});
+
+export const UpdateTasklistSchema = Type.Object({
+  tasklist_guid: Type.String({ description: "Tasklist GUID to update" }),
+  tasklist: TasklistUpdateContentSchema,
+  update_fields: Type.Optional(
+    Type.Array(TasklistUpdateFieldSchema, {
+      description:
+        "Fields to update. If omitted, this tool infers from keys in tasklist (e.g. name, owner, archive_tasklist)",
+      minItems: 1,
+      uniqueItems: true,
+    }),
+  ),
+  origin_owner_to_role: Type.Optional(TasklistOriginOwnerRoleSchema),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type when tasklist body contains user-related fields" }),
+  ),
+});
+
+export const DeleteTasklistSchema = Type.Object({
+  tasklist_guid: Type.String({ description: "Tasklist GUID to delete" }),
+});
+
+export const AddTasklistMembersSchema = Type.Object({
+  tasklist_guid: Type.String({ description: "Tasklist GUID to add members to" }),
+  members: Type.Array(TasklistMemberSchema, {
+    description: "Members to add",
+    minItems: 1,
+  }),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type for member IDs, e.g. open_id/user_id/union_id" }),
+  ),
+});
+
+export const RemoveTasklistMembersSchema = Type.Object({
+  tasklist_guid: Type.String({ description: "Tasklist GUID to remove members from" }),
+  members: Type.Array(TasklistMemberSchema, {
+    description: "Members to remove",
+    minItems: 1,
+  }),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type for member IDs, e.g. open_id/user_id/union_id" }),
+  ),
+});
+
+export const UploadTaskAttachmentSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to upload attachment to" }),
+  file_path: Type.Optional(
+    Type.String({
+      description: "Local file path on the OpenClaw host (provide either file_path or file_url)",
+    }),
+  ),
+  file_url: Type.Optional(
+    Type.String({
+      description: "Remote file URL to download and upload (provide either file_path or file_url)",
+    }),
+  ),
+  filename: Type.Optional(
+    Type.String({ description: "Override filename for uploaded attachment (only with file_url)" }),
+  ),
+  user_id_type: Type.Optional(Type.String({ description: "User ID type for returned uploader" })),
+});
+
+export const ListTaskAttachmentsSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to list attachments for" }),
+  page_size: Type.Optional(
+    Type.Number({
+      description: "Page size (1-100)",
+      minimum: 1,
+      maximum: 100,
+    }),
+  ),
+  page_token: Type.Optional(Type.String({ description: "Pagination token" })),
+  updated_mesc: Type.Optional(Type.String({ description: "Updated timestamp filter" })),
+  user_id_type: Type.Optional(Type.String({ description: "User ID type for returned uploader" })),
+});
+
+export const GetTaskAttachmentSchema = Type.Object({
+  attachment_guid: Type.String({ description: "Attachment GUID to retrieve" }),
+  user_id_type: Type.Optional(Type.String({ description: "User ID type for returned uploader" })),
+});
+
+export const DeleteTaskAttachmentSchema = Type.Object({
+  attachment_guid: Type.String({ description: "Attachment GUID to delete" }),
+});

--- a/extensions/feishu/src/task.ts
+++ b/extensions/feishu/src/task.ts
@@ -1,0 +1,384 @@
+import type { TSchema } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import {
+  addTaskToTasklist,
+  addTasklistMembers,
+  createSubtask,
+  createTask,
+  createTaskComment,
+  createTasklist,
+  deleteTask,
+  deleteTaskAttachment,
+  deleteTaskComment,
+  deleteTasklist,
+  getTask,
+  getTaskAttachment,
+  getTaskComment,
+  getTasklist,
+  listTaskAttachments,
+  listTaskComments,
+  listTasklistTasks,
+  listTasklists,
+  removeTaskFromTasklist,
+  removeTasklistMembers,
+  updateTask,
+  updateTaskComment,
+  updateTasklist,
+  uploadTaskAttachment,
+  BYTES_PER_MEGABYTE,
+  DEFAULT_TASK_MEDIA_MAX_MB,
+} from "./task-actions.js";
+import {
+  type TaskClient,
+  AddTaskToTasklistSchema,
+  type AddTaskToTasklistParams,
+  AddTasklistMembersSchema,
+  type AddTasklistMembersParams,
+  CreateSubtaskSchema,
+  type CreateSubtaskParams,
+  CreateTaskCommentSchema,
+  type CreateTaskCommentParams,
+  CreateTaskSchema,
+  type CreateTaskParams,
+  CreateTasklistSchema,
+  type CreateTasklistParams,
+  DeleteTaskAttachmentSchema,
+  type DeleteTaskAttachmentParams,
+  DeleteTaskCommentSchema,
+  type DeleteTaskCommentParams,
+  DeleteTaskSchema,
+  type DeleteTaskParams,
+  DeleteTasklistSchema,
+  type DeleteTasklistParams,
+  GetTaskAttachmentSchema,
+  type GetTaskAttachmentParams,
+  GetTaskCommentSchema,
+  type GetTaskCommentParams,
+  GetTaskSchema,
+  type GetTaskParams,
+  GetTasklistSchema,
+  type GetTasklistParams,
+  ListTaskAttachmentsSchema,
+  type ListTaskAttachmentsParams,
+  ListTasklistTasksSchema,
+  type ListTasklistTasksParams,
+  ListTaskCommentsSchema,
+  type ListTaskCommentsParams,
+  ListTasklistsSchema,
+  type ListTasklistsParams,
+  RemoveTaskFromTasklistSchema,
+  type RemoveTaskFromTasklistParams,
+  RemoveTasklistMembersSchema,
+  type RemoveTasklistMembersParams,
+  UpdateTaskCommentSchema,
+  type UpdateTaskCommentParams,
+  UpdateTaskSchema,
+  type UpdateTaskParams,
+  UpdateTasklistSchema,
+  type UpdateTasklistParams,
+  UploadTaskAttachmentSchema,
+  type UploadTaskAttachmentParams,
+} from "./task-schema.js";
+import {
+  createFeishuToolClient,
+  resolveAnyEnabledFeishuToolsConfig,
+  resolveFeishuToolAccount,
+} from "./tool-account.js";
+import { resolveToolsConfig } from "./tools-config.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+
+function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    details: data,
+  };
+}
+
+function errorResult(err: unknown) {
+  return json({ error: err instanceof Error ? err.message : String(err) });
+}
+
+type TaskToolSpec<P> = {
+  name: string;
+  label: string;
+  description: string;
+  parameters: TSchema;
+  run: (
+    args: { client: TaskClient; account: ResolvedFeishuAccount },
+    params: P,
+  ) => Promise<unknown>;
+};
+
+function registerTaskTool<P>(api: OpenClawPluginApi, spec: TaskToolSpec<P>) {
+  api.registerTool(
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: spec.name,
+        label: spec.label,
+        description: spec.description,
+        parameters: spec.parameters,
+        async execute(_toolCallId, params) {
+          const p = params as P & { accountId?: string };
+          try {
+            const account = resolveFeishuToolAccount({
+              api,
+              executeParams: p,
+              defaultAccountId,
+            });
+            if (!account.enabled) {
+              throw new Error(`Feishu account "${account.accountId}" is disabled`);
+            }
+            if (!account.configured) {
+              throw new Error(`Feishu account "${account.accountId}" is not configured`);
+            }
+
+            const toolsCfg = resolveToolsConfig(account.config.tools);
+            if (!toolsCfg.task) {
+              throw new Error(
+                `Feishu tool "${spec.name}" is disabled for account "${account.accountId}"`,
+              );
+            }
+
+            const client = createFeishuToolClient({
+              api,
+              executeParams: p,
+              defaultAccountId,
+            }) as TaskClient;
+            return json(await spec.run({ client, account }, p));
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      };
+    },
+    { name: spec.name },
+  );
+}
+
+export function registerFeishuTaskTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_task: No config available, skipping task tools");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_task: No Feishu accounts configured, skipping task tools");
+    return;
+  }
+
+  // Register if enabled on any account; account routing is resolved per execution.
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  if (!toolsCfg.task) {
+    api.logger.debug?.("feishu_task: task tools disabled in config");
+    return;
+  }
+
+  registerTaskTool<CreateTaskParams>(api, {
+    name: "feishu_task_create",
+    label: "Feishu Task Create",
+    description: "Create a Feishu task (task v2)",
+    parameters: CreateTaskSchema,
+    run: async ({ client }, params) => createTask(client, params),
+  });
+
+  registerTaskTool<CreateSubtaskParams>(api, {
+    name: "feishu_task_subtask_create",
+    label: "Feishu Task Subtask Create",
+    description: "Create a Feishu subtask under a parent task (task v2)",
+    parameters: CreateSubtaskSchema,
+    run: async ({ client }, params) => createSubtask(client, params),
+  });
+
+  registerTaskTool<AddTaskToTasklistParams>(api, {
+    name: "feishu_task_add_tasklist",
+    label: "Feishu Task Add Tasklist",
+    description: "Add a task into a tasklist (task v2)",
+    parameters: AddTaskToTasklistSchema,
+    run: async ({ client }, params) => addTaskToTasklist(client, params),
+  });
+
+  registerTaskTool<RemoveTaskFromTasklistParams>(api, {
+    name: "feishu_task_remove_tasklist",
+    label: "Feishu Task Remove Tasklist",
+    description: "Remove a task from a tasklist (task v2)",
+    parameters: RemoveTaskFromTasklistSchema,
+    run: async ({ client }, params) => removeTaskFromTasklist(client, params),
+  });
+
+  registerTaskTool<CreateTasklistParams>(api, {
+    name: "feishu_tasklist_create",
+    label: "Feishu Tasklist Create",
+    description: "Create a Feishu tasklist (task v2)",
+    parameters: CreateTasklistSchema,
+    run: async ({ client }, params) => createTasklist(client, params),
+  });
+
+  registerTaskTool<GetTasklistParams>(api, {
+    name: "feishu_tasklist_get",
+    label: "Feishu Tasklist Get",
+    description: "Get a Feishu tasklist by tasklist_guid (task v2)",
+    parameters: GetTasklistSchema,
+    run: async ({ client }, params) => getTasklist(client, params),
+  });
+
+  registerTaskTool<ListTasklistTasksParams>(api, {
+    name: "feishu_tasklist_get_tasks",
+    label: "Feishu Tasklist Get Tasks",
+    description:
+      "List tasks under a specific Feishu tasklist by tasklist_guid (task v2, paginated)",
+    parameters: ListTasklistTasksSchema,
+    run: async ({ client }, params) => listTasklistTasks(client, params),
+  });
+
+  registerTaskTool<ListTasklistsParams>(api, {
+    name: "feishu_tasklist_list",
+    label: "Feishu Tasklist List",
+    description: "List Feishu tasklists (task v2)",
+    parameters: ListTasklistsSchema,
+    run: async ({ client }, params) => listTasklists(client, params),
+  });
+
+  registerTaskTool<UpdateTasklistParams>(api, {
+    name: "feishu_tasklist_update",
+    label: "Feishu Tasklist Update",
+    description: "Update a Feishu tasklist by tasklist_guid (task v2 patch)",
+    parameters: UpdateTasklistSchema,
+    run: async ({ client }, params) => updateTasklist(client, params),
+  });
+
+  registerTaskTool<DeleteTasklistParams>(api, {
+    name: "feishu_tasklist_delete",
+    label: "Feishu Tasklist Delete",
+    description: "Delete a Feishu tasklist by tasklist_guid (task v2)",
+    parameters: DeleteTasklistSchema,
+    run: async ({ client }, params) => {
+      if (!params.tasklist_guid) {
+        throw new Error("tasklist_guid is required");
+      }
+      return deleteTasklist(client, params.tasklist_guid);
+    },
+  });
+
+  registerTaskTool<AddTasklistMembersParams>(api, {
+    name: "feishu_tasklist_add_members",
+    label: "Feishu Tasklist Add Members",
+    description: "Add members to a Feishu tasklist (task v2)",
+    parameters: AddTasklistMembersSchema,
+    run: async ({ client }, params) => addTasklistMembers(client, params),
+  });
+
+  registerTaskTool<RemoveTasklistMembersParams>(api, {
+    name: "feishu_tasklist_remove_members",
+    label: "Feishu Tasklist Remove Members",
+    description: "Remove members from a Feishu tasklist (task v2)",
+    parameters: RemoveTasklistMembersSchema,
+    run: async ({ client }, params) => removeTasklistMembers(client, params),
+  });
+
+  registerTaskTool<CreateTaskCommentParams>(api, {
+    name: "feishu_task_comment_create",
+    label: "Feishu Task Comment Create",
+    description: "Create a comment on a Feishu task (task v2)",
+    parameters: CreateTaskCommentSchema,
+    run: async ({ client }, params) => createTaskComment(client, params),
+  });
+
+  registerTaskTool<ListTaskCommentsParams>(api, {
+    name: "feishu_task_comment_list",
+    label: "Feishu Task Comment List",
+    description: "List comments for a Feishu task (task v2)",
+    parameters: ListTaskCommentsSchema,
+    run: async ({ client }, params) => listTaskComments(client, params),
+  });
+
+  registerTaskTool<GetTaskCommentParams>(api, {
+    name: "feishu_task_comment_get",
+    label: "Feishu Task Comment Get",
+    description: "Get a Feishu task comment by comment_id (task v2)",
+    parameters: GetTaskCommentSchema,
+    run: async ({ client }, params) => getTaskComment(client, params),
+  });
+
+  registerTaskTool<UpdateTaskCommentParams>(api, {
+    name: "feishu_task_comment_update",
+    label: "Feishu Task Comment Update",
+    description: "Update a Feishu task comment by comment_id (task v2 patch)",
+    parameters: UpdateTaskCommentSchema,
+    run: async ({ client }, params) => updateTaskComment(client, params),
+  });
+
+  registerTaskTool<DeleteTaskCommentParams>(api, {
+    name: "feishu_task_comment_delete",
+    label: "Feishu Task Comment Delete",
+    description: "Delete a Feishu task comment by comment_id (task v2)",
+    parameters: DeleteTaskCommentSchema,
+    run: async ({ client }, params) => deleteTaskComment(client, params),
+  });
+
+  registerTaskTool<UploadTaskAttachmentParams>(api, {
+    name: "feishu_task_attachment_upload",
+    label: "Feishu Task Attachment Upload",
+    description: "Upload an attachment to a Feishu task (task v2)",
+    parameters: UploadTaskAttachmentSchema,
+    run: async ({ client, account }, params) => {
+      const mediaMaxBytes =
+        (account.config?.mediaMaxMb ?? DEFAULT_TASK_MEDIA_MAX_MB) * BYTES_PER_MEGABYTE;
+      return uploadTaskAttachment(client, params, { maxBytes: mediaMaxBytes });
+    },
+  });
+
+  registerTaskTool<ListTaskAttachmentsParams>(api, {
+    name: "feishu_task_attachment_list",
+    label: "Feishu Task Attachment List",
+    description: "List attachments for a Feishu task (task v2)",
+    parameters: ListTaskAttachmentsSchema,
+    run: async ({ client }, params) => listTaskAttachments(client, params),
+  });
+
+  registerTaskTool<GetTaskAttachmentParams>(api, {
+    name: "feishu_task_attachment_get",
+    label: "Feishu Task Attachment Get",
+    description: "Get a Feishu task attachment by attachment_guid (task v2)",
+    parameters: GetTaskAttachmentSchema,
+    run: async ({ client }, params) => getTaskAttachment(client, params),
+  });
+
+  registerTaskTool<DeleteTaskAttachmentParams>(api, {
+    name: "feishu_task_attachment_delete",
+    label: "Feishu Task Attachment Delete",
+    description: "Delete a Feishu task attachment by attachment_guid (task v2)",
+    parameters: DeleteTaskAttachmentSchema,
+    run: async ({ client }, params) => deleteTaskAttachment(client, params),
+  });
+
+  registerTaskTool<DeleteTaskParams>(api, {
+    name: "feishu_task_delete",
+    label: "Feishu Task Delete",
+    description: "Delete a Feishu task by task_guid (task v2)",
+    parameters: DeleteTaskSchema,
+    run: async ({ client }, { task_guid }) => deleteTask(client, task_guid),
+  });
+
+  registerTaskTool<GetTaskParams>(api, {
+    name: "feishu_task_get",
+    label: "Feishu Task Get",
+    description: "Get Feishu task details by task_guid (task v2)",
+    parameters: GetTaskSchema,
+    run: async ({ client }, params) => getTask(client, params),
+  });
+
+  registerTaskTool<UpdateTaskParams>(api, {
+    name: "feishu_task_update",
+    label: "Feishu Task Update",
+    description: "Update a Feishu task by task_guid (task v2 patch)",
+    parameters: UpdateTaskSchema,
+    run: async ({ client }, params) => updateTask(client, params),
+  });
+
+  api.logger.info?.(
+    "feishu_task: Registered task, tasklist, tasklist-task, subtask, comment, and attachment tools",
+  );
+}

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { registerFeishuBitableTools } from "./bitable.js";
 import { registerFeishuDriveTools } from "./drive.js";
 import { registerFeishuPermTools } from "./perm.js";
+import { registerFeishuTaskTools } from "./task.js";
 import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
 import { registerFeishuWikiTools } from "./wiki.js";
 
@@ -19,11 +20,13 @@ function createConfig(params: {
     wiki?: boolean;
     drive?: boolean;
     perm?: boolean;
+    task?: boolean;
   };
   toolsB?: {
     wiki?: boolean;
     drive?: boolean;
     perm?: boolean;
+    task?: boolean;
   };
   defaultAccount?: string;
 }): OpenClawPluginApi["config"] {
@@ -125,5 +128,20 @@ describe("feishu tool account routing", () => {
 
     expect(createFeishuClientMock.mock.calls[0]?.[0]?.appId).toBe("app-b");
     expect(createFeishuClientMock.mock.calls[1]?.[0]?.appId).toBe("app-a");
+  });
+
+  test("task tools register when enabled on one account and route to agentAccountId", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        toolsA: { task: false },
+        toolsB: { task: true },
+      }),
+    );
+    registerFeishuTaskTools(api);
+
+    const tool = resolveTool("feishu_task_get", { agentAccountId: "b" });
+    await tool.execute("call", { task_guid: "task-guid-1" });
+
+    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
   });
 });

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -54,6 +54,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     chat: false,
     wiki: false,
     drive: false,
+    task: false,
     perm: false,
     scopes: false,
   };
@@ -63,6 +64,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     merged.chat = merged.chat || cfg.chat;
     merged.wiki = merged.wiki || cfg.wiki;
     merged.drive = merged.drive || cfg.drive;
+    merged.task = merged.task || cfg.task;
     merged.perm = merged.perm || cfg.perm;
     merged.scopes = merged.scopes || cfg.scopes;
   }

--- a/extensions/feishu/src/tools-config.test.ts
+++ b/extensions/feishu/src/tools-config.test.ts
@@ -8,6 +8,11 @@ describe("feishu tools config", () => {
     expect(resolved.chat).toBe(true);
   });
 
+  it("enables task tool by default", () => {
+    const resolved = resolveToolsConfig(undefined);
+    expect(resolved.task).toBe(true);
+  });
+
   it("accepts tools.chat in config schema", () => {
     const parsed = FeishuConfigSchema.parse({
       enabled: true,
@@ -17,5 +22,16 @@ describe("feishu tools config", () => {
     });
 
     expect(parsed.tools?.chat).toBe(false);
+  });
+
+  it("accepts tools.task in config schema", () => {
+    const parsed = FeishuConfigSchema.parse({
+      enabled: true,
+      tools: {
+        task: false,
+      },
+    });
+
+    expect(parsed.tools?.task).toBe(false);
   });
 });

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -2,7 +2,7 @@ import type { FeishuToolsConfig } from "./types.js";
 
 /**
  * Default tool configuration.
- * - doc, chat, wiki, drive, scopes: enabled by default
+ * - doc, chat, wiki, drive, task, scopes: enabled by default
  * - perm: disabled by default (sensitive operation)
  */
 export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
@@ -10,6 +10,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   chat: true,
   wiki: true,
   drive: true,
+  task: true,
   perm: false,
   scopes: true,
 };

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -77,6 +77,7 @@ export type FeishuToolsConfig = {
   chat?: boolean;
   wiki?: boolean;
   drive?: boolean;
+  task?: boolean;
   perm?: boolean;
   scopes?: boolean;
 };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** The existing Feishu integration lacks native support for task and project management, forcing users to leave the conversational context to manage actionable items.
- **Why it matters:** Agents cannot autonomously track work, break down complex projects into subtasks, or organize team deliverables within Feishu's native ecosystem.
- **What changed:** Introduced a comprehensive `feishu-task` skill supporting task v2 endpoints. Added 24 new tools for full CRUD operations on tasks, tasklists, subtasks, comments, and attachments.
- **What did NOT change (scope boundary):** Existing Feishu tools (doc, drive, wiki, chat, bitable) and core authentication remain untouched. 

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # 
- Related #

## User-visible / Behavior Changes

- A new `task` boolean flag is available in the Feishu tool configuration (defaults to `true`).
- Agents can now understand and execute requests related to Feishu Tasks, including creating lists, assigning members, adding comments, and attaching files.

## Security Impact (required)

- New permissions/capabilities? `Yes` (Requires Feishu Task v2 API scopes if enabled)
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` (Outbound calls to Feishu Task API; remote fetching for attachment uploads)
- Command/tool execution surface changed? `Yes` (24 new tools registered)
- Data access scope changed? `Yes` (Read/write access to Feishu Tasks)
- If any `Yes`, explain risk + mitigation:
  - **Risk:** Downloading remote URLs for task attachments could lead to SSRF or disk/memory exhaustion. 
  - **Mitigation:** Attachment uploads route through OpenClaw's runtime media safety checks (`loadWebMedia`) and strictly enforce the configured `mediaMaxMb` limit (default 30MB). Temporary files are reliably unlinked in a `finally` cleanup block.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js v23.11.0, pnpm 10.23.0
- Model/provider: (Local testing)
- Integration/channel (if any): Feishu
- Relevant config (redacted): `tools: { task: true }`

### Steps

1. Configure a Feishu account with Task v2 API scopes enabled.
2. Prompt the agent: "Create a tasklist called 'Project Alpha', add a task named 'Quarterly review', and upload this image URL as an attachment."
3. Observe the tool calls executing successfully.

### Expected

- Agent successfully registers the `feishu-task` tools.
- Tasks, subtasks, and tasklists are created and populated via the API.

### Actual

- Tool execution completes successfully with appropriate API response parsing and error handling (`runFeishuApiCall`).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after (Verified via `pnpm check` and `pnpm test`)
- [ ] Trace/log snippets
- [ ] Screenshot/recording 
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Successfully built and ran the test suite (`pnpm build && pnpm check && pnpm test`) locally on an isolated clone.
- Edge cases checked: Verified that missing update fields throw clear, descriptive errors before hitting the API. Checked that file size limits correctly reject oversized attachments.
- What you did **not** verify: Extensive live production traffic with high concurrency.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` (Added `task` toggle to Feishu config)
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Set `task: false` under the Feishu account `tools` configuration block.
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: Leaked temporary files in `os.tmpdir()` if the `finally` cleanup block fails during edge-case crash scenarios.

## Risks and Mitigations

- Risk: Unassigned tasks becoming invisible to the user creating them due to Feishu's visibility rules.
  - Mitigation: Added explicit system instructions in `SKILL.md` directing the model to set the assignee to the requesting user if none is specified.
- Risk: Moving tasks between tasklists using the generic patch endpoint instead of the dedicated membership endpoints.
  - Mitigation: Added explicit instructions in `SKILL.md` forbidding the use of `feishu_task_update` for tasklist movements.