### PR TITLE
Matrix: resolve mention regexes with routed agent id

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -139,4 +139,114 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
       }),
     );
   });
+
+  it("resolves mention regexes with the routed agent id", async () => {
+    const recordInboundSession = vi.fn().mockResolvedValue(undefined);
+    const buildMentionRegexes = vi.fn().mockReturnValue([/@workbot/i]);
+    const core = {
+      channel: {
+        pairing: {
+          readAllowFromStore: vi.fn().mockResolvedValue([]),
+        },
+        routing: {
+          resolveAgentRoute: vi.fn().mockReturnValue({
+            agentId: "work",
+            accountId: undefined,
+            sessionKey: "agent:work:matrix:channel:!room:example.org",
+            mainSessionKey: "agent:work:main",
+          }),
+        },
+        mentions: {
+          buildMentionRegexes,
+        },
+        session: {
+          resolveStorePath: vi.fn().mockReturnValue("/tmp/openclaw-test-session.json"),
+          readSessionUpdatedAt: vi.fn().mockReturnValue(123),
+          recordInboundSession,
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+          formatInboundEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          formatAgentEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          finalizeInboundContext: vi.fn().mockImplementation((ctx: Record<string, unknown>) => ctx),
+          resolveHumanDelayConfig: vi.fn().mockReturnValue(undefined),
+          createReplyDispatcherWithTyping: vi.fn().mockReturnValue({
+            dispatcher: {},
+            replyOptions: {},
+            markDispatchIdle: vi.fn(),
+          }),
+          withReplyDispatcher: vi
+            .fn()
+            .mockResolvedValue({ queuedFinal: false, counts: { final: 0, partial: 0, tool: 0 } }),
+        },
+        commands: {
+          shouldHandleTextCommands: vi.fn().mockReturnValue(true),
+        },
+        text: {
+          hasControlCommand: vi.fn().mockReturnValue(false),
+          resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
+        },
+      },
+      system: {
+        enqueueSystemEvent: vi.fn(),
+      },
+    } as unknown as PluginRuntime;
+
+    const handler = createMatrixRoomMessageHandler({
+      client: {
+        getUserId: vi.fn().mockResolvedValue("@bot:matrix.example.org"),
+      } as unknown as MatrixClient,
+      core,
+      cfg: {},
+      runtime: {
+        error: vi.fn(),
+      } as unknown as RuntimeEnv,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+      } as unknown as RuntimeLogger,
+      logVerboseMessage: vi.fn(),
+      allowFrom: [],
+      roomsConfig: undefined,
+      mentionRegexes: [/@global/i],
+      groupPolicy: "open",
+      replyToMode: "first",
+      threadReplies: "inbound",
+      dmEnabled: true,
+      dmPolicy: "open",
+      textLimit: 4000,
+      mediaMaxBytes: 5 * 1024 * 1024,
+      startupMs: Date.now(),
+      startupGraceMs: 60_000,
+      directTracker: {
+        isDirectMessage: vi.fn().mockResolvedValue(false),
+      },
+      getRoomInfo: vi.fn().mockResolvedValue({
+        name: "Dev Room",
+        canonicalAlias: "#dev:matrix.example.org",
+        altAliases: [],
+      }),
+      getMemberDisplayName: vi.fn().mockResolvedValue("Alice"),
+      accountId: undefined,
+    });
+
+    await handler("!room:example.org", {
+      type: EventType.RoomMessage,
+      event_id: "$event2",
+      sender: "@alice:matrix.example.org",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body: "@workbot ping",
+        "m.mentions": { user_ids: ["@bot:matrix.example.org"] },
+      },
+    } as unknown as MatrixRawEvent);
+
+    expect(buildMentionRegexes).toHaveBeenCalledWith({}, "work");
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -342,11 +342,27 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         return;
       }
 
+      const baseRoute = core.channel.routing.resolveAgentRoute({
+        cfg,
+        channel: "matrix",
+        accountId,
+        peer: {
+          kind: isDirectMessage ? "direct" : "channel",
+          id: isDirectMessage ? senderId : roomId,
+        },
+      });
+      const agentMentionRegexes =
+        typeof core.channel.mentions?.buildMentionRegexes === "function"
+          ? core.channel.mentions.buildMentionRegexes(cfg, baseRoute.agentId)
+          : mentionRegexes;
+      const resolvedMentionRegexes =
+        agentMentionRegexes.length > 0 ? agentMentionRegexes : mentionRegexes;
+
       const { wasMentioned, hasExplicitMention } = resolveMentions({
         content,
         userId: selfUserId,
         text: bodyText,
-        mentionRegexes,
+        mentionRegexes: resolvedMentionRegexes,
       });
       const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
         cfg,
@@ -408,7 +424,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         !hasExplicitMention &&
         commandAuthorized &&
         hasControlCommandInMessage;
-      const canDetectMention = mentionRegexes.length > 0 || hasExplicitMention;
+      const canDetectMention = resolvedMentionRegexes.length > 0 || hasExplicitMention;
       if (isRoom && shouldRequireMention && !wasMentioned && !shouldBypassMention) {
         logger.info("skipping room message", { roomId, reason: "no-mention" });
         return;
@@ -422,16 +438,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         messageId,
         threadRootId,
         isThreadRoot: false, // @vector-im/matrix-bot-sdk doesn't have this info readily available
-      });
-
-      const baseRoute = core.channel.routing.resolveAgentRoute({
-        cfg,
-        channel: "matrix",
-        accountId,
-        peer: {
-          kind: isDirectMessage ? "direct" : "channel",
-          id: isDirectMessage ? senderId : roomId,
-        },
       });
 
       const route = {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Matrix monitor used mention regexes precomputed at startup without routed `agentId`, so agent-specific mentionPatterns could be ignored.
- Why it matters: room messages with valid custom mentions for a non-default agent can be dropped as `no-mention`.
- What changed: mention regexes are now resolved per message using the routed `agentId` (`core.channel.mentions.buildMentionRegexes(cfg, baseRoute.agentId)`).
- What did NOT change (scope boundary): no change to route selection, send path, threading, or access policy decisions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32982
- Related #

## User-visible / Behavior Changes

- Matrix mention detection now respects routed agent context for custom mention patterns.
- Messages that mention an agent using that agent's configured pattern are no longer incorrectly skipped.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Matrix monitor handler
- Relevant config (redacted): routed agent with custom mention pattern

### Steps

1. Route a Matrix room message to a non-default agent.
2. Resolve mentions in handler for a message that matches that agent's custom mention pattern.
3. Verify mention regex builder receives the routed `agentId`.

### Expected

- Mention regexes are built with routed `agentId` and mention detection uses them.

### Actual

- Before fix global precomputed regexes were used without agent context.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - New test confirms `buildMentionRegexes` is called with routed `agentId`.
  - Existing Matrix handler body-for-agent test still passes.
  - Matrix mentions unit tests still pass.
- Edge cases checked:
  - Fallback to precomputed regexes remains when mention builder is unavailable.
- What you did **not** verify:
  - Live Matrix homeserver end-to-end behavior.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Matrix: resolve mention patterns with routed agent context`.
- Files/config to restore:
  - `extensions/matrix/src/matrix/monitor/handler.ts`
- Known bad symptoms reviewers should watch for:
  - Matrix room messages dropped unexpectedly due mention detection mismatch.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: per-message regex resolution adds a tiny overhead.
  - Mitigation: regex build is cached in core mention helper; fallback path retained.
