### PR TITLE
fix: strip ANSI codes from skills list JSON output (#27530)

### DIFF
--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -67,13 +67,16 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
   const skills = opts.eligible ? report.skills.filter((s) => s.eligible) : report.skills;
 
   if (opts.json) {
+    // eslint-disable-next-line no-control-regex
+    const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
     const jsonReport = {
       workspaceDir: report.workspaceDir,
       managedSkillsDir: report.managedSkillsDir,
       skills: skills.map((s) => ({
         name: s.name,
         description: s.description,
-        emoji: s.emoji,
+        // Strip ANSI codes from emoji for JSON output
+        emoji: s.emoji ? s.emoji.replace(ANSI_PATTERN, "") : null,
         eligible: s.eligible,
         disabled: s.disabled,
         blockedByAllowlist: s.blockedByAllowlist,

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -2,6 +2,7 @@ import type { SkillStatusEntry, SkillStatusReport } from "../agents/skills-statu
 import { renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
 import { shortenHomePath } from "../utils.js";
+import { stripAnsi } from "../terminal/ansi.js";
 import { formatCliCommand } from "./command-format.js";
 
 export type SkillsListOptions = {
@@ -67,16 +68,14 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
   const skills = opts.eligible ? report.skills.filter((s) => s.eligible) : report.skills;
 
   if (opts.json) {
-    // eslint-disable-next-line no-control-regex
-    const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
     const jsonReport = {
       workspaceDir: report.workspaceDir,
       managedSkillsDir: report.managedSkillsDir,
       skills: skills.map((s) => ({
         name: s.name,
         description: s.description,
-        // Strip ANSI codes from emoji for JSON output
-        emoji: s.emoji ? s.emoji.replace(ANSI_PATTERN, "") : null,
+        // Strip ANSI codes from emoji for JSON output (preserves undefined for omitted keys)
+        emoji: s.emoji != null ? stripAnsi(s.emoji) : s.emoji,
         eligible: s.eligible,
         disabled: s.disabled,
         blockedByAllowlist: s.blockedByAllowlist,


### PR DESCRIPTION
## Summary

Fixes ANSI escape codes appearing in skills list JSON output.

## Root Cause

When skills are displayed in terminal, emoji fields may contain ANSI escape codes for color/formatting. These codes should be stripped when outputting JSON for programmatic consumption.

## Fix

Add ANSI pattern regex to strip escape codes from emoji field when `--json` flag is used.

## Changes

- **`src/cli/skills-cli.format.ts`**: Strip ANSI codes from emoji in JSON output

## Related

- Split from PR #31707
- Fixes #27530