### PR TITLE
fix(agents): normalize nvidia-api model provider alias

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -59,6 +59,7 @@ describe("model-selection", () => {
       expect(normalizeProviderId("OpenCode-Zen")).toBe("opencode");
       expect(normalizeProviderId("qwen")).toBe("qwen-portal");
       expect(normalizeProviderId("kimi-code")).toBe("kimi-coding");
+      expect(normalizeProviderId("nvidia-api")).toBe("nvidia");
       expect(normalizeProviderId("bedrock")).toBe("amazon-bedrock");
       expect(normalizeProviderId("aws-bedrock")).toBe("amazon-bedrock");
       expect(normalizeProviderId("amazon-bedrock")).toBe("amazon-bedrock");
@@ -85,6 +86,13 @@ describe("model-selection", () => {
       expect(parseModelRef("nvidia/moonshotai/kimi-k2.5", "anthropic")).toEqual({
         provider: "nvidia",
         model: "moonshotai/kimi-k2.5",
+      });
+    });
+
+    it("normalizes nvidia-api provider alias in model refs", () => {
+      expect(parseModelRef("nvidia-api/meta/llama-3.2-90b-vision-instruct", "anthropic")).toEqual({
+        provider: "nvidia",
+        model: "meta/llama-3.2-90b-vision-instruct",
       });
     });
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -51,6 +51,9 @@ export function normalizeProviderId(provider: string): string {
   if (normalized === "kimi-code") {
     return "kimi-coding";
   }
+  if (normalized === "nvidia-api") {
+    return "nvidia";
+  }
   if (normalized === "bedrock" || normalized === "aws-bedrock") {
     return "amazon-bedrock";
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `agents.defaults.imageModel` entries using provider alias `nvidia-api/...` can fail registry lookup with `Unknown model` because model selection normalization does not map that alias to canonical provider `nvidia`.
- Why it matters: configured image model refs that are otherwise valid can be rejected before provider execution.
- What changed: added provider alias normalization `nvidia-api -> nvidia` in model ref normalization.
- What changed: added regression tests for provider normalization and `parseModelRef` behavior with `nvidia-api/...` refs.
- What did NOT change (scope boundary): no changes to model catalogs, auth resolution order, or fallback execution logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33185
- Related #33179

## User-visible / Behavior Changes

Model refs using `nvidia-api/...` are normalized to `nvidia/...` during parsing, so compatible image model configs resolve against the built-in NVIDIA provider registry instead of failing early with unknown-model parsing mismatch.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: model-selection parsing path
- Integration/channel (if any): image model resolution path
- Relevant config (redacted): `agents.defaults.imageModel.primary="nvidia-api/..."`

### Steps

1. Configure a model ref with `nvidia-api/<nested-model-id>`.
2. Parse/normalize model refs via model-selection path.
3. Resolve model lookup candidates.

### Expected

- Provider alias should normalize to canonical `nvidia` so lookup can target built-in `nvidia` provider catalog.

### Actual

- Before fix: alias remained `nvidia-api`, causing mismatch vs canonical provider keys.
- After fix: alias resolves to `nvidia`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest src/agents/model-selection.test.ts` passes with new alias regression tests.
- Edge cases checked:
  - Nested model IDs (`provider/a/b`) remain preserved.
  - Existing provider alias mappings remain unchanged.
- What you did **not** verify:
  - Full live image tool execution across all third-party providers referenced in the issue.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `326c3ddd53`.
- Files/config to restore:
  - `src/agents/model-selection.ts`
  - `src/agents/model-selection.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected provider canonicalization for `nvidia-api` references.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: users intentionally depending on literal provider id `nvidia-api` in custom provider maps may now resolve to canonical `nvidia` instead.
  - Mitigation: this alias targets compatibility with built-in normalization behavior and aligns with existing alias pattern used for other providers.
