### PR TITLE
fix: cap cache hit rate at 100% (#26643)

### DIFF
--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -40,7 +40,8 @@ export const formatTokensCompact = (
       typeof used === "number"
         ? used
         : cacheRead + (typeof cacheWrite === "number" ? cacheWrite : 0);
-    const hitRate = Math.round((cacheRead / total) * 100);
+    // Cap at 100% since cache read can exceed tokens used in some edge cases
+    const hitRate = Math.min(100, Math.round((cacheRead / total) * 100));
     result += ` · 🗄️ ${hitRate}% cached`;
   }
 


### PR DESCRIPTION
## Summary

Fixes cache hit rate display showing values over 100% in some edge cases.

## Root Cause

When cache read can exceed total tokens used in certain edge cases, the calculated hit rate would exceed 100%, which is misleading.

## Fix

Cap the displayed hit rate at 100% using `Math.min(100, ...)` for accurate representation.

## Changes

- **`src/commands/status.format.ts`**: Cap cache hit rate calculation at 100%

## Related

- Split from PR #31707
- Fixes #26643