### PR TITLE
fix(googlechat): guard null channel config during account merge

### DIFF
--- a/extensions/googlechat/src/accounts.test.ts
+++ b/extensions/googlechat/src/accounts.test.ts
@@ -1,0 +1,21 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import { describe, expect, it } from "vitest";
+import { listGoogleChatAccountIds, resolveGoogleChatAccount } from "./accounts.js";
+
+describe("googlechat accounts null-safety", () => {
+  it("does not throw when channels.googlechat is null", () => {
+    const cfg = {
+      channels: {
+        googlechat: null,
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(listGoogleChatAccountIds(cfg)).toEqual([DEFAULT_ACCOUNT_ID]);
+    expect(() => resolveGoogleChatAccount({ cfg })).not.toThrow();
+
+    const account = resolveGoogleChatAccount({ cfg });
+    expect(account.accountId).toBe(DEFAULT_ACCOUNT_ID);
+    expect(account.credentialSource).toBe("none");
+  });
+});

--- a/extensions/googlechat/src/accounts.test.ts
+++ b/extensions/googlechat/src/accounts.test.ts
@@ -5,17 +5,35 @@ import { listGoogleChatAccountIds, resolveGoogleChatAccount } from "./accounts.j
 
 describe("googlechat accounts null-safety", () => {
   it("does not throw when channels.googlechat is null", () => {
+    const originalServiceAccount = process.env["GOOGLE_CHAT_SERVICE_ACCOUNT"];
+    const originalServiceAccountFile = process.env["GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"];
+    delete process.env["GOOGLE_CHAT_SERVICE_ACCOUNT"];
+    delete process.env["GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"];
+
     const cfg = {
       channels: {
         googlechat: null,
       },
     } as unknown as OpenClawConfig;
 
-    expect(listGoogleChatAccountIds(cfg)).toEqual([DEFAULT_ACCOUNT_ID]);
-    expect(() => resolveGoogleChatAccount({ cfg })).not.toThrow();
+    try {
+      expect(listGoogleChatAccountIds(cfg)).toEqual([DEFAULT_ACCOUNT_ID]);
+      expect(() => resolveGoogleChatAccount({ cfg })).not.toThrow();
 
-    const account = resolveGoogleChatAccount({ cfg });
-    expect(account.accountId).toBe(DEFAULT_ACCOUNT_ID);
-    expect(account.credentialSource).toBe("none");
+      const account = resolveGoogleChatAccount({ cfg });
+      expect(account.accountId).toBe(DEFAULT_ACCOUNT_ID);
+      expect(account.credentialSource).toBe("none");
+    } finally {
+      if (originalServiceAccount === undefined) {
+        delete process.env["GOOGLE_CHAT_SERVICE_ACCOUNT"];
+      } else {
+        process.env["GOOGLE_CHAT_SERVICE_ACCOUNT"] = originalServiceAccount;
+      }
+      if (originalServiceAccountFile === undefined) {
+        delete process.env["GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"];
+      } else {
+        process.env["GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"] = originalServiceAccountFile;
+      }
+    }
   });
 });

--- a/extensions/googlechat/src/accounts.test.ts
+++ b/extensions/googlechat/src/accounts.test.ts
@@ -39,18 +39,36 @@ describe("googlechat accounts null-safety", () => {
   });
 
   it("ignores malformed primitive channels.googlechat values", () => {
+    const originalServiceAccount = process.env["GOOGLE_CHAT_SERVICE_ACCOUNT"];
+    const originalServiceAccountFile = process.env["GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"];
+    delete process.env["GOOGLE_CHAT_SERVICE_ACCOUNT"];
+    delete process.env["GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"];
+
     const cfg = {
       channels: {
         googlechat: "enabled",
       },
     } as unknown as OpenClawConfig;
 
-    expect(listGoogleChatAccountIds(cfg)).toEqual([DEFAULT_ACCOUNT_ID]);
-    expect(() => resolveGoogleChatAccount({ cfg })).not.toThrow();
+    try {
+      expect(listGoogleChatAccountIds(cfg)).toEqual([DEFAULT_ACCOUNT_ID]);
+      expect(() => resolveGoogleChatAccount({ cfg })).not.toThrow();
 
-    const account = resolveGoogleChatAccount({ cfg });
-    expect(account.accountId).toBe(DEFAULT_ACCOUNT_ID);
-    expect(account.credentialSource).toBe("none");
-    expect(Object.keys(account.config)).toEqual([]);
+      const account = resolveGoogleChatAccount({ cfg });
+      expect(account.accountId).toBe(DEFAULT_ACCOUNT_ID);
+      expect(account.credentialSource).toBe("none");
+      expect(Object.keys(account.config)).toEqual([]);
+    } finally {
+      if (originalServiceAccount === undefined) {
+        delete process.env["GOOGLE_CHAT_SERVICE_ACCOUNT"];
+      } else {
+        process.env["GOOGLE_CHAT_SERVICE_ACCOUNT"] = originalServiceAccount;
+      }
+      if (originalServiceAccountFile === undefined) {
+        delete process.env["GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"];
+      } else {
+        process.env["GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"] = originalServiceAccountFile;
+      }
+    }
   });
 });

