### PR TITLE
fix(gateway): include assistant image attachments in webchat final events

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -656,6 +656,7 @@ describe("agent event handler", () => {
         mediaUrls: [
           "https://example.com/cat.png",
           "https://example.com/cat.png",
+          "https://example.com/media/2c6d7fef",
           "https://example.com/file.pdf",
         ],
       },
@@ -678,6 +679,10 @@ describe("agent event handler", () => {
     expect(content).toContainEqual({
       type: "image_url",
       image_url: { url: "https://example.com/cat.png" },
+    });
+    expect(content).toContainEqual({
+      type: "image_url",
+      image_url: { url: "https://example.com/media/2c6d7fef" },
     });
     expect(content).not.toContainEqual({
       type: "image_url",

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -638,4 +638,50 @@ describe("agent event handler", () => {
       "Disk usage crossed 95 percent on /data and needs cleanup now.",
     );
   });
+
+  it("includes assistant image_url blocks in final chat payload when mediaUrls are present", () => {
+    const { broadcast, chatRunState, handler } = createHarness({ now: 4_000 });
+    chatRunState.registry.add("run-images", {
+      sessionKey: "session-images",
+      clientRunId: "client-images",
+    });
+
+    handler({
+      runId: "run-images",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: {
+        text: "Read image file",
+        mediaUrls: [
+          "https://example.com/cat.png",
+          "https://example.com/cat.png",
+          "https://example.com/file.pdf",
+        ],
+      },
+    });
+    emitLifecycleEnd(handler, "run-images");
+
+    const payload = chatBroadcastCalls(broadcast)
+      .map(([, eventPayload]) => eventPayload as { state?: string; message?: unknown })
+      .find((eventPayload) => eventPayload.state === "final") as
+      | {
+          message?: { content?: Array<Record<string, unknown>> };
+        }
+      | undefined;
+    expect(payload).toBeDefined();
+    const finalPayload = payload as {
+      message?: { content?: Array<Record<string, unknown>> };
+    };
+    const content = finalPayload.message?.content ?? [];
+    expect(content).toContainEqual({ type: "text", text: "Read image file" });
+    expect(content).toContainEqual({
+      type: "image_url",
+      image_url: { url: "https://example.com/cat.png" },
+    });
+    expect(content).not.toContainEqual({
+      type: "image_url",
+      image_url: { url: "https://example.com/file.pdf" },
+    });
+  });
 });

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -590,6 +590,7 @@ describe("agent event handler", () => {
       ts: Date.now(),
       data: {
         text: "HEARTBEAT_OK Read HEARTBEAT.md if it exists (workspace context). Follow it strictly.",
+        mediaUrls: ["https://example.com/hidden-heartbeat-image.png"],
       },
     });
 

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -658,6 +658,8 @@ describe("agent event handler", () => {
           "https://example.com/cat.png",
           "https://example.com/media/2c6d7fef",
           "https://example.com/file.pdf",
+          "/tmp/render.png",
+          "file:///tmp/render.png",
         ],
       },
     });
@@ -687,6 +689,14 @@ describe("agent event handler", () => {
     expect(content).not.toContainEqual({
       type: "image_url",
       image_url: { url: "https://example.com/file.pdf" },
+    });
+    expect(content).not.toContainEqual({
+      type: "image_url",
+      image_url: { url: "/tmp/render.png" },
+    });
+    expect(content).not.toContainEqual({
+      type: "image_url",
+      image_url: { url: "file:///tmp/render.png" },
     });
   });
 });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -89,6 +89,34 @@ function isSilentReplyLeadFragment(text: string): boolean {
   return SILENT_REPLY_TOKEN.startsWith(normalized);
 }
 
