### PR TITLE
feat: add 'xai' to reasoning tag providers (#27533)

### DIFF
--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -21,7 +21,8 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   if (
     normalized === "google" ||
     normalized === "google-gemini-cli" ||
-    normalized === "google-generative-ai"
+    normalized === "google-generative-ai" ||
+    normalized === "xai"
   ) {
     return true;
   }


### PR DESCRIPTION
## Summary

Adds XAI (Grok) to the list of reasoning tag providers that require reasoning/thinking to be wrapped in tags.

## Root Cause

XAI (Grok) models require reasoning to be wrapped in `` and `<final>` tags rather than using native API fields for reasoning/thinking.

## Fix

Add 'xai' to the list of reasoning tag providers in `isReasoningTagProvider()`.

## Changes

- **`src/utils/provider-utils.ts`**: Add 'xai' to reasoning tag provider check

## Related

- Split from PR #31707
- Fixes #27533