### PR TITLE
feat(discord): use bot presence as runtime healthcheck signal (self-profile + quota-aware status)

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -836,6 +836,36 @@ Default slash command settings:
     - 4: Custom (uses the activity text as the status state; emoji is optional)
     - 5: Competing
 
+    Automatic runtime/quota signaling (optional):
+
+```json5
+{
+  channels: {
+    discord: {
+      autoPresence: {
+        enabled: true,
+        intervalMs: 30000,
+        minUpdateIntervalMs: 15000,
+        exhaustedText: "token exhausted",
+        degradedText: "runtime degraded",
+      },
+    },
+  },
+}
+```
+
+    Auto-presence state mapping:
+
+    - healthy + usable auth profile available → `online`
+    - degraded/unknown runtime or auth visibility → `idle`
+    - no usable profile with strong unavailable signal (`rate_limit`, `billing`, `auth`) → `dnd`
+
+    Notes:
+
+    - This uses auth profile cooldown/disable state as the strongest available runtime quota signal (not direct token counters).
+    - Updates are throttled (`minUpdateIntervalMs`) and deduped to avoid status spam.
+    - Manual `setPresence` / `self-profile` calls still work; auto-presence may overwrite them on the next auto evaluation when enabled.
+
   </Accordion>
 
   <Accordion title="Exec approvals in Discord">
@@ -1127,7 +1157,7 @@ High-signal Discord fields:
 - streaming: `streaming` (legacy alias: `streamMode`), `draftChunk`, `blockStreaming`, `blockStreamingCoalesce`
 - media/retry: `mediaMaxMb`, `retry`
 - actions: `actions.*`
-- presence: `activity`, `status`, `activityType`, `activityUrl`
+- presence: `activity`, `status`, `activityType`, `activityUrl`, `autoPresence.*`
 - UI: `ui.components.accentColor`
 - features: `pluralkit`, `execApprovals`, `intents`, `agentComponents`, `heartbeat`, `responsePrefix`
 

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -867,6 +867,7 @@ Core examples:
 - reactions: `react`, `reactions`, `emojiList`
 - moderation: `timeout`, `kick`, `ban`
 - presence: `setPresence`
+- self profile (bot-only): `self-profile`
 
 Action gates live under `channels.discord.actions.*`.
 
@@ -878,6 +879,42 @@ Default gate behavior:
 | roles                                                                                                                                                                    | disabled |
 | moderation                                                                                                                                                               | disabled |
 | presence                                                                                                                                                                 | disabled |
+| selfProfile                                                                                                                                                              | disabled |
+
+### `self-profile` (strict bot self-only updates)
+
+`self-profile` lets the bot update only its own Discord profile/presence fields:
+
+- guild nickname (`nickname`, requires `guildId`)
+- account avatar (`avatar` or `media`/`path`/`filePath`/`buffer`)
+- status (`online`/`idle`/`dnd`/`invisible`)
+- activity/custom status text (`activity*` or `statusMessage`)
+
+Safety behavior:
+
+- action defaults to self (bot account)
+- if `userId` or `memberId` is provided and does not match the bot user id, the action is rejected
+- channel/member edits for other users are not permitted through this action
+
+Examples:
+
+```json
+{
+  "action": "self-profile",
+  "channel": "discord",
+  "guildId": "123456789012345678",
+  "nickname": "OpenClaw Bot"
+}
+```
+
+```json
+{
+  "action": "self-profile",
+  "channel": "discord",
+  "status": "idle",
+  "statusMessage": "Shipping fixes"
+}
+```
 
 ## Components v2 UI
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -236,6 +236,8 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
         voiceStatus: true,
         events: true,
         moderation: false,
+        presence: false,
+        selfProfile: false,
       },
       replyToMode: "off", // off | first | all
       dmPolicy: "pairing",
@@ -317,6 +319,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - `channels.discord.voice.daveEncryption` and `channels.discord.voice.decryptionFailureTolerance` pass through to `@discordjs/voice` DAVE options (`true` and `24` by default).
 - OpenClaw additionally attempts voice receive recovery by leaving/rejoining a voice session after repeated decrypt failures.
 - `channels.discord.streaming` is the canonical stream mode key. Legacy `streamMode` and boolean `streaming` values are auto-migrated.
