### PR TITLE
fix(discord): add reconnect grace period to health monitor to prevent false stuck restarts

### DIFF
--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -127,7 +127,13 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             staleEventThresholdMs: timing.staleEventThresholdMs,
             channelConnectGraceMs: timing.channelConnectGraceMs,
           };
-          const health = evaluateChannelHealth(status, healthPolicy);
+          // Extract lastDisconnectAt from the channel account snapshot so
+          // the health policy can apply a reconnect grace period (#31710).
+          const lastDisconnectAt =
+            status.lastDisconnect != null && typeof status.lastDisconnect === "object"
+              ? status.lastDisconnect.at
+              : undefined;
+          const health = evaluateChannelHealth({ ...status, lastDisconnectAt }, healthPolicy);
           if (health.healthy) {
             continue;
           }

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -2,6 +2,7 @@ import type { ChannelId } from "../channels/plugins/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   evaluateChannelHealth,
+  extractLastDisconnectAt,
   resolveChannelRestartReason,
   type ChannelHealthPolicy,
 } from "./channel-health-policy.js";
@@ -127,12 +128,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             staleEventThresholdMs: timing.staleEventThresholdMs,
             channelConnectGraceMs: timing.channelConnectGraceMs,
           };
-          // Extract lastDisconnectAt from the channel account snapshot so
-          // the health policy can apply a reconnect grace period (#31710).
-          const lastDisconnectAt =
-            status.lastDisconnect != null && typeof status.lastDisconnect === "object"
-              ? status.lastDisconnect.at
-              : undefined;
+          const lastDisconnectAt = extractLastDisconnectAt(status.lastDisconnect);
           const health = evaluateChannelHealth({ ...status, lastDisconnectAt }, healthPolicy);
           if (health.healthy) {
             continue;

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -68,3 +68,56 @@ describe("resolveChannelRestartReason", () => {
     expect(reason).toBe("gave-up");
   });
 });
+
+describe("reconnect grace period (#31710)", () => {
+  const policy = {
+    now: 500_000,
+    channelConnectGraceMs: 120_000,
+    staleEventThresholdMs: 1_800_000,
+  };
+
+  it("treats recently disconnected channel as healthy during reconnect grace", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: false,
+        enabled: true,
+        configured: true,
+        lastStartAt: 10_000, // well outside startup grace
+        lastDisconnectAt: 495_000, // 5s ago, within 120s reconnect grace
+      },
+      policy,
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "reconnect-grace" });
+  });
+
+  it("flags disconnected channel after reconnect grace expires", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: false,
+        enabled: true,
+        configured: true,
+        lastStartAt: 10_000,
+        lastDisconnectAt: 300_000, // 200s ago > 120s grace
+      },
+      policy,
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "disconnected" });
+  });
+
+  it("flags disconnected when lastDisconnectAt is missing", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: false,
+        enabled: true,
+        configured: true,
+        lastStartAt: 10_000, // well outside startup grace
+        // no lastDisconnectAt
+      },
+      policy,
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "disconnected" });
+  });
+});

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { evaluateChannelHealth, resolveChannelRestartReason } from "./channel-health-policy.js";
+import {
+  evaluateChannelHealth,
+  extractLastDisconnectAt,
+  resolveChannelRestartReason,
+} from "./channel-health-policy.js";
 
 describe("evaluateChannelHealth", () => {
   it("treats disabled accounts as healthy unmanaged", () => {
@@ -119,5 +123,23 @@ describe("reconnect grace period (#31710)", () => {
       policy,
     );
     expect(evaluation).toEqual({ healthy: false, reason: "disconnected" });
+  });
+});
+
+describe("extractLastDisconnectAt", () => {
+  it("extracts at from object", () => {
+    expect(extractLastDisconnectAt({ at: 12345, status: 1006 })).toBe(12345);
+  });
+
+  it("returns undefined for string", () => {
+    expect(extractLastDisconnectAt("some error")).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(extractLastDisconnectAt(null)).toBeUndefined();
+  });
+
+  it("returns undefined for undefined", () => {
+    expect(extractLastDisconnectAt(undefined)).toBeUndefined();
   });
 });

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -90,3 +90,16 @@ export function resolveChannelRestartReason(
   }
   return "stuck";
 }
