### PR TITLE
feat: per-agent `cwd` config option for tool working directory

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import {
   hasConfiguredModelFallbacks,
   resolveAgentConfig,
+  resolveAgentCwd,
   resolveAgentDir,
   resolveAgentEffectiveModelPrimary,
   resolveAgentExplicitModelPrimary,
@@ -54,6 +55,7 @@ describe("resolveAgentConfig", () => {
     expect(result).toEqual({
       name: "Main Agent",
       workspace: "~/openclaw",
+      cwd: undefined,
       agentDir: "~/.openclaw/agents/main",
       model: "anthropic/claude-opus-4",
       identity: undefined,
@@ -426,5 +428,95 @@ describe("resolveAgentConfig", () => {
 
     const agentDir = resolveAgentDir({} as OpenClawConfig, "main");
     expect(agentDir).toBe(path.join(path.resolve(home), ".openclaw", "agents", "main", "agent"));
+  });
+});
+
+describe("resolveAgentCwd (#32637)", () => {
+  it("returns undefined when no cwd is configured", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", workspace: "~/openclaw" }],
+      },
+    };
+    expect(resolveAgentCwd(cfg, "main")).toBeUndefined();
+  });
+
+  it("returns undefined when no agents config exists", () => {
+    expect(resolveAgentCwd({} as OpenClawConfig, "main")).toBeUndefined();
+  });
+
+  it("returns resolved cwd path when configured", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "worker-1",
+            workspace: "~/shared-workspace",
+            cwd: "/home/user/projects/repo-1",
+          },
+        ],
+      },
+    };
+    expect(resolveAgentCwd(cfg, "worker-1")).toBe("/home/user/projects/repo-1");
+  });
+
+  it("expands tilde in cwd path", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "worker",
+            cwd: "~/projects/my-repo",
+          },
+        ],
+      },
+    };
+    const result = resolveAgentCwd(cfg, "worker");
+    expect(result).toBeDefined();
+    expect(result).not.toContain("~");
+    expect(result!.endsWith("/projects/my-repo") || result!.endsWith("\\projects\\my-repo")).toBe(
+      true,
+    );
+  });
+
+  it("strips null bytes from cwd path", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            cwd: "/home/user\0/projects",
+          },
+        ],
+      },
+    };
+    const result = resolveAgentCwd(cfg, "main");
+    expect(result).toBe("/home/user/projects");
+  });
+
+  it("ignores empty or whitespace-only cwd", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", cwd: "   " }],
+      },
+    };
+    expect(resolveAgentCwd(cfg, "main")).toBeUndefined();
+  });
+
+  it("resolveAgentConfig includes cwd field", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "dev",
+            workspace: "~/shared",
+            cwd: "/opt/projects/repo",
+          },
+        ],
+      },
+    };
+    const result = resolveAgentConfig(cfg, "dev");
+    expect(result?.cwd).toBe("/opt/projects/repo");
+    expect(result?.workspace).toBe("~/shared");
   });
 });

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -27,6 +27,7 @@ type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[num
 type ResolvedAgentConfig = {
   name?: string;
   workspace?: string;
+  cwd?: string;
   agentDir?: string;
   model?: AgentEntry["model"];
   skills?: AgentEntry["skills"];
@@ -126,6 +127,7 @@ export function resolveAgentConfig(
   return {
     name: typeof entry.name === "string" ? entry.name : undefined,
     workspace: typeof entry.workspace === "string" ? entry.workspace : undefined,
+    cwd: typeof entry.cwd === "string" ? entry.cwd : undefined,
     agentDir: typeof entry.agentDir === "string" ? entry.agentDir : undefined,
     model:
       typeof entry.model === "string" || (entry.model && typeof entry.model === "object")
@@ -268,6 +270,20 @@ export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
   }
   const stateDir = resolveStateDir(process.env);
   return stripNullBytes(path.join(stateDir, `workspace-${id}`));
+}
+
+/**
+ * Resolve the per-agent working directory for tool operations.
+ * Returns `undefined` when no `cwd` is configured — callers should fall back
+ * to the agent's workspace directory.
+ */
+export function resolveAgentCwd(cfg: OpenClawConfig, agentId: string): string | undefined {
+  const id = normalizeAgentId(agentId);
+  const configured = resolveAgentConfig(cfg, id)?.cwd?.trim();
+  if (configured) {
+    return stripNullBytes(resolveUserPath(configured));
+  }
+  return undefined;
 }
 
 export function resolveAgentDir(cfg: OpenClawConfig, agentId: string) {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -6,7 +6,7 @@ import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { isSubagentSessionKey } from "../routing/session-key.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
-import { resolveAgentConfig } from "./agent-scope.js";
+import { resolveAgentConfig, resolveAgentCwd } from "./agent-scope.js";
 import { createApplyPatchTool } from "./apply-patch.js";
 import {
   createExecTool,
@@ -313,6 +313,14 @@ export function createOpenClawCodingTools(options?: {
   const sandboxFsBridge = sandbox?.fsBridge;
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
   const workspaceRoot = resolveWorkspaceRoot(options?.workspaceDir);
+  // Per-agent cwd overrides the tool working directory.  Bootstrap files
+  // (AGENTS.md, SOUL.md) still load from `workspaceDir`; only the tool-facing
+  // root (exec cwd, read/write/edit default path) changes.
+  const agentCwdRaw =
+    options?.config && options?.agentId
+      ? resolveAgentCwd(options.config, options.agentId)
+      : undefined;
+  const effectiveToolRoot = agentCwdRaw ? resolveWorkspaceRoot(agentCwdRaw) : workspaceRoot;
   const workspaceOnly = fsPolicy.workspaceOnly;
   const applyPatchConfig = execConfig.applyPatch;
   // Secure by default: apply_patch is workspace-contained unless explicitly disabled.
@@ -349,12 +357,12 @@ export function createOpenClawCodingTools(options?: {
             : sandboxed,
         ];
       }
-      const freshReadTool = createReadTool(workspaceRoot);
+      const freshReadTool = createReadTool(effectiveToolRoot);
       const wrapped = createOpenClawReadTool(freshReadTool, {
         modelContextWindowTokens: options?.modelContextWindowTokens,
         imageSanitization,
       });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, effectiveToolRoot) : wrapped];
     }
     if (tool.name === "bash" || tool.name === execToolName) {
       return [];
@@ -363,15 +371,15 @@ export function createOpenClawCodingTools(options?: {
       if (sandboxRoot) {
         return [];
       }
-      const wrapped = createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      const wrapped = createHostWorkspaceWriteTool(effectiveToolRoot, { workspaceOnly });
+      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, effectiveToolRoot) : wrapped];
     }
     if (tool.name === "edit") {
       if (sandboxRoot) {
         return [];
       }
-      const wrapped = createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      const wrapped = createHostWorkspaceEditTool(effectiveToolRoot, { workspaceOnly });
+      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, effectiveToolRoot) : wrapped];
     }
     return [tool];
   });
