### PR TITLE
Fix skills.entries.<key>.enabled: true to override requires.bins (#32752)

### DIFF
--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -83,6 +83,10 @@ export function shouldIncludeSkill(params: {
   if (!isBundledSkillAllowed(entry, allowBundled)) {
     return false;
   }
+  // Force-enable when explicitly set; symmetric with enabled: false (fixes #32752).
+  if (skillConfig?.enabled === true) {
+    return true;
+  }
   return evaluateRuntimeEligibility({
     os: entry.metadata?.os,
     remotePlatforms: eligibility?.remote?.platforms,


### PR DESCRIPTION
Fixes #32752

## Summary

Allow `skills.entries.<key>.enabled: true` to force-include a skill and skip runtime eligibility (e.g. `requires.bins` on the gateway host). Behavior is now symmetric with `enabled: false`, which already force-disables regardless of requirements.

## Changes

- In `shouldIncludeSkill()` (`src/agents/skills/config.ts`), after the allowlist check, if `skillConfig?.enabled === true` return `true` so we do not call `evaluateRuntimeEligibility()`. Thus explicit `enabled: true` overrides `requires.bins` / env / config checks that run only on the gateway host.
- Entries that do not set `enabled` (undefined) are unchanged: they still go through `evaluateRuntimeEligibility()`.

## Impact

- Deployments where the skill’s binary exists in the sandbox (or sidecar) but not on the gateway host can set `enabled: true` for that skill and have it included without placing a dummy binary on the host.
- No behavior change for skills without `enabled` or with `enabled: false`.

## Testing

- `pnpm test src/agents/skills --run` (22 files, 80 tests passed).