### PR TITLE
fix(matrix): honor per-agent mentionPatterns in room gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Matrix/group mention gating: build mention regexes from the routed agent id in room handlers so per-agent `groupChat.mentionPatterns` are honored instead of falling back to global-only matching. (#32982) Thanks @liuxiaopai-ai.
 - Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
 - Exec heartbeat routing: scope exec-triggered heartbeat wakes to agent session keys so unrelated agents are no longer awakened by exec events, while preserving legacy unscoped behavior for non-canonical session keys. (#32724) thanks @altaywtf
 - macOS/Tailscale remote gateway discovery: add a Tailscale Serve fallback peer probe path (`wss://<peer>.ts.net`) when Bonjour and wide-area DNS-SD discovery return no gateways, and refresh both discovery paths from macOS onboarding. (#32860) Thanks @ngutman.

--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -1,6 +1,7 @@
 import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import type { PluginRuntime, RuntimeEnv, RuntimeLogger } from "openclaw/plugin-sdk";
 import { describe, expect, it, vi } from "vitest";
+import { setMatrixRuntime } from "../../runtime.js";
 import { createMatrixRoomMessageHandler } from "./handler.js";
 import { EventType, type MatrixRawEvent } from "./types.js";
 
@@ -52,6 +53,10 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
         commands: {
           shouldHandleTextCommands: vi.fn().mockReturnValue(true),
         },
+        mentions: {
+          buildMentionRegexes: vi.fn().mockReturnValue([]),
+          matchesMentionPatterns: vi.fn().mockReturnValue(false),
+        },
         text: {
           hasControlCommand: vi.fn().mockReturnValue(false),
           resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
@@ -84,7 +89,6 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
       logVerboseMessage,
       allowFrom: [],
       roomsConfig: undefined,
-      mentionRegexes: [],
       groupPolicy: "open",
       replyToMode: "first",
       threadReplies: "inbound",
@@ -105,6 +109,7 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
       getMemberDisplayName: vi.fn().mockResolvedValue("Bu"),
       accountId: undefined,
     });
+    setMatrixRuntime(core);
 
     const event = {
       type: EventType.RoomMessage,
@@ -138,5 +143,119 @@ describe("createMatrixRoomMessageHandler BodyForAgent sender label", () => {
         }),
       }),
     );
+  });
+
+  it("uses routed agent mention patterns when gating room messages", async () => {
+    const recordInboundSession = vi.fn().mockResolvedValue(undefined);
+    const buildMentionRegexes = vi
+      .fn()
+      .mockImplementation((_cfg: unknown, agentId?: string) =>
+        agentId === "work" ? [/@workbot/i] : [],
+      );
+
+    const core = {
+      channel: {
+        pairing: {
+          readAllowFromStore: vi.fn().mockResolvedValue([]),
+        },
+        routing: {
+          resolveAgentRoute: vi.fn().mockReturnValue({
+            agentId: "work",
+            accountId: undefined,
+            sessionKey: "agent:work:matrix:channel:!room:example.org",
+            mainSessionKey: "agent:work:main",
+          }),
+        },
+        session: {
+          resolveStorePath: vi.fn().mockReturnValue("/tmp/openclaw-test-session.json"),
+          readSessionUpdatedAt: vi.fn().mockReturnValue(123),
+          recordInboundSession,
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+          formatInboundEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          formatAgentEnvelope: vi
+            .fn()
+            .mockImplementation((params: { body: string }) => params.body),
+          finalizeInboundContext: vi.fn().mockImplementation((ctx: Record<string, unknown>) => ctx),
+          resolveHumanDelayConfig: vi.fn().mockReturnValue(undefined),
+          createReplyDispatcherWithTyping: vi.fn().mockReturnValue({
+            dispatcher: {},
+            replyOptions: {},
+            markDispatchIdle: vi.fn(),
+          }),
+          withReplyDispatcher: vi
+            .fn()
+            .mockResolvedValue({ queuedFinal: false, counts: { final: 0, partial: 0, tool: 0 } }),
+        },
+        commands: {
+          shouldHandleTextCommands: vi.fn().mockReturnValue(true),
+        },
+        mentions: {
+          buildMentionRegexes,
+          matchesMentionPatterns: vi
+            .fn()
+            .mockImplementation((text: string, regexes: RegExp[]) =>
+              regexes.some((regex) => regex.test(text)),
+            ),
+        },
+        text: {
+          hasControlCommand: vi.fn().mockReturnValue(false),
+          resolveMarkdownTableMode: vi.fn().mockReturnValue("code"),
+        },
+      },
+      system: {
+        enqueueSystemEvent: vi.fn(),
+      },
+    } as unknown as PluginRuntime;
+
+    const handler = createMatrixRoomMessageHandler({
+      client: {
+        getUserId: vi.fn().mockResolvedValue("@bot:matrix.example.org"),
+      } as unknown as MatrixClient,
+      core,
+      cfg: {},
+      runtime: { error: vi.fn() } as unknown as RuntimeEnv,
+      logger: { info: vi.fn(), warn: vi.fn() } as unknown as RuntimeLogger,
+      logVerboseMessage: vi.fn(),
+      allowFrom: [],
+      roomsConfig: undefined,
+      groupPolicy: "open",
+      replyToMode: "first",
+      threadReplies: "inbound",
+      dmEnabled: true,
+      dmPolicy: "open",
+      textLimit: 4000,
+      mediaMaxBytes: 5 * 1024 * 1024,
+      startupMs: Date.now(),
+      startupGraceMs: 60_000,
+      directTracker: {
+        isDirectMessage: vi.fn().mockResolvedValue(false),
+      },
+      getRoomInfo: vi.fn().mockResolvedValue({
+        name: "Dev Room",
+        canonicalAlias: "#dev:matrix.example.org",
+        altAliases: [],
+      }),
+      getMemberDisplayName: vi.fn().mockResolvedValue("Bu"),
+      accountId: undefined,
+    });
+    setMatrixRuntime(core);
+
+    await handler("!room:example.org", {
+      type: EventType.RoomMessage,
+      event_id: "$event2",
+      sender: "@bu:matrix.example.org",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body: "@workbot summarize recent changes",
+      },
+    } as unknown as MatrixRawEvent);
+
+    expect(buildMentionRegexes).toHaveBeenCalledWith({}, "work");
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -50,7 +50,6 @@ export type MatrixMonitorHandlerParams = {
   logVerboseMessage: (message: string) => void;
   allowFrom: string[];
   roomsConfig: Record<string, MatrixRoomConfig> | undefined;
-  mentionRegexes: ReturnType<PluginRuntime["channel"]["mentions"]["buildMentionRegexes"]>;
   groupPolicy: "open" | "allowlist" | "disabled";
   replyToMode: ReplyToMode;
   threadReplies: "off" | "inbound" | "always";
@@ -84,7 +83,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     logVerboseMessage,
     allowFrom,
     roomsConfig,
-    mentionRegexes,
     groupPolicy,
     replyToMode,
     threadReplies,
@@ -342,6 +340,17 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         return;
       }
 
+      const baseRoute = core.channel.routing.resolveAgentRoute({
+        cfg,
+        channel: "matrix",
+        accountId,
+        peer: {
+          kind: isDirectMessage ? "direct" : "channel",
+          id: isDirectMessage ? senderId : roomId,
+        },
+      });
+      const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, baseRoute.agentId);
+
       const { wasMentioned, hasExplicitMention } = resolveMentions({
         content,
         userId: selfUserId,
@@ -422,16 +431,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         messageId,
         threadRootId,
         isThreadRoot: false, // @vector-im/matrix-bot-sdk doesn't have this info readily available
-      });
-
-      const baseRoute = core.channel.routing.resolveAgentRoute({
-        cfg,
-        channel: "matrix",
-        accountId,
-        peer: {
-          kind: isDirectMessage ? "direct" : "channel",
-          id: isDirectMessage ? senderId : roomId,
-        },
       });
 
       const route = {

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -296,7 +296,6 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   });
   setActiveMatrixClient(client, opts.accountId);
 
