### PR TITLE
fix(gateway): include disk-only agents in session store scan

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import {
@@ -10,6 +10,7 @@ import {
   deriveSessionTitle,
   listAgentsForGateway,
   listSessionsFromStore,
+  loadCombinedSessionStoreForGateway,
   parseGroupKey,
   pruneLegacyStoreKeys,
   resolveGatewaySessionStoreTarget,
@@ -744,5 +745,65 @@ describe("listSessionsFromStore search", () => {
     expect(stale?.totalTokensFresh).toBe(false);
     expect(missing?.totalTokens).toBeUndefined();
     expect(missing?.totalTokensFresh).toBe(false);
+  });
+});
+
+describe("loadCombinedSessionStoreForGateway (#32804)", () => {
+  const savedStateDir = process.env.OPENCLAW_STATE_DIR;
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    if (savedStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = savedStateDir;
+    }
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("includes sessions from disk-only agents when agents.list is configured", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "session-utils-acp-"));
+    tempDirs.push(root);
+
+    // Set up state dir with two agent dirs: "main" (configured) and "codex" (ACP-spawned, disk-only).
+    process.env.OPENCLAW_STATE_DIR = root;
+    const mainStore = path.join(root, "agents", "main", "sessions", "sessions.json");
+    const codexStore = path.join(root, "agents", "codex", "sessions", "sessions.json");
+    fs.mkdirSync(path.dirname(mainStore), { recursive: true });
+    fs.mkdirSync(path.dirname(codexStore), { recursive: true });
+
+    const now = Date.now();
+    fs.writeFileSync(
+      mainStore,
+      JSON.stringify({
+        work: { sessionId: "sess-main", updatedAt: now },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      codexStore,
+      JSON.stringify({
+        "acp-task-1": { sessionId: "sess-acp", updatedAt: now - 1000 },
+      }),
+      "utf8",
+    );
+
+    const cfg = {
+      session: {
+        mainKey: "main",
+        store: path.join(root, "agents", "{agentId}", "sessions", "sessions.json"),
+      },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+
+    const result = loadCombinedSessionStoreForGateway(cfg);
+
+    // The "codex" agent is only on disk (not in agents.list), but its sessions
+    // must still appear in the combined store.  (#32804)
+    const keys = Object.keys(result.store);
+    expect(keys).toContain("agent:main:work");
+    expect(keys).toContain("agent:codex:acp-task-1");
   });
 });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -310,35 +310,27 @@ function listExistingAgentIdsFromDisk(): string[] {
 }
 
 function listConfiguredAgentIds(cfg: OpenClawConfig): string[] {
-  const agents = cfg.agents?.list ?? [];
-  if (agents.length > 0) {
-    const ids = new Set<string>();
-    for (const entry of agents) {
-      if (entry?.id) {
-        ids.add(normalizeAgentId(entry.id));
-      }
-    }
-    const defaultId = normalizeAgentId(resolveDefaultAgentId(cfg));
-    ids.add(defaultId);
-    const sorted = Array.from(ids).filter(Boolean);
-    sorted.sort((a, b) => a.localeCompare(b));
-    return sorted.includes(defaultId)
-      ? [defaultId, ...sorted.filter((id) => id !== defaultId)]
-      : sorted;
-  }
-
   const ids = new Set<string>();
   const defaultId = normalizeAgentId(resolveDefaultAgentId(cfg));
   ids.add(defaultId);
+
+  // Always include configured agents.
+  for (const entry of cfg.agents?.list ?? []) {
+    if (entry?.id) {
+      ids.add(normalizeAgentId(entry.id));
+    }
+  }
+
+  // Always include agents that exist on disk (covers ACP-spawned agent dirs).
   for (const id of listExistingAgentIdsFromDisk()) {
     ids.add(id);
   }
+
   const sorted = Array.from(ids).filter(Boolean);
   sorted.sort((a, b) => a.localeCompare(b));
-  if (sorted.includes(defaultId)) {
-    return [defaultId, ...sorted.filter((id) => id !== defaultId)];
-  }
-  return sorted;
+  return sorted.includes(defaultId)
+    ? [defaultId, ...sorted.filter((id) => id !== defaultId)]
+    : sorted;
 }
 
 export function listAgentsForGateway(cfg: OpenClawConfig): {


### PR DESCRIPTION
## Summary

Fixes #32804.

`listConfiguredAgentIds()` had an early-return branch when `agents.list` was populated — it returned **only** config IDs and the default, skipping the `listExistingAgentIdsFromDisk()` scan entirely. ACP-spawned agent directories (e.g. `agents/codex/`) were never discovered, making their sessions invisible to `sessions_list` and `loadCombinedSessionStoreForGateway`.

**Fix:** Remove the branching and always merge both sources (config list + disk scan) unconditionally.

## What changed

- `src/gateway/session-utils.ts` — Simplified `listConfiguredAgentIds()` to always merge configured IDs with disk-scanned IDs (was two branches, now one linear flow)
- `src/gateway/session-utils.test.ts` — Added integration test that sets up a disk-only agent dir (simulating ACP spawn) alongside a configured agent, and verifies `loadCombinedSessionStoreForGateway` picks up sessions from both

## What did NOT change

- `listAgentsForGateway()` — still filters by `allowedIds` for the agents API response (separate concern from session visibility)
- `loadCombinedSessionStoreForGateway()` — no changes needed, it already iterates `listConfiguredAgentIds()` correctly
- No changes to ACP dispatch, session key resolution, or store path templates

## Test plan

- [x] Existing 43 gateway/session-utils tests pass
- [x] New test verifies disk-only agent sessions appear in combined store when `agents.list` is configured