### PR TITLE
fix: remove default tools profile from onboarding

### DIFF
--- a/src/commands/onboard-config.test.ts
+++ b/src/commands/onboard-config.test.ts
@@ -3,7 +3,6 @@ import type { OpenClawConfig } from "../config/config.js";
 import {
   applyOnboardingLocalWorkspaceConfig,
   ONBOARDING_DEFAULT_DM_SCOPE,
-  ONBOARDING_DEFAULT_TOOLS_PROFILE,
 } from "./onboard-config.js";
 
 describe("applyOnboardingLocalWorkspaceConfig", () => {
@@ -14,7 +13,8 @@ describe("applyOnboardingLocalWorkspaceConfig", () => {
     expect(result.session?.dmScope).toBe(ONBOARDING_DEFAULT_DM_SCOPE);
     expect(result.gateway?.mode).toBe("local");
     expect(result.agents?.defaults?.workspace).toBe("/tmp/workspace");
-    expect(result.tools?.profile).toBe(ONBOARDING_DEFAULT_TOOLS_PROFILE);
+    // tools.profile should not be set by onboarding - use system default
+    expect(result.tools?.profile).toBeUndefined();
   });
 
   it("preserves existing dmScope when already configured", () => {

--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -1,9 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { DmScope } from "../config/types.base.js";
-import type { ToolProfileId } from "../config/types.tools.js";
 
 export const ONBOARDING_DEFAULT_DM_SCOPE: DmScope = "per-channel-peer";
-export const ONBOARDING_DEFAULT_TOOLS_PROFILE: ToolProfileId = "messaging";
 
 export function applyOnboardingLocalWorkspaceConfig(
   baseConfig: OpenClawConfig,
@@ -25,10 +23,6 @@ export function applyOnboardingLocalWorkspaceConfig(
     session: {
       ...baseConfig.session,
       dmScope: baseConfig.session?.dmScope ?? ONBOARDING_DEFAULT_DM_SCOPE,
-    },
-    tools: {
-      ...baseConfig.tools,
-      profile: baseConfig.tools?.profile ?? ONBOARDING_DEFAULT_TOOLS_PROFILE,
     },
   };
 }


### PR DESCRIPTION
## Summary

Removes the default `tools.profile='messaging'` setting from onboarding configuration. This profile restricts agents to messaging-only tools, preventing them from accessing filesystem and shell tools.

## Issue

Fixes issue #33225 where agents onboarded via `openclaw onboard` (non-interactive) cannot write files — models report "no file-writing tools available".

## Root Cause

The `applyOnboardingLocalWorkspaceConfig` function in `src/commands/onboard-config.ts` was setting `tools.profile` to `messaging` by default. This profile limits the agent to only messaging tools, stripping all filesystem and shell access.

## Solution

Removed the default tools profile from onboarding, allowing agents to use the system's default toolset.

## Testing

- Updated unit tests to reflect the new expected behavior
- All tests pass

## Files Changed

- `src/commands/onboard-config.ts`: Removed default tools.profile setting
- `src/commands/onboard-config.test.ts`: Updated test expectations