### PR TITLE
fix(telegram): avoid sendMessageDraft for DM partial streaming

### DIFF
--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -270,6 +270,37 @@ describe("createTelegramDraftStream", () => {
     expect(api.editMessageText).not.toHaveBeenCalled();
   });
 
+  it("does not count superseded DM draft sends as delivered preview revisions", async () => {
+    let resolveFirstDraft: ((value: boolean) => void) | undefined;
+    const firstDraftSend = new Promise<boolean>((resolve) => {
+      resolveFirstDraft = resolve;
+    });
+    const api = {
+      sendMessageDraft: vi.fn().mockReturnValueOnce(firstDraftSend).mockResolvedValueOnce(true),
+      sendMessage: vi.fn().mockResolvedValue({ message_id: 17 }),
+      editMessageText: vi.fn().mockResolvedValue(true),
+      deleteMessage: vi.fn().mockResolvedValue(true),
+    };
+    const stream = createThreadedDraftStream(
+      api as unknown as ReturnType<typeof createMockDraftApi>,
+      { id: 42, scope: "dm" },
+    );
+
+    stream.update("Message A");
+    await vi.waitFor(() => expect(api.sendMessageDraft).toHaveBeenCalledTimes(1));
+
+    const beforeRotationRevision = stream.previewRevision?.() ?? 0;
+    stream.forceNewMessage();
+    stream.update("Message B");
+
+    resolveFirstDraft?.(true);
+    await stream.flush();
+
+    const afterFlushRevision = stream.previewRevision?.() ?? 0;
+    expect(afterFlushRevision - beforeRotationRevision).toBe(1);
+    expect(stream.lastDeliveredText?.()).toBe("Message B");
+  });
+
   it("creates new message after forceNewMessage is called", async () => {
     const { api, stream } = createForceNewMessageHarness();
 

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -116,21 +116,16 @@ describe("createTelegramDraftStream", () => {
     await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined));
   });
 
