### PR TITLE
fix(feishu): avoid [System:] tags in inbound body hints

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -96,8 +96,29 @@ describe("buildFeishuAgentBody", () => {
     });
 
     expect(body).toBe(
-      '[message_id: msg-42]\nSender Name: [Replying to: "previous message"]\n\nhello world\n\n[System: Your reply will automatically @mention: Target User. Do not write @xxx yourself.]\n\n[System: The bot encountered a Feishu API permission error. Please inform the user about this issue and provide the permission grant URL for the admin to authorize. Permission grant URL: https://open.feishu.cn/app/cli_test]',
+      '[message_id: msg-42]\nSender Name: [Replying to: "previous message"]\n\nhello world\n\n[Feishu hint: Your reply will automatically @mention: Target User. Do not write @xxx yourself.]\n\n[Feishu hint: The bot encountered a Feishu API permission error. Please inform the user about this issue and provide the permission grant URL for the admin to authorize. Permission grant URL: https://open.feishu.cn/app/cli_test]',
     );
+  });
+
+  it("avoids [System:] tags in user body hints to prevent role confusion", () => {
+    const body = buildFeishuAgentBody({
+      ctx: {
+        content: "hello world",
+        senderName: "Sender Name",
+        senderOpenId: "ou-sender",
+        messageId: "msg-43",
+        hasAnyMention: true,
+      },
+      permissionErrorForAgent: {
+        code: 99991672,
+        message: "permission denied",
+        grantUrl: "https://open.feishu.cn/app/cli_test",
+      },
+      botOpenId: "ou-bot",
+    });
+
+    expect(body).not.toContain("[System:");
+    expect(body).toContain("[Feishu hint:");
   });
 });
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -835,16 +835,16 @@ export function buildFeishuAgentBody(params: {
   if (ctx.hasAnyMention) {
     const botIdHint = botOpenId?.trim();
     messageBody +=
-      `\n\n[System: The content may include mention tags in the form <at user_id="...">name</at>. ` +
+      `\n\n[Feishu hint: The content may include mention tags in the form <at user_id="...">name</at>. ` +
       `Treat these as real mentions of Feishu entities (users or bots).]`;
     if (botIdHint) {
-      messageBody += `\n[System: If user_id is "${botIdHint}", that mention refers to you.]`;
+      messageBody += `\n[Feishu hint: If user_id is "${botIdHint}", that mention refers to you.]`;
     }
   }
 
   if (ctx.mentionTargets && ctx.mentionTargets.length > 0) {
     const targetNames = ctx.mentionTargets.map((t) => t.name).join(", ");
-    messageBody += `\n\n[System: Your reply will automatically @mention: ${targetNames}. Do not write @xxx yourself.]`;
+    messageBody += `\n\n[Feishu hint: Your reply will automatically @mention: ${targetNames}. Do not write @xxx yourself.]`;
   }
 
   // Keep message_id on its own line so shared message-id hint stripping can parse it reliably.
@@ -852,7 +852,7 @@ export function buildFeishuAgentBody(params: {
 
   if (permissionErrorForAgent) {
     const grantUrl = permissionErrorForAgent.grantUrl ?? "";
-    messageBody += `\n\n[System: The bot encountered a Feishu API permission error. Please inform the user about this issue and provide the permission grant URL for the admin to authorize. Permission grant URL: ${grantUrl}]`;
+    messageBody += `\n\n[Feishu hint: The bot encountered a Feishu API permission error. Please inform the user about this issue and provide the permission grant URL for the admin to authorize. Permission grant URL: ${grantUrl}]`;
   }
 
   return messageBody;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Feishu inbound `BodyForAgent` appended instructional hints with `[System: ...]` markers.
- Why it matters: These markers can be interpreted as system-role content in downstream/web chat rendering, producing confusing split/duplicate-looking message presentation.
- What changed: Replaced Feishu hint labels from `[System: ...]` to `[Feishu hint: ...]` while keeping the same informational text and ordering.
- What did NOT change (scope boundary): No routing, permissions, mention detection, sessioning, or dispatch behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30308
- Related #

## User-visible / Behavior Changes

Feishu inbound prompts no longer inject `[System: ...]` bracket markers; equivalent guidance now appears as `[Feishu hint: ...]`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22+, pnpm
- Model/provider: N/A
- Integration/channel (if any): Feishu extension
- Relevant config (redacted): default test config + feishu test fixtures

### Steps

1. Call `buildFeishuAgentBody` for a message that includes mention/permission guidance.
2. Inspect returned `BodyForAgent` string.
3. Observe hint markers.

### Expected

- Hints should not use `[System: ...]` tags in user-controlled inbound message body text.

### Actual

- Hints used `[System: ...]`, which can cause role-confusing rendering/splitting in web chat flows.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `buildFeishuAgentBody` output now uses `[Feishu hint: ...]`; regression test asserts no `[System:` remains.
- Edge cases checked: mention hints + bot-id hint + permission hint all avoid `[System:` markers.
- What you did **not** verify: live Feishu workspace E2E rendering.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `cc7c9d108b`.
- Files/config to restore: `extensions/feishu/src/bot.ts`, `extensions/feishu/src/bot.test.ts`.
- Known bad symptoms reviewers should watch for: none beyond restored old `[System: ...]` markers.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Prompts trained against literal `[System: ...]` token may react slightly differently.
  - Mitigation: Kept hint content and placement identical; only label prefix changed and regression test added.
