### PR TITLE
fix(telegram): prevent stale topic inheritance for topic-scoped sessions

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1392,6 +1392,47 @@ describe("initSessionState stale threadId fallback", () => {
     });
     expect(result.sessionEntry.lastThreadId).toBe(99);
   });
+
+  it("preserves thread ID 0 using nullish coalescing instead of logical OR", async () => {
+    const storePath = await createStorePath("thread-zero-");
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "topic zero",
+        SessionKey: "agent:main:main:topic:0",
+        MessageThreadId: 0,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(result.sessionEntry.lastThreadId).toBe(0);
+  });
+
+  it("does not inherit lastThreadId for topic-scoped session when MessageThreadId is absent", async () => {
+    const storePath = await createStorePath("topic-retry-");
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    await initSessionState({
+      ctx: {
+        Body: "first in topic",
+        SessionKey: "agent:main:main:topic:5",
+        MessageThreadId: 5,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    const retryResult = await initSessionState({
+      ctx: {
+        Body: "retry without threadId",
+        SessionKey: "agent:main:main:topic:5",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(retryResult.sessionEntry.lastThreadId).toBeUndefined();
+  });
 });
 
 describe("initSessionState dmScope delivery migration", () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -263,7 +263,10 @@ export async function initSessionState(params: {
   // Only fall back to persisted threadId for thread sessions.  Non-thread
   // sessions (e.g. DM without topics) must not inherit a stale threadId from a
   // previous interaction that happened inside a topic/thread.
-  const lastThreadIdRaw = ctx.MessageThreadId || (isThread ? baseEntry?.lastThreadId : undefined);
+  const isTopicScopedSession = sessionKey?.includes(":topic:");
+  const lastThreadIdRaw =
+    ctx.MessageThreadId ??
+    (isThread && !isTopicScopedSession ? baseEntry?.lastThreadId : undefined);
   const deliveryFields = normalizeSessionDeliveryFields({
     deliveryContext: {
       channel: lastChannelRaw,


### PR DESCRIPTION
## Summary

- **Problem:** After Anthropic API returns 529 (overloaded) and OpenClaw retries, the reply is sent to the wrong Telegram forum topic. When `ctx.MessageThreadId` was absent during retry, the code inherited a stale `lastThreadId` from a previous turn in a different topic.
- **Why it matters:** Users in Telegram forum groups see replies in the wrong topic or in the General topic.
- **What changed:** Used nullish coalescing (`??`) instead of logical OR (`||`) to preserve thread ID 0, and skip `lastThreadId` inheritance for topic-scoped sessions (sessionKey containing `:topic:`).
- **What did NOT change:** Thread ID handling for non-topic sessions, DM threads, or normal (non-retry) message flow.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32949

## User-visible / Behavior Changes

- Telegram forum replies stay in the correct topic after provider retries.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Telegram (forum groups)

### Steps

1. Send a message in a Telegram forum topic
2. Trigger Anthropic 529 (overload) causing retry
3. Check where the reply appears

### Expected

- Reply in the same topic as the original message.

### Actual

- Before fix: Reply in wrong topic or General.
- After fix: Reply in correct topic.

## Evidence

Test seeds session store with stale lastThreadId, calls initSessionState with `:topic:` session key but no MessageThreadId, and asserts lastThreadId is undefined.

## Human Verification (required)

- Verified scenarios: topic-scoped session retry, normal topic session, non-topic session
- Edge cases checked: thread ID 0 (preserved by ??), missing MessageThreadId
- What I did **not** verify: Cross-topic message batching

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Restore `||` and remove isTopicScopedSession guard
- Files/config to restore: `src/auto-reply/reply/session.ts`
- Known bad symptoms: Replies could go to wrong topic again

## Risks and Mitigations

- Risk: Non-topic sessions losing lastThreadId — Mitigated: guard only activates for `:topic:` session keys
