### PR TITLE
Plugins: harden core-src import failures and dist fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,9 @@ jobs:
       - name: Strict TS build smoke
         run: pnpm build:strict-smoke
 
+      - name: Validate bundled plugin runtime from packed dist artifact
+        run: pnpm check:plugins:dist-runtime
+
       - name: Enforce safe external URL opening policy
         run: pnpm lint:ui:no-raw-window-open
 

--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -3,11 +3,11 @@ import path from "node:path";
 import { Type } from "@sinclair/typebox";
 import Ajv from "ajv";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 // NOTE: This extension is intended to be bundled with OpenClaw.
 // When running from source (tests/dev), OpenClaw internals live under src/.
 // When running from a built install, internals live under dist/ (no src/ tree).
 // So we resolve internal imports dynamically with src-first, dist-fallback.
-import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
 
 type RunEmbeddedPiAgentFn = (params: Record<string, unknown>) => Promise<unknown>;
 
@@ -25,7 +25,7 @@ async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
   }
 
   // Bundled install (built)
-  const mod = await import("../../../src/agents/pi-embedded-runner.js");
+  const mod = await import("../../../dist/agents/pi-embedded-runner.js");
   if (typeof mod.runEmbeddedPiAgent !== "function") {
     throw new Error("Internal error: runEmbeddedPiAgent not available");
   }

--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -25,7 +25,8 @@ async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
   }
 
   // Bundled install (built)
-  const mod = await import("../../../dist/agents/pi-embedded-runner.js");
+  const distModulePath = "../../../dist/agents/pi-embedded-runner.js";
+  const mod = await import(distModulePath);
   if (typeof mod.runEmbeddedPiAgent !== "function") {
     throw new Error("Internal error: runEmbeddedPiAgent not available");
   }

--- a/extensions/twitch/src/token.ts
+++ b/extensions/twitch/src/token.ts
@@ -9,8 +9,9 @@
  * 2. Environment variable: OPENCLAW_TWITCH_ACCESS_TOKEN (default account only)
  */
 
-import type { OpenClawConfig } from "../../../src/config/config.js";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../../src/routing/session-key.js";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { DEFAULT_ACCOUNT_ID } from "./config.js";
 
 export type TwitchTokenSource = "env" | "config" | "none";
 

--- a/extensions/twitch/src/token.ts
+++ b/extensions/twitch/src/token.ts
@@ -10,8 +10,7 @@
  */
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
-import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
-import { DEFAULT_ACCOUNT_ID } from "./config.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 
 export type TwitchTokenSource = "env" | "config" | "none";
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "check:docs": "pnpm format:docs:check && pnpm lint:docs && pnpm docs:check-links",
     "check:host-env-policy:swift": "node scripts/generate-host-env-security-policy-swift.mjs --check",
     "check:loc": "node --import tsx scripts/check-ts-max-loc.ts --max 500",
+    "check:plugins:dist-runtime": "node scripts/check-plugin-dist-runtime.mjs",
     "deadcode:ci": "pnpm deadcode:report:ci:knip && pnpm deadcode:report:ci:ts-prune && pnpm deadcode:report:ci:ts-unused",
     "deadcode:knip": "pnpm dlx knip --no-progress",
     "deadcode:report": "pnpm deadcode:knip; pnpm deadcode:ts-prune; pnpm deadcode:ts-unused",

