### PR TITLE
fix(memory): preserve query params when building embedding endpoint URL

### DIFF
--- a/src/memory/embeddings-remote-provider.append-path.test.ts
+++ b/src/memory/embeddings-remote-provider.append-path.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { appendEmbeddingsPath } from "./embeddings-remote-provider.js";
+
+describe("appendEmbeddingsPath", () => {
+  it("appends /embeddings to a plain base URL", () => {
+    expect(appendEmbeddingsPath("https://api.openai.com/v1")).toBe(
+      "https://api.openai.com/v1/embeddings",
+    );
+  });
+
+  it("strips a trailing slash before appending", () => {
+    expect(appendEmbeddingsPath("https://api.openai.com/v1/")).toBe(
+      "https://api.openai.com/v1/embeddings",
+    );
+  });
+
+  it("preserves existing query parameters (Azure OpenAI api-version)", () => {
+    const base =
+      "https://my-resource.cognitiveservices.azure.com/openai/deployments/text-embedding-3-large?api-version=2024-02-01";
+    const result = appendEmbeddingsPath(base);
+    expect(result).toBe(
+      "https://my-resource.cognitiveservices.azure.com/openai/deployments/text-embedding-3-large/embeddings?api-version=2024-02-01",
+    );
+  });
+
+  it("preserves multiple query parameters", () => {
+    const base = "https://example.com/v2?foo=bar&baz=qux";
+    const result = appendEmbeddingsPath(base);
+    expect(result).toBe("https://example.com/v2/embeddings?foo=bar&baz=qux");
+  });
+
+  it("preserves query parameters when base has trailing slash", () => {
+    const base = "https://example.com/v2/?api-version=2024-02-01";
+    const result = appendEmbeddingsPath(base);
+    expect(result).toBe("https://example.com/v2/embeddings?api-version=2024-02-01");
+  });
+
+  it("falls back gracefully for relative/non-parseable URLs", () => {
+    expect(appendEmbeddingsPath("/v1")).toBe("/v1/embeddings");
+  });
+});

--- a/src/memory/embeddings-remote-provider.ts
+++ b/src/memory/embeddings-remote-provider.ts
@@ -13,6 +13,37 @@ export type RemoteEmbeddingClient = {
   model: string;
 };
 
+/**
+ * Appends "/embeddings" to the pathname of a base URL while preserving any
+ * existing query parameters and fragments.
+ *
+ * This is necessary for Azure OpenAI deployments whose base URLs include
+ * required query parameters such as `?api-version=2024-02-01`.  A naïve
+ * string concatenation (`${baseUrl}/embeddings`) would produce a malformed
+ * URL when the base already carries a query string.
+ *
+ * @example
+ *   // Plain base URL (standard OpenAI-compatible endpoint)
+ *   appendEmbeddingsPath("https://api.openai.com/v1")
+ *   // => "https://api.openai.com/v1/embeddings"
+ *
+ *   // Azure OpenAI deployment URL with api-version query param
+ *   appendEmbeddingsPath(
+ *     "https://my.cognitiveservices.azure.com/openai/deployments/text-embedding-3-large?api-version=2024-02-01"
+ *   )
+ *   // => "https://my.cognitiveservices.azure.com/openai/deployments/text-embedding-3-large/embeddings?api-version=2024-02-01"
+ */
+export function appendEmbeddingsPath(baseUrl: string): string {
+  try {
+    const parsed = new URL(baseUrl);
+    parsed.pathname = parsed.pathname.replace(/\/$/, "") + "/embeddings";
+    return parsed.toString();
+  } catch {
+    // Fallback for non-parseable URLs (e.g. relative paths in tests)
+    return `${baseUrl.replace(/\/$/, "")}/embeddings`;
+  }
+}
+
 export function createRemoteEmbeddingProvider(params: {
   id: string;
   client: RemoteEmbeddingClient;
@@ -20,7 +51,7 @@ export function createRemoteEmbeddingProvider(params: {
   maxInputTokens?: number;
 }): EmbeddingProvider {
   const { client } = params;
-  const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
+  const url = appendEmbeddingsPath(client.baseUrl);
 
   const embed = async (input: string[]): Promise<number[][]> => {
     if (input.length === 0) {


### PR DESCRIPTION
## Problem

Azure OpenAI deployment URLs require a mandatory `?api-version=` query parameter. For example:

```
https://my-resource.cognitiveservices.azure.com/openai/deployments/text-embedding-3-large?api-version=2024-02-01
```

The current `createRemoteEmbeddingProvider` builds the final endpoint with:

```ts
const url = `${client.baseUrl.replace(/\/$/, '')}/embeddings`;
```

This naive string concatenation drops any query string already present in `baseUrl`, producing a 404:

```
Memory index failed: openai embeddings failed: 404 {"error":{"code":"404","message": "Resource not found"}}
```

## Fix

Replace the string concatenation with a proper URL manipulation using the WHATWG `URL` API. The new `appendEmbeddingsPath` helper appends `/embeddings` to the **pathname** only, leaving the query string and fragment intact:

```ts
export function appendEmbeddingsPath(baseUrl: string): string {
  try {
    const parsed = new URL(baseUrl);
    parsed.pathname = parsed.pathname.replace(/\/$/, '') + '/embeddings';
    return parsed.toString();
  } catch {
    return `${baseUrl.replace(/\/$/, '')}/embeddings`;
  }
}
```

### Before / After

| Input `baseUrl` | Old result | New result |
|---|---|---|
| `https://api.openai.com/v1` | `https://api.openai.com/v1/embeddings` ✅ | `https://api.openai.com/v1/embeddings` ✅ |
| `https://my.cognitiveservices.azure.com/openai/deployments/text-embedding-3-large?api-version=2024-02-01` | `https://my.cognitiveservices.azure.com/openai/deployments/text-embedding-3-large?api-version=2024-02-01/embeddings` ❌ | `https://my.cognitiveservices.azure.com/openai/deployments/text-embedding-3-large/embeddings?api-version=2024-02-01` ✅ |

## Configuration example (Azure OpenAI)

```json
"memorySearch": {
  "provider": "openai",
  "model": "text-embedding-3-large",
  "remote": {
    "baseUrl": "https://<resource>.cognitiveservices.azure.com/openai/deployments/<deployment>?api-version=2024-02-01",
    "apiKey": "<key>",
    "headers": { "api-key": "<key>" }
  }
}
```

Note: Azure expects the API key in the `api-key` header rather than `Authorization: Bearer`, which is already supported via `remote.headers`.

## Tests

6 new unit tests covering:
- Plain base URL (regression)
- Trailing slash stripping (regression)
- Azure-style URL with `api-version` query param ← new case
- Multiple query params
- Query params with trailing slash
- Fallback for non-parseable relative URLs

```
✓ src/memory/embeddings-remote-provider.append-path.test.ts (6 tests)
```