### PR TITLE
daemon: fix readSystemctlDetail to prefer stdout when stderr is generic error

### DIFF
--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -143,6 +143,11 @@ async function execSystemctl(
 }
 
 function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
+  // When systemctl fails, stderr might be replaced with error.message from execFileUtf8.
+  // Prefer stdout when stderr contains generic error message and stdout has actual output.
+  if (result.stdout && result.stderr.toLowerCase().includes("command failed")) {
+    return result.stdout.trim();
+  }
   return (result.stderr || result.stdout || "").trim();
 }
 


### PR DESCRIPTION
## Summary

Fixes gateway install failures on Linux when systemctl returns \"not-found\" in stdout but execFileUtf8 replaces empty stderr with error.message.

## Root Cause

When systemctl fails with a non-zero exit code (e.g., unit not found), stderr is empty and stdout contains the actual output like \"not-found\". However, execFileUtf8 replaces empty stderr with error.message (\"Command failed: ...\"), causing readSystemctlDetail to return the generic error message instead of the actual output.

## Fix

Updated readSystemctlDetail to prefer stdout when stderr contains the generic \"Command failed\" error message. This allows proper detection of systemd unit states like \"not-found\".

Fixes #32635

## Testing

- pnpm build completes successfully
- The fix ensures systemctl output is correctly parsed when units are not found