### PR TITLE
Gateway: persist ACP spawn delivery context for announce routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACP/Subagent announce routing: persist inferred spawn delivery context (`channel`, `to`, `accountId`, `threadId`) into session state so announce follow-up turns no longer fail due to missing delivery route metadata. Fixes #33049. Thanks @liuxiaopai-ai.
 - Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
 - Exec heartbeat routing: scope exec-triggered heartbeat wakes to agent session keys so unrelated agents are no longer awakened by exec events, while preserving legacy unscoped behavior for non-canonical session keys. (#32724) thanks @altaywtf
 - macOS/Tailscale remote gateway discovery: add a Tailscale Serve fallback peer probe path (`wss://<peer>.ts.net`) when Bonjour and wide-area DNS-SD discovery return no gateways, and refresh both discovery paths from macOS onboarding. (#32860) Thanks @ngutman.

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -410,6 +410,39 @@ export async function spawnAcpDirect(
     ? `channel:${boundThreadId}`
     : requesterOrigin?.to?.trim() || (deliveryThreadId ? `channel:${deliveryThreadId}` : undefined);
   const hasDeliveryTarget = Boolean(requesterOrigin?.channel && inferredDeliveryTo);
+  const finalDeliveryContext = hasDeliveryTarget
+    ? normalizeDeliveryContext({
+        channel: requesterOrigin?.channel,
+        to: inferredDeliveryTo,
+        accountId: requesterOrigin?.accountId ?? undefined,
+        threadId: deliveryThreadId,
+      })
+    : undefined;
+  if (finalDeliveryContext) {
+    try {
+      await callGateway({
+        method: "sessions.patch",
+        params: {
+          key: sessionKey,
+          deliveryContext: finalDeliveryContext,
+        },
+        timeoutMs: 10_000,
+      });
+    } catch (err) {
+      await cleanupFailedAcpSpawn({
+        cfg,
+        sessionKey,
+        shouldDeleteSession: true,
+        deleteTranscript: true,
+        runtimeCloseHandle: initializedRuntime,
+      });
+      return {
+        status: "error",
+        error: summarizeError(err),
+        childSessionKey: sessionKey,
+      };
+    }
+  }
   const childIdem = crypto.randomUUID();
   let childRunId: string = childIdem;
   try {

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -78,6 +78,20 @@ export const SessionsPatchParamsSchema = Type.Object(
     groupActivation: Type.Optional(
       Type.Union([Type.Literal("mention"), Type.Literal("always"), Type.Null()]),
     ),
+    deliveryContext: Type.Optional(
+      Type.Union([
+        Type.Object(
+          {
+            channel: Type.Optional(NonEmptyString),
+            to: Type.Optional(NonEmptyString),
+            accountId: Type.Optional(NonEmptyString),
+            threadId: Type.Optional(Type.Union([NonEmptyString, Type.Integer()])),
+          },
+          { additionalProperties: false },
+        ),
+        Type.Null(),
+      ]),
+    ),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -302,6 +302,64 @@ describe("gateway sessions patch", () => {
     expectPatchError(result, "invalid groupActivation");
   });
 
+  test("normalizes and persists deliveryContext patch fields", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        patch: {
+          key: MAIN_SESSION_KEY,
+          deliveryContext: {
+            channel: " Telegram ",
+            to: " telegram:-100123 ",
+            accountId: " work ",
+            threadId: " 42 ",
+          },
+        },
+      }),
+    );
+    expect(entry.deliveryContext).toEqual({
+      channel: "telegram",
+      to: "telegram:-100123",
+      accountId: "work",
+      threadId: "42",
+    });
+    expect(entry.lastChannel).toBe("telegram");
+    expect(entry.lastTo).toBe("telegram:-100123");
+    expect(entry.lastAccountId).toBe("work");
+    expect(entry.lastThreadId).toBe("42");
+  });
+
+  test("clears deliveryContext and legacy last-route fields when set to null", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        store: {
+          [MAIN_SESSION_KEY]: {
+            sessionId: "sess",
+            updatedAt: 1,
+            deliveryContext: {
+              channel: "telegram",
+              to: "telegram:-100123",
+              accountId: "work",
+              threadId: "42",
+            },
+            lastChannel: "telegram",
+            lastTo: "telegram:-100123",
+            lastAccountId: "work",
+            lastThreadId: "42",
+          } as SessionEntry,
+        },
+        patch: {
+          key: MAIN_SESSION_KEY,
+          deliveryContext: null,
+        },
+      }),
+    );
+    expect(entry.deliveryContext).toBeUndefined();
+    expect(entry.lastChannel).toBeUndefined();
+    expect(entry.lastTo).toBeUndefined();
+    expect(entry.lastAccountId).toBeUndefined();
+    expect(entry.lastThreadId).toBeUndefined();
+  });
+
   test("allows target agent own model for subagent session even when missing from global allowlist", async () => {
     const cfg = makeKimiSubagentCfg({
       agentPrimaryModel: "synthetic/hf:moonshotai/Kimi-K2.5",

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -27,6 +27,7 @@ import { applyVerboseOverride, parseVerboseOverride } from "../sessions/level-ov
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
 import { normalizeSendPolicy } from "../sessions/send-policy.js";
 import { parseSessionLabel } from "../sessions/session-label.js";
+import { normalizeSessionDeliveryFields } from "../utils/delivery-context.js";
 import {
   ErrorCodes,
   type ErrorShape,
@@ -356,6 +357,37 @@ export async function applySessionsPatchToStore(params: {
         return invalid('invalid groupActivation (use "mention"|"always")');
       }
       next.groupActivation = normalized;
+    }
+  }
+
+  if ("deliveryContext" in patch) {
+    const raw = patch.deliveryContext;
+    if (raw === null) {
+      delete next.deliveryContext;
+      delete next.lastChannel;
+      delete next.lastTo;
+      delete next.lastAccountId;
+      delete next.lastThreadId;
+    } else if (raw !== undefined) {
+      if (!raw || typeof raw !== "object") {
+        return invalid("invalid deliveryContext (use an object or null)");
+      }
+      const deliveryFields = normalizeSessionDeliveryFields({
+        deliveryContext: raw as {
+          channel?: string;
+          to?: string;
+          accountId?: string;
+          threadId?: string | number;
+        },
+      });
+      if (!deliveryFields.deliveryContext) {
+        return invalid("invalid deliveryContext (must include at least one non-empty field)");
+      }
+      next.deliveryContext = deliveryFields.deliveryContext;
+      next.lastChannel = deliveryFields.lastChannel;
+      next.lastTo = deliveryFields.lastTo;
+      next.lastAccountId = deliveryFields.lastAccountId;
+      next.lastThreadId = deliveryFields.lastThreadId;
     }
   }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: ACP sub-sessions spawned from Telegram topic sessions could end up with `deliveryContext` containing only `channel`, so announce follow-up turns had no routable `to`/`accountId` target.
- Why it matters: completed ACP runs could not reliably announce results back to the originating chat/thread.
- What changed: persist the finalized spawn delivery context via `sessions.patch`, add schema + patch-handler support for `deliveryContext`, and normalize/update legacy `last*` route fields at the same time.
- What did NOT change (scope boundary): no changes to ACP task execution logic, no new routing policy, and no changes to non-ACP runtimes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33049
- Related #32889

## User-visible / Behavior Changes

ACP sub-sessions now persist the inferred delivery route (`channel`/`to`/`accountId`/`threadId`) during spawn, so completion announcements can route back to the originating Telegram topic/chat instead of failing from missing delivery metadata.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 + pnpm
- Model/provider: N/A (unit-level)
- Integration/channel (if any): ACP + Telegram routing context
- Relevant config (redacted): N/A

### Steps

1. Spawn an ACP session from a requester session with inherited delivery routing.
2. Ensure spawn computes a final delivery target (`to`, optional `accountId`/`threadId`).
3. Verify the spawned session state includes persisted normalized `deliveryContext` and legacy `last*` fields.

### Expected

- Spawned session keeps complete delivery routing context needed for announce routing.

### Actual

- Fixed: `deliveryContext` is now persisted and normalized during ACP spawn; explicit patch behavior is covered by tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test src/gateway/sessions-patch.test.ts src/agents/acp-spawn.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran targeted gateway/ACP tests; validated delivery-context patch normalization and null-clearing behavior.
- Edge cases checked: `deliveryContext: null` clears both structured context and legacy `last*` fields; invalid patch values are rejected.
- What you did **not** verify: live Telegram forum end-to-end announce behavior against a real bot account.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit to restore previous spawn/session-patch behavior.
- Files/config to restore: `src/agents/acp-spawn.ts`, `src/gateway/sessions-patch.ts`, `src/gateway/protocol/schema/sessions.ts`.
- Known bad symptoms reviewers should watch for: ACP spawn returning error due to `sessions.patch` failures; missing delivery metadata in spawned session state.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: New `sessions.patch` surface for `deliveryContext` could accept malformed shapes.
  - Mitigation: schema validation + runtime guard + normalization + regression tests.

## AI-assisted disclosure

- AI-assisted: Yes (Codex)
- Testing degree: Fully tested for touched unit/integration tests in this PR scope.
