### PR TITLE
Fix #32678: Feishu plugin bindings configuration

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1230,6 +1230,72 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("passes guildId to resolveAgentRoute for group messages", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-group-user" } },
+      message: {
+        message_id: "msg-guild-id-test",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "group message" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockResolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guildId: "oc-group",
+      }),
+    );
+  });
+
+  it("passes undefined guildId to resolveAgentRoute for DM messages", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-dm-user" } },
+      message: {
+        message_id: "msg-guild-id-dm-test",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "dm message" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockResolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guildId: undefined,
+      }),
+    );
+  });
+
   it("keeps root_id as topic key when root_id and thread_id both exist", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1172,6 +1172,7 @@ export async function handleFeishuMessage(params: {
         id: peerId,
       },
       parentPeer,
+      guildId: isGroup ? ctx.chatId : undefined,
     });
 
     // Dynamic agent creation for DM users


### PR DESCRIPTION
Fixes #32678: Feishu plugin bindings configuration not working - all messages routed to main agent

The bindings configuration allows routing specific Feishu groups to specific agents, but this wasn't working because guildId wasn't being passed to resolveAgentRoute.

Changes:
- Add guildId parameter to resolveAgentRoute call in Feishu bot.ts
- Pass chat_id as guildId for group messages

Now users can configure bindings like:
```json
{
  "bindings": [{
    "agentId": "custom-agent",
    "match": { "channel": "feishu", "guildId": "oc_xxxxxxxxxxxxx" }
  }]
}
```