### PR TITLE
fix(feishu): reply to triggering message in group reply chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/group reply targeting: send bot replies to the triggering inbound message (instead of the thread root `root_id`) while preserving topic root context for routing/thread affinity, so @mention replies stay attached to the message that invoked the bot. (#32980) Thanks @miaciswang.
 - Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
 - Exec heartbeat routing: scope exec-triggered heartbeat wakes to agent session keys so unrelated agents are no longer awakened by exec events, while preserving legacy unscoped behavior for non-canonical session keys. (#32724) thanks @altaywtf
 - macOS/Tailscale remote gateway discovery: add a Tailscale Serve fallback peer probe path (`wss://<peer>.ts.net`) when Bonjour and wide-area DNS-SD discovery return no gateways, and refresh both discovery paths from macOS onboarding. (#32860) Thanks @ngutman.

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1479,7 +1479,7 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
-  it("replies to the topic root when handling a message inside an existing topic", async () => {
+  it("replies to the triggering message while preserving topic root context", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
     const cfg: ClawdbotConfig = {
@@ -1511,7 +1511,7 @@ describe("handleFeishuMessage command authorization", () => {
 
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
-        replyToMessageId: "om_root_topic",
+        replyToMessageId: "om_child_message",
         rootId: "om_root_topic",
       }),
     );

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1337,7 +1337,9 @@ export async function handleFeishuMessage(params: {
     const messageCreateTimeMs = event.message.create_time
       ? parseInt(event.message.create_time, 10)
       : undefined;
-    const replyTargetMessageId = ctx.rootId ?? ctx.messageId;
+    // Always reply to the triggering message so quoted-reply mention chains
+    // don't snap replies back to the thread root.
+    const replyTargetMessageId = ctx.messageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 
     if (broadcastAgents) {


### PR DESCRIPTION
## Summary
- fix Feishu group reply targeting to use the triggering inbound message id instead of `root_id`
- keep `rootId` unchanged in reply dispatcher context for topic routing/thread affinity
- add regression coverage and changelog entry

## Testing
- pnpm test extensions/feishu/src/bot.test.ts

Fixes #32980
