### PR TITLE
fix(config): make status command resilient to unresolved SecretRefs

### DIFF
--- a/src/commands/status-all/channels.test.ts
+++ b/src/commands/status-all/channels.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  listChannelPlugins: vi.fn(() => []),
+}));
+
+vi.mock("../../channels/plugins/helpers.js", () => ({
+  resolveChannelDefaultAccountId: vi.fn(() => "default"),
+}));
+
+vi.mock("../../channels/account-summary.js", () => ({
+  buildChannelAccountSnapshot: vi.fn(
+    (params: { accountId: string; enabled: boolean; configured: boolean }) => ({
+      accountId: params.accountId,
+      enabled: params.enabled,
+      configured: params.configured,
+    }),
+  ),
+  formatChannelAllowFrom: vi.fn(() => []),
+  resolveChannelAccountEnabled: vi.fn(() => true),
+  resolveChannelAccountConfigured: vi.fn(async () => true),
+}));
+
+const { listChannelPlugins } = await import("../../channels/plugins/index.js");
+const { buildChannelsTable } = await import("./channels.js");
+
+function createThrowingPlugin() {
+  return {
+    id: "telegram",
+    meta: {
+      id: "telegram",
+      label: "Telegram",
+      selectionLabel: "Telegram",
+      docsPath: "/telegram",
+      blurb: "mock",
+    },
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => {
+        throw new Error(
+          'channels.telegram.botToken: unresolved SecretRef "env:MY_TOKEN". Resolve this command against an active gateway runtime snapshot before reading it.',
+        );
+      },
+    },
+  };
+}
+
+function createWorkingPlugin() {
+  return {
+    id: "discord",
+    meta: {
+      id: "discord",
+      label: "Discord",
+      selectionLabel: "Discord",
+      docsPath: "/discord",
+      blurb: "mock",
+    },
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({ enabled: true, configured: true }),
+    },
+  };
+}
+
+describe("buildChannelsTable resilience", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("produces a degraded row when resolveAccount throws due to unresolved SecretRef", async () => {
+    const throwingPlugin = createThrowingPlugin();
+    (listChannelPlugins as ReturnType<typeof vi.fn>).mockReturnValue([throwingPlugin]);
+
+    const result = await buildChannelsTable({} as never);
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.id).toBe("telegram");
+    expect(result.rows[0]?.state).toBe("warn");
+    expect(result.rows[0]?.enabled).toBe(false);
+    expect(result.rows[0]?.detail).toContain("unresolved SecretRef");
+  });
+
+  it("does not crash when one plugin throws and another succeeds", async () => {
+    const throwingPlugin = createThrowingPlugin();
+    const workingPlugin = createWorkingPlugin();
+    (listChannelPlugins as ReturnType<typeof vi.fn>).mockReturnValue([
+      throwingPlugin,
+      workingPlugin,
+    ]);
+
+    const result = await buildChannelsTable({} as never);
+
+    expect(result.rows).toHaveLength(2);
+    const telegramRow = result.rows.find((r) => r.id === "telegram");
+    const discordRow = result.rows.find((r) => r.id === "discord");
+    expect(telegramRow?.state).toBe("warn");
+    expect(discordRow).toBeDefined();
+  });
+
+  it("marks degraded account as disabled", async () => {
+    const throwingPlugin = createThrowingPlugin();
+    (listChannelPlugins as ReturnType<typeof vi.fn>).mockReturnValue([throwingPlugin]);
+
+    const result = await buildChannelsTable({} as never);
+
+    expect(result.rows[0]?.enabled).toBe(false);
+  });
+});

