### PR TITLE
Fix #32638: Normalize reasoning_effort for Groq models

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -349,6 +349,103 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]).not.toHaveProperty("reasoning_effort");
   });
 
+  it("normalizes reasoning_effort to 'default' for Groq models with non-standard values (#32638)", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { reasoning_effort: "high" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "groq", "llama-3.3-70b-versatile", undefined, "high");
+
+    const model = {
+      api: "openai-completions",
+      provider: "groq",
+      id: "llama-3.3-70b-versatile",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.reasoning_effort).toBe("default");
+  });
+
+  it("normalizes reasoning_effort to 'none' for Groq models when thinkingLevel is 'off' (#32638)", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { reasoning_effort: "low" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "groq", "llama-3.3-70b-versatile", undefined, "off");
+
+    const model = {
+      api: "openai-completions",
+      provider: "groq",
+      id: "llama-3.3-70b-versatile",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.reasoning_effort).toBe("none");
+  });
+
+  it("preserves valid reasoning_effort values for Groq models (#32638)", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { reasoning_effort: "default" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "groq", "llama-3.3-70b-versatile", undefined, "medium");
+
+    const model = {
+      api: "openai-completions",
+      provider: "groq",
+      id: "llama-3.3-70b-versatile",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.reasoning_effort).toBe("default");
+  });
+
+  it("detects Groq models via baseUrl containing groq.com (#32638)", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { reasoning_effort: "high" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "custom", "llama-3.3-70b", undefined, "high");
+
+    const model = {
+      api: "openai-completions",
+      provider: "custom",
+      id: "llama-3.3-70b",
+      baseUrl: "https://api.groq.com/openai/v1",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.reasoning_effort).toBe("default");
+  });
+
   it("normalizes thinking=off to null for SiliconFlow Pro models", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -524,6 +524,24 @@ function mapThinkingLevelToOpenRouterReasoningEffort(
   return thinkingLevel;
 }
 
+function isGroqModel(model: { provider?: unknown; baseUrl?: unknown }): boolean {
+  if (typeof model.provider === "string" && model.provider.toLowerCase() === "groq") {
+    return true;
+  }
+  if (typeof model.baseUrl === "string") {
+    const baseUrl = model.baseUrl.toLowerCase();
+    return baseUrl.includes("groq.com") || baseUrl.includes("api.groq");
+  }
+  return false;
+}
+
+function mapThinkingLevelToGroqReasoningEffort(thinkingLevel: ThinkLevel): "none" | "default" {
+  if (thinkingLevel === "off") {
+    return "none";
+  }
+  return "default";
+}
+
 function shouldApplySiliconFlowThinkingOffCompat(params: {
   provider: string;
   modelId: string;
@@ -819,6 +837,41 @@ function createGoogleThinkingPayloadWrapper(
   };
 }
 
+function createGroqReasoningWrapper(
+  baseStreamFn: StreamFn | undefined,
+  thinkingLevel?: ThinkLevel,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (!isGroqModel(model)) {
+      return underlying(model, context, options);
+    }
+
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          const payloadObj = payload as Record<string, unknown>;
+          if ("reasoning_effort" in payloadObj) {
+            const currentValue = payloadObj.reasoning_effort;
+            if (currentValue !== "none" && currentValue !== "default") {
+              const normalized = thinkingLevel
+                ? mapThinkingLevelToGroqReasoningEffort(thinkingLevel)
+                : "default";
+              payloadObj.reasoning_effort = normalized;
+              log.debug(
+                `normalized Groq reasoning_effort from "${currentValue}" to "${normalized}" (${model.id})`,
+              );
+            }
+          }
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
 /**
  * Create a streamFn wrapper that injects tool_stream=true for Z.AI providers.
  *
@@ -959,6 +1012,10 @@ export function applyExtraParamsToAgent(
   // Guard Google payloads against invalid negative thinking budgets emitted by
   // upstream model-ID heuristics for Gemini 3.1 variants.
   agent.streamFn = createGoogleThinkingPayloadWrapper(agent.streamFn, thinkingLevel);
+
+  // Normalize reasoning_effort for Groq models to "none" or "default".
+  // See: openclaw/openclaw#32638
+  agent.streamFn = createGroqReasoningWrapper(agent.streamFn, thinkingLevel);
 
   // Work around upstream pi-ai hardcoding `store: false` for Responses API.
   // Force `store=true` for direct OpenAI Responses models and auto-enable

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -530,7 +530,7 @@ function isGroqModel(model: { provider?: unknown; baseUrl?: unknown }): boolean 
   }
   if (typeof model.baseUrl === "string") {
     const baseUrl = model.baseUrl.toLowerCase();
-    return baseUrl.includes("groq.com") || baseUrl.includes("api.groq");
+    return baseUrl.includes("groq.com") || baseUrl.includes(".groq.");
   }
   return false;
 }
@@ -861,7 +861,13 @@ function createGroqReasoningWrapper(
                 : "default";
               payloadObj.reasoning_effort = normalized;
               log.debug(
-                `normalized Groq reasoning_effort from "${currentValue}" to "${normalized}" (${model.id})`,
+                `normalized Groq reasoning_effort from "${String(currentValue)}" to "${String(normalized)}" (${model.id})`,
+              );
+            } else if (thinkingLevel === "off" && currentValue !== "none") {
+              // Ensure thinkingLevel="off" always results in "none"
+              payloadObj.reasoning_effort = "none";
+              log.debug(
+                `normalized Groq reasoning_effort from "${currentValue}" to "none" (${model.id})`,
               );
             }
           }


### PR DESCRIPTION
Fixes #32638: Groq + reasoning models fail with 400

Groq only accepts 'none' or 'default' for reasoning_effort, but OpenClaw passes values like 'low', 'medium'. This PR normalizes reasoning_effort values for Groq models.

Changes:
- Add isGroqModel() helper to detect Groq by provider or baseUrl
- Add mapThinkingLevelToGroqReasoningEffort() to normalize values
- Create wrapper to apply normalization at runtime
- Add 4 comprehensive tests

Tested: All 51 tests pass (47 existing + 4 new)