### PR TITLE
fix(msteams): send thread replies via proactive conversation

### DIFF
--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -171,6 +171,27 @@ describe("msteams messenger", () => {
       expect(ref.activityId).toBe("activity123");
     });
 
+    it("fails fast when thread fallback lacks activityId and context", async () => {
+      const continueConversation = vi.fn(async () => {});
+      const adapter: MSTeamsAdapter = {
+        continueConversation,
+        process: async () => {},
+      };
+
+      await expect(
+        sendMSTeamsMessages({
+          replyStyle: "thread",
+          adapter,
+          appId: "app123",
+          conversationRef: { ...baseRef, activityId: undefined },
+          messages: [{ text: "one" }],
+        }),
+      ).rejects.toThrow(
+        "Missing conversationRef.activityId for replyStyle=thread proactive fallback",
+      );
+      expect(continueConversation).not.toHaveBeenCalled();
+    });
+
     it("sends top-level messages via continueConversation and strips activityId", async () => {
       const seen: { reference?: unknown; texts: string[] } = { texts: [] };
 

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -137,24 +137,38 @@ describe("msteams messenger", () => {
       serviceUrl: "https://service.example.com",
     };
 
-    it("sends thread messages via the provided context", async () => {
-      const sent: string[] = [];
-      const ctx = {
-        sendActivity: createRecordedSendActivity(sent),
+    it("sends thread messages via proactive messaging with replyToId", async () => {
+      const sent: Array<{ text?: string; replyToId?: string }> = [];
+      const seenRef: { reference?: unknown } = {};
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, reference, logic) => {
+          seenRef.reference = reference;
+          await logic({
+            sendActivity: async (activity: unknown) => {
+              const value = activity as { text?: string; replyToId?: string };
+              sent.push({ text: value.text, replyToId: value.replyToId });
+              return { id: `id:${value.text ?? ""}` };
+            },
+          });
+        },
+        process: async () => {},
       };
-      const adapter = createNoopAdapter();
 
       const ids = await sendMSTeamsMessages({
         replyStyle: "thread",
         adapter,
         appId: "app123",
         conversationRef: baseRef,
-        context: ctx,
         messages: [{ text: "one" }, { text: "two" }],
       });
 
-      expect(sent).toEqual(["one", "two"]);
+      expect(sent).toEqual([
+        { text: "one", replyToId: "activity123" },
+        { text: "two", replyToId: "activity123" },
+      ]);
       expect(ids).toEqual(["id:one", "id:two"]);
+      const ref = seenRef.reference as { activityId?: string };
+      expect(ref.activityId).toBe("activity123");
     });
 
     it("sends top-level messages via continueConversation and strips activityId", async () => {
@@ -196,14 +210,17 @@ describe("msteams messenger", () => {
 
       try {
         const sent: Array<{ text?: string; entities?: unknown[] }> = [];
-        const ctx = {
-          sendActivity: async (activity: unknown) => {
-            sent.push(activity as { text?: string; entities?: unknown[] });
-            return { id: "id:one" };
+        const adapter: MSTeamsAdapter = {
+          continueConversation: async (_appId, _reference, logic) => {
+            await logic({
+              sendActivity: async (activity: unknown) => {
+                sent.push(activity as { text?: string; entities?: unknown[] });
+                return { id: "id:one" };
+              },
+            });
           },
+          process: async () => {},
         };
-
-        const adapter = createNoopAdapter();
 
         const ids = await sendMSTeamsMessages({
           replyStyle: "thread",
@@ -216,7 +233,6 @@ describe("msteams messenger", () => {
               conversationType: "channel",
             },
           },
-          context: ctx,
           messages: [{ text: "Hello @[John](29:08q2j2o3jc09au90eucae)", mediaUrl: localFile }],
           tokenProvider: {
             getAccessToken: async () => "token",
@@ -249,17 +265,18 @@ describe("msteams messenger", () => {
       const attempts: string[] = [];
       const retryEvents: Array<{ nextAttempt: number; delayMs: number }> = [];
 
-      const ctx = {
-        sendActivity: createRecordedSendActivity(attempts, 429),
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, _reference, logic) => {
+          await logic({ sendActivity: createRecordedSendActivity(attempts, 429) });
+        },
+        process: async () => {},
       };
-      const adapter = createNoopAdapter();
 
       const ids = await sendMSTeamsMessages({
         replyStyle: "thread",
         adapter,
         appId: "app123",
         conversationRef: baseRef,
-        context: ctx,
         messages: [{ text: "one" }],
         retry: { maxAttempts: 2, baseDelayMs: 0, maxDelayMs: 0 },
         onRetry: (e) => retryEvents.push({ nextAttempt: e.nextAttempt, delayMs: e.delayMs }),
@@ -271,13 +288,16 @@ describe("msteams messenger", () => {
     });
 
     it("does not retry thread sends on client errors (4xx)", async () => {
-      const ctx = {
-        sendActivity: async () => {
-          throw Object.assign(new Error("bad request"), { statusCode: 400 });
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, _reference, logic) => {
+          await logic({
+            sendActivity: async () => {
+              throw Object.assign(new Error("bad request"), { statusCode: 400 });
+            },
+          });
         },
+        process: async () => {},
       };
-
-      const adapter = createNoopAdapter();
 
       await expect(
         sendMSTeamsMessages({
@@ -285,7 +305,6 @@ describe("msteams messenger", () => {
           adapter,
           appId: "app123",
           conversationRef: baseRef,
-          context: ctx,
           messages: [{ text: "one" }],
           retry: { maxAttempts: 3, baseDelayMs: 0, maxDelayMs: 0 },
         }),

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -495,7 +495,7 @@ export async function sendMSTeamsMessages(params: {
   if (params.replyStyle === "thread") {
     const ctx = params.context;
     if (!ctx) {
-      throw new Error("Missing context for replyStyle=thread");
+      return await sendProactively(messages, 0);
     }
     const messageIds: string[] = [];
     for (const [idx, message] of messages.entries()) {

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -448,20 +448,25 @@ export async function sendMSTeamsMessages(params: {
     messageIndex: number,
     options?: { replyToId?: string },
   ): Promise<string> => {
-    const activity = await buildActivity(
-      message,
-      params.conversationRef,
-      params.tokenProvider,
-      params.sharePointSiteId,
-      params.mediaMaxBytes,
+    const response = await sendWithRetry(
+      async () => {
+        const activity = await buildActivity(
+          message,
+          params.conversationRef,
+          params.tokenProvider,
+          params.sharePointSiteId,
+          params.mediaMaxBytes,
+        );
+        if (options?.replyToId) {
+          activity.replyToId = options.replyToId;
+        }
+        return await ctx.sendActivity(activity);
+      },
+      {
+        messageIndex,
+        messageCount: messages.length,
+      },
     );
-    if (options?.replyToId) {
-      activity.replyToId = options.replyToId;
-    }
-    const response = await sendWithRetry(async () => await ctx.sendActivity(activity), {
-      messageIndex,
-      messageCount: messages.length,
-    });
     return extractMessageId(response) ?? "unknown";
   };
 

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -506,8 +506,19 @@ export async function sendMSTeamsMessages(params: {
   if (params.replyStyle === "thread") {
     const ctx = params.context;
     const replyToId = params.conversationRef.activityId;
+    const requireReplyTargetForFallback = (): string => {
+      if (!replyToId) {
+        throw new Error(
+          "Missing conversationRef.activityId for replyStyle=thread proactive fallback",
+        );
+      }
+      return replyToId;
+    };
     if (!ctx) {
-      return await sendProactively(messages, 0, { replyToId, keepActivityId: true });
+      return await sendProactively(messages, 0, {
+        replyToId: requireReplyTargetForFallback(),
+        keepActivityId: true,
+      });
     }
     const messageIds: string[] = [];
     for (const [idx, message] of messages.entries()) {
@@ -521,7 +532,10 @@ export async function sendMSTeamsMessages(params: {
           return {
             ids:
               remaining.length > 0
-                ? await sendProactively(remaining, idx, { replyToId, keepActivityId: true })
+                ? await sendProactively(remaining, idx, {
+                    replyToId: requireReplyTargetForFallback(),
+                    keepActivityId: true,
+                  })
                 : [],
             fellBack: true,
           };

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -446,20 +446,22 @@ export async function sendMSTeamsMessages(params: {
     ctx: SendContext,
     message: MSTeamsRenderedMessage,
     messageIndex: number,
+    options?: { replyToId?: string },
   ): Promise<string> => {
-    const response = await sendWithRetry(
-      async () =>
-        await ctx.sendActivity(
-          await buildActivity(
-            message,
-            params.conversationRef,
-            params.tokenProvider,
-            params.sharePointSiteId,
-            params.mediaMaxBytes,
-          ),
-        ),
-      { messageIndex, messageCount: messages.length },
+    const activity = await buildActivity(
+      message,
+      params.conversationRef,
+      params.tokenProvider,
+      params.sharePointSiteId,
+      params.mediaMaxBytes,
     );
+    if (options?.replyToId) {
+      activity.replyToId = options.replyToId;
+    }
+    const response = await sendWithRetry(async () => await ctx.sendActivity(activity), {
+      messageIndex,
+      messageCount: messages.length,
+    });
     return extractMessageId(response) ?? "unknown";
   };
 
@@ -467,10 +469,11 @@ export async function sendMSTeamsMessages(params: {
     ctx: SendContext,
     batch: MSTeamsRenderedMessage[],
     startIndex: number,
+    options?: { replyToId?: string },
   ): Promise<string[]> => {
     const messageIds: string[] = [];
     for (const [idx, message] of batch.entries()) {
-      messageIds.push(await sendMessageInContext(ctx, message, startIndex + idx));
+      messageIds.push(await sendMessageInContext(ctx, message, startIndex + idx, options));
     }
     return messageIds;
   };
@@ -478,24 +481,28 @@ export async function sendMSTeamsMessages(params: {
   const sendProactively = async (
     batch: MSTeamsRenderedMessage[],
     startIndex: number,
+    options?: { replyToId?: string; keepActivityId?: boolean },
   ): Promise<string[]> => {
     const baseRef = buildConversationReference(params.conversationRef);
-    const proactiveRef: MSTeamsConversationReference = {
-      ...baseRef,
-      activityId: undefined,
-    };
+    const reference: MSTeamsConversationReference = options?.keepActivityId
+      ? baseRef
+      : {
+          ...baseRef,
+          activityId: undefined,
+        };
 
     const messageIds: string[] = [];
-    await params.adapter.continueConversation(params.appId, proactiveRef, async (ctx) => {
-      messageIds.push(...(await sendMessageBatchInContext(ctx, batch, startIndex)));
+    await params.adapter.continueConversation(params.appId, reference, async (ctx) => {
+      messageIds.push(...(await sendMessageBatchInContext(ctx, batch, startIndex, options)));
     });
     return messageIds;
   };
 
   if (params.replyStyle === "thread") {
     const ctx = params.context;
+    const replyToId = params.conversationRef.activityId;
     if (!ctx) {
-      return await sendProactively(messages, 0);
+      return await sendProactively(messages, 0, { replyToId, keepActivityId: true });
     }
     const messageIds: string[] = [];
     for (const [idx, message] of messages.entries()) {
@@ -507,7 +514,10 @@ export async function sendMSTeamsMessages(params: {
         onRevoked: async () => {
           const remaining = messages.slice(idx);
           return {
-            ids: remaining.length > 0 ? await sendProactively(remaining, idx) : [],
+            ids:
+              remaining.length > 0
+                ? await sendProactively(remaining, idx, { replyToId, keepActivityId: true })
+                : [],
             fellBack: true,
           };
         },


### PR DESCRIPTION
## Summary
- route thread replies through proactive conversation flow so delayed sends are not tied to revoked webhook contexts
- preserve thread `replyToId` during proactive fallback and keep retry semantics intact
- align messenger tests to assert proactive thread behavior

## Scope
- `extensions/msteams/**`

## Verification
- `pnpm test extensions/msteams/src/messenger.test.ts`
