### PR TITLE
fix(cron): bypass HEARTBEAT.md file gate for cron-triggered runs

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1015,7 +1015,7 @@ describe("runHeartbeatOnce", () => {
 
   async function runHeartbeatFileScenario(params: {
     fileState: HeartbeatFileState;
-    reason?: "interval" | "wake";
+    reason?: string;
     queueCronEvent?: boolean;
     replyText?: string;
   }) {
@@ -1087,7 +1087,7 @@ describe("runHeartbeatOnce", () => {
     const cases: Array<{
       name: string;
       fileState: HeartbeatFileState;
-      reason?: "interval" | "wake";
+      reason?: string;
       queueCronEvent?: boolean;
       expectedStatus: "ran" | "skipped";
       expectedSkipReason?: "empty-heartbeat-file";
@@ -1123,6 +1123,14 @@ describe("runHeartbeatOnce", () => {
         expectedReplyCalls: 1,
         expectCronContext: true,
         replyText: "Relay this cron update now",
+      },
+      {
+        name: "empty file + cron-triggered reason bypasses file gate",
+        fileState: "empty",
+        reason: "cron:my-system-job",
+        expectedStatus: "ran",
+        expectedSendCalls: 1,
+        expectedReplyCalls: 1,
       },
       {
         name: "actionable file runs",


### PR DESCRIPTION
## Summary

- **Problem:** Cron jobs with `payload.kind: 'systemEvent'` were skipped with "empty-heartbeat-file" when HEARTBEAT.md was empty or contained only comments.
- **Why it matters:** Scheduled system event jobs (e.g. daily reports, cleanup tasks) silently fail, and users see no output or error other than the skipped status.
- **What changed:** Added `isCronTriggered` check (reason starts with "cron:") to `shouldBypassFileGates` so cron-triggered heartbeat runs skip the HEARTBEAT.md file gate.
- **What did NOT change:** Normal interval-triggered heartbeat behavior and HEARTBEAT.md gating for non-cron runs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33090

## User-visible / Behavior Changes

- Cron systemEvent jobs now execute even when HEARTBEAT.md is empty.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Cron scheduler

### Steps

1. Create a cron job with `payload.kind: 'systemEvent'`
2. Leave HEARTBEAT.md empty
3. Wait for the scheduled time

### Expected

- Job executes normally.

### Actual

- Before fix: Job skipped with "empty-heartbeat-file".
- After fix: Job executes, bypassing the file gate.

## Evidence

Added `isCronTriggered` variable checking `params.reason.startsWith("cron:")`. Test verifies empty HEARTBEAT.md + cron reason bypasses the file gate.

## Human Verification (required)

- Verified scenarios: cron-triggered with empty HEARTBEAT.md, interval-triggered with empty HEARTBEAT.md (still skipped)
- Edge cases checked: reason string edge cases
- What I did **not** verify: All wakeMode combinations

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `isCronTriggered` from `shouldBypassFileGates`
- Files/config to restore: `src/infra/heartbeat-runner.ts`
- Known bad symptoms: Cron jobs would again be blocked by empty HEARTBEAT.md

## Risks and Mitigations

None — only relaxes the file gate for cron-triggered runs.
