### PR TITLE
fix(agents): pass explicit baseUrl to moonshot provider for CN endpoint support

### DIFF
--- a/src/agents/models-config.providers.moonshot.test.ts
+++ b/src/agents/models-config.providers.moonshot.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { captureEnv } from "../test-utils/env.js";
+import { resolveImplicitProviders } from "./models-config.providers.js";
+
+describe("moonshot implicit provider (#32607)", () => {
+  it("uses explicit baseUrl when user configures a custom endpoint", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const envSnapshot = captureEnv(["MOONSHOT_API_KEY"]);
+    process.env.MOONSHOT_API_KEY = "sk-test";
+
+    try {
+      const providers = await resolveImplicitProviders({
+        agentDir,
+        explicitProviders: {
+          moonshot: {
+            baseUrl: "https://api.moonshot.cn/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      });
+      expect(providers?.moonshot).toBeDefined();
+      expect(providers?.moonshot?.baseUrl).toBe("https://api.moonshot.cn/v1");
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("falls back to default international URL when no explicit baseUrl is set", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const envSnapshot = captureEnv(["MOONSHOT_API_KEY"]);
+    process.env.MOONSHOT_API_KEY = "sk-test";
+
+    try {
+      const providers = await resolveImplicitProviders({ agentDir });
+      expect(providers?.moonshot).toBeDefined();
+      expect(providers?.moonshot?.baseUrl).toBe("https://api.moonshot.ai/v1");
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("does not include moonshot when no API key is configured", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const envSnapshot = captureEnv(["MOONSHOT_API_KEY"]);
+    delete process.env.MOONSHOT_API_KEY;
+
+    try {
+      const providers = await resolveImplicitProviders({ agentDir });
+      expect(providers?.moonshot).toBeUndefined();
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -635,9 +635,9 @@ function buildMinimaxPortalProvider(): ProviderConfig {
   };
 }
 
-function buildMoonshotProvider(): ProviderConfig {
+function buildMoonshotProvider(configuredBaseUrl?: string): ProviderConfig {
   return {
-    baseUrl: MOONSHOT_BASE_URL,
+    baseUrl: configuredBaseUrl ?? MOONSHOT_BASE_URL,
     api: "openai-completions",
     models: [
       {
@@ -948,7 +948,8 @@ export async function resolveImplicitProviders(params: {
     resolveEnvApiKeyVarName("moonshot") ??
     resolveApiKeyFromProfiles({ provider: "moonshot", store: authStore });
   if (moonshotKey) {
-    providers.moonshot = { ...buildMoonshotProvider(), apiKey: moonshotKey };
+    const explicitMoonshotBaseUrl = params.explicitProviders?.moonshot?.baseUrl;
+    providers.moonshot = { ...buildMoonshotProvider(explicitMoonshotBaseUrl), apiKey: moonshotKey };
   }
 
   const kimiCodingKey =


### PR DESCRIPTION
## Summary
- `buildMoonshotProvider()` hardcoded `MOONSHOT_BASE_URL` (`api.moonshot.ai/v1`), ignoring the user-configured baseUrl from `openclaw.json`
- When `resolveImplicitProviders()` builds the moonshot provider, it now passes the explicit provider's `baseUrl` (e.g. `api.moonshot.cn/v1`) so CN users get the correct endpoint
- Follows the same pattern already used by the Ollama provider

## What did NOT change
- Default international endpoint (`api.moonshot.ai/v1`) unchanged for users without explicit config
- No schema or type changes required — `baseUrl` is already part of `ProviderConfig`
- Kimi Coding provider unaffected (separate builder)

## Test plan
- [x] New test: explicit CN baseUrl is respected when `explicitProviders` has `moonshot.baseUrl`
- [x] New test: falls back to default international URL when no explicit baseUrl
- [x] New test: no moonshot provider when API key is absent
- [x] Existing kimi-coding tests still pass

Closes #32607

🤖 Generated with [Claude Code](https://claude.com/claude-code)