### PR TITLE
fix: allow channels without sendMedia in createPluginHandler

### DIFF
--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -143,12 +143,15 @@ function createPluginHandler(
   params: ChannelHandlerParams & { outbound?: ChannelOutboundAdapter },
 ): ChannelHandler | null {
   const outbound = params.outbound;
-  if (!outbound?.sendText || !outbound?.sendMedia) {
+  if (!outbound?.sendText) {
     return null;
   }
   const baseCtx = createChannelOutboundContextBase(params);
   const sendText = outbound.sendText;
-  const sendMedia = outbound.sendMedia;
+  // Provide fallback for optional sendMedia to satisfy ChannelHandler type
+  const sendMedia = outbound.sendMedia ?? (async () => {
+    throw new Error(`sendMedia not supported by channel: ${params.channel}`);
+  });
   const chunker = outbound.chunker ?? null;
   const chunkerMode = outbound.chunkerMode;
   const resolveCtx = (overrides?: {


### PR DESCRIPTION
## Summary

This PR fixes #32711 by making `sendMedia` optional in `createPluginHandler()`.

## Problem

The `ChannelOutboundAdapter` type defines `sendMedia` as optional (`sendMedia?`), but `createPluginHandler()` was enforcing its presence, causing a type mismatch.

## Solution

- Remove the `sendMedia` check from the guard clause
- Provide a fallback implementation that throws a descriptive error when `sendMedia` is not available

## Testing

This change allows channel adapters that only support text messaging to be used without requiring a `sendMedia` implementation.

Fixes #32711