### PR TITLE
fix: session resume 400 when transcriptPath persisted as null

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -314,7 +314,7 @@ function resolveTranscriptPath(params: {
   agentId?: string;
 }): string | null {
   const { sessionId, storePath, sessionFile, agentId } = params;
-  if (!storePath && !sessionFile) {
+  if (!storePath && !sessionFile && !agentId) {
     return null;
   }
   try {
@@ -458,6 +458,7 @@ function persistAbortedPartials(params: {
     return;
   }
   const { storePath, entry } = loadSessionEntry(params.sessionKey);
+  const agentId = resolveSessionAgentId({ sessionKey: params.sessionKey });
   for (const snapshot of params.snapshots) {
     const sessionId = entry?.sessionId ?? snapshot.sessionId ?? snapshot.runId;
     const appended = appendAssistantTranscriptMessage({
@@ -465,6 +466,7 @@ function persistAbortedPartials(params: {
       sessionId,
       storePath,
       sessionFile: entry?.sessionFile,
+      agentId,
       createIfMissing: true,
       idempotencyKey: `${snapshot.runId}:assistant`,
       abortMeta: {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -457,8 +457,8 @@ function persistAbortedPartials(params: {
   if (params.snapshots.length === 0) {
     return;
   }
-  const { storePath, entry } = loadSessionEntry(params.sessionKey);
-  const agentId = resolveSessionAgentId({ sessionKey: params.sessionKey });
+  const { cfg, storePath, entry } = loadSessionEntry(params.sessionKey);
+  const agentId = resolveSessionAgentId({ sessionKey: params.sessionKey, config: cfg });
   for (const snapshot of params.snapshots) {
     const sessionId = entry?.sessionId ?? snapshot.sessionId ?? snapshot.runId;
     const appended = appendAssistantTranscriptMessage({


### PR DESCRIPTION
## Summary
- fixes session resume returning 400 "transcript path not resolved" when `sessionFile` is persisted as null in sessions.json
- `resolveTranscriptPath` now falls through to `resolveSessionFilePath` when `agentId` is available, which can derive a valid path from the agent's sessions directory
- `persistAbortedPartials` now passes `agentId` (derived from sessionKey) so aborted partial transcripts also resolve correctly

## Details

when a session entry is created/updated without `sessionFile` being set, it persists as null in sessions.json. on restart, `resolveTranscriptPath` (`chat.ts:317`) short-circuits with `if (!storePath && !sessionFile) return null`, which returns 400 to the client.

`resolveSessionFilePath` in `paths.ts` already handles missing sessionFile gracefully by deriving a default path from sessionId + agentId. but the early null guard prevented it from being called.

**two changes:**

1. **`resolveTranscriptPath`** — weakened the guard to `if (!storePath && !sessionFile && !agentId)` so resolution proceeds when agentId is available
2. **`persistAbortedPartials`** — now derives and passes `agentId` via `resolveSessionAgentId({ sessionKey })`, preventing silent misrouting of aborted partial transcripts in multi-agent setups

## Test plan
- [x] type-check passes (`pnpm tsgo` — no new errors)
- [x] manual: create session, remove `sessionFile` from sessions.json entry, resume session — should resolve path via agentId fallback instead of 400
- [x] verified `resolveSessionAgentId({ sessionKey })` correctly parses agentId from session key format

Fixes #32633