### PR TITLE
Fix doctor migration for loopback Control UI origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Doctor/Control UI origin seeding: include loopback/default-bind installs in `gateway.controlUi.allowedOrigins` migration repair so `openclaw doctor` backfills localhost origins after upgrade and avoids Control UI origin-rejection loops. (#33124)
 - Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
 - Exec heartbeat routing: scope exec-triggered heartbeat wakes to agent session keys so unrelated agents are no longer awakened by exec events, while preserving legacy unscoped behavior for non-canonical session keys. (#32724) thanks @altaywtf
 - macOS/Tailscale remote gateway discovery: add a Tailscale Serve fallback peer probe path (`wss://<peer>.ts.net`) when Bonjour and wide-area DNS-SD discovery return no gateways, and refresh both discovery paths from macOS onboarding. (#32860) Thanks @ngutman.

--- a/src/config/legacy-migrate.test.ts
+++ b/src/config/legacy-migrate.test.ts
@@ -179,15 +179,31 @@ describe("legacy migrate controlUi.allowedOrigins seed (issue #29385)", () => {
     expect(res.changes.some((c) => c.includes("gateway.controlUi.allowedOrigins"))).toBe(true);
   });
 
-  it("does not migrate loopback bind — returns null", () => {
+  it("seeds allowedOrigins for explicit loopback bind", () => {
     const res = migrateLegacyConfig({
       gateway: {
         bind: "loopback",
         auth: { mode: "token", token: "tok" },
       },
     });
-    expect(res.config).toBeNull();
-    expect(res.changes).toHaveLength(0);
+    expect(res.config?.gateway?.controlUi?.allowedOrigins).toEqual([
+      "http://localhost:18789",
+      "http://127.0.0.1:18789",
+    ]);
+    expect(res.changes.some((c) => c.includes("bind=loopback"))).toBe(true);
+  });
+
+  it("seeds allowedOrigins when bind is omitted (defaults to loopback)", () => {
+    const res = migrateLegacyConfig({
+      gateway: {
+        auth: { mode: "token", token: "tok" },
+      },
+    });
+    expect(res.config?.gateway?.controlUi?.allowedOrigins).toEqual([
+      "http://localhost:18789",
+      "http://127.0.0.1:18789",
+    ]);
+    expect(res.changes.some((c) => c.includes("bind=loopback"))).toBe(true);
   });
 
   it("preserves existing controlUi fields when seeding allowedOrigins", () => {

--- a/src/config/legacy.migrations.part-3.ts
+++ b/src/config/legacy.migrations.part-3.ts
@@ -22,24 +22,22 @@ import { DEFAULT_GATEWAY_PORT } from "./paths.js";
 
 export const LEGACY_CONFIG_MIGRATIONS_PART_3: LegacyConfigMigration[] = [
   {
-    // v2026.2.26 added a startup guard requiring gateway.controlUi.allowedOrigins (or the
-    // host-header fallback flag) for any non-loopback bind. The onboarding wizard was updated
-    // to seed this for new installs, but existing bind=lan/bind=custom installs that upgrade
-    // crash-loop immediately on next startup with no recovery path (issue #29385).
+    // v2026.2.26 introduced stricter Control UI origin handling. Existing installs may
+    // miss gateway.controlUi.allowedOrigins after upgrade (including loopback/default-bind
+    // setups surfaced in #33124), so we seed safe local defaults when the allowlist is absent.
     //
     // This migration runs on every gateway start via migrateLegacyConfig → applyLegacyMigrations
-    // and writes the seeded origins to disk before the startup guard fires, preventing the loop.
+    // and writes the seeded origins to disk before startup checks run.
     id: "gateway.controlUi.allowedOrigins-seed-for-non-loopback",
-    describe: "Seed gateway.controlUi.allowedOrigins for existing non-loopback gateway installs",
+    describe: "Seed gateway.controlUi.allowedOrigins for existing gateway installs",
     apply: (raw, changes) => {
       const gateway = getRecord(raw.gateway);
       if (!gateway) {
         return;
       }
       const bind = gateway.bind;
-      if (!isGatewayNonLoopbackBindMode(bind)) {
-        return;
-      }
+      const effectiveBind =
+        bind === "loopback" || isGatewayNonLoopbackBindMode(bind) ? bind : "loopback";
       const controlUi = getRecord(gateway.controlUi) ?? {};
       if (
         hasConfiguredControlUiAllowedOrigins({
@@ -53,14 +51,14 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_3: LegacyConfigMigration[] = [
       const port = resolveGatewayPortWithDefault(gateway.port, DEFAULT_GATEWAY_PORT);
       const origins = buildDefaultControlUiAllowedOrigins({
         port,
-        bind,
+        bind: effectiveBind,
         customBindHost:
           typeof gateway.customBindHost === "string" ? gateway.customBindHost : undefined,
       });
       gateway.controlUi = { ...controlUi, allowedOrigins: origins };
       raw.gateway = gateway;
       changes.push(
-        `Seeded gateway.controlUi.allowedOrigins ${JSON.stringify(origins)} for bind=${String(bind)}. ` +
+        `Seeded gateway.controlUi.allowedOrigins ${JSON.stringify(origins)} for bind=${String(effectiveBind)}. ` +
           "Required since v2026.2.26. Add other machine origins to gateway.controlUi.allowedOrigins if needed.",
       );
     },

--- a/src/config/legacy.migrations.part-3.ts
+++ b/src/config/legacy.migrations.part-3.ts
@@ -28,7 +28,7 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_3: LegacyConfigMigration[] = [
     //
     // This migration runs on every gateway start via migrateLegacyConfig → applyLegacyMigrations
     // and writes the seeded origins to disk before startup checks run.
-    id: "gateway.controlUi.allowedOrigins-seed-for-non-loopback",
+    id: "gateway.controlUi.allowedOrigins-seed-for-existing-binds",
     describe: "Seed gateway.controlUi.allowedOrigins for existing gateway installs",
     apply: (raw, changes) => {
       const gateway = getRecord(raw.gateway);


### PR DESCRIPTION
## Summary
- expand the legacy doctor migration for `gateway.controlUi.allowedOrigins` to also cover loopback/default-bind installs
- keep existing non-loopback behavior, while defaulting unknown/missing bind values to loopback during migration
- add regression tests for explicit loopback and omitted bind paths
- add changelog entry under 2026.3.3 fixes

Fixes #33124

## Testing
- pnpm test src/config/legacy-migrate.test.ts
