### PR TITLE
fix(gateway): include disk-scanned agent IDs in listConfiguredAgentIds

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import {
@@ -10,6 +10,7 @@ import {
   deriveSessionTitle,
   listAgentsForGateway,
   listSessionsFromStore,
+  loadCombinedSessionStoreForGateway,
   parseGroupKey,
   pruneLegacyStoreKeys,
   resolveGatewaySessionStoreTarget,
@@ -815,5 +816,86 @@ describe("listSessionsFromStore search", () => {
     expect(stale?.totalTokensFresh).toBe(false);
     expect(missing?.totalTokens).toBeUndefined();
     expect(missing?.totalTokensFresh).toBe(false);
+  });
+});
+
+describe("loadCombinedSessionStoreForGateway includes disk-scanned ACP agents", () => {
+  let tempStateDir: string;
+  let savedStateDir: string | undefined;
+
+  beforeEach(() => {
+    tempStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-acp-visibility-"));
+    savedStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+  });
+
+  afterEach(() => {
+    if (savedStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = savedStateDir;
+    }
+    fs.rmSync(tempStateDir, { recursive: true, force: true });
+  });
+
+  test("sessions from disk-only ACP agent dirs are visible when agents.list is configured", () => {
+    // Set up disk structure: configured agent "ops" + ACP-spawned agent "acp-codex-123"
+    const agentsDir = path.join(tempStateDir, "agents");
+    for (const agentId of ["ops", "acp-codex-123"]) {
+      const sessionsDir = path.join(agentsDir, agentId, "sessions");
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sessionsDir, "sessions.json"),
+        JSON.stringify({
+          [`agent:${agentId}:main`]: { sessionId: `sid-${agentId}`, updatedAt: Date.now() },
+        }),
+        "utf8",
+      );
+    }
+
+    // Config only lists "ops" -- ACP agent "acp-codex-123" is NOT in the config list.
+    const cfg = {
+      session: {
+        mainKey: "main",
+        store: path.join(tempStateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+      },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+
+    const { store } = loadCombinedSessionStoreForGateway(cfg);
+
+    // The configured agent's session must be present.
+    expect(store["agent:ops:main"]).toBeDefined();
+    expect(store["agent:ops:main"].sessionId).toBe("sid-ops");
+
+    // The dynamically-created ACP agent's session must also be visible.
+    expect(store["agent:acp-codex-123:main"]).toBeDefined();
+    expect(store["agent:acp-codex-123:main"].sessionId).toBe("sid-acp-codex-123");
+  });
+
+  test("disk-only agents are included even when agents.list is empty", () => {
+    const agentsDir = path.join(tempStateDir, "agents");
+    const sessionsDir = path.join(agentsDir, "dynamic-agent", "sessions");
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:dynamic-agent:main": { sessionId: "sid-dynamic", updatedAt: Date.now() },
+      }),
+      "utf8",
+    );
+
+    // No agents.list configured at all.
+    const cfg = {
+      session: {
+        mainKey: "main",
+        store: path.join(tempStateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+      },
+    } as OpenClawConfig;
+
+    const { store } = loadCombinedSessionStoreForGateway(cfg);
+
+    expect(store["agent:dynamic-agent:main"]).toBeDefined();
+    expect(store["agent:dynamic-agent:main"].sessionId).toBe("sid-dynamic");
   });
 });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -310,29 +310,24 @@ function listExistingAgentIdsFromDisk(): string[] {
 }
 
 function listConfiguredAgentIds(cfg: OpenClawConfig): string[] {
-  const agents = cfg.agents?.list ?? [];
-  if (agents.length > 0) {
-    const ids = new Set<string>();
-    for (const entry of agents) {
-      if (entry?.id) {
-        ids.add(normalizeAgentId(entry.id));
-      }
-    }
-    const defaultId = normalizeAgentId(resolveDefaultAgentId(cfg));
-    ids.add(defaultId);
-    const sorted = Array.from(ids).filter(Boolean);
-    sorted.sort((a, b) => a.localeCompare(b));
-    return sorted.includes(defaultId)
-      ? [defaultId, ...sorted.filter((id) => id !== defaultId)]
-      : sorted;
-  }
-
   const ids = new Set<string>();
   const defaultId = normalizeAgentId(resolveDefaultAgentId(cfg));
   ids.add(defaultId);
+
+  // Always include agents from the config list.
+  const agents = cfg.agents?.list ?? [];
+  for (const entry of agents) {
+    if (entry?.id) {
+      ids.add(normalizeAgentId(entry.id));
+    }
+  }
+
+  // Always merge disk-scanned agent directories so dynamically-created
+  // ACP agent directories are visible even when agents.list is configured.
   for (const id of listExistingAgentIdsFromDisk()) {
     ids.add(id);
   }
+
   const sorted = Array.from(ids).filter(Boolean);
   sorted.sort((a, b) => a.localeCompare(b));
   if (sorted.includes(defaultId)) {


### PR DESCRIPTION
## Summary

- Problem: When `agents.list` is configured in `openclaw.json`, ACP sessions spawned via `sessions_spawn` with `runtime: "acp"` are invisible to `sessions_list` because `listConfiguredAgentIds()` only returns config-listed agent IDs and never falls through to the disk scan path.
- Why it matters: Dynamically-created ACP agent directories are silently excluded from session listing, making ACP sessions unreachable through the gateway API.
- What changed: `listConfiguredAgentIds()` now always merges both config-listed IDs and disk-scanned agent IDs from `listExistingAgentIdsFromDisk()`, regardless of whether `agents.list` is populated.
- What did NOT change (scope boundary): No changes to `listAgentsForGateway` filtering, session store resolution, or any other gateway logic. The fix is scoped to a single function.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32804

## User-visible / Behavior Changes

`sessions_list` now correctly returns ACP-spawned sessions even when `agents.list` is explicitly configured in `openclaw.json`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No — the fix makes already-existing on-disk agent session data visible through the existing session listing API, restoring intended behavior.

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): ACP
- Relevant config (redacted): `{ "agents": { "list": [{ "id": "ops", "default": true }] } }`

### Steps

1. Configure `agents.list` in `openclaw.json` with at least one agent.
2. Spawn an ACP session with `sessions_spawn` (runtime: "acp"), which creates a new agent directory on disk not in the config list.
3. Call `sessions_list`.

### Expected

- The ACP session appears in the listing.

### Actual

- Before fix: The ACP session is invisible.
- After fix: The ACP session is visible.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Two new tests added in `src/gateway/session-utils.test.ts`:
- `sessions from disk-only ACP agent dirs are visible when agents.list is configured`
- `disk-only agents are included even when agents.list is empty`

## Human Verification (required)

- Verified scenarios: Both new tests pass; all 45 existing tests in `session-utils.test.ts` still pass.
- Edge cases checked: Tested with `agents.list` populated (bug case) and with `agents.list` empty (regression check).
- What you did **not** verify: Live ACP session spawning on a running gateway instance.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit.
- Files/config to restore: `src/gateway/session-utils.ts`
- Known bad symptoms reviewers should watch for: Unexpected agent IDs appearing in `sessions_list` from stale/orphaned disk directories.

## Risks and Mitigations

- Risk: Stale or orphaned agent directories on disk could surface unexpected sessions in the listing.
  - Mitigation: This is existing behavior when `agents.list` is not configured; the fix makes the behavior consistent. Orphaned directories were always visible in the no-config case.