### PR TITLE
fix: replace YYYY-MM-DD placeholder in AGENTS.md at load and in post-compaction context (#32363)

### DIFF
--- a/src/agents/date-time.ts
+++ b/src/agents/date-time.ts
@@ -191,3 +191,14 @@ export function formatUserTime(
     return undefined;
   }
 }
+
+/**
+ * Returns current date in YYYY-MM-DD (UTC).
+ * Used to replace the YYYY-MM-DD placeholder in AGENTS.md at runtime so the agent
+ * receives the actual date (e.g. for memory/YYYY-MM-DD.md paths).
+ */
+export function getDateStampUTC(nowMs?: number): string {
+  const d =
+    typeof nowMs === "number" && Number.isFinite(nowMs) ? new Date(nowMs) : new Date();
+  return d.toISOString().slice(0, 10);
+}

--- a/src/agents/date-time.ts
+++ b/src/agents/date-time.ts
@@ -198,7 +198,6 @@ export function formatUserTime(
  * receives the actual date (e.g. for memory/YYYY-MM-DD.md paths).
  */
 export function getDateStampUTC(nowMs?: number): string {
-  const d =
-    typeof nowMs === "number" && Number.isFinite(nowMs) ? new Date(nowMs) : new Date();
+  const d = typeof nowMs === "number" && Number.isFinite(nowMs) ? new Date(nowMs) : new Date();
   return d.toISOString().slice(0, 10);
 }

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, FileOperations } from "@mariozechner/pi-coding-agent";
 import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
-import { getDateStampUTC } from "../date-time.js";
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
@@ -19,6 +18,7 @@ import {
   summarizeInStages,
 } from "../compaction.js";
 import { collectTextContentBlocks } from "../content-blocks.js";
+import { getDateStampUTC } from "../date-time.js";
 import { getCompactionSafeguardRuntime } from "./compaction-safeguard-runtime.js";
 
 const log = createSubsystemLogger("compaction-safeguard");

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, FileOperations } from "@mariozechner/pi-coding-agent";
 import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
+import { getDateStampUTC } from "../date-time.js";
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
@@ -193,10 +194,11 @@ async function readWorkspaceContextForSummary(): Promise<string> {
     }
 
     const combined = sections.join("\n\n");
+    const withDate = combined.replaceAll("YYYY-MM-DD", getDateStampUTC());
     const safeContent =
-      combined.length > MAX_SUMMARY_CONTEXT_CHARS
-        ? combined.slice(0, MAX_SUMMARY_CONTEXT_CHARS) + "\n...[truncated]..."
-        : combined;
+      withDate.length > MAX_SUMMARY_CONTEXT_CHARS
+        ? withDate.slice(0, MAX_SUMMARY_CONTEXT_CHARS) + "\n...[truncated]..."
+        : withDate;
 
     return `\n\n<workspace-critical-rules>\n${safeContent}\n</workspace-critical-rules>`;
   } catch {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -2,6 +2,7 @@ import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { getDateStampUTC } from "./date-time.js";
 import { openBoundaryFile } from "../infra/boundary-file-read.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -541,10 +542,14 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
       workspaceDir: resolvedDir,
     });
     if (loaded.ok) {
+      const content =
+        entry.name === DEFAULT_AGENTS_FILENAME
+          ? loaded.content.replaceAll("YYYY-MM-DD", getDateStampUTC())
+          : loaded.content;
       result.push({
         name: entry.name,
         path: entry.filePath,
-        content: loaded.content,
+        content,
         missing: false,
       });
     } else {
@@ -629,10 +634,14 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
       workspaceDir: resolvedDir,
     });
     if (loaded.ok) {
+      const content =
+        baseName === DEFAULT_AGENTS_FILENAME
+          ? loaded.content.replaceAll("YYYY-MM-DD", getDateStampUTC())
+          : loaded.content;
       files.push({
         name: baseName as WorkspaceBootstrapFileName,
         path: filePath,
-        content: loaded.content,
+        content,
         missing: false,
       });
       continue;

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -2,12 +2,12 @@ import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { getDateStampUTC } from "./date-time.js";
 import { openBoundaryFile } from "../infra/boundary-file-read.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
+import { getDateStampUTC } from "./date-time.js";
 import { resolveWorkspaceTemplateDir } from "./workspace-templates.js";
 
 export function resolveDefaultAgentWorkspaceDir(

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { getDateStampUTC } from "../../agents/date-time.js";
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
 
 const MAX_CONTEXT_CHARS = 3000;
@@ -37,10 +38,11 @@ export async function readPostCompactionContext(workspaceDir: string): Promise<s
     }
 
     const combined = sections.join("\n\n");
+    const withDate = combined.replaceAll("YYYY-MM-DD", getDateStampUTC());
     const safeContent =
-      combined.length > MAX_CONTEXT_CHARS
-        ? combined.slice(0, MAX_CONTEXT_CHARS) + "\n...[truncated]..."
-        : combined;
+      withDate.length > MAX_CONTEXT_CHARS
+        ? withDate.slice(0, MAX_CONTEXT_CHARS) + "\n...[truncated]..."
+        : withDate;
 
     return (
       "[Post-compaction context refresh]\n\n" +


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** The placeholder `YYYY-MM-DD` in AGENTS.md is documented as “replaced at runtime with the current date,” but it was never replaced when loading or in post-compaction context; it always appeared literally.
- **Why it matters:** Maintainers and scripts relying on this placeholder cannot get “today’s date” semantics; behavior does not match the documented contract.
- **What changed:** When loading AGENTS.md (workspace bootstrap, extra bootstrap, post-compaction context, and compaction-safeguard read), content is passed through `replaceAll("YYYY-MM-DD", getDateStampUTC())`. Added and reused `getDateStampUTC(nowMs?)` (UTC `YYYY-MM-DD`) in those four code paths.
- **What did NOT change (scope boundary):** Only the literal string `YYYY-MM-DD` is replaced; no change to AGENTS.md parsing, permissions, or other placeholders; no changes to extensions or other channel logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32363
- Related #

## User-visible / Behavior Changes

Any literal `YYYY-MM-DD` in AGENTS.md is now replaced with the current UTC date (`YYYY-MM-DD`) when the file is loaded and in post-compaction context. No config or CLI changes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Workspace whose AGENTS.md contains `YYYY-MM-DD`

### Steps

1. Put a sentence containing `YYYY-MM-DD` in AGENTS.md.
2. Load that workspace or trigger post-compaction context / compaction-safeguard reading AGENTS.md.
3. Inspect the AGENTS.md content passed to the agent.

### Expected

- The string `YYYY-MM-DD` is replaced with today’s UTC date (e.g. `2026-03-03`).

### Actual

- Before fix: literal `YYYY-MM-DD` unchanged. After fix: replaced with current date.

## Evidence

- [x] Trace/log snippets: Compare AGENTS.md text before vs after fix to confirm the literal is replaced by a date string.
- [ ] Failing test/log before + passing after (no new dedicated test; logic is a simple string replace).
- [ ] Screenshot/recording (N/A).

## Human Verification (required)

- **Verified scenarios:** After local changes, confirmed the replace logic runs on workspace load and on the post-compaction path and outputs a UTC date string.
- **Edge cases checked:** AGENTS.md without `YYYY-MM-DD` is unchanged; multiple occurrences are all replaced.
- **What you did not verify:** No end-to-end run in a real Pi/agent long session.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- Revert this PR and restore the previous code (remove `getDateStampUTC` usage and export).
- Files: `src/agents/date-