### PR TITLE
fix: finalize Telegram reasoning preview instead of deleting

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -188,7 +188,7 @@ export const dispatchTelegramMessage = async ({
   const draftMinInitialChars = DRAFT_MIN_INITIAL_CHARS;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const archivedAnswerPreviews: ArchivedPreview[] = [];
-  const archivedReasoningPreviewIds: number[] = [];
+  const archivedReasoningPreviews: ArchivedPreview[] = [];
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
     const useMessagePreviewTransportForDmReasoning =
       laneName === "reasoning" && threadSpec?.scope === "dm" && canStreamAnswerDraft;
@@ -206,8 +206,11 @@ export const dispatchTelegramMessage = async ({
             laneName === "answer" || laneName === "reasoning"
               ? (preview) => {
                   if (laneName === "reasoning") {
-                    if (!archivedReasoningPreviewIds.includes(preview.messageId)) {
-                      archivedReasoningPreviewIds.push(preview.messageId);
+                    if (!archivedReasoningPreviews.some((p) => p.messageId === preview.messageId)) {
+                      archivedReasoningPreviews.push({
+                        messageId: preview.messageId,
+                        textSnapshot: preview.textSnapshot ?? "",
+                      });
                     }
                     return;
                   }
@@ -694,10 +697,11 @@ export const dispatchTelegramMessage = async ({
       }
     }
     // Finalize reasoning previews (edit to spoiler format instead of deleting)
-    for (const messageId of archivedReasoningPreviewIds) {
+    for (const { messageId, textSnapshot } of archivedReasoningPreviews) {
       try {
-        // Get the final reasoning text from the reasoning lane
-        const finalReasoningText = reasoningLane.lastPartialText || "";
+        // Use the snapshot if available, otherwise fall back to last partial text
+        const finalReasoningText =
+          textSnapshot.trim().length > 0 ? textSnapshot : reasoningLane.lastPartialText || "";
         if (finalReasoningText.trim().length > 0) {
           // Wrap in spoiler tags so users can still view it if interested
           const spoilerText = `<tg-spoiler>${renderTelegramHtmlText(finalReasoningText)}</tg-spoiler>`;

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -693,12 +693,24 @@ export const dispatchTelegramMessage = async ({
         );
       }
     }
+    // Finalize reasoning previews (edit to spoiler format instead of deleting)
     for (const messageId of archivedReasoningPreviewIds) {
       try {
-        await bot.api.deleteMessage(chatId, messageId);
+        // Get the final reasoning text from the reasoning lane
+        const finalReasoningText = reasoningLane.lastPartialText || "";
+        if (finalReasoningText.trim().length > 0) {
+          // Wrap in spoiler tags so users can still view it if interested
+          const spoilerText = `<tg-spoiler>${renderTelegramHtmlText(finalReasoningText)}</tg-spoiler>`;
+          await bot.api.editMessageText(chatId, messageId, spoilerText, {
+            parse_mode: "HTML",
+          });
+        } else {
+          // If no reasoning text available, fall back to deletion
+          await bot.api.deleteMessage(chatId, messageId);
+        }
       } catch (err) {
         logVerbose(
-          `telegram: archived reasoning preview cleanup failed (${messageId}): ${String(err)}`,
+          `telegram: reasoning preview finalization failed (${messageId}): ${String(err)}`,
         );
       }
     }

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -209,7 +209,7 @@ export const dispatchTelegramMessage = async ({
                     if (!archivedReasoningPreviews.some((p) => p.messageId === preview.messageId)) {
                       archivedReasoningPreviews.push({
                         messageId: preview.messageId,
-                        textSnapshot: preview.textSnapshot ?? "",
+                        textSnapshot: preview.textSnapshot ?? reasoningLane.lastPartialText ?? "",
                       });
                     }
                     return;
@@ -704,7 +704,7 @@ export const dispatchTelegramMessage = async ({
           textSnapshot.trim().length > 0 ? textSnapshot : reasoningLane.lastPartialText || "";
         if (finalReasoningText.trim().length > 0) {
           // Wrap in spoiler tags so users can still view it if interested
-          const spoilerText = `<tg-spoiler>${renderTelegramHtmlText(finalReasoningText)}</tg-spoiler>`;
+          const spoilerText = `<tg-spoiler>${renderTelegramHtmlText(finalReasoningText, { tableMode })}</tg-spoiler>`;
           await bot.api.editMessageText(chatId, messageId, spoilerText, {
             parse_mode: "HTML",
           });


### PR DESCRIPTION
## Description

Fixes #32911

This PR eliminates the "Deleted message" ghost artifact that appears when Telegram reasoning previews are deleted after streaming completion.

## Root Cause

When streaming with reasoning enabled:
1. Answer lane uses `editMessageText` → seamless finalization ✅
2. Reasoning lane uses `deleteMessage` → leaves "Deleted message" artifact ❌

Telegram's native UI renders deleted messages as "Deleted message", which looks like a bug to users.

## Solution

**Mirror the answer lane behavior:** Edit the reasoning preview to final formatted text instead of deleting it.

```typescript
// ❌ Old (causes "Deleted message"):
await bot.api.deleteMessage(chatId, messageId);

// ✅ New (seamless finalization):
const spoilerText = `<tg-spoiler>${renderTelegramHtmlText(finalReasoningText)}</tg-spoiler>`;
await bot.api.editMessageText(chatId, messageId, spoilerText, { parse_mode: 'HTML' });
```

## Benefits

- ✅ No "Deleted message" artifacts
- ✅ Users can still see reasoning (via spoiler tap)
- ✅ Consistent with answer lane behavior
- ✅ Minimal code change (~16 lines)

## Testing

### Manual test steps:

1. Configure Telegram bot with `streaming: "partial"`
2. Enable reasoning: `thinking: "high"` or `"on"`
3. Send a prompt that triggers reasoning (e.g., "Explain quantum computing")
4. **Verify during streaming:**
   - Reasoning text appears as separate message/section
5. **Verify on completion:**
   - ✅ NO "Deleted message" artifact
   - ✅ Reasoning shown in spoiler (tap to expand)
   - ✅ Answer message displays correctly

### Example behavior:

**Before this fix:**
```
[Deleted message]  ← 😱 Ghost artifact
[Bot]: This is my answer
```

**After this fix:**
```
[💭 Hidden reasoning - tap to expand]  ← Spoiler
[Bot]: This is my answer
```

## Impact

- **Users affected:** All Telegram users with reasoning enabled
- **Breaking changes:** None (only changes cleanup behavior)
- **Risk level:** Low (affects only Telegram reasoning display)
- **Lines changed:** +14, -2

## Checklist

- [x] Mirrors answer lane finalization pattern
- [x] Preserves reasoning content in spoiler tags
- [x] Falls back to deletion if no text available
- [x] Error handling maintained
- [x] Log message updated to reflect finalization

## Related

- Issue: #32911
- Initial discussion: https://github.com/openclaw/openclaw/issues/32911#issuecomment-3990239964
- Related PR #17218: Fixed answer lane (this PR completes reasoning lane)