### PR TITLE
Plugins: trust fixed Gemini OAuth hosts in SSRF guard

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -1,21 +1,28 @@
 import { join, parse } from "node:path";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
+const mockFetchWithSsrFGuard = vi.hoisted(() =>
+  vi.fn(
+    async (params: {
+      url: string;
+      init?: RequestInit;
+      policy?: { allowedHostnames?: string[] };
+      fetchImpl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+    }) => {
+      const fetchImpl = params.fetchImpl ?? globalThis.fetch;
+      const response = await fetchImpl(params.url, params.init);
+      return {
+        response,
+        finalUrl: params.url,
+        release: async () => {},
+      };
+    },
+  ),
+);
+
 vi.mock("openclaw/plugin-sdk/google-gemini-cli-auth", () => ({
   isWSL2Sync: () => false,
-  fetchWithSsrFGuard: async (params: {
-    url: string;
-    init?: RequestInit;
-    fetchImpl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
-  }) => {
-    const fetchImpl = params.fetchImpl ?? globalThis.fetch;
-    const response = await fetchImpl(params.url, params.init);
-    return {
-      response,
-      finalUrl: params.url,
-      release: async () => {},
-    };
-  },
+  fetchWithSsrFGuard: mockFetchWithSsrFGuard,
 }));
 
 // Mock fs module before importing the module under test
