### PR TITLE
fix(discord): make /acp action use autocomplete

### DIFF
--- a/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.test.ts
+++ b/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.test.ts
@@ -2,6 +2,7 @@ import type { Client } from "@buape/carbon";
 import { ChannelType, MessageType } from "@buape/carbon";
 import { Routes } from "discord-api-types/v10";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { listNativeCommandSpecsForConfig } from "../auto-reply/commands-registry.js";
 import { createReplyDispatcherWithTyping } from "../auto-reply/reply/reply-dispatcher.js";
 import {
   dispatchMock,
@@ -345,6 +346,37 @@ describe("discord tool result dispatch", () => {
       expect(reply.mock.calls[0]?.[0]?.content).toContain("final");
     },
   );
+
+  it("registers /acp action with autocomplete instead of static choices", () => {
+    const cfg = {
+      commands: { native: true },
+      channels: {
+        discord: { dm: { enabled: true, policy: "open" } },
+      },
+      agents: { defaults: { workspace: "/tmp/openclaw" } },
+      session: { store: "/tmp/openclaw-sessions.json" },
+    } as ReturnType<typeof import("../config/config.js").loadConfig>;
+
+    const acpSpec = listNativeCommandSpecsForConfig(cfg, { provider: "discord" }).find(
+      (spec) => spec.name === "acp",
+    );
+    expect(acpSpec).toBeTruthy();
+
+    const command = createDiscordNativeCommand({
+      command: acpSpec!,
+      cfg,
+      discordConfig: cfg.channels!.discord!,
+      accountId: "default",
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager("default"),
+    });
+
+    const actionOption = (command.options ?? []).find((option) => option.name === "action");
+    expect(actionOption).toBeTruthy();
+    expect(actionOption?.autocomplete).toBeTypeOf("function");
+    expect(actionOption?.choices).toBeUndefined();
+  });
 
   it("accepts guild reply-to-bot messages as implicit mentions", async () => {
     const cfg = createMentionRequiredGuildConfig();

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -118,7 +118,9 @@ function buildDiscordCommandOptions(params: {
     const resolvedChoices = resolveCommandArgChoices({ command, arg, cfg });
     const shouldAutocomplete =
       resolvedChoices.length > 0 &&
-      (typeof arg.choices === "function" || resolvedChoices.length > 25);
+      (typeof arg.choices === "function" ||
+        resolvedChoices.length > 25 ||
+        (command.key === "acp" && arg.name === "action"));
     const autocomplete = shouldAutocomplete
       ? async (interaction: AutocompleteInteraction) => {
           const focused = interaction.options.getFocused();


### PR DESCRIPTION
## Summary\n- force   arg to register with  in Discord command options\n- keep static choices disabled for this arg so inline values (e.g. ) are preserved\n- add a Discord command registration test to verify  uses autocomplete and no static choices\n\n## Testing\n- pnpm exec vitest run --config vitest.unit.config.ts src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.test.ts\n- pnpm exec vitest run --config vitest.unit.config.ts src/auto-reply/commands-registry.test.ts\n\nFixes #32753