### PR TITLE
fix(feishu): restore quoted card content by avoiding lossy interactive placeholder

### DIFF
--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -96,6 +96,42 @@ describe("getMessageFeishu", () => {
     );
   });
 
+  it("falls back to raw interactive payload when card structure is unknown", async () => {
+    const rawInteractive = JSON.stringify({
+      schema: "2.0",
+      body: { direction: "vertical" },
+    });
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_interactive_unknown",
+            chat_id: "oc_interactive_unknown",
+            msg_type: "interactive",
+            body: {
+              content: rawInteractive,
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_interactive_unknown",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_interactive_unknown",
+        chatId: "oc_interactive_unknown",
+        contentType: "interactive",
+        content: rawInteractive,
+      }),
+    );
+  });
+
   it("extracts text content from post messages", async () => {
     mockClientGet.mockResolvedValueOnce({
       code: 0,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -174,20 +174,19 @@ async function sendReplyOrFallbackDirect(
   return toFeishuSendResult(response, params.directParams.receiveId);
 }
 
-function parseInteractiveCardContent(parsed: unknown): string {
+function parseInteractiveCardContent(parsed: unknown): string | undefined {
   if (!parsed || typeof parsed !== "object") {
-    return "[Interactive Card]";
+    return undefined;
   }
 
-  // Support both schema 1.0 (top-level `elements`) and 2.0 (`body.elements`).
   const candidate = parsed as { elements?: unknown; body?: { elements?: unknown } };
   const elements = Array.isArray(candidate.elements)
     ? candidate.elements
     : Array.isArray(candidate.body?.elements)
-      ? candidate.body!.elements
+      ? candidate.body.elements
       : null;
   if (!elements) {
-    return "[Interactive Card]";
+    return undefined;
   }
 
   const texts: string[] = [];
@@ -208,7 +207,8 @@ function parseInteractiveCardContent(parsed: unknown): string {
       texts.push(item.content);
     }
   }
-  return texts.join("\n").trim() || "[Interactive Card]";
+  const extracted = texts.join("\n").trim();
+  return extracted || undefined;
 }
 
 function parseFeishuMessageContent(rawContent: string, msgType: string): string {
@@ -233,7 +233,8 @@ function parseFeishuMessageContent(rawContent: string, msgType: string): string 
   }
 
   if (msgType === "interactive") {
-    return parseInteractiveCardContent(parsed);
+    const extracted = parseInteractiveCardContent(parsed);
+    return extracted ?? rawContent;
   }
 
   if (typeof parsed === "string") {


### PR DESCRIPTION
## Summary
Fix Feishu quoted interactive-card regression by preserving raw quoted payload when card-text extraction cannot decode the card structure.

- keep existing extraction for known `interactive` card element shapes
- if extraction cannot find text (`elements` missing/unsupported), fallback to raw quoted payload instead of hardcoded `"[Interactive Card]"`
- add regression test that simulates unknown interactive-card schema and verifies raw payload is preserved

Fixes #32712.

---

## Root cause analysis (version diff)

### Behavior in `v2026.2.26` (worked)
In `extensions/feishu/src/send.ts`, quoted-message parsing for non-text messages effectively preserved useful raw content. For quoted interactive cards, OpenClaw still had structured payload available to downstream reasoning (at minimum raw JSON content), so quoting a card in Feishu groups remained usable.

### Behavior introduced by `v2026.3.1` (regression)
`v2026.3.1` introduced stricter quoted parsing in `extensions/feishu/src/send.ts` (commit `6ea3a47da`, `fix(feishu): harden routing, parsing, and media delivery`):

- `parseQuotedMessageContent()` now routes `msg_type === "interactive"` into `parseInteractiveCardContent()`
- `parseInteractiveCardContent()` only extracts text from a narrow shape (`elements[]` with `markdown` / `div.text.content`)
- when that shape does not match, it returns hardcoded `"[Interactive Card]"`

That means quoted card payload gets flattened to a placeholder, which is exactly the user-visible regression:

`[Replying to: "[Interactive Card]"]`

So the regression is not failure to fetch quoted message ID; it is **over-aggressive lossy normalization** after fetch.

---

## What this PR changes

### Before
- Unknown interactive-card schemas -> `"[Interactive Card]"` (payload lost)

### After
- Known schema -> extracted text (unchanged)
- Unknown schema -> fallback to raw `body.content` JSON string (payload preserved)

This restores practical behavior from pre-regression versions while keeping improved parsing for recognized card structures.

---

## Tests

Added regression coverage in `extensions/feishu/src/send.test.ts`:

- `falls back to raw interactive payload when card structure is unknown`

Local run:

```bash
pnpm exec vitest run extensions/feishu/src/send.test.ts
```

Passed: 5/5 tests.
