### PR TITLE
fix(gateway): expose legacy dispatcher alias for external channel plugins

### DIFF
--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -235,6 +235,12 @@ export type ChannelGatewayContext<ResolvedAccount = unknown> = {
    * @see {@link https://docs.openclaw.ai/plugins/developing-plugins | Plugin SDK documentation}
    */
   channelRuntime?: PluginRuntime["channel"];
+  /**
+   * Legacy dispatcher alias for external plugins built before `channelRuntime` landed.
+   *
+   * @deprecated Prefer `channelRuntime.reply.dispatchReplyWithBufferedBlockDispatcher`.
+   */
+  dispatchReplyWithBufferedBlockDispatcher?: PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"];
 };
 
 export type ChannelLogoutResult = {

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -180,4 +180,22 @@ describe("server-channels auto restart", () => {
     await manager.startChannels();
     expect(startAccount).toHaveBeenCalledTimes(1);
   });
+
+  it("provides legacy dispatcher alias when channelRuntime reply dispatcher exists", async () => {
+    const dispatcher = vi.fn(async () => ({ queuedFinal: false }));
+    const channelRuntime = {
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: dispatcher,
+      },
+    } as unknown as PluginRuntime["channel"];
+    const startAccount = vi.fn(async (ctx) => {
+      expect(ctx.dispatchReplyWithBufferedBlockDispatcher).toBe(dispatcher);
+    });
+
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager({ channelRuntime });
+
+    await manager.startChannels();
+    expect(startAccount).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -231,6 +231,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           getStatus: () => getRuntime(channelId, id),
           setStatus: (next) => setRuntime(channelId, id, next),
           ...(channelRuntime ? { channelRuntime } : {}),
+          ...(channelRuntime?.reply?.dispatchReplyWithBufferedBlockDispatcher
+            ? {
+                dispatchReplyWithBufferedBlockDispatcher:
+                  channelRuntime.reply.dispatchReplyWithBufferedBlockDispatcher,
+              }
+            : {}),
         });
         const trackedPromise = Promise.resolve(task)
           .catch((err) => {


### PR DESCRIPTION
## Summary
- add a backward-compatible `dispatchReplyWithBufferedBlockDispatcher` alias on `ChannelGatewayContext`
- wire the alias from `channelRuntime.reply.dispatchReplyWithBufferedBlockDispatcher` in the channel manager
- cover the compatibility contract in `server-channels` tests

## Problem
Some external channel plugins still probe `ctx.dispatchReplyWithBufferedBlockDispatcher` instead of the newer `ctx.channelRuntime.reply.dispatchReplyWithBufferedBlockDispatcher`.
When only the new runtime path is present, those plugins can connect but fail to dispatch inbound messages.

## Fix
- keep the modern `channelRuntime` API as-is
- expose a deprecated alias in gateway context for legacy plugins
- do not change behavior when `channelRuntime` is absent

## Validation
- `pnpm -s exec vitest run src/gateway/server-channels.test.ts`
- `pnpm -s exec oxlint --type-aware src/channels/plugins/types.adapters.ts src/gateway/server-channels.ts src/gateway/server-channels.test.ts`
- `pnpm -s exec tsc -p tsconfig.json --noEmit`
