### PR TITLE
fix(outbound): suppress internal SILENT_REPLY_TOKEN (NO_REPLY) artifacts (fixes #32403)

### DIFF
--- a/src/commands/message-format.ts
+++ b/src/commands/message-format.ts
@@ -33,7 +33,7 @@ export type MessageCliJsonEnvelope = {
   action: ChannelMessageActionName;
   channel: ChannelId;
   dryRun: boolean;
-  handledBy: "plugin" | "core" | "dry-run";
+  handledBy: "plugin" | "core" | "dry-run" | "silent";
   payload: unknown;
 };
 
@@ -262,6 +262,10 @@ export function formatMessageCliText(result: MessageActionRunResult): string[] {
 
   if (result.handledBy === "dry-run") {
     return [muted(`[dry-run] would run ${result.action} via ${result.channel}`)];
+  }
+
+  if (result.handledBy === "silent") {
+    return [muted(`[silent] suppressed ${result.action} via ${result.channel}`)];
   }
 
   if (result.kind === "broadcast") {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -109,7 +109,7 @@ export type MessageActionRunResult =
       channel: ChannelId;
       action: "send";
       to: string;
-      handledBy: "plugin" | "core";
+      handledBy: "plugin" | "core" | "silent";
       payload: unknown;
       toolResult?: AgentToolResult<unknown>;
       sendResult?: MessageSendResult;

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -61,6 +61,9 @@ export type MessageSendResult = {
   mediaUrls?: string[];
   result?: OutboundDeliveryResult | { messageId: string };
   dryRun?: boolean;
+  ok?: boolean;
+  delivered?: boolean;
+  discarded?: boolean;
 };
 
 type MessagePollParams = {

--- a/src/infra/outbound/outbound-send-service.test.ts
+++ b/src/infra/outbound/outbound-send-service.test.ts
@@ -339,4 +339,52 @@ describe("executeSendAction", () => {
       }),
     );
   });
+
+  it("suppresses outbound message when content is SILENT_REPLY_TOKEN", async () => {
+    const result = await executeSendAction({
+      ctx: {
+        cfg: {},
+        channel: "telegram",
+        params: {},
+        dryRun: false,
+      },
+      to: "user:123",
+      message: "NO_REPLY",
+    });
+
+    expect(result.handledBy).toBe("silent");
+    expect(result.sendResult?.channel).toBe("telegram");
+    expect(result.sendResult?.to).toBe("user:123");
+    expect(result.sendResult?.via).toBe("direct");
+    expect(result.sendResult?.mediaUrl).toBeNull();
+    expect(result.sendResult?.delivered).toBe(false);
+    expect(result.sendResult?.discarded).toBe(true);
+    expect(mocks.dispatchChannelMessageAction).not.toHaveBeenCalled();
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("does NOT suppress SILENT_REPLY_TOKEN when media is attached", async () => {
+    mocks.dispatchChannelMessageAction.mockResolvedValue(null);
+    mocks.sendMessage.mockResolvedValue({
+      channel: "telegram",
+      to: "user:123",
+      via: "direct",
+      mediaUrl: "https://example.com/photo.jpg",
+    });
+
+    const result = await executeSendAction({
+      ctx: {
+        cfg: {},
+        channel: "telegram",
+        params: {},
+        dryRun: false,
+      },
+      to: "user:123",
+      message: "NO_REPLY",
+      mediaUrl: "https://example.com/photo.jpg",
+    });
+
+    expect(result.handledBy).toBe("core");
+    expect(mocks.sendMessage).toHaveBeenCalled();
+  });
 });

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-actions.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -88,12 +89,33 @@ export async function executeSendAction(params: {
   replyToId?: string;
   threadId?: string | number;
 }): Promise<{
-  handledBy: "plugin" | "core";
+  handledBy: "plugin" | "core" | "silent";
   payload: unknown;
   toolResult?: AgentToolResult<unknown>;
   sendResult?: MessageSendResult;
 }> {
   throwIfAborted(params.ctx.abortSignal);
+
+  if (
+    isSilentReplyText(params.message) &&
+    !params.mediaUrl &&
+    (!params.mediaUrls || params.mediaUrls.length === 0)
+  ) {
+    return {
+      handledBy: "silent",
+      payload: { ok: true, reason: SILENT_REPLY_TOKEN },
+      sendResult: {
+        ok: true,
+        channel: params.ctx.channel,
+        to: params.to,
+        via: "direct" as const,
+        mediaUrl: null,
+        delivered: false,
+        discarded: true,
+      },
+    };
+  }
+
   const pluginHandled = await tryHandleWithPluginAction({
     ctx: params.ctx,
     action: "send",


### PR DESCRIPTION
## Problem

Fixes #32403.

Internal control tokens like `NO_REPLY` (used by the auto-reply system to signal "do not send a message") occasionally leak as visible messages to end users when the outbound send pipeline does not intercept them before reaching channel adapters.

## Fix

Added an early-return guard in `executeSendAction` that checks `isSilentReplyText(params.message)` before any channel dispatch. When the message is a silent token **and** no media is attached, the function returns immediately with `handledBy: "silent"` and a result indicating `delivered: false, discarded: true`. Messages with media attachments pass through normally — the silent token acts as a placeholder caption and the media should still be delivered.

## Changes

- `src/infra/outbound/outbound-send-service.ts` — silent token guard with media-aware bypass
- `src/infra/outbound/message.ts` — added `ok`, `delivered`, `discarded` optional fields to `MessageSendResult`
- `src/infra/outbound/message-action-runner.ts` — extended `handledBy` union with `"silent"`
- `src/commands/message-format.ts` — added `[silent] suppressed` CLI display branch

## Test plan

- [x] `pnpm test` passes (7/7 in `outbound-send-service.test.ts`)
- [x] Silent token without media → suppressed, no channel calls
- [x] Silent token WITH media → passes through to normal send path
- [x] `pnpm build` and `pnpm check` pass locally