### PR TITLE
Agents: normalize toolUse/functionCall names before dispatch

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -190,6 +190,37 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     expect(baseFn).toHaveBeenCalledTimes(1);
   });
 
+  it("trims whitespace for toolUse/functionCall blocks in streamed and final messages", async () => {
+    const partialToolUse = { type: "toolUse", name: " read " };
+    const messageFunctionCall = { type: "functionCall", name: " exec " };
+    const finalToolUse = { type: "toolUse", name: " write " };
+    const event = {
+      type: "toolcall_delta",
+      partial: { role: "assistant", content: [partialToolUse] },
+      message: { role: "assistant", content: [messageFunctionCall] },
+    };
+    const finalMessage = { role: "assistant", content: [finalToolUse] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [event],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+
+    for await (const _item of stream) {
+      // drain
+    }
+    const result = await stream.result();
+
+    expect(partialToolUse.name).toBe("read");
+    expect(messageFunctionCall.name).toBe("exec");
+    expect(finalToolUse.name).toBe("write");
+    expect(result).toBe(finalMessage);
+    expect(baseFn).toHaveBeenCalledTimes(1);
+  });
+
   it("supports async stream functions that return a promise", async () => {
     const finalToolCall = { type: "toolCall", name: " browser " };
     const finalMessage = { role: "assistant", content: [finalToolCall] };

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -348,7 +348,7 @@ function trimWhitespaceFromToolCallNamesInMessage(
       continue;
     }
     const typedBlock = block as { type?: unknown; name?: unknown };
-    if (typedBlock.type !== "toolCall" || typeof typedBlock.name !== "string") {
+    if (!isToolCallBlockType(typedBlock.type) || typeof typedBlock.name !== "string") {
       continue;
     }
     const normalized = normalizeToolCallNameForDispatch(typedBlock.name, allowedToolNames);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: stream-time tool name sanitization only handled `toolCall` blocks, while `toolUse` and `functionCall` names were left untrimmed.
- Why it matters: multi-tool/session-start flows can include these alternate block types; untrimmed names can miss canonical tool matches and fail execution.
- What changed: `trimWhitespaceFromToolCallNamesInMessage` now applies to all tool-call block types (`toolCall`, `toolUse`, `functionCall`) via `isToolCallBlockType(...)`.
- What did NOT change (scope boundary): tool argument validation/execution behavior is unchanged; no transcript persistence logic changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33143
- Related #19094

## User-visible / Behavior Changes

Assistant tool blocks using `toolUse`/`functionCall` now get the same name whitespace normalization as `toolCall` blocks before dispatch.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22 + pnpm
- Model/provider: unit-test path
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

1. Create an assistant stream event with `toolUse` or `functionCall` content blocks whose `name` has surrounding whitespace.
2. Pass it through `wrapStreamFnTrimToolCallNames(...)`.
3. Compare normalized names on streamed partial/message blocks and final result message.

### Expected

- All tool-call block types normalize names consistently before dispatch.

### Actual

- Previously only `toolCall` names were normalized; `toolUse`/`functionCall` names retained whitespace.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/agents/pi-embedded-runner/run/attempt.test.ts` and `pnpm check`.
- Edge cases checked: existing `toolCall` trimming remains unchanged; `toolUse`/`functionCall` now trim in streamed and final messages.
- What you did **not** verify: live provider/channel end-to-end behavior.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `a6ee6b4505`.
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts`, `src/agents/pi-embedded-runner/run/attempt.test.ts`.
- Known bad symptoms reviewers should watch for: unexpected name changes on non-tool content blocks (not expected due type guard).

## Risks and Mitigations

- Risk: broader normalization could affect provider-specific tool name casing assumptions.
  - Mitigation: logic already used for `toolCall`; this extends the same proven path to equivalent tool-call block types and is regression-tested.