+- `channels.discord.actions.selfProfile` enables the Discord `self-profile` message action (strict bot self-only nickname/avatar/status/activity updates).
 - `channels.discord.dangerouslyAllowNameMatching` re-enables mutable name/tag matching (break-glass compatibility mode).
 
 **Reaction notification modes:** `off` (none), `own` (bot's messages, default), `all` (all messages), `allowlist` (from `guilds.<id>.users` on all messages).

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -320,6 +320,11 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - OpenClaw additionally attempts voice receive recovery by leaving/rejoining a voice session after repeated decrypt failures.
 - `channels.discord.streaming` is the canonical stream mode key. Legacy `streamMode` and boolean `streaming` values are auto-migrated.
 - `channels.discord.actions.selfProfile` enables the Discord `self-profile` message action (strict bot self-only nickname/avatar/status/activity updates).
+- `channels.discord.autoPresence` enables automatic runtime/quota presence signaling (`online`/`idle`/`dnd`) with throttled updates.
+  - `enabled`: turn on auto-presence.
+  - `intervalMs`: evaluation interval.
+  - `minUpdateIntervalMs`: minimum spacing between actual Discord presence updates (anti-spam throttle).
+  - `healthyText`, `degradedText`, `exhaustedText`: optional status texts (`exhaustedText` supports `{reason}`).
 - `channels.discord.dangerouslyAllowNameMatching` re-enables mutable name/tag matching (break-glass compatibility mode).
 
 **Reaction notification modes:** `off` (none), `own` (bot's messages, default), `all` (all messages), `allowlist` (from `guilds.<id>.users` on all messages).

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -422,6 +422,7 @@ Core actions:
 - `role-add` / `role-remove`
 - `channel-info` / `channel-list`
 - `voice-status`
+- `self-profile` (Discord bot self-only nickname/avatar/status/activity updates)
 - `event-list` / `event-create`
 - `timeout` / `kick` / `ban`
 

--- a/src/agents/tools/discord-actions-presence.test.ts
+++ b/src/agents/tools/discord-actions-presence.test.ts
@@ -7,11 +7,27 @@ import { handleDiscordPresenceAction } from "./discord-actions-presence.js";
 
 const mockUpdatePresence = vi.fn();
 
+const discordSendMocks = vi.hoisted(() => ({
+  fetchCurrentUserDiscord: vi.fn(async () => ({ id: "bot-1" })),
+  updateCurrentUserAvatarDiscord: vi.fn(async () => ({ id: "bot-1" })),
+  updateSelfNicknameDiscord: vi.fn(async () => ({ nick: "Bot" })),
+}));
+
+const { fetchCurrentUserDiscord, updateCurrentUserAvatarDiscord, updateSelfNicknameDiscord } =
+  discordSendMocks;
+
+vi.mock("../../discord/send.js", () => ({
+  ...discordSendMocks,
+}));
+
 function createMockGateway(connected = true): GatewayPlugin {
   return { isConnected: connected, updatePresence: mockUpdatePresence } as unknown as GatewayPlugin;
 }
 
 const presenceEnabled: ActionGate<DiscordActionConfig> = (key) => key === "presence";
+const selfProfileEnabled: ActionGate<DiscordActionConfig> = (key) => key === "selfProfile";
+const presenceAndSelfProfileEnabled: ActionGate<DiscordActionConfig> = (key) =>
+  key === "presence" || key === "selfProfile";
 const presenceDisabled: ActionGate<DiscordActionConfig> = () => false;
 
 describe("handleDiscordPresenceAction", () => {
@@ -22,8 +38,18 @@ describe("handleDiscordPresenceAction", () => {
     return await handleDiscordPresenceAction("setPresence", params, actionGate);
   }
 
+  async function updateSelfProfile(
+    params: Record<string, unknown>,
+    actionGate: ActionGate<DiscordActionConfig> = selfProfileEnabled,
+  ) {
+    return await handleDiscordPresenceAction("updateSelfProfile", params, actionGate);
+  }
+
   beforeEach(() => {
     mockUpdatePresence.mockClear();
+    fetchCurrentUserDiscord.mockClear();
+    updateCurrentUserAvatarDiscord.mockClear();
+    updateSelfNicknameDiscord.mockClear();
     clearGateways();
     registerGateway(undefined, createMockGateway());
   });
@@ -40,10 +66,10 @@ describe("handleDiscordPresenceAction", () => {
       status: "online",
       afk: false,
     });
-    const textBlock = result.content.find((block) => block.type === "text");
-    const payload = JSON.parse(
-      (textBlock as { type: "text"; text: string } | undefined)?.text ?? "{}",
-    );
+    const payload = result.details as {
+      ok: boolean;
+      activities: Array<{ type: number; name: string }>;
+    };
     expect(payload.ok).toBe(true);
     expect(payload.activities[0]).toEqual({ type: 0, name: "with fire" });
   });
@@ -152,9 +178,115 @@ describe("handleDiscordPresenceAction", () => {
     );
   });
 
-  it("rejects unknown presence actions", async () => {
-    await expect(handleDiscordPresenceAction("unknownAction", {}, presenceEnabled)).rejects.toThrow(
-      /Unknown presence action/,
+  it("updates self profile fields (nickname/avatar/presence)", async () => {
+    const result = await updateSelfProfile({
+      guildId: "guild-1",
+      nickname: "OpenClaw Bot",
+      userId: "user:bot-1",
+      buffer: "Zm9v",
+      contentType: "image/png",
+      status: "idle",
+      statusMessage: "Shipping features",
+    });
+
+    expect(fetchCurrentUserDiscord).toHaveBeenCalledWith();
+    expect(updateSelfNicknameDiscord).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      nickname: "OpenClaw Bot",
+    });
+    expect(updateCurrentUserAvatarDiscord).toHaveBeenCalledWith({
+      avatar: "data:image/png;base64,Zm9v",
+    });
+    expect(mockUpdatePresence).toHaveBeenCalledWith({
+      since: null,
+      activities: [{ name: "", type: 4, state: "Shipping features" }],
+      status: "idle",
+      afk: false,
+    });
+
+    const payload = result.details as {
+      ok: boolean;
+      selfUserId: string;
+      updates: Record<string, unknown>;
+    };
+    expect(payload.ok).toBe(true);
+    expect(payload.selfUserId).toBe("bot-1");
+    expect(payload.updates).toEqual(
+      expect.objectContaining({
+        nickname: { guildId: "guild-1", nickname: "OpenClaw Bot" },
+        avatar: { updated: true },
+      }),
     );
+  });
+
+  it("rejects non-self user selectors", async () => {
+    await expect(
+      updateSelfProfile({ guildId: "guild-1", nickname: "Nope", userId: "user:bot-2" }),
+    ).rejects.toThrow(/restricted to the bot account/);
+    expect(updateSelfNicknameDiscord).not.toHaveBeenCalled();
+  });
+
+  it("rejects when no update fields are provided", async () => {
+    await expect(updateSelfProfile({ userId: "user:bot-1" })).rejects.toThrow(
+      /No self-profile fields provided/,
+    );
+  });
+
+  it("requires guildId when nickname is provided", async () => {
+    await expect(updateSelfProfile({ nickname: "Nick" })).rejects.toThrow(/guildId required/);
+  });
+
+  it("rejects avatar buffers without a valid image content type", async () => {
+    await expect(updateSelfProfile({ buffer: "Zm9v", contentType: "text/plain" })).rejects.toThrow(
+      /avatar updates require PNG, JPEG, GIF, or WEBP/i,
+    );
+  });
+
+  it("updates nickname without needing an active gateway connection", async () => {
+    clearGateways();
+    await updateSelfProfile({ guildId: "guild-1", nickname: "Only Nick" });
+    expect(updateSelfNicknameDiscord).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      nickname: "Only Nick",
+    });
+    expect(mockUpdatePresence).not.toHaveBeenCalled();
+  });
+
+  it("uses accountId for self-profile REST and gateway operations", async () => {
+    registerGateway("my-account", createMockGateway());
+    await updateSelfProfile(
+      {
+        accountId: "my-account",
+        guildId: "guild-1",
+        nickname: "Per Account",
+        status: "online",
+      },
+      presenceAndSelfProfileEnabled,
+    );
+    expect(fetchCurrentUserDiscord).toHaveBeenCalledWith({ accountId: "my-account" });
+    expect(updateSelfNicknameDiscord).toHaveBeenCalledWith(
+      {
+        guildId: "guild-1",
+        nickname: "Per Account",
+      },
+      { accountId: "my-account" },
+    );
+    expect(mockUpdatePresence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "online",
+      }),
+    );
+  });
+
+  it("respects self-profile gating", async () => {
+    await expect(
+      updateSelfProfile({ guildId: "guild-1", nickname: "n" }, presenceEnabled),
+    ).rejects.toThrow(/self-profile updates are disabled/);
+  });
+
+  it("rejects unknown presence actions", async () => {
+    await expect(
+      handleDiscordPresenceAction("unknownAction", {}, presenceAndSelfProfileEnabled),
+    ).rejects.toThrow(/Unknown presence action/);
   });
 });

--- a/src/agents/tools/discord-actions-presence.ts
+++ b/src/agents/tools/discord-actions-presence.ts
@@ -2,6 +2,13 @@ import type { Activity, UpdatePresenceData } from "@buape/carbon/gateway";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { DiscordActionConfig } from "../../config/config.js";
 import { getGateway } from "../../discord/monitor/gateway-registry.js";
+import {
+  fetchCurrentUserDiscord,
+  updateCurrentUserAvatarDiscord,
+  updateSelfNicknameDiscord,
+} from "../../discord/send.js";
+import { parseDiscordTarget } from "../../discord/targets.js";
+import { loadWebMediaRaw } from "../../web/media.js";
 import { type ActionGate, jsonResult, readStringParam } from "./common.js";
 
 const ACTIVITY_TYPE_MAP: Record<string, number> = {
@@ -14,50 +21,70 @@ const ACTIVITY_TYPE_MAP: Record<string, number> = {
 };
 
 const VALID_STATUSES = new Set(["online", "dnd", "idle", "invisible"]);
+const ALLOWED_AVATAR_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/gif",
+  "image/webp",
+]);
+const DISCORD_MAX_AVATAR_BYTES = 10 * 1024 * 1024;
 
