### PR TITLE
Agents: sanitize transcript error payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Transcript error hygiene: sanitize assistant `errorMessage` before storing in transcript by stripping HTML error pages, compacting structured API error payloads, and truncating long raw failures to prevent retry loops from bloating session context windows. (#32995, #32996)
 - Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
 - Exec heartbeat routing: scope exec-triggered heartbeat wakes to agent session keys so unrelated agents are no longer awakened by exec events, while preserving legacy unscoped behavior for non-canonical session keys. (#32724) thanks @altaywtf
 - macOS/Tailscale remote gateway discovery: add a Tailscale Serve fallback peer probe path (`wss://<peer>.ts.net`) when Bonjour and wide-area DNS-SD discovery return no gateways, and refresh both discovery paths from macOS onboarding. (#32860) Thanks @ngutman.

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -5,6 +5,7 @@ import {
   formatBillingErrorMessage,
   formatAssistantErrorText,
   formatRawAssistantErrorForUi,
+  sanitizeRawAssistantErrorForTranscript,
 } from "./pi-embedded-helpers.js";
 import { makeAssistantMessageFixture } from "./test-helpers/assistant-message-fixtures.js";
 
@@ -151,5 +152,32 @@ describe("formatRawAssistantErrorForUi", () => {
     expect(formatRawAssistantErrorForUi(htmlError)).toBe(
       "The AI service is temporarily unavailable (HTTP 521). Please try again in a moment.",
     );
+  });
+
+  it("sanitizes raw HTML payloads even without a leading HTTP status", () => {
+    const htmlError = `<!DOCTYPE html><html><body>error page</body></html>`;
+    expect(formatRawAssistantErrorForUi(htmlError)).toBe(
+      "The AI service is temporarily unavailable. Please try again in a moment.",
+    );
+  });
+});
+
+describe("sanitizeRawAssistantErrorForTranscript", () => {
+  it("removes HTML payloads before transcript storage", () => {
+    const htmlError = `<!DOCTYPE html><html><body>cloudflare challenge</body></html>`;
+    expect(sanitizeRawAssistantErrorForTranscript(htmlError)).toBe(
+      "The AI service returned an HTML error page.",
+    );
+  });
+
+  it("drops volatile request ids and truncates long payloads", () => {
+    const raw =
+      '429 {"type":"error","error":{"type":"rate_limit_error","message":"' +
+      "x".repeat(300) +
+      '"},"request_id":"req_123"}';
+    const text = sanitizeRawAssistantErrorForTranscript(raw);
+    expect(text).toContain("HTTP 429 rate_limit_error:");
+    expect(text).not.toContain("req_123");
+    expect(text.length).toBeLessThanOrEqual(181);
   });
 });

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -12,6 +12,7 @@ export {
   formatBillingErrorMessage,
   classifyFailoverReason,
   formatRawAssistantErrorForUi,
+  sanitizeRawAssistantErrorForTranscript,
   formatAssistantErrorText,
   getApiErrorPayloadFingerprint,
   isAuthAssistantError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -184,8 +184,10 @@ const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
 const HTTP_STATUS_PREFIX_RE = /^(?:http\s*)?(\d{3})\s+(.+)$/i;
 const HTTP_STATUS_CODE_PREFIX_RE = /^(?:http\s*)?(\d{3})(?:\s+([\s\S]+))?$/i;
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
+const HTML_TAG_RE = /<\s*\/?\s*[a-z][^>]*>/i;
 const CLOUDFLARE_HTML_ERROR_CODES = new Set([521, 522, 523, 524, 525, 526, 530]);
 const TRANSIENT_HTTP_ERROR_CODES = new Set([500, 502, 503, 504, 521, 522, 523, 524, 529]);
+const MAX_TRANSCRIPT_ERROR_CHARS = 180;
 const HTTP_ERROR_HINTS = [
   "error",
   "bad request",
@@ -453,6 +455,10 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
     return "LLM request failed with an unknown error.";
   }
 
+  if (HTML_ERROR_PREFIX_RE.test(trimmed) && /<\/html>/i.test(trimmed)) {
+    return "The AI service is temporarily unavailable. Please try again in a moment.";
+  }
+
   const leadingStatus = extractLeadingHttpStatus(trimmed);
   if (leadingStatus && isCloudflareOrHtmlErrorPage(trimmed)) {
     return `The AI service is temporarily unavailable (HTTP ${leadingStatus.code}). Please try again in a moment.`;
@@ -475,6 +481,51 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
   }
 
   return trimmed.length > 600 ? `${trimmed.slice(0, 600)}…` : trimmed;
+}
+
+function truncateForTranscript(text: string): string {
+  return text.length > MAX_TRANSCRIPT_ERROR_CHARS
+    ? `${text.slice(0, MAX_TRANSCRIPT_ERROR_CHARS)}…`
+    : text;
+}
+
+export function sanitizeRawAssistantErrorForTranscript(raw?: string): string {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) {
+    return "LLM request failed with an unknown error.";
+  }
+
+  const leadingStatus = extractLeadingHttpStatus(trimmed);
+  if (leadingStatus && isCloudflareOrHtmlErrorPage(trimmed)) {
+    return `The AI service is temporarily unavailable (HTTP ${leadingStatus.code}).`;
+  }
+
+  if (HTML_ERROR_PREFIX_RE.test(trimmed) && /<\/html>/i.test(trimmed)) {
+    return "The AI service returned an HTML error page.";
+  }
+
+  const info = parseApiErrorInfo(trimmed);
+  if (info?.message) {
+    const prefix = info.httpCode ? `HTTP ${info.httpCode}` : "LLM error";
+    const type = info.type ? ` ${info.type}` : "";
+    const compact = info.message.replace(/\s+/g, " ").trim();
+    return truncateForTranscript(`${prefix}${type}: ${compact}`);
+  }
+
+  const httpMatch = trimmed.match(HTTP_STATUS_PREFIX_RE);
+  if (httpMatch) {
+    const rest = httpMatch[2].trim();
+    if (!rest.startsWith("{")) {
+      return truncateForTranscript(`HTTP ${httpMatch[1]}: ${rest.replace(/\s+/g, " ").trim()}`);
+    }
+  }
+
+  if (HTML_TAG_RE.test(trimmed)) {
+    return "The AI service returned an HTML error page.";
+  }
+
+  const normalized = trimmed.replace(/\s+/g, " ").trim();
+  return truncateForTranscript(normalized);
 }
 
 export function formatAssistantErrorText(

--- a/src/agents/stream-message-shared.test.ts
+++ b/src/agents/stream-message-shared.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { buildStreamErrorAssistantMessage } from "./stream-message-shared.js";
+
+const MODEL = {
+  api: "responses",
+  provider: "openai",
+  id: "gpt-5",
+};
+
+describe("buildStreamErrorAssistantMessage", () => {
+  it("stores a sanitized transcript error payload", () => {
+    const message = buildStreamErrorAssistantMessage({
+      model: MODEL,
+      errorMessage: `<!DOCTYPE html><html><body>cf challenge</body></html>`,
+    });
+    expect(message.errorMessage).toBe("The AI service returned an HTML error page.");
+  });
+});

--- a/src/agents/stream-message-shared.ts
+++ b/src/agents/stream-message-shared.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessage, StopReason, Usage } from "@mariozechner/pi-ai";
+import { sanitizeRawAssistantErrorForTranscript } from "./pi-embedded-helpers.js";
 
 export type StreamModelDescriptor = {
   api: string;
@@ -85,6 +86,7 @@ export function buildStreamErrorAssistantMessage(params: {
       timestamp: params.timestamp,
     }),
     stopReason: "error",
-    errorMessage: params.errorMessage,
+    // Keep transcript error payloads compact to avoid context bloat during retries.
+    errorMessage: sanitizeRawAssistantErrorForTranscript(params.errorMessage),
   };
 }


### PR DESCRIPTION
## Summary
- sanitize assistant stream `errorMessage` before persisting to transcript to prevent context bloat from raw provider payloads
- strip HTML/error-page payloads from transcript entries and add compact truncation for long errors
- keep UI formatting behavior while also handling raw HTML pages without leading HTTP status
- add regression tests for transcript sanitization and stream error message construction
- add changelog entry under 2026.3.3 Fixes

## Testing
- `pnpm vitest run src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/stream-message-shared.test.ts`
- `pnpm format`

Closes #32995
Closes #32996
