### PR TITLE
fix(ui): route unauthenticated entrypoint to overview

### DIFF
--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -226,4 +226,28 @@ describe("connectGateway", () => {
     expect(host.lastError).toContain("gateway token mismatch");
     expect(host.lastErrorCode).toBe("AUTH_TOKEN_MISMATCH");
   });
+
+  it("switches from chat to overview on token-missing close when no token is configured", () => {
+    const host = createHost();
+    host.tab = "chat";
+    host.settings.token = "";
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitClose({
+      code: 4008,
+      reason: "connect failed",
+      error: {
+        code: "INVALID_REQUEST",
+        message:
+          "unauthorized: gateway token missing (open the dashboard URL and paste the token in Control UI settings)",
+        details: { code: "INVALID_REQUEST" },
+      },
+    });
+
+    expect(host.tab).toBe("overview");
+    expect(host.lastError).toContain("gateway token missing");
+  });
 });

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -1,6 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "../../../src/gateway/events.js";
-import { connectGateway } from "./app-gateway.ts";
+
+vi.stubGlobal("localStorage", {
+  getItem: vi.fn(() => null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+  key: vi.fn(() => null),
+  length: 0,
+});
+
+vi.mock("./app-settings.ts", async () => {
+  const actual = await vi.importActual<typeof import("./app-settings.ts")>("./app-settings.ts");
+  return {
+    ...actual,
+    setTab: vi.fn(
+      (host: Parameters<typeof actual.setTab>[0], next: Parameters<typeof actual.setTab>[1]) => {
+        host.tab = next;
+      },
+    ),
+    setTabFromRoute: vi.fn(actual.setTabFromRoute),
+    syncUrlWithTab: vi.fn(),
+  };
+});
+
+const { connectGateway } = await import("./app-gateway.ts");
+const appSettings = await import("./app-settings.ts");
 
 type GatewayClientMock = {
   start: ReturnType<typeof vi.fn>;
@@ -112,6 +137,7 @@ function createHost() {
 describe("connectGateway", () => {
   beforeEach(() => {
     gatewayClientInstances.length = 0;
+    vi.clearAllMocks();
   });
 
   it("ignores stale client onGap callbacks after reconnect", () => {
@@ -249,5 +275,34 @@ describe("connectGateway", () => {
 
     expect(host.tab).toBe("overview");
     expect(host.lastError).toContain("gateway token missing");
+    expect(appSettings.setTabFromRoute).toHaveBeenCalledWith(host, "overview");
+    expect(appSettings.syncUrlWithTab).toHaveBeenCalledWith(host, "overview", false);
+    expect(appSettings.setTab).not.toHaveBeenCalled();
+  });
+
+  it("stays on chat when password auth is configured", () => {
+    const host = createHost();
+    host.tab = "chat";
+    host.settings.token = "";
+    host.password = "sekret";
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitClose({
+      code: 4008,
+      reason: "connect failed",
+      error: {
+        code: "INVALID_REQUEST",
+        message:
+          "unauthorized: gateway token missing (open the dashboard URL and paste the token in Control UI settings)",
+        details: { code: "INVALID_REQUEST" },
+      },
+    });
+
+    expect(host.tab).toBe("chat");
+    expect(appSettings.setTabFromRoute).not.toHaveBeenCalled();
+    expect(appSettings.syncUrlWithTab).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -9,6 +9,7 @@ import {
   loadCron,
   refreshActiveTab,
   setLastActiveSessionKey,
+  setTab,
 } from "./app-settings.ts";
 import { handleAgentEvent, resetToolStream, type AgentEventPayload } from "./app-tool-stream.ts";
 import type { OpenClawApp } from "./app.ts";
@@ -186,6 +187,13 @@ export function connectGateway(host: GatewayHost) {
       if (code !== 1012) {
         if (error?.message) {
           host.lastError = error.message;
+          if (
+            !host.settings.token.trim() &&
+            /gateway token missing/i.test(error.message) &&
+            host.tab === "chat"
+          ) {
+            setTab(host as unknown as Parameters<typeof setTab>[0], "overview");
+          }
           return;
         }
         host.lastError = `disconnected (${code}): ${reason || "no reason"}`;

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -9,7 +9,8 @@ import {
   loadCron,
   refreshActiveTab,
   setLastActiveSessionKey,
-  setTab,
+  setTabFromRoute,
+  syncUrlWithTab,
 } from "./app-settings.ts";
 import { handleAgentEvent, resetToolStream, type AgentEventPayload } from "./app-tool-stream.ts";
 import type { OpenClawApp } from "./app.ts";
@@ -189,10 +190,16 @@ export function connectGateway(host: GatewayHost) {
           host.lastError = error.message;
           if (
             !host.settings.token.trim() &&
+            !host.password.trim() &&
             /gateway token missing/i.test(error.message) &&
             host.tab === "chat"
           ) {
-            setTab(host as unknown as Parameters<typeof setTab>[0], "overview");
+            setTabFromRoute(host as unknown as Parameters<typeof setTabFromRoute>[0], "overview");
+            syncUrlWithTab(
+              host as unknown as Parameters<typeof syncUrlWithTab>[0],
+              "overview",
+              false,
+            );
           }
           return;
         }

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -318,6 +318,8 @@ export function syncTabWithLocation(host: SettingsHost, replace: boolean) {
   const hasAuth = Boolean(host.settings.token.trim() || host.password?.trim());
   const atEntrypoint = isBaseEntrypointPath(window.location.pathname, host.basePath);
   const resolvedFromPath = tabFromPath(window.location.pathname, host.basePath);
+  // Entrypoint without auth lands on overview; unknown routes also fall back to
+  // overview when unauthenticated so we avoid defaulting typo URLs to chat.
   const resolved =
     atEntrypoint && !hasAuth ? "overview" : (resolvedFromPath ?? (hasAuth ? "chat" : "overview"));
   setTabFromRoute(host, resolved);

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -61,6 +61,15 @@ type SettingsHost = {
   pendingGatewayUrl?: string | null;
 };
 
+function isBaseEntrypointPath(pathname: string, basePath: string): boolean {
+  const normalizedPath = normalizePath(pathname);
+  const base = normalizeBasePath(basePath);
+  if (!base) {
+    return normalizedPath === "/";
+  }
+  return normalizedPath === normalizePath(base);
+}
+
 export function applySettings(host: SettingsHost, next: UiSettings) {
   const normalized = {
     ...next,
@@ -303,7 +312,11 @@ export function syncTabWithLocation(host: SettingsHost, replace: boolean) {
   if (typeof window === "undefined") {
     return;
   }
-  const resolved = tabFromPath(window.location.pathname, host.basePath) ?? "chat";
+  const hasAuth = Boolean(host.settings.token.trim() || host.password?.trim());
+  const atEntrypoint = isBaseEntrypointPath(window.location.pathname, host.basePath);
+  const resolvedFromPath = tabFromPath(window.location.pathname, host.basePath);
+  const resolved =
+    atEntrypoint && !hasAuth ? "overview" : (resolvedFromPath ?? (hasAuth ? "chat" : "overview"));
   setTabFromRoute(host, resolved);
   syncUrlWithTab(host, resolved, replace);
 }

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -62,7 +62,10 @@ type SettingsHost = {
 };
 
 function isBaseEntrypointPath(pathname: string, basePath: string): boolean {
-  const normalizedPath = normalizePath(pathname);
+  let normalizedPath = normalizePath(pathname);
+  if (normalizedPath.endsWith("/index.html")) {
+    normalizedPath = normalizePath(normalizedPath.slice(0, -"/index.html".length)) || "/";
+  }
   const base = normalizeBasePath(basePath);
   if (!base) {
     return normalizedPath === "/";

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -15,6 +15,15 @@ function nextFrame() {
 }
 
 describe("control UI routing", () => {
+  it("routes entrypoint to overview when token is missing", async () => {
+    const app = mountApp("/");
+    await app.updateComplete;
+
+    expect(app.settings.token).toBe("");
+    expect(app.tab).toBe("overview");
+    expect(window.location.pathname).toBe("/overview");
+  });
+
   it("hydrates the tab from the location", async () => {
     const app = mountApp("/sessions");
     await app.updateComplete;

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -24,6 +24,25 @@ describe("control UI routing", () => {
     expect(window.location.pathname).toBe("/overview");
   });
 
+  it("routes /index.html entrypoint to overview when token is missing", async () => {
+    const app = mountApp("/index.html");
+    await app.updateComplete;
+
+    expect(app.settings.token).toBe("");
+    expect(app.tab).toBe("overview");
+    expect(window.location.pathname).toBe("/overview");
+  });
+
+  it("routes /ui/index.html entrypoint to overview when token is missing", async () => {
+    const app = mountApp("/ui/index.html");
+    await app.updateComplete;
+
+    expect(app.settings.token).toBe("");
+    expect(app.basePath).toBe("/ui");
+    expect(app.tab).toBe("overview");
+    expect(window.location.pathname).toBe("/ui/overview");
+  });
+
   it("hydrates the tab from the location", async () => {
     const app = mountApp("/sessions");
     await app.updateComplete;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: opening Control UI entrypoint (`/`) with no configured token routes users directly to `chat`, which immediately produces websocket auth errors (`gateway token missing`).
- Why it matters: first-time/tunneled users land on an error state instead of the token input surface, making setup look broken.
- What changed: entrypoint routing now defaults to `overview` (not `chat`) when no token/password is configured.
- What changed: when websocket closes with `gateway token missing` and token is empty, UI auto-switches from `chat` to `overview` so users can paste token in settings.
- What did NOT change (scope boundary): no auth protocol/server changes; only Control UI client-side routing/error UX.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33157
- Related #33088

## User-visible / Behavior Changes

When opening dashboard entrypoint without token configured, Control UI now lands on `overview` (token input available) instead of `chat`. If a chat websocket fails with `gateway token missing` and no token is set, UI redirects to `overview`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Browser UI tests (Chromium) + Node test runtime
- Runtime/container: pnpm + vitest
- Model/provider: N/A
- Integration/channel (if any): Control UI webchat/auth routing
- Relevant config (redacted): empty `settings.token`

### Steps

1. Load Control UI at `/` with no token in settings/local storage.
2. Observe initial tab/route.
3. Simulate websocket close error with `unauthorized: gateway token missing` while on chat.

### Expected

- Entrypoint routes to `overview` when unauthenticated.
- Token-missing close on chat returns user to `overview`.

### Actual

- Before fix, root routed to `chat`, often ending in `token missing` errors without guiding users to token input first.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm --dir ui exec vitest src/ui/navigation.browser.test.ts src/ui/app-gateway.node.test.ts --run`
  - New browser test asserts `/` -> `overview` when token missing.
  - New gateway close test asserts token-missing close transitions `chat` -> `overview`.
- Edge cases checked:
  - Existing route hydration behavior for explicit routes remains unchanged.
  - Authenticated fallback still uses `chat`.
- What you did **not** verify:
  - Did not run manual SSH-tunnel browser repro in this PR; covered by deterministic UI tests.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `fix(ui): route unauthenticated entrypoint to overview`.
- Files/config to restore:
  - `ui/src/ui/app-settings.ts`
  - `ui/src/ui/app-gateway.ts`
  - `ui/src/ui/navigation.browser.test.ts`
  - `ui/src/ui/app-gateway.node.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected default tab selection when authenticated.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: entrypoint fallback behavior change could surprise users expecting direct chat on unauthenticated fresh loads.
  - Mitigation: behavior only changes at base entrypoint with empty token/password; explicit `/chat` route remains available.
