### PR TITLE
Nextcloud Talk: avoid core src import in plugin runtime

### DIFF
--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -12,7 +12,6 @@ import {
   type OpenClawConfig,
   type ChannelSetupInput,
 } from "openclaw/plugin-sdk";
-import { waitForAbortSignal } from "../../../src/infra/abort-signal.js";
 import {
   listNextcloudTalkAccountIds,
   resolveDefaultNextcloudTalkAccountId,
@@ -30,6 +29,19 @@ import { resolveNextcloudTalkGroupToolPolicy } from "./policy.js";
 import { getNextcloudTalkRuntime } from "./runtime.js";
 import { sendMessageNextcloudTalk } from "./send.js";
 import type { CoreConfig } from "./types.js";
+
+function waitForAbortSignal(signal?: AbortSignal): Promise<void> {
+  if (!signal || signal.aborted) {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
 
 const meta = {
   id: "nextcloud-talk",


### PR DESCRIPTION
## Summary
- remove `nextcloud-talk` plugin runtime import of core `src/infra/abort-signal.js`
- replace with a local abort wait helper so npm-installed plugin bundles load correctly

## Testing
- `pnpm exec vitest run extensions/nextcloud-talk/src/channel.startup.test.ts`

Closes #32662.
