### PR TITLE
fix(gateway): block global chat/agent broadcasts to node-role WS clients

### DIFF
--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -209,6 +209,43 @@ describe("gateway broadcaster", () => {
     expect(approvalsSocket.send).toHaveBeenCalledTimes(1);
     expect(pairingSocket.send).toHaveBeenCalledTimes(1);
   });
+
+  it("does not deliver chat/agent broadcasts to node clients", () => {
+    const nodeSocket: TestSocket = {
+      bufferedAmount: 0,
+      send: vi.fn(),
+      close: vi.fn(),
+    };
+    const operatorSocket: TestSocket = {
+      bufferedAmount: 0,
+      send: vi.fn(),
+      close: vi.fn(),
+    };
+
+    const clients = new Set<GatewayWsClient>([
+      {
+        socket: nodeSocket as unknown as GatewayWsClient["socket"],
+        connect: { role: "node", scopes: [] as string[] } as unknown as GatewayWsClient["connect"],
+        connId: "c-node",
+      },
+      {
+        socket: operatorSocket as unknown as GatewayWsClient["socket"],
+        connect: {
+          role: "operator",
+          scopes: ["operator.read"],
+        } as unknown as GatewayWsClient["connect"],
+        connId: "c-operator",
+      },
+    ]);
+
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { text: "hello" });
+    broadcast("agent", { runId: "r1", phase: "delta" });
+
+    expect(nodeSocket.send).toHaveBeenCalledTimes(0);
+    expect(operatorSocket.send).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("chat run registry", () => {

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -39,11 +39,17 @@ export type GatewayBroadcastToConnIdsFn = (
 ) => void;
 
 function hasEventScope(client: GatewayWsClient, event: string): boolean {
+  const role = client.connect.role ?? "operator";
+  // Node-role websocket clients must not receive global chat/agent broadcasts.
+  // Node message delivery should flow through explicit session subscriptions.
+  if (role === "node" && (event === "chat" || event === "agent")) {
+    return false;
+  }
+
   const required = EVENT_SCOPE_GUARDS[event];
   if (!required) {
     return true;
   }
-  const role = client.connect.role ?? "operator";
   if (role !== "operator") {
     return false;
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: node-role WebSocket clients could receive global `chat` / `agent` event broadcasts unrelated to their subscribed sessions.
- Why it matters: this creates conversation-content exposure risk and violates intended node isolation.
- What changed: gateway broadcaster now blocks global `chat`/`agent` delivery when `role=node`; added regression test confirming node gets 0 while operator still gets events.
- What did NOT change (scope boundary): node session-scoped subscription routing (`server-node-subscriptions`) and operator broadcast behavior remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32964
- Related #

## User-visible / Behavior Changes

- Node-role WS clients no longer receive global `chat`/`agent` broadcasts.
- Operator WS clients continue to receive those broadcasts as before.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`Yes`)
- If any `Yes`, explain risk + mitigation:
  - This narrows node-role data access by denying unrelated global chat/agent stream delivery. Mitigation is explicit role guard in broadcaster plus regression test.

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime/container: local Node runtime
- Model/provider: N/A
- Integration/channel (if any): Gateway WebSocket
- Relevant config (redacted): default

### Steps

1. Connect one WS client as `role=node` and another as `role=operator`.
2. Emit broadcaster events `chat` and `agent`.
3. Assert node receives no payload while operator receives both.

### Expected

- Node client receives 0 global `chat`/`agent` events.
- Operator client receives normal events.

### Actual

- Matches expected after patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `vitest` for `gateway-misc` + `server-chat.agent-events`; confirmed new test passes and existing broadcaster behavior remains intact.
- Edge cases checked: verified non-node/operator routing still delivers global events.
- What you did **not** verify: full multi-node end-to-end deployment over live paired devices.

## Compatibility / Migration

- Backward compatible? (`Mostly`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/gateway/server-broadcast.ts`, `src/gateway/gateway-misc.test.ts`
- Known bad symptoms reviewers should watch for: non-standard node clients expecting global `chat`/`agent` broadcasts will stop receiving them.

## Risks and Mitigations

- Risk: legacy/unsupported node consumers that relied on global chat/agent broadcasts may lose those events.
  - Mitigation: intended supported path is session-scoped node subscriptions; rollback is a single commit if regression is found.
