### PR TITLE
fix(models): Preserve explicit baseUrl for Moonshot provider

### DIFF
--- a/src/agents/models-config.providers.moonshot.test.ts
+++ b/src/agents/models-config.providers.moonshot.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { captureEnv } from "../test-utils/env.js";
+import { resolveImplicitProviders } from "./models-config.providers.js";
+
+describe("moonshot implicit provider (#32607)", () => {
+  const createAgentDir = () => mkdtempSync(join(tmpdir(), "openclaw-test-"));
+
+  it("preserves explicit moonshot CN baseUrl on implicit provider injection", async () => {
+    const agentDir = createAgentDir();
+    const envSnapshot = captureEnv(["MOONSHOT_API_KEY"]);
+    process.env.MOONSHOT_API_KEY = "sk-test-cn-key";
+
+    try {
+      const providers = await resolveImplicitProviders({
+        agentDir,
+        explicitProviders: {
+          moonshot: {
+            baseUrl: "https://api.moonshot.cn/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      });
+
+      expect(providers?.moonshot).toBeDefined();
+      expect(providers?.moonshot?.baseUrl).toBe("https://api.moonshot.cn/v1");
+      expect(providers?.moonshot?.apiKey).toBe("MOONSHOT_API_KEY");
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("defaults to api.moonshot.ai when no explicit baseUrl is set", async () => {
+    const agentDir = createAgentDir();
+    const envSnapshot = captureEnv(["MOONSHOT_API_KEY"]);
+    process.env.MOONSHOT_API_KEY = "sk-test-intl-key";
+
+    try {
+      const providers = await resolveImplicitProviders({ agentDir });
+
+      expect(providers?.moonshot).toBeDefined();
+      expect(providers?.moonshot?.baseUrl).toBe("https://api.moonshot.ai/v1");
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("does not include moonshot when no API key is configured", async () => {
+    const agentDir = createAgentDir();
+    const envSnapshot = captureEnv(["MOONSHOT_API_KEY"]);
+    delete process.env.MOONSHOT_API_KEY;
+
+    try {
+      const providers = await resolveImplicitProviders({ agentDir });
+      expect(providers?.moonshot).toBeUndefined();
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -637,7 +637,7 @@ function buildMinimaxPortalProvider(): ProviderConfig {
 
 function buildMoonshotProvider(baseUrl?: string): ProviderConfig {
   return {
-    baseUrl: baseUrl?.trim() ?? MOONSHOT_BASE_URL,
+    baseUrl: baseUrl?.trim() || MOONSHOT_BASE_URL,
     api: "openai-completions",
     models: [
       {

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -635,9 +635,9 @@ function buildMinimaxPortalProvider(): ProviderConfig {
   };
 }
 
-function buildMoonshotProvider(): ProviderConfig {
+function buildMoonshotProvider(baseUrl?: string): ProviderConfig {
   return {
-    baseUrl: MOONSHOT_BASE_URL,
+    baseUrl: baseUrl?.trim() ?? MOONSHOT_BASE_URL,
     api: "openai-completions",
     models: [
       {
@@ -947,8 +947,12 @@ export async function resolveImplicitProviders(params: {
   const moonshotKey =
     resolveEnvApiKeyVarName("moonshot") ??
     resolveApiKeyFromProfiles({ provider: "moonshot", store: authStore });
+  const explicitMoonshot = params.explicitProviders?.moonshot;
   if (moonshotKey) {
-    providers.moonshot = { ...buildMoonshotProvider(), apiKey: moonshotKey };
+    providers.moonshot = {
+      ...buildMoonshotProvider(explicitMoonshot?.baseUrl),
+      apiKey: moonshotKey,
+    };
   }
 
   const kimiCodingKey =


### PR DESCRIPTION
### Problem

When a user configures an explicit `baseUrl` for the Moonshot provider in their `openclaw.toml` (e.g., to use the `https://api.moonshot.cn/v1` endpoint ), the implicit provider resolution logic overwrites it with the hardcoded default (`https://api.moonshot.ai/v1` ). This happens when an API key is found in the environment, triggering the injection of the "implicit" provider.

This behavior prevents users who require a non-default endpoint from using the Moonshot integration, as their requests are sent to the wrong API base, resulting in authentication errors.

### Fix

This PR modifies the implicit provider resolution logic to honor the user's explicitly configured `baseUrl`.

1.  The `buildMoonshotProvider` function is updated to accept an optional `baseUrl` parameter.
2.  In `resolveImplicitProviders`, the logic now first checks for an existing explicit Moonshot provider configuration.
3.  If found, its `baseUrl` is passed to `buildMoonshotProvider`, ensuring the user's setting is preserved.
4.  If no explicit `baseUrl` is provided, the logic safely falls back to the default `MOONSHOT_BASE_URL`.

This ensures that a user's specific endpoint configuration takes precedence while maintaining correct default behavior.

### Test Plan

- Added a new test suite `models-config.providers.moonshot.test.ts`.
- **Test Case 1**: Verifies that an explicit `baseUrl` (e.g., `https://api.moonshot.cn/v1` ) is preserved during implicit provider injection.
- **Test Case 2**: Confirms that the provider correctly falls back to the default `https://api.moonshot.ai/v1` when no explicit `baseUrl` is set.
- **Test Case 3**: Ensures the Moonshot provider is not added if no API key is configured.


Fixes #32607
