### PR TITLE
fix(auto-reply): use configured userTimezone for system event timestamps

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -13,6 +13,29 @@ import {
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 import { drainSystemEventEntries } from "../../infra/system-events.js";
 
+export const resolveSystemEventTimezone = (cfg: OpenClawConfig) => {
+  const raw = cfg.agents?.defaults?.envelopeTimezone?.trim();
+  if (!raw) {
+    const userTz = resolveUserTimezone(cfg?.agents?.defaults?.userTimezone);
+    return { mode: "iana" as const, timeZone: userTz };
+  }
+  const lowered = raw.toLowerCase();
+  if (lowered === "utc" || lowered === "gmt") {
+    return { mode: "utc" as const };
+  }
+  if (lowered === "local" || lowered === "host") {
+    return { mode: "local" as const };
+  }
+  if (lowered === "user") {
+    return {
+      mode: "iana" as const,
+      timeZone: resolveUserTimezone(cfg.agents?.defaults?.userTimezone),
+    };
+  }
+  const explicit = resolveTimezone(raw);
+  return explicit ? { mode: "iana" as const, timeZone: explicit } : { mode: "local" as const };
+};
+
 export async function buildQueuedSystemPrompt(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -41,28 +64,6 @@ export async function buildQueuedSystemPrompt(params: {
       return trimmed.replace(/ · last input [^·]+/i, "").trim();
     }
     return trimmed;
-  };
-
-  const resolveSystemEventTimezone = (cfg: OpenClawConfig) => {
-    const raw = cfg.agents?.defaults?.envelopeTimezone?.trim();
-    if (!raw) {
-      return { mode: "local" as const };
-    }
-    const lowered = raw.toLowerCase();
-    if (lowered === "utc" || lowered === "gmt") {
-      return { mode: "utc" as const };
-    }
-    if (lowered === "local" || lowered === "host") {
-      return { mode: "local" as const };
-    }
-    if (lowered === "user") {
-      return {
-        mode: "iana" as const,
-        timeZone: resolveUserTimezone(cfg.agents?.defaults?.userTimezone),
-      };
-    }
-    const explicit = resolveTimezone(raw);
-    return explicit ? { mode: "iana" as const, timeZone: explicit } : { mode: "local" as const };
   };
 
   const formatSystemEventTimestamp = (ts: number, cfg: OpenClawConfig) => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -8,7 +8,7 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.ts";
 import { enqueueSystemEvent, resetSystemEventsForTest } from "../../infra/system-events.js";
 import { applyResetModelOverride } from "./session-reset-model.js";
-import { buildQueuedSystemPrompt } from "./session-updates.js";
+import { buildQueuedSystemPrompt, resolveSystemEventTimezone } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
 import { initSessionState } from "./session.js";
 
@@ -1164,6 +1164,43 @@ describe("buildQueuedSystemPrompt", () => {
   });
 });
 
+describe("resolveSystemEventTimezone", () => {
+  it("uses userTimezone when envelopeTimezone is not set", () => {
+    const result = resolveSystemEventTimezone({
+      agents: { defaults: { userTimezone: "America/Vancouver" } },
+    } as OpenClawConfig);
+    expect(result).toEqual({ mode: "iana", timeZone: "America/Vancouver" });
+  });
+
+  it("uses userTimezone when envelopeTimezone is empty string", () => {
+    const result = resolveSystemEventTimezone({
+      agents: { defaults: { envelopeTimezone: "  ", userTimezone: "Asia/Tokyo" } },
+    } as OpenClawConfig);
+    expect(result).toEqual({ mode: "iana", timeZone: "Asia/Tokyo" });
+  });
+
+  it("returns utc for envelopeTimezone 'utc'", () => {
+    const result = resolveSystemEventTimezone({
+      agents: { defaults: { envelopeTimezone: "utc" } },
+    } as OpenClawConfig);
+    expect(result).toEqual({ mode: "utc" });
+  });
+
+  it("returns iana with resolved user timezone for envelopeTimezone 'user'", () => {
+    const result = resolveSystemEventTimezone({
+      agents: { defaults: { envelopeTimezone: "user", userTimezone: "Europe/Vienna" } },
+    } as OpenClawConfig);
+    expect(result).toEqual({ mode: "iana", timeZone: "Europe/Vienna" });
+  });
+
+  it("returns local for envelopeTimezone 'local'", () => {
+    const result = resolveSystemEventTimezone({
+      agents: { defaults: { envelopeTimezone: "local" } },
+    } as OpenClawConfig);
+    expect(result).toEqual({ mode: "local" });
+  });
+});
+
 describe("persistSessionUsageUpdate", () => {
   async function seedSessionStore(params: {
     storePath: string;
@@ -1363,6 +1400,30 @@ describe("initSessionState stale threadId fallback", () => {
     });
     expect(mainResult.sessionEntry.lastThreadId).toBeUndefined();
     expect(mainResult.sessionEntry.deliveryContext?.threadId).toBeUndefined();
+  });
+
+  it("does not inherit lastThreadId for topic-scoped sessions on retry", async () => {
+    const storePath = await createStorePath("topic-scoped-no-inherit-");
+    const sessionKey = "agent:main:telegram:group:123:topic:456";
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: "topic-session-1",
+        updatedAt: Date.now(),
+        lastThreadId: 456,
+      },
+    });
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "retry without MessageThreadId",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionEntry.lastThreadId).toBeUndefined();
   });
 
   it("preserves lastThreadId within the same thread session", async () => {


### PR DESCRIPTION
## Summary

- **Problem:** System event timestamps appeared ~11.5 hours off because `resolveSystemEventTimezone` fell back to `{ mode: "local" }` (host timezone, often UTC in containers) when `envelopeTimezone` was not set.
- **Why it matters:** Users see incorrect timestamps in exec failure logs and session events, causing confusion about when events actually occurred.
- **What changed:** When `envelopeTimezone` is not set, now falls back to `resolveUserTimezone(cfg.agents.defaults.userTimezone)` instead of the host timezone.
- **What did NOT change:** Behavior when `envelopeTimezone` is explicitly set ("utc", "user", "local", or IANA timezone string).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33083

## User-visible / Behavior Changes

- System event timestamps now use the user's configured timezone instead of the host timezone when no envelope timezone is set.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (or any containerized environment where host TZ differs from user TZ)
- Runtime: Node.js
- Integration/channel: Any

### Steps

1. Configure `userTimezone: "America/Vancouver"` in agents.defaults
2. Start a session and trigger an exec event
3. Check the timestamp in the exec failure log

### Expected

- Timestamp matches America/Vancouver timezone.

### Actual

- Before fix: Timestamp uses UTC (host timezone), appearing ~11.5 hours off.
- After fix: Timestamp uses configured userTimezone.

## Evidence

Changed fallback from `{ mode: "local" }` to `{ mode: "iana", timeZone: resolveUserTimezone(...) }`. Added 5 test cases covering various timezone configurations.

## Human Verification (required)

- Verified scenarios: missing envelopeTimezone, blank envelopeTimezone, explicit "utc"/"user"/"local" modes
- Edge cases checked: empty string envelopeTimezone treated as unset
- What I did **not** verify: All IANA timezone identifiers

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Restore `{ mode: "local" }` fallback in resolveSystemEventTimezone
- Files/config to restore: `src/auto-reply/reply/session-updates.ts`
- Known bad symptoms: Timestamps would revert to using host timezone

## Risks and Mitigations

None — only affects display timestamps when envelopeTimezone is not configured.