+
+/**
+ * Extract `lastDisconnectAt` from a channel account snapshot's `lastDisconnect`
+ * field, which can be a string, an object with `at`, or null.
+ */
+export function extractLastDisconnectAt(
+  lastDisconnect: string | { at: number; [key: string]: unknown } | null | undefined,
+): number | undefined {
+  if (lastDisconnect != null && typeof lastDisconnect === "object") {
+    return lastDisconnect.at;
+  }
+  return undefined;
+}

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -5,6 +5,7 @@ export type ChannelHealthSnapshot = {
   configured?: boolean;
   lastEventAt?: number | null;
   lastStartAt?: number | null;
+  lastDisconnectAt?: number | null;
   reconnectAttempts?: number;
 };
 
@@ -13,6 +14,7 @@ export type ChannelHealthEvaluationReason =
   | "unmanaged"
   | "not-running"
   | "startup-connect-grace"
+  | "reconnect-grace"
   | "disconnected"
   | "stale-socket";
 
@@ -50,6 +52,16 @@ export function evaluateChannelHealth(
     }
   }
   if (snapshot.connected === false) {
+    // Allow a grace period for WebSocket reconnection cycles.
+    // Without this, normal reconnect attempts (where connected briefly flips
+    // to false) would be flagged as unhealthy, causing unnecessary provider
+    // restarts that leak event listeners and duplicate messages (#31710).
+    if (snapshot.lastDisconnectAt != null) {
+      const disconnectAge = policy.now - snapshot.lastDisconnectAt;
+      if (disconnectAge < policy.channelConnectGraceMs) {
+        return { healthy: true, reason: "reconnect-grace" };
+      }
+    }
     return { healthy: false, reason: "disconnected" };
   }
   if (snapshot.lastEventAt != null || snapshot.lastStartAt != null) {


### PR DESCRIPTION
## What
Add a reconnect grace period to the channel health monitor so that normal WebSocket reconnection cycles are not flagged as unhealthy.

## Why
Fixes #31710 — Discord provider is repeatedly restarted by the health monitor (reason: stuck), causing duplicate messages due to leaked event listeners.

The root cause: when a Discord WebSocket briefly disconnects during a normal reconnect cycle, `evaluateChannelHealth` immediately returns `{ healthy: false, reason: "disconnected" }`. This maps to restart reason `"stuck"` via `resolveChannelRestartReason` (the default fallback). The existing `channelConnectGraceMs` only covers the initial startup window based on `lastStartAt`, not subsequent reconnection cycles.

## How
- Added `lastDisconnectAt` field to `ChannelHealthSnapshot`
- Added `reconnect-grace` evaluation reason: if `connected === false` but the disconnect happened within `channelConnectGraceMs` (default 120s), the channel is treated as healthy
- In `channel-health-monitor.ts`, extract `lastDisconnectAt` from `ChannelAccountSnapshot.lastDisconnect.at` before passing to `evaluateChannelHealth`
- The extraction is intentionally fail-safe: if `lastDisconnect` is missing or a string (not an object), `lastDisconnectAt` is `undefined` and the behavior falls back to the original (no grace period)

### Scope note
This PR addresses the **false positive restart** side of #31710. The issue also mentions event listener leakage during legitimate restarts — the lifecycle cleanup logic in `provider.lifecycle.ts` (finally block) already handles listener removal via `removeListener` and `abort.abort()`. The remaining edge case (listener overlap during async stop/start race) would require deeper changes to the channel manager restart sequencing and is tracked separately.

## Testing
- [x] `pnpm build` passes
- [x] `pnpm check` passes (format + lint + type check)
- [x] All 31 existing + new tests pass (`channel-health-policy.test.ts` + `channel-health-monitor.test.ts`)
- [x] 3 new test cases for reconnect grace period:
  - Recently disconnected → healthy (reconnect-grace)
  - Disconnect older than grace → unhealthy (disconnected)
  - Missing lastDisconnectAt → unhealthy (disconnected)
- [x] AI-assisted (Claude, fully tested)
- [x] Confirmed: `reason: stuck` in issue logs maps to `evaluation.reason: disconnected` via `resolveChannelRestartReason` default fallback