### PR TITLE
chore(ci): make host env swift generation swiftformat-safe

### DIFF
--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -22,17 +22,17 @@ enum HostEnvSecurityPolicy {
         "PS4",
         "GCONV_PATH",
         "IFS",
-        "SSLKEYLOGFILE"
+        "SSLKEYLOGFILE",
     ]
 
     static let blockedOverrideKeys: Set<String> = [
         "HOME",
-        "ZDOTDIR"
+        "ZDOTDIR",
     ]
 
     static let blockedPrefixes: [String] = [
         "DYLD_",
         "LD_",
-        "BASH_FUNC_"
+        "BASH_FUNC_",
     ]
 }

--- a/scripts/generate-host-env-security-policy-swift.mjs
+++ b/scripts/generate-host-env-security-policy-swift.mjs
@@ -27,7 +27,7 @@ const outputPath = path.join(
 /** @type {{blockedKeys: string[]; blockedOverrideKeys?: string[]; blockedPrefixes: string[]}} */
 const policy = JSON.parse(fs.readFileSync(policyPath, "utf8"));
 
-const renderSwiftStringArray = (items) => items.map((item) => `        "${item}"`).join(",\n");
+const renderSwiftStringArray = (items) => items.map((item) => `        "${item}",`).join("\n");
 
 const generated = `// Generated file. Do not edit directly.
 // Source: src/infra/host-env-security-policy.json


### PR DESCRIPTION
## Summary
- update host-env Swift policy generator output formatting to align with swiftformat expectations
- include regenerated `HostEnvSecurityPolicy.generated.swift`

## Scope
- `scripts/generate-host-env-security-policy-swift.mjs`
- `apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift`

## Verification
- `swiftformat --lint apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift --config .swiftformat`
- `swiftformat --lint apps/macos/Sources --config .swiftformat` currently reports unrelated existing lint failures in `OpenClawDiscovery/*` on this base.
