### PR TITLE
fix(build): add missing keyed-async-queue entry to tsdown config

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -45,6 +45,13 @@ export default defineConfig([
     platform: "node",
   },
   {
+    entry: "src/plugin-sdk/keyed-async-queue.ts",
+    outDir: "dist/plugin-sdk",
+    env,
+    fixedExtension: false,
+    platform: "node",
+  },
+  {
     entry: "src/extensionAPI.ts",
     env,
     fixedExtension: false,


### PR DESCRIPTION
## Summary

The Matrix plugin fails to load in v2026.3.2 because `dist/plugin-sdk/keyed-async-queue.js` is not emitted by the build. The `package.json` exports map declares this subpath, and `extensions/matrix/src/matrix/send-queue.ts` imports `KeyedAsyncQueue` from it — so the plugin crashes on startup:

```
Cannot find module '.../dist/plugin-sdk/index.js/keyed-async-queue'
```

## Root Cause

`tsdown.config.ts` is missing a build entry for `src/plugin-sdk/keyed-async-queue.ts`. The source file, its tests, and the exports map all exist — the build just never produces the output file. The `account-id` subpath follows the exact same pattern and works because it has a build entry.

## Fix

Add one entry block to `tsdown.config.ts` (7 lines), mirroring the existing `account-id` pattern.

Fixes #32772