--- a/extensions/googlechat/src/accounts.test.ts
+++ b/extensions/googlechat/src/accounts.test.ts
@@ -23,6 +23,7 @@ describe("googlechat accounts null-safety", () => {
       const account = resolveGoogleChatAccount({ cfg });
       expect(account.accountId).toBe(DEFAULT_ACCOUNT_ID);
       expect(account.credentialSource).toBe("none");
+      expect(Object.keys(account.config)).toEqual([]);
     } finally {
       if (originalServiceAccount === undefined) {
         delete process.env["GOOGLE_CHAT_SERVICE_ACCOUNT"];
@@ -35,5 +36,21 @@ describe("googlechat accounts null-safety", () => {
         process.env["GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"] = originalServiceAccountFile;
       }
     }
+  });
+
+  it("ignores malformed primitive channels.googlechat values", () => {
+    const cfg = {
+      channels: {
+        googlechat: "enabled",
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(listGoogleChatAccountIds(cfg)).toEqual([DEFAULT_ACCOUNT_ID]);
+    expect(() => resolveGoogleChatAccount({ cfg })).not.toThrow();
+
+    const account = resolveGoogleChatAccount({ cfg });
+    expect(account.accountId).toBe(DEFAULT_ACCOUNT_ID);
+    expect(account.credentialSource).toBe("none");
+    expect(Object.keys(account.config)).toEqual([]);
   });
 });

--- a/extensions/googlechat/src/accounts.ts
+++ b/extensions/googlechat/src/accounts.ts
@@ -69,7 +69,11 @@ function mergeGoogleChatAccountConfig(
   cfg: OpenClawConfig,
   accountId: string,
 ): GoogleChatAccountConfig {
-  const raw = cfg.channels?.["googlechat"] ?? {};
+  const rawChannel = cfg.channels?.["googlechat"];
+  const raw =
+    rawChannel && typeof rawChannel === "object"
+      ? (rawChannel as Record<string, unknown>)
+      : ({} as Record<string, unknown>);
   const { accounts: _ignored, defaultAccount: _ignored2, ...base } = raw;
   const account = resolveAccountConfig(cfg, accountId) ?? {};
   return { ...base, ...account } as GoogleChatAccountConfig;

--- a/extensions/googlechat/src/accounts.ts
+++ b/extensions/googlechat/src/accounts.ts
@@ -70,6 +70,7 @@ function mergeGoogleChatAccountConfig(
   accountId: string,
 ): GoogleChatAccountConfig {
   const rawChannel = cfg.channels?.["googlechat"];
+  // Guard malformed primitives (`"googlechat": "enabled"`, `42`, etc.) before destructuring.
   const raw =
     rawChannel && typeof rawChannel === "object"
       ? (rawChannel as Record<string, unknown>)


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Google Chat account config merge assumed `channels.googlechat` is always an object and destructured it directly.
- Why it matters: when config contains `channels.googlechat: null` (or equivalent invalid shape), account resolution throws `Cannot convert undefined or null to object`, breaking channel checks/startup.
- What changed: added null-safe normalization before destructuring in `mergeGoogleChatAccountConfig` and added a regression test for null channel config.
- What did NOT change (scope boundary): no webhook routing/auth logic changed; no Google Chat API behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33117
- Related #

## User-visible / Behavior Changes

Google Chat channel account resolution no longer crashes on null-shaped `channels.googlechat` config values; it safely falls back to empty config.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22+, pnpm
- Model/provider: N/A
- Integration/channel (if any): Google Chat extension
- Relevant config (redacted): `channels.googlechat = null`

### Steps

1. Set config shape with `channels.googlechat` as `null`.
2. Resolve Google Chat account config (`resolveGoogleChatAccount`) or list account ids.
3. Observe behavior.

### Expected

- Account resolution should not throw; channel should fail gracefully with normal status warnings.

### Actual

- Threw `Cannot convert undefined or null to object` during account config merge.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: new test with `channels.googlechat: null` passes and `resolveGoogleChatAccount` no longer throws.
- Edge cases checked: existing startup test still passes.
- What you did **not** verify: live Google Chat webhook integration on external workspace.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `1bfbf73c9f`.
- Files/config to restore: `extensions/googlechat/src/accounts.ts`, `extensions/googlechat/src/accounts.test.ts`.
- Known bad symptoms reviewers should watch for: regression to null-config crash (`Cannot convert undefined or null to object`).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: none significant; change is a guarded normalization before destructuring.
  - Mitigation: regression test locks expected null-safe behavior.
