### PR TITLE
fix(daemon): handle systemctl not-found without clobbering stdout

### DIFF
--- a/src/daemon/exec-file.ts
+++ b/src/daemon/exec-file.ts
@@ -19,12 +19,19 @@ export async function execFileUtf8(
       }
 
       const e = error as { code?: unknown; message?: unknown };
+      const stdoutText = String(stdout ?? "");
       const stderrText = String(stderr ?? "");
       resolve({
-        stdout: String(stdout ?? ""),
+        stdout: stdoutText,
         stderr:
           stderrText ||
-          (typeof e.message === "string" ? e.message : typeof error === "string" ? error : ""),
+          (!stdoutText
+            ? typeof e.message === "string"
+              ? e.message
+              : typeof error === "string"
+                ? error
+                : ""
+            : ""),
         code: typeof e.code === "number" ? e.code : 1,
       });
     });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,6 +79,19 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false when systemctl reports not-found on stdout with empty stderr", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & { code?: number };
+      err.code = 4;
+      cb(err, "not-found\n", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
   it("throws when systemctl is-enabled fails for non-state errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {


### PR DESCRIPTION
## Summary
- fix `execFileUtf8` to avoid replacing empty `stderr` with `error.message` when `stdout` is present
- this preserves meaningful command output like `not-found` from `systemctl --user is-enabled`
- add regression test for `isSystemdServiceEnabled()` covering exit code 4 + `stdout=not-found` + empty `stderr`

## Root cause
`execFileUtf8` always substituted `error.message` into `stderr` when stderr was empty.
For `systemctl --user is-enabled <unit>` on a missing unit, systemctl returns:
- code: 4
- stdout: `not-found`
- stderr: empty

The fallback clobbered detail parsing and caused install flow to throw instead of treating unit as not-enabled.

## Testing
- `pnpm exec vitest run src/daemon/systemd.test.ts`

Fixes #32635
