### PR TITLE
fix(gateway): avoid stale-socket restarts for webhook channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- BlueBubbles/health monitor stale-socket guard: limit stale-socket restarts to channels that report explicit connected state, preventing false restarts for webhook-style channels during normal quiet periods. (#32990) Thanks @liuxiaopai-ai.
 - Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
 - Exec heartbeat routing: scope exec-triggered heartbeat wakes to agent session keys so unrelated agents are no longer awakened by exec events, while preserving legacy unscoped behavior for non-canonical session keys. (#32724) thanks @altaywtf
 - macOS/Tailscale remote gateway discovery: add a Tailscale Serve fallback peer probe path (`wss://<peer>.ts.net`) when Bonjour and wide-area DNS-SD discovery return no gateways, and refresh both discovery paths from macOS onboarding. (#32860) Thanks @ngutman.

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -399,6 +399,22 @@ describe("channel-health-monitor", () => {
   describe("stale socket detection", () => {
     const STALE_THRESHOLD = 30 * 60_000;
 
+    it("does not restart webhook-style channels that omit connection state", async () => {
+      const now = Date.now();
+      const manager = createSnapshotManager({
+        bluebubbles: {
+          default: {
+            running: true,
+            enabled: true,
+            configured: true,
+            lastStartAt: now - STALE_THRESHOLD - 60_000,
+            lastEventAt: now - STALE_THRESHOLD - 30_000,
+          },
+        },
+      });
+      await expectNoRestart(manager);
+    });
+
     it("restarts a channel with no events past the stale threshold", async () => {
       const now = Date.now();
       const manager = createSlackSnapshotManager(

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -54,6 +54,24 @@ describe("evaluateChannelHealth", () => {
     );
     expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
   });
+
+  it("does not apply stale-socket detection when connection state is unknown", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: null,
+      },
+      {
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
 });
 
 describe("resolveChannelRestartReason", () => {

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -52,7 +52,13 @@ export function evaluateChannelHealth(
   if (snapshot.connected === false) {
     return { healthy: false, reason: "disconnected" };
   }
-  if (snapshot.lastEventAt != null || snapshot.lastStartAt != null) {
+  // Stale-socket checks only apply to channels that report an explicit
+  // long-lived connection state. Webhook channels can be quiet for long
+  // periods without being unhealthy.
+  if (
+    snapshot.connected === true &&
+    (snapshot.lastEventAt != null || snapshot.lastStartAt != null)
+  ) {
     const upSince = snapshot.lastStartAt ?? 0;
     const upDuration = policy.now - upSince;
     if (upDuration > policy.staleEventThresholdMs) {


### PR DESCRIPTION
## Summary

- Problem: webhook-style channels (notably BlueBubbles) were treated as stale sockets after quiet periods and got restarted by the health monitor.
- Why it matters: periodic false restarts can interrupt webhook delivery windows and trigger downstream retry/backoff behavior.
- What changed: stale-socket detection now runs only when a channel reports explicit `connected: true` socket state.
- What did NOT change (scope boundary): disconnected handling (`connected: false`) and restart behavior for socket-based channels are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32990
- Related #28622

## User-visible / Behavior Changes

- BlueBubbles/webhook channels no longer get health-monitor restarts just because there were no inbound events for 30 minutes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + Vitest
- Model/provider: N/A
- Integration/channel (if any): BlueBubbles/webhook health-monitor path
- Relevant config (redacted): `gateway.healthMonitor` defaults; channel runtime without explicit `connected` state

### Steps

1. Start health monitor with a running webhook-style channel snapshot that omits `connected` and has old `lastStartAt/lastEventAt` timestamps.
2. Let one monitor cycle run.
3. Observe restart behavior.

### Expected

- No restart for webhook-style channel quiet periods.

### Actual

- Before fix: stale-socket restart triggered.
- After fix: no restart unless channel explicitly reports socket-connected state and then goes stale.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts`

## Human Verification (required)

- Verified scenarios:
  - `evaluateChannelHealth` returns healthy when connection state is unknown, even with stale timestamps.
  - health monitor does not restart webhook-style runtime snapshots without `connected`.
  - socket channels with `connected: true` still get stale-socket restart behavior.
- Edge cases checked:
  - existing disconnected path (`connected: false`) remains unchanged.
- What you did **not** verify:
  - live BlueBubbles server integration in this PR run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore:
  - `src/gateway/channel-health-policy.ts`
- Known bad symptoms reviewers should watch for:
  - socket channels not getting stale restarts when `connected: true` and no events arrive beyond threshold.

## Risks and Mitigations

- Risk: channels that never report `connected` will not use stale-socket restarts.
  - Mitigation: this is intentional for webhook-style channels; disconnected/not-running paths remain active.
