### PR TITLE
Feishu: reply to triggering message in topic chains

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1479,7 +1479,7 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
-  it("replies to the topic root when handling a message inside an existing topic", async () => {
+  it("replies to the triggering message when handling a message inside an existing topic", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
     const cfg: ClawdbotConfig = {
@@ -1511,7 +1511,7 @@ describe("handleFeishuMessage command authorization", () => {
 
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
-        replyToMessageId: "om_root_topic",
+        replyToMessageId: "om_child_message",
         rootId: "om_root_topic",
       }),
     );

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1337,7 +1337,7 @@ export async function handleFeishuMessage(params: {
     const messageCreateTimeMs = event.message.create_time
       ? parseInt(event.message.create_time, 10)
       : undefined;
-    const replyTargetMessageId = ctx.rootId ?? ctx.messageId;
+    const replyTargetMessageId = ctx.messageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 
     if (broadcastAgents) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Feishu group reply target preferred `root_id`, so bot replies in a reply chain attached to the root message rather than the triggering message.
- Why it matters: in active groups, bot replies become detached from the user message that requested them.
- What changed: reply target now always uses `ctx.messageId`; `rootId` is still preserved for topic/thread routing context.
- What did NOT change (scope boundary): topic session key resolution and thread affinity behavior remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32980
- Related #

## User-visible / Behavior Changes

- In Feishu group reply chains, bot replies now attach to the triggering message instead of the root message.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Feishu bot handler
- Relevant config (redacted): Feishu group with `replyInThread: enabled`

### Steps

1. Receive a Feishu group message inside an existing topic (`root_id` + child `message_id`).
2. Build reply dispatcher params.
3. Check `replyToMessageId` used by dispatcher.

### Expected

- `replyToMessageId` is the triggering child message id.

### Actual

- Before fix it was `root_id`; after fix it is `message_id`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Updated test expectation for topic reply target to child message id.
  - Full `extensions/feishu/src/bot.test.ts` suite passes.
- Edge cases checked:
  - `rootId` is still passed to dispatcher and retained for topic context.
- What you did **not** verify:
  - Live Feishu tenant end-to-end behavior.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Feishu: reply to triggering message instead of topic root`.
- Files/config to restore:
  - `extensions/feishu/src/bot.ts`
- Known bad symptoms reviewers should watch for:
  - Replies unexpectedly reattaching to topic roots.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: topic UX expectation may differ in some teams that preferred root-attached replies.
  - Mitigation: `rootId` context is still preserved for routing; only visible reply target changed to match triggering message.
