### PR TITLE
security: add missing env var blocklist entries

### DIFF
--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -22,7 +22,10 @@ enum HostEnvSecurityPolicy {
         "PS4",
         "GCONV_PATH",
         "IFS",
-        "SSLKEYLOGFILE"
+        "SSLKEYLOGFILE",
+        "GLIBC_TUNABLES",
+        "JAVA_TOOL_OPTIONS",
+        "JDK_JAVA_OPTIONS"
     ]
 
     static let blockedOverrideKeys: Set<String> = [

--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -25,7 +25,8 @@ enum HostEnvSecurityPolicy {
         "SSLKEYLOGFILE",
         "GLIBC_TUNABLES",
         "JAVA_TOOL_OPTIONS",
-        "JDK_JAVA_OPTIONS"
+        "JDK_JAVA_OPTIONS",
+        "_JAVA_OPTIONS"
     ]
 
     static let blockedOverrideKeys: Set<String> = [

--- a/src/infra/host-env-security-policy.json
+++ b/src/infra/host-env-security-policy.json
@@ -16,7 +16,10 @@
     "PS4",
     "GCONV_PATH",
     "IFS",
-    "SSLKEYLOGFILE"
+    "SSLKEYLOGFILE",
+    "GLIBC_TUNABLES",
+    "JAVA_TOOL_OPTIONS",
+    "JDK_JAVA_OPTIONS"
   ],
   "blockedOverrideKeys": ["HOME", "ZDOTDIR"],
   "blockedPrefixes": ["DYLD_", "LD_", "BASH_FUNC_"]

--- a/src/infra/host-env-security-policy.json
+++ b/src/infra/host-env-security-policy.json
@@ -19,7 +19,8 @@
     "SSLKEYLOGFILE",
     "GLIBC_TUNABLES",
     "JAVA_TOOL_OPTIONS",
-    "JDK_JAVA_OPTIONS"
+    "JDK_JAVA_OPTIONS",
+    "_JAVA_OPTIONS"
   ],
   "blockedOverrideKeys": ["HOME", "ZDOTDIR"],
   "blockedPrefixes": ["DYLD_", "LD_", "BASH_FUNC_"]

--- a/src/infra/host-env-security.test.ts
+++ b/src/infra/host-env-security.test.ts
@@ -22,6 +22,9 @@ describe("isDangerousHostEnvVarName", () => {
     expect(isDangerousHostEnvVarName("DYLD_INSERT_LIBRARIES")).toBe(true);
     expect(isDangerousHostEnvVarName("ld_preload")).toBe(true);
     expect(isDangerousHostEnvVarName("BASH_FUNC_echo%%")).toBe(true);
+    expect(isDangerousHostEnvVarName("GLIBC_TUNABLES")).toBe(true);
+    expect(isDangerousHostEnvVarName("JAVA_TOOL_OPTIONS")).toBe(true);
+    expect(isDangerousHostEnvVarName("JDK_JAVA_OPTIONS")).toBe(true);
     expect(isDangerousHostEnvVarName("PATH")).toBe(false);
     expect(isDangerousHostEnvVarName("FOO")).toBe(false);
   });
@@ -35,6 +38,8 @@ describe("sanitizeHostExecEnv", () => {
         BASH_ENV: "/tmp/pwn.sh",
         GIT_EXTERNAL_DIFF: "/tmp/pwn.sh",
         LD_PRELOAD: "/tmp/pwn.so",
+        GLIBC_TUNABLES: "glibc.malloc.hugetlb=2",
+        JAVA_TOOL_OPTIONS: "-javaagent:/tmp/pwn.jar",
         OK: "1",
       },
     });

--- a/src/infra/host-env-security.test.ts
+++ b/src/infra/host-env-security.test.ts
@@ -25,6 +25,7 @@ describe("isDangerousHostEnvVarName", () => {
     expect(isDangerousHostEnvVarName("GLIBC_TUNABLES")).toBe(true);
     expect(isDangerousHostEnvVarName("JAVA_TOOL_OPTIONS")).toBe(true);
     expect(isDangerousHostEnvVarName("JDK_JAVA_OPTIONS")).toBe(true);
+    expect(isDangerousHostEnvVarName("_JAVA_OPTIONS")).toBe(true);
     expect(isDangerousHostEnvVarName("PATH")).toBe(false);
     expect(isDangerousHostEnvVarName("FOO")).toBe(false);
   });
@@ -40,6 +41,8 @@ describe("sanitizeHostExecEnv", () => {
         LD_PRELOAD: "/tmp/pwn.so",
         GLIBC_TUNABLES: "glibc.malloc.hugetlb=2",
         JAVA_TOOL_OPTIONS: "-javaagent:/tmp/pwn.jar",
+        JDK_JAVA_OPTIONS: "-javaagent:/tmp/pwn.jar",
+        _JAVA_OPTIONS: "-javaagent:/tmp/pwn.jar",
         OK: "1",
       },
     });


### PR DESCRIPTION
## Summary
- adds `GLIBC_TUNABLES`, `JAVA_TOOL_OPTIONS`, `JDK_JAVA_OPTIONS` to `host-env-security-policy.json` blockedKeys
- same risk class as already-blocked `NODE_OPTIONS`/`PYTHONPATH`/`RUBYOPT` — runtime agent/code injection via environment
- regenerated `HostEnvSecurityPolicy.generated.swift`

## Details

`GLIBC_TUNABLES` can bypass glibc security hardening (CVE-2023-4911 class). `JAVA_TOOL_OPTIONS` and `JDK_JAVA_OPTIONS` allow arbitrary `-javaagent` injection into any JVM process spawned in the environment.

All three were missing from the blocklist while similar vectors (NODE_OPTIONS, PYTHONPATH, RUBYLIB, etc.) were already covered.

## Test plan
- [x] added assertions to `isDangerousHostEnvVarName` test
- [x] added new keys to `sanitizeHostExecEnv` baseEnv test
- [x] `pnpm vitest run src/infra/host-env-security.test.ts` — 10/10 pass
- [x] `node scripts/generate-host-env-security-policy-swift.mjs --check` — OK

Fixes #22681