### PR TITLE
fix(imessage): allow image tool reads from attachment roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iMessage/image tool local-path allowlist: include iMessage attachment roots in the image tool's trusted local roots for iMessage sessions (including current-user materialization for `/Users/*/...` defaults), so inbound attachment paths can be analyzed without `path-not-allowed` failures. (#33045) Thanks @liuxiaopai-ai.
 - Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
 - Exec heartbeat routing: scope exec-triggered heartbeat wakes to agent session keys so unrelated agents are no longer awakened by exec events, while preserving legacy unscoped behavior for non-canonical session keys. (#32724) thanks @altaywtf
 - macOS/Tailscale remote gateway discovery: add a Tailscale Serve fallback peer probe path (`wss://<peer>.ts.net`) when Bonjour and wide-area DNS-SD discovery return no gateways, and refresh both discovery paths from macOS onboarding. (#32860) Thanks @ngutman.

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -79,6 +79,8 @@ export function createOpenClawTools(options?: {
         config: options?.config,
         agentDir: options.agentDir,
         workspaceDir,
+        messageProvider: options?.agentChannel,
+        agentAccountId: options?.agentAccountId,
         sandbox:
           options?.sandboxRoot && options?.sandboxFsBridge
             ? { root: options.sandboxRoot, bridge: options.sandboxFsBridge }

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -543,6 +543,36 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("allows iMessage attachment-root images for iMessage sessions", async () => {
+    const fetch = stubMinimaxOkFetch();
+    await withTempAgentDir(async (agentDir) => {
+      const attachmentRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-imsg-attachments-"));
+      const imagePath = path.join(attachmentRoot, "img.png");
+      await fs.writeFile(imagePath, Buffer.from(ONE_PIXEL_PNG_B64, "base64"));
+      const cfg: OpenClawConfig = {
+        ...createMinimaxImageConfig(),
+        channels: {
+          imessage: {
+            attachmentRoots: [attachmentRoot],
+          },
+        },
+      };
+      try {
+        const tools = createOpenClawCodingTools({
+          config: cfg,
+          agentDir,
+          messageProvider: "imessage",
+          agentAccountId: "default",
+        });
+        const tool = requireImageTool(tools.find((candidate) => candidate.name === "image"));
+        await expectImageToolExecOk(tool, imagePath);
+        expect(fetch).toHaveBeenCalledTimes(1);
+      } finally {
+        await fs.rm(attachmentRoot, { recursive: true, force: true });
+      }
+    });
+  });
+
   it("sandboxes image paths like the read tool", async () => {
     await withTempSandboxState(async ({ agentDir, sandboxRoot }) => {
       await fs.writeFile(path.join(sandboxRoot, "img.png"), "fake", "utf8");

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -1,6 +1,7 @@
 import { type Context, complete } from "@mariozechner/pi-ai";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
+import { getChannelScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { resolveUserPath } from "../../utils.js";
 import { loadWebMedia } from "../../web/media.js";
 import { minimaxUnderstandImage } from "../minimax-vlm.js";
@@ -271,6 +272,8 @@ export function createImageTool(options?: {
   config?: OpenClawConfig;
   agentDir?: string;
   workspaceDir?: string;
+  messageProvider?: string;
+  agentAccountId?: string;
   sandbox?: ImageSandboxConfig;
   fsPolicy?: ToolFsPolicy;
   /** If true, the model has native vision capability and images in the prompt are auto-injected */
@@ -300,6 +303,11 @@ export function createImageTool(options?: {
 
   const localRoots = resolveMediaToolLocalRoots(options?.workspaceDir, {
     workspaceOnly: options?.fsPolicy?.workspaceOnly === true,
+    extraRoots: getChannelScopedMediaLocalRoots({
+      cfg: options?.config,
+      channel: options?.messageProvider,
+      accountId: options?.agentAccountId,
+    }),
   });
 
   return {

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -38,17 +38,20 @@ export function applyImageModelConfigDefaults(
 
 export function resolveMediaToolLocalRoots(
   workspaceDirRaw: string | undefined,
-  options?: { workspaceOnly?: boolean },
+  options?: { workspaceOnly?: boolean; extraRoots?: readonly string[] },
 ): string[] {
+  const extraRoots = options?.extraRoots?.filter(
+    (root): root is string => typeof root === "string" && root.trim().length > 0,
+  );
   const workspaceDir = normalizeWorkspaceDir(workspaceDirRaw);
   if (options?.workspaceOnly) {
-    return workspaceDir ? [workspaceDir] : [];
+    return Array.from(new Set([workspaceDir, ...(extraRoots ?? [])].filter(Boolean)));
   }
   const roots = getDefaultLocalRoots();
-  if (!workspaceDir) {
+  if (!workspaceDir && (!extraRoots || extraRoots.length === 0)) {
     return [...roots];
   }
-  return Array.from(new Set([...roots, workspaceDir]));
+  return Array.from(new Set([...roots, workspaceDir, ...(extraRoots ?? [])].filter(Boolean)));
 }
 
 export function resolvePromptAndModelOverride(

--- a/src/media/local-roots.test.ts
+++ b/src/media/local-roots.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { __testing, getChannelScopedMediaLocalRoots } from "./local-roots.js";
+
+describe("local media roots", () => {
+  it("materializes a single home-relative wildcard segment", () => {
+    expect(
+      __testing.materializeRootPatternForHome(
+        "/Users/*/Library/Messages/Attachments",
+        "/Users/alice",
+      ),
+    ).toBe("/Users/alice/Library/Messages/Attachments");
+  });
+
+  it("ignores wildcard patterns that do not match home prefix", () => {
+    expect(
+      __testing.materializeRootPatternForHome(
+        "/Users/*/Library/Messages/Attachments",
+        "/home/alice",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("includes configured iMessage attachment roots for iMessage sessions", () => {
+    const cfg = {
+      channels: {
+        imessage: {
+          attachmentRoots: ["/tmp/imessage-attachments"],
+        },
+      },
+    } as OpenClawConfig;
+    expect(
+      getChannelScopedMediaLocalRoots({
+        cfg,
+        channel: "imessage",
+        accountId: "default",
+      }),
+    ).toContain("/tmp/imessage-attachments");
+  });
+
+  it("returns no channel-scoped roots for non-iMessage channels", () => {
+    const cfg = {
+      channels: {
+        imessage: {
+          attachmentRoots: ["/tmp/imessage-attachments"],
+        },
+      },
+    } as OpenClawConfig;
+    expect(
+      getChannelScopedMediaLocalRoots({
+        cfg,
+        channel: "telegram",
+        accountId: "default",
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -1,8 +1,11 @@
+import os from "node:os";
 import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { normalizeMessageChannel } from "../utils/message-channel.js";
+import { resolveIMessageAttachmentRoots } from "./inbound-path-policy.js";
 
 type BuildMediaLocalRootsOptions = {
   preferredTmpDir?: string;
@@ -54,3 +57,51 @@ export function getAgentScopedMediaLocalRoots(
   }
   return roots;
 }
+
+function materializeRootPatternForHome(rootPattern: string, homeDir: string): string | undefined {
+  if (!rootPattern.includes("*")) {
+    return path.posix.normalize(rootPattern);
+  }
+  const normalizedHome = path.posix.normalize(homeDir.replaceAll("\\", "/"));
+  const homeSegments = normalizedHome.split("/").filter(Boolean);
+  const patternSegments = rootPattern.split("/").filter(Boolean);
+  const wildcardIndex = patternSegments.indexOf("*");
+  if (wildcardIndex < 0 || patternSegments.includes("*", wildcardIndex + 1)) {
+    return undefined;
+  }
+  if (wildcardIndex >= homeSegments.length) {
+    return undefined;
+  }
+  for (let idx = 0; idx < wildcardIndex; idx += 1) {
+    if (patternSegments[idx] !== homeSegments[idx]) {
+      return undefined;
+    }
+  }
+  const materializedSegments = [...patternSegments];
+  materializedSegments[wildcardIndex] = homeSegments[wildcardIndex];
+  return `/${materializedSegments.join("/")}`;
+}
+
+export function getChannelScopedMediaLocalRoots(params: {
+  cfg: OpenClawConfig | undefined;
+  channel?: string;
+  accountId?: string;
+}): readonly string[] {
+  const normalizedChannel = normalizeMessageChannel(params.channel);
+  if (normalizedChannel !== "imessage" || !params.cfg) {
+    return [];
+  }
+  const homeDir = os.homedir();
+  const roots = resolveIMessageAttachmentRoots({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  const materialized = roots
+    .map((root) => materializeRootPatternForHome(root, homeDir))
+    .filter((root): root is string => typeof root === "string" && root.length > 0);
+  return Array.from(new Set(materialized));
+}
+
+export const __testing = {
+  materializeRootPatternForHome,
+};


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: iMessage inbound attachments under `~/Library/Messages/Attachments/...` could be accepted by inbound checks but still fail in the `image` tool with `path-not-allowed`.
- Why it matters: users cannot analyze freshly received iMessage images by local path, which is a regression after stricter local media allowlists.
- What changed: image tool local roots now include channel-scoped iMessage attachment roots (materialized from configured patterns), threaded via `createOpenClawTools` and `resolveMediaToolLocalRoots`.
- What did NOT change (scope boundary): no changes to outbound delivery behavior, no relaxation for non-iMessage channels, and no changes to remote URL/media fetching policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33045
- Related #32970

## User-visible / Behavior Changes

- In iMessage sessions, `image` tool local-path allowlist now includes iMessage attachment roots so inbound attachment files can be read directly.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - Risk: local file read scope for `image` tool is expanded for iMessage sessions.
  - Mitigation: expansion is limited to configured iMessage attachment roots (plus default pattern materialized for current user), not arbitrary filesystem roots; non-iMessage sessions remain unchanged.

## Repro + Verification

### Environment

- OS: macOS path model covered + unit/integration tests
- Runtime/container: Node 22 + Vitest
- Model/provider: MiniMax test fixture in image tool tests
- Integration/channel (if any): iMessage
- Relevant config (redacted): `channels.imessage.attachmentRoots`

### Steps

1. Configure iMessage and receive an attachment under an allowed iMessage attachment root.
2. In the same iMessage session, call `image` tool with that local file path.
3. Observe tool reads the file instead of failing allowlist validation.

### Expected

- `image` tool accepts the inbound iMessage attachment path.

### Actual

- Before fix: `Local media path is not under an allowed directory`.
- After fix: path is accepted and processed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing tests:

- `pnpm test src/media/local-roots.test.ts src/agents/tools/image-tool.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added and ran unit tests for wildcard root materialization and iMessage channel-scoped roots; added integration-style image tool test to confirm iMessage attachment root path is accepted.
- Edge cases checked: wildcard root mismatch vs home dir; non-iMessage channel returns no extra roots.
- What you did **not** verify: live iMessage device runtime on macOS host.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/media/local-roots.ts`, `src/agents/tools/image-tool.ts`, `src/agents/tools/media-tool-shared.ts`, `src/agents/openclaw-tools.ts`.
- Known bad symptoms reviewers should watch for: unexpected acceptance of non-attachment local paths (should not happen outside configured/materialized roots).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: wildcard materialization could behave unexpectedly on non-standard home path layouts.
  - Mitigation: unsupported wildcard patterns are ignored (fail closed), and explicit non-wildcard roots remain supported.
