### PR TITLE
Nextcloud Talk: fix runtime src import leak for abort-signal

### DIFF
--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -8,11 +8,11 @@ import {
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   setAccountEnabledInConfigSection,
+  waitForAbortSignal,
   type ChannelPlugin,
   type OpenClawConfig,
   type ChannelSetupInput,
 } from "openclaw/plugin-sdk";
-import { waitForAbortSignal } from "../../../src/infra/abort-signal.js";
 import {
   listNextcloudTalkAccountIds,
   resolveDefaultNextcloudTalkAccountId,

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -166,6 +166,7 @@ export {
 } from "../channels/plugins/onboarding/helpers.js";
 export { buildOauthProviderAuthResult } from "./provider-auth-result.js";
 export { formatResolvedUnresolvedNote } from "./resolution-notes.js";
+export { waitForAbortSignal } from "../infra/abort-signal.js";
 export type { ChannelDock } from "../channels/dock.js";
 export { getChatChannelMeta } from "../channels/registry.js";
 export { resolveAllowlistMatchByCandidates } from "../channels/allowlist-match.js";


### PR DESCRIPTION
## Summary
- route Nextcloud Talk abort waiting through `openclaw/plugin-sdk` instead of importing from core `src/infra`
- export `waitForAbortSignal` from the plugin SDK surface for extension-safe runtime usage

## Why
`@openclaw/nextcloud-talk` could fail to load when installed from npm because `channel.ts` imported `../../../src/infra/abort-signal.js`, which does not exist in the packaged extension runtime. Using the plugin SDK public surface keeps extension runtime imports stable.

Closes #32662.

## Testing
- `pnpm exec oxfmt --check extensions/nextcloud-talk/src/channel.ts src/plugin-sdk/index.ts`
- `pnpm exec vitest run extensions/nextcloud-talk/src/channel.startup.test.ts`
