### PR TITLE
fix(skills): respect enabled: true as force-include override

### DIFF
--- a/src/agents/skills/config.test.ts
+++ b/src/agents/skills/config.test.ts
@@ -46,4 +46,21 @@ describe("shouldIncludeSkill — enabled override (#32752)", () => {
     const entry = makeEntry({ metadata: undefined });
     expect(shouldIncludeSkill({ entry })).toBe(true);
   });
+
+  it("respects allowBundled even with enabled: true for bundled skills", () => {
+    const entry = makeEntry({
+      skill: {
+        name: "test-skill",
+        source: "openclaw-bundled",
+        content: "",
+      } as SkillEntry["skill"],
+    });
+    const config: OpenClawConfig = {
+      skills: {
+        entries: { "test-skill": { enabled: true } },
+        allowBundled: ["other-skill"],
+      },
+    } as unknown as OpenClawConfig;
+    expect(shouldIncludeSkill({ entry, config })).toBe(false);
+  });
 });

--- a/src/agents/skills/config.test.ts
+++ b/src/agents/skills/config.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { shouldIncludeSkill } from "./config.js";
+import type { SkillEntry } from "./types.js";
+
+function makeEntry(overrides?: Partial<SkillEntry>): SkillEntry {
+  return {
+    skill: {
+      name: "test-skill",
+      source: "plugin",
+      content: "",
+      ...overrides?.skill,
+    } as SkillEntry["skill"],
+    frontmatter: {},
+    metadata: {
+      requires: { bins: ["missing-binary-xyz"] },
+      ...overrides?.metadata,
+    },
+    ...overrides,
+  };
+}
+
+describe("shouldIncludeSkill — enabled override (#32752)", () => {
+  it("excludes skill when required binary is missing (default)", () => {
+    const entry = makeEntry();
+    expect(shouldIncludeSkill({ entry })).toBe(false);
+  });
+
+  it("force-disables skill with enabled: false", () => {
+    const entry = makeEntry({ metadata: undefined });
+    const config: OpenClawConfig = {
+      skills: { entries: { "test-skill": { enabled: false } } },
+    } as OpenClawConfig;
+    expect(shouldIncludeSkill({ entry, config })).toBe(false);
+  });
+
+  it("force-enables skill with enabled: true even when binary is missing", () => {
+    const entry = makeEntry();
+    const config: OpenClawConfig = {
+      skills: { entries: { "test-skill": { enabled: true } } },
+    } as OpenClawConfig;
+    expect(shouldIncludeSkill({ entry, config })).toBe(true);
+  });
+
+  it("includes skill with no requirements and no config override", () => {
+    const entry = makeEntry({ metadata: undefined });
+    expect(shouldIncludeSkill({ entry })).toBe(true);
+  });
+});

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -80,8 +80,8 @@ export function shouldIncludeSkill(params: {
   if (skillConfig?.enabled === false) {
     return false;
   }
-  // Symmetric with `enabled: false` — force-include the skill even when
-  // its `requires.bins` check fails on the gateway host.  (#32752)
+  // Force-include: skip runtime eligibility (requires.bins, etc.) but
+  // still respect the bundled allowlist.  (#32752)
   if (skillConfig?.enabled === true) {
     return isBundledSkillAllowed(entry, allowBundled);
   }

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -80,6 +80,11 @@ export function shouldIncludeSkill(params: {
   if (skillConfig?.enabled === false) {
     return false;
   }
+  // Symmetric with `enabled: false` — force-include the skill even when
+  // its `requires.bins` check fails on the gateway host.  (#32752)
+  if (skillConfig?.enabled === true) {
+    return isBundledSkillAllowed(entry, allowBundled);
+  }
   if (!isBundledSkillAllowed(entry, allowBundled)) {
     return false;
   }


### PR DESCRIPTION
## Summary
- `skills.entries.<key>.enabled: false` correctly force-disables a skill, but `enabled: true` fell through to `evaluateRuntimeEligibility()` which rejected skills whose `requires.bins` were missing from the gateway host PATH
- Added symmetric early-return: when `enabled === true`, skip runtime eligibility and return `true` (still respecting `allowBundled`)
- Unblocks deployments where binaries are available inside the sandbox but not on the gateway host

## What did NOT change
- `enabled: false` behavior — unchanged
- `evaluateRuntimeEligibility()` — unchanged
- `resolveSkillConfig()` — unchanged
- Default behavior when `enabled` is `undefined` — unchanged (falls through to runtime check as before)
- `allowBundled` filtering — still respected even with `enabled: true`

## Test plan
- [x] New test: skill excluded when required binary missing (default behavior)
- [x] New test: `enabled: false` force-disables
- [x] New test: `enabled: true` force-includes even with missing binary
- [x] New test: skill included when no requirements and no config
- [x] All 22 tests in `src/agents/skills/` pass

Closes #32752

🤖 Generated with [Claude Code](https://claude.com/claude-code)