### PR TITLE
refactor: replace explicit any types with proper types in production code

### DIFF
--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import {
@@ -40,8 +41,10 @@ export function guardSessionManager(
     : undefined;
 
   const transform = hookRunner?.hasHooks("tool_result_persist")
-    ? // oxlint-disable-next-line typescript/no-explicit-any
-      (message: any, meta: { toolCallId?: string; toolName?: string; isSynthetic?: boolean }) => {
+    ? (
+        message: AgentMessage,
+        meta: { toolCallId?: string; toolName?: string; isSynthetic?: boolean },
+      ) => {
         const out = hookRunner.runToolResultPersist(
           {
             toolName: meta.toolName,

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -61,8 +61,7 @@ export type InlineActionResult =
       abortedLastRun: boolean;
     };
 
-// oxlint-disable-next-line typescript/no-explicit-any
-function extractTextFromToolResult(result: any): string | null {
+function extractTextFromToolResult(result: unknown): string | null {
   if (!result || typeof result !== "object") {
     return null;
   }
@@ -223,8 +222,7 @@ export async function handleInlineActions(params: {
           command: rawArgs,
           commandName: skillInvocation.command.name,
           skillName: skillInvocation.command.skillName,
-          // oxlint-disable-next-line typescript/no-explicit-any
-        } as any);
+        } as Record<string, unknown>);
         const text = extractTextFromToolResult(result) ?? "✅ Done.";
         typing.cleanup();
         return { kind: "reply", reply: { text } };

--- a/src/discord/monitor/sender-identity.ts
+++ b/src/discord/monitor/sender-identity.ts
@@ -28,8 +28,8 @@ export function resolveDiscordWebhookId(message: DiscordWebhookMessageLike): str
 
 export function resolveDiscordSenderIdentity(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  /** Accepts Carbon GuildMember (.nickname) or raw API member (.nick); only .nickname is read. */
+  member?: { nickname?: string | null; nick?: string | null } | null;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): DiscordSenderIdentity {
   const pkInfo = params.pluralkitInfo ?? null;
@@ -74,8 +74,7 @@ export function resolveDiscordSenderIdentity(params: {
 
 export function resolveDiscordSenderLabel(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  member?: { nickname?: string | null; nick?: string | null } | null;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): string {
   return resolveDiscordSenderIdentity(params).label;

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -47,8 +47,7 @@ async function getRecentSessionContent(
             }
             // Extract text content
             const text = Array.isArray(msg.content)
-              ? // oxlint-disable-next-line typescript/no-explicit-any
-                msg.content.find((c: any) => c.type === "text")?.text
+              ? msg.content.find((c: { type?: string; text?: string }) => c.type === "text")?.text
               : msg.content;
             if (text && !text.startsWith("/")) {
               allMessages.push(`${role}: ${text}`);


### PR DESCRIPTION
## Summary
- Replace 6 explicit `any` type annotations with proper types across 4 production files
- Removes associated `oxlint-disable-next-line` comments that are no longer needed

## Changes
- `src/discord/monitor/sender-identity.ts`: `member?: any` → structural type `{ nickname?: string | null; nick?: string | null } | null`
- `src/hooks/bundled/session-memory/handler.ts`: `(c: any)` → `(c: { type?: string; text?: string })`
- `src/auto-reply/reply/get-reply-inline-actions.ts`: `result: any` → `unknown`; `as any` → `as Record<string, unknown>`
- `src/agents/session-tool-result-guard-wrapper.ts`: `message: any` → `AgentMessage` (proper import added)

## Test plan
- [ ] `pnpm tsgo` passes with no type errors
- [ ] Existing tests pass with `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)