### PR TITLE
fix(gateway): allow launchagent start after stop bootout

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -59,6 +59,7 @@ describe("runServiceRestart token drift", () => {
     service.isLoaded.mockClear();
     service.readCommand.mockClear();
     service.restart.mockClear();
+    service.label = "TestService";
     service.isLoaded.mockResolvedValue(true);
     service.readCommand.mockResolvedValue({
       environment: { OPENCLAW_GATEWAY_TOKEN: "service-token" },

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -125,6 +125,36 @@ describe("runServiceRestart token drift", () => {
     const payload = JSON.parse(jsonLine ?? "{}") as { warnings?: string[] };
     expect(payload.warnings).toBeUndefined();
   });
+});
+
+describe("runServiceStart LaunchAgent", () => {
+  beforeAll(async () => {
+    ({ runServiceRestart, runServiceStart } = await import("./lifecycle-core.js"));
+  });
+
+  beforeEach(() => {
+    runtimeLogs.length = 0;
+    loadConfig.mockReset();
+    loadConfig.mockReturnValue({
+      gateway: {
+        auth: {
+          token: "config-token",
+        },
+      },
+    });
+    service.isLoaded.mockClear();
+    service.readCommand.mockClear();
+    service.restart.mockClear();
+    service.label = "TestService";
+    service.isLoaded.mockResolvedValue(true);
+    service.readCommand.mockResolvedValue({
+      environment: { OPENCLAW_GATEWAY_TOKEN: "service-token" },
+    });
+    service.restart.mockResolvedValue(undefined);
+    vi.unstubAllEnvs();
+    vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", "");
+    vi.stubEnv("CLAWDBOT_GATEWAY_TOKEN", "");
+  });
 
   it("restarts unloaded LaunchAgent services on start", async () => {
     service.label = "LaunchAgent";
@@ -179,5 +209,25 @@ describe("runServiceRestart token drift", () => {
     const payload = JSON.parse(jsonLine ?? "{}") as { result?: string; ok?: boolean };
     expect(payload.ok).toBe(true);
     expect(payload.result).toBe("not-loaded");
+  });
+
+  it("propagates LaunchAgent restart failures as start failures", async () => {
+    service.label = "LaunchAgent";
+    service.isLoaded.mockResolvedValue(false);
+    service.restart.mockRejectedValue(new Error("launchctl error"));
+
+    await expect(
+      runServiceStart({
+        serviceNoun: "Gateway",
+        service,
+        renderStartHints: () => ["openclaw gateway install --force"],
+        opts: { json: true },
+      }),
+    ).rejects.toThrow("__exit__:1");
+
+    const jsonLine = runtimeLogs.find((line) => line.trim().startsWith("{"));
+    const payload = JSON.parse(jsonLine ?? "{}") as { ok?: boolean; error?: string };
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toContain("Gateway start failed");
   });
 });

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -39,10 +39,11 @@ vi.mock("../../runtime.js", () => ({
 }));
 
 let runServiceRestart: typeof import("./lifecycle-core.js").runServiceRestart;
+let runServiceStart: typeof import("./lifecycle-core.js").runServiceStart;
 
 describe("runServiceRestart token drift", () => {
   beforeAll(async () => {
-    ({ runServiceRestart } = await import("./lifecycle-core.js"));
+    ({ runServiceRestart, runServiceStart } = await import("./lifecycle-core.js"));
   });
 
   beforeEach(() => {
@@ -122,5 +123,41 @@ describe("runServiceRestart token drift", () => {
     const jsonLine = runtimeLogs.find((line) => line.trim().startsWith("{"));
     const payload = JSON.parse(jsonLine ?? "{}") as { warnings?: string[] };
     expect(payload.warnings).toBeUndefined();
+  });
+
+  it("restarts unloaded LaunchAgent services on start", async () => {
+    service.label = "LaunchAgent";
+    service.isLoaded.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await runServiceStart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => ["openclaw gateway install --force"],
+      opts: { json: true },
+    });
+
+    expect(service.restart).toHaveBeenCalledTimes(1);
+    const jsonLine = runtimeLogs.find((line) => line.trim().startsWith("{"));
+    const payload = JSON.parse(jsonLine ?? "{}") as { result?: string; ok?: boolean };
+    expect(payload.ok).toBe(true);
+    expect(payload.result).toBe("started");
+  });
+
+  it("keeps non-LaunchAgent start behavior when service is not loaded", async () => {
+    service.label = "TestService";
+    service.isLoaded.mockResolvedValue(false);
+
+    await runServiceStart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => ["openclaw gateway install --force"],
+      opts: { json: true },
+    });
+
+    expect(service.restart).not.toHaveBeenCalled();
+    const jsonLine = runtimeLogs.find((line) => line.trim().startsWith("{"));
+    const payload = JSON.parse(jsonLine ?? "{}") as { result?: string; ok?: boolean };
+    expect(payload.ok).toBe(true);
+    expect(payload.result).toBe("not-loaded");
   });
 });

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -143,6 +143,25 @@ describe("runServiceRestart token drift", () => {
     expect(payload.result).toBe("started");
   });
 
+  it("keeps LaunchAgent not-loaded result when plist command is missing", async () => {
+    service.label = "LaunchAgent";
+    service.isLoaded.mockResolvedValue(false);
+    service.readCommand.mockResolvedValue(null);
+
+    await runServiceStart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => ["openclaw gateway install --force"],
+      opts: { json: true },
+    });
+
+    expect(service.restart).not.toHaveBeenCalled();
+    const jsonLine = runtimeLogs.find((line) => line.trim().startsWith("{"));
+    const payload = JSON.parse(jsonLine ?? "{}") as { result?: string; ok?: boolean };
+    expect(payload.ok).toBe(true);
+    expect(payload.result).toBe("not-loaded");
+  });
+
   it("keeps non-LaunchAgent start behavior when service is not loaded", async () => {
     service.label = "TestService";
     service.isLoaded.mockResolvedValue(false);

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -165,6 +165,23 @@ export async function runServiceStart(params: {
   }
   if (!loaded) {
     if (params.service.label === "LaunchAgent") {
+      let hasLaunchAgentConfig = false;
+      try {
+        hasLaunchAgentConfig = (await params.service.readCommand(process.env)) != null;
+      } catch {
+        hasLaunchAgentConfig = false;
+      }
+      if (!hasLaunchAgentConfig) {
+        await handleServiceNotLoaded({
+          serviceNoun: params.serviceNoun,
+          service: params.service,
+          loaded,
+          renderStartHints: params.renderStartHints,
+          json,
+          emit,
+        });
+        return;
+      }
       try {
         await params.service.restart({ env: process.env, stdout });
       } catch (err) {

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -164,6 +164,28 @@ export async function runServiceStart(params: {
     return;
   }
   if (!loaded) {
+    if (params.service.label === "LaunchAgent") {
+      try {
+        await params.service.restart({ env: process.env, stdout });
+      } catch (err) {
+        const hints = params.renderStartHints();
+        fail(`${params.serviceNoun} start failed: ${String(err)}`, hints);
+        return;
+      }
+
+      let started = true;
+      try {
+        started = await params.service.isLoaded({ env: process.env });
+      } catch {
+        started = true;
+      }
+      emit({
+        ok: true,
+        result: "started",
+        service: buildDaemonServiceSnapshot(params.service, started),
+      });
+      return;
+    }
     await handleServiceNotLoaded({
       serviceNoun: params.serviceNoun,
       service: params.service,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw gateway stop` (LaunchAgent `bootout`) followed by `openclaw gateway start` leaves gateway stopped on macOS.
- Why it matters: a basic stop/start cycle silently fails and requires users to discover `gateway install --force` as a workaround.
- What changed: `runServiceStart` now attempts `service.restart()` when the service is `not loaded` and the service backend is LaunchAgent.
- What changed: added regression tests to lock LaunchAgent-specific start behavior and preserve existing behavior for non-LaunchAgent services.
- What did NOT change (scope boundary): no changes to Linux systemd or Windows Scheduled Task startup semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33265
- Related #33193

## User-visible / Behavior Changes

On macOS LaunchAgent installs, `openclaw gateway start` now starts successfully after a prior `openclaw gateway stop` (bootout) instead of returning a `not loaded` hint and leaving gateway stopped.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (LaunchAgent service path)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default gateway daemon config

### Steps

1. Install and run gateway as LaunchAgent.
2. Run `openclaw gateway stop`.
3. Run `openclaw gateway start`.

### Expected

- Gateway restarts successfully and reports as loaded/running.

### Actual

- Gateway remained stopped because start path exited early when `isLoaded=false` after `bootout`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest src/cli/daemon-cli/lifecycle-core.test.ts`
  - New test: unloaded LaunchAgent path calls restart and returns `started`.
  - Existing semantics preserved for non-LaunchAgent `not-loaded` starts.
- Edge cases checked:
  - LaunchAgent restart failures still propagate as start failures with start hints.
- What you did **not** verify:
  - Did not run live macOS launchctl integration in this PR; validated through daemon lifecycle unit tests.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `fix(gateway): allow launchagent start after stop bootout`.
- Files/config to restore:
  - `src/cli/daemon-cli/lifecycle-core.ts`
  - `src/cli/daemon-cli/lifecycle-core.test.ts`
- Known bad symptoms reviewers should watch for:
  - Non-macOS daemon `start` behavior unexpectedly switching from `not-loaded` to restart attempt.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: LaunchAgent-only condition could be too narrow if label names change.
  - Mitigation: backend label is controlled by `resolveGatewayService()` and covered by explicit test assertions.
