### PR TITLE
fix: respect enabled: true as force-enable in shouldIncludeSkill

### DIFF
--- a/src/agents/skills/config.test.ts
+++ b/src/agents/skills/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { shouldIncludeSkill } from "./config.js";
+import type { SkillEntry } from "./types.js";
+
+function makeEntry(overrides?: Partial<SkillEntry>): SkillEntry {
+  return {
+    skill: {
+      name: "test-skill",
+      description: "A test skill",
+      filePath: "/skills/test-skill/SKILL.md",
+      baseDir: "/skills/test-skill",
+      source: "openclaw-bundled",
+      disableModelInvocation: false,
+    },
+    frontmatter: {},
+    metadata: {
+      requires: { bins: ["nonexistent-bin"] },
+    },
+    ...overrides,
+  };
+}
+
+describe("shouldIncludeSkill", () => {
+  it("force-disables when enabled is false", () => {
+    const result = shouldIncludeSkill({
+      entry: makeEntry(),
+      config: { skills: { entries: { "test-skill": { enabled: false } } } },
+    });
+    expect(result).toBe(false);
+  });
+
+  it("force-enables when enabled is true, bypassing requires.bins", () => {
+    const result = shouldIncludeSkill({
+      entry: makeEntry(),
+      config: { skills: { entries: { "test-skill": { enabled: true } } } },
+    });
+    expect(result).toBe(true);
+  });
+
+  it("falls through to runtime eligibility when enabled is undefined", () => {
+    // requires.bins = ["nonexistent-bin"] and hasBinary will return false
+    const result = shouldIncludeSkill({
+      entry: makeEntry(),
+    });
+    expect(result).toBe(false);
+  });
+
+  it("respects allowBundled even when enabled is true", () => {
+    const config: OpenClawConfig = {
+      skills: {
+        allowBundled: ["other-skill"],
+        entries: { "test-skill": { enabled: true } },
+      },
+    };
+    const result = shouldIncludeSkill({
+      entry: makeEntry(),
+      config,
+    });
+    expect(result).toBe(false);
+  });
+});

--- a/src/agents/skills/config.test.ts
+++ b/src/agents/skills/config.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { shouldIncludeSkill } from "./config.js";
 import type { SkillEntry } from "./types.js";
+
+vi.mock("../../shared/config-eval.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../shared/config-eval.js")>()),
+  hasBinary: vi.fn().mockReturnValue(false),
+}));
 
 function makeEntry(overrides?: Partial<SkillEntry>): SkillEntry {
   return {
@@ -39,7 +44,7 @@ describe("shouldIncludeSkill", () => {
   });
 
   it("falls through to runtime eligibility when enabled is undefined", () => {
-    // requires.bins = ["nonexistent-bin"] and hasBinary will return false
+    // hasBinary is mocked to return false, so requires.bins rejects
     const result = shouldIncludeSkill({
       entry: makeEntry(),
     });

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -83,6 +83,9 @@ export function shouldIncludeSkill(params: {
   if (!isBundledSkillAllowed(entry, allowBundled)) {
     return false;
   }
+  if (skillConfig?.enabled === true) {
+    return true;
+  }
   return evaluateRuntimeEligibility({
     os: entry.metadata?.os,
     remotePlatforms: eligibility?.remote?.platforms,


### PR DESCRIPTION
## Summary

- Problem: `skills.entries.<key>.enabled: true` does not force-enable a skill — it still runs `evaluateRuntimeEligibility()` which rejects the skill if `requires.bins` binaries are missing from the host PATH
- Why it matters: Deployments where a skill's binary lives inside a sidecar/sandbox (not on the gateway host) cannot opt-in to the skill via config
- What changed: Added an early return in `shouldIncludeSkill()` when `enabled === true`, symmetric with the existing `enabled === false` early return
- What did NOT change: `allowBundled` filtering is still respected; `enabled: true` only bypasses runtime eligibility (requires.bins, requires.env, etc.)

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32752

## User-visible / Behavior Changes

- Setting `skills.entries.<key>.enabled: true` in config now force-enables the skill, bypassing `requires.bins` / `requires.env` / `requires.config` checks
- No change when `enabled` is omitted (`undefined`) — existing behavior is preserved
- `enabled: false` behavior is unchanged

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — users could already enable skills by placing binaries on PATH; this just adds a config-only path
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Amazon Linux 2023)
- Runtime/container: Node 24, gateway on EC2 with sandbox sidecar
- Model/provider: N/A (skill loading, not model interaction)
- Integration/channel (if any): N/A
- Relevant config (redacted): `{ "skills": { "entries": { "some-skill": { "enabled": true } } } }`

### Steps

1. Bundle a skill with `requires: { bins: ["some-cli"] }` in its SKILL.md frontmatter
2. Ensure `some-cli` is NOT on the gateway host's PATH (but available inside the sandbox)
3. Set `skills.entries.some-skill.enabled: true` in config
4. Start the gateway

### Expected

- The skill is force-enabled and available to the agent

### Actual (before fix)

- The skill remains unavailable because `hasBinary("some-cli")` returns false

### Actual (after fix)

- The skill is force-enabled, symmetric with how `enabled: false` force-disables

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test file `src/agents/skills/config.test.ts` with 4 test cases:
1. `enabled: false` → force-disables (existing behavior, regression guard)
2. `enabled: true` → force-enables, bypassing `requires.bins` (new behavior)
3. `enabled: undefined` → falls through to `evaluateRuntimeEligibility` (existing behavior)
4. `enabled: true` + `allowBundled` excludes skill → still rejected (allowBundled is respected)

## Human Verification (required)

- Verified scenarios: All 4 test cases pass; `pnpm check` passes; `pnpm vitest run src/agents/skills/config.test.ts` passes
- Edge cases checked: `allowBundled` interaction with `enabled: true`; `enabled: undefined` (default) unchanged
- What you did **not** verify: E2E with a real gateway deployment (planned for after merge)

## Compatibility / Migration

- Backward compatible? `Yes` — `enabled` defaults to `undefined` (not `true`), so no existing behavior changes
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the 3-line `if` block in `shouldIncludeSkill()`, or set `enabled: false` for affected skills
- Files/config to restore: `src/agents/skills/config.ts`
- Known bad symptoms reviewers should watch for: Skills appearing when they shouldn't (would require explicit `enabled: true` in config, so unlikely to happen accidentally)

## Risks and Mitigations

- Risk: A user sets `enabled: true` for a skill whose binary truly doesn't exist anywhere (not in sandbox either), leading to runtime errors when the skill tries to invoke the binary
  - Mitigation: This is an explicit opt-in — users setting `enabled: true` are asserting the binary is available somewhere in their deployment. The default (`undefined`) preserves the existing safety check.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)