### PR TITLE
fix: add Matrix auto-thread-id injection for same-room replies

### DIFF
--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -2,10 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { ChannelThreadingToolContext } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   hydrateAttachmentParamsForAction,
   normalizeSandboxMediaParams,
+  resolveMatrixAutoThreadId,
 } from "./message-action-params.js";
 
 const cfg = {} as OpenClawConfig;
@@ -53,5 +55,87 @@ describe("message action sandbox media hydration", () => {
       await fs.rm(sandboxRoot, { recursive: true, force: true });
       await fs.rm(outsideRoot, { recursive: true, force: true });
     }
+  });
+});
+
+describe("resolveMatrixAutoThreadId", () => {
+  const baseContext: ChannelThreadingToolContext = {
+    currentChannelId: "room:!abc123:matrix.org",
+    currentThreadTs: "$thread_event_id",
+  };
+
+  it("returns threadTs when target room matches currentChannelId", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!abc123:matrix.org",
+        toolContext: baseContext,
+      }),
+    ).toBe("$thread_event_id");
+  });
+
+  it("matches when target omits room: prefix", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "!abc123:matrix.org",
+        toolContext: baseContext,
+      }),
+    ).toBe("$thread_event_id");
+  });
+
+  it("matches case-insensitively", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!ABC123:Matrix.Org",
+        toolContext: baseContext,
+      }),
+    ).toBe("$thread_event_id");
+  });
+
+  it("returns undefined when rooms differ", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!other_room:matrix.org",
+        toolContext: baseContext,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when no currentThreadTs", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!abc123:matrix.org",
+        toolContext: { currentChannelId: "room:!abc123:matrix.org" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when no currentChannelId", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!abc123:matrix.org",
+        toolContext: { currentThreadTs: "$thread_event_id" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when no toolContext", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!abc123:matrix.org",
+        toolContext: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("matches when currentChannelId omits room: prefix", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!abc123:matrix.org",
+        toolContext: {
+          currentChannelId: "!abc123:matrix.org",
+          currentThreadTs: "$thread_event_id",
+        },
+      }),
+    ).toBe("$thread_event_id");
   });
 });

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -71,6 +71,45 @@ export function resolveTelegramAutoThreadId(params: {
   return context.currentThreadTs;
 }
 
+/**
+ * Strip the leading `room:` prefix used internally by the Matrix channel plugin
+ * when building `To` / `currentChannelId` values.  This lets us compare the raw
+ * room id regardless of whether the prefix is present.
+ */
+function stripMatrixRoomPrefix(raw: string): string {
+  const lowered = raw.toLowerCase();
+  if (lowered.startsWith("room:")) {
+    return raw.slice("room:".length);
+  }
+  return raw;
+}
+
+/**
+ * Auto-inject Matrix thread ID when the message tool targets the same room the
+ * session originated from.  Mirrors the Telegram auto-threading pattern so
+ * replies land in the correct thread instead of appearing as new top-level
+ * messages.
+ *
+ * Unlike Slack, we do not gate on `replyToMode`: Matrix threads are persistent
+ * (similar to Telegram forum topics), so auto-injection should always apply
+ * when the target room matches.
+ */
+export function resolveMatrixAutoThreadId(params: {
+  to: string;
+  toolContext?: ChannelThreadingToolContext;
+}): string | undefined {
+  const context = params.toolContext;
+  if (!context?.currentThreadTs || !context.currentChannelId) {
+    return undefined;
+  }
+  const normalizedTo = stripMatrixRoomPrefix(params.to.trim());
+  const normalizedChannel = stripMatrixRoomPrefix(context.currentChannelId.trim());
+  if (normalizedTo.toLowerCase() !== normalizedChannel.toLowerCase()) {
+    return undefined;
+  }
+  return context.currentThreadTs;
+}
+
 function resolveAttachmentMaxBytes(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -33,6 +33,7 @@ import {
   parseComponentsParam,
   readBooleanParam,
   resolveAttachmentMediaPolicy,
+  resolveMatrixAutoThreadId,
   resolveSlackAutoThreadId,
   resolveTelegramAutoThreadId,
 } from "./message-action-params.js";
@@ -76,7 +77,11 @@ function resolveAndApplyOutboundThreadId(
     ctx.channel === "telegram" && !threadId
       ? resolveTelegramAutoThreadId({ to: ctx.to, toolContext: ctx.toolContext })
       : undefined;
-  const resolved = threadId ?? slackAutoThreadId ?? telegramAutoThreadId;
+  const matrixAutoThreadId =
+    ctx.channel === "matrix" && !threadId
+      ? resolveMatrixAutoThreadId({ to: ctx.to, toolContext: ctx.toolContext })
+      : undefined;
+  const resolved = threadId ?? slackAutoThreadId ?? telegramAutoThreadId ?? matrixAutoThreadId;
   // Write auto-resolved threadId back into params so downstream dispatch
   // (plugin `readStringParam(params, "threadId")`) picks it up.
   if (resolved && !params.threadId) {


### PR DESCRIPTION
## Summary

- Problem: Matrix channel has no auto-thread-injection logic. Slack has `slackAutoThreadId` and Telegram has `telegramAutoThreadId`, but Matrix has no equivalent. Replies in the same room appear as new top-level messages instead of threaded replies.
- Why it matters: Threaded conversations in Matrix rooms break when the agent replies -- the reply becomes a new message instead of continuing the thread.
- What changed: Added `resolveMatrixAutoThreadId` in `message-action-params.ts` and wired it into the `resolveAndApplyOutboundThreadId` resolution chain in `message-action-runner.ts`. Added 8 unit tests.
- What did NOT change (scope boundary): No changes to Slack or Telegram auto-threading. No changes to Matrix extension code. No changes to the `ChannelThreadingToolContext` type.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #32744

## User-visible / Behavior Changes

When an agent replies in a Matrix room thread, the reply now correctly lands in that thread instead of appearing as a new top-level message in the room. This mirrors the existing behavior for Slack and Telegram channels.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Matrix

### Steps

1. Configure a Matrix channel and start a thread in a room
2. Send a message in that thread to the agent
3. Agent replies -- before this fix the reply was a new top-level message; after, it lands in the thread

### Expected

- Agent reply appears in the same thread

### Actual

- Before fix: Agent reply appears as a new top-level message
- After fix: Agent reply appears in the thread

## Evidence

- [x] Failing test/log before + passing after: 8 new unit tests cover matching rooms (with/without `room:` prefix), case-insensitive matching, mismatched rooms, and missing context fields

## Human Verification (required)

- Verified scenarios: All 8 new unit tests pass, existing tests unaffected, type checking passes
- Edge cases checked: Missing `currentThreadTs`, missing `currentChannelId`, missing `toolContext`, room prefix mismatch (`room:` present/absent on either side), case sensitivity
- What you did **not** verify: Live Matrix server end-to-end testing

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/infra/outbound/message-action-params.ts`, `src/infra/outbound/message-action-runner.ts`
- Known bad symptoms reviewers should watch for: Matrix replies incorrectly threaded to wrong thread, or auto-threading when it should not (different rooms)

## Risks and Mitigations

- Risk: Auto-thread injection triggers for the wrong room if room ID normalization differs from what the Matrix extension provides
  - Mitigation: The resolver strips only the `room:` prefix and does case-insensitive comparison, matching the exact pattern the Matrix channel plugin uses in `buildToolContext` (`To` = `room:${roomId}`)