### PR TITLE
Agents: strip leaked legacy tool_call snippets from assistant text

### DIFF
--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -232,6 +232,22 @@ describe("extractAssistantText", () => {
     expect(result).toBe("I'll help you with that.\nHere are the results.");
   });
 
+  it("strips leaked legacy tool_call snippets rendered as text", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Before<tool_call>exec tool="exec" command="ls -la /tmp" />After',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("BeforeAfter");
+  });
+
   it("handles multiple invoke blocks in one message", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -316,6 +316,22 @@ describe("extractAssistantText", () => {
     expect(result).toBe('~~~\n<tool_call>exec tool="exec" command="ls -la /tmp" />\n~~~');
   });
 
+  it("keeps triple-backtick fenced code examples of legacy tool_call snippets", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: '```\n<tool_call>exec tool="exec" command="ls -la /tmp" />\n```',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe('```\n<tool_call>exec tool="exec" command="ls -la /tmp" />\n```');
+  });
+
   it("does not strip invoke examples when no Minimax marker is present", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -300,6 +300,22 @@ describe("extractAssistantText", () => {
     );
   });
 
+  it("keeps tilde-fenced code examples of legacy tool_call snippets", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: '~~~\n<tool_call>exec tool="exec" command="ls -la /tmp" />\n~~~',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe('~~~\n<tool_call>exec tool="exec" command="ls -la /tmp" />\n~~~');
+  });
+
   it("does not strip invoke examples when no Minimax marker is present", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -248,6 +248,22 @@ describe("extractAssistantText", () => {
     expect(result).toBe("BeforeAfter");
   });
 
+  it("strips multiple leaked legacy tool_call snippets in one text block", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'A<tool_call>exec tool="exec" command="ls" />B<tool_call>exec tool="read" command="cat /tmp/f" />C',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("ABC");
+  });
+
   it("strips leaked legacy tool_call snippets with '<' inside quoted arguments", () => {
     const msg = makeAssistantMessage({
       role: "assistant",
@@ -262,6 +278,22 @@ describe("extractAssistantText", () => {
 
     const result = extractAssistantText(msg);
     expect(result).toBe("BeforeAfter");
+  });
+
+  it("strips both minimax markers and legacy tool_call snippets when both are present", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Before<tool_call>exec tool="exec" command="ls" />Mid<invoke name="Bash">pwd</invoke></minimax:tool_call>After',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("BeforeMidAfter");
   });
 
   it("keeps literal tool_call explanations with unrelated self-closing tags", () => {

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -248,6 +248,22 @@ describe("extractAssistantText", () => {
     expect(result).toBe("BeforeAfter");
   });
 
+  it("strips leaked legacy tool_call snippets with '<' inside quoted arguments", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Before<tool_call>exec tool="exec" command="cat < /tmp/in" />After',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("BeforeAfter");
+  });
+
   it("keeps literal tool_call explanations with unrelated self-closing tags", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -248,6 +248,24 @@ describe("extractAssistantText", () => {
     expect(result).toBe("BeforeAfter");
   });
 
+  it("keeps literal tool_call explanations with unrelated self-closing tags", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "To use the legacy format, write <tool_call> followed by args.\nHere is a JSX snippet: <Component />",
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe(
+      "To use the legacy format, write <tool_call> followed by args.\nHere is a JSX snippet: <Component />",
+    );
+  });
+
   it("handles multiple invoke blocks in one message", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -284,6 +284,24 @@ describe("extractAssistantText", () => {
     );
   });
 
+  it("does not strip invoke examples when no Minimax marker is present", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Use `<tool_call>exec tool="exec" command="ls -la /tmp" />` and <invoke name="Bash">pwd</invoke> in the docs.',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe(
+      'Use `<tool_call>exec tool="exec" command="ls -la /tmp" />` and <invoke name="Bash">pwd</invoke> in the docs.',
+    );
+  });
+
   it("handles multiple invoke blocks in one message", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -296,6 +296,36 @@ describe("extractAssistantText", () => {
     expect(result).toBe("BeforeAfter");
   });
 
+  it("strips self-closing legacy tool_call tags with attributes", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Before<tool_call tool="exec" command="cat /etc/hosts" />After',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantText(msg)).toBe("BeforeAfter");
+  });
+
+  it("strips paired legacy tool_call tags", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Before<tool_call>exec tool="exec"</tool_call>After',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantText(msg)).toBe("BeforeAfter");
+  });
+
   it("strips both minimax markers and legacy tool_call snippets when both are present", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -266,6 +266,24 @@ describe("extractAssistantText", () => {
     );
   });
 
+  it("keeps inline code examples of legacy tool_call snippets", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Use `<tool_call>exec tool="exec" command="ls -la /tmp" />` to describe the legacy format.',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe(
+      'Use `<tool_call>exec tool="exec" command="ls -la /tmp" />` to describe the legacy format.',
+    );
+  });
+
   it("handles multiple invoke blocks in one message", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -248,6 +248,22 @@ describe("extractAssistantText", () => {
     expect(result).toBe("BeforeAfter");
   });
 
+  it("strips leaked legacy tool_call snippets regardless of tag case", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Before<TOOL_CALL>exec tool="exec" command="ls -la /tmp" />After',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("BeforeAfter");
+  });
+
   it("strips multiple leaked legacy tool_call snippets in one text block", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -15,12 +15,15 @@ export function isAssistantMessage(msg: AgentMessage | undefined): msg is Assist
  * proper structured tool calls. This removes:
  * - <invoke name="...">...</invoke> blocks
  * - </minimax:tool_call> closing tags
+ * - leaked legacy <tool_call> ... /> snippets rendered as plain text
  */
 export function stripMinimaxToolCallXml(text: string): string {
   if (!text) {
     return text;
   }
-  if (!/minimax:tool_call/i.test(text)) {
+  const hasMinimaxMarkers = /minimax:tool_call/i.test(text);
+  const hasLegacyToolCallSnippet = /<tool_call\b/i.test(text) && /\/>/i.test(text);
+  if (!hasMinimaxMarkers && !hasLegacyToolCallSnippet) {
     return text;
   }
 
@@ -29,6 +32,8 @@ export function stripMinimaxToolCallXml(text: string): string {
 
   // Remove stray minimax tool tags.
   cleaned = cleaned.replace(/<\/?minimax:tool_call>/gi, "");
+  // Remove legacy self-closing tool call snippets that can leak into user text.
+  cleaned = cleaned.replace(/<tool_call\b[^>]*>[\s\S]*?\/>/gi, "");
 
   return cleaned;
 }

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -39,10 +39,12 @@ export function stripMinimaxToolCallXml(text: string): string {
     // Remove stray minimax tool tags.
     cleaned = cleaned.replace(/<\/?minimax:tool_call>/gi, "");
   }
-  // Remove legacy self-closing tool call snippets that can leak into user text.
-  cleaned = cleaned.replace(MARKDOWN_CODE_OR_LEGACY_TOOL_CALL_RE, (match) =>
-    match.startsWith("<tool_call") ? "" : match,
-  );
+  if (hasLegacyToolCallSnippet) {
+    // Remove legacy self-closing tool call snippets that can leak into user text.
+    cleaned = cleaned.replace(MARKDOWN_CODE_OR_LEGACY_TOOL_CALL_RE, (match) =>
+      match.startsWith("<tool_call") ? "" : match,
+    );
+  }
 
   return cleaned;
 }

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -11,7 +11,7 @@ export function isAssistantMessage(msg: AgentMessage | undefined): msg is Assist
 
 const LEGACY_TOOL_CALL_SNIPPET_RE = /<tool_call\b[^>]*>(?:(?:"[^"]*"|'[^']*'|[^<"'`])+?)\/>/i;
 const MARKDOWN_CODE_OR_LEGACY_TOOL_CALL_RE =
-  /```[\s\S]*?```|`[^`\n]+`|<tool_call\b[^>]*>(?:(?:"[^"]*"|'[^']*'|[^<"'`])+?)\/>/gi;
+  /```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]+`|<tool_call\b[^>]*>(?:(?:"[^"]*"|'[^']*'|[^<"'`])+?)\/>/gi;
 
 /**
  * Strip malformed Minimax tool invocations that leak into text content.
@@ -41,7 +41,7 @@ export function stripMinimaxToolCallXml(text: string): string {
   }
   // Remove legacy self-closing tool call snippets that can leak into user text.
   cleaned = cleaned.replace(MARKDOWN_CODE_OR_LEGACY_TOOL_CALL_RE, (match) =>
-    match.startsWith("`") ? match : "",
+    match.startsWith("<tool_call") ? "" : match,
   );
 
   return cleaned;

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -9,9 +9,60 @@ export function isAssistantMessage(msg: AgentMessage | undefined): msg is Assist
   return msg?.role === "assistant";
 }
 
-const LEGACY_TOOL_CALL_SNIPPET_RE = /<tool_call\b[^>]*>(?:(?:"[^"]*"|'[^']*'|[^<"'`])+?)\/>/i;
-const MARKDOWN_CODE_OR_LEGACY_TOOL_CALL_RE =
-  /```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]+`|<tool_call\b[^>]*>(?:(?:"[^"]*"|'[^']*'|[^<"'`])+?)\/>/gi;
+const MARKDOWN_CODE_RE = /```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]+`/gi;
+
+function findLegacyToolCallEnd(text: string, start: number): number | null {
+  let index = start;
+  let inSingle = false;
+  let inDouble = false;
+  while (index < text.length) {
+    const ch = text[index];
+    if (!inDouble && ch === "'") {
+      inSingle = !inSingle;
+      index += 1;
+      continue;
+    }
+    if (!inSingle && ch === '"') {
+      inDouble = !inDouble;
+      index += 1;
+      continue;
+    }
+    if (!inSingle && !inDouble) {
+      if (ch === "\n" || ch === "\r") {
+        return null;
+      }
+      if (text.startsWith("/>", index)) {
+        return index + 2;
+      }
+      if (text.slice(index, index + 12).toLowerCase() === "</tool_call>") {
+        return index + 12;
+      }
+    }
+    index += 1;
+  }
+  return null;
+}
+
+function stripLegacyToolCallSnippets(text: string): string {
+  const lower = text.toLowerCase();
+  let cursor = 0;
+  let cleaned = "";
+  while (cursor < text.length) {
+    const start = lower.indexOf("<tool_call", cursor);
+    if (start === -1) {
+      cleaned += text.slice(cursor);
+      break;
+    }
+    cleaned += text.slice(cursor, start);
+    const end = findLegacyToolCallEnd(text, start + "<tool_call".length);
+    if (end === null) {
+      cleaned += text.slice(start);
+      break;
+    }
+    cursor = end;
+  }
+  return cleaned;
+}
 
 /**
  * Strip leaked tool-call syntax that shows up as plain assistant text.
@@ -24,7 +75,7 @@ export function stripLeakedToolCallSyntax(text: string): string {
     return text;
   }
   const hasMinimaxMarkers = /minimax:tool_call/i.test(text);
-  const hasLegacyToolCallSnippet = LEGACY_TOOL_CALL_SNIPPET_RE.test(text);
+  const hasLegacyToolCallSnippet = /<tool_call\b/i.test(text);
   if (!hasMinimaxMarkers && !hasLegacyToolCallSnippet) {
     return text;
   }
@@ -38,10 +89,16 @@ export function stripLeakedToolCallSyntax(text: string): string {
     cleaned = cleaned.replace(/<\/?minimax:tool_call>/gi, "");
   }
   if (hasLegacyToolCallSnippet) {
-    // Remove legacy self-closing tool call snippets that can leak into user text.
-    cleaned = cleaned.replace(MARKDOWN_CODE_OR_LEGACY_TOOL_CALL_RE, (match) =>
-      /^<tool_call\b/i.test(match) ? "" : match,
-    );
+    let result = "";
+    let lastIndex = 0;
+    for (const match of cleaned.matchAll(MARKDOWN_CODE_RE)) {
+      const index = match.index ?? 0;
+      result += stripLegacyToolCallSnippets(cleaned.slice(lastIndex, index));
+      result += match[0];
+      lastIndex = index + match[0].length;
+    }
+    result += stripLegacyToolCallSnippets(cleaned.slice(lastIndex));
+    cleaned = result;
   }
 
   return cleaned;

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -40,7 +40,7 @@ export function stripLeakedToolCallSyntax(text: string): string {
   if (hasLegacyToolCallSnippet) {
     // Remove legacy self-closing tool call snippets that can leak into user text.
     cleaned = cleaned.replace(MARKDOWN_CODE_OR_LEGACY_TOOL_CALL_RE, (match) =>
-      match.startsWith("<tool_call") ? "" : match,
+      /^<tool_call\b/i.test(match) ? "" : match,
     );
   }
 

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -27,11 +27,14 @@ export function stripMinimaxToolCallXml(text: string): string {
     return text;
   }
 
-  // Remove <invoke ...>...</invoke> blocks (non-greedy to handle multiple).
-  let cleaned = text.replace(/<invoke\b[^>]*>[\s\S]*?<\/invoke>/gi, "");
+  let cleaned = text;
+  if (hasMinimaxMarkers) {
+    // Remove <invoke ...>...</invoke> blocks (non-greedy to handle multiple).
+    cleaned = cleaned.replace(/<invoke\b[^>]*>[\s\S]*?<\/invoke>/gi, "");
 
-  // Remove stray minimax tool tags.
-  cleaned = cleaned.replace(/<\/?minimax:tool_call>/gi, "");
+    // Remove stray minimax tool tags.
+    cleaned = cleaned.replace(/<\/?minimax:tool_call>/gi, "");
+  }
   // Remove legacy self-closing tool call snippets that can leak into user text.
   cleaned = cleaned.replace(/```[\s\S]*?```|`[^`\n]+`|<tool_call\b[^>]*>[^<]*\/>/gi, (match) =>
     match.startsWith("`") ? match : "",

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -14,14 +14,12 @@ const MARKDOWN_CODE_OR_LEGACY_TOOL_CALL_RE =
   /```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]+`|<tool_call\b[^>]*>(?:(?:"[^"]*"|'[^']*'|[^<"'`])+?)\/>/gi;
 
 /**
- * Strip malformed Minimax tool invocations that leak into text content.
- * Minimax sometimes embeds tool calls as XML in text blocks instead of
- * proper structured tool calls. This removes:
- * - <invoke name="...">...</invoke> blocks
- * - </minimax:tool_call> closing tags
- * - leaked legacy <tool_call> ... /> snippets rendered as plain text
+ * Strip leaked tool-call syntax that shows up as plain assistant text.
+ * This removes both:
+ * - Minimax XML markers (<invoke ...>...</invoke>, </minimax:tool_call>)
+ * - legacy inline <tool_call ... /> snippets
  */
-export function stripMinimaxToolCallXml(text: string): string {
+export function stripLeakedToolCallSyntax(text: string): string {
   if (!text) {
     return text;
   }
@@ -48,6 +46,8 @@ export function stripMinimaxToolCallXml(text: string): string {
 
   return cleaned;
 }
+
+export const stripMinimaxToolCallXml = stripLeakedToolCallSyntax;
 
 /**
  * Strip downgraded tool call text representations that leak into text content.
@@ -228,7 +228,7 @@ export function extractAssistantText(msg: AssistantMessage): string {
     extractTextFromChatContent(msg.content, {
       sanitizeText: (text) =>
         stripThinkingTagsFromText(
-          stripDowngradedToolCallText(stripMinimaxToolCallXml(text)),
+          stripDowngradedToolCallText(stripLeakedToolCallSyntax(text)),
         ).trim(),
       joinWith: "\n",
       normalizeText: (text) => text.trim(),

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -22,7 +22,7 @@ export function stripMinimaxToolCallXml(text: string): string {
     return text;
   }
   const hasMinimaxMarkers = /minimax:tool_call/i.test(text);
-  const hasLegacyToolCallSnippet = /<tool_call\b/i.test(text) && /\/>/i.test(text);
+  const hasLegacyToolCallSnippet = /<tool_call\b[^>]*>[^<]*\/>/i.test(text);
   if (!hasMinimaxMarkers && !hasLegacyToolCallSnippet) {
     return text;
   }
@@ -33,7 +33,7 @@ export function stripMinimaxToolCallXml(text: string): string {
   // Remove stray minimax tool tags.
   cleaned = cleaned.replace(/<\/?minimax:tool_call>/gi, "");
   // Remove legacy self-closing tool call snippets that can leak into user text.
-  cleaned = cleaned.replace(/<tool_call\b[^>]*>[\s\S]*?\/>/gi, "");
+  cleaned = cleaned.replace(/<tool_call\b[^>]*>[^<]*\/>/gi, "");
 
   return cleaned;
 }

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -33,7 +33,9 @@ export function stripMinimaxToolCallXml(text: string): string {
   // Remove stray minimax tool tags.
   cleaned = cleaned.replace(/<\/?minimax:tool_call>/gi, "");
   // Remove legacy self-closing tool call snippets that can leak into user text.
-  cleaned = cleaned.replace(/<tool_call\b[^>]*>[^<]*\/>/gi, "");
+  cleaned = cleaned.replace(/```[\s\S]*?```|`[^`\n]+`|<tool_call\b[^>]*>[^<]*\/>/gi, (match) =>
+    match.startsWith("`") ? match : "",
+  );
 
   return cleaned;
 }

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -9,6 +9,10 @@ export function isAssistantMessage(msg: AgentMessage | undefined): msg is Assist
   return msg?.role === "assistant";
 }
 
+const LEGACY_TOOL_CALL_SNIPPET_RE = /<tool_call\b[^>]*>(?:(?:"[^"]*"|'[^']*'|[^<"'`])+?)\/>/i;
+const MARKDOWN_CODE_OR_LEGACY_TOOL_CALL_RE =
+  /```[\s\S]*?```|`[^`\n]+`|<tool_call\b[^>]*>(?:(?:"[^"]*"|'[^']*'|[^<"'`])+?)\/>/gi;
+
 /**
  * Strip malformed Minimax tool invocations that leak into text content.
  * Minimax sometimes embeds tool calls as XML in text blocks instead of
@@ -22,7 +26,7 @@ export function stripMinimaxToolCallXml(text: string): string {
     return text;
   }
   const hasMinimaxMarkers = /minimax:tool_call/i.test(text);
-  const hasLegacyToolCallSnippet = /<tool_call\b[^>]*>[^<]*\/>/i.test(text);
+  const hasLegacyToolCallSnippet = LEGACY_TOOL_CALL_SNIPPET_RE.test(text);
   if (!hasMinimaxMarkers && !hasLegacyToolCallSnippet) {
     return text;
   }
@@ -36,7 +40,7 @@ export function stripMinimaxToolCallXml(text: string): string {
     cleaned = cleaned.replace(/<\/?minimax:tool_call>/gi, "");
   }
   // Remove legacy self-closing tool call snippets that can leak into user text.
-  cleaned = cleaned.replace(/```[\s\S]*?```|`[^`\n]+`|<tool_call\b[^>]*>[^<]*\/>/gi, (match) =>
+  cleaned = cleaned.replace(MARKDOWN_CODE_OR_LEGACY_TOOL_CALL_RE, (match) =>
     match.startsWith("`") ? match : "",
   );
 

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -31,7 +31,7 @@ import { extractTextFromChatContent } from "../../shared/chat-content.js";
 import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
 import {
   stripDowngradedToolCallText,
-  stripMinimaxToolCallXml,
+  stripLeakedToolCallSyntax,
   stripThinkingTagsFromText,
 } from "../pi-embedded-utils.js";
 
@@ -142,7 +142,7 @@ export function sanitizeTextContent(text: string): string {
   if (!text) {
     return text;
   }
-  return stripThinkingTagsFromText(stripDowngradedToolCallText(stripMinimaxToolCallXml(text)));
+  return stripThinkingTagsFromText(stripDowngradedToolCallText(stripLeakedToolCallSyntax(text)));
 }
 
 export function extractAssistantText(message: unknown): string | undefined {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: assistant responses can leak legacy XML-like tool snippets (for example `<tool_call>exec tool=... />`) into user-visible text.
- Why it matters: users see raw tool-call syntax in chat output instead of clean assistant text.
- What changed: extended `stripMinimaxToolCallXml(...)` to also remove leaked legacy `<tool_call> ... />` snippets from display text extraction.
- What did NOT change (scope boundary): no changes to tool execution/dispatch or provider request building.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33258
- Related #

## User-visible / Behavior Changes

Leaked legacy `<tool_call> ... />` snippets are now stripped from assistant text output.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22 + pnpm
- Model/provider: unit-test path
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

1. Build an assistant message text block containing leaked tool syntax like: `Before<tool_call>exec tool="exec" command="ls -la /tmp" />After`.
2. Run through `extractAssistantText(...)`.
3. Inspect the final visible text.

### Expected

- Tool-call leak syntax is removed from user-visible assistant text.

### Actual

- The leaked snippet previously remained in output and appeared as plain text.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/agents/pi-embedded-utils.test.ts` and `pnpm check`.
- Edge cases checked: existing Minimax `<invoke ...>`/`</minimax:tool_call>` sanitization remains intact; legacy `<tool_call> ... />` now strips.
- What you did **not** verify: live provider/channel end-to-end behavior.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `74f5759dca`.
- Files/config to restore: `src/agents/pi-embedded-utils.ts`, `src/agents/pi-embedded-utils.test.ts`.
- Known bad symptoms reviewers should watch for: legitimate literal `<tool_call>` examples disappearing from assistant text.

## Risks and Mitigations

- Risk: overly broad regex could strip non-tool instructional text containing `<tool_call>` markup.
  - Mitigation: regex requires both `<tool_call` and closing `/>` pattern, and is limited to the assistant text sanitization path only.
