### PR TITLE
fix(matrix): import KeyedAsyncQueue from main plugin-sdk entry

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 


### PR DESCRIPTION
## Summary
- Matrix plugin fails to load in v2026.3.2 because `keyed-async-queue.js` is missing from the build output at the declared subpath
- Changed the import from `openclaw/plugin-sdk/keyed-async-queue` to `openclaw/plugin-sdk` where `KeyedAsyncQueue` is already re-exported

## What did NOT change
- `KeyedAsyncQueue` implementation — unchanged
- `plugin-sdk/index.ts` exports — unchanged (already re-exports `KeyedAsyncQueue`)
- `send-queue.ts` logic — unchanged, only the import path changed
- No other extensions use the subpath import

## Test plan
- [x] All 100 Matrix extension tests pass (27 test files)
- [x] Verified `KeyedAsyncQueue` is exported from `src/plugin-sdk/index.ts` (line 124)

Closes #32772
Closes #33427

🤖 Generated with [Claude Code](https://claude.com/claude-code)