### PR TITLE
fix(slack): wake session after interaction system event enqueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/button interaction wake-up: trigger heartbeat wake after enqueueing authorized `openclaw:*` Slack interaction system events so button clicks reliably activate the target session without requiring a manual follow-up message. (#33039) Thanks @liuxiaopai-ai.
 - Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
 - Exec heartbeat routing: scope exec-triggered heartbeat wakes to agent session keys so unrelated agents are no longer awakened by exec events, while preserving legacy unscoped behavior for non-canonical session keys. (#32724) thanks @altaywtf
 - macOS/Tailscale remote gateway discovery: add a Tailscale Serve fallback peer probe path (`wss://<peer>.ts.net`) when Bonjour and wide-area DNS-SD discovery return no gateways, and refresh both discovery paths from macOS onboarding. (#32860) Thanks @ngutman.

--- a/src/slack/monitor/events/interactions.test.ts
+++ b/src/slack/monitor/events/interactions.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import { registerSlackInteractionEvents } from "./interactions.js";
 
 const enqueueSystemEventMock = vi.fn();
+const requestHeartbeatNowMock = vi.fn();
 
 vi.mock("../../../infra/system-events.js", () => ({
   enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+}));
+
+vi.mock("../../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
 }));
 
 type RegisteredHandler = (args: {
@@ -153,6 +158,8 @@ function createContext(overrides?: {
 describe("registerSlackInteractionEvents", () => {
   it("enqueues structured events and updates button rows", async () => {
     enqueueSystemEventMock.mockClear();
+    enqueueSystemEventMock.mockReturnValue(true);
+    requestHeartbeatNowMock.mockClear();
     const { ctx, app, getHandler, resolveSessionKey } = createContext();
     registerSlackInteractionEvents({ ctx: ctx as never });
 
@@ -223,6 +230,10 @@ describe("registerSlackInteractionEvents", () => {
     expect(resolveSessionKey).toHaveBeenCalledWith({
       channelId: "C1",
       channelType: "channel",
+    });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "slack-interaction",
+      sessionKey: "agent:ops:slack:channel:C1",
     });
     expect(app.client.chat.update).toHaveBeenCalledTimes(1);
   });

--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -1,5 +1,6 @@
 import type { SlackActionMiddlewareArgs } from "@slack/bolt";
 import type { Block, KnownBlock } from "@slack/web-api";
+import { requestHeartbeatNow } from "../../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../../infra/system-events.js";
 import { authorizeSlackSystemEventSender } from "../auth.js";
 import type { SlackMonitorContext } from "../context.js";
@@ -577,10 +578,16 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
       const contextParts = ["slack:interaction", channelId, messageTs, actionId].filter(Boolean);
       const contextKey = contextParts.join(":");
 
-      enqueueSystemEvent(formatSlackInteractionSystemEvent(eventPayload), {
+      const queued = enqueueSystemEvent(formatSlackInteractionSystemEvent(eventPayload), {
         sessionKey,
         contextKey,
       });
+      if (queued) {
+        requestHeartbeatNow({
+          reason: "slack-interaction",
+          sessionKey,
+        });
+      }
 
       const originalBlocks = typedBody.message?.blocks;
       if (!Array.isArray(originalBlocks) || !channelId || !messageTs) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Slack `openclaw:*` interaction events were enqueued as system events but did not wake the target session.
- Why it matters: button clicks looked successful in Slack UI yet the agent never processed the interaction until a manual follow-up message arrived.
- What changed: after enqueueing a Slack interaction system event, trigger `requestHeartbeatNow` with the resolved session key.
- What did NOT change (scope boundary): no changes to Slack authz checks, interaction payload formatting, or message update UX.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33039
- Related #

## User-visible / Behavior Changes

Slack button interactions now reliably wake the mapped session, so the agent processes interaction events without requiring a manual prompt.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (unit tests)
- Runtime/container: Node + pnpm test runner
- Model/provider: N/A
- Integration/channel (if any): Slack interactions
- Relevant config (redacted): Slack interaction `action_id` with `openclaw:` prefix

### Steps

1. Trigger a Slack block action with `action_id` starting `openclaw:`.
2. Observe system-event enqueue and wake behavior.
3. Verify test assertions.

### Expected

- Interaction event is enqueued and heartbeat wake is requested for the resolved session key.

### Actual

- Behavior matches expected with new wake assertion in interaction tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/slack/monitor/events/interactions.test.ts`
  - Added assertion that interaction flow calls `requestHeartbeatNow({ reason: "slack-interaction", sessionKey })`.
- Edge cases checked:
  - Existing interaction enqueue behavior remains intact.
- What you did **not** verify:
  - Live Slack workspace click-through in production.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Slack: wake session on interaction system events`.
- Files/config to restore:
  - `src/slack/monitor/events/interactions.ts`
  - `src/slack/monitor/events/interactions.test.ts`
- Known bad symptoms reviewers should watch for:
  - Interaction logs present but no heartbeat wake emitted.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: duplicate wake requests if identical interaction events are replayed.
  - Mitigation: wake is gated by event enqueue dedupe signal (`enqueueSystemEvent` return value).
