### PR TITLE
fix(daemon): systemd is-enabled check fails on fresh Linux installs due to execFile stderr fallback

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -90,6 +90,21 @@ describe("isSystemdServiceEnabled", () => {
       "systemctl is-enabled unavailable: Failed to connect to bus",
     );
   });
+
+  it("returns false when is-enabled returns not-found on stdout with empty stderr", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      // Real behavior: systemctl exits 4, stdout="not-found\n", stderr=""
+      // Node execFile wraps this as an Error with generic message
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service\n",
+      ) as Error & { code?: number };
+      err.code = 4;
+      cb(err, "not-found\n", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
 });
 
 describe("systemd runtime parsing", () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -355,6 +355,12 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
   if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
     return false;
   }
+  // stdout may contain the real status text (e.g. "not-found") even when
+  // readSystemctlDetail() returns a generic error.message from execFile,
+  // because execFileUtf8 falls back to error.message when stderr is empty.
+  if (isSystemctlMissing(res.stdout) || isSystemdUnitNotEnabled(res.stdout)) {
+    return false;
+  }
   throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());
 }
 


### PR DESCRIPTION
## Summary

On a fresh Linux system where `openclaw-gateway.service` has never been installed, `openclaw gateway install` fails with:

```
Error: systemctl is-enabled unavailable: Command failed: systemctl --user is-enabled openclaw-gateway.service
```

This PR adds a fallback check against `res.stdout` in `isSystemdServiceEnabled()` so the `not-found` status text is recognized even when `readSystemctlDetail()` returns the generic error message.

## Root Cause

1. `systemctl --user is-enabled openclaw-gateway.service` exits with code 4, `stdout = "not-found\\n"`, `stderr = ""`
2. Node.js `execFile` wraps non-zero exits in an Error with `message = "Command failed: systemctl ..."`
3. `execFileUtf8` does `stderrText || e.message` — since `stderrText` is `""`, it uses the generic `e.message` as `result.stderr`
4. `readSystemctlDetail()` returns `result.stderr || result.stdout` — picks the populated (but wrong) stderr
5. `isSystemdUnitNotEnabled()` checks for `"not-found"` in `"Command failed: systemctl ..."` — doesn't match
6. The function throws instead of returning `false`

Related to #26089 (container systemctl checks) but affects regular desktop/server Linux installs, not just containers.

## Changes

- **`src/daemon/systemd.ts`**: Added fallback check of `res.stdout` in `isSystemdServiceEnabled()` before throwing
- **`src/daemon/systemd.test.ts`**: Added regression test reproducing the exact real-world `execFile` callback behavior (exit code 4, `stdout="not-found"`, empty stderr, generic error message)

## Testing

- [x] Ran `npx vitest run src/daemon/systemd.test.ts` — all 20 tests pass
- [x] Verified fix locally on Arch Linux with systemd 256 — `openclaw gateway install` succeeds after the fix

## AI Disclosure

- [x] AI-assisted (built with Antigravity/Gemini)
- [x] Fully tested locally
- [x] I understand what the code does
