### PR TITLE
fix(macos): sync remote gateway auth fields

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -431,6 +431,8 @@ final class AppState {
             changed = Self.updateGatewayString(&remote, key: "sshIdentity", value: remoteIdentity) || changed
         }
 
+        // Keep token/password in openclaw.json for cross-surface parity with gateway/CLI config loading.
+        // This is intentionally plaintext today; follow-up hardening can move storage to Keychain.
         changed = Self.updateGatewayString(&remote, key: "token", value: remoteToken) || changed
         changed = Self.updateGatewayString(&remote, key: "password", value: remotePassword) || changed
 

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -213,6 +213,14 @@ final class AppState {
         didSet { self.syncGatewayConfigIfNeeded() }
     }
 
+    var remoteToken: String {
+        didSet { self.syncGatewayConfigIfNeeded() }
+    }
+
+    var remotePassword: String {
+        didSet { self.syncGatewayConfigIfNeeded() }
+    }
+
     var remoteIdentity: String {
         didSet { self.ifNotPreview { UserDefaults.standard.set(self.remoteIdentity, forKey: remoteIdentityKey) } }
     }
@@ -281,6 +289,8 @@ final class AppState {
 
         let configRoot = OpenClawConfigFile.loadDict()
         let configRemoteUrl = GatewayRemoteConfig.resolveUrlString(root: configRoot)
+        let configRemoteToken = GatewayRemoteConfig.resolveTokenString(root: configRoot)
+        let configRemotePassword = GatewayRemoteConfig.resolvePasswordString(root: configRoot)
         let configRemoteTransport = GatewayRemoteConfig.resolveTransport(root: configRoot)
         let resolvedConnectionMode = ConnectionModeResolver.resolve(root: configRoot).mode
         self.remoteTransport = configRemoteTransport
@@ -297,6 +307,8 @@ final class AppState {
             self.remoteTarget = storedRemoteTarget
         }
         self.remoteUrl = configRemoteUrl ?? ""
+        self.remoteToken = configRemoteToken ?? ""
+        self.remotePassword = configRemotePassword ?? ""
         self.remoteIdentity = UserDefaults.standard.string(forKey: remoteIdentityKey) ?? ""
         self.remoteProjectRoot = UserDefaults.standard.string(forKey: remoteProjectRootKey) ?? ""
         self.remoteCliPath = UserDefaults.standard.string(forKey: remoteCliPathKey) ?? ""
@@ -380,7 +392,9 @@ final class AppState {
         remoteUrl: String,
         remoteHost: String?,
         remoteTarget: String,
-        remoteIdentity: String) -> (remote: [String: Any], changed: Bool)
+        remoteIdentity: String,
+        remoteToken: String,
+        remotePassword: String) -> (remote: [String: Any], changed: Bool)
     {
         var remote = current
         var changed = false
@@ -417,6 +431,9 @@ final class AppState {
             changed = Self.updateGatewayString(&remote, key: "sshIdentity", value: remoteIdentity) || changed
         }
 
+        changed = Self.updateGatewayString(&remote, key: "token", value: remoteToken) || changed
+        changed = Self.updateGatewayString(&remote, key: "password", value: remotePassword) || changed
+
         return (remote, changed)
     }
 
