### PR TITLE
Discord: guard message:received hook session keys

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1507,6 +1507,37 @@ describe("dispatchReplyFromConfig", () => {
     expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
   });
 
+  it("uses CommandTargetSessionKey for internal message:received hooks when SessionKey is missing", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: undefined,
+      CommandSource: "native",
+      CommandTargetSessionKey: "agent:main:discord:channel:c1",
+      CommandBody: "hello",
+      MessageSid: "msg-99",
+    });
+
+    const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledWith(
+      "message",
+      "received",
+      "agent:main:discord:channel:c1",
+      expect.objectContaining({
+        from: ctx.From,
+        content: "hello",
+        channelId: "discord",
+        messageId: "msg-99",
+      }),
+    );
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
+  });
+
   it("skips internal message:received hook when session key is unavailable", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -176,6 +176,7 @@ export async function dispatchReplyFromConfig(params: {
     ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
   const hookContext = deriveInboundMessageHookContext(ctx, { messageId: messageIdForHook });
   const { isGroup, groupId } = hookContext;
+  const hookSessionKey = ctx.SessionKey?.trim() || ctx.CommandTargetSessionKey?.trim() || undefined;
 
   // Trigger plugin hooks (fire-and-forget)
   if (hookRunner?.hasHooks("message_received")) {
@@ -189,10 +190,10 @@ export async function dispatchReplyFromConfig(params: {
   }
 
   // Bridge to internal hooks (HOOK.md discovery system) - refs #8807
-  if (sessionKey) {
+  if (hookSessionKey) {
     fireAndForgetHook(
       triggerInternalHook(
-        createInternalHookEvent("message", "received", sessionKey, {
+        createInternalHookEvent("message", "received", hookSessionKey, {
           ...toInternalMessageReceivedContext(hookContext),
           timestamp,
         }),

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -387,6 +387,32 @@ describe("processDiscordMessage session routing", () => {
     });
   });
 
+  it("falls back to route session key when derived session key is empty", async () => {
+    const ctx = await createBaseContext({
+      baseSessionKey: "",
+      route: {
+        agentId: "main",
+        channel: "discord",
+        accountId: "default",
+        sessionKey: "agent:main:discord:channel:c1",
+        mainSessionKey: "agent:main:main",
+      },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(getLastDispatchCtx()).toMatchObject({
+      SessionKey: "agent:main:discord:channel:c1",
+    });
+    expect(getLastRouteUpdate()).toEqual({
+      sessionKey: "agent:main:discord:channel:c1",
+      channel: "discord",
+      to: "channel:c1",
+      accountId: "default",
+    });
+  });
+
   it("prefers bound session keys and sets MessageThreadId for bound thread messages", async () => {
     const threadBindings = createThreadBindingManager({
       accountId: "default",

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -333,6 +333,12 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           timestamp: entry.timestamp,
         }))
       : undefined;
+  const inboundSessionKey = [
+    boundSessionKey,
+    autoThreadContext?.SessionKey,
+    threadKeys.sessionKey,
+    route.sessionKey,
+  ].find((value): value is string => typeof value === "string" && value.trim().length > 0);
 
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
@@ -342,7 +348,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     CommandBody: baseText,
     From: effectiveFrom,
     To: effectiveTo,
-    SessionKey: boundSessionKey ?? autoThreadContext?.SessionKey ?? threadKeys.sessionKey,
+    SessionKey: inboundSessionKey,
     AccountId: route.accountId,
     ChatType: isDirectMessage ? "direct" : "channel",
     ConversationLabel: fromLabel,
@@ -375,7 +381,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     OriginatingChannel: "discord" as const,
     OriginatingTo: autoThreadContext?.OriginatingTo ?? replyTarget,
   });
-  const persistedSessionKey = ctxPayload.SessionKey ?? route.sessionKey;
+  const persistedSessionKey = inboundSessionKey ?? route.sessionKey;
 
   await recordInboundSession({
     storePath,


### PR DESCRIPTION
## Summary
- preserve `message:received` internal hook delivery when `SessionKey` is blank by falling back to `CommandTargetSessionKey`
- keep Discord monitor session-key fallback aligned by using `route.sessionKey` when context/session fields are missing
- include focused regressions for both fallback paths

## Testing
- pnpm test -- src/auto-reply/reply/dispatch-from-config.test.ts
- pnpm test -- src/discord/monitor/message-handler.process.test.ts

Supersedes #31264 (same fix rebased on current `main`).
