### PR TITLE
Matrix: use plugin-sdk root export for send queue

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 


### PR DESCRIPTION
## Summary
- switch Matrix send queue to import `KeyedAsyncQueue` from `openclaw/plugin-sdk` instead of the deep subpath
- avoid brittle deep-subpath resolution in git-checkout/plugin runtime setups

## Testing
- pnpm test -- extensions/matrix/src/matrix/send-queue.test.ts
- pnpm test -- extensions/matrix/src/matrix/send.test.ts

Closes #33001 (problem no. 1 import failure).