--- a/scripts/check-plugin-dist-runtime.mjs
+++ b/scripts/check-plugin-dist-runtime.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+function ensureBuiltDist(repoRoot) {
+  const candidates = [
+    path.join(repoRoot, "dist", "entry.js"),
+    path.join(repoRoot, "dist", "entry.mjs"),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const stat = statSync(candidate);
+      if (stat.isFile()) {
+        return;
+      }
+    } catch {
+      // try next candidate
+    }
+  }
+  console.error(
+    "check-plugin-dist-runtime: dist/entry.(m)js not found. Run `pnpm build:strict-smoke` first.",
+  );
+  process.exit(1);
+}
+
+function createPackArtifact(repoRoot, workDir) {
+  const raw = execFileSync(
+    "npm",
+    ["pack", "--json", "--ignore-scripts", "--pack-destination", workDir],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 1024 * 1024 * 100,
+    },
+  );
+  const parsed = JSON.parse(raw);
+  const filename = parsed?.[0]?.filename;
+  if (!filename || typeof filename !== "string") {
+    throw new Error("npm pack did not return a tarball filename");
+  }
+  return path.join(workDir, filename);
+}
+
+function extractPackArtifact(tarballPath, workDir) {
+  const extractDir = path.join(workDir, "extract");
+  mkdirSync(extractDir, { recursive: true });
+  execFileSync("tar", ["-xzf", tarballPath, "-C", extractDir], {
+    stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer: 1024 * 1024 * 100,
+  });
+  return path.join(extractDir, "package");
+}
+
+function parsePluginsListJson(stdout) {
+  const trimmed = stdout.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const first = trimmed.indexOf("{");
+    const last = trimmed.lastIndexOf("}");
+    if (first >= 0 && last > first) {
+      return JSON.parse(trimmed.slice(first, last + 1));
+    }
+    throw new Error("plugins list output did not contain valid JSON");
+  }
+}
+
+function attachNodeModules(packageDir, repoRoot) {
+  const source = path.join(repoRoot, "node_modules");
+  const target = path.join(packageDir, "node_modules");
+  try {
+    const stat = statSync(source);
+    if (!stat.isDirectory()) {
+      throw new Error("not a directory");
+    }
+  } catch {
+    throw new Error(
+      "check-plugin-dist-runtime: node_modules not found in repo root. Run `pnpm install` first.",
+    );
+  }
+  symlinkSync(source, target, "dir");
+}
+
+function runBundledPluginValidation(packageDir, workDir, repoRoot) {
+  attachNodeModules(packageDir, repoRoot);
+  const configPath = path.join(workDir, "openclaw.json");
+  const stateDir = path.join(workDir, "state");
+  writeFileSync(configPath, "{}\n", "utf8");
+  mkdirSync(stateDir, { recursive: true });
+
+  let stdout = "";
+  try {
+    stdout = execFileSync(process.execPath, ["./openclaw.mjs", "plugins", "list", "--json"], {
+      cwd: packageDir,
+      env: {
+        ...process.env,
+        NODE_ENV: "production",
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_DISABLE_CONFIG_CACHE: "1",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(packageDir, "extensions"),
+        NO_COLOR: "1",
+        FORCE_COLOR: "0",
+      },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 1024 * 1024 * 100,
+    });
+  } catch (error) {
+    const stdoutOut = typeof error.stdout === "string" ? error.stdout.trim() : "";
+    const stderrOut = typeof error.stderr === "string" ? error.stderr.trim() : "";
+    const lines = [
+      "check-plugin-dist-runtime: packaged `openclaw plugins list --json` failed",
+      stdoutOut ? `stdout:\n${stdoutOut}` : null,
+      stderrOut ? `stderr:\n${stderrOut}` : null,
+    ].filter(Boolean);
+    throw new Error(lines.join("\n\n"), { cause: error });
+  }
+
+  const payload = parsePluginsListJson(stdout);
+  const plugins = Array.isArray(payload?.plugins) ? payload.plugins : [];
+  const pluginErrors = plugins.filter((plugin) => plugin?.status === "error");
+  const diagnostics = Array.isArray(payload?.diagnostics) ? payload.diagnostics : [];
+  const diagnosticErrors = diagnostics.filter((diag) => diag?.level === "error");
+
+  if (pluginErrors.length > 0 || diagnosticErrors.length > 0) {
+    const lines = ["check-plugin-dist-runtime: detected plugin load errors from packed artifact"];
+    for (const plugin of pluginErrors) {
+      lines.push(`- plugin ${plugin?.id ?? "unknown"}: ${plugin?.error ?? "failed to load"}`);
+    }
+    for (const diag of diagnosticErrors) {
+      const target =
+        typeof diag?.pluginId === "string" && diag.pluginId ? `${diag.pluginId}: ` : "";
+      lines.push(`- diagnostic ${target}${diag?.message ?? "unknown error"}`);
+    }
+    throw new Error(lines.join("\n"));
+  }
+
+  const bundledCount = plugins.filter((plugin) => plugin?.origin === "bundled").length;
+  console.log(
+    `check-plugin-dist-runtime: validated packaged plugin runtime (${bundledCount} bundled plugins discovered, ${plugins.length} total entries).`,
+  );
+}
+
+async function main() {
+  const repoRoot = process.cwd();
+  ensureBuiltDist(repoRoot);
+  const workDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-dist-runtime-"));
+  const tarballPath = createPackArtifact(repoRoot, workDir);
+  const packageDir = extractPackArtifact(tarballPath, workDir);
+  runBundledPluginValidation(packageDir, workDir, repoRoot);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -473,6 +473,29 @@ describe("loadOpenClawPlugins", () => {
     expect(registry.diagnostics.some((d) => d.level === "error")).toBe(true);
   });
 
+  it("adds hint when plugin load fails due to core src import", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "core-src-import",
+      filename: "core-src-import.cjs",
+      body: `require("../../../src/infra/abort-signal.js");
+module.exports = { id: "core-src-import", register() {} };`,
+    });
+
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["core-src-import"],
+      },
+    });
+
+    const entry = registry.plugins.find((item) => item.id === "core-src-import");
+    expect(entry?.status).toBe("error");
+    expect(entry?.error).toContain("Cannot find module");
+    expect(entry?.error).toContain("plugin runtime imports cannot reference OpenClaw core src/*");
+    expect(entry?.error).toContain("openclaw/plugin-sdk");
+  });
+
   it("registers channel plugins", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -496,6 +496,30 @@ module.exports = { id: "core-src-import", register() {} };`,
     expect(entry?.error).toContain("openclaw/plugin-sdk");
   });
 
+  it("does not add core src hint for non-core /src/ module paths", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "non-core-src-import",
+      filename: "non-core-src-import.cjs",
+      body: `require("/home/alice/src/my-plugin/missing.js");
+module.exports = { id: "non-core-src-import", register() {} };`,
+    });
+
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["non-core-src-import"],
+      },
+    });
+
+    const entry = registry.plugins.find((item) => item.id === "non-core-src-import");
+    expect(entry?.status).toBe("error");
+    expect(entry?.error).toContain("Cannot find module");
+    expect(entry?.error).not.toContain(
+      "plugin runtime imports cannot reference OpenClaw core src/*",
+    );
+  });
+
   it("registers channel plugins", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -191,7 +191,8 @@ function appendCoreSrcImportHint(errorText: string): string {
   if (!failedToLoadModule) {
     return errorText;
   }
-  const referencesCoreSrc = normalized.includes("/src/") || normalized.includes("../src/");
+  const referencesCoreSrc =
+    normalized.includes("/openclaw/src/") || /(?:^|[\s"'`(])(?:\.\.\/){2,}src\//.test(normalized);
   if (!referencesCoreSrc) {
     return errorText;
   }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -184,6 +184,25 @@ function createPluginRecord(params: {
   };
 }
 
