### PR TITLE
fix(daemon): fix systemd is-enabled check failing on fresh Linux installs

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,6 +79,19 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false when unit is not-found (exit code 4, stdout only)", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & { code?: number };
+      err.code = 4;
+      cb(err, "not-found\n", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
   it("throws when systemctl is-enabled fails for non-state errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -382,7 +382,7 @@ export async function readSystemdServiceRuntime(
     "ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode",
   ]);
   if (res.code !== 0) {
-    const detail = (res.stderr || res.stdout).trim();
+    const detail = `${res.stderr} ${res.stdout}`.trim();
     const missing = detail.toLowerCase().includes("not found");
     return {
       status: missing ? "stopped" : "unknown",

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -143,7 +143,9 @@ async function execSystemctl(
 }
 
 function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
-  return (result.stderr || result.stdout || "").trim();
+  // Combine both streams so patterns like "not-found" in stdout are not
+  // masked when execFileUtf8 replaces empty stderr with the error message.
+  return `${result.stderr} ${result.stdout}`.trim();
 }
 
 function isSystemctlMissing(detail: string): boolean {


### PR DESCRIPTION
## Summary

Fixes #32635

On fresh Linux servers where the openclaw-gateway systemd service has never been installed, `openclaw gateway install` fails with:

```
Gateway service check failed: Error: systemctl is-enabled unavailable: Command failed: systemctl --user is-enabled openclaw-gateway.service
```

### Root cause

`readSystemctlDetail()` in `src/daemon/systemd.ts` uses `result.stderr || result.stdout` to pick the detail string. When `systemctl --user is-enabled` exits with code 4 for a non-existent unit:

- **stdout**: `"not-found\n"`
- **stderr**: `""` (empty)

But `execFileUtf8` replaces empty stderr with the error message (`"Command failed: ..."`), so `readSystemctlDetail` picks the clobbered stderr and never sees `"not-found"` from stdout. `isSystemdUnitNotEnabled()` then fails to match and throws.

### Fix

Change `readSystemctlDetail` to combine both stderr and stdout (`\.trim()`), matching the pattern already used by `isSystemdUserServiceAvailable()` on line 183.

### Changes

- **`src/daemon/systemd.ts`**: `readSystemctlDetail` now combines stderr + stdout instead of either-or
- **`src/daemon/systemd.test.ts`**: Added test for exit code 4 with stdout-only "not-found" scenario

## Test plan

- [x] `pnpm test src/daemon/systemd.test.ts` — all 20 tests pass (including new test)
- [x] `pnpm format` — no formatting issues

> **Note:** The fork's main branch is behind upstream, so the diff may appear larger than the actual change. Only the two files listed above are modified.