@@ -439,6 +456,8 @@ final class AppState {
         let gateway = root["gateway"] as? [String: Any]
         let modeRaw = (gateway?["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         let remoteUrl = GatewayRemoteConfig.resolveUrlString(root: root)
+        let remoteToken = GatewayRemoteConfig.resolveTokenString(root: root)
+        let remotePassword = GatewayRemoteConfig.resolvePasswordString(root: root)
         let hasRemoteUrl = !(remoteUrl?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .isEmpty ?? true)
@@ -469,6 +488,14 @@ final class AppState {
         let remoteUrlText = remoteUrl ?? ""
         if remoteUrlText != self.remoteUrl {
             self.remoteUrl = remoteUrlText
+        }
+        let remoteTokenText = remoteToken ?? ""
+        if remoteTokenText != self.remoteToken {
+            self.remoteToken = remoteTokenText
+        }
+        let remotePasswordText = remotePassword ?? ""
+        if remotePasswordText != self.remotePassword {
+            self.remotePassword = remotePasswordText
         }
 
         let targetMode = desiredMode ?? self.connectionMode
@@ -504,6 +531,8 @@ final class AppState {
         let remoteIdentity = self.remoteIdentity
         let remoteTransport = self.remoteTransport
         let remoteUrl = self.remoteUrl
+        let remoteToken = self.remoteToken
+        let remotePassword = self.remotePassword
         let desiredMode: String? = switch connectionMode {
         case .local:
             "local"
@@ -541,7 +570,9 @@ final class AppState {
                     remoteUrl: remoteUrl,
                     remoteHost: remoteHost,
                     remoteTarget: remoteTarget,
-                    remoteIdentity: remoteIdentity)
+                    remoteIdentity: remoteIdentity,
+                    remoteToken: remoteToken,
+                    remotePassword: remotePassword)
                 if updated.changed {
                     gateway["remote"] = updated.remote
                     changed = true
@@ -697,12 +728,39 @@ extension AppState {
         state.canvasEnabled = true
         state.remoteTarget = "user@example.com"
         state.remoteUrl = "wss://gateway.example.ts.net"
+        state.remoteToken = "gateway-token"
+        state.remotePassword = "gateway-password"
         state.remoteIdentity = "~/.ssh/id_ed25519"
         state.remoteProjectRoot = "~/Projects/openclaw"
         state.remoteCliPath = ""
         return state
     }
 }
+
+#if DEBUG
+extension AppState {
+    static func _testUpdatedRemoteGatewayConfig(
+        current: [String: Any],
+        transport: RemoteTransport,
+        remoteUrl: String,
+        remoteHost: String?,
+        remoteTarget: String,
+        remoteIdentity: String,
+        remoteToken: String,
+        remotePassword: String) -> (remote: [String: Any], changed: Bool)
+    {
+        self.updatedRemoteGatewayConfig(
+            current: current,
+            transport: transport,
+            remoteUrl: remoteUrl,
+            remoteHost: remoteHost,
+            remoteTarget: remoteTarget,
+            remoteIdentity: remoteIdentity,
+            remoteToken: remoteToken,
+            remotePassword: remotePassword)
+    }
+}
+#endif
 
 @MainActor
 enum AppStateStore {

--- a/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
@@ -24,6 +24,28 @@ enum GatewayRemoteConfig {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    static func resolveTokenString(root: [String: Any]) -> String? {
+        guard let gateway = root["gateway"] as? [String: Any],
+              let remote = gateway["remote"] as? [String: Any],
+              let tokenRaw = remote["token"] as? String
+        else {
+            return nil
+        }
+        let trimmed = tokenRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func resolvePasswordString(root: [String: Any]) -> String? {
+        guard let gateway = root["gateway"] as? [String: Any],
+              let remote = gateway["remote"] as? [String: Any],
+              let passwordRaw = remote["password"] as? String
+        else {
+            return nil
+        }
+        let trimmed = passwordRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     static func resolveGatewayUrl(root: [String: Any]) -> URL? {
         guard let raw = self.resolveUrlString(root: root) else { return nil }
         return self.normalizeGatewayUrl(raw)

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -149,6 +149,7 @@ struct GeneralSettings: View {
             } else {
                 self.remoteDirectRow
             }
+            self.remoteAuthRows
 
             GatewayDiscoveryInlineList(
                 discovery: self.gatewayDiscovery,
@@ -288,6 +289,27 @@ struct GeneralSettings: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .padding(.leading, self.remoteLabelWidth + 10)
+        }
+    }
+
+    private var remoteAuthRows: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 10) {
+                Text("Token")
+                    .font(.callout.weight(.semibold))
+                    .frame(width: self.remoteLabelWidth, alignment: .leading)
+                SecureField("gateway token", text: self.$state.remoteToken)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: .infinity)
+            }
+            HStack(alignment: .center, spacing: 10) {
+                Text("Password")
+                    .font(.callout.weight(.semibold))
+                    .frame(width: self.remoteLabelWidth, alignment: .leading)
+                SecureField("gateway password", text: self.$state.remotePassword)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: .infinity)
+            }
         }
     }
 
@@ -692,6 +714,8 @@ extension GeneralSettings {
         state.remoteTransport = .ssh
         state.remoteTarget = "user@host:2222"
         state.remoteUrl = "wss://gateway.example.ts.net"
+        state.remoteToken = "gateway-token"
+        state.remotePassword = "gateway-password"
         state.remoteIdentity = "/tmp/id_ed25519"
         state.remoteProjectRoot = "/tmp/openclaw"
         state.remoteCliPath = "/tmp/openclaw"

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -257,6 +257,22 @@ extension OnboardingView {
                                 .frame(width: fieldWidth)
                         }
                     }
+                    GridRow {
+                        Text("Token")
+                            .font(.callout.weight(.semibold))
+                            .frame(width: labelWidth, alignment: .leading)
+                        SecureField("gateway token", text: self.$state.remoteToken)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: fieldWidth)
+                    }
+                    GridRow {
+                        Text("Password")
+                            .font(.callout.weight(.semibold))
+                            .frame(width: labelWidth, alignment: .leading)
+                        SecureField("gateway password", text: self.$state.remotePassword)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: fieldWidth)
+                    }
                 }
 
                 Text(self.state.remoteTransport == .direct

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Testing.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Testing.swift
@@ -38,6 +38,8 @@ extension OnboardingView {
         view.workspacePath = "/tmp/openclaw"
         view.workspaceStatus = "Saved workspace"
         view.state.connectionMode = .local
+        view.state.remoteToken = "gateway-token"
+        view.state.remotePassword = "gateway-password"
         _ = view.welcomePage()
         _ = view.connectionPage()
         _ = view.wizardPage()

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteAuthSyncTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteAuthSyncTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct AppStateRemoteAuthSyncTests {
+    @Test
+    func appStateLoadsRemoteCredentialsFromConfig() async {
+        let override = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-config-\(UUID().uuidString)")
+            .appendingPathComponent("openclaw.json")
+            .path
+
+        await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": override]) {
+            OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "remote",
+                    "remote": [
+                        "url": "wss://gateway.example.ts.net",
+                        "token": " remote-token ",
+                        "password": " remote-password ",
+                    ],
+                ],
+            ])
+
+            let state = AppState(preview: true)
+            #expect(state.remoteToken == "remote-token")
+            #expect(state.remotePassword == "remote-password")
+        }
+    }
+
+    @Test
+    func updatedRemoteGatewayConfigWritesRemoteCredentials() {
+        let updated = AppState._testUpdatedRemoteGatewayConfig(
+            current: [:],
+            transport: .direct,
+            remoteUrl: "wss://gateway.example.ts.net",
+            remoteHost: nil,
+            remoteTarget: "",
+            remoteIdentity: "",
+            remoteToken: " test-token ",
+            remotePassword: " test-password ")
+
+        #expect(updated.changed)
+        #expect((updated.remote["token"] as? String) == "test-token")
+        #expect((updated.remote["password"] as? String) == "test-password")
+    }
+
+    @Test
+    func updatedRemoteGatewayConfigRemovesEmptyRemoteCredentials() {
+        let updated = AppState._testUpdatedRemoteGatewayConfig(
+            current: [
+                "token": "old-token",
+                "password": "old-password",
+                "url": "wss://gateway.example.ts.net",
+            ],
+            transport: .direct,
+            remoteUrl: "wss://gateway.example.ts.net",
+            remoteHost: nil,
+            remoteTarget: "",
+            remoteIdentity: "",
+            remoteToken: " ",
+            remotePassword: "\n")
+
+        #expect(updated.changed)
+        #expect(updated.remote["token"] == nil)
+        #expect(updated.remote["password"] == nil)
+        #expect((updated.remote["url"] as? String) == "wss://gateway.example.ts.net")
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -75,6 +75,57 @@ import Testing
         #expect(password == "launchd-pass")
     }
 
