### PR TITLE
Reply: keep explicit reply-tag payloads under same-target suppression

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -114,6 +114,24 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
+  it("keeps explicit reply-tag payloads even when same-target suppression is active", () => {
+    const { replyPayloads } = buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "[[reply_to_current]]hello world!" }],
+      currentMessageId: "om_current_1",
+      messageProvider: "heartbeat",
+      originatingChannel: "feishu",
+      originatingTo: "ou_abc123",
+      messagingToolSentTexts: ["different message"],
+      messagingToolSentTargets: [{ tool: "message", provider: "lark", to: "ou_abc123" }],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe("hello world!");
+    expect(replyPayloads[0]?.replyToTag).toBe(true);
+    expect(replyPayloads[0]?.replyToCurrent).toBe(true);
+  });
+
   it("does not suppress same-target replies when accountId differs", () => {
     const { replyPayloads } = buildReplyPayloads({
       ...baseParams,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -134,7 +134,14 @@ export function buildReplyPayloads(params: {
             (payload) => !params.directlySentBlockKeys!.has(createBlockReplyPayloadKey(payload)),
           )
         : mediaFilteredPayloads;
-  const replyPayloads = suppressMessagingToolReplies ? [] : filteredPayloads;
+  // Keep explicit thread-targeted replies (for example [[reply_to_current]])
+  // even when same-target messaging tool suppression is active. These payloads
+  // are intentional reply operations, not duplicate generic finals.
+  const hasExplicitThreadTargeting = filteredPayloads.some(
+    (payload) => payload.replyToTag || payload.replyToCurrent || Boolean(payload.replyToId),
+  );
+  const replyPayloads =
+    suppressMessagingToolReplies && !hasExplicitThreadTargeting ? [] : filteredPayloads;
 
   return {
     replyPayloads,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: same-target messaging-tool suppression could drop all final payloads, including explicit reply-tag payloads like `[[reply_to_current]]`.
- Why it matters: Feishu DM users can get no visible reply even though the run produced tagged final content.
- What changed: when suppression is active, explicit thread-targeted payloads (`replyToTag`/`replyToCurrent`/`replyToId`) are preserved instead of being globally dropped.
- What did NOT change (scope boundary): generic same-target duplicate suppression still applies for untagged final replies.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32953
- Related #31526

## User-visible / Behavior Changes

- `[[reply_to_current]]`/explicit reply-tag payloads are no longer suppressed by same-target messaging-tool duplicate suppression.
- Untagged same-target duplicate suppression behavior is unchanged.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A (payload post-processing)
- Integration/channel (if any): Feishu path covered via generic payload suppression logic
- Relevant config (redacted): default config

### Steps

1. Produce a final payload containing `[[reply_to_current]]...` in a run that also records same-target messaging-tool send metadata.
2. Build final reply payloads through `buildReplyPayloads()`.
3. Observe suppression result.

### Expected

- Explicit reply-tag payload survives and is deliverable.

### Actual

- Before fix the payload could be dropped; after fix it is preserved.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - New test preserves reply-tag payload under same-target suppression.
  - Existing suppression tests for same-target and cross-target behavior still pass.
- Edge cases checked:
  - Reply tag parsed and cleaned text still returned.
  - Account-id mismatch behavior remains unchanged.
- What you did **not** verify:
  - Live Feishu gateway end-to-end run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Reply: keep explicit reply tags when suppressing same-target duplicates`.
- Files/config to restore:
  - `src/auto-reply/reply/agent-runner-payloads.ts`
- Known bad symptoms reviewers should watch for:
  - Duplicate replies when both message tool and explicit reply tags are used intentionally.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: explicit thread-targeted payloads may allow a second message in mixed tool+tag flows.
  - Mitigation: scope is limited to explicitly tagged replies; untagged same-target suppression is unchanged.
