### PR TITLE
WhatsApp: add sender labels to DM BodyForAgent

### DIFF
--- a/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
+++ b/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
@@ -183,6 +183,55 @@ describe("web processMessage inbound contract", () => {
     expect(ctx.OriginatingTo).not.toBe(ctx.To);
   });
 
+  it("prefixes direct BodyForAgent with sender label", async () => {
+    capturedCtx = undefined;
+
+    await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:direct:+1000",
+        groupHistoryKey: "+1000",
+        msg: {
+          id: "msg2",
+          from: "+1000",
+          to: "+2000",
+          chatType: "direct",
+          body: "hello there",
+          senderName: "Alice",
+          senderE164: "+1000",
+        },
+      }),
+    );
+
+    expect(capturedCtx).toBeTruthy();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const ctx = capturedCtx as any;
+    expect(ctx.BodyForAgent).toBe("[Alice]: hello there");
+  });
+
+  it("prefixes direct BodyForAgent with self label for fromMe messages", async () => {
+    capturedCtx = undefined;
+
+    await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:direct:+1000",
+        groupHistoryKey: "+1000",
+        msg: {
+          id: "msg3",
+          from: "+1000",
+          to: "+2000",
+          chatType: "direct",
+          body: "noted",
+          fromMe: true,
+        },
+      }),
+    );
+
+    expect(capturedCtx).toBeTruthy();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const ctx = capturedCtx as any;
+    expect(ctx.BodyForAgent).toBe("[self]: noted");
+  });
+
   it("defaults responsePrefix to identity name in self-chats when unset", async () => {
     capturedDispatchParams = undefined;
 

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -293,9 +293,23 @@ export async function processMessage(params: {
         )
       : undefined;
 
+  const bodyForAgent =
+    params.msg.chatType === "group"
+      ? params.msg.body
+      : (() => {
+          const speakerLabel = params.msg.fromMe
+            ? "self"
+            : params.msg.senderName?.trim() ||
+              params.msg.senderE164?.trim() ||
+              params.msg.senderJid?.trim() ||
+              params.msg.from?.trim() ||
+              "Unknown";
+          return `[${speakerLabel}]: ${params.msg.body}`;
+        })();
+
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
-    BodyForAgent: params.msg.body,
+    BodyForAgent: bodyForAgent,
     InboundHistory: inboundHistory,
     RawBody: params.msg.body,
     CommandBody: params.msg.body,

--- a/src/web/auto-reply/web-auto-reply-monitor.test.ts
+++ b/src/web/auto-reply/web-auto-reply-monitor.test.ts
@@ -345,6 +345,23 @@ describe("buildInboundLine", () => {
     expect(line).toContain("+15550001111");
     expect(line).not.toContain("whatsapp:+15550001111");
   });
+
+  it("marks direct self-sent messages in the envelope", () => {
+    const line = buildInboundLine({
+      cfg: makeInboundCfg(""),
+      agentId: "main",
+      msg: {
+        from: "+15550001111",
+        to: "+2666",
+        body: "ping",
+        chatType: "direct",
+        fromMe: true,
+      } as never,
+      envelope: { includeTimestamp: false },
+    });
+
+    expect(line).toContain("(self): ping");
+  });
 });
 
 describe("formatReplyContext", () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: WhatsApp direct-message `BodyForAgent` used raw text only, so the model could not distinguish sender identity in DM streams.
- Why it matters: without speaker labels, multi-turn DM context is ambiguous and can produce incorrect role understanding.
- What changed: direct-message `BodyForAgent` is now prefixed with a sender label (`[Name]: ...` / `[self]: ...`), while group behavior is unchanged.
- What did NOT change (scope boundary): no routing, session-key, or command-gating behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32954
- Related #32061

## User-visible / Behavior Changes

- In WhatsApp DMs, the model now sees sender-labeled `BodyForAgent` text:
  - inbound user message example: `[Alice]: hello`
  - self echo message example: `[self]: noted`
- Group message formatting remains unchanged.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A (inbound context shaping)
- Integration/channel (if any): WhatsApp web inbound monitor
- Relevant config (redacted): default + WhatsApp monitor test configs

### Steps

1. Process a WhatsApp direct inbound message through `processMessage()`.
2. Inspect finalized `MsgContext` passed to dispatcher.
3. Verify `BodyForAgent` label behavior for both normal DM and `fromMe` DM.

### Expected

- DM `BodyForAgent` includes sender label.

### Actual

- Before fix it was raw text only; after fix it is labeled.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - New test: direct DM `BodyForAgent` is `[Alice]: ...`.
  - New test: `fromMe` direct DM `BodyForAgent` is `[self]: ...`.
  - New test: envelope still marks direct self messages as `(self): ...`.
- Edge cases checked:
  - Group message path still untouched.
  - Sender-id fallback behavior test remains passing.
- What you did **not** verify:
  - Live WhatsApp device end-to-end.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `WhatsApp: add DM sender label to BodyForAgent`.
- Files/config to restore:
  - `src/web/auto-reply/monitor/process-message.ts`
- Known bad symptoms reviewers should watch for:
  - DM prompts unexpectedly include malformed speaker prefixes.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: slight prompt-shape change for WhatsApp DMs can alter model behavior.
  - Mitigation: only DM `BodyForAgent` changed; group and command bodies are unchanged; tests cover contract-critical paths.
