### PR TITLE
gateway/health-monitor: skip stale idle checks for LINE webhook runtime

### DIFF
--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -607,6 +607,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
         ...base,
         tokenSource: account.tokenSource,
         mode: "webhook",
+        connectionModel: runtime?.connectionModel ?? "stateless",
       };
     },
   },

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -640,6 +640,11 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       }
 
       ctx.log?.info(`[${account.accountId}] starting LINE provider${lineBotLabel}`);
+      ctx.setStatus({
+        accountId: account.accountId,
+        mode: "webhook",
+        connectionModel: "stateless",
+      });
 
       const monitor = await getLineRuntime().channel.line.monitorLineProvider({
         channelAccessToken: token,

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -96,6 +96,8 @@ export type ChannelMeta = {
 
 export type ChannelAccountSnapshot = {
   accountId: string;
+  /** Connection model for health-monitor policy selection. */
+  connectionModel?: "stateful" | "stateless";
   name?: string;
   enabled?: boolean;
   configured?: boolean;

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -242,6 +242,43 @@ describe("evaluateChannelHealth", () => {
     );
     expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
   });
+
+  it("treats stateless channels as healthy when running even if disconnected/idle", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        connectionModel: "stateless",
+        running: true,
+        connected: false,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: null,
+      },
+      {
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("still marks stateless channels unhealthy when not running", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        connectionModel: "stateless",
+        running: false,
+        enabled: true,
+        configured: true,
+      },
+      {
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "not-running" });
+  });
 });
 
 describe("resolveChannelRestartReason", () => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -255,6 +255,7 @@ describe("evaluateChannelHealth", () => {
         lastEventAt: null,
       },
       {
+        channelId: "line",
         now: 100_000,
         channelConnectGraceMs: 10_000,
         staleEventThresholdMs: 30_000,
@@ -272,6 +273,7 @@ describe("evaluateChannelHealth", () => {
         configured: true,
       },
       {
+        channelId: "line",
         now: 100_000,
         channelConnectGraceMs: 10_000,
         staleEventThresholdMs: 30_000,

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -1,6 +1,7 @@
 import type { ChannelId } from "../channels/plugins/types.js";
 
 export type ChannelHealthSnapshot = {
+  connectionModel?: "stateful" | "stateless";
   running?: boolean;
   connected?: boolean;
   enabled?: boolean;
@@ -63,6 +64,11 @@ export function evaluateChannelHealth(
   }
   if (!snapshot.running) {
     return { healthy: false, reason: "not-running" };
+  }
+  // Stateless/webhook channels should not be judged by idle event age or
+  // "connected" state. Keep auto-restart only for true stopped/crashed tasks.
+  if (snapshot.connectionModel === "stateless") {
+    return { healthy: true, reason: "healthy" };
   }
   const activeRuns =
     typeof snapshot.activeRuns === "number" && Number.isFinite(snapshot.activeRuns)


### PR DESCRIPTION
## Summary
- add optional `connectionModel` to `ChannelAccountSnapshot` for health-policy selection
- treat `connectionModel: "stateless"` channels as healthy when running (skip connected/stale-idle checks)
- mark LINE gateway runtime as `connectionModel: "stateless"` at startup
- add policy tests for stateless running/not-running behavior

## Why
Webhook channels like LINE are passive by design and can stay idle for long periods. Applying stale-event checks can trigger unnecessary channel restarts and intermittent webhook 404 windows.

## Backward compatibility
- `connectionModel` is optional
- unset value preserves existing behavior for current channels/plugins

## Validation
- Added/updated unit tests in `src/gateway/channel-health-policy.test.ts`
- Local full suite was not run in this environment.