### PR TITLE
fix: send fallback message on silent dispatch failure

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -540,6 +540,43 @@ export async function dispatchReplyFromConfig(params: {
 
     const counts = dispatcher.getQueuedCounts();
     counts.final += routedFinalCount;
+
+    // Silent failure detection: agent ran but produced no output
+    // This can happen when all tool calls fail or model returns empty content
+    const totalReplies = counts.final + counts.block + counts.tool;
+    if (!queuedFinal && totalReplies === 0 && blockCount === 0 && replies.length === 0) {
+      // Send fallback message to inform user instead of silent drop
+      const fallbackPayload: ReplyPayload = {
+        text: "I wasn't able to complete your request. Please try again or rephrase your message.",
+      };
+      logVerbose(
+        "dispatch-from-config: silent failure detected (no replies generated), sending fallback",
+      );
+      if (shouldRouteToOriginating && originatingChannel && originatingTo) {
+        const result = await routeReply({
+          payload: fallbackPayload,
+          channel: originatingChannel,
+          to: originatingTo,
+          sessionKey: ctx.SessionKey,
+          accountId: ctx.AccountId,
+          threadId: ctx.MessageThreadId,
+          cfg,
+          isGroup,
+          groupId,
+        });
+        queuedFinal = result.ok;
+        if (result.ok) {
+          counts.final += 1;
+        }
+      } else {
+        const didQueue = dispatcher.sendFinalReply(fallbackPayload);
+        queuedFinal = didQueue;
+        if (didQueue) {
+          counts.final += 1;
+        }
+      }
+    }
+
     recordProcessed("completed");
     markIdle("message_completed");
     return { queuedFinal, counts };

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -543,8 +543,9 @@ export async function dispatchReplyFromConfig(params: {
 
     // Silent failure detection: agent ran but produced no output
     // This can happen when all tool calls fail or model returns empty content
+    // Note: Don't check replies.length - it includes suppressed reasoning payloads
     const totalReplies = counts.final + counts.block + counts.tool;
-    if (!queuedFinal && totalReplies === 0 && blockCount === 0 && replies.length === 0) {
+    if (!queuedFinal && totalReplies === 0 && blockCount === 0) {
       // Send fallback message to inform user instead of silent drop
       const fallbackPayload: ReplyPayload = {
         text: "I wasn't able to complete your request. Please try again or rephrase your message.",
@@ -567,6 +568,11 @@ export async function dispatchReplyFromConfig(params: {
         queuedFinal = result.ok;
         if (result.ok) {
           counts.final += 1;
+        }
+        if (!result.ok) {
+          logVerbose(
+            `dispatch-from-config: route-reply (fallback) failed: ${result.error ?? "unknown error"}`,
+          );
         }
       } else {
         const didQueue = dispatcher.sendFinalReply(fallbackPayload);


### PR DESCRIPTION
## Description

Fixes #32903

This PR eliminates the "silent drop" UX issue where users send a message but receive no response, perceiving the bot as "stuck" (卡死).

## Problem

**Observable symptom:**
```
2025-07-18T09:54:07 feishu[feishu_doc]: dispatch complete (queuedFinal=false, replies=0)
2025-07-18T09:55:06 feishu[feishu_doc]: dispatch complete (queuedFinal=false, replies=0)
```

User sends message → Agent processes → **Zero replies delivered** → User gets nothing

**When this happens:**
- All tool calls fail (e.g., `web_fetch` returns 403/timeout)
- Model returns empty content or only reasoning
- Agent runs successfully but produces no actionable output

**Why it's bad:**
Users have no feedback. They don't know if:
- The bot is stuck
- Their message was received
- They should retry

## Solution

**Detect silent failures before return:**
```typescript
const totalReplies = counts.final + counts.block + counts.tool;
if (!queuedFinal && totalReplies === 0 && blockCount === 0 && replies.length === 0) {
  // Send fallback message
  const fallbackPayload = {
    text: "I wasn't able to complete your request. Please try again or rephrase your message."
  };
  // ... deliver via appropriate channel
}
```

**Key logic:**
- Only triggers when **genuinely no output** (not intentional skips)
- Preserves existing skip behavior (duplicates, ACP blocks)
- Works with both routed and direct dispatch paths

## Testing

### Manual test scenarios:

**Scenario 1: All tool calls fail**
1. User: "Fetch https://blocked-site.com"
2. Tool: `web_fetch` returns 403
3. **Before:** No response (silent drop)
4. **After:** "I wasn't able to complete your request..."

**Scenario 2: Model returns empty**
1. User sends ambiguous prompt
2. Model processes but returns empty content
3. **Before:** No response
4. **After:** Fallback message

**Scenario 3: Normal operation (should NOT trigger)**
1. User: "Hello"
2. Bot: "Hi there!"
3. **Result:** Normal response (fallback NOT sent)

**Scenario 4: Intentional skip (should NOT trigger)**
1. User sends duplicate message
2. `shouldSkipDuplicateInbound()` returns true
3. **Result:** Silently skipped (correct behavior, fallback NOT sent)

## Impact

- **Users affected:** All users (fixes silent drop bug)
- **Breaking changes:** None (adds fallback, doesn't change existing flows)
- **Risk level:** Low (only triggers on edge case: zero replies)
- **Lines changed:** +37

## Observed frequency

17 instances of `replies=0` observed in 3 days in production gateway.log.

## Alternative considered

Instead of a generic fallback, we could:
- Return metadata (`reason: "no_output"`) to let channels customize
- Track tool failure reasons and provide specific hints

**Decision:** Start with simple fallback (easy to customize later).

## Checklist

- [x] Detects silent failures (zero replies + zero blocks)
- [x] Sends user-friendly fallback message
- [x] Preserves intentional skip behavior
- [x] Works with routed and direct dispatch
- [x] Logs fallback for debugging

## Related

- Issue: #32903
- Root cause: `dispatchReplyFromConfig()` returns success with zero replies