### PR TITLE
fix(agents): prevent stale baseUrl in models.json from overwriting Moonshot CN endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Moonshot CN endpoint: prevent stale `api.moonshot.ai` baseUrl in `models.json` from overwriting user-configured `api.moonshot.cn` URL on subsequent runs; also thread explicit `baseUrl` through implicit provider build so the CN endpoint is used consistently from first write. (#32607)
+- Agents/HuggingFace provider: fix falsy guard for undefined apiKey in `buildHuggingfaceProvider` that caused a potential TypeError via unchecked `!` assertions.
+- Agents/Ollama constants: remove redundant `OLLAMA_BASE_URL` alias that shadowed the imported `OLLAMA_NATIVE_BASE_URL` constant.
+
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.
 - Gateway/status self version reporting: make Gateway self version in `openclaw status` prefer runtime `VERSION` (while preserving explicit `OPENCLAW_VERSION` override), preventing stale post-upgrade app version output. (#32655) thanks @liuxiaopai-ai.

--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -207,7 +207,7 @@ describe("models-config", () => {
     });
   });
 
-  it("preserves non-empty agent apiKey/baseUrl for matching providers in merge mode", async () => {
+  it("preserves non-empty agent apiKey for matching providers in merge mode", async () => {
     await withTempHome(async () => {
       const parsed = await runCustomProviderMergeTest({
         baseUrl: "https://agent.example/v1",
@@ -216,7 +216,8 @@ describe("models-config", () => {
         models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
       });
       expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
-      expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
+      // baseUrl comes from current config, not from stale models.json
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
     });
   });
 
@@ -230,6 +231,46 @@ describe("models-config", () => {
       });
       expect(parsed.providers.custom?.apiKey).toBe("CONFIG_KEY");
       expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
+    });
+  });
+
+  it("preserves moonshot CN baseUrl across ensureOpenClawModelsJson re-runs", async () => {
+    await withTempHome(async () => {
+      await withEnvVar("MOONSHOT_API_KEY", "sk-moonshot-cn-test", async () => {
+        const cnCfg: OpenClawConfig = {
+          models: {
+            providers: {
+              moonshot: {
+                baseUrl: "https://api.moonshot.cn/v1",
+                api: "openai-completions",
+                models: [],
+              },
+            },
+          },
+        };
+
+        // First run: write models.json with CN baseUrl
+        await ensureOpenClawModelsJson(cnCfg);
+
+        // Second run: simulate stale models.json with international URL
+        await writeAgentModelsJson({
+          providers: {
+            moonshot: {
+              baseUrl: "https://api.moonshot.ai/v1",
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        });
+
+        // Re-run: CN baseUrl from config must NOT be overwritten by stale models.json
+        await ensureOpenClawModelsJson(cnCfg);
+
+        const parsed = await readGeneratedModelsJson<{
+          providers: Record<string, { baseUrl?: string }>;
+        }>();
+        expect(parsed.providers.moonshot?.baseUrl).toBe("https://api.moonshot.cn/v1");
+      });
     });
   });
 

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -142,8 +142,7 @@ const QWEN_PORTAL_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
-const OLLAMA_BASE_URL = OLLAMA_NATIVE_BASE_URL;
-const OLLAMA_API_BASE_URL = OLLAMA_BASE_URL;
+const OLLAMA_API_BASE_URL = OLLAMA_NATIVE_BASE_URL;
 const OLLAMA_SHOW_CONCURRENCY = 8;
 const OLLAMA_SHOW_MAX_MODELS = 200;
 const OLLAMA_DEFAULT_CONTEXT_WINDOW = 128000;
@@ -635,9 +634,9 @@ function buildMinimaxPortalProvider(): ProviderConfig {
   };
 }
 
-function buildMoonshotProvider(): ProviderConfig {
+function buildMoonshotProvider(baseUrl?: string): ProviderConfig {
   return {
-    baseUrl: MOONSHOT_BASE_URL,
+    baseUrl: baseUrl ?? MOONSHOT_BASE_URL,
     api: "openai-completions",
     models: [
       {
@@ -780,10 +779,10 @@ async function buildOllamaProvider(
 async function buildHuggingfaceProvider(apiKey?: string): Promise<ProviderConfig> {
   // Resolve env var name to value for discovery (GET /v1/models requires Bearer token).
   const resolvedSecret =
-    apiKey?.trim() !== ""
-      ? /^[A-Z][A-Z0-9_]*$/.test(apiKey!.trim())
-        ? (process.env[apiKey!.trim()] ?? "").trim()
-        : apiKey!.trim()
+    apiKey != null && apiKey.trim() !== ""
+      ? /^[A-Z][A-Z0-9_]*$/.test(apiKey.trim())
+        ? (process.env[apiKey.trim()] ?? "").trim()
+        : apiKey.trim()
       : "";
   const models =
     resolvedSecret !== ""
@@ -948,7 +947,12 @@ export async function resolveImplicitProviders(params: {
     resolveEnvApiKeyVarName("moonshot") ??
     resolveApiKeyFromProfiles({ provider: "moonshot", store: authStore });
   if (moonshotKey) {
-    providers.moonshot = { ...buildMoonshotProvider(), apiKey: moonshotKey };
+    const explicitBaseUrl =
+      typeof params.explicitProviders?.moonshot?.baseUrl === "string" &&
+      params.explicitProviders.moonshot.baseUrl
+        ? params.explicitProviders.moonshot.baseUrl
+        : undefined;
+    providers.moonshot = { ...buildMoonshotProvider(explicitBaseUrl), apiKey: moonshotKey };
   }
 
   const kimiCodingKey =

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -162,9 +162,6 @@ function mergeWithExistingProviderSecrets(params: {
     if (typeof existing.apiKey === "string" && existing.apiKey) {
       preserved.apiKey = existing.apiKey;
     }
-    if (typeof existing.baseUrl === "string" && existing.baseUrl) {
-      preserved.baseUrl = existing.baseUrl;
-    }
     mergedProviders[key] = { ...newEntry, ...preserved };
   }
   return mergedProviders;


### PR DESCRIPTION
## Summary

Fixes #32607

### Root cause

mergeWithExistingProviderSecrets in src/agents/models-config.ts was preserving baseUrl from the existing models.json on every re-run. When a user onboards with Moonshot CN, openclaw.json is written with the correct CN URL. However, if models.json already exists with the old international URL, the merge function restores the stale URL, causing all API calls to use the wrong endpoint and return 401s.

### Changes

- **src/agents/models-config.ts**: Remove baseUrl from the list of preserved fields in mergeWithExistingProviderSecrets. baseUrl is a configuration value, not a secret -- it should always come from the current config, not from a stale models.json.
- **src/agents/models-config.providers.ts**:
  - buildMoonshotProvider() now accepts an optional baseUrl parameter so the explicit CN URL from openclaw.json is threaded through the implicit provider build (belt-and-suspenders).
  - resolveImplicitProviders() passes explicitProviders.moonshot.baseUrl to buildMoonshotProvider when set.
  - Fix falsy guard in buildHuggingfaceProvider: apiKey?.trim() !== '' evaluates to true when apiKey is undefined, leading to unsafe non-null assertions. Changed to apiKey != null and apiKey.trim() !== ''.
  - Remove dead OLLAMA_BASE_URL alias (was simply = OLLAMA_NATIVE_BASE_URL, then re-aliased as OLLAMA_API_BASE_URL).
- **src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts**:
  - Update merge-mode test: baseUrl now correctly comes from the current config rather than stale models.json.
  - Add regression test: CN baseUrl must survive a re-run that finds a stale international URL in models.json.

### Testing

All 71 models-config tests pass.