### PR TITLE
fix(msteams): sanitize error messages sent to users (CWE-209)

### DIFF
--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -112,8 +112,8 @@ async function handleFileConsentInvoke(
           uniqueId: consentResponse.uploadInfo.uniqueId,
         });
       } catch (err) {
-        log.debug?.("file upload failed", { uploadId, error: String(err) });
-        await context.sendActivity(`File upload failed: ${String(err)}`);
+        log.error("file upload failed", { uploadId, error: String(err) });
+        await context.sendActivity("File upload failed. Please try again.");
       } finally {
         removePendingUpload(uploadId);
       }

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -600,9 +600,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       log.error("dispatch failed", { error: String(err) });
       runtime.error?.(`msteams dispatch failed: ${String(err)}`);
       try {
-        await context.sendActivity(
-          `⚠️ Agent failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        await context.sendActivity("⚠️ Something went wrong. Please try again.");
       } catch {
         // Best effort.
       }


### PR DESCRIPTION
## Summary

Replaces raw error propagation with generic user-facing messages to prevent internal stack traces, file paths, and Graph API error details from leaking to Teams users (CWE-209 information disclosure).

### Changes

- `monitor-handler.ts`: Replace `File upload failed: ${String(err)}` with generic `"File upload failed. Please try again."` and upgrade log level from `debug` to `error`
- `message-handler.ts`: Replace `⚠️ Agent failed: ${err.message}` with generic `"⚠️ Something went wrong. Please try again."`

Error details are preserved in server-side logs for debugging.

Supersedes #23629 (closed by stale bot during rebase).