### PR TITLE
tools(web): guard non-ByteString web_search api keys

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -336,6 +336,25 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
   };
 }
 
+function isHeaderSafeByteString(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    if (value.charCodeAt(i) > 0xff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function invalidSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
+  const providerLabel = provider === "brave" ? "Brave" : provider;
+  return {
+    error: "invalid_api_key_encoding",
+    provider,
+    message: `${providerLabel} web_search API key contains unsupported characters. Re-enter the key with plain text (smart quotes/em dashes are not valid in API keys).`,
+    docs: "https://docs.openclaw.ai/tools/web",
+  };
+}
+
 function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDERS)[number] {
   const raw =
     search && "provider" in search && typeof search.provider === "string"
@@ -1382,6 +1401,11 @@ export function createWebSearchTool(options?: {
 
       if (!apiKey) {
         return jsonResult(missingSearchKeyPayload(provider));
+      }
+      // Undici headers require ByteString values; reject smart punctuation/Unicode early
+      // so users get actionable setup guidance instead of a low-level runtime error.
+      if (!isHeaderSafeByteString(apiKey)) {
+        return jsonResult(invalidSearchKeyPayload(provider));
       }
       const params = args as Record<string, unknown>;
       const query = readStringParam(params, "query", { required: true });

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -210,6 +210,29 @@ describe("web_search country and language parameters", () => {
   });
 });
 
+describe("web_search api key validation", () => {
+  const priorFetch = global.fetch;
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    global.fetch = priorFetch;
+  });
+
+  it("returns setup guidance when Brave key contains non-ByteString chars", async () => {
+    vi.stubEnv("BRAVE_API_KEY", "brv-test—bad");
+    const mockFetch = installMockFetch({ web: { results: [] } });
+    const tool = createWebSearchTool({ config: undefined, sandboxed: true });
+
+    const result = await tool?.execute?.("call-1", { query: "test" });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result?.details).toMatchObject({
+      error: "invalid_api_key_encoding",
+      provider: "brave",
+    });
+  });
+});
+
 describe("web_search provider proxy dispatch", () => {
   const priorFetch = global.fetch;
 


### PR DESCRIPTION
## Summary
- validate `web_search` API keys before network calls to avoid Undici ByteString header crashes
- return a structured setup error when the key contains unsupported Unicode chars (for example smart punctuation)
- add a regression test proving no fetch occurs and the tool returns actionable guidance

## Testing
- `pnpm test -- src/agents/tools/web-tools.enabled-defaults.test.ts src/agents/tools/web-search.test.ts`

Closes #33222
