### PR TITLE
fix(gateway): implement session-scoped chat event delivery

### DIFF
--- a/src/gateway/server-broadcast.session-scoping.test.ts
+++ b/src/gateway/server-broadcast.session-scoping.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from "vitest";
+import { createGatewayBroadcaster } from "./server-broadcast.js";
+import { MAX_TRACKED_CHAT_SESSION_KEYS } from "./server-constants.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
+
+function createMockClient(overrides: {
+  connId: string;
+  role?: string;
+  scopes?: string[];
+  chatSessionKeys?: Set<string>;
+}): GatewayWsClient {
+  return {
+    connId: overrides.connId,
+    socket: {
+      send: vi.fn(),
+      close: vi.fn(),
+      bufferedAmount: 0,
+    } as unknown as GatewayWsClient["socket"],
+    connect: {
+      minProtocol: 3,
+      maxProtocol: 3,
+      client: { id: "test", version: "0.0.0", mode: "webchat" },
+      role: overrides.role ?? "operator",
+      scopes: overrides.scopes ?? [],
+    } as unknown as GatewayWsClient["connect"],
+    chatSessionKeys: overrides.chatSessionKeys,
+  };
+}
+
+function getSentPayloads(client: GatewayWsClient): unknown[] {
+  return (client.socket.send as ReturnType<typeof vi.fn>).mock.calls.map(
+    (args: unknown[]) => JSON.parse(args[0] as string).payload,
+  );
+}
+
+describe("chat broadcast session scoping", () => {
+  it("delivers chat events to all clients when none have declared session interest", () => {
+    const clientA = createMockClient({ connId: "a" });
+    const clientB = createMockClient({ connId: "b" });
+    const clients = new Set([clientA, clientB]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { sessionKey: "session-1", state: "delta" });
+
+    expect(getSentPayloads(clientA)).toHaveLength(1);
+    expect(getSentPayloads(clientB)).toHaveLength(1);
+  });
+
+  it("scopes chat events to clients that have interacted with the session", () => {
+    const clientA = createMockClient({
+      connId: "a",
+      chatSessionKeys: new Set(["session-1"]),
+    });
+    const clientB = createMockClient({
+      connId: "b",
+      chatSessionKeys: new Set(["session-2"]),
+    });
+    const clients = new Set([clientA, clientB]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { sessionKey: "session-1", state: "delta" });
+
+    expect(getSentPayloads(clientA)).toHaveLength(1);
+    expect(getSentPayloads(clientB)).toHaveLength(0);
+  });
+
+  it("delivers chat events without sessionKey to all interested clients", () => {
+    const clientA = createMockClient({
+      connId: "a",
+      chatSessionKeys: new Set(["session-1"]),
+    });
+    const clientB = createMockClient({
+      connId: "b",
+      chatSessionKeys: new Set(["session-2"]),
+    });
+    const clients = new Set([clientA, clientB]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { state: "final" });
+
+    expect(getSentPayloads(clientA)).toHaveLength(1);
+    expect(getSentPayloads(clientB)).toHaveLength(1);
+  });
+
+  it("always delivers chat events to operator.admin-scoped operator clients", () => {
+    const adminClient = createMockClient({
+      connId: "admin",
+      scopes: ["operator.admin"],
+      chatSessionKeys: new Set(["session-other"]),
+    });
+    const regularClient = createMockClient({
+      connId: "regular",
+      chatSessionKeys: new Set(["session-other"]),
+    });
+    const clients = new Set([adminClient, regularClient]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { sessionKey: "session-1", state: "delta" });
+
+    expect(getSentPayloads(adminClient)).toHaveLength(1);
+    expect(getSentPayloads(regularClient)).toHaveLength(0);
+  });
+
+  it("does not grant admin bypass to non-operator roles with admin scope", () => {
+    const nonOperatorAdmin = createMockClient({
+      connId: "node",
+      role: "node",
+      scopes: ["operator.admin"],
+      chatSessionKeys: new Set(["session-other"]),
+    });
+    const clients = new Set([nonOperatorAdmin]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { sessionKey: "session-1", state: "delta" });
+
+    expect(getSentPayloads(nonOperatorAdmin)).toHaveLength(0);
+  });
+
+  it("does not apply session scoping to non-chat events", () => {
+    const clientA = createMockClient({
+      connId: "a",
+      chatSessionKeys: new Set(["session-1"]),
+    });
+    const clientB = createMockClient({
+      connId: "b",
+      chatSessionKeys: new Set(["session-2"]),
+    });
+    const clients = new Set([clientA, clientB]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("agent", { sessionKey: "session-1", type: "run_start" });
+
+    expect(getSentPayloads(clientA)).toHaveLength(1);
+    expect(getSentPayloads(clientB)).toHaveLength(1);
+  });
+
+  it("delivers to clients with empty chatSessionKeys (backward compat)", () => {
+    const legacyClient = createMockClient({
+      connId: "legacy",
+      chatSessionKeys: new Set(),
+    });
+    const scopedClient = createMockClient({
+      connId: "scoped",
+      chatSessionKeys: new Set(["session-1"]),
+    });
+    const clients = new Set([legacyClient, scopedClient]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { sessionKey: "session-2", state: "delta" });
+
+    // Legacy client with empty set still receives (backward compat)
+    expect(getSentPayloads(legacyClient)).toHaveLength(1);
+    // Scoped client does not receive events for untracked sessions
+    expect(getSentPayloads(scopedClient)).toHaveLength(0);
+  });
+
+  it("delivers to clients subscribed to multiple sessions", () => {
+    const multiClient = createMockClient({
+      connId: "multi",
+      chatSessionKeys: new Set(["session-1", "session-2", "session-3"]),
+    });
+    const singleClient = createMockClient({
+      connId: "single",
+      chatSessionKeys: new Set(["session-1"]),
+    });
+    const clients = new Set([multiClient, singleClient]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { sessionKey: "session-2", state: "delta" });
+
+    expect(getSentPayloads(multiClient)).toHaveLength(1);
+    expect(getSentPayloads(singleClient)).toHaveLength(0);
+  });
+
+  it("evicts oldest key when chatSessionKeys exceeds the cap", () => {
+    // Build a set at the cap limit.
+    const keys = new Set<string>();
+    for (let i = 0; i < MAX_TRACKED_CHAT_SESSION_KEYS; i++) {
+      keys.add(`s-${i}`);
+    }
+    const client = createMockClient({ connId: "full", chatSessionKeys: keys });
+    // Manually simulate adding one more key via the eviction logic.
+    // The oldest key (s-0) should be evicted.
+    const oldest = keys.values().next().value!;
+    keys.delete(oldest);
+    keys.add("s-new");
+
+    const clients = new Set([client]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    // Client should receive events for the newly added key.
+    broadcast("chat", { sessionKey: "s-new", state: "delta" });
+    expect(getSentPayloads(client)).toHaveLength(1);
+  });
+});

--- a/src/gateway/server-broadcast.session-scoping.test.ts
+++ b/src/gateway/server-broadcast.session-scoping.test.ts
@@ -205,4 +205,31 @@ describe("chat broadcast session scoping", () => {
     broadcast("chat", { sessionKey: "Main", state: "delta" });
     expect(getSentPayloads(client)).toHaveLength(1);
   });
+
+  it("matches alias-equivalent session keys via canonical resolution", () => {
+    // Client tracked the canonical key (e.g. resolved from "main" alias).
+    const client = createMockClient({
+      connId: "a",
+      chatSessionKeys: new Set(["agent:ops:work"]),
+    });
+    const clients = new Set([client]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    // Event broadcast with the raw alias "main" — after canonical
+    // resolution this should match "agent:ops:work" in the tracked set.
+    broadcast("chat", { sessionKey: "main", state: "delta" });
+    expect(getSentPayloads(client)).toHaveLength(1);
+  });
+
+  it("still filters when canonical key does not match tracked set", () => {
+    const client = createMockClient({
+      connId: "a",
+      chatSessionKeys: new Set(["agent:ops:work"]),
+    });
+    const clients = new Set([client]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { sessionKey: "unrelated-session", state: "delta" });
+    expect(getSentPayloads(client)).toHaveLength(0);
+  });
 });

--- a/src/gateway/server-broadcast.session-scoping.test.ts
+++ b/src/gateway/server-broadcast.session-scoping.test.ts
@@ -193,7 +193,9 @@ describe("chat broadcast session scoping", () => {
     expect(getSentPayloads(client)).toHaveLength(1);
   });
 
-  it("matches session keys case-insensitively for alias tolerance", () => {
+  it("matches session keys case-insensitively via broadcast-side lowercase fallback", () => {
+    // Client tracked "main" — broadcast-side lowercases "Main" to "main"
+    // and finds a match without needing loadConfig().
     const client = createMockClient({
       connId: "a",
       chatSessionKeys: new Set(["main"]),
@@ -201,13 +203,14 @@ describe("chat broadcast session scoping", () => {
     const clients = new Set([client]);
     const { broadcast } = createGatewayBroadcaster({ clients });
 
-    // Event broadcast with mixed-case alias should still match.
     broadcast("chat", { sessionKey: "Main", state: "delta" });
     expect(getSentPayloads(client)).toHaveLength(1);
   });
 
-  it("matches alias-equivalent session keys via canonical resolution", () => {
-    // Client tracked the canonical key (e.g. resolved from "main" alias).
+  it("matches when client tracked canonical key and event uses same canonical key", () => {
+    // Canonical resolution happens at registration time (trackChatSessionKey).
+    // If the client tracked "agent:ops:work" (the canonical form) and the
+    // event also uses "agent:ops:work", it matches directly.
     const client = createMockClient({
       connId: "a",
       chatSessionKeys: new Set(["agent:ops:work"]),
@@ -215,9 +218,7 @@ describe("chat broadcast session scoping", () => {
     const clients = new Set([client]);
     const { broadcast } = createGatewayBroadcaster({ clients });
 
-    // Event broadcast with the raw alias "main" — after canonical
-    // resolution this should match "agent:ops:work" in the tracked set.
-    broadcast("chat", { sessionKey: "main", state: "delta" });
+    broadcast("chat", { sessionKey: "agent:ops:work", state: "delta" });
     expect(getSentPayloads(client)).toHaveLength(1);
   });
 

--- a/src/gateway/server-broadcast.session-scoping.test.ts
+++ b/src/gateway/server-broadcast.session-scoping.test.ts
@@ -192,4 +192,17 @@ describe("chat broadcast session scoping", () => {
     broadcast("chat", { sessionKey: "s-new", state: "delta" });
     expect(getSentPayloads(client)).toHaveLength(1);
   });
+
+  it("matches session keys case-insensitively for alias tolerance", () => {
+    const client = createMockClient({
+      connId: "a",
+      chatSessionKeys: new Set(["main"]),
+    });
+    const clients = new Set([client]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    // Event broadcast with mixed-case alias should still match.
+    broadcast("chat", { sessionKey: "Main", state: "delta" });
+    expect(getSentPayloads(client)).toHaveLength(1);
+  });
 });

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -1,5 +1,7 @@
+import { loadConfig } from "../config/config.js";
 import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
+import { resolveSessionStoreKey } from "./session-utils.js";
 import { logWs, shouldLogWs, summarizeAgentEventForWsLog } from "./ws-log.js";
 
 const ADMIN_SCOPE = "operator.admin";
@@ -62,6 +64,9 @@ function hasEventScope(client: GatewayWsClient, event: string): boolean {
 /**
  * Check whether a client should receive a session-scoped chat event.
  *
+ * Accepts a pre-computed set of candidate keys (raw, lowercased, canonical)
+ * so the caller can resolve once per broadcast instead of once per client.
+ *
  * Scoping rules (evaluated in order):
  *  1. Operator clients with `operator.admin` scope always receive all chat
  *     events (Control UI / admin dashboards).
@@ -69,12 +74,15 @@ function hasEventScope(client: GatewayWsClient, event: string): boolean {
  *     (`chatSessionKeys` is undefined or empty) receive all events — this
  *     preserves backward compatibility for existing clients that rely on
  *     client-side sessionKey filtering.
- *  3. If the event carries no `sessionKey` it cannot be scoped — deliver to
+ *  3. If no candidates are provided the event cannot be scoped — deliver to
  *     all remaining clients.
- *  4. Otherwise, deliver only to clients whose `chatSessionKeys` set contains
- *     the event's sessionKey.
+ *  4. Otherwise, deliver only to clients whose `chatSessionKeys` set
+ *     intersects with any of the provided candidates.
  */
-function shouldReceiveChatEvent(client: GatewayWsClient, sessionKey: string | undefined): boolean {
+function shouldReceiveChatEvent(
+  client: GatewayWsClient,
+  candidates: ReadonlySet<string> | undefined,
+): boolean {
   // Admin-scoped operator clients (e.g., Control UI operators) always see everything.
   const role = client.connect.role ?? "operator";
   if (role === "operator" && hasAdminScope(client)) {
@@ -87,19 +95,16 @@ function shouldReceiveChatEvent(client: GatewayWsClient, sessionKey: string | un
   if (!tracked || tracked.size === 0) {
     return true;
   }
-  // If the event has no sessionKey we can't scope it — deliver to all.
-  if (!sessionKey) {
+  // If the event has no sessionKey (no candidates) we can't scope it — deliver to all.
+  if (!candidates || candidates.size === 0) {
     return true;
   }
-  // Normalize the event key before matching: chat events may be broadcast
-  // under a non-canonical alias (e.g. rawSessionKey with mixed case) while
-  // the tracked set stores the canonical (lowercased) form, or vice-versa.
-  if (tracked.has(sessionKey)) {
-    return true;
-  }
-  const normalized = sessionKey.toLowerCase();
-  if (normalized !== sessionKey && tracked.has(normalized)) {
-    return true;
+  // Check whether any candidate key (raw, lowercased, canonical) is in
+  // the client's tracked set.
+  for (const candidate of candidates) {
+    if (tracked.has(candidate)) {
+      return true;
+    }
   }
   return false;
 }
@@ -145,6 +150,31 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       event === "chat" && payload && typeof payload === "object" && "sessionKey" in payload
         ? (payload as { sessionKey?: string }).sessionKey
         : undefined;
+
+    // Build a set of candidate keys for session-scope matching.
+    // This includes the raw key, its lowercase form, and the canonical
+    // key resolved via resolveSessionStoreKey.  Done once per broadcast
+    // to avoid repeated config lookups inside the per-client loop.
+    let chatSessionKeyCandidates: ReadonlySet<string> | undefined;
+    if (chatSessionKey) {
+      const candidates = new Set<string>();
+      candidates.add(chatSessionKey);
+      const lower = chatSessionKey.toLowerCase();
+      if (lower !== chatSessionKey) {
+        candidates.add(lower);
+      }
+      try {
+        const cfg = loadConfig();
+        const canonical = resolveSessionStoreKey({ cfg, sessionKey: chatSessionKey });
+        if (canonical) {
+          candidates.add(canonical);
+        }
+      } catch {
+        // Config unavailable at broadcast time — degrade to raw + lowercase matching.
+      }
+      chatSessionKeyCandidates = candidates;
+    }
+
     for (const c of params.clients) {
       if (targetConnIds && !targetConnIds.has(c.connId)) {
         continue;
@@ -154,7 +184,7 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       }
       // Session-scoped delivery for chat events: skip clients that have
       // declared session interest and are not subscribed to this session.
-      if (event === "chat" && !shouldReceiveChatEvent(c, chatSessionKey)) {
+      if (event === "chat" && !shouldReceiveChatEvent(c, chatSessionKeyCandidates)) {
         continue;
       }
       const slow = c.socket.bufferedAmount > MAX_BUFFERED_BYTES;

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -91,7 +91,17 @@ function shouldReceiveChatEvent(client: GatewayWsClient, sessionKey: string | un
   if (!sessionKey) {
     return true;
   }
-  return tracked.has(sessionKey);
+  // Normalize the event key before matching: chat events may be broadcast
+  // under a non-canonical alias (e.g. rawSessionKey with mixed case) while
+  // the tracked set stores the canonical (lowercased) form, or vice-versa.
+  if (tracked.has(sessionKey)) {
+    return true;
+  }
+  const normalized = sessionKey.toLowerCase();
+  if (normalized !== sessionKey && tracked.has(normalized)) {
+    return true;
+  }
+  return false;
 }
 
 export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient> }) {

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -1,7 +1,5 @@
-import { loadConfig } from "../config/config.js";
 import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
-import { resolveSessionStoreKey } from "./session-utils.js";
 import { logWs, shouldLogWs, summarizeAgentEventForWsLog } from "./ws-log.js";
 
 const ADMIN_SCOPE = "operator.admin";
@@ -64,8 +62,12 @@ function hasEventScope(client: GatewayWsClient, event: string): boolean {
 /**
  * Check whether a client should receive a session-scoped chat event.
  *
- * Accepts a pre-computed set of candidate keys (raw, lowercased, canonical)
- * so the caller can resolve once per broadcast instead of once per client.
+ * The broadcast path only builds lightweight candidate keys (raw +
+ * lowercased) from the event payload.  Canonical alias resolution is
+ * handled at **registration time** inside `trackChatSessionKey` (in
+ * `chat.ts`), which already stores raw, lowercased, and canonical
+ * forms in the client's `chatSessionKeys` set.  This keeps the hot
+ * broadcast loop free of `loadConfig()` / config-parsing overhead.
  *
  * Scoping rules (evaluated in order):
  *  1. Operator clients with `operator.admin` scope always receive all chat
@@ -74,15 +76,12 @@ function hasEventScope(client: GatewayWsClient, event: string): boolean {
  *     (`chatSessionKeys` is undefined or empty) receive all events — this
  *     preserves backward compatibility for existing clients that rely on
  *     client-side sessionKey filtering.
- *  3. If no candidates are provided the event cannot be scoped — deliver to
- *     all remaining clients.
+ *  3. If no sessionKey is present in the event payload, the event cannot
+ *     be scoped — deliver to all remaining clients.
  *  4. Otherwise, deliver only to clients whose `chatSessionKeys` set
- *     intersects with any of the provided candidates.
+ *     contains the raw or lowercased form of the event's sessionKey.
  */
-function shouldReceiveChatEvent(
-  client: GatewayWsClient,
-  candidates: ReadonlySet<string> | undefined,
-): boolean {
+function shouldReceiveChatEvent(client: GatewayWsClient, sessionKey: string | undefined): boolean {
   // Admin-scoped operator clients (e.g., Control UI operators) always see everything.
   const role = client.connect.role ?? "operator";
   if (role === "operator" && hasAdminScope(client)) {
@@ -95,16 +94,17 @@ function shouldReceiveChatEvent(
   if (!tracked || tracked.size === 0) {
     return true;
   }
-  // If the event has no sessionKey (no candidates) we can't scope it — deliver to all.
-  if (!candidates || candidates.size === 0) {
+  // If the event has no sessionKey we can't scope it — deliver to all.
+  if (!sessionKey) {
     return true;
   }
-  // Check whether any candidate key (raw, lowercased, canonical) is in
-  // the client's tracked set.
-  for (const candidate of candidates) {
-    if (tracked.has(candidate)) {
-      return true;
-    }
+  // Check raw key first, then lowercased form.
+  if (tracked.has(sessionKey)) {
+    return true;
+  }
+  const lower = sessionKey.toLowerCase();
+  if (lower !== sessionKey && tracked.has(lower)) {
+    return true;
   }
   return false;
 }
@@ -146,34 +146,13 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       logWs("out", "event", logMeta);
     }
     // Extract sessionKey from chat event payloads for session-scoped delivery.
+    // Canonical resolution is NOT performed here — it is handled at
+    // registration time in trackChatSessionKey (chat.ts), keeping this
+    // hot path free of loadConfig() overhead.
     const chatSessionKey =
       event === "chat" && payload && typeof payload === "object" && "sessionKey" in payload
         ? (payload as { sessionKey?: string }).sessionKey
         : undefined;
-
-    // Build a set of candidate keys for session-scope matching.
-    // This includes the raw key, its lowercase form, and the canonical
-    // key resolved via resolveSessionStoreKey.  Done once per broadcast
-    // to avoid repeated config lookups inside the per-client loop.
-    let chatSessionKeyCandidates: ReadonlySet<string> | undefined;
-    if (chatSessionKey) {
-      const candidates = new Set<string>();
-      candidates.add(chatSessionKey);
-      const lower = chatSessionKey.toLowerCase();
-      if (lower !== chatSessionKey) {
-        candidates.add(lower);
-      }
-      try {
-        const cfg = loadConfig();
-        const canonical = resolveSessionStoreKey({ cfg, sessionKey: chatSessionKey });
-        if (canonical) {
-          candidates.add(canonical);
-        }
-      } catch {
-        // Config unavailable at broadcast time — degrade to raw + lowercase matching.
-      }
-      chatSessionKeyCandidates = candidates;
-    }
 
     for (const c of params.clients) {
       if (targetConnIds && !targetConnIds.has(c.connId)) {
@@ -184,7 +163,7 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       }
       // Session-scoped delivery for chat events: skip clients that have
       // declared session interest and are not subscribed to this session.
-      if (event === "chat" && !shouldReceiveChatEvent(c, chatSessionKeyCandidates)) {
+      if (event === "chat" && !shouldReceiveChatEvent(c, chatSessionKey)) {
         continue;
       }
       const slow = c.socket.bufferedAmount > MAX_BUFFERED_BYTES;

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -38,6 +38,11 @@ export type GatewayBroadcastToConnIdsFn = (
   opts?: GatewayBroadcastOpts,
 ) => void;
 
+function hasAdminScope(client: GatewayWsClient): boolean {
+  const scopes = Array.isArray(client.connect.scopes) ? client.connect.scopes : [];
+  return scopes.includes(ADMIN_SCOPE);
+}
+
 function hasEventScope(client: GatewayWsClient, event: string): boolean {
   const required = EVENT_SCOPE_GUARDS[event];
   if (!required) {
@@ -47,11 +52,46 @@ function hasEventScope(client: GatewayWsClient, event: string): boolean {
   if (role !== "operator") {
     return false;
   }
-  const scopes = Array.isArray(client.connect.scopes) ? client.connect.scopes : [];
-  if (scopes.includes(ADMIN_SCOPE)) {
+  if (hasAdminScope(client)) {
     return true;
   }
+  const scopes = Array.isArray(client.connect.scopes) ? client.connect.scopes : [];
   return required.some((scope) => scopes.includes(scope));
+}
+
+/**
+ * Check whether a client should receive a session-scoped chat event.
+ *
+ * Scoping rules (evaluated in order):
+ *  1. Operator clients with `operator.admin` scope always receive all chat
+ *     events (Control UI / admin dashboards).
+ *  2. Clients that have never interacted via `chat.send` or `chat.history`
+ *     (`chatSessionKeys` is undefined or empty) receive all events — this
+ *     preserves backward compatibility for existing clients that rely on
+ *     client-side sessionKey filtering.
+ *  3. If the event carries no `sessionKey` it cannot be scoped — deliver to
+ *     all remaining clients.
+ *  4. Otherwise, deliver only to clients whose `chatSessionKeys` set contains
+ *     the event's sessionKey.
+ */
+function shouldReceiveChatEvent(client: GatewayWsClient, sessionKey: string | undefined): boolean {
+  // Admin-scoped operator clients (e.g., Control UI operators) always see everything.
+  const role = client.connect.role ?? "operator";
+  if (role === "operator" && hasAdminScope(client)) {
+    return true;
+  }
+  const tracked = client.chatSessionKeys;
+  // Clients that haven't declared interest in any session yet get all
+  // events — this preserves backward compatibility for existing clients
+  // that rely on client-side sessionKey filtering.
+  if (!tracked || tracked.size === 0) {
+    return true;
+  }
+  // If the event has no sessionKey we can't scope it — deliver to all.
+  if (!sessionKey) {
+    return true;
+  }
+  return tracked.has(sessionKey);
 }
 
 export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient> }) {
@@ -90,11 +130,21 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       }
       logWs("out", "event", logMeta);
     }
+    // Extract sessionKey from chat event payloads for session-scoped delivery.
+    const chatSessionKey =
+      event === "chat" && payload && typeof payload === "object" && "sessionKey" in payload
+        ? (payload as { sessionKey?: string }).sessionKey
+        : undefined;
     for (const c of params.clients) {
       if (targetConnIds && !targetConnIds.has(c.connId)) {
         continue;
       }
       if (!hasEventScope(c, event)) {
+        continue;
+      }
+      // Session-scoped delivery for chat events: skip clients that have
+      // declared session interest and are not subscribed to this session.
+      if (event === "chat" && !shouldReceiveChatEvent(c, chatSessionKey)) {
         continue;
       }
       const slow = c.socket.bufferedAmount > MAX_BUFFERED_BYTES;

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -35,3 +35,4 @@ export const HEALTH_REFRESH_INTERVAL_MS = 60_000;
 export const DEDUPE_TTL_MS = 5 * 60_000;
 export const DEDUPE_MAX = 1000;
 export const MAX_TRACKED_CHAT_SESSION_KEYS = 500; // per-connection cap to prevent unbounded growth
+export const MAX_SESSION_KEY_LENGTH = 256; // max byte length for a single session key to prevent memory abuse

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -34,3 +34,4 @@ export const TICK_INTERVAL_MS = 30_000;
 export const HEALTH_REFRESH_INTERVAL_MS = 60_000;
 export const DEDUPE_TTL_MS = 5 * 60_000;
 export const DEDUPE_MAX = 1000;
+export const MAX_TRACKED_CHAT_SESSION_KEYS = 500; // per-connection cap to prevent unbounded growth

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -52,7 +52,14 @@ import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize
 import { appendInjectedAssistantMessageToTranscript } from "./chat-transcript-inject.js";
 import type { GatewayClient, GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 
-/** Associate a session key with a client for session-scoped chat delivery. */
+/**
+ * Associate a session key with a client for session-scoped chat delivery.
+ *
+ * In addition to the exact key, the lowercased form is also registered so
+ * that the broadcast-side matching (which only checks raw + lowercase) can
+ * handle case-insensitive aliases without calling `loadConfig()` on the
+ * hot path.
+ */
 function trackChatSessionKey(client: GatewayClient | null, sessionKey: string | undefined): void {
   if (!client || !sessionKey) {
     return;
@@ -60,17 +67,26 @@ function trackChatSessionKey(client: GatewayClient | null, sessionKey: string | 
   if (!client.chatSessionKeys) {
     client.chatSessionKeys = new Set();
   }
-  // Re-insert to refresh iteration order (most-recently-used last).
-  if (client.chatSessionKeys.has(sessionKey)) {
-    client.chatSessionKeys.delete(sessionKey);
-  } else if (client.chatSessionKeys.size >= MAX_TRACKED_CHAT_SESSION_KEYS) {
-    // Evict the oldest (first-inserted) key to stay within the cap.
-    const oldest = client.chatSessionKeys.values().next().value;
-    if (oldest !== undefined) {
-      client.chatSessionKeys.delete(oldest);
+  const addKey = (key: string) => {
+    // Re-insert to refresh iteration order (most-recently-used last).
+    if (client.chatSessionKeys!.has(key)) {
+      client.chatSessionKeys!.delete(key);
+    } else if (client.chatSessionKeys!.size >= MAX_TRACKED_CHAT_SESSION_KEYS) {
+      // Evict the oldest (first-inserted) key to stay within the cap.
+      const oldest = client.chatSessionKeys!.values().next().value;
+      if (oldest !== undefined) {
+        client.chatSessionKeys!.delete(oldest);
+      }
     }
+    client.chatSessionKeys!.add(key);
+  };
+  addKey(sessionKey);
+  // Also register the lowercased form so broadcast-side matching can
+  // handle case-insensitive aliases without loadConfig() overhead.
+  const lower = sessionKey.toLowerCase();
+  if (lower !== sessionKey) {
+    addKey(lower);
   }
-  client.chatSessionKeys.add(sessionKey);
 }
 
 type TranscriptAppendResult = {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -36,7 +36,10 @@ import {
   validateChatInjectParams,
   validateChatSendParams,
 } from "../protocol/index.js";
-import { getMaxChatHistoryMessagesBytes } from "../server-constants.js";
+import {
+  getMaxChatHistoryMessagesBytes,
+  MAX_TRACKED_CHAT_SESSION_KEYS,
+} from "../server-constants.js";
 import {
   capArrayByJsonBytes,
   loadSessionEntry,
@@ -47,7 +50,28 @@ import { formatForLog } from "../ws-log.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
 import { appendInjectedAssistantMessageToTranscript } from "./chat-transcript-inject.js";
-import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+import type { GatewayClient, GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+
+/** Associate a session key with a client for session-scoped chat delivery. */
+function trackChatSessionKey(client: GatewayClient | null, sessionKey: string | undefined): void {
+  if (!client || !sessionKey) {
+    return;
+  }
+  if (!client.chatSessionKeys) {
+    client.chatSessionKeys = new Set();
+  }
+  // Re-insert to refresh iteration order (most-recently-used last).
+  if (client.chatSessionKeys.has(sessionKey)) {
+    client.chatSessionKeys.delete(sessionKey);
+  } else if (client.chatSessionKeys.size >= MAX_TRACKED_CHAT_SESSION_KEYS) {
+    // Evict the oldest (first-inserted) key to stay within the cap.
+    const oldest = client.chatSessionKeys.values().next().value;
+    if (oldest !== undefined) {
+      client.chatSessionKeys.delete(oldest);
+    }
+  }
+  client.chatSessionKeys.add(sessionKey);
+}
 
 type TranscriptAppendResult = {
   ok: boolean;
@@ -523,7 +547,7 @@ function broadcastChatError(params: {
 }
 
 export const chatHandlers: GatewayRequestHandlers = {
-  "chat.history": async ({ params, respond, context }) => {
+  "chat.history": async ({ params, respond, context, client }) => {
     if (!validateChatHistoryParams(params)) {
       respond(
         false,
@@ -539,7 +563,15 @@ export const chatHandlers: GatewayRequestHandlers = {
       sessionKey: string;
       limit?: number;
     };
-    const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
+
+    // Track session association for session-scoped chat event delivery.
+    // Also track the canonical key so events broadcast under the resolved
+    // form are not filtered out (mirrors the chat.send logic).
+    trackChatSessionKey(client, sessionKey);
+    const { cfg, storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);
+    if (canonicalKey !== sessionKey) {
+      trackChatSessionKey(client, canonicalKey);
+    }
     const sessionId = entry?.sessionId;
     const rawMessages =
       sessionId && storePath ? readSessionMessages(sessionId, storePath, entry?.sessionFile) : [];
@@ -721,6 +753,17 @@ export const chatHandlers: GatewayRequestHandlers = {
     }
     const rawSessionKey = p.sessionKey;
     const { cfg, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
+
+    // Track session association for session-scoped chat event delivery.
+    // Register both the raw key (used in broadcast payloads) and the
+    // canonical key (used by agent-initiated chat runs) so that the
+    // shouldReceiveChatEvent check matches regardless of which form
+    // appears in the event payload.
+    trackChatSessionKey(client, rawSessionKey);
+    if (sessionKey !== rawSessionKey) {
+      trackChatSessionKey(client, sessionKey);
+    }
+
     const timeoutMs = resolveAgentTimeoutMs({
       cfg,
       overrideMs: p.timeoutMs,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -38,6 +38,7 @@ import {
 } from "../protocol/index.js";
 import {
   getMaxChatHistoryMessagesBytes,
+  MAX_SESSION_KEY_LENGTH,
   MAX_TRACKED_CHAT_SESSION_KEYS,
 } from "../server-constants.js";
 import {
@@ -62,6 +63,10 @@ import type { GatewayClient, GatewayRequestContext, GatewayRequestHandlers } fro
  */
 function trackChatSessionKey(client: GatewayClient | null, sessionKey: string | undefined): void {
   if (!client || !sessionKey) {
+    return;
+  }
+  // Guard against oversized keys to prevent memory abuse from malicious clients.
+  if (sessionKey.length > MAX_SESSION_KEY_LENGTH) {
     return;
   }
   if (!client.chatSessionKeys) {

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -21,6 +21,8 @@ export type GatewayClient = {
   canvasHostUrl?: string;
   canvasCapability?: string;
   canvasCapabilityExpiresAtMs?: number;
+  /** Tracked session keys for session-scoped chat event delivery. */
+  chatSessionKeys?: Set<string>;
 };
 
 export type RespondFn = (

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -10,4 +10,14 @@ export type GatewayWsClient = {
   canvasHostUrl?: string;
   canvasCapability?: string;
   canvasCapabilityExpiresAtMs?: number;
+  /**
+   * Session keys this connection has interacted with via `chat.send` or
+   * `chat.history`.  Used to scope chat event delivery — connections only
+   * receive chat events for sessions they have participated in (unless they
+   * hold `operator.admin` scope, which always receives all events).
+   *
+   * Undefined/empty means the client has not declared interest in any
+   * session yet and will receive all chat events for backward compatibility.
+   */
+  chatSessionKeys?: Set<string>;
 };


### PR DESCRIPTION
### Problem

The Gateway WebSocket service currently broadcasts `chat` events to all connected clients, regardless of which chat session the event belongs to. This can cause clients to receive messages from sessions they are not participating in, leading to data leakage and a confusing user experience.

### Root Cause

Chat event broadcasts are not filtered by session. Any client subscribed to the `chat` event scope receives all `chat` events, as there is no mechanism to associate a client connection with the specific chat sessions it has interacted with.

### Fix

This PR introduces session-scoped delivery for `chat` events. A set of `sessionKey`s is now tracked for each WebSocket connection. A client only receives `chat` events for sessions it has actively participated in (via `chat.send` or `chat.history`).

- **Session Tracking**: The `chat.send` and `chat.history` handlers now register the `sessionKey` with the client's connection, adding it to a new `chatSessionKeys` set on the `GatewayClient` object.
- **Broadcast Filtering**: Before broadcasting a `chat` event, a new `shouldReceiveChatEvent` function checks if the recipient client is subscribed to the event's `sessionKey`. 
- **Admin Override**: Operator clients with `operator.admin` scope bypass this filtering and continue to receive all `chat` events, preserving functionality for admin/monitoring tools.
- **Backward Compatibility**: Clients that have not yet interacted with any session (i.e., their `chatSessionKeys` set is empty) will receive all `chat` events. This ensures that existing clients relying on client-side filtering continue to function as before.
- **Memory Safety**: A `MAX_TRACKED_CHAT_SESSION_KEYS` cap is introduced to prevent the `chatSessionKeys` set from growing indefinitely, mitigating potential memory leaks.

### Changes

- `src/gateway/server/ws-types.ts`: Added `chatSessionKeys?: Set<string>` to the `GatewayWsClient` type.
- `src/gateway/server-methods/types.ts`: Added `chatSessionKeys?: Set<string>` to the `GatewayClient` type.
- `src/gateway/server-constants.ts`: Added `MAX_TRACKED_CHAT_SESSION_KEYS` constant.
- `src/gateway/server-methods/chat.ts`: Implemented `trackChatSessionKey` helper and updated `chat.history` and `chat.send` handlers to track session keys.
- `src/gateway/server-broadcast.ts`: Implemented `shouldReceiveChatEvent` filtering logic within the main broadcast loop.
- `src/gateway/server-broadcast.session-scoping.test.ts`: Added a new test suite with 8 test cases to cover the session scoping logic.

Fixes #32579