### PR TITLE
fix(feishu): reply to triggering message in group threads (#32980)

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1337,7 +1337,9 @@ export async function handleFeishuMessage(params: {
     const messageCreateTimeMs = event.message.create_time
       ? parseInt(event.message.create_time, 10)
       : undefined;
-    const replyTargetMessageId = ctx.rootId ?? ctx.messageId;
+    // In reply chains, always reply to the triggering message instead of the root of the thread.
+    // Root ID is still used for session/thread routing via RootMessageId above.
+    const replyTargetMessageId = ctx.messageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 
     if (broadcastAgents) {


### PR DESCRIPTION
﻿Fixes #32980.

## Problem

In Feishu group chats, when a user replies in a thread and mentions the bot, the bot's response is attached to the root message of the thread instead of the actual triggering message, which makes the reply hard to discover in busy groups.

## Fix

- Change `replyTargetMessageId` to always use `ctx.messageId` (the triggering message).
- Keep using `ctx.rootId` for `RootMessageId` so thread/session routing behavior is unchanged.

This makes the bot reply show up directly under the message that mentioned it, while preserving thread affinity.
