### PR TITLE
Onboarding: surface DingTalk as a community channel plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,11 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **DingTalk** — DingTalk (钉钉) channel plugin for OpenClaw
+  npm: `@soimy/dingtalk`
+  repo: `https://github.com/soimy/openclaw-channel-dingtalk`
+  install: `openclaw plugins install @soimy/dingtalk`
+
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`

--- a/src/commands/onboard-channels.ts
+++ b/src/commands/onboard-channels.ts
@@ -1,5 +1,6 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { listChannelPluginCatalogEntries } from "../channels/plugins/catalog.js";
+import type { ChannelPluginCatalogEntry } from "../channels/plugins/catalog.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { listChannelPlugins, getChannelPlugin } from "../channels/plugins/index.js";
 import type { ChannelMeta } from "../channels/plugins/types.js";
@@ -41,6 +42,24 @@ type ChannelStatusSummary = {
   catalogEntries: ReturnType<typeof listChannelPluginCatalogEntries>;
   statusByChannel: Map<ChannelChoice, ChannelOnboardingStatus>;
   statusLines: string[];
+};
+
+const DINGTALK_COMMUNITY_CATALOG_ENTRY: ChannelPluginCatalogEntry = {
+  id: "dingtalk",
+  meta: {
+    id: "dingtalk",
+    label: "DingTalk",
+    selectionLabel: "DingTalk (钉钉)",
+    docsPath: "/channels/dingtalk",
+    docsLabel: "dingtalk",
+    blurb: "钉钉企业内部机器人（社区插件），使用 Stream 模式，无需公网 IP。",
+    order: 70,
+    aliases: ["dd", "ding"],
+  },
+  install: {
+    npmSpec: "@soimy/dingtalk",
+    defaultChoice: "npm",
+  },
 };
 
 function formatAccountLabel(accountId: string): string {
@@ -121,6 +140,12 @@ async function collectChannelStatus(params: {
   const catalogEntries = listChannelPluginCatalogEntries({ workspaceDir }).filter(
     (entry) => !installedIds.has(entry.id),
   );
+
+  if (!installedIds.has(DINGTALK_COMMUNITY_CATALOG_ENTRY.id)) {
+    if (!catalogEntries.some((entry) => entry.id === DINGTALK_COMMUNITY_CATALOG_ENTRY.id)) {
+      catalogEntries.push(DINGTALK_COMMUNITY_CATALOG_ENTRY);
+    }
+  }
   const statusEntries = await Promise.all(
     listChannelOnboardingAdapters().map((adapter) =>
       adapter.getStatus({
@@ -417,6 +442,12 @@ export async function setupChannels(
     const catalog = listChannelPluginCatalogEntries({ workspaceDir }).filter(
       (entry) => !installedIds.has(entry.id),
     );
+
+    if (!installedIds.has(DINGTALK_COMMUNITY_CATALOG_ENTRY.id)) {
+      if (!catalog.some((entry) => entry.id === DINGTALK_COMMUNITY_CATALOG_ENTRY.id)) {
+        catalog.push(DINGTALK_COMMUNITY_CATALOG_ENTRY);
+      }
+    }
     const metaById = new Map<string, ChannelMeta>();
     for (const meta of core) {
       metaById.set(meta.id, meta);


### PR DESCRIPTION
Closes #26534.

This does **not** add a first-party DingTalk extension. It follows maintainer guidance from the previously-closed PR #27429 (comment by openclaw-barnacle[bot]): make DingTalk a third-party plugin and list it on the community plugins page.

Changes:
- Add DingTalk (@soimy/dingtalk) to docs/plugins/community.md
- Surface DingTalk as a community plugin option in the onboarding channel picker, using the existing onboarding plugin-install flow (install via npm, then enable the plugin).

Install command used by onboarding: `openclaw plugins install @soimy/dingtalk`
Repo: https://github.com/soimy/openclaw-channel-dingtalk

Tests:
- pnpm test src/wizard/onboarding.test.ts