### PR TITLE
fix(slack): pass mediaLocalRoots through sendSlackMessage to file uploads

### DIFF
--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -206,9 +206,13 @@ export async function handleSlackAction(
           to,
           context,
         );
+        const mediaLocalRoots = Array.isArray(params.mediaLocalRoots)
+          ? (params.mediaLocalRoots as string[])
+          : undefined;
         const result = await sendSlackMessage(to, content ?? "", {
           ...writeOpts,
           mediaUrl: mediaUrl ?? undefined,
+          mediaLocalRoots,
           threadTs: threadTs ?? undefined,
           blocks,
         });

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -52,6 +52,7 @@ export async function handleSlackMessageAction(params: {
         to,
         content: content ?? "",
         mediaUrl: mediaUrl ?? undefined,
+        mediaLocalRoots: ctx.mediaLocalRoots,
         blocks,
         accountId,
         threadTs: threadId ?? replyTo ?? undefined,

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -5,8 +5,8 @@ import { resolveSlackAccount } from "./accounts.js";
 import { buildSlackBlocksFallbackText } from "./blocks-fallback.js";
 import { validateSlackBlocksArray } from "./blocks-input.js";
 import { createSlackWebClient } from "./client.js";
-import { resolveSlackMedia } from "./monitor/media.js";
 import type { SlackMediaResult } from "./monitor/media.js";
+import { resolveSlackMedia } from "./monitor/media.js";
 import { sendMessageSlack } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
 
@@ -159,6 +159,7 @@ export async function sendSlackMessage(
   content: string,
   opts: SlackActionClientOpts & {
     mediaUrl?: string;
+    mediaLocalRoots?: readonly string[];
     threadTs?: string;
     blocks?: (Block | KnownBlock)[];
   } = {},
@@ -167,6 +168,7 @@ export async function sendSlackMessage(
     accountId: opts.accountId,
     token: opts.token,
     mediaUrl: opts.mediaUrl,
+    mediaLocalRoots: opts.mediaLocalRoots,
     client: opts.client,
     threadTs: opts.threadTs,
     blocks: opts.blocks,


### PR DESCRIPTION
## Summary

- Thread `mediaLocalRoots` from `ChannelMessageActionContext` through the Slack message action chain to `sendSlackMessage` → `sendMessageSlack` → `uploadSlackFile` → `loadWebMedia`
- Without this, Slack file uploads from sandboxed agents fail with "path not allowed" because `assertLocalMediaAllowed` falls back to default roots that don't include agent workspace directories
- Discord and Telegram already wire `mediaLocalRoots` correctly; this brings Slack to parity

Fixes #30871

## Changes

1. **`src/slack/actions.ts`** — Added `mediaLocalRoots` to `sendSlackMessage` opts type and forwarding to `sendMessageSlack`
2. **`src/agents/tools/slack-actions.ts`** — Extract `mediaLocalRoots` from action params in `sendMessage` handler and pass to `sendSlackMessage`
3. **`src/plugin-sdk/slack-message-actions.ts`** — Include `ctx.mediaLocalRoots` in the invoke action dict for the "send" action

## Test plan

- [ ] Verify sandboxed agent can send media via Slack (previously failed with "path not allowed")
- [ ] Verify non-sandboxed Slack media upload still works (mediaLocalRoots is undefined, falls back to defaults)
- [ ] Run existing `slack-actions.test.ts` tests pass
- [ ] Verify Telegram and Discord media uploads remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)