### PR TITLE
fix(onboard): restore default tools profile to full

### DIFF
--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -3,7 +3,7 @@ import type { DmScope } from "../config/types.base.js";
 import type { ToolProfileId } from "../config/types.tools.js";
 
 export const ONBOARDING_DEFAULT_DM_SCOPE: DmScope = "per-channel-peer";
-export const ONBOARDING_DEFAULT_TOOLS_PROFILE: ToolProfileId = "messaging";
+export const ONBOARDING_DEFAULT_TOOLS_PROFILE: ToolProfileId = "full";
 
 export function applyOnboardingLocalWorkspaceConfig(
   baseConfig: OpenClawConfig,

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -145,7 +145,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       }>(configPath);
 
       expect(cfg?.agents?.defaults?.workspace).toBe(workspace);
-      expect(cfg?.tools?.profile).toBe("messaging");
+      expect(cfg?.tools?.profile).toBe("full");
       expect(cfg?.gateway?.auth?.mode).toBe("token");
       expect(cfg?.gateway?.auth?.token).toBe(token);
     });


### PR DESCRIPTION
## Summary
- change onboarding local-workspace default `tools.profile` from `messaging` back to `full`
- keep existing explicit `tools.profile` values unchanged
- update non-interactive onboarding gateway test expectation accordingly

## Root cause
In v2026.3.2, onboarding started writing `tools.profile: "messaging"` when unset. This profile intentionally excludes runtime tools like `exec` and `browser`, which made users think plugin install failed because those tools disappeared after onboarding.

## Testing
- `pnpm -s vitest run src/commands/onboard-config.test.ts src/commands/onboard-non-interactive.gateway.test.ts`
  - `onboard-config.test.ts` passes
  - one existing unrelated failure remains in `onboard-non-interactive.gateway.test.ts` remote call path (`hello.features` undefined in mocked gateway client), but the updated expectation for tools profile is covered.
