### PR TITLE
Slack: print app manifest JSON outside note framing

### DIFF
--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -109,11 +109,14 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
       `Docs: ${formatDocsLink("/slack", "slack")}`,
       "",
-      "Manifest (JSON):",
-      manifest,
+      "Manifest JSON is printed raw below for copy/paste.",
     ].join("\n"),
     "Slack socket mode tokens",
   );
+  // Print raw JSON (outside clack note framing) so users can copy valid manifest
+  // directly without removing decorative box characters.
+  process.stdout.write("\nSlack App Manifest (raw JSON):\n");
+  process.stdout.write(`${manifest}\n\n`);
 }
 
 function setSlackChannelAllowlist(


### PR DESCRIPTION
## Summary
- print Slack app manifest as raw JSON outside the boxed note output
- avoid copy/paste breakage from note framing characters in some terminals

## Testing
- manual output validation via onboarding flow
