### PR TITLE
fix(media): add per-chunk timeout to readResponseWithLimit to prevent deadlock on large files (#27984)

### DIFF
--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -300,7 +300,7 @@ async function resolveImagesForRequest(
   for (const url of urls) {
     const source = parseImageUrlToSource(url);
     if (source.type === "base64") {
-      totalBytes += estimateBase64DecodedBytes(source.data);
+      totalBytes += estimateBase64DecodedBytes(source.data ?? "");
       if (totalBytes > limits.maxTotalImageBytes) {
         throw new Error(
           `Total image payload too large (${totalBytes}; limit ${limits.maxTotalImageBytes})`,

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -1,14 +1,35 @@
+const CHUNK_TIMEOUT_MS = 30_000;
+
+function withReadTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Stream read timed out after ${ms}ms`)), ms);
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    );
+  });
+}
+
 export async function readResponseWithLimit(
   res: Response,
   maxBytes: number,
   opts?: {
     onOverflow?: (params: { size: number; maxBytes: number; res: Response }) => Error;
+    chunkTimeoutMs?: number;
   },
 ): Promise<Buffer> {
   const onOverflow =
     opts?.onOverflow ??
     ((params: { size: number; maxBytes: number }) =>
       new Error(`Content too large: ${params.size} bytes (limit: ${params.maxBytes} bytes)`));
+
+  const chunkTimeoutMs = opts?.chunkTimeoutMs ?? CHUNK_TIMEOUT_MS;
 
   const body = res.body;
   if (!body || typeof body.getReader !== "function") {
@@ -24,7 +45,7 @@ export async function readResponseWithLimit(
   let total = 0;
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await withReadTimeout(reader.read(), chunkTimeoutMs);
       if (done) {
         break;
       }


### PR DESCRIPTION
fix(media): add per-chunk timeout to readResponseWithLimit to prevent deadlock on large files

Closes #27984

**Root cause:** `readResponseWithLimit` calls `await reader.read()` in an unbounded `while (true)` loop with no timeout — for 5–20 MB files, streaming backpressure causes it to hang forever and lock the chat session.

**Fix:** Added `withReadTimeout` helper that wraps each `reader.read()` call in `Promise.race` against a configurable per-chunk deadline (default 30 s). Added `chunkTimeoutMs` option to `opts` for callers that need a custom value.

**Verification:**
- Build: clean compile on host (`build-output.log`)
- Tests: 804 files / 6485 tests, no regressions (`test-output.log`)
- Code proof: old pattern removed, new pattern confirmed (`step6-verify.log`)
