### PR TITLE
feat(matrix): add auto-thread-injection for same-room replies

### DIFF
--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -52,6 +52,45 @@ export function resolveSlackAutoThreadId(params: {
  * are persistent sub-channels (not ephemeral reply threads), so auto-injection
  * should always apply when the target chat matches.
  */
+/**
+ * Strip Matrix target prefixes (`matrix:`, `room:`, `channel:`) to extract
+ * the bare room ID for comparison.  Mirrors `normalizeMatrixMessagingTarget`
+ * in the Matrix plugin.
+ */
+function stripMatrixTargetPrefix(raw: string): string {
+  let s = raw.trim();
+  if (s.toLowerCase().startsWith("matrix:")) {
+    s = s.slice("matrix:".length).trim();
+  }
+  s = s.replace(/^(room|channel):/i, "").trim();
+  return s;
+}
+
+/**
+ * Auto-inject Matrix thread ID when the message tool targets the same room
+ * the session originated from.  Mirrors the Telegram auto-threading pattern:
+ * Matrix threads are persistent (like Telegram forum topics), so we do not
+ * gate on `replyToMode`.
+ */
+export function resolveMatrixAutoThreadId(params: {
+  to: string;
+  toolContext?: ChannelThreadingToolContext;
+}): string | undefined {
+  const context = params.toolContext;
+  if (!context?.currentThreadTs || !context.currentChannelId) {
+    return undefined;
+  }
+  const parsedTo = stripMatrixTargetPrefix(params.to);
+  const parsedChannel = stripMatrixTargetPrefix(context.currentChannelId);
+  if (!parsedTo || !parsedChannel) {
+    return undefined;
+  }
+  if (parsedTo.toLowerCase() !== parsedChannel.toLowerCase()) {
+    return undefined;
+  }
+  return context.currentThreadTs;
+}
+
 export function resolveTelegramAutoThreadId(params: {
   to: string;
   toolContext?: ChannelThreadingToolContext;

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { matrixPlugin } from "../../../extensions/matrix/src/channel.js";
 import { slackPlugin } from "../../../extensions/slack/src/channel.js";
 import { telegramPlugin } from "../../../extensions/telegram/src/channel.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -49,6 +50,15 @@ const telegramConfig = {
   },
 } as OpenClawConfig;
 
+const matrixConfig = {
+  channels: {
+    matrix: {
+      homeserverUrl: "https://matrix.example.org",
+      accessToken: "matrix-test",
+    },
+  },
+} as OpenClawConfig;
+
 async function runThreadingAction(params: {
   cfg: OpenClawConfig;
   actionParams: Record<string, unknown>;
@@ -81,22 +91,30 @@ const defaultTelegramToolContext = {
 } as const;
 
 let createPluginRuntime: typeof import("../../plugins/runtime/index.js").createPluginRuntime;
+let setMatrixRuntime: typeof import("../../../extensions/matrix/src/runtime.js").setMatrixRuntime;
 let setSlackRuntime: typeof import("../../../extensions/slack/src/runtime.js").setSlackRuntime;
 let setTelegramRuntime: typeof import("../../../extensions/telegram/src/runtime.js").setTelegramRuntime;
 
 describe("runMessageAction threading auto-injection", () => {
   beforeAll(async () => {
     ({ createPluginRuntime } = await import("../../plugins/runtime/index.js"));
+    ({ setMatrixRuntime } = await import("../../../extensions/matrix/src/runtime.js"));
     ({ setSlackRuntime } = await import("../../../extensions/slack/src/runtime.js"));
     ({ setTelegramRuntime } = await import("../../../extensions/telegram/src/runtime.js"));
   });
 
   beforeEach(() => {
     const runtime = createPluginRuntime();
+    setMatrixRuntime(runtime);
     setSlackRuntime(runtime);
     setTelegramRuntime(runtime);
     setActivePluginRegistry(
       createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: matrixPlugin,
+        },
         {
           pluginId: "slack",
           source: "test",
@@ -220,5 +238,69 @@ describe("runMessageAction threading auto-injection", () => {
 
     expect(call?.replyToId).toBe("777");
     expect(call?.ctx?.params?.replyTo).toBe("777");
+  });
+
+  it.each([
+    {
+      name: "injects threadId for matching room target",
+      target: "room:!abc:matrix.org",
+      expectedThreadId: "$thread-event-id",
+    },
+    {
+      name: "injects threadId for bare room id",
+      target: "!abc:matrix.org",
+      expectedThreadId: "$thread-event-id",
+    },
+    {
+      name: "injects threadId for matrix-prefixed room target",
+      target: "matrix:room:!abc:matrix.org",
+      expectedThreadId: "$thread-event-id",
+    },
+    {
+      name: "skips threadId when target room differs",
+      target: "room:!other:matrix.org",
+      expectedThreadId: undefined,
+    },
+  ] as const)("matrix auto-threading: $name", async (testCase) => {
+    mockHandledSendAction();
+
+    const call = await runThreadingAction({
+      cfg: matrixConfig,
+      actionParams: {
+        channel: "matrix",
+        target: testCase.target,
+        message: "hi",
+      },
+      toolContext: {
+        currentChannelId: "room:!abc:matrix.org",
+        currentThreadTs: "$thread-event-id",
+      },
+    });
+
+    expect(call?.ctx?.params?.threadId).toBe(testCase.expectedThreadId);
+    if (testCase.expectedThreadId !== undefined) {
+      expect(call?.threadId).toBe(testCase.expectedThreadId);
+    }
+  });
+
+  it("uses explicit matrix threadId when provided", async () => {
+    mockHandledSendAction();
+
+    const call = await runThreadingAction({
+      cfg: matrixConfig,
+      actionParams: {
+        channel: "matrix",
+        target: "room:!abc:matrix.org",
+        message: "hi",
+        threadId: "$explicit-thread",
+      },
+      toolContext: {
+        currentChannelId: "room:!abc:matrix.org",
+        currentThreadTs: "$thread-event-id",
+      },
+    });
+
+    expect(call?.threadId).toBe("$explicit-thread");
+    expect(call?.ctx?.params?.threadId).toBe("$explicit-thread");
   });
 });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -16,19 +16,14 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
-import {
-  isDeliverableMessageChannel,
-  normalizeMessageChannel,
-  type GatewayClientMode,
-  type GatewayClientName,
-} from "../../utils/message-channel.js";
+import { type GatewayClientMode, type GatewayClientName } from "../../utils/message-channel.js";
 import { throwIfAborted } from "./abort.js";
 import {
   listConfiguredMessageChannels,
   resolveMessageChannelSelection,
 } from "./channel-selection.js";
-import { applyTargetToParams } from "./channel-target.js";
 import type { OutboundSendDeps } from "./deliver.js";
+import { normalizeMessageActionInput } from "./message-action-normalization.js";
 import {
   hydrateAttachmentParamsForAction,
   normalizeSandboxMediaList,
@@ -38,10 +33,10 @@ import {
   parseComponentsParam,
   readBooleanParam,
   resolveAttachmentMediaPolicy,
+  resolveMatrixAutoThreadId,
   resolveSlackAutoThreadId,
   resolveTelegramAutoThreadId,
 } from "./message-action-params.js";
-import { actionHasTarget, actionRequiresTarget } from "./message-action-spec.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
 import {
   applyCrossContextDecoration,
@@ -82,7 +77,11 @@ function resolveAndApplyOutboundThreadId(
     ctx.channel === "telegram" && !threadId
       ? resolveTelegramAutoThreadId({ to: ctx.to, toolContext: ctx.toolContext })
       : undefined;
-  const resolved = threadId ?? slackAutoThreadId ?? telegramAutoThreadId;
+  const matrixAutoThreadId =
+    ctx.channel === "matrix" && !threadId
+      ? resolveMatrixAutoThreadId({ to: ctx.to, toolContext: ctx.toolContext })
+      : undefined;
+  const resolved = threadId ?? slackAutoThreadId ?? telegramAutoThreadId ?? matrixAutoThreadId;
   // Write auto-resolved threadId back into params so downstream dispatch
   // (plugin `readStringParam(params, "threadId")`) picks it up.
   if (resolved && !params.threadId) {
@@ -217,12 +216,19 @@ async function maybeApplyCrossContextMarker(params: {
   });
 }
 
-async function resolveChannel(cfg: OpenClawConfig, params: Record<string, unknown>) {
-  const channelHint = readStringParam(params, "channel");
+async function resolveChannel(
+  cfg: OpenClawConfig,
+  params: Record<string, unknown>,
+  toolContext?: { currentChannelProvider?: string },
+) {
   const selection = await resolveMessageChannelSelection({
     cfg,
-    channel: channelHint,
+    channel: readStringParam(params, "channel"),
+    fallbackChannel: toolContext?.currentChannelProvider,
   });
+  if (selection.source === "tool-context-fallback") {
+    params.channel = selection.channel;
+  }
   return selection.channel;
 }
 
@@ -317,7 +323,7 @@ async function handleBroadcastAction(
   }
   const targetChannels =
     channelHint && channelHint.trim().toLowerCase() !== "all"
-      ? [await resolveChannel(input.cfg, { channel: channelHint })]
+      ? [await resolveChannel(input.cfg, { channel: channelHint }, input.toolContext)]
       : configured;
   const results: Array<{
     channel: ChannelId;
@@ -695,7 +701,7 @@ export async function runMessageAction(
   input: RunMessageActionParams,
 ): Promise<MessageActionRunResult> {
   const cfg = input.cfg;
-  const params = { ...input.params };
+  let params = { ...input.params };
   const resolvedAgentId =
     input.agentId ??
     (input.sessionKey
@@ -709,52 +715,13 @@ export async function runMessageAction(
   if (action === "broadcast") {
     return handleBroadcastAction(input, params);
   }
+  params = normalizeMessageActionInput({
+    action,
+    args: params,
+    toolContext: input.toolContext,
+  });
 
-  const explicitTarget = typeof params.target === "string" ? params.target.trim() : "";
-  const hasLegacyTarget =
-    (typeof params.to === "string" && params.to.trim().length > 0) ||
-    (typeof params.channelId === "string" && params.channelId.trim().length > 0);
-  if (explicitTarget && hasLegacyTarget) {
-    delete params.to;
-    delete params.channelId;
-  }
-  if (
-    !explicitTarget &&
-    !hasLegacyTarget &&
-    actionRequiresTarget(action) &&
-    !actionHasTarget(action, params)
-  ) {
-    const inferredTarget = input.toolContext?.currentChannelId?.trim();
-    if (inferredTarget) {
-      params.target = inferredTarget;
-    }
-  }
-  if (!explicitTarget && actionRequiresTarget(action) && hasLegacyTarget) {
-    const legacyTo = typeof params.to === "string" ? params.to.trim() : "";
-    const legacyChannelId = typeof params.channelId === "string" ? params.channelId.trim() : "";
-    const legacyTarget = legacyTo || legacyChannelId;
-    if (legacyTarget) {
-      params.target = legacyTarget;
-      delete params.to;
-      delete params.channelId;
-    }
-  }
-  const explicitChannel = typeof params.channel === "string" ? params.channel.trim() : "";
-  if (!explicitChannel) {
-    const inferredChannel = normalizeMessageChannel(input.toolContext?.currentChannelProvider);
-    if (inferredChannel && isDeliverableMessageChannel(inferredChannel)) {
-      params.channel = inferredChannel;
-    }
-  }
-
-  applyTargetToParams({ action, args: params });
-  if (actionRequiresTarget(action)) {
-    if (!actionHasTarget(action, params)) {
-      throw new Error(`Action ${action} requires a target.`);
-    }
-  }
-
-  const channel = await resolveChannel(cfg, params);
+  const channel = await resolveChannel(cfg, params, input.toolContext);
   let accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;
   if (!accountId && resolvedAgentId) {
     const byAgent = buildChannelAccountBindings(cfg).get(channel);


### PR DESCRIPTION
## Summary

- Add auto-thread-injection for Matrix channel replies, matching the existing Slack and Telegram patterns
- When an agent replies to a message in a Matrix room, the reply is now automatically threaded under the original message instead of appearing as a new top-level message
- Add `resolveMatrixAutoThreadId()` that strips Matrix target prefixes (`matrix:`, `room:`, `channel:`) and compares normalized room IDs
- Wire it into `resolveAndApplyOutboundThreadId()` alongside the existing Slack and Telegram branches

## Test plan

- [x] New test: injects threadId for matching room target (`room:\!abc:matrix.org`)
- [x] New test: injects threadId for bare room id (`\!abc:matrix.org`)
- [x] New test: injects threadId for matrix-prefixed target (`matrix:room:\!abc:matrix.org`)
- [x] New test: skips threadId when target room differs
- [x] New test: explicit threadId takes precedence over auto-injection
- [x] All 12 threading tests pass (7 existing + 5 new)

Fixes #32744
