### PR TITLE
fix(build): add missing keyed-async-queue entry to tsdown config

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -45,6 +45,13 @@ export default defineConfig([
     platform: "node",
   },
   {
+    entry: "src/plugin-sdk/keyed-async-queue.ts",
+    outDir: "dist/plugin-sdk",
+    env,
+    fixedExtension: false,
+    platform: "node",
+  },
+  {
     entry: "src/extensionAPI.ts",
     env,
     fixedExtension: false,


### PR DESCRIPTION
## Summary
The bundled Matrix plugin fails to load because a declared package export has no corresponding build output.

## Root Cause
`package.json` exports map declares `./plugin-sdk/keyed-async-queue` pointing to `dist/plugin-sdk/keyed-async-queue.{js,d.ts}`, but `tsdown.config.ts` doesn't include `keyed-async-queue.ts` as a build entry — so the files are never generated.

The Matrix plugin's `send-queue.ts` imports `KeyedAsyncQueue` from this subpath (correctly per the exports map), but fails at runtime:

```
Cannot find module '.../dist/plugin-sdk/keyed-async-queue'
```

## Fix
Add one entry block to `tsdown.config.ts` — identical pattern to the existing `account-id.ts` entry:

```ts
{
  entry: "src/plugin-sdk/keyed-async-queue.ts",
  outDir: "dist/plugin-sdk",
  env,
  fixedExtension: false,
  platform: "node",
},
```

## Files Changed
- `tsdown.config.ts` — 7 lines added (1 new entry block)

## Testing
- Verified on 3 separate machines (Linux x64, Linux Mint, SteamOS/Steam Deck)
- 6 Matrix accounts across 2 OpenClaw instances responding correctly after fix
- Multi-account routing (different bot identities per room) working
- Cross-machine communication via Tailscale mesh verified

## Notes
- Source file `src/plugin-sdk/keyed-async-queue.ts` already exists with tests
- `vitest.config.ts` already has an alias for this module
- The `account-id` subpath follows the exact same pattern and works correctly
- This is simply a missing build entry — code, tests, and exports map are all already correct