### PR TITLE
fix(media): allow Discord CDN fake-ip in media attachment SSRF guard

### DIFF
--- a/src/media-understanding/attachments.cache.discord-ssrf.test.ts
+++ b/src/media-understanding/attachments.cache.discord-ssrf.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../media/fetch.js", () => ({
+  fetchRemoteMedia: vi.fn(),
+  MediaFetchError: class MediaFetchError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.code = code;
+    }
+  },
+}));
+
+import { fetchRemoteMedia } from "../media/fetch.js";
+import { MediaAttachmentCache } from "./attachments.js";
+
+const mockedFetchRemoteMedia = vi.mocked(fetchRemoteMedia);
+
+describe("MediaAttachmentCache Discord SSRF policy", () => {
+  beforeEach(() => {
+    mockedFetchRemoteMedia.mockReset();
+    mockedFetchRemoteMedia.mockResolvedValue({
+      buffer: Buffer.from("ok"),
+      contentType: "image/png",
+      fileName: "a.png",
+    });
+  });
+
+  it("passes Discord CDN SSRF policy for discord attachment URLs", async () => {
+    const cache = new MediaAttachmentCache([
+      { index: 0, url: "https://cdn.discordapp.com/attachments/1/a.png" },
+    ]);
+
+    await cache.getBuffer({ attachmentIndex: 0, maxBytes: 1024, timeoutMs: 1000 });
+
+    expect(mockedFetchRemoteMedia).toHaveBeenCalledTimes(1);
+    expect(mockedFetchRemoteMedia.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        url: "https://cdn.discordapp.com/attachments/1/a.png",
+        ssrfPolicy: {
+          allowedHostnames: ["cdn.discordapp.com", "media.discordapp.net"],
+          allowRfc2544BenchmarkRange: true,
+        },
+      }),
+    );
+  });
+
+  it("does not apply Discord-specific SSRF policy to non-Discord URLs", async () => {
+    const cache = new MediaAttachmentCache([{ index: 0, url: "https://example.com/a.png" }]);
+
+    await cache.getBuffer({ attachmentIndex: 0, maxBytes: 1024, timeoutMs: 1000 });
+
+    expect(mockedFetchRemoteMedia).toHaveBeenCalledTimes(1);
+    expect(mockedFetchRemoteMedia.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        url: "https://example.com/a.png",
+        ssrfPolicy: undefined,
+      }),
+    );
+  });
+});

--- a/src/media-understanding/attachments.cache.ts
+++ b/src/media-understanding/attachments.cache.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
+import { normalizeHostname } from "../infra/net/hostname.js";
+import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { isAbortError } from "../infra/unhandled-rejections.js";
 import { fetchRemoteMedia, MediaFetchError } from "../media/fetch.js";
 import {
@@ -43,6 +45,25 @@ const DEFAULT_LOCAL_PATH_ROOTS = mergeInboundPathRoots(
   getDefaultMediaLocalRoots(),
   DEFAULT_IMESSAGE_ATTACHMENT_ROOTS,
 );
+
+const DISCORD_CDN_HOSTNAMES = new Set(["cdn.discordapp.com", "media.discordapp.net"]);
+
+const DISCORD_MEDIA_SSRF_POLICY: SsrFPolicy = {
+  allowedHostnames: ["cdn.discordapp.com", "media.discordapp.net"],
+  allowRfc2544BenchmarkRange: true,
+};
+
+function resolveDiscordMediaSsrFPolicy(url: string): SsrFPolicy | undefined {
+  try {
+    const hostname = normalizeHostname(new URL(url).hostname);
+    if (DISCORD_CDN_HOSTNAMES.has(hostname)) {
+      return DISCORD_MEDIA_SSRF_POLICY;
+    }
+  } catch {
+    // Ignore malformed URLs; downstream fetch path surfaces a proper error.
+  }
+  return undefined;
+}
 
 export type MediaAttachmentCacheOptions = {
   localPathRoots?: readonly string[];
@@ -133,7 +154,12 @@ export class MediaAttachmentCache {
     try {
       const fetchImpl = (input: RequestInfo | URL, init?: RequestInit) =>
         fetchWithTimeout(resolveRequestUrl(input), init ?? {}, params.timeoutMs, fetch);
-      const fetched = await fetchRemoteMedia({ url, fetchImpl, maxBytes: params.maxBytes });
+      const fetched = await fetchRemoteMedia({
+        url,
+        fetchImpl,
+        maxBytes: params.maxBytes,
+        ssrfPolicy: resolveDiscordMediaSsrFPolicy(url),
+      });
       entry.buffer = fetched.buffer;
       entry.bufferMime =
         entry.attachment.mime ??


### PR DESCRIPTION
## Summary
- fix media-understanding attachment downloads to pass the same Discord CDN SSRF policy already used by Discord monitor message media fetch
- allow `cdn.discordapp.com` / `media.discordapp.net` to pass with `allowRfc2544BenchmarkRange` for Clash TUN fake-ip (`198.18.0.0/15`) scenarios
- keep default SSRF behavior unchanged for non-Discord hosts

## Root cause
Discord monitor path already set a Discord-specific SSRF policy, but media-understanding attachment cache fetched remote URLs without that policy. Behind Clash Verge TUN fake-ip, Discord CDN resolves to `198.18.x.x`, so strict SSRF blocked all Discord attachments in media-understanding flows (including voice/image/file understanding).

## Changes
- `src/media-understanding/attachments.cache.ts`
  - add `resolveDiscordMediaSsrFPolicy(url)`
  - apply Discord-only SSRF policy when fetching attachment URLs
- `src/media-understanding/attachments.cache.discord-ssrf.test.ts`
  - add regression tests for Discord URL policy injection and non-Discord no-op

## Test
- `pnpm exec vitest run src/media-understanding/attachments.cache.discord-ssrf.test.ts src/discord/monitor/message-utils.test.ts`
