### PR TITLE
fix(errors): sanitize HTML and cap raw assistant payload rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/error payload hygiene: cap user-facing raw assistant error rendering to 200 chars and always sanitize HTML error pages (including statusless HTML) into safe unavailable copy so chat/transcript surfaces do not get flooded with raw markup dumps. (#32996) Thanks @liuxiaopai-ai.
 - Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
 - Exec heartbeat routing: scope exec-triggered heartbeat wakes to agent session keys so unrelated agents are no longer awakened by exec events, while preserving legacy unscoped behavior for non-canonical session keys. (#32724) thanks @altaywtf
 - macOS/Tailscale remote gateway discovery: add a Tailscale Serve fallback peer probe path (`wss://<peer>.ts.net`) when Bonjour and wide-area DNS-SD discovery return no gateways, and refresh both discovery paths from macOS onboarding. (#32860) Thanks @ngutman.

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -152,4 +152,23 @@ describe("formatRawAssistantErrorForUi", () => {
       "The AI service is temporarily unavailable (HTTP 521). Please try again in a moment.",
     );
   });
+
+  it("sanitizes statusless HTML error pages without leaking raw HTML", () => {
+    const htmlError = `<!DOCTYPE html>
+<html lang="en-US">
+  <head><title>Web server is down | example.com | Cloudflare</title></head>
+  <body>Ray ID: abc123</body>
+</html>`;
+
+    expect(formatRawAssistantErrorForUi(htmlError)).toBe(
+      "The AI service is temporarily unavailable. Please try again in a moment.",
+    );
+  });
+
+  it("caps long unstructured errors to 200 chars", () => {
+    const longError = `ERR: ${"x".repeat(400)}`;
+    const formatted = formatRawAssistantErrorForUi(longError);
+    expect(formatted.length).toBe(201);
+    expect(formatted.endsWith("…")).toBe(true);
+  });
 });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -187,6 +187,11 @@ describe("isCloudflareOrHtmlErrorPage", () => {
     expect(isCloudflareOrHtmlErrorPage(htmlError)).toBe(true);
   });
 
