### PR TITLE
fix(gateway): reset event seq on ws close to avoid gap false positives (fixes #32628)

### DIFF
--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -184,6 +184,9 @@ export class GatewayClient {
     this.ws.on("close", (code, reason) => {
       const reasonText = rawDataToString(reason);
       this.ws = null;
+      // Reset sequence so after reconnect (or gateway restart) we don't treat the new
+      // stream as a gap. See: https://github.com/openclaw/openclaw/issues/32628
+      this.lastSeq = null;
       // Clear persisted device auth state only when device-token auth was active.
       // Shared token/password failures can return the same close reason but should
       // not erase a valid cached device token.

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -130,7 +130,7 @@ describe("connectGateway", () => {
 
     secondClient.emitGap(20, 24);
     expect(host.lastError).toBe(
-      "event gap detected (expected seq 20, got 24); refresh recommended",
+      "event gap (expected 20, got 24). Can occur after gateway restart or reconnection; functionality is unaffected. Refresh to clear.",
     );
   });
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -204,7 +204,7 @@ export function connectGateway(host: GatewayHost) {
       if (host.client !== client) {
         return;
       }
-      host.lastError = `event gap detected (expected seq ${expected}, got ${received}); refresh recommended`;
+      host.lastError = `event gap (expected ${expected}, got ${received}). Can occur after gateway restart or reconnection; functionality is unaffected. Refresh to clear.`;
       host.lastErrorCode = null;
     },
   });

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -133,6 +133,8 @@ export class GatewayBrowserClient {
       const connectError = this.pendingConnectError;
       this.pendingConnectError = undefined;
       this.ws = null;
+      // Reset sequence so after auto-reconnect we don't treat the new stream as a gap (fixes #32628).
+      this.lastSeq = null;
       this.flushPending(new Error(`gateway closed (${ev.code}): ${reason}`));
       this.opts.onClose?.({ code: ev.code, reason, error: connectError });
       this.scheduleReconnect();


### PR DESCRIPTION
## Summary

- **Problem:** Control UI frequently shows "event gap detected (expected seq X, got Y)" after browser refresh or gateway restart. The client kept the previous connection’s `lastSeq`, so the new stream (seq starting from 0/1 after restart) was wrongly treated as a sequence gap.
- **Why it matters:** Users see repeated, alarming errors even when nothing is broken; the message suggested a serious issue although functionality is unaffected.
- **What changed:** (1) Reset `lastSeq` to `null` in the gateway client when the WebSocket closes, so each new connection has a clean sequence expectation. (2) Updated the Control UI gap message to state that it can occur after gateway restart or reconnection and that functionality is unaffected.
- **What did NOT change:** Event sequence semantics, server-side `seq` counter, or any API/contract; only client-side sequence reset and UI copy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32628
- Related #

## User-visible / Behavior Changes

- **Before:** "event gap detected (expected seq X, got Y); refresh recommended" (repeated after refresh/restart).
- **After:** Gap no longer reported after a clean reconnect or gateway restart. When a gap is still detected (e.g. real reorder/loss), the message is: "event gap (expected X, got Y). Can occur after gateway restart or reconnection; functionality is unaffected. Refresh to clear."

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Any (e.g. WSL2/Linux as in issue)
- Runtime/container: Node 22+
- Control UI in browser; gateway `mode: local`, `bind: lan`

### Steps

1. Open Control UI, connect to gateway.
2. Restart gateway (or trigger reconnect).
3. Observe status/error area.

### Expected

- No "event gap detected" after reconnect/restart. If a gap is ever shown, message explains it can follow restart/reconnect and does not affect functionality.

### Actual

- Matches expected after this fix.

## Evidence

- [x] Failing test/log before + passing after: `src/gateway/client.test.ts` and `client.watchdog.test.ts` pass; `ui/src/ui/app-gateway.node.test.ts` updated for new gap message and passes.
- [x] Logic: `lastSeq` reset in `client.ts` on `ws.on("close")`; UI string change in `app-gateway.ts`.

## Human Verification (required)

- **Verified scenarios:** Build and tests (`pnpm build && pnpm check && pnpm test` for touched areas). Logic reviewed: close handler resets `lastSeq`; UI copy updated and test expectation updated.
- **Edge cases checked:** Reconnect path, gateway restart path; no change to server seq or event payloads.
- **What you did not verify:** Long-running Control UI session under heavy event load in production.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- Revert the PR or the single commit; no config or data migration.
- Known bad symptoms: If gap detection were accidentally disabled or reset too aggressive, users might not see real sequence issues; this change only resets on close and keeps gap detection for the same connection.

## Risks and Mitigations

- **Risk:** Resetting `lastSeq` on every close could, in theory, hide a real gap that occurs exactly at the moment of a brief disconnect.
- **Mitigation:** Gaps are only meaningful within a single connection; after close, the stream is new and treating the next `seq` as the start is correct. Real gaps are still reported for the same WebSocket session.