### PR TITLE
fix(subagents): release cleanup lock when announce flow fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Sessions/Attachments: add inline file attachment support for `sessions_spawn` (subagent runtime only) with base64/utf8 encoding, transcript content redaction, lifecycle cleanup, and configurable limits via `tools.sessions_spawn.attachments`. (#16761) Thanks @napetrov.
 - Agents/Thinking defaults: set `adaptive` as the default thinking level for Anthropic Claude 4.6 models (including Bedrock Claude 4.6 refs) while keeping other reasoning-capable models at `low` unless explicitly configured.
 - Gateway/Container probes: add built-in HTTP liveness/readiness endpoints (`/health`, `/healthz`, `/ready`, `/readyz`) for Docker/Kubernetes health checks, with fallback routing so existing handlers on those paths are not shadowed. (#31272) Thanks @vincentkoc.
 - Android/Nodes: add `camera.list`, `device.permissions`, `device.health`, and `notifications.actions` (`open`/`dismiss`/`reply`) on Android nodes, plus first-class node-tool actions for the new device/notification commands. (#28260) Thanks @obviyus.

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -157,6 +157,8 @@ Parameters:
 - `mode?` (`run|session`; defaults to `run`, but defaults to `session` when `thread=true`; `mode="session"` requires `thread=true`)
 - `cleanup?` (`delete|keep`, default `keep`)
 - `sandbox?` (`inherit|require`, default `inherit`; `require` rejects spawn unless the target child runtime is sandboxed)
+- `attachments?` (optional array of inline files; subagent runtime only, ACP rejects). Each entry: `{ name, content, encoding?: "utf8" | "base64", mimeType? }`. Files are materialized into the child workspace at `.openclaw/attachments/<uuid>/`. Returns a receipt with sha256 per file.
+- `attachAs?` (optional; `{ mountPath? }` hint reserved for future mount implementations)
 
 Allowlist:
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1816,6 +1816,35 @@ Notes:
 - `all`: any session. Cross-agent targeting still requires `tools.agentToAgent`.
 - Sandbox clamp: when the current session is sandboxed and `agents.defaults.sandbox.sessionToolsVisibility="spawned"`, visibility is forced to `tree` even if `tools.sessions.visibility="all"`.
 
+### `tools.sessions_spawn`
+
+Controls inline attachment support for `sessions_spawn`.
+
+```json5
+{
+  tools: {
+    sessions_spawn: {
+      attachments: {
+        enabled: false, // opt-in: set true to allow inline file attachments
+        maxTotalBytes: 5242880, // 5 MB total across all files
+        maxFiles: 50,
+        maxFileBytes: 1048576, // 1 MB per file
+        retainOnSessionKeep: false, // keep attachments when cleanup="keep"
+      },
+    },
+  },
+}
+```
+
+Notes:
+
+- Attachments are only supported for `runtime: "subagent"`. ACP runtime rejects them.
+- Files are materialized into the child workspace at `.openclaw/attachments/<uuid>/` with a `.manifest.json`.
+- Attachment content is automatically redacted from transcript persistence.
+- Base64 inputs are validated with strict alphabet/padding checks and a pre-decode size guard.
+- File permissions are `0700` for directories and `0600` for files.
+- Cleanup follows the `cleanup` policy: `delete` always removes attachments; `keep` retains them only when `retainOnSessionKeep: true`.
+
 ### `tools.subagents`
 
 ```json5

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -466,7 +466,7 @@ Core parameters:
 - `sessions_list`: `kinds?`, `limit?`, `activeMinutes?`, `messageLimit?` (0 = none)
 - `sessions_history`: `sessionKey` (or `sessionId`), `limit?`, `includeTools?`
 - `sessions_send`: `sessionKey` (or `sessionId`), `message`, `timeoutSeconds?` (0 = fire-and-forget)
-- `sessions_spawn`: `task`, `label?`, `runtime?`, `agentId?`, `model?`, `thinking?`, `cwd?`, `runTimeoutSeconds?`, `thread?`, `mode?`, `cleanup?`, `sandbox?`
+- `sessions_spawn`: `task`, `label?`, `runtime?`, `agentId?`, `model?`, `thinking?`, `cwd?`, `runTimeoutSeconds?`, `thread?`, `mode?`, `cleanup?`, `sandbox?`, `attachments?`, `attachAs?`
 - `session_status`: `sessionKey?` (default current; accepts `sessionId`), `model?` (`default` clears override)
 
 Notes:
@@ -486,6 +486,9 @@ Notes:
   - Reply format includes `Status`, `Result`, and compact stats.
   - `Result` is the assistant completion text; if missing, the latest `toolResult` is used as fallback.
 - Manual completion-mode spawns send directly first, with queue fallback and retry on transient failures (`status: "ok"` means run finished, not that announce delivered).
+- `sessions_spawn` supports inline file attachments for subagent runtime only (ACP rejects them). Each attachment has `name`, `content`, and optional `encoding` (`utf8` or `base64`) and `mimeType`. Files are materialized into the child workspace at `.openclaw/attachments/<uuid>/` with a `.manifest.json` metadata file. The tool returns a receipt with `count`, `totalBytes`, per file `sha256`, and `relDir`. Attachment content is automatically redacted from transcript persistence.
+  - Configure limits via `tools.sessions_spawn.attachments` (`enabled`, `maxTotalBytes`, `maxFiles`, `maxFileBytes`, `retainOnSessionKeep`).
+  - `attachAs.mountPath` is a reserved hint for future mount implementations.
 - `sessions_spawn` is non-blocking and returns `status: "accepted"` immediately.
 - `sessions_send` runs a reply‑back ping‑pong (reply `REPLY_SKIP` to stop; max turns via `session.agentToAgent.maxPingPongTurns`, 0–5).
 - After the ping‑pong, the target agent runs an **announce step**; reply `ANNOUNCE_SKIP` to suppress the announcement.

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -922,7 +922,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "https://api.openai.com/v1",
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(true);
   });
@@ -936,7 +936,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "https://proxy.example.com/v1",
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(false);
   });
@@ -950,7 +950,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "",
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(false);
   });
@@ -971,7 +971,7 @@ describe("applyExtraParamsToAgent", () => {
         contextWindow: 128_000,
         maxTokens: 16_384,
         compat: { supportsStore: false },
-      } as Model<"openai-responses"> & { compat?: { supportsStore?: boolean } },
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(false);
   });
@@ -986,7 +986,7 @@ describe("applyExtraParamsToAgent", () => {
         id: "gpt-5",
         baseUrl: "https://api.openai.com/v1",
         contextWindow: 200_000,
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.context_management).toEqual([
       {
@@ -1005,7 +1005,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "azure-openai-responses",
         id: "gpt-4o",
         baseUrl: "https://example.openai.azure.com/openai/v1",
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload).not.toHaveProperty("context_management");
   });
@@ -1033,7 +1033,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "azure-openai-responses",
         id: "gpt-4o",
         baseUrl: "https://example.openai.azure.com/openai/v1",
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.context_management).toEqual([
       {
@@ -1052,7 +1052,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "https://api.openai.com/v1",
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
       payload: {
         store: false,
         context_management: [{ type: "compaction", compact_threshold: 12_345 }],
@@ -1083,7 +1083,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "https://api.openai.com/v1",
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload).not.toHaveProperty("context_management");
   });

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -4,7 +4,7 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 const TOOL_CALL_NAME_MAX_CHARS = 64;
 const TOOL_CALL_NAME_RE = /^[A-Za-z0-9_-]+$/;
 
-type ToolCallBlock = {
+type RawToolCallBlock = {
   type?: unknown;
   id?: unknown;
   name?: unknown;
@@ -12,7 +12,7 @@ type ToolCallBlock = {
   arguments?: unknown;
 };
 
-function isToolCallBlock(block: unknown): block is ToolCallBlock {
+function isRawToolCallBlock(block: unknown): block is RawToolCallBlock {
   if (!block || typeof block !== "object") {
     return false;
   }
@@ -23,7 +23,7 @@ function isToolCallBlock(block: unknown): block is ToolCallBlock {
   );
 }
 
-function hasToolCallInput(block: ToolCallBlock): boolean {
+function hasToolCallInput(block: RawToolCallBlock): boolean {
   const hasInput = "input" in block ? block.input !== undefined && block.input !== null : false;
   const hasArguments =
     "arguments" in block ? block.arguments !== undefined && block.arguments !== null : false;
@@ -34,7 +34,7 @@ function hasNonEmptyStringField(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function hasToolCallId(block: ToolCallBlock): boolean {
+function hasToolCallId(block: RawToolCallBlock): boolean {
   return hasNonEmptyStringField(block.id);
 }
 
@@ -55,7 +55,7 @@ function normalizeAllowedToolNames(allowedToolNames?: Iterable<string>): Set<str
   return normalized.size > 0 ? normalized : null;
 }
 
-function hasToolCallName(block: ToolCallBlock, allowedToolNames: Set<string> | null): boolean {
+function hasToolCallName(block: RawToolCallBlock, allowedToolNames: Set<string> | null): boolean {
   if (typeof block.name !== "string") {
     return false;
   }
@@ -70,6 +70,66 @@ function hasToolCallName(block: ToolCallBlock, allowedToolNames: Set<string> | n
     return true;
   }
   return allowedToolNames.has(trimmed.toLowerCase());
+}
+
+function redactSessionsSpawnAttachmentsArgs(value: unknown): unknown {
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const rec = value as Record<string, unknown>;
+  const raw = rec.attachments;
+  if (!Array.isArray(raw)) {
+    return value;
+  }
+  const next = raw.map((item) => {
+    if (!item || typeof item !== "object") {
+      return item;
+    }
+    const a = item as Record<string, unknown>;
+    if (!Object.hasOwn(a, "content")) {
+      return item;
+    }
+    const { content: _content, ...rest } = a;
+    return { ...rest, content: "__OPENCLAW_REDACTED__" };
+  });
+  return { ...rec, attachments: next };
+}
+
+function sanitizeToolCallBlock(block: RawToolCallBlock): RawToolCallBlock {
+  const rawName = typeof block.name === "string" ? block.name : undefined;
+  const trimmedName = rawName?.trim();
+  const hasTrimmedName = typeof trimmedName === "string" && trimmedName.length > 0;
+  const normalizedName = hasTrimmedName ? trimmedName : undefined;
+  const nameChanged = hasTrimmedName && rawName !== trimmedName;
+
+  const isSessionsSpawn = normalizedName?.toLowerCase() === "sessions_spawn";
+
+  if (!isSessionsSpawn) {
+    if (!nameChanged) {
+      return block;
+    }
+    return { ...(block as Record<string, unknown>), name: normalizedName } as RawToolCallBlock;
+  }
+
+  // Redact large/sensitive inline attachment content from persisted transcripts.
+  // Apply redaction to both `.arguments` and `.input` properties since block structures can vary
+  const nextArgs = redactSessionsSpawnAttachmentsArgs(block.arguments);
+  const nextInput = redactSessionsSpawnAttachmentsArgs(block.input);
+  if (nextArgs === block.arguments && nextInput === block.input && !nameChanged) {
+    return block;
+  }
+
+  const next = { ...(block as Record<string, unknown>) };
+  if (nameChanged && normalizedName) {
+    next.name = normalizedName;
+  }
+  if (nextArgs !== block.arguments || Object.hasOwn(block, "arguments")) {
+    next.arguments = nextArgs;
+  }
+  if (nextInput !== block.input || Object.hasOwn(block, "input")) {
+    next.input = nextInput;
+  }
+  return next as RawToolCallBlock;
 }
 
 function makeMissingToolResult(params: {
@@ -147,9 +207,10 @@ export function stripToolResultDetails(messages: AgentMessage[]): AgentMessage[]
       out.push(msg);
       continue;
     }
-    const { details: _details, ...rest } = msg as unknown as Record<string, unknown>;
+    const sanitized = { ...(msg as object) } as { details?: unknown };
+    delete sanitized.details;
     touched = true;
-    out.push(rest as unknown as AgentMessage);
+    out.push(sanitized as unknown as AgentMessage);
   }
   return touched ? out : messages;
 }
@@ -177,11 +238,11 @@ export function repairToolCallInputs(
 
     const nextContent: typeof msg.content = [];
     let droppedInMessage = 0;
-    let trimmedInMessage = 0;
+    let messageChanged = false;
 
     for (const block of msg.content) {
       if (
-        isToolCallBlock(block) &&
+        isRawToolCallBlock(block) &&
         (!hasToolCallInput(block) ||
           !hasToolCallId(block) ||
           !hasToolCallName(block, allowedToolNames))
@@ -189,22 +250,49 @@ export function repairToolCallInputs(
         droppedToolCalls += 1;
         droppedInMessage += 1;
         changed = true;
+        messageChanged = true;
         continue;
       }
-      // Normalize tool call names by trimming whitespace so that downstream
-      // lookup (toolsByName map) matches correctly even when the model emits
-      // names with leading/trailing spaces (e.g. " read" → "read").
-      if (isToolCallBlock(block) && typeof (block as ToolCallBlock).name === "string") {
-        const rawName = (block as ToolCallBlock).name as string;
-        if (rawName !== rawName.trim()) {
-          const normalized = { ...block, name: rawName.trim() } as typeof block;
-          nextContent.push(normalized);
-          trimmedInMessage += 1;
-          changed = true;
+      if (isRawToolCallBlock(block)) {
+        if (
+          (block as { type?: unknown }).type === "toolCall" ||
+          (block as { type?: unknown }).type === "toolUse" ||
+          (block as { type?: unknown }).type === "functionCall"
+        ) {
+          // Only sanitize (redact) sessions_spawn blocks; all others are passed through
+          // unchanged to preserve provider-specific shapes (e.g. toolUse.input for Anthropic).
+          const blockName =
+            typeof (block as { name?: unknown }).name === "string"
+              ? (block as { name: string }).name.trim()
+              : undefined;
+          if (blockName?.toLowerCase() === "sessions_spawn") {
+            const sanitized = sanitizeToolCallBlock(block);
+            if (sanitized !== block) {
+              changed = true;
+              messageChanged = true;
+            }
+            nextContent.push(sanitized as typeof block);
+          } else {
+            if (typeof (block as { name?: unknown }).name === "string") {
+              const rawName = (block as { name: string }).name;
+              const trimmedName = rawName.trim();
+              if (rawName !== trimmedName && trimmedName) {
+                const renamed = { ...(block as object), name: trimmedName } as typeof block;
+                nextContent.push(renamed);
+                changed = true;
+                messageChanged = true;
+              } else {
+                nextContent.push(block);
+              }
+            } else {
+              nextContent.push(block);
+            }
+          }
           continue;
         }
+      } else {
+        nextContent.push(block);
       }
-      nextContent.push(block);
     }
 
     if (droppedInMessage > 0) {
@@ -217,9 +305,7 @@ export function repairToolCallInputs(
       continue;
     }
 
-    // When tool names were trimmed but nothing was dropped,
-    // we still need to emit the message with the normalized content.
-    if (trimmedInMessage > 0) {
+    if (messageChanged) {
       out.push({ ...msg, content: nextContent });
       continue;
     }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -408,6 +408,14 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
       defaultRuntime.log(
         `[warn] Subagent announce flow failed during cleanup for run ${runId}: ${String(error)}`,
       );
+      // Release cleanup lock immediately so resume/retry is not blocked if
+      // finalize runs on a later turn.
+      const current = subagentRuns.get(runId);
+      if (current && !current.cleanupCompletedAt) {
+        current.cleanupHandled = false;
+        resumedRuns.delete(runId);
+        persistSubagentRuns();
+      }
       void finalizeSubagentCleanup(runId, entry.cleanup, false);
     });
   return true;

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -32,4 +32,7 @@ export type SubagentRunRecord = {
   endedReason?: SubagentLifecycleEndedReason;
   /** Set after the subagent_ended hook has been emitted successfully once. */
   endedHookEmittedAt?: number;
+  attachmentsDir?: string;
+  attachmentsRootDir?: string;
+  retainAttachmentsOnKeep?: boolean;
 };

--- a/src/agents/subagent-spawn.attachments.test.ts
+++ b/src/agents/subagent-spawn.attachments.test.ts
@@ -1,0 +1,213 @@
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resetSubagentRegistryForTests } from "./subagent-registry.js";
+import { decodeStrictBase64, spawnSubagentDirect } from "./subagent-spawn.js";
+
+const callGatewayMock = vi.fn();
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+let configOverride: Record<string, unknown> = {
+  session: {
+    mainKey: "main",
+    scope: "per-sender",
+  },
+  tools: {
+    sessions_spawn: {
+      attachments: {
+        enabled: true,
+        maxFiles: 50,
+        maxFileBytes: 1 * 1024 * 1024,
+        maxTotalBytes: 5 * 1024 * 1024,
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      workspace: os.tmpdir(),
+    },
+  },
+};
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => configOverride,
+  };
+});
+
+vi.mock("./subagent-registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./subagent-registry.js")>();
+  return {
+    ...actual,
+    countActiveRunsForSession: () => 0,
+    registerSubagentRun: () => {},
+  };
+});
+
+vi.mock("./subagent-announce.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./subagent-announce.js")>();
+  return {
+    ...actual,
+    buildSubagentSystemPrompt: () => "system-prompt",
+  };
+});
+
+vi.mock("./agent-scope.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./agent-scope.js")>();
+  return {
+    ...actual,
+    resolveAgentWorkspaceDir: () => path.join(os.tmpdir(), "agent-workspace"),
+  };
+});
+
+vi.mock("./subagent-depth.js", () => ({
+  getSubagentDepthFromSessionStore: () => 0,
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => ({ hasHooks: () => false }),
+}));
+
+function setupGatewayMock() {
+  callGatewayMock.mockImplementation(async (opts: { method?: string; params?: unknown }) => {
+    if (opts.method === "sessions.patch") {
+      return { ok: true };
+    }
+    if (opts.method === "sessions.delete") {
+      return { ok: true };
+    }
+    if (opts.method === "agent") {
+      return { runId: "run-1" };
+    }
+    return {};
+  });
+}
+
+// --- decodeStrictBase64 ---
+
+describe("decodeStrictBase64", () => {
+  const maxBytes = 1024;
+
+  it("valid base64 returns buffer with correct bytes", () => {
+    const input = "hello world";
+    const encoded = Buffer.from(input).toString("base64");
+    const result = decodeStrictBase64(encoded, maxBytes);
+    expect(result).not.toBeNull();
+    expect(result?.toString("utf8")).toBe(input);
+  });
+
+  it("empty string returns null", () => {
+    expect(decodeStrictBase64("", maxBytes)).toBeNull();
+  });
+
+  it("bad padding (length % 4 !== 0) returns null", () => {
+    expect(decodeStrictBase64("abc", maxBytes)).toBeNull();
+  });
+
+  it("non-base64 chars returns null", () => {
+    expect(decodeStrictBase64("!@#$", maxBytes)).toBeNull();
+  });
+
+  it("whitespace-only returns null (empty after strip)", () => {
+    expect(decodeStrictBase64("   ", maxBytes)).toBeNull();
+  });
+
+  it("pre-decode oversize guard: encoded string > maxEncodedBytes * 2 returns null", () => {
+    // maxEncodedBytes = ceil(1024/3)*4 = 1368; *2 = 2736
+    const oversized = "A".repeat(2737);
+    expect(decodeStrictBase64(oversized, maxBytes)).toBeNull();
+  });
+
+  it("decoded byteLength exceeds maxDecodedBytes returns null", () => {
+    const bigBuf = Buffer.alloc(1025, 0x42);
+    const encoded = bigBuf.toString("base64");
+    expect(decodeStrictBase64(encoded, maxBytes)).toBeNull();
+  });
+
+  it("valid base64 at exact boundary returns Buffer", () => {
+    const exactBuf = Buffer.alloc(1024, 0x41);
+    const encoded = exactBuf.toString("base64");
+    const result = decodeStrictBase64(encoded, maxBytes);
+    expect(result).not.toBeNull();
+    expect(result?.byteLength).toBe(1024);
+  });
+});
+
+// --- filename validation via spawnSubagentDirect ---
+
+describe("spawnSubagentDirect filename validation", () => {
+  beforeEach(() => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockClear();
+    setupGatewayMock();
+  });
+
+  const ctx = {
+    agentSessionKey: "agent:main:main",
+    agentChannel: "telegram" as const,
+    agentAccountId: "123",
+    agentTo: "456",
+  };
+
+  const validContent = Buffer.from("hello").toString("base64");
+
+  async function spawnWithName(name: string) {
+    return spawnSubagentDirect(
+      {
+        task: "test",
+        attachments: [{ name, content: validContent, encoding: "base64" }],
+      },
+      ctx,
+    );
+  }
+
+  it("name with / returns attachments_invalid_name", async () => {
+    const result = await spawnWithName("foo/bar");
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/attachments_invalid_name/);
+  });
+
+  it("name '..' returns attachments_invalid_name", async () => {
+    const result = await spawnWithName("..");
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/attachments_invalid_name/);
+  });
+
+  it("name '.manifest.json' returns attachments_invalid_name", async () => {
+    const result = await spawnWithName(".manifest.json");
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/attachments_invalid_name/);
+  });
+
+  it("name with newline returns attachments_invalid_name", async () => {
+    const result = await spawnWithName("foo\nbar");
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/attachments_invalid_name/);
+  });
+
+  it("duplicate name returns attachments_duplicate_name", async () => {
+    const result = await spawnSubagentDirect(
+      {
+        task: "test",
+        attachments: [
+          { name: "file.txt", content: validContent, encoding: "base64" },
+          { name: "file.txt", content: validContent, encoding: "base64" },
+        ],
+      },
+      ctx,
+    );
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/attachments_duplicate_name/);
+  });
+
+  it("empty name returns attachments_invalid_name", async () => {
+    const result = await spawnWithName("");
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/attachments_invalid_name/);
+  });
+});

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -53,7 +53,6 @@ describe("sessions_spawn tool", () => {
       thread: true,
       mode: "session",
       cleanup: "keep",
-      sandbox: "require",
     });
 
     expect(result.details).toMatchObject({
@@ -71,32 +70,12 @@ describe("sessions_spawn tool", () => {
         thread: true,
         mode: "session",
         cleanup: "keep",
-        sandbox: "require",
       }),
       expect.objectContaining({
         agentSessionKey: "agent:main:main",
       }),
     );
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-  });
-
-  it('defaults sandbox to "inherit" for subagent runtime', async () => {
-    const tool = createSessionsSpawnTool({
-      agentSessionKey: "agent:main:main",
-      agentChannel: "discord",
-    });
-
-    await tool.execute("call-sandbox-default", {
-      task: "summarize logs",
-      agentId: "main",
-    });
-
-    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sandbox: "inherit",
-      }),
-      expect.any(Object),
-    );
   });
 
   it("routes to ACP runtime when runtime=acp", async () => {
@@ -137,25 +116,27 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
-  it.each(["target", "transport", "channel", "to", "threadId", "thread_id", "replyTo", "reply_to"])(
-    "rejects unsupported routing parameter %s",
-    async (key) => {
-      const tool = createSessionsSpawnTool({
-        agentSessionKey: "agent:main:main",
-        agentChannel: "discord",
-        agentAccountId: "default",
-        agentTo: "channel:123",
-        agentThreadId: "456",
-      });
+  it("rejects attachments for ACP runtime", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "discord",
+      agentAccountId: "default",
+      agentTo: "channel:123",
+      agentThreadId: "456",
+    });
 
-      await expect(
-        tool.execute("call-unsupported-param", {
-          task: "build feature",
-          [key]: "value",
-        }),
-      ).rejects.toThrow(`sessions_spawn does not support "${key}"`);
-      expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
-      expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    },
-  );
+    const result = await tool.execute("call-3", {
+      runtime: "acp",
+      task: "analyze file",
+      attachments: [{ name: "a.txt", content: "hello", encoding: "utf8" }],
+    });
+
+    expect(result.details).toMatchObject({
+      status: "error",
+    });
+    const details = result.details as { error?: string };
+    expect(details.error).toContain("attachments are currently unsupported for runtime=acp");
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -776,6 +776,21 @@ export const ToolsSchema = z
       })
       .strict()
       .optional(),
+    sessions_spawn: z
+      .object({
+        attachments: z
+          .object({
+            enabled: z.boolean().optional(),
+            maxTotalBytes: z.number().optional(),
+            maxFiles: z.number().optional(),
+            maxFileBytes: z.number().optional(),
+            retainOnSessionKeep: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .superRefine((value, ctx) => {


### PR DESCRIPTION
## Summary
- release `cleanupHandled` lock when announce-flow cleanup fails
- clear resumed run marker and persist state before running finalize fallback
- prevent resume/retry from getting blocked until a later turn

## Testing
- pre-commit hook checks on changed file