### PR TITLE
Status: show selected session model instead of transient runtime model

### DIFF
--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTestText } from "../../../test/helpers/normalize-text.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { buildStatusReply } from "./commands-status.js";
+
+const baseCommand = {
+  surface: "text",
+  channel: "telegram",
+  ownerList: [],
+  senderIsOwner: true,
+  isAuthorizedSender: true,
+  rawBodyNormalized: "/status",
+  commandBodyNormalized: "/status",
+};
+
+describe("buildStatusReply", () => {
+  it("uses the session/config-selected model instead of transient runtime model", async () => {
+    const reply = await buildStatusReply({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openrouter/deepseek/deepseek-v3.2",
+          },
+        },
+      } as unknown as OpenClawConfig,
+      command: baseCommand,
+      sessionEntry: {
+        sessionId: "status-selected-model",
+        updatedAt: 0,
+      },
+      sessionKey: "agent:main:telegram:direct:123",
+      provider: "google",
+      model: "gemini-3-flash-preview",
+      contextTokens: 200_000,
+      resolvedThinkLevel: "off",
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolvedElevatedLevel: "off",
+      resolveDefaultThinkingLevel: async () => "off",
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+    });
+
+    const normalized = normalizeTestText(reply?.text ?? "");
+    expect(normalized).toContain("Model: openrouter/deepseek/deepseek-v3.2");
+    expect(normalized).not.toContain("Model: google/gemini-3-flash-preview");
+  });
+
+  it("keeps explicit session model overrides in status output", async () => {
+    const reply = await buildStatusReply({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openrouter/deepseek/deepseek-v3.2",
+          },
+        },
+      } as unknown as OpenClawConfig,
+      command: baseCommand,
+      sessionEntry: {
+        sessionId: "status-session-override",
+        updatedAt: 0,
+        providerOverride: "openrouter",
+        modelOverride: "x-ai/grok-4.1-fast",
+      },
+      sessionKey: "agent:main:telegram:direct:123",
+      provider: "google",
+      model: "gemini-3-flash-preview",
+      contextTokens: 200_000,
+      resolvedThinkLevel: "off",
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolvedElevatedLevel: "off",
+      resolveDefaultThinkingLevel: async () => "off",
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+    });
+
+    const normalized = normalizeTestText(reply?.text ?? "");
+    expect(normalized).toContain("Model: openrouter/x-ai/grok-4.1-fast");
+    expect(normalized).not.toContain("Model: google/gemini-3-flash-preview");
+  });
+});

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -25,6 +25,7 @@ import { buildStatusMessage } from "../status.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import type { CommandContext } from "./commands-types.js";
+import { resolveDefaultModel } from "./directive-handling.js";
 import { getFollowupQueueDepth, resolveQueueSettings } from "./queue.js";
 import { resolveSubagentLabel } from "./subagents-utils.js";
 
@@ -75,9 +76,17 @@ export async function buildStatusReply(params: {
     ? resolveSessionAgentId({ sessionKey, config: cfg })
     : resolveDefaultAgentId(cfg);
   const statusAgentDir = resolveAgentDir(cfg, statusAgentId);
+  const { defaultProvider, defaultModel } = resolveDefaultModel({
+    cfg,
+    agentId: statusAgentId,
+  });
+  // /status should reflect the session's configured model selection, not the
+  // transient model used by the current command-processing turn (e.g. heartbeat).
+  const selectedProvider = sessionEntry?.providerOverride?.trim() || defaultProvider || provider;
+  const selectedModel = sessionEntry?.modelOverride?.trim() || defaultModel || model;
   const currentUsageProvider = (() => {
     try {
-      return resolveUsageProviderId(provider);
+      return resolveUsageProviderId(selectedProvider);
     } catch {
       return undefined;
     }
@@ -141,12 +150,12 @@ export async function buildStatusReply(params: {
     ? (normalizeGroupActivation(sessionEntry?.groupActivation) ?? defaultGroupActivation())
     : undefined;
   const modelRefs = resolveSelectedAndActiveModel({
-    selectedProvider: provider,
-    selectedModel: model,
+    selectedProvider,
+    selectedModel,
     sessionEntry,
   });
   const selectedModelAuth = resolveModelAuthLabel({
-    provider,
+    provider: selectedProvider,
     cfg,
     sessionEntry,
     agentDir: statusAgentDir,
@@ -166,7 +175,7 @@ export async function buildStatusReply(params: {
       ...agentDefaults,
       model: {
         ...toAgentModelListLike(agentDefaults.model),
-        primary: `${provider}/${model}`,
+        primary: `${selectedProvider}/${selectedModel}`,
       },
       contextTokens,
       thinkingDefault: agentDefaults.thinkingDefault,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `/status` could display a transient runtime model (for example heartbeat/command-processing model) instead of the session's configured model.
- Why it matters: it misleads debugging and makes users think model routing is broken.
- What changed: `buildStatusReply` now resolves selected model from session/config (`resolveDefaultModel` + session overrides) and uses that for model display/auth/usage provider selection.
- What did NOT change (scope boundary): no changes to actual model routing/execution logic; this is status rendering selection only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32948
- Related #

## User-visible / Behavior Changes

- `/status` now shows the session/config-selected model instead of a transient command-turn model.
- Session model overrides still take precedence and are shown as before.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: status model selection only
- Integration/channel (if any): Telegram-style session key in unit tests
- Relevant config (redacted): `agents.defaults.model=openrouter/deepseek/deepseek-v3.2`

### Steps

1. Configure default model as `openrouter/deepseek/deepseek-v3.2`.
2. Call `buildStatusReply` with a transient runtime model (`google/gemini-3-flash-preview`).
3. Inspect status output model line.

### Expected

- Model line shows configured/session-selected model, not transient runtime model.

### Actual

- Before fix it could show transient runtime model; after fix it shows selected model.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - New test: defaults model beats transient runtime model.
  - New test: session override model still wins.
  - Existing `status.test.ts` suite still passes.
- Edge cases checked:
  - Session with no overrides.
  - Session with explicit provider/model overrides.
- What you did **not** verify:
  - Live channel end-to-end `/status` on a running gateway.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Status: use selected model in status output`.
- Files/config to restore:
  - `src/auto-reply/reply/commands-status.ts`
- Known bad symptoms reviewers should watch for:
  - `/status` model line no longer matching selected/session model.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: provider usage summary now uses selected provider instead of transient provider.
  - Mitigation: this aligns usage line with status model selection and is covered by the same selection path.
