### PR TITLE
fix(telegram): throttle repeated getUpdates conflict retry logs

### DIFF
--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -91,6 +91,14 @@ function makeRecoverableFetchError() {
   });
 }
 
+function makeGetUpdatesConflictError() {
+  return {
+    error_code: 409,
+    description: "Conflict: terminated by other getUpdates request",
+    method: "getUpdates",
+  };
+}
+
 const createAbortTask = (
   abort: AbortController,
   beforeAbort?: () => void,
@@ -291,6 +299,37 @@ describe("monitorTelegramProvider (grammY)", () => {
     await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
 
     expectRecoverableRetryState(2);
+  });
+
+  it("throttles repeated getUpdates conflict retry logs", async () => {
+    const abort = new AbortController();
+    const runtimeError = vi.fn();
+    const conflictError = makeGetUpdatesConflictError();
+
+    runSpy
+      .mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: () => Promise.reject(conflictError),
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeRunnerStub({
+          task: () => Promise.reject(conflictError),
+        }),
+      )
+      .mockImplementationOnce(() => makeAbortRunner(abort));
+
+    await monitorTelegramProvider({
+      token: "tok",
+      abortSignal: abort.signal,
+      runtime: { log: vi.fn(), error: runtimeError, exit: vi.fn() },
+    });
+
+    const conflictLogs = runtimeError.mock.calls
+      .map((call) => String(call[0] ?? ""))
+      .filter((line) => line.includes("Telegram getUpdates conflict"));
+    expect(conflictLogs).toHaveLength(1);
+    expect(conflictLogs[0]).toContain("retrying in");
   });
 
   it("deletes webhook before starting polling", async () => {

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -60,6 +60,7 @@ const TELEGRAM_POLL_RESTART_POLICY = {
   factor: 1.8,
   jitter: 0.25,
 };
+const GET_UPDATES_CONFLICT_LOG_EVERY = 20;
 
 type TelegramBot = ReturnType<typeof createTelegramBot>;
 
@@ -179,13 +180,17 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
 
     // Use grammyjs/runner for concurrent update processing
     let restartAttempts = 0;
+    let getUpdatesConflictCount = 0;
     let webhookCleared = false;
     const runnerOptions = createTelegramRunnerOptions(cfg);
     const waitBeforeRestart = async (buildLine: (delay: string) => string): Promise<boolean> => {
       restartAttempts += 1;
       const delayMs = computeBackoff(TELEGRAM_POLL_RESTART_POLICY, restartAttempts);
       const delay = formatDurationPrecise(delayMs);
-      log(buildLine(delay));
+      const line = buildLine(delay).trim();
+      if (line) {
+        log(line);
+      }
       try {
         await sleepWithAbort(delayMs, opts.abortSignal);
       } catch (sleepErr) {
@@ -286,6 +291,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       try {
         // runner.task() returns a promise that resolves when the runner stops
         await runner.task();
+        getUpdatesConflictCount = 0;
         if (opts.abortSignal?.aborted) {
           return "exit";
         }
@@ -307,11 +313,24 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         if (!isConflict && !isRecoverable) {
           throw err;
         }
-        const reason = isConflict ? "getUpdates conflict" : "network error";
         const errMsg = formatErrorMessage(err);
-        const shouldRestart = await waitBeforeRestart(
-          (delay) => `Telegram ${reason}: ${errMsg}; retrying in ${delay}.`,
-        );
+        const shouldRestart = await waitBeforeRestart((delay) => {
+          if (!isConflict) {
+            getUpdatesConflictCount = 0;
+            return `Telegram network error: ${errMsg}; retrying in ${delay}.`;
+          }
+          getUpdatesConflictCount += 1;
+          const shouldIncludeCount =
+            getUpdatesConflictCount > 1 &&
+            getUpdatesConflictCount % GET_UPDATES_CONFLICT_LOG_EVERY === 0;
+          if (shouldIncludeCount) {
+            return `Telegram getUpdates conflict (${getUpdatesConflictCount}x): ${errMsg}; retrying in ${delay}.`;
+          }
+          if (getUpdatesConflictCount === 1) {
+            return `Telegram getUpdates conflict: ${errMsg}; retrying in ${delay}.`;
+          }
+          return "";
+        });
         return shouldRestart ? "continue" : "exit";
       } finally {
         opts.abortSignal?.removeEventListener("abort", stopOnAbort);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: repeated Telegram polling `409 getUpdates conflict` retries can spam logs at very high volume in multi-account deployments.
- Why it matters: this log flood hides actionable errors and creates large noisy logs without improving recovery behavior.
- What changed: throttled `getUpdates conflict` retry logging in polling restart loop (log first conflict, then every 20th conflict).
- What changed: retry/backoff/recovery behavior is unchanged; only logging frequency is reduced for repeated conflicts.
- What did NOT change (scope boundary): webhook flow, bot startup/stop sequencing, and network error retry behavior remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33154
- Related #33174

## User-visible / Behavior Changes

Repeated Telegram polling conflicts no longer emit one log line per retry. The first conflict is logged immediately, then periodic count-bearing lines are emitted every 20 conflicts.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Telegram polling (`@grammyjs/runner`)
- Relevant config (redacted): multiple Telegram accounts with polling enabled

### Steps

1. Start Telegram polling with a conflict-prone setup (multiple pollers / 409 `getUpdates` responses).
2. Allow repeated retry cycles to occur.
3. Inspect runtime error logs.

### Expected

- Logs should retain signal without flooding: first conflict should log, repeated identical conflicts should be throttled.

### Actual

- Before fix: every conflict retry logged.
- After fix: first conflict + periodic aggregate lines (`(...20x)` etc.) logged; retries continue unchanged.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added unit test asserting repeated conflict retries produce one conflict log across two immediate retries.
  - Confirmed monitor test suite passes with new behavior.
- Edge cases checked:
  - Non-conflict recoverable network retry logging remains unchanged.
  - Empty/suppressed log lines are not emitted.
- What you did **not** verify:
  - Live Telegram API end-to-end on real multi-account deployment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `bb7b81de1e`.
- Files/config to restore:
  - `src/telegram/monitor.ts`
  - `src/telegram/monitor.test.ts`
- Known bad symptoms reviewers should watch for:
  - Missing first conflict log line.
  - Network (non-conflict) retry logs unexpectedly suppressed.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: reduced log granularity may hide exact retry cadence during conflict storms.
  - Mitigation: first conflict is still logged immediately and periodic aggregate count logs preserve operational signal.
