### PR TITLE
feat(webchat): track and expose AI response duration

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -566,3 +566,71 @@ describe("loadChatHistory", () => {
     expect(state.lastError).toBeNull();
   });
 });
+
+describe("handleChatEvent response duration", () => {
+  it("computes responseDurationMs on final event with message", () => {
+    const now = Date.now();
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Hello",
+      chatStreamStartedAt: now - 5000,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+      },
+    };
+    handleChatEvent(state, payload);
+    expect(state.chatMessages).toHaveLength(1);
+    const msg = state.chatMessages[0] as Record<string, unknown>;
+    expect(typeof msg.responseDurationMs).toBe("number");
+    expect(msg.responseDurationMs).toBeGreaterThanOrEqual(5000);
+  });
+
+  it("computes responseDurationMs on final event with stream fallback", () => {
+    const now = Date.now();
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Hello world",
+      chatStreamStartedAt: now - 3000,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+    };
+    handleChatEvent(state, payload);
+    expect(state.chatMessages).toHaveLength(1);
+    const msg = state.chatMessages[0] as Record<string, unknown>;
+    expect(typeof msg.responseDurationMs).toBe("number");
+    expect(msg.responseDurationMs).toBeGreaterThanOrEqual(3000);
+  });
+
+  it("does not attach responseDurationMs when chatStreamStartedAt is null", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Hello world",
+      chatStreamStartedAt: null,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+      },
+    };
+    handleChatEvent(state, payload);
+    expect(state.chatMessages).toHaveLength(1);
+    const msg = state.chatMessages[0] as Record<string, unknown>;
+    expect(msg.responseDurationMs).toBeUndefined();
+  });
+});

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -273,7 +273,13 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
+    const responseDurationMs = state.chatStreamStartedAt
+      ? Date.now() - state.chatStreamStartedAt
+      : undefined;
     if (finalMessage && !isAssistantSilentReply(finalMessage)) {
+      if (responseDurationMs !== undefined) {
+        finalMessage.responseDurationMs = responseDurationMs;
+      }
       state.chatMessages = [...state.chatMessages, finalMessage];
     } else if (state.chatStream?.trim() && !isSilentReplyStream(state.chatStream)) {
       state.chatMessages = [
@@ -282,6 +288,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
           role: "assistant",
           content: [{ type: "text", text: state.chatStream }],
           timestamp: Date.now(),
+          ...(responseDurationMs !== undefined ? { responseDurationMs } : {}),
         },
       ];
     }


### PR DESCRIPTION
## Summary

- **Problem:** Webchat only displayed timestamps, with no indication of how long the AI took to respond.
- **Why it matters:** Users need response time visibility for performance monitoring and optimization.
- **What changed:** Compute `responseDurationMs` from `chatStreamStartedAt` when the final event arrives, attaching it to the persisted chat message.
- **What did NOT change:** Message content, streaming behavior, or UI rendering.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33087

## User-visible / Behavior Changes

- Chat messages now include `responseDurationMs` for UI rendering.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Browser
- Integration/channel: Webchat

### Steps

1. Open webchat
2. Send a message
3. Check the message object for `responseDurationMs`

### Expected

- Message includes `responseDurationMs` with the response time in milliseconds.

### Actual

- Before fix: No duration information.
- After fix: Duration computed and attached to message.

## Evidence

3 tests verify: duration computed with final message, duration with stream fallback, no duration when streamStartedAt is null.

## Human Verification (required)

- Verified scenarios: normal response, streamed response, no stream
- Edge cases checked: null chatStreamStartedAt, very fast responses
- What I did **not** verify: UI rendering of the duration value

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove responseDurationMs computation
- Files/config to restore: `ui/src/ui/controllers/chat.ts`
- Known bad symptoms: Undefined responseDurationMs (harmless)

## Risks and Mitigations

None — adds optional metadata to messages with no behavioral impact.
