### PR TITLE
fix(gateway): expose channel health monitor timing config

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs/promises";
-import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   getConfigValueAtPath,
@@ -8,7 +6,7 @@ import {
   unsetConfigValueAtPath,
 } from "./config-paths.js";
 import { readConfigFileSnapshot, validateConfigObject } from "./config.js";
-import { buildWebSearchProviderConfig, withTempHome } from "./test-helpers.js";
+import { buildWebSearchProviderConfig, withTempHome, writeOpenClawConfig } from "./test-helpers.js";
 import { OpenClawSchema } from "./zod-schema.js";
 
 describe("$schema key in config (#14998)", () => {
@@ -171,6 +169,54 @@ describe("gateway.channelHealthCheckMinutes", () => {
   });
 });
 
+describe("gateway.channelHealthTiming", () => {
+  it("accepts valid timing config", () => {
+    const res = validateConfigObject({
+      gateway: {
+        channelHealthTiming: {
+          startupGraceMinutes: 2,
+          connectGraceMinutes: 5,
+          staleEventThresholdMinutes: 60,
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts partial timing config", () => {
+    const res = validateConfigObject({
+      gateway: {
+        channelHealthTiming: {
+          connectGraceMinutes: 10,
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects negative values", () => {
+    const res = validateConfigObject({
+      gateway: {
+        channelHealthTiming: {
+          staleEventThresholdMinutes: -1,
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects unknown keys", () => {
+    const res = validateConfigObject({
+      gateway: {
+        channelHealthTiming: {
+          unknownKey: 5,
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+});
+
 describe("cron webhook schema", () => {
   it("accepts cron.webhookToken and legacy cron.webhook", () => {
     const res = OpenClawSchema.safeParse({
@@ -178,6 +224,21 @@ describe("cron webhook schema", () => {
         enabled: true,
         webhook: "https://example.invalid/legacy-cron-webhook",
         webhookToken: "secret-token",
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
+
+  it("accepts cron.webhookToken SecretRef values", () => {
+    const res = OpenClawSchema.safeParse({
+      cron: {
+        webhook: "https://example.invalid/legacy-cron-webhook",
+        webhookToken: {
+          source: "env",
+          provider: "default",
+          id: "CRON_WEBHOOK_TOKEN",
+        },
       },
     });
 
@@ -304,16 +365,10 @@ describe("config strict validation", () => {
 
   it("flags legacy config entries without auto-migrating", async () => {
     await withTempHome(async (home) => {
-      const configDir = path.join(home, ".openclaw");
-      await fs.mkdir(configDir, { recursive: true });
-      await fs.writeFile(
-        path.join(configDir, "openclaw.json"),
-        JSON.stringify({
-          agents: { list: [{ id: "pi" }] },
-          routing: { allowFrom: ["+15555550123"] },
-        }),
-        "utf-8",
-      );
+      await writeOpenClawConfig(home, {
+        agents: { list: [{ id: "pi" }] },
+        routing: { allowFrom: ["+15555550123"] },
+      });
 
       const snap = await readConfigFileSnapshot();
 
@@ -324,15 +379,9 @@ describe("config strict validation", () => {
 
   it("does not mark resolved-only gateway.bind aliases as auto-migratable legacy", async () => {
     await withTempHome(async (home) => {
-      const configDir = path.join(home, ".openclaw");
-      await fs.mkdir(configDir, { recursive: true });
-      await fs.writeFile(
-        path.join(configDir, "openclaw.json"),
-        JSON.stringify({
-          gateway: { bind: "${OPENCLAW_BIND}" },
-        }),
-        "utf-8",
-      );
+      await writeOpenClawConfig(home, {
+        gateway: { bind: "${OPENCLAW_BIND}" },
+      });
 
       const prev = process.env.OPENCLAW_BIND;
       process.env.OPENCLAW_BIND = "0.0.0.0";
@@ -353,15 +402,9 @@ describe("config strict validation", () => {
 
   it("still marks literal gateway.bind host aliases as legacy", async () => {
     await withTempHome(async (home) => {
-      const configDir = path.join(home, ".openclaw");
-      await fs.mkdir(configDir, { recursive: true });
-      await fs.writeFile(
-        path.join(configDir, "openclaw.json"),
-        JSON.stringify({
-          gateway: { bind: "0.0.0.0" },
-        }),
-        "utf-8",
-      );
+      await writeOpenClawConfig(home, {
+        gateway: { bind: "0.0.0.0" },
+      });
 
       const snap = await readConfigFileSnapshot();
       expect(snap.valid).toBe(false);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1,3 +1,4 @@
+import { MEDIA_AUDIO_FIELD_HELP } from "./media-audio-field-metadata.js";
 import { IRC_FIELD_HELP } from "./schema.irc.js";
 
 export const FIELD_HELP: Record<string, string> = {
@@ -45,6 +46,11 @@ export const FIELD_HELP: Record<string, string> = {
     'Sensitive redaction mode: "off" disables built-in masking, while "tools" redacts sensitive tool/config payload fields. Keep "tools" in shared logs unless you have isolated secure log sinks.',
   "logging.redactPatterns":
     "Additional custom redact regex patterns applied to log output before emission/storage. Use this to mask org-specific tokens and identifiers not covered by built-in redaction rules.",
+  cli: "CLI presentation controls for local command output behavior such as banner and tagline style. Use this section to keep startup output aligned with operator preference without changing runtime behavior.",
+  "cli.banner":
+    "CLI startup banner controls for title/version line and tagline style behavior. Keep banner enabled for fast version/context checks, then tune tagline mode to your preferred noise level.",
+  "cli.banner.taglineMode":
+    'Controls tagline style in the CLI startup banner: "random" (default) picks from the rotating tagline pool, "default" always shows the neutral default tagline, and "off" hides tagline text while keeping the banner version line.',
   update:
     "Update-channel and startup-check behavior for keeping OpenClaw runtime versions current. Use conservative channels in production and more experimental channels only in controlled environments.",
   "update.channel": 'Update channel for git + npm installs ("stable", "beta", or "dev").',
@@ -91,6 +97,14 @@ export const FIELD_HELP: Record<string, string> = {
     "Explicit gateway-level tool denylist to block risky tools even if lower-level policies allow them. Use deny rules for emergency response and defense-in-depth hardening.",
   "gateway.channelHealthCheckMinutes":
     "Interval in minutes for automatic channel health probing and status updates. Use lower intervals for faster detection, or higher intervals to reduce periodic probe noise.",
+  "gateway.channelHealthTiming":
+    "Timing thresholds for the channel health monitor. Tune these to reduce spurious restarts caused by slow AI message processing or transient WebSocket disconnects.",
+  "gateway.channelHealthTiming.startupGraceMinutes":
+    "Grace period in minutes after the health monitor starts before health checks begin. Default: 1.",
+  "gateway.channelHealthTiming.connectGraceMinutes":
+    "Grace period in minutes for a channel to establish its connection after starting. Increase if channels need more time to complete handshake. Default: 2.",
+  "gateway.channelHealthTiming.staleEventThresholdMinutes":
+    "A connected channel with no gateway events for this many minutes is treated as a stale socket and restarted. Increase if slow AI responses cause spurious stale-socket restarts. Default: 30.",
   "gateway.tailscale":
     "Tailscale integration settings for Serve/Funnel exposure and lifecycle handling on gateway start/exit. Keep off unless your deployment intentionally relies on Tailscale ingress.",
   "gateway.tailscale.mode":
@@ -157,7 +171,7 @@ export const FIELD_HELP: Record<string, string> = {
   "acp.enabled":
     "Global ACP feature gate. Keep disabled unless ACP runtime + policy are configured.",
   "acp.dispatch.enabled":
-    "Independent dispatch gate for ACP session turns. Disable to keep ACP commands available while blocking ACP turn execution.",
+    "Independent dispatch gate for ACP session turns (default: true). Set false to keep ACP commands available while blocking ACP turn execution.",
   "acp.backend":
     "Default ACP runtime backend id (for example: acpx). Must match a registered ACP runtime plugin backend.",
   "acp.defaultAgent":
@@ -527,24 +541,7 @@ export const FIELD_HELP: Record<string, string> = {
     "Ordered model preferences specifically for image understanding when you want to override shared media models. Put the most reliable multimodal model first to reduce fallback attempts.",
   "tools.media.image.scope":
     "Scope selector for when image understanding is attempted (for example only explicit requests versus broader auto-detection). Keep narrow scope in busy channels to control token and API spend.",
-  "tools.media.audio.enabled":
-    "Enable audio understanding so voice notes or audio clips can be transcribed/summarized for agent context. Disable when audio ingestion is outside policy or unnecessary for your workflows.",
-  "tools.media.audio.maxBytes":
-    "Maximum accepted audio payload size in bytes before processing is rejected or clipped by policy. Set this based on expected recording length and upstream provider limits.",
-  "tools.media.audio.maxChars":
-    "Maximum characters retained from audio understanding output to prevent oversized transcript injection. Increase for long-form dictation, or lower to keep conversational turns compact.",
-  "tools.media.audio.prompt":
-    "Instruction template guiding audio understanding output style, such as concise summary versus near-verbatim transcript. Keep wording consistent so downstream automations can rely on output format.",
-  "tools.media.audio.timeoutSeconds":
-    "Timeout in seconds for audio understanding execution before the operation is cancelled. Use longer timeouts for long recordings and tighter ones for interactive chat responsiveness.",
-  "tools.media.audio.language":
-    "Preferred language hint for audio understanding/transcription when provider support is available. Set this to improve recognition accuracy for known primary languages.",
-  "tools.media.audio.attachments":
-    "Attachment policy for audio inputs indicating which uploaded files are eligible for audio processing. Keep restrictive defaults in mixed-content channels to avoid unintended audio workloads.",
-  "tools.media.audio.models":
-    "Ordered model preferences specifically for audio understanding, used before shared media model fallback. Choose models optimized for transcription quality in your primary language/domain.",
-  "tools.media.audio.scope":
-    "Scope selector for when audio understanding runs across inbound messages and attachments. Keep focused scopes in high-volume channels to reduce cost and avoid accidental transcription.",
+  ...MEDIA_AUDIO_FIELD_HELP,
   "tools.media.video.enabled":
     "Enable video understanding so clips can be summarized into text for downstream reasoning and responses. Disable when processing video is out of policy or too expensive for your deployment.",
   "tools.media.video.maxBytes":
@@ -735,7 +732,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.experimental.sessionMemory":
     "Indexes session transcripts into memory search so responses can reference prior chat turns. Keep this off unless transcript recall is needed, because indexing cost and storage usage both increase.",
   "agents.defaults.memorySearch.provider":
-    'Selects the embedding backend used to build/query memory vectors: "openai", "gemini", "voyage", "mistral", or "local". Keep your most reliable provider here and configure fallback for resilience.',
+    'Selects the embedding backend used to build/query memory vectors: "openai", "gemini", "voyage", "mistral", "ollama", or "local". Keep your most reliable provider here and configure fallback for resilience.',
   "agents.defaults.memorySearch.model":
     "Embedding model override used by the selected memory provider when a non-default model is required. Set this only when you need explicit recall quality/cost tuning beyond provider defaults.",
   "agents.defaults.memorySearch.remote.baseUrl":
@@ -757,7 +754,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.local.modelPath":
     "Specifies the local embedding model source for local memory search, such as a GGUF file path or `hf:` URI. Use this only when provider is `local`, and verify model compatibility before large index rebuilds.",
   "agents.defaults.memorySearch.fallback":
-    'Backup provider used when primary embeddings fail: "openai", "gemini", "voyage", "mistral", "local", or "none". Set a real fallback for production reliability; use "none" only if you prefer explicit failures.',
+    'Backup provider used when primary embeddings fail: "openai", "gemini", "voyage", "mistral", "ollama", "local", or "none". Set a real fallback for production reliability; use "none" only if you prefer explicit failures.',
   "agents.defaults.memorySearch.store.path":
     "Sets where the SQLite memory index is stored on disk for each agent. Keep the default `~/.openclaw/memory/{agentId}.sqlite` unless you need custom storage placement or backup policy alignment.",
   "agents.defaults.memorySearch.store.vector.enabled":
@@ -1386,7 +1383,7 @@ export const FIELD_HELP: Record<string, string> = {
   "channels.telegram.dmPolicy":
     'Direct message access control ("pairing" recommended). "open" requires channels.telegram.allowFrom=["*"].',
   "channels.telegram.streaming":
-    'Unified Telegram stream preview mode: "off" | "partial" | "block" | "progress". "progress" maps to "partial" on Telegram. Legacy boolean/streamMode keys are auto-mapped.',
+    'Unified Telegram stream preview mode: "off" | "partial" | "block" | "progress" (default: "partial"). "progress" maps to "partial" on Telegram. Legacy boolean/streamMode keys are auto-mapped.',
   "channels.discord.streaming":
     'Unified Discord stream preview mode: "off" | "partial" | "block" | "progress". "progress" maps to "partial" on Discord. Legacy boolean/streamMode keys are auto-mapped.',
   "channels.discord.streamMode":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -1,3 +1,4 @@
+import { MEDIA_AUDIO_FIELD_LABELS } from "./media-audio-field-metadata.js";
 import { IRC_FIELD_LABELS } from "./schema.irc.js";
 
 export const FIELD_LABELS: Record<string, string> = {
@@ -25,6 +26,9 @@ export const FIELD_LABELS: Record<string, string> = {
   "logging.consoleStyle": "Console Log Style",
   "logging.redactSensitive": "Sensitive Data Redaction Mode",
   "logging.redactPatterns": "Custom Redaction Patterns",
+  cli: "CLI",
+  "cli.banner": "CLI Banner",
+  "cli.banner.taglineMode": "CLI Banner Tagline Mode",
   update: "Updates",
   "update.channel": "Update Channel",
   "update.checkOnStart": "Update Check on Start",
@@ -73,6 +77,10 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.tools.allow": "Gateway Tool Allowlist",
   "gateway.tools.deny": "Gateway Tool Denylist",
   "gateway.channelHealthCheckMinutes": "Gateway Channel Health Check Interval (min)",
+  "gateway.channelHealthTiming": "Gateway Channel Health Timing",
+  "gateway.channelHealthTiming.startupGraceMinutes": "Health Monitor Startup Grace (min)",
+  "gateway.channelHealthTiming.connectGraceMinutes": "Channel Connect Grace (min)",
+  "gateway.channelHealthTiming.staleEventThresholdMinutes": "Stale Socket Threshold (min)",
   "gateway.tailscale": "Gateway Tailscale",
   "gateway.tailscale.mode": "Gateway Tailscale Mode",
   "gateway.tailscale.resetOnExit": "Gateway Tailscale Reset on Exit",
@@ -128,15 +136,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.media.image.scope": "Image Understanding Scope",
   "tools.media.models": "Media Understanding Shared Models",
   "tools.media.concurrency": "Media Understanding Concurrency",
-  "tools.media.audio.enabled": "Enable Audio Understanding",
-  "tools.media.audio.maxBytes": "Audio Understanding Max Bytes",
-  "tools.media.audio.maxChars": "Audio Understanding Max Chars",
-  "tools.media.audio.prompt": "Audio Understanding Prompt",
-  "tools.media.audio.timeoutSeconds": "Audio Understanding Timeout (sec)",
-  "tools.media.audio.language": "Audio Understanding Language",
-  "tools.media.audio.attachments": "Audio Understanding Attachment Policy",
-  "tools.media.audio.models": "Audio Understanding Models",
-  "tools.media.audio.scope": "Audio Understanding Scope",
+  ...MEDIA_AUDIO_FIELD_LABELS,
   "tools.media.video.enabled": "Enable Video Understanding",
   "tools.media.video.maxBytes": "Video Understanding Max Bytes",
   "tools.media.video.maxChars": "Video Understanding Max Chars",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -1,3 +1,5 @@
+import type { SecretInput } from "./types.secrets.js";
+
 export type GatewayBindMode = "auto" | "lan" | "loopback" | "custom" | "tailnet";
 
 export type GatewayTlsConfig = {
@@ -56,7 +58,7 @@ export type TalkProviderConfig = {
   /** Default provider output format (for example pcm_44100). */
   outputFormat?: string;
   /** Provider API key (optional; provider-specific env fallback may apply). */
-  apiKey?: string;
+  apiKey?: SecretInput;
   /** Provider-specific extensions. */
   [key: string]: unknown;
 };
@@ -77,7 +79,7 @@ export type TalkConfig = {
   voiceAliases?: Record<string, string>;
   modelId?: string;
   outputFormat?: string;
-  apiKey?: string;
+  apiKey?: SecretInput;
 };
 
 export type GatewayControlUiConfig = {
@@ -137,7 +139,7 @@ export type GatewayAuthConfig = {
   /** Shared token for token mode (stored locally for CLI auth). */
   token?: string;
   /** Shared password for password mode (consider env instead). */
-  password?: string;
+  password?: SecretInput;
   /** Allow Tailscale identity headers when serve mode is enabled. */
   allowTailscale?: boolean;
   /** Rate-limit configuration for failed authentication attempts. */
@@ -175,9 +177,9 @@ export type GatewayRemoteConfig = {
   /** Transport for macOS remote connections (ssh tunnel or direct WS). */
   transport?: "ssh" | "direct";
   /** Token for remote auth (when the gateway requires token auth). */
-  token?: string;
+  token?: SecretInput;
   /** Password for remote auth (when the gateway requires password auth). */
-  password?: string;
+  password?: SecretInput;
   /** Expected TLS certificate fingerprint (sha256) for remote gateways. */
   tlsFingerprint?: string;
   /** SSH target for tunneling remote Gateway (user@host). */
@@ -315,6 +317,18 @@ export type GatewayToolsConfig = {
   allow?: string[];
 };
 
+export type ChannelHealthTimingConfig = {
+  /** Grace period in minutes after the monitor starts before health checks begin. Default: 1. */
+  startupGraceMinutes?: number;
+  /** Grace period in minutes for a channel to connect after starting. Default: 2. */
+  connectGraceMinutes?: number;
+  /**
+   * A connected channel with no events for this many minutes triggers a stale-socket restart.
+   * Increase this if long-running AI responses cause spurious restarts. Default: 30.
+   */
+  staleEventThresholdMinutes?: number;
+};
+
 export type GatewayConfig = {
   /** Single multiplexed port for Gateway WS + HTTP (default: 18789). */
   port?: number;
@@ -362,4 +376,10 @@ export type GatewayConfig = {
    * Set to 0 to disable. Default: 5.
    */
   channelHealthCheckMinutes?: number;
+  /**
+   * Timing thresholds for the channel health monitor.
+   * Tune these to reduce spurious restarts caused by slow AI message processing
+   * or transient WebSocket disconnects.
+   */
+  channelHealthTiming?: ChannelHealthTimingConfig;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -128,6 +128,31 @@ const HttpUrlSchema = z
     return protocol === "http:" || protocol === "https:";
   }, "Expected http:// or https:// URL");
 
+const ResponsesEndpointUrlFetchShape = {
+  allowUrl: z.boolean().optional(),
+  urlAllowlist: z.array(z.string()).optional(),
+  allowedMimes: z.array(z.string()).optional(),
+  maxBytes: z.number().int().positive().optional(),
+  maxRedirects: z.number().int().nonnegative().optional(),
+  timeoutMs: z.number().int().positive().optional(),
+};
+
+const SkillEntrySchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    apiKey: SecretInputSchema.optional().register(sensitive),
+    env: z.record(z.string(), z.string()).optional(),
+    config: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+const PluginEntrySchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    config: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
 export const OpenClawSchema = z
   .object({
     $schema: z.string().optional(),
@@ -219,6 +244,19 @@ export const OpenClawSchema = z
           .optional(),
         redactSensitive: z.union([z.literal("off"), z.literal("tools")]).optional(),
         redactPatterns: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
+    cli: z
+      .object({
+        banner: z
+          .object({
+            taglineMode: z
+              .union([z.literal("random"), z.literal("default"), z.literal("off")])
+              .optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),
@@ -403,7 +441,7 @@ export const OpenClawSchema = z
           .strict()
           .optional(),
         webhook: HttpUrlSchema.optional(),
-        webhookToken: z.string().optional().register(sensitive),
+        webhookToken: SecretInputSchema.optional().register(sensitive),
         sessionRetention: z.union([z.string(), z.literal(false)]).optional(),
         runLog: z
           .object({
@@ -417,6 +455,17 @@ export const OpenClawSchema = z
             enabled: z.boolean().optional(),
             after: z.number().int().min(1).optional(),
             cooldownMs: z.number().int().min(0).optional(),
+            mode: z.enum(["announce", "webhook"]).optional(),
+            accountId: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+        failureDestination: z
+          .object({
+            channel: z.string().optional(),
+            to: z.string().optional(),
+            accountId: z.string().optional(),
+            mode: z.enum(["announce", "webhook"]).optional(),
           })
           .strict()
           .optional(),
@@ -521,7 +570,7 @@ export const OpenClawSchema = z
                 voiceAliases: z.record(z.string(), z.string()).optional(),
                 modelId: z.string().optional(),
                 outputFormat: z.string().optional(),
-                apiKey: z.string().optional().register(sensitive),
+                apiKey: SecretInputSchema.optional().register(sensitive),
               })
               .catchall(z.unknown()),
           )
@@ -530,7 +579,7 @@ export const OpenClawSchema = z
         voiceAliases: z.record(z.string(), z.string()).optional(),
         modelId: z.string().optional(),
         outputFormat: z.string().optional(),
-        apiKey: z.string().optional().register(sensitive),
+        apiKey: SecretInputSchema.optional().register(sensitive),
         interruptOnSpeech: z.boolean().optional(),
       })
       .strict()
@@ -572,7 +621,7 @@ export const OpenClawSchema = z
               ])
               .optional(),
             token: z.string().optional().register(sensitive),
-            password: z.string().optional().register(sensitive),
+            password: SecretInputSchema.optional().register(sensitive),
             allowTailscale: z.boolean().optional(),
             rateLimit: z
               .object({
@@ -604,6 +653,14 @@ export const OpenClawSchema = z
           .strict()
           .optional(),
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
+        channelHealthTiming: z
+          .object({
+            startupGraceMinutes: z.number().min(0).optional(),
+            connectGraceMinutes: z.number().min(0).optional(),
+            staleEventThresholdMinutes: z.number().min(0).optional(),
+          })
+          .strict()
+          .optional(),
         tailscale: z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),
@@ -615,8 +672,8 @@ export const OpenClawSchema = z
           .object({
             url: z.string().optional(),
             transport: z.union([z.literal("ssh"), z.literal("direct")]).optional(),
-            token: z.string().optional().register(sensitive),
-            password: z.string().optional().register(sensitive),
+            token: SecretInputSchema.optional().register(sensitive),
+            password: SecretInputSchema.optional().register(sensitive),
             tlsFingerprint: z.string().optional(),
             sshTarget: z.string().optional(),
             sshIdentity: z.string().optional(),
@@ -663,13 +720,8 @@ export const OpenClawSchema = z
                     maxUrlParts: z.number().int().nonnegative().optional(),
                     files: z
                       .object({
-                        allowUrl: z.boolean().optional(),
-                        urlAllowlist: z.array(z.string()).optional(),
-                        allowedMimes: z.array(z.string()).optional(),
-                        maxBytes: z.number().int().positive().optional(),
+                        ...ResponsesEndpointUrlFetchShape,
                         maxChars: z.number().int().positive().optional(),
-                        maxRedirects: z.number().int().nonnegative().optional(),
-                        timeoutMs: z.number().int().positive().optional(),
                         pdf: z
                           .object({
                             maxPages: z.number().int().positive().optional(),
@@ -683,12 +735,7 @@ export const OpenClawSchema = z
                       .optional(),
                     images: z
                       .object({
-                        allowUrl: z.boolean().optional(),
-                        urlAllowlist: z.array(z.string()).optional(),
-                        allowedMimes: z.array(z.string()).optional(),
-                        maxBytes: z.number().int().positive().optional(),
-                        maxRedirects: z.number().int().nonnegative().optional(),
-                        timeoutMs: z.number().int().positive().optional(),
+                        ...ResponsesEndpointUrlFetchShape,
                       })
                       .strict()
                       .optional(),
@@ -757,19 +804,7 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
-        entries: z
-          .record(
-            z.string(),
-            z
-              .object({
-                enabled: z.boolean().optional(),
-                apiKey: SecretInputSchema.optional().register(sensitive),
-                env: z.record(z.string(), z.string()).optional(),
-                config: z.record(z.string(), z.unknown()).optional(),
-              })
-              .strict(),
-          )
-          .optional(),
+        entries: z.record(z.string(), SkillEntrySchema).optional(),
       })
       .strict()
       .optional(),
@@ -790,17 +825,7 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
-        entries: z
-          .record(
-            z.string(),
-            z
-              .object({
-                enabled: z.boolean().optional(),
-                config: z.record(z.string(), z.unknown()).optional(),
-              })
-              .strict(),
-          )
-          .optional(),
+        entries: z.record(z.string(), PluginEntrySchema).optional(),
         installs: z
           .record(
             z.string(),

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { ChannelAccountSnapshot } from "../channels/plugins/types.js";
-import { startChannelHealthMonitor } from "./channel-health-monitor.js";
+import {
+  resolveHealthTimingFromConfig,
+  startChannelHealthMonitor,
+} from "./channel-health-monitor.js";
 import type { ChannelManager, ChannelRuntimeSnapshot } from "./server-channels.js";
 
 function createMockChannelManager(overrides?: Partial<ChannelManager>): ChannelManager {
@@ -65,7 +68,7 @@ async function startAndRunCheck(
   overrides: Partial<Omit<Parameters<typeof startChannelHealthMonitor>[0], "channelManager">> = {},
 ) {
   const monitor = startDefaultMonitor(manager, overrides);
-  const startupGraceMs = overrides.startupGraceMs ?? 0;
+  const startupGraceMs = overrides.timing?.monitorStartupGraceMs ?? overrides.startupGraceMs ?? 0;
   const checkIntervalMs = overrides.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS;
   await vi.advanceTimersByTimeAsync(startupGraceMs + checkIntervalMs + 1);
   return monitor;
@@ -78,6 +81,56 @@ function managedStoppedAccount(lastError: string): Partial<ChannelAccountSnapsho
     configured: true,
     lastError,
   };
+}
+
+function runningConnectedSlackAccount(
+  overrides: Partial<ChannelAccountSnapshot>,
+): Partial<ChannelAccountSnapshot> {
+  return {
+    running: true,
+    connected: true,
+    enabled: true,
+    configured: true,
+    ...overrides,
+  };
+}
+
+function createSlackSnapshotManager(
+  account: Partial<ChannelAccountSnapshot>,
+  overrides?: Partial<ChannelManager>,
+): ChannelManager {
+  return createSnapshotManager(
+    {
+      slack: {
+        default: account,
+      },
+    },
+    overrides,
+  );
+}
+
+async function expectRestartedChannel(
+  manager: ChannelManager,
+  channel: ChannelId,
+  accountId = "default",
+) {
+  const monitor = await startAndRunCheck(manager);
+  expect(manager.stopChannel).toHaveBeenCalledWith(channel, accountId);
+  expect(manager.startChannel).toHaveBeenCalledWith(channel, accountId);
+  monitor.stop();
+}
+
+async function expectNoRestart(manager: ChannelManager) {
+  const monitor = await startAndRunCheck(manager);
+  expect(manager.stopChannel).not.toHaveBeenCalled();
+  expect(manager.startChannel).not.toHaveBeenCalled();
+  monitor.stop();
+}
+
+async function expectNoStart(manager: ChannelManager) {
+  const monitor = await startAndRunCheck(manager);
+  expect(manager.startChannel).not.toHaveBeenCalled();
+  monitor.stop();
 }
 
 describe("channel-health-monitor", () => {
@@ -100,6 +153,14 @@ describe("channel-health-monitor", () => {
     const manager = createMockChannelManager();
     const monitor = await startAndRunCheck(manager, { startupGraceMs: 1_000 });
     expect(manager.getRuntimeSnapshot).toHaveBeenCalled();
+    monitor.stop();
+  });
+
+  it("accepts timing.monitorStartupGraceMs", async () => {
+    const manager = createMockChannelManager();
+    const monitor = startDefaultMonitor(manager, { timing: { monitorStartupGraceMs: 60_000 } });
+    await vi.advanceTimersByTimeAsync(5_001);
+    expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
     monitor.stop();
   });
 
@@ -126,9 +187,7 @@ describe("channel-health-monitor", () => {
         },
       },
     });
-    const monitor = await startAndRunCheck(manager);
-    expect(manager.startChannel).not.toHaveBeenCalled();
-    monitor.stop();
+    await expectNoStart(manager);
   });
 
   it("skips unconfigured channels", async () => {
@@ -137,9 +196,7 @@ describe("channel-health-monitor", () => {
         default: { running: false, enabled: true, configured: false },
       },
     });
-    const monitor = await startAndRunCheck(manager);
-    expect(manager.startChannel).not.toHaveBeenCalled();
-    monitor.stop();
+    await expectNoStart(manager);
   });
 
   it("skips manually stopped channels", async () => {
@@ -151,12 +208,11 @@ describe("channel-health-monitor", () => {
       },
       { isManuallyStopped: vi.fn(() => true) },
     );
-    const monitor = await startAndRunCheck(manager);
-    expect(manager.startChannel).not.toHaveBeenCalled();
-    monitor.stop();
+    await expectNoStart(manager);
   });
 
   it("restarts a stuck channel (running but not connected)", async () => {
+    const now = Date.now();
     const manager = createSnapshotManager({
       whatsapp: {
         default: {
@@ -165,6 +221,7 @@ describe("channel-health-monitor", () => {
           enabled: true,
           configured: true,
           linked: true,
+          lastStartAt: now - 300_000,
         },
       },
     });
@@ -172,6 +229,41 @@ describe("channel-health-monitor", () => {
     expect(manager.stopChannel).toHaveBeenCalledWith("whatsapp", "default");
     expect(manager.resetRestartAttempts).toHaveBeenCalledWith("whatsapp", "default");
     expect(manager.startChannel).toHaveBeenCalledWith("whatsapp", "default");
+    monitor.stop();
+  });
+
+  it("skips recently-started channels while they are still connecting", async () => {
+    const now = Date.now();
+    const manager = createSnapshotManager({
+      discord: {
+        default: {
+          running: true,
+          connected: false,
+          enabled: true,
+          configured: true,
+          lastStartAt: now - 5_000,
+        },
+      },
+    });
+    await expectNoRestart(manager);
+  });
+
+  it("respects custom per-channel startup grace", async () => {
+    const now = Date.now();
+    const manager = createSnapshotManager({
+      discord: {
+        default: {
+          running: true,
+          connected: false,
+          enabled: true,
+          configured: true,
+          lastStartAt: now - 30_000,
+        },
+      },
+    });
+    const monitor = await startAndRunCheck(manager, { channelStartupGraceMs: 60_000 });
+    expect(manager.stopChannel).not.toHaveBeenCalled();
+    expect(manager.startChannel).not.toHaveBeenCalled();
     monitor.stop();
   });
 
@@ -312,104 +404,103 @@ describe("channel-health-monitor", () => {
 
     it("restarts a channel with no events past the stale threshold", async () => {
       const now = Date.now();
-      const manager = createSnapshotManager({
-        slack: {
-          default: {
-            running: true,
-            connected: true,
-            enabled: true,
-            configured: true,
-            lastStartAt: now - STALE_THRESHOLD - 60_000,
-            lastEventAt: now - STALE_THRESHOLD - 30_000,
-          },
-        },
-      });
-      const monitor = await startAndRunCheck(manager);
-      expect(manager.stopChannel).toHaveBeenCalledWith("slack", "default");
-      expect(manager.startChannel).toHaveBeenCalledWith("slack", "default");
-      monitor.stop();
+      const manager = createSlackSnapshotManager(
+        runningConnectedSlackAccount({
+          lastStartAt: now - STALE_THRESHOLD - 60_000,
+          lastEventAt: now - STALE_THRESHOLD - 30_000,
+        }),
+      );
+      await expectRestartedChannel(manager, "slack");
     });
 
     it("skips channels with recent events", async () => {
       const now = Date.now();
-      const manager = createSnapshotManager({
-        slack: {
-          default: {
-            running: true,
-            connected: true,
-            enabled: true,
-            configured: true,
-            lastStartAt: now - STALE_THRESHOLD - 60_000,
-            lastEventAt: now - 5_000,
-          },
-        },
-      });
-      const monitor = await startAndRunCheck(manager);
-      expect(manager.stopChannel).not.toHaveBeenCalled();
-      expect(manager.startChannel).not.toHaveBeenCalled();
-      monitor.stop();
+      const manager = createSlackSnapshotManager(
+        runningConnectedSlackAccount({
+          lastStartAt: now - STALE_THRESHOLD - 60_000,
+          lastEventAt: now - 5_000,
+        }),
+      );
+      await expectNoRestart(manager);
     });
 
     it("skips channels still within the startup grace window for stale detection", async () => {
       const now = Date.now();
-      const manager = createSnapshotManager({
-        slack: {
-          default: {
-            running: true,
-            connected: true,
-            enabled: true,
-            configured: true,
-            lastStartAt: now - 5_000,
-            lastEventAt: null,
-          },
-        },
-      });
-      const monitor = await startAndRunCheck(manager);
-      expect(manager.stopChannel).not.toHaveBeenCalled();
-      expect(manager.startChannel).not.toHaveBeenCalled();
-      monitor.stop();
+      const manager = createSlackSnapshotManager(
+        runningConnectedSlackAccount({
+          lastStartAt: now - 5_000,
+          lastEventAt: null,
+        }),
+      );
+      await expectNoRestart(manager);
     });
 
     it("restarts a channel that never received any event past the stale threshold", async () => {
       const now = Date.now();
-      const manager = createSnapshotManager({
-        slack: {
-          default: {
-            running: true,
-            connected: true,
-            enabled: true,
-            configured: true,
-            lastStartAt: now - STALE_THRESHOLD - 60_000,
-          },
-        },
-      });
-      const monitor = await startAndRunCheck(manager);
-      expect(manager.stopChannel).toHaveBeenCalledWith("slack", "default");
-      expect(manager.startChannel).toHaveBeenCalledWith("slack", "default");
-      monitor.stop();
+      const manager = createSlackSnapshotManager(
+        runningConnectedSlackAccount({
+          lastStartAt: now - STALE_THRESHOLD - 60_000,
+        }),
+      );
+      await expectRestartedChannel(manager, "slack");
     });
 
     it("respects custom staleEventThresholdMs", async () => {
       const customThreshold = 10 * 60_000;
       const now = Date.now();
-      const manager = createSnapshotManager({
-        slack: {
-          default: {
-            running: true,
-            connected: true,
-            enabled: true,
-            configured: true,
-            lastStartAt: now - customThreshold - 60_000,
-            lastEventAt: now - customThreshold - 30_000,
-          },
-        },
-      });
+      const manager = createSlackSnapshotManager(
+        runningConnectedSlackAccount({
+          lastStartAt: now - customThreshold - 60_000,
+          lastEventAt: now - customThreshold - 30_000,
+        }),
+      );
       const monitor = await startAndRunCheck(manager, {
         staleEventThresholdMs: customThreshold,
       });
       expect(manager.stopChannel).toHaveBeenCalledWith("slack", "default");
       expect(manager.startChannel).toHaveBeenCalledWith("slack", "default");
       monitor.stop();
+    });
+  });
+});
+
+describe("resolveHealthTimingFromConfig", () => {
+  it("returns undefined when no config is given", () => {
+    expect(resolveHealthTimingFromConfig(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty config object", () => {
+    expect(resolveHealthTimingFromConfig({})).toBeUndefined();
+  });
+
+  it("converts minutes to milliseconds", () => {
+    const timing = resolveHealthTimingFromConfig({
+      startupGraceMinutes: 2,
+      connectGraceMinutes: 5,
+      staleEventThresholdMinutes: 60,
+    });
+    expect(timing).toEqual({
+      monitorStartupGraceMs: 120_000,
+      channelConnectGraceMs: 300_000,
+      staleEventThresholdMs: 3_600_000,
+    });
+  });
+
+  it("handles partial config", () => {
+    const timing = resolveHealthTimingFromConfig({
+      connectGraceMinutes: 10,
+    });
+    expect(timing).toEqual({
+      channelConnectGraceMs: 600_000,
+    });
+  });
+
+  it("accepts zero values", () => {
+    const timing = resolveHealthTimingFromConfig({
+      startupGraceMinutes: 0,
+    });
+    expect(timing).toEqual({
+      monitorStartupGraceMs: 0,
     });
   });
 });

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -1,11 +1,16 @@
 import type { ChannelId } from "../channels/plugins/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  evaluateChannelHealth,
+  resolveChannelRestartReason,
+  type ChannelHealthPolicy,
+} from "./channel-health-policy.js";
 import type { ChannelManager } from "./server-channels.js";
 
 const log = createSubsystemLogger("gateway/health-monitor");
 
 const DEFAULT_CHECK_INTERVAL_MS = 5 * 60_000;
-const DEFAULT_STARTUP_GRACE_MS = 60_000;
+const DEFAULT_MONITOR_STARTUP_GRACE_MS = 60_000;
 const DEFAULT_COOLDOWN_CYCLES = 2;
 const DEFAULT_MAX_RESTARTS_PER_HOUR = 10;
 const ONE_HOUR_MS = 60 * 60_000;
@@ -17,14 +22,26 @@ const ONE_HOUR_MS = 60 * 60_000;
  * alive (health checks pass) but Slack silently stops delivering events.
  */
 const DEFAULT_STALE_EVENT_THRESHOLD_MS = 30 * 60_000;
+const DEFAULT_CHANNEL_CONNECT_GRACE_MS = 120_000;
+
+export type ChannelHealthTimingPolicy = {
+  monitorStartupGraceMs: number;
+  channelConnectGraceMs: number;
+  staleEventThresholdMs: number;
+};
 
 export type ChannelHealthMonitorDeps = {
   channelManager: ChannelManager;
   checkIntervalMs?: number;
+  /** @deprecated use timing.monitorStartupGraceMs */
   startupGraceMs?: number;
+  /** @deprecated use timing.channelConnectGraceMs */
+  channelStartupGraceMs?: number;
+  /** @deprecated use timing.staleEventThresholdMs */
+  staleEventThresholdMs?: number;
+  timing?: Partial<ChannelHealthTimingPolicy>;
   cooldownCycles?: number;
   maxRestartsPerHour?: number;
-  staleEventThresholdMs?: number;
   abortSignal?: AbortSignal;
 };
 
@@ -37,59 +54,60 @@ type RestartRecord = {
   restartsThisHour: { at: number }[];
 };
 
-function isManagedAccount(snapshot: { enabled?: boolean; configured?: boolean }): boolean {
-  return snapshot.enabled !== false && snapshot.configured !== false;
+function resolveTimingPolicy(
+  deps: Pick<
+    ChannelHealthMonitorDeps,
+    "startupGraceMs" | "channelStartupGraceMs" | "staleEventThresholdMs" | "timing"
+  >,
+): ChannelHealthTimingPolicy {
+  return {
+    monitorStartupGraceMs:
+      deps.timing?.monitorStartupGraceMs ?? deps.startupGraceMs ?? DEFAULT_MONITOR_STARTUP_GRACE_MS,
+    channelConnectGraceMs:
+      deps.timing?.channelConnectGraceMs ??
+      deps.channelStartupGraceMs ??
+      DEFAULT_CHANNEL_CONNECT_GRACE_MS,
+    staleEventThresholdMs:
+      deps.timing?.staleEventThresholdMs ??
+      deps.staleEventThresholdMs ??
+      DEFAULT_STALE_EVENT_THRESHOLD_MS,
+  };
 }
 
-function isChannelHealthy(
-  snapshot: {
-    running?: boolean;
-    connected?: boolean;
-    enabled?: boolean;
-    configured?: boolean;
-    lastEventAt?: number | null;
-    lastStartAt?: number | null;
-  },
-  opts: { now: number; staleEventThresholdMs: number },
-): boolean {
-  if (!isManagedAccount(snapshot)) {
-    return true;
+/**
+ * Convert user-facing config (minutes) to the internal timing policy (ms).
+ * Returns undefined when no overrides are present (use defaults).
+ */
+export function resolveHealthTimingFromConfig(config?: {
+  startupGraceMinutes?: number;
+  connectGraceMinutes?: number;
+  staleEventThresholdMinutes?: number;
+}): Partial<ChannelHealthTimingPolicy> | undefined {
+  if (!config) {
+    return undefined;
   }
-  if (!snapshot.running) {
-    return false;
+  const timing: Partial<ChannelHealthTimingPolicy> = {};
+  if (config.startupGraceMinutes != null) {
+    timing.monitorStartupGraceMs = config.startupGraceMinutes * 60_000;
   }
-  if (snapshot.connected === false) {
-    return false;
+  if (config.connectGraceMinutes != null) {
+    timing.channelConnectGraceMs = config.connectGraceMinutes * 60_000;
   }
-
-  // Stale socket detection: if the channel has been running long enough
-  // (past the stale threshold) and we have never received an event, or the
-  // last event was received longer ago than the threshold, treat as unhealthy.
-  if (snapshot.lastEventAt != null || snapshot.lastStartAt != null) {
-    const upSince = snapshot.lastStartAt ?? 0;
-    const upDuration = opts.now - upSince;
-    if (upDuration > opts.staleEventThresholdMs) {
-      const lastEvent = snapshot.lastEventAt ?? 0;
-      const eventAge = opts.now - lastEvent;
-      if (eventAge > opts.staleEventThresholdMs) {
-        return false;
-      }
-    }
+  if (config.staleEventThresholdMinutes != null) {
+    timing.staleEventThresholdMs = config.staleEventThresholdMinutes * 60_000;
   }
-
-  return true;
+  return Object.keys(timing).length > 0 ? timing : undefined;
 }
 
 export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): ChannelHealthMonitor {
   const {
     channelManager,
     checkIntervalMs = DEFAULT_CHECK_INTERVAL_MS,
-    startupGraceMs = DEFAULT_STARTUP_GRACE_MS,
     cooldownCycles = DEFAULT_COOLDOWN_CYCLES,
     maxRestartsPerHour = DEFAULT_MAX_RESTARTS_PER_HOUR,
-    staleEventThresholdMs = DEFAULT_STALE_EVENT_THRESHOLD_MS,
     abortSignal,
   } = deps;
+  const timing = resolveTimingPolicy(deps);
 
   const cooldownMs = cooldownCycles * checkIntervalMs;
   const restartRecords = new Map<string, RestartRecord>();
@@ -112,7 +130,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
 
     try {
       const now = Date.now();
-      if (now - startedAt < startupGraceMs) {
+      if (now - startedAt < timing.monitorStartupGraceMs) {
         return;
       }
 
@@ -126,13 +144,16 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           if (!status) {
             continue;
           }
-          if (!isManagedAccount(status)) {
-            continue;
-          }
           if (channelManager.isManuallyStopped(channelId as ChannelId, accountId)) {
             continue;
           }
-          if (isChannelHealthy(status, { now, staleEventThresholdMs })) {
+          const healthPolicy: ChannelHealthPolicy = {
+            now,
+            staleEventThresholdMs: timing.staleEventThresholdMs,
+            channelConnectGraceMs: timing.channelConnectGraceMs,
+          };
+          const health = evaluateChannelHealth(status, healthPolicy);
+          if (health.healthy) {
             continue;
           }
 
@@ -154,19 +175,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             continue;
           }
 
-          const isStaleSocket =
-            status.running &&
-            status.connected !== false &&
-            status.lastEventAt != null &&
-            now - (status.lastEventAt ?? 0) > staleEventThresholdMs;
-
-          const reason = !status.running
-            ? status.reconnectAttempts && status.reconnectAttempts >= 10
-              ? "gave-up"
-              : "stopped"
-            : isStaleSocket
-              ? "stale-socket"
-              : "stuck";
+          const reason = resolveChannelRestartReason(status, health);
 
           log.info?.(`[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason})`);
 
@@ -208,7 +217,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
       timer.unref();
     }
     log.info?.(
-      `started (interval: ${Math.round(checkIntervalMs / 1000)}s, grace: ${Math.round(startupGraceMs / 1000)}s)`,
+      `started (interval: ${Math.round(checkIntervalMs / 1000)}s, startup-grace: ${Math.round(timing.monitorStartupGraceMs / 1000)}s, channel-connect-grace: ${Math.round(timing.channelConnectGraceMs / 1000)}s)`,
     );
   }
 

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -1,0 +1,215 @@
+import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
+
+export type ChannelKind = ChannelId;
+
+export type GatewayReloadPlan = {
+  changedPaths: string[];
+  restartGateway: boolean;
+  restartReasons: string[];
+  hotReasons: string[];
+  reloadHooks: boolean;
+  restartGmailWatcher: boolean;
+  restartBrowserControl: boolean;
+  restartCron: boolean;
+  restartHeartbeat: boolean;
+  restartHealthMonitor: boolean;
+  restartChannels: Set<ChannelKind>;
+  noopPaths: string[];
+};
+
+type ReloadRule = {
+  prefix: string;
+  kind: "restart" | "hot" | "none";
+  actions?: ReloadAction[];
+};
+
+type ReloadAction =
+  | "reload-hooks"
+  | "restart-gmail-watcher"
+  | "restart-browser-control"
+  | "restart-cron"
+  | "restart-heartbeat"
+  | "restart-health-monitor"
+  | `restart-channel:${ChannelId}`;
+
+const BASE_RELOAD_RULES: ReloadRule[] = [
+  { prefix: "gateway.remote", kind: "none" },
+  { prefix: "gateway.reload", kind: "none" },
+  {
+    prefix: "gateway.channelHealthCheckMinutes",
+    kind: "hot",
+    actions: ["restart-health-monitor"],
+  },
+  {
+    prefix: "gateway.channelHealthTiming",
+    kind: "hot",
+    actions: ["restart-health-monitor"],
+  },
+  // Stuck-session warning threshold is read by the diagnostics heartbeat loop.
+  { prefix: "diagnostics.stuckSessionWarnMs", kind: "none" },
+  { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },
+  { prefix: "hooks", kind: "hot", actions: ["reload-hooks"] },
+  {
+    prefix: "agents.defaults.heartbeat",
+    kind: "hot",
+    actions: ["restart-heartbeat"],
+  },
+  {
+    prefix: "agents.defaults.model",
+    kind: "hot",
+    actions: ["restart-heartbeat"],
+  },
+  {
+    prefix: "models",
+    kind: "hot",
+    actions: ["restart-heartbeat"],
+  },
+  { prefix: "agent.heartbeat", kind: "hot", actions: ["restart-heartbeat"] },
+  { prefix: "cron", kind: "hot", actions: ["restart-cron"] },
+  {
+    prefix: "browser",
+    kind: "hot",
+    actions: ["restart-browser-control"],
+  },
+];
+
+const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
+  { prefix: "meta", kind: "none" },
+  { prefix: "identity", kind: "none" },
+  { prefix: "wizard", kind: "none" },
+  { prefix: "logging", kind: "none" },
+  { prefix: "agents", kind: "none" },
+  { prefix: "tools", kind: "none" },
+  { prefix: "bindings", kind: "none" },
+  { prefix: "audio", kind: "none" },
+  { prefix: "agent", kind: "none" },
+  { prefix: "routing", kind: "none" },
+  { prefix: "messages", kind: "none" },
+  { prefix: "session", kind: "none" },
+  { prefix: "talk", kind: "none" },
+  { prefix: "skills", kind: "none" },
+  { prefix: "secrets", kind: "none" },
+  { prefix: "plugins", kind: "restart" },
+  { prefix: "ui", kind: "none" },
+  { prefix: "gateway", kind: "restart" },
+  { prefix: "discovery", kind: "restart" },
+  { prefix: "canvasHost", kind: "restart" },
+];
+
+let cachedReloadRules: ReloadRule[] | null = null;
+let cachedRegistry: ReturnType<typeof getActivePluginRegistry> | null = null;
+
+function listReloadRules(): ReloadRule[] {
+  const registry = getActivePluginRegistry();
+  if (registry !== cachedRegistry) {
+    cachedReloadRules = null;
+    cachedRegistry = registry;
+  }
+  if (cachedReloadRules) {
+    return cachedReloadRules;
+  }
+  // Channel docking: plugins contribute hot reload/no-op prefixes here.
+  const channelReloadRules: ReloadRule[] = listChannelPlugins().flatMap((plugin) => [
+    ...(plugin.reload?.configPrefixes ?? []).map(
+      (prefix): ReloadRule => ({
+        prefix,
+        kind: "hot",
+        actions: [`restart-channel:${plugin.id}` as ReloadAction],
+      }),
+    ),
+    ...(plugin.reload?.noopPrefixes ?? []).map(
+      (prefix): ReloadRule => ({
+        prefix,
+        kind: "none",
+      }),
+    ),
+  ]);
+  const rules = [...BASE_RELOAD_RULES, ...channelReloadRules, ...BASE_RELOAD_RULES_TAIL];
+  cachedReloadRules = rules;
+  return rules;
+}
+
+function matchRule(path: string): ReloadRule | null {
+  for (const rule of listReloadRules()) {
+    if (path === rule.prefix || path.startsWith(`${rule.prefix}.`)) {
+      return rule;
+    }
+  }
+  return null;
+}
+
+export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPlan {
+  const plan: GatewayReloadPlan = {
+    changedPaths,
+    restartGateway: false,
+    restartReasons: [],
+    hotReasons: [],
+    reloadHooks: false,
+    restartGmailWatcher: false,
+    restartBrowserControl: false,
+    restartCron: false,
+    restartHeartbeat: false,
+    restartHealthMonitor: false,
+    restartChannels: new Set(),
+    noopPaths: [],
+  };
+
+  const applyAction = (action: ReloadAction) => {
+    if (action.startsWith("restart-channel:")) {
+      const channel = action.slice("restart-channel:".length) as ChannelId;
+      plan.restartChannels.add(channel);
+      return;
+    }
+    switch (action) {
+      case "reload-hooks":
+        plan.reloadHooks = true;
+        break;
+      case "restart-gmail-watcher":
+        plan.restartGmailWatcher = true;
+        break;
+      case "restart-browser-control":
+        plan.restartBrowserControl = true;
+        break;
+      case "restart-cron":
+        plan.restartCron = true;
+        break;
+      case "restart-heartbeat":
+        plan.restartHeartbeat = true;
+        break;
+      case "restart-health-monitor":
+        plan.restartHealthMonitor = true;
+        break;
+      default:
+        break;
+    }
+  };
+
+  for (const path of changedPaths) {
+    const rule = matchRule(path);
+    if (!rule) {
+      plan.restartGateway = true;
+      plan.restartReasons.push(path);
+      continue;
+    }
+    if (rule.kind === "restart") {
+      plan.restartGateway = true;
+      plan.restartReasons.push(path);
+      continue;
+    }
+    if (rule.kind === "none") {
+      plan.noopPaths.push(path);
+      continue;
+    }
+    plan.hotReasons.push(path);
+    for (const action of rule.actions ?? []) {
+      applyAction(action);
+    }
+  }
+
+  if (plan.restartGmailWatcher) {
+    plan.reloadHooks = true;
+  }
+
+  return plan;
+}

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -147,6 +147,32 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartChannels).toEqual(expected);
   });
 
+  it("restarts heartbeat when model-related config changes", () => {
+    const plan = buildGatewayReloadPlan([
+      "models.providers.openai.models",
+      "agents.defaults.model",
+    ]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartHeartbeat).toBe(true);
+    expect(plan.hotReasons).toEqual(
+      expect.arrayContaining(["models.providers.openai.models", "agents.defaults.model"]),
+    );
+  });
+
+  it("hot-reloads health monitor when channelHealthCheckMinutes changes", () => {
+    const plan = buildGatewayReloadPlan(["gateway.channelHealthCheckMinutes"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartHealthMonitor).toBe(true);
+    expect(plan.hotReasons).toContain("gateway.channelHealthCheckMinutes");
+  });
+
+  it("hot-reloads health monitor when channelHealthTiming changes", () => {
+    const plan = buildGatewayReloadPlan(["gateway.channelHealthTiming.staleEventThresholdMinutes"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartHealthMonitor).toBe(true);
+    expect(plan.hotReasons).toContain("gateway.channelHealthTiming.staleEventThresholdMinutes");
+  });
+
   it("treats gateway.remote as no-op", () => {
     const plan = buildGatewayReloadPlan(["gateway.remote.url"]);
     expect(plan.restartGateway).toBe(false);
@@ -168,6 +194,53 @@ describe("buildGatewayReloadPlan", () => {
   it("defaults unknown paths to restart", () => {
     const plan = buildGatewayReloadPlan(["unknownField"]);
     expect(plan.restartGateway).toBe(true);
+  });
+
+  it.each([
+    {
+      path: "gateway.channelHealthCheckMinutes",
+      expectRestartGateway: false,
+      expectHotPath: "gateway.channelHealthCheckMinutes",
+      expectRestartHealthMonitor: true,
+    },
+    {
+      path: "hooks.gmail.account",
+      expectRestartGateway: false,
+      expectHotPath: "hooks.gmail.account",
+      expectRestartGmailWatcher: true,
+      expectReloadHooks: true,
+    },
+    {
+      path: "gateway.remote.url",
+      expectRestartGateway: false,
+      expectNoopPath: "gateway.remote.url",
+    },
+    {
+      path: "unknownField",
+      expectRestartGateway: true,
+      expectRestartReason: "unknownField",
+    },
+  ])("classifies reload path: $path", (testCase) => {
+    const plan = buildGatewayReloadPlan([testCase.path]);
+    expect(plan.restartGateway).toBe(testCase.expectRestartGateway);
+    if (testCase.expectHotPath) {
+      expect(plan.hotReasons).toContain(testCase.expectHotPath);
+    }
+    if (testCase.expectNoopPath) {
+      expect(plan.noopPaths).toContain(testCase.expectNoopPath);
+    }
+    if (testCase.expectRestartReason) {
+      expect(plan.restartReasons).toContain(testCase.expectRestartReason);
+    }
+    if (testCase.expectRestartHealthMonitor) {
+      expect(plan.restartHealthMonitor).toBe(true);
+    }
+    if (testCase.expectRestartGmailWatcher) {
+      expect(plan.restartGmailWatcher).toBe(true);
+    }
+    if (testCase.expectReloadHooks) {
+      expect(plan.reloadHooks).toBe(true);
+    }
   });
 });
 

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -16,7 +16,13 @@ import {
 } from "../infra/restart.js";
 import { setCommandLaneConcurrency, getTotalQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
-import type { ChannelKind, GatewayReloadPlan } from "./config-reload.js";
+import {
+  resolveHealthTimingFromConfig,
+  type ChannelHealthMonitor,
+  type ChannelHealthTimingPolicy,
+} from "./channel-health-monitor.js";
+import type { ChannelKind } from "./config-reload-plan.js";
+import type { GatewayReloadPlan } from "./config-reload.js";
 import { resolveHooksConfig } from "./hooks.js";
 import { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { buildGatewayCronService, type GatewayCronState } from "./server-cron.js";
@@ -26,6 +32,7 @@ type GatewayHotReloadState = {
   heartbeatRunner: HeartbeatRunner;
   cronState: GatewayCronState;
   browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> | null;
+  channelHealthMonitor: ChannelHealthMonitor | null;
 };
 
 export function createGatewayReloadHandlers(params: {
@@ -44,6 +51,10 @@ export function createGatewayReloadHandlers(params: {
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   logCron: { error: (msg: string) => void };
   logReload: { info: (msg: string) => void; warn: (msg: string) => void };
+  createHealthMonitor: (
+    checkIntervalMs: number,
+    timing?: Partial<ChannelHealthTimingPolicy>,
+  ) => ChannelHealthMonitor;
 }) {
   const applyHotReload = async (
     plan: GatewayReloadPlan,
@@ -88,6 +99,14 @@ export function createGatewayReloadHandlers(params: {
       } catch (err) {
         params.logBrowser.error(`server failed to start: ${String(err)}`);
       }
+    }
+
+    if (plan.restartHealthMonitor) {
+      state.channelHealthMonitor?.stop();
+      const minutes = nextConfig.gateway?.channelHealthCheckMinutes;
+      const timing = resolveHealthTimingFromConfig(nextConfig.gateway?.channelHealthTiming);
+      nextState.channelHealthMonitor =
+        minutes === 0 ? null : params.createHealthMonitor((minutes ?? 5) * 60_000, timing);
     }
 
     if (plan.restartGmailWatcher) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -18,6 +18,7 @@ import {
   readConfigFileSnapshot,
   writeConfigFile,
 } from "../config/config.js";
+import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
@@ -45,18 +46,28 @@ import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/di
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
 import type { RuntimeEnv } from "../runtime.js";
+import type { CommandSecretAssignment } from "../secrets/command-config.js";
+import {
+  GATEWAY_AUTH_SURFACE_PATHS,
+  evaluateGatewayAuthSurfaceStates,
+} from "../secrets/runtime-gateway-auth-surfaces.js";
 import {
   activateSecretsRuntimeSnapshot,
   clearSecretsRuntimeSnapshot,
   getActiveSecretsRuntimeSnapshot,
   prepareSecretsRuntimeSnapshot,
+  resolveCommandSecretsFromActiveRuntimeSnapshot,
 } from "../secrets/runtime.js";
 import { runOnboardingWizard } from "../wizard/onboarding.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
-import { startChannelHealthMonitor } from "./channel-health-monitor.js";
+import {
+  resolveHealthTimingFromConfig,
+  startChannelHealthMonitor,
+} from "./channel-health-monitor.js";
 import { startGatewayConfigReloader } from "./config-reload.js";
 import type { ControlUiRootState } from "./control-ui.js";
 import {
@@ -135,6 +146,35 @@ function createGatewayAuthRateLimiters(rateLimitConfig: AuthRateLimitConfig | un
     exemptLoopback: false,
   });
   return { rateLimiter, browserRateLimiter };
+}
+
+function logGatewayAuthSurfaceDiagnostics(prepared: {
+  sourceConfig: OpenClawConfig;
+  warnings: Array<{ code: string; path: string; message: string }>;
+}): void {
+  const states = evaluateGatewayAuthSurfaceStates({
+    config: prepared.sourceConfig,
+    defaults: prepared.sourceConfig.secrets?.defaults,
+    env: process.env,
+  });
+  const inactiveWarnings = new Map<string, string>();
+  for (const warning of prepared.warnings) {
+    if (warning.code !== "SECRETS_REF_IGNORED_INACTIVE_SURFACE") {
+      continue;
+    }
+    inactiveWarnings.set(warning.path, warning.message);
+  }
+  for (const path of GATEWAY_AUTH_SURFACE_PATHS) {
+    const state = states[path];
+    if (!state.hasSecretRef) {
+      continue;
+    }
+    const stateLabel = state.active ? "active" : "inactive";
+    const inactiveDetails =
+      !state.active && inactiveWarnings.get(path) ? inactiveWarnings.get(path) : undefined;
+    const details = inactiveDetails ?? state.reason;
+    logSecrets.info(`[SECRETS_GATEWAY_AUTH_SURFACE] ${path} is ${stateLabel}. ${details}`);
+  }
 }
 
 export type GatewayServer = {
@@ -237,9 +277,7 @@ export async function startGatewayServer(
   if (configSnapshot.exists && !configSnapshot.valid) {
     const issues =
       configSnapshot.issues.length > 0
-        ? configSnapshot.issues
-            .map((issue) => `${issue.path || "<root>"}: ${issue.message}`)
-            .join("\n")
+        ? formatConfigIssueLines(configSnapshot.issues, "", { normalizeRoot: true }).join("\n")
         : "Unknown validation issue.";
     throw new Error(
       `Invalid config at ${configSnapshot.path}.\n${issues}\nRun "${formatCliCommand("openclaw doctor")}" to repair, then retry.`,
@@ -289,6 +327,7 @@ export async function startGatewayServer(
         const prepared = await prepareSecretsRuntimeSnapshot({ config });
         if (params.activate) {
           activateSecretsRuntimeSnapshot(prepared);
+          logGatewayAuthSurfaceDiagnostics(prepared);
         }
         for (const warning of prepared.warnings) {
           logSecrets.warn(`[${warning.code}] ${warning.message}`);
@@ -332,9 +371,7 @@ export async function startGatewayServer(
     if (!freshSnapshot.valid) {
       const issues =
         freshSnapshot.issues.length > 0
-          ? freshSnapshot.issues
-              .map((issue) => `${issue.path || "<root>"}: ${issue.message}`)
-              .join("\n")
+          ? formatConfigIssueLines(freshSnapshot.issues, "", { normalizeRoot: true }).join("\n")
           : "Unknown validation issue.";
       throw new Error(`Invalid config at ${freshSnapshot.path}.\n${issues}`);
     }
@@ -557,6 +594,7 @@ export async function startGatewayServer(
     loadConfig,
     channelLogs,
     channelRuntimeEnvs,
+    channelRuntime: createPluginRuntime().channel,
   });
   const { getRuntimeSnapshot, startChannels, startChannel, stopChannel, markChannelLoggedOut } =
     channelManager;
@@ -656,11 +694,13 @@ export async function startGatewayServer(
 
   const healthCheckMinutes = cfgAtStart.gateway?.channelHealthCheckMinutes;
   const healthCheckDisabled = healthCheckMinutes === 0;
-  const channelHealthMonitor = healthCheckDisabled
+  const healthTiming = resolveHealthTimingFromConfig(cfgAtStart.gateway?.channelHealthTiming);
+  let channelHealthMonitor = healthCheckDisabled
     ? null
     : startChannelHealthMonitor({
         channelManager,
         checkIntervalMs: (healthCheckMinutes ?? 5) * 60_000,
+        timing: healthTiming,
       });
 
   if (!minimalTestGateway) {
@@ -697,6 +737,17 @@ export async function startGatewayServer(
         activate: true,
       });
       return { warningCount: prepared.warnings.length };
+    },
+    resolveSecrets: async ({ commandName, targetIds }) => {
+      const { assignments, diagnostics, inactiveRefPaths } =
+        resolveCommandSecretsFromActiveRuntimeSnapshot({
+          commandName,
+          targetIds: new Set(targetIds),
+        });
+      if (assignments.length === 0) {
+        return { assignments: [] as CommandSecretAssignment[], diagnostics, inactiveRefPaths };
+      }
+      return { assignments, diagnostics, inactiveRefPaths };
     },
   });
 
@@ -841,6 +892,7 @@ export async function startGatewayServer(
             heartbeatRunner,
             cronState,
             browserControl,
+            channelHealthMonitor,
           }),
           setState: (nextState) => {
             hooksConfig = nextState.hooksConfig;
@@ -849,6 +901,7 @@ export async function startGatewayServer(
             cron = cronState.cron;
             cronStorePath = cronState.storePath;
             browserControl = nextState.browserControl;
+            channelHealthMonitor = nextState.channelHealthMonitor;
           },
           startChannel,
           stopChannel,
@@ -857,6 +910,8 @@ export async function startGatewayServer(
           logChannels,
           logCron,
           logReload,
+          createHealthMonitor: (checkIntervalMs, timing) =>
+            startChannelHealthMonitor({ channelManager, checkIntervalMs, timing }),
         });
 
         return startGatewayConfigReloader({


### PR DESCRIPTION
## Summary

- Add `gateway.channelHealthTiming` config with `startupGraceMinutes`, `connectGraceMinutes`, and `staleEventThresholdMinutes`
- Wire timing through to `startChannelHealthMonitor()` on both startup and hot-reload paths
- Add `resolveHealthTimingFromConfig()` helper to convert user-facing minutes to internal ms
- Add hot-reload support: changes to `gateway.channelHealthTiming` restart the health monitor without a full gateway restart

Fixes #32651

## Test plan

- [x] `resolveHealthTimingFromConfig` unit tests (undefined, empty, partial, full, zero values)
- [x] Zod schema validation tests (valid, partial, negative, unknown keys)
- [x] Config reload plan test (channelHealthTiming triggers health monitor restart)
- [x] All 29 existing health monitor tests still pass
- [x] All 55 config + reload tests pass
- [x] Format check passes