### PR TITLE
Fix Control UI hang when WebSocket disconnects during streaming

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -33,6 +33,11 @@ function resolveSidebarChatSessionKey(state: AppViewState): string {
 }
 
 function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string) {
+  // Clear any pending stream timeout
+  if ((state as unknown as OpenClawApp).chatStreamTimeoutId) {
+    clearTimeout((state as unknown as OpenClawApp).chatStreamTimeoutId!);
+    (state as unknown as OpenClawApp).chatStreamTimeoutId = null;
+  }
   state.sessionKey = sessionKey;
   state.chatMessage = "";
   state.chatStream = null;
@@ -180,6 +185,11 @@ export function renderChatControls(state: AppViewState) {
           ?disabled=${!state.connected}
           @change=${(e: Event) => {
             const next = (e.target as HTMLSelectElement).value;
+            // Clear any pending stream timeout
+            if ((state as unknown as OpenClawApp).chatStreamTimeoutId) {
+              clearTimeout((state as unknown as OpenClawApp).chatStreamTimeoutId!);
+              (state as unknown as OpenClawApp).chatStreamTimeoutId = null;
+            }
             state.sessionKey = next;
             state.chatMessage = "";
             state.chatStream = null;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -59,6 +59,7 @@ export type AppViewState = {
   chatToolMessages: unknown[];
   chatStream: string | null;
   chatStreamStartedAt: number | null;
+  chatStreamTimeoutId: ReturnType<typeof setTimeout> | null;
   chatRunId: string | null;
   compactionStatus: CompactionStatus | null;
   fallbackStatus: FallbackStatus | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -144,6 +144,7 @@ export class OpenClawApp extends LitElement {
   @state() chatToolMessages: unknown[] = [];
   @state() chatStream: string | null = null;
   @state() chatStreamStartedAt: number | null = null;
+  @state() chatStreamTimeoutId: ReturnType<typeof setTimeout> | null = null;
   @state() chatRunId: string | null = null;
   @state() compactionStatus: CompactionStatus | null = null;
   @state() fallbackStatus: FallbackStatus | null = null;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { handleChatEvent, loadChatHistory, type ChatEventPayload, type ChatState } from "./chat.ts";
+
+// Mock timers for timeout tests
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 function createState(overrides: Partial<ChatState> = {}): ChatState {
   return {
@@ -11,6 +21,7 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
     chatSending: false,
     chatStream: null,
     chatStreamStartedAt: null,
+    chatStreamTimeoutId: null,
     chatThinkingLevel: null,
     client: null,
     connected: true,
@@ -491,6 +502,72 @@ describe("handleChatEvent", () => {
     // entry.text takes precedence — "real reply" is NOT silent, so the message is kept.
     expect(handleChatEvent(state, payload)).toBe("final");
     expect(state.chatMessages).toHaveLength(1);
+  });
+
+  it("clears timeout when final event arrives", () => {
+    const mockTimeoutId = setTimeout(() => {}, 10000);
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Reply",
+      chatStreamStartedAt: 100,
+      chatStreamTimeoutId: mockTimeoutId,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Reply" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatStreamTimeoutId).toBe(null);
+    clearTimeout(mockTimeoutId); // Cleanup
+  });
+
+  it("clears timeout when aborted event arrives", () => {
+    const mockTimeoutId = setTimeout(() => {}, 10000);
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Partial",
+      chatStreamStartedAt: 100,
+      chatStreamTimeoutId: mockTimeoutId,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "aborted",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("aborted");
+    expect(state.chatStreamTimeoutId).toBe(null);
+    clearTimeout(mockTimeoutId); // Cleanup
+  });
+
+  it("clears timeout when error event arrives", () => {
+    const mockTimeoutId = setTimeout(() => {}, 10000);
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Partial",
+      chatStreamStartedAt: 100,
+      chatStreamTimeoutId: mockTimeoutId,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "Something went wrong",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.chatStreamTimeoutId).toBe(null);
+    expect(state.lastError).toBe("Something went wrong");
+    clearTimeout(mockTimeoutId); // Cleanup
   });
 });
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -5,6 +5,10 @@ import { generateUUID } from "../uuid.ts";
 
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 
+// Timeout for detecting stuck chat streams (e.g., when WebSocket disconnects during streaming)
+// Set to 60 seconds to allow for legitimate long responses while catching network issues
+const CHAT_STREAM_TIMEOUT_MS = 60_000;
+
 function isSilentReplyStream(text: string): boolean {
   return SILENT_REPLY_PATTERN.test(text);
 }
@@ -39,6 +43,7 @@ export type ChatState = {
   chatRunId: string | null;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
+  chatStreamTimeoutId: ReturnType<typeof setTimeout> | null;
   lastError: string | null;
 };
 
@@ -178,6 +183,38 @@ export async function sendChatMessage(
   state.chatStream = "";
   state.chatStreamStartedAt = now;
 
+  // Set up timeout guard to detect stuck streams (e.g., WebSocket disconnect during streaming)
+  if (state.chatStreamTimeoutId) {
+    clearTimeout(state.chatStreamTimeoutId);
+  }
+  state.chatStreamTimeoutId = setTimeout(() => {
+    // Only reset if this timeout is for the current run and stream hasn't ended
+    if (state.chatRunId === runId && state.chatStreamStartedAt !== null) {
+      console.warn("[chat] Stream timeout, resetting state");
+
+      // Save partial streamed text before resetting
+      const streamedText = state.chatStream?.trim();
+
+      state.chatRunId = null;
+      state.chatStream = null;
+      state.chatStreamStartedAt = null;
+      state.chatStreamTimeoutId = null;
+      state.lastError = "Response timed out. Please try again.";
+
+      // Add partial streamed text as assistant message if available
+      if (streamedText) {
+        state.chatMessages = [
+          ...state.chatMessages,
+          {
+            role: "assistant",
+            content: [{ type: "text", text: streamedText }],
+            timestamp: Date.now(),
+          },
+        ];
+      }
+    }
+  }, CHAT_STREAM_TIMEOUT_MS);
+
   // Convert attachments to API format
   const apiAttachments = hasAttachments
     ? attachments
@@ -205,6 +242,11 @@ export async function sendChatMessage(
     });
     return runId;
   } catch (err) {
+    // Clear timeout on error since stream won't start
+    if (state.chatStreamTimeoutId) {
+      clearTimeout(state.chatStreamTimeoutId);
+      state.chatStreamTimeoutId = null;
+    }
     const error = String(err);
     state.chatRunId = null;
     state.chatStream = null;
@@ -241,6 +283,17 @@ export async function abortChatRun(state: ChatState): Promise<boolean> {
   }
 }
 
+/**
+ * Clears the chat stream timeout if one is pending.
+ * Should be called when a stream ends (final/aborted/error) to prevent spurious timeouts.
+ */
+function clearChatStreamTimeout(state: ChatState) {
+  if (state.chatStreamTimeoutId) {
+    clearTimeout(state.chatStreamTimeoutId);
+    state.chatStreamTimeoutId = null;
+  }
+}
+
 export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (!payload) {
     return null;
@@ -272,6 +325,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       }
     }
   } else if (payload.state === "final") {
+    clearChatStreamTimeout(state);
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
     if (finalMessage && !isAssistantSilentReply(finalMessage)) {
       state.chatMessages = [...state.chatMessages, finalMessage];
@@ -289,6 +343,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
   } else if (payload.state === "aborted") {
+    clearChatStreamTimeout(state);
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
     if (normalizedMessage && !isAssistantSilentReply(normalizedMessage)) {
       state.chatMessages = [...state.chatMessages, normalizedMessage];
@@ -309,6 +364,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
   } else if (payload.state === "error") {
+    clearChatStreamTimeout(state);
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;


### PR DESCRIPTION
Fixes #32400

## Problem
Control UI hangs indefinitely when WebSocket disconnects during long streaming responses.

## Solution
- Add 60-second timeout guard to detect stuck chat streams
- Clear timeout when final/aborted/error events arrive
- Reset state and show user-friendly error on timeout
- Preserve partial streamed text when timeout occurs
- Clear timeout on session switches to prevent memory leaks

## Testing
- All 30 controller tests pass
- No compilation errors
- Linting passed