### PR TITLE
Telegram: warn when accounts.default is missing in multi-account setup (#32137)

### DIFF
--- a/src/telegram/accounts.test.ts
+++ b/src/telegram/accounts.test.ts
@@ -105,6 +105,10 @@ describe("resolveTelegramAccount", () => {
 });
 
 describe("resolveDefaultTelegramAccountId", () => {
+  afterEach(() => {
+    warnMock.mockClear();
+  });
+
   it("prefers channels.telegram.defaultAccount when it matches a configured account", () => {
     const cfg: OpenClawConfig = {
       channels: {
@@ -142,6 +146,76 @@ describe("resolveDefaultTelegramAccountId", () => {
     };
 
     expect(resolveDefaultTelegramAccountId(cfg)).toBe("default");
+  });
+
+  it("warns when accounts.default is missing in multi-account setup", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          accounts: { work: { botToken: "tok-work" }, alerts: { botToken: "tok-alerts" } },
+        },
+      },
+    };
+
+    const result = resolveDefaultTelegramAccountId(cfg);
+    // Falls back to first account alphabetically
+    expect(result).toBe("alerts");
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining('accounts.default is missing; falling back to "alerts"'),
+    );
+  });
+
+  it("does not warn when accounts.default exists in multi-account setup", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          accounts: {
+            default: { botToken: "tok-default" },
+            work: { botToken: "tok-work" },
+            alerts: { botToken: "tok-alerts" },
+          },
+        },
+      },
+    };
+
+    const result = resolveDefaultTelegramAccountId(cfg);
+    expect(result).toBe("default");
+    expect(warnMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("accounts.default is missing"),
+    );
+  });
+
+  it("does not warn in single-account setup without accounts.default", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          accounts: { work: { botToken: "tok-work" } },
+        },
+      },
+    };
+
+    const result = resolveDefaultTelegramAccountId(cfg);
+    expect(result).toBe("work");
+    expect(warnMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("accounts.default is missing"),
+    );
+  });
+
+  it("does not warn when defaultAccount is explicitly set", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          defaultAccount: "work",
+          accounts: { work: { botToken: "tok-work" }, alerts: { botToken: "tok-alerts" } },
+        },
+      },
+    };
+
+    const result = resolveDefaultTelegramAccountId(cfg);
+    expect(result).toBe("work");
+    expect(warnMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("accounts.default is missing"),
+    );
   });
 });
 

--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -79,6 +79,14 @@ export function resolveDefaultTelegramAccountId(cfg: OpenClawConfig): string {
   if (ids.includes(DEFAULT_ACCOUNT_ID)) {
     return DEFAULT_ACCOUNT_ID;
   }
+  // Warn when falling back to the first configured account in multi-account setups
+  // to help users detect missing default configuration.
+  const configuredAccounts = cfg.channels?.telegram?.accounts;
+  if (configuredAccounts && Object.keys(configuredAccounts).length > 1 && ids[0]) {
+    log.warn(
+      `channels.telegram: accounts.default is missing; falling back to "${ids[0]}". Set channels.telegram.defaultAccount or add an accounts.default entry to avoid routing surprises in multi-account setups.`,
+    );
+  }
   return ids[0] ?? DEFAULT_ACCOUNT_ID;
 }
 


### PR DESCRIPTION
…p (#32137)

 ## Summary
  - Problem: When configuring Telegram multi-account via \`channels.telegram.accounts\`, omitting \`accounts.default\`
  leads to confusing default routing behavior. The system silently falls back to the first configured account
  alphabetically.
  - Solution: Added a \`log.warn\` in \`resolveDefaultTelegramAccountId\` that fires once when the fallback occurs,
  guiding users to set \`channels.telegram.defaultAccount\` or add \`accounts.default\`.

  ## Change Type
  - [x] Bug fix

  ## Scope
  - [x] Integrations
  - [x] UI / DX

  ## Linked Issue
  Closes #32137

  ## Verification
  - \`pnpm check\` passes
  - Added unit tests for warning behavior in multi-account setups
