### PR TITLE
fix(slack): skip is_share attachments in bot fallback text extraction (#27616)

### DIFF
--- a/src/slack/monitor/message-handler/prepare-content.ts
+++ b/src/slack/monitor/message-handler/prepare-content.ts
@@ -77,10 +77,15 @@ export async function resolveSlackMessageContent(params: {
       : undefined;
   const fileOnlyPlaceholder = fileOnlyFallback ? `[Slack file: ${fileOnlyFallback}]` : undefined;
 
+  // Bot messages (e.g. Prometheus, Gatus webhooks) often carry content only in
+  // non-forwarded attachments (is_share !== true). Extract their text/fallback
+  // so the message isn't silently dropped when `allowBots: true` (#27616).
+  // Skip is_share attachments since resolveSlackAttachmentContent already handles those.
   const botAttachmentText =
     params.isBotMessage && !attachmentContent?.text
       ? (params.message.attachments ?? [])
-          .map((attachment) => attachment.text?.trim() || attachment.fallback?.trim())
+          .filter((a) => !a.is_share)
+          .map((a) => a.text?.trim() || a.fallback?.trim())
           .filter(Boolean)
           .join("\n")
       : undefined;

--- a/src/slack/monitor/message-handler/prepare-content.ts
+++ b/src/slack/monitor/message-handler/prepare-content.ts
@@ -80,13 +80,24 @@ export async function resolveSlackMessageContent(params: {
   // Bot messages (e.g. Prometheus, Gatus webhooks) often carry content only in
   // non-forwarded attachments (is_share !== true). Extract their text/fallback
   // so the message isn't silently dropped when `allowBots: true` (#27616).
-  // Skip is_share attachments since resolveSlackAttachmentContent already handles those.
+  // Skip the first 8 is_share attachments since resolveSlackAttachmentContent already handles those.
+  // However, keep is_share attachments beyond the first 8 as a fallback in case there are more
+  // than MAX_SLACK_FORWARDED_ATTACHMENTS (8), since resolveSlackAttachmentContent only processes
+  // the first 8.
+  let isShareCount = 0;
   const botAttachmentText =
     params.isBotMessage && !attachmentContent?.text
       ? (params.message.attachments ?? [])
-          .filter((a) => !a.is_share)
-          .map((a) => a.text?.trim() || a.fallback?.trim())
-          .filter(Boolean)
+          .flatMap((a) => {
+            if (a.is_share) {
+              if (isShareCount < MAX_SLACK_FORWARDED_ATTACHMENTS) {
+                isShareCount++;
+                return [];
+              }
+            }
+            const text = a.text?.trim() || a.fallback?.trim();
+            return text ? [text] : [];
+          })
           .join("\n")
       : undefined;
 

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -296,6 +296,37 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared!.ctxPayload.RawBody).toContain("Readiness probe failed");
   });
 
+  it("does not duplicate is_share attachment text in bot messages (#27616)", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: {
+          slack: { enabled: true },
+        },
+      } as OpenClawConfig,
+      defaultRequireMention: false,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Bot" }) as any;
+
+    const account = createSlackAccount({ allowBots: true });
+    const message = createSlackMessage({
+      text: "",
+      bot_id: "B0AGV8EQYA3",
+      subtype: "bot_message",
+      attachments: [
+        // is_share — handled by resolveSlackAttachmentContent
+        { is_share: true, author_name: "Alice", text: "Forwarded alert" },
+      ],
+    });
+
+    const prepared = await prepareMessageWith(slackCtx, account, message);
+
+    expect(prepared).toBeTruthy();
+    // Text should appear exactly once, not duplicated
+    const body: string = prepared!.ctxPayload.RawBody;
+    expect(body.indexOf("Forwarded alert")).toBe(body.lastIndexOf("Forwarded alert"));
+  });
+
   it("keeps channel metadata out of GroupSystemPrompt", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {


### PR DESCRIPTION
## Summary

Fixes Codex bot comment from PR #31707 about duplicate attachment content in bot messages.

## Root Cause

When processing bot messages with empty `text` but non-empty `attachments`, the code was extracting `text/fallback` from **all** attachments including `is_share: true` attachments. However, `resolveSlackAttachmentContent` already handles `is_share` attachments, causing duplicate content in `rawBody`.

## Fix

Add `.filter((a) => !a.is_share)` before extracting bot attachment text, so we only process non-forwarded attachments. This prevents:
- Duplicate content in `rawBody`
- Bloated context
- Repeated/echoed responses in channels ingesting forwarded bot alerts

## Changes

- **`src/slack/monitor/message-handler/prepare-content.ts`**: Skip `is_share` attachments when extracting bot fallback text

## Related

- Split from PR #31707
- Fixes #27616
- Addresses Codex comment: "Skip is_share attachments in bot fallback text extraction"