### PR TITLE
fix(auto-reply): use userTimezone fallback for system event timestamps

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -13,6 +13,32 @@ import {
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 import { drainSystemEventEntries } from "../../infra/system-events.js";
 
+/** Resolve which timezone to use for system-event timestamps. Exported for testing. */
+export const resolveSystemEventTimezone = (cfg: OpenClawConfig) => {
+  const raw = cfg.agents?.defaults?.envelopeTimezone?.trim();
+  if (!raw) {
+    // Fall back to the user's configured timezone instead of host timezone
+    // to avoid incorrect timestamps when host TZ differs from user TZ (#33083)
+    const userTz = resolveUserTimezone(cfg?.agents?.defaults?.userTimezone);
+    return { mode: "iana" as const, timeZone: userTz };
+  }
+  const lowered = raw.toLowerCase();
+  if (lowered === "utc" || lowered === "gmt") {
+    return { mode: "utc" as const };
+  }
+  if (lowered === "local" || lowered === "host") {
+    return { mode: "local" as const };
+  }
+  if (lowered === "user") {
+    return {
+      mode: "iana" as const,
+      timeZone: resolveUserTimezone(cfg.agents?.defaults?.userTimezone),
+    };
+  }
+  const explicit = resolveTimezone(raw);
+  return explicit ? { mode: "iana" as const, timeZone: explicit } : { mode: "local" as const };
+};
+
 /** Drain queued system events, format as `System:` lines, return the block (or undefined). */
 export async function drainFormattedSystemEvents(params: {
   cfg: OpenClawConfig;
@@ -42,28 +68,6 @@ export async function drainFormattedSystemEvents(params: {
       return trimmed.replace(/ · last input [^·]+/i, "").trim();
     }
     return trimmed;
-  };
-
-  const resolveSystemEventTimezone = (cfg: OpenClawConfig) => {
-    const raw = cfg.agents?.defaults?.envelopeTimezone?.trim();
-    if (!raw) {
-      return { mode: "local" as const };
-    }
-    const lowered = raw.toLowerCase();
-    if (lowered === "utc" || lowered === "gmt") {
-      return { mode: "utc" as const };
-    }
-    if (lowered === "local" || lowered === "host") {
-      return { mode: "local" as const };
-    }
-    if (lowered === "user") {
-      return {
-        mode: "iana" as const,
-        timeZone: resolveUserTimezone(cfg.agents?.defaults?.userTimezone),
-      };
-    }
-    const explicit = resolveTimezone(raw);
-    return explicit ? { mode: "iana" as const, timeZone: explicit } : { mode: "local" as const };
   };
 
   const formatSystemEventTimestamp = (ts: number, cfg: OpenClawConfig) => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../../infra/outbound/session-binding-service.js";
 import { enqueueSystemEvent, resetSystemEventsForTest } from "../../infra/system-events.js";
 import { applyResetModelOverride } from "./session-reset-model.js";
-import { drainFormattedSystemEvents } from "./session-updates.js";
+import { drainFormattedSystemEvents, resolveSystemEventTimezone } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
 import { initSessionState } from "./session.js";
 
@@ -1582,6 +1582,43 @@ describe("drainFormattedSystemEvents", () => {
       resetSystemEventsForTest();
       vi.useRealTimers();
     }
+  });
+});
+
+describe("resolveSystemEventTimezone", () => {
+  it("uses userTimezone when envelopeTimezone is not set", () => {
+    const result = resolveSystemEventTimezone({
+      agents: { defaults: { userTimezone: "America/Vancouver" } },
+    } as OpenClawConfig);
+    expect(result).toEqual({ mode: "iana", timeZone: "America/Vancouver" });
+  });
+
+  it("uses userTimezone when envelopeTimezone is empty string", () => {
+    const result = resolveSystemEventTimezone({
+      agents: { defaults: { envelopeTimezone: "  ", userTimezone: "Asia/Tokyo" } },
+    } as OpenClawConfig);
+    expect(result).toEqual({ mode: "iana", timeZone: "Asia/Tokyo" });
+  });
+
+  it("returns utc for envelopeTimezone 'utc'", () => {
+    const result = resolveSystemEventTimezone({
+      agents: { defaults: { envelopeTimezone: "utc" } },
+    } as OpenClawConfig);
+    expect(result).toEqual({ mode: "utc" });
+  });
+
+  it("returns iana with resolved user timezone for envelopeTimezone 'user'", () => {
+    const result = resolveSystemEventTimezone({
+      agents: { defaults: { envelopeTimezone: "user", userTimezone: "Europe/Vienna" } },
+    } as OpenClawConfig);
+    expect(result).toEqual({ mode: "iana", timeZone: "Europe/Vienna" });
+  });
+
+  it("returns local for envelopeTimezone 'local'", () => {
+    const result = resolveSystemEventTimezone({
+      agents: { defaults: { envelopeTimezone: "local" } },
+    } as OpenClawConfig);
+    expect(result).toEqual({ mode: "local" });
   });
 });
 


### PR DESCRIPTION
## Summary
- Fixes exec event timestamps appearing incorrect (off by ~11.5 hours) when `envelopeTimezone` is not set
- Extracted `resolveSystemEventTimezone` helper that falls back to `userTimezone` config instead of host local timezone
- Added 5 unit tests covering the timezone resolution logic

Closes #33083

## Test plan
- [ ] Verify system event timestamps use configured `userTimezone` when envelope timezone is absent
- [ ] Verify envelope timezone still takes priority when present
- [ ] Run `pnpm vitest run src/auto-reply/reply/session.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)