+  it("detects statusless HTML pages", () => {
+    const htmlError = `<!DOCTYPE html><html><head><title>Cloudflare</title></head><body>down</body></html>`;
+    expect(isCloudflareOrHtmlErrorPage(htmlError)).toBe(true);
+  });
+
   it("does not flag non-HTML status lines", () => {
     expect(isCloudflareOrHtmlErrorPage("500 Internal Server Error")).toBe(false);
     expect(isCloudflareOrHtmlErrorPage("429 Too Many Requests")).toBe(false);

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -186,6 +186,7 @@ const HTTP_STATUS_CODE_PREFIX_RE = /^(?:http\s*)?(\d{3})(?:\s+([\s\S]+))?$/i;
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const CLOUDFLARE_HTML_ERROR_CODES = new Set([521, 522, 523, 524, 525, 526, 530]);
 const TRANSIENT_HTTP_ERROR_CODES = new Set([500, 502, 503, 504, 521, 522, 523, 524, 529]);
+const MAX_UI_ERROR_CHARS = 200;
 const HTTP_ERROR_HINTS = [
   "error",
   "bad request",
@@ -220,6 +221,10 @@ export function isCloudflareOrHtmlErrorPage(raw: string): boolean {
   const trimmed = raw.trim();
   if (!trimmed) {
     return false;
+  }
+
+  if (HTML_ERROR_PREFIX_RE.test(trimmed) && /<\/html>/i.test(trimmed)) {
+    return true;
   }
 
   const status = extractLeadingHttpStatus(trimmed);
@@ -448,21 +453,27 @@ export function parseApiErrorInfo(raw?: string): ApiErrorInfo | null {
 }
 
 export function formatRawAssistantErrorForUi(raw?: string): string {
+  const truncateUiError = (text: string): string =>
+    text.length > MAX_UI_ERROR_CHARS ? `${text.slice(0, MAX_UI_ERROR_CHARS)}…` : text;
+
   const trimmed = (raw ?? "").trim();
   if (!trimmed) {
     return "LLM request failed with an unknown error.";
   }
 
   const leadingStatus = extractLeadingHttpStatus(trimmed);
-  if (leadingStatus && isCloudflareOrHtmlErrorPage(trimmed)) {
-    return `The AI service is temporarily unavailable (HTTP ${leadingStatus.code}). Please try again in a moment.`;
+  if (isCloudflareOrHtmlErrorPage(trimmed)) {
+    if (leadingStatus) {
+      return `The AI service is temporarily unavailable (HTTP ${leadingStatus.code}). Please try again in a moment.`;
+    }
+    return "The AI service is temporarily unavailable. Please try again in a moment.";
   }
 
   const httpMatch = trimmed.match(HTTP_STATUS_PREFIX_RE);
   if (httpMatch) {
     const rest = httpMatch[2].trim();
     if (!rest.startsWith("{")) {
-      return `HTTP ${httpMatch[1]}: ${rest}`;
+      return `HTTP ${httpMatch[1]}: ${truncateUiError(rest)}`;
     }
   }
 
@@ -471,10 +482,10 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
     const prefix = info.httpCode ? `HTTP ${info.httpCode}` : "LLM error";
     const type = info.type ? ` ${info.type}` : "";
     const requestId = info.requestId ? ` (request_id: ${info.requestId})` : "";
-    return `${prefix}${type}: ${info.message}${requestId}`;
+    return `${prefix}${type}: ${truncateUiError(info.message)}${requestId}`;
   }
 
-  return trimmed.length > 600 ? `${trimmed.slice(0, 600)}…` : trimmed;
+  return truncateUiError(trimmed);
 }
 
 export function formatAssistantErrorText(
@@ -561,10 +572,10 @@ export function formatAssistantErrorText(
   }
 
   // Never return raw unhandled errors - log for debugging but return safe message
-  if (raw.length > 600) {
+  if (raw.length > MAX_UI_ERROR_CHARS) {
     log.warn(`Long error truncated: ${raw.slice(0, 200)}`);
   }
-  return raw.length > 600 ? `${raw.slice(0, 600)}…` : raw;
+  return raw.length > MAX_UI_ERROR_CHARS ? `${raw.slice(0, MAX_UI_ERROR_CHARS)}…` : raw;
 }
 
 export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boolean }): string {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: raw assistant error payloads could include long JSON/HTML blobs, and statusless HTML pages were not always normalized before rendering.
- Why it matters: oversized/raw markup error payloads can pollute chat/transcript surfaces and make retries noisy.
- What changed: capped user-facing raw error rendering at 200 chars, normalized HTML error pages (with or without status prefix) into unavailable-copy, and applied the same cap to unhandled fallback error text.
- What did NOT change (scope boundary): no transcript-level consecutive-error dedupe logic in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32996
- Related #32995

## User-visible / Behavior Changes

- HTML error pages are now always shown as safe unavailable-copy (no raw HTML dump).
- Raw/unstructured assistant error text now truncates at 200 chars in user-facing formatting.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm test runner
- Model/provider: N/A
- Integration/channel (if any): assistant error formatting helpers
- Relevant config (redacted): N/A

### Steps

1. Pass long raw error text (>200 chars) to `formatRawAssistantErrorForUi`.
2. Pass statusless HTML error payload (`<!DOCTYPE html>...`) to `formatRawAssistantErrorForUi`.
3. Run helper test suite.

### Expected

- Long raw errors are truncated to 200 chars + ellipsis.
- HTML payloads render as safe unavailable message, with no HTML leak.

### Actual

- Behavior matches expected with new regression tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
  - Added tests for statusless HTML normalization + 200-char truncation.
- Edge cases checked:
  - Existing HTTP status-line formatting still preserved.
  - Cloudflare/status-prefixed HTML normalization remains unchanged.
- What you did **not** verify:
  - Live provider outage traffic in an external environment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Errors: cap and sanitize raw assistant payloads`.
- Files/config to restore:
  - `src/agents/pi-embedded-helpers/errors.ts`
  - `src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`
  - `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected truncation in user-facing error copy.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some verbose provider error detail becomes shorter due 200-char cap.
  - Mitigation: keeps key prefix/type/request_id context while preventing large payload leaks.
