### PR TITLE
fix(control-ui): allow bundled Control UI hardlinks for pnpm installs

### DIFF
--- a/run_openclaw_apple.sh
+++ b/run_openclaw_apple.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# -------------------------------
+# Configuration
+# -------------------------------
+# Persistent output folder on host
+HOST_DATA_DIR="$HOME/Sites/openclaw/data"
+mkdir -p "$HOST_DATA_DIR"
+
+# Container image and name
+IMAGE_NAME="openclaw-fork"
+CONTAINER_NAME="openclaw-test"
+
+# RAM allocation
+MEMORY="4g"
+
+# CLI command to run inside container (adjust as needed)
+CLI_CMD="openclaw run --output /app/data"
+
+# -------------------------------
+# Step 1: Build container using existing Dockerfile
+# -------------------------------
+echo "Building container image '$IMAGE_NAME' from existing Dockerfile..."
+container build -t "$IMAGE_NAME" .
+
+# -------------------------------
+# Step 2: Run container with 4 GB RAM and persistent volume
+# -------------------------------
+echo "Running container '$CONTAINER_NAME' with $MEMORY RAM..."
+container run \
+  --memory "$MEMORY" \
+  -v "$HOST_DATA_DIR:/app/data" \
+  --name "$CONTAINER_NAME" \
+  -it "$IMAGE_NAME" \
+  $CLI_CMD
+
+echo "Done! Outputs/logs are persisted in $HOST_DATA_DIR"

