### PR TITLE
fix(discord): always use autocomplete for slash command choices

### DIFF
--- a/src/discord/monitor/native-command.autocomplete.test.ts
+++ b/src/discord/monitor/native-command.autocomplete.test.ts
@@ -1,0 +1,82 @@
+import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { describe, expect, it } from "vitest";
+import type { ChatCommandDefinition } from "../../auto-reply/commands-registry.types.js";
+import { buildDiscordCommandOptions } from "./native-command.js";
+
+describe("buildDiscordCommandOptions — autocomplete for choices (#32753)", () => {
+  const baseCfg = {} as ReturnType<typeof import("../../config/config.js").loadConfig>;
+
+  function makeCommand(overrides?: Partial<ChatCommandDefinition>): ChatCommandDefinition {
+    return {
+      name: "test",
+      nativeName: "test",
+      description: "test command",
+      args: [
+        {
+          name: "action",
+          description: "action to perform",
+          type: "string",
+          choices: ["close", "pause", "resume", "status"],
+        },
+      ],
+      ...overrides,
+    } as ChatCommandDefinition;
+  }
+
+  it("uses autocomplete (not static choices) when arg has choices under 25", () => {
+    const command = makeCommand();
+    const options = buildDiscordCommandOptions({ command, cfg: baseCfg });
+    expect(options).toBeDefined();
+    expect(options!.length).toBe(1);
+
+    const opt = options![0] as {
+      name: string;
+      type: number;
+      choices?: unknown[];
+      autocomplete?: unknown;
+    };
+    expect(opt.name).toBe("action");
+    expect(opt.type).toBe(ApplicationCommandOptionType.String);
+    // Must use autocomplete, NOT static choices — static choices cause
+    // Discord to send null for typed-in values like `/acp close`.
+    expect(opt.autocomplete).toBeDefined();
+    expect(typeof opt.autocomplete).toBe("function");
+    expect(opt.choices).toBeUndefined();
+  });
+
+  it("uses autocomplete when arg has more than 25 choices", () => {
+    const manyChoices = Array.from({ length: 30 }, (_, i) => `choice-${i}`);
+    const command = makeCommand({
+      args: [
+        {
+          name: "action",
+          description: "action to perform",
+          type: "string",
+          choices: manyChoices,
+        },
+      ],
+    });
+    const options = buildDiscordCommandOptions({ command, cfg: baseCfg });
+    expect(options).toBeDefined();
+    const opt = options![0] as { choices?: unknown[]; autocomplete?: unknown };
+    expect(opt.autocomplete).toBeDefined();
+    expect(opt.choices).toBeUndefined();
+  });
+
+  it("does not use autocomplete when arg has no choices", () => {
+    const command = makeCommand({
+      args: [
+        {
+          name: "input",
+          description: "free text input",
+          type: "string",
+        },
+      ],
+    });
+    const options = buildDiscordCommandOptions({ command, cfg: baseCfg });
+    expect(options).toBeDefined();
+    const opt = options![0] as { choices?: unknown[]; autocomplete?: unknown };
+    expect(opt.autocomplete).toBeUndefined();
+    expect(opt.choices).toBeUndefined();
+  });
+});

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -87,7 +87,8 @@ import { resolveDiscordThreadParentInfo } from "./threading.js";
 type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
 const log = createSubsystemLogger("discord/native-command");
 
-function buildDiscordCommandOptions(params: {
+/** @internal exported for testing only */
+export function buildDiscordCommandOptions(params: {
   command: ChatCommandDefinition;
   cfg: ReturnType<typeof loadConfig>;
 }): CommandOptions | undefined {
@@ -115,9 +116,11 @@ function buildDiscordCommandOptions(params: {
       };
     }
     const resolvedChoices = resolveCommandArgChoices({ command, arg, cfg });
-    const shouldAutocomplete =
-      resolvedChoices.length > 0 &&
-      (typeof arg.choices === "function" || resolvedChoices.length > 25);
+    // Always use autocomplete when choices exist.  Static `choices` force
+    // Discord's dropdown UI which sends `null` for typed-in values (e.g.
+    // `/acp close`).  Autocomplete lets users both pick from suggestions AND
+    // type inline, with Discord passing the typed value through.  (#32753)
+    const shouldAutocomplete = resolvedChoices.length > 0;
     const autocomplete = shouldAutocomplete
       ? async (interaction: AutocompleteInteraction) => {
           const focused = interaction.options.getFocused();


### PR DESCRIPTION
## Summary
- `/acp close` (and other commands with <25 static choices) sends `action = null` because Discord's static dropdown UI doesn't pass through typed inline values
- Changed `buildDiscordCommandOptions` to always use `autocomplete: true` when an arg has choices, regardless of count
- With autocomplete, Discord passes the typed value through and users can both pick from suggestions AND type inline

## What did NOT change
- Autocomplete handler logic (filtering, slicing to 25, respond format) — unchanged
- Commands without choices (free-text `input` args) — unchanged
- `resolveCommandArgMenu` / button picker fallback — unchanged, it correctly returns `null` when `args.values[argName] != null`

## Test plan
- [x] New unit tests verify autocomplete is used for args with choices (under and over 25)
- [x] New unit test verifies no autocomplete for args without choices
- [x] Existing `native-command.model-picker.test.ts` tests still pass

Closes #32753

🤖 Generated with [Claude Code](https://claude.com/claude-code)