### PR TITLE
fix: add post-write recovery wrapper to sandbox edit tool

### DIFF
--- a/src/agents/pi-tools.host-edit.ts
+++ b/src/agents/pi-tools.host-edit.ts
@@ -18,10 +18,15 @@ function resolveHostEditPath(root: string, pathParam: string): string {
  * the file may be correctly updated but the tool reports failure. This wrapper catches errors and
  * if the target file on disk contains the intended newText, returns success so we don't surface
  * a false "edit failed" to the user (fixes #32333, same pattern as #30773 for write).
+ *
+ * @param readFileFn - Optional custom readFile function. When provided (e.g., for sandbox mode),
+ *   it will be used instead of Node.js fs.readFile. This allows the wrapper to work in sandbox
+ *   environments where files exist in containers inaccessible to the host filesystem.
  */
 export function wrapHostEditToolWithPostWriteRecovery(
   base: AnyAgentTool,
   root: string,
+  readFileFn?: (absolutePath: string) => Promise<string>,
 ): AnyAgentTool {
   return {
     ...base,
@@ -54,7 +59,9 @@ export function wrapHostEditToolWithPostWriteRecovery(
         }
         try {
           const absolutePath = resolveHostEditPath(root, pathParam);
-          const content = await fs.readFile(absolutePath, "utf-8");
+          // Use custom readFileFn if provided (e.g., for sandbox mode), otherwise fall back to fs.readFile
+          const readFile = readFileFn ?? ((p: string) => fs.readFile(p, "utf-8"));
+          const content = await readFile(absolutePath);
           // Only recover when the replacement likely occurred: newText is present and oldText
           // is no longer present. This avoids false success when upstream threw before writing
           // (e.g. oldText not found) but the file already contained newText (review feedback).

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -462,7 +462,14 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
   const base = createEditTool(params.root, {
     operations: createSandboxEditOperations(params),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
+  // For sandbox mode, use bridge.readFile to read files from within the container
+  const sandboxReadFile = async (absolutePath: string) => {
+    const resolved = params.bridge.resolvePath({ filePath: absolutePath, cwd: params.root });
+    const buffer = await params.bridge.readFile({ filePath: resolved.containerPath });
+    return buffer.toString("utf-8");
+  };
+  const withRecovery = wrapHostEditToolWithPostWriteRecovery(base, params.root, sandboxReadFile);
+  return wrapToolParamNormalization(withRecovery, CLAUDE_PARAM_GROUPS.edit);
 }
 
 export function createHostWorkspaceWriteTool(root: string, options?: { workspaceOnly?: boolean }) {


### PR DESCRIPTION
The createSandboxedEditTool was missing the wrapHostEditToolWithPostWriteRecovery wrapper that exists in createHostWorkspaceEditTool. This caused false 'edit failed' errors when the upstream edit tool throws after successfully writing the file (e.g., when generateDiffString fails).

Now createSandboxedEditTool uses the same recovery logic as the host version, checking if the file was actually updated and returning success even if the upstream tool threw an error.

Fixes #32333