### PR TITLE
fix(telegram): edit reasoning preview instead of deleting to avoid "Deleted message" artifact

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -740,10 +740,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(reasoningDraftParams?.onSupersededPreview).toBeTypeOf("function");
-    const deleteMessageCalls = (
-      bot.api as unknown as { deleteMessage: { mock: { calls: unknown[][] } } }
-    ).deleteMessage.mock.calls;
-    expect(deleteMessageCalls).toContainEqual([123, 4444]);
+    // Archived reasoning previews should be edited to a minimal indicator
+    // instead of deleted, to avoid Telegram's "Deleted message" UI artifact.
+    const editMessageTextCalls = (
+      bot.api as unknown as { editMessageText: { mock: { calls: unknown[][] } } }
+    ).editMessageText.mock.calls;
+    expect(editMessageTextCalls).toContainEqual([123, 4444, "💭"]);
   });
 
   it.each(["block", "partial"] as const)(
@@ -1488,7 +1490,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
       }),
     ]);
 
+    // Answer lane preview is cleared normally.
     expect(draftA.clear).toHaveBeenCalledTimes(1);
-    expect(draftB.clear).toHaveBeenCalledTimes(1);
+    // Reasoning lane preview (draftB) is edited to a minimal indicator
+    // instead of cleared, to avoid Telegram's "Deleted message" artifact.
+    expect(draftB.clear).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -188,7 +188,7 @@ export const dispatchTelegramMessage = async ({
   const draftMinInitialChars = DRAFT_MIN_INITIAL_CHARS;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const archivedAnswerPreviews: ArchivedPreview[] = [];
-  const archivedReasoningPreviewIds: number[] = [];
+  const archivedReasoningPreviews: ArchivedPreview[] = [];
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
     const useMessagePreviewTransportForDmReasoning =
       laneName === "reasoning" && threadSpec?.scope === "dm" && canStreamAnswerDraft;
@@ -206,8 +206,11 @@ export const dispatchTelegramMessage = async ({
             laneName === "answer" || laneName === "reasoning"
               ? (preview) => {
                   if (laneName === "reasoning") {
-                    if (!archivedReasoningPreviewIds.includes(preview.messageId)) {
-                      archivedReasoningPreviewIds.push(preview.messageId);
+                    if (!archivedReasoningPreviews.some((p) => p.messageId === preview.messageId)) {
+                      archivedReasoningPreviews.push({
+                        messageId: preview.messageId,
+                        textSnapshot: preview.textSnapshot,
+                      });
                     }
                     return;
                   }
@@ -632,7 +635,7 @@ export const dispatchTelegramMessage = async ({
     // Must stop() first to flush debounced content before clear() wipes state.
     const streamCleanupStates = new Map<
       NonNullable<DraftLaneState["stream"]>,
-      { shouldClear: boolean }
+      { shouldClear: boolean; isReasoningLane: boolean }
     >();
     const lanesToCleanup: Array<{ laneName: LaneName; lane: DraftLaneState }> = [
       { laneName: "answer", lane: answerLane },
@@ -646,7 +649,10 @@ export const dispatchTelegramMessage = async ({
       const shouldClear = !finalizedPreviewByLane[laneState.laneName];
       const existing = streamCleanupStates.get(stream);
       if (!existing) {
-        streamCleanupStates.set(stream, { shouldClear });
+        streamCleanupStates.set(stream, {
+          shouldClear,
+          isReasoningLane: laneState.laneName === "reasoning",
+        });
         continue;
       }
       existing.shouldClear = existing.shouldClear && shouldClear;
@@ -654,7 +660,24 @@ export const dispatchTelegramMessage = async ({
     for (const [stream, cleanupState] of streamCleanupStates) {
       await stream.stop();
       if (cleanupState.shouldClear) {
-        await stream.clear();
+        // For reasoning lane with real message preview, edit to a minimal
+        // indicator instead of deleting. Telegram shows a persistent
+        // "Deleted message" placeholder when a message is removed, which
+        // degrades UX. Editing to a thought bubble avoids this artifact.
+        if (cleanupState.isReasoningLane && stream.previewMode?.() === "message") {
+          const messageId = stream.messageId();
+          if (typeof messageId === "number") {
+            try {
+              await bot.api.editMessageText(chatId, messageId, "💭");
+            } catch {
+              await stream.clear();
+            }
+          } else {
+            await stream.clear();
+          }
+        } else {
+          await stream.clear();
+        }
       }
     }
     for (const archivedPreview of archivedAnswerPreviews) {
@@ -666,13 +689,19 @@ export const dispatchTelegramMessage = async ({
         );
       }
     }
-    for (const messageId of archivedReasoningPreviewIds) {
+    // Edit archived reasoning previews to minimal indicator instead of
+    // deleting, to avoid Telegram's "Deleted message" UI artifact.
+    for (const preview of archivedReasoningPreviews) {
       try {
-        await bot.api.deleteMessage(chatId, messageId);
-      } catch (err) {
-        logVerbose(
-          `telegram: archived reasoning preview cleanup failed (${messageId}): ${String(err)}`,
-        );
+        await bot.api.editMessageText(chatId, preview.messageId, "💭");
+      } catch {
+        try {
+          await bot.api.deleteMessage(chatId, preview.messageId);
+        } catch (err) {
+          logVerbose(
+            `telegram: archived reasoning preview cleanup failed (${preview.messageId}): ${String(err)}`,
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- When streaming with extended thinking, reasoning lane preview messages are deleted on completion, causing Telegram to show a persistent "Deleted message" placeholder
- Changed cleanup to edit reasoning previews to a minimal "💭" indicator instead of deleting them
- Applies to both the current reasoning lane preview and archived superseded previews from multi-step responses
- Falls back to deletion if the edit fails (e.g., message already removed)

## Root Cause

The reasoning lane uses real Telegram messages (`previewTransport: "message"`) for streaming visibility. On completion, these are cleaned up via `deleteMessage()`. Unlike the answer lane (which finalizes in place via `editMessageText`), reasoning previews were always deleted — producing the "Deleted message" artifact that Telegram displays for removed messages.

## Changes

- `bot-message-dispatch.ts`: Changed `archivedReasoningPreviewIds: number[]` to `archivedReasoningPreviews: ArchivedPreview[]` to preserve text snapshots; cleanup now calls `editMessageText(chatId, messageId, "💭")` before falling back to `deleteMessage`
- `bot-message-dispatch.test.ts`: Updated test expectations to match new edit-instead-of-delete behavior

## Test plan

- [x] All 49 existing tests in `bot-message-dispatch.test.ts` pass
- [x] All 30 tests in `lane-delivery.test.ts` and `draft-stream.test.ts` pass
- [ ] Manual test: send a message that triggers extended thinking in Telegram DM, verify no "Deleted message" appears

Fixes #32911

🤖 Generated with [Claude Code](https://claude.com/claude-code)