### PR TITLE
feat(plugins): add after_message_write hook for real-time message capture

### DIFF
--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -1,4 +1,5 @@
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
+import { fireAndForgetHook } from "../hooks/fire-and-forget.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import {
   applyInputProvenanceToUserMessage,
@@ -39,6 +40,18 @@ export function guardSessionManager(
       }
     : undefined;
 
+  const afterMessageWrite = hookRunner?.hasHooks("after_message_write")
+    ? (event: import("../plugins/types.js").PluginHookAfterMessageWriteEvent) => {
+        fireAndForgetHook(
+          hookRunner.runAfterMessageWrite(event, {
+            agentId: opts?.agentId,
+            sessionKey: opts?.sessionKey,
+          }),
+          "session-tool-result-guard: after_message_write hook failed",
+        );
+      }
+    : undefined;
+
   const transform = hookRunner?.hasHooks("tool_result_persist")
     ? // oxlint-disable-next-line typescript/no-explicit-any
       (message: any, meta: { toolCallId?: string; toolName?: string; isSynthetic?: boolean }) => {
@@ -67,6 +80,7 @@ export function guardSessionManager(
     allowSyntheticToolResults: opts?.allowSyntheticToolResults,
     allowedToolNames: opts?.allowedToolNames,
     beforeMessageWriteHook: beforeMessageWrite,
+    afterMessageWriteHook: afterMessageWrite,
   });
   (sessionManager as GuardedSessionManager).flushPendingToolResults = guard.flushPendingToolResults;
   return sessionManager as GuardedSessionManager;

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
 
