### PR TITLE
fix(mentions): avoid false no-mention drops when explicit identity is unavailable

### DIFF
--- a/src/auto-reply/reply/mentions.test.ts
+++ b/src/auto-reply/reply/mentions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { stripStructuralPrefixes } from "./mentions.js";
+import { matchesMentionWithExplicit, stripStructuralPrefixes } from "./mentions.js";
 
 describe("stripStructuralPrefixes", () => {
   it("returns empty string for undefined input at runtime", () => {
@@ -16,5 +16,21 @@ describe("stripStructuralPrefixes", () => {
 
   it("passes through plain text", () => {
     expect(stripStructuralPrefixes("just a message")).toBe("just a message");
+  });
+});
+
+describe("matchesMentionWithExplicit", () => {
+  it("treats explicit mentions as mentioned when explicit identity cannot be resolved", () => {
+    const wasMentioned = matchesMentionWithExplicit({
+      text: "@J_A_R_V_1_S_bot hola",
+      mentionRegexes: [],
+      explicit: {
+        hasAnyMention: true,
+        isExplicitlyMentioned: false,
+        canResolveExplicit: false,
+      },
+    });
+
+    expect(wasMentioned).toBe(true);
   });
 });

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -117,6 +117,10 @@ export function matchesMentionWithExplicit(params: {
   const transcriptCleaned = params.transcript ? normalizeMentionText(params.transcript) : "";
   const textToCheck = cleaned || transcriptCleaned;
 
+  if (hasAnyMention && !explicitAvailable) {
+    return true;
+  }
+
   if (hasAnyMention && explicitAvailable) {
     return explicit || params.mentionRegexes.some((re) => re.test(textToCheck));
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: group mention-gated turns can be dropped as `no-mention` when Telegram explicit mention entities exist but explicit bot identity cannot be resolved at that moment.
- Why it matters: this creates false negatives for valid mention-triggered group messages and silently skips user messages.
- What changed: `matchesMentionWithExplicit` now treats explicit mention presence (`hasAnyMention`) as sufficient when explicit identity resolution is unavailable; added a regression test for this path.
- What did NOT change (scope boundary): no channel transport parsing changes; no text_link/text_mention parsing additions in Telegram helpers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33218
- Related #28939

## User-visible / Behavior Changes

Messages with explicit Telegram mention entities are no longer dropped as `no-mention` when explicit identity resolution is temporarily unavailable.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Telegram mention gating logic
- Relevant config (redacted): `requireMention` group gating

### Steps

1. Evaluate mention matching with explicit mention signal present (`hasAnyMention=true`).
2. Simulate unresolved explicit identity (`canResolveExplicit=false`, `isExplicitlyMentioned=false`).
3. Observe mention decision.

### Expected

- Mention should be treated as present to avoid false `no-mention` drops.

### Actual

- Before fix, result was `false` and the turn could be dropped.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added and ran `matchesMentionWithExplicit` regression test for unresolved explicit identity.
  - Ran mention-focused Telegram tests to confirm gating behavior stays green.
- Edge cases checked:
  - Existing mention regex behavior remains unchanged when explicit mention is not present.
  - Implicit mention + audio transcript gating tests still pass.
- What you did **not** verify:
  - Live Telegram group delivery with real bot credentials.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/auto-reply/reply/mentions.ts`, `src/auto-reply/reply/mentions.test.ts`.
- Known bad symptoms reviewers should watch for: over-triggered mention gating where any explicit mention should not count.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: counting any explicit mention as sufficient when explicit identity is unavailable could admit some non-bot mentions.
  - Mitigation: scope is limited to the unresolved-identity branch; normal explicit bot matching path remains unchanged when identity is resolvable.
