### PR TITLE
fix(heartbeat): disable global model fallback when heartbeat.model is set

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -180,8 +180,16 @@ export async function runAgentTurnWithFallback(params: {
       };
       const blockReplyPipeline = params.blockReplyPipeline;
       const onToolResult = params.opts?.onToolResult;
+      const fallbackOptions = resolveModelFallbackOptions(params.followupRun.run);
       const fallbackResult = await runWithModelFallback({
-        ...resolveModelFallbackOptions(params.followupRun.run),
+        ...fallbackOptions,
+        // When a heartbeat model override was resolved (either from
+        // opts.heartbeatModelOverride or the backward-compat agentCfg path),
+        // disable the global fallback chain to prevent silent cost escalation.
+        // See #32983.
+        ...(params.isHeartbeat && params.opts?.hasResolvedHeartbeatModelOverride
+          ? { fallbacksOverride: [] }
+          : {}),
         run: (provider, model) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -151,6 +151,13 @@ export function createFollowupRunner(params: {
             agentId: queued.run.agentId,
             sessionKey: queued.run.sessionKey,
           }),
+          // When a heartbeat model override was resolved (either from
+          // opts.heartbeatModelOverride or the backward-compat agentCfg path),
+          // disable the global fallback chain to prevent silent cost escalation.
+          // See #32983.
+          ...(opts?.isHeartbeat && opts?.hasResolvedHeartbeatModelOverride
+            ? { fallbacksOverride: [] }
+            : {}),
           run: (provider, model) => {
             const authProfile = resolveRunAuthProfile(queued.run, provider);
             return runEmbeddedPiAgent({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -354,6 +354,12 @@ export async function getReplyFromConfig(
     workspaceDir,
   });
 
+  // Propagate the resolved heartbeat model override flag so downstream
+  // fallback logic can disable the global fallback chain.  See #32983.
+  const finalOpts = hasResolvedHeartbeatModelOverride
+    ? { ...resolvedOpts, hasResolvedHeartbeatModelOverride }
+    : resolvedOpts;
+
   return runPreparedReply({
     ctx,
     sessionCtx,
@@ -384,7 +390,7 @@ export async function getReplyFromConfig(
     perMessageQueueMode,
     perMessageQueueOptions,
     typing,
-    opts: resolvedOpts,
+    opts: finalOpts,
     defaultProvider,
     defaultModel,
     timeoutMs,

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -40,6 +40,12 @@ export type GetReplyOptions = {
   suppressTyping?: boolean;
   /** Resolved heartbeat model override (provider/model string from merged per-agent config). */
   heartbeatModelOverride?: string;
+  /**
+   * Set internally by get-reply when a heartbeat model override was resolved
+   * (from opts.heartbeatModelOverride OR the backward-compat agentCfg path).
+   * Used downstream to disable the global model fallback chain for heartbeats.
+   */
+  hasResolvedHeartbeatModelOverride?: boolean;
   /** Controls bootstrap workspace context injection (default: full). */
   bootstrapContextMode?: "full" | "lightweight";
   /** If true, suppress tool error warning payloads for this run. */


### PR DESCRIPTION
## Summary

**Issue**: #32983 — `heartbeat.model` configuration is ignored; heartbeat silently falls back to the expensive default model when the configured cheap model fails (e.g., auth cooldown).

**Root cause**: `heartbeat.model` is correctly resolved as the primary model, but `runWithModelFallback` still loads the global `agents.defaults.model.fallbacks` chain. When the heartbeat model is unavailable, the system silently escalates to the configured primary (e.g., `anthropic/claude-sonnet-4-6`), causing unexpected cost.

**Fix**: Propagate the `hasResolvedHeartbeatModelOverride` flag (already computed in `get-reply.ts`) through `opts` to the downstream `runWithModelFallback` call sites. When this flag is true and the run is a heartbeat, pass `fallbacksOverride: []` to disable the global fallback chain. This covers both the explicit `opts.heartbeatModelOverride` path (used by `src/infra/heartbeat-runner.ts`) and the backward-compat `agentCfg?.heartbeat?.model` path (used by `src/web/auto-reply/heartbeat-runner.ts`). Non-heartbeat runs are unaffected.

**Changed files**:
- `src/auto-reply/types.ts` — add `hasResolvedHeartbeatModelOverride` to `GetReplyOptions`
- `src/auto-reply/reply/get-reply.ts` — propagate the flag into opts before calling `runPreparedReply`
- `src/auto-reply/reply/agent-runner-execution.ts` — disable fallback chain when flag is set
- `src/auto-reply/reply/followup-runner.ts` — disable fallback chain when flag is set

Fixes #32983

