### PR TITLE
slack: harden stream-mode edge-case tests

### DIFF
--- a/src/slack/stream-mode.test.ts
+++ b/src/slack/stream-mode.test.ts
@@ -115,6 +115,41 @@ describe("applyAppendOnlyStreamUpdate", () => {
       changed: true,
     });
   });
+
+  it("ignores incoming chunks that are empty after trimEnd", () => {
+    const next = applyAppendOnlyStreamUpdate({
+      incoming: "   \n\t  ",
+      rendered: "hello",
+      source: "hello",
+    });
+    expect(next).toEqual({ rendered: "hello", source: "hello", changed: false });
+  });
+
+  it("uses rendered prefix when incoming extends rendered text", () => {
+    const next = applyAppendOnlyStreamUpdate({
+      incoming: "hello world!!!",
+      rendered: "hello world",
+      source: "hello",
+    });
+    expect(next).toEqual({
+      rendered: "hello world!!!",
+      source: "hello world!!!",
+      changed: true,
+    });
+  });
+
+  it("does not insert extra newline when rendered already ends with newline", () => {
+    const next = applyAppendOnlyStreamUpdate({
+      incoming: "second line",
+      rendered: "first line\n",
+      source: "first line",
+    });
+    expect(next).toEqual({
+      rendered: "first line\nsecond line",
+      source: "second line",
+      changed: true,
+    });
+  });
 });
 
 describe("buildStatusFinalPreviewText", () => {
@@ -122,5 +157,14 @@ describe("buildStatusFinalPreviewText", () => {
     expect(buildStatusFinalPreviewText(1)).toBe("Status: thinking..");
     expect(buildStatusFinalPreviewText(2)).toBe("Status: thinking...");
     expect(buildStatusFinalPreviewText(3)).toBe("Status: thinking.");
+  });
+
+  it("handles zero and large update counts consistently", () => {
+    // 0 is clamped to 1
+    expect(buildStatusFinalPreviewText(0)).toBe("Status: thinking..");
+    // 4 -> 4 % 3 = 1 -> two dots
+    expect(buildStatusFinalPreviewText(4)).toBe("Status: thinking..");
+    // 5 -> 5 % 3 = 2 -> three dots
+    expect(buildStatusFinalPreviewText(5)).toBe("Status: thinking...");
   });
 });

--- a/src/slack/stream-mode.test.ts
+++ b/src/slack/stream-mode.test.ts
@@ -129,7 +129,7 @@ describe("applyAppendOnlyStreamUpdate", () => {
     const next = applyAppendOnlyStreamUpdate({
       incoming: "hello world!!!",
       rendered: "hello world",
-      source: "hello",
+      source: "not-a-prefix",
     });
     expect(next).toEqual({
       rendered: "hello world!!!",


### PR DESCRIPTION
## Summary

Tightens edge-case test coverage for Slack `stream-mode` helpers to prevent regressions in streaming preview behavior.

- Adds append-only streaming tests for:
  - trimming/ignoring whitespace-only partials,
  - extending `rendered` content via cumulative incoming text,
  - avoiding extra newlines when `rendered` already ends with `\n`.
- Expands `status_final` preview tests to cover `updateCount = 0` and larger counts (e.g. 4, 5) to lock in the dot-cycling behavior.

## Type

- [x] Tests only (no runtime behavior change)