### PR TITLE
LINE: fix status false alarm for access token not configured

### DIFF
--- a/extensions/line/src/channel.startup.test.ts
+++ b/extensions/line/src/channel.startup.test.ts
@@ -129,3 +129,25 @@ describe("linePlugin gateway.startAccount", () => {
     await task;
   });
 });
+
+describe("linePlugin status.collectStatusIssues", () => {
+  it("reports no issues when snapshot is configured", () => {
+    const collect = linePlugin.status!.collectStatusIssues!;
+    const issues = collect([{ accountId: "default", configured: true, enabled: true }]);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("reports one issue when snapshot is not configured", () => {
+    const collect = linePlugin.status!.collectStatusIssues!;
+    const issues = collect([{ accountId: "default", configured: false, enabled: true }]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("LINE channel not configured");
+    expect(issues[0].channel).toBe("line");
+  });
+
+  it("uses snapshot.configured only (no token/secret in snapshot)", () => {
+    const collect = linePlugin.status!.collectStatusIssues!;
+    const issues = collect([{ accountId: "default", configured: true } as ChannelAccountSnapshot]);
+    expect(issues).toHaveLength(0);
+  });
+});

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -573,24 +573,18 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       lastStopAt: null,
       lastError: null,
     },
-    collectStatusIssues: (accounts) => {
+    collectStatusIssues: (snapshots) => {
       const issues: ChannelStatusIssue[] = [];
-      for (const account of accounts) {
-        const accountId = account.accountId ?? DEFAULT_ACCOUNT_ID;
-        if (!account.channelAccessToken?.trim()) {
+      for (const snapshot of snapshots) {
+        const accountId = snapshot.accountId ?? DEFAULT_ACCOUNT_ID;
+        // Snapshots do not include channelAccessToken/channelSecret; use configured flag.
+        if (snapshot.configured !== true) {
           issues.push({
             channel: "line",
             accountId,
             kind: "config",
-            message: "LINE channel access token not configured",
-          });
-        }
-        if (!account.channelSecret?.trim()) {
-          issues.push({
-            channel: "line",
-            accountId,
-            kind: "config",
-            message: "LINE channel secret not configured",
+            message:
+              "LINE channel not configured (set channelAccessToken and channelSecret in channels.line, or LINE_CHANNEL_ACCESS_TOKEN and LINE_CHANNEL_SECRET)",
           });
         }
       }


### PR DESCRIPTION
Fixes #32584

## Problem
`openclaw status --deep` always showed "LINE channel access token not configured" in the Channels section even when `channelAccessToken` was set in `channels.line` or `LINE_CHANNEL_ACCESS_TOKEN` was set.

## Cause
`collectStatusIssues` receives **snapshots** (from `buildChannelsTable`), which intentionally do not include `channelAccessToken`/`channelSecret`. The LINE plugin was checking `account.channelAccessToken` on those snapshots, so the value was always undefined.

## Fix
- Use the snapshot's `configured` flag instead (already computed in `buildAccountSnapshot` from token + secret).
- When `configured !== true`, report a single issue with a clear message pointing to config or env vars.

## Testing
- Added unit tests in `extensions/line/src/channel.startup.test.ts` for `collectStatusIssues` (configured true/false, snapshot without token).
- `pnpm test -- extensions/line/src/channel.startup.test.ts` passes.

Note: Webhook 404 in the issue may be environmental (e.g. gateway started without env). Once status shows OK, (re)starting the gateway with `LINE_CHANNEL_ACCESS_TOKEN` and `LINE_CHANNEL_SECRET` set should register the webhook route.

Made with [Cursor](https://cursor.com)