### PR TITLE
Slack: fix react action failures in DMs and add messageId auto-inference

### DIFF
--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -260,6 +260,7 @@ export type ChannelThreadingToolContext = {
   currentChannelId?: string;
   currentChannelProvider?: ChannelId;
   currentThreadTs?: string;
+  currentMessageTs?: string;
   currentMessageId?: string | number;
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -656,6 +656,12 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
   const { cfg, params, channel, accountId, dryRun, gateway, input, abortSignal } = ctx;
   throwIfAborted(abortSignal);
   const action = input.action as Exclude<ChannelMessageActionName, "send" | "poll" | "broadcast">;
+
+  // Auto-infer messageId for react actions when not provided
+  if (action === "react" && !params.messageId && input.toolContext?.currentMessageTs) {
+    params.messageId = input.toolContext.currentMessageTs;
+  }
+
   if (dryRun) {
     return {
       kind: "action",

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -657,8 +657,13 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
   throwIfAborted(abortSignal);
   const action = input.action as Exclude<ChannelMessageActionName, "send" | "poll" | "broadcast">;
 
-  // Auto-infer messageId for react actions when not provided
-  if (action === "react" && !params.messageId && input.toolContext?.currentMessageTs) {
+  // Auto-infer messageId for react actions when not provided (Slack only)
+  if (
+    channel === "slack" &&
+    action === "react" &&
+    !params.messageId &&
+    input.toolContext?.currentMessageTs
+  ) {
     params.messageId = input.toolContext.currentMessageTs;
   }
 

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -638,7 +638,9 @@ export async function prepareSlackMessage(params: {
     });
   }
 
-  const slackTo = isDirectMessage ? `user:${message.user}` : `channel:${message.channel}`;
+  // Always use channel: format for Slack targets, even in DMs.
+  // Slack API requires channel ID for reactions and other operations.
+  const slackTo = `channel:${message.channel}`;
 
   const { untrustedChannelMetadata, groupSystemPrompt } = resolveSlackRoomContextHints({
     isRoomish,

--- a/src/slack/threading-tool-context.ts
+++ b/src/slack/threading-tool-context.ts
@@ -24,6 +24,9 @@ export function buildSlackThreadingToolContext(params: {
       ? params.context.To.slice("channel:".length)
       : undefined,
     currentThreadTs: threadId != null ? String(threadId) : undefined,
+    currentMessageTs: params.context.CurrentMessageId
+      ? String(params.context.CurrentMessageId)
+      : undefined,
     replyToMode: effectiveReplyToMode,
     hasRepliedRef: params.hasRepliedRef,
   };


### PR DESCRIPTION
Fixes #32639

## Summary

This PR fixes three issues causing Slack react action failures:

1. **Fix slackTo format (prepare.ts)** - Always use channel: format instead of user: in DMs
2. **Add currentMessageTs (types.core.ts + threading-tool-context.ts)** - Expose current message timestamp in tool context  
3. **Auto-infer messageId for react actions (message-action-runner.ts)** - Infer messageId from toolContext when not provided

## Changes

- src/slack/monitor/message-handler/prepare.ts: Always use channel: format for slackTo
- src/channels/plugins/types.core.ts: Add currentMessageTs to ChannelThreadingToolContext type
- src/slack/threading-tool-context.ts: Add currentMessageTs to buildSlackThreadingToolContext return
- src/infra/outbound/message-action-runner.ts: Auto-infer messageId for react actions

## Testing

- Build passes: pnpm build succeeds
- Changes are minimal and focused on the specific issue