### PR TITLE
fix(status): show fallback model count in /status and session status

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -357,6 +357,65 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("Fallback:");
   });
 
+  it("shows fallback count in model line when one fallback is configured", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: {
+          primary: "anthropic/claude-opus-4-6",
+          fallbacks: ["anthropic/claude-sonnet-4-5"],
+        },
+      },
+      sessionEntry: { sessionId: "fb1", updatedAt: 0 },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Model: anthropic/claude-opus-4-6 (+1 fallback)");
+  });
+
+  it("shows fallback count in model line when multiple fallbacks are configured", () => {
+    const text = buildStatusMessage({
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["anthropic/claude-sonnet-4-5", "openai/gpt-4.1"],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: {
+        model: {
+          primary: "anthropic/claude-opus-4-6",
+          fallbacks: ["anthropic/claude-sonnet-4-5", "openai/gpt-4.1"],
+        },
+      },
+      sessionEntry: { sessionId: "fb2", updatedAt: 0 },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Model: anthropic/claude-opus-4-6 (+2 fallbacks)");
+  });
+
+  it("does not show fallback suffix when no fallbacks are configured", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/claude-opus-4-6",
+      },
+      sessionEntry: { sessionId: "fb0", updatedAt: 0 },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Model: anthropic/claude-opus-4-6");
+    expect(normalized).not.toContain("fallback");
+  });
+
   it("keeps provider prefix from configured model", () => {
     const text = buildStatusMessage({
       agent: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -13,6 +13,7 @@ import { derivePromptTokens, normalizeUsage, type UsageLike } from "../agents/us
 import { resolveChannelModelOverride } from "../channels/model-overrides.js";
 import { isCommandFlagEnabled } from "../config/commands.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import {
   resolveMainSessionKey,
   resolveSessionFilePath,
@@ -648,7 +649,14 @@ export function buildStatusMessage(args: StatusArgs): string {
     return "channel override";
   })();
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
-  const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`;
+  const configuredFallbacks = resolveAgentModelFallbackValues(
+    args.agent?.model ?? args.config?.agents?.defaults?.model,
+  );
+  const fallbackSuffix =
+    configuredFallbacks.length > 0
+      ? ` (+${configuredFallbacks.length} fallback${configuredFallbacks.length > 1 ? "s" : ""})`
+      : "";
+  const modelLine = `🧠 Model: ${selectedModelLabel}${fallbackSuffix}${selectedAuthLabel}${modelNote}`;
   const showFallbackAuth = activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;
   const fallbackLine = fallbackState.active
     ? `↪️ Fallback: ${activeModelLabel}${

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -1,6 +1,7 @@
 import { formatCliCommand } from "../cli/command-format.js";
 import { withProgress } from "../cli/progress.js";
 import { loadConfig, resolveGatewayPort } from "../config/config.js";
+import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
 import { info } from "../globals.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
@@ -421,7 +422,12 @@ export async function statusCommand(
     ...(lastHeartbeatValue ? [{ Item: "Last heartbeat", Value: lastHeartbeatValue }] : []),
     {
       Item: "Sessions",
-      Value: `${summary.sessions.count} active · default ${defaults.model ?? "unknown"}${defaultCtx} · ${storeLabel}`,
+      Value: (() => {
+        const fb = resolveAgentModelFallbackValues(cfg.agents?.defaults?.model);
+        const fbSuffix =
+          fb.length > 0 ? ` (+${fb.length} fallback${fb.length > 1 ? "s" : ""})` : "";
+        return `${summary.sessions.count} active · default ${defaults.model ?? "unknown"}${fbSuffix}${defaultCtx} · ${storeLabel}`;
+      })(),
     },
   ];
 


### PR DESCRIPTION
## Summary

- **Problem:** When fallback models are configured in `agents.defaults.model.fallbacks`, the `/status` command and session status card only displayed the primary model.
- **Why it matters:** Users have no visibility into whether fallback models are configured and active.
- **What changed:** Appended "(+N fallback(s))" suffix to the model display line in both the session status message and CLI status command.
- **What did NOT change:** Model selection logic, fallback behavior, or any other status information.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33099

## User-visible / Behavior Changes

- `/status` and session status card now show fallback model count (e.g. `anthropic/claude-opus-4-6 (+1 fallback)`).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Any (webchat, TUI, Telegram, etc.)

### Steps

1. Configure fallback models in `agents.defaults.model.fallbacks`
2. Run `/status` or check session status card

### Expected

- Model line shows primary model with fallback count.

### Actual

- Before fix: Only primary model shown.
- After fix: Shows `model (+N fallback(s))`.

## Evidence

Used `resolveAgentModelFallbackValues()` to get fallback count. Added 3 test cases: single fallback, multiple fallbacks, no fallbacks.

## Human Verification (required)

- Verified scenarios: 0 fallbacks, 1 fallback, 2+ fallbacks
- Edge cases checked: model as string vs object config
- What I did **not** verify: Session-level model overrides

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove fallbackSuffix logic from status.ts and status.command.ts
- Files/config to restore: `src/auto-reply/status.ts`, `src/commands/status.command.ts`
- Known bad symptoms: Model line would show incorrect text

## Risks and Mitigations

None — display-only change with no behavior impact.