@@ -387,7 +395,7 @@ export function createOpenClawCodingTools(options?: {
     safeBinTrustedDirs: options?.exec?.safeBinTrustedDirs ?? execConfig.safeBinTrustedDirs,
     safeBinProfiles: options?.exec?.safeBinProfiles ?? execConfig.safeBinProfiles,
     agentId,
-    cwd: workspaceRoot,
+    cwd: effectiveToolRoot,
     allowBackground,
     scopeKey,
     sessionKey: options?.sessionKey,
@@ -419,7 +427,7 @@ export function createOpenClawCodingTools(options?: {
     !applyPatchEnabled || (sandboxRoot && !allowWorkspaceWrites)
       ? null
       : createApplyPatchTool({
-          cwd: sandboxRoot ?? workspaceRoot,
+          cwd: sandboxRoot ?? effectiveToolRoot,
           sandbox:
             sandboxRoot && allowWorkspaceWrites
               ? { root: sandboxRoot, bridge: sandboxFsBridge! }
@@ -472,7 +480,7 @@ export function createOpenClawCodingTools(options?: {
       sandboxRoot,
       sandboxFsBridge,
       fsPolicy,
-      workspaceDir: workspaceRoot,
+      workspaceDir: effectiveToolRoot,
       sandboxed: !!sandbox,
       config: options?.config,
       pluginToolAllowlist: collectExplicitAllowlist([

--- a/src/agents/pi-tools.workspace-paths.test.ts
+++ b/src/agents/pi-tools.workspace-paths.test.ts
@@ -190,6 +190,111 @@ describe("workspace path resolution", () => {
   });
 });
 
+describe("per-agent cwd (#32637)", () => {
+  it("uses agent cwd as exec default when configured", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      await withTempDir("openclaw-cwd-", async (cwdDir) => {
+        const cfg: OpenClawConfig = {
+          agents: {
+            list: [
+              {
+                id: "worker",
+                default: true,
+                workspace: workspaceDir,
+                cwd: cwdDir,
+              },
+            ],
+          },
+        };
+        const tools = createOpenClawCodingTools({
+          workspaceDir,
+          config: cfg,
+          agentId: "worker",
+          exec: { host: "gateway", ask: "off", security: "full" },
+        });
+        const execTool = tools.find((t) => t.name === "exec");
+        expect(execTool).toBeDefined();
+        await expectExecCwdResolvesTo(execTool, "cwd-exec", { command: "echo ok" }, cwdDir);
+      });
+    });
+  });
+
+  it("read/write/edit tools resolve relative paths against agent cwd", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      await withTempDir("openclaw-cwd-", async (cwdDir) => {
+        const cfg: OpenClawConfig = {
+          agents: {
+            list: [
+              {
+                id: "worker",
+                default: true,
+                workspace: workspaceDir,
+                cwd: cwdDir,
+              },
+            ],
+          },
+        };
+        const tools = createOpenClawCodingTools({
+          workspaceDir,
+          config: cfg,
+          agentId: "worker",
+        });
+        const { readTool, writeTool, editTool } = expectReadWriteEditTools(tools);
+
+        // Write a file via the write tool — it should land in cwdDir.
+        await writeTool.execute("cwd-write", {
+          path: "hello.txt",
+          content: "from cwd",
+        });
+        expect(await fs.readFile(path.join(cwdDir, "hello.txt"), "utf8")).toBe("from cwd");
+
+        // Read should resolve relative paths from cwdDir.
+        const readResult = await readTool.execute("cwd-read", { path: "hello.txt" });
+        expect(getTextContent(readResult)).toContain("from cwd");
+
+        // Edit should also work against cwdDir.
+        await editTool.execute("cwd-edit", {
+          path: "hello.txt",
+          oldText: "from cwd",
+          newText: "edited in cwd",
+        });
+        expect(await fs.readFile(path.join(cwdDir, "hello.txt"), "utf8")).toBe("edited in cwd");
+      });
+    });
+  });
+
+  it("falls back to workspaceDir when no cwd is configured", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            {
+              id: "main",
+              default: true,
+              workspace: workspaceDir,
+              // No cwd field
+            },
+          ],
+        },
+      };
+      const tools = createOpenClawCodingTools({
+        workspaceDir,
+        config: cfg,
+        agentId: "main",
+        exec: { host: "gateway", ask: "off", security: "full" },
+      });
+      const execTool = tools.find((t) => t.name === "exec");
+      expect(execTool).toBeDefined();
+      await expectExecCwdResolvesTo(
+        execTool,
+        "fallback-exec",
+        { command: "echo ok" },
+        workspaceDir,
+      );
+    });
+  });
+});
+
 describe("sandboxed workspace paths", () => {
   it("uses sandbox workspace for relative read/write/edit", async () => {
     await withTempDir("openclaw-sandbox-", async (sandboxDir) => {

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -10,6 +10,10 @@ export type AgentConfig = {
   default?: boolean;
   name?: string;
   workspace?: string;
+  /** Optional working directory for tool operations (exec, read, write, edit).
+   *  When set, tools default to this path instead of `workspace`.
+   *  Bootstrap files (AGENTS.md, SOUL.md) still load from `workspace`. */
+  cwd?: string;
   agentDir?: string;
   model?: AgentModelConfig;
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -683,6 +683,7 @@ export const AgentEntrySchema = z
     default: z.boolean().optional(),
     name: z.string().optional(),
     workspace: z.string().optional(),
+    cwd: z.string().optional(),
     agentDir: z.string().optional(),
     model: AgentModelSchema.optional(),
     skills: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

Closes #32637

- Adds an optional `cwd` field to `agents.list[]` that separates the tool working directory from the bootstrap workspace
- When `cwd` is set, exec/process/read/write/edit tools default to that path instead of `workspace`
- Bootstrap files (AGENTS.md, SOUL.md) still load from `workspace`
- When `cwd` is not set, behavior is unchanged — fully backward-compatible

### Config example

```json5
{
  agents: {
    list: [
      {
        id: "worker-1",
        workspace: "~/.openclaw/workspace",  // shared context files
        cwd: "/home/user/projects/repo-1",   // tool working directory
      },
      {
        id: "worker-2",
        workspace: "~/.openclaw/workspace",  // same shared context
        cwd: "/home/user/projects/repo-2",   // different code directory
      },
    ],
  },
}
```

### Changes

| File | What changed |
|------|-------------|
| `config/types.agents.ts` | Add `cwd?: string` to `AgentConfig` type |
| `config/zod-schema.agent-runtime.ts` | Add `cwd` field to `AgentEntrySchema` validation |
| `agents/agent-scope.ts` | Add `resolveAgentCwd()` function; extract `cwd` in `resolveAgentConfig()` |
| `agents/pi-tools.ts` | Compute `effectiveToolRoot` from agent cwd; use it for exec cwd, read/write/edit root, apply_patch cwd, and openclaw-tools workspace |

### What did NOT change

- Bootstrap file loading (`AGENTS.md`, `SOUL.md`, `USER.md`) — still loads from `workspace`
- Skills snapshot resolution — still uses `workspace`
- System prompt workspace info — still uses `workspace`
- Sandbox mode — sandboxed tools still use their container workspace
- Existing configs without `cwd` — no behavior change, no migration needed

## Test plan

- [x] `resolveAgentCwd` returns resolved path when configured (6 unit tests)
- [x] `resolveAgentCwd` returns `undefined` when cwd is absent, empty, or whitespace
- [x] `resolveAgentConfig` includes `cwd` in resolved output
- [x] Exec tool defaults to agent `cwd` when configured (integration test)
- [x] Read/write/edit tools resolve relative paths against agent `cwd` (integration test)
- [x] Falls back to `workspaceDir` when no `cwd` is configured (integration test)
- [x] All 675 config tests pass
- [x] All 2924 agent tests pass (4 pre-existing failures in web-search.redirect unrelated)


🤖 Generated with [Claude Code](https://claude.com/claude-code)