### PR TITLE
feat: add blockInterToolText config to suppress inter-tool text

### DIFF
--- a/src/agents/pi-embedded-subscribe.block-inter-tool-text.test.ts
+++ b/src/agents/pi-embedded-subscribe.block-inter-tool-text.test.ts
@@ -1,0 +1,186 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  createSubscribedSessionHarness,
+  emitAssistantTextDelta,
+  emitAssistantTextEnd,
+  extractTextPayloads,
+} from "./pi-embedded-subscribe.e2e-harness.js";
+
+function createInterToolHarness(params?: {
+  blockInterToolText?: boolean;
+  blockReplyBreak?: "text_end" | "message_end";
+}) {
+  const onBlockReply = vi.fn();
+  const config: OpenClawConfig = {
+    agents: {
+      defaults: {
+        blockInterToolText: params?.blockInterToolText ?? true,
+      },
+    },
+  } as OpenClawConfig;
+
+  const { emit, subscription } = createSubscribedSessionHarness({
+    runId: "test-run",
+    onBlockReply,
+    blockReplyBreak: params?.blockReplyBreak ?? "text_end",
+    config,
+  });
+
+  return { emit, onBlockReply, subscription };
+}
+
+/** Emit a text_delta + text_end + message_end sequence for an assistant message WITH tool_use. */
+function emitMessageWithToolUse(params: { emit: (evt: unknown) => void; text: string }) {
+  params.emit({
+    type: "message_start",
+    message: { role: "assistant" },
+  });
+  emitAssistantTextDelta({ emit: params.emit, delta: params.text });
+  emitAssistantTextEnd({ emit: params.emit });
+  // Message containing both text and tool_use content blocks
+  const assistantMessage = {
+    role: "assistant",
+    stop_reason: "tool_use",
+    content: [
+      { type: "text", text: params.text },
+      { type: "tool_use", id: "tool_1", name: "read_file", input: { path: "test.txt" } },
+    ],
+  } as unknown as AssistantMessage;
+  params.emit({ type: "message_end", message: assistantMessage });
+}
+
+/** Emit a text_delta + text_end + message_end sequence for an assistant message WITHOUT tool_use. */
+function emitMessageWithoutToolUse(params: { emit: (evt: unknown) => void; text: string }) {
+  params.emit({
+    type: "message_start",
+    message: { role: "assistant" },
+  });
+  emitAssistantTextDelta({ emit: params.emit, delta: params.text });
+  emitAssistantTextEnd({ emit: params.emit });
+  const assistantMessage = {
+    role: "assistant",
+    stop_reason: "end_turn",
+    content: [{ type: "text", text: params.text }],
+  } as unknown as AssistantMessage;
+  params.emit({ type: "message_end", message: assistantMessage });
+}
+
+describe("blockInterToolText (#32512)", () => {
+  it("suppresses text from messages that contain tool_use blocks", () => {
+    const { emit, onBlockReply } = createInterToolHarness({ blockInterToolText: true });
+
+    // Message 1: "I'll check the file" + tool_use → should be suppressed
+    emitMessageWithToolUse({ emit, text: "I'll check the file" });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("delivers text from messages without tool_use blocks", () => {
+    const { emit, onBlockReply } = createInterToolHarness({ blockInterToolText: true });
+
+    // Final answer message: no tool calls
+    emitMessageWithoutToolUse({ emit, text: "Here is the answer." });
+
+    const texts = extractTextPayloads(onBlockReply.mock.calls);
+    expect(texts).toEqual(["Here is the answer."]);
+  });
+
+  it("delivers only the final answer when inter-tool messages precede it", () => {
+    const { emit, onBlockReply } = createInterToolHarness({ blockInterToolText: true });
+
+    // Turn 1: text + tool_use → suppressed
+    emitMessageWithToolUse({ emit, text: "Let me check the file" });
+    expect(onBlockReply).not.toHaveBeenCalled();
+
+    // Simulate tool execution (these don't affect block replies directly)
+    emit({ type: "tool_execution_start", toolName: "read_file", toolCallId: "t1", args: {} });
+    emit({ type: "tool_execution_end", toolName: "read_file", toolCallId: "t1", result: {} });
+
+    // Turn 2: text + tool_use → suppressed
+    emitMessageWithToolUse({ emit, text: "Now checking another file" });
+    expect(onBlockReply).not.toHaveBeenCalled();
+
+    // Turn 3: final answer (no tool_use) → delivered
+    emitMessageWithoutToolUse({ emit, text: "Based on my analysis, here is the result." });
+
+    const texts = extractTextPayloads(onBlockReply.mock.calls);
+    expect(texts).toEqual(["Based on my analysis, here is the result."]);
+  });
+
+  it("delivers all text when blockInterToolText is disabled", () => {
+    const { emit, onBlockReply } = createInterToolHarness({ blockInterToolText: false });
+
+    // Message with tool_use → should be delivered (feature disabled)
+    emitMessageWithToolUse({ emit, text: "I'll check the file" });
+
+    const texts = extractTextPayloads(onBlockReply.mock.calls);
+    expect(texts.length).toBeGreaterThanOrEqual(1);
+    expect(texts[0]).toBe("I'll check the file");
+  });
+
+  it("forces blockReplyBreak to message_end when enabled", () => {
+    const { emit, onBlockReply } = createInterToolHarness({
+      blockInterToolText: true,
+      blockReplyBreak: "text_end", // user configured text_end, but feature overrides
+    });
+
+    // If break was still text_end, text would be emitted at text_end before
+    // we know about tool_use. The feature overrides to message_end.
+    emitMessageWithToolUse({ emit, text: "This should be suppressed" });
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("suppresses text from messages detected via content blocks (not stop_reason)", () => {
+    const { emit, onBlockReply } = createInterToolHarness({ blockInterToolText: true });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "Checking..." });
+    emitAssistantTextEnd({ emit });
+
+    // Message with tool_use in content but no stop_reason field
+    const assistantMessage = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Checking..." },
+        { type: "tool_use", id: "t1", name: "exec", input: {} },
+      ],
+    } as unknown as AssistantMessage;
+    emit({ type: "message_end", message: assistantMessage });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress text when config is not set (default behavior)", () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createSubscribedSessionHarness({
+      runId: "test-run",
+      onBlockReply,
+      blockReplyBreak: "message_end",
+      // No config → blockInterToolText defaults to false
+    });
+
+    emitMessageWithToolUse({ emit, text: "Should be delivered" });
+
+    const texts = extractTextPayloads(onBlockReply.mock.calls);
+    expect(texts).toEqual(["Should be delivered"]);
+  });
+
+  it("excludes suppressed text from assistantTexts", () => {
+    const { emit, onBlockReply, subscription } = createInterToolHarness({
+      blockInterToolText: true,
+    });
+
+    // Suppressed message
+    emitMessageWithToolUse({ emit, text: "I'll check the file" });
+    expect(onBlockReply).not.toHaveBeenCalled();
+
+    // Final answer
+    emitMessageWithoutToolUse({ emit, text: "Here is the answer." });
+
+    // Only the final answer should appear in assistantTexts (used for final payloads)
+    const texts = subscription.assistantTexts.map((t) => t.trim()).filter(Boolean);
+    expect(texts).toEqual(["Here is the answer."]);
+  });
+});

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -249,6 +249,28 @@ export function handleMessageUpdate(
   }
 }
 
