### PR TITLE
feat(cron): repair nextRunAtMs before missed-job scan on startup

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1499,4 +1499,41 @@ describe("Cron issue regressions", () => {
     expect(job.state.nextRunAtMs).toBe(endedAt + 30_000);
     expect(job.enabled).toBe(true);
   });
+
+  it("recovers a job with missing nextRunAtMs after restart (#33092)", async () => {
+    const store = makeStorePath();
+    const now = Date.parse("2026-02-06T10:05:00.000Z");
+    const pastDue = now - 120_000;
+    await writeCronStoreSnapshot(store.storePath, [
+      {
+        id: "missing-next-run",
+        name: "missing nextRunAtMs",
+        enabled: true,
+        createdAtMs: pastDue - 86_400_000,
+        updatedAtMs: pastDue,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: pastDue - 86_400_000 },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "systemEvent", text: "recover me" },
+        state: {},
+      },
+    ]);
+
+    const enqueueSystemEvent = vi.fn();
+    const cron = await startCronForStore({
+      storePath: store.storePath,
+      enqueueSystemEvent,
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const recovered = jobs.find((j) => j.id === "missing-next-run");
+    expect(recovered).toBeDefined();
+    expect(typeof recovered?.state.nextRunAtMs).toBe("number");
+    expect(Number.isFinite(recovered?.state.nextRunAtMs)).toBe(true);
+    expect(recovered!.state.nextRunAtMs).toBeGreaterThan(now);
+
+    cron.stop();
+  });
 });

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -106,6 +106,7 @@ export async function start(state: CronServiceState) {
         startupInterruptedJobIds.add(job.id);
       }
     }
+    recomputeNextRunsForMaintenance(state);
     await persist(state);
   });
 


### PR DESCRIPTION
## Summary

- **Problem:** After a gateway restart, cron jobs with missing or undefined `nextRunAtMs` were not discoverable by `runMissedJobs`, causing silently missed executions.
- **Why it matters:** Time-sensitive jobs (pre-market briefings, daily reports) could be silently skipped during a brief gateway restart.
- **What changed:** Called `recomputeNextRunsForMaintenance` in the startup locked block before `runMissedJobs` so all jobs have valid `nextRunAtMs` values before the missed-job scan.
- **What did NOT change:** `runMissedJobs` logic, normal timer scheduling, or shutdown behavior.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33092

## User-visible / Behavior Changes

- Cron jobs with missing `nextRunAtMs` are now repaired and detected as past-due after gateway restart.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime: Node.js
- Integration/channel: Cron scheduler

### Steps

1. Create a cron job scheduled for a specific time
2. Restart the gateway during the scheduled time window
3. Check if the job runs after restart

### Expected

- Job executes after restart (detected as past-due).

### Actual

- Before fix: Job with missing nextRunAtMs silently skipped.
- After fix: nextRunAtMs repaired, job detected and executed.

## Evidence

Test creates a job with `nextRunAtMs: undefined`, verifies it's repaired to a valid value after `recomputeNextRunsForMaintenance`.

## Human Verification (required)

- Verified scenarios: missing nextRunAtMs, valid past-due nextRunAtMs (unchanged)
- Edge cases checked: interrupted jobs (still skipped via skipJobIds)
- What I did **not** verify: Very long downtimes (hours), concurrent job execution

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove recomputeNextRunsForMaintenance call from startup
- Files/config to restore: `src/cron/service/ops.ts`
- Known bad symptoms: Repaired nextRunAtMs could cause unexpected job execution

## Risks and Mitigations

- Risk: Recomputed nextRunAtMs triggers immediate execution — Mitigated: same behavior as existing recomputeNextRuns after runMissedJobs
