### PR TITLE
fix(gateway): avoid active health probes on CLI reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/logs follow probe churn: avoid forcing post-connect channel probes for gateway CLI clients, reducing repeated external `probeAccount` calls during `openclaw logs --follow` reconnect polling while keeping probes for non-CLI clients. (#32986) Thanks @liuxiaopai-ai.
 - Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
 - Exec heartbeat routing: scope exec-triggered heartbeat wakes to agent session keys so unrelated agents are no longer awakened by exec events, while preserving legacy unscoped behavior for non-canonical session keys. (#32724) thanks @altaywtf
 - macOS/Tailscale remote gateway discovery: add a Tailscale Serve fallback peer probe path (`wss://<peer>.ts.net`) when Bonjour and wide-area DNS-SD discovery return no gateways, and refresh both discovery paths from macOS onboarding. (#32860) Thanks @ngutman.

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -84,6 +84,7 @@ import {
   resolveControlUiAuthPolicy,
   shouldSkipControlUiPairing,
 } from "./connect-policy.js";
+import { resolvePostConnectHealthRefreshOptions } from "./post-connect-health.js";
 import { isUnauthorizedRoleError, UnauthorizedFloodGuard } from "./unauthorized-flood-guard.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
@@ -1125,7 +1126,9 @@ export function attachGatewayWsMessageHandler(params: {
         });
 
         send({ type: "res", id: frame.id, ok: true, payload: helloOk });
-        void refreshGatewayHealthSnapshot({ probe: true }).catch((err) =>
+        void refreshGatewayHealthSnapshot(
+          resolvePostConnectHealthRefreshOptions(connectParams.client),
+        ).catch((err) =>
           logHealth.error(`post-connect health refresh failed: ${formatError(err)}`),
         );
         return;

--- a/src/gateway/server/ws-connection/post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/post-connect-health.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
+import { resolvePostConnectHealthRefreshOptions } from "./post-connect-health.js";
+
+describe("resolvePostConnectHealthRefreshOptions", () => {
+  it("disables active probes for gateway CLI reconnects", () => {
+    expect(
+      resolvePostConnectHealthRefreshOptions({
+        id: GATEWAY_CLIENT_IDS.CLI,
+        version: "2026.3.3",
+        platform: "linux",
+        mode: GATEWAY_CLIENT_MODES.CLI,
+      }),
+    ).toEqual({ probe: false });
+  });
+
+  it("keeps active probes enabled for non-CLI clients", () => {
+    expect(
+      resolvePostConnectHealthRefreshOptions({
+        id: GATEWAY_CLIENT_IDS.CONTROL_UI,
+        version: "2026.3.3",
+        platform: "darwin",
+        mode: GATEWAY_CLIENT_MODES.UI,
+      }),
+    ).toEqual({ probe: true });
+  });
+});

--- a/src/gateway/server/ws-connection/post-connect-health.ts
+++ b/src/gateway/server/ws-connection/post-connect-health.ts
@@ -1,0 +1,8 @@
+import { isGatewayCliClient } from "../../../utils/message-channel.js";
+import type { ConnectParams } from "../../protocol/index.js";
+
+export function resolvePostConnectHealthRefreshOptions(client: ConnectParams["client"]): {
+  probe: boolean;
+} {
+  return { probe: !isGatewayCliClient(client) };
+}


### PR DESCRIPTION
## Summary

- Problem: every new websocket client handshake triggered `refreshGatewayHealthSnapshot({ probe: true })`, including short-lived gateway CLI reconnects used by `openclaw logs --follow`.
- Why it matters: polling reconnects can repeatedly call channel `probeAccount` flows (for example Feishu bot info API), causing unnecessary external API traffic.
- What changed: post-connect refresh now resolves probe behavior by client type and disables active probe for gateway CLI clients.
- What did NOT change (scope boundary): non-CLI clients still use post-connect probing behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32986
- Related #32990

## User-visible / Behavior Changes

- `openclaw logs --follow` no longer triggers active channel probes on every CLI reconnect.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + Vitest
- Model/provider: N/A
- Integration/channel (if any): Gateway websocket hello + channel health refresh path
- Relevant config (redacted): gateway default ws endpoint; CLI mode client

### Steps

1. Connect as gateway CLI client and complete hello handshake.
2. Trigger post-connect health refresh.
3. Inspect resolved refresh options.

### Expected

- CLI client should avoid active probing (`probe: false`).

### Actual

- Before fix: CLI hello used `probe: true`.
- After fix: CLI hello resolves to `probe: false`; non-CLI remains `probe: true`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test src/gateway/server/ws-connection/post-connect-health.test.ts`

## Human Verification (required)

- Verified scenarios:
  - gateway CLI mode resolves post-connect health refresh with probing disabled.
  - control-ui/ui mode resolves post-connect health refresh with probing enabled.
- Edge cases checked:
  - central ws handshake path still performs refresh call.
- What you did **not** verify:
  - long-running live Feishu API call count sampling in production.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore:
  - `src/gateway/server/ws-connection/message-handler.ts`
  - `src/gateway/server/ws-connection/post-connect-health.ts`
- Known bad symptoms reviewers should watch for:
  - CLI reconnections still triggering external account probes.

## Risks and Mitigations

- Risk: reduced immediate probe updates for CLI-only reconnect paths.
  - Mitigation: non-CLI probes remain unchanged; periodic/probe-on-demand paths still available.