+function appendCoreSrcImportHint(errorText: string): string {
+  const normalized = errorText.replaceAll("\\", "/");
+  const failedToLoadModule =
+    normalized.includes("Cannot find module") || normalized.includes("ERR_MODULE_NOT_FOUND");
+  if (!failedToLoadModule) {
+    return errorText;
+  }
+  const referencesCoreSrc = normalized.includes("/src/") || normalized.includes("../src/");
+  if (!referencesCoreSrc) {
+    return errorText;
+  }
+  const hint =
+    "Hint: plugin runtime imports cannot reference OpenClaw core src/* paths. Use openclaw/plugin-sdk exports (or a dist-safe fallback for bundled-only extensions).";
+  if (errorText.includes(hint)) {
+    return errorText;
+  }
+  return `${errorText}\n${hint}`;
+}
+
 function recordPluginError(params: {
   logger: PluginLogger;
   registry: PluginRegistry;
@@ -195,7 +214,7 @@ function recordPluginError(params: {
   logPrefix: string;
   diagnosticMessagePrefix: string;
 }) {
-  const errorText = String(params.error);
+  const errorText = appendCoreSrcImportHint(String(params.error));
   params.logger.error(`${params.logPrefix}${errorText}`);
   params.record.status = "error";
   params.record.error = errorText;


### PR DESCRIPTION
## Summary
- fix Twitch plugin token resolution to use plugin-sdk account-id helpers instead of importing core `src/*` runtime modules
- fix `llm-task` internal runner loading so built installs actually fall back to `dist/agents/pi-embedded-runner.js`
- improve plugin loader diagnostics: when a plugin fails on missing `src/*` module paths, append an actionable hint to use `openclaw/plugin-sdk` (or dist-safe fallback for bundled-only plugins)
- add a loader test that locks this remediation message behavior

## Why this matters
This tightens extension/runtime boundaries so plugin load failures are easier to debug and less likely in npm-installed environments.

## Testing
- `pnpm exec vitest run extensions/twitch/src/token.test.ts extensions/llm-task/src/llm-task-tool.test.ts src/plugins/loader.test.ts`
- `pnpm exec oxfmt --check extensions/twitch/src/token.ts extensions/llm-task/src/llm-task-tool.ts src/plugins/loader.ts src/plugins/loader.test.ts`
