### PR TITLE
feat(hooks): emit message_sending hook for explicit message tool sends

### DIFF
--- a/src/commands/message-format.ts
+++ b/src/commands/message-format.ts
@@ -293,6 +293,9 @@ export function formatMessageCliText(result: MessageActionRunResult): string[] {
   }
 
   if (result.kind === "send") {
+    if (result.handledBy === "hook-cancelled") {
+      return [muted("⛔ Message cancelled by message_sending hook.")];
+    }
     if (result.handledBy === "core" && result.sendResult) {
       const send = result.sendResult;
       if (send.via === "direct") {

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -1081,3 +1081,144 @@ describe("runMessageAction accountId defaults", () => {
     expect(ctx.params.accountId).toBe("account-b");
   });
 });
+
+describe("message_sending hook for explicit message tool sends (#32621)", () => {
+  const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>
+    jsonResult({ ok: true, message: params.message }),
+  );
+
+  const testPlugin: ChannelPlugin = {
+    id: "hooktest",
+    meta: {
+      id: "hooktest",
+      label: "HookTest",
+      selectionLabel: "HookTest",
+      docsPath: "/channels/hooktest",
+      blurb: "Test channel plugin for hook testing.",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({ enabled: true }),
+      isConfigured: () => true,
+    },
+    actions: {
+      listActions: () => ["send"],
+      supportsAction: ({ action }) => action === "send",
+      handleAction,
+    },
+  };
+
+  const cfg = {
+    channels: { hooktest: { enabled: true } },
+  } as OpenClawConfig;
+
+  let initHookRunner: typeof import("../../plugins/hook-runner-global.js").initializeGlobalHookRunner;
+  let resetHookRunner: typeof import("../../plugins/hook-runner-global.js").resetGlobalHookRunner;
+  let createMockRegistry: typeof import("../../plugins/hooks.test-helpers.js").createMockPluginRegistry;
+
+  beforeAll(async () => {
+    const hookGlobal = await import("../../plugins/hook-runner-global.js");
+    initHookRunner = hookGlobal.initializeGlobalHookRunner;
+    resetHookRunner = hookGlobal.resetGlobalHookRunner;
+    const helpers = await import("../../plugins/hooks.test-helpers.js");
+    createMockRegistry = helpers.createMockPluginRegistry;
+  });
+
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "hooktest", source: "test", plugin: testPlugin }]),
+    );
+    handleAction.mockClear();
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+    resetHookRunner();
+    vi.clearAllMocks();
+  });
+
+  it("fires message_sending hook before explicit send and allows content modification", async () => {
+    const hookHandler = vi.fn().mockReturnValue({ content: "modified by hook" });
+    const registry = createMockRegistry([{ hookName: "message_sending", handler: hookHandler }]);
+    initHookRunner(registry);
+
+    const result = await runMessageAction({
+      cfg,
+      action: "send",
+      params: { channel: "hooktest", target: "user:1", message: "original text" },
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(hookHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "user:1", content: "original text" }),
+      expect.objectContaining({ channelId: "hooktest" }),
+    );
+    // Plugin should receive the modified message.
+    expect(handleAction).toHaveBeenCalled();
+    const ctx = (
+      handleAction.mock.calls as unknown as Array<[{ params: Record<string, unknown> }]>
+    )[0]?.[0];
+    expect(ctx?.params.message).toBe("modified by hook");
+  });
+
+  it("cancels send when message_sending hook returns cancel: true", async () => {
+    const hookHandler = vi.fn().mockReturnValue({ cancel: true });
+    const registry = createMockRegistry([{ hookName: "message_sending", handler: hookHandler }]);
+    initHookRunner(registry);
+
+    const result = await runMessageAction({
+      cfg,
+      action: "send",
+      params: { channel: "hooktest", target: "user:1", message: "should be blocked" },
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    if (result.kind !== "send") {
+      throw new Error("expected send");
+    }
+    expect(result.handledBy).toBe("hook-cancelled");
+    // Plugin should NOT have been called.
+    expect(handleAction).not.toHaveBeenCalled();
+  });
+
+  it("skips hook for dry-run sends", async () => {
+    const hookHandler = vi.fn().mockReturnValue({ cancel: true });
+    const registry = createMockRegistry([{ hookName: "message_sending", handler: hookHandler }]);
+    initHookRunner(registry);
+
+    const result = await runMessageAction({
+      cfg,
+      action: "send",
+      params: { channel: "hooktest", target: "user:1", message: "dry run" },
+      dryRun: true,
+    });
+
+    expect(result.kind).toBe("send");
+    // Hook should not fire during dry-run.
+    expect(hookHandler).not.toHaveBeenCalled();
+  });
+
+  it("proceeds normally when hook throws an error", async () => {
+    const hookHandler = vi.fn().mockRejectedValue(new Error("hook crash"));
+    const registry = createMockRegistry([{ hookName: "message_sending", handler: hookHandler }]);
+    initHookRunner(registry);
+
+    const result = await runMessageAction({
+      cfg,
+      action: "send",
+      params: { channel: "hooktest", target: "user:1", message: "resilient send" },
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    // Send should succeed despite hook failure.
+    expect(handleAction).toHaveBeenCalled();
+    if (result.kind !== "send") {
+      throw new Error("expected send");
+    }
+    expect(result.handledBy).toBe("plugin");
+  });
+});

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -6,6 +6,7 @@ import {
   readStringParam,
 } from "../../agents/tools/common.js";
 import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
+import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-actions.js";
 import type {
   ChannelId,
@@ -523,42 +524,54 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   // Without this, only deliverOutboundPayloads() emits the hook, so plugins
   // using registerHook("message_sending", …) miss all message(action=send)
   // calls that go through the plugin dispatch path.  (#32621)
+  //
+  // IMPORTANT: We only fire the hook here when the channel's plugin will
+  // handle the send action.  Core-path sends (no plugin handler) already
+  // invoke the hook inside deliverOutboundPayloads → applyMessageSendingHook,
+  // so firing here would cause a double invocation.
   if (!dryRun) {
-    const hookRunner = getGlobalHookRunner();
-    if (hookRunner?.hasHooks("message_sending")) {
-      try {
-        const hookResult = await hookRunner.runMessageSending(
-          {
-            to,
-            content: message,
-            metadata: {
-              channel,
-              accountId: accountId ?? undefined,
-              mediaUrls: mergedMediaUrls.length > 0 ? mergedMediaUrls : undefined,
+    const plugin = getChannelPlugin(channel);
+    const pluginWillHandle =
+      !!plugin?.actions?.handleAction &&
+      (!plugin.actions.supportsAction || plugin.actions.supportsAction({ action: "send" }));
+
+    if (pluginWillHandle) {
+      const hookRunner = getGlobalHookRunner();
+      if (hookRunner?.hasHooks("message_sending")) {
+        try {
+          const hookResult = await hookRunner.runMessageSending(
+            {
+              to,
+              content: message,
+              metadata: {
+                channel,
+                accountId: accountId ?? undefined,
+                mediaUrls: mergedMediaUrls.length > 0 ? mergedMediaUrls : undefined,
+              },
             },
-          },
-          {
-            channelId: channel,
-            accountId: accountId ?? undefined,
-          },
-        );
-        if (hookResult?.cancel) {
-          return {
-            kind: "send",
-            channel,
-            action,
-            to,
-            handledBy: "hook-cancelled",
-            payload: { cancelled: true, reason: "message_sending hook" },
-            dryRun,
-          };
+            {
+              channelId: channel,
+              accountId: accountId ?? undefined,
+            },
+          );
+          if (hookResult?.cancel) {
+            return {
+              kind: "send",
+              channel,
+              action,
+              to,
+              handledBy: "hook-cancelled",
+              payload: { cancelled: true, reason: "message_sending hook" },
+              dryRun,
+            };
+          }
+          if (hookResult?.content != null) {
+            message = hookResult.content;
+            params.message = message;
+          }
+        } catch {
+          // Don't block message sends on hook failure.
         }
-        if (hookResult?.content != null) {
-          message = hookResult.content;
-          params.message = message;
-        }
-      } catch {
-        // Don't block message sends on hook failure.
       }
     }
   }

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -14,6 +14,7 @@ import type {
 } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { type GatewayClientMode, type GatewayClientName } from "../../utils/message-channel.js";
@@ -107,7 +108,7 @@ export type MessageActionRunResult =
       channel: ChannelId;
       action: "send";
       to: string;
-      handledBy: "plugin" | "core";
+      handledBy: "plugin" | "core" | "hook-cancelled";
       payload: unknown;
       toolResult?: AgentToolResult<unknown>;
       sendResult?: MessageSendResult;
@@ -516,6 +517,52 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   }
   const mirrorMediaUrls =
     mergedMediaUrls.length > 0 ? mergedMediaUrls : mediaUrl ? [mediaUrl] : undefined;
+
+  // Run message_sending hook so plugins can intercept explicit message tool
+  // sends the same way they intercept implicit delivery-pipeline replies.
+  // Without this, only deliverOutboundPayloads() emits the hook, so plugins
+  // using registerHook("message_sending", …) miss all message(action=send)
+  // calls that go through the plugin dispatch path.  (#32621)
+  if (!dryRun) {
+    const hookRunner = getGlobalHookRunner();
+    if (hookRunner?.hasHooks("message_sending")) {
+      try {
+        const hookResult = await hookRunner.runMessageSending(
+          {
+            to,
+            content: message,
+            metadata: {
+              channel,
+              accountId: accountId ?? undefined,
+              mediaUrls: mergedMediaUrls.length > 0 ? mergedMediaUrls : undefined,
+            },
+          },
+          {
+            channelId: channel,
+            accountId: accountId ?? undefined,
+          },
+        );
+        if (hookResult?.cancel) {
+          return {
+            kind: "send",
+            channel,
+            action,
+            to,
+            handledBy: "hook-cancelled",
+            payload: { cancelled: true, reason: "message_sending hook" },
+            dryRun,
+          };
+        }
+        if (hookResult?.content != null) {
+          message = hookResult.content;
+          params.message = message;
+        }
+      } catch {
+        // Don't block message sends on hook failure.
+      }
+    }
+  }
+
   throwIfAborted(abortSignal);
   const send = await executeSendAction({
     ctx: {


### PR DESCRIPTION
## Summary

Fixes #32621.

The `message_sending` plugin hook only fires from the implicit delivery pipeline (`deliverOutboundPayloads`). When agents use the `message(action=send)` tool explicitly — the recommended pattern for avoiding thread creation in Slack — the hook is **never emitted**. This means plugins that register `message_sending` hooks (e.g. content guards, OPSATYA plugins, message transformers) miss all explicit sends that route through channel plugin dispatch.

**Fix:** Emit the `message_sending` hook in `handleSendAction()` before calling `executeSendAction()`, so both the plugin dispatch path and the core delivery path trigger the hook consistently.

## What changed

- `src/infra/outbound/message-action-runner.ts` — Import `getGlobalHookRunner`, add `"hook-cancelled"` to the `handledBy` union for send results, emit `message_sending` hook before `executeSendAction()` with support for content modification and cancellation. Skipped for dry-run. Hook failures are caught and don't block sends.
- `src/commands/message-format.ts` — Handle `"hook-cancelled"` in send result formatting with `⛔ Message cancelled by message_sending hook.`
- `src/infra/outbound/message-action-runner.test.ts` — 4 new tests: hook content modification, hook cancellation, dry-run bypass, hook error resilience

## What did NOT change

- `deliverOutboundPayloads()` in `deliver.ts` — still emits its own `message_sending` hook for the core path (no double-fire: the plugin path that bypasses delivery is the one that was missing the hook)
- Hook runner API — no changes to `runMessageSending()` signature or behavior
- Existing message tool behavior when no hooks are registered — zero overhead (early-return on `!hasHooks`)

## Test plan

- [x] 39 message-action-runner tests pass (35 existing + 4 new)
- [x] All 263 outbound tests pass
- [x] New test: hook modifies content → plugin receives modified text
- [x] New test: hook cancels → send blocked, plugin not called
- [x] New test: dry-run → hook skipped entirely
- [x] New test: hook throws → send proceeds normally