### PR TITLE
onboard: keep non-interactive tools profile unset by default

### DIFF
--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -9,7 +9,7 @@ const gatewayClientCalls: Array<{
   url?: string;
   token?: string;
   password?: string;
-  onHelloOk?: () => void;
+  onHelloOk?: (hello?: { features?: { methods?: string[] } }) => void;
   onClose?: (code: number, reason: string) => void;
 }> = [];
 const ensureWorkspaceAndSessionsMock = vi.fn(async (..._args: unknown[]) => {});
@@ -20,13 +20,13 @@ vi.mock("../gateway/client.js", () => ({
       url?: string;
       token?: string;
       password?: string;
-      onHelloOk?: () => void;
+      onHelloOk?: (hello?: { features?: { methods?: string[] } }) => void;
     };
     constructor(params: {
       url?: string;
       token?: string;
       password?: string;
-      onHelloOk?: () => void;
+      onHelloOk?: (hello?: { features?: { methods?: string[] } }) => void;
     }) {
       this.params = params;
       gatewayClientCalls.push(params);
@@ -35,7 +35,7 @@ vi.mock("../gateway/client.js", () => ({
       return { ok: true };
     }
     start() {
-      queueMicrotask(() => this.params.onHelloOk?.());
+      queueMicrotask(() => this.params.onHelloOk?.({ features: { methods: ["health"] } }));
     }
     stop() {}
   },
@@ -145,9 +145,36 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       }>(configPath);
 
       expect(cfg?.agents?.defaults?.workspace).toBe(workspace);
-      expect(cfg?.tools?.profile).toBe("messaging");
+      expect(cfg?.tools?.profile).toBeUndefined();
       expect(cfg?.gateway?.auth?.mode).toBe("token");
       expect(cfg?.gateway?.auth?.token).toBe(token);
+    });
+  }, 60_000);
+
+  it("preserves explicit tools.profile from existing config", async () => {
+    await withStateDir("state-tools-profile-", async (stateDir) => {
+      const configPath = resolveStateConfigPath(process.env, stateDir);
+      await fs.writeFile(configPath, JSON.stringify({ tools: { profile: "full" } }));
+      const workspace = path.join(stateDir, "openclaw");
+
+      await runNonInteractiveOnboarding(
+        {
+          nonInteractive: true,
+          mode: "local",
+          workspace,
+          authChoice: "skip",
+          skipSkills: true,
+          skipHealth: true,
+          installDaemon: false,
+          gatewayBind: "loopback",
+          gatewayAuth: "token",
+          gatewayToken: "tok_tools_profile_123",
+        },
+        runtime,
+      );
+
+      const cfg = await readJsonFile<{ tools?: { profile?: string } }>(configPath);
+      expect(cfg?.tools?.profile).toBe("full");
     });
   }, 60_000);
 

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -4,7 +4,10 @@ import { resolveGatewayPort, writeConfigFile } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME } from "../daemon-runtime.js";
-import { applyOnboardingLocalWorkspaceConfig } from "../onboard-config.js";
+import {
+  applyOnboardingLocalWorkspaceConfig,
+  ONBOARDING_DEFAULT_TOOLS_PROFILE,
+} from "../onboard-config.js";
 import {
   applyWizardMetadata,
   DEFAULT_WORKSPACE,
@@ -34,6 +37,17 @@ export async function runNonInteractiveOnboardingLocal(params: {
   });
 
   let nextConfig: OpenClawConfig = applyOnboardingLocalWorkspaceConfig(baseConfig, workspaceDir);
+  if (
+    !baseConfig.tools?.profile &&
+    nextConfig.tools?.profile === ONBOARDING_DEFAULT_TOOLS_PROFILE
+  ) {
+    // Non-interactive onboard should not silently force messaging-only tools.
+    const { profile: _profile, ...restTools } = nextConfig.tools;
+    nextConfig = {
+      ...nextConfig,
+      tools: Object.keys(restTools).length > 0 ? restTools : undefined,
+    };
+  }
 
   const inferredAuthChoice = inferAuthChoiceFromFlags(opts);
   if (!opts.authChoice && inferredAuthChoice.matches.length > 1) {


### PR DESCRIPTION
## Summary
- avoid forcing `tools.profile: "messaging"` during non-interactive local onboarding when no tools profile is explicitly configured
- preserve an explicitly configured tools profile from existing config
- keep gateway onboarding tests aligned with the new default behavior

## Why
`openclaw onboard --non-interactive` was writing `tools.profile: "messaging"`, which can strip file-writing/shell tools and block bootstrap workflows.

## Testing
- pnpm test -- src/commands/onboard-non-interactive.gateway.test.ts
- pnpm test -- src/commands/onboard-config.test.ts

Closes #33225.
