### PR TITLE
fix(telegram): canonicalize native command auth precedence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,7 @@
 - Signal: "update fly" => `fly ssh console -a flawd-bot -C "bash -lc 'cd /data/clawd/openclaw && git pull --rebase origin main'"` then `fly machines restart e825232f34d058 -a flawd-bot`.
 - When working on a GitHub Issue or PR, print the full URL at the end of the task.
 - When answering questions, respond with high-confidence answers only: verify in code; do not guess.
+- Command auth canonical rule: keep `commands.allowFrom` precedence in `src/auto-reply/command-auth.ts` via `resolveCanonicalCommandSenderAuthorization`; channel/native handlers must call that helper instead of reimplementing precedence logic, and auth-path changes must include parity tests.
 - Never update the Carbon dependency.
 - Any dependency with `pnpm.patchedDependencies` must use an exact version (no `^`/`~`).
 - Patching dependencies (pnpm patches, overrides, or vendored changes) requires explicit approval; do not do this by default.

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -250,6 +250,53 @@ function resolveSenderCandidates(params: {
   return normalized;
 }
 
+export function resolveCommandSenderCandidates(params: {
+  cfg: OpenClawConfig;
+  providerId?: ChannelId;
+  accountId?: string | null;
+  senderId?: string | null;
+  senderE164?: string | null;
+  from?: string | null;
+  chatType?: string | null;
+}): string[] {
+  const dock = params.providerId ? getChannelDock(params.providerId) : undefined;
+  return resolveSenderCandidates({
+    dock,
+    providerId: params.providerId,
+    cfg: params.cfg,
+    accountId: params.accountId,
+    senderId: params.senderId,
+    senderE164: params.senderE164,
+    from: params.from,
+    chatType: params.chatType,
+  });
+}
+
+// Canonical commands.allowFrom precedence for every command path (text + native).
+export function resolveCanonicalCommandSenderAuthorization(params: {
+  dock?: ChannelDock;
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  providerId?: ChannelId;
+  senderCandidates: string[];
+  fallbackAuthorized: boolean;
+}): boolean {
+  const commandsAllowFromList = resolveCommandsAllowFromList({
+    dock: params.dock,
+    cfg: params.cfg,
+    accountId: params.accountId,
+    providerId: params.providerId,
+  });
+  if (commandsAllowFromList === null) {
+    return params.fallbackAuthorized;
+  }
+  const commandsAllowAll = commandsAllowFromList.some((entry) => entry.trim() === "*");
+  if (commandsAllowAll) {
+    return true;
+  }
+  return params.senderCandidates.some((candidate) => commandsAllowFromList.includes(candidate));
+}
+
 export function resolveCommandAuthorization(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
@@ -260,14 +307,6 @@ export function resolveCommandAuthorization(params: {
   const dock = providerId ? getChannelDock(providerId) : undefined;
   const from = (ctx.From ?? "").trim();
   const to = (ctx.To ?? "").trim();
-
-  // Check if commands.allowFrom is configured (separate command authorization)
-  const commandsAllowFromList = resolveCommandsAllowFromList({
-    dock,
-    cfg,
-    accountId: ctx.AccountId,
-    providerId,
-  });
 
   const allowFromRaw = dock?.config?.resolveAllowFrom
     ? dock.config.resolveAllowFrom({ cfg, accountId: ctx.AccountId })
@@ -322,8 +361,7 @@ export function resolveCommandAuthorization(params: {
     ),
   );
 
-  const senderCandidates = resolveSenderCandidates({
-    dock,
+  const senderCandidates = resolveCommandSenderCandidates({
     providerId,
     cfg,
     accountId: ctx.AccountId,
@@ -351,21 +389,14 @@ export function resolveCommandAuthorization(params: {
       : ownerAllowlistConfigured
         ? senderIsOwner
         : allowAll || ownerCandidatesForCommands.length === 0 || Boolean(matchedCommandOwner);
-
-  // If commands.allowFrom is configured, use it for command authorization
-  // Otherwise, fall back to existing behavior (channel allowFrom + owner checks)
-  let isAuthorizedSender: boolean;
-  if (commandsAllowFromList !== null) {
-    // commands.allowFrom is configured - use it for authorization
-    const commandsAllowAll = commandsAllowFromList.some((entry) => entry.trim() === "*");
-    const matchedCommandsAllowFrom = commandsAllowFromList.length
-      ? senderCandidates.find((candidate) => commandsAllowFromList.includes(candidate))
-      : undefined;
-    isAuthorizedSender = commandsAllowAll || Boolean(matchedCommandsAllowFrom);
-  } else {
-    // Fall back to existing behavior
-    isAuthorizedSender = commandAuthorized && isOwnerForCommands;
-  }
+  const isAuthorizedSender = resolveCanonicalCommandSenderAuthorization({
+    dock,
+    cfg,
+    accountId: ctx.AccountId,
+    providerId,
+    senderCandidates,
+    fallbackAuthorized: commandAuthorized && isOwnerForCommands,
+  });
 
   return {
     providerId,

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -281,8 +281,9 @@ export function resolveCanonicalCommandSenderAuthorization(params: {
   senderCandidates: string[];
   fallbackAuthorized: boolean;
 }): boolean {
+  const dock = params.dock ?? (params.providerId ? getChannelDock(params.providerId) : undefined);
   const commandsAllowFromList = resolveCommandsAllowFromList({
-    dock: params.dock,
+    dock,
     cfg: params.cfg,
     accountId: params.accountId,
     providerId: params.providerId,

--- a/src/telegram/bot-native-commands.plugin-auth.test.ts
+++ b/src/telegram/bot-native-commands.plugin-auth.test.ts
@@ -23,6 +23,72 @@ vi.mock("../pairing/pairing-store.js", () => ({
 }));
 
 describe("registerTelegramNativeCommands (plugin auth)", () => {
+  function registerPluginCommandHandler(params: {
+    cfg: OpenClawConfig;
+    allowFrom?: string[];
+    groupAllowFrom?: string[];
+  }): {
+    handler: ((ctx: unknown) => Promise<void>) | undefined;
+    sendMessage: ReturnType<typeof vi.fn>;
+  } {
+    getPluginCommandSpecs.mockClear();
+    matchPluginCommand.mockClear();
+    executePluginCommand.mockClear();
+    deliverReplies.mockClear();
+
+    const command = {
+      name: "plugin",
+      description: "Plugin command",
+      requireAuth: true,
+      handler: vi.fn(),
+    } as const;
+
+    getPluginCommandSpecs.mockReturnValue([{ name: "plugin", description: "Plugin command" }]);
+    matchPluginCommand.mockReturnValue({ command, args: undefined });
+    executePluginCommand.mockResolvedValue({ text: "ok" });
+
+    const handlers: Record<string, (ctx: unknown) => Promise<void>> = {};
+    const sendMessage = vi.fn();
+    const bot = {
+      api: {
+        setMyCommands: vi.fn().mockResolvedValue(undefined),
+        sendMessage,
+      },
+      command: (name: string, handler: (ctx: unknown) => Promise<void>) => {
+        handlers[name] = handler;
+      },
+    } as const;
+
+    registerTelegramNativeCommands({
+      bot: bot as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+      cfg: params.cfg,
+      runtime: {} as unknown as RuntimeEnv,
+      accountId: "default",
+      telegramCfg: {} as TelegramAccountConfig,
+      allowFrom: params.allowFrom ?? [],
+      groupAllowFrom: params.groupAllowFrom ?? [],
+      replyToMode: "off",
+      textLimit: 4000,
+      useAccessGroups: false,
+      nativeEnabled: false,
+      nativeSkillsEnabled: false,
+      nativeDisabledExplicit: false,
+      resolveGroupPolicy: () =>
+        ({
+          allowlistEnabled: false,
+          allowed: true,
+        }) as ChannelGroupPolicy,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: undefined,
+        topicConfig: undefined,
+      }),
+      shouldSkipUpdate: () => false,
+      opts: { token: "token" },
+    });
+
+    return { handler: handlers.plugin, sendMessage };
+  }
+
   it("does not register plugin commands in menu when native=false but keeps handlers available", () => {
     const specs = Array.from({ length: 101 }, (_, i) => ({
       name: `cmd_${i}`,
@@ -153,5 +219,117 @@ describe("registerTelegramNativeCommands (plugin auth)", () => {
       }),
     );
     expect(bot.api.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("allows native group plugin commands via commands.allowFrom global override", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {
+        commands: {
+          allowFrom: {
+            "*": ["111"],
+          },
+        },
+      } as OpenClawConfig,
+      allowFrom: ["999"],
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: -100123, type: "supergroup" },
+        from: { id: 111, username: "allowed" },
+        message_id: 10,
+        date: 123456,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalledWith(
+      -100123,
+      "You are not authorized to use this command.",
+    );
+  });
+
+  it("allows native group plugin commands via commands.allowFrom provider-specific override", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {
+        commands: {
+          allowFrom: {
+            "*": ["global-user"],
+            telegram: ["111"],
+          },
+        },
+      } as OpenClawConfig,
+      allowFrom: ["999"],
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: -100456, type: "supergroup" },
+        from: { id: 111, username: "allowed" },
+        message_id: 11,
+        date: 123457,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalledWith(
+      -100456,
+      "You are not authorized to use this command.",
+    );
+  });
+
+  it("keeps native fallback authorization when commands.allowFrom is not configured", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {} as OpenClawConfig,
+      allowFrom: ["999"],
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: -100789, type: "supergroup" },
+        from: { id: 111, username: "denied" },
+        message_id: 12,
+        date: 123458,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      -100789,
+      "You are not authorized to use this command.",
+    );
+  });
+
+  it("prefers provider-specific commands.allowFrom over global for native auth", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {
+        commands: {
+          allowFrom: {
+            "*": ["111"],
+            telegram: ["222"],
+          },
+        },
+      } as OpenClawConfig,
+      allowFrom: ["999"],
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: -100987, type: "supergroup" },
+        from: { id: 111, username: "global-only" },
+        message_id: 13,
+        date: 123459,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      -100987,
+      "You are not authorized to use this command.",
+    );
   });
 });

--- a/src/telegram/bot-native-commands.plugin-auth.test.ts
+++ b/src/telegram/bot-native-commands.plugin-auth.test.ts
@@ -250,6 +250,35 @@ describe("registerTelegramNativeCommands (plugin auth)", () => {
     );
   });
 
+  it("allows native group plugin commands when commands.allowFrom uses telegram prefix", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {
+        commands: {
+          allowFrom: {
+            "*": ["telegram:111"],
+          },
+        },
+      } as OpenClawConfig,
+      allowFrom: ["999"],
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: -100124, type: "supergroup" },
+        from: { id: 111, username: "allowed" },
+        message_id: 14,
+        date: 123460,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalledWith(
+      -100124,
+      "You are not authorized to use this command.",
+    );
+  });
+
   it("allows native group plugin commands via commands.allowFrom provider-specific override", async () => {
     const { handler, sendMessage } = registerPluginCommandHandler({
       cfg: {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -1,5 +1,9 @@
 import type { Bot, Context } from "grammy";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
+import {
+  resolveCanonicalCommandSenderAuthorization,
+  resolveCommandSenderCandidates,
+} from "../auto-reply/command-auth.js";
 import type { CommandArgs } from "../auto-reply/commands-registry.js";
 import {
   buildCommandTextFromArgs,
@@ -284,7 +288,24 @@ async function resolveTelegramCommandAuth(params: {
     authorizers: [{ configured: dmAllow.hasEntries, allowed: senderAllowed }],
     modeWhenAccessGroupsOff: "configured",
   });
-  if (requireAuth && !commandAuthorized) {
+  const senderCandidates = resolveCommandSenderCandidates({
+    cfg,
+    providerId: "telegram",
+    accountId,
+    senderId,
+    from: isGroup ? buildTelegramGroupFrom(chatId, resolvedThreadId) : `telegram:${chatId}`,
+    chatType: isGroup ? "group" : "direct",
+  });
+  // Keep Telegram-specific prechecks above, but route final sender auth through the
+  // canonical command-auth helper so commands.allowFrom precedence cannot drift.
+  const commandAuthorizedWithOverrides = resolveCanonicalCommandSenderAuthorization({
+    cfg,
+    accountId,
+    providerId: "telegram",
+    senderCandidates,
+    fallbackAuthorized: commandAuthorized,
+  });
+  if (requireAuth && !commandAuthorizedWithOverrides) {
     return await rejectNotAuthorized();
   }
 
@@ -297,7 +318,7 @@ async function resolveTelegramCommandAuth(params: {
     senderUsername,
     groupConfig,
     topicConfig,
-    commandAuthorized,
+    commandAuthorized: commandAuthorizedWithOverrides,
   };
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram native command auth used a separate final authorization path and could bypass canonical `commands.allowFrom` precedence used by text-command auth.
- Why it matters: users can be rejected with `You are not authorized to use this command.` even when configured in `commands.allowFrom` (contract drift between native vs text paths).
- What changed: extracted canonical auth-precedence helper in `src/auto-reply/command-auth.ts`, reused it from `src/telegram/bot-native-commands.ts`, added native Telegram regression tests, and added an `AGENTS.md` rule to keep precedence canonicalized.
- What did NOT change (scope boundary): Telegram group/topic base checks and policy checks remain as-is; fallback behavior when `commands.allowFrom` is not configured remains as-is; no non-Telegram channel behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28216
- Related #30234

## User-visible / Behavior Changes

- Telegram native commands now honor canonical `commands.allowFrom` precedence in the same way as text-command flow.
- Provider-specific command allowlists (for example `commands.allowFrom.telegram`) override global `*` in native Telegram flow, matching documented behavior.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
- Risk: authorization behavior changed in native Telegram command path.
- Mitigation: centralized precedence logic in canonical helper + explicit regression tests for global override, provider-specific override, and fallback behavior.

## Repro + Verification

### Environment

- OS: Linux (local dev)
- Runtime/container: Node 22 + pnpm 10 + Vitest 4
- Model/provider: N/A
- Integration/channel (if any): Telegram native commands
- Relevant config (redacted):
- `commands.allowFrom: { "*": ["111"] }`
- `commands.allowFrom: { "*": ["global-user"], telegram: ["111"] }`
- `channels.telegram.allowFrom: ["999"]` (fallback path test)

### Steps

1. Configure Telegram native command path with `commands.allowFrom` global and provider-specific variants.
2. Trigger native command handler in group context for matching/non-matching sender IDs.
3. Run targeted tests for Telegram native auth and canonical command auth.

### Expected

- Native Telegram command auth follows documented `commands.allowFrom` precedence (provider-specific over global, and override of fallback auth).

### Actual

- Before fix: native path could reject authorized senders because it used a separate final auth decision.
- After fix: native path uses canonical precedence and passes regression tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Added tests that failed before implementation and pass after:
- `src/telegram/bot-native-commands.plugin-auth.test.ts` global `commands.allowFrom` override
- `src/telegram/bot-native-commands.plugin-auth.test.ts` provider-specific override
- `src/telegram/bot-native-commands.plugin-auth.test.ts` fallback unchanged when `commands.allowFrom` unset
- `src/telegram/bot-native-commands.plugin-auth.test.ts` provider-specific beats global
- Ran `pnpm test src/telegram/bot-native-commands.plugin-auth.test.ts` (pass).
- Ran `pnpm test src/auto-reply/command-control.test.ts` (pass).
- Edge cases checked:
- Group sender IDs through canonical normalization path.
- Override precedence and fallback behavior parity.
- What you did **not** verify:
- Live Telegram bot/manual end-to-end execution with real network.
- Full repo test suite.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
- None.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Set `commands.native=false` (or `channels.telegram.commands.native=false`) to disable native command path temporarily.
- Revert changes in:
- `src/auto-reply/command-auth.ts`
- `src/telegram/bot-native-commands.ts`
- `src/telegram/bot-native-commands.plugin-auth.test.ts`
- `AGENTS.md`
- Known bad symptoms reviewers should watch for:
- Authorized senders in `commands.allowFrom` still rejected in Telegram native group commands.
- Unauthorized senders unexpectedly allowed after override configs.

## Risks and Mitigations

- Risk: sender normalization differences between native context and canonical helper could cause false deny/allow.
- Mitigation: helper reuses existing normalization path and added explicit regression tests for precedence and fallback.
- Risk: future native handlers re-implement precedence logic and drift again.
- Mitigation: added canonical rule in `AGENTS.md` plus in-code comment at Telegram call site.
- Risk: unrelated baseline test failure may distract review signal.
- Mitigation: documented pre-existing failure (`src/telegram/bot-native-commands.test.ts:148`) confirmed on clean `upstream/main`.

https://github.com/openclaw/openclaw/issues/28216  
https://github.com/openclaw/openclaw/issues/30234
