### PR TITLE
UI: allow saving tool toggles for default agent on fresh installs

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -5,6 +5,7 @@ import { refreshChatAvatar } from "./app-chat.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
 import { renderChatControls, renderTab, renderThemeToggle } from "./app-render.helpers.ts";
 import type { AppViewState } from "./app-view-state.ts";
+import { planAgentConfigEntryEdit } from "./controllers/agent-config-entry.ts";
 import { loadAgentFileContent, loadAgentFiles, saveAgentFile } from "./controllers/agent-files.ts";
 import { loadAgentIdentities, loadAgentIdentity } from "./controllers/agent-identity.ts";
 import { loadAgentSkills } from "./controllers/agent-skills.ts";
@@ -160,6 +161,18 @@ export function renderApp(state: AppViewState) {
   const chatAvatarUrl = state.chatAvatarUrl ?? assistantAvatarUrl ?? null;
   const configValue =
     state.configForm ?? (state.configSnapshot?.config as Record<string, unknown> | null);
+  const resolveAgentConfigListIndex = (agentId: string, createIfMissing: boolean) => {
+    const plan = planAgentConfigEntryEdit(configValue, agentId, createIfMissing);
+    if (!plan) {
+      return null;
+    }
+    if (plan.initializeList) {
+      updateConfigFormValue(state, ["agents", "list"], [{ id: agentId }]);
+    } else if (plan.initializeEntry) {
+      updateConfigFormValue(state, ["agents", "list", plan.index], { id: agentId });
+    }
+    return plan.index;
+  };
   const basePath = normalizeBasePath(state.basePath ?? "");
   const resolvedAgentId =
     state.agentsSelectedId ??
@@ -663,21 +676,8 @@ export function renderApp(state: AppViewState) {
                   void saveAgentFile(state, resolvedAgentId, name, content);
                 },
                 onToolsProfileChange: (agentId, profile, clearAllow) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
+                  const index = resolveAgentConfigListIndex(agentId, Boolean(profile));
+                  if (index == null) {
                     return;
                   }
                   const basePath = ["agents", "list", index, "tools"];
@@ -691,21 +691,11 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 onToolsOverridesChange: (agentId, alsoAllow, deny) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
+                  const index = resolveAgentConfigListIndex(
+                    agentId,
+                    alsoAllow.length > 0 || deny.length > 0,
                   );
-                  if (index < 0) {
+                  if (index == null) {
                     return;
                   }
                   const basePath = ["agents", "list", index, "tools"];
@@ -731,24 +721,14 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 onAgentSkillToggle: (agentId, skillName, enabled) => {
-                  if (!configValue) {
+                  const index = resolveAgentConfigListIndex(agentId, true);
+                  if (index == null) {
                     return;
                   }
                   const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  const entry = list[index] as { skills?: unknown };
+                  const entry = Array.isArray(list)
+                    ? (list[index] as { skills?: unknown })
+                    : undefined;
                   const normalizedSkill = skillName.trim();
                   if (!normalizedSkill) {
                     return;
@@ -756,7 +736,7 @@ export function renderApp(state: AppViewState) {
                   const allSkills =
                     state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
                     [];
-                  const existing = Array.isArray(entry.skills)
+                  const existing = Array.isArray(entry?.skills)
                     ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
                     : undefined;
                   const base = existing ?? allSkills;
@@ -769,103 +749,58 @@ export function renderApp(state: AppViewState) {
                   updateConfigFormValue(state, ["agents", "list", index, "skills"], [...next]);
                 },
                 onAgentSkillsClear: (agentId) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
+                  const index = resolveAgentConfigListIndex(agentId, false);
+                  if (index == null) {
                     return;
                   }
                   removeConfigFormValue(state, ["agents", "list", index, "skills"]);
                 },
                 onAgentSkillsDisableAll: (agentId) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
+                  const index = resolveAgentConfigListIndex(agentId, true);
+                  if (index == null) {
                     return;
                   }
                   updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
                 },
                 onModelChange: (agentId, modelId) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
+                  const normalizedModelId = typeof modelId === "string" ? modelId.trim() : "";
+                  const index = resolveAgentConfigListIndex(agentId, normalizedModelId.length > 0);
+                  if (index == null) {
                     return;
                   }
                   const basePath = ["agents", "list", index, "model"];
-                  if (!modelId) {
+                  if (!normalizedModelId) {
                     removeConfigFormValue(state, basePath);
                     return;
                   }
-                  const entry = list[index] as { model?: unknown };
+                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+                  const entry = Array.isArray(list)
+                    ? (list[index] as { model?: unknown })
+                    : undefined;
                   const existing = entry?.model;
                   if (existing && typeof existing === "object" && !Array.isArray(existing)) {
                     const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
                     const next = {
-                      primary: modelId,
+                      primary: normalizedModelId,
                       ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
                     };
                     updateConfigFormValue(state, basePath, next);
                   } else {
-                    updateConfigFormValue(state, basePath, modelId);
+                    updateConfigFormValue(state, basePath, normalizedModelId);
                   }
                 },
                 onModelFallbacksChange: (agentId, fallbacks) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
+                  const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
+                  const index = resolveAgentConfigListIndex(agentId, normalized.length > 0);
+                  if (index == null) {
                     return;
                   }
                   const basePath = ["agents", "list", index, "model"];
-                  const entry = list[index] as { model?: unknown };
-                  const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
-                  const existing = entry.model;
+                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+                  const entry = Array.isArray(list)
+                    ? (list[index] as { model?: unknown })
+                    : undefined;
+                  const existing = entry?.model;
                   const resolvePrimary = () => {
                     if (typeof existing === "string") {
                       return existing.trim() || null;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -173,6 +173,13 @@ export function renderApp(state: AppViewState) {
     }
     return plan.index;
   };
+  const resolveFreshAgentConfigEntry = (index: number) => {
+    const currentConfig = (state.configForm ?? configValue) as {
+      agents?: { list?: unknown[] };
+    } | null;
+    const list = currentConfig?.agents?.list;
+    return Array.isArray(list) ? (list[index] as Record<string, unknown> | undefined) : undefined;
+  };
   const basePath = normalizeBasePath(state.basePath ?? "");
   const resolvedAgentId =
     state.agentsSelectedId ??
@@ -725,10 +732,9 @@ export function renderApp(state: AppViewState) {
                   if (index == null) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  const entry = Array.isArray(list)
-                    ? (list[index] as { skills?: unknown })
-                    : undefined;
+                  const entry = resolveFreshAgentConfigEntry(index) as
+                    | { skills?: unknown }
+                    | undefined;
                   const normalizedSkill = skillName.trim();
                   if (!normalizedSkill) {
                     return;
@@ -773,10 +779,9 @@ export function renderApp(state: AppViewState) {
                     removeConfigFormValue(state, basePath);
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  const entry = Array.isArray(list)
-                    ? (list[index] as { model?: unknown })
-                    : undefined;
+                  const entry = resolveFreshAgentConfigEntry(index) as
+                    | { model?: unknown }
+                    | undefined;
                   const existing = entry?.model;
                   if (existing && typeof existing === "object" && !Array.isArray(existing)) {
                     const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
@@ -796,10 +801,9 @@ export function renderApp(state: AppViewState) {
                     return;
                   }
                   const basePath = ["agents", "list", index, "model"];
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  const entry = Array.isArray(list)
-                    ? (list[index] as { model?: unknown })
-                    : undefined;
+                  const entry = resolveFreshAgentConfigEntry(index) as
+                    | { model?: unknown }
+                    | undefined;
                   const existing = entry?.model;
                   const resolvePrimary = () => {
                     if (typeof existing === "string") {

--- a/ui/src/ui/controllers/agent-config-entry.ts
+++ b/ui/src/ui/controllers/agent-config-entry.ts
@@ -1,0 +1,50 @@
+export type AgentConfigEditPlan = {
+  index: number;
+  initializeList: boolean;
+  initializeEntry: boolean;
+};
+
+type ConfigWithAgentsList = {
+  agents?: {
+    list?: unknown;
+  };
+};
+
+function resolveAgentIndex(list: unknown[], agentId: string): number {
+  return list.findIndex(
+    (entry) =>
+      entry &&
+      typeof entry === "object" &&
+      "id" in entry &&
+      (entry as { id?: string }).id === agentId,
+  );
+}
+
+/**
+ * Resolve where a per-agent config edit should be written.
+ *
+ * On fresh installs, `agents.list` may be absent even though runtime reports
+ * a `main` agent. In that case, callers can opt into creating list/entry
+ * scaffolding before writing tool/model/skills overrides.
+ */
+export function planAgentConfigEntryEdit(
+  configValue: Record<string, unknown> | null,
+  agentId: string,
+  createIfMissing: boolean,
+): AgentConfigEditPlan | null {
+  if (!configValue) {
+    return null;
+  }
+  const list = (configValue as ConfigWithAgentsList).agents?.list;
+  if (!Array.isArray(list)) {
+    return createIfMissing ? { index: 0, initializeList: true, initializeEntry: false } : null;
+  }
+  const index = resolveAgentIndex(list, agentId);
+  if (index >= 0) {
+    return { index, initializeList: false, initializeEntry: false };
+  }
+  if (!createIfMissing) {
+    return null;
+  }
+  return { index: list.length, initializeList: false, initializeEntry: true };
+}

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { planAgentConfigEntryEdit } from "../controllers/agent-config-entry.ts";
 import {
   resolveConfiguredCronModelSuggestions,
   resolveEffectiveModelFallbacks,
@@ -96,5 +97,86 @@ describe("sortLocaleStrings", () => {
 
   it("accepts any iterable input, including sets", () => {
     expect(sortLocaleStrings(new Set(["beta", "alpha"]))).toEqual(["alpha", "beta"]);
+  });
+});
+
+describe("planAgentConfigEntryEdit", () => {
+  it("returns null when config is unavailable", () => {
+    expect(planAgentConfigEntryEdit(null, "main", true)).toBeNull();
+  });
+
+  it("returns existing index without initialization when agent entry exists", () => {
+    const plan = planAgentConfigEntryEdit(
+      {
+        agents: {
+          list: [{ id: "main" }, { id: "writer" }],
+        },
+      },
+      "writer",
+      true,
+    );
+    expect(plan).toEqual({
+      index: 1,
+      initializeList: false,
+      initializeEntry: false,
+    });
+  });
+
+  it("plans list initialization when agents.list is missing and creation is requested", () => {
+    const plan = planAgentConfigEntryEdit(
+      {
+        agents: {},
+      },
+      "main",
+      true,
+    );
+    expect(plan).toEqual({
+      index: 0,
+      initializeList: true,
+      initializeEntry: false,
+    });
+  });
+
+  it("returns null when agents.list is missing and creation is not requested", () => {
+    expect(
+      planAgentConfigEntryEdit(
+        {
+          agents: {},
+        },
+        "main",
+        false,
+      ),
+    ).toBeNull();
+  });
+
+  it("plans entry initialization when list exists but target agent is missing", () => {
+    const plan = planAgentConfigEntryEdit(
+      {
+        agents: {
+          list: [{ id: "main" }],
+        },
+      },
+      "writer",
+      true,
+    );
+    expect(plan).toEqual({
+      index: 1,
+      initializeList: false,
+      initializeEntry: true,
+    });
+  });
+
+  it("returns null for missing entry when creation is disabled", () => {
+    expect(
+      planAgentConfigEntryEdit(
+        {
+          agents: {
+            list: [{ id: "main" }],
+          },
+        },
+        "writer",
+        false,
+      ),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- fix agent tools/skills/model callbacks so first per-agent edit works when `agents.list` has no entry for that agent (fresh install default)
- add `planAgentConfigEntryEdit` helper to plan list/entry initialization before per-agent writes
- keep remove/inherit operations non-creating so "clear" actions remain no-op when no override exists

## Why
Issue [#32812](https://github.com/openclaw/openclaw/issues/32812) reports that toggling tools in the dashboard cannot be saved on new installs. The UI previously required an existing `agents.list[i]` entry and silently no-op'd edits for default agents without one, so `configDirty` never flipped.

## Testing
- `pnpm check`
- `pnpm exec vitest run ui/src/ui/views/agents-utils.test.ts`

Fixes #32812
