### PR TITLE
Fix Discord /acp action arg to respect inline values (#32753)

### DIFF
--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -96,6 +96,14 @@ function buildDiscordCommandOptions(params: {
   if (!args || args.length === 0) {
     return undefined;
   }
+  // Use autocomplete for the argsMenu arg so Discord passes inline values (e.g. /acp close)
+  // instead of forcing the dropdown and sending null (fixes #32753).
+  const argsMenuArgName =
+    command.argsMenu === "auto"
+      ? args.find((a) => resolveCommandArgChoices({ command, arg: a, cfg }).length > 0)?.name
+      : typeof command.argsMenu === "object"
+        ? command.argsMenu.arg
+        : undefined;
   return args.map((arg) => {
     const required = arg.required ?? false;
     if (arg.type === "number") {
@@ -115,9 +123,10 @@ function buildDiscordCommandOptions(params: {
       };
     }
     const resolvedChoices = resolveCommandArgChoices({ command, arg, cfg });
+    const isMenuArg = argsMenuArgName !== undefined && arg.name === argsMenuArgName;
     const shouldAutocomplete =
       resolvedChoices.length > 0 &&
-      (typeof arg.choices === "function" || resolvedChoices.length > 25);
+      (isMenuArg || typeof arg.choices === "function" || resolvedChoices.length > 25);
     const autocomplete = shouldAutocomplete
       ? async (interaction: AutocompleteInteraction) => {
           const focused = interaction.options.getFocused();


### PR DESCRIPTION
Fixes #32753
## Summary

- Make Discord native commands use autocomplete for the `argsMenu` argument even when it has <=25 static choices.
- For `/acp`, this makes the `action` argument use autocomplete so inline values like `/acp close` are passed through correctly.

## Background

Previously, the Discord command builder only enabled `autocomplete` when:

- `arg.choices` was a function, or
- the resolved choices length was > 25.

For `/acp`, the `action` arg has 16 static choices, so Discord used static `choices` instead of autocomplete. When a user typed `/acp close` and hit enter, Discord did not treat `"close"` as a selected choice value and sent `null` for `action`. OpenClaw then treated this as “no value provided” and invoked `resolveCommandArgMenu`, showing the picker UI instead of executing the chosen action.

## Changes

- In `buildDiscordCommandOptions`, compute the args-menu argument name using the same rules as `resolveCommandArgMenu`:
  - When `argsMenu === "auto"`, use the first arg with resolved choices.
  - When `argsMenu` is an object, use `argsMenu.arg`.
- Force `shouldAutocomplete = true` for the args-menu argument whenever it has any resolved choices, so Discord will:
  - Use autocomplete instead of static choices for that arg.
  - Pass through inline values typed by the user (e.g. `/acp close` -> `action="close"`).

## Impact

- `/acp` on Discord now respects inline `action` values and no longer pops up the picker when the user already typed a valid action.
- Other commands that use `argsMenu` will also have their menu arg use autocomplete, but behavior remains compatible: static choices are still respected, and the choice list is capped at 25 as before.

## Testing

- `pnpm test src/discord/monitor/native-command --run`