### PR TITLE
fix(gateway): disable control-ui shell caching after upgrades

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -46,7 +46,7 @@ describe("handleControlUiHttpRequest", () => {
     rootPath: string;
     basePath?: string;
   }) {
-    const { res, end } = makeMockHttpResponse();
+    const { res, end, setHeader } = makeMockHttpResponse();
     const handled = handleControlUiHttpRequest(
       { url: params.url, method: params.method } as IncomingMessage,
       res,
@@ -55,7 +55,7 @@ describe("handleControlUiHttpRequest", () => {
         root: { kind: "resolved", path: params.rootPath },
       },
     );
-    return { res, end, handled };
+    return { res, end, setHeader, handled };
   }
 
   function runAvatarRequest(params: {
@@ -146,10 +146,25 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("serves control-ui shell HTML with no-store cache policy", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { res, setHeader } = makeMockHttpResponse();
+        const handled = handleControlUiHttpRequest(
+          { url: "/", method: "GET" } as IncomingMessage,
+          res,
+          { root: { kind: "resolved", path: tmp } },
+        );
+        expect(handled).toBe(true);
+        expect(setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
+      },
+    });
+  });
+
   it("serves bootstrap config JSON", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        const { res, end } = makeMockHttpResponse();
+        const { res, end, setHeader } = makeMockHttpResponse();
         const handled = handleControlUiHttpRequest(
           { url: CONTROL_UI_BOOTSTRAP_CONFIG_PATH, method: "GET" } as IncomingMessage,
           res,
@@ -167,6 +182,22 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.assistantName).toBe("</script><script>alert(1)//");
         expect(parsed.assistantAvatar).toBe("/avatar/main");
         expect(parsed.assistantAgentId).toBe("main");
+        expect(setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
+      },
+    });
+  });
+
+  it("serves static assets with revalidation cache policy", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        await writeAssetFile(tmp, "main.js", "console.log('ok');\n");
+        const { handled, setHeader } = runControlUiRequest({
+          url: "/assets/main.js",
+          method: "GET",
+          rootPath: tmp,
+        });
+        expect(handled).toBe(true);
+        expect(setHeader).toHaveBeenCalledWith("Cache-Control", "no-cache");
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -115,7 +115,7 @@ function applyControlUiSecurityHeaders(res: ServerResponse) {
 function sendJson(res: ServerResponse, status: number, body: unknown) {
   res.statusCode = status;
   res.setHeader("Content-Type", "application/json; charset=utf-8");
-  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Cache-Control", "no-store");
   res.end(JSON.stringify(body));
 }
 
@@ -218,9 +218,10 @@ export function handleControlUiAvatarRequest(
 function setStaticFileHeaders(res: ServerResponse, filePath: string) {
   const ext = path.extname(filePath).toLowerCase();
   res.setHeader("Content-Type", contentTypeForExt(ext));
-  // Static UI should never be cached aggressively while iterating; allow the
-  // browser to revalidate.
-  res.setHeader("Cache-Control", "no-cache");
+  const isShellHtml = path.basename(filePath).toLowerCase() === "index.html";
+  // Keep shell HTML uncached so upgrades do not pin old UI versions in browsers
+  // while still allowing revalidation behavior for versioned static assets.
+  res.setHeader("Cache-Control", isShellHtml ? "no-store" : "no-cache");
 }
 
 function serveResolvedFile(res: ServerResponse, filePath: string, body: Buffer) {
@@ -230,7 +231,7 @@ function serveResolvedFile(res: ServerResponse, filePath: string, body: Buffer) 
 
 function serveResolvedIndexHtml(res: ServerResponse, body: string) {
   res.setHeader("Content-Type", "text/html; charset=utf-8");
-  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Cache-Control", "no-store");
   res.end(body);
 }
 
@@ -341,7 +342,7 @@ export function handleControlUiHttpRequest(
     if (req.method === "HEAD") {
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/json; charset=utf-8");
-      res.setHeader("Cache-Control", "no-cache");
+      res.setHeader("Cache-Control", "no-store");
       res.end();
       return true;
     }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: after upgrades, Control UI can continue showing stale version information because shell/bootstrap responses are cacheable enough to reuse old UI state.
- Why it matters: users can see outdated version/status in Control UI even when gateway/CLI is updated.
- What changed: switched shell HTML (`index.html`) and bootstrap config JSON to `Cache-Control: no-store`; kept static asset responses on `no-cache` revalidation.
- What did NOT change (scope boundary): no routing/auth/session logic changed; only cache headers in control-ui HTTP serving path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33259
- Related #33259

## User-visible / Behavior Changes

Control UI now serves shell HTML + bootstrap config with `no-store`, reducing stale version/shell state after gateway upgrades.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway Control UI HTTP handler
- Relevant config (redacted): default Control UI root serving

### Steps

1. Serve Control UI from gateway.
2. Request `/` and `/<base>/__openclaw/control-ui-config.json`.
3. Inspect cache headers.

### Expected

- Shell HTML and bootstrap config are not stored by browser caches (`Cache-Control: no-store`).
- Versioned static assets still use revalidation policy (`Cache-Control: no-cache`).

### Actual

- Before fix, shell/config used `no-cache`, which can still retain stale shell/state across upgrade flows.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added tests that assert `/` shell uses `no-store`.
  - Added tests that assert bootstrap config uses `no-store`.
  - Added tests that assert static assets keep `no-cache`.
- Edge cases checked:
  - Existing security headers + avatar/static serving tests remain green.
- What you did **not** verify:
  - Manual browser upgrade flow over SSH tunnel with real cache profile.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/gateway/control-ui.ts`, `src/gateway/control-ui.http.test.ts`.
- Known bad symptoms reviewers should watch for: increased shell/bootstrap refetch frequency.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: more frequent shell/bootstrap fetches in browsers due `no-store`.
  - Mitigation: static assets remain `no-cache` revalidation, so payload impact stays limited.
