### PR TITLE
fix(telegram): fire message hooks in reply delivery path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.
+- Telegram/plugin outbound hook parity: run `message_sending` + `message_sent` in Telegram reply delivery, include reply-path hook metadata (`mediaUrls`, `threadId`), and report `message_sent.success=false` when hooks blank text and no outbound message is delivered. (#32649) Thanks @KimGLee.
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.
 - Gateway/status self version reporting: make Gateway self version in `openclaw status` prefer runtime `VERSION` (while preserving explicit `OPENCLAW_VERSION` override), preventing stale post-upgrade app version output. (#32655) thanks @liuxiaopai-ai.

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -33,6 +33,7 @@ const CAPTION_TOO_LONG_RE = /caption is too long/i;
 type DeliveryProgress = {
   hasReplied: boolean;
   hasDelivered: boolean;
+  deliveredCount: number;
 };
 
 type ChunkTextFn = (markdown: string) => ReturnType<typeof markdownToTelegramChunks>;
@@ -85,6 +86,7 @@ function markReplyApplied(progress: DeliveryProgress, replyToId?: number): void 
 
 function markDelivered(progress: DeliveryProgress): void {
   progress.hasDelivered = true;
+  progress.deliveredCount += 1;
 }
 
 async function deliverTextReply(params: {
@@ -445,6 +447,7 @@ export async function deliverReplies(params: {
   const progress: DeliveryProgress = {
     hasReplied: false,
     hasDelivered: false,
+    deliveredCount: 0,
   };
   const hookRunner = getGlobalHookRunner();
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
@@ -489,6 +492,7 @@ export async function deliverReplies(params: {
     const contentForSentHook = reply.text || "";
 
     try {
+      const deliveredCountBeforeReply = progress.deliveredCount;
       const replyToId =
         params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
       const mediaList = reply.mediaUrls?.length
@@ -537,11 +541,12 @@ export async function deliverReplies(params: {
       }
 
       if (hasMessageSentHooks) {
+        const deliveredThisReply = progress.deliveredCount > deliveredCountBeforeReply;
         void hookRunner?.runMessageSent(
           {
             to: params.chatId,
             content: contentForSentHook,
-            success: true,
+            success: deliveredThisReply,
           },
           {
             channelId: "telegram",

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -7,6 +7,7 @@ import { danger, logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { buildOutboundMediaLoadOptions } from "../../media/load-options.js";
 import { isGifMedia, kindFromMime } from "../../media/mime.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { loadWebMedia } from "../../web/media.js";
 import type { TelegramInlineButtons } from "../button-types.js";
@@ -445,12 +446,16 @@ export async function deliverReplies(params: {
     hasReplied: false,
     hasDelivered: false,
   };
+  const hookRunner = getGlobalHookRunner();
+  const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
+  const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
   const chunkText = buildChunkTextResolver({
     textLimit: params.textLimit,
     chunkMode: params.chunkMode ?? "length",
     tableMode: params.tableMode,
   });
-  for (const reply of params.replies) {
+  for (const originalReply of params.replies) {
+    let reply = originalReply;
     const hasMedia = Boolean(reply?.mediaUrl) || (reply?.mediaUrls?.length ?? 0) > 0;
     if (!reply?.text && !hasMedia) {
       if (reply?.audioAsVoice) {
@@ -460,52 +465,107 @@ export async function deliverReplies(params: {
       params.runtime.error?.(danger("reply missing text/media"));
       continue;
     }
-    const replyToId =
-      params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
-    const mediaList = reply.mediaUrls?.length
-      ? reply.mediaUrls
-      : reply.mediaUrl
-        ? [reply.mediaUrl]
-        : [];
-    const telegramData = reply.channelData?.telegram as
-      | { buttons?: TelegramInlineButtons }
-      | undefined;
-    const replyMarkup = buildInlineKeyboard(telegramData?.buttons);
-    if (mediaList.length === 0) {
-      await deliverTextReply({
-        bot: params.bot,
-        chatId: params.chatId,
-        runtime: params.runtime,
-        thread: params.thread,
-        chunkText,
-        replyText: reply.text || "",
-        replyMarkup,
-        replyQuoteText: params.replyQuoteText,
-        linkPreview: params.linkPreview,
-        replyToId,
-        replyToMode: params.replyToMode,
-        progress,
-      });
-      continue;
+
+    const rawContent = reply.text || "";
+    if (hasMessageSendingHooks) {
+      const hookResult = await hookRunner?.runMessageSending(
+        {
+          to: params.chatId,
+          content: rawContent,
+        },
+        {
+          channelId: "telegram",
+          conversationId: params.chatId,
+        },
+      );
+      if (hookResult?.cancel) {
+        continue;
+      }
+      if (typeof hookResult?.content === "string" && hookResult.content !== rawContent) {
+        reply = { ...reply, text: hookResult.content };
+      }
     }
-    await deliverMediaReply({
-      reply,
-      mediaList,
-      bot: params.bot,
-      chatId: params.chatId,
-      runtime: params.runtime,
-      thread: params.thread,
-      tableMode: params.tableMode,
-      mediaLocalRoots: params.mediaLocalRoots,
-      chunkText,
-      onVoiceRecording: params.onVoiceRecording,
-      linkPreview: params.linkPreview,
-      replyQuoteText: params.replyQuoteText,
-      replyMarkup,
-      replyToId,
-      replyToMode: params.replyToMode,
-      progress,
-    });
+
+    const contentForSentHook = reply.text || "";
+
+    try {
+      const replyToId =
+        params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
+      const mediaList = reply.mediaUrls?.length
+        ? reply.mediaUrls
+        : reply.mediaUrl
+          ? [reply.mediaUrl]
+          : [];
+      const telegramData = reply.channelData?.telegram as
+        | { buttons?: TelegramInlineButtons }
+        | undefined;
+      const replyMarkup = buildInlineKeyboard(telegramData?.buttons);
+      if (mediaList.length === 0) {
+        await deliverTextReply({
+          bot: params.bot,
+          chatId: params.chatId,
+          runtime: params.runtime,
+          thread: params.thread,
+          chunkText,
+          replyText: reply.text || "",
+          replyMarkup,
+          replyQuoteText: params.replyQuoteText,
+          linkPreview: params.linkPreview,
+          replyToId,
+          replyToMode: params.replyToMode,
+          progress,
+        });
+      } else {
+        await deliverMediaReply({
+          reply,
+          mediaList,
+          bot: params.bot,
+          chatId: params.chatId,
+          runtime: params.runtime,
+          thread: params.thread,
+          tableMode: params.tableMode,
+          mediaLocalRoots: params.mediaLocalRoots,
+          chunkText,
+          onVoiceRecording: params.onVoiceRecording,
+          linkPreview: params.linkPreview,
+          replyQuoteText: params.replyQuoteText,
+          replyMarkup,
+          replyToId,
+          replyToMode: params.replyToMode,
+          progress,
+        });
+      }
+
+      if (hasMessageSentHooks) {
+        void hookRunner?.runMessageSent(
+          {
+            to: params.chatId,
+            content: contentForSentHook,
+            success: true,
+          },
+          {
+            channelId: "telegram",
+            conversationId: params.chatId,
+          },
+        );
+      }
+    } catch (error) {
+      if (hasMessageSentHooks) {
+        void hookRunner?.runMessageSent(
+          {
+            to: params.chatId,
+            content: contentForSentHook,
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          {
+            channelId: "telegram",
+            conversationId: params.chatId,
+          },
+        );
+      }
+      throw error;
+    }
   }
 
   return { delivered: progress.hasDelivered };

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -459,7 +459,12 @@ export async function deliverReplies(params: {
   });
   for (const originalReply of params.replies) {
     let reply = originalReply;
-    const hasMedia = Boolean(reply?.mediaUrl) || (reply?.mediaUrls?.length ?? 0) > 0;
+    const mediaList = reply.mediaUrls?.length
+      ? reply.mediaUrls
+      : reply.mediaUrl
+        ? [reply.mediaUrl]
+        : [];
+    const hasMedia = mediaList.length > 0;
     if (!reply?.text && !hasMedia) {
       if (reply?.audioAsVoice) {
         logVerbose("telegram reply has audioAsVoice without media/text; skipping");
@@ -475,6 +480,11 @@ export async function deliverReplies(params: {
         {
           to: params.chatId,
           content: rawContent,
+          metadata: {
+            channel: "telegram",
+            mediaUrls: mediaList,
+            threadId: params.thread?.id,
+          },
         },
         {
           channelId: "telegram",
@@ -495,11 +505,6 @@ export async function deliverReplies(params: {
       const deliveredCountBeforeReply = progress.deliveredCount;
       const replyToId =
         params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
-      const mediaList = reply.mediaUrls?.length
-        ? reply.mediaUrls
-        : reply.mediaUrl
-          ? [reply.mediaUrl]
-          : [];
       const telegramData = reply.channelData?.telegram as
         | { buttons?: TelegramInlineButtons }
         | undefined;

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -4,6 +4,11 @@ import type { RuntimeEnv } from "../../runtime.js";
 import { deliverReplies } from "./delivery.js";
 
 const loadWebMedia = vi.fn();
+const messageHookRunner = vi.hoisted(() => ({
+  hasHooks: vi.fn<(name: string) => boolean>(() => false),
+  runMessageSending: vi.fn(),
+  runMessageSent: vi.fn(),
+}));
 const baseDeliveryParams = {
   chatId: "123",
   token: "tok",
@@ -20,6 +25,10 @@ type RuntimeStub = Pick<RuntimeEnv, "error" | "log" | "exit">;
 
 vi.mock("../../web/media.js", () => ({
   loadWebMedia: (...args: unknown[]) => loadWebMedia(...args),
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => messageHookRunner,
 }));
 
 vi.mock("grammy", () => ({
@@ -99,6 +108,10 @@ function createVoiceFailureHarness(params: {
 describe("deliverReplies", () => {
   beforeEach(() => {
     loadWebMedia.mockClear();
+    messageHookRunner.hasHooks.mockReset();
+    messageHookRunner.hasHooks.mockReturnValue(false);
+    messageHookRunner.runMessageSending.mockReset();
+    messageHookRunner.runMessageSent.mockReset();
   });
 
   it("skips audioAsVoice-only payloads without logging an error", async () => {
@@ -111,6 +124,29 @@ describe("deliverReplies", () => {
     });
 
     expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("reports message_sent success=false when hooks blank out a text-only reply", async () => {
+    messageHookRunner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending" || name === "message_sent",
+    );
+    messageHookRunner.runMessageSending.mockResolvedValue({ content: "" });
+
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn();
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [{ text: "hello" }],
+      runtime,
+      bot,
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, content: "" }),
+      expect.objectContaining({ channelId: "telegram", conversationId: "123" }),
+    );
   });
 
   it("invokes onVoiceRecording before sending a voice note", async () => {

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -149,6 +149,34 @@ describe("deliverReplies", () => {
     );
   });
 
+  it("passes media metadata to message_sending hooks", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sending");
+
+    const runtime = createRuntime(false);
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 2, chat: { id: "123" } });
+    const bot = createBot({ sendPhoto });
+
+    mockMediaLoad("photo.jpg", "image/jpeg", "image");
+
+    await deliverWith({
+      replies: [{ text: "caption", mediaUrl: "https://example.com/photo.jpg" }],
+      runtime,
+      bot,
+    });
+
+    expect(messageHookRunner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "123",
+        content: "caption",
+        metadata: expect.objectContaining({
+          channel: "telegram",
+          mediaUrls: ["https://example.com/photo.jpg"],
+        }),
+      }),
+      expect.objectContaining({ channelId: "telegram", conversationId: "123" }),
+    );
+  });
+
   it("invokes onVoiceRecording before sending a voice note", async () => {
     const events: string[] = [];
     const runtime = createRuntime(false);


### PR DESCRIPTION
## Summary
- wire Telegram reply delivery through plugin message hooks
- run `message_sending` before each reply payload send (supports modify/cancel)
- run `message_sent` after send success/failure for Telegram reply path

## Root cause
Telegram's direct reply path (`deliverReplies`) bypassed outbound hook execution, so plugins relying on `message_sending` / `message_sent` never fired for Telegram replies.

## Notes
- hook context uses `channelId: "telegram"` and `conversationId: chatId`
- send failures emit `message_sent` with `success: false` before rethrowing

Fixes #32581.

## Test
- `pnpm exec vitest run src/telegram/bot/delivery.test.ts`
