### PR TITLE
fix(telegram): groupPolicy='open' should not require mention (#33218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/groupPolicy="open" mention requirement: fix `resolveChannelGroupRequireMention` to default to `requireMention=false` when `groupPolicy="open"`, preventing group messages from being incorrectly skipped with "no-mention" reason. (#33218)
 - Docs/tool-loop detection config keys: align `docs/tools/loop-detection.md` examples and field names with the current `tools.loopDetection` schema to prevent copy-paste validation failures from outdated keys. (#33182) Thanks @Mylszd.
 - Discord/presence defaults: send an online presence update on ready when no custom presence is configured so bots no longer appear offline by default. Thanks @thewilloftheshadow.
 - Discord/typing cleanup: stop typing indicators after silent/NO_REPLY runs by marking the run complete before dispatch idle cleanup. Thanks @thewilloftheshadow.

--- a/src/config/group-policy.grouppolicy-open-requiremention.test.ts
+++ b/src/config/group-policy.grouppolicy-open-requiremention.test.ts
@@ -20,13 +20,6 @@ describe("Issue #33218: groupPolicy='open' should not require mention", () => {
       groupId: "-123456789",
     });
 
-    console.log("✅ FIX VERIFIED:");
-    console.log(`  groupPolicy: "open"`);
-    console.log(`  requireMention config: undefined`);
-    console.log(`  resolveChannelGroupRequireMention returns: ${requireMention}`);
-    console.log(`  Expected: false (open policy should not require mention)`);
-    console.log(`  Result: ${requireMention ? "❌ FAIL" : "✅ PASS"}`);
-
     // After fix: should return false
     expect(requireMention).toBe(false);
   });

--- a/src/config/group-policy.grouppolicy-open-requiremention.test.ts
+++ b/src/config/group-policy.grouppolicy-open-requiremention.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest";
+import type { OpenClawConfig } from "./config.js";
+import { resolveChannelGroupRequireMention } from "./group-policy.js";
+
+describe("Issue #33218: groupPolicy='open' should not require mention", () => {
+  test("✅ FIXED: groupPolicy='open' with no requireMention config defaults to requireMention=false", () => {
+    const config: OpenClawConfig = {
+      channels: {
+        telegram: {
+          enabled: true,
+          groupPolicy: "open",
+          // No requireMention configured
+        },
+      },
+    };
+
+    const requireMention = resolveChannelGroupRequireMention({
+      cfg: config,
+      channel: "telegram",
+      groupId: "-123456789",
+    });
+
+    console.log("✅ FIX VERIFIED:");
+    console.log(`  groupPolicy: "open"`);
+    console.log(`  requireMention config: undefined`);
+    console.log(`  resolveChannelGroupRequireMention returns: ${requireMention}`);
+    console.log(`  Expected: false (open policy should not require mention)`);
+    console.log(`  Result: ${requireMention ? "❌ FAIL" : "✅ PASS"}`);
+
+    // After fix: should return false
+    expect(requireMention).toBe(false);
+  });
+
+  test("groupPolicy='allowlist' should default to requireMention=true", () => {
+    const config: OpenClawConfig = {
+      channels: {
+        telegram: {
+          enabled: true,
+          groupPolicy: "allowlist",
+        },
+      },
+    };
+
+    const requireMention = resolveChannelGroupRequireMention({
+      cfg: config,
+      channel: "telegram",
+      groupId: "-123456789",
+    });
+
+    // allowlist should require mention by default
+    expect(requireMention).toBe(true);
+  });
+
+  test("explicit requireMention=false should override groupPolicy", () => {
+    const config: OpenClawConfig = {
+      channels: {
+        telegram: {
+          enabled: true,
+          groupPolicy: "allowlist",
+          groups: {
+            "-123456789": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    };
+
+    const requireMention = resolveChannelGroupRequireMention({
+      cfg: config,
+      channel: "telegram",
+      groupId: "-123456789",
+    });
+
+    expect(requireMention).toBe(false);
+  });
+});

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -385,6 +385,13 @@ export function resolveChannelGroupRequireMention(params: {
   if (overrideOrder !== "before-config" && typeof requireMentionOverride === "boolean") {
     return requireMentionOverride;
   }
+
+  // When groupPolicy is "open", default to not requiring mention (issue #33218)
+  const groupPolicy = resolveChannelGroupPolicyMode(params.cfg, params.channel, params.accountId);
+  if (groupPolicy === "open") {
+    return false;
+  }
+
   return true;
 }
 

--- a/src/telegram/bot-message-context.grouppolicy-open.test.ts
+++ b/src/telegram/bot-message-context.grouppolicy-open.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveChannelGroupRequireMention } from "../config/group-policy.js";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+
+describe("Issue #33218: groupPolicy='open' should not require mention (INTEGRATION TEST)", () => {
+  it("✅ FIXED: groupPolicy='open' allows messages WITHOUT @mention to be processed", async () => {
+    const logger = { info: vi.fn() };
+
+    const cfg = {
+      agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+      channels: {
+        telegram: {
+          enabled: true,
+          groupPolicy: "open", // ← User configured "open" policy
+          // No requireMention configured
+        },
+      },
+      messages: { groupChat: { mentionPatterns: [] } },
+    };
+
+    // Simulate a Telegram group message WITHOUT @mention
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 100,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+        date: 1700000000,
+        text: "hello everyone", // ← NO @mention
+        from: { id: 42, first_name: "Alice" },
+      },
+      cfg,
+      logger,
+      // Use the REAL resolveChannelGroupRequireMention function (now fixed)
+      resolveGroupRequireMention: (chatId) => {
+        const result = resolveChannelGroupRequireMention({
+          cfg: cfg as never,
+          channel: "telegram",
+          groupId: String(chatId),
+        });
+        console.log(`  resolveChannelGroupRequireMention(${chatId}) = ${result}`);
+        return result;
+      },
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: undefined, // No explicit group config
+        topicConfig: undefined,
+      }),
+    });
+
+    console.log("✅ FIX VERIFIED (INTEGRATION TEST):");
+    console.log(`  Config: groupPolicy="open", no requireMention`);
+    console.log(`  Message: "hello everyone" (NO @mention) in group chat`);
+    console.log(
+      `  Result: ctx = ${ctx === null ? "null (message SKIPPED)" : "not null (message PROCESSED ✅)"}`,
+    );
+
+    // After fix: message should be processed (ctx is not null)
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.Body).toContain("hello everyone");
+    console.log("  ✅ FIX VERIFIED: Message was processed with groupPolicy='open'");
+  });
+
+  it("groupPolicy='allowlist' should still require mention and skip messages without @mention", async () => {
+    const logger = { info: vi.fn() };
+
+    const cfg = {
+      agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+      channels: {
+        telegram: {
+          enabled: true,
+          groupPolicy: "allowlist", // allowlist should require mention
+        },
+      },
+      messages: { groupChat: { mentionPatterns: [] } },
+    };
+
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 100,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+        date: 1700000000,
+        text: "hello without mention",
+        from: { id: 42, first_name: "Alice" },
+      },
+      cfg,
+      logger,
+      resolveGroupRequireMention: (chatId) => {
+        return resolveChannelGroupRequireMention({
+          cfg: cfg as never,
+          channel: "telegram",
+          groupId: String(chatId),
+        });
+      },
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: undefined,
+        topicConfig: undefined,
+      }),
+    });
+
+    // allowlist should still skip messages without mention
+    expect(ctx).toBeNull();
+  });
+
+  it("groupPolicy='open' with explicit @mention should also be processed", async () => {
+    const logger = { info: vi.fn() };
+
+    const cfg = {
+      agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+      channels: {
+        telegram: {
+          enabled: true,
+          groupPolicy: "open",
+        },
+      },
+      messages: { groupChat: { mentionPatterns: [] } },
+    };
+
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 100,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+        date: 1700000000,
+        text: "@bot hello",
+        from: { id: 42, first_name: "Alice" },
+      },
+      cfg,
+      logger,
+      resolveGroupRequireMention: (chatId) => {
+        return resolveChannelGroupRequireMention({
+          cfg: cfg as never,
+          channel: "telegram",
+          groupId: String(chatId),
+        });
+      },
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: undefined,
+        topicConfig: undefined,
+      }),
+    });
+
+    // With @mention, message should definitely be processed
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.WasMentioned).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug**: Telegram `groupPolicy='open'` incorrectly requires mention by default
- **Root cause**: `resolveChannelGroupRequireMention` in `src/config/group-policy.ts` defaults to `requireMention=true` regardless of `groupPolicy` value
- **Fix**: Check `groupPolicy` and return `false` when `groupPolicy='open'`

