### PR TITLE
fix(webchat): dedupe duplicate delivery-mirror transcript appends

### DIFF
--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -356,6 +356,7 @@ describe("appendAssistantMessageToSessionTranscript", () => {
             content: [{ type: "text", text: "same reply" }],
             provider: "openclaw",
             model: "delivery-mirror",
+            timestamp: Date.now() - 100,
           },
         }),
       ].join("\n") + "\n",
@@ -371,6 +372,55 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     expect(result).toEqual({ ok: false, reason: "duplicate assistant text" });
     const lines = fs.readFileSync(transcriptPath, "utf-8").trim().split("\n");
     expect(lines.length).toBe(2);
+  });
+
+  it("does not dedupe stale delivery-mirror tail entries with matching text", async () => {
+    const sessionId = "stale-tail-session-id";
+    const sessionKey = "stale-tail-session-key";
+    const store = {
+      [sessionKey]: {
+        sessionId,
+        chatType: "direct",
+        channel: "webchat",
+      },
+    };
+    fs.writeFileSync(fixture.storePath(), JSON.stringify(store), "utf-8");
+
+    const transcriptPath = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+    fs.writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 1,
+          id: sessionId,
+          timestamp: new Date().toISOString(),
+          cwd: process.cwd(),
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "same reply" }],
+            provider: "openclaw",
+            model: "delivery-mirror",
+            timestamp: Date.now() - 10_000,
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "same reply",
+      storePath: fixture.storePath(),
+    });
+
+    expect(result.ok).toBe(true);
+    const lines = fs.readFileSync(transcriptPath, "utf-8").trim().split("\n");
+    expect(lines.length).toBe(3);
   });
 
   it("does not dedupe against non-delivery-mirror assistant tail entries", async () => {

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -325,7 +325,7 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     }
   });
 
-  it("skips delivery-mirror append when the latest assistant text already matches", async () => {
+  it("skips delivery-mirror append when the latest real assistant text already matches", async () => {
     const sessionId = "dup-session-id";
     const sessionKey = "dup-session-key";
     const store = {
@@ -354,9 +354,8 @@ describe("appendAssistantMessageToSessionTranscript", () => {
           message: {
             role: "assistant",
             content: [{ type: "text", text: "same reply" }],
-            provider: "openclaw",
-            model: "delivery-mirror",
-            timestamp: Date.now() - 100,
+            provider: "openai-codex",
+            model: "gpt-5.3-codex",
           },
         }),
       ].join("\n") + "\n",
@@ -374,9 +373,9 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     expect(lines.length).toBe(2);
   });
 
-  it("does not dedupe stale delivery-mirror tail entries with matching text", async () => {
-    const sessionId = "stale-tail-session-id";
-    const sessionKey = "stale-tail-session-key";
+  it("does not dedupe repeated delivery-mirror sends with matching text", async () => {
+    const sessionId = "mirror-tail-session-id";
+    const sessionKey = "mirror-tail-session-key";
     const store = {
       [sessionKey]: {
         sessionId,
@@ -405,7 +404,6 @@ describe("appendAssistantMessageToSessionTranscript", () => {
             content: [{ type: "text", text: "same reply" }],
             provider: "openclaw",
             model: "delivery-mirror",
-            timestamp: Date.now() - 10_000,
           },
         }),
       ].join("\n") + "\n",
@@ -423,9 +421,9 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     expect(lines.length).toBe(3);
   });
 
-  it("does not dedupe against non-delivery-mirror assistant tail entries", async () => {
-    const sessionId = "non-mirror-tail-session-id";
-    const sessionKey = "non-mirror-tail-session-key";
+  it("does not dedupe when the latest real assistant text differs", async () => {
+    const sessionId = "different-tail-session-id";
+    const sessionKey = "different-tail-session-key";
     const store = {
       [sessionKey]: {
         sessionId,
@@ -451,7 +449,7 @@ describe("appendAssistantMessageToSessionTranscript", () => {
           type: "message",
           message: {
             role: "assistant",
-            content: [{ type: "text", text: "same reply" }],
+            content: [{ type: "text", text: "different reply" }],
             provider: "openai-codex",
             model: "gpt-5.3-codex",
           },

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -354,8 +354,8 @@ describe("appendAssistantMessageToSessionTranscript", () => {
           message: {
             role: "assistant",
             content: [{ type: "text", text: "same reply" }],
-            provider: "openai-codex",
-            model: "gpt-5.3-codex",
+            provider: "openclaw",
+            model: "delivery-mirror",
           },
         }),
       ].join("\n") + "\n",
@@ -371,6 +371,58 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     expect(result).toEqual({ ok: false, reason: "duplicate assistant text" });
     const lines = fs.readFileSync(transcriptPath, "utf-8").trim().split("\n");
     expect(lines.length).toBe(2);
+  });
+
+  it("does not dedupe against non-delivery-mirror assistant tail entries", async () => {
+    const sessionId = "non-mirror-tail-session-id";
+    const sessionKey = "non-mirror-tail-session-key";
+    const store = {
+      [sessionKey]: {
+        sessionId,
+        chatType: "direct",
+        channel: "webchat",
+      },
+    };
+    fs.writeFileSync(fixture.storePath(), JSON.stringify(store), "utf-8");
+
+    const transcriptPath = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+    fs.writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 1,
+          id: sessionId,
+          timestamp: new Date().toISOString(),
+          cwd: process.cwd(),
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "same reply" }],
+            provider: "openai-codex",
+            model: "gpt-5.3-codex",
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "same reply",
+      storePath: fixture.storePath(),
+    });
+
+    expect(result.ok).toBe(true);
+    const lines = fs.readFileSync(transcriptPath, "utf-8").trim().split("\n");
+    expect(lines.length).toBe(3);
+    const messageLine = JSON.parse(lines[2] ?? "{}");
+    expect(messageLine?.message?.provider).toBe("openclaw");
+    expect(messageLine?.message?.model).toBe("delivery-mirror");
+    expect(messageLine?.message?.content?.[0]?.text).toBe("same reply");
   });
 });
 

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -324,6 +324,54 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       expect(messageLine.message.content[0].text).toBe("Hello from delivery mirror!");
     }
   });
