### PR TITLE
Agents: fix browser host base URL resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Browser host target resolution: return the configured browser control base URL for host-targeted browser tool calls so embedded browser actions no longer time out with an undefined base URL. Fixes #32814.
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.

--- a/src/agents/tools/browser-tool.test.ts
+++ b/src/agents/tools/browser-tool.test.ts
@@ -96,6 +96,8 @@ vi.mock("./common.js", async () => {
 import { DEFAULT_AI_SNAPSHOT_MAX_CHARS } from "../../browser/constants.js";
 import { createBrowserTool } from "./browser-tool.js";
 
+const HOST_BROWSER_BASE_URL = "http://127.0.0.1:18791";
+
 function mockSingleBrowserProxyNode() {
   nodesUtilsMocks.listNodes.mockResolvedValue([
     {
@@ -137,7 +139,7 @@ describe("browser tool snapshot maxChars", () => {
     await runSnapshotToolCall({ snapshotFormat: "ai" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_BASE_URL,
       expect.objectContaining({
         format: "ai",
         maxChars: DEFAULT_AI_SNAPSHOT_MAX_CHARS,
@@ -155,7 +157,7 @@ describe("browser tool snapshot maxChars", () => {
     });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_BASE_URL,
       expect.objectContaining({
         maxChars: override,
       }),
@@ -181,7 +183,7 @@ describe("browser tool snapshot maxChars", () => {
     const tool = createBrowserTool();
     await tool.execute?.("call-1", { action: "profiles" });
 
-    expect(browserClientMocks.browserProfiles).toHaveBeenCalledWith(undefined);
+    expect(browserClientMocks.browserProfiles).toHaveBeenCalledWith(HOST_BROWSER_BASE_URL);
   });
 
   it("passes refs mode through to browser snapshot", async () => {
@@ -189,7 +191,7 @@ describe("browser tool snapshot maxChars", () => {
     await tool.execute?.("call-1", { action: "snapshot", snapshotFormat: "ai", refs: "aria" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_BASE_URL,
       expect.objectContaining({
         format: "ai",
         refs: "aria",
@@ -204,7 +206,7 @@ describe("browser tool snapshot maxChars", () => {
     await runSnapshotToolCall({ snapshotFormat: "ai" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_BASE_URL,
       expect.objectContaining({
         mode: "efficient",
       }),
@@ -230,10 +232,20 @@ describe("browser tool snapshot maxChars", () => {
     await tool.execute?.("call-1", { action: "snapshot", profile: "chrome", snapshotFormat: "ai" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_BASE_URL,
       expect.objectContaining({
         profile: "chrome",
       }),
+    );
+  });
+
+  it("uses host browser control url when target resolves to host", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", { action: "status" });
+
+    expect(browserClientMocks.browserStatus).toHaveBeenCalledWith(
+      HOST_BROWSER_BASE_URL,
+      expect.objectContaining({ profile: undefined }),
     );
   });
 
@@ -271,7 +283,7 @@ describe("browser tool snapshot maxChars", () => {
     await tool.execute?.("call-1", { action: "status", profile: "chrome" });
 
     expect(browserClientMocks.browserStatus).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_BASE_URL,
       expect.objectContaining({ profile: "chrome" }),
     );
     expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
@@ -286,7 +298,7 @@ describe("browser tool url alias support", () => {
     await tool.execute?.("call-1", { action: "open", url: "https://example.com" });
 
     expect(browserClientMocks.browserOpenTab).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_BASE_URL,
       "https://example.com",
       expect.objectContaining({ profile: undefined }),
     );
@@ -301,7 +313,7 @@ describe("browser tool url alias support", () => {
     });
 
     expect(browserActionsMocks.browserNavigate).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_BASE_URL,
       expect.objectContaining({
         url: "https://example.com",
         targetId: "tab-1",
@@ -334,7 +346,7 @@ describe("browser tool act compatibility", () => {
     });
 
     expect(browserActionsMocks.browserAct).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_BASE_URL,
       expect.objectContaining({
         kind: "type",
         ref: "f1e3",
@@ -360,7 +372,7 @@ describe("browser tool act compatibility", () => {
     });
 
     expect(browserActionsMocks.browserAct).toHaveBeenCalledWith(
-      undefined,
+      HOST_BROWSER_BASE_URL,
       {
         kind: "press",
         key: "Enter",
@@ -547,13 +559,13 @@ describe("browser tool act stale target recovery", () => {
     expect(browserActionsMocks.browserAct).toHaveBeenCalledTimes(2);
     expect(browserActionsMocks.browserAct).toHaveBeenNthCalledWith(
       1,
-      undefined,
+      HOST_BROWSER_BASE_URL,
       expect.objectContaining({ targetId: "stale-tab", action: "click", ref: "btn-1" }),
       expect.objectContaining({ profile: "chrome" }),
     );
     expect(browserActionsMocks.browserAct).toHaveBeenNthCalledWith(
       2,
-      undefined,
+      HOST_BROWSER_BASE_URL,
       expect.not.objectContaining({ targetId: expect.anything() }),
       expect.objectContaining({ profile: "chrome" }),
     );

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -269,7 +269,7 @@ function resolveBrowserBaseUrl(params: {
       "Browser control is disabled. Set browser.enabled=true in ~/.openclaw/openclaw.json.",
     );
   }
-  return undefined;
+  return `http://127.0.0.1:${resolved.controlPort}`;
 }
 
 export function createBrowserTool(opts?: {


### PR DESCRIPTION
## Summary
- fix `resolveBrowserBaseUrl` to return the host browser control URL when target resolves to host
- align browser tool tests to expect the resolved host base URL for host-targeted calls
- add a changelog fix entry for browser tool host timeout regression

## Testing
- pnpm test src/agents/tools/browser-tool.test.ts

Fixes #32814
