### PR TITLE
fix(gateway): return 503 when control-ui index is unavailable

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -303,6 +303,25 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("returns 503 when control-ui root exists but index.html is missing", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-missing-index-"));
+    try {
+      const { res, end, handled } = runControlUiRequest({
+        url: "/",
+        method: "GET",
+        rootPath: tmp,
+      });
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(503);
+      expect(String(end.mock.calls[0]?.[0] ?? "")).toContain(
+        `Control UI assets not found at ${tmp}.`,
+      );
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("rejects symlinked SPA fallback index.html outside control-ui root", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -240,6 +240,17 @@ function isExpectedSafePathError(error: unknown): boolean {
   return code === "ENOENT" || code === "ENOTDIR" || code === "ELOOP";
 }
 
+function shouldRespondNotFoundForIndex(indexPath: string): boolean {
+  try {
+    return fs.lstatSync(indexPath).isSymbolicLink();
+  } catch (error) {
+    if (isExpectedSafePathError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
 function resolveSafeAvatarFile(filePath: string): { path: string; fd: number } | null {
   const opened = openVerifiedFileSync({
     filePath,
@@ -459,6 +470,10 @@ export function handleControlUiHttpRequest(
     }
   }
 
-  respondControlUiNotFound(res);
+  if (shouldRespondNotFoundForIndex(indexPath)) {
+    respondControlUiNotFound(res);
+    return true;
+  }
+  respondControlUiAssetsUnavailable(res, { configuredRootPath: root });
   return true;
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `GET /` on the gateway can return `404 Not Found` when a control-ui root exists but `index.html` is missing/unreadable.
- Why it matters: this is an assets-availability failure, not a missing route; returning `404` misleads operators and slows recovery.
- What changed: the SPA fallback path now returns `503` with the control-ui assets recovery message when `index.html` is unavailable.
- What changed: symlinked `index.html` paths that fail safety checks still return `404` (no behavior relaxation for path hardening).
- What did NOT change (scope boundary): static asset 404 behavior and control-ui routing/auth behavior remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32937
- Related #33124

## User-visible / Behavior Changes

When control-ui root is resolved but `index.html` is missing/unreadable, HTTP requests that require SPA fallback (including `/`) now return a `503` “Control UI assets not found …” response instead of `404 Not Found`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev), issue reported on Ubuntu 24.04
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): gateway control-ui HTTP
- Relevant config (redacted): `gateway.controlUi.enabled=true`

### Steps

1. Start gateway with a resolved control-ui root directory that does not contain `index.html`.
2. Send `GET /` to the gateway HTTP port.
3. Observe response status/body.

### Expected

- The response should indicate control-ui assets are unavailable (operator-actionable), not a route miss.

### Actual

- Before fix: `404 Not Found`.
- After fix: `503` with control-ui assets-not-found guidance.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest src/gateway/control-ui.http.test.ts` passes with new regression case.
  - Existing symlink-hardening test still passes and remains `404`.
- Edge cases checked:
  - Missing `index.html` in resolved root now returns `503`.
  - Symlinked `index.html` outside root remains `404`.
- What you did **not** verify:
  - Full end-to-end gateway runtime with live packaged assets.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `21de90c918`.
- Files/config to restore:
  - `src/gateway/control-ui.ts`
  - `src/gateway/control-ui.http.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected `503` responses for valid control-ui roots containing `index.html`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: legitimate edge-cases that previously surfaced as `404` on SPA fallback now surface as `503`.
  - Mitigation: scope is limited to missing/unreadable fallback index path; static asset missing behavior and symlink hardening remain covered by tests.