@@ -306,6 +313,7 @@ describe("loginGeminiCliOAuth", () => {
 
   let envSnapshot: Partial<Record<(typeof ENV_KEYS)[number], string>>;
   beforeEach(() => {
+    mockFetchWithSsrFGuard.mockClear();
     envSnapshot = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
     process.env.OPENCLAW_GEMINI_OAUTH_CLIENT_ID = "test-client-id.apps.googleusercontent.com";
     process.env.OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET = "GOCSPX-test-client-secret";
@@ -419,5 +427,51 @@ describe("loginGeminiCliOAuth", () => {
     expect(result.projectId).toBe("env-project");
     expect(requests.filter((url) => url.includes("v1internal:loadCodeAssist"))).toHaveLength(3);
     expect(requests.some((url) => url.includes("v1internal:onboardUser"))).toBe(false);
+  });
+
+  it("passes explicit trusted Google hostnames to SSRF guard for OAuth requests", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = getRequestUrl(input);
+      if (url === TOKEN_URL) {
+        return responseJson({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_in: 3600,
+        });
+      }
+      if (url === USERINFO_URL) {
+        return responseJson({ email: "lobster@openclaw.ai" });
+      }
+      if (url === LOAD_PROD) {
+        return responseJson({
+          currentTier: { id: "standard-tier" },
+          cloudaicompanionProject: { id: "prod-project" },
+        });
+      }
+      if ([LOAD_DAILY, LOAD_AUTOPUSH].includes(url)) {
+        return responseJson({ error: { message: "unused fallback" } }, 503);
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { loginGeminiCliOAuth } = await import("./oauth.js");
+    await runRemoteLoginWithCapturedAuthUrl(loginGeminiCliOAuth);
+
+    const tokenCall = mockFetchWithSsrFGuard.mock.calls.find(
+      (call) => call[0]?.url === TOKEN_URL,
+    )?.[0];
+    expect(tokenCall).toBeDefined();
+    const allowedHostnames = tokenCall?.policy?.allowedHostnames as string[] | undefined;
+    expect(allowedHostnames).toEqual(
+      expect.arrayContaining([
+        "accounts.google.com",
+        "oauth2.googleapis.com",
+        "www.googleapis.com",
+        "cloudcode-pa.googleapis.com",
+        "daily-cloudcode-pa.sandbox.googleapis.com",
+        "autopush-cloudcode-pa.sandbox.googleapis.com",
+      ]),
+    );
   });
 });

--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -463,9 +463,9 @@ describe("loginGeminiCliOAuth", () => {
     )?.[0];
     expect(tokenCall).toBeDefined();
     const allowedHostnames = tokenCall?.policy?.allowedHostnames as string[] | undefined;
+    expect(allowedHostnames).toHaveLength(5);
     expect(allowedHostnames).toEqual(
       expect.arrayContaining([
-        "accounts.google.com",
         "oauth2.googleapis.com",
         "www.googleapis.com",
         "cloudcode-pa.googleapis.com",

--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -6,7 +6,7 @@ const mockFetchWithSsrFGuard = vi.hoisted(() =>
     async (params: {
       url: string;
       init?: RequestInit;
-      policy?: { allowedHostnames?: string[] };
+      policy?: { hostnameAllowlist?: string[] };
       fetchImpl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
     }) => {
       const fetchImpl = params.fetchImpl ?? globalThis.fetch;
@@ -462,9 +462,9 @@ describe("loginGeminiCliOAuth", () => {
       (call) => call[0]?.url === TOKEN_URL,
     )?.[0];
     expect(tokenCall).toBeDefined();
-    const allowedHostnames = tokenCall?.policy?.allowedHostnames as string[] | undefined;
-    expect(allowedHostnames).toHaveLength(5);
-    expect(allowedHostnames).toEqual(
+    const hostnameAllowlist = tokenCall?.policy?.hostnameAllowlist as string[] | undefined;
+    expect(hostnameAllowlist).toHaveLength(5);
+    expect(hostnameAllowlist).toEqual(
       expect.arrayContaining([
         "oauth2.googleapis.com",
         "www.googleapis.com",

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -27,6 +27,14 @@ const SCOPES = [
   "https://www.googleapis.com/auth/userinfo.email",
   "https://www.googleapis.com/auth/userinfo.profile",
 ];
+const GEMINI_OAUTH_ALLOWED_HOSTNAMES = Array.from(
+  new Set(
+    [AUTH_URL, TOKEN_URL, USERINFO_URL, ...LOAD_CODE_ASSIST_ENDPOINTS].map((url) => {
+      const parsed = new URL(url);
+      return parsed.hostname;
+    }),
+  ),
+);
 
 const TIER_FREE = "free-tier";
 const TIER_LEGACY = "legacy-tier";
@@ -245,6 +253,12 @@ async function fetchWithTimeout(
     url,
     init,
     timeoutMs,
+    policy: {
+      // Explicitly trust fixed Google OAuth/Code Assist hostnames used by this plugin.
+      // This prevents false-positive private-IP blocks on misconfigured DNS while
+      // keeping the trust boundary narrow to known endpoints.
+      allowedHostnames: GEMINI_OAUTH_ALLOWED_HOSTNAMES,
+    },
   });
   try {
     const body = await response.arrayBuffer();

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -29,7 +29,7 @@ const SCOPES = [
 ];
 const GEMINI_OAUTH_ALLOWED_HOSTNAMES = Array.from(
   new Set(
-    [AUTH_URL, TOKEN_URL, USERINFO_URL, ...LOAD_CODE_ASSIST_ENDPOINTS].map((url) => {
+    [TOKEN_URL, USERINFO_URL, ...LOAD_CODE_ASSIST_ENDPOINTS].map((url) => {
       const parsed = new URL(url);
       return parsed.hostname;
     }),

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -254,10 +254,9 @@ async function fetchWithTimeout(
     init,
     timeoutMs,
     policy: {
-      // Explicitly trust fixed Google OAuth/Code Assist hostnames used by this plugin.
-      // This prevents false-positive private-IP blocks on misconfigured DNS while
-      // keeping the trust boundary narrow to known endpoints.
-      allowedHostnames: GEMINI_OAUTH_ALLOWED_HOSTNAMES,
+      // Restrict requests to the fixed Google OAuth/Code Assist hostnames used by this plugin
+      // without disabling the SSRF guard's private-network protections.
+      hostnameAllowlist: GEMINI_OAUTH_ALLOWED_HOSTNAMES,
     },
   });
   try {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Google Gemini CLI OAuth token exchange can fail with `SsrFBlockedError` during requests to fixed Google OAuth / Code Assist endpoints.
- Why it matters: `openclaw models auth login --provider google-gemini-cli --set-default` fails even though the flow targets trusted Google endpoints.
- What changed: Gemini OAuth guarded fetches now pass an explicit hostname allowlist limited to the plugin's known Google OAuth and Code Assist hosts.
- What did NOT change (scope boundary): no private-network bypass was added; the plugin still uses SSRF-guarded fetches and only trusts specific public hostnames.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32873
- Related #

## User-visible / Behavior Changes

`openclaw models auth login --provider google-gemini-cli` now succeeds through the guarded fetch path for the plugin's trusted Google OAuth hosts instead of failing early with an SSRF block.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22 + pnpm
- Model/provider: `google-gemini-cli` OAuth plugin path
- Integration/channel (if any): n/a
- Relevant config (redacted): test OAuth client env vars

### Steps

1. Enable the `google-gemini-cli-auth` plugin.
2. Run `openclaw models auth login --provider google-gemini-cli --set-default`.
3. Follow the Google OAuth flow until token exchange / project discovery requests fire.

### Expected

- Requests to Google OAuth / Code Assist hosts pass the SSRF guard and the OAuth flow can complete.

### Actual

- The guarded fetch path could fail with `SsrFBlockedError: Blocked: resolves to private/internal/special-use IP address` for these trusted Google endpoints.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test extensions/google-gemini-cli-auth/oauth.test.ts` and `pnpm check`.
- Edge cases checked: allowlist is restricted to the plugin's fixed Google OAuth and Code Assist hostnames; SSRF guard remains enabled.
- What you did **not** verify: live Google account OAuth end-to-end.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `39129df0b4`.
- Files/config to restore: `extensions/google-gemini-cli-auth/oauth.ts`, `extensions/google-gemini-cli-auth/oauth.test.ts`.
- Known bad symptoms reviewers should watch for: OAuth requests unexpectedly blocked again, or requests outside the fixed host set being allowed (not expected).

## Risks and Mitigations

- Risk: host allowlist could become stale if Google changes the plugin's fixed OAuth / Code Assist endpoints.
  - Mitigation: the allowlist is derived from the plugin constants in one place and covered by regression test.
