### PR TITLE
feat(discord): inject proxy dispatcher into carbon RequestClient

### DIFF
--- a/src/discord/monitor/carbon-rest-proxy.test.ts
+++ b/src/discord/monitor/carbon-rest-proxy.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { patchCarbonRestProxy } from "./carbon-rest-proxy.js";
+
+const { proxyAgentSpy } = vi.hoisted(() => ({
+  proxyAgentSpy: vi.fn(),
+}));
+
+vi.mock("undici", () => {
+  class ProxyAgent {
+    proxyUrl: string;
+    constructor(proxyUrl: string) {
+      if (proxyUrl === "bad-proxy") {
+        throw new Error("bad proxy");
+      }
+      this.proxyUrl = proxyUrl;
+      proxyAgentSpy(proxyUrl);
+    }
+  }
+
+  const mockFetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("") });
+
+  return { ProxyAgent, fetch: mockFetch };
+});
+
+function makeRuntime() {
+  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as const;
+}
+
+describe("patchCarbonRestProxy", () => {
+  const savedFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = savedFetch;
+  });
+
+  it("is a no-op when proxy URL is empty", () => {
+    const executeRequest = vi.fn();
+    const client = { rest: { executeRequest } };
+    const runtime = makeRuntime();
+
+    patchCarbonRestProxy(client, "   ", runtime);
+
+    expect(client.rest.executeRequest).toBe(executeRequest);
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when proxy URL is undefined", () => {
+    const executeRequest = vi.fn();
+    const client = { rest: { executeRequest } };
+    const runtime = makeRuntime();
+
+    patchCarbonRestProxy(client, undefined, runtime);
+
+    expect(client.rest.executeRequest).toBe(executeRequest);
+  });
+
+  it("wraps executeRequest to temporarily swap globalThis.fetch", async () => {
+    const originalFetch = vi.fn();
+    globalThis.fetch = originalFetch;
+
+    let capturedFetch: typeof fetch | undefined;
+    const fakeExecuteRequest = vi.fn().mockImplementation(async () => {
+      // Inside executeRequest, globalThis.fetch should be the proxy version
+      capturedFetch = globalThis.fetch;
+      return { ok: true };
+    });
+
+    const client = { rest: { executeRequest: fakeExecuteRequest } };
+    const runtime = makeRuntime();
+    proxyAgentSpy.mockClear();
+
+    patchCarbonRestProxy(client, "http://proxy.test:8080", runtime);
+
+    expect(proxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(runtime.log).toHaveBeenCalledWith("discord: carbon rest proxy enabled");
+
+    // Call the patched executeRequest
+    const request = { method: "GET", path: "/test", routeKey: "GET:/test" };
+    await client.rest.executeRequest(request);
+
+    // During execution, fetch should have been swapped
+    expect(capturedFetch).toBeDefined();
+    expect(capturedFetch).not.toBe(originalFetch);
+
+    // After execution, fetch should be restored
+    expect(globalThis.fetch).toBe(originalFetch);
+
+    // The original executeRequest should have been called with the request
+    expect(fakeExecuteRequest).toHaveBeenCalledWith(request);
+  });
+
+  it("restores globalThis.fetch even when executeRequest throws", async () => {
+    const originalFetch = vi.fn();
+    globalThis.fetch = originalFetch;
+
+    const fakeExecuteRequest = vi.fn().mockRejectedValue(new Error("boom"));
+    const client = { rest: { executeRequest: fakeExecuteRequest } };
+    const runtime = makeRuntime();
+
+    patchCarbonRestProxy(client, "http://proxy.test:8080", runtime);
+
+    await expect(client.rest.executeRequest({ method: "GET" })).rejects.toThrow("boom");
+
+    // fetch must be restored
+    expect(globalThis.fetch).toBe(originalFetch);
+  });
+
+  it("does not double-patch", () => {
+    const executeRequest = vi.fn();
+    const client = { rest: { executeRequest } };
+    const runtime = makeRuntime();
+
+    patchCarbonRestProxy(client, "http://proxy.test:8080", runtime);
+    const firstPatch = client.rest.executeRequest;
+
+    patchCarbonRestProxy(client, "http://proxy.test:9090", runtime);
+    expect(client.rest.executeRequest).toBe(firstPatch);
+  });
+
+  it("logs error and leaves executeRequest untouched for invalid proxy", () => {
+    const executeRequest = vi.fn();
+    const client = { rest: { executeRequest } };
+    const runtime = makeRuntime();
+
+    patchCarbonRestProxy(client, "bad-proxy", runtime);
+
+    expect(client.rest.executeRequest).toBe(executeRequest);
+    expect(runtime.error).toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+});

--- a/src/discord/monitor/carbon-rest-proxy.ts
+++ b/src/discord/monitor/carbon-rest-proxy.ts
@@ -1,0 +1,71 @@
+import { ProxyAgent, fetch as undiciFetch } from "undici";
+import { danger } from "../../globals.js";
+import type { RuntimeEnv } from "../../runtime.js";
+
+/**
+ * Patch a @buape/carbon Client's rest property to route all Discord REST API
+ * requests through a proxy. This works around carbon's RequestClient not
+ * supporting a custom fetch / dispatcher option.
+ *
+ * The approach: replace the global `fetch` visible to `executeRequest` by
+ * wrapping the method so that during its execution, every `fetch()` call
+ * goes through an undici ProxyAgent dispatcher.
+ *
+ * No-op when `proxyUrl` is empty/undefined.
+ */
+
+const PATCHED = Symbol("openclawProxyPatched");
+
+type RestLike = Record<string, unknown> & {
+  executeRequest?: (request: unknown) => Promise<unknown>;
+  [PATCHED]?: boolean;
+};
+
+type CarbonClientLike = {
+  rest?: RestLike;
+};
+
+export function patchCarbonRestProxy(
+  client: CarbonClientLike,
+  proxyUrl: string | undefined,
+  runtime: RuntimeEnv,
+): void {
+  const proxy = proxyUrl?.trim();
+  if (!proxy) return;
+
+  const rest = client.rest;
+  if (!rest || typeof rest.executeRequest !== "function" || rest[PATCHED]) return;
+
+  try {
+    const agent = new ProxyAgent(proxy);
+    const originalExecuteRequest = rest.executeRequest.bind(rest);
+
+    // Wrap executeRequest to intercept the internal fetch() call.
+    // Carbon's executeRequest builds url/headers/body then calls fetch(url, init).
+    // We replace it with a version that injects `dispatcher` into the fetch init.
+    const proxyFetch = ((input: string | URL | RequestInfo, init?: RequestInit) =>
+      undiciFetch(input as string | URL, {
+        ...(init as Record<string, unknown>),
+        dispatcher: agent,
+      }) as unknown as Promise<Response>) as typeof globalThis.fetch;
+
+    rest.executeRequest = async function patchedExecuteRequest(
+      this: RestLike,
+      request: unknown,
+    ): Promise<unknown> {
+      // Temporarily replace globalThis.fetch so carbon's executeRequest picks it up.
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = proxyFetch;
+      try {
+        return await originalExecuteRequest(request);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    };
+
+    rest[PATCHED] = true;
+    runtime.log?.("discord: carbon rest proxy enabled");
+  } catch (err) {
+    runtime.error?.(danger(`discord: invalid carbon rest proxy: ${String(err)}`));
+  }
+}

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -54,6 +54,7 @@ import {
   createDiscordComponentStringSelect,
   createDiscordComponentUserSelect,
 } from "./agent-components.js";
+import { patchCarbonRestProxy } from "./carbon-rest-proxy.js";
 import { resolveDiscordSlashCommandConfig } from "./commands.js";
 import { createExecApprovalButton, DiscordExecApprovalHandler } from "./exec-approvals.js";
 import { attachEarlyGatewayErrorGuard } from "./gateway-error-guard.js";
@@ -494,6 +495,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       },
       clientPlugins,
     );
+    patchCarbonRestProxy(client, rawDiscordCfg.proxy, runtime);
     const earlyGatewayErrorGuard = attachEarlyGatewayErrorGuard(client);
     releaseEarlyGatewayErrorGuard = earlyGatewayErrorGuard.release;
 


### PR DESCRIPTION
Carbon's RequestClient does not support a custom fetch or dispatcher option, so when channels.discord.proxy is configured, the proxy is not applied to REST calls made through the carbon library.

This patch wraps client.rest.executeRequest() to temporarily swap globalThis.fetch with an undici ProxyAgent-backed fetch during execution, ensuring all Discord REST traffic from carbon goes through the configured proxy.

Fixes proxy support for users behind firewalls (e.g. China) who need Discord traffic routed through a SOCKS/HTTP proxy.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
