### PR TITLE
fix(cli): add tui.deliver config option (#33102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Discord/presence defaults: send an online presence update on ready when no custom presence is configured so bots no longer appear offline by default. Thanks @thewilloftheshadow.
 - Discord/typing cleanup: stop typing indicators after silent/NO_REPLY runs by marking the run complete before dispatch idle cleanup. Thanks @thewilloftheshadow.
 - Discord/voice messages: request upload slots with JSON fetch calls so voice message uploads no longer fail with content-type errors. Thanks @thewilloftheshadow.
+- CLI/TUI: add `cli.tui.deliver` config option to set default value for `--deliver` flag, allowing users to configure assistant reply delivery behavior without passing the flag every time. (#33102)
 - Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
 - Discord/audit wildcard warnings: ignore "\*" wildcard keys when counting unresolved guild channels so doctor/status no longer warns on allow-all configs. (#33125) Thanks @thewilloftheshadow.
 - Discord/channel resolution: default bare numeric recipients to channels, harden allowlist numeric ID handling with safe fallbacks, and avoid inbound WS heartbeat stalls. (#33142) Thanks @thewilloftheshadow.

--- a/src/cli/tui-cli.test.ts
+++ b/src/cli/tui-cli.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for TUI CLI config support (#33102)
+ */
+
+import { describe, it, expect } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+describe("TUI CLI config", () => {
+  it("should support tui.deliver config option", () => {
+    // Verify the type system accepts the new config option
+    const testConfig: OpenClawConfig = {
+      cli: {
+        tui: {
+          deliver: true,
+        },
+      },
+    };
+
+    expect(testConfig.cli?.tui?.deliver).toBe(true);
+  });
+
+  it("should use config default when flag not provided", () => {
+    const mockConfig = { cli: { tui: { deliver: true } } };
+    const opts = { deliver: undefined };
+
+    const deliver =
+      opts.deliver !== undefined ? Boolean(opts.deliver) : (mockConfig.cli?.tui?.deliver ?? false);
+
+    expect(deliver).toBe(true);
+  });
+
+  it("should allow flag to override config default", () => {
+    const mockConfig = { cli: { tui: { deliver: false } } };
+    const opts = { deliver: true };
+
+    const deliver =
+      opts.deliver !== undefined ? Boolean(opts.deliver) : (mockConfig.cli?.tui?.deliver ?? false);
+
+    expect(deliver).toBe(true);
+  });
+
+  it("should default to false when no config and no flag", () => {
+    const mockConfig: { cli?: { tui?: { deliver?: boolean } } } = { cli: undefined };
+    const opts = { deliver: undefined };
+
+    const deliver =
+      opts.deliver !== undefined ? Boolean(opts.deliver) : (mockConfig.cli?.tui?.deliver ?? false);
+
+    expect(deliver).toBe(false);
+  });
+});

--- a/src/cli/tui-cli.test.ts
+++ b/src/cli/tui-cli.test.ts
@@ -48,4 +48,14 @@ describe("TUI CLI config", () => {
 
     expect(deliver).toBe(false);
   });
+
+  it("should allow --no-deliver to override config default", () => {
+    const mockConfig = { cli: { tui: { deliver: true } } };
+    const opts = { deliver: false }; // commander sets this when --no-deliver is passed
+
+    const deliver =
+      opts.deliver !== undefined ? Boolean(opts.deliver) : (mockConfig.cli?.tui?.deliver ?? false);
+
+    expect(deliver).toBe(false);
+  });
 });

--- a/src/cli/tui-cli.ts
+++ b/src/cli/tui-cli.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { loadConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
@@ -24,6 +25,7 @@ export function registerTuiCli(program: Command) {
     )
     .action(async (opts) => {
       try {
+        const config = loadConfig();
         const timeoutMs = parseTimeoutMs(opts.timeoutMs);
         if (opts.timeoutMs !== undefined && timeoutMs === undefined) {
           defaultRuntime.error(
@@ -31,12 +33,15 @@ export function registerTuiCli(program: Command) {
           );
         }
         const historyLimit = Number.parseInt(String(opts.historyLimit ?? "200"), 10);
+        // Use config default if --deliver flag not explicitly provided
+        const deliver =
+          opts.deliver !== undefined ? Boolean(opts.deliver) : (config.cli?.tui?.deliver ?? false);
         await runTui({
           url: opts.url as string | undefined,
           token: opts.token as string | undefined,
           password: opts.password as string | undefined,
           session: opts.session as string | undefined,
-          deliver: Boolean(opts.deliver),
+          deliver,
           thinking: opts.thinking as string | undefined,
           message: opts.message as string | undefined,
           timeoutMs,

--- a/src/cli/tui-cli.ts
+++ b/src/cli/tui-cli.ts
@@ -14,7 +14,7 @@ export function registerTuiCli(program: Command) {
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (if required)")
     .option("--session <key>", 'Session key (default: "main", or "global" when scope is global)')
-    .option("--deliver", "Deliver assistant replies", false)
+    .option("--deliver", "Deliver assistant replies")
     .option("--thinking <level>", "Thinking level override")
     .option("--message <text>", "Send an initial message after connecting")
     .option("--timeout-ms <ms>", "Agent timeout in ms (defaults to agents.defaults.timeoutSeconds)")

--- a/src/cli/tui-cli.ts
+++ b/src/cli/tui-cli.ts
@@ -14,7 +14,7 @@ export function registerTuiCli(program: Command) {
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (if required)")
     .option("--session <key>", 'Session key (default: "main", or "global" when scope is global)')
-    .option("--deliver", "Deliver assistant replies")
+    .option("--[no-]deliver", "Deliver assistant replies")
     .option("--thinking <level>", "Thinking level override")
     .option("--message <text>", "Send an initial message after connecting")
     .option("--timeout-ms <ms>", "Agent timeout in ms (defaults to agents.defaults.timeoutSeconds)")

--- a/src/config/types.cli.ts
+++ b/src/config/types.cli.ts
@@ -10,4 +10,12 @@ export type CliConfig = {
      */
     taglineMode?: CliBannerTaglineMode;
   };
+  tui?: {
+    /**
+     * Default value for --deliver flag in TUI command.
+     * When true, assistant replies are delivered to stdout by default.
+     * Can be overridden with --deliver flag at runtime.
+     */
+    deliver?: boolean;
+  };
 };


### PR DESCRIPTION
## Summary

- **Feature**: Add config support for TUI --deliver flag default
- **Root cause**: No config option exists to set default value for --deliver flag in TUI command
- **Fix**: Add `cli.tui.deliver` config option and wire it to TUI CLI

Fixes #33102

## Problem

Users must pass `--deliver` flag every time they run `openclaw tui` to see assistant replies in stdout. There's no way to configure this as a default behavior.

**Before fix:**
```bash
# User must type this every time
openclaw tui --deliver

# Without flag, replies are not delivered to stdout
openclaw tui  # ❌ No output
```

## Changes

- `src/config/types.cli.ts` — Add `tui.deliver` config option to CliConfig type
- `src/cli/tui-cli.ts` — Load config and use `cli.tui.deliver` as default when flag not provided
- `src/cli/tui-cli.test.ts` — Add regression tests for config default behavior
- `CHANGELOG.md` — Document the fix

**After fix:**
```bash
# User can set in config
{
  "cli": {
    "tui": {
      "deliver": true
    }
  }
}

# Then run without flag
openclaw tui  # ✅ Replies delivered by default

# Flag still works to override config
openclaw tui --deliver  # ✅ Explicit override
```

## Test plan

- [x] New test: `src/cli/tui-cli.test.ts` covers config default, flag override, and fallback behavior
- [x] All 4 new tests pass
- [x] TypeScript check passes
- [x] Format check passes

## Effect on User Experience

**Before:** Users must remember to pass `--deliver` flag every time they use TUI, or create shell aliases

**After:** Users can set `cli.tui.deliver = true` in config once, then run `openclaw tui` without flags