### PR TITLE
fix(browser): add missing return statement in resolveBrowserBaseUrl for host target

### DIFF
--- a/src/agents/tools/browser-tool.test.ts
+++ b/src/agents/tools/browser-tool.test.ts
@@ -96,6 +96,9 @@ vi.mock("./common.js", async () => {
 import { DEFAULT_AI_SNAPSHOT_MAX_CHARS } from "../../browser/constants.js";
 import { createBrowserTool } from "./browser-tool.js";
 
+// Expected base URL for host browser control based on mock controlPort
+const HOST_BROWSER_URL = "http://127.0.0.1:18791";
+
 function mockSingleBrowserProxyNode() {
   nodesUtilsMocks.listNodes.mockResolvedValue([
     {
@@ -137,7 +140,7 @@ describe("browser tool snapshot maxChars", () => {
     await runSnapshotToolCall({ snapshotFormat: "ai" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_URL,
       expect.objectContaining({
         format: "ai",
         maxChars: DEFAULT_AI_SNAPSHOT_MAX_CHARS,
@@ -155,7 +158,7 @@ describe("browser tool snapshot maxChars", () => {
     });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_URL,
       expect.objectContaining({
         maxChars: override,
       }),
@@ -181,7 +184,7 @@ describe("browser tool snapshot maxChars", () => {
     const tool = createBrowserTool();
     await tool.execute?.("call-1", { action: "profiles" });
 
-    expect(browserClientMocks.browserProfiles).toHaveBeenCalledWith(undefined);
+    expect(browserClientMocks.browserProfiles).toHaveBeenCalledWith(HOST_BROWSER_URL);
   });
 
   it("passes refs mode through to browser snapshot", async () => {
@@ -189,7 +192,7 @@ describe("browser tool snapshot maxChars", () => {
     await tool.execute?.("call-1", { action: "snapshot", snapshotFormat: "ai", refs: "aria" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_URL,
       expect.objectContaining({
         format: "ai",
         refs: "aria",
@@ -204,7 +207,7 @@ describe("browser tool snapshot maxChars", () => {
     await runSnapshotToolCall({ snapshotFormat: "ai" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_URL,
       expect.objectContaining({
         mode: "efficient",
       }),
@@ -230,7 +233,7 @@ describe("browser tool snapshot maxChars", () => {
     await tool.execute?.("call-1", { action: "snapshot", profile: "chrome", snapshotFormat: "ai" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_URL,
       expect.objectContaining({
         profile: "chrome",
       }),
@@ -271,7 +274,7 @@ describe("browser tool snapshot maxChars", () => {
     await tool.execute?.("call-1", { action: "status", profile: "chrome" });
 
     expect(browserClientMocks.browserStatus).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_URL,
       expect.objectContaining({ profile: "chrome" }),
     );
     expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
@@ -286,7 +289,7 @@ describe("browser tool url alias support", () => {
     await tool.execute?.("call-1", { action: "open", url: "https://example.com" });
 
     expect(browserClientMocks.browserOpenTab).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_URL,
       "https://example.com",
       expect.objectContaining({ profile: undefined }),
     );
@@ -301,7 +304,7 @@ describe("browser tool url alias support", () => {
     });
 
     expect(browserActionsMocks.browserNavigate).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_URL,
       expect.objectContaining({
         url: "https://example.com",
         targetId: "tab-1",
@@ -334,7 +337,7 @@ describe("browser tool act compatibility", () => {
     });
 
     expect(browserActionsMocks.browserAct).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_URL,
       expect.objectContaining({
         kind: "type",
         ref: "f1e3",
@@ -360,7 +363,7 @@ describe("browser tool act compatibility", () => {
     });
 
     expect(browserActionsMocks.browserAct).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_URL,
       {
         kind: "press",
         key: "Enter",
@@ -547,13 +550,13 @@ describe("browser tool act stale target recovery", () => {
     expect(browserActionsMocks.browserAct).toHaveBeenCalledTimes(2);
     expect(browserActionsMocks.browserAct).toHaveBeenNthCalledWith(
       1,
-      undefined,
+      HOST_BROWSER_URL,
       expect.objectContaining({ targetId: "stale-tab", action: "click", ref: "btn-1" }),
       expect.objectContaining({ profile: "chrome" }),
     );
     expect(browserActionsMocks.browserAct).toHaveBeenNthCalledWith(
       2,
-      undefined,
+      HOST_BROWSER_URL,
       expect.not.objectContaining({ targetId: expect.anything() }),
       expect.objectContaining({ profile: "chrome" }),
     );

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -246,7 +246,7 @@ function resolveBrowserBaseUrl(params: {
   target?: "sandbox" | "host";
   sandboxBridgeUrl?: string;
   allowHostControl?: boolean;
-}): string | undefined {
+}): string {
   const cfg = loadConfig();
   const resolved = resolveBrowserConfig(cfg.browser, cfg);
   const normalizedSandbox = params.sandboxBridgeUrl?.trim() ?? "";
@@ -269,7 +269,7 @@ function resolveBrowserBaseUrl(params: {
       "Browser control is disabled. Set browser.enabled=true in ~/.openclaw/openclaw.json.",
     );
   }
-  return undefined;
+  return `http://127.0.0.1:${resolved.controlPort}`;
 }
 
 export function createBrowserTool(opts?: {


### PR DESCRIPTION
## Summary

Fixes the browser tool timing out in embedded agent mode when using `target="host"`.

## Problem

The `resolveBrowserBaseUrl` function was returning `undefined` for `target="host"`, which caused `fetchBrowserJson` to try using the local dispatcher path. This works in the main gateway process but fails in the embedded agent context, resulting in a 15-second timeout.

## Root Cause

```typescript
function resolveBrowserBaseUrl(params: {...}): string | undefined {
  // ...
  if (target === "sandbox") {
    return normalizedSandbox.replace(/\$/,'');  // Has return
  }
  // ...
  return undefined;  // BUG: No return for host case!
}
```

## Solution

Added the missing return statement for the host target case:

```typescript
return \`http://127.0.0.1:\${resolved.controlPort}\`;
```

Also updated the return type from `string | undefined` to `string` since the function now always returns a value (or throws an error).

## Testing

- Updated all affected tests to expect the new URL instead of `undefined`
- All 21 browser tool tests pass

Fixes #32814