### PR TITLE
fix: allow ollama without api key in auth preflight (closes #33041)

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -132,6 +132,10 @@ export type ResolvedProviderAuth = {
   mode: "api-key" | "oauth" | "token" | "aws-sdk";
 };
 
+export function canRunWithoutApiKey(provider: string, mode: ResolvedProviderAuth["mode"]): boolean {
+  return mode === "aws-sdk" || normalizeProviderId(provider) === "ollama";
+}
+
 export async function resolveApiKeyForProvider(params: {
   provider: string;
   cfg?: OpenClawConfig;
@@ -221,15 +225,22 @@ export async function resolveApiKeyForProvider(params: {
     }
   }
 
-  const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
-  const resolvedAgentDir = path.dirname(authStorePath);
-  throw new Error(
-    [
-      `No API key found for provider "${provider}".`,
-      `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
-      `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
-    ].join(" "),
-  );
+  if (!canRunWithoutApiKey(provider, "api-key")) {
+    const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
+    const resolvedAgentDir = path.dirname(authStorePath);
+    throw new Error(
+      [
+        `No API key found for provider "${provider}".`,
+        `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
+        `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
+      ].join(" "),
+    );
+  }
+
+  return {
+    source: `${normalizeProviderId(provider)} local runtime`,
+    mode: "api-key",
+  };
 }
 
 export type EnvApiKeyResult = { apiKey: string; source: string };

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -29,7 +29,7 @@ import { listChannelSupportedActions, resolveChannelMessageToolHints } from "../
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawDocsPath } from "../docs-path.js";
-import { getApiKeyForModel, resolveModelAuthMode } from "../model-auth.js";
+import { canRunWithoutApiKey, getApiKeyForModel, resolveModelAuthMode } from "../model-auth.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
   ensureSessionHeader,
@@ -145,7 +145,7 @@ export async function compactEmbeddedPiSessionDirect(
     });
 
     if (!apiKeyInfo.apiKey) {
-      if (apiKeyInfo.mode !== "aws-sdk") {
+      if (!canRunWithoutApiKey(model.provider, apiKeyInfo.mode)) {
         throw new Error(
           `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
         );

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -20,6 +20,7 @@ import {
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
 import {
+  canRunWithoutApiKey,
   ensureAuthProfileStore,
   getApiKeyForModel,
   resolveAuthProfileOrder,
@@ -305,7 +306,7 @@ export async function runEmbeddedPiAgent(
         apiKeyInfo = await resolveApiKeyForCandidate(candidate);
         const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
         if (!apiKeyInfo.apiKey) {
-          if (apiKeyInfo.mode !== "aws-sdk") {
+          if (!canRunWithoutApiKey(model.provider, apiKeyInfo.mode)) {
             throw new Error(
               `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
             );


### PR DESCRIPTION
Closes #33041

## Problem
A recent auth preflight regression treated local Ollama like a cloud provider, so model startup failed with a missing API key error when `auth-profiles.json` had no Ollama key.

## Fix
Allow keyless runtime for Ollama in the shared auth resolver and runner preflight checks, while keeping API key enforcement unchanged for providers that still require credentials.