+    @Test func resolveGatewayTokenUsesRemoteConfigInRemoteMode() {
+        let root: [String: Any] = [
+            "gateway": [
+                "remote": [
+                    "token": " remote-token ",
+                ],
+            ],
+        ]
+
+        let token = GatewayEndpointStore._testResolveGatewayToken(
+            isRemote: true,
+            root: root,
+            env: [:],
+            launchdSnapshot: nil)
+        #expect(token == "remote-token")
+    }
+
+    @Test func resolveGatewayPasswordUsesRemoteConfigInRemoteMode() {
+        let root: [String: Any] = [
+            "gateway": [
+                "remote": [
+                    "password": " remote-password ",
+                ],
+            ],
+        ]
+
+        let password = GatewayEndpointStore._testResolveGatewayPassword(
+            isRemote: true,
+            root: root,
+            env: [:],
+            launchdSnapshot: nil)
+        #expect(password == "remote-password")
+    }
+
+    @Test func resolveGatewayTokenPrefersEnvOverRemoteConfig() {
+        let root: [String: Any] = [
+            "gateway": [
+                "remote": [
+                    "token": "config-token",
+                ],
+            ],
+        ]
+
+        let token = GatewayEndpointStore._testResolveGatewayToken(
+            isRemote: true,
+            root: root,
+            env: ["OPENCLAW_GATEWAY_TOKEN": "env-token"],
+            launchdSnapshot: nil)
+        #expect(token == "env-token")
+    }
+
     @Test func connectionModeResolverPrefersConfigModeOverDefaults() {
         let defaults = self.makeDefaults()
         defaults.set("remote", forKey: connectionModeKey)

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -126,6 +126,23 @@ import Testing
         #expect(token == "env-token")
     }
 
