### PR TITLE
Gateway: run plugin HTTP handlers before canvas host

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -616,6 +616,25 @@ export function createGatewayHttpServer(opts: {
             }),
         });
       }
+      // Plugin routes run before canvas/control-ui catch-alls so explicitly
+      // registered plugin endpoints stay reachable (e.g. POST webhooks).
+      // Core built-in gateway routes above still keep precedence.
+      requestStages.push(
+        ...buildPluginRequestStages({
+          req,
+          res,
+          requestPath,
+          mattermostSlashCallbackPaths,
+          pluginPathContext,
+          handlePluginRequest,
+          shouldEnforcePluginGatewayAuth,
+          resolvedAuth,
+          trustedProxies,
+          allowRealIpFallback,
+          rateLimiter,
+        }),
+      );
+
       if (canvasHost) {
         requestStages.push({
           name: "canvas-auth",
@@ -649,24 +668,6 @@ export function createGatewayHttpServer(opts: {
           run: () => canvasHost.handleHttpRequest(req, res),
         });
       }
-      // Plugin routes run before the Control UI SPA catch-all so explicitly
-      // registered plugin endpoints stay reachable. Core built-in gateway
-      // routes above still keep precedence on overlapping paths.
-      requestStages.push(
-        ...buildPluginRequestStages({
-          req,
-          res,
-          requestPath,
-          mattermostSlashCallbackPaths,
-          pluginPathContext,
-          handlePluginRequest,
-          shouldEnforcePluginGatewayAuth,
-          resolvedAuth,
-          trustedProxies,
-          allowRealIpFallback,
-          rateLimiter,
-        }),
-      );
 
       if (controlUiEnabled) {
         requestStages.push({

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -398,6 +398,52 @@ describe("gateway plugin HTTP auth boundary", () => {
     });
   });
 
+  test("checks plugin handlers before canvas host request handling", async () => {
+    const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+      const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+      if (req.method === "POST" && pathname === "/googlechat") {
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "application/json; charset=utf-8");
+        res.end(JSON.stringify({ ok: true, route: "plugin-webhook" }));
+        return true;
+      }
+      return false;
+    });
+    const canvasHandleHttpRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+      if (req.method && req.method !== "GET" && req.method !== "HEAD") {
+        res.statusCode = 405;
+        res.end("Method Not Allowed");
+        return true;
+      }
+      return false;
+    });
+    const canvasHost = {
+      handleHttpRequest: canvasHandleHttpRequest,
+      handleUpgrade: vi.fn(() => false),
+      close: vi.fn(async () => {}),
+    };
+
+    await withGatewayServer({
+      prefix: "openclaw-plugin-http-canvas-order-test-",
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        handlePluginRequest,
+        canvasHost: canvasHost as never,
+      },
+      run: async (server) => {
+        const response = await sendRequest(server, {
+          path: "/googlechat",
+          method: "POST",
+        });
+
+        expect(response.res.statusCode).toBe(200);
+        expect(response.getBody()).toContain('"route":"plugin-webhook"');
+        expect(handlePluginRequest).toHaveBeenCalledTimes(1);
+        expect(canvasHandleHttpRequest).not.toHaveBeenCalled();
+      },
+    });
+  });
+
   test("serves plugin routes before control ui spa fallback", async () => {
     const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
       const pathname = new URL(req.url ?? "/", "http://localhost").pathname;


### PR DESCRIPTION
## Summary
- run plugin HTTP stages before canvas host stages in gateway request handling
- prevents plugin webhook POST routes from being intercepted by canvas `405 Method Not Allowed`
- adds a gateway regression test covering plugin-vs-canvas ordering

## Testing
- `pnpm exec vitest run src/gateway/server.plugin-http-auth.test.ts`

Closes #32682.
