### PR TITLE
Matrix: forward audioAsVoice in message action send path

### DIFF
--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -1,5 +1,6 @@
 import {
   createActionGate,
+  readBooleanParam,
   readNumberParam,
   readStringParam,
   type ChannelMessageActionAdapter,
@@ -69,6 +70,8 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
       const mediaUrl = readStringParam(params, "media", { trim: false });
       const replyTo = readStringParam(params, "replyTo");
       const threadId = readStringParam(params, "threadId");
+      const audioAsVoice = readBooleanParam(params, "audioAsVoice");
+      const asVoice = readBooleanParam(params, "asVoice");
       return await handleMatrixAction(
         {
           action: "sendMessage",
@@ -77,6 +80,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyTo ?? undefined,
           threadId: threadId ?? undefined,
+          audioAsVoice: audioAsVoice ?? asVoice ?? undefined,
         },
         cfg as CoreConfig,
       );

--- a/extensions/matrix/src/matrix/actions/messages.test.ts
+++ b/extensions/matrix/src/matrix/actions/messages.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+const sendMessageMatrixMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    messageId: "evt-1",
+    roomId: "!room:example",
+  })),
+);
+
+vi.mock("../send.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../send.js")>();
+  return {
+    ...actual,
+    sendMessageMatrix: sendMessageMatrixMock,
+  };
+});
+
+import { sendMatrixMessage } from "./messages.js";
+
+describe("sendMatrixMessage", () => {
+  it("forwards audioAsVoice to sendMessageMatrix", async () => {
+    sendMessageMatrixMock.mockClear();
+
+    await sendMatrixMessage("!room:example", "Voice note", {
+      mediaUrl: "https://example.com/voice.ogg",
+      replyToId: "$reply",
+      threadId: "$thread",
+      audioAsVoice: true,
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledWith("!room:example", "Voice note", {
+      mediaUrl: "https://example.com/voice.ogg",
+      replyToId: "$reply",
+      threadId: "$thread",
+      audioAsVoice: true,
+      client: undefined,
+      timeoutMs: undefined,
+    });
+  });
+});

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -19,12 +19,14 @@ export async function sendMatrixMessage(
     mediaUrl?: string;
     replyToId?: string;
     threadId?: string;
+    audioAsVoice?: boolean;
   } = {},
 ) {
   return await sendMessageMatrix(to, content, {
     mediaUrl: opts.mediaUrl,
     replyToId: opts.replyToId,
     threadId: opts.threadId,
+    audioAsVoice: opts.audioAsVoice,
     client: opts.client,
     timeoutMs: opts.timeoutMs,
   });

--- a/extensions/matrix/src/tool-actions.send-voice.test.ts
+++ b/extensions/matrix/src/tool-actions.send-voice.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CoreConfig } from "./types.js";
+
+const sendMatrixMessageMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    messageId: "evt-1",
+    roomId: "!room:example",
+  })),
+);
+
+vi.mock("./matrix/actions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./matrix/actions.js")>();
+  return {
+    ...actual,
+    sendMatrixMessage: sendMatrixMessageMock,
+  };
+});
+
+import { handleMatrixAction } from "./tool-actions.js";
+
+const cfg = {
+  channels: {
+    matrix: {
+      actions: {
+        messages: true,
+      },
+    },
+  },
+} as CoreConfig;
+
+describe("handleMatrixAction sendMessage voice flags", () => {
+  it("passes audioAsVoice through to sendMatrixMessage", async () => {
+    sendMatrixMessageMock.mockClear();
+
+    await handleMatrixAction(
+      {
+        action: "sendMessage",
+        to: "!room:example",
+        content: "Voice note",
+        mediaUrl: "https://example.com/voice.ogg",
+        audioAsVoice: true,
+      },
+      cfg,
+    );
+
+    expect(sendMatrixMessageMock).toHaveBeenCalledWith("!room:example", "Voice note", {
+      mediaUrl: "https://example.com/voice.ogg",
+      replyToId: undefined,
+      threadId: undefined,
+      audioAsVoice: true,
+    });
+  });
+
+  it("supports asVoice as an alias for audioAsVoice", async () => {
+    sendMatrixMessageMock.mockClear();
+
+    await handleMatrixAction(
+      {
+        action: "sendMessage",
+        to: "!room:example",
+        content: "Voice alias",
+        mediaUrl: "https://example.com/voice.ogg",
+        asVoice: true,
+      },
+      cfg,
+    );
+
+    expect(sendMatrixMessageMock).toHaveBeenCalledWith("!room:example", "Voice alias", {
+      mediaUrl: "https://example.com/voice.ogg",
+      replyToId: undefined,
+      threadId: undefined,
+      audioAsVoice: true,
+    });
+  });
+});

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -2,6 +2,7 @@ import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import {
   createActionGate,
   jsonResult,
+  readBooleanParam,
   readNumberParam,
   readReactionParams,
   readStringParam,
@@ -82,10 +83,13 @@ export async function handleMatrixAction(
         const replyToId =
           readStringParam(params, "replyToId") ?? readStringParam(params, "replyTo");
         const threadId = readStringParam(params, "threadId");
+        const audioAsVoice = readBooleanParam(params, "audioAsVoice");
+        const asVoice = readBooleanParam(params, "asVoice");
         const result = await sendMatrixMessage(to, content, {
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyToId ?? undefined,
           threadId: threadId ?? undefined,
+          audioAsVoice: audioAsVoice ?? asVoice ?? undefined,
         });
         return jsonResult({ ok: true, result });
       }


### PR DESCRIPTION
## Summary
- forward `audioAsVoice` (and `asVoice` alias) through Matrix action send paths
- ensure message-action sends preserve voice intent for media uploads

## Testing
- `pnpm exec vitest run extensions/matrix/src/tool-actions.send-voice.test.ts`