+    @Test func resolveGatewayPasswordPrefersEnvOverRemoteConfig() {
+        let root: [String: Any] = [
+            "gateway": [
+                "remote": [
+                    "password": "config-password",
+                ],
+            ],
+        ]
+
+        let password = GatewayEndpointStore._testResolveGatewayPassword(
+            isRemote: true,
+            root: root,
+            env: ["OPENCLAW_GATEWAY_PASSWORD": "env-password"],
+            launchdSnapshot: nil)
+        #expect(password == "env-password")
+    }
+
     @Test func connectionModeResolverPrefersConfigModeOverDefaults() {
         let defaults = self.makeDefaults()
         defaults.set("remote", forKey: connectionModeKey)

--- a/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
@@ -71,6 +71,7 @@ struct OpenClawConfigFileTests {
                     "remote": [
                         "url": "wss://old-host:111",
                         "token": "tok",
+                        "password": "pw",
                     ],
                 ],
             ])
@@ -79,6 +80,7 @@ struct OpenClawConfigFileTests {
             let remote = ((root["gateway"] as? [String: Any])?["remote"] as? [String: Any]) ?? [:]
             #expect((remote["url"] as? String) == nil)
             #expect((remote["token"] as? String) == "tok")
+            #expect((remote["password"] as? String) == "pw")
         }
     }
 


### PR DESCRIPTION
## Summary
- load remote token/password from config into macOS app state on startup
- persist remote token/password when saving remote gateway settings
- add macOS tests covering config load/write and env-precedence for remote auth

## Scope
- `apps/macos/**` only

## Verification
- `swift test --package-path apps/macos --filter AppStateRemoteAuthSyncTests`
- `swift test --package-path apps/macos --filter GatewayEndpointStoreTests`
- `swift test --package-path apps/macos --filter OpenClawConfigFileTests`
