### PR TITLE
fix(render): bind gateway to $PORT and reduce build OOM risk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,10 +99,10 @@ RUN for dir in /app/extensions /app/.agent /app/.agents; do \
         find "$dir" -type f -exec chmod 644 {} +; \
       fi; \
     done
-RUN pnpm build
+RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1
-RUN pnpm ui:build
+RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm ui:build
 
 # Expose the CLI binary without requiring npm global writes as non-root.
 USER root

--- a/docs/install/render.mdx
+++ b/docs/install/render.mdx
@@ -32,6 +32,7 @@ services:
     name: openclaw
     runtime: docker
     plan: starter
+    dockerCommand: node openclaw.mjs gateway run --allow-unconfigured --bind lan --port $PORT
     healthCheckPath: /health
     envVars:
       - key: PORT
@@ -55,10 +56,19 @@ Key Blueprint features used:
 | Feature               | Purpose                                                    |
 | --------------------- | ---------------------------------------------------------- |
 | `runtime: docker`     | Builds from the repo's Dockerfile                          |
+| `dockerCommand`       | Runs gateway on Render's `$PORT` with LAN binding          |
 | `healthCheckPath`     | Render monitors `/health` and restarts unhealthy instances |
 | `sync: false`         | Prompts for value during deploy (secrets)                  |
 | `generateValue: true` | Auto-generates a cryptographically secure value            |
 | `disk`                | Persistent storage that survives redeploys                 |
+
+The Blueprint sets `dockerCommand` to:
+
+```bash
+node openclaw.mjs gateway run --allow-unconfigured --bind lan --port $PORT
+```
+
+This is required on Render because binding to loopback (`127.0.0.1`) only exposes the port inside the container. Render's port scanner and ingress proxy cannot reach loopback listeners, which causes deploy failures like "No open ports detected."
 
 ## Choosing a plan
 
@@ -140,7 +150,8 @@ This downloads a portable backup you can restore on any OpenClaw host.
 Check the deploy logs in the Render Dashboard. Common issues:
 
 - Missing `SETUP_PASSWORD` — the Blueprint prompts for this, but verify it's set
-- Port mismatch — ensure `PORT=8080` matches the Dockerfile's exposed port
+- No open ports detected — ensure `dockerCommand` includes `--bind lan --port $PORT`; loopback binding is not reachable by Render ingress
+- Build OOM (`JavaScript heap out of memory`) — use the current Dockerfile, which sets `NODE_OPTIONS=--max-old-space-size=2048` for `pnpm build` and `pnpm ui:build`
 
 ### Slow cold starts (free tier)
 

--- a/render.yaml
+++ b/render.yaml
@@ -3,6 +3,7 @@ services:
     name: openclaw
     runtime: docker
     plan: starter
+    dockerCommand: node openclaw.mjs gateway run --allow-unconfigured --bind lan --port $PORT
     healthCheckPath: /health
     envVars:
       - key: PORT


### PR DESCRIPTION
Fixes #2334.

## Summary
- Render ingress can report No open ports detected when the gateway binds to loopback inside the container.
- Docker image build can fail with Node JavaScript heap out of memory during pnpm build steps.

## Changes
- Add Render Blueprint dockerCommand to run the gateway on --bind lan and --port $PORT.
- Apply NODE_OPTIONS=--max-old-space-size=2048 to pnpm build + pnpm ui:build during Docker image build.
- Update Render docs + troubleshooting.

## Testing
- pnpm format:check
