### PR TITLE
fix(node-host): sync rawCommand with hardened argv after executable path pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Nodes/system.run approval hardening: use explicit argv-mutation signaling when regenerating prepared `rawCommand`, and cover the `system.run.prepare -> system.run` handoff so direct PATH-based `nodes.run` commands no longer fail with `rawCommand does not match command`. (#33137) thanks @Sid-Qin.
 - Models/custom provider headers: propagate `models.providers.<name>.headers` across inline, fallback, and registry-found model resolution so header-authenticated proxies consistently receive configured request headers. (#27490) thanks @Sid-Qin.
 - Daemon/systemd install robustness: treat `systemctl --user is-enabled` exit-code-4 `not-found` responses as not-enabled by combining stderr/stdout detail parsing, so Ubuntu fresh installs no longer fail with `systemctl is-enabled unavailable`. (#33634) Thanks @Yuandiaodiaodiao.
 - Slack/system-event session routing: resolve reaction/member/pin/interaction system-event session keys through channel/account bindings (with sender-aware DM routing) so inbound Slack events target the correct agent session in multi-account setups instead of defaulting to `agent:main`. (#34045) Thanks @paulomcg, @daht-mad and @vincentkoc.

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -19,6 +19,7 @@ type HardeningCase = {
   shellCommand?: string | null;
   withPathToken?: boolean;
   expectedArgv: (ctx: { pathToken: PathTokenSetup | null }) => string[];
+  expectedArgvChanged?: boolean;
   expectedCmdText?: string;
   checkRawCommandMatchesArgv?: boolean;
 };
@@ -38,6 +39,7 @@ describe("hardenApprovedExecutionPaths", () => {
       argv: ["env", "tr", "a", "b"],
       shellCommand: null,
       expectedArgv: () => ["env", "tr", "a", "b"],
+      expectedArgvChanged: false,
     },
     {
       name: "pins direct PATH-token executable during approval hardening",
@@ -46,6 +48,7 @@ describe("hardenApprovedExecutionPaths", () => {
       shellCommand: null,
       withPathToken: true,
       expectedArgv: ({ pathToken }) => [pathToken!.expected, "SAFE"],
+      expectedArgvChanged: true,
     },
     {
       name: "preserves env-wrapper PATH-token argv during approval hardening",
@@ -54,6 +57,7 @@ describe("hardenApprovedExecutionPaths", () => {
       shellCommand: null,
       withPathToken: true,
       expectedArgv: () => ["env", "poccmd", "SAFE"],
+      expectedArgvChanged: false,
     },
     {
       name: "rawCommand matches hardened argv after executable path pinning",
@@ -109,6 +113,9 @@ describe("hardenApprovedExecutionPaths", () => {
           throw new Error("unreachable");
         }
         expect(hardened.argv).toEqual(testCase.expectedArgv({ pathToken }));
+        if (typeof testCase.expectedArgvChanged === "boolean") {
+          expect(hardened.argvChanged).toBe(testCase.expectedArgvChanged);
+        }
       } finally {
         if (testCase.withPathToken) {
           if (oldPath === undefined) {

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { formatExecCommand } from "../infra/system-run-command.js";
 import {
   buildSystemRunApprovalPlan,
   hardenApprovedExecutionPaths,
@@ -19,6 +20,7 @@ type HardeningCase = {
   withPathToken?: boolean;
   expectedArgv: (ctx: { pathToken: PathTokenSetup | null }) => string[];
   expectedCmdText?: string;
+  checkRawCommandMatchesArgv?: boolean;
 };
 
 describe("hardenApprovedExecutionPaths", () => {
@@ -53,6 +55,14 @@ describe("hardenApprovedExecutionPaths", () => {
       withPathToken: true,
       expectedArgv: () => ["env", "poccmd", "SAFE"],
     },
+    {
+      name: "rawCommand matches hardened argv after executable path pinning",
+      mode: "build-plan",
+      argv: ["poccmd", "hello"],
+      withPathToken: true,
+      expectedArgv: ({ pathToken }) => [pathToken!.expected, "hello"],
+      checkRawCommandMatchesArgv: true,
+    },
   ];
 
   for (const testCase of cases) {
@@ -81,6 +91,9 @@ describe("hardenApprovedExecutionPaths", () => {
           expect(prepared.plan.argv).toEqual(testCase.expectedArgv({ pathToken }));
           if (testCase.expectedCmdText) {
             expect(prepared.cmdText).toBe(testCase.expectedCmdText);
+          }
+          if (testCase.checkRawCommandMatchesArgv) {
+            expect(prepared.plan.rawCommand).toBe(formatExecCommand(prepared.plan.argv));
           }
           return;
         }

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -144,6 +144,7 @@ export function hardenApprovedExecutionPaths(params: {
   | {
       ok: true;
       argv: string[];
+      argvChanged: boolean;
       cwd: string | undefined;
       approvedCwdSnapshot: ApprovedCwdSnapshot | undefined;
     }
@@ -152,6 +153,7 @@ export function hardenApprovedExecutionPaths(params: {
     return {
       ok: true,
       argv: params.argv,
+      argvChanged: false,
       cwd: params.cwd,
       approvedCwdSnapshot: undefined,
     };
@@ -172,6 +174,7 @@ export function hardenApprovedExecutionPaths(params: {
     return {
       ok: true,
       argv: params.argv,
+      argvChanged: false,
       cwd: hardenedCwd,
       approvedCwdSnapshot,
     };
@@ -190,6 +193,7 @@ export function hardenApprovedExecutionPaths(params: {
     return {
       ok: true,
       argv: params.argv,
+      argvChanged: false,
       cwd: hardenedCwd,
       approvedCwdSnapshot,
     };
@@ -203,11 +207,22 @@ export function hardenApprovedExecutionPaths(params: {
     };
   }
 
+  if (pinnedExecutable === params.argv[0]) {
+    return {
+      ok: true,
+      argv: params.argv,
+      argvChanged: false,
+      cwd: hardenedCwd,
+      approvedCwdSnapshot,
+    };
+  }
+
   const argv = [...params.argv];
   argv[0] = pinnedExecutable;
   return {
     ok: true,
     argv,
+    argvChanged: true,
     cwd: hardenedCwd,
     approvedCwdSnapshot,
   };
@@ -239,10 +254,9 @@ export function buildSystemRunApprovalPlan(params: {
   if (!hardening.ok) {
     return { ok: false, message: hardening.message };
   }
-  const rawCommand =
-    hardening.argv === command.argv
-      ? command.cmdText.trim() || null
-      : formatExecCommand(hardening.argv) || null;
+  const rawCommand = hardening.argvChanged
+    ? formatExecCommand(hardening.argv) || null
+    : command.cmdText.trim() || null;
   return {
     ok: true,
     plan: {

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import type { SystemRunApprovalPlan } from "../infra/exec-approvals.js";
 import { resolveCommandResolutionFromArgv } from "../infra/exec-command-resolution.js";
 import { sameFileIdentity } from "../infra/file-identity.js";
-import { resolveSystemRunCommand } from "../infra/system-run-command.js";
+import { formatExecCommand, resolveSystemRunCommand } from "../infra/system-run-command.js";
 
 export type ApprovedCwdSnapshot = {
   cwd: string;
@@ -239,12 +239,16 @@ export function buildSystemRunApprovalPlan(params: {
   if (!hardening.ok) {
     return { ok: false, message: hardening.message };
   }
+  const rawCommand =
+    hardening.argv === command.argv
+      ? command.cmdText.trim() || null
+      : formatExecCommand(hardening.argv) || null;
   return {
     ok: true,
     plan: {
       argv: hardening.argv,
       cwd: hardening.cwd ?? null,
-      rawCommand: command.cmdText.trim() || null,
+      rawCommand,
       agentId: normalizeString(params.agentId),
       sessionKey: normalizeString(params.sessionKey),
     },

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it, type Mock, vi } from "vitest";
 import { saveExecApprovals } from "../infra/exec-approvals.js";
 import type { ExecHostResponse } from "../infra/exec-host.js";
+import { buildSystemRunApprovalPlan } from "./invoke-system-run-plan.js";
 import { handleSystemRunInvoke, formatSystemRunAllowlistMissMessage } from "./invoke-system-run.js";
 import type { HandleSystemRunInvokeOptions } from "./invoke-system-run.js";
 
@@ -233,6 +234,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     preferMacAppExecHost: boolean;
     runViaResponse?: ExecHostResponse | null;
     command?: string[];
+    rawCommand?: string | null;
     cwd?: string;
     security?: "full" | "allowlist";
     ask?: "off" | "on-miss" | "always";
@@ -286,6 +288,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       client: {} as never,
       params: {
         command: params.command ?? ["echo", "ok"],
+        rawCommand: params.rawCommand,
         cwd: params.cwd,
         approved: params.approved ?? false,
         sessionKey: "agent:main:main",
@@ -485,6 +488,39 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
             runCommand,
             expected,
             commandTail: ["-n", "SAFE"],
+          });
+          expectInvokeOk(sendInvokeResult);
+        },
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "accepts prepared plans after PATH-token hardening rewrites argv",
+    async () => {
+      await withPathTokenCommand({
+        tmpPrefix: "openclaw-prepare-run-path-pin-",
+        run: async ({ expected }) => {
+          const prepared = buildSystemRunApprovalPlan({
+            command: ["poccmd", "hello"],
+          });
+          expect(prepared.ok).toBe(true);
+          if (!prepared.ok) {
+            throw new Error("unreachable");
+          }
+
+          const { runCommand, sendInvokeResult } = await runSystemInvoke({
+            preferMacAppExecHost: false,
+            command: prepared.plan.argv,
+            rawCommand: prepared.plan.rawCommand,
+            approved: true,
+            security: "full",
+            ask: "off",
+          });
+          expectCommandPinnedToCanonicalPath({
+            runCommand,
+            expected,
+            commandTail: ["hello"],
           });
           expectInvokeOk(sendInvokeResult);
         },


### PR DESCRIPTION
## Summary

- **Problem:** Since 2026.3.2, all `nodes.run` (system.run) commands fail with "rawCommand does not match command". The security fix for GHSA-h3f9-mjwj-w476 added rawCommand/command[] consistency validation, but `hardenApprovedExecutionPaths` pins executables to absolute paths without updating rawCommand.
- **Why it matters:** Every nodes.run command is rejected — even `echo hello`. Remote node execution is completely broken.
- **What changed:** After hardening pins an executable to its absolute path, rawCommand is regenerated via `formatExecCommand(hardening.argv)` so the consistency check passes.
- **What did NOT change:** The security validation itself, hardening behavior, or any other exec tool behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33080

## User-visible / Behavior Changes

- `nodes.run` commands work again after the 2026.3.2 security fix.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` (restores pre-regression behavior)
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js + macOS companion app
- Integration/channel: nodes.run tool

### Steps

1. Update to 2026.3.2
2. Run any command via nodes.run (e.g. `["echo", "hello"]`)

### Expected

- Command executes normally.

### Actual

- Before fix: "rawCommand does not match command" rejection.
- After fix: Command executes, rawCommand matches hardened argv.

## Evidence

Identity comparison `hardening.argv === command.argv` detects when hardening created a new array. Test creates a PATH-resolvable symlink and verifies plan.rawCommand matches formatExecCommand(plan.argv).

## Human Verification (required)

- Verified scenarios: direct command, bash-wrapped command, command with arguments
- Edge cases checked: no-hardening case (argv unchanged), hardening with path pinning
- What I did **not** verify: Windows path resolution

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the rawCommand regeneration
- Files/config to restore: `src/node-host/invoke-system-run-plan.ts`
- Known bad symptoms: nodes.run would fail validation again

## Risks and Mitigations

- Risk: rawCommand mismatch in edge cases — Mitigated: only regenerates when hardening actually changes argv (identity check)