-  it("uses sendMessageDraft for dm threads and does not create a preview message", async () => {
+  it("defaults to message transport for dm threads when previewTransport is auto", async () => {
     const api = createMockDraftApi();
     const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });
 
     stream.update("Hello");
-    await vi.waitFor(() =>
-      expect(api.sendMessageDraft).toHaveBeenCalledWith(123, expect.any(Number), "Hello", {
-        message_thread_id: 42,
-      }),
-    );
-    expect(api.sendMessage).not.toHaveBeenCalled();
-    expect(api.editMessageText).not.toHaveBeenCalled();
-    await stream.clear();
+    await stream.flush();
 
-    expect(api.deleteMessage).not.toHaveBeenCalled();
+    expectDmMessagePreviewViaSendMessage(api);
+    expect(api.sendMessageDraft).not.toHaveBeenCalled();
+    expect(stream.previewMode?.()).toBe("message");
   });
 
   it("supports forcing message transport in dm threads", async () => {
@@ -220,7 +215,10 @@ describe("createTelegramDraftStream", () => {
 
   it("does not edit or delete messages after DM draft stream finalization", async () => {
     const api = createMockDraftApi();
-    const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });
+    const stream = createDraftStream(api, {
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "draft",
+    });
 
     stream.update("Hello");
     await stream.flush();
@@ -245,10 +243,10 @@ describe("createTelegramDraftStream", () => {
       editMessageText: vi.fn().mockResolvedValue(true),
       deleteMessage: vi.fn().mockResolvedValue(true),
     };
-    const stream = createThreadedDraftStream(
-      api as unknown as ReturnType<typeof createMockDraftApi>,
-      { id: 42, scope: "dm" },
-    );
+    const stream = createDraftStream(api as unknown as ReturnType<typeof createMockDraftApi>, {
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "draft",
+    });
 
     stream.update("Message A");
     await vi.waitFor(() => expect(api.sendMessageDraft).toHaveBeenCalledTimes(1));
@@ -281,10 +279,10 @@ describe("createTelegramDraftStream", () => {
       editMessageText: vi.fn().mockResolvedValue(true),
       deleteMessage: vi.fn().mockResolvedValue(true),
     };
-    const stream = createThreadedDraftStream(
-      api as unknown as ReturnType<typeof createMockDraftApi>,
-      { id: 42, scope: "dm" },
-    );
+    const stream = createDraftStream(api as unknown as ReturnType<typeof createMockDraftApi>, {
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "draft",
+    });
 
     stream.update("Message A");
     await vi.waitFor(() => expect(api.sendMessageDraft).toHaveBeenCalledTimes(1));

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -107,12 +107,7 @@ export function createTelegramDraftStream(params: {
   const minInitialChars = params.minInitialChars;
   const chatId = params.chatId;
   const requestedPreviewTransport = params.previewTransport ?? "auto";
-  const prefersDraftTransport =
-    requestedPreviewTransport === "draft"
-      ? true
-      : requestedPreviewTransport === "message"
-        ? false
-        : params.thread?.scope === "dm";
+  const prefersDraftTransport = requestedPreviewTransport === "draft";
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyParams =
     params.replyToMessageId != null

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -77,6 +77,11 @@ type SupersededTelegramPreview = {
   parseMode?: "HTML";
 };
 
+type PreviewSendResult = {
+  sent: boolean;
+  appliedToActiveGeneration: boolean;
+};
+
 export function createTelegramDraftStream(params: {
   api: Bot["api"];
   chatId: number;
@@ -141,7 +146,7 @@ export function createTelegramDraftStream(params: {
     renderedText,
     renderedParseMode,
     sendGeneration,
-  }: PreviewSendParams): Promise<boolean> => {
+  }: PreviewSendParams): Promise<PreviewSendResult> => {
     if (typeof streamMessageId === "number") {
       if (renderedParseMode) {
         await params.api.editMessageText(chatId, streamMessageId, renderedText, {
@@ -150,7 +155,10 @@ export function createTelegramDraftStream(params: {
       } else {
         await params.api.editMessageText(chatId, streamMessageId, renderedText);
       }
-      return true;
+      return {
+        sent: true,
+        appliedToActiveGeneration: sendGeneration === generation,
+      };
     }
     const sendParams = renderedParseMode
       ? {
@@ -185,7 +193,7 @@ export function createTelegramDraftStream(params: {
     if (typeof sentMessageId !== "number" || !Number.isFinite(sentMessageId)) {
       streamState.stopped = true;
       params.warn?.("telegram stream preview stopped (missing message id from sendMessage)");
-      return false;
+      return { sent: false, appliedToActiveGeneration: false };
     }
     const normalizedMessageId = Math.trunc(sentMessageId);
     if (sendGeneration !== generation) {
@@ -194,15 +202,16 @@ export function createTelegramDraftStream(params: {
         textSnapshot: renderedText,
         parseMode: renderedParseMode,
       });
-      return true;
+      return { sent: true, appliedToActiveGeneration: false };
     }
     streamMessageId = normalizedMessageId;
-    return true;
+    return { sent: true, appliedToActiveGeneration: true };
   };
   const sendDraftTransportPreview = async ({
     renderedText,
     renderedParseMode,
-  }: PreviewSendParams): Promise<boolean> => {
+    sendGeneration,
+  }: PreviewSendParams): Promise<PreviewSendResult> => {
     const draftId = streamDraftId ?? allocateTelegramDraftId();
     streamDraftId = draftId;
     const draftParams = {
@@ -217,7 +226,10 @@ export function createTelegramDraftStream(params: {
       renderedText,
       Object.keys(draftParams).length > 0 ? draftParams : undefined,
     );
-    return true;
+    return {
+      sent: true,
+      appliedToActiveGeneration: sendGeneration === generation,
+    };
   };
 
   const sendOrEditStreamMessage = async (text: string): Promise<boolean> => {
@@ -258,11 +270,12 @@ export function createTelegramDraftStream(params: {
 
     lastSentText = renderedText;
     lastSentParseMode = renderedParseMode;
+
     try {
-      let sent = false;
+      let sendResult: PreviewSendResult = { sent: false, appliedToActiveGeneration: false };
       if (previewTransport === "draft") {
         try {
-          sent = await sendDraftTransportPreview({
+          sendResult = await sendDraftTransportPreview({
             renderedText,
             renderedParseMode,
             sendGeneration,
@@ -276,24 +289,24 @@ export function createTelegramDraftStream(params: {
           params.warn?.(
             "telegram stream preview: sendMessageDraft rejected by API; falling back to sendMessage/editMessageText",
           );
-          sent = await sendMessageTransportPreview({
+          sendResult = await sendMessageTransportPreview({
             renderedText,
             renderedParseMode,
             sendGeneration,
           });
         }
       } else {
-        sent = await sendMessageTransportPreview({
+        sendResult = await sendMessageTransportPreview({
           renderedText,
           renderedParseMode,
           sendGeneration,
         });
       }
-      if (sent) {
+      if (sendResult.sent && sendResult.appliedToActiveGeneration) {
         previewRevision += 1;
         lastDeliveredText = trimmed;
       }
-      return sent;
+      return sendResult.sent;
     } catch (err) {
       streamState.stopped = true;
       params.warn?.(


### PR DESCRIPTION
## Summary
- stop auto-selecting `sendMessageDraft` for Telegram DM (`thread.scope === "dm"`) streaming previews
- keep `sendMessageDraft` available only when explicitly requested via `previewTransport: "draft"`
- update tests to assert DM auto mode uses `sendMessage/editMessageText` transport while explicit draft mode remains covered

## Why
Issue #33180 reports Telegram iOS showing streamed DM previews as pinned messages when using `sendMessageDraft`.
Using message transport by default for DM partial streaming avoids this client-side pinned-message side effect and keeps visible message delivery ordering stable.

## Testing
- `pnpm -s vitest src/telegram/draft-stream.test.ts src/telegram/lane-delivery.test.ts src/telegram/bot-message-dispatch.test.ts`

Closes #33180