-  const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg);
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const { groupPolicy: groupPolicyRaw, providerMissingFallbackApplied } =
     resolveAllowlistProviderRuntimeGroupPolicy({
@@ -341,7 +340,6 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     logVerboseMessage,
     allowFrom,
     roomsConfig,
-    mentionRegexes,
     groupPolicy,
     replyToMode,
     threadReplies,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Matrix room mention gating built regexes once at monitor startup without agent context, so `agents.list[].groupChat.mentionPatterns` were ignored for routed agents.
- Why it matters: per-agent mention rules are expected to gate group messages; ignoring them drops valid `@bot` prompts in multi-agent setups.
- What changed: route is now resolved before mention checks in the room handler, and mention regexes are built with `core.channel.mentions.buildMentionRegexes(cfg, baseRoute.agentId)` per message.
- What did NOT change (scope boundary): no changes to Matrix room allowlists, DM policy, reply dispatching, or mention parsing logic beyond selecting the correct regex set.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32982
- Related #

## User-visible / Behavior Changes

Matrix group messages now honor per-agent `groupChat.mentionPatterns` when routing selects that agent.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm test runner
- Model/provider: N/A
- Integration/channel (if any): Matrix plugin
- Relevant config (redacted): agent route resolves to `agentId=work`; mention pattern `@workbot`

### Steps

1. Configure a routed Matrix room for agent `work` with `agents.list[].groupChat.mentionPatterns: ["@workbot"]` and no global mention pattern.
2. Send room message `@workbot summarize recent changes`.
3. Observe message gating and session recording.

### Expected

- Message is treated as mentioned for routed agent `work` and proceeds to inbound session handling.

### Actual

- With this change, routed agent mention regexes are used and the message is accepted.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts`
  - Added regression test `uses routed agent mention patterns when gating room messages`.
- Edge cases checked:
  - Existing explicit Matrix mentions (`m.mentions`) path still records inbound session.
- What you did **not** verify:
  - Live Matrix homeserver integration run.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Matrix: route mention patterns by agent id`.
- Files/config to restore:
  - `extensions/matrix/src/matrix/monitor/handler.ts`
  - `extensions/matrix/src/matrix/monitor/index.ts`
  - `extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts`
- Known bad symptoms reviewers should watch for:
  - Matrix room messages dropped as `reason: no-mention` despite matching per-agent mention pattern.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: mention regexes are now built per message, which could add minor overhead in very high-throughput rooms.
  - Mitigation: regex construction is lightweight and scoped to inbound room events only; no behavior changes outside mention gating path.
