### PR TITLE
fix(matrix): resolve keyed-async-queue import for Docker builds

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 


### PR DESCRIPTION
## Summary

- Fix Matrix plugin failing to load in Docker image due to `keyed-async-queue` subpath not resolving after Rolldown bundling
- Change import from `"openclaw/plugin-sdk/keyed-async-queue"` to `"openclaw/plugin-sdk"` (where `KeyedAsyncQueue` is already re-exported)

## Problem

The Docker image bundles `plugin-sdk` into a single `index.js` via Rolldown. The `/keyed-async-queue` subpath export declared in `package.json` doesn't produce a separate chunk in the bundle, so the Matrix extension's import fails:

```
[plugins] matrix failed to load: Cannot find module '/app/dist/plugin-sdk/index.js/keyed-async-queue'
```

This silently breaks Matrix for **all Docker users** — the container starts healthy but can't send or receive messages.

## Fix

One-line import change. `KeyedAsyncQueue` is already re-exported from the main `plugin-sdk/index.ts` barrel (`export { enqueueKeyedTask, KeyedAsyncQueue } from "./keyed-async-queue.js"`), so importing from the top-level path works in both bundled (Docker) and unbundled (npm) environments.

## Test plan

- [x] Verified `KeyedAsyncQueue` is exported from `plugin-sdk/index.js` in the Docker bundle
- [x] Verified Matrix plugin loads successfully with the patched import (4 bots, self-hosted Synapse)
- [x] E2EE handshake completes, messages send and receive normally

Fixes #33266