### PR TITLE
fix(outbound): make sendMedia optional for channel plugins

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -826,6 +826,124 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("supports text-only plugin outbound adapters that omit sendMedia", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "line", messageId: "ln-text-1" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "hello from text-only plugin" }],
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "hello from text-only plugin" }),
+    );
+    expect(results).toEqual([{ channel: "line", messageId: "ln-text-1" }]);
+  });
+
+  it("falls back to sendText for media payloads when plugin sendMedia is omitted", async () => {
+    const sendText = vi
+      .fn()
+      .mockResolvedValue({ channel: "line", messageId: "ln-media-fallback-1" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "media caption", mediaUrl: "https://example.com/a.png" }],
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith(expect.objectContaining({ text: "media caption" }));
+    expect(results).toEqual([{ channel: "line", messageId: "ln-media-fallback-1" }]);
+  });
+
+  it("uses mediaUrl as text when caption is empty on sendMedia fallback", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "line", messageId: "ln-media-url-1" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "", mediaUrl: "https://example.com/photo.jpg" }],
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "https://example.com/photo.jpg" }),
+    );
+    expect(results).toEqual([{ channel: "line", messageId: "ln-media-url-1" }]);
+  });
+
+  it("logs a warning when media payload degrades to sendText fallback", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "line", messageId: "ln-warn-1" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "caption", mediaUrl: "https://example.com/a.png" }],
+    });
+
+    expect(logMocks.warn).toHaveBeenCalledWith(
+      "plugin sendMedia not defined; degrading media payload to sendText",
+      expect.objectContaining({
+        channel: "line",
+        mediaUrl: "https://example.com/a.png",
+      }),
+    );
+  });
+
   it("emits message_sent success for sendPayload deliveries", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -880,7 +880,9 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(sendText).toHaveBeenCalledTimes(1);
-    expect(sendText).toHaveBeenCalledWith(expect.objectContaining({ text: "media caption" }));
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "media caption\nhttps://example.com/a.png" }),
+    );
     expect(results).toEqual([{ channel: "line", messageId: "ln-media-fallback-1" }]);
   });
 
@@ -936,11 +938,8 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(logMocks.warn).toHaveBeenCalledWith(
-      "plugin sendMedia not defined; degrading media payload to sendText",
-      expect.objectContaining({
-        channel: "line",
-        mediaUrl: "https://example.com/a.png",
-      }),
+      "plugin sendMedia not defined; degrading media payloads to sendText",
+      expect.objectContaining({ channel: "line" }),
     );
   });
 

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -184,17 +184,26 @@ function createPluginHandler(
             text: caption,
             mediaUrl,
           })
-      : async (caption, mediaUrl, overrides) => {
-          log.warn("plugin sendMedia not defined; degrading media payload to sendText", {
-            channel: params.channel,
-            mediaUrl,
-          });
-          const text = caption || mediaUrl;
-          return sendText({
-            ...resolveCtx(overrides),
-            text,
-          });
-        },
+      : (() => {
+          let warnedOnce = false;
+          return async (
+            caption: string,
+            mediaUrl: string,
+            overrides?: { replyToId?: string | null; threadId?: string | number | null },
+          ) => {
+            if (!warnedOnce) {
+              warnedOnce = true;
+              log.warn("plugin sendMedia not defined; degrading media payloads to sendText", {
+                channel: params.channel,
+              });
+            }
+            const text = caption ? `${caption}\n${mediaUrl}` : mediaUrl;
+            return sendText({
+              ...resolveCtx(overrides),
+              text,
+            });
+          };
+        })(),
   };
 }
 

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -143,7 +143,7 @@ function createPluginHandler(
   params: ChannelHandlerParams & { outbound?: ChannelOutboundAdapter },
 ): ChannelHandler | null {
   const outbound = params.outbound;
-  if (!outbound?.sendText || !outbound?.sendMedia) {
+  if (!outbound?.sendText) {
     return null;
   }
   const baseCtx = createChannelOutboundContextBase(params);
@@ -177,12 +177,24 @@ function createPluginHandler(
         ...resolveCtx(overrides),
         text,
       }),
-    sendMedia: async (caption, mediaUrl, overrides) =>
-      sendMedia({
-        ...resolveCtx(overrides),
-        text: caption,
-        mediaUrl,
-      }),
+    sendMedia: sendMedia
+      ? async (caption, mediaUrl, overrides) =>
+          sendMedia({
+            ...resolveCtx(overrides),
+            text: caption,
+            mediaUrl,
+          })
+      : async (caption, mediaUrl, overrides) => {
+          log.warn("plugin sendMedia not defined; degrading media payload to sendText", {
+            channel: params.channel,
+            mediaUrl,
+          });
+          const text = caption || mediaUrl;
+          return sendText({
+            ...resolveCtx(overrides),
+            text,
+          });
+        },
   };
 }
 


### PR DESCRIPTION
### Summary

This PR fixes an issue where `createPluginHandler` crashes at runtime for channel plugins that only implement `sendText` without `sendMedia`.

### Root Cause

In `src/infra/outbound/deliver.ts`, the `createPluginHandler` function guards on both `sendText` and `sendMedia`:

```ts
if (!outbound?.sendText || !outbound?.sendMedia) {
  return null;
}
```

However, the `ChannelOutboundAdapter` type definition in `src/channels/plugins/types.adapters.ts` declares `sendMedia` as **optional** (`sendMedia?: ...`). This means a plugin that legitimately omits `sendMedia` (e.g. a text-only notification channel) will cause `createPluginHandler` to return `null`, which then throws `"Outbound not configured for channel: ${channel}"` — even though the plugin is properly registered.

### Solution

- Relax the guard in `createPluginHandler` to only require `sendText`. Plugins that omit `sendMedia` are now accepted.
- When `sendMedia` is not defined, provide a graceful fallback that delegates media payloads to `sendText`. If the caption is non-empty, it is used as the text; if the caption is empty (media-only payload), the `mediaUrl` itself is used as the text to avoid sending blank messages.
- Emit a `log.warn` each time the fallback is triggered, so operators can diagnose degraded media delivery without it being a silent failure.
- Add four regression tests covering: text-only plugin delivery, media-with-caption fallback, media-only (empty caption) fallback, and warning log emission.

### Changed Files

| File | Change |
|---|---|
| `src/infra/outbound/deliver.ts` | Relax `createPluginHandler` guard to only require `sendText`; add `sendMedia` → `sendText` fallback with `log.warn` |
| `src/infra/outbound/deliver.test.ts` | Add 4 new test cases for text-only plugin, media fallback, media-only fallback, and warning log |

### Fixes

Fixes #32711

