### PR TITLE
Fix Feishu card message content retrieval when quoted and @mentioned

### DIFF
--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -165,4 +165,78 @@ describe("getMessageFeishu", () => {
       }),
     );
   });
+
+  it("extracts content from interactive card with body.elements structure", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_card_body",
+            chat_id: "oc_1",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                header: { title: { content: "Card Header" } },
+                body: {
+                  elements: [
+                    { tag: "markdown", content: "Body content" },
+                    { tag: "div", text: { content: "Div content" } },
+                  ],
+                },
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_card_body",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_card_body",
+        chatId: "oc_1",
+        contentType: "interactive",
+        content: "Card Header\nBody content\nDiv content",
+      }),
+    );
+  });
+
+  it("extracts header title when elements are missing", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_card_header_only",
+            chat_id: "oc_1",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                header: { title: { content: "Only Header Title" } },
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_card_header_only",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_card_header_only",
+        chatId: "oc_1",
+        contentType: "interactive",
+        content: "Only Header Title",
+      }),
+    );
+  });
 });

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -35,13 +35,32 @@ function parseInteractiveCardContent(parsed: unknown): string {
     return "[Interactive Card]";
   }
 
-  const candidate = parsed as { elements?: unknown };
-  if (!Array.isArray(candidate.elements)) {
+  const candidate = parsed as {
+    header?: { title?: { content?: string } };
+    body?: { elements?: unknown };
+    elements?: unknown;
+  };
+
+  // Handle both structures: direct elements or body.elements
+  const elements = candidate.body?.elements ?? candidate.elements;
+  if (!Array.isArray(elements)) {
+    // Try to extract at least the header title if elements are not available
+    const headerTitle = candidate.header?.title?.content;
+    if (typeof headerTitle === "string" && headerTitle.trim()) {
+      return headerTitle.trim();
+    }
     return "[Interactive Card]";
   }
 
   const texts: string[] = [];
-  for (const element of candidate.elements) {
+
+  // Include header title if present
+  const headerTitle = candidate.header?.title?.content;
+  if (typeof headerTitle === "string" && headerTitle.trim()) {
+    texts.push(headerTitle.trim());
+  }
+
+  for (const element of elements) {
     if (!element || typeof element !== "object") {
       continue;
     }
@@ -49,6 +68,7 @@ function parseInteractiveCardContent(parsed: unknown): string {
       tag?: string;
       content?: string;
       text?: { content?: string };
+      title?: { content?: string };
     };
     if (item.tag === "div" && typeof item.text?.content === "string") {
       texts.push(item.text.content);
@@ -56,6 +76,11 @@ function parseInteractiveCardContent(parsed: unknown): string {
     }
     if (item.tag === "markdown" && typeof item.content === "string") {
       texts.push(item.content);
+      continue;
+    }
+    // Handle header tag within elements (some card formats use this)
+    if (item.tag === "header" && typeof item.title?.content === "string") {
+      texts.push(item.title.content);
     }
   }
   return texts.join("\n").trim() || "[Interactive Card]";

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -79,8 +79,9 @@ function parseInteractiveCardContent(parsed: unknown): string {
       continue;
     }
     // Handle header tag within elements (some card formats use this)
-    if (item.tag === "header" && typeof item.title?.content === "string") {
-      texts.push(item.title.content);
+    // Note: card "header" elements have tag "header", title lives on the element directly
+    if (item.tag === "header" && typeof item.title === "string") {
+      texts.push(item.title);
     }
   }
   return texts.join("\n").trim() || "[Interactive Card]";


### PR DESCRIPTION
## Summary

This PR fixes Issue #32712 where the bot cannot retrieve card message content when a Feishu card is quoted and @mentioned.

## Root Cause

The `parseInteractiveCardContent` function in `extensions/feishu/src/send.ts` only checked for a direct `elements` array, but Feishu card messages can have:
- Elements nested in `body.elements` (instead of direct `elements`)
- Header information in `header.title` that should be extracted

## Changes

### Code Changes
- **extensions/feishu/src/send.ts**: Updated `parseInteractiveCardContent` to:
  1. Check both `body.elements` and direct `elements`
  2. Extract header title when present
  3. Handle header tag within elements

### Test Changes  
- **extensions/feishu/src/send.test.ts**: Added test cases for:
  - Interactive card with `body.elements` structure
  - Header-only cards (when elements are missing)

## Testing

All tests pass:
- ✓ extracts text content from interactive card elements
- ✓ extracts content from interactive card with body.elements structure (NEW)
- ✓ extracts header title when elements are missing (NEW)
- ✓ extracts text content from post messages
- ✓ returns text placeholder for unsupported message types
- ✓ supports single-object response shape from Feishu API

Fixes #32712