### PR TITLE
Fix resolveBrowserBaseUrl host case so browser tool works in embedded agent (#32814)

### DIFF
--- a/src/agents/tools/browser-tool.test.ts
+++ b/src/agents/tools/browser-tool.test.ts
@@ -96,6 +96,9 @@ vi.mock("./common.js", async () => {
 import { DEFAULT_AI_SNAPSHOT_MAX_CHARS } from "../../browser/constants.js";
 import { createBrowserTool } from "./browser-tool.js";
 
+/** Host base URL when no sandbox bridge is set (from resolveBrowserConfig mock controlPort: 18791). */
+const EXPECTED_HOST_BASE_URL = "http://127.0.0.1:18791";
+
 function mockSingleBrowserProxyNode() {
   nodesUtilsMocks.listNodes.mockResolvedValue([
     {
@@ -137,7 +140,7 @@ describe("browser tool snapshot maxChars", () => {
     await runSnapshotToolCall({ snapshotFormat: "ai" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      EXPECTED_HOST_BASE_URL,
       expect.objectContaining({
         format: "ai",
         maxChars: DEFAULT_AI_SNAPSHOT_MAX_CHARS,
@@ -155,7 +158,7 @@ describe("browser tool snapshot maxChars", () => {
     });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      EXPECTED_HOST_BASE_URL,
       expect.objectContaining({
         maxChars: override,
       }),
@@ -181,7 +184,7 @@ describe("browser tool snapshot maxChars", () => {
     const tool = createBrowserTool();
     await tool.execute?.("call-1", { action: "profiles" });
 
-    expect(browserClientMocks.browserProfiles).toHaveBeenCalledWith(undefined);
+    expect(browserClientMocks.browserProfiles).toHaveBeenCalledWith(EXPECTED_HOST_BASE_URL);
   });
 
   it("passes refs mode through to browser snapshot", async () => {
@@ -189,7 +192,7 @@ describe("browser tool snapshot maxChars", () => {
     await tool.execute?.("call-1", { action: "snapshot", snapshotFormat: "ai", refs: "aria" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      EXPECTED_HOST_BASE_URL,
       expect.objectContaining({
         format: "ai",
         refs: "aria",
@@ -204,7 +207,7 @@ describe("browser tool snapshot maxChars", () => {
     await runSnapshotToolCall({ snapshotFormat: "ai" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      EXPECTED_HOST_BASE_URL,
       expect.objectContaining({
         mode: "efficient",
       }),
@@ -230,7 +233,7 @@ describe("browser tool snapshot maxChars", () => {
     await tool.execute?.("call-1", { action: "snapshot", profile: "chrome", snapshotFormat: "ai" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      EXPECTED_HOST_BASE_URL,
       expect.objectContaining({
         profile: "chrome",
       }),
@@ -271,7 +274,7 @@ describe("browser tool snapshot maxChars", () => {
     await tool.execute?.("call-1", { action: "status", profile: "chrome" });
 
     expect(browserClientMocks.browserStatus).toHaveBeenCalledWith(
-      undefined,
+      EXPECTED_HOST_BASE_URL,
       expect.objectContaining({ profile: "chrome" }),
     );
     expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
@@ -286,7 +289,7 @@ describe("browser tool url alias support", () => {
     await tool.execute?.("call-1", { action: "open", url: "https://example.com" });
 
     expect(browserClientMocks.browserOpenTab).toHaveBeenCalledWith(
-      undefined,
+      EXPECTED_HOST_BASE_URL,
       "https://example.com",
       expect.objectContaining({ profile: undefined }),
     );
@@ -301,7 +304,7 @@ describe("browser tool url alias support", () => {
     });
 
     expect(browserActionsMocks.browserNavigate).toHaveBeenCalledWith(
-      undefined,
+      EXPECTED_HOST_BASE_URL,
       expect.objectContaining({
         url: "https://example.com",
         targetId: "tab-1",
@@ -334,7 +337,7 @@ describe("browser tool act compatibility", () => {
     });
 
     expect(browserActionsMocks.browserAct).toHaveBeenCalledWith(
-      undefined,
+      EXPECTED_HOST_BASE_URL,
       expect.objectContaining({
         kind: "type",
         ref: "f1e3",
@@ -360,7 +363,7 @@ describe("browser tool act compatibility", () => {
     });
 
     expect(browserActionsMocks.browserAct).toHaveBeenCalledWith(
-      undefined,
+      EXPECTED_HOST_BASE_URL,
       {
         kind: "press",
         key: "Enter",
@@ -547,13 +550,13 @@ describe("browser tool act stale target recovery", () => {
     expect(browserActionsMocks.browserAct).toHaveBeenCalledTimes(2);
     expect(browserActionsMocks.browserAct).toHaveBeenNthCalledWith(
       1,
-      undefined,
+      EXPECTED_HOST_BASE_URL,
       expect.objectContaining({ targetId: "stale-tab", action: "click", ref: "btn-1" }),
       expect.objectContaining({ profile: "chrome" }),
     );
     expect(browserActionsMocks.browserAct).toHaveBeenNthCalledWith(
       2,
-      undefined,
+      EXPECTED_HOST_BASE_URL,
       expect.not.objectContaining({ targetId: expect.anything() }),
       expect.objectContaining({ profile: "chrome" }),
     );

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -269,7 +269,7 @@ function resolveBrowserBaseUrl(params: {
       "Browser control is disabled. Set browser.enabled=true in ~/.openclaw/openclaw.json.",
     );
   }
-  return undefined;
+  return `http://127.0.0.1:${resolved.controlPort}`;
 }
 
 export function createBrowserTool(opts?: {


### PR DESCRIPTION
Fixes #32814

## Summary

When the browser tool runs with `target="host"` (default when no sandbox bridge is set), `resolveBrowserBaseUrl` was returning `undefined` instead of the host control URL. The client then called `browserStatus(undefined, ...)` and similar, leading to invalid requests and a 15s timeout: "Can't reach the OpenClaw browser control service (timed out after 15000ms)".

## Changes

- **`src/agents/tools/browser-tool.ts`**: In `resolveBrowserBaseUrl`, return `http://127.0.0.1:${resolved.controlPort}` for the host case after the policy/enabled checks, instead of `return undefined`.
- **`src/agents/tools/browser-tool.test.ts`**: Add `EXPECTED_HOST_BASE_URL` and update all tests that previously expected `undefined` as the first (baseUrl) argument to expect the resolved host URL, so tests assert the fixed behavior.

## Impact

- Embedded agent browser tool (e.g. `browser(action="status")`) now works when targeting the host; no more 15s timeout.
- CLI and other code paths unchanged.

## Testing

- `pnpm test src/agents/tools/browser-tool --run` — 21 tests passed.