### PR TITLE
Discord: allow /acp inline action

### DIFF
--- a/src/discord/monitor/native-command.command-options.test.ts
+++ b/src/discord/monitor/native-command.command-options.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { listChatCommands } from "../../auto-reply/commands-registry.js";
+import type { loadConfig } from "../../config/config.js";
+import { __testing } from "./native-command.js";
+
+describe("buildDiscordCommandOptions", () => {
+  it("forces autocomplete for /acp action", () => {
+    const acpCommand = listChatCommands().find((command) => command.key === "acp");
+    if (!acpCommand) {
+      throw new Error("acp command missing from registry");
+    }
+    const options = __testing.buildDiscordCommandOptions({
+      command: acpCommand,
+      cfg: {} as ReturnType<typeof loadConfig>,
+    });
+    const actionOption = options?.find((option) => option.name === "action");
+    expect(actionOption?.autocomplete).toBeTypeOf("function");
+    expect(actionOption?.choices).toBeUndefined();
+  });
+});

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -115,9 +115,10 @@ function buildDiscordCommandOptions(params: {
       };
     }
     const resolvedChoices = resolveCommandArgChoices({ command, arg, cfg });
+    const forceAutocomplete = command.key === "acp" && arg.name === "action";
     const shouldAutocomplete =
       resolvedChoices.length > 0 &&
-      (typeof arg.choices === "function" || resolvedChoices.length > 25);
+      (forceAutocomplete || typeof arg.choices === "function" || resolvedChoices.length > 25);
     const autocomplete = shouldAutocomplete
       ? async (interaction: AutocompleteInteraction) => {
           const focused = interaction.options.getFocused();
@@ -1207,6 +1208,10 @@ export function createDiscordNativeCommand(params: {
     }
   })();
 }
+
+export const __testing = {
+  buildDiscordCommandOptions,
+};
 
 async function dispatchDiscordCommandInteraction(params: {
   interaction: CommandInteraction | ButtonInteraction | StringSelectMenuInteraction;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord slash command for /acp uses static choices, so inline args like `/acp close` send `action=null` and always show the menu.
- Why it matters: Users can’t bypass the picker for common actions; regression in inline usage.
- What changed: Force autocomplete for the `/acp` `action` option so Discord passes typed values through.
- What did NOT change (scope boundary): No changes to ACP command parsing or menu behavior when no action is provided.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32753
- Related #

## User-visible / Behavior Changes

- Discord `/acp` accepts inline action values (e.g. `/acp close`) without forcing the picker menu.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows/macOS (Discord)
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): N/A

### Steps

1. In Discord, type `/acp close` and submit.
2. Observe command processing.

### Expected

- `/acp close` executes directly without opening the action picker.

### Actual

- Action picker opens instead of executing (before fix).

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Not run locally.
- Edge cases checked: None.
- What you did **not** verify: Discord interaction behavior in a live server.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit or re-register the /acp command with static choices.
- Files/config to restore: `src/discord/monitor/native-command.ts`
- Known bad symptoms reviewers should watch for: `/acp` autocompletion not showing choices.

## Risks and Mitigations

- Risk: Autocomplete might behave unexpectedly for /acp in some clients.
  - Mitigation: Limited to the /acp action arg; menu still appears when no action provided.
