### PR TITLE
fix(discord): ignore wildcard in audit unresolved count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
+- Discord/audit wildcard warnings: ignore "\*" wildcard keys when counting unresolved guild channels so doctor/status no longer warns on allow-all configs. (#33125) Thanks @thewilloftheshadow.
 - Exec heartbeat routing: scope exec-triggered heartbeat wakes to agent session keys so unrelated agents are no longer awakened by exec events, while preserving legacy unscoped behavior for non-canonical session keys. (#32724) thanks @altaywtf
 - macOS/Tailscale remote gateway discovery: add a Tailscale Serve fallback peer probe path (`wss://<peer>.ts.net`) when Bonjour and wide-area DNS-SD discovery return no gateways, and refresh both discovery paths from macOS onboarding. (#32860) Thanks @ngutman.
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.

--- a/src/discord/audit.test.ts
+++ b/src/discord/audit.test.ts
@@ -53,4 +53,55 @@ describe("discord audit", () => {
     expect(audit.channels[0]?.channelId).toBe("111");
     expect(audit.channels[0]?.missing).toContain("SendMessages");
   });
+
+  it("does not count '*' wildcard key as unresolved channel", async () => {
+    const { collectDiscordAuditChannelIds } = await import("./audit.js");
+
+    const cfg = {
+      channels: {
+        discord: {
+          enabled: true,
+          token: "t",
+          groupPolicy: "allowlist",
+          guilds: {
+            "123": {
+              channels: {
+                "111": { allow: true },
+                "*": { allow: true },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as import("../config/config.js").OpenClawConfig;
+
+    const collected = collectDiscordAuditChannelIds({ cfg, accountId: "default" });
+    expect(collected.channelIds).toEqual(["111"]);
+    expect(collected.unresolvedChannels).toBe(0);
+  });
+
+  it("handles guild with only '*' wildcard and no numeric channel ids", async () => {
+    const { collectDiscordAuditChannelIds } = await import("./audit.js");
+
+    const cfg = {
+      channels: {
+        discord: {
+          enabled: true,
+          token: "t",
+          groupPolicy: "allowlist",
+          guilds: {
+            "123": {
+              channels: {
+                "*": { allow: true },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as import("../config/config.js").OpenClawConfig;
+
+    const collected = collectDiscordAuditChannelIds({ cfg, accountId: "default" });
+    expect(collected.channelIds).toEqual([]);
+    expect(collected.unresolvedChannels).toBe(0);
+  });
 });

--- a/src/discord/audit.ts
+++ b/src/discord/audit.ts
@@ -56,6 +56,11 @@ function listConfiguredGuildChannelKeys(
       if (!channelId) {
         continue;
       }
+      // Skip wildcard keys (e.g. "*" meaning "all channels") — they are valid
+      // config but are not real channel IDs and should not be audited.
+      if (channelId === "*") {
+        continue;
+      }
       if (!shouldAuditChannelConfig(value as DiscordGuildChannelConfig | undefined)) {
         continue;
       }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord audit counted "*" wildcard keys as unresolved channels.
- Why it matters: `openclaw doctor` / `channels status --probe` showed false positive warnings for valid wildcard configs.
- What changed: Skip the "*" key when collecting configured guild channel IDs and add regression tests.
- What did NOT change (scope boundary): Allowlist matching, routing, and permission probing logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32517
- Related #32816 #32608 #32528

## User-visible / Behavior Changes

`openclaw doctor` and `channels status --probe` no longer report unresolved Discord channels when only the "*" wildcard is present.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted):

```json5
{
  channels: {
    discord: {
      guilds: {
        "123": {
          channels: {
            "*": { allow: true }
          }
        }
      }
    }
  }
}
```

### Steps

1. Configure a Discord guild with a "*" channel wildcard.
2. Run `openclaw doctor` or `openclaw channels status --probe`.
3. Observe unresolved channel warnings.

### Expected

- No unresolved channel warning when the only non-numeric key is "*".

### Actual

- Before: Unresolved warning with `unresolvedChannels=1`.
- After: No warning.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm vitest run src/discord/audit.test.ts`
- Edge cases checked: wildcard-only guild + mixed wildcard/numeric
- What you did **not** verify: live Discord permission probing in a real guild

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `src/discord/audit.ts`, `src/discord/audit.test.ts`
- Known bad symptoms reviewers should watch for: wildcard keys appear as unresolved

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: N/A
