### PR TITLE
fix(macos): guard talkEnabled didSet against Swift exclusivity crash during init

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -137,6 +137,7 @@ final class AppState {
 
     var talkEnabled: Bool {
         didSet {
+            guard !self.isInitializing else { return }
             self.ifNotPreview {
                 UserDefaults.standard.set(self.talkEnabled, forKey: talkEnabledKey)
                 Task { await TalkModeController.shared.setEnabled(self.talkEnabled) }

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -137,9 +137,9 @@ final class AppState {
 
     var talkEnabled: Bool {
         didSet {
-            guard !self.isInitializing else { return }
             self.ifNotPreview {
                 UserDefaults.standard.set(self.talkEnabled, forKey: talkEnabledKey)
+                guard !self.isInitializing else { return }
                 Task { await TalkModeController.shared.setEnabled(self.talkEnabled) }
             }
         }


### PR DESCRIPTION
## Problem

On macOS v2026.3.2, the app crashes on launch for anyone with Talk Mode enabled. SIGABRT, no recovery — it just never opens.

**Root cause:** `AppState.init()` sets `self.talkEnabled`, which fires its `didSet` and enqueues `Task { await TalkModeController.shared.setEnabled(...) }`. That task runs on MainActor while init is still executing, SwiftUI renders `TalkOverlayView`, which reads `appState.seamColorHex` — and Swift's exclusivity checker sees a simultaneous read+write on the same `@Observable` object. Abort.

**Crash trace (from `OpenClaw-2026-03-03-132931.ips`):**
```
swift::runtime::AccessSet::insert (exclusivity violation)
swift_beginAccess
closure #1 in TalkOverlayView.body.getter
TalkOverlayController.present()
TalkModeController.setEnabled(_:)
closure #3 in AppState.init(preview:)   ← Task spawned by talkEnabled.didSet
```

## Fix

Move the `isInitializing` guard inside `ifNotPreview`, after the `UserDefaults` write. This way:

- UserDefaults always reflects the actual value (including init-time permission resets)
- The crash-causing async Task is still blocked until initialization completes

```swift
var talkEnabled: Bool {
    didSet {
        self.ifNotPreview {
            UserDefaults.standard.set(self.talkEnabled, forKey: talkEnabledKey)
+           guard !self.isInitializing else { return }
            Task { await TalkModeController.shared.setEnabled(self.talkEnabled) }
        }
    }
}
```

The original placement (guard before `ifNotPreview`) caused a state divergence: when talkEnabled is forced to false during init due to missing permissions, UserDefaults would keep `true`, creating an infinite cycle on every launch. Caught by Greptile in review.

`launchAtLogin` already has the guard pattern — this just aligns `talkEnabled` with the same approach.

## Testing

Built locally with Xcode 26.3 — **Build complete, zero errors, zero warnings on AppState.swift.**

Workaround confirmed: `defaults write ai.openclaw.mac "openclaw.talkEnabled" -bool false` lets the affected version open.

## Note

`heartbeatsEnabled`, `swabbleEnabled`, and `peekabooBridgeEnabled` follow a similar pattern (async Task in didSet, set during init). They don't touch SwiftUI views so they won't cause this specific crash, but worth a follow-up pass.

---
> Used AI (Claude) to help parse the IPS crash log.