### PR TITLE
fix(agents): wake parent agent on subagent completion for deliverable channels

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
@@ -27,6 +27,25 @@ vi.mock("./tools/agent-step.js", () => ({
   readLatestAssistantReply: async () => "done",
 }));
 
+vi.mock("../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions.js")>();
+  return {
+    ...actual,
+    loadSessionStore: vi.fn((path) => {
+      if (typeof path === "string" && path.includes("whatsapp-targeted")) {
+        return {
+          "agent:whatsapp-targeted:main": {
+            channel: "whatsapp",
+            lastTo: "+123",
+            accountId: "kev",
+          },
+        };
+      }
+      return {};
+    }),
+  };
+});
+
 const callGatewayMock = getCallGatewayMock();
 const RUN_TIMEOUT_SECONDS = 1;
 
@@ -368,5 +387,73 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
     expect(announceParams?.deliver).toBe(false);
     expect(announceParams?.channel).toBeUndefined();
     expect(announceParams?.accountId).toBeUndefined();
+  });
+
+  it("sessions_spawn on deliverable channel (whatsapp) notifies BOTH user and agent", async () => {
+    const ctx = setupSessionsSpawnGatewayMock({
+      includeSessionsList: true,
+      includeChatHistory: true,
+    });
+
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:whatsapp-targeted:main",
+      agentChannel: "whatsapp",
+      agentTo: "+123",
+      agentAccountId: "kev",
+    });
+
+    await executeSpawnAndExpectAccepted({
+      tool,
+      callId: "call-deliverable",
+      cleanup: "keep",
+    });
+
+    const child = ctx.getChild();
+    if (!child.runId) {
+      throw new Error("missing child runId");
+    }
+
+    // Trigger completion
+    await emitLifecycleEndAndFlush({
+      runId: child.runId,
+      startedAt: 1000,
+      endedAt: 2000,
+    });
+
+    await waitFor(() => {
+      const sendCalls = ctx.calls.filter((c) => c.method === "send");
+      const agentTriggerCalls = ctx.calls.filter((c) => {
+        if (c.method !== "agent") {
+          return false;
+        }
+        const params = c.params as Record<string, unknown>;
+        return params.lane !== "subagent";
+      });
+      return sendCalls.length === 1 && agentTriggerCalls.length === 1;
+    });
+
+    const sendCalls = ctx.calls.filter((c) => c.method === "send");
+    const agentTriggerCalls = ctx.calls.filter((c) => {
+      if (c.method !== "agent") {
+        return false;
+      }
+      const params = c.params as Record<string, unknown>;
+      return params.lane !== "subagent";
+    });
+
+    expect(sendCalls).toHaveLength(1);
+    expect(agentTriggerCalls).toHaveLength(1);
+
+    expect(sendCalls[0].params).toMatchObject({
+      channel: "whatsapp",
+      to: "+123",
+      message: expect.stringContaining("✅ Subagent"),
+    });
+
+    expect(agentTriggerCalls[0].params).toMatchObject({
+      sessionKey: "agent:whatsapp-targeted:main",
+      deliver: true,
+      message: expect.stringContaining("[System Message]"),
+    });
   });
 });

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
@@ -453,7 +453,7 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
     expect(agentTriggerCalls[0].params).toMatchObject({
       sessionKey: "agent:whatsapp-targeted:main",
       deliver: true,
-      message: expect.stringContaining("[System Message]"),
+      message: expect.stringContaining("[Internal task completion event]"),
     });
   });
 });

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -418,7 +418,9 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).toHaveBeenCalledTimes(1);
-    expect(agentSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const agentCall = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(agentCall?.params?.deliver).toBe(true);
     const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
     const rawMessage = call?.params?.message;
     const msg = typeof rawMessage === "string" ? rawMessage : "";
@@ -539,7 +541,7 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).toHaveBeenCalledTimes(3);
-    expect(agentSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
   });
 
   it("does not retry completion direct send on permanent channel errors", async () => {
@@ -674,7 +676,9 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).toHaveBeenCalledTimes(1);
-    expect(agentSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const agentCall = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(agentCall?.params?.deliver).toBe(true);
     const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
     expect(call?.params?.channel).toBe("discord");
     expect(call?.params?.to).toBe("channel:thread-bound-1");
@@ -772,7 +776,7 @@ describe("subagent announce formatting", () => {
     ]);
 
     expect(sendSpy).toHaveBeenCalledTimes(2);
-    expect(agentSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(2);
 
     const directTargets = sendSpy.mock.calls.map(
       (call) => (call?.[0] as { params?: { to?: string } })?.params?.to,
@@ -902,8 +906,9 @@ describe("subagent announce formatting", () => {
 
       expect(didAnnounce).toBe(true);
       expect(sendSpy).toHaveBeenCalledTimes(1);
-      expect(agentSpy).not.toHaveBeenCalled();
+      expect(agentSpy).toHaveBeenCalledTimes(1);
       const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+
       expect(call?.params?.channel).toBe("discord");
       expect(call?.params?.to).toBe("channel:12345");
       expect(call?.params?.threadId).toBe(testCase.expectedThreadId);
@@ -1005,7 +1010,9 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).toHaveBeenCalledTimes(1);
-    expect(agentSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const agentCall = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(agentCall?.params?.deliver).toBe(true);
     const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
     expect(call?.params?.channel).toBe("telegram");
     expect(call?.params?.to).toBe("123");
@@ -1346,9 +1353,6 @@ describe("subagent announce formatting", () => {
         sessionId: "requester-session-direct-route",
       },
     };
-    agentSpy.mockImplementationOnce(async () => {
-      throw new Error("agent fallback should not run when direct route exists");
-    });
 
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:worker",
@@ -1362,7 +1366,7 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).toHaveBeenCalledTimes(1);
-    expect(agentSpy).toHaveBeenCalledTimes(0);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
     expect(sendSpy.mock.calls[0]?.[0]).toMatchObject({
       method: "send",
       params: {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -837,11 +837,9 @@ async function sendSubagentAnnounceDirectly(params: {
               timeoutMs: announceTimeoutMs,
             }),
         });
-
-        return {
-          delivered: true,
-          path: "direct",
-        };
+        defaultRuntime.log(
+          `Subagent task completion direct notification sent to ${completionChannel}:${completionTo} (session: ${canonicalRequesterSessionKey})`,
+        );
       }
     }
 
@@ -860,6 +858,17 @@ async function sendSubagentAnnounceDirectly(params: {
       directOrigin?.threadId != null && directOrigin.threadId !== ""
         ? String(directOrigin.threadId)
         : undefined;
+
+    if (shouldDeliverExternally) {
+      defaultRuntime.log(
+        `Triggering main agent for task completion with external delivery to ${directChannel}:${directTo} (session: ${canonicalRequesterSessionKey})`,
+      );
+    } else {
+      defaultRuntime.log(
+        `Triggering main agent for task completion via internal injection (session: ${canonicalRequesterSessionKey})`,
+      );
+    }
+
     if (params.signal?.aborted) {
       return {
         delivered: false,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Subagent completions on deliverable channels (e.g. Matrix) were sending a direct notification and returning early, skipping the parent agent trigger call.
- Why it matters: This prevented the parent agent from being "woken up" to process the subagent's findings, causing the orchestration to stall until manually poked.
- What changed: Removed the early return in `sendSubagentAnnounceDirectly` to ensure the parent agent is always triggered after a direct notification is sent.
- What did NOT change (scope boundary): The direct notification logic remains intact; we only added the missing trigger step.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (Please link the relevant issue if exists)
- Related #

## User-visible / Behavior Changes

Parent agents will now correctly resume execution immediately after a subagent finishes on channels like WhatsApp/Matrix/Telegram, whereas previously they might have stayed idle.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js
- Integration/channel (if any): Matrix

### Steps

1. Spawn a subagent on a deliverable channel (e.g., Matrix).
2. Wait for the subagent to complete its task.
3. Observe if the parent agent automatically processes the result.

### Expected

- Parent agent is triggered and continues the task.

### Actual

- Parent agent remains idle despite the subagent finishing.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after (See `src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts`)

## Human Verification (required)

Verified that subagent completion now correctly triggers both a direct message to the user and an internal system message to the parent agent.

- Verified scenarios: Matrix targeted subagent completion.
- Edge cases checked: Aborted signals during delivery.
- What you did **not** verify: 

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the removal of early return in `src/agents/subagent-announce.ts`.
- Files/config to restore: `src/agents/subagent-announce.ts`
- Known bad symptoms reviewers should watch for: Duplicate notifications (though unlikely as the paths are distinct).

## Risks and Mitigations

- Risk: Potentially redundant agent triggers if other paths also trigger the agent.
  - Mitigation: The trigger uses idempotency keys and is standard for internal task completion events.
