### PR TITLE
feat(cron): allow sessionTarget 'main' for non-default agents

### DIFF
--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -389,18 +389,18 @@ describe("createJob rejects sessionTarget main for non-default agents", () => {
     expect(() => createJob(state, mainJobInput("MAIN"))).not.toThrow();
   });
 
-  it("rejects creating a main-session job for a non-default agentId", () => {
+  it("allows creating a main-session job for a non-default agentId (#33155)", () => {
     const state = createMockState(now, { defaultAgentId: "main" });
-    expect(() => createJob(state, mainJobInput("custom-agent"))).toThrow(
-      'cron: sessionTarget "main" is only valid for the default agent',
-    );
+    const job = createJob(state, mainJobInput("custom-agent"));
+    expect(job.sessionTarget).toBe("main");
+    expect(job.agentId).toBe("custom-agent");
   });
 
-  it("rejects main-session job for non-default agent even without explicit defaultAgentId", () => {
+  it("allows main-session job for non-default agent even without explicit defaultAgentId (#33155)", () => {
     const state = createMockState(now);
-    expect(() => createJob(state, mainJobInput("custom-agent"))).toThrow(
-      'cron: sessionTarget "main" is only valid for the default agent',
-    );
+    const job = createJob(state, mainJobInput("custom-agent"));
+    expect(job.sessionTarget).toBe("main");
+    expect(job.agentId).toBe("custom-agent");
   });
 
   it("allows isolated session job for non-default agents", () => {
@@ -438,7 +438,7 @@ describe("createJob rejects sessionTarget main for non-default agents", () => {
   });
 });
 
-describe("applyJobPatch rejects sessionTarget main for non-default agents", () => {
+describe("applyJobPatch allows sessionTarget main for any agent (#33155)", () => {
   const now = Date.now();
 
   const createMainJob = (agentId?: string): CronJob => ({
@@ -455,13 +455,14 @@ describe("applyJobPatch rejects sessionTarget main for non-default agents", () =
     agentId,
   });
 
-  it("rejects patching agentId to non-default on a main-session job", () => {
+  it("allows patching agentId to non-default on a main-session job (#33155)", () => {
     const job = createMainJob();
     expect(() =>
       applyJobPatch(job, { agentId: "custom-agent" } as CronJobPatch, {
         defaultAgentId: "main",
       }),
-    ).toThrow('cron: sessionTarget "main" is only valid for the default agent');
+    ).not.toThrow();
+    expect(job.agentId).toBe("custom-agent");
   });
 
   it("allows patching agentId to the default agent on a main-session job", () => {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import { normalizeAgentId } from "../../routing/session-key.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
 import { computeNextRunAtMs } from "../schedule.js";
 import {
@@ -104,25 +103,6 @@ export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "pay
   }
   if (job.sessionTarget === "isolated" && job.payload.kind !== "agentTurn") {
     throw new Error('isolated cron jobs require payload.kind="agentTurn"');
-  }
-}
-
-function assertMainSessionAgentId(
-  job: Pick<CronJob, "sessionTarget" | "agentId">,
-  defaultAgentId: string | undefined,
-) {
-  if (job.sessionTarget !== "main") {
-    return;
-  }
-  if (!job.agentId) {
-    return;
-  }
-  const normalized = normalizeAgentId(job.agentId);
-  const normalizedDefault = normalizeAgentId(defaultAgentId);
-  if (normalized !== normalizedDefault) {
-    throw new Error(
-      `cron: sessionTarget "main" is only valid for the default agent. Use sessionTarget "isolated" with payload.kind "agentTurn" for non-default agents (agentId: ${job.agentId})`,
-    );
   }
 }
 
@@ -487,17 +467,20 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     },
   };
   assertSupportedJobSpec(job);
-  assertMainSessionAgentId(job, state.deps.defaultAgentId);
   assertDeliverySupport(job);
   assertFailureDestinationSupport(job);
   job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
   return job;
 }
 
+/**
+ * @param _opts - Reserved; `defaultAgentId` is no longer enforced since
+ *   any agent may now target its own main session (#33155).
+ */
 export function applyJobPatch(
   job: CronJob,
   patch: CronJobPatch,
-  opts?: { defaultAgentId?: string },
+  _opts?: { defaultAgentId?: string },
 ) {
   if ("name" in patch) {
     job.name = normalizeRequiredName(patch.name);
@@ -577,7 +560,6 @@ export function applyJobPatch(
     job.sessionKey = normalizeOptionalSessionKey((patch as { sessionKey?: unknown }).sessionKey);
   }
   assertSupportedJobSpec(job);
-  assertMainSessionAgentId(job, opts?.defaultAgentId);
   assertDeliverySupport(job);
   assertFailureDestinationSupport(job);
 }


### PR DESCRIPTION
## Summary

- **Problem:** `sessionTarget: "main"` was restricted to the default agent only, preventing non-default agents from scheduling cron jobs in their own main session.
- **Why it matters:** Multi-agent setups (9+ agents) can't use session-persistent cron tasks for non-default agents, forcing them into isolated sessions which lose conversational context.
- **What changed:** Removed the `assertMainSessionAgentId` restriction so any agent can target its own main session.
- **What did NOT change:** Isolated session behavior, cron job execution logic, or default agent behavior.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33155

## User-visible / Behavior Changes

- Non-default agents can now use `sessionTarget: "main"` in cron jobs.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Cron scheduler

### Steps

1. Create a cron job for a non-default agent with `sessionTarget: "main"`
2. Observe that it no longer throws an error

### Expected

- Job is created and runs in the agent's main session.

### Actual

- Before fix: Error "sessionTarget 'main' is only valid for the default agent"
- After fix: Job created successfully.

## Evidence

Test verifies `createJob` accepts `sessionTarget: "main"` with a non-default agentId.

## Human Verification (required)

- Verified scenarios: non-default agent with main session, default agent (unchanged)
- Edge cases checked: no agentId (still allowed), isolated sessions (unchanged)
- What I did **not** verify: Cross-agent session targeting (not supported)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Restore assertMainSessionAgentId function
- Files/config to restore: `src/cron/service/jobs.ts`
- Known bad symptoms: Non-default agents could access other agents' main sessions (mitigated by session key isolation)

## Risks and Mitigations

None — each agent's main session is independently keyed by agentId.
