### PR TITLE
fix(telegram): add setStatus integration for channel health monitoring

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -495,6 +495,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         webhookPath: account.config.webhookPath,
         webhookHost: account.config.webhookHost,
         webhookPort: account.config.webhookPort,
+        setStatus: ctx.setStatus as (next: Record<string, unknown>) => void,
       });
     },
     logoutAccount: async ({ accountId, cfg }) => {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -48,6 +48,7 @@ export type TelegramBotOptions = {
   replyToMode?: ReplyToMode;
   proxyFetch?: typeof fetch;
   config?: OpenClawConfig;
+  setStatus?: (next: Record<string, unknown>) => void;
   updateOffset?: {
     lastUpdateId?: number | null;
     onUpdateId?: (updateId: number) => void | Promise<void>;
@@ -163,6 +164,21 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       }
     }
   });
+
+  // Update health-monitoring timestamps on every inbound update so the gateway
+  // can distinguish a working-but-quiet channel from a dead one.
+  if (opts.setStatus) {
+    const setStatus = opts.setStatus;
+    bot.use(async (ctx, next) => {
+      try {
+        const now = Date.now();
+        setStatus({ lastEventAt: now, lastInboundAt: now });
+      } catch {
+        // Error isolation: never let status tracking break the update pipeline.
+      }
+      await next();
+    });
+  }
 
   bot.use(sequentialize(getTelegramSequentialKey));
 

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -30,6 +30,7 @@ export type MonitorTelegramOpts = {
   webhookHost?: string;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
+  setStatus?: (next: Record<string, unknown>) => void;
 };
 
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
@@ -172,6 +173,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         fetch: proxyFetch,
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
+        setStatus: opts.setStatus,
       });
       await waitForAbortSignal(opts.abortSignal);
       return;
@@ -220,6 +222,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           proxyFetch,
           config: cfg,
           accountId: account.accountId,
+          setStatus: opts.setStatus,
           updateOffset: {
             lastUpdateId,
             onUpdateId: persistUpdateId,

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -87,6 +87,7 @@ export async function startTelegramWebhook(opts: {
   abortSignal?: AbortSignal;
   healthPath?: string;
   publicUrl?: string;
+  setStatus?: (next: Record<string, unknown>) => void;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -107,6 +108,7 @@ export async function startTelegramWebhook(opts: {
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    setStatus: opts.setStatus,
   });
   await initializeTelegramWebhookBot({
     bot,


### PR DESCRIPTION
## Summary

Thread `setStatus` callback from extension → monitor → bot/webhook, following the established Slack/Discord pattern. This enables the gateway's channel health monitoring system to track Telegram inbound activity.

## Problem

The Telegram provider lacks `setStatus` integration, causing `lastEventAt` and `lastInboundAt` timestamps to remain `null` even when messages are actively received. This prevents the channel health monitoring system from distinguishing between a functional quiet channel and a half-dead connection.

## Changes

| File | Change |
|------|--------|
| `src/telegram/monitor.ts` | Add `setStatus` to `MonitorTelegramOpts`, pass through to bot/webhook |
| `src/telegram/bot.ts` | Add `setStatus` to `TelegramBotOptions`, add grammY middleware to update timestamps on every inbound update |
| `src/telegram/webhook.ts` | Add `setStatus` to webhook opts, pass through to `createTelegramBot` |
| `extensions/telegram/src/channel.ts` | Pass `ctx.setStatus` from `startAccount` to `monitorTelegramProvider` |

## Design Decisions

- **Middleware placement**: The `setStatus` middleware is added early in the chain (before `sequentialize`) so timestamps update even if downstream handlers fail.
- **Error isolation**: The `setStatus` call is wrapped in try/catch — status tracking never breaks the message processing pipeline.
- **Timestamps**: Uses `Date.now()` (epoch ms) for both `lastEventAt` and `lastInboundAt`, matching the pattern used by Slack/Discord.

## Testing

- Manual verification with a live Telegram bot
- The middleware is a pure side-effect (try/catch isolated), minimal risk to existing behavior

Closes #32850