### PR TITLE
fix(agents): use configured exec timeout for system.run.prepare call

### DIFF
--- a/src/agents/bash-tools.exec-host-node.invoke-timeout.test.ts
+++ b/src/agents/bash-tools.exec-host-node.invoke-timeout.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { callGateway } = vi.hoisted(() => ({
+  callGateway: vi.fn(),
+}));
+
+vi.mock("../gateway/call.js", () => ({ callGateway }));
+vi.mock("../infra/exec-obfuscation-detect.js", () => ({
+  detectCommandObfuscation: () => ({ detected: false, reasons: [] }),
+}));
+vi.mock("../logger.js", () => ({ logInfo: vi.fn() }));
+
+import { executeNodeHostCommand } from "./bash-tools.exec-host-node.js";
+
+const NODE_ID = "node-1";
+
+function createPreparePayload() {
+  return {
+    payload: {
+      cmdText: "openclaw gateway restart",
+      plan: {
+        argv: ["/bin/sh", "-c", "openclaw gateway restart"],
+        cwd: "/tmp",
+        rawCommand: "openclaw gateway restart",
+        agentId: null,
+        sessionKey: null,
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  callGateway.mockClear();
+});
+
+describe("executeNodeHostCommand invoke timeout propagation", () => {
+  it("uses computed invokeTimeoutMs for system.run.prepare instead of a hardcoded value", async () => {
+    const capturedTimeouts: { command: string; timeoutMs: number }[] = [];
+
+    callGateway.mockImplementation(async ({ method, params: gatewayParams, timeoutMs }) => {
+      if (method === "node.list") {
+        return {
+          nodes: [{ nodeId: NODE_ID, commands: ["system.run"] }],
+        };
+      }
+      if (method === "node.invoke") {
+        const command = (gatewayParams as { command?: string } | undefined)?.command;
+        capturedTimeouts.push({ command: command ?? "unknown", timeoutMs });
+        if (command === "system.run.prepare") {
+          return createPreparePayload();
+        }
+        return {
+          payload: { stdout: "ok", stderr: "", exitCode: 0, success: true },
+        };
+      }
+      throw new Error(`unexpected method: ${String(method)}`);
+    });
+
+    const defaultTimeoutSec = 1800;
+    const expectedInvokeTimeoutMs = defaultTimeoutSec * 1000 + 5_000;
+
+    await executeNodeHostCommand({
+      command: "openclaw gateway restart",
+      workdir: "/tmp",
+      env: {},
+      security: "full",
+      ask: "off",
+      defaultTimeoutSec,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+    });
+
+    expect(capturedTimeouts).toHaveLength(2);
+
+    const prepareCall = capturedTimeouts.find((c) => c.command === "system.run.prepare");
+    expect(prepareCall).toBeDefined();
+    expect(prepareCall!.timeoutMs).toBe(expectedInvokeTimeoutMs);
+
+    const runCall = capturedTimeouts.find((c) => c.command === "system.run");
+    expect(runCall).toBeDefined();
+    expect(runCall!.timeoutMs).toBe(expectedInvokeTimeoutMs);
+  });
+
+  it("respects explicit timeoutSec over defaultTimeoutSec for prepare call", async () => {
+    const capturedTimeouts: { command: string; timeoutMs: number }[] = [];
+
+    callGateway.mockImplementation(async ({ method, params: gatewayParams, timeoutMs }) => {
+      if (method === "node.list") {
+        return {
+          nodes: [{ nodeId: NODE_ID, commands: ["system.run"] }],
+        };
+      }
+      if (method === "node.invoke") {
+        const command = (gatewayParams as { command?: string } | undefined)?.command;
+        capturedTimeouts.push({ command: command ?? "unknown", timeoutMs });
+        if (command === "system.run.prepare") {
+          return createPreparePayload();
+        }
+        return {
+          payload: { stdout: "ok", stderr: "", exitCode: 0, success: true },
+        };
+      }
+      throw new Error(`unexpected method: ${String(method)}`);
+    });
+
+    const explicitTimeoutSec = 60;
+    const expectedInvokeTimeoutMs = explicitTimeoutSec * 1000 + 5_000;
+
+    await executeNodeHostCommand({
+      command: "openclaw gateway restart",
+      workdir: "/tmp",
+      env: {},
+      security: "full",
+      ask: "off",
+      timeoutSec: explicitTimeoutSec,
+      defaultTimeoutSec: 1800,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+    });
+
+    const prepareCall = capturedTimeouts.find((c) => c.command === "system.run.prepare");
+    expect(prepareCall).toBeDefined();
+    expect(prepareCall!.timeoutMs).toBe(expectedInvokeTimeoutMs);
+  });
+
+  it("enforces minimum 10s for invokeTimeoutMs on prepare call", async () => {
+    const capturedTimeouts: { command: string; timeoutMs: number }[] = [];
+
+    callGateway.mockImplementation(async ({ method, params: gatewayParams, timeoutMs }) => {
+      if (method === "node.list") {
+        return {
+          nodes: [{ nodeId: NODE_ID, commands: ["system.run"] }],
+        };
+      }
+      if (method === "node.invoke") {
+        const command = (gatewayParams as { command?: string } | undefined)?.command;
+        capturedTimeouts.push({ command: command ?? "unknown", timeoutMs });
+        if (command === "system.run.prepare") {
+          return createPreparePayload();
+        }
+        return {
+          payload: { stdout: "ok", stderr: "", exitCode: 0, success: true },
+        };
+      }
+      throw new Error(`unexpected method: ${String(method)}`);
+    });
+
+    await executeNodeHostCommand({
+      command: "echo hi",
+      workdir: "/tmp",
+      env: {},
+      security: "full",
+      ask: "off",
+      timeoutSec: 1,
+      defaultTimeoutSec: 1,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+    });
+
+    const prepareCall = capturedTimeouts.find((c) => c.command === "system.run.prepare");
+    expect(prepareCall).toBeDefined();
+    expect(prepareCall!.timeoutMs).toBe(10_000);
+  });
+});

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -93,10 +93,15 @@ export async function executeNodeHostCommand(
       "exec host=node requires a node that supports system.run (companion app or node host).",
     );
   }
+  const invokeTimeoutMs = Math.max(
+    10_000,
+    (typeof params.timeoutSec === "number" ? params.timeoutSec : params.defaultTimeoutSec) * 1000 +
+      5_000,
+  );
   const argv = buildNodeShellCommand(params.command, nodeInfo?.platform);
   const prepareRaw = await callGatewayTool<{ payload?: unknown }>(
     "node.invoke",
-    { timeoutMs: 15_000 },
+    { timeoutMs: invokeTimeoutMs },
     {
       nodeId,
       command: "system.run.prepare",
@@ -180,11 +185,6 @@ export async function executeNodeHostCommand(
       analysisOk,
       allowlistSatisfied,
     }) || obfuscation.detected;
-  const invokeTimeoutMs = Math.max(
-    10_000,
-    (typeof params.timeoutSec === "number" ? params.timeoutSec : params.defaultTimeoutSec) * 1000 +
-      5_000,
-  );
   const buildInvokeParams = (
     approvedByAsk: boolean,
     approvalDecision: "allow-once" | "allow-always" | null,


### PR DESCRIPTION
## Summary

- **Problem:** The `system.run.prepare` gateway call used a hardcoded 15-second timeout. Commands like `openclaw gateway restart` (10-15s) would time out during the prepare step, losing the exec result.
- **Why it matters:** Users see "missing tool result" transcript repair errors instead of actual command output for any command taking >15s.
- **What changed:** Moved `invokeTimeoutMs` computation before the prepare call and used it for both prepare and execution, ensuring the configured timeout (default 1800s) applies consistently.
- **What did NOT change:** Default exec timeout value, exec tool behavior, or transcript repair logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32933

## User-visible / Behavior Changes

- Long-running exec commands no longer fail with synthetic error during the prepare step.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js
- Integration/channel: Any (exec tool)

### Steps

1. Run `openclaw gateway restart` via the exec tool
2. Wait for the result

### Expected

- Command completes and returns output.

### Actual

- Before fix: Times out at 15s, synthetic error inserted.
- After fix: Uses configured timeout (default 1800s).

## Evidence

Test verifies system.run.prepare uses computed invokeTimeoutMs, explicit timeoutSec is respected, and 10s minimum floor is enforced.

## Human Verification (required)

- Verified scenarios: gateway restart, normal short commands, custom timeoutSec
- Edge cases checked: minimum timeout floor, default timeout
- What I did **not** verify: Very long commands (>30 minutes)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Restore hardcoded `{ timeoutMs: 15_000 }` for prepare call
- Files/config to restore: `src/agents/bash-tools.exec-host-node.ts`
- Known bad symptoms: Long commands would time out during prepare again

## Risks and Mitigations

None — aligns prepare timeout with execution timeout, which is the intended behavior.