@@ -419,6 +419,62 @@ describe("installSessionToolResultGuard", () => {
 
     const messages = getPersistedMessages(sm);
     expect(messages.map((m) => m.role)).toEqual(["assistant"]);
+  });
+
+  it("emits after_message_write for regular, toolResult, and synthetic flush writes", () => {
+    const sm = SessionManager.inMemory();
+    const afterMessageWriteHook = vi.fn();
+    const guard = installSessionToolResultGuard(sm, {
+      afterMessageWriteHook,
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "regular" }],
+      }),
+    );
+    appendToolResultText(sm, "tool result payload");
+    sm.appendMessage(toolCallMessage);
+    guard.flushPendingToolResults();
+
+    const calls = afterMessageWriteHook.mock.calls.map((args) => args[0]) as Array<{
+      message?: { role?: string };
+      isSynthetic?: boolean;
+    }>;
+
+    const regularCount = calls.filter(
+      (entry) => entry.message?.role === "assistant" && entry.isSynthetic !== true,
+    ).length;
+    const toolResultCount = calls.filter(
+      (entry) => entry.message?.role === "toolResult" && entry.isSynthetic !== true,
+    ).length;
+    const syntheticCount = calls.filter((entry) => entry.isSynthetic === true).length;
+
+    expect(regularCount).toBeGreaterThanOrEqual(2);
+    expect(toolResultCount).toBeGreaterThanOrEqual(1);
+    expect(syntheticCount).toBe(1);
+  });
+
+  it("does not block append when after_message_write callback throws", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, {
+      afterMessageWriteHook: () => {
+        throw new Error("boom");
+      },
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: "still persisted",
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = getPersistedMessages(sm);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.role).toBe("user");
   });
 
   it("applies message persistence transform to user messages", () => {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -270,6 +270,7 @@ export function installSessionToolResultGuard(
       afterWrite?.({
         message: finalMessage,
         sessionFile: getSessionFile(),
+        isSynthetic: false,
       });
     } catch {
       // Keep append path resilient even if callback wiring is broken.

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import type {
+  PluginHookAfterMessageWriteEvent,
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
 } from "../plugins/types.js";
@@ -101,6 +102,10 @@ export function installSessionToolResultGuard(
     beforeMessageWriteHook?: (
       event: PluginHookBeforeMessageWriteEvent,
     ) => PluginHookBeforeMessageWriteResult | undefined;
+    /**
+     * Fire-and-forget hook invoked after a message is successfully appended.
+     */
+    afterMessageWriteHook?: (event: PluginHookAfterMessageWriteEvent) => void;
   },
 ): {
   flushPendingToolResults: () => void;
@@ -123,6 +128,9 @@ export function installSessionToolResultGuard(
 
   const allowSyntheticToolResults = opts?.allowSyntheticToolResults ?? true;
   const beforeWrite = opts?.beforeMessageWriteHook;
+  const afterWrite = opts?.afterMessageWriteHook;
+  const getSessionFile = () =>
+    (sessionManager as { getSessionFile?: () => string | null }).getSessionFile?.() ?? undefined;
 
   /**
    * Run the before_message_write hook. Returns the (possibly modified) message,
@@ -158,6 +166,17 @@ export function installSessionToolResultGuard(
         );
         if (flushed) {
           originalAppend(flushed as never);
+          try {
+            afterWrite?.({
+              message: flushed,
+              sessionFile: getSessionFile(),
+              toolCallId: id,
+              toolName: name,
+              isSynthetic: true,
+            });
+          } catch {
+            // Keep append path resilient even if callback wiring is broken.
+          }
         }
       }
     }
@@ -201,7 +220,19 @@ export function installSessionToolResultGuard(
       if (!persisted) {
         return undefined;
       }
-      return originalAppend(persisted as never);
+      const result = originalAppend(persisted as never);
+      try {
+        afterWrite?.({
+          message: persisted,
+          sessionFile: getSessionFile(),
+          toolCallId: id ?? undefined,
+          toolName,
+          isSynthetic: false,
+        });
+      } catch {
+        // Keep append path resilient even if callback wiring is broken.
+      }
+      return result;
     }
 
     // Skip tool call extraction for aborted/errored assistant messages.
@@ -235,10 +266,16 @@ export function installSessionToolResultGuard(
       return undefined;
     }
     const result = originalAppend(finalMessage as never);
+    try {
+      afterWrite?.({
+        message: finalMessage,
+        sessionFile: getSessionFile(),
+      });
+    } catch {
+      // Keep append path resilient even if callback wiring is broken.
+    }
 
-    const sessionFile = (
-      sessionManager as { getSessionFile?: () => string | null }
-    ).getSessionFile?.();
+    const sessionFile = getSessionFile();
     if (sessionFile) {
       emitSessionTranscriptUpdate(sessionFile);
     }

--- a/src/config/sessions/transcript.after-message-write.test.ts
+++ b/src/config/sessions/transcript.after-message-write.test.ts
@@ -58,7 +58,10 @@ describe("appendAssistantMessageToSessionTranscript after_message_write wiring",
     expect(result.ok).toBe(true);
     expect(hookMocks.runner.runAfterMessageWrite).toHaveBeenCalledTimes(1);
 
-    const firstCall = hookMocks.runner.runAfterMessageWrite.mock.calls[0];
+    const mockCalls = hookMocks.runner.runAfterMessageWrite.mock.calls as unknown as Array<
+      unknown[]
+    >;
+    const firstCall = mockCalls[0];
     expect(firstCall).toBeDefined();
     const event = firstCall?.[0] as { sessionFile?: string; message?: { role?: string } };
     const ctx = firstCall?.[1] as { sessionKey?: string; agentId?: string };

--- a/src/config/sessions/transcript.after-message-write.test.ts
+++ b/src/config/sessions/transcript.after-message-write.test.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hookMocks = vi.hoisted(() => ({
+  runner: {
+    hasHooks: vi.fn(() => false),
+    runAfterMessageWrite: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookMocks.runner,
+}));
+
+describe("appendAssistantMessageToSessionTranscript after_message_write wiring", () => {
+  let tempDir = "";
+  let storePath = "";
+  let appendAssistantMessageToSessionTranscript: typeof import("./transcript.js").appendAssistantMessageToSessionTranscript;
+
+  beforeEach(async () => {
+    ({ appendAssistantMessageToSessionTranscript } = await import("./transcript.js"));
+
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-transcript-hook-"));
+    const sessionsDir = path.join(tempDir, "agents", "main", "sessions");
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    storePath = path.join(sessionsDir, "sessions.json");
+
+    hookMocks.runner.hasHooks.mockClear();
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+    hookMocks.runner.runAfterMessageWrite.mockClear();
+    hookMocks.runner.runAfterMessageWrite.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("emits after_message_write after successful mirror append", async () => {
+    const sessionKey = "agent:main:telegram:direct:u1";
+    const store = {
+      [sessionKey]: {
+        sessionId: "sess-hook",
+        chatType: "direct",
+        channel: "telegram",
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store), "utf-8");
+
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "mirrored reply",
+      storePath,
+      agentId: "main",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(hookMocks.runner.runAfterMessageWrite).toHaveBeenCalledTimes(1);
+
+    const firstCall = hookMocks.runner.runAfterMessageWrite.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const event = firstCall?.[0] as { sessionFile?: string; message?: { role?: string } };
+    const ctx = firstCall?.[1] as { sessionKey?: string; agentId?: string };
+    expect(event?.sessionFile).toBe((result as { ok: true; sessionFile: string }).sessionFile);
+    expect(event?.message?.role).toBe("assistant");
+    expect(ctx).toEqual({ sessionKey, agentId: "main" });
+  });
+});

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -1,14 +1,14 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import fs from "node:fs";
 import path from "node:path";
-import type { SessionEntry } from "./types.js";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { resolveDefaultSessionStorePath } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { loadSessionStore } from "./store.js";
+import type { SessionEntry } from "./types.js";
 
 function stripQuery(value: string): string {
   const noHash = value.split("#")[0] ?? value;

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -1,11 +1,14 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import fs from "node:fs";
 import path from "node:path";
-import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
+import type { SessionEntry } from "./types.js";
+import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { resolveDefaultSessionStorePath } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { loadSessionStore } from "./store.js";
-import type { SessionEntry } from "./types.js";
 
 function stripQuery(value: string): string {
   const noHash = value.split("#")[0] ?? value;
@@ -129,7 +132,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
 
   const sessionManager = SessionManager.open(sessionFile);
-  sessionManager.appendMessage({
+  const message: Parameters<typeof sessionManager.appendMessage>[0] = {
     role: "assistant",
     content: [{ type: "text", text: mirrorText }],
     api: "openai-responses",
@@ -151,7 +154,25 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     },
     stopReason: "stop",
     timestamp: Date.now(),
-  });
+  };
+  sessionManager.appendMessage(message);
+
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("after_message_write")) {
+    fireAndForgetHook(
+      hookRunner.runAfterMessageWrite(
+        {
+          message: message as AgentMessage,
+          sessionFile,
+        },
+        {
+          sessionKey,
+          agentId: params.agentId,
+        },
+      ),
+      "appendAssistantMessageToSessionTranscript: after_message_write hook failed",
+    );
+  }
 
   emitSessionTranscriptUpdate(sessionFile);
   return { ok: true, sessionFile };

--- a/src/gateway/server-methods/chat-transcript-inject.after-message-write.test.ts
+++ b/src/gateway/server-methods/chat-transcript-inject.after-message-write.test.ts
@@ -44,7 +44,10 @@ describe("appendInjectedAssistantMessageToTranscript after_message_write wiring"
       expect(appended.ok).toBe(true);
       expect(hookMocks.runner.runAfterMessageWrite).toHaveBeenCalledTimes(1);
 
-      const firstCall = hookMocks.runner.runAfterMessageWrite.mock.calls[0];
+      const mockCalls = hookMocks.runner.runAfterMessageWrite.mock.calls as unknown as Array<
+        unknown[]
+      >;
+      const firstCall = mockCalls[0];
       expect(firstCall).toBeDefined();
       const event = firstCall?.[0] as { sessionFile?: string; message?: { role?: string } };
       const ctx = firstCall?.[1] as { sessionKey?: string; agentId?: string };

--- a/src/gateway/server-methods/chat-transcript-inject.after-message-write.test.ts
+++ b/src/gateway/server-methods/chat-transcript-inject.after-message-write.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTranscriptFixtureSync } from "./chat.test-helpers.js";
+
+const hookMocks = vi.hoisted(() => ({
+  runner: {
+    hasHooks: vi.fn(() => false),
+    runAfterMessageWrite: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookMocks.runner,
+}));
+
+describe("appendInjectedAssistantMessageToTranscript after_message_write wiring", () => {
+  let appendInjectedAssistantMessageToTranscript: typeof import("./chat-transcript-inject.js").appendInjectedAssistantMessageToTranscript;
+
+  beforeAll(async () => {
+    ({ appendInjectedAssistantMessageToTranscript } = await import("./chat-transcript-inject.js"));
+  });
+
+  beforeEach(() => {
+    hookMocks.runner.hasHooks.mockClear();
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+    hookMocks.runner.runAfterMessageWrite.mockClear();
+    hookMocks.runner.runAfterMessageWrite.mockResolvedValue(undefined);
+  });
+
+  it("emits after_message_write with session context after successful append", () => {
+    const { dir, transcriptPath } = createTranscriptFixtureSync({
+      prefix: "openclaw-chat-inject-hook-",
+      sessionId: "sess-hook",
+    });
+
+    try {
+      const appended = appendInjectedAssistantMessageToTranscript({
+        transcriptPath,
+        message: "hook me",
+        sessionKey: "agent:main:web:direct:abc",
+        agentId: "main",
+      });
+
+      expect(appended.ok).toBe(true);
+      expect(hookMocks.runner.runAfterMessageWrite).toHaveBeenCalledTimes(1);
+
+      const firstCall = hookMocks.runner.runAfterMessageWrite.mock.calls[0];
+      expect(firstCall).toBeDefined();
+      const event = firstCall?.[0] as { sessionFile?: string; message?: { role?: string } };
+      const ctx = firstCall?.[1] as { sessionKey?: string; agentId?: string };
+      expect(event?.sessionFile).toBe(transcriptPath);
+      expect(event?.message?.role).toBe("assistant");
+      expect(ctx).toEqual({
+        sessionKey: "agent:main:web:direct:abc",
+        agentId: "main",
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/gateway/server-methods/chat-transcript-inject.ts
+++ b/src/gateway/server-methods/chat-transcript-inject.ts
@@ -1,4 +1,6 @@
 import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 
 type AppendMessageArg = Parameters<SessionManager["appendMessage"]>[0];
 
@@ -21,6 +23,8 @@ export function appendInjectedAssistantMessageToTranscript(params: {
   label?: string;
   idempotencyKey?: string;
   abortMeta?: GatewayInjectedAbortMeta;
+  sessionKey?: string;
+  agentId?: string;
   now?: number;
 }): GatewayInjectedTranscriptAppendResult {
   const now = params.now ?? Date.now();
@@ -68,6 +72,22 @@ export function appendInjectedAssistantMessageToTranscript(params: {
     // Raw jsonl appends break the parent chain and can hide compaction summaries from context.
     const sessionManager = SessionManager.open(params.transcriptPath);
     const messageId = sessionManager.appendMessage(messageBody);
+    const hookRunner = getGlobalHookRunner();
+    if (hookRunner?.hasHooks("after_message_write")) {
+      fireAndForgetHook(
+        hookRunner.runAfterMessageWrite(
+          {
+            message: messageBody as import("@mariozechner/pi-agent-core").AgentMessage,
+            sessionFile: params.transcriptPath,
+          },
+          {
+            sessionKey: params.sessionKey,
+            agentId: params.agentId,
+          },
+        ),
+        "appendInjectedAssistantMessageToTranscript: after_message_write hook failed",
+      );
+    }
     return { ok: true, messageId, message: messageBody };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1,13 +1,12 @@
-import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
 import fs from "node:fs";
 import path from "node:path";
-import type { MsgContext } from "../../auto-reply/templating.js";
-import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveThinkingDefault } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
+import type { MsgContext } from "../../auto-reply/templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
@@ -49,6 +48,7 @@ import { formatForLog } from "../ws-log.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
 import { appendInjectedAssistantMessageToTranscript } from "./chat-transcript-inject.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 
 type TranscriptAppendResult = {
   ok: boolean;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -460,13 +460,15 @@ function persistAbortedPartials(params: {
   if (params.snapshots.length === 0) {
     return;
   }
-  const { storePath, entry } = loadSessionEntry(params.sessionKey);
+  const { storePath, entry, cfg } = loadSessionEntry(params.sessionKey);
+  const agentId = resolveSessionAgentId({ sessionKey: params.sessionKey, config: cfg });
   for (const snapshot of params.snapshots) {
     const sessionId = entry?.sessionId ?? snapshot.sessionId ?? snapshot.runId;
     const appended = appendAssistantTranscriptMessage({
       message: snapshot.text,
       sessionId,
       sessionKey: params.sessionKey,
+      agentId,
       storePath,
       sessionFile: entry?.sessionFile,
       createIfMissing: true,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1,12 +1,13 @@
+import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
 import fs from "node:fs";
 import path from "node:path";
-import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveThinkingDefault } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
-import type { MsgContext } from "../../auto-reply/templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
@@ -48,7 +49,6 @@ import { formatForLog } from "../ws-log.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
 import { appendInjectedAssistantMessageToTranscript } from "./chat-transcript-inject.js";
-import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 
 type TranscriptAppendResult = {
   ok: boolean;
@@ -377,6 +377,7 @@ function appendAssistantTranscriptMessage(params: {
   message: string;
   label?: string;
   sessionId: string;
+  sessionKey?: string;
   storePath: string | undefined;
   sessionFile?: string;
   agentId?: string;
@@ -421,6 +422,8 @@ function appendAssistantTranscriptMessage(params: {
     label: params.label,
     idempotencyKey: params.idempotencyKey,
     abortMeta: params.abortMeta,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
   });
 }
 
@@ -463,6 +466,7 @@ function persistAbortedPartials(params: {
     const appended = appendAssistantTranscriptMessage({
       message: snapshot.text,
       sessionId,
+      sessionKey: params.sessionKey,
       storePath,
       sessionFile: entry?.sessionFile,
       createIfMissing: true,
@@ -958,6 +962,7 @@ export const chatHandlers: GatewayRequestHandlers = {
               const appended = appendAssistantTranscriptMessage({
                 message: combinedReply,
                 sessionId,
+                sessionKey,
                 storePath: latestStorePath,
                 sessionFile: latestEntry?.sessionFile,
                 agentId,
@@ -1066,6 +1071,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       message: p.message,
       label: p.label,
       sessionId,
+      sessionKey: rawSessionKey,
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -49,6 +49,8 @@ import type {
   PluginHookToolResultPersistResult,
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
+  PluginHookAfterMessageWriteEvent,
+  PluginHookAfterMessageWriteContext,
 } from "./types.js";
 
 // Re-export types for consumers
@@ -80,6 +82,8 @@ export type {
   PluginHookToolResultPersistResult,
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
+  PluginHookAfterMessageWriteEvent,
+  PluginHookAfterMessageWriteContext,
   PluginHookSessionContext,
   PluginHookSessionStartEvent,
   PluginHookSessionEndEvent,
@@ -589,6 +593,17 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     return undefined;
   }
 
+  /**
+   * Run after_message_write hook.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runAfterMessageWrite(
+    event: PluginHookAfterMessageWriteEvent,
+    ctx: PluginHookAfterMessageWriteContext,
+  ): Promise<void> {
+    return runVoidHook("after_message_write", event, ctx);
+  }
+
   // =========================================================================
   // Session Hooks
   // =========================================================================
@@ -734,6 +749,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runToolResultPersist,
     // Message write hooks
     runBeforeMessageWrite,
+    runAfterMessageWrite,
     // Session hooks
     runSessionStart,
     runSessionEnd,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,6 +1,6 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { Command } from "commander";
-import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AuthProfileCredential, OAuthCredential } from "../agents/auth-profiles/types.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ReplyPayload } from "../auto-reply/types.js";

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,6 +1,6 @@
-import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { Command } from "commander";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AuthProfileCredential, OAuthCredential } from "../agents/auth-profiles/types.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
@@ -324,6 +324,7 @@ export type PluginHookName =
   | "after_tool_call"
   | "tool_result_persist"
   | "before_message_write"
+  | "after_message_write"
   | "session_start"
   | "session_end"
   | "subagent_spawning"
@@ -562,6 +563,23 @@ export type PluginHookBeforeMessageWriteResult = {
   message?: AgentMessage; // Optional: modified message to write instead
 };
 
+// after_message_write hook
+export type PluginHookAfterMessageWriteEvent = {
+  /** The message that was successfully appended to the transcript. */
+  message: AgentMessage;
+  /** Transcript file path when available. */
+  sessionFile?: string;
+  toolCallId?: string;
+  toolName?: string;
+  /** True when this append came from a synthetic tool-result flush. */
+  isSynthetic?: boolean;
+};
+
+export type PluginHookAfterMessageWriteContext = {
+  sessionKey?: string;
+  agentId?: string;
+};
+
 // Session context
 export type PluginHookSessionContext = {
   agentId?: string;
@@ -740,6 +758,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeMessageWriteEvent,
     ctx: { agentId?: string; sessionKey?: string },
   ) => PluginHookBeforeMessageWriteResult | void;
+  after_message_write: (
+    event: PluginHookAfterMessageWriteEvent,
+    ctx: PluginHookAfterMessageWriteContext,
+  ) => Promise<void> | void;
   session_start: (
     event: PluginHookSessionStartEvent,
     ctx: PluginHookSessionContext,

--- a/src/plugins/wired-hooks-message.test.ts
+++ b/src/plugins/wired-hooks-message.test.ts
@@ -72,3 +72,33 @@ describe("message_sent hook runner", () => {
     );
   });
 });
+
+describe("after_message_write hook runner", () => {
+  it("runAfterMessageWrite invokes registered hooks", async () => {
+    const handler = vi.fn();
+    const registry = createMockPluginRegistry([{ hookName: "after_message_write", handler }]);
+    const runner = createHookRunner(registry);
+
+    await runner.runAfterMessageWrite(
+      {
+        message: { role: "assistant", content: [{ type: "text", text: "persisted" }] } as never,
+        sessionFile: "/tmp/session.jsonl",
+      },
+      {
+        sessionKey: "session_1",
+        agentId: "default",
+      },
+    );
+
+    expect(handler).toHaveBeenCalledWith(
+      {
+        message: { role: "assistant", content: [{ type: "text", text: "persisted" }] },
+        sessionFile: "/tmp/session.jsonl",
+      },
+      {
+        sessionKey: "session_1",
+        agentId: "default",
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The existing plugin system offers no efficient way for memory backends to observe
individual messages as they are persisted. The current options are:

- Subscribe to `emitSessionTranscriptUpdate`, which emits only a file path and
  requires the consumer to re-read and re-parse the JSONL file on disk.
- Use `agent_end` to receive all messages at once after the conversation ends —
  batch-only and crash-unsafe.
- Use `before_compaction` / `before_reset` as last-chance durability hooks, not
  capture hooks.

None of these provide a structured `AgentMessage` object at the moment of write,
which forces memory plugins to do redundant I/O and accept multi-second latency.

## Solution

This PR adds an `after_message_write` void hook that fires asynchronously after
every successful transcript append. It is fire-and-forget (`fireAndForgetHook`),
so it never blocks the write path. It carries the full typed message along with
session metadata (`agentId`, `sessionKey`, `sessionFile`, `toolCallId`,
`toolName`, `isSynthetic`) so backends can route and store without any file I/O.

This approach has the same zero-cost-when-unused guarantee as other hooks: the
`hasHooks` guard prevents event object construction when no handlers are
registered.

## Emission sites

Three write paths now emit the hook:

1. The guarded session append path (`session-tool-result-guard.ts`) — covers
   regular messages, tool results, and synthetic tool-result flushes.
2. The transcript mirror path (`transcript.ts`) — covers outbound delivery mirrors.
3. The gateway inject path (`chat-transcript-inject.ts`) — covers RPC-injected
   messages.

The truncation/replay path in the pi-embedded runner is intentionally excluded to
avoid duplicate captures.

## Files changed

- `src/plugins/types.ts` — `PluginHookAfterMessageWriteEvent`, `PluginHookAfterMessageWriteContext`, hook map entry, re-exports
- `src/plugins/hooks.ts` — `runAfterMessageWrite` runner method
- `src/plugins/wired-hooks-message.test.ts` — hook wiring test
- `src/agents/session-tool-result-guard.ts` — emit on all three append branches
- `src/agents/session-tool-result-guard-wrapper.ts` — thread `sessionKey`/`agentId` through to guard context
- `src/agents/session-tool-result-guard.test.ts` — emission count + resilience tests
- `src/config/sessions/transcript.ts` — emit on mirror append
- `src/config/sessions/transcript.after-message-write.test.ts` — new test file
- `src/gateway/server-methods/chat-transcript-inject.ts` — emit on RPC inject
- `src/gateway/server-methods/chat-transcript-inject.after-message-write.test.ts` — new test file
- `src/gateway/server-methods/chat.ts` — pass `sessionKey` into inject context