### PR TITLE
fix(reply): detect Mistral tool/user role-ordering conflicts

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.role-ordering.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.role-ordering.test.ts
@@ -18,6 +18,12 @@ describe("isRoleOrderingConflictError", () => {
     ).toBe(true);
   });
 
+  it("does not match mixed quote delimiters in role ordering errors", () => {
+    expect(
+      isRoleOrderingConflictError("ValueError: Unexpected role 'user\" after role \"tool'"),
+    ).toBe(false);
+  });
+
   it("does not match unrelated errors", () => {
     expect(isRoleOrderingConflictError("network timeout")).toBe(false);
   });

--- a/src/auto-reply/reply/agent-runner-execution.role-ordering.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.role-ordering.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isRoleOrderingConflictError } from "./agent-runner-execution.js";
+
+describe("isRoleOrderingConflictError", () => {
+  it("matches legacy role-ordering conflict errors", () => {
+    expect(isRoleOrderingConflictError("400 Incorrect role information")).toBe(true);
+    expect(
+      isRoleOrderingConflictError('messages: roles must alternate between "user" and "assistant"'),
+    ).toBe(true);
+  });
+
+  it("matches Mistral user-after-tool role ordering errors", () => {
+    expect(
+      isRoleOrderingConflictError("ValueError: Unexpected role 'user' after role 'tool'"),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isRoleOrderingConflictError("network timeout")).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution.role-ordering.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.role-ordering.test.ts
@@ -13,6 +13,9 @@ describe("isRoleOrderingConflictError", () => {
     expect(
       isRoleOrderingConflictError("ValueError: Unexpected role 'user' after role 'tool'"),
     ).toBe(true);
+    expect(
+      isRoleOrderingConflictError('ValueError: Unexpected role "user" after role "tool"'),
+    ).toBe(true);
   });
 
   it("does not match unrelated errors", () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -70,7 +70,7 @@ export type AgentRunLoopResult =
   | { kind: "final"; payload: ReplyPayload };
 
 export function isRoleOrderingConflictError(message: string): boolean {
-  return /incorrect role information|roles must alternate|unexpected role ['"]\w+['"] after role ['"]\w+['"]/i.test(
+  return /incorrect role information|roles must alternate|unexpected role (['"])\w+\1 after role (['"])\w+\2/i.test(
     message,
   );
 }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -69,6 +69,12 @@ export type AgentRunLoopResult =
     }
   | { kind: "final"; payload: ReplyPayload };
 
+export function isRoleOrderingConflictError(message: string): boolean {
+  return /incorrect role information|roles must alternate|unexpected role ['"]\w+['"] after role ['"]\w+['"]/i.test(
+    message,
+  );
+}
+
 export async function runAgentTurnWithFallback(params: {
   commandBody: string;
   followupRun: FollowupRun;
@@ -478,7 +484,7 @@ export async function runAgentTurnWithFallback(params: {
       const isContextOverflow = isLikelyContextOverflowError(message);
       const isCompactionFailure = isCompactionFailureError(message);
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
-      const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
+      const isRoleOrderingError = isRoleOrderingConflictError(message);
       const isTransientHttp = isTransientHttpError(message);
 
       if (


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Mistral-compatible backends can return role-ordering errors like `Unexpected role 'user' after role 'tool'`.
- Why it matters: this error path was not classified as a role-ordering conflict, so automatic session reset recovery did not trigger.
- What changed: expanded role-ordering detection to include `Unexpected role ... after role ...` pattern; added targeted unit tests for detection.
- What did NOT change (scope boundary): no model/provider request formatting changed; no transcript mutation logic changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33177
- Related #

## User-visible / Behavior Changes

For Mistral role-ordering failures (`Unexpected role 'user' after role 'tool'`), OpenClaw now takes the same conflict-recovery path used by other ordering errors, instead of treating it as a generic failure.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22+, pnpm
- Model/provider: Mistral-compatible error string simulation
- Integration/channel (if any): reply runner
- Relevant config (redacted): default test config

### Steps

1. Trigger embedded run failure with message `Unexpected role 'user' after role 'tool'`.
2. Let reply runner classify the error.
3. Observe recovery branch.

### Expected

- Error is treated as role-ordering conflict and follows reset-recovery behavior.

### Actual

- Previously fell through as generic error classification.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: new unit test matches legacy patterns and Mistral `Unexpected role ... after role ...` pattern.
- Edge cases checked: unrelated errors do not match.
- What you did **not** verify: live Mistral backend E2E run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `531b071edf`.
- Files/config to restore: `src/auto-reply/reply/agent-runner-execution.ts`, `src/auto-reply/reply/agent-runner-execution.role-ordering.test.ts`.
- Known bad symptoms reviewers should watch for: legitimate non-ordering errors incorrectly classified as ordering conflicts.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: regex may over-match unusual error text.
  - Mitigation: narrow pattern requires explicit `Unexpected role ... after role ...` phrase and is covered by negative test.
