### PR TITLE
Plugins: fix keyed-async-queue subpath alias for Matrix runtime

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -215,11 +215,15 @@ function createPluginSdkAliasFixture() {
   const root = makeTempDir();
   const srcFile = path.join(root, "src", "plugin-sdk", "index.ts");
   const distFile = path.join(root, "dist", "plugin-sdk", "index.js");
+  const srcKeyedQueueFile = path.join(root, "src", "plugin-sdk", "keyed-async-queue.ts");
+  const distKeyedQueueFile = path.join(root, "dist", "plugin-sdk", "keyed-async-queue.js");
   fs.mkdirSync(path.dirname(srcFile), { recursive: true });
   fs.mkdirSync(path.dirname(distFile), { recursive: true });
   fs.writeFileSync(srcFile, "export {};\n", "utf-8");
   fs.writeFileSync(distFile, "export {};\n", "utf-8");
-  return { root, srcFile, distFile };
+  fs.writeFileSync(srcKeyedQueueFile, "export {};\n", "utf-8");
+  fs.writeFileSync(distKeyedQueueFile, "export {};\n", "utf-8");
+  return { root, srcFile, distFile, srcKeyedQueueFile, distKeyedQueueFile };
 }
 
 afterEach(() => {
@@ -996,5 +1000,24 @@ describe("loadOpenClawPlugins", () => {
       }),
     );
     expect(resolved).toBe(srcFile);
+  });
+
+  it("aliases keyed-async-queue to the dedicated dist file when available", () => {
+    const { root, distKeyedQueueFile } = createPluginSdkAliasFixture();
+    const aliases = __testing.resolvePluginSdkImportAliases(
+      path.join(root, "dist", "plugins", "loader.js"),
+    );
+    expect(aliases["openclaw/plugin-sdk/keyed-async-queue"]).toBe(distKeyedQueueFile);
+  });
+
+  it("falls back keyed-async-queue alias to plugin-sdk index when subpath file is missing", () => {
+    const { root, distFile, distKeyedQueueFile, srcKeyedQueueFile } = createPluginSdkAliasFixture();
+    fs.rmSync(distKeyedQueueFile);
+    fs.rmSync(srcKeyedQueueFile);
+    const aliases = __testing.resolvePluginSdkImportAliases(
+      path.join(root, "dist", "plugins", "loader.js"),
+    );
+    expect(aliases["openclaw/plugin-sdk"]).toBe(distFile);
+    expect(aliases["openclaw/plugin-sdk/keyed-async-queue"]).toBe(distFile);
   });
 });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -84,15 +84,46 @@ const resolvePluginSdkAliasFile = (params: {
   return null;
 };
 
-const resolvePluginSdkAlias = (): string | null =>
-  resolvePluginSdkAliasFile({ srcFile: "index.ts", distFile: "index.js" });
+const resolvePluginSdkAlias = (modulePath?: string): string | null =>
+  resolvePluginSdkAliasFile({ srcFile: "index.ts", distFile: "index.js", modulePath });
 
-const resolvePluginSdkAccountIdAlias = (): string | null => {
-  return resolvePluginSdkAliasFile({ srcFile: "account-id.ts", distFile: "account-id.js" });
+const resolvePluginSdkAccountIdAlias = (modulePath?: string): string | null => {
+  return resolvePluginSdkAliasFile({
+    srcFile: "account-id.ts",
+    distFile: "account-id.js",
+    modulePath,
+  });
+};
+
+const resolvePluginSdkKeyedAsyncQueueAlias = (modulePath?: string): string | null => {
+  return resolvePluginSdkAliasFile({
+    srcFile: "keyed-async-queue.ts",
+    distFile: "keyed-async-queue.js",
+    modulePath,
+  });
+};
+
+const resolvePluginSdkImportAliases = (modulePath?: string): Record<string, string> => {
+  const pluginSdkAlias = resolvePluginSdkAlias(modulePath);
+  const pluginSdkAccountIdAlias = resolvePluginSdkAccountIdAlias(modulePath);
+  const pluginSdkKeyedAsyncQueueAlias =
+    resolvePluginSdkKeyedAsyncQueueAlias(modulePath) ?? pluginSdkAlias;
+  const aliasMap: Record<string, string> = {};
+  if (pluginSdkAlias) {
+    aliasMap["openclaw/plugin-sdk"] = pluginSdkAlias;
+  }
+  if (pluginSdkAccountIdAlias) {
+    aliasMap["openclaw/plugin-sdk/account-id"] = pluginSdkAccountIdAlias;
+  }
+  if (pluginSdkKeyedAsyncQueueAlias) {
+    aliasMap["openclaw/plugin-sdk/keyed-async-queue"] = pluginSdkKeyedAsyncQueueAlias;
+  }
+  return aliasMap;
 };
 
 export const __testing = {
   resolvePluginSdkAliasFile,
+  resolvePluginSdkImportAliases,
 };
 
 function buildCacheKey(params: {
@@ -433,19 +464,14 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     if (jitiLoader) {
       return jitiLoader;
     }
-    const pluginSdkAlias = resolvePluginSdkAlias();
-    const pluginSdkAccountIdAlias = resolvePluginSdkAccountIdAlias();
+    const pluginSdkAliases = resolvePluginSdkImportAliases();
+    const hasPluginSdkAliases = Object.keys(pluginSdkAliases).length > 0;
     jitiLoader = createJiti(import.meta.url, {
       interopDefault: true,
       extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
-      ...(pluginSdkAlias || pluginSdkAccountIdAlias
+      ...(hasPluginSdkAliases
         ? {
-            alias: {
-              ...(pluginSdkAlias ? { "openclaw/plugin-sdk": pluginSdkAlias } : {}),
-              ...(pluginSdkAccountIdAlias
-                ? { "openclaw/plugin-sdk/account-id": pluginSdkAccountIdAlias }
-                : {}),
-            },
+            alias: pluginSdkAliases,
           }
         : {}),
     });


### PR DESCRIPTION
## Summary
- add plugin-loader alias support for `openclaw/plugin-sdk/keyed-async-queue`
- fall back that subpath alias to `openclaw/plugin-sdk` when the dedicated keyed queue artifact is missing
- add regression tests that cover both dedicated-file and fallback alias resolution

## Why
Matrix imports `KeyedAsyncQueue` from `openclaw/plugin-sdk/keyed-async-queue`. In some packaged/runtime combinations, subpath resolution can collapse into an invalid `.../index.js/keyed-async-queue` lookup or fail when a dedicated keyed queue artifact is absent. This keeps bundled extensions loading by resolving that subpath explicitly.

## Testing
- `pnpm exec oxfmt --check src/plugins/loader.ts src/plugins/loader.test.ts`
- `pnpm exec vitest run src/plugins/loader.test.ts`
