### PR TITLE
fix(ui): make /skills workspace scope explicit by agent

### DIFF
--- a/src/agents/skills-status.test.ts
+++ b/src/agents/skills-status.test.ts
@@ -38,6 +38,12 @@ describe("buildWorkspaceSkillStatus", () => {
 
     const report = buildWorkspaceSkillStatus("/tmp/ws", { entries: [entry] });
     expect(report.skills).toHaveLength(1);
+    expect(report.agentId).toBeUndefined();
     expect(report.skills[0]?.install).toEqual([]);
+  });
+
+  it("propagates agentId when provided", () => {
+    const report = buildWorkspaceSkillStatus("/tmp/ws", { entries: [], agentId: "main" });
+    expect(report.agentId).toBe("main");
   });
 });

--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -49,6 +49,7 @@ export type SkillStatusEntry = {
 };
 
 export type SkillStatusReport = {
+  agentId?: string;
   workspaceDir: string;
   managedSkillsDir: string;
   skills: SkillStatusEntry[];
@@ -227,6 +228,7 @@ function buildSkillStatus(
 export function buildWorkspaceSkillStatus(
   workspaceDir: string,
   opts?: {
+    agentId?: string;
     config?: OpenClawConfig;
     managedSkillsDir?: string;
     entries?: SkillEntry[];
@@ -244,6 +246,7 @@ export function buildWorkspaceSkillStatus(
     });
   const prefs = resolveSkillsInstallPreferences(opts?.config);
   return {
+    agentId: opts?.agentId,
     workspaceDir,
     managedSkillsDir,
     skills: skillEntries.map((entry) =>

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -83,6 +83,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
     }
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     const report = buildWorkspaceSkillStatus(workspaceDir, {
+      agentId,
       config: cfg,
       eligibility: { remote: getRemoteSkillEligibility() },
     });

--- a/src/gateway/server.skills-status.test.ts
+++ b/src/gateway/server.skills-status.test.ts
@@ -25,6 +25,7 @@ describe("gateway skills.status", () => {
         await withServer(async (ws) => {
           await connectOk(ws, { token: "secret", scopes: ["operator.read"] });
           const res = await rpcReq<{
+            agentId?: string;
             skills?: Array<{
               name?: string;
               configChecks?: Array<
@@ -35,6 +36,7 @@ describe("gateway skills.status", () => {
 
           expect(res.ok).toBe(true);
           expect(JSON.stringify(res.payload)).not.toContain(secret);
+          expect(res.payload?.agentId).toBe("main");
 
           const discord = res.payload?.skills?.find((s) => s.name === "discord");
           expect(discord).toBeTruthy();

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -606,6 +606,7 @@ export type SkillStatusEntry = {
 };
 
 export type SkillStatusReport = {
+  agentId?: string;
   workspaceDir: string;
   managedSkillsDir: string;
   skills: SkillStatusEntry[];

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -25,6 +25,18 @@ export type SkillsProps = {
   onInstall: (skillKey: string, name: string, installId: string) => void;
 };
 
+export function resolveSkillsGroupLabel(params: {
+  groupId: string;
+  defaultLabel: string;
+  report: SkillStatusReport | null;
+}): string {
+  if (params.groupId !== "workspace") {
+    return params.defaultLabel;
+  }
+  const agentId = params.report?.agentId?.trim();
+  return agentId ? `Workspace Skills (${agentId})` : params.defaultLabel;
+}
+
 export function renderSkills(props: SkillsProps) {
   const skills = props.report?.skills ?? [];
   const filter = props.filter.trim().toLowerCase();
@@ -74,10 +86,15 @@ export function renderSkills(props: SkillsProps) {
             <div class="agent-skills-groups" style="margin-top: 16px;">
               ${groups.map((group) => {
                 const collapsedByDefault = group.id === "workspace" || group.id === "built-in";
+                const label = resolveSkillsGroupLabel({
+                  groupId: group.id,
+                  defaultLabel: group.label,
+                  report: props.report,
+                });
                 return html`
                   <details class="agent-skills-group" ?open=${!collapsedByDefault}>
                     <summary class="agent-skills-header">
-                      <span>${group.label}</span>
+                      <span>${label}</span>
                       <span class="muted">${group.skills.length}</span>
                     </summary>
                     <div class="list skills-grid">


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `/skills` reads like a global page, but workspace skills are sourced from one agent workspace, which is misleading in multi-agent setups.
- Why it matters: operators can misinterpret workspace skill scope and assume they are viewing/editing global state.
- What changed: `skills.status` now returns `agentId`; Control UI labels the workspace group as `Workspace Skills (<agentId>)` when available.
- What did NOT change (scope boundary): no selector UX or cross-agent aggregation was introduced; this is a clarity/scope-label fix only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33261
- Related #33261

## User-visible / Behavior Changes

Control UI `/skills` now shows explicit workspace scope in the group heading (for example `Workspace Skills (main)`), avoiding ambiguity in multi-agent environments.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway `skills.status` + Control UI `/skills`
- Relevant config (redacted): multi-agent configuration with per-agent workspaces

### Steps

1. Request `skills.status` in a multi-agent setup.
2. Open Control UI `/skills`.
3. Observe workspace skills group heading.

### Expected

- Workspace scope is explicit in UI label (`Workspace Skills (<agentId>)`) so users know the scope is agent-specific.

### Actual

- Before fix, heading was generic `Workspace Skills`, implying global scope.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added/ran gateway test asserting `skills.status` includes `agentId`.
  - Added/ran skills status unit test asserting `agentId` propagation.
  - Ran skills status build tests to ensure no eligibility/install regressions.
- Edge cases checked:
  - `agentId` remains optional for non-gateway callers.
  - Non-workspace skill groups are unchanged.
- What you did **not** verify:
  - Manual browser walkthrough on a live multi-agent gateway instance.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/agents/skills-status.ts`, `src/gateway/server-methods/skills.ts`, `ui/src/ui/views/skills.ts`, related type/tests.
- Known bad symptoms reviewers should watch for: missing/incorrect workspace scope label in `/skills`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: downstream clients that strict-parse `skills.status` payload could ignore/flag new `agentId` field.
  - Mitigation: field is additive and optional; existing fields and behavior are unchanged.
