### PR TITLE
fix: display actual gateway version in status command

### DIFF
--- a/src/cli/daemon-cli/probe.ts
+++ b/src/cli/daemon-cli/probe.ts
@@ -12,7 +12,7 @@ export async function probeGatewayStatus(opts: {
   configPath?: string;
 }) {
   try {
-    await withProgress(
+    const statusResponse = await withProgress(
       {
         label: "Checking gateway status...",
         indeterminate: true,
@@ -31,7 +31,7 @@ export async function probeGatewayStatus(opts: {
           ...(opts.configPath ? { configPath: opts.configPath } : {}),
         }),
     );
-    return { ok: true } as const;
+    return { ok: true, data: statusResponse } as const;
   } catch (err) {
     return {
       ok: false,

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -88,6 +88,7 @@ export type DaemonStatus = {
     ok: boolean;
     error?: string;
     url?: string;
+    version?: string;
   };
   extraServices: Array<{ label: string; detail: string; scope: string }>;
 };
@@ -291,7 +292,7 @@ export async function gatherDaemonStatus(
       })
     : undefined;
 
-  const rpc = opts.probe
+  const probeResult = opts.probe
     ? await probeGatewayStatus({
         url: probeUrl,
         token:
@@ -308,6 +309,17 @@ export async function gatherDaemonStatus(
         configPath: daemonConfigSummary.path,
       })
     : undefined;
+
+  const rpc =
+    probeResult && probeResult.ok
+      ? {
+          ok: true,
+          version:
+            (probeResult.data as { version?: string } | undefined)?.version ?? undefined,
+        }
+      : probeResult
+        ? { ok: false, error: probeResult.error }
+        : undefined;
 
   let lastError: string | undefined;
   if (loaded && runtime?.status === "running" && portStatus && portStatus.status !== "busy") {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -314,8 +314,7 @@ export async function gatherDaemonStatus(
     probeResult && probeResult.ok
       ? {
           ok: true,
-          version:
-            (probeResult.data as { version?: string } | undefined)?.version ?? undefined,
+          version: (probeResult.data as { version?: string })?.version,
         }
       : probeResult
         ? { ok: false, error: probeResult.error }

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -15,6 +15,7 @@ import { getResolvedLoggerSettings } from "../../logging.js";
 import { defaultRuntime } from "../../runtime.js";
 import { colorize } from "../../terminal/theme.js";
 import { shortenHomePath } from "../../utils.js";
+import { VERSION } from "../../version.js";
 import { formatCliCommand } from "../command-format.js";
 import {
   createCliStatusTextStyles,
@@ -169,6 +170,17 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
   if (runtimeLine) {
     const runtimeColor = resolveRuntimeStatusColor(service.runtime?.status);
     defaultRuntime.log(`${label("Runtime:")} ${colorize(rich, runtimeColor, runtimeLine)}`);
+  }
+
+  // Display gateway version (from RPC if available, otherwise CLI version)
+  const gatewayVersion = rpc?.version ?? VERSION;
+  const cliVersion = VERSION;
+  if (gatewayVersion === cliVersion) {
+    defaultRuntime.log(`${label("Version:")} ${infoText(gatewayVersion)}`);
+  } else {
+    defaultRuntime.log(
+      `${label("Version:")} gateway=${infoText(gatewayVersion)} | cli=${infoText(cliVersion)}`,
+    );
   }
 
   if (rpc && !rpc.ok && service.loaded && service.runtime?.status === "running") {

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -173,15 +173,24 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
   }
 
   // Display gateway version (from RPC if available, otherwise CLI version)
-  const gatewayVersion = rpc?.version ?? VERSION;
+  // Only show gateway version if we actually got one from the probe
+  const gatewayVersion: string | undefined = rpc?.ok ? rpc.version : undefined;
   const cliVersion = VERSION;
-  if (gatewayVersion === cliVersion) {
-    defaultRuntime.log(`${label("Version:")} ${infoText(gatewayVersion)}`);
-  } else {
-    defaultRuntime.log(
-      `${label("Version:")} gateway=${infoText(gatewayVersion)} | cli=${infoText(cliVersion)}`,
-    );
+  
+  if (gatewayVersion !== undefined) {
+    if (gatewayVersion !== cliVersion) {
+      defaultRuntime.log(
+        `${label("Version:")} gateway=${infoText(gatewayVersion)} | cli=${infoText(cliVersion)}`,
+      );
+    } else {
+      defaultRuntime.log(`${label("Version:")} ${infoText(gatewayVersion)}`);
+    }
+  } else if (rpc === undefined || !rpc.ok) {
+    // No probe or probe failed - show CLI version only
+    defaultRuntime.log(`${label("Version (CLI):")} ${infoText(cliVersion)}`);
   }
+  // If probe succeeded but no version field, don't show version line
+  // (transitional state - older gateway without version support)
 
   if (rpc && !rpc.ok && service.loaded && service.runtime?.status === "running") {
     defaultRuntime.log(

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -19,6 +19,7 @@ import { buildChannelSummary } from "../infra/channel-summary.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-runner.js";
 import { peekSystemEvents } from "../infra/system-events.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
+import { VERSION } from "../version.js";
 import { resolveLinkChannelContext } from "./status.link-channel.js";
 import type { HeartbeatStatus, SessionStatus, StatusSummary } from "./status.types.js";
 
@@ -205,6 +206,7 @@ export async function getStatusSummary(
   const totalSessions = allSessions.length;
 
   const summary: StatusSummary = {
+    version: VERSION,
     linkChannel: linkContext
       ? {
           id: linkContext.plugin.id,

--- a/src/commands/status.types.ts
+++ b/src/commands/status.types.ts
@@ -34,6 +34,7 @@ export type HeartbeatStatus = {
 };
 
 export type StatusSummary = {
+  version: string;
   linkChannel?: {
     id: ChannelId;
     label: string;


### PR DESCRIPTION
## Description

Fixes #32913

This PR fixes the bug where `openclaw status` displays the stale `wizard.lastRunVersion` from onboard instead of the actual running gateway version.

## Changes

- **Gateway side:** Added `version` field to `StatusSummary` type and return `VERSION` in status RPC response
- **CLI side:** Modified `probeGatewayStatus()` to capture the gateway version from RPC response
- **Display:** Added version line in `status.print.ts` that shows:
  - Gateway version when RPC probe succeeds
  - CLI version as fallback when RPC unavailable
  - Both versions when they differ (e.g., `Version: gateway=2026.3.2 | cli=2026.2.26`)

## Testing

### Manual verification steps:

1. Install OpenClaw 2026.2.26
2. Run onboard → `wizard.lastRunVersion` = 2026.2.26
3. Update to 2026.3.2 via `gateway update.run`
4. Restart gateway
5. Run `openclaw status`
6. **Before this fix:** Would show `app 2026.2.26` (stale)
7. **After this fix:** Shows `Version: 2026.3.2` (correct)

### Example output:

```
Runtime: running (pid 12345)
Version: 2026.3.2
RPC probe: ok
```

Or when versions differ:
```
Version: gateway=2026.3.2 | cli=2026.2.26
```

## Impact

- **Users affected:** All users (fixes a display bug everyone encounters)
- **Breaking changes:** None
- **Risk level:** Very low (display-only change, no core logic affected)
- **Lines changed:** ~30 lines across 5 files

## Checklist

- [x] Code changes follow the project's code style
- [x] Changes are minimal and focused on the fix
- [x] No breaking changes introduced
- [x] Type safety maintained (StatusSummary type extended)
- [x] Fallback logic included (CLI version when gateway unavailable)

## Related

- Issue: #32913
- Initial discussion: https://github.com/openclaw/openclaw/issues/32913#issuecomment-3990235705