### PR TITLE
feat(skills): add globalSkillsPath config for multi-agent shared skills

### DIFF
--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -155,4 +155,32 @@ describe("loadWorkspaceSkillEntries", () => {
 
     expect(entries.map((entry) => entry.skill.name)).not.toContain("diffs");
   });
+
+  it("loads skills from globalSkillsPath", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const globalDir = path.join(workspaceDir, ".global-skills");
+
+    await fs.mkdir(path.join(globalDir, "shared-tool"), { recursive: true });
+    await fs.writeFile(
+      path.join(globalDir, "shared-tool", "SKILL.md"),
+      `---\nname: shared-tool\ndescription: A globally shared skill\n---\nGlobal skill content.\n`,
+      "utf-8",
+    );
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      config: {
+        skills: {
+          load: { globalSkillsPath: globalDir },
+        },
+      },
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("shared-tool");
+    const globalEntry = entries.find((entry) => entry.skill.name === "shared-tool");
+    expect(globalEntry?.skill.source).toBe("openclaw-global");
+  });
 });

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -334,6 +334,14 @@ function loadSkillEntries(
   });
   const mergedExtraDirs = [...extraDirs, ...pluginSkillDirs];
 
+  const globalSkillsPathRaw = opts?.config?.skills?.load?.globalSkillsPath?.trim();
+  const globalSkills = globalSkillsPathRaw
+    ? loadSkills({
+        dir: resolveUserPath(globalSkillsPathRaw),
+        source: "openclaw-global",
+      })
+    : [];
+
   const bundledSkills = bundledSkillsDir
     ? loadSkills({
         dir: bundledSkillsDir,
@@ -367,8 +375,11 @@ function loadSkillEntries(
   });
 
   const merged = new Map<string, Skill>();
-  // Precedence: extra < bundled < managed < agents-skills-personal < agents-skills-project < workspace
+  // Precedence: extra < global < bundled < managed < agents-skills-personal < agents-skills-project < workspace
   for (const skill of extraSkills) {
+    merged.set(skill.name, skill);
+  }
+  for (const skill of globalSkills) {
     merged.set(skill.name, skill);
   }
   for (const skill of bundledSkills) {

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -9,6 +9,11 @@ export type SkillConfig = {
 
 export type SkillsLoadConfig = {
   /**
+   * Path to a shared directory containing skills available to all agents.
+   * Loaded with source name "openclaw-global", precedence between extra and bundled.
+   */
+  globalSkillsPath?: string;
+  /**
    * Additional skill folders to scan (lowest precedence).
    * Each directory should contain skill subfolders with `SKILL.md`.
    */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -771,6 +771,7 @@ export const OpenClawSchema = z
         allowBundled: z.array(z.string()).optional(),
         load: z
           .object({
+            globalSkillsPath: z.string().optional(),
             extraDirs: z.array(z.string()).optional(),
             watch: z.boolean().optional(),
             watchDebounceMs: z.number().int().min(0).optional(),


### PR DESCRIPTION
## Summary

- **Problem:** In multi-agent setups, sharing skills across all agents required copying skill directories to each workspace or using brittle absolute paths.
- **Why it matters:** With 6+ agents, maintaining duplicated skills is a maintenance nightmare and a source of inconsistency.
- **What changed:** Added `globalSkillsPath` field to `skills.load` config that points to a shared directory. Skills from this path are loaded with source "openclaw-global" and merged between extraDirs and bundled skills.
- **What did NOT change:** Existing skill loading behavior, precedence for workspace/managed/bundled skills, or extraDirs behavior.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32927

## User-visible / Behavior Changes

- New optional config field `skills.load.globalSkillsPath` in openclaw.json.
- Skills from the global path are available to all agents without per-workspace duplication.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Any

### Steps

1. Create a shared skills directory (e.g. `/root/.openclaw/shared/skills`)
2. Add `"skills": { "load": { "globalSkillsPath": "/root/.openclaw/shared/skills" } }` to openclaw.json
3. Verify skills appear in all agents

### Expected

- Skills from globalSkillsPath are loaded for all agents.

### Actual

- Before fix: No globalSkillsPath option exists.
- After fix: Shared skills are loaded with "openclaw-global" source.

## Evidence

Added type to SkillsLoadConfig, schema validation in zod-schema.ts, and loading logic in workspace.ts. Test verifies skills are loaded from a temporary global directory.

## Human Verification (required)

- Verified scenarios: globalSkillsPath set, not set, invalid path
- Edge cases checked: empty directory, precedence with workspace skills
- What I did **not** verify: Hot-reload / watch mode for global skills

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` (optional new field)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove globalSkillsPath from config
- Files/config to restore: `src/config/types.skills.ts`, `src/config/zod-schema.ts`, `src/agents/skills/workspace.ts`
- Known bad symptoms: Skills from global path would not load

## Risks and Mitigations

None — new optional config field with no impact on existing behavior.
