### PR TITLE
fix(agents): exclude Jinja/template errors from context overflow classification

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -301,6 +301,27 @@ describe("isContextOverflowError", () => {
       expect(isContextOverflowError(sample)).toBe(false);
     }
   });
+
+  it("does not classify Jinja template errors as context overflow", () => {
+    expect(isContextOverflowError("No user query found in messages")).toBe(false);
+    expect(isContextOverflowError("jinja2.exceptions.TemplateError: No user query found")).toBe(
+      false,
+    );
+    expect(isContextOverflowError("Chat template error: raise_exception('No user query')")).toBe(
+      false,
+    );
+  });
+
+  it("excludes template errors even when overflow keywords are present", () => {
+    expect(
+      isContextOverflowError(
+        "jinja2.exceptions.TemplateError: context length exceeded in template",
+      ),
+    ).toBe(false);
+    expect(
+      isContextOverflowError("Chat template error: request size exceeds model context window"),
+    ).toBe(false);
+  });
 });
 
 describe("error classifiers", () => {
@@ -389,6 +410,22 @@ describe("isLikelyContextOverflowError", () => {
     for (const sample of samples) {
       expect(isLikelyContextOverflowError(sample)).toBe(false);
     }
+  });
+
+  it("does not classify template errors as likely context overflow", () => {
+    expect(isLikelyContextOverflowError("No user query found in messages")).toBe(false);
+    expect(isLikelyContextOverflowError("Jinja template compilation failed")).toBe(false);
+  });
+
+  it("excludes template errors even when hint keywords are present", () => {
+    expect(
+      isLikelyContextOverflowError(
+        "context window limit hit: no user query found in messages",
+      ),
+    ).toBe(false);
+    expect(
+      isLikelyContextOverflowError("prompt too long: jinja template render failed"),
+    ).toBe(false);
   });
 });
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -70,6 +70,18 @@ function hasRateLimitTpmHint(raw: string): boolean {
   return /\btpm\b/i.test(lower) || lower.includes("tokens per minute");
 }
 
+function isTemplateOrJinjaError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("jinja") ||
+    lower.includes("chat template") ||
+    lower.includes("raise_exception") ||
+    lower.includes("no user query found in messages") ||
+    /\btemplate\s*(render|compil|pars|execut)\w*\s*(error|fail)/i.test(message) ||
+    /\b(template_?error|jinja_?error)\b/i.test(message)
+  );
+}
+
 export function isContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {
     return false;
@@ -82,6 +94,10 @@ export function isContextOverflowError(errorMessage?: string): boolean {
   }
 
   if (isReasoningConstraintErrorMessage(errorMessage)) {
+    return false;
+  }
+
+  if (isTemplateOrJinjaError(errorMessage)) {
     return false;
   }
 
@@ -131,6 +147,10 @@ export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   }
 
   if (isReasoningConstraintErrorMessage(errorMessage)) {
+    return false;
+  }
+
+  if (isTemplateOrJinjaError(errorMessage)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** Qwen3.5 and similar models behind LM Studio emit Jinja template errors (e.g. "No user query found in messages") that were misclassified as context overflow, triggering misleading error messages and failed auto-compaction loops.
- **Why it matters:** Users see confusing "context too long" errors and the agent enters a compaction loop that never resolves the actual template error.
- **What changed:** Added `isTemplateOrJinjaError()` guard in both `isContextOverflowError()` and `isLikelyContextOverflowError()` to return false for Jinja/template-related error messages.
- **What did NOT change:** All existing context overflow detection patterns remain unchanged; only template errors are now excluded.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32936

## User-visible / Behavior Changes

- Jinja/template errors are now reported as provider errors instead of context overflow, with accurate error messages.
- Auto-compaction is no longer triggered for template errors.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: LM Studio with Qwen3.x models

### Steps

1. Configure LM Studio as provider with a Qwen3.x model
2. Send any message that triggers a Jinja template error

### Expected

- Error is reported as a provider error, not context overflow.

### Actual

- Before fix: Error misclassified as context overflow, compaction loop triggered.
- After fix: Error correctly classified, no compaction attempt.

## Evidence

Added `isTemplateOrJinjaError()` helper detecting patterns: "jinja", "chat template", "raise_exception", "no user query found in messages", and template.*error regex. Tests verify 5 error strings are correctly excluded.

## Human Verification (required)

- Verified scenarios: Jinja errors, chat template errors, raise_exception errors
- Edge cases checked: legitimate context overflow errors still detected correctly
- What I did **not** verify: All possible Qwen error message formats

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the `isTemplateOrJinjaError` guard
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`
- Known bad symptoms: Template errors would again be misclassified as overflow

## Risks and Mitigations

None — only adds an exclusion path; existing overflow detection is unchanged.
