### PR TITLE
fix(web_fetch): retry guarded fetch with env proxy after network failure

### DIFF
--- a/src/agents/tools/web-fetch.proxy-retry.e2e.test.ts
+++ b/src/agents/tools/web-fetch.proxy-retry.e2e.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchWithWebToolsNetworkGuardMock } = vi.hoisted(() => ({
+  fetchWithWebToolsNetworkGuardMock: vi.fn(),
+}));
+
+vi.mock("./web-guarded-fetch.js", () => ({
+  fetchWithWebToolsNetworkGuard: fetchWithWebToolsNetworkGuardMock,
+}));
+
+import { createWebFetchTool } from "./web-tools.js";
+
+describe("web_fetch env proxy retry", () => {
+  beforeEach(() => {
+    fetchWithWebToolsNetworkGuardMock.mockReset();
+  });
+
+  it("retries with useEnvProxy when strict fetch fails with TypeError('fetch failed')", async () => {
+    const response = new Response("ok-body", {
+      status: 200,
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    });
+
+    fetchWithWebToolsNetworkGuardMock
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce({
+        response,
+        finalUrl: "https://example.com/",
+        release: vi.fn().mockResolvedValue(undefined),
+      });
+
+    const tool = createWebFetchTool({
+      config: {
+        tools: {
+          web: {
+            fetch: {
+              cacheTtlMinutes: 0,
+              firecrawl: { enabled: false },
+            },
+          },
+        },
+      },
+      sandboxed: false,
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com" });
+    const details = result?.details as { text?: string };
+
+    expect(fetchWithWebToolsNetworkGuardMock).toHaveBeenCalledTimes(2);
+    expect(fetchWithWebToolsNetworkGuardMock.mock.calls[0]?.[0]).not.toMatchObject({
+      useEnvProxy: true,
+    });
+    expect(fetchWithWebToolsNetworkGuardMock.mock.calls[1]?.[0]).toMatchObject({
+      url: "https://example.com",
+      useEnvProxy: true,
+    });
+    expect(details.text).toContain("ok-body");
+  });
+});

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -348,6 +348,10 @@ function normalizeContentType(value: string | null | undefined): string | undefi
   return trimmed || undefined;
 }
 
+function isFetchFailedTypeError(error: unknown): boolean {
+  return error instanceof TypeError && error.message === "fetch failed";
+}
+
 export async function fetchFirecrawlContent(params: {
   url: string;
   extractMode: ExtractMode;
@@ -523,7 +527,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   let release: (() => Promise<void>) | null = null;
   let finalUrl = params.url;
   try {
-    const result = await fetchWithWebToolsNetworkGuard({
+    const requestParams = {
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
@@ -534,7 +538,18 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
           "Accept-Language": "en-US,en;q=0.9",
         },
       },
-    });
+    };
+
+    let result;
+    try {
+      result = await fetchWithWebToolsNetworkGuard(requestParams);
+    } catch (error) {
+      if (!isFetchFailedTypeError(error)) {
+        throw error;
+      }
+      result = await fetchWithWebToolsNetworkGuard({ ...requestParams, useEnvProxy: true });
+    }
+
     res = result.response;
     finalUrl = result.finalUrl;
     release = result.release;


### PR DESCRIPTION
## Summary
- retry `web_fetch` once with `useEnvProxy: true` when strict guarded fetch throws `TypeError("fetch failed")`
- keep existing behavior for all other errors
- add e2e test verifying strict-first then env-proxy retry path

## Why
Closes #32947.

In some environments, direct guarded fetch fails with `fetch failed` while connectivity still works through configured proxy paths. This patch keeps strict mode as default and adds a minimal targeted retry path.

## Testing
- `pnpm vitest --config vitest.e2e.config.ts src/agents/tools/web-fetch.proxy-retry.e2e.test.ts`
- `pnpm vitest src/agents/tools/web-tools.fetch.test.ts`