--- a/src/commands/status-all/channels.ts
+++ b/src/commands/status-all/channels.ts
@@ -320,23 +320,40 @@ export async function buildChannelsTable(
 
     const accounts: ChannelAccountRow[] = [];
     for (const accountId of resolvedAccountIds) {
-      const account = plugin.config.resolveAccount(cfg, accountId);
-      const enabled = resolveChannelAccountEnabled({ plugin, account, cfg });
-      const configured = await resolveChannelAccountConfigured({
-        plugin,
-        account,
-        cfg,
-        readAccountConfiguredField: true,
-      });
-      const snapshot = buildChannelAccountSnapshot({
-        plugin,
-        cfg,
-        accountId,
-        account,
-        enabled,
-        configured,
-      });
-      accounts.push({ accountId, account, enabled, configured, snapshot });
+      try {
+        const account = plugin.config.resolveAccount(cfg, accountId);
+        const enabled = resolveChannelAccountEnabled({ plugin, account, cfg });
+        const configured = await resolveChannelAccountConfigured({
+          plugin,
+          account,
+          cfg,
+          readAccountConfiguredField: true,
+        });
+        const snapshot = buildChannelAccountSnapshot({
+          plugin,
+          cfg,
+          accountId,
+          account,
+          enabled,
+          configured,
+        });
+        accounts.push({ accountId, account, enabled, configured, snapshot });
+      } catch (e) {
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        const degraded: ChannelAccountSnapshot = {
+          accountId,
+          enabled: false,
+          configured: false,
+          lastError: errorMessage || "account resolution failed",
+        };
+        accounts.push({
+          accountId,
+          account: {},
+          enabled: false,
+          configured: false,
+          snapshot: degraded,
+        });
+      }
     }
 
     const anyEnabled = accounts.some((a) => a.enabled);
@@ -369,9 +386,13 @@ export async function buildChannelsTable(
 
     const label = plugin.meta.label ?? plugin.id;
 
+    const hasDegradedAccount = accounts.some((a) =>
+      a.snapshot.lastError?.includes("unresolved SecretRef"),
+    );
+
     const state = (() => {
       if (!anyEnabled) {
-        return "off";
+        return hasDegradedAccount ? "warn" : "off";
       }
       if (missingPaths.length > 0) {
         return "warn";
@@ -396,6 +417,9 @@ export async function buildChannelsTable(
 
     const detail = (() => {
       if (!anyEnabled) {
+        if (hasDegradedAccount) {
+          return "unresolved SecretRef (gateway unreachable)";
+        }
         if (!defaultEntry) {
           return "disabled";
         }


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw status` crashed when `channels.telegram.botToken` used a SecretRef that couldn't be resolved (e.g., gateway unreachable).
- **Why it matters:** Blocks production monitoring and status auditing when using SecretRef for tokens.
- **What changed:** Wrapped per-account resolution in `buildChannelsTable` with try/catch. Unresolved accounts produce a degraded row with a warning instead of crashing the entire command.
- **What did NOT change:** Secret resolution logic, gateway communication, or channel configuration.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33070

## User-visible / Behavior Changes

- `openclaw status` shows degraded channel state instead of crashing on unresolved SecretRefs.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Ubuntu)
- Runtime: Node.js
- Integration/channel: Telegram with SecretRef

### Steps

1. Configure `botToken` as SecretRef with file provider
2. Run `openclaw status` when gateway is unreachable

### Expected

- Status shows channel in degraded state.

### Actual

- Before fix: Crash with "unresolved SecretRef" error.
- After fix: Degraded row with warning.

## Evidence

3 tests verify: degraded row on resolution failure, isolation between plugins, degraded accounts marked as disabled.

## Human Verification (required)

- Verified scenarios: unresolved SecretRef, resolved SecretRef (unchanged), multiple plugins
- Edge cases checked: all accounts failing, partial failure
- What I did **not** verify: All SecretRef providers

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove try/catch wrapper
- Files/config to restore: `src/commands/status-all/channels.ts`
- Known bad symptoms: Status would crash again on unresolved SecretRefs

## Risks and Mitigations

- Risk: Degraded state masking real issues — Mitigated: warning message clearly indicates the cause