--- a/src/gateway/control-ui.auto-root.http.test.ts
+++ b/src/gateway/control-ui.auto-root.http.test.ts
@@ -4,8 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { resolveControlUiRootSyncMock } = vi.hoisted(() => ({
+const { resolveControlUiRootSyncMock, isPackageProvenControlUiRootSyncMock } = vi.hoisted(() => ({
   resolveControlUiRootSyncMock: vi.fn(),
+  isPackageProvenControlUiRootSyncMock: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../infra/control-ui-assets.js", async (importOriginal) => {
@@ -13,6 +14,7 @@ vi.mock("../infra/control-ui-assets.js", async (importOriginal) => {
   return {
     ...actual,
     resolveControlUiRootSync: resolveControlUiRootSyncMock,
+    isPackageProvenControlUiRootSync: isPackageProvenControlUiRootSyncMock,
   };
 });
 
@@ -31,6 +33,8 @@ async function withControlUiRoot<T>(fn: (tmp: string) => Promise<T>) {
 
 afterEach(() => {
   resolveControlUiRootSyncMock.mockReset();
+  isPackageProvenControlUiRootSyncMock.mockReset();
+  isPackageProvenControlUiRootSyncMock.mockReturnValue(true);
 });
 
 describe("handleControlUiHttpRequest auto-detected root", () => {
@@ -72,6 +76,26 @@ describe("handleControlUiHttpRequest auto-detected root", () => {
       expect(handled).toBe(true);
       expect(res.statusCode).toBe(200);
       expect(String(end.mock.calls[0]?.[0] ?? "")).toBe("<html>fallback-hardlink</html>\n");
+    });
+  });
+
+  it("rejects hardlinked assets for non-package-proven auto-detected roots", async () => {
+    isPackageProvenControlUiRootSyncMock.mockReturnValue(false);
+    await withControlUiRoot(async (tmp) => {
+      const assetsDir = path.join(tmp, "assets");
+      await fs.mkdir(assetsDir, { recursive: true });
+      await fs.writeFile(path.join(assetsDir, "app.js"), "console.log('hi');");
+      await fs.link(path.join(assetsDir, "app.js"), path.join(assetsDir, "app.hl.js"));
+      resolveControlUiRootSyncMock.mockReturnValue(tmp);
+
+      const { res } = makeMockHttpResponse();
+      const handled = handleControlUiHttpRequest(
+        { url: "/assets/app.hl.js", method: "GET" } as IncomingMessage,
+        res,
+      );
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(404);
     });
   });
 });

--- a/src/gateway/control-ui.auto-root.http.test.ts
+++ b/src/gateway/control-ui.auto-root.http.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs/promises";
+import type { IncomingMessage } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { resolveControlUiRootSyncMock } = vi.hoisted(() => ({
+  resolveControlUiRootSyncMock: vi.fn(),
+}));
+
+vi.mock("../infra/control-ui-assets.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/control-ui-assets.js")>();
+  return {
+    ...actual,
+    resolveControlUiRootSync: resolveControlUiRootSyncMock,
+  };
+});
+
+const { handleControlUiHttpRequest } = await import("./control-ui.js");
+const { makeMockHttpResponse } = await import("./test-http-response.js");
+
+async function withControlUiRoot<T>(fn: (tmp: string) => Promise<T>) {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-auto-root-"));
+  try {
+    await fs.writeFile(path.join(tmp, "index.html"), "<html>fallback</html>\n");
+    return await fn(tmp);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+}
+
+afterEach(() => {
+  resolveControlUiRootSyncMock.mockReset();
+});
+
+describe("handleControlUiHttpRequest auto-detected root", () => {
+  it("serves hardlinked asset files for bundled auto-detected roots", async () => {
+    await withControlUiRoot(async (tmp) => {
+      const assetsDir = path.join(tmp, "assets");
+      await fs.mkdir(assetsDir, { recursive: true });
+      await fs.writeFile(path.join(assetsDir, "app.js"), "console.log('hi');");
+      await fs.link(path.join(assetsDir, "app.js"), path.join(assetsDir, "app.hl.js"));
+      resolveControlUiRootSyncMock.mockReturnValue(tmp);
+
+      const { res, end } = makeMockHttpResponse();
+      const handled = handleControlUiHttpRequest(
+        { url: "/assets/app.hl.js", method: "GET" } as IncomingMessage,
+        res,
+      );
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(String(end.mock.calls[0]?.[0] ?? "")).toBe("console.log('hi');");
+    });
+  });
+
+  it("serves hardlinked SPA fallback index.html for bundled auto-detected roots", async () => {
+    await withControlUiRoot(async (tmp) => {
+      const sourceIndex = path.join(tmp, "index.source.html");
+      const indexPath = path.join(tmp, "index.html");
+      await fs.writeFile(sourceIndex, "<html>fallback-hardlink</html>\n");
+      await fs.rm(indexPath);
+      await fs.link(sourceIndex, indexPath);
+      resolveControlUiRootSyncMock.mockReturnValue(tmp);
+
+      const { res, end } = makeMockHttpResponse();
+      const handled = handleControlUiHttpRequest(
+        { url: "/dashboard", method: "GET" } as IncomingMessage,
+        res,
+      );
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(String(end.mock.calls[0]?.[0] ?? "")).toBe("<html>fallback-hardlink</html>\n");
+    });
+  });
+});

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -4,10 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "./control-ui-contract.js";
-import {
-  handleControlUiAvatarRequest,
-  handleControlUiHttpRequest,
-} from "./control-ui.js";
+import { handleControlUiAvatarRequest, handleControlUiHttpRequest } from "./control-ui.js";
 import { makeMockHttpResponse } from "./test-http-response.js";
 
 describe("handleControlUiHttpRequest", () => {
@@ -17,19 +14,14 @@ describe("handleControlUiHttpRequest", () => {
   }) {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-"));
     try {
-      await fs.writeFile(
-        path.join(tmp, "index.html"),
-        params.indexHtml ?? "<html></html>\n",
-      );
+      await fs.writeFile(path.join(tmp, "index.html"), params.indexHtml ?? "<html></html>\n");
       return await params.fn(tmp);
     } finally {
       await fs.rm(tmp, { recursive: true, force: true });
     }
   }
 
-  function parseBootstrapPayload(
-    end: ReturnType<typeof makeMockHttpResponse>["end"],
-  ) {
+  function parseBootstrapPayload(end: ReturnType<typeof makeMockHttpResponse>["end"]) {
     return JSON.parse(String(end.mock.calls[0]?.[0] ?? "")) as {
       basePath: string;
       assistantName: string;
@@ -70,9 +62,7 @@ describe("handleControlUiHttpRequest", () => {
   function runAvatarRequest(params: {
     url: string;
     method: "GET" | "HEAD";
-    resolveAvatar: Parameters<
-      typeof handleControlUiAvatarRequest
-    >[2]["resolveAvatar"];
+    resolveAvatar: Parameters<typeof handleControlUiAvatarRequest>[2]["resolveAvatar"];
     basePath?: string;
   }) {
     const { res, end } = makeMockHttpResponse();
@@ -87,11 +77,7 @@ describe("handleControlUiHttpRequest", () => {
     return { res, end, handled };
   }
 
-  async function writeAssetFile(
-    rootPath: string,
-    filename: string,
-    contents: string,
-  ) {
+  async function writeAssetFile(rootPath: string, filename: string, contents: string) {
     const assetsDir = path.join(rootPath, "assets");
     await fs.mkdir(assetsDir, { recursive: true });
     const filePath = path.join(assetsDir, filename);
@@ -129,9 +115,7 @@ describe("handleControlUiHttpRequest", () => {
         );
         expect(handled).toBe(true);
         expect(setHeader).toHaveBeenCalledWith("X-Frame-Options", "DENY");
-        const csp = setHeader.mock.calls.find(
-          (call) => call[0] === "Content-Security-Policy",
-        )?.[1];
+        const csp = setHeader.mock.calls.find((call) => call[0] === "Content-Security-Policy")?.[1];
         expect(typeof csp).toBe("string");
         expect(String(csp)).toContain("frame-ancestors 'none'");
         expect(String(csp)).toContain("script-src 'self'");
@@ -231,9 +215,7 @@ describe("handleControlUiHttpRequest", () => {
   });
 
   it("serves local avatar bytes through hardened avatar handler", async () => {
-    const tmp = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-avatar-http-"),
-    );
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-avatar-http-"));
     try {
       const avatarPath = path.join(tmp, "main.png");
       await fs.writeFile(avatarPath, "avatar-bytes\n");
@@ -253,12 +235,8 @@ describe("handleControlUiHttpRequest", () => {
   });
 
   it("rejects avatar symlink paths from resolver", async () => {
-    const tmp = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-avatar-http-link-"),
-    );
-    const outside = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-avatar-http-outside-"),
-    );
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-avatar-http-link-"));
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-avatar-http-outside-"));
     try {
       const outsideFile = path.join(outside, "secret.txt");
       await fs.writeFile(outsideFile, "outside-secret\n");
@@ -282,9 +260,7 @@ describe("handleControlUiHttpRequest", () => {
     await withControlUiRoot({
       fn: async (tmp) => {
         const assetsDir = path.join(tmp, "assets");
-        const outsideDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), "openclaw-ui-outside-"),
-        );
+        const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-outside-"));
         try {
           const outsideFile = path.join(outsideDir, "secret.txt");
           await fs.mkdir(assetsDir, { recursive: true });
@@ -310,11 +286,7 @@ describe("handleControlUiHttpRequest", () => {
   it("allows symlinked assets that resolve inside control-ui root", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        const { assetsDir, filePath } = await writeAssetFile(
-          tmp,
-          "actual.txt",
-          "inside-ok\n",
-        );
+        const { assetsDir, filePath } = await writeAssetFile(tmp, "actual.txt", "inside-ok\n");
         await fs.symlink(filePath, path.join(assetsDir, "linked.txt"));
 
         const { res, end, handled } = runControlUiRequest({
@@ -351,9 +323,7 @@ describe("handleControlUiHttpRequest", () => {
   it("rejects symlinked SPA fallback index.html outside control-ui root", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        const outsideDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), "openclaw-ui-index-outside-"),
-        );
+        const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-index-outside-"));
         try {
           const outsideIndex = path.join(outsideDir, "index.html");
           await fs.writeFile(outsideIndex, "<html>outside</html>\n");
@@ -376,21 +346,16 @@ describe("handleControlUiHttpRequest", () => {
   it("does not handle POST to root-mounted paths (plugin webhook passthrough)", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        for (const webhookPath of [
-          "/bluebubbles-webhook",
-          "/custom-webhook",
-          "/callback",
-        ]) {
+        for (const webhookPath of ["/bluebubbles-webhook", "/custom-webhook", "/callback"]) {
           const { res } = makeMockHttpResponse();
           const handled = handleControlUiHttpRequest(
             { url: webhookPath, method: "POST" } as IncomingMessage,
             res,
             { root: { kind: "resolved", path: tmp } },
           );
-          expect(
-            handled,
-            `POST to ${webhookPath} should pass through to plugin handlers`,
-          ).toBe(false);
+          expect(handled, `POST to ${webhookPath} should pass through to plugin handlers`).toBe(
+            false,
+          );
         }
       },
     });
@@ -413,11 +378,7 @@ describe("handleControlUiHttpRequest", () => {
   it("does not handle /api paths when basePath is empty", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        for (const apiPath of [
-          "/api",
-          "/api/sessions",
-          "/api/channels/nostr",
-        ]) {
+        for (const apiPath of ["/api", "/api/sessions", "/api/channels/nostr"]) {
           const { handled } = runControlUiRequest({
             url: apiPath,
             method: "GET",
@@ -438,9 +399,7 @@ describe("handleControlUiHttpRequest", () => {
             method: "GET",
             rootPath: tmp,
           });
-          expect(handled, `expected ${pluginPath} to not be handled`).toBe(
-            false,
-          );
+          expect(handled, `expected ${pluginPath} to not be handled`).toBe(false);
         }
       },
     });
@@ -463,25 +422,15 @@ describe("handleControlUiHttpRequest", () => {
   it("falls through POST requests under configured basePath (plugin webhook passthrough)", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        for (const route of [
-          "/openclaw",
-          "/openclaw/",
-          "/openclaw/some-page",
-        ]) {
+        for (const route of ["/openclaw", "/openclaw/", "/openclaw/some-page"]) {
           const { handled, end } = runControlUiRequest({
             url: route,
             method: "POST",
             rootPath: tmp,
             basePath: "/openclaw",
           });
-          expect(
-            handled,
-            `POST to ${route} should pass through to plugin handlers`,
-          ).toBe(false);
-          expect(
-            end,
-            `POST to ${route} should not write a response`,
-          ).not.toHaveBeenCalled();
+          expect(handled, `POST to ${route} should pass through to plugin handlers`).toBe(false);
+          expect(end, `POST to ${route} should not write a response`).not.toHaveBeenCalled();
         }
       },
     });
@@ -495,9 +444,7 @@ describe("handleControlUiHttpRequest", () => {
         await fs.writeFile(secretPath, "sensitive-data");
 
         const secretPathUrl = secretPath.split(path.sep).join("/");
-        const absolutePathUrl = secretPathUrl.startsWith("/")
-          ? secretPathUrl
-          : `/${secretPathUrl}`;
+        const absolutePathUrl = secretPathUrl.startsWith("/") ? secretPathUrl : `/${secretPathUrl}`;
         const { res, end, handled } = runControlUiRequest({
           url: `/openclaw/${absolutePathUrl}`,
           method: "GET",
@@ -543,14 +490,8 @@ describe("handleControlUiHttpRequest", () => {
       fn: async (tmp) => {
         const assetsDir = path.join(tmp, "assets");
         await fs.mkdir(assetsDir, { recursive: true });
-        await fs.writeFile(
-          path.join(assetsDir, "app.js"),
-          "console.log('hi');",
-        );
-        await fs.link(
-          path.join(assetsDir, "app.js"),
-          path.join(assetsDir, "app.hl.js"),
-        );
+        await fs.writeFile(path.join(assetsDir, "app.js"), "console.log('hi');");
+        await fs.link(path.join(assetsDir, "app.js"), path.join(assetsDir, "app.hl.js"));
         const { res, end, handled } = runControlUiRequest({
           url: "/assets/app.hl.js",
           method: "GET",
@@ -568,14 +509,8 @@ describe("handleControlUiHttpRequest", () => {
       fn: async (tmp) => {
         const assetsDir = path.join(tmp, "assets");
         await fs.mkdir(assetsDir, { recursive: true });
-        await fs.writeFile(
-          path.join(assetsDir, "app.js"),
-          "console.log('hi');",
-        );
-        await fs.link(
-          path.join(assetsDir, "app.js"),
-          path.join(assetsDir, "app.hl.js"),
-        );
+        await fs.writeFile(path.join(assetsDir, "app.js"), "console.log('hi');");
+        await fs.link(path.join(assetsDir, "app.js"), path.join(assetsDir, "app.hl.js"));
 
         const { res, end, handled } = runControlUiRequest({
           url: "/assets/app.hl.js",

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -4,7 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "./control-ui-contract.js";
-import { handleControlUiAvatarRequest, handleControlUiHttpRequest } from "./control-ui.js";
+import {
+  handleControlUiAvatarRequest,
+  handleControlUiHttpRequest,
+} from "./control-ui.js";
 import { makeMockHttpResponse } from "./test-http-response.js";
 
 describe("handleControlUiHttpRequest", () => {
@@ -14,14 +17,19 @@ describe("handleControlUiHttpRequest", () => {
   }) {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-"));
     try {
-      await fs.writeFile(path.join(tmp, "index.html"), params.indexHtml ?? "<html></html>\n");
+      await fs.writeFile(
+        path.join(tmp, "index.html"),
+        params.indexHtml ?? "<html></html>\n",
+      );
       return await params.fn(tmp);
     } finally {
       await fs.rm(tmp, { recursive: true, force: true });
     }
   }
 
-  function parseBootstrapPayload(end: ReturnType<typeof makeMockHttpResponse>["end"]) {
+  function parseBootstrapPayload(
+    end: ReturnType<typeof makeMockHttpResponse>["end"],
+  ) {
     return JSON.parse(String(end.mock.calls[0]?.[0] ?? "")) as {
       basePath: string;
       assistantName: string;
@@ -62,7 +70,9 @@ describe("handleControlUiHttpRequest", () => {
   function runAvatarRequest(params: {
     url: string;
     method: "GET" | "HEAD";
-    resolveAvatar: Parameters<typeof handleControlUiAvatarRequest>[2]["resolveAvatar"];
+    resolveAvatar: Parameters<
+      typeof handleControlUiAvatarRequest
+    >[2]["resolveAvatar"];
     basePath?: string;
   }) {
     const { res, end } = makeMockHttpResponse();
@@ -77,7 +87,11 @@ describe("handleControlUiHttpRequest", () => {
     return { res, end, handled };
   }
 
-  async function writeAssetFile(rootPath: string, filename: string, contents: string) {
+  async function writeAssetFile(
+    rootPath: string,
+    filename: string,
+    contents: string,
+  ) {
     const assetsDir = path.join(rootPath, "assets");
     await fs.mkdir(assetsDir, { recursive: true });
     const filePath = path.join(assetsDir, filename);
@@ -115,7 +129,9 @@ describe("handleControlUiHttpRequest", () => {
         );
         expect(handled).toBe(true);
         expect(setHeader).toHaveBeenCalledWith("X-Frame-Options", "DENY");
-        const csp = setHeader.mock.calls.find((call) => call[0] === "Content-Security-Policy")?.[1];
+        const csp = setHeader.mock.calls.find(
+          (call) => call[0] === "Content-Security-Policy",
+        )?.[1];
         expect(typeof csp).toBe("string");
         expect(String(csp)).toContain("frame-ancestors 'none'");
         expect(String(csp)).toContain("script-src 'self'");
@@ -215,7 +231,9 @@ describe("handleControlUiHttpRequest", () => {
   });
 
   it("serves local avatar bytes through hardened avatar handler", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-avatar-http-"));
+    const tmp = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-avatar-http-"),
+    );
     try {
       const avatarPath = path.join(tmp, "main.png");
       await fs.writeFile(avatarPath, "avatar-bytes\n");
@@ -235,8 +253,12 @@ describe("handleControlUiHttpRequest", () => {
   });
 
   it("rejects avatar symlink paths from resolver", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-avatar-http-link-"));
-    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-avatar-http-outside-"));
+    const tmp = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-avatar-http-link-"),
+    );
+    const outside = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-avatar-http-outside-"),
+    );
     try {
       const outsideFile = path.join(outside, "secret.txt");
       await fs.writeFile(outsideFile, "outside-secret\n");
@@ -260,7 +282,9 @@ describe("handleControlUiHttpRequest", () => {
     await withControlUiRoot({
       fn: async (tmp) => {
         const assetsDir = path.join(tmp, "assets");
-        const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-outside-"));
+        const outsideDir = await fs.mkdtemp(
+          path.join(os.tmpdir(), "openclaw-ui-outside-"),
+        );
         try {
           const outsideFile = path.join(outsideDir, "secret.txt");
           await fs.mkdir(assetsDir, { recursive: true });
@@ -286,7 +310,11 @@ describe("handleControlUiHttpRequest", () => {
   it("allows symlinked assets that resolve inside control-ui root", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        const { assetsDir, filePath } = await writeAssetFile(tmp, "actual.txt", "inside-ok\n");
+        const { assetsDir, filePath } = await writeAssetFile(
+          tmp,
+          "actual.txt",
+          "inside-ok\n",
+        );
         await fs.symlink(filePath, path.join(assetsDir, "linked.txt"));
 
         const { res, end, handled } = runControlUiRequest({
@@ -323,7 +351,9 @@ describe("handleControlUiHttpRequest", () => {
   it("rejects symlinked SPA fallback index.html outside control-ui root", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-index-outside-"));
+        const outsideDir = await fs.mkdtemp(
+          path.join(os.tmpdir(), "openclaw-ui-index-outside-"),
+        );
         try {
           const outsideIndex = path.join(outsideDir, "index.html");
           await fs.writeFile(outsideIndex, "<html>outside</html>\n");
@@ -346,16 +376,21 @@ describe("handleControlUiHttpRequest", () => {
   it("does not handle POST to root-mounted paths (plugin webhook passthrough)", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        for (const webhookPath of ["/bluebubbles-webhook", "/custom-webhook", "/callback"]) {
+        for (const webhookPath of [
+          "/bluebubbles-webhook",
+          "/custom-webhook",
+          "/callback",
+        ]) {
           const { res } = makeMockHttpResponse();
           const handled = handleControlUiHttpRequest(
             { url: webhookPath, method: "POST" } as IncomingMessage,
             res,
             { root: { kind: "resolved", path: tmp } },
           );
-          expect(handled, `POST to ${webhookPath} should pass through to plugin handlers`).toBe(
-            false,
-          );
+          expect(
+            handled,
+            `POST to ${webhookPath} should pass through to plugin handlers`,
+          ).toBe(false);
         }
       },
     });
@@ -378,7 +413,11 @@ describe("handleControlUiHttpRequest", () => {
   it("does not handle /api paths when basePath is empty", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        for (const apiPath of ["/api", "/api/sessions", "/api/channels/nostr"]) {
+        for (const apiPath of [
+          "/api",
+          "/api/sessions",
+          "/api/channels/nostr",
+        ]) {
           const { handled } = runControlUiRequest({
             url: apiPath,
             method: "GET",
@@ -399,7 +438,9 @@ describe("handleControlUiHttpRequest", () => {
             method: "GET",
             rootPath: tmp,
           });
-          expect(handled, `expected ${pluginPath} to not be handled`).toBe(false);
+          expect(handled, `expected ${pluginPath} to not be handled`).toBe(
+            false,
+          );
         }
       },
     });
@@ -422,15 +463,25 @@ describe("handleControlUiHttpRequest", () => {
   it("falls through POST requests under configured basePath (plugin webhook passthrough)", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        for (const route of ["/openclaw", "/openclaw/", "/openclaw/some-page"]) {
+        for (const route of [
+          "/openclaw",
+          "/openclaw/",
+          "/openclaw/some-page",
+        ]) {
           const { handled, end } = runControlUiRequest({
             url: route,
             method: "POST",
             rootPath: tmp,
             basePath: "/openclaw",
           });
-          expect(handled, `POST to ${route} should pass through to plugin handlers`).toBe(false);
-          expect(end, `POST to ${route} should not write a response`).not.toHaveBeenCalled();
+          expect(
+            handled,
+            `POST to ${route} should pass through to plugin handlers`,
+          ).toBe(false);
+          expect(
+            end,
+            `POST to ${route} should not write a response`,
+          ).not.toHaveBeenCalled();
         }
       },
     });
@@ -444,7 +495,9 @@ describe("handleControlUiHttpRequest", () => {
         await fs.writeFile(secretPath, "sensitive-data");
 
         const secretPathUrl = secretPath.split(path.sep).join("/");
-        const absolutePathUrl = secretPathUrl.startsWith("/") ? secretPathUrl : `/${secretPathUrl}`;
+        const absolutePathUrl = secretPathUrl.startsWith("/")
+          ? secretPathUrl
+          : `/${secretPathUrl}`;
         const { res, end, handled } = runControlUiRequest({
           url: `/openclaw/${absolutePathUrl}`,
           method: "GET",
@@ -490,8 +543,14 @@ describe("handleControlUiHttpRequest", () => {
       fn: async (tmp) => {
         const assetsDir = path.join(tmp, "assets");
         await fs.mkdir(assetsDir, { recursive: true });
-        await fs.writeFile(path.join(assetsDir, "app.js"), "console.log('hi');");
-        await fs.link(path.join(assetsDir, "app.js"), path.join(assetsDir, "app.hl.js"));
+        await fs.writeFile(
+          path.join(assetsDir, "app.js"),
+          "console.log('hi');",
+        );
+        await fs.link(
+          path.join(assetsDir, "app.js"),
+          path.join(assetsDir, "app.hl.js"),
+        );
         const { res, end, handled } = runControlUiRequest({
           url: "/assets/app.hl.js",
           method: "GET",
@@ -509,8 +568,14 @@ describe("handleControlUiHttpRequest", () => {
       fn: async (tmp) => {
         const assetsDir = path.join(tmp, "assets");
         await fs.mkdir(assetsDir, { recursive: true });
-        await fs.writeFile(path.join(assetsDir, "app.js"), "console.log('hi');");
-        await fs.link(path.join(assetsDir, "app.js"), path.join(assetsDir, "app.hl.js"));
+        await fs.writeFile(
+          path.join(assetsDir, "app.js"),
+          "console.log('hi');",
+        );
+        await fs.link(
+          path.join(assetsDir, "app.js"),
+          path.join(assetsDir, "app.hl.js"),
+        );
 
         const { res, end, handled } = runControlUiRequest({
           url: "/assets/app.hl.js",

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -467,4 +467,23 @@ describe("handleControlUiHttpRequest", () => {
       },
     });
   });
+
+  it("rejects hardlinked asset files for custom/resolved roots (security boundary)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const assetsDir = path.join(tmp, "assets");
+        await fs.mkdir(assetsDir, { recursive: true });
+        await fs.writeFile(path.join(assetsDir, "app.js"), "console.log('hi');");
+        await fs.link(path.join(assetsDir, "app.js"), path.join(assetsDir, "app.hl.js"));
+        const { res, end, handled } = runControlUiRequest({
+          url: "/assets/app.hl.js",
+          method: "GET",
+          rootPath: tmp,
+        });
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(404);
+        expect(end).toHaveBeenCalledWith("Not Found");
+      },
+    });
+  });
 });

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -45,6 +45,7 @@ describe("handleControlUiHttpRequest", () => {
     method: "GET" | "HEAD" | "POST";
     rootPath: string;
     basePath?: string;
+    rootKind?: "resolved" | "bundled";
   }) {
     const { res, end } = makeMockHttpResponse();
     const handled = handleControlUiHttpRequest(
@@ -52,7 +53,7 @@ describe("handleControlUiHttpRequest", () => {
       res,
       {
         ...(params.basePath ? { basePath: params.basePath } : {}),
-        root: { kind: "resolved", path: params.rootPath },
+        root: { kind: params.rootKind ?? "resolved", path: params.rootPath },
       },
     );
     return { res, end, handled };
@@ -136,7 +137,12 @@ describe("handleControlUiHttpRequest", () => {
             root: { kind: "resolved", path: tmp },
             config: {
               agents: { defaults: { workspace: tmp } },
-              ui: { assistant: { name: "</script><script>alert(1)//", avatar: "evil.png" } },
+              ui: {
+                assistant: {
+                  name: "</script><script>alert(1)//",
+                  avatar: "evil.png",
+                },
+              },
             },
           },
         );
@@ -151,13 +157,21 @@ describe("handleControlUiHttpRequest", () => {
       fn: async (tmp) => {
         const { res, end } = makeMockHttpResponse();
         const handled = handleControlUiHttpRequest(
-          { url: CONTROL_UI_BOOTSTRAP_CONFIG_PATH, method: "GET" } as IncomingMessage,
+          {
+            url: CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
+            method: "GET",
+          } as IncomingMessage,
           res,
           {
             root: { kind: "resolved", path: tmp },
             config: {
               agents: { defaults: { workspace: tmp } },
-              ui: { assistant: { name: "</script><script>alert(1)//", avatar: "</script>.png" } },
+              ui: {
+                assistant: {
+                  name: "</script><script>alert(1)//",
+                  avatar: "</script>.png",
+                },
+              },
             },
           },
         );
@@ -176,7 +190,10 @@ describe("handleControlUiHttpRequest", () => {
       fn: async (tmp) => {
         const { res, end } = makeMockHttpResponse();
         const handled = handleControlUiHttpRequest(
-          { url: `/openclaw${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`, method: "GET" } as IncomingMessage,
+          {
+            url: `/openclaw${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`,
+            method: "GET",
+          } as IncomingMessage,
           res,
           {
             basePath: "/openclaw",
@@ -483,6 +500,28 @@ describe("handleControlUiHttpRequest", () => {
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(404);
         expect(end).toHaveBeenCalledWith("Not Found");
+      },
+    });
+  });
+
+  it("serves hardlinked asset files for bundled roots (pnpm global install)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const assetsDir = path.join(tmp, "assets");
+        await fs.mkdir(assetsDir, { recursive: true });
+        await fs.writeFile(path.join(assetsDir, "app.js"), "console.log('hi');");
+        await fs.link(path.join(assetsDir, "app.js"), path.join(assetsDir, "app.hl.js"));
+
+        const { res, end, handled } = runControlUiRequest({
+          url: "/assets/app.hl.js",
+          method: "GET",
+          rootPath: tmp,
+          rootKind: "bundled",
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(String(end.mock.calls[0]?.[0] ?? "")).toBe("console.log('hi');");
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -263,6 +263,7 @@ function resolveSafeControlUiFile(
     rootRealPath: rootReal,
     boundaryLabel: "control ui root",
     skipLexicalRootCheck: true,
+    rejectHardlinks: false,
   });
   if (!opened.ok) {
     if (opened.reason === "io") {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -39,6 +39,7 @@ export type ControlUiRequestOptions = {
 };
 
 export type ControlUiRootState =
+  | { kind: "bundled"; path: string }
   | { kind: "resolved"; path: string }
   | { kind: "invalid"; path: string }
   | { kind: "missing" };
@@ -152,7 +153,10 @@ function isValidAgentId(agentId: string): boolean {
 export function handleControlUiAvatarRequest(
   req: IncomingMessage,
   res: ServerResponse,
-  opts: { basePath?: string; resolveAvatar: (agentId: string) => ControlUiAvatarResolution },
+  opts: {
+    basePath?: string;
+    resolveAvatar: (agentId: string) => ControlUiAvatarResolution;
+  },
 ): boolean {
   const urlRaw = req.url;
   if (!urlRaw) {
@@ -360,7 +364,9 @@ export function handleControlUiHttpRequest(
 
   const rootState = opts?.root;
   if (rootState?.kind === "invalid") {
-    respondControlUiAssetsUnavailable(res, { configuredRootPath: rootState.path });
+    respondControlUiAssetsUnavailable(res, {
+      configuredRootPath: rootState.path,
+    });
     return true;
   }
   if (rootState?.kind === "missing") {
@@ -421,7 +427,7 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
-  const safeFile = resolveSafeControlUiFile(rootReal, filePath, rootState?.kind === "resolved");
+  const safeFile = resolveSafeControlUiFile(rootReal, filePath, rootState?.kind !== "bundled");
   if (safeFile) {
     try {
       if (respondHeadForFile(req, res, safeFile.path)) {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -427,7 +427,7 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
-  const rejectHardlinks = rootState !== undefined && rootState.kind !== "bundled";
+  const rejectHardlinks = rootState?.kind === "resolved";
   const safeFile = resolveSafeControlUiFile(rootReal, filePath, rejectHardlinks);
   if (safeFile) {
     try {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -256,6 +256,7 @@ function resolveSafeAvatarFile(filePath: string): { path: string; fd: number } |
 function resolveSafeControlUiFile(
   rootReal: string,
   filePath: string,
+  rejectHardlinks: boolean,
 ): { path: string; fd: number } | null {
   const opened = openBoundaryFileSync({
     absolutePath: filePath,
@@ -263,7 +264,7 @@ function resolveSafeControlUiFile(
     rootRealPath: rootReal,
     boundaryLabel: "control ui root",
     skipLexicalRootCheck: true,
-    rejectHardlinks: false,
+    rejectHardlinks,
   });
   if (!opened.ok) {
     if (opened.reason === "io") {
@@ -420,7 +421,7 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
-  const safeFile = resolveSafeControlUiFile(rootReal, filePath);
+  const safeFile = resolveSafeControlUiFile(rootReal, filePath, rootState?.kind === "resolved");
   if (safeFile) {
     try {
       if (respondHeadForFile(req, res, safeFile.path)) {
@@ -449,7 +450,7 @@ export function handleControlUiHttpRequest(
 
   // SPA fallback (client-side router): serve index.html for unknown paths.
   const indexPath = path.join(root, "index.html");
-  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath);
+  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath, rootState?.kind === "resolved");
   if (safeIndex) {
     try {
       if (respondHeadForFile(req, res, safeIndex.path)) {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -427,7 +427,8 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
-  const safeFile = resolveSafeControlUiFile(rootReal, filePath, rootState?.kind !== "bundled");
+  const rejectHardlinks = rootState !== undefined && rootState.kind !== "bundled";
+  const safeFile = resolveSafeControlUiFile(rootReal, filePath, rejectHardlinks);
   if (safeFile) {
     try {
       if (respondHeadForFile(req, res, safeFile.path)) {
@@ -456,7 +457,7 @@ export function handleControlUiHttpRequest(
 
   // SPA fallback (client-side router): serve index.html for unknown paths.
   const indexPath = path.join(root, "index.html");
-  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath, rootState?.kind !== "bundled");
+  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath, rejectHardlinks);
   if (safeIndex) {
     try {
       if (respondHeadForFile(req, res, safeIndex.path)) {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -375,7 +375,7 @@ export function handleControlUiHttpRequest(
   }
 
   const root =
-    rootState?.kind === "resolved"
+    rootState?.kind === "resolved" || rootState?.kind === "bundled"
       ? rootState.path
       : resolveControlUiRootSync({
           moduleUrl: import.meta.url,
@@ -456,7 +456,7 @@ export function handleControlUiHttpRequest(
 
   // SPA fallback (client-side router): serve index.html for unknown paths.
   const indexPath = path.join(root, "index.html");
-  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath, rootState?.kind === "resolved");
+  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath, rootState?.kind !== "bundled");
   if (safeIndex) {
     try {
       if (respondHeadForFile(req, res, safeIndex.path)) {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -432,7 +432,12 @@ export function handleControlUiHttpRequest(
 
   const isBundledRoot =
     rootState?.kind === "bundled" ||
-    (rootState === undefined && isPackageProvenControlUiRootSync(root));
+    (rootState === undefined &&
+      isPackageProvenControlUiRootSync(root, {
+        moduleUrl: import.meta.url,
+        argv1: process.argv[1],
+        cwd: process.cwd(),
+      }));
   const rejectHardlinks = !isBundledRoot;
   const safeFile = resolveSafeControlUiFile(rootReal, filePath, rejectHardlinks);
   if (safeFile) {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -427,7 +427,7 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
-  const rejectHardlinks = rootState?.kind === "resolved";
+  const rejectHardlinks = rootState?.kind !== "bundled" && rootState !== undefined;
   const safeFile = resolveSafeControlUiFile(rootReal, filePath, rejectHardlinks);
   if (safeFile) {
     try {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -3,7 +3,10 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
-import { resolveControlUiRootSync } from "../infra/control-ui-assets.js";
+import {
+  isPackageProvenControlUiRootSync,
+  resolveControlUiRootSync,
+} from "../infra/control-ui-assets.js";
 import { isWithinDir } from "../infra/path-safety.js";
 import { openVerifiedFileSync } from "../infra/safe-open-sync.js";
 import { AVATAR_MAX_BYTES } from "../shared/avatar-policy.js";
@@ -427,7 +430,10 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
-  const rejectHardlinks = rootState?.kind !== "bundled" && rootState !== undefined;
+  const isBundledRoot =
+    rootState?.kind === "bundled" ||
+    (rootState === undefined && isPackageProvenControlUiRootSync(root));
+  const rejectHardlinks = !isBundledRoot;
   const safeFile = resolveSafeControlUiFile(rootReal, filePath, rejectHardlinks);
   if (safeFile) {
     try {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -308,14 +308,19 @@ export async function startGatewayServer(
   if (configSnapshot.exists && !configSnapshot.valid) {
     const issues =
       configSnapshot.issues.length > 0
-        ? formatConfigIssueLines(configSnapshot.issues, "", { normalizeRoot: true }).join("\n")
+        ? formatConfigIssueLines(configSnapshot.issues, "", {
+            normalizeRoot: true,
+          }).join("\n")
         : "Unknown validation issue.";
     throw new Error(
       `Invalid config at ${configSnapshot.path}.\n${issues}\nRun "${formatCliCommand("openclaw doctor")}" to repair, then retry.`,
     );
   }
 
-  const autoEnable = applyPluginAutoEnable({ config: configSnapshot.config, env: process.env });
+  const autoEnable = applyPluginAutoEnable({
+    config: configSnapshot.config,
+    env: process.env,
+  });
   if (autoEnable.changes.length > 0) {
     try {
       await writeConfigFile(autoEnable.config);
@@ -351,7 +356,10 @@ export async function startGatewayServer(
   };
   const activateRuntimeSecrets = async (
     config: OpenClawConfig,
-    params: { reason: "startup" | "reload" | "restart-check"; activate: boolean },
+    params: {
+      reason: "startup" | "reload" | "restart-check";
+      activate: boolean;
+    },
   ) =>
     await runWithSecretsActivationLock(async () => {
       try {
@@ -402,7 +410,9 @@ export async function startGatewayServer(
     if (!freshSnapshot.valid) {
       const issues =
         freshSnapshot.issues.length > 0
-          ? formatConfigIssueLines(freshSnapshot.issues, "", { normalizeRoot: true }).join("\n")
+          ? formatConfigIssueLines(freshSnapshot.issues, "", {
+              normalizeRoot: true,
+            }).join("\n")
           : "Unknown validation issue.";
       throw new Error(`Invalid config at ${freshSnapshot.path}.\n${issues}`);
     }
@@ -449,7 +459,9 @@ export async function startGatewayServer(
   if (diagnosticsEnabled) {
     startDiagnosticHeartbeat();
   }
-  setGatewaySigusr1RestartPolicy({ allowExternal: isRestartEnabled(cfgAtStart) });
+  setGatewaySigusr1RestartPolicy({
+    allowExternal: isRestartEnabled(cfgAtStart),
+  });
   setPreRestartDeferralCheck(
     () => getTotalQueueSize() + getTotalPendingReplies() + getActiveEmbeddedRunCount(),
   );
@@ -545,7 +557,7 @@ export async function startGatewayServer(
       });
     }
     controlUiRootState = resolvedRoot
-      ? { kind: "resolved", path: resolvedRoot }
+      ? { kind: "bundled", path: resolvedRoot }
       : { kind: "missing" };
   }
 
@@ -793,7 +805,11 @@ export async function startGatewayServer(
           targetIds: new Set(targetIds),
         });
       if (assignments.length === 0) {
-        return { assignments: [] as CommandSecretAssignment[], diagnostics, inactiveRefPaths };
+        return {
+          assignments: [] as CommandSecretAssignment[],
+          diagnostics,
+          inactiveRefPaths,
+        };
       }
       return { assignments, diagnostics, inactiveRefPaths };
     },
@@ -897,8 +913,12 @@ export async function startGatewayServer(
         log,
         isNixMode,
         onUpdateAvailableChange: (updateAvailable) => {
-          const payload: GatewayUpdateAvailableEventPayload = { updateAvailable };
-          broadcast(GATEWAY_EVENT_UPDATE_AVAILABLE, payload, { dropIfSlow: true });
+          const payload: GatewayUpdateAvailableEventPayload = {
+            updateAvailable,
+          };
+          broadcast(GATEWAY_EVENT_UPDATE_AVAILABLE, payload, {
+            dropIfSlow: true,
+          });
         },
       });
   const tailscaleCleanup = minimalTestGateway
@@ -990,7 +1010,10 @@ export async function startGatewayServer(
             }
           },
           onRestart: async (plan, nextConfig) => {
-            await activateRuntimeSecrets(nextConfig, { reason: "restart-check", activate: false });
+            await activateRuntimeSecrets(nextConfig, {
+              reason: "restart-check",
+              activate: false,
+            });
             requestGatewayRestart(plan, nextConfig);
           },
           log: {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -24,6 +24,7 @@ import { resolveMainSessionKey } from "../config/sessions.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
+  isPackageProvenControlUiRootSync,
   resolveControlUiRootOverrideSync,
   resolveControlUiRootSync,
 } from "../infra/control-ui-assets.js";
@@ -557,7 +558,16 @@ export async function startGatewayServer(
       });
     }
     controlUiRootState = resolvedRoot
-      ? { kind: "bundled", path: resolvedRoot }
+      ? {
+          kind: isPackageProvenControlUiRootSync(resolvedRoot, {
+            moduleUrl: import.meta.url,
+            argv1: process.argv[1],
+            cwd: process.cwd(),
+          })
+            ? "bundled"
+            : "resolved",
+          path: resolvedRoot,
+        }
       : { kind: "missing" };
   }
 

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -76,6 +76,7 @@ vi.mock("./openclaw-root.js", () => ({
 let resolveControlUiRepoRoot: typeof import("./control-ui-assets.js").resolveControlUiRepoRoot;
 let resolveControlUiDistIndexPath: typeof import("./control-ui-assets.js").resolveControlUiDistIndexPath;
 let resolveControlUiDistIndexHealth: typeof import("./control-ui-assets.js").resolveControlUiDistIndexHealth;
+let isPackageProvenControlUiRootSync: typeof import("./control-ui-assets.js").isPackageProvenControlUiRootSync;
 let resolveControlUiRootOverrideSync: typeof import("./control-ui-assets.js").resolveControlUiRootOverrideSync;
 let resolveControlUiRootSync: typeof import("./control-ui-assets.js").resolveControlUiRootSync;
 let openclawRoot: typeof import("./openclaw-root.js");
@@ -86,6 +87,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
       resolveControlUiRepoRoot,
       resolveControlUiDistIndexPath,
       resolveControlUiDistIndexHealth,
+      isPackageProvenControlUiRootSync,
       resolveControlUiRootOverrideSync,
       resolveControlUiRootSync,
     } = await import("./control-ui-assets.js"));
@@ -198,5 +200,37 @@ describe("control UI assets helpers (fs-mocked)", () => {
     // moduleUrl candidate: <moduleDir>/control-ui
     const moduleUrl = pathToFileURL(path.join(pkgRoot, "dist", "bundle.js")).toString();
     expect(resolveControlUiRootSync({ moduleUrl })).toBe(uiDir);
+  });
+
+  it("detects package-proven control-ui roots", () => {
+    const pkgRoot = abs("fixtures/openclaw-package-root");
+    const uiDir = path.join(pkgRoot, "dist", "control-ui");
+    setDir(uiDir);
+    setFile(path.join(uiDir, "index.html"), "<html></html>\n");
+    (
+      openclawRoot.resolveOpenClawPackageRootSync as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValueOnce(pkgRoot);
+
+    expect(
+      isPackageProvenControlUiRootSync(uiDir, {
+        cwd: abs("fixtures/cwd"),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat fallback roots as package-proven", () => {
+    const pkgRoot = abs("fixtures/openclaw-package-root");
+    const fallbackRoot = abs("fixtures/fallback-root/dist/control-ui");
+    setDir(fallbackRoot);
+    setFile(path.join(fallbackRoot, "index.html"), "<html></html>\n");
+    (
+      openclawRoot.resolveOpenClawPackageRootSync as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValueOnce(pkgRoot);
+
+    expect(
+      isPackageProvenControlUiRootSync(fallbackRoot, {
+        cwd: abs("fixtures/fallback-root"),
+      }),
+    ).toBe(false);
   });
 });

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -128,6 +128,14 @@ export type ControlUiRootResolveOptions = {
   execPath?: string;
 };
 
+function pathsMatchByRealpathOrResolve(left: string, right: string): boolean {
+  try {
+    return fs.realpathSync(left) === fs.realpathSync(right);
+  } catch {
+    return path.resolve(left) === path.resolve(right);
+  }
+}
+
 function addCandidate(candidates: Set<string>, value: string | null) {
   if (!value) {
     return;
@@ -199,6 +207,24 @@ export function resolveControlUiRootSync(opts: ControlUiRootResolveOptions = {})
     }
   }
   return null;
+}
+
+export function isPackageProvenControlUiRootSync(
+  root: string,
+  opts: ControlUiRootResolveOptions = {},
+): boolean {
+  const argv1 = opts.argv1 ?? process.argv[1];
+  const cwd = opts.cwd ?? process.cwd();
+  const packageRoot = resolveOpenClawPackageRootSync({
+    argv1,
+    moduleUrl: opts.moduleUrl,
+    cwd,
+  });
+  if (!packageRoot) {
+    return false;
+  }
+  const packageDistRoot = path.join(packageRoot, "dist", "control-ui");
+  return pathsMatchByRealpathOrResolve(root, packageDistRoot);
 }
 
 export type EnsureControlUiAssetsResult = {

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -129,11 +129,19 @@ export type ControlUiRootResolveOptions = {
 };
 
 function pathsMatchByRealpathOrResolve(left: string, right: string): boolean {
+  let realLeft: string;
+  let realRight: string;
   try {
-    return fs.realpathSync(left) === fs.realpathSync(right);
+    realLeft = fs.realpathSync(left);
   } catch {
-    return path.resolve(left) === path.resolve(right);
+    realLeft = path.resolve(left);
   }
+  try {
+    realRight = fs.realpathSync(right);
+  } catch {
+    realRight = path.resolve(right);
+  }
+  return realLeft === realRight;
 }
 
 function addCandidate(candidates: Set<string>, value: string | null) {


### PR DESCRIPTION
## What this does

If you install OpenClaw with `pnpm add -g`, the Control UI shows 404 for everything. That's because pnpm stores files as hardlinks, and the gateway rejects hardlinks by default (security thing).

This fix lets hardlinks through for the **package-proven** bundled control-ui files (the ones that come with the package), but keeps rejecting them for custom control-ui paths and non-package-proven auto-detected fallback roots. That way pnpm users get a working UI, but anyone with a custom setup or using fallback directories still has the security protection.

## Summary

- Fixes Control UI 404s for bundled installs where UI assets may be hardlinked (for example `pnpm -g`).
- Preserves hardlink rejection for non-bundled/custom roots.
- Tightens root classification: only **package-proven** Control UI roots get bundled behavior (hardlinks allowed).
- Auto-detected fallback roots that aren't package-proven are now correctly classified as `resolved`, so hardlink checks still apply there.
- Hardens the `pathsMatchByRealpathOrResolve` helper to handle asymmetric realpath resolution (one path resolves, other doesn't).

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening (boundary correctness)

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Infra (Control UI root resolution)
- [x] Tests

## Linked Issue/PR

- Closes #33454
- Related #32119

## User-visible / Behavior Changes

- Bundled/package-proven Control UI assets can be served when hardlinked (expected for some package manager/global install layouts).
- Custom/resolved roots still reject hardlinked files.
- Auto-detected fallback roots that aren't package-proven are now correctly treated as `resolved`, not bundled.
- Security boundary is now enforced even when `opts.root` is omitted (auto-resolved mode).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

Security boundary after this change:
- `bundled` roots: hardlinks allowed (only when package-proven).
- `resolved` roots: hardlinks rejected.
- Auto-resolved fallback roots: hardlinks rejected unless package-proven.
- Non-package fallback directories (for example `${cwd}/dist/control-ui`) are correctly treated as `resolved`, not bundled.

## Repro + Verification

### Environment

- OS: Linux/macOS (test logic is cross-platform Node FS behavior)
- Runtime: Node.js
- Install mode: includes global/bundled layouts (for example `pnpm -g`)

### Steps

1. Start gateway with a bundled install where Control UI assets are hardlinked.
2. Open Control UI; request `/assets/*` and SPA routes.
3. Confirm responses are `200`.
4. Point to a custom/resolved root with hardlinked asset files.
5. Confirm hardlinked assets are rejected (`404 Not Found`).
6. Start gateway without explicit root (auto-resolved mode); use a fallback directory that isn't package-proven with hardlinked assets.
7. Confirm hardlinked assets are rejected (`404 Not Found`).

### Expected

- Package-proven bundled roots serve hardlinked assets.
- Resolved/custom roots reject hardlinked assets.
- Non-package-proven auto-detected fallback roots reject hardlinked assets.

### Actual (before fix)

- Some bundled hardlinked assets returned 404.
- Auto-detected fallback roots could bypass hardlink checks entirely (too permissive).

## Human Verification (required)

- Verified hardlinked asset rejection for `resolved` roots.
- Verified hardlinked asset serving for package-proven `bundled` roots.
- Verified hardlinked asset rejection for non-package-proven auto-detected fallback roots.
- Verified package-proven classification via `isPackageProvenControlUiRootSync`.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

Revert Control UI root-kind classification and hardlink-gate behavior in:
- `src/gateway/server.impl.ts`
- `src/gateway/control-ui.ts`
- `src/infra/control-ui-assets.ts`

## Risks and Mitigations

- Risk: incorrect root classification could over-trust fallback directories.
- Mitigation: bundled classification now requires package-root proof (`isPackageProvenControlUiRootSync`), fallback roots remain resolved.

## Files Changed (current PR stack)

- `src/gateway/server.impl.ts` (root-kind classification)
- `src/gateway/control-ui.ts` (hardlink gate by root kind + package provenance check)
- `src/infra/control-ui-assets.ts` (package-proven root helper + split realpath calls)
- `src/gateway/control-ui.http.test.ts` (resolved vs bundled hardlink behavior)
- `src/gateway/control-ui.auto-root.http.test.ts` (auto-detected root behavior + package-proven regression)
- `src/infra/control-ui-assets.test.ts` (package-proven vs fallback classification)
