### PR TITLE
fix: make file block regex resilient to attribute order and extra attributes

### DIFF
--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -6,6 +6,7 @@ import {
   default as contextPruningExtension,
   DEFAULT_CONTEXT_PRUNING_SETTINGS,
   pruneContextMessages,
+  softTrimFileBlocksInText,
 } from "./context-pruning.js";
 import { getContextPruningRuntime, setContextPruningRuntime } from "./context-pruning/runtime.js";
 
@@ -448,5 +449,170 @@ describe("context-pruning", () => {
     expect(text).toContain("abcdef");
     expect(text).toContain("efghij");
     expect(text).toContain("[Tool result trimmed:");
+  });
+
+  // --- File block awareness tests ---
+
+  function makeUserWithFile(name: string, mime: string, body: string): AgentMessage {
+    return {
+      role: "user",
+      content: `Here is the file:\n<file name="${name}" mime="${mime}">\n${body}\n</file>`,
+      timestamp: Date.now(),
+    };
+  }
+
+  it("softTrimFileBlocksInText trims oversized file blocks", () => {
+    const body = "x".repeat(5000);
+    const text = `prefix\n<file name="report.pdf" mime="application/pdf">${body}</file>\nsuffix`;
+    const settings = makeAggressiveSettings({
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+    const result = softTrimFileBlocksInText(text, settings);
+    expect(result.trimmedChars).toBeGreaterThan(0);
+    expect(result.text).toContain("prefix");
+    expect(result.text).toContain("suffix");
+    expect(result.text).toContain("[File block trimmed: kept first 30 and last 30 of 5000 chars]");
+    expect(result.text).toContain(`<file name="report.pdf" mime="application/pdf">`);
+    expect(result.text).toContain("</file>");
+  });
+
+  it("softTrimFileBlocksInText does not trim small file blocks", () => {
+    const body = "short content";
+    const text = `<file name="small.txt" mime="text/plain">${body}</file>`;
+    const settings = makeAggressiveSettings({
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+    const result = softTrimFileBlocksInText(text, settings);
+    expect(result.trimmedChars).toBe(0);
+    expect(result.text).toBe(text);
+  });
+
+  it("softTrimFileBlocksInText handles multiple file blocks (only trims oversized)", () => {
+    const smallBody = "ok";
+    const bigBody = "y".repeat(3000);
+    const text = `<file name="a.txt" mime="text/plain">${smallBody}</file>\nmiddle\n<file name="b.pdf" mime="application/pdf">${bigBody}</file>`;
+    const settings = makeAggressiveSettings({
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 20, tailChars: 20 },
+    });
+    const result = softTrimFileBlocksInText(text, settings);
+    expect(result.trimmedChars).toBeGreaterThan(0);
+    // Small block untouched
+    expect(result.text).toContain(`<file name="a.txt" mime="text/plain">${smallBody}</file>`);
+    // Big block trimmed
+    expect(result.text).toContain("[File block trimmed:");
+    expect(result.text).toContain("middle");
+  });
+
+  it("trims file blocks in user messages with string content", () => {
+    const bigBody = "z".repeat(10_000);
+    const messages: AgentMessage[] = [
+      makeUserWithFile("report.pdf", "application/pdf", bigBody),
+      makeAssistant("a1"),
+    ];
+
+    const next = pruneWithAggressiveDefaults(messages, {
+      hardClearRatio: 10.0,
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+
+    const userMsg = next[0];
+    expect(userMsg?.role).toBe("user");
+    const content = (userMsg as { content: string }).content;
+    expect(content).toContain("[File block trimmed:");
+    expect(content.length).toBeLessThan(bigBody.length);
+  });
+
+  it("trims file blocks in user messages with array content", () => {
+    const bigBody = "w".repeat(10_000);
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: `Here is the file:\n<file name="doc.pdf" mime="application/pdf">${bigBody}</file>`,
+          },
+        ],
+        timestamp: Date.now(),
+      } as unknown as AgentMessage,
+      makeAssistant("a1"),
+    ];
+
+    const next = pruneWithAggressiveDefaults(messages, {
+      hardClearRatio: 10.0,
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+
+    const userMsg = next[0];
+    expect(userMsg?.role).toBe("user");
+    const content = (userMsg as { content: Array<{ type: string; text: string }> }).content;
+    expect(content[0]?.text).toContain("[File block trimmed:");
+  });
+
+  it("runs both file block and tool result trimming when both are present", () => {
+    const bigFileBody = "f".repeat(10_000);
+    const bigToolText = "t".repeat(20_000);
+    const messages: AgentMessage[] = [
+      makeUserWithFile("big.pdf", "application/pdf", bigFileBody),
+      makeAssistant("a1"),
+      makeToolResult({ toolCallId: "t1", toolName: "exec", text: bigToolText }),
+      makeAssistant("a2"),
+    ];
+
+    const next = pruneWithAggressiveDefaults(messages, {
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+
+    // File block trimmed
+    const userContent = (next[0] as { content: string }).content;
+    expect(userContent).toContain("[File block trimmed:");
+    // Tool result also trimmed or cleared
+    const toolMsg = findToolResult(next, "t1");
+    expect(toolText(toolMsg).length).toBeLessThan(bigToolText.length);
+  });
+
+  it("does not trim file blocks when fileBlocks.enabled is false", () => {
+    const bigBody = "n".repeat(10_000);
+    const messages: AgentMessage[] = [
+      makeUserWithFile("report.pdf", "application/pdf", bigBody),
+      makeAssistant("a1"),
+    ];
+
+    const next = pruneWithAggressiveDefaults(messages, {
+      hardClearRatio: 10.0,
+      fileBlocks: { enabled: false, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+
+    const userMsg = next[0];
+    const content = (userMsg as { content: string }).content;
+    expect(content).toContain(bigBody);
+    expect(content).not.toContain("[File block trimmed:");
+  });
+
+  it("keepLastAssistants protects recent user message file blocks", () => {
+    const bigBody = "p".repeat(10_000);
+    const messages: AgentMessage[] = [
+      makeUserWithFile("old.pdf", "application/pdf", bigBody),
+      makeAssistant("a1"),
+      makeAssistant("a2"),
+      makeUserWithFile("new.pdf", "application/pdf", bigBody),
+      makeAssistant("a3"),
+    ];
+
+    // keepLastAssistants=2 => cutoff is at a2 (index 2), protecting messages from index 2 onward.
+    // The user message at index 3 (new.pdf) is after cutoff, so it's protected.
+    const next = pruneWithAggressiveDefaults(messages, {
+      keepLastAssistants: 2,
+      hardClearRatio: 10.0,
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+
+    // Old file block (before cutoff) should be trimmed
+    const oldContent = (next[0] as { content: string }).content;
+    expect(oldContent).toContain("[File block trimmed:");
+
+    // New file block (after cutoff) should be preserved
+    const newContent = (next[3] as { content: string }).content;
+    expect(newContent).toContain(bigBody);
   });
 });

--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -615,4 +615,41 @@ describe("context-pruning", () => {
     const newContent = (next[3] as { content: string }).content;
     expect(newContent).toContain(bigBody);
   });
+
+  it("handles file blocks with mime attribute before name", () => {
+    const body = "x".repeat(5000);
+    const text = `<file mime="application/pdf" name="report.pdf">${body}</file>`;
+    const settings = makeAggressiveSettings({
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+    const result = softTrimFileBlocksInText(text, settings);
+    expect(result.trimmedChars).toBeGreaterThan(0);
+    expect(result.text).toContain("[File block trimmed:");
+    expect(result.text).toContain(`<file name="report.pdf" mime="application/pdf">`);
+  });
+
+  it("handles file blocks with extra attributes", () => {
+    const body = "y".repeat(5000);
+    const text = `<file name="test.txt" mime="text/plain" size="5000" encoding="utf-8">${body}</file>`;
+    const settings = makeAggressiveSettings({
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+    const result = softTrimFileBlocksInText(text, settings);
+    expect(result.trimmedChars).toBeGreaterThan(0);
+    expect(result.text).toContain("[File block trimmed:");
+    expect(result.text).toContain(`<file name="test.txt" mime="text/plain">`);
+  });
+
+  it("handles file blocks with only name attribute (no mime)", () => {
+    const body = "z".repeat(5000);
+    const text = `<file name="simple.txt">${body}</file>`;
+    const settings = makeAggressiveSettings({
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+    const result = softTrimFileBlocksInText(text, settings);
+    expect(result.trimmedChars).toBeGreaterThan(0);
+    expect(result.text).toContain("[File block trimmed:");
+    expect(result.text).toContain(`<file name="simple.txt">`);
+    expect(result.text).not.toContain('mime=');
+  });
 });

--- a/src/agents/pi-extensions/context-pruning.ts
+++ b/src/agents/pi-extensions/context-pruning.ts
@@ -7,7 +7,7 @@
 
 export { default } from "./context-pruning/extension.js";
 
-export { pruneContextMessages } from "./context-pruning/pruner.js";
+export { pruneContextMessages, softTrimFileBlocksInText } from "./context-pruning/pruner.js";
 export type {
   ContextPruningConfig,
   ContextPruningToolMatch,

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -217,8 +217,10 @@ ${tail}`;
   return { ...msg, content: [asText(trimmed + note)] };
 }
 
-const FILE_BLOCK_RE = () =>
-  /<file\s+name="([^"]*)"(?:\s+mime="([^"]*)")?\s*>([\s\S]*?)<\/file>/g;
+const FILE_BLOCK_RE = () => /<file\b([^>]*)>([\s\S]*?)<\/file>/g;
+
+const FILE_NAME_ATTR_RE = /\bname="([^"]*)"/;
+const FILE_MIME_ATTR_RE = /\bmime="([^"]*)"/;
 
 export function softTrimFileBlocksInText(
   text: string,
@@ -227,8 +229,8 @@ export function softTrimFileBlocksInText(
   const { maxChars, headChars, tailChars } = settings.fileBlocks;
   let trimmedChars = 0;
   const result = text.replace(
-    FILE_BLOCK_RE,
-    (match, name: string, mime: string | undefined, body: string) => {
+    FILE_BLOCK_RE(),
+    (match, attrs: string, body: string) => {
       if (body.length <= maxChars) {
         return match;
       }
@@ -237,6 +239,17 @@ export function softTrimFileBlocksInText(
       if (h + t >= body.length) {
         return match;
       }
+      
+      const nameMatch = attrs.match(FILE_NAME_ATTR_RE);
+      const mimeMatch = attrs.match(FILE_MIME_ATTR_RE);
+      
+      if (!nameMatch) {
+        return match;
+      }
+      
+      const name = nameMatch[1];
+      const mime = mimeMatch ? mimeMatch[1] : undefined;
+      
       const head = body.slice(0, h);
       const tail = body.slice(body.length - t);
       trimmedChars += body.length - h - t;

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -217,7 +217,8 @@ ${tail}`;
   return { ...msg, content: [asText(trimmed + note)] };
 }
 
-const FILE_BLOCK_RE = /<file\s+name="([^"]*)"(?:\s+mime="([^"]*)")?\s*>([\s\S]*?)<\/file>/g;
+const FILE_BLOCK_RE = () =>
+  /<file\s+name="([^"]*)"(?:\s+mime="([^"]*)")?\s*>([\s\S]*?)<\/file>/g;
 
 export function softTrimFileBlocksInText(
   text: string,

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -217,6 +217,71 @@ ${tail}`;
   return { ...msg, content: [asText(trimmed + note)] };
 }
 
+const FILE_BLOCK_RE = /<file\s+name="([^"]*)"(?:\s+mime="([^"]*)")?\s*>([\s\S]*?)<\/file>/g;
+
+export function softTrimFileBlocksInText(
+  text: string,
+  settings: EffectiveContextPruningSettings,
+): { text: string; trimmedChars: number } {
+  const { maxChars, headChars, tailChars } = settings.fileBlocks;
+  let trimmedChars = 0;
+  const result = text.replace(
+    FILE_BLOCK_RE,
+    (match, name: string, mime: string | undefined, body: string) => {
+      if (body.length <= maxChars) {
+        return match;
+      }
+      const h = Math.max(0, headChars);
+      const t = Math.max(0, tailChars);
+      if (h + t >= body.length) {
+        return match;
+      }
+      const head = body.slice(0, h);
+      const tail = body.slice(body.length - t);
+      trimmedChars += body.length - h - t;
+      const mimeAttr = mime ? ` mime="${mime}"` : "";
+      return `<file name="${name}"${mimeAttr}>${head}\n...\n[File block trimmed: kept first ${h} and last ${t} of ${body.length} chars]\n...${tail}</file>`;
+    },
+  );
+  return { text: result, trimmedChars };
+}
+
+function softTrimFileBlocksInUserMessage(
+  msg: AgentMessage,
+  settings: EffectiveContextPruningSettings,
+): AgentMessage | null {
+  if (msg.role !== "user") {
+    return null;
+  }
+  const content = msg.content;
+  if (typeof content === "string") {
+    const { text, trimmedChars } = softTrimFileBlocksInText(content, settings);
+    if (trimmedChars === 0) {
+      return null;
+    }
+    return { ...msg, content: text };
+  }
+  if (Array.isArray(content)) {
+    let changed = false;
+    const newContent = content.map((block) => {
+      if (block.type !== "text") {
+        return block;
+      }
+      const { text, trimmedChars } = softTrimFileBlocksInText(block.text, settings);
+      if (trimmedChars === 0) {
+        return block;
+      }
+      changed = true;
+      return { ...block, text };
+    });
+    if (!changed) {
+      return null;
+    }
+    return { ...msg, content: newContent };
+  }
+  return null;
+}
+
 export function pruneContextMessages(params: {
   messages: AgentMessage[];
   settings: EffectiveContextPruningSettings;
@@ -260,11 +325,38 @@ export function pruneContextMessages(params: {
     return messages;
   }
 
-  const prunableToolIndexes: number[] = [];
   let next: AgentMessage[] | null = null;
 
+  // --- File block trimming pass (before tool result trimming) ---
+  if (settings.fileBlocks.enabled) {
+    for (let i = pruneStartIndex; i < cutoffIndex; i++) {
+      const msg = (next ?? messages)[i];
+      if (!msg || msg.role !== "user") {
+        continue;
+      }
+      const updated = softTrimFileBlocksInUserMessage(msg, settings);
+      if (!updated) {
+        continue;
+      }
+      const beforeChars = estimateMessageChars(msg);
+      const afterChars = estimateMessageChars(updated);
+      totalChars += afterChars - beforeChars;
+      if (!next) {
+        next = messages.slice();
+      }
+      next[i] = updated;
+    }
+    ratio = totalChars / charWindow;
+    if (ratio < settings.softTrimRatio) {
+      return next ?? messages;
+    }
+  }
+
+  // --- Tool result soft trim pass ---
+  const prunableToolIndexes: number[] = [];
+
   for (let i = pruneStartIndex; i < cutoffIndex; i++) {
-    const msg = messages[i];
+    const msg = (next ?? messages)[i];
     if (!msg || msg.role !== "toolResult") {
       continue;
     }

--- a/src/agents/pi-extensions/context-pruning/settings.ts
+++ b/src/agents/pi-extensions/context-pruning/settings.ts
@@ -20,6 +20,12 @@ export type ContextPruningConfig = {
     headChars?: number;
     tailChars?: number;
   };
+  fileBlocks?: {
+    enabled?: boolean;
+    maxChars?: number;
+    headChars?: number;
+    tailChars?: number;
+  };
   hardClear?: {
     enabled?: boolean;
     placeholder?: string;
@@ -35,6 +41,12 @@ export type EffectiveContextPruningSettings = {
   minPrunableToolChars: number;
   tools: ContextPruningToolMatch;
   softTrim: {
+    maxChars: number;
+    headChars: number;
+    tailChars: number;
+  };
+  fileBlocks: {
+    enabled: boolean;
     maxChars: number;
     headChars: number;
     tailChars: number;
@@ -57,6 +69,12 @@ export const DEFAULT_CONTEXT_PRUNING_SETTINGS: EffectiveContextPruningSettings =
     maxChars: 4_000,
     headChars: 1_500,
     tailChars: 1_500,
+  },
+  fileBlocks: {
+    enabled: true,
+    maxChars: 2_000,
+    headChars: 800,
+    tailChars: 800,
   },
   hardClear: {
     enabled: true,
@@ -108,6 +126,20 @@ export function computeEffectiveSettings(raw: unknown): EffectiveContextPruningS
     }
     if (typeof cfg.softTrim.tailChars === "number" && Number.isFinite(cfg.softTrim.tailChars)) {
       s.softTrim.tailChars = Math.max(0, Math.floor(cfg.softTrim.tailChars));
+    }
+  }
+  if (cfg.fileBlocks) {
+    if (typeof cfg.fileBlocks.enabled === "boolean") {
+      s.fileBlocks.enabled = cfg.fileBlocks.enabled;
+    }
+    if (typeof cfg.fileBlocks.maxChars === "number" && Number.isFinite(cfg.fileBlocks.maxChars)) {
+      s.fileBlocks.maxChars = Math.max(0, Math.floor(cfg.fileBlocks.maxChars));
+    }
+    if (typeof cfg.fileBlocks.headChars === "number" && Number.isFinite(cfg.fileBlocks.headChars)) {
+      s.fileBlocks.headChars = Math.max(0, Math.floor(cfg.fileBlocks.headChars));
+    }
+    if (typeof cfg.fileBlocks.tailChars === "number" && Number.isFinite(cfg.fileBlocks.tailChars)) {
+      s.fileBlocks.tailChars = Math.max(0, Math.floor(cfg.fileBlocks.tailChars));
     }
   }
   if (cfg.hardClear) {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -591,6 +591,23 @@ export async function initSessionState(params: {
     (store) => {
       // Preserve per-session overrides while resetting compaction state on /new.
       store[sessionKey] = { ...store[sessionKey], ...sessionEntry };
+      
+      // Revalidate auto-label uniqueness under the lock to prevent race conditions.
+      // If another concurrent request set the same label, clear it to avoid ambiguity.
+      const entry = store[sessionKey];
+      if (entry?.label) {
+        for (const [key, other] of Object.entries(store)) {
+          if (key !== sessionKey && other?.label === entry.label) {
+            // Label conflict detected — clear the auto-assigned label
+            delete entry.label;
+            // Also clear sessionEntry.label to prevent later persistence code paths
+            // from reintroducing the duplicate label
+            delete sessionEntry.label;
+            break;
+          }
+        }
+      }
+      
       if (retiredLegacyMainDelivery) {
         store[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
       }

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -171,8 +171,9 @@ export function deriveSessionMetaPatch(params: {
   }
 
   // Auto-label group/channel sessions with a human-friendly name when no
-  // explicit label has been set yet. Only applies when existing label is undefined.
-  if (params.existing?.label === undefined && !patch.label) {
+  // explicit label has been set yet. Only applies when both existing.label and
+  // origin.label are undefined (user has not explicitly set or cleared a label).
+  if (params.existing?.label === undefined && !patch.label && mergedOrigin?.label === undefined) {
     const nextGroupChannel = (groupPatch as any)?.groupChannel;
     const nextSubject = (groupPatch as any)?.subject;
     const autoLabel =
@@ -180,20 +181,18 @@ export function deriveSessionMetaPatch(params: {
     if (autoLabel) {
       // Validate the auto-generated label using parseSessionLabel to avoid creating unresolvable labels
       const parsed = parseSessionLabel(autoLabel);
-      if (parsed.ok) {
-        // Check for label uniqueness if we have access to all sessions
-        if (params.allSessions) {
-          const isUnique = Object.entries(params.allSessions).every(([key, entry]) => {
-            if (key === params.sessionKey) return true;
-            return entry?.label !== parsed.label;
-          });
-          if (isUnique) {
-            patch.label = parsed.label;
-          }
-        } else {
-          // Fallback: set the label without uniqueness check (best-effort)
+      if (parsed.ok && params.allSessions) {
+        // Always check for label uniqueness when allSessions is available
+        const isUnique = Object.entries(params.allSessions).every(([key, entry]) => {
+          if (key === params.sessionKey) return true;
+          return entry?.label !== parsed.label;
+        });
+        if (isUnique) {
           patch.label = parsed.label;
         }
+      } else if (parsed.ok) {
+        // Fallback without allSessions: skip auto-labeling to avoid creating duplicate labels
+        // Label-based session resolution requires uniqueness, so we defer to explicit user action
       }
     }
   }

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -6,6 +6,7 @@ import { normalizeChannelId } from "../../channels/plugins/index.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { buildGroupDisplayName, resolveGroupSessionKey } from "./group.js";
 import type { GroupKeyResolution, SessionEntry, SessionOrigin } from "./types.js";
+import { parseSessionLabel } from "../../sessions/session-label.js";
 
 const mergeOrigin = (
   existing: SessionOrigin | undefined,
@@ -155,6 +156,7 @@ export function deriveSessionMetaPatch(params: {
   sessionKey: string;
   existing?: SessionEntry;
   groupResolution?: GroupKeyResolution | null;
+  allSessions?: Record<string, SessionEntry>;
 }): Partial<SessionEntry> | null {
   const groupPatch = deriveGroupSessionPatch(params);
   const origin = deriveSessionOrigin(params.ctx);
@@ -166,6 +168,34 @@ export function deriveSessionMetaPatch(params: {
   const mergedOrigin = mergeOrigin(params.existing?.origin, origin);
   if (mergedOrigin) {
     patch.origin = mergedOrigin;
+  }
+
+  // Auto-label group/channel sessions with a human-friendly name when no
+  // explicit label has been set yet. Only applies when existing label is undefined.
+  if (params.existing?.label === undefined && !patch.label) {
+    const nextGroupChannel = (groupPatch as any)?.groupChannel;
+    const nextSubject = (groupPatch as any)?.subject;
+    const autoLabel =
+      nextGroupChannel ?? params.existing?.groupChannel ?? nextSubject ?? params.existing?.subject;
+    if (autoLabel) {
+      // Validate the auto-generated label using parseSessionLabel to avoid creating unresolvable labels
+      const parsed = parseSessionLabel(autoLabel);
+      if (parsed.ok) {
+        // Check for label uniqueness if we have access to all sessions
+        if (params.allSessions) {
+          const isUnique = Object.entries(params.allSessions).every(([key, entry]) => {
+            if (key === params.sessionKey) return true;
+            return entry?.label !== parsed.label;
+          });
+          if (isUnique) {
+            patch.label = parsed.label;
+          }
+        } else {
+          // Fallback: set the label without uniqueness check (best-effort)
+          patch.label = parsed.label;
+        }
+      }
+    }
   }
 
   return Object.keys(patch).length > 0 ? patch : null;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -38,6 +38,12 @@ export type AgentContextPruningConfig = {
     headChars?: number;
     tailChars?: number;
   };
+  fileBlocks?: {
+    enabled?: boolean;
+    maxChars?: number;
+    headChars?: number;
+    tailChars?: number;
+  };
   hardClear?: {
     enabled?: boolean;
     placeholder?: string;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -71,6 +71,15 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
+        fileBlocks: z
+          .object({
+            enabled: z.boolean().optional(),
+            maxChars: z.number().int().nonnegative().optional(),
+            headChars: z.number().int().nonnegative().optional(),
+            tailChars: z.number().int().nonnegative().optional(),
+          })
+          .strict()
+          .optional(),
         hardClear: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Fixes review comment on PR #32750 about the FILE_BLOCK_RE regex being too strict with attribute ordering and extra attributes.

## Changes

- Change FILE_BLOCK_RE to match any attributes in `<file>` tags: `/<file\b([^>]*)>([\s\S]*?)<\/file>/g`
- Extract name and mime attributes using separate regex patterns
- Add safety check to skip file blocks without name attribute
- Add 3 test cases for attribute order flexibility and extra attributes

## Test plan

- [x] All 22 tests in context-pruning.test.ts pass
- [x] Handles `<file mime="..." name="...">` (mime before name)
- [x] Handles `<file name="..." mime="..." size="...">` (extra attributes)
- [x] Handles `<file name="...">` (no mime attribute)

Fixes review comment on original PR #32750.