Fixes #33218

## Problem

When users configure `groupPolicy: 'open'` for Telegram groups, they expect messages to be processed without requiring @mention. However, the current implementation defaults to `requireMention=true` for all group policies, causing messages to be skipped with `reason: 'no-mention'`.

**Before fix:**
```
Config:  groupPolicy: 'open', requireMention: undefined
Result:  resolveChannelGroupRequireMention returns true
Effect:  Messages skipped with 'no-mention' reason
```

## Changes

- `src/config/group-policy.ts` — Add `groupPolicy` check in `resolveChannelGroupRequireMention`, return `false` when `groupPolicy='open'`
- `src/config/group-policy.grouppolicy-open-requiremention.test.ts` — Add regression tests covering `groupPolicy='open'`, `groupPolicy='allowlist'`, and explicit `requireMention` override
- `CHANGELOG.md` — Add fix entry under 2026.3.3 Fixes

**After fix:**
```
Config:  groupPolicy: 'open', requireMention: undefined
Result:  resolveChannelGroupRequireMention returns false
Effect:  Messages processed normally without requiring mention
```

## Test plan

- [x] New test: `groupPolicy='open'` defaults to `requireMention=false`
- [x] New test: `groupPolicy='allowlist'` still defaults to `requireMention=true`
- [x] New test: Explicit `requireMention=false` overrides `groupPolicy`
- [x] All 13 existing `group-policy.test.ts` tests pass
- [x] Format check passes

## Effect on User Experience

**Before:** Users with `groupPolicy: 'open'` see messages skipped with 'no-mention' reason, even when @mention is present in the message text.

**After:** Users with `groupPolicy: 'open'` can receive group messages without requiring @mention, matching the expected 'open' policy behavior.