### PR TITLE
fix: respect user timezone for default system event timestamps

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -46,7 +46,10 @@ export async function buildQueuedSystemPrompt(params: {
   const resolveSystemEventTimezone = (cfg: OpenClawConfig) => {
     const raw = cfg.agents?.defaults?.envelopeTimezone?.trim();
     if (!raw) {
-      return { mode: "local" as const };
+      return {
+        mode: "iana" as const,
+        timeZone: resolveUserTimezone(cfg.agents?.defaults?.userTimezone),
+      };
     }
     const lowered = raw.toLowerCase();
     if (lowered === "utc" || lowered === "gmt") {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1162,6 +1162,42 @@ describe("buildQueuedSystemPrompt", () => {
       vi.useRealTimers();
     }
   });
+
+  it("defaults system event timestamps to userTimezone when envelopeTimezone is unset", async () => {
+    vi.useFakeTimers();
+    const originalTz = process.env.TZ;
+    process.env.TZ = "Asia/Shanghai";
+    try {
+      const timestamp = new Date("2026-03-03T13:53:00Z");
+      const expectedTimestamp = formatZonedTimestamp(timestamp, {
+        timeZone: "America/Vancouver",
+        displaySeconds: true,
+      });
+      vi.setSystemTime(timestamp);
+
+      enqueueSystemEvent("Exec failed.", { sessionKey: "agent:main:main" });
+
+      const result = await buildQueuedSystemPrompt({
+        cfg: {
+          agents: {
+            defaults: {
+              userTimezone: "America/Vancouver",
+            },
+          },
+        } as OpenClawConfig,
+        sessionKey: "agent:main:main",
+        isMainSession: false,
+        isNewSession: false,
+      });
+
+      expect(expectedTimestamp).toBeDefined();
+      expect(result).toContain(`- [${expectedTimestamp}] Exec failed.`);
+    } finally {
+      resetSystemEventsForTest();
+      process.env.TZ = originalTz;
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("persistSessionUsageUpdate", () => {


### PR DESCRIPTION
## Summary\n- fix system event timestamp fallback when  is unset\n- default to configured  (via ) instead of host local timezone\n- add regression test to ensure queued system events render in user timezone even when host TZ differs\n\n## Root cause\n used host local time whenever  was unset. In environments where host TZ differs from configured user timezone, exec/system event lines showed shifted timestamps.\n\n## Testing\n- 
> openclaw@2026.3.3 test /root/openclaw/workspace/openclaw-33041
> node scripts/test-parallel.mjs -- src/auto-reply/reply/session.test.ts -t 'defaults system event timestamps to userTimezone when envelopeTimezone is unset'


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/root/openclaw/workspace/openclaw-33041[39m

 [32m✓[39m src/auto-reply/reply/session.test.ts [2m([22m[2m41 tests[22m[2m | [22m[33m40 skipped[39m[2m)[22m[32m 23[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m1 passed[39m[22m[2m | [22m[33m40 skipped[39m[90m (41)[39m
[2m   Start at [22m 00:14:04
[2m   Duration [22m 13.86s[2m (transform 9.21s, setup 384ms, import 13.28s, tests 23ms, environment 0ms)[22m\n\nCloses #33083