### PR TITLE
Discord: accept inline /acp action args via autocomplete

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -322,6 +322,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
           name: "action",
           description: "Action to run",
           type: "string",
+          preferAutocomplete: true,
           choices: [
             "spawn",
             "cancel",

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -31,6 +31,7 @@ export type CommandArgDefinition = {
   type: CommandArgType;
   required?: boolean;
   choices?: CommandArgChoice[] | CommandArgChoicesProvider;
+  preferAutocomplete?: boolean;
   captureRemaining?: boolean;
 };
 

--- a/src/discord/monitor/native-command.options.test.ts
+++ b/src/discord/monitor/native-command.options.test.ts
@@ -24,22 +24,46 @@ function createNativeCommand(name: string): ReturnType<typeof createDiscordNativ
   });
 }
 
+type CommandOption = NonNullable<ReturnType<typeof createDiscordNativeCommand>["options"]>[number];
+
+function findOption(
+  command: ReturnType<typeof createDiscordNativeCommand>,
+  name: string,
+): CommandOption | undefined {
+  return command.options?.find((entry) => entry.name === name);
+}
+
+function readAutocomplete(option: CommandOption | undefined): unknown {
+  if (!option || typeof option !== "object") {
+    return undefined;
+  }
+  return (option as { autocomplete?: unknown }).autocomplete;
+}
+
+function readChoices(option: CommandOption | undefined): unknown[] | undefined {
+  if (!option || typeof option !== "object") {
+    return undefined;
+  }
+  const value = (option as { choices?: unknown }).choices;
+  return Array.isArray(value) ? value : undefined;
+}
+
 describe("createDiscordNativeCommand option wiring", () => {
   it("uses autocomplete for /acp action so inline action values are accepted", () => {
     const command = createNativeCommand("acp");
-    const action = command.options?.find((option) => option.name === "action");
+    const action = findOption(command, "action");
 
     expect(action).toBeDefined();
-    expect(typeof action?.autocomplete).toBe("function");
-    expect(action?.choices).toBeUndefined();
+    expect(typeof readAutocomplete(action)).toBe("function");
+    expect(readChoices(action)).toBeUndefined();
   });
 
   it("keeps static choices for non-acp string action arguments", () => {
     const command = createNativeCommand("voice");
-    const action = command.options?.find((option) => option.name === "action");
+    const action = findOption(command, "action");
 
     expect(action).toBeDefined();
-    expect(action?.autocomplete).toBeUndefined();
-    expect(action?.choices?.length).toBeGreaterThan(0);
+    expect(readAutocomplete(action)).toBeUndefined();
+    expect(readChoices(action)?.length).toBeGreaterThan(0);
   });
 });

--- a/src/discord/monitor/native-command.options.test.ts
+++ b/src/discord/monitor/native-command.options.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { listNativeCommandSpecs } from "../../auto-reply/commands-registry.js";
+import type { OpenClawConfig, loadConfig } from "../../config/config.js";
+import { createDiscordNativeCommand } from "./native-command.js";
+import { createNoopThreadBindingManager } from "./thread-bindings.js";
+
+function createNativeCommand(name: string): ReturnType<typeof createDiscordNativeCommand> {
+  const command = listNativeCommandSpecs({ provider: "discord" }).find(
+    (entry) => entry.name === name,
+  );
+  if (!command) {
+    throw new Error(`missing native command: ${name}`);
+  }
+  const cfg = {} as ReturnType<typeof loadConfig>;
+  const discordConfig = {} as NonNullable<OpenClawConfig["channels"]>["discord"];
+  return createDiscordNativeCommand({
+    command,
+    cfg,
+    discordConfig,
+    accountId: "default",
+    sessionPrefix: "discord:slash",
+    ephemeralDefault: true,
+    threadBindings: createNoopThreadBindingManager("default"),
+  });
+}
+
+describe("createDiscordNativeCommand option wiring", () => {
+  it("uses autocomplete for /acp action so inline action values are accepted", () => {
+    const command = createNativeCommand("acp");
+    const action = command.options?.find((option) => option.name === "action");
+
+    expect(action).toBeDefined();
+    expect(typeof action?.autocomplete).toBe("function");
+    expect(action?.choices).toBeUndefined();
+  });
+
+  it("keeps static choices for non-acp string action arguments", () => {
+    const command = createNativeCommand("voice");
+    const action = command.options?.find((option) => option.name === "action");
+
+    expect(action).toBeDefined();
+    expect(action?.autocomplete).toBeUndefined();
+    expect(action?.choices?.length).toBeGreaterThan(0);
+  });
+});

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -115,9 +115,8 @@ function buildDiscordCommandOptions(params: {
       };
     }
     const resolvedChoices = resolveCommandArgChoices({ command, arg, cfg });
-    const isAcpActionArg = command.key === "acp" && arg.name === "action";
     const shouldAutocomplete =
-      isAcpActionArg ||
+      arg.preferAutocomplete === true ||
       (resolvedChoices.length > 0 &&
         (typeof arg.choices === "function" || resolvedChoices.length > 25));
     const autocomplete = shouldAutocomplete

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -115,9 +115,11 @@ function buildDiscordCommandOptions(params: {
       };
     }
     const resolvedChoices = resolveCommandArgChoices({ command, arg, cfg });
+    const isAcpActionArg = command.key === "acp" && arg.name === "action";
     const shouldAutocomplete =
-      resolvedChoices.length > 0 &&
-      (typeof arg.choices === "function" || resolvedChoices.length > 25);
+      isAcpActionArg ||
+      (resolvedChoices.length > 0 &&
+        (typeof arg.choices === "function" || resolvedChoices.length > 25));
     const autocomplete = shouldAutocomplete
       ? async (interaction: AutocompleteInteraction) => {
           const focused = interaction.options.getFocused();


### PR DESCRIPTION
## Summary
- switch Discord `/acp` `action` option wiring from static choices to autocomplete
- keep existing choice suggestions while allowing inline typed values (for example `/acp close`)
- add tests verifying `/acp` uses autocomplete and non-ACP action args still use static choices

## Why
With static choices on `/acp action`, Discord can return `action=null` when users type inline without selecting from the dropdown, which triggers the fallback button menu. Using autocomplete preserves suggestions but allows direct inline action input.

Closes #32753.

## Testing
- `pnpm exec oxfmt --check src/discord/monitor/native-command.ts src/discord/monitor/native-command.options.test.ts`
- `pnpm exec vitest run src/discord/monitor/native-command.options.test.ts`