+function isLikelyImageUrl(url: string): boolean {
+  if (!url) {
+    return false;
+  }
+  if (/^data:image\//i.test(url)) {
+    return true;
+  }
+  return /\.(png|jpe?g|gif|webp|bmp|svg)(?:[?#]|$)/i.test(url);
+}
+
+function collectAssistantImageUrls(data: Record<string, unknown>): string[] {
+  const rawMediaUrls = Array.isArray(data.mediaUrls) ? data.mediaUrls : [];
+  const out: string[] = [];
+  for (const entry of rawMediaUrls) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    const trimmed = entry.trim();
+    if (!trimmed || !isLikelyImageUrl(trimmed)) {
+      continue;
+    }
+    if (!out.includes(trimmed)) {
+      out.push(trimmed);
+    }
+  }
+  return out;
+}
+
 export type ChatRunEntry = {
   sessionKey: string;
   clientRunId: string;
@@ -160,6 +188,7 @@ export type ChatRunState = {
   deltaSentAt: Map<string, number>;
   /** Length of text at the time of the last broadcast, used to avoid duplicate flushes. */
   deltaLastBroadcastLen: Map<string, number>;
+  imageUrls: Map<string, string[]>;
   abortedRuns: Map<string, number>;
   clear: () => void;
 };
@@ -169,6 +198,7 @@ export function createChatRunState(): ChatRunState {
   const buffers = new Map<string, string>();
   const deltaSentAt = new Map<string, number>();
   const deltaLastBroadcastLen = new Map<string, number>();
+  const imageUrls = new Map<string, string[]>();
   const abortedRuns = new Map<string, number>();
 
   const clear = () => {
@@ -176,6 +206,7 @@ export function createChatRunState(): ChatRunState {
     buffers.clear();
     deltaSentAt.clear();
     deltaLastBroadcastLen.clear();
+    imageUrls.clear();
     abortedRuns.clear();
   };
 
@@ -184,6 +215,7 @@ export function createChatRunState(): ChatRunState {
     buffers,
     deltaSentAt,
     deltaLastBroadcastLen,
+    imageUrls,
     abortedRuns,
     clear,
   };
@@ -357,6 +389,7 @@ export function createAgentEventHandler({
       text: bufferedText,
     });
     const text = normalizedHeartbeatText.text.trim();
+    const imageUrls = chatRunState.imageUrls.get(clientRunId) ?? [];
     const shouldSuppressSilent =
       normalizedHeartbeatText.suppress || isSilentReplyText(text, SILENT_REPLY_TOKEN);
     const shouldSuppressSilentLeadFragment = isSilentReplyLeadFragment(text);
@@ -394,7 +427,15 @@ export function createAgentEventHandler({
     chatRunState.deltaLastBroadcastLen.delete(clientRunId);
     chatRunState.buffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
+    chatRunState.imageUrls.delete(clientRunId);
     if (jobState === "done") {
+      const content: Array<Record<string, unknown>> = [];
+      if (text && !shouldSuppressSilent) {
+        content.push({ type: "text", text });
+      }
+      for (const imageUrl of imageUrls) {
+        content.push({ type: "image_url", image_url: { url: imageUrl } });
+      }
       const payload = {
         runId: clientRunId,
         sessionKey,
@@ -402,10 +443,10 @@ export function createAgentEventHandler({
         state: "final" as const,
         ...(stopReason && { stopReason }),
         message:
-          text && !shouldSuppressSilent
+          content.length > 0
             ? {
                 role: "assistant",
-                content: [{ type: "text", text }],
+                content,
                 timestamp: Date.now(),
               }
             : undefined,
@@ -511,8 +552,20 @@ export function createAgentEventHandler({
       if (!isToolEvent || toolVerbose !== "off") {
         nodeSendToSession(sessionKey, "agent", isToolEvent ? toolPayload : agentPayload);
       }
-      if (!isAborted && evt.stream === "assistant" && typeof evt.data?.text === "string") {
-        emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text);
+      if (!isAborted && evt.stream === "assistant") {
+        const imageUrls = collectAssistantImageUrls(evt.data);
+        if (imageUrls.length > 0) {
+          const existing = chatRunState.imageUrls.get(clientRunId) ?? [];
+          for (const url of imageUrls) {
+            if (!existing.includes(url)) {
+              existing.push(url);
+            }
+          }
+          chatRunState.imageUrls.set(clientRunId, existing);
+        }
+        if (typeof evt.data?.text === "string") {
+          emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text);
+        }
       } else if (!isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {
         const evtStopReason =
           typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
@@ -547,6 +600,7 @@ export function createAgentEventHandler({
         chatRunState.abortedRuns.delete(evt.runId);
         chatRunState.buffers.delete(clientRunId);
         chatRunState.deltaSentAt.delete(clientRunId);
+        chatRunState.imageUrls.delete(clientRunId);
         if (chatLink) {
           chatRunState.registry.remove(evt.runId, clientRunId, sessionKey);
         }

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -453,8 +453,10 @@ export function createAgentEventHandler({
       if (text && !shouldSuppressSilent) {
         content.push({ type: "text", text });
       }
-      for (const imageUrl of imageUrls) {
-        content.push({ type: "image_url", image_url: { url: imageUrl } });
+      if (!shouldSuppressSilent) {
+        for (const imageUrl of imageUrls) {
+          content.push({ type: "image_url", image_url: { url: imageUrl } });
+        }
       }
       const payload = {
         runId: clientRunId,

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -96,9 +96,6 @@ function isLikelyImageUrl(url: string): boolean {
   if (/^data:image\//i.test(url)) {
     return true;
   }
-  if (/\.(png|jpe?g|gif|webp|bmp|svg)(?:[?#]|$)/i.test(url)) {
-    return true;
-  }
 
   let parsed: URL;
   try {
@@ -109,6 +106,10 @@ function isLikelyImageUrl(url: string): boolean {
 
   if (!/^https?:$/i.test(parsed.protocol)) {
     return false;
+  }
+
+  if (/\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(parsed.pathname)) {
+    return true;
   }
 
   const leaf = parsed.pathname.split("/").pop() ?? "";

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -96,7 +96,26 @@ function isLikelyImageUrl(url: string): boolean {
   if (/^data:image\//i.test(url)) {
     return true;
   }
-  return /\.(png|jpe?g|gif|webp|bmp|svg)(?:[?#]|$)/i.test(url);
+  if (/\.(png|jpe?g|gif|webp|bmp|svg)(?:[?#]|$)/i.test(url)) {
+    return true;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (!/^https?:$/i.test(parsed.protocol)) {
+    return false;
+  }
+
+  const leaf = parsed.pathname.split("/").pop() ?? "";
+  if (!leaf || leaf.includes(".")) {
+    return false;
+  }
+  return true;
 }
 
 function collectAssistantImageUrls(data: Record<string, unknown>): string[] {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Control UI chat final events dropped assistant image attachments even when agent events carried `mediaUrls`.
- Why it matters: Users only saw text like "Read image file" with no inline image in webchat.
- What changed: Gateway chat event mapping now accumulates assistant image URLs from `assistant` stream events and includes them as OpenAI-style `image_url` content blocks in the `final` message payload.
- What did NOT change (scope boundary): No model/tool execution behavior changed; no channel delivery changes; only gateway chat event shaping for webchat.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33119
- Related #

## User-visible / Behavior Changes

Control UI webchat now displays assistant image attachments inline when agent events include image URLs.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22+, pnpm
- Model/provider: N/A (unit test)
- Integration/channel (if any): Control UI webchat via gateway chat events
- Relevant config (redacted): default test config

### Steps

1. Emit assistant event stream with text + `mediaUrls` containing an image URL.
2. Emit lifecycle `end` for the same run.
3. Inspect gateway `chat` final payload.

### Expected

- Final payload contains assistant `message.content` with both text block and `image_url` block(s) for image attachments.

### Actual

- Final payload previously included text only, dropping image attachments.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `server-chat.agent-events` now emits final payload with `image_url` content when `mediaUrls` has image links.
- Edge cases checked: dedupe repeated URLs; ignore non-image URLs; preserve text + image combination.
- What you did **not** verify: browser-level manual UI session against live gateway.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `ceead02199`.
- Files/config to restore: `src/gateway/server-chat.ts`, `src/gateway/server-chat.agent-events.test.ts`.
- Known bad symptoms reviewers should watch for: missing inline image rendering for assistant replies in Control UI.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: non-standard image URLs without image-like suffix may be filtered out.
  - Mitigation: accepts `data:image/*` and common image extensions; keeps behavior conservative to avoid mis-rendering arbitrary files as images.
