### PR TITLE
Matrix: fix per-agent mentionPatterns and improve gating logs

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -52,6 +52,10 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
         commands: {
           shouldHandleTextCommands: vi.fn().mockReturnValue(true),
         },
+        mentions: {
+          buildMentionRegexes: vi.fn().mockReturnValue([]),
+          matchesMentionPatterns: vi.fn().mockReturnValue(false),
+        },
         text: {
           hasControlCommand: vi.fn().mockReturnValue(false),
           resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
@@ -84,7 +88,6 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
       logVerboseMessage,
       allowFrom: [],
       roomsConfig: undefined,
-      mentionRegexes: [],
       groupPolicy: "open",
       replyToMode: "first",
       threadReplies: "inbound",

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -50,7 +50,6 @@ export type MatrixMonitorHandlerParams = {
   logVerboseMessage: (message: string) => void;
   allowFrom: string[];
   roomsConfig: Record<string, MatrixRoomConfig> | undefined;
-  mentionRegexes: ReturnType<PluginRuntime["channel"]["mentions"]["buildMentionRegexes"]>;
   groupPolicy: "open" | "allowlist" | "disabled";
   replyToMode: ReplyToMode;
   threadReplies: "off" | "inbound" | "always";
@@ -84,7 +83,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     logVerboseMessage,
     allowFrom,
     roomsConfig,
-    mentionRegexes,
     groupPolicy,
     replyToMode,
     threadReplies,
@@ -342,6 +340,21 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         return;
       }
 
+      const messageId = event.event_id ?? "";
+      const replyToEventId = content["m.relates_to"]?.["m.in_reply_to"]?.event_id;
+      const threadRootId = resolveMatrixThreadRootId({ event, content });
+
+      const baseRoute = core.channel.routing.resolveAgentRoute({
+        cfg,
+        channel: "matrix",
+        accountId,
+        peer: {
+          kind: isDirectMessage ? "direct" : "channel",
+          id: isDirectMessage ? senderId : roomId,
+        },
+      });
+
+      const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, baseRoute.agentId);
       const { wasMentioned, hasExplicitMention } = resolveMentions({
         content,
         userId: selfUserId,
@@ -410,28 +423,17 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         hasControlCommandInMessage;
       const canDetectMention = mentionRegexes.length > 0 || hasExplicitMention;
       if (isRoom && shouldRequireMention && !wasMentioned && !shouldBypassMention) {
-        logger.info("skipping room message", { roomId, reason: "no-mention" });
+        logger.info(
+          `skipping room message room=${roomId} reason=no-mention agent=${baseRoute.agentId}`,
+        );
         return;
       }
 
-      const messageId = event.event_id ?? "";
-      const replyToEventId = content["m.relates_to"]?.["m.in_reply_to"]?.event_id;
-      const threadRootId = resolveMatrixThreadRootId({ event, content });
       const threadTarget = resolveMatrixThreadTarget({
         threadReplies,
         messageId,
         threadRootId,
         isThreadRoot: false, // @vector-im/matrix-bot-sdk doesn't have this info readily available
-      });
-
-      const baseRoute = core.channel.routing.resolveAgentRoute({
-        cfg,
-        channel: "matrix",
-        accountId,
-        peer: {
-          kind: isDirectMessage ? "direct" : "channel",
-          id: isDirectMessage ? senderId : roomId,
-        },
       });
 
       const route = {

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -296,7 +296,6 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   });
   setActiveMatrixClient(client, opts.accountId);
 
-  const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg);
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const { groupPolicy: groupPolicyRaw, providerMissingFallbackApplied } =
     resolveAllowlistProviderRuntimeGroupPolicy({
@@ -341,7 +340,6 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     logVerboseMessage,
     allowFrom,
     roomsConfig,
-    mentionRegexes,
     groupPolicy,
     replyToMode,
     threadReplies,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** `mentionPatterns` configured at the agent level (`agents.list[].groupChat.mentionPatterns`) were completely ignored in the Matrix channel because mention regexes were resolved during startup without any agent context.
- **Why it matters:** Custom trigger patterns (like `@bot` or nicknames) wouldn't work at all for specific agents; they would only respond to direct Matrix User ID mentions or fallback to global patterns.
- **What changed:** Moved `buildMentionRegexes` resolution into the message handler loop. It now resolves patterns dynamically using the correct `agentId` for each incoming message, ensuring agent-specific patterns are honored.
- **What changed (Logs):** Improved "skipping room message" logs to include `agentId` and `roomId` for easier troubleshooting of mention gating.
- **What did NOT change (scope boundary):** No changes to the core regex matching logic or other integrations.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations (Matrix)
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32982 

## User-visible / Behavior Changes

Custom `mentionPatterns` configured in `agents.list[].groupChat.mentionPatterns` now correctly trigger Matrix agents.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js v22.22.0
- Integration/channel (if any): Matrix
- Relevant config (redacted): `agents.list[].groupChat.mentionPatterns: ["@bot"]`

### Steps

1. Configure a custom pattern in `agents.list[0].groupChat.mentionPatterns` for a Matrix agent (e.g., `"@bot"`).
2. Send a message matching that pattern (e.g., `@bot hello`) in a Matrix room.
3. Observe the agent's behavior.

### Expected

The agent should recognize the custom pattern and respond.

### Actual (Before Fix)

The agent ignores the message.

## Evidence

- [x] Passing tests: `extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts`
- [x] Manual verification: Confirmed in a live Matrix environment (Linux/Node v22.22.0) that per-agent `mentionPatterns` now work correctly.

## Human Verification (required)

- Verified scenarios: Agent-specific patterns, fallback to global patterns.
- Edge cases checked: Direct messages vs. room messages.
- What you did **not** verify: Multi-account Matrix setups with a large number of agents (>5).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit in the Matrix extension.
- Files/config to restore: `extensions/matrix/src/matrix/monitor/handler.ts`.

## Risks and Mitigations

- Risk: Minimal. Re-calculating regexes per message adds negligible latency.
  - Mitigation: The accuracy gain in multi-agent environments is critical for correct behavior.
