### PR TITLE
fix(security): add brute-force protection to pairing code validation

### DIFF
--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -446,6 +446,64 @@ describe("pairing store", () => {
     });
   });
 
+  it("tracks failed pairing attempts and auto-expires after threshold", async () => {
+    await withTempStateDir(async () => {
+      const created = await upsertChannelPairingRequest({
+        channel: "telegram",
+        id: "12345",
+      });
+      expect(created.created).toBe(true);
+
+      // Submit 9 wrong codes — request should still exist
+      for (let i = 0; i < 9; i++) {
+        const result = await approveChannelPairingCode({
+          channel: "telegram",
+          code: "WRONGCODE",
+        });
+        expect(result).toBeNull();
+      }
+
+      let pending = await listChannelPairingRequests("telegram");
+      expect(pending).toHaveLength(1);
+      expect(pending[0]?.failedAttempts).toBe(9);
+
+      // 10th wrong attempt — should auto-expire the request
+      const result = await approveChannelPairingCode({
+        channel: "telegram",
+        code: "WRONGCODE",
+      });
+      expect(result).toBeNull();
+
+      pending = await listChannelPairingRequests("telegram");
+      expect(pending).toHaveLength(0);
+    });
+  });
+
+  it("correct code still works before brute-force threshold", async () => {
+    await withTempStateDir(async () => {
+      const created = await upsertChannelPairingRequest({
+        channel: "telegram",
+        id: "12345",
+      });
+      expect(created.created).toBe(true);
+
+      // Submit 5 wrong codes
+      for (let i = 0; i < 5; i++) {
+        await approveChannelPairingCode({
+          channel: "telegram",
+          code: "WRONGCODE",
+        });
+      }
+
+      // Correct code still works
+      const approved = await approveChannelPairingCode({
+        channel: "telegram",
+        code: created.code,
+      });
+      expect(approved?.id).toBe("12345");
+    });
+  });
+
   it("reads legacy channel-scoped allowFrom for default account", async () => {
     await withTempStateDir(async (stateDir) => {
       await seedTelegramAllowFromFixtures({

--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -504,6 +504,35 @@ describe("pairing store", () => {
     });
   });
 
+  it("does not increment account-scoped requests for unscoped wrong attempts", async () => {
+    await withTempStateDir(async () => {
+      await upsertChannelPairingRequest({
+        channel: "telegram",
+        id: "alice-1",
+        accountId: "alice",
+      });
+      await upsertChannelPairingRequest({
+        channel: "telegram",
+        id: "bob-1",
+        accountId: "bob",
+      });
+
+      // Wrong code with no accountId should NOT burn account-scoped requests.
+      for (let i = 0; i < 12; i++) {
+        await approveChannelPairingCode({
+          channel: "telegram",
+          code: "WRONGCODE",
+        });
+      }
+
+      const pending = await listChannelPairingRequests("telegram");
+      expect(pending).toHaveLength(2);
+      const byId = new Map(pending.map((p) => [p.id, p]));
+      expect(byId.get("alice-1")?.failedAttempts ?? 0).toBe(0);
+      expect(byId.get("bob-1")?.failedAttempts ?? 0).toBe(0);
+    });
+  });
+
   it("reads legacy channel-scoped allowFrom for default account", async () => {
     await withTempStateDir(async (stateDir) => {
       await seedTelegramAllowFromFixtures({

--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -451,6 +451,7 @@ describe("pairing store", () => {
       const created = await upsertChannelPairingRequest({
         channel: "telegram",
         id: "12345",
+        accountId: DEFAULT_ACCOUNT_ID,
       });
       expect(created.created).toBe(true);
 
@@ -484,6 +485,7 @@ describe("pairing store", () => {
       const created = await upsertChannelPairingRequest({
         channel: "telegram",
         id: "12345",
+        accountId: DEFAULT_ACCOUNT_ID,
       });
       expect(created.created).toBe(true);
 

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -248,11 +248,9 @@ function requestShouldTrackFailedAttempt(
   const entryAccountId = String(entry.meta?.accountId ?? "")
     .trim()
     .toLowerCase();
-  if (!normalizedAccountId) {
-    // Unscoped attempts should only affect unscoped requests.
-    return !entryAccountId;
-  }
-  return entryAccountId === normalizedAccountId;
+  const resolvedEntryAccountId = entryAccountId || DEFAULT_ACCOUNT_ID;
+  const resolvedAccountId = normalizedAccountId || DEFAULT_ACCOUNT_ID;
+  return resolvedEntryAccountId === resolvedAccountId;
 }
 
 function normalizeId(value: string | number): string {

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -14,6 +14,7 @@ const PAIRING_CODE_LENGTH = 8;
 const PAIRING_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const PAIRING_PENDING_TTL_MS = 60 * 60 * 1000;
 const PAIRING_PENDING_MAX = 3;
+const PAIRING_MAX_FAILED_ATTEMPTS = 10;
 const PAIRING_STORE_LOCK_OPTIONS = {
   retries: {
     retries: 10,
@@ -42,6 +43,8 @@ export type PairingRequest = {
   createdAt: string;
   lastSeenAt: string;
   meta?: Record<string, string>;
+  /** Number of failed code validation attempts against this request. */
+  failedAttempts?: number;
 };
 
 type PairingStore = {
@@ -814,10 +817,28 @@ export async function approveChannelPairingCode(params: {
         return requestMatchesAccountId(r, normalizedAccountId);
       });
       if (idx < 0) {
-        if (removed) {
+        // Wrong code — increment failed attempts on all matching pending requests.
+        // If any request exceeds the threshold, expire it to prevent brute-force.
+        let mutated = removed;
+        const surviving: PairingRequest[] = [];
+        for (const req of pruned) {
+          if (!requestMatchesAccountId(req, normalizedAccountId)) {
+            surviving.push(req);
+            continue;
+          }
+          const attempts = (req.failedAttempts ?? 0) + 1;
+          if (attempts >= PAIRING_MAX_FAILED_ATTEMPTS) {
+            // Auto-expire: too many wrong guesses
+            mutated = true;
+            continue;
+          }
+          surviving.push({ ...req, failedAttempts: attempts });
+          mutated = true;
+        }
+        if (mutated) {
           await writeJsonFile(filePath, {
             version: 1,
-            requests: pruned,
+            requests: surviving,
           } satisfies PairingStore);
         }
         return null;

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -241,6 +241,20 @@ function resolveAllowFromAccountId(accountId?: string): string {
   return normalizePairingAccountId(accountId) || DEFAULT_ACCOUNT_ID;
 }
 
+function requestShouldTrackFailedAttempt(
+  entry: PairingRequest,
+  normalizedAccountId: string,
+): boolean {
+  const entryAccountId = String(entry.meta?.accountId ?? "")
+    .trim()
+    .toLowerCase();
+  if (!normalizedAccountId) {
+    // Unscoped attempts should only affect unscoped requests.
+    return !entryAccountId;
+  }
+  return entryAccountId === normalizedAccountId;
+}
+
 function normalizeId(value: string | number): string {
   return String(value).trim();
 }
@@ -822,7 +836,7 @@ export async function approveChannelPairingCode(params: {
         let mutated = removed;
         const surviving: PairingRequest[] = [];
         for (const req of pruned) {
-          if (!requestMatchesAccountId(req, normalizedAccountId)) {
+          if (!requestShouldTrackFailedAttempt(req, normalizedAccountId)) {
             surviving.push(req);
             continue;
           }


### PR DESCRIPTION
## Summary

Adds failed attempt tracking to `approveChannelPairingCode()`. After 10 incorrect guesses, pending pairing requests are automatically expired to prevent brute-force attacks.

## Problem

Pairing codes are 8 characters from a 32-char alphabet (~40 bits of entropy) with a 1-hour TTL. There is **no rate limiting or attempt tracking** on code validation. An attacker who knows a pairing request exists (e.g., by messaging the bot from an unknown number) could systematically brute-force the code within the TTL window.

Successful brute-force grants a **persistent DM session** with tool, skill, and host command access — depending on session policy.

## Fix

- Add optional `failedAttempts` field to `PairingRequest` type
- On wrong code: increment `failedAttempts` on all account-matching pending requests
- Auto-expire (remove) requests that exceed `PAIRING_MAX_FAILED_ATTEMPTS` (10)
- Correct codes continue to work at any point before the threshold
- **Backward compatible**: existing pairing state files without `failedAttempts` default to 0

## Why 10 attempts?

- 40-bit code space means even 10 billion guesses/sec needs ~100 seconds
- 10 attempts provides a generous margin for typos while making brute-force futile
- Combined with the existing 1-hour TTL and 3-request cap, this closes the attack surface

## Tests

- `tracks failed pairing attempts and auto-expires after threshold` — verifies requests survive 9 wrong guesses but expire on 10th
- `correct code still works before brute-force threshold` — verifies legitimate use after partial failures
- All 12 tests pass

## Checklist

- [x] Minimal, focused change (2 files, ~80 lines)
- [x] Backward compatible with existing pairing state files
- [x] All existing tests still pass
- [x] Two new tests covering the protection logic
- [x] oxlint clean

Fixes #16458

> 🤖 AI-assisted: fix identified and implemented with Claude, reviewed by human.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds brute-force protection by tracking failed pairing code attempts and auto-expiring requests after 10 wrong guesses. The implementation adds a `failedAttempts` field to `PairingRequest` and increments it on wrong codes, removing requests that hit the threshold.

**Critical Issue Found**: The failed attempt tracking has a denial-of-service vulnerability. When `approveChannelPairingCode()` is called without an `accountId` parameter, the matching logic treats ALL pending requests as matches (because `requestMatchesAccountId(req, "")` returns `true` for all requests when normalized accountId is empty). This means an attacker can submit 10 wrong codes without specifying an accountId and expire ALL pending pairing requests across all accounts, not just their own.

The intended behavior should track failed attempts per request based on which specific code was attempted, not increment counters on all requests when no accountId filter is provided.

<h3>Confidence Score: 1/5</h3>

- This PR should NOT be merged - it contains a critical denial-of-service vulnerability
- Score of 1 reflects a critical security flaw where wrong pairing codes submitted without accountId will increment failedAttempts on ALL pending requests (regardless of their accountId), allowing an attacker to expire all users' pairing requests with just 10 wrong guesses
- src/pairing/pairing-store.ts requires immediate attention - the failed attempt tracking logic at lines 600-613 needs to be revised to prevent cross-account denial of service

<sub>Last reviewed commit: f0d9209</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---
Supersedes #26533 (auto-closed while refreshing branch).
