### PR TITLE
fix(cron): ensure nextRunAtMs is always in the future after job completion

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -162,4 +162,19 @@ describe("cron schedule", () => {
       expect(next).toBe(noonMs + 86_400_000); // next day
     });
   });
+
+  it("does not return a past time when job finishes after the daily scheduled time (#33126)", () => {
+    // Job scheduled at 03:00 Asia/Shanghai (19:00 UTC prev day),
+    // finishes at 06:01:44 UTC (14:01 CST) — well after today's 03:00 CST
+    const endedAtMs = Date.parse("2026-03-03T06:01:44.000Z");
+    const next = computeNextRunAtMs(
+      { kind: "cron", expr: "0 3 * * *", tz: "Asia/Shanghai" },
+      endedAtMs,
+    );
+    // Next run should be 03:00 CST on March 4 = 19:00 UTC March 3
+    const expectedNext = Date.parse("2026-03-03T19:00:00.000Z");
+    expect(next).toBeDefined();
+    expect(next).toBeGreaterThan(endedAtMs);
+    expect(next).toBe(expectedNext);
+  });
 });

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -102,6 +102,17 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
         return retry2Ms;
       }
     }
+    // All retries returned past times — try one minute ahead as a last resort
+    // to work around timezone edge cases where the job finished after its
+    // daily scheduled time (#33126).
+    const oneMinuteAhead = nowMs + 60_000;
+    const retry3 = cron.nextRun(new Date(oneMinuteAhead));
+    if (retry3) {
+      const retry3Ms = retry3.getTime();
+      if (Number.isFinite(retry3Ms) && retry3Ms > nowMs) {
+        return retry3Ms;
+      }
+    }
     return undefined;
   }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -414,6 +414,17 @@ export function applyJobResult(
         // so a persistent throw doesn't cause a MIN_REFIRE_GAP_MS hot loop.
         recordScheduleComputeError({ state, job, err });
       }
+      if (
+        job.schedule.kind === "cron" &&
+        naturalNext !== undefined &&
+        naturalNext <= result.endedAt
+      ) {
+        try {
+          naturalNext = computeJobNextRunAtMs(job, result.endedAt + 60_000);
+        } catch {
+          // ignore
+        }
+      }
       if (job.schedule.kind === "cron") {
         // Safety net: ensure the next fire is at least MIN_REFIRE_GAP_MS
         // after the current run ended.  Prevents spin-loops when the


### PR DESCRIPTION
## Summary

- **Problem:** After a cron job finishes past its daily scheduled time, `nextRunAtMs` could be set to a time in the past due to croner timezone edge cases (e.g., `Asia/Shanghai` with `0 3 * * *`).
- **Why it matters:** Scheduler thinks the job is overdue and may trigger immediate re-execution or skip to the wrong next occurrence.
- **What changed:** Added a last-resort retry from one minute ahead in `computeNextRunAtMs`, and a guard in `applyJobResult` to recompute when `naturalNext <= endedAt`.
- **What did NOT change:** Normal cron scheduling behavior, retry logic, or error backoff.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33126

## User-visible / Behavior Changes

- Cron jobs with timezone-sensitive schedules no longer produce past-time `nextRunAtMs` values.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (x64)
- Runtime: Node.js v22
- Integration/channel: Cron scheduler

### Steps

1. Create a daily cron job `0 3 * * *` with `tz: "Asia/Shanghai"`
2. Let it complete at 06:01:44 UTC (14:01 CST)
3. Check `nextRunAtMs`

### Expected

- `nextRunAtMs` is next day at 03:00 CST.

### Actual

- Before fix: `nextRunAtMs` could be same-day 03:00 CST (past).
- After fix: `nextRunAtMs` is always in the future.

## Evidence

Test verifies `computeNextRunAtMs` returns a future time when called with a timestamp after the daily schedule.

## Human Verification (required)

- Verified scenarios: Asia/Shanghai daily cron, job finishing hours after scheduled time
- Edge cases checked: year-rollback (existing), same-second edge (MIN_REFIRE_GAP_MS)
- What I did **not** verify: All IANA timezone combinations

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove retry3 and naturalNext guard
- Files/config to restore: `src/cron/schedule.ts`, `src/cron/service/timer.ts`
- Known bad symptoms: nextRunAtMs could be in the past again

## Risks and Mitigations

- Risk: One-minute-ahead retry could skip a legitimate next occurrence — Mitigated: only used as last resort when all other retries failed
