### PR TITLE
gateway: fix HTTP handler order to prevent 405 errors on plugin endpoints

### DIFF
--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -8,11 +8,11 @@ import {
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   setAccountEnabledInConfigSection,
+  waitForAbortSignal,
   type ChannelPlugin,
   type OpenClawConfig,
   type ChannelSetupInput,
 } from "openclaw/plugin-sdk";
-import { waitForAbortSignal } from "../../../src/infra/abort-signal.js";
 import {
   listNextcloudTalkAccountIds,
   resolveDefaultNextcloudTalkAccountId,

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -616,6 +616,24 @@ export function createGatewayHttpServer(opts: {
             }),
         });
       }
+      // Plugin routes run before canvasHost so explicitly registered
+      // plugin endpoints (e.g., Google Chat handlers) take precedence and
+      // don't get shadowed by canvas catch-all routes that return 405.
+      requestStages.push(
+        ...buildPluginRequestStages({
+          req,
+          res,
+          requestPath,
+          mattermostSlashCallbackPaths,
+          pluginPathContext,
+          handlePluginRequest,
+          shouldEnforcePluginGatewayAuth,
+          resolvedAuth,
+          trustedProxies,
+          allowRealIpFallback,
+          rateLimiter,
+        }),
+      );
       if (canvasHost) {
         requestStages.push({
           name: "canvas-auth",
@@ -649,24 +667,6 @@ export function createGatewayHttpServer(opts: {
           run: () => canvasHost.handleHttpRequest(req, res),
         });
       }
-      // Plugin routes run before the Control UI SPA catch-all so explicitly
-      // registered plugin endpoints stay reachable. Core built-in gateway
-      // routes above still keep precedence on overlapping paths.
-      requestStages.push(
-        ...buildPluginRequestStages({
-          req,
-          res,
-          requestPath,
-          mattermostSlashCallbackPaths,
-          pluginPathContext,
-          handlePluginRequest,
-          shouldEnforcePluginGatewayAuth,
-          resolvedAuth,
-          trustedProxies,
-          allowRealIpFallback,
-          rateLimiter,
-        }),
-      );
 
       if (controlUiEnabled) {
         requestStages.push({

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -399,6 +399,7 @@ export { rawDataToString } from "../infra/ws.js";
 export { isWSLSync, isWSL2Sync, isWSLEnv } from "../infra/wsl.js";
 export { isTruthyEnvValue } from "../infra/env.js";
 export { resolveToolsBySender } from "../config/group-policy.js";
+export { waitForAbortSignal } from "../infra/abort-signal.js";
 export {
   buildPendingHistoryContextFromMap,
   clearHistoryEntries,


### PR DESCRIPTION
Fixes #32682

## Problem
The compiled gateway bundle was reordering `handlePluginRequest` after `canvasHost.handleHttpRequest`, causing plugin HTTP endpoints (e.g., Google Chat handlers) to return 405 errors.

## Solution
This change moves the plugin request stages before canvasHost stages to ensure explicitly registered plugin endpoints take precedence and don't get shadowed by canvas catch-all routes.

## Changes
- Moved `buildPluginRequestStages` call before `canvasHost` stages in `src/gateway/server-http.ts`
- Added clarifying comment explaining why plugin routes need to run before canvasHost

## Testing
- Built the gateway successfully with `pnpm build`
- The handler order is now explicitly controlled in source code rather than relying on bundler ordering