### PR TITLE
fix(compact): surface specific cancel reasons and debounce rapid /compact clicks

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -747,7 +747,7 @@ export async function compactEmbeddedPiSessionDirect(
     // The Pi SDK emits a generic "Compaction cancelled" when the safeguard
     // returns { cancel: true }. Surface the specific reason stored by the
     // safeguard so the user understands why compaction was cancelled.
-    if (safeguardSessionManager && /\bcancelled\b/i.test(reason)) {
+    if (safeguardSessionManager && /\bcompaction\s+cancelled\b/i.test(reason)) {
       const runtime = getCompactionSafeguardRuntime(safeguardSessionManager);
       if (runtime?.lastCancelReason) {
         reason = runtime.lastCancelReason;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -39,6 +39,7 @@ import {
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "../pi-embedded-helpers.js";
+import { getCompactionSafeguardRuntime } from "../pi-extensions/compaction-safeguard-runtime.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../pi-project-settings.js";
 import { createOpenClawCodingTools } from "../pi-tools.js";
 import { resolveSandboxContext } from "../sandbox.js";
@@ -271,6 +272,9 @@ export async function compactEmbeddedPiSessionDirect(
       reason,
     };
   };
+  // Hoisted so the outer catch can read the safeguard's cancel reason.
+  let safeguardSessionManager: unknown;
+
   const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
   await ensureOpenClawModelsJson(params.config, agentDir);
   const { model, error, authStorage, modelRegistry } = resolveModel(
@@ -539,6 +543,7 @@ export async function compactEmbeddedPiSessionDirect(
         allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
         allowedToolNames,
       });
+      safeguardSessionManager = sessionManager;
       trackSessionManagerAccess(params.sessionFile);
       const settingsManager = createPreparedEmbeddedPiSettingsManager({
         cwd: effectiveWorkspace,
@@ -738,7 +743,16 @@ export async function compactEmbeddedPiSessionDirect(
       await sessionLock.release();
     }
   } catch (err) {
-    const reason = describeUnknownError(err);
+    let reason = describeUnknownError(err);
+    // The Pi SDK emits a generic "Compaction cancelled" when the safeguard
+    // returns { cancel: true }. Surface the specific reason stored by the
+    // safeguard so the user understands why compaction was cancelled.
+    if (safeguardSessionManager && /\bcancelled\b/i.test(reason)) {
+      const runtime = getCompactionSafeguardRuntime(safeguardSessionManager);
+      if (runtime?.lastCancelReason) {
+        reason = runtime.lastCancelReason;
+      }
+    }
     return fail(reason);
   } finally {
     restoreSkillEnv?.();

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -14,6 +14,11 @@ export type CompactionSafeguardRuntimeValue = {
    */
   model?: Model<Api>;
   recentTurnsPreserve?: number;
+  /**
+   * Set by the safeguard when it returns `{ cancel: true }` so the caller
+   * can surface a specific reason instead of the generic "Compaction cancelled".
+   */
+  lastCancelReason?: string;
 };
 
 const registry = createSessionManagerRuntimeRegistry<CompactionSafeguardRuntimeValue>();

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -740,6 +740,78 @@ describe("compaction-safeguard double-compaction guard", () => {
   });
 });
 
+describe("compaction-safeguard cancel reasons", () => {
+  it("sets lastCancelReason when there are no messages to compact", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1500,
+        fileOps: { read: [], edited: [], written: [] },
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+    await runCompactionScenario({ sessionManager, event: mockEvent, apiKey: "sk-test" });
+
+    const runtime = getCompactionSafeguardRuntime(sessionManager);
+    expect(runtime?.lastCancelReason).toBe("No conversation history to compact");
+  });
+
+  it("sets lastCancelReason when no model is configured", async () => {
+    const sessionManager = stubSessionManager();
+    // No model in runtime, no ctx.model either → model missing path
+
+    const mockEvent = createCompactionEvent({ messageText: "hello", tokensBefore: 1500 });
+    await runCompactionScenario({ sessionManager, event: mockEvent, apiKey: null });
+
+    const runtime = getCompactionSafeguardRuntime(sessionManager);
+    expect(runtime?.lastCancelReason).toBe("No model configured for compaction summarization");
+  });
+
+  it("sets lastCancelReason when no API key is available", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const mockEvent = createCompactionEvent({ messageText: "hello", tokensBefore: 1500 });
+    await runCompactionScenario({ sessionManager, event: mockEvent, apiKey: null });
+
+    const runtime = getCompactionSafeguardRuntime(sessionManager);
+    expect(runtime?.lastCancelReason).toBe("No API key available for compaction model");
+  });
+
+  it("preserves existing runtime fields when setting lastCancelReason", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model, maxHistoryShare: 0.6 });
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 500,
+        fileOps: { read: [], edited: [], written: [] },
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+    await runCompactionScenario({ sessionManager, event: mockEvent, apiKey: "sk-test" });
+
+    const runtime = getCompactionSafeguardRuntime(sessionManager);
+    expect(runtime?.lastCancelReason).toBe("No conversation history to compact");
+    // Other fields must be untouched
+    expect(runtime?.maxHistoryShare).toBe(0.6);
+    expect(runtime?.model).toEqual(model);
+  });
+});
+
 async function expectWorkspaceSummaryEmptyForAgentsAlias(
   createAlias: (outsidePath: string, agentsPath: string) => void,
 ) {

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -12,6 +12,14 @@ import {
 } from "./compaction-safeguard-runtime.js";
 import compactionSafeguardExtension, { __testing } from "./compaction-safeguard.js";
 
+// Hoist mock so summarizeInStages can be stubbed per-test without affecting
+// the other exports (computeAdaptiveChunkRatio, etc.) used by __testing.
+vi.mock("../compaction.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../compaction.js")>();
+  return { ...actual, summarizeInStages: vi.fn().mockImplementation(actual.summarizeInStages) };
+});
+import { summarizeInStages } from "../compaction.js";
+
 const {
   collectToolFailures,
   formatToolFailuresSection,
@@ -809,6 +817,37 @@ describe("compaction-safeguard cancel reasons", () => {
     // Other fields must be untouched
     expect(runtime?.maxHistoryShare).toBe(0.6);
     expect(runtime?.model).toEqual(model);
+  });
+
+  it("sets lastCancelReason when summarization throws", async () => {
+    vi.mocked(summarizeInStages).mockRejectedValueOnce(new Error("Rate limit exceeded"));
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    // recentTurnsPreserve: 0 keeps all messages in the summarizable bucket so
+    // summarizeInStages is actually invoked (otherwise the single message would
+    // be moved to preservedMessages and summarization would be skipped).
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    // Include settings.reserveTokens so execution reaches summarizeInStages.
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "hello", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1500,
+        settings: { reserveTokens: 1024 },
+        fileOps: { read: [], edited: [], written: [] },
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+    await runCompactionScenario({ sessionManager, event: mockEvent, apiKey: "sk-test" });
+
+    const runtime = getCompactionSafeguardRuntime(sessionManager);
+    expect(runtime?.lastCancelReason).toBe("Summarization failed: Rate limit exceeded");
   });
 });
 

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -20,7 +20,10 @@ import {
 import { collectTextContentBlocks } from "../content-blocks.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
-import { getCompactionSafeguardRuntime } from "./compaction-safeguard-runtime.js";
+import {
+  getCompactionSafeguardRuntime,
+  setCompactionSafeguardRuntime,
+} from "./compaction-safeguard-runtime.js";
 
 const log = createSubsystemLogger("compaction-safeguard");
 
@@ -434,11 +437,24 @@ async function readWorkspaceContextForSummary(): Promise<string> {
 export default function compactionSafeguardExtension(api: ExtensionAPI): void {
   api.on("session_before_compact", async (event, ctx) => {
     const { preparation, customInstructions, signal } = event;
+
+    // Store a specific cancel reason in the runtime registry before returning
+    // { cancel: true }, so compact.ts can surface it to the user instead of
+    // the Pi SDK's generic "Compaction cancelled" message.
+    function cancelWithReason(reason: string): { cancel: true } {
+      const existing = getCompactionSafeguardRuntime(ctx.sessionManager);
+      setCompactionSafeguardRuntime(ctx.sessionManager, {
+        ...existing,
+        lastCancelReason: reason,
+      });
+      return { cancel: true };
+    }
+
     if (!preparation.messagesToSummarize.some(isRealConversationMessage)) {
       log.warn(
         "Compaction safeguard: cancelling compaction with no real conversation messages to summarize.",
       );
-      return { cancel: true };
+      return cancelWithReason("No conversation history to compact");
     }
     const { readFiles, modifiedFiles } = computeFileLists(preparation.fileOps);
     const fileOpsSummary = formatFileOperations(readFiles, modifiedFiles);
@@ -457,8 +473,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     };
     const model = ctx.model ?? runtime?.model;
     if (!model) {
-      // Log warning once per session when both models are missing (diagnostic for future issues).
-      // Use a WeakSet to track which session managers have already logged the warning.
       if (!ctx.model && !runtime?.model && !missedModelWarningSessions.has(ctx.sessionManager)) {
         missedModelWarningSessions.add(ctx.sessionManager);
         console.warn(
@@ -467,7 +481,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
             "was not called and model was not passed through runtime registry.",
         );
       }
-      return { cancel: true };
+      return cancelWithReason("No model configured for compaction summarization");
     }
 
     const apiKey = await ctx.modelRegistry.getApiKey(model);
@@ -475,7 +489,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       console.warn(
         "Compaction safeguard: no API key available; cancelling compaction to preserve history.",
       );
-      return { cancel: true };
+      return cancelWithReason("No API key available for compaction model");
     }
 
     try {
@@ -634,12 +648,11 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         },
       };
     } catch (error) {
+      const errorDetail = error instanceof Error ? error.message : String(error);
       log.warn(
-        `Compaction summarization failed; cancelling compaction to preserve history: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `Compaction summarization failed; cancelling compaction to preserve history: ${errorDetail}`,
       );
-      return { cancel: true };
+      return cancelWithReason(`Summarization failed: ${errorDetail}`);
     }
   });
 }

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
+  abortEmbeddedPiRun: vi.fn(),
+  waitForEmbeddedPiRunEnd: vi.fn().mockResolvedValue(undefined),
+  compactEmbeddedPiSession: vi.fn().mockResolvedValue({
+    ok: true,
+    compacted: true,
+    result: { tokensBefore: 50_000, tokensAfter: 10_000 },
+  }),
+}));
+
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: vi.fn().mockReturnValue({}),
+  };
+});
+
+vi.mock("../../config/sessions.js", () => ({
+  resolveSessionFilePath: vi.fn().mockReturnValue("/tmp/test-session.jsonl"),
+  resolveSessionFilePathOptions: vi.fn().mockReturnValue({}),
+  resolveFreshSessionTotalTokens: vi.fn().mockReturnValue(100_000),
+}));
+
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: vi.fn(),
+}));
+
+vi.mock("./session-updates.js", () => ({
+  incrementCompactionCount: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { handleCompactCommand } from "./commands-compact.js";
+
+function buildParams(overrides: Record<string, unknown> = {}) {
+  return {
+    command: {
+      commandBodyNormalized: "/compact",
+      isAuthorizedSender: true,
+      senderIsOwner: true,
+      ownerList: [],
+      channel: "test",
+      senderId: "test-user",
+      ...(overrides.command as Record<string, unknown>),
+    },
+    sessionEntry: {
+      sessionId: `test-session-${Date.now()}`,
+      ...(overrides.sessionEntry as Record<string, unknown>),
+    },
+    sessionKey: "main",
+    ctx: { CommandBody: "/compact", RawBody: "/compact", Body: "/compact" },
+    cfg: {},
+    isGroup: false,
+    storePath: "/tmp",
+    agentId: "main",
+    contextTokens: 50_000,
+    provider: "anthropic",
+    model: "claude-sonnet-4-20250514",
+    resolvedThinkLevel: undefined,
+    resolveDefaultThinkingLevel: vi.fn().mockResolvedValue("default"),
+    sessionStore: {},
+    workspaceDir: "/tmp",
+    agentDir: "/tmp",
+    ...overrides,
+  } as Parameters<typeof handleCompactCommand>[0];
+}
+
+describe("handleCompactCommand cooldown", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("allows first compaction", async () => {
+    const params = buildParams();
+    const result = await handleCompactCommand(params);
+    expect(result).not.toBeNull();
+    expect(result?.reply?.text).toContain("Compacted");
+  });
+
+  it("blocks rapid second compaction with cooldown message", async () => {
+    const sessionId = "cooldown-test-session";
+    const params = buildParams({
+      sessionEntry: { sessionId },
+    });
+
+    const first = await handleCompactCommand(params);
+    expect(first?.reply?.text).toContain("Compacted");
+
+    const second = await handleCompactCommand(params);
+    expect(second?.reply?.text).toContain("already run recently");
+  });
+
+  it("allows compaction after cooldown expires", async () => {
+    const sessionId = "cooldown-expire-test";
+    const params = buildParams({
+      sessionEntry: { sessionId },
+    });
+
+    await handleCompactCommand(params);
+
+    vi.advanceTimersByTime(16_000);
+
+    const result = await handleCompactCommand(params);
+    expect(result?.reply?.text).toContain("Compacted");
+  });
+});

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -19,11 +19,15 @@ vi.mock("../../config/config.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../../config/sessions.js", () => ({
-  resolveSessionFilePath: vi.fn().mockReturnValue("/tmp/test-session.jsonl"),
-  resolveSessionFilePathOptions: vi.fn().mockReturnValue({}),
-  resolveFreshSessionTotalTokens: vi.fn().mockReturnValue(100_000),
-}));
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...actual,
+    resolveSessionFilePath: vi.fn().mockReturnValue("/tmp/test-session.jsonl"),
+    resolveSessionFilePathOptions: vi.fn().mockReturnValue({}),
+    resolveFreshSessionTotalTokens: vi.fn().mockReturnValue(100_000),
+  };
+});
 
 vi.mock("../../globals.js", () => ({
   logVerbose: vi.fn(),
@@ -38,8 +42,9 @@ vi.mock("./session-updates.js", () => ({
 }));
 
 import { handleCompactCommand } from "./commands-compact.js";
+import type { HandleCommandsParams } from "./commands-types.js";
 
-function buildParams(overrides: Record<string, unknown> = {}) {
+function buildParams(overrides: Partial<HandleCommandsParams> = {}): HandleCommandsParams {
   return {
     command: {
       commandBodyNormalized: "/compact",
@@ -48,15 +53,19 @@ function buildParams(overrides: Record<string, unknown> = {}) {
       ownerList: [],
       channel: "test",
       senderId: "test-user",
-      ...(overrides.command as Record<string, unknown>),
+      surface: "test",
+      rawBodyNormalized: "/compact",
     },
     sessionEntry: {
       sessionId: `test-session-${Date.now()}`,
-      ...(overrides.sessionEntry as Record<string, unknown>),
-    },
+    } as HandleCommandsParams["sessionEntry"],
     sessionKey: "main",
-    ctx: { CommandBody: "/compact", RawBody: "/compact", Body: "/compact" },
-    cfg: {},
+    ctx: {
+      CommandBody: "/compact",
+      RawBody: "/compact",
+      Body: "/compact",
+    } as HandleCommandsParams["ctx"],
+    cfg: {} as HandleCommandsParams["cfg"],
     isGroup: false,
     storePath: "/tmp",
     agentId: "main",
@@ -64,12 +73,16 @@ function buildParams(overrides: Record<string, unknown> = {}) {
     provider: "anthropic",
     model: "claude-sonnet-4-20250514",
     resolvedThinkLevel: undefined,
+    resolvedVerboseLevel: "off" as const,
+    resolvedReasoningLevel: "off" as const,
     resolveDefaultThinkingLevel: vi.fn().mockResolvedValue("default"),
-    sessionStore: {},
     workspaceDir: "/tmp",
     agentDir: "/tmp",
+    directives: {} as HandleCommandsParams["directives"],
+    elevated: { enabled: false, allowed: false, failures: [] },
+    defaultGroupActivation: () => "always" as const,
     ...overrides,
-  } as Parameters<typeof handleCompactCommand>[0];
+  } as HandleCommandsParams;
 }
 
 describe("handleCompactCommand cooldown", () => {
@@ -83,7 +96,7 @@ describe("handleCompactCommand cooldown", () => {
 
   it("allows first compaction", async () => {
     const params = buildParams();
-    const result = await handleCompactCommand(params);
+    const result = await handleCompactCommand(params, true);
     expect(result).not.toBeNull();
     expect(result?.reply?.text).toContain("Compacted");
   });
@@ -91,27 +104,27 @@ describe("handleCompactCommand cooldown", () => {
   it("blocks rapid second compaction with cooldown message", async () => {
     const sessionId = "cooldown-test-session";
     const params = buildParams({
-      sessionEntry: { sessionId },
+      sessionEntry: { sessionId } as HandleCommandsParams["sessionEntry"],
     });
 
-    const first = await handleCompactCommand(params);
+    const first = await handleCompactCommand(params, true);
     expect(first?.reply?.text).toContain("Compacted");
 
-    const second = await handleCompactCommand(params);
+    const second = await handleCompactCommand(params, true);
     expect(second?.reply?.text).toContain("already run recently");
   });
 
   it("allows compaction after cooldown expires", async () => {
     const sessionId = "cooldown-expire-test";
     const params = buildParams({
-      sessionEntry: { sessionId },
+      sessionEntry: { sessionId } as HandleCommandsParams["sessionEntry"],
     });
 
-    await handleCompactCommand(params);
+    await handleCompactCommand(params, true);
 
     vi.advanceTimersByTime(16_000);
 
-    const result = await handleCompactCommand(params);
+    const result = await handleCompactCommand(params, true);
     expect(result?.reply?.text).toContain("Compacted");
   });
 });

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -17,6 +17,30 @@ import type { CommandHandler } from "./commands-types.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import { incrementCompactionCount } from "./session-updates.js";
 
+const COMPACT_COOLDOWN_MS = 15_000;
+const recentCompactions = new Map<string, number>();
+
+function isCompactionOnCooldown(sessionId: string): boolean {
+  const lastCompactedAt = recentCompactions.get(sessionId);
+  if (!lastCompactedAt) {
+    return false;
+  }
+  return Date.now() - lastCompactedAt < COMPACT_COOLDOWN_MS;
+}
+
+function recordCompaction(sessionId: string): void {
+  recentCompactions.set(sessionId, Date.now());
+  // Lazy cleanup to avoid unbounded growth.
+  if (recentCompactions.size > 200) {
+    const now = Date.now();
+    for (const [key, ts] of recentCompactions) {
+      if (now - ts > COMPACT_COOLDOWN_MS) {
+        recentCompactions.delete(key);
+      }
+    }
+  }
+}
+
 function extractCompactInstructions(params: {
   rawBody?: string;
   ctx: import("../templating.js").MsgContext;
@@ -64,6 +88,13 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     };
   }
   const sessionId = params.sessionEntry.sessionId;
+  if (isCompactionOnCooldown(sessionId)) {
+    logVerbose(`Ignoring /compact for ${sessionId} (cooldown)`);
+    return {
+      shouldContinue: false,
+      reply: { text: "⚙️ Compaction was already run recently. Please wait a moment." },
+    };
+  }
   if (isEmbeddedPiRunActive(sessionId)) {
     abortEmbeddedPiRun(sessionId);
     await waitForEmbeddedPiRunEnd(sessionId, 15_000);
@@ -108,6 +139,8 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     senderIsOwner: params.command.senderIsOwner,
     ownerNumbers: params.command.ownerList.length > 0 ? params.command.ownerList : undefined,
   });
+
+  recordCompaction(sessionId);
 
   const compactLabel = result.ok
     ? result.compacted

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -140,7 +140,11 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     ownerNumbers: params.command.ownerList.length > 0 ? params.command.ownerList : undefined,
   });
 
-  recordCompaction(sessionId);
+  // Only record cooldown after successful compaction so transient failures
+  // don't block the user's retry.
+  if (result.ok && result.compacted) {
+    recordCompaction(sessionId);
+  }
 
   const compactLabel = result.ok
     ? result.compacted


### PR DESCRIPTION
## Summary

Fixes the `/compact` command failing with a generic "Compaction cancelled" message that gives users no insight into what went wrong (#33316). This occurs when:

1. **Rapid /compact clicks**: First compaction succeeds, second finds no messages left -> generic "Compaction cancelled"
2. **Chinese/other models**: Summarization API errors get swallowed -> generic "Compaction cancelled"

## Changes

| File | What |
|------|------|
| `src/agents/pi-extensions/compaction-safeguard-runtime.ts` | Added `lastCancelReason` field to runtime type for cancel reason side-channel |
| `src/agents/pi-extensions/compaction-safeguard.ts` | Set specific cancel reasons before each `{ cancel: true }` via `cancelWithReason()` helper |
| `src/agents/pi-embedded-runner/compact.ts` | Read `lastCancelReason` from safeguard runtime when catching "Compaction cancelled" errors |
| `src/auto-reply/reply/commands-compact.ts` | Added 15s cooldown to prevent rapid re-compaction |

### Before vs After error messages

| Scenario | Before | After |
|----------|--------|-------|
| Rapid double-click | `Compaction failed: Compaction cancelled` | `Compaction was already run recently. Please wait a moment.` |
| No history after compaction | `Compaction failed: Compaction cancelled` | `Compaction failed: No conversation history to compact` |
| Missing model | `Compaction failed: Compaction cancelled` | `Compaction failed: No model configured for compaction summarization` |
| No API key | `Compaction failed: Compaction cancelled` | `Compaction failed: No API key available for compaction model` |
| API error (e.g. rate limit) | `Compaction failed: Compaction cancelled` | `Compaction failed: Summarization failed: <actual error>` |

## Test plan

- [x] 3 new tests for cooldown behavior (first allowed, rapid blocked, allowed after expiry)
- [x] All 36 existing compaction safeguard tests pass
- [x] Lint and format clean

## Risks and Mitigations

- **15s cooldown**: Conservative window that prevents the most common rapid-click scenario without blocking intentional retry after a failure
- **Side-channel pattern**: Uses the existing `CompactionSafeguardRuntime` WeakMap registry -- no new global state, automatically GCd with the session manager

Closes #33316

-- [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
