### PR TITLE
Outbound: support text-only channel adapters without sendMedia

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -881,6 +881,54 @@ describe("deliverOutboundPayloads", () => {
     const firstCall = sendText.mock.calls[0]?.[0];
     expect(firstCall).toEqual(expect.objectContaining({ to: "U123", text: "caption" }));
     expect(firstCall?.mediaUrl).toBeUndefined();
+    expect(logMocks.warn).toHaveBeenCalledWith(
+      "deliverOutboundPayloads: sendMedia not configured for channel; dropping mediaUrl and falling back to caption",
+      expect.objectContaining({
+        channel: "line",
+        to: "U123",
+        mediaUrl: "https://x.test/a.jpg",
+      }),
+    );
+    expect(results).toEqual([{ channel: "line", messageId: "ln-media-1" }]);
+  });
+
+  it("does not send empty fallback text for additional media URLs on text-only plugin channels", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "line", messageId: "ln-media-1" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "caption", mediaUrls: ["https://x.test/a.jpg", "https://x.test/b.jpg"] }],
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "U123",
+        text: "caption",
+      }),
+    );
+    expect(logMocks.warn).toHaveBeenCalledWith(
+      "deliverOutboundPayloads: sendMedia not configured and caption empty; dropping mediaUrl without fallback",
+      expect.objectContaining({
+        channel: "line",
+        to: "U123",
+        mediaUrl: "https://x.test/b.jpg",
+      }),
+    );
     expect(results).toEqual([{ channel: "line", messageId: "ln-media-1" }]);
   });
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -826,6 +826,64 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("delivers text payloads for plugin channels that omit sendMedia", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "line", messageId: "ln-text-1" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "text-only" }],
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "U123", text: "text-only" }),
+    );
+    expect(results).toEqual([{ channel: "line", messageId: "ln-text-1" }]);
+  });
+
+  it("falls back to sendText for media payloads when plugin sendMedia is omitted", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "line", messageId: "ln-media-1" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "caption", mediaUrl: "https://x.test/a.jpg" }],
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    const firstCall = sendText.mock.calls[0]?.[0];
+    expect(firstCall).toEqual(expect.objectContaining({ to: "U123", text: "caption" }));
+    expect(firstCall?.mediaUrl).toBeUndefined();
+    expect(results).toEqual([{ channel: "line", messageId: "ln-media-1" }]);
+  });
+
   it("emits message_sent success for sendPayload deliveries", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -91,6 +91,7 @@ type ChannelHandler = {
   chunker: Chunker | null;
   chunkerMode?: "text" | "markdown";
   textChunkLimit?: number;
+  supportsNativeMedia: boolean;
   sendPayload?: (
     payload: ReplyPayload,
     overrides?: {
@@ -163,6 +164,7 @@ function createPluginHandler(
     chunker,
     chunkerMode,
     textChunkLimit: outbound.textChunkLimit,
+    supportsNativeMedia: Boolean(sendMedia),
     sendPayload: outbound.sendPayload
       ? async (payload, overrides) =>
           outbound.sendPayload!({
@@ -186,6 +188,14 @@ function createPluginHandler(
         });
       }
       // Text-only channels may omit sendMedia. Fall back to caption delivery.
+      log.warn(
+        "deliverOutboundPayloads: sendMedia not configured for channel; dropping mediaUrl and falling back to caption",
+        {
+          channel: params.channel,
+          to: baseCtx.to,
+          mediaUrl,
+        },
+      );
       return sendText({
         ...resolveCtx(overrides),
         text: caption,
@@ -732,6 +742,7 @@ async function deliverOutboundPayloadsCore(
 
       let first = true;
       let lastMessageId: string | undefined;
+      const beforeCount = results.length;
       for (const url of payloadSummary.mediaUrls) {
         throwIfAborted(abortSignal);
         const caption = first ? payloadSummary.text : "";
@@ -741,13 +752,24 @@ async function deliverOutboundPayloadsCore(
           results.push(delivery);
           lastMessageId = delivery.messageId;
         } else {
+          if (!handler.supportsNativeMedia && !caption.trim()) {
+            log.warn(
+              "deliverOutboundPayloads: sendMedia not configured and caption empty; dropping mediaUrl without fallback",
+              {
+                channel,
+                to,
+                mediaUrl: url,
+              },
+            );
+            continue;
+          }
           const delivery = await handler.sendMedia(caption, url, sendOverrides);
           results.push(delivery);
           lastMessageId = delivery.messageId;
         }
       }
       emitMessageSent({
-        success: true,
+        success: results.length > beforeCount,
         content: payloadSummary.text,
         messageId: lastMessageId,
       });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -143,7 +143,7 @@ function createPluginHandler(
   params: ChannelHandlerParams & { outbound?: ChannelOutboundAdapter },
 ): ChannelHandler | null {
   const outbound = params.outbound;
-  if (!outbound?.sendText || !outbound?.sendMedia) {
+  if (!outbound?.sendText) {
     return null;
   }
   const baseCtx = createChannelOutboundContextBase(params);
@@ -177,12 +177,20 @@ function createPluginHandler(
         ...resolveCtx(overrides),
         text,
       }),
-    sendMedia: async (caption, mediaUrl, overrides) =>
-      sendMedia({
+    sendMedia: async (caption, mediaUrl, overrides) => {
+      if (sendMedia) {
+        return sendMedia({
+          ...resolveCtx(overrides),
+          text: caption,
+          mediaUrl,
+        });
+      }
+      // Text-only channels may omit sendMedia. Fall back to caption delivery.
+      return sendText({
         ...resolveCtx(overrides),
         text: caption,
-        mediaUrl,
-      }),
+      });
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- require only `outbound.sendText` when building plugin outbound handlers
- add runtime fallback for media payloads on text-only channels: if `sendMedia` is omitted, deliver caption text via `sendText`
- add regression tests covering both text payloads and media-caption fallback for plugins that omit `sendMedia`

## Why
`ChannelOutboundAdapter` marks `sendMedia` optional, but runtime previously required both `sendText` and `sendMedia`, causing text-only channel plugins to fail all outbound sends with "Outbound not configured". This aligns runtime behavior with the adapter type and plugin docs.

Closes #32711.

## Testing
- `pnpm exec oxfmt --check src/infra/outbound/deliver.ts src/infra/outbound/deliver.test.ts`
- `pnpm exec vitest run src/infra/outbound/deliver.test.ts`
