### PR TITLE
Models: preserve explicit Moonshot baseUrl in implicit providers

### DIFF
--- a/src/agents/models-config.providers.moonshot.test.ts
+++ b/src/agents/models-config.providers.moonshot.test.ts
@@ -1,0 +1,28 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
+import { resolveImplicitProviders } from "./models-config.providers.js";
+
+describe("Moonshot implicit provider", () => {
+  it("preserves explicit moonshot baseUrl when auth is inferred", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    await withEnvAsync({ MOONSHOT_API_KEY: "moonshot-test-key" }, async () => {
+      const providers = await resolveImplicitProviders({
+        agentDir,
+        explicitProviders: {
+          moonshot: {
+            baseUrl: "https://api.moonshot.cn/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      });
+
+      expect(providers?.moonshot).toBeDefined();
+      expect(providers?.moonshot?.baseUrl).toBe("https://api.moonshot.cn/v1");
+      expect(providers?.moonshot?.apiKey).toBe("MOONSHOT_API_KEY");
+    });
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -635,9 +635,10 @@ function buildMinimaxPortalProvider(): ProviderConfig {
   };
 }
 
-function buildMoonshotProvider(): ProviderConfig {
+function buildMoonshotProvider(configuredBaseUrl?: string): ProviderConfig {
+  const baseUrl = configuredBaseUrl?.trim() || MOONSHOT_BASE_URL;
   return {
-    baseUrl: MOONSHOT_BASE_URL,
+    baseUrl,
     api: "openai-completions",
     models: [
       {
@@ -948,7 +949,8 @@ export async function resolveImplicitProviders(params: {
     resolveEnvApiKeyVarName("moonshot") ??
     resolveApiKeyFromProfiles({ provider: "moonshot", store: authStore });
   if (moonshotKey) {
-    providers.moonshot = { ...buildMoonshotProvider(), apiKey: moonshotKey };
+    const moonshotBaseUrl = params.explicitProviders?.moonshot?.baseUrl;
+    providers.moonshot = { ...buildMoonshotProvider(moonshotBaseUrl), apiKey: moonshotKey };
   }
 
   const kimiCodingKey =


### PR DESCRIPTION
## Summary
- preserve an explicit `models.providers.moonshot.baseUrl` when Moonshot is inferred from env vars
- avoid silently resetting users back to `https://api.moonshot.ai/v1` when they configured `.cn` or other endpoints

## Testing
- `pnpm exec vitest run src/agents/models-config.providers.moonshot.test.ts`