+/**
+ * Detect whether an assistant message contains tool_use content blocks.
+ * Checks both the Anthropic `stop_reason` field and content block types
+ * for cross-provider compatibility.
+ */
+function messageHasToolUse(msg: AgentMessage): boolean {
+  const record = msg as Record<string, unknown>;
+  if (record.stop_reason === "tool_use") {
+    return true;
+  }
+  const content = record.content;
+  if (Array.isArray(content)) {
+    return content.some(
+      (block) =>
+        block &&
+        typeof block === "object" &&
+        (block as Record<string, unknown>).type === "tool_use",
+    );
+  }
+  return false;
+}
+
 export function handleMessageEnd(
   ctx: EmbeddedPiSubscribeContext,
   evt: AgentEvent & { message: AgentMessage },
@@ -300,6 +322,12 @@ export function handleMessageEnd(
     }
   }
 
+  // ── blockInterToolText suppression ──────────────────────────────────────────
+  // When enabled, suppress text from messages that also contain tool_use blocks.
+  // Only the final answer (a message without tool calls) is delivered.
+  const shouldSuppressInterTool =
+    ctx.state.suppressInterToolText && messageHasToolUse(assistantMessage);
+
   if (!ctx.state.emittedAssistantUpdate && (cleanedText || hasMedia)) {
     emitAgentEvent({
       runId: ctx.params.runId,
@@ -323,7 +351,16 @@ export function handleMessageEnd(
 
   const addedDuringMessage = ctx.state.assistantTexts.length > ctx.state.assistantTextBaseline;
   const chunkerHasBuffered = ctx.blockChunker?.hasBuffered() ?? false;
-  ctx.finalizeAssistantTexts({ text, addedDuringMessage, chunkerHasBuffered });
+
+  if (shouldSuppressInterTool) {
+    // Suppress inter-tool text: clear buffers without emitting, finalize with empty text.
+    // Text from this message will not appear in block replies or final payloads.
+    ctx.blockChunker?.reset();
+    ctx.state.blockBuffer = "";
+    ctx.finalizeAssistantTexts({ text: "", addedDuringMessage, chunkerHasBuffered: false });
+  } else {
+    ctx.finalizeAssistantTexts({ text, addedDuringMessage, chunkerHasBuffered });
+  }
 
   const onBlockReply = ctx.params.onBlockReply;
   const shouldEmitReasoning = Boolean(
@@ -373,7 +410,9 @@ export function handleMessageEnd(
     }
   };
 
+  // Skip block reply emission when suppressing inter-tool text.
   if (
+    !shouldSuppressInterTool &&
     (ctx.state.blockReplyBreak === "message_end" ||
       (ctx.blockChunker ? ctx.blockChunker.hasBuffered() : ctx.state.blockBuffer.length > 0)) &&
     text &&

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -38,6 +38,8 @@ export type EmbeddedPiSubscribeState = {
   lastToolError?: ToolErrorSummary;
 
   blockReplyBreak: "text_end" | "message_end";
+  /** When true, suppress text from messages that contain tool_use blocks. */
+  suppressInterToolText: boolean;
   reasoningMode: ReasoningLevel;
   includeReasoning: boolean;
   shouldEmitPartialReplies: boolean;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -41,7 +41,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     toolMetaById: new Map(),
     toolSummaryById: new Set(),
     lastToolError: undefined,
-    blockReplyBreak: params.blockReplyBreak ?? "text_end",
+    blockReplyBreak:
+      params.config?.agents?.defaults?.blockInterToolText === true
+        ? "message_end"
+        : (params.blockReplyBreak ?? "text_end"),
+    suppressInterToolText: params.config?.agents?.defaults?.blockInterToolText === true,
     reasoningMode,
     includeReasoning: reasoningMode === "on",
     shouldEmitPartialReplies: !(reasoningMode === "on" && !params.onBlockReply),

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -190,6 +190,16 @@ export type AgentDefaultsConfig = {
    * - "message_end": end of the whole assistant message (may include tool blocks)
    */
   blockStreamingBreak?: "text_end" | "message_end";
+  /**
+   * When enabled, suppress text blocks emitted from assistant messages that
+   * also contain tool-use calls. Only the final answer (a message without
+   * tool calls) is delivered. Requires block streaming to be enabled.
+   *
+   * Internally forces `blockStreamingBreak` to `"message_end"` so that text
+   * is buffered until the full message is received, at which point the
+   * handler can determine whether tool calls are present.
+   */
+  blockInterToolText?: boolean;
   /** Soft block chunking for streamed replies (min/max chars, prefer paragraph/newline). */
   blockStreamingChunk?: BlockStreamingChunkConfig;
   /**

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -137,6 +137,7 @@ export const AgentDefaultsSchema = z
       .optional(),
     blockStreamingDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
     blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
+    blockInterToolText: z.boolean().optional(),
     blockStreamingChunk: BlockStreamingChunkSchema.optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     humanDelay: HumanDelaySchema.optional(),


### PR DESCRIPTION
## Summary
- Adds `agents.defaults.blockInterToolText` boolean config option that suppresses text blocks emitted from assistant messages containing tool_use calls
- Only the final answer (messages without tool calls) is delivered to the user via block streaming
- Internally forces `blockStreamingBreak` to `"message_end"` when enabled, so text is buffered until the full message is received and tool_use presence can be determined

Closes #32512

## What changed

### Config (`types.agent-defaults.ts`, `zod-schema.agent-defaults.ts`)
- Added `blockInterToolText?: boolean` to `AgentDefaultsConfig` with JSDoc explaining behavior
- Added Zod schema validation

### Subscribe handler (`pi-embedded-subscribe.ts`)
- Resolves `blockInterToolText` from `params.config.agents.defaults` at subscription init
- When enabled, overrides `state.blockReplyBreak` to `"message_end"` and sets `state.suppressInterToolText`

### Message handler (`pi-embedded-subscribe.handlers.messages.ts`)
- Added `messageHasToolUse()` helper that detects tool_use via both `stop_reason === "tool_use"` and content block type inspection (cross-provider compatible)
- In `handleMessageEnd`: when `suppressInterToolText && messageHasToolUse`, clears chunker/buffer without emitting and finalizes with empty text — preventing inter-tool text from appearing in block replies or final payloads

### State type (`pi-embedded-subscribe.handlers.types.ts`)
- Added `suppressInterToolText: boolean` field to `EmbeddedPiSubscribeState`

## What did NOT change
- `blockStreamingBreak` resolution in `get-reply-directives.ts` — the override happens internally in the subscribe handler
- Reasoning delivery — reasoning blocks are still emitted even for suppressed messages
- Non-streaming behavior — when block streaming is disabled, text accumulates in final payloads as before
- No per-agent override yet (can be added as follow-up)

## Test plan
- [x] 8 new tests covering: suppression of tool_use messages, delivery of non-tool messages, multi-turn scenario, disabled feature, forced message_end break, content-block-based detection, default behavior, assistantTexts exclusion
- [x] All 140 existing subscribe handler tests pass
- [x] All 744 config schema tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)