### PR TITLE
fix: normalize Feishu delivery target for cron duplicate suppression

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -21,6 +21,21 @@ import {
   waitForDescendantSubagentSummary,
 } from "./subagent-followup.js";
 
+function normalizeDeliveryTarget(channel: string, to: string): string {
+  const channelLower = channel.trim().toLowerCase();
+  const toTrimmed = to.trim();
+  if (channelLower === "feishu" || channelLower === "lark") {
+    const lowered = toTrimmed.toLowerCase();
+    if (lowered.startsWith("user:")) {
+      return toTrimmed.slice("user:".length).trim();
+    }
+    if (lowered.startsWith("chat:")) {
+      return toTrimmed.slice("chat:".length).trim();
+    }
+  }
+  return toTrimmed;
+}
+
 export function matchesMessagingToolDeliveryTarget(
   target: { provider?: string; to?: string; accountId?: string },
   delivery: { channel?: string; to?: string; accountId?: string },
@@ -36,7 +51,8 @@ export function matchesMessagingToolDeliveryTarget(
   if (target.accountId && delivery.accountId && target.accountId !== delivery.accountId) {
     return false;
   }
-  return target.to === delivery.to;
+  const normalizedDeliveryTo = normalizeDeliveryTarget(channel, delivery.to);
+  return target.to === normalizedDeliveryTo;
 }
 
 export function resolveCronDeliveryBestEffort(job: CronJob): boolean {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -51,8 +51,11 @@ export function matchesMessagingToolDeliveryTarget(
   if (target.accountId && delivery.accountId && target.accountId !== delivery.accountId) {
     return false;
   }
+  // Normalize both target.to and delivery.to for Feishu/Lark to handle cases where
+  // messaging tool records targets with prefixes (user:ou_xxx) when provider is "message"
+  const normalizedTargetTo = normalizeDeliveryTarget(channel, target.to);
   const normalizedDeliveryTo = normalizeDeliveryTarget(channel, delivery.to);
-  return target.to === normalizedDeliveryTo;
+  return normalizedTargetTo === normalizedDeliveryTo;
 }
 
 export function resolveCronDeliveryBestEffort(job: CronJob): boolean {

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -845,13 +845,30 @@ function resolveFeishuSession(
     accountId: params.accountId,
     peer,
   });
+
+  // Normalize the session "to" field so that downstream tooling (including the
+  // message tool in isolated/cron runs) sees the same Feishu target shapes as
+  // the main session:
+  // - DM/user targets -> user:ou_xxx
+  // - Chat/group targets -> chat:oc_xxx
+  // This keeps DeliveryContext.To aligned with the Feishu plugin's
+  // normalizeFeishuTarget/looksLikeFeishuId helpers and avoids
+  // Unknown target "user" for Feishu / missing-target errors when the
+  // message tool infers its default target from the session route.
+  const to =
+    isGroup || idLower.startsWith("oc_")
+      ? `chat:${trimmed}`
+      : idLower.startsWith("ou_") || idLower.startsWith("on_")
+        ? `user:${trimmed}`
+        : trimmed;
+
   return {
     sessionKey: baseSessionKey,
     baseSessionKey,
     peer,
     chatType: isGroup ? "group" : "direct",
     from: isGroup ? `feishu:group:${trimmed}` : `feishu:${trimmed}`,
-    to: trimmed,
+    to,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes review comment on PR #32755 about Feishu session target normalization causing cron duplicate suppression to fail.

## Problem

When `resolveFeishuSession` normalizes the `to` field to `user:ou_xxx` or `chat:oc_xxx` format, it conflicts with the messaging tool's target extraction which uses `normalizeFeishuTarget()` to strip prefixes and return bare IDs (`ou_xxx`).

The cron duplicate suppression uses exact string comparison in `matchesMessagingToolDeliveryTarget()`, causing:
- `target.to` = `ou_xxx` (from messaging tool, normalized)
- `delivery.to` = `user:ou_xxx` (from session, prefixed)
- Comparison fails → duplicate delivery occurs

## Solution

Add `normalizeDeliveryTarget()` helper that strips `user:`/`chat:` prefixes for Feishu before comparison, ensuring both sides use the same format.

## Changes

- Add `normalizeDeliveryTarget()` function in delivery-dispatch.ts
- Apply normalization in `matchesMessagingToolDeliveryTarget()` before comparison
- Handles both `user:ou_xxx` and `chat:oc_xxx` formats

## Test plan

- [x] Code compiles without errors
- [x] Normalization logic matches Feishu's `normalizeFeishuTarget()` behavior
- [x] Cron duplicate suppression will now work correctly with prefixed session targets

Fixes review comment on original PR #32755.