### PR TITLE
fix: pass user-configured baseUrl to Moonshot provider

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -635,9 +635,9 @@ function buildMinimaxPortalProvider(): ProviderConfig {
   };
 }
 
-function buildMoonshotProvider(): ProviderConfig {
+function buildMoonshotProvider(baseUrl?: string): ProviderConfig {
   return {
-    baseUrl: MOONSHOT_BASE_URL,
+    baseUrl: baseUrl ?? MOONSHOT_BASE_URL,
     api: "openai-completions",
     models: [
       {
@@ -948,7 +948,10 @@ export async function resolveImplicitProviders(params: {
     resolveEnvApiKeyVarName("moonshot") ??
     resolveApiKeyFromProfiles({ provider: "moonshot", store: authStore });
   if (moonshotKey) {
-    providers.moonshot = { ...buildMoonshotProvider(), apiKey: moonshotKey };
+    providers.moonshot = {
+      ...buildMoonshotProvider(params.explicitProviders?.moonshot?.baseUrl),
+      apiKey: moonshotKey,
+    };
   }
 
   const kimiCodingKey =


### PR DESCRIPTION
Fixes #32607

When a CN user configures `api.moonshot.cn` during onboarding, the baseUrl wasn't being passed to `buildMoonshotProvider()` — it always used the hardcoded international endpoint (`api.moonshot.ai`), causing 401s.

**Changes:**
- `buildMoonshotProvider()` now accepts an optional `baseUrl`, falling back to the default
- `resolveImplicitProviders()` passes the user's configured baseUrl from `explicitProviders`

Follows the same pattern already used by other providers (e.g. Ollama).

`pnpm check` passes. AI-assisted (Codex), reviewed and verified manually.