### PR TITLE
fix(outbound): allow channel plugins without sendMedia in createPluginHandler

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -775,6 +775,68 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("delivers text via plugin that only implements sendText (no sendMedia)", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "line", messageId: "ln-1" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "text-only message" }],
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith(expect.objectContaining({ text: "text-only message" }));
+    expect(results).toEqual([{ channel: "line", messageId: "ln-1" }]);
+  });
+
+  it("degrades media payloads to sendText when plugin omits sendMedia", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "line", messageId: "ln-2" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "photo caption", mediaUrl: "https://example.com/photo.png" }],
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    // The fallback should pass the caption text but strip mediaUrl
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "photo caption", mediaUrl: undefined }),
+    );
+    expect(results).toEqual([{ channel: "line", messageId: "ln-2" }]);
+    // Should emit a warning log for the degradation
+    expect(logMocks.warn).toHaveBeenCalledWith(
+      "sendMedia not implemented; degrading to sendText",
+      expect.objectContaining({ channel: "line" }),
+    );
+  });
+
   it("emits message_sent success for sendPayload deliveries", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -135,12 +135,20 @@ function createPluginHandler(
   params: ChannelHandlerParams & { outbound?: ChannelOutboundAdapter },
 ): ChannelHandler | null {
   const outbound = params.outbound;
-  if (!outbound?.sendText || !outbound?.sendMedia) {
+  if (!outbound?.sendText) {
     return null;
   }
   const baseCtx = createChannelOutboundContextBase(params);
   const sendText = outbound.sendText;
-  const sendMedia = outbound.sendMedia;
+  // When sendMedia is absent, degrade media payloads to caption-only text delivery.
+  const sendMedia =
+    outbound.sendMedia ??
+    ((ctx: ChannelOutboundContext) => {
+      log.warn("sendMedia not implemented; degrading to sendText", {
+        channel: params.channel,
+      });
+      return sendText({ ...ctx, mediaUrl: undefined });
+    });
   const chunker = outbound.chunker ?? null;
   const chunkerMode = outbound.chunkerMode;
   const resolveCtx = (overrides?: {


### PR DESCRIPTION
## Summary

- Problem: `createPluginHandler()` rejects channel plugins that omit `sendMedia`, even though `ChannelOutboundAdapter` marks it optional. This blocks all outbound (including text) for text-only channels.
- Why it matters: text-only channels (IRC bridges, webhook notifiers, inter-agent messaging) cannot deliver any outbound messages at all.
- What changed: removed `sendMedia` from the guard clause; when `sendMedia` is absent, media payloads degrade to caption-only text via `sendText` with a warning log for observability.
- What did NOT change (scope boundary): channels that implement `sendMedia` are unaffected. The `ChannelHandler` internal type keeps `sendMedia` required (the fallback satisfies it).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #32711

## User-visible / Behavior Changes

- Channel plugins that implement only `sendText` (no `sendMedia`) now load and deliver text normally.
- When a media payload is sent to a text-only channel, the caption text is delivered via `sendText` and a warning is logged (`sendMedia not implemented; degrading to sendText`).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node 22+
- Integration/channel (if any): any channel plugin

### Steps

1. Create a channel plugin with only `sendText` (no `sendMedia`)
2. Attempt to send a text message through it
3. Attempt to send a media message through it

### Expected

- Text messages deliver normally
- Media messages degrade to caption text with a log warning

### Actual

- Before fix: `Error: Outbound not configured for channel: <id>` for all messages
- After fix: text delivers; media degrades to caption text

## Evidence

- [x] Failing test/log before + passing after

Two new tests added:
- `delivers text via plugin that only implements sendText (no sendMedia)` -- verifies text-only plugins load and deliver
- `degrades media payloads to sendText when plugin omits sendMedia` -- verifies media fallback strips `mediaUrl` and logs warning

All 37 tests pass (`pnpm test src/infra/outbound/deliver.test.ts`).

## Human Verification (required)

- Verified scenarios: text-only plugin text delivery, media-to-text degradation, warning log emission
- Edge cases checked: mediaUrl is explicitly set to `undefined` in fallback (not leaked to text-only adapter)
- What you did **not** verify: live channel plugin testing

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert single commit
- Files/config to restore: `src/infra/outbound/deliver.ts`
- Known bad symptoms reviewers should watch for: media payloads silently losing content on channels that previously had `sendMedia`

## Risks and Mitigations

- Risk: channels that previously defined `sendMedia` but broke it would now silently fall back to text instead of failing loudly.
  - Mitigation: fallback only activates when `sendMedia` is entirely absent from the adapter, not when it exists but throws. Channels with a defined `sendMedia` are unaffected.