+
+  it("skips delivery-mirror append when the latest assistant text already matches", async () => {
+    const sessionId = "dup-session-id";
+    const sessionKey = "dup-session-key";
+    const store = {
+      [sessionKey]: {
+        sessionId,
+        chatType: "direct",
+        channel: "webchat",
+      },
+    };
+    fs.writeFileSync(fixture.storePath(), JSON.stringify(store), "utf-8");
+
+    const transcriptPath = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+    fs.writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 1,
+          id: sessionId,
+          timestamp: new Date().toISOString(),
+          cwd: process.cwd(),
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "same reply" }],
+            provider: "openai-codex",
+            model: "gpt-5.3-codex",
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "same reply",
+      storePath: fixture.storePath(),
+    });
+
+    expect(result).toEqual({ ok: false, reason: "duplicate assistant text" });
+    const lines = fs.readFileSync(transcriptPath, "utf-8").trim().split("\n");
+    expect(lines.length).toBe(2);
+  });
 });
 
 describe("resolveAndPersistSessionFile", () => {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -100,7 +100,10 @@ function isDuplicateAssistantTail(params: {
     }
     const message = entry.message as Record<string, unknown>;
     if (typeof message.role !== "string" || message.role !== "assistant") {
-      continue;
+      return false;
+    }
+    if (message.provider !== "openclaw" || message.model !== "delivery-mirror") {
+      return false;
     }
     const lastAssistantText = extractAssistantText(message);
     return lastAssistantText === params.mirrorText;

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -7,6 +7,8 @@ import { resolveAndPersistSessionFile } from "./session-file.js";
 import { loadSessionStore } from "./store.js";
 import type { SessionEntry } from "./types.js";
 
+const MIRROR_TAIL_DEDUPE_WINDOW_MS = 500;
+
 function stripQuery(value: string): string {
   const noHash = value.split("#")[0] ?? value;
   return noHash.split("?")[0] ?? noHash;
@@ -91,6 +93,7 @@ function extractAssistantText(message: unknown): string | null {
 function isDuplicateAssistantTail(params: {
   sessionManager: SessionManager;
   mirrorText: string;
+  nowMs: number;
 }): boolean {
   const entries = params.sessionManager.getEntries();
   for (let index = entries.length - 1; index >= 0; index -= 1) {
@@ -106,7 +109,18 @@ function isDuplicateAssistantTail(params: {
       return false;
     }
     const lastAssistantText = extractAssistantText(message);
-    return lastAssistantText === params.mirrorText;
+    if (lastAssistantText !== params.mirrorText) {
+      return false;
+    }
+    const lastTimestamp =
+      typeof message.timestamp === "number" && Number.isFinite(message.timestamp)
+        ? message.timestamp
+        : null;
+    if (lastTimestamp == null) {
+      return false;
+    }
+    const ageMs = params.nowMs - lastTimestamp;
+    return ageMs >= 0 && ageMs <= MIRROR_TAIL_DEDUPE_WINDOW_MS;
   }
   return false;
 }
@@ -181,8 +195,9 @@ export async function appendAssistantMessageToSessionTranscript(params: {
 
   await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
 
+  const nowMs = Date.now();
   const sessionManager = SessionManager.open(sessionFile);
-  if (isDuplicateAssistantTail({ sessionManager, mirrorText })) {
+  if (isDuplicateAssistantTail({ sessionManager, mirrorText, nowMs })) {
     return { ok: false, reason: "duplicate assistant text" };
   }
   sessionManager.appendMessage({
@@ -206,7 +221,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
       },
     },
     stopReason: "stop",
-    timestamp: Date.now(),
+    timestamp: nowMs,
   });
 
   emitSessionTranscriptUpdate(sessionFile);

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -7,8 +7,6 @@ import { resolveAndPersistSessionFile } from "./session-file.js";
 import { loadSessionStore } from "./store.js";
 import type { SessionEntry } from "./types.js";
 
-const MIRROR_TAIL_DEDUPE_WINDOW_MS = 500;
-
 function stripQuery(value: string): string {
   const noHash = value.split("#")[0] ?? value;
   return noHash.split("?")[0] ?? noHash;
@@ -93,7 +91,6 @@ function extractAssistantText(message: unknown): string | null {
 function isDuplicateAssistantTail(params: {
   sessionManager: SessionManager;
   mirrorText: string;
-  nowMs: number;
 }): boolean {
   const entries = params.sessionManager.getEntries();
   for (let index = entries.length - 1; index >= 0; index -= 1) {
@@ -105,22 +102,13 @@ function isDuplicateAssistantTail(params: {
     if (typeof message.role !== "string" || message.role !== "assistant") {
       return false;
     }
-    if (message.provider !== "openclaw" || message.model !== "delivery-mirror") {
-      return false;
-    }
     const lastAssistantText = extractAssistantText(message);
     if (lastAssistantText !== params.mirrorText) {
       return false;
     }
-    const lastTimestamp =
-      typeof message.timestamp === "number" && Number.isFinite(message.timestamp)
-        ? message.timestamp
-        : null;
-    if (lastTimestamp == null) {
-      return false;
-    }
-    const ageMs = params.nowMs - lastTimestamp;
-    return ageMs >= 0 && ageMs <= MIRROR_TAIL_DEDUPE_WINDOW_MS;
+    // Only skip the synthetic delivery-mirror write when it would immediately
+    // duplicate a real assistant turn that is already in the transcript.
+    return !(message.provider === "openclaw" && message.model === "delivery-mirror");
   }
   return false;
 }
@@ -197,7 +185,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
 
   const nowMs = Date.now();
   const sessionManager = SessionManager.open(sessionFile);
-  if (isDuplicateAssistantTail({ sessionManager, mirrorText, nowMs })) {
+  if (isDuplicateAssistantTail({ sessionManager, mirrorText })) {
     return { ok: false, reason: "duplicate assistant text" };
   }
   sessionManager.appendMessage({

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -58,6 +58,56 @@ export function resolveMirroredTranscriptText(params: {
   return trimmed ? trimmed : null;
 }
 
+function extractAssistantText(message: unknown): string | null {
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+  const candidate = message as Record<string, unknown>;
+  const content = candidate.content;
+  if (typeof content === "string") {
+    const trimmed = content.trim();
+    return trimmed ? trimmed : null;
+  }
+  if (Array.isArray(content)) {
+    const textParts = content
+      .map((part) => {
+        const item = part as Record<string, unknown>;
+        return item.type === "text" && typeof item.text === "string" ? item.text : null;
+      })
+      .filter((text): text is string => typeof text === "string")
+      .map((text) => text.trim())
+      .filter(Boolean);
+    if (textParts.length > 0) {
+      return textParts.join("\n");
+    }
+  }
+  if (typeof candidate.text === "string") {
+    const trimmed = candidate.text.trim();
+    return trimmed ? trimmed : null;
+  }
+  return null;
+}
+
+function isDuplicateAssistantTail(params: {
+  sessionManager: SessionManager;
+  mirrorText: string;
+}): boolean {
+  const entries = params.sessionManager.getEntries();
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index] as { type?: unknown; message?: unknown };
+    if (entry.type !== "message" || !entry.message || typeof entry.message !== "object") {
+      continue;
+    }
+    const message = entry.message as Record<string, unknown>;
+    if (typeof message.role !== "string" || message.role !== "assistant") {
+      continue;
+    }
+    const lastAssistantText = extractAssistantText(message);
+    return lastAssistantText === params.mirrorText;
+  }
+  return false;
+}
+
 async function ensureSessionHeader(params: {
   sessionFile: string;
   sessionId: string;
@@ -129,6 +179,9 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
 
   const sessionManager = SessionManager.open(sessionFile);
+  if (isDuplicateAssistantTail({ sessionManager, mirrorText })) {
+    return { ok: false, reason: "duplicate assistant text" };
+  }
   sessionManager.appendMessage({
     role: "assistant",
     content: [{ type: "text", text: mirrorText }],


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: webchat sessions can persist an immediate duplicate assistant turn from `openclaw/delivery-mirror` right after the real model assistant turn.
- Why it matters: duplicate assistant messages pollute transcript history and cause confusing double replies in Control UI chat history.
- What changed: `appendAssistantMessageToSessionTranscript` now checks the latest assistant transcript entry and skips appending when visible assistant text already matches the mirror text.
- What changed: added regression test proving duplicate mirror append is skipped while preserving existing append behavior.
- What did NOT change (scope boundary): no changes to outbound channel delivery behavior or non-duplicate transcript append semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33263
- Related #5964

## User-visible / Behavior Changes

When a delivery-mirror write would duplicate the latest assistant transcript text, OpenClaw now skips that mirror append. This prevents duplicated assistant turns in chat history for the same response.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (report) + unit test runtime
- Runtime/container: Node 22 + pnpm
- Model/provider: openai-codex (report context)
- Integration/channel (if any): Control UI webchat
- Relevant config (redacted): main session with transcript mirroring enabled via outbound mirror path

### Steps

1. Have a session transcript whose latest assistant message text is `same reply`.
2. Trigger delivery-mirror append for the same session with text `same reply`.
3. Read transcript lines.

### Expected

- No additional duplicate assistant message should be appended.

### Actual

- Before fix, a second assistant message with `provider=openclaw`, `model=delivery-mirror` was appended.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest src/config/sessions/sessions.test.ts src/infra/outbound/deliver.test.ts`
  - New regression test confirms duplicate mirror append is skipped.
  - Existing transcript append test still passes for non-duplicate message.
- Edge cases checked:
  - Deduper only compares against latest assistant turn and only blocks exact visible-text matches.
- What you did **not** verify:
  - Did not run live end-to-end webchat manually in this PR; validated via targeted transcript + outbound unit tests.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `fix(webchat): skip duplicate delivery-mirror transcript appends`.
- Files/config to restore:
  - `src/config/sessions/transcript.ts`
  - `src/config/sessions/sessions.test.ts`
- Known bad symptoms reviewers should watch for:
  - Legitimate mirror entries skipped when latest assistant text is intentionally identical.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: exact-text dedupe can skip a mirror append when two consecutive assistant turns intentionally share identical text.
  - Mitigation: dedupe is limited to immediate latest assistant text match and only impacts mirror append path; core assistant turn persistence remains unchanged.
