### PR TITLE
fix(gateway): align health and doctor with runtime state

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -145,6 +145,30 @@ describe("doctor config flow", () => {
     ).toBe(false);
   });
 
+  it("does not warn for accounts explicitly enabled under disabled channels", async () => {
+    const doctorWarnings = await collectDoctorWarnings({
+      channels: {
+        whatsapp: {
+          enabled: false,
+          accounts: {
+            work: {
+              enabled: true,
+              groupPolicy: "allowlist",
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      doctorWarnings.some(
+        (line) =>
+          line.includes('channels.whatsapp.accounts.work.groupPolicy is "allowlist"') &&
+          line.includes("groupAllowFrom"),
+      ),
+    ).toBe(false);
+  });
+
   it("drops unknown keys on repair", async () => {
     const result = await runDoctorConfigWithInput({
       repair: true,

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -126,6 +126,25 @@ describe("doctor config flow", () => {
     ).toBe(true);
   });
 
+  it("does not warn for disabled channels with empty allowlists", async () => {
+    const doctorWarnings = await collectDoctorWarnings({
+      channels: {
+        whatsapp: {
+          enabled: false,
+          groupPolicy: "allowlist",
+        },
+      },
+    });
+
+    expect(
+      doctorWarnings.some(
+        (line) =>
+          line.includes('channels.whatsapp.groupPolicy is "allowlist"') &&
+          line.includes("groupAllowFrom"),
+      ),
+    ).toBe(false);
+  });
+
   it("drops unknown keys on repair", async () => {
     const result = await runDoctorConfigWithInput({
       repair: true,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1293,8 +1293,10 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
     parent?: Record<string, unknown>,
     channelName?: string,
   ) => {
+    // Match runtime account resolution: a disabled channel disables all child accounts.
     const effectiveEnabled =
-      (account.enabled as boolean | undefined) ?? (parent?.enabled as boolean | undefined) ?? true;
+      ((parent?.enabled as boolean | undefined) ?? true) &&
+      ((account.enabled as boolean | undefined) ?? true);
     if (!effectiveEnabled) {
       return;
     }

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1293,6 +1293,12 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
     parent?: Record<string, unknown>,
     channelName?: string,
   ) => {
+    const effectiveEnabled =
+      (account.enabled as boolean | undefined) ?? (parent?.enabled as boolean | undefined) ?? true;
+    if (!effectiveEnabled) {
+      return;
+    }
+
     const dmEntry = account.dm;
     const dm =
       dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -105,6 +105,7 @@ import {
   getPresenceVersion,
   incrementPresenceVersion,
   refreshGatewayHealthSnapshot,
+  setHealthRuntimeSnapshotProvider,
 } from "./server/health-state.js";
 import { loadGatewayTlsRuntime } from "./server/tls.js";
 import { ensureGatewayStartupAuth } from "./startup-auth.js";
@@ -595,6 +596,7 @@ export async function startGatewayServer(
   });
   const { getRuntimeSnapshot, startChannels, startChannel, stopChannel, markChannelLoggedOut } =
     channelManager;
+  setHealthRuntimeSnapshotProvider(getRuntimeSnapshot);
 
   if (!minimalTestGateway) {
     const machineDisplayName = await getMachineDisplayName();
@@ -988,6 +990,7 @@ export async function startGatewayServer(
       browserAuthRateLimiter.dispose();
       channelHealthMonitor?.stop();
       clearSecretsRuntimeSnapshot();
+      setHealthRuntimeSnapshotProvider(null);
       await close(opts);
     },
   };

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -597,401 +597,408 @@ export async function startGatewayServer(
   const { getRuntimeSnapshot, startChannels, startChannel, stopChannel, markChannelLoggedOut } =
     channelManager;
   setHealthRuntimeSnapshotProvider(getRuntimeSnapshot);
+  try {
+    if (!minimalTestGateway) {
+      const machineDisplayName = await getMachineDisplayName();
+      const discovery = await startGatewayDiscovery({
+        machineDisplayName,
+        port,
+        gatewayTls: gatewayTls.enabled
+          ? { enabled: true, fingerprintSha256: gatewayTls.fingerprintSha256 }
+          : undefined,
+        wideAreaDiscoveryEnabled: cfgAtStart.discovery?.wideArea?.enabled === true,
+        wideAreaDiscoveryDomain: cfgAtStart.discovery?.wideArea?.domain,
+        tailscaleMode,
+        mdnsMode: cfgAtStart.discovery?.mdns?.mode,
+        logDiscovery,
+      });
+      bonjourStop = discovery.bonjourStop;
+    }
 
-  if (!minimalTestGateway) {
-    const machineDisplayName = await getMachineDisplayName();
-    const discovery = await startGatewayDiscovery({
-      machineDisplayName,
-      port,
-      gatewayTls: gatewayTls.enabled
-        ? { enabled: true, fingerprintSha256: gatewayTls.fingerprintSha256 }
-        : undefined,
-      wideAreaDiscoveryEnabled: cfgAtStart.discovery?.wideArea?.enabled === true,
-      wideAreaDiscoveryDomain: cfgAtStart.discovery?.wideArea?.domain,
-      tailscaleMode,
-      mdnsMode: cfgAtStart.discovery?.mdns?.mode,
-      logDiscovery,
+    if (!minimalTestGateway) {
+      setSkillsRemoteRegistry(nodeRegistry);
+      void primeRemoteSkillsCache();
+    }
+    // Debounce skills-triggered node probes to avoid feedback loops and rapid-fire invokes.
+    // Skills changes can happen in bursts (e.g., file watcher events), and each probe
+    // takes time to complete. A 30-second delay ensures we batch changes together.
+    let skillsRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+    const skillsRefreshDelayMs = 30_000;
+    const skillsChangeUnsub = minimalTestGateway
+      ? () => {}
+      : registerSkillsChangeListener((event) => {
+          if (event.reason === "remote-node") {
+            return;
+          }
+          if (skillsRefreshTimer) {
+            clearTimeout(skillsRefreshTimer);
+          }
+          skillsRefreshTimer = setTimeout(() => {
+            skillsRefreshTimer = null;
+            const latest = loadConfig();
+            void refreshRemoteBinsForConnectedNodes(latest);
+          }, skillsRefreshDelayMs);
+        });
+
+    const noopInterval = () => setInterval(() => {}, 1 << 30);
+    let tickInterval = noopInterval();
+    let healthInterval = noopInterval();
+    let dedupeCleanup = noopInterval();
+    if (!minimalTestGateway) {
+      ({ tickInterval, healthInterval, dedupeCleanup } = startGatewayMaintenanceTimers({
+        broadcast,
+        nodeSendToAllSubscribed,
+        getPresenceVersion,
+        getHealthVersion,
+        refreshGatewayHealthSnapshot,
+        logHealth,
+        dedupe,
+        chatAbortControllers,
+        chatRunState,
+        chatRunBuffers,
+        chatDeltaSentAt,
+        removeChatRun,
+        agentRunSeq,
+        nodeSendToSession,
+      }));
+    }
+
+    const agentUnsub = minimalTestGateway
+      ? null
+      : onAgentEvent(
+          createAgentEventHandler({
+            broadcast,
+            broadcastToConnIds,
+            nodeSendToSession,
+            agentRunSeq,
+            chatRunState,
+            resolveSessionKeyForRun,
+            clearAgentRunContext,
+            toolEventRecipients,
+          }),
+        );
+
+    const heartbeatUnsub = minimalTestGateway
+      ? null
+      : onHeartbeatEvent((evt) => {
+          broadcast("heartbeat", evt, { dropIfSlow: true });
+        });
+
+    let heartbeatRunner: HeartbeatRunner = minimalTestGateway
+      ? {
+          stop: () => {},
+          updateConfig: () => {},
+        }
+      : startHeartbeatRunner({ cfg: cfgAtStart });
+
+    const healthCheckMinutes = cfgAtStart.gateway?.channelHealthCheckMinutes;
+    const healthCheckDisabled = healthCheckMinutes === 0;
+    let channelHealthMonitor = healthCheckDisabled
+      ? null
+      : startChannelHealthMonitor({
+          channelManager,
+          checkIntervalMs: (healthCheckMinutes ?? 5) * 60_000,
+        });
+
+    if (!minimalTestGateway) {
+      void cron.start().catch((err) => logCron.error(`failed to start: ${String(err)}`));
+    }
+
+    // Recover pending outbound deliveries from previous crash/restart.
+    if (!minimalTestGateway) {
+      void (async () => {
+        const { recoverPendingDeliveries } = await import("../infra/outbound/delivery-queue.js");
+        const { deliverOutboundPayloads } = await import("../infra/outbound/deliver.js");
+        const logRecovery = log.child("delivery-recovery");
+        await recoverPendingDeliveries({
+          deliver: deliverOutboundPayloads,
+          log: logRecovery,
+          cfg: cfgAtStart,
+        });
+      })().catch((err) => log.error(`Delivery recovery failed: ${String(err)}`));
+    }
+
+    const execApprovalManager = new ExecApprovalManager();
+    const execApprovalForwarder = createExecApprovalForwarder();
+    const execApprovalHandlers = createExecApprovalHandlers(execApprovalManager, {
+      forwarder: execApprovalForwarder,
     });
-    bonjourStop = discovery.bonjourStop;
-  }
+    const secretsHandlers = createSecretsHandlers({
+      reloadSecrets: async () => {
+        const active = getActiveSecretsRuntimeSnapshot();
+        if (!active) {
+          throw new Error("Secrets runtime snapshot is not active.");
+        }
+        const prepared = await activateRuntimeSecrets(active.sourceConfig, {
+          reason: "reload",
+          activate: true,
+        });
+        return { warningCount: prepared.warnings.length };
+      },
+      resolveSecrets: async ({ commandName, targetIds }) => {
+        const { assignments, diagnostics, inactiveRefPaths } =
+          resolveCommandSecretsFromActiveRuntimeSnapshot({
+            commandName,
+            targetIds: new Set(targetIds),
+          });
+        if (assignments.length === 0) {
+          return { assignments: [] as CommandSecretAssignment[], diagnostics, inactiveRefPaths };
+        }
+        return { assignments, diagnostics, inactiveRefPaths };
+      },
+    });
 
-  if (!minimalTestGateway) {
-    setSkillsRemoteRegistry(nodeRegistry);
-    void primeRemoteSkillsCache();
-  }
-  // Debounce skills-triggered node probes to avoid feedback loops and rapid-fire invokes.
-  // Skills changes can happen in bursts (e.g., file watcher events), and each probe
-  // takes time to complete. A 30-second delay ensures we batch changes together.
-  let skillsRefreshTimer: ReturnType<typeof setTimeout> | null = null;
-  const skillsRefreshDelayMs = 30_000;
-  const skillsChangeUnsub = minimalTestGateway
-    ? () => {}
-    : registerSkillsChangeListener((event) => {
-        if (event.reason === "remote-node") {
-          return;
+    const canvasHostServerPort = (canvasHostServer as CanvasHostServer | null)?.port;
+
+    attachGatewayWsHandlers({
+      wss,
+      clients,
+      port,
+      gatewayHost: bindHost ?? undefined,
+      canvasHostEnabled: Boolean(canvasHost),
+      canvasHostServerPort,
+      resolvedAuth,
+      rateLimiter: authRateLimiter,
+      browserRateLimiter: browserAuthRateLimiter,
+      gatewayMethods,
+      events: GATEWAY_EVENTS,
+      logGateway: log,
+      logHealth,
+      logWsControl,
+      extraHandlers: {
+        ...pluginRegistry.gatewayHandlers,
+        ...execApprovalHandlers,
+        ...secretsHandlers,
+      },
+      broadcast,
+      context: {
+        deps,
+        cron,
+        cronStorePath,
+        execApprovalManager,
+        loadGatewayModelCatalog,
+        getHealthCache,
+        refreshHealthSnapshot: refreshGatewayHealthSnapshot,
+        logHealth,
+        logGateway: log,
+        incrementPresenceVersion,
+        getHealthVersion,
+        broadcast,
+        broadcastToConnIds,
+        nodeSendToSession,
+        nodeSendToAllSubscribed,
+        nodeSubscribe,
+        nodeUnsubscribe,
+        nodeUnsubscribeAll,
+        hasConnectedMobileNode: hasMobileNodeConnected,
+        hasExecApprovalClients: () => {
+          for (const gatewayClient of clients) {
+            const scopes = Array.isArray(gatewayClient.connect.scopes)
+              ? gatewayClient.connect.scopes
+              : [];
+            if (scopes.includes("operator.admin") || scopes.includes("operator.approvals")) {
+              return true;
+            }
+          }
+          return false;
+        },
+        nodeRegistry,
+        agentRunSeq,
+        chatAbortControllers,
+        chatAbortedRuns: chatRunState.abortedRuns,
+        chatRunBuffers: chatRunState.buffers,
+        chatDeltaSentAt: chatRunState.deltaSentAt,
+        addChatRun,
+        removeChatRun,
+        registerToolEventRecipient: toolEventRecipients.add,
+        dedupe,
+        wizardSessions,
+        findRunningWizard,
+        purgeWizardSession,
+        getRuntimeSnapshot,
+        startChannel,
+        stopChannel,
+        markChannelLoggedOut,
+        wizardRunner,
+        broadcastVoiceWakeChanged,
+      },
+    });
+    logGatewayStartup({
+      cfg: cfgAtStart,
+      bindHost,
+      bindHosts: httpBindHosts,
+      port,
+      tlsEnabled: gatewayTls.enabled,
+      log,
+      isNixMode,
+    });
+    const stopGatewayUpdateCheck = minimalTestGateway
+      ? () => {}
+      : scheduleGatewayUpdateCheck({
+          cfg: cfgAtStart,
+          log,
+          isNixMode,
+          onUpdateAvailableChange: (updateAvailable) => {
+            const payload: GatewayUpdateAvailableEventPayload = { updateAvailable };
+            broadcast(GATEWAY_EVENT_UPDATE_AVAILABLE, payload, { dropIfSlow: true });
+          },
+        });
+    const tailscaleCleanup = minimalTestGateway
+      ? null
+      : await startGatewayTailscaleExposure({
+          tailscaleMode,
+          resetOnExit: tailscaleConfig.resetOnExit,
+          port,
+          controlUiBasePath,
+          logTailscale,
+        });
+
+    let browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> = null;
+    if (!minimalTestGateway) {
+      ({ browserControl, pluginServices } = await startGatewaySidecars({
+        cfg: cfgAtStart,
+        pluginRegistry,
+        defaultWorkspaceDir,
+        deps,
+        startChannels,
+        log,
+        logHooks,
+        logChannels,
+        logBrowser,
+      }));
+    }
+
+    // Run gateway_start plugin hook (fire-and-forget)
+    if (!minimalTestGateway) {
+      const hookRunner = getGlobalHookRunner();
+      if (hookRunner?.hasHooks("gateway_start")) {
+        void hookRunner.runGatewayStart({ port }, { port }).catch((err) => {
+          log.warn(`gateway_start hook failed: ${String(err)}`);
+        });
+      }
+    }
+
+    const configReloader = minimalTestGateway
+      ? { stop: async () => {} }
+      : (() => {
+          const { applyHotReload, requestGatewayRestart } = createGatewayReloadHandlers({
+            deps,
+            broadcast,
+            getState: () => ({
+              hooksConfig,
+              heartbeatRunner,
+              cronState,
+              browserControl,
+              channelHealthMonitor,
+            }),
+            setState: (nextState) => {
+              hooksConfig = nextState.hooksConfig;
+              heartbeatRunner = nextState.heartbeatRunner;
+              cronState = nextState.cronState;
+              cron = cronState.cron;
+              cronStorePath = cronState.storePath;
+              browserControl = nextState.browserControl;
+              channelHealthMonitor = nextState.channelHealthMonitor;
+            },
+            startChannel,
+            stopChannel,
+            logHooks,
+            logBrowser,
+            logChannels,
+            logCron,
+            logReload,
+            createHealthMonitor: (checkIntervalMs: number) =>
+              startChannelHealthMonitor({ channelManager, checkIntervalMs }),
+          });
+
+          return startGatewayConfigReloader({
+            initialConfig: cfgAtStart,
+            readSnapshot: readConfigFileSnapshot,
+            onHotReload: async (plan, nextConfig) => {
+              const previousSnapshot = getActiveSecretsRuntimeSnapshot();
+              const prepared = await activateRuntimeSecrets(nextConfig, {
+                reason: "reload",
+                activate: true,
+              });
+              try {
+                await applyHotReload(plan, prepared.config);
+              } catch (err) {
+                if (previousSnapshot) {
+                  activateSecretsRuntimeSnapshot(previousSnapshot);
+                } else {
+                  clearSecretsRuntimeSnapshot();
+                }
+                throw err;
+              }
+            },
+            onRestart: async (plan, nextConfig) => {
+              await activateRuntimeSecrets(nextConfig, {
+                reason: "restart-check",
+                activate: false,
+              });
+              requestGatewayRestart(plan, nextConfig);
+            },
+            log: {
+              info: (msg) => logReload.info(msg),
+              warn: (msg) => logReload.warn(msg),
+              error: (msg) => logReload.error(msg),
+            },
+            watchPath: CONFIG_PATH,
+          });
+        })();
+
+    const close = createGatewayCloseHandler({
+      bonjourStop,
+      tailscaleCleanup,
+      canvasHost,
+      canvasHostServer,
+      stopChannel,
+      pluginServices,
+      cron,
+      heartbeatRunner,
+      updateCheckStop: stopGatewayUpdateCheck,
+      nodePresenceTimers,
+      broadcast,
+      tickInterval,
+      healthInterval,
+      dedupeCleanup,
+      agentUnsub,
+      heartbeatUnsub,
+      chatRunState,
+      clients,
+      configReloader,
+      browserControl,
+      wss,
+      httpServer,
+      httpServers,
+    });
+
+    return {
+      close: async (opts) => {
+        // Run gateway_stop plugin hook before shutdown
+        await runGlobalGatewayStopSafely({
+          event: { reason: opts?.reason ?? "gateway stopping" },
+          ctx: { port },
+          onError: (err) => log.warn(`gateway_stop hook failed: ${String(err)}`),
+        });
+        if (diagnosticsEnabled) {
+          stopDiagnosticHeartbeat();
         }
         if (skillsRefreshTimer) {
           clearTimeout(skillsRefreshTimer);
-        }
-        skillsRefreshTimer = setTimeout(() => {
           skillsRefreshTimer = null;
-          const latest = loadConfig();
-          void refreshRemoteBinsForConnectedNodes(latest);
-        }, skillsRefreshDelayMs);
-      });
-
-  const noopInterval = () => setInterval(() => {}, 1 << 30);
-  let tickInterval = noopInterval();
-  let healthInterval = noopInterval();
-  let dedupeCleanup = noopInterval();
-  if (!minimalTestGateway) {
-    ({ tickInterval, healthInterval, dedupeCleanup } = startGatewayMaintenanceTimers({
-      broadcast,
-      nodeSendToAllSubscribed,
-      getPresenceVersion,
-      getHealthVersion,
-      refreshGatewayHealthSnapshot,
-      logHealth,
-      dedupe,
-      chatAbortControllers,
-      chatRunState,
-      chatRunBuffers,
-      chatDeltaSentAt,
-      removeChatRun,
-      agentRunSeq,
-      nodeSendToSession,
-    }));
-  }
-
-  const agentUnsub = minimalTestGateway
-    ? null
-    : onAgentEvent(
-        createAgentEventHandler({
-          broadcast,
-          broadcastToConnIds,
-          nodeSendToSession,
-          agentRunSeq,
-          chatRunState,
-          resolveSessionKeyForRun,
-          clearAgentRunContext,
-          toolEventRecipients,
-        }),
-      );
-
-  const heartbeatUnsub = minimalTestGateway
-    ? null
-    : onHeartbeatEvent((evt) => {
-        broadcast("heartbeat", evt, { dropIfSlow: true });
-      });
-
-  let heartbeatRunner: HeartbeatRunner = minimalTestGateway
-    ? {
-        stop: () => {},
-        updateConfig: () => {},
-      }
-    : startHeartbeatRunner({ cfg: cfgAtStart });
-
-  const healthCheckMinutes = cfgAtStart.gateway?.channelHealthCheckMinutes;
-  const healthCheckDisabled = healthCheckMinutes === 0;
-  let channelHealthMonitor = healthCheckDisabled
-    ? null
-    : startChannelHealthMonitor({
-        channelManager,
-        checkIntervalMs: (healthCheckMinutes ?? 5) * 60_000,
-      });
-
-  if (!minimalTestGateway) {
-    void cron.start().catch((err) => logCron.error(`failed to start: ${String(err)}`));
-  }
-
-  // Recover pending outbound deliveries from previous crash/restart.
-  if (!minimalTestGateway) {
-    void (async () => {
-      const { recoverPendingDeliveries } = await import("../infra/outbound/delivery-queue.js");
-      const { deliverOutboundPayloads } = await import("../infra/outbound/deliver.js");
-      const logRecovery = log.child("delivery-recovery");
-      await recoverPendingDeliveries({
-        deliver: deliverOutboundPayloads,
-        log: logRecovery,
-        cfg: cfgAtStart,
-      });
-    })().catch((err) => log.error(`Delivery recovery failed: ${String(err)}`));
-  }
-
-  const execApprovalManager = new ExecApprovalManager();
-  const execApprovalForwarder = createExecApprovalForwarder();
-  const execApprovalHandlers = createExecApprovalHandlers(execApprovalManager, {
-    forwarder: execApprovalForwarder,
-  });
-  const secretsHandlers = createSecretsHandlers({
-    reloadSecrets: async () => {
-      const active = getActiveSecretsRuntimeSnapshot();
-      if (!active) {
-        throw new Error("Secrets runtime snapshot is not active.");
-      }
-      const prepared = await activateRuntimeSecrets(active.sourceConfig, {
-        reason: "reload",
-        activate: true,
-      });
-      return { warningCount: prepared.warnings.length };
-    },
-    resolveSecrets: async ({ commandName, targetIds }) => {
-      const { assignments, diagnostics, inactiveRefPaths } =
-        resolveCommandSecretsFromActiveRuntimeSnapshot({
-          commandName,
-          targetIds: new Set(targetIds),
-        });
-      if (assignments.length === 0) {
-        return { assignments: [] as CommandSecretAssignment[], diagnostics, inactiveRefPaths };
-      }
-      return { assignments, diagnostics, inactiveRefPaths };
-    },
-  });
-
-  const canvasHostServerPort = (canvasHostServer as CanvasHostServer | null)?.port;
-
-  attachGatewayWsHandlers({
-    wss,
-    clients,
-    port,
-    gatewayHost: bindHost ?? undefined,
-    canvasHostEnabled: Boolean(canvasHost),
-    canvasHostServerPort,
-    resolvedAuth,
-    rateLimiter: authRateLimiter,
-    browserRateLimiter: browserAuthRateLimiter,
-    gatewayMethods,
-    events: GATEWAY_EVENTS,
-    logGateway: log,
-    logHealth,
-    logWsControl,
-    extraHandlers: {
-      ...pluginRegistry.gatewayHandlers,
-      ...execApprovalHandlers,
-      ...secretsHandlers,
-    },
-    broadcast,
-    context: {
-      deps,
-      cron,
-      cronStorePath,
-      execApprovalManager,
-      loadGatewayModelCatalog,
-      getHealthCache,
-      refreshHealthSnapshot: refreshGatewayHealthSnapshot,
-      logHealth,
-      logGateway: log,
-      incrementPresenceVersion,
-      getHealthVersion,
-      broadcast,
-      broadcastToConnIds,
-      nodeSendToSession,
-      nodeSendToAllSubscribed,
-      nodeSubscribe,
-      nodeUnsubscribe,
-      nodeUnsubscribeAll,
-      hasConnectedMobileNode: hasMobileNodeConnected,
-      hasExecApprovalClients: () => {
-        for (const gatewayClient of clients) {
-          const scopes = Array.isArray(gatewayClient.connect.scopes)
-            ? gatewayClient.connect.scopes
-            : [];
-          if (scopes.includes("operator.admin") || scopes.includes("operator.approvals")) {
-            return true;
-          }
         }
-        return false;
+        skillsChangeUnsub();
+        authRateLimiter?.dispose();
+        browserAuthRateLimiter.dispose();
+        channelHealthMonitor?.stop();
+        clearSecretsRuntimeSnapshot();
+        setHealthRuntimeSnapshotProvider(null);
+        await close(opts);
       },
-      nodeRegistry,
-      agentRunSeq,
-      chatAbortControllers,
-      chatAbortedRuns: chatRunState.abortedRuns,
-      chatRunBuffers: chatRunState.buffers,
-      chatDeltaSentAt: chatRunState.deltaSentAt,
-      addChatRun,
-      removeChatRun,
-      registerToolEventRecipient: toolEventRecipients.add,
-      dedupe,
-      wizardSessions,
-      findRunningWizard,
-      purgeWizardSession,
-      getRuntimeSnapshot,
-      startChannel,
-      stopChannel,
-      markChannelLoggedOut,
-      wizardRunner,
-      broadcastVoiceWakeChanged,
-    },
-  });
-  logGatewayStartup({
-    cfg: cfgAtStart,
-    bindHost,
-    bindHosts: httpBindHosts,
-    port,
-    tlsEnabled: gatewayTls.enabled,
-    log,
-    isNixMode,
-  });
-  const stopGatewayUpdateCheck = minimalTestGateway
-    ? () => {}
-    : scheduleGatewayUpdateCheck({
-        cfg: cfgAtStart,
-        log,
-        isNixMode,
-        onUpdateAvailableChange: (updateAvailable) => {
-          const payload: GatewayUpdateAvailableEventPayload = { updateAvailable };
-          broadcast(GATEWAY_EVENT_UPDATE_AVAILABLE, payload, { dropIfSlow: true });
-        },
-      });
-  const tailscaleCleanup = minimalTestGateway
-    ? null
-    : await startGatewayTailscaleExposure({
-        tailscaleMode,
-        resetOnExit: tailscaleConfig.resetOnExit,
-        port,
-        controlUiBasePath,
-        logTailscale,
-      });
-
-  let browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> = null;
-  if (!minimalTestGateway) {
-    ({ browserControl, pluginServices } = await startGatewaySidecars({
-      cfg: cfgAtStart,
-      pluginRegistry,
-      defaultWorkspaceDir,
-      deps,
-      startChannels,
-      log,
-      logHooks,
-      logChannels,
-      logBrowser,
-    }));
+    };
+  } catch (err) {
+    setHealthRuntimeSnapshotProvider(null);
+    throw err;
   }
-
-  // Run gateway_start plugin hook (fire-and-forget)
-  if (!minimalTestGateway) {
-    const hookRunner = getGlobalHookRunner();
-    if (hookRunner?.hasHooks("gateway_start")) {
-      void hookRunner.runGatewayStart({ port }, { port }).catch((err) => {
-        log.warn(`gateway_start hook failed: ${String(err)}`);
-      });
-    }
-  }
-
-  const configReloader = minimalTestGateway
-    ? { stop: async () => {} }
-    : (() => {
-        const { applyHotReload, requestGatewayRestart } = createGatewayReloadHandlers({
-          deps,
-          broadcast,
-          getState: () => ({
-            hooksConfig,
-            heartbeatRunner,
-            cronState,
-            browserControl,
-            channelHealthMonitor,
-          }),
-          setState: (nextState) => {
-            hooksConfig = nextState.hooksConfig;
-            heartbeatRunner = nextState.heartbeatRunner;
-            cronState = nextState.cronState;
-            cron = cronState.cron;
-            cronStorePath = cronState.storePath;
-            browserControl = nextState.browserControl;
-            channelHealthMonitor = nextState.channelHealthMonitor;
-          },
-          startChannel,
-          stopChannel,
-          logHooks,
-          logBrowser,
-          logChannels,
-          logCron,
-          logReload,
-          createHealthMonitor: (checkIntervalMs: number) =>
-            startChannelHealthMonitor({ channelManager, checkIntervalMs }),
-        });
-
-        return startGatewayConfigReloader({
-          initialConfig: cfgAtStart,
-          readSnapshot: readConfigFileSnapshot,
-          onHotReload: async (plan, nextConfig) => {
-            const previousSnapshot = getActiveSecretsRuntimeSnapshot();
-            const prepared = await activateRuntimeSecrets(nextConfig, {
-              reason: "reload",
-              activate: true,
-            });
-            try {
-              await applyHotReload(plan, prepared.config);
-            } catch (err) {
-              if (previousSnapshot) {
-                activateSecretsRuntimeSnapshot(previousSnapshot);
-              } else {
-                clearSecretsRuntimeSnapshot();
-              }
-              throw err;
-            }
-          },
-          onRestart: async (plan, nextConfig) => {
-            await activateRuntimeSecrets(nextConfig, { reason: "restart-check", activate: false });
-            requestGatewayRestart(plan, nextConfig);
-          },
-          log: {
-            info: (msg) => logReload.info(msg),
-            warn: (msg) => logReload.warn(msg),
-            error: (msg) => logReload.error(msg),
-          },
-          watchPath: CONFIG_PATH,
-        });
-      })();
-
-  const close = createGatewayCloseHandler({
-    bonjourStop,
-    tailscaleCleanup,
-    canvasHost,
-    canvasHostServer,
-    stopChannel,
-    pluginServices,
-    cron,
-    heartbeatRunner,
-    updateCheckStop: stopGatewayUpdateCheck,
-    nodePresenceTimers,
-    broadcast,
-    tickInterval,
-    healthInterval,
-    dedupeCleanup,
-    agentUnsub,
-    heartbeatUnsub,
-    chatRunState,
-    clients,
-    configReloader,
-    browserControl,
-    wss,
-    httpServer,
-    httpServers,
-  });
-
-  return {
-    close: async (opts) => {
-      // Run gateway_stop plugin hook before shutdown
-      await runGlobalGatewayStopSafely({
-        event: { reason: opts?.reason ?? "gateway stopping" },
-        ctx: { port },
-        onError: (err) => log.warn(`gateway_stop hook failed: ${String(err)}`),
-      });
-      if (diagnosticsEnabled) {
-        stopDiagnosticHeartbeat();
-      }
-      if (skillsRefreshTimer) {
-        clearTimeout(skillsRefreshTimer);
-        skillsRefreshTimer = null;
-      }
-      skillsChangeUnsub();
-      authRateLimiter?.dispose();
-      browserAuthRateLimiter.dispose();
-      channelHealthMonitor?.stop();
-      clearSecretsRuntimeSnapshot();
-      setHealthRuntimeSnapshotProvider(null);
-      await close(opts);
-    },
-  };
 }

--- a/src/gateway/server/health-state.test.ts
+++ b/src/gateway/server/health-state.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { ChannelPlugin } from "../../channels/plugins/types.js";
+import type { HealthSummary } from "../../commands/health.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
+import { installGatewayTestHooks, setTestPluginRegistry, testState } from "../test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+let healthStateModule: typeof import("./health-state.js");
+
+const createSlackHealthPlugin = (): ChannelPlugin => ({
+  ...createChannelTestPluginBase({
+    id: "slack",
+    label: "Slack",
+    config: {
+      resolveAccount: () => ({
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+      }),
+      isConfigured: async () => true,
+    },
+  }),
+  status: {
+    buildAccountSnapshot: async ({ runtime }) => ({
+      accountId: "default",
+      configured: true,
+      botTokenSource: "config",
+      appTokenSource: "config",
+      running: runtime?.running === true,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+    }),
+    buildChannelSummary: async () => ({
+      accountId: "default",
+      configured: true,
+      botTokenSource: "none",
+      appTokenSource: "none",
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    }),
+  },
+});
+
+const buildBaseHealthSummary = (): HealthSummary => ({
+  ok: true,
+  ts: 1,
+  durationMs: 5,
+  channels: {
+    slack: {
+      accountId: "default",
+      configured: true,
+      botTokenSource: "none",
+      appTokenSource: "none",
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+      accounts: {
+        default: {
+          accountId: "default",
+          configured: true,
+          botTokenSource: "none",
+          appTokenSource: "none",
+          running: false,
+          lastStartAt: null,
+          lastStopAt: null,
+          lastError: null,
+        },
+      },
+    },
+  },
+  channelOrder: ["slack"],
+  channelLabels: { slack: "Slack" },
+  heartbeatSeconds: 0,
+  defaultAgentId: "main",
+  agents: [],
+  sessions: {
+    path: "/tmp/test-sessions.json",
+    count: 0,
+    recent: [],
+  },
+});
+
+describe("refreshGatewayHealthSnapshot", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    healthStateModule = await import("./health-state.js");
+    testState.channelsConfig = {
+      slack: {
+        enabled: true,
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+      },
+    };
+    setTestPluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          source: "test",
+          plugin: createSlackHealthPlugin(),
+        },
+      ]),
+    );
+    healthStateModule.setHealthRuntimeSnapshotProvider(() => ({
+      channels: {
+        slack: {
+          accountId: "default",
+          enabled: true,
+          configured: true,
+          running: true,
+          lastStartAt: 1_777_000_000_000,
+          lastStopAt: null,
+          lastError: null,
+        },
+      },
+      channelAccounts: {
+        slack: {
+          default: {
+            accountId: "default",
+            enabled: true,
+            configured: true,
+            running: true,
+            lastStartAt: 1_777_000_000_000,
+            lastStopAt: null,
+            lastError: null,
+          },
+        },
+      },
+    }));
+  });
+
+  test("merges live runtime channel state into health snapshots", async () => {
+    const snap = await healthStateModule.overlayHealthSnapshotWithRuntime(buildBaseHealthSummary());
+
+    expect(snap.channels.slack.botTokenSource).toBe("config");
+    expect(snap.channels.slack.appTokenSource).toBe("config");
+    expect(snap.channels.slack.running).toBe(true);
+    expect(snap.channels.slack.lastStartAt).toBe(1_777_000_000_000);
+    expect(snap.channels.slack.accounts?.default?.running).toBe(true);
+    expect(snap.channels.slack.accounts?.default?.botTokenSource).toBe("config");
+    expect(healthStateModule.getHealthCache()).toBeNull();
+  });
+});

--- a/src/gateway/server/health-state.test.ts
+++ b/src/gateway/server/health-state.test.ts
@@ -113,6 +113,8 @@ describe("refreshGatewayHealthSnapshot", () => {
           accountId: "default",
           enabled: true,
           configured: true,
+          botTokenSource: "config",
+          appTokenSource: "config",
           running: true,
           lastStartAt: 1_777_000_000_000,
           lastStopAt: null,
@@ -125,6 +127,8 @@ describe("refreshGatewayHealthSnapshot", () => {
             accountId: "default",
             enabled: true,
             configured: true,
+            botTokenSource: "config",
+            appTokenSource: "config",
             running: true,
             lastStartAt: 1_777_000_000_000,
             lastStopAt: null,
@@ -138,6 +142,9 @@ describe("refreshGatewayHealthSnapshot", () => {
   test("merges live runtime channel state into health snapshots", async () => {
     const input = buildBaseHealthSummary();
     input.channels.slack.configured = false;
+    if (input.channels.slack.accounts?.default) {
+      input.channels.slack.accounts.default.configured = false;
+    }
     const snap = await healthStateModule.overlayHealthSnapshotWithRuntime(input);
 
     expect(snap.channels.slack.botTokenSource).toBe("config");
@@ -147,6 +154,7 @@ describe("refreshGatewayHealthSnapshot", () => {
     expect(snap.channels.slack.configured).toBe(false);
     expect(snap.channels.slack.accounts?.default?.running).toBe(true);
     expect(snap.channels.slack.accounts?.default?.botTokenSource).toBe("config");
+    expect(snap.channels.slack.accounts?.default?.configured).toBe(false);
     expect(healthStateModule.getHealthCache()).toBeNull();
   });
 });

--- a/src/gateway/server/health-state.test.ts
+++ b/src/gateway/server/health-state.test.ts
@@ -136,12 +136,15 @@ describe("refreshGatewayHealthSnapshot", () => {
   });
 
   test("merges live runtime channel state into health snapshots", async () => {
-    const snap = await healthStateModule.overlayHealthSnapshotWithRuntime(buildBaseHealthSummary());
+    const input = buildBaseHealthSummary();
+    input.channels.slack.configured = false;
+    const snap = await healthStateModule.overlayHealthSnapshotWithRuntime(input);
 
     expect(snap.channels.slack.botTokenSource).toBe("config");
     expect(snap.channels.slack.appTokenSource).toBe("config");
     expect(snap.channels.slack.running).toBe(true);
     expect(snap.channels.slack.lastStartAt).toBe(1_777_000_000_000);
+    expect(snap.channels.slack.configured).toBe(false);
     expect(snap.channels.slack.accounts?.default?.running).toBe(true);
     expect(snap.channels.slack.accounts?.default?.botTokenSource).toBe("config");
     expect(healthStateModule.getHealthCache()).toBeNull();

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -18,6 +18,21 @@ let healthCache: HealthSummary | null = null;
 let healthRefresh: Promise<HealthSummary> | null = null;
 let broadcastHealthUpdate: ((snap: HealthSummary) => void) | null = null;
 let healthRuntimeSnapshotProvider: (() => ChannelRuntimeSnapshot) | null = null;
+const CHANNEL_RUNTIME_OVERLAY_KEYS = [
+  "running",
+  "connected",
+  "lastStartAt",
+  "lastStopAt",
+  "lastError",
+  "lastConnectedAt",
+  "lastDisconnect",
+  "lastMessageAt",
+  "lastEventAt",
+  "reconnectAttempts",
+  "botTokenSource",
+  "appTokenSource",
+  "userTokenSource",
+] as const;
 
 export function buildGatewaySnapshot(): Snapshot {
   const cfg = loadConfig();
@@ -150,9 +165,13 @@ export async function overlayHealthSnapshotWithRuntime(
       channelSummary;
     const nextChannel = {
       ...channelSummary,
-      ...defaultAccount,
       accounts: mergedAccounts,
     };
+    for (const key of CHANNEL_RUNTIME_OVERLAY_KEYS) {
+      if (defaultAccount[key] !== undefined) {
+        nextChannel[key] = defaultAccount[key];
+      }
+    }
     if (channelSummary.probe !== undefined) {
       nextChannel.probe = channelSummary.probe;
     }

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -1,4 +1,7 @@
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
+import { listChannelPlugins } from "../../channels/plugins/index.js";
+import { buildChannelAccountSnapshot } from "../../channels/plugins/status.js";
 import { getHealthSnapshot, type HealthSummary } from "../../commands/health.js";
 import { CONFIG_PATH, STATE_DIR, loadConfig } from "../../config/config.js";
 import { resolveMainSessionKey } from "../../config/sessions.js";
@@ -7,12 +10,14 @@ import { getUpdateAvailable } from "../../infra/update-startup.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { resolveGatewayAuth } from "../auth.js";
 import type { Snapshot } from "../protocol/index.js";
+import type { ChannelRuntimeSnapshot } from "../server-channels.js";
 
 let presenceVersion = 1;
 let healthVersion = 1;
 let healthCache: HealthSummary | null = null;
 let healthRefresh: Promise<HealthSummary> | null = null;
 let broadcastHealthUpdate: ((snap: HealthSummary) => void) | null = null;
+let healthRuntimeSnapshotProvider: (() => ChannelRuntimeSnapshot) | null = null;
 
 export function buildGatewaySnapshot(): Snapshot {
   const cfg = loadConfig();
@@ -66,10 +71,109 @@ export function setBroadcastHealthUpdate(fn: ((snap: HealthSummary) => void) | n
   broadcastHealthUpdate = fn;
 }
 
+export function setHealthRuntimeSnapshotProvider(fn: (() => ChannelRuntimeSnapshot) | null) {
+  healthRuntimeSnapshotProvider = fn;
+}
+
+export async function overlayHealthSnapshotWithRuntime(
+  snapshot: HealthSummary,
+): Promise<HealthSummary> {
+  if (!healthRuntimeSnapshotProvider) {
+    return snapshot;
+  }
+
+  const cfg = loadConfig();
+  const runtime = healthRuntimeSnapshotProvider();
+  const pluginMap = new Map(listChannelPlugins().map((plugin) => [plugin.id, plugin]));
+  const nextChannels: HealthSummary["channels"] = {};
+
+  for (const [channelId, channelSummary] of Object.entries(snapshot.channels ?? {})) {
+    const plugin = pluginMap.get(channelId);
+    if (!plugin) {
+      nextChannels[channelId] = channelSummary;
+      continue;
+    }
+
+    const accountEntries =
+      channelSummary.accounts && typeof channelSummary.accounts === "object"
+        ? channelSummary.accounts
+        : {};
+    const accountIds = plugin.config.listAccountIds(cfg);
+    const defaultAccountId = resolveChannelDefaultAccountId({
+      plugin,
+      cfg,
+      accountIds,
+    });
+    const accountIdsToOverlay = Array.from(
+      new Set(
+        [defaultAccountId, ...accountIds, ...Object.keys(accountEntries)].filter(
+          (value): value is string => typeof value === "string" && value.length > 0,
+        ),
+      ),
+    );
+
+    const mergedAccounts: NonNullable<typeof channelSummary.accounts> = {};
+    for (const accountId of accountIdsToOverlay) {
+      const previous =
+        accountEntries[accountId] && typeof accountEntries[accountId] === "object"
+          ? accountEntries[accountId]
+          : { accountId };
+      const runtimeSnapshot =
+        runtime.channelAccounts[channelId]?.[accountId] ??
+        (accountId === defaultAccountId ? runtime.channels[channelId] : undefined);
+      const overlay = await buildChannelAccountSnapshot({
+        plugin,
+        cfg,
+        accountId,
+        runtime: runtimeSnapshot,
+        probe: previous.probe,
+      });
+      const nextAccount = {
+        ...previous,
+        ...overlay,
+        accountId,
+      };
+      if (previous.probe !== undefined) {
+        nextAccount.probe = previous.probe;
+      }
+      if (previous.lastProbeAt !== undefined) {
+        nextAccount.lastProbeAt = previous.lastProbeAt;
+      }
+      mergedAccounts[accountId] = nextAccount;
+    }
+
+    const preferredAccountId = channelSummary.accountId ?? defaultAccountId;
+    const defaultAccount =
+      mergedAccounts[preferredAccountId] ??
+      mergedAccounts[defaultAccountId] ??
+      Object.values(mergedAccounts)[0] ??
+      channelSummary;
+    const nextChannel = {
+      ...channelSummary,
+      ...defaultAccount,
+      accounts: mergedAccounts,
+    };
+    if (channelSummary.probe !== undefined) {
+      nextChannel.probe = channelSummary.probe;
+    }
+    if (channelSummary.lastProbeAt !== undefined) {
+      nextChannel.lastProbeAt = channelSummary.lastProbeAt;
+    }
+    nextChannels[channelId] = nextChannel;
+  }
+
+  return {
+    ...snapshot,
+    channels: nextChannels,
+  };
+}
+
 export async function refreshGatewayHealthSnapshot(opts?: { probe?: boolean }) {
   if (!healthRefresh) {
     healthRefresh = (async () => {
-      const snap = await getHealthSnapshot({ probe: opts?.probe });
+      const snap = await overlayHealthSnapshotWithRuntime(
+        await getHealthSnapshot({ probe: opts?.probe }),
+      );
       healthCache = snap;
       healthVersion += 1;
       if (broadcastHealthUpdate) {

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -167,9 +167,12 @@ export async function overlayHealthSnapshotWithRuntime(
       ...channelSummary,
       accounts: mergedAccounts,
     };
+    const nextChannelRecord = nextChannel as Record<string, unknown>;
+    const defaultAccountRecord = defaultAccount as Record<string, unknown>;
     for (const key of CHANNEL_RUNTIME_OVERLAY_KEYS) {
-      if (defaultAccount[key] !== undefined) {
-        nextChannel[key] = defaultAccount[key];
+      const value = defaultAccountRecord[key];
+      if (value !== undefined) {
+        nextChannelRecord[key] = value;
       }
     }
     if (channelSummary.probe !== undefined) {

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -1,7 +1,6 @@
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
-import { buildChannelAccountSnapshot } from "../../channels/plugins/status.js";
 import { getHealthSnapshot, type HealthSummary } from "../../commands/health.js";
 import { CONFIG_PATH, STATE_DIR, loadConfig } from "../../config/config.js";
 import { resolveMainSessionKey } from "../../config/sessions.js";
@@ -136,18 +135,23 @@ export async function overlayHealthSnapshotWithRuntime(
       const runtimeSnapshot =
         runtime.channelAccounts[channelId]?.[accountId] ??
         (accountId === defaultAccountId ? runtime.channels[channelId] : undefined);
-      const overlay = await buildChannelAccountSnapshot({
-        plugin,
-        cfg,
-        accountId,
-        runtime: runtimeSnapshot,
-        probe: previous.probe,
-      });
       const nextAccount = {
         ...previous,
-        ...overlay,
         accountId,
       };
+      const nextAccountRecord = nextAccount as Record<string, unknown>;
+      const runtimeSnapshotRecord =
+        runtimeSnapshot && typeof runtimeSnapshot === "object"
+          ? (runtimeSnapshot as Record<string, unknown>)
+          : null;
+      if (runtimeSnapshotRecord) {
+        for (const key of CHANNEL_RUNTIME_OVERLAY_KEYS) {
+          const value = runtimeSnapshotRecord[key];
+          if (value !== undefined) {
+            nextAccountRecord[key] = value;
+          }
+        }
+      }
       if (previous.probe !== undefined) {
         nextAccount.probe = previous.probe;
       }


### PR DESCRIPTION
## Summary

- Problem: gateway health snapshots can report stale channel/account state because they are cached from config/probe data without merging live runtime fields.
- Why it matters: `openclaw health --json` can disagree with `openclaw channels status --json` and with the running gateway logs, which makes debugging channel outages harder.
- What changed: health cache refresh now overlays the live runtime snapshot before caching/broadcasting it, and doctor skips empty-allowlist warnings for disabled channels/accounts.
- What did NOT change (scope boundary): this does not change channel startup logic, token resolution precedence, or allowlist enforcement rules for enabled channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32689
- Related #32689

## User-visible / Behavior Changes

- `openclaw health --json` now keeps live runtime channel fields such as `running`, `lastStartAt`, and plugin-derived account metadata after the gateway has started channels.
- Doctor no longer warns about empty allowlists for channels/accounts that are explicitly disabled.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS for local validation, Linux VPS for live validation
- Runtime/container: local source checkout + remote `systemd --user` gateway service
- Model/provider: not model-specific
- Integration/channel (if any): Slack enabled, WhatsApp disabled
- Relevant config (redacted): `channels.slack` configured with tokens in config, `channels.whatsapp.enabled=false`

### Steps

1. Configure Slack with valid credentials and set WhatsApp to `enabled: false`.
2. Start or restart `openclaw-gateway`.
3. Compare `openclaw channels status --json` with `openclaw health --json`.
4. Check startup logs for doctor warnings.

### Expected

- Health should reflect the live runtime snapshot for started channels.
- Disabled channels should not emit empty-allowlist doctor warnings.

### Actual

- Before this patch, health could still show Slack as `running:false` / token sources `none`, and doctor could still warn about disabled WhatsApp allowlists.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified (AI-assisted implementation, manually reviewed by me):

- Verified scenarios:
  - Focused tests for the new health overlay helper and disabled-channel doctor warning case
  - Type-aware lint on the touched files
  - `pnpm build:strict-smoke`
  - Live VPS behavior on OpenClaw `2026.3.2`: Slack Socket Mode connected, `openclaw health --json` matched runtime, disabled WhatsApp warning disappeared
- Edge cases checked:
  - Channels present in cached health but missing a plugin runtime entry still keep their previous summary
  - Disabled channel configs stop warning without changing enabled-channel allowlist behavior
- What I did **not** verify:
  - Full `pnpm check && pnpm test`
  - Non-Slack live channels

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit
- Files/config to restore:
  - `src/gateway/server/health-state.ts`
  - `src/gateway/server.impl.ts`
  - `src/commands/doctor-config-flow.ts`
- Known bad symptoms reviewers should watch for:
  - Health snapshots losing channel entries entirely
  - Disabled channels unexpectedly affecting enabled-channel warnings

## Risks and Mitigations

- Risk:
  - Runtime overlay could accidentally overwrite probe-derived fields that should stay in health output.
  - Mitigation:
  - The overlay preserves existing `probe` and `lastProbeAt` fields and only layers runtime-aware account/channel state on top.

- Risk:
  - Skipping disabled channels in doctor could hide warnings for nested enabled accounts.
  - Mitigation:
  - The guard only returns early when the effective enabled state resolves to `false`; enabled accounts under enabled channels still flow through the existing checks.
