### PR TITLE
fix(bluebubbles): gracefully handle unparseable webhook payloads

### DIFF
--- a/extensions/bluebubbles/src/monitor-normalize.test.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.test.ts
@@ -56,6 +56,38 @@ describe("normalizeWebhookMessage", () => {
 });
 
 describe("normalizeWebhookReaction", () => {
+  it("parses reaction from payload.reaction path", () => {
+    const result = normalizeWebhookReaction({
+      type: "new-message",
+      reaction: {
+        guid: "react-1",
+        text: 'Loved "hello"',
+        isFromMe: false,
+        handle: { address: "+15551234567" },
+        associatedMessageGuid: "msg-original-1",
+        associatedMessageType: 2000,
+        chats: [{ guid: "iMessage;-;+15559876543" }],
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result?.emoji).toBe("❤️");
+    expect(result?.action).toBe("added");
+  });
+
+  it("returns null when reaction payload has no associated guid", () => {
+    const result = normalizeWebhookReaction({
+      type: "message-reaction",
+      data: {
+        guid: "msg-2",
+        text: "Liked",
+        isFromMe: false,
+        handle: { address: "+15551234567" },
+        chats: [{ guid: "iMessage;-;+15559876543" }],
+      },
+    });
+    expect(result).toBeNull();
+  });
+
   it("falls back to DM chatGuid handle when reaction sender handle is missing", () => {
     const result = normalizeWebhookReaction({
       type: "updated-message",

--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -761,7 +761,7 @@ export function normalizeWebhookMessage(
 export function normalizeWebhookReaction(
   payload: Record<string, unknown>,
 ): NormalizedWebhookReaction | null {
-  const message = extractMessagePayload(payload);
+  const message = extractMessagePayload(payload) ?? parseRecord(payload.reaction);
   if (!message) {
     return null;
   }

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -225,9 +225,15 @@ export async function handleBlueBubblesWebhookRequest(
     }
     const message = reaction ? null : normalizeWebhookMessage(payload);
     if (!message && !reaction) {
-      res.statusCode = 400;
-      res.end("invalid payload");
-      console.warn("[bluebubbles] webhook rejected: unable to parse message payload");
+      res.statusCode = 200;
+      res.end("ok");
+      if (firstTarget) {
+        logVerbose(
+          firstTarget.core,
+          firstTarget.runtime,
+          `webhook ignored unparseable ${eventType || "event"} payload (missing sender or message data)`,
+        );
+      }
       return true;
     }
 


### PR DESCRIPTION
## Summary

- **Problem:** BlueBubbles webhook handler rejected reaction/tapback payloads with "unable to parse message payload" (HTTP 400), filling logs with warnings in active group chats.
- **Why it matters:** Agents monitoring group chats miss context from reactions; hundreds of 400 errors per day in active chats.
- **What changed:** Changed the fallback from 400 error to 200 with debug log for unparseable payloads. Extended `extractMessagePayload` to check `payload.reaction` path.
- **What did NOT change:** Normal text message parsing, recognized reaction handling, or webhook authentication.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33085

## User-visible / Behavior Changes

- Reactions/tapbacks no longer produce 400 errors or warning-level log entries.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js
- Integration/channel: BlueBubbles iMessage

### Steps

1. Configure BlueBubbles with webhook
2. Send a reaction (tapback) in a group chat
3. Check gateway logs

### Expected

- Reaction processed or silently ignored with 200.

### Actual

- Before fix: 400 error "unable to parse message payload".
- After fix: 200 with debug log.

## Evidence

Tests verify reaction parsing from `payload.reaction` path and graceful handling of missing associated guid.

## Human Verification (required)

- Verified scenarios: group chat tapbacks, DM reactions, missing sender handle
- Edge cases checked: empty payload, unknown event types
- What I did **not** verify: All BlueBubbles server versions

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Restore 400 response for unparseable payloads
- Files/config to restore: `extensions/bluebubbles/src/monitor.ts`
- Known bad symptoms: Genuine payload errors would be silently ignored

## Risks and Mitigations

- Risk: Masking genuine malformed payloads — Mitigated: debug logging preserves visibility
