### PR TITLE
fix(agents): cache repeated session history image sanitization

### DIFF
--- a/src/agents/tool-images.log.test.ts
+++ b/src/agents/tool-images.log.test.ts
@@ -63,4 +63,16 @@ describe("tool-images log context", () => {
     expect(typeof message).toBe("string");
     expect(String(message)).toContain("sample-diagram.png");
   });
+
+  it("does not re-log identical resize work for repeated session history payloads", async () => {
+    const png = await createLargePng();
+    const blocks = [
+      { type: "image" as const, data: png.toString("base64"), mimeType: "image/png" },
+    ];
+
+    await sanitizeContentBlocksImages(blocks, "session:history");
+    await sanitizeContentBlocksImages(blocks, "session:history");
+
+    expect(infoMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/tool-images.log.test.ts
+++ b/src/agents/tool-images.log.test.ts
@@ -75,4 +75,16 @@ describe("tool-images log context", () => {
 
     expect(infoMock).toHaveBeenCalledTimes(1);
   });
+
+  it("does not cache repeated resize work for non-session labels", async () => {
+    const png = await createLargePng();
+    const blocks = [
+      { type: "image" as const, data: png.toString("base64"), mimeType: "image/png" },
+    ];
+
+    await sanitizeContentBlocksImages(blocks, "nodes:camera_snap");
+    await sanitizeContentBlocksImages(blocks, "nodes:camera_snap");
+
+    expect(infoMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -352,15 +352,9 @@ export async function sanitizeContentBlocksImages(
       const inferredMimeType = inferMimeTypeFromBase64(canonicalData);
       const mimeType = inferredMimeType ?? block.mimeType;
       const fileName = inferImageFileName({ block, label, mediaPathHint });
-      const cacheKey = buildSanitizedImageCacheKey({
-        canonicalData,
-        label,
-        mimeType,
-        maxDimensionPx,
-        maxBytes,
-      });
+      const cacheEnabled = shouldCacheSanitizedImage(label);
       const resized = await (() => {
-        if (!shouldCacheSanitizedImage(label)) {
+        if (!cacheEnabled) {
           return resizeImageBase64IfNeeded({
             base64: canonicalData,
             mimeType,
@@ -370,6 +364,13 @@ export async function sanitizeContentBlocksImages(
             fileName,
           });
         }
+        const cacheKey = buildSanitizedImageCacheKey({
+          canonicalData,
+          label,
+          mimeType,
+          maxDimensionPx,
+          maxBytes,
+        });
         const cached = sanitizedImageCache.get(cacheKey);
         if (cached) {
           return cached;

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -27,11 +27,16 @@ type TextContentBlock = Extract<ToolContentBlock, { type: "text" }>;
 // and recompress base64 image blocks when they exceed these limits.
 const MAX_IMAGE_DIMENSION_PX = DEFAULT_IMAGE_MAX_DIMENSION_PX;
 const MAX_IMAGE_BYTES = DEFAULT_IMAGE_MAX_BYTES;
-const SANITIZED_IMAGE_CACHE_MAX_ENTRIES = 256;
+const SANITIZED_IMAGE_CACHE_MAX_ENTRIES = 16;
 const log = createSubsystemLogger("agents/tool-images");
 
 type SanitizedImageResult = Awaited<ReturnType<typeof resizeImageBase64IfNeeded>>;
 const sanitizedImageCache = new Map<string, Promise<SanitizedImageResult>>();
+const SANITIZED_IMAGE_CACHE_LABEL_PREFIX = "session:history";
+
+function shouldCacheSanitizedImage(label: string): boolean {
+  return label.startsWith(SANITIZED_IMAGE_CACHE_LABEL_PREFIX);
+}
 
 function isImageBlock(block: unknown): block is ImageContentBlock {
   if (!block || typeof block !== "object") {
@@ -355,6 +360,16 @@ export async function sanitizeContentBlocksImages(
         maxBytes,
       });
       const resized = await (() => {
+        if (!shouldCacheSanitizedImage(label)) {
+          return resizeImageBase64IfNeeded({
+            base64: canonicalData,
+            mimeType,
+            maxDimensionPx,
+            maxBytes,
+            label,
+            fileName,
+          });
+        }
         const cached = sanitizedImageCache.get(cacheKey);
         if (cached) {
           return cached;

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -26,7 +27,11 @@ type TextContentBlock = Extract<ToolContentBlock, { type: "text" }>;
 // and recompress base64 image blocks when they exceed these limits.
 const MAX_IMAGE_DIMENSION_PX = DEFAULT_IMAGE_MAX_DIMENSION_PX;
 const MAX_IMAGE_BYTES = DEFAULT_IMAGE_MAX_BYTES;
+const SANITIZED_IMAGE_CACHE_MAX_ENTRIES = 256;
 const log = createSubsystemLogger("agents/tool-images");
+
+type SanitizedImageResult = Awaited<ReturnType<typeof resizeImageBase64IfNeeded>>;
+const sanitizedImageCache = new Map<string, Promise<SanitizedImageResult>>();
 
 function isImageBlock(block: unknown): block is ImageContentBlock {
   if (!block || typeof block !== "object") {
@@ -266,6 +271,38 @@ async function resizeImageBase64IfNeeded(params: {
   throw new Error(`Image could not be reduced below ${maxMb}MB (got ${gotMb}MB)`);
 }
 
+function buildSanitizedImageCacheKey(params: {
+  canonicalData: string;
+  label: string;
+  mimeType: string;
+  maxDimensionPx: number;
+  maxBytes: number;
+}): string {
+  const digest = createHash("sha1").update(params.canonicalData, "utf8").digest("hex");
+  return `${params.label}|${params.mimeType}|${params.maxDimensionPx}|${params.maxBytes}|${digest}`;
+}
+
+function rememberSanitizedImageCacheValue(
+  key: string,
+  value: Promise<SanitizedImageResult>,
+): Promise<SanitizedImageResult> {
+  sanitizedImageCache.set(key, value);
+  while (sanitizedImageCache.size > SANITIZED_IMAGE_CACHE_MAX_ENTRIES) {
+    const oldest = sanitizedImageCache.keys().next().value;
+    if (!oldest) {
+      break;
+    }
+    sanitizedImageCache.delete(oldest);
+  }
+  value.catch(() => {
+    // Don't keep failed conversions in cache; allow a future retry.
+    if (sanitizedImageCache.get(key) === value) {
+      sanitizedImageCache.delete(key);
+    }
+  });
+  return value;
+}
+
 export async function sanitizeContentBlocksImages(
   blocks: ToolContentBlock[],
   label: string,
@@ -310,14 +347,30 @@ export async function sanitizeContentBlocksImages(
       const inferredMimeType = inferMimeTypeFromBase64(canonicalData);
       const mimeType = inferredMimeType ?? block.mimeType;
       const fileName = inferImageFileName({ block, label, mediaPathHint });
-      const resized = await resizeImageBase64IfNeeded({
-        base64: canonicalData,
+      const cacheKey = buildSanitizedImageCacheKey({
+        canonicalData,
+        label,
         mimeType,
         maxDimensionPx,
         maxBytes,
-        label,
-        fileName,
       });
+      const resized = await (() => {
+        const cached = sanitizedImageCache.get(cacheKey);
+        if (cached) {
+          return cached;
+        }
+        return rememberSanitizedImageCacheValue(
+          cacheKey,
+          resizeImageBase64IfNeeded({
+            base64: canonicalData,
+            mimeType,
+            maxDimensionPx,
+            maxBytes,
+            label,
+            fileName,
+          }),
+        );
+      })();
       out.push({
         ...block,
         data: resized.base64,

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -27,7 +27,7 @@ type TextContentBlock = Extract<ToolContentBlock, { type: "text" }>;
 // and recompress base64 image blocks when they exceed these limits.
 const MAX_IMAGE_DIMENSION_PX = DEFAULT_IMAGE_MAX_DIMENSION_PX;
 const MAX_IMAGE_BYTES = DEFAULT_IMAGE_MAX_BYTES;
-const SANITIZED_IMAGE_CACHE_MAX_ENTRIES = 16;
+const SANITIZED_IMAGE_CACHE_MAX_ENTRIES = 256;
 const log = createSubsystemLogger("agents/tool-images");
 
 type SanitizedImageResult = Awaited<ReturnType<typeof resizeImageBase64IfNeeded>>;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: repeated `session:history` sanitization can re-run identical image resize work and emit repeated `agents/tool-images` resize logs.
- Why it matters: this creates noisy logs and redundant image processing during Control UI history refreshes.
- What changed: added a bounded in-memory cache for sanitized image results keyed by label + limits + image payload hash.
- What changed: failed sanitization results are not cached; successful results are reused and resize logs are emitted only on first sanitize for a given key.
- What did NOT change (scope boundary): image size/dimension limits and sanitization behavior are unchanged; only repeated-work reuse was added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33179
- Related #33119

## User-visible / Behavior Changes

Repeated Control UI `session:history` image sanitization reuses previous sanitized output for identical payloads, reducing duplicate `Image resized to fit limits` log lines and redundant resize work.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev), issue reported on Windows
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Control UI session history sanitization path
- Relevant config (redacted): default image sanitization limits

### Steps

1. Feed identical image payload(s) through `sanitizeContentBlocksImages(..., "session:history")` repeatedly.
2. Observe resize logs and sanitization calls.
3. Repeat with unchanged limits and payload.

### Expected

- Repeated identical history payloads should not re-run resize work/logging every time.

### Actual

- Before fix: repeated calls can re-log and reprocess the same image payload.
- After fix: repeated calls reuse cached sanitize output and do not emit duplicate resize logs for same key.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest src/agents/tool-images.log.test.ts src/agents/tool-images.test.ts` passes.
  - New test confirms identical `session:history` payload sanitization logs resize once across repeated calls.
- Edge cases checked:
  - Cache is bounded (256 entries).
  - Failed sanitizations are removed from cache.
- What you did **not** verify:
  - End-to-end live gateway logs under long-running production session history polling.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `1531d50ec1`.
- Files/config to restore:
  - `src/agents/tool-images.ts`
  - `src/agents/tool-images.log.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected stale sanitization output across distinct image payloads.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: cache key hash collisions could cause incorrect reuse in rare cases.
  - Mitigation: key also includes label/mime/limits and uses SHA-1 digest; practical collision risk is negligible for this internal reuse optimization.
