### PR TITLE
Agents: drop whitespace-only tool calls before dispatch

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -224,7 +224,7 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     expect(result).toBe(finalMessage);
   });
 
-  it("does not collapse whitespace-only tool names to empty strings", async () => {
+  it("drops whitespace-only tool calls from streamed and final messages", async () => {
     const partialToolCall = { type: "toolCall", name: "   " };
     const finalToolCall = { type: "toolCall", name: "\t  " };
     const event = {
@@ -238,10 +238,10 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     for await (const _item of stream) {
       // drain
     }
-    await stream.result();
+    const result = await stream.result();
 
-    expect(partialToolCall.name).toBe("   ");
-    expect(finalToolCall.name).toBe("\t  ");
+    expect((event.partial as { content: unknown[] }).content).toEqual([]);
+    expect((result as { content: unknown[] }).content).toEqual([]);
     expect(baseFn).toHaveBeenCalledTimes(1);
   });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -363,7 +363,7 @@ function trimWhitespaceFromToolCallNamesInMessage(
     }
     filteredBlocks.push(block);
   }
-  if (droppedToolCall && filteredBlocks.length !== content.length) {
+  if (droppedToolCall) {
     content.length = 0;
     content.push(...filteredBlocks);
   }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -231,9 +231,7 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
 function normalizeToolCallNameForDispatch(rawName: string, allowedToolNames?: Set<string>): string {
   const trimmed = rawName.trim();
   if (!trimmed) {
-    // Keep whitespace-only placeholders unchanged so they do not collapse to
-    // empty names (which can later surface as toolName="" loops).
-    return rawName;
+    return "";
   }
   if (!allowedToolNames || allowedToolNames.size === 0) {
     return trimmed;
@@ -343,18 +341,31 @@ function trimWhitespaceFromToolCallNamesInMessage(
   if (!Array.isArray(content)) {
     return;
   }
+  const filteredBlocks: unknown[] = [];
+  let droppedToolCall = false;
   for (const block of content) {
     if (!block || typeof block !== "object") {
+      filteredBlocks.push(block);
       continue;
     }
     const typedBlock = block as { type?: unknown; name?: unknown };
     if (typedBlock.type !== "toolCall" || typeof typedBlock.name !== "string") {
+      filteredBlocks.push(block);
       continue;
     }
     const normalized = normalizeToolCallNameForDispatch(typedBlock.name, allowedToolNames);
+    if (!normalized) {
+      droppedToolCall = true;
+      continue;
+    }
     if (normalized !== typedBlock.name) {
       typedBlock.name = normalized;
     }
+    filteredBlocks.push(block);
+  }
+  if (droppedToolCall && filteredBlocks.length !== content.length) {
+    content.length = 0;
+    content.push(...filteredBlocks);
   }
   normalizeToolCallIdsInMessage(message);
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: assistant tool calls with whitespace-only names can reach dispatch and trigger `Tool  not found` errors.
- Why it matters: the run fails with a confusing missing-tool error even though the tool call is effectively invalid noise.
- What changed: whitespace-only tool names are normalized to empty names and whitespace-only `toolCall` blocks are dropped before dispatch.
- What did NOT change (scope boundary): valid tool names and regular trimming behavior for non-empty names are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32991
- Related #

## User-visible / Behavior Changes

Whitespace-only tool calls are now ignored instead of causing a `Tool  not found` failure.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22 + pnpm
- Model/provider: unit-test path
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

1. Build a run attempt input containing an assistant message with a `toolCall` whose name is whitespace-only (for example `"   "`).
2. Execute the attempt pipeline (`buildExecuteModelInstructionsInput`) with available tools.
3. Observe dispatch behavior.

### Expected

- Whitespace-only tool calls are treated as invalid/empty and do not trigger tool dispatch.

### Actual

- The whitespace-only name previously survived normalization and produced a `Tool  not found` dispatch error.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/agents/pi-embedded-runner/run/attempt.test.ts` and `pnpm check`.
- Edge cases checked: non-empty tool names with leading/trailing spaces still trim and dispatch normally; whitespace-only tool calls are removed.
- What you did **not** verify: live provider/channel end-to-end runs.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `c339aa742d`.
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts`, `src/agents/pi-embedded-runner/run/attempt.test.ts`.
- Known bad symptoms reviewers should watch for: legitimate non-empty tool calls being dropped (not expected).

## Risks and Mitigations

- Risk: dropping whitespace-only tool calls could hide malformed upstream model output.
  - Mitigation: behavior is now deterministic and covered by regression test; valid tool calls remain untouched.