-export async function handleDiscordPresenceAction(
-  action: string,
-  params: Record<string, unknown>,
-  isActionEnabled: ActionGate<DiscordActionConfig>,
-): Promise<AgentToolResult<unknown>> {
-  if (action !== "setPresence") {
-    throw new Error(`Unknown presence action: ${action}`);
-  }
-
-  if (!isActionEnabled("presence", false)) {
-    throw new Error("Discord presence changes are disabled.");
-  }
-
-  const accountId = readStringParam(params, "accountId");
-  const gateway = getGateway(accountId);
-  if (!gateway) {
-    throw new Error(
-      `Discord gateway not available${accountId ? ` for account "${accountId}"` : ""}. The bot may not be connected.`,
-    );
-  }
-  if (!gateway.isConnected) {
-    throw new Error(
-      `Discord gateway is not connected${accountId ? ` for account "${accountId}"` : ""}.`,
-    );
-  }
-
-  const statusRaw = readStringParam(params, "status") ?? "online";
-  if (!VALID_STATUSES.has(statusRaw)) {
+function buildPresencePayload(params: {
+  values: Record<string, unknown>;
+  defaultStatus: UpdatePresenceData["status"];
+  includeStatusMessageAlias: boolean;
+  allowEmpty: boolean;
+}): UpdatePresenceData | undefined {
+  const statusRaw = readStringParam(params.values, "status");
+  if (statusRaw && !VALID_STATUSES.has(statusRaw)) {
     throw new Error(
       `Invalid status "${statusRaw}". Must be one of: ${[...VALID_STATUSES].join(", ")}`,
     );
   }
-  const status = statusRaw as UpdatePresenceData["status"];
 
-  const activityTypeRaw = readStringParam(params, "activityType");
-  const activityName = readStringParam(params, "activityName");
+  let activityTypeRaw = readStringParam(params.values, "activityType");
+  const activityName = readStringParam(params.values, "activityName");
+  const activityUrl = readStringParam(params.values, "activityUrl");
+  let activityState = readStringParam(params.values, "activityState");
+  const statusMessage = params.includeStatusMessageAlias
+    ? readStringParam(params.values, "statusMessage", { allowEmpty: true })
+    : undefined;
+
+  if (statusMessage !== undefined) {
+    if (activityState === undefined) {
+      activityState = statusMessage;
+    }
+    if (!activityTypeRaw) {
+      activityTypeRaw = "custom";
+    }
+  }
+
+  const hasPresenceInputs =
+    statusRaw !== undefined ||
+    activityTypeRaw !== undefined ||
+    activityName !== undefined ||
+    activityUrl !== undefined ||
+    activityState !== undefined;
+
+  if (!hasPresenceInputs) {
+    if (!params.allowEmpty) {
+      return undefined;
+    }
+    return {
+      since: null,
+      activities: [],
+      status: params.defaultStatus,
+      afk: false,
+    };
+  }
 
   const activities: Activity[] = [];
 
-  if (activityTypeRaw || activityName) {
+  if (activityTypeRaw || activityName || activityUrl || activityState !== undefined) {
     if (!activityTypeRaw) {
       throw new Error(
-        "activityType is required when activityName is provided. " +
+        "activityType is required when activityName/activityState/activityUrl is provided. " +
           `Valid types: ${Object.keys(ACTIVITY_TYPE_MAP).join(", ")}`,
       );
     }
@@ -73,39 +100,261 @@ export async function handleDiscordPresenceAction(
       type: typeNum,
     };
 
-    // Streaming URL (Twitch/YouTube). May not render for bots but is the correct payload shape.
-    if (typeNum === 1) {
-      const url = readStringParam(params, "activityUrl");
-      if (url) {
-        activity.url = url;
-      }
+    if (typeNum === 1 && activityUrl) {
+      activity.url = activityUrl;
     }
 
-    const state = readStringParam(params, "activityState");
-    if (state) {
-      activity.state = state;
+    if (activityState !== undefined) {
+      activity.state = activityState;
     }
 
     activities.push(activity);
   }
 
-  const presenceData: UpdatePresenceData = {
+  return {
     since: null,
     activities,
-    status,
+    status: (statusRaw ?? params.defaultStatus) as UpdatePresenceData["status"],
     afk: false,
   };
+}
 
-  gateway.updatePresence(presenceData);
+function requireConnectedGateway(accountId?: string): {
+  updatePresence: (payload: UpdatePresenceData) => void;
+} {
+  const gateway = getGateway(accountId);
+  if (!gateway) {
+    throw new Error(
+      `Discord gateway not available${accountId ? ` for account "${accountId}"` : ""}. The bot may not be connected.`,
+    );
+  }
+  if (!gateway.isConnected) {
+    throw new Error(
+      `Discord gateway is not connected${accountId ? ` for account "${accountId}"` : ""}.`,
+    );
+  }
+  return gateway;
+}
 
-  return jsonResult({
-    ok: true,
-    status,
-    activities: activities.map((a) => ({
-      type: a.type,
-      name: a.name,
-      ...(a.url ? { url: a.url } : {}),
-      ...(a.state ? { state: a.state } : {}),
-    })),
+function normalizeUserLikeTarget(raw: string, label: string): string {
+  let parsed: ReturnType<typeof parseDiscordTarget> | undefined;
+  try {
+    parsed = parseDiscordTarget(raw, { defaultKind: "user" });
+  } catch {
+    parsed = undefined;
+  }
+  if (parsed) {
+    if (parsed.kind !== "user") {
+      throw new Error(
+        `Discord self-profile updates only accept user/member selectors. ${label} must resolve to a user id.`,
+      );
+    }
+    return parsed.id;
+  }
+  return raw.trim();
+}
+
+function enforceSelfOnlyScope(params: { values: Record<string, unknown>; selfId: string }): void {
+  const checks: Array<{ label: string; value?: string }> = [
+    { label: "userId", value: readStringParam(params.values, "userId") },
+    { label: "memberId", value: readStringParam(params.values, "memberId") },
+    { label: "target", value: readStringParam(params.values, "target") },
+  ];
+
+  for (const check of checks) {
+    if (!check.value) {
+      continue;
+    }
+    const normalized = normalizeUserLikeTarget(check.value, check.label);
+    if (normalized !== params.selfId) {
+      throw new Error(
+        `Discord self-profile updates are restricted to the bot account. ${check.label} "${check.value}" does not match bot user id "${params.selfId}".`,
+      );
+    }
+  }
+}
+
+function normalizeAvatarMime(raw?: string): string | undefined {
+  const contentType = raw?.trim().toLowerCase();
+  if (!contentType) {
+    return undefined;
+  }
+  if (contentType === "image/jpg") {
+    return "image/jpeg";
+  }
+  return contentType;
+}
+
+function validateAvatarMime(contentType?: string): string {
+  const normalized = normalizeAvatarMime(contentType);
+  if (!normalized || !ALLOWED_AVATAR_MIME_TYPES.has(normalized)) {
+    throw new Error(
+      "Discord avatar updates require PNG, JPEG, GIF, or WEBP image input (contentType/mimeType).",
+    );
+  }
+  return normalized;
+}
+
+async function resolveAvatarDataUri(params: {
+  values: Record<string, unknown>;
+  mediaLocalRoots?: readonly string[];
+}): Promise<string | undefined> {
+  const explicitAvatar = readStringParam(params.values, "avatar", { trim: false });
+  const mediaUrl =
+    explicitAvatar ??
+    readStringParam(params.values, "mediaUrl", { trim: false }) ??
+    readStringParam(params.values, "media", { trim: false }) ??
+    readStringParam(params.values, "path", { trim: false }) ??
+    readStringParam(params.values, "filePath", { trim: false });
+
+  const rawBuffer = readStringParam(params.values, "buffer", { trim: false });
+  const hintedContentType =
+    readStringParam(params.values, "contentType") ?? readStringParam(params.values, "mimeType");
+
+  if (!mediaUrl && !rawBuffer) {
+    return undefined;
+  }
+
+  if (rawBuffer) {
+    const dataUrlMatch = /^data:([^;]+);base64,(.*)$/i.exec(rawBuffer.trim());
+    const contentType = validateAvatarMime(hintedContentType ?? dataUrlMatch?.[1]);
+    const payload = dataUrlMatch ? dataUrlMatch[2] : rawBuffer.trim();
+    if (!payload) {
+      throw new Error("Avatar buffer is empty.");
+    }
+    return `data:${contentType};base64,${payload}`;
+  }
+
+  const media = await loadWebMediaRaw(mediaUrl as string, {
+    maxBytes: DISCORD_MAX_AVATAR_BYTES,
+    localRoots: params.mediaLocalRoots,
   });
+  const contentType = validateAvatarMime(hintedContentType ?? media.contentType);
+  return `data:${contentType};base64,${media.buffer.toString("base64")}`;
+}
+
+export async function handleDiscordPresenceAction(
+  action: string,
+  params: Record<string, unknown>,
+  isActionEnabled: ActionGate<DiscordActionConfig>,
+  options?: {
+    mediaLocalRoots?: readonly string[];
+  },
+): Promise<AgentToolResult<unknown>> {
+  const accountId = readStringParam(params, "accountId");
+
+  if (action === "setPresence") {
+    if (!isActionEnabled("presence", false)) {
+      throw new Error("Discord presence changes are disabled.");
+    }
+
+    const gateway = requireConnectedGateway(accountId);
+    const presenceData = buildPresencePayload({
+      values: params,
+      defaultStatus: "online",
+      includeStatusMessageAlias: false,
+      allowEmpty: true,
+    });
+
+    if (!presenceData) {
+      throw new Error("Failed to build Discord presence payload.");
+    }
+
+    gateway.updatePresence(presenceData);
+
+    return jsonResult({
+      ok: true,
+      status: presenceData.status,
+      activities: presenceData.activities.map((a) => ({
+        type: a.type,
+        name: a.name,
+        ...(a.url ? { url: a.url } : {}),
+        ...(a.state !== undefined ? { state: a.state } : {}),
+      })),
+    });
+  }
+
+  if (action === "updateSelfProfile") {
+    if (!isActionEnabled("selfProfile", false)) {
+      throw new Error("Discord self-profile updates are disabled.");
+    }
+
+    const selfUser = accountId
+      ? await fetchCurrentUserDiscord({ accountId })
+      : await fetchCurrentUserDiscord();
+    enforceSelfOnlyScope({ values: params, selfId: selfUser.id });
+
+    const nickname = readStringParam(params, "nickname", { allowEmpty: true });
+    const avatarDataUri = await resolveAvatarDataUri({
+      values: params,
+      mediaLocalRoots: options?.mediaLocalRoots,
+    });
+    const presenceData = buildPresencePayload({
+      values: params,
+      defaultStatus: "online",
+      includeStatusMessageAlias: true,
+      allowEmpty: false,
+    });
+
+    if (nickname === undefined && !avatarDataUri && !presenceData) {
+      throw new Error(
+        "No self-profile fields provided. Set at least one of: nickname, avatar (avatar/media/path/filePath/buffer), status, statusMessage, or activity* fields.",
+      );
+    }
+
+    const updates: Record<string, unknown> = {};
+
+    if (nickname !== undefined) {
+      const guildId = readStringParam(params, "guildId", { required: true });
+      if (accountId) {
+        await updateSelfNicknameDiscord(
+          {
+            guildId,
+            nickname: nickname || null,
+          },
+          { accountId },
+        );
+      } else {
+        await updateSelfNicknameDiscord({
+          guildId,
+          nickname: nickname || null,
+        });
+      }
+      updates.nickname = {
+        guildId,
+        nickname: nickname || null,
+      };
+    }
+
+    if (avatarDataUri) {
+      if (accountId) {
+        await updateCurrentUserAvatarDiscord({ avatar: avatarDataUri }, { accountId });
+      } else {
+        await updateCurrentUserAvatarDiscord({ avatar: avatarDataUri });
+      }
+      updates.avatar = { updated: true };
+    }
+
+    if (presenceData) {
+      const gateway = requireConnectedGateway(accountId);
+      gateway.updatePresence(presenceData);
+      updates.presence = {
+        status: presenceData.status,
+        activities: presenceData.activities.map((a) => ({
+          type: a.type,
+          name: a.name,
+          ...(a.url ? { url: a.url } : {}),
+          ...(a.state !== undefined ? { state: a.state } : {}),
+        })),
+      };
+    }
+
+    return jsonResult({
+      ok: true,
+      selfUserId: selfUser.id,
+      updates,
+    });
+  }
+
+  throw new Error(`Unknown presence action: ${action}`);
 }

--- a/src/agents/tools/discord-actions.ts
+++ b/src/agents/tools/discord-actions.ts
@@ -53,7 +53,7 @@ const guildActions = new Set([
 
 const moderationActions = new Set(["timeout", "kick", "ban"]);
 
-const presenceActions = new Set(["setPresence"]);
+const presenceActions = new Set(["setPresence", "updateSelfProfile"]);
 
 export async function handleDiscordAction(
   params: Record<string, unknown>,
@@ -76,7 +76,7 @@ export async function handleDiscordAction(
     return await handleDiscordModerationAction(action, params, isActionEnabled);
   }
   if (presenceActions.has(action)) {
-    return await handleDiscordPresenceAction(action, params, isActionEnabled);
+    return await handleDiscordPresenceAction(action, params, isActionEnabled, options);
   }
   throw new Error(`Unknown action: ${action}`);
 }

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -375,6 +375,34 @@ function buildPresenceSchema() {
   };
 }
 
+function buildDiscordSelfProfileSchema() {
+  return {
+    nickname: Type.Optional(
+      Type.String({
+        description: "Guild-specific bot nickname (self-only). Requires guildId.",
+      }),
+    ),
+    memberId: Type.Optional(
+      Type.String({
+        description:
+          "Optional self-check id. If provided, must match the bot account user id (self-only action).",
+      }),
+    ),
+    statusMessage: Type.Optional(
+      Type.String({
+        description:
+          "Custom status text for Discord self-profile action (maps to custom activity state).",
+      }),
+    ),
+    avatar: Type.Optional(
+      Type.String({
+        description:
+          "Avatar source URL or local path for Discord self-profile action (alias for media/path/filePath).",
+      }),
+    ),
+  };
+}
+
 function buildChannelManagementSchema() {
   return {
     name: Type.Optional(Type.String()),
@@ -412,6 +440,7 @@ function buildMessageToolSchemaProps(options: {
     ...buildGatewaySchema(),
     ...buildChannelManagementSchema(),
     ...buildPresenceSchema(),
+    ...buildDiscordSelfProfileSchema(),
   };
 }
 

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -203,6 +203,21 @@ describe("discord message actions", () => {
     expect(actions).toContain("emoji-upload");
     expect(actions).toContain("sticker-upload");
     expect(actions).toContain("channel-create");
+    expect(actions).not.toContain("self-profile");
+  });
+
+  it("lists self-profile action only when gate is enabled", () => {
+    const disabledCfg = { channels: { discord: { token: "d0" } } } as OpenClawConfig;
+    const enabledCfg = {
+      channels: { discord: { token: "d0", actions: { selfProfile: true } } },
+    } as OpenClawConfig;
+
+    expect(discordMessageActions.listActions?.({ cfg: disabledCfg }) ?? []).not.toContain(
+      "self-profile",
+    );
+    expect(discordMessageActions.listActions?.({ cfg: enabledCfg }) ?? []).toContain(
+      "self-profile",
+    );
   });
 
   it("respects disabled channel actions", async () => {
@@ -395,6 +410,29 @@ describe("handleDiscordMessageAction", () => {
         archived: true,
         locked: false,
         autoArchiveDuration: 1440,
+      },
+    },
+    {
+      name: "forwards self-profile update payload",
+      input: {
+        action: "self-profile" as const,
+        params: {
+          guildId: "guild-1",
+          userId: "bot-1",
+          nickname: "Bot",
+          statusMessage: "Working",
+          buffer: "Zm9v",
+          contentType: "image/png",
+        },
+      },
+      expected: {
+        action: "updateSelfProfile",
+        guildId: "guild-1",
+        userId: "bot-1",
+        nickname: "Bot",
+        statusMessage: "Working",
+        buffer: "Zm9v",
+        contentType: "image/png",
       },
     },
   ] as const;

--- a/src/channels/plugins/actions/discord.ts
+++ b/src/channels/plugins/actions/discord.ts
@@ -98,6 +98,9 @@ export const discordMessageActions: ChannelMessageActionAdapter = {
     if (isEnabled("presence", false)) {
       actions.add("set-presence");
     }
+    if (isEnabled("selfProfile", false)) {
+      actions.add("self-profile");
+    }
     return Array.from(actions);
   },
   extractToolSend: ({ args }) => {

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -280,6 +280,35 @@ export async function handleDiscordMessageAction(
     );
   }
 
+  if (action === "self-profile") {
+    return await handleDiscordAction(
+      {
+        action: "updateSelfProfile",
+        accountId: accountId ?? undefined,
+        guildId: readStringParam(params, "guildId"),
+        userId: readStringParam(params, "userId"),
+        memberId: readStringParam(params, "memberId"),
+        target: readStringParam(params, "target"),
+        nickname: readStringParam(params, "nickname", { allowEmpty: true }),
+        avatar: readStringParam(params, "avatar", { trim: false }),
+        mediaUrl:
+          readStringParam(params, "media", { trim: false }) ??
+          readStringParam(params, "path", { trim: false }) ??
+          readStringParam(params, "filePath", { trim: false }),
+        buffer: readStringParam(params, "buffer", { trim: false }),
+        contentType: readStringParam(params, "contentType") ?? readStringParam(params, "mimeType"),
+        status: readStringParam(params, "status"),
+        statusMessage: readStringParam(params, "statusMessage", { allowEmpty: true }),
+        activityType: readStringParam(params, "activityType"),
+        activityName: readStringParam(params, "activityName"),
+        activityUrl: readStringParam(params, "activityUrl"),
+        activityState: readStringParam(params, "activityState", { allowEmpty: true }),
+      },
+      cfg,
+      actionOptions,
+    );
+  }
+
   const adminResult = await tryHandleDiscordMessageActionGuildAdmin({
     ctx,
     resolveChannelId,

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -50,6 +50,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "kick",
   "ban",
   "set-presence",
+  "self-profile",
   "download-file",
 ] as const;
 

--- a/src/config/config.discord-presence.test.ts
+++ b/src/config/config.discord-presence.test.ts
@@ -64,4 +64,37 @@ describe("config discord presence", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts auto presence config", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          autoPresence: {
+            enabled: true,
+            intervalMs: 30000,
+            minUpdateIntervalMs: 15000,
+            exhaustedText: "token exhausted",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects auto presence min update interval above check interval", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          autoPresence: {
+            enabled: true,
+            intervalMs: 5000,
+            minUpdateIntervalMs: 6000,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
 });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1455,6 +1455,18 @@ export const FIELD_HELP: Record<string, string> = {
     "Optional PluralKit token for resolving private systems or members.",
   "channels.discord.activity": "Discord presence activity text (defaults to custom status).",
   "channels.discord.status": "Discord presence status (online, dnd, idle, invisible).",
+  "channels.discord.autoPresence.enabled":
+    "Enable automatic Discord bot presence updates based on runtime/model availability signals. When enabled: healthy=>online, degraded/unknown=>idle, exhausted/unavailable=>dnd.",
+  "channels.discord.autoPresence.intervalMs":
+    "How often to evaluate Discord auto-presence state in milliseconds (default: 30000).",
+  "channels.discord.autoPresence.minUpdateIntervalMs":
+    "Minimum time between actual Discord presence update calls in milliseconds (default: 15000). Prevents status spam on noisy state changes.",
+  "channels.discord.autoPresence.healthyText":
+    "Optional custom status text while runtime is healthy (online). If omitted, falls back to static channels.discord.activity when set.",
+  "channels.discord.autoPresence.degradedText":
+    "Optional custom status text while runtime/model availability is degraded or unknown (idle).",
+  "channels.discord.autoPresence.exhaustedText":
+    "Optional custom status text while runtime detects exhausted/unavailable model quota (dnd). Supports {reason} template placeholder.",
   "channels.discord.activityType":
     "Discord presence activity type (0=Playing,1=Streaming,2=Listening,3=Watching,4=Custom,5=Competing).",
   "channels.discord.activityUrl": "Discord presence streaming URL (required for activityType=1).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -725,6 +725,13 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.discord.pluralkit.token": "Discord PluralKit Token",
   "channels.discord.activity": "Discord Presence Activity",
   "channels.discord.status": "Discord Presence Status",
+  "channels.discord.autoPresence.enabled": "Discord Auto Presence Enabled",
+  "channels.discord.autoPresence.intervalMs": "Discord Auto Presence Check Interval (ms)",
+  "channels.discord.autoPresence.minUpdateIntervalMs":
+    "Discord Auto Presence Min Update Interval (ms)",
+  "channels.discord.autoPresence.healthyText": "Discord Auto Presence Healthy Text",
+  "channels.discord.autoPresence.degradedText": "Discord Auto Presence Degraded Text",
+  "channels.discord.autoPresence.exhaustedText": "Discord Auto Presence Exhausted Text",
   "channels.discord.activityType": "Discord Presence Activity Type",
   "channels.discord.activityUrl": "Discord Presence Activity URL",
   "channels.slack.dm.policy": "Slack DM Policy",

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -182,6 +182,21 @@ export type DiscordSlashCommandConfig = {
   ephemeral?: boolean;
 };
 
+export type DiscordAutoPresenceConfig = {
+  /** Enable automatic runtime/quota-based Discord presence updates. Default: false. */
+  enabled?: boolean;
+  /** Poll interval for evaluating runtime availability state (ms). Default: 30000. */
+  intervalMs?: number;
+  /** Minimum spacing between actual gateway presence updates (ms). Default: 15000. */
+  minUpdateIntervalMs?: number;
+  /** Optional custom status text while runtime is healthy; supports plain text. */
+  healthyText?: string;
+  /** Optional custom status text while runtime/quota state is degraded/unknown. */
+  degradedText?: string;
+  /** Optional custom status text while runtime detects quota/token exhaustion. */
+  exhaustedText?: string;
+};
+
 export type DiscordAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
@@ -300,6 +315,8 @@ export type DiscordAccountConfig = {
   activity?: string;
   /** Bot status (online|dnd|idle|invisible). Defaults to online when presence is configured. */
   status?: "online" | "dnd" | "idle" | "invisible";
+  /** Automatic runtime/quota presence signaling (status text + status mapping). */
+  autoPresence?: DiscordAutoPresenceConfig;
   /** Activity type (0=Game, 1=Streaming, 2=Listening, 3=Watching, 4=Custom, 5=Competing). Defaults to 4 (Custom) when activity is set. */
   activityType?: 0 | 1 | 2 | 3 | 4 | 5;
   /** Streaming URL (Twitch/YouTube). Required when activityType=1. */

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -86,6 +86,8 @@ export type DiscordActionConfig = {
   channels?: boolean;
   /** Enable bot presence/activity changes (default: false). */
   presence?: boolean;
+  /** Enable self-only bot profile updates (nickname/avatar/status/activity). Default: false. */
+  selfProfile?: boolean;
 };
 
 export type DiscordIntentsConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -448,6 +448,7 @@ export const DiscordAccountSchema = z
         moderation: z.boolean().optional(),
         channels: z.boolean().optional(),
         presence: z.boolean().optional(),
+        selfProfile: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -511,6 +511,17 @@ export const DiscordAccountSchema = z
       .optional(),
     activity: z.string().optional(),
     status: z.enum(["online", "dnd", "idle", "invisible"]).optional(),
+    autoPresence: z
+      .object({
+        enabled: z.boolean().optional(),
+        intervalMs: z.number().int().positive().optional(),
+        minUpdateIntervalMs: z.number().int().positive().optional(),
+        healthyText: z.string().optional(),
+        degradedText: z.string().optional(),
+        exhaustedText: z.string().optional(),
+      })
+      .strict()
+      .optional(),
     activityType: z
       .union([z.literal(0), z.literal(1), z.literal(2), z.literal(3), z.literal(4), z.literal(5)])
       .optional(),
@@ -555,6 +566,21 @@ export const DiscordAccountSchema = z
         code: z.ZodIssueCode.custom,
         message: "channels.discord.activityType must be 1 (Streaming) when activityUrl is set",
         path: ["activityType"],
+      });
+    }
+
+    const autoPresenceInterval = value.autoPresence?.intervalMs;
+    const autoPresenceMinUpdate = value.autoPresence?.minUpdateIntervalMs;
+    if (
+      typeof autoPresenceInterval === "number" &&
+      typeof autoPresenceMinUpdate === "number" &&
+      autoPresenceMinUpdate > autoPresenceInterval
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "channels.discord.autoPresence.minUpdateIntervalMs must be less than or equal to channels.discord.autoPresence.intervalMs",
+        path: ["autoPresence", "minUpdateIntervalMs"],
       });
     }
 

--- a/src/discord/monitor/auto-presence.test.ts
+++ b/src/discord/monitor/auto-presence.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../../agents/auth-profiles.js";
+import {
+  createDiscordAutoPresenceController,
+  resolveDiscordAutoPresenceDecision,
+} from "./auto-presence.js";
+
+function createStore(params?: {
+  cooldownUntil?: number;
+  failureCounts?: Record<string, number>;
+}): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      "openai:default": {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-test",
+      },
+    },
+    usageStats: {
+      "openai:default": {
+        ...(typeof params?.cooldownUntil === "number"
+          ? { cooldownUntil: params.cooldownUntil }
+          : {}),
+        ...(params?.failureCounts ? { failureCounts: params.failureCounts } : {}),
+      },
+    },
+  };
+}
+
+describe("discord auto presence", () => {
+  it("maps exhausted runtime signal to dnd", () => {
+    const now = Date.now();
+    const decision = resolveDiscordAutoPresenceDecision({
+      discordConfig: {
+        autoPresence: {
+          enabled: true,
+          exhaustedText: "token exhausted",
+        },
+      },
+      authStore: createStore({ cooldownUntil: now + 60_000, failureCounts: { rate_limit: 2 } }),
+      gatewayConnected: true,
+      now,
+    });
+
+    expect(decision).toBeTruthy();
+    expect(decision?.state).toBe("exhausted");
+    expect(decision?.presence.status).toBe("dnd");
+    expect(decision?.presence.activities[0]?.state).toBe("token exhausted");
+  });
+
+  it("recovers from exhausted to online once a profile becomes usable", () => {
+    let now = Date.now();
+    let store = createStore({ cooldownUntil: now + 60_000, failureCounts: { rate_limit: 1 } });
+    const updatePresence = vi.fn();
+    const controller = createDiscordAutoPresenceController({
+      accountId: "default",
+      discordConfig: {
+        autoPresence: {
+          enabled: true,
+          intervalMs: 5_000,
+          minUpdateIntervalMs: 1_000,
+          exhaustedText: "token exhausted",
+        },
+      },
+      gateway: {
+        isConnected: true,
+        updatePresence,
+      },
+      loadAuthStore: () => store,
+      now: () => now,
+    });
+
+    controller.runNow();
+
+    now += 2_000;
+    store = createStore();
+    controller.runNow();
+
+    expect(updatePresence).toHaveBeenCalledTimes(2);
+    expect(updatePresence.mock.calls[0]?.[0]?.status).toBe("dnd");
+    expect(updatePresence.mock.calls[1]?.[0]?.status).toBe("online");
+  });
+
+  it("does nothing when auto presence is disabled", () => {
+    const updatePresence = vi.fn();
+    const controller = createDiscordAutoPresenceController({
+      accountId: "default",
+      discordConfig: {
+        autoPresence: {
+          enabled: false,
+        },
+      },
+      gateway: {
+        isConnected: true,
+        updatePresence,
+      },
+      loadAuthStore: () => createStore(),
+    });
+
+    controller.runNow();
+    controller.start();
+    controller.refresh();
+    controller.stop();
+
+    expect(controller.enabled).toBe(false);
+    expect(updatePresence).not.toHaveBeenCalled();
+  });
+});

--- a/src/discord/monitor/auto-presence.ts
+++ b/src/discord/monitor/auto-presence.ts
@@ -1,0 +1,357 @@
+import type { Activity, UpdatePresenceData } from "@buape/carbon/gateway";
+import {
+  clearExpiredCooldowns,
+  ensureAuthProfileStore,
+  isProfileInCooldown,
+  resolveProfilesUnavailableReason,
+  type AuthProfileFailureReason,
+  type AuthProfileStore,
+} from "../../agents/auth-profiles.js";
+import type { DiscordAccountConfig, DiscordAutoPresenceConfig } from "../../config/config.js";
+import { warn } from "../../globals.js";
+import { resolveDiscordPresenceUpdate } from "./presence.js";
+
+const DEFAULT_CUSTOM_ACTIVITY_TYPE = 4;
+const CUSTOM_STATUS_NAME = "Custom Status";
+const DEFAULT_INTERVAL_MS = 30_000;
+const DEFAULT_MIN_UPDATE_INTERVAL_MS = 15_000;
+const MIN_INTERVAL_MS = 5_000;
+const MIN_UPDATE_INTERVAL_MS = 1_000;
+
+export type DiscordAutoPresenceState = "healthy" | "degraded" | "exhausted";
+
+type ResolvedDiscordAutoPresenceConfig = {
+  enabled: boolean;
+  intervalMs: number;
+  minUpdateIntervalMs: number;
+  healthyText?: string;
+  degradedText?: string;
+  exhaustedText?: string;
+};
+
+export type DiscordAutoPresenceDecision = {
+  state: DiscordAutoPresenceState;
+  unavailableReason?: AuthProfileFailureReason | null;
+  presence: UpdatePresenceData;
+};
+
+type PresenceGateway = {
+  isConnected: boolean;
+  updatePresence: (payload: UpdatePresenceData) => void;
+};
+
+function normalizeOptionalText(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function clampPositiveInt(value: unknown, fallback: number, minValue: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  const rounded = Math.round(value);
+  if (rounded <= 0) {
+    return fallback;
+  }
+  return Math.max(minValue, rounded);
+}
+
+function resolveAutoPresenceConfig(
+  config?: DiscordAutoPresenceConfig,
+): ResolvedDiscordAutoPresenceConfig {
+  const intervalMs = clampPositiveInt(config?.intervalMs, DEFAULT_INTERVAL_MS, MIN_INTERVAL_MS);
+  const minUpdateIntervalMs = clampPositiveInt(
+    config?.minUpdateIntervalMs,
+    DEFAULT_MIN_UPDATE_INTERVAL_MS,
+    MIN_UPDATE_INTERVAL_MS,
+  );
+
+  return {
+    enabled: config?.enabled === true,
+    intervalMs,
+    minUpdateIntervalMs,
+    healthyText: normalizeOptionalText(config?.healthyText),
+    degradedText: normalizeOptionalText(config?.degradedText),
+    exhaustedText: normalizeOptionalText(config?.exhaustedText),
+  };
+}
+
+function buildCustomStatusActivity(text: string): Activity {
+  return {
+    name: CUSTOM_STATUS_NAME,
+    type: DEFAULT_CUSTOM_ACTIVITY_TYPE,
+    state: text,
+  };
+}
+
+function renderTemplate(
+  template: string,
+  vars: Record<string, string | undefined>,
+): string | undefined {
+  const rendered = template
+    .replace(/\{([a-zA-Z0-9_]+)\}/g, (_full, key: string) => vars[key] ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return rendered.length > 0 ? rendered : undefined;
+}
+
+function isExhaustedUnavailableReason(reason: AuthProfileFailureReason | null): boolean {
+  if (!reason) {
+    return false;
+  }
+  return (
+    reason === "rate_limit" ||
+    reason === "billing" ||
+    reason === "auth" ||
+    reason === "auth_permanent"
+  );
+}
+
+function formatUnavailableReason(reason: AuthProfileFailureReason | null): string {
+  if (!reason) {
+    return "unknown";
+  }
+  return reason.replace(/_/g, " ");
+}
+
+function resolveAuthAvailability(params: { store: AuthProfileStore; now: number }): {
+  state: DiscordAutoPresenceState;
+  unavailableReason?: AuthProfileFailureReason | null;
+} {
+  const profileIds = Object.keys(params.store.profiles);
+  if (profileIds.length === 0) {
+    return { state: "degraded", unavailableReason: null };
+  }
+
+  clearExpiredCooldowns(params.store, params.now);
+
+  const hasUsableProfile = profileIds.some(
+    (profileId) => !isProfileInCooldown(params.store, profileId),
+  );
+  if (hasUsableProfile) {
+    return { state: "healthy", unavailableReason: null };
+  }
+
+  const unavailableReason = resolveProfilesUnavailableReason({
+    store: params.store,
+    profileIds,
+    now: params.now,
+  });
+
+  if (isExhaustedUnavailableReason(unavailableReason)) {
+    return {
+      state: "exhausted",
+      unavailableReason,
+    };
+  }
+
+  return {
+    state: "degraded",
+    unavailableReason,
+  };
+}
+
+function resolvePresenceActivities(params: {
+  state: DiscordAutoPresenceState;
+  cfg: ResolvedDiscordAutoPresenceConfig;
+  basePresence: UpdatePresenceData | null;
+  unavailableReason?: AuthProfileFailureReason | null;
+}): Activity[] {
+  const reasonLabel = formatUnavailableReason(params.unavailableReason ?? null);
+
+  if (params.state === "healthy") {
+    if (params.cfg.healthyText) {
+      return [buildCustomStatusActivity(params.cfg.healthyText)];
+    }
+    return params.basePresence?.activities ?? [];
+  }
+
+  if (params.state === "degraded") {
+    const template = params.cfg.degradedText ?? "runtime degraded";
+    const text = renderTemplate(template, { reason: reasonLabel });
+    return text ? [buildCustomStatusActivity(text)] : [];
+  }
+
+  const defaultTemplate = isExhaustedUnavailableReason(params.unavailableReason ?? null)
+    ? "token exhausted"
+    : "model unavailable ({reason})";
+  const template = params.cfg.exhaustedText ?? defaultTemplate;
+  const text = renderTemplate(template, { reason: reasonLabel });
+  return text ? [buildCustomStatusActivity(text)] : [];
+}
+
+function resolvePresenceStatus(state: DiscordAutoPresenceState): UpdatePresenceData["status"] {
+  if (state === "healthy") {
+    return "online";
+  }
+  if (state === "exhausted") {
+    return "dnd";
+  }
+  return "idle";
+}
+
+export function resolveDiscordAutoPresenceDecision(params: {
+  discordConfig: Pick<
+    DiscordAccountConfig,
+    "autoPresence" | "activity" | "status" | "activityType" | "activityUrl"
+  >;
+  authStore: AuthProfileStore;
+  gatewayConnected: boolean;
+  now?: number;
+}): DiscordAutoPresenceDecision | null {
+  const autoPresence = resolveAutoPresenceConfig(params.discordConfig.autoPresence);
+  if (!autoPresence.enabled) {
+    return null;
+  }
+
+  const now = params.now ?? Date.now();
+  const basePresence = resolveDiscordPresenceUpdate(params.discordConfig);
+
+  const availability = resolveAuthAvailability({
+    store: params.authStore,
+    now,
+  });
+  const state = params.gatewayConnected ? availability.state : "degraded";
+  const unavailableReason = params.gatewayConnected
+    ? availability.unavailableReason
+    : (availability.unavailableReason ?? "unknown");
+
+  const activities = resolvePresenceActivities({
+    state,
+    cfg: autoPresence,
+    basePresence,
+    unavailableReason,
+  });
+
+  return {
+    state,
+    unavailableReason,
+    presence: {
+      since: null,
+      activities,
+      status: resolvePresenceStatus(state),
+      afk: false,
+    },
+  };
+}
+
+function stablePresenceSignature(payload: UpdatePresenceData): string {
+  return JSON.stringify({
+    status: payload.status,
+    afk: payload.afk,
+    since: payload.since,
+    activities: payload.activities.map((activity) => ({
+      type: activity.type,
+      name: activity.name,
+      state: activity.state,
+      url: activity.url,
+    })),
+  });
+}
+
+export type DiscordAutoPresenceController = {
+  start: () => void;
+  stop: () => void;
+  refresh: () => void;
+  runNow: () => void;
+  enabled: boolean;
+};
+
+export function createDiscordAutoPresenceController(params: {
+  accountId: string;
+  discordConfig: Pick<
+    DiscordAccountConfig,
+    "autoPresence" | "activity" | "status" | "activityType" | "activityUrl"
+  >;
+  gateway: PresenceGateway;
+  loadAuthStore?: () => AuthProfileStore;
+  now?: () => number;
+  setIntervalFn?: typeof setInterval;
+  clearIntervalFn?: typeof clearInterval;
+  log?: (message: string) => void;
+}): DiscordAutoPresenceController {
+  const autoCfg = resolveAutoPresenceConfig(params.discordConfig.autoPresence);
+  if (!autoCfg.enabled) {
+    return {
+      enabled: false,
+      start: () => undefined,
+      stop: () => undefined,
+      refresh: () => undefined,
+      runNow: () => undefined,
+    };
+  }
+
+  const loadAuthStore = params.loadAuthStore ?? (() => ensureAuthProfileStore());
+  const now = params.now ?? (() => Date.now());
+  const setIntervalFn = params.setIntervalFn ?? setInterval;
+  const clearIntervalFn = params.clearIntervalFn ?? clearInterval;
+
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let lastAppliedSignature: string | null = null;
+  let lastAppliedAt = 0;
+
+  const runEvaluation = () => {
+    let decision: DiscordAutoPresenceDecision | null = null;
+    try {
+      decision = resolveDiscordAutoPresenceDecision({
+        discordConfig: params.discordConfig,
+        authStore: loadAuthStore(),
+        gatewayConnected: params.gateway.isConnected,
+        now: now(),
+      });
+    } catch (err) {
+      params.log?.(
+        warn(
+          `discord: auto-presence evaluation failed for account ${params.accountId}: ${String(err)}`,
+        ),
+      );
+      return;
+    }
+
+    if (!decision || !params.gateway.isConnected) {
+      return;
+    }
+
+    const ts = now();
+    const signature = stablePresenceSignature(decision.presence);
+    if (signature === lastAppliedSignature) {
+      return;
+    }
+    if (lastAppliedAt > 0 && ts - lastAppliedAt < autoCfg.minUpdateIntervalMs) {
+      return;
+    }
+
+    params.gateway.updatePresence(decision.presence);
+    lastAppliedSignature = signature;
+    lastAppliedAt = ts;
+  };
+
+  return {
+    enabled: true,
+    runNow: runEvaluation,
+    refresh: runEvaluation,
+    start: () => {
+      if (timer) {
+        return;
+      }
+      runEvaluation();
+      timer = setIntervalFn(runEvaluation, autoCfg.intervalMs);
+    },
+    stop: () => {
+      if (!timer) {
+        return;
+      }
+      clearIntervalFn(timer);
+      timer = undefined;
+    },
+  };
+}
+
+export const __testing = {
+  resolveAutoPresenceConfig,
+  resolveAuthAvailability,
+  stablePresenceSignature,
+};

--- a/src/discord/monitor/provider.test.ts
+++ b/src/discord/monitor/provider.test.ts
@@ -7,6 +7,7 @@ const {
   clientFetchUserMock,
   clientGetPluginMock,
   clientConstructorOptionsMock,
+  createDiscordAutoPresenceControllerMock,
   createDiscordNativeCommandMock,
   createNoopThreadBindingManagerMock,
   createThreadBindingManagerMock,
@@ -23,6 +24,13 @@ const {
   const createdBindingManagers: Array<{ stop: ReturnType<typeof vi.fn> }> = [];
   return {
     clientConstructorOptionsMock: vi.fn(),
+    createDiscordAutoPresenceControllerMock: vi.fn(() => ({
+      enabled: false,
+      start: vi.fn(),
+      stop: vi.fn(),
+      refresh: vi.fn(),
+      runNow: vi.fn(),
+    })),
     clientFetchUserMock: vi.fn(async (_target: string) => ({ id: "bot-1" })),
     clientGetPluginMock: vi.fn<(_name: string) => unknown>(() => undefined),
     createDiscordNativeCommandMock: vi.fn(() => ({ name: "mock-command" })),
@@ -220,6 +228,10 @@ vi.mock("./presence.js", () => ({
   resolveDiscordPresenceUpdate: () => undefined,
 }));
 
+vi.mock("./auto-presence.js", () => ({
+  createDiscordAutoPresenceController: createDiscordAutoPresenceControllerMock,
+}));
+
 vi.mock("./provider.allowlist.js", () => ({
   resolveDiscordAllowlistConfig: resolveDiscordAllowlistConfigMock,
 }));
@@ -268,6 +280,13 @@ describe("monitorDiscordProvider", () => {
 
   beforeEach(() => {
     clientConstructorOptionsMock.mockClear();
+    createDiscordAutoPresenceControllerMock.mockClear().mockImplementation(() => ({
+      enabled: false,
+      start: vi.fn(),
+      stop: vi.fn(),
+      refresh: vi.fn(),
+      runNow: vi.fn(),
+    }));
     clientFetchUserMock.mockClear().mockResolvedValue({ id: "bot-1" });
     clientGetPluginMock.mockClear().mockReturnValue(undefined);
     createDiscordNativeCommandMock.mockClear().mockReturnValue({ name: "mock-command" });

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -54,6 +54,7 @@ import {
   createDiscordComponentStringSelect,
   createDiscordComponentUserSelect,
 } from "./agent-components.js";
+import { createDiscordAutoPresenceController } from "./auto-presence.js";
 import { resolveDiscordSlashCommandConfig } from "./commands.js";
 import { createExecApprovalButton, DiscordExecApprovalHandler } from "./exec-approvals.js";
 import { attachEarlyGatewayErrorGuard } from "./gateway-error-guard.js";
@@ -356,6 +357,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   }
   let lifecycleStarted = false;
   let releaseEarlyGatewayErrorGuard = () => {};
+  let autoPresenceController: ReturnType<typeof createDiscordAutoPresenceController> | null = null;
   try {
     const commands: BaseCommand[] = commandSpecs.map((spec) =>
       createDiscordNativeCommand({
@@ -450,6 +452,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
 
     class DiscordStatusReadyListener extends ReadyListener {
       async handle(_data: unknown, client: Client) {
+        if (autoPresenceController?.enabled) {
+          autoPresenceController.refresh();
+          return;
+        }
+
         const gateway = client.getPlugin<GatewayPlugin>("gateway");
         if (!gateway) {
           return;
@@ -496,6 +503,17 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     );
     const earlyGatewayErrorGuard = attachEarlyGatewayErrorGuard(client);
     releaseEarlyGatewayErrorGuard = earlyGatewayErrorGuard.release;
+
+    const lifecycleGateway = client.getPlugin<GatewayPlugin>("gateway");
+    if (lifecycleGateway) {
+      autoPresenceController = createDiscordAutoPresenceController({
+        accountId: account.accountId,
+        discordConfig: discordCfg,
+        gateway: lifecycleGateway,
+        log: (message) => runtime.log?.(message),
+      });
+      autoPresenceController.start();
+    }
 
     await deployDiscordCommands({ client, runtime, enabled: nativeEnabled });
 
@@ -615,6 +633,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       releaseEarlyGatewayErrorGuard,
     });
   } finally {
+    autoPresenceController?.stop();
     releaseEarlyGatewayErrorGuard();
     if (!lifecycleStarted) {
       threadBindings.stop();

--- a/src/discord/send.profile.ts
+++ b/src/discord/send.profile.ts
@@ -1,0 +1,28 @@
+import { Routes, type APIGuildMember, type APIUser } from "discord-api-types/v10";
+import { resolveDiscordRest } from "./send.shared.js";
+import type { DiscordReactOpts } from "./send.types.js";
+
+export async function fetchCurrentUserDiscord(opts: DiscordReactOpts = {}): Promise<APIUser> {
+  const rest = resolveDiscordRest(opts);
+  return (await rest.get(Routes.user("@me"))) as APIUser;
+}
+
+export async function updateSelfNicknameDiscord(
+  payload: { guildId: string; nickname: string | null },
+  opts: DiscordReactOpts = {},
+): Promise<APIGuildMember> {
+  const rest = resolveDiscordRest(opts);
+  return (await rest.patch(Routes.guildMember(payload.guildId, "@me"), {
+    body: { nick: payload.nickname },
+  })) as APIGuildMember;
+}
+
+export async function updateCurrentUserAvatarDiscord(
+  payload: { avatar: string | null },
+  opts: DiscordReactOpts = {},
+): Promise<APIUser> {
+  const rest = resolveDiscordRest(opts);
+  return (await rest.patch(Routes.user("@me"), {
+    body: { avatar: payload.avatar },
+  })) as APIUser;
+}

--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -12,6 +12,11 @@ export {
   uploadStickerDiscord,
 } from "./send.emojis-stickers.js";
 export {
+  fetchCurrentUserDiscord,
+  updateCurrentUserAvatarDiscord,
+  updateSelfNicknameDiscord,
+} from "./send.profile.js";
+export {
   addRoleDiscord,
   banMemberDiscord,
   createScheduledEventDiscord,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -278,6 +278,7 @@ type ResolvedActionContext = {
   channel: ChannelId;
   accountId?: string | null;
   dryRun: boolean;
+  mediaLocalRoots?: readonly string[];
   gateway?: MessageActionRunnerGateway;
   input: RunMessageActionParams;
   agentId?: string;
@@ -653,7 +654,8 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
 }
 
 async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
-  const { cfg, params, channel, accountId, dryRun, gateway, input, abortSignal } = ctx;
+  const { cfg, params, channel, accountId, dryRun, mediaLocalRoots, gateway, input, abortSignal } =
+    ctx;
   throwIfAborted(abortSignal);
   const action = input.action as Exclude<ChannelMessageActionName, "send" | "poll" | "broadcast">;
   if (dryRun) {
@@ -672,6 +674,7 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
     action,
     cfg,
     params,
+    mediaLocalRoots,
     accountId: accountId ?? undefined,
     requesterSenderId: input.requesterSenderId ?? undefined,
     gateway,
@@ -802,6 +805,7 @@ export async function runMessageAction(
     channel,
     accountId,
     dryRun,
+    mediaLocalRoots,
     gateway,
     input,
     abortSignal: input.abortSignal,

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -55,6 +55,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     kick: "none",
     ban: "none",
     "set-presence": "none",
+    "self-profile": "none",
     "download-file": "none",
   };
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenClaw Discord actions could not update bot self-profile fields (nickname/avatar) and did not auto-signal runtime quota exhaustion in bot presence.
- Why it matters: Operators need safe self-service identity updates and clear at-a-glance runtime health/quota signaling in Discord.
- What changed:
  - Added `self-profile` Discord message action (self-only) for nickname/avatar/status/activity updates.
  - Added `channels.discord.actions.selfProfile` gate (default `false`).
  - Added Discord `autoPresence` monitor that maps runtime availability to presence (`online`/`idle`/`dnd`) with exhaustion text support.
  - Added config schema/type/docs/tests for both features.
- What did NOT change (scope boundary):
  - No support for editing other users/members.
  - No new cross-provider generic profile-edit API beyond Discord self scope.
  - No change to existing manual `set-presence` action semantics.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- New Discord message action: `self-profile`.
- New Discord gate: `channels.discord.actions.selfProfile` (default `false`).
- `self-profile` supports:
  - `nickname` (guild-specific; requires `guildId`)
  - `avatar` (image payload/path/media)
  - `status` (`online|idle|dnd|invisible`)
  - `statusMessage` / `activity*`
- Self-only enforcement:
  - If `userId` / `memberId` / `target` is provided and not bot self, request is rejected.
- New Discord auto presence signaling:
  - `channels.discord.autoPresence.enabled`
  - status mapping: healthy→online, degraded→idle, exhausted/unavailable→dnd
  - default exhausted message: `token exhausted`
  - dedupe + min interval throttling to avoid presence spam.

## Security Impact (required)

- New permissions/capabilities? (`Yes`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

  - Risk: New capability can mutate bot profile/presence in Discord.
  - Mitigations:
    - Disabled by default (`channels.discord.actions.selfProfile=false`).
    - Strict self-only checks (reject non-self `userId/memberId/target`).
    - Uses Discord official self endpoints only (`@me`, `members/@me`).
    - Existing action-gate model preserved.

## Repro + Verification

### Environment

- OS: Linux (containerized)
- Runtime/container: OpenClaw Gateway (Docker)
- Model/provider: openai-codex / gpt-5.3-codex
- Integration/channel (if any): Discord
- Relevant config (redacted):

```json5
{
  channels: {
    discord: {
      actions: {
        selfProfile: true,
      },
      autoPresence: {
        enabled: true,
        intervalMs: 60000,
        minUpdateIntervalMs: 15000,
        exhaustedText: "token exhausted",
      },
    },
  },
}
```

### Steps

1. Enable `channels.discord.actions.selfProfile=true`.
2. Call message tool with `action:"self-profile"` and update `nickname`/`avatar`/`statusMessage`/`status`.
3. Attempt a non-self target edit (`userId` not equal to bot id).
4. Enable `channels.discord.autoPresence.enabled=true`.
5. Simulate exhausted/unavailable runtime signal in monitor tests.

### Expected

- Self updates succeed for bot only.
- Non-self request is rejected with clear validation error.
- Auto presence changes to `dnd` with exhausted text on exhaustion signal.
- Presence returns to `online` after recovery signal.
- No noisy rapid presence updates.

### Actual

- Matches expected in targeted tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted commands run:

- `pnpm vitest run --config vitest.channels.config.ts src/discord/monitor/auto-presence.test.ts src/discord/monitor/provider.test.ts`
- `pnpm vitest run --config vitest.unit.config.ts src/config/config.discord-presence.test.ts`
- `pnpm vitest run --config vitest.unit.config.ts src/config/schema.help.quality.test.ts src/config/schema.hints.test.ts`
- `pnpm exec oxlint --type-aware <changed-files>`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `self-profile` dispatch path is wired and gated.
  - non-self identifiers are rejected.
  - autoPresence status mapping and text generation are correct.
  - provider monitor starts/stops autoPresence lifecycle cleanly.
- Edge cases checked:
  - action disabled gate (`selfProfile=false`) path.
  - autoPresence disabled path.
  - duplicate presence payloads / min interval throttling.
- What you did **not** verify:
  - Full end-to-end live Discord API mutation against production bot in this environment.
  - Full repo-wide typecheck due unrelated workspace dependency issue.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

  - Optional config enablement only:
    - set `channels.discord.actions.selfProfile=true` to use self-profile updates.
    - set `channels.discord.autoPresence.enabled=true` to enable quota/runtime signaling.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Disable gate: `channels.discord.actions.selfProfile=false`
  - Disable monitor: `channels.discord.autoPresence.enabled=false`
- Files/config to restore:
  - Revert commits:
    - `8cdbe0c63`
    - `733ba083f`
    - `5cbbeb4a8`
    - `902cd4d68`
- Known bad symptoms reviewers should watch for:
  - Unexpected frequent presence flips/spam.
  - False-positive `dnd` when runtime actually healthy.
  - Self-profile action available without gate enabled.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Presence can oscillate under noisy health signals.
  - Mitigation: dedupe + `minUpdateIntervalMs` throttling.
- Risk: Misuse of profile-edit action to target others.
  - Mitigation: strict self-only identifier checks + default-off gate.
- Risk: Semantic mismatch between “token exhausted” text and underlying provider signal.
  - Mitigation: docs explicitly define this as runtime availability signal based on auth profile cooldown/disable state, not exact provider token counters.
