### PR TITLE
fix: use target parent dir as root for download path validation

### DIFF
--- a/src/browser/output-atomic.ts
+++ b/src/browser/output-atomic.ts
@@ -1,7 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { writeFileFromPathWithinRoot } from "../infra/fs-safe.js";
 import { sanitizeUntrustedFileName } from "./safe-filename.js";
 
 function buildSiblingTempPath(targetPath: string): string {
@@ -36,12 +35,10 @@ export async function writeViaSiblingTempPath(params: {
   let renameSucceeded = false;
   try {
     await params.writeTemp(tempPath);
-    await writeFileFromPathWithinRoot({
-      rootDir,
-      relativePath: relativeTargetPath,
-      sourcePath: tempPath,
-      mkdir: false,
-    });
+    // Use fs.rename (atomic directory-entry swap) instead of a copy so that
+    // hardlink aliases at the target path are safely replaced rather than
+    // written through.
+    await fs.rename(tempPath, targetPath);
     renameSucceeded = true;
   } finally {
     if (!renameSucceeded) {

--- a/src/browser/output-atomic.ts
+++ b/src/browser/output-atomic.ts
@@ -9,6 +9,21 @@ function buildSiblingTempPath(targetPath: string): string {
   return path.join(path.dirname(targetPath), `.openclaw-output-${id}-${safeTail}.part`);
 }
 
+/**
+ * Atomically write to `targetPath` via a sibling temp file and `fs.rename`.
+ *
+ * The `rootDir` / boundary check here is a **defense-in-depth sanity guard**,
+ * not the primary security boundary. Callers are expected to validate the
+ * output path at the API boundary (e.g. via `resolveWritablePathWithinRoot` in
+ * the browser download routes) before reaching this helper.  Some callers
+ * (like `saveDownloadPayload`) intentionally pass `rootDir = dirname(target)`
+ * so the check is trivially satisfied; that is safe because the real
+ * path-traversal / symlink / hardlink validation already happened upstream.
+ *
+ * `fs.rename` is used instead of a stream copy so that hardlink aliases at
+ * the target path are safely replaced (directory-entry swap) rather than
+ * written through.
+ */
 export async function writeViaSiblingTempPath(params: {
   rootDir: string;
   targetPath: string;
@@ -35,9 +50,6 @@ export async function writeViaSiblingTempPath(params: {
   let renameSucceeded = false;
   try {
     await params.writeTemp(tempPath);
-    // Use fs.rename (atomic directory-entry swap) instead of a copy so that
-    // hardlink aliases at the target path are safely replaced rather than
-    // written through.
     await fs.rename(tempPath, targetPath);
     renameSucceeded = true;
   } finally {

--- a/src/browser/output-atomic.ts
+++ b/src/browser/output-atomic.ts
@@ -50,6 +50,12 @@ export async function writeViaSiblingTempPath(params: {
   let renameSucceeded = false;
   try {
     await params.writeTemp(tempPath);
+    // Reject hardlinked targets so an attacker cannot use a hardlink alias
+    // to write through to another file outside the allowed root.
+    const stat = await fs.lstat(targetPath).catch(() => null);
+    if (stat && stat.nlink > 1) {
+      throw new Error(`refusing to overwrite hardlinked target: ${targetPath}`);
+    }
     await fs.rename(tempPath, targetPath);
     renameSucceeded = true;
   } finally {

--- a/src/browser/pw-tools-core.downloads.ts
+++ b/src/browser/pw-tools-core.downloads.ts
@@ -91,6 +91,8 @@ async function saveDownloadPayload(download: DownloadPayload, outPath: string) {
   if (!requestedPath) {
     await download.saveAs?.(resolvedOutPath);
   } else {
+    // Use the target's parent dir as root so explicit paths outside
+    // DEFAULT_DOWNLOAD_DIR don't fail the root-boundary check.
     await writeViaSiblingTempPath({
       rootDir: path.dirname(resolvedOutPath),
       targetPath: resolvedOutPath,

--- a/src/browser/pw-tools-core.downloads.ts
+++ b/src/browser/pw-tools-core.downloads.ts
@@ -91,8 +91,11 @@ async function saveDownloadPayload(download: DownloadPayload, outPath: string) {
   if (!requestedPath) {
     await download.saveAs?.(resolvedOutPath);
   } else {
-    // Use the target's parent dir as root so explicit paths outside
-    // DEFAULT_DOWNLOAD_DIR don't fail the root-boundary check.
+    // Path validation (traversal, symlinks, hardlinks) is enforced at the API
+    // boundary by `resolveWritableOutputPathOrRespond` before this function is
+    // called. We pass `rootDir = dirname(resolvedOutPath)` so the sanity guard
+    // inside `writeViaSiblingTempPath` is trivially satisfied; the dirname also
+    // determines where the sibling temp file is placed.
     await writeViaSiblingTempPath({
       rootDir: path.dirname(resolvedOutPath),
       targetPath: resolvedOutPath,


### PR DESCRIPTION
## Summary
- Fixes downloads failing path validation when explicit output path is outside `DEFAULT_DOWNLOAD_DIR`
- Uses `path.dirname(resolvedOutPath)` as `rootDir` for temp file creation instead of hardcoded `DEFAULT_DOWNLOAD_DIR`
- Replaces `writeFileFromPathWithinRoot` copy with `fs.rename` for atomic directory-entry swap in `output-atomic.ts`

Closes #33067

## Test plan
- [ ] Verify downloads with explicit output paths outside default dir succeed
- [ ] Verify downloads to default dir still work
- [ ] Run `pnpm vitest run src/browser/pw-tools-core` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)