### PR TITLE
feat(feishu): add cardFormat config option for legacy card support

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -114,6 +114,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         chunkMode: { type: "string", enum: ["length", "newline"] },
         mediaMaxMb: { type: "number", minimum: 0 },
         renderMode: { type: "string", enum: ["auto", "raw", "card"] },
+        cardFormat: { type: "string", enum: ["streaming", "legacy"] },
         accounts: {
           type: "object",
           additionalProperties: {

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -139,6 +139,37 @@ describe("FeishuConfigSchema optimization flags", () => {
   });
 });
 
+describe("FeishuConfigSchema cardFormat", () => {
+  it("defaults cardFormat to undefined when not set", () => {
+    const result = FeishuConfigSchema.parse({});
+    expect(result.cardFormat).toBeUndefined();
+  });
+
+  it("accepts cardFormat streaming", () => {
+    const result = FeishuConfigSchema.parse({ cardFormat: "streaming" });
+    expect(result.cardFormat).toBe("streaming");
+  });
+
+  it("accepts cardFormat legacy", () => {
+    const result = FeishuConfigSchema.parse({ cardFormat: "legacy" });
+    expect(result.cardFormat).toBe("legacy");
+  });
+
+  it("rejects invalid cardFormat value", () => {
+    const result = FeishuConfigSchema.safeParse({ cardFormat: "invalid" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts cardFormat in account config", () => {
+    const result = FeishuConfigSchema.parse({
+      accounts: {
+        main: { cardFormat: "legacy" },
+      },
+    });
+    expect(result.accounts?.main?.cardFormat).toBe("legacy");
+  });
+});
+
 describe("FeishuConfigSchema defaultAccount", () => {
   it("accepts defaultAccount when it matches an account key", () => {
     const result = FeishuConfigSchema.safeParse({

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -41,6 +41,11 @@ const RenderModeSchema = z.enum(["auto", "raw", "card"]).optional();
 // for incremental text display with a "Thinking..." placeholder
 const StreamingModeSchema = z.boolean().optional();
 
+// Card format: "streaming" uses Cardkit streaming cards (real-time UX but opaque to
+// im.message.get); "legacy" sends completed responses as old-format interactive cards
+// (no streaming, but fully readable/forwardable/quotable by other bots).
+const CardFormatSchema = z.enum(["streaming", "legacy"]).optional();
+
 const BlockStreamingCoalesceSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -164,6 +169,7 @@ const FeishuSharedConfigShape = {
   heartbeat: ChannelHeartbeatVisibilitySchema,
   renderMode: RenderModeSchema,
   streaming: StreamingModeSchema,
+  cardFormat: CardFormatSchema,
   tools: FeishuToolsConfigSchema,
   replyInThread: ReplyInThreadSchema,
   reactionNotifications: ReactionNotificationModeSchema,

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -369,6 +369,84 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("disables streaming and sends legacy card when cardFormat is legacy", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: true,
+        cardFormat: "legacy",
+      },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses streaming when cardFormat is streaming (explicit)", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: true,
+        cardFormat: "streaming",
+      },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not expose onPartialReply when cardFormat is legacy", () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+        cardFormat: "legacy",
+      },
+    });
+
+    const { replyOptions } = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    expect(replyOptions.onPartialReply).toBeUndefined();
+  });
+
   it("disables streaming for thread replies and keeps reply metadata", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -225,7 +225,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         }
 
         if (hasText) {
-          const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
+          const useCard =
+            renderMode === "card" ||
+            cardFormat === "legacy" ||
+            (renderMode === "auto" && shouldUseCard(text));
 
           if (info?.kind === "final" && streamingEnabled && useCard) {
             startStreaming();

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -130,9 +130,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const chunkMode = core.channel.text.resolveChunkMode(cfg, "feishu");
   const tableMode = core.channel.text.resolveMarkdownTableMode({ cfg, channel: "feishu" });
   const renderMode = account.config?.renderMode ?? "auto";
+  const cardFormat = account.config?.cardFormat ?? "streaming";
   // Card streaming may miss thread affinity in topic contexts; use direct replies there.
+  // Legacy card format also disables streaming to produce quotable/forwardable cards.
   const streamingEnabled =
-    !threadReplyMode && account.config?.streaming !== false && renderMode !== "raw";
+    !threadReplyMode &&
+    account.config?.streaming !== false &&
+    renderMode !== "raw" &&
+    cardFormat !== "legacy";
 
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";


### PR DESCRIPTION
## Summary

- Add `cardFormat` config option (`"streaming"` | `"legacy"`) to the Feishu channel configuration
- When set to `"legacy"`, bot responses are sent as old-format interactive cards instead of Cardkit streaming cards
- Legacy cards are fully readable via `im.message.get`, forwardable, and quotable by other bots — enabling bot-to-bot async communication workflows

Closes #32940

## Changes

- **`config-schema.ts`**: Add `CardFormatSchema` enum (`"streaming"` | `"legacy"`) and include it in `FeishuSharedConfigShape` (inherited by both top-level and per-account config)
- **`reply-dispatcher.ts`**: Check `cardFormat` setting; when `"legacy"`, disable streaming session so responses are sent as complete legacy cards via `sendMarkdownCardFeishu`
- **`channel.ts`**: Expose `cardFormat` in the JSON Schema for web UI configuration

## Test plan

- [x] Added config schema tests: validates `cardFormat` accepts `"streaming"`, `"legacy"`, rejects invalid values, works at both top-level and account-level
- [x] Added reply dispatcher tests: verifies streaming is disabled when `cardFormat: "legacy"`, streaming works with explicit `"streaming"`, `onPartialReply` is not exposed in legacy mode
- [x] All 40 existing + new tests pass

Made with [Cursor](https://cursor.com)