### PR TITLE
fix(gateway): avoid false restart timeout when lsof is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/restart health checks: treat `port=busy` with no listener metadata as healthy ownership when runtime PID is running, so `openclaw gateway restart` no longer false-times out on systems where `lsof` is unavailable. (#32620) Thanks @riftzen-bit.
 - Telegram/DM draft finalization reliability: require verified final-text draft emission before treating preview finalization as delivered, and fall back to normal payload send when final draft delivery is not confirmed (preventing missing final responses and preserving media/button delivery). (#32118) Thanks @OpenCils.
 - Exec heartbeat routing: scope exec-triggered heartbeat wakes to agent session keys so unrelated agents are no longer awakened by exec events, while preserving legacy unscoped behavior for non-canonical session keys. (#32724) thanks @altaywtf
 - macOS/Tailscale remote gateway discovery: add a Tailscale Serve fallback peer probe path (`wss://<peer>.ts.net`) when Bonjour and wide-area DNS-SD discovery return no gateways, and refresh both discovery paths from macOS onboarding. (#32860) Thanks @ngutman.

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -96,6 +96,26 @@ describe("inspectGatewayRestart", () => {
     expect(snapshot.staleGatewayPids).toEqual([9000]);
   });
 
+  it("treats busy port without listener metadata as healthy when runtime is running", async () => {
+    const service = {
+      readRuntime: vi.fn(async () => ({ status: "running", pid: 8000 })),
+    } as unknown as GatewayService;
+
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [],
+      hints: [],
+      errors: ["Error: spawn lsof ENOENT"],
+    });
+
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({ service, port: 18789 });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.staleGatewayPids).toEqual([]);
+  });
+
   it("treats unknown listeners as stale on Windows when enabled", async () => {
     const snapshot = await inspectUnknownListenerFallback({
       runtime: { status: "stopped" },

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -76,7 +76,10 @@ export async function inspectGatewayRestart(params: {
   const runtimePid = runtime.pid;
   const ownsPort =
     runtimePid != null
-      ? portUsage.listeners.some((listener) => listenerOwnedByRuntimePid({ listener, runtimePid }))
+      ? portUsage.listeners.some((listener) =>
+          listenerOwnedByRuntimePid({ listener, runtimePid }),
+        ) ||
+        (portUsage.status === "busy" && portUsage.listeners.length === 0)
       : gatewayListeners.length > 0 ||
         (portUsage.status === "busy" && portUsage.listeners.length === 0);
   const healthy = running && ownsPort;


### PR DESCRIPTION
## Summary
- fix `inspectGatewayRestart` ownership fallback for running runtime PID when port is busy but listener metadata is unavailable
- treat `portUsage.status === "busy" && listeners.length === 0` as owned in the `runtimePid != null` branch (same fallback used in the `runtimePid == null` branch)
- add regression test for `spawn lsof ENOENT` style diagnostics with runtime running
- add changelog entry under `2026.3.3` Fixes

## Why
On systems without `lsof`, port inspection can return `busy` with an empty listeners list. Before this patch, the runtime-PID branch required `.some(...)` ownership and never hit the empty-list fallback, causing false unhealthy status and 60s restart timeout.

## Testing
- `pnpm format:check`
- `pnpm vitest src/cli/daemon-cli/restart-health.test.ts`

Fixes #32620

Note: overlaps in scope with #32613, but includes regression coverage + changelog update in this branch.
