### PR TITLE
docs(zh-CN): add Chinese translations for 5 CLI reference pages

### DIFF
--- a/docs/zh-CN/cli/clawbot.md
+++ b/docs/zh-CN/cli/clawbot.md
@@ -1,0 +1,21 @@
+---
+summary: "`openclaw clawbot` CLI 参考（旧版别名命名空间）"
+read_when:
+  - 维护使用 `openclaw clawbot ...` 的旧脚本
+  - 需要迁移到当前命令的指导
+title: "clawbot"
+---
+
+# `openclaw clawbot`
+
+为向后兼容保留的旧版别名命名空间。
+
+当前支持的别名：
+
+- `openclaw clawbot qr`（与 [`openclaw qr`](/cli/qr) 行为相同）
+
+## 迁移
+
+请直接使用现代顶级命令：
+
+- `openclaw clawbot qr` → `openclaw qr`

--- a/docs/zh-CN/cli/completion.md
+++ b/docs/zh-CN/cli/completion.md
@@ -1,0 +1,35 @@
+---
+summary: "`openclaw completion` CLI 参考（生成/安装 Shell 补全脚本）"
+read_when:
+  - 需要 zsh/bash/fish/PowerShell 的命令补全
+  - 需要将补全脚本缓存到 OpenClaw 状态目录
+title: "completion"
+---
+
+# `openclaw completion`
+
+生成 Shell 补全脚本，并可选择自动安装到 Shell 配置文件中。
+
+## 用法
+
+```bash
+openclaw completion
+openclaw completion --shell zsh
+openclaw completion --install
+openclaw completion --shell fish --install
+openclaw completion --write-state
+openclaw completion --shell bash --write-state
+```
+
+## 选项
+
+- `-s, --shell <shell>`：目标 Shell（`zsh`、`bash`、`powershell`、`fish`；默认：`zsh`）
+- `-i, --install`：安装补全，将 source 行添加到 Shell 配置文件
+- `--write-state`：将补全脚本写入 `$OPENCLAW_STATE_DIR/completions`，不输出到终端
+- `-y, --yes`：跳过安装确认提示
+
+## 说明
+
+- `--install` 会在 Shell 配置文件中写入一个 "OpenClaw Completion" 代码块，指向缓存的补全脚本。
+- 不加 `--install` 或 `--write-state` 时，命令会将脚本输出到标准输出。
+- 补全生成会预加载命令树，以包含所有嵌套子命令。

--- a/docs/zh-CN/cli/daemon.md
+++ b/docs/zh-CN/cli/daemon.md
@@ -1,0 +1,43 @@
+---
+summary: "`openclaw daemon` CLI 参考（Gateway 服务管理的旧别名）"
+read_when:
+  - 脚本中仍在使用 `openclaw daemon ...`
+  - 需要服务生命周期管理命令（安装/启动/停止/重启/状态）
+title: "daemon"
+---
+
+# `openclaw daemon`
+
+Gateway 服务管理命令的旧别名。
+
+`openclaw daemon ...` 与 `openclaw gateway ...` 的服务控制功能完全相同。
+
+## 用法
+
+```bash
+openclaw daemon status
+openclaw daemon install
+openclaw daemon start
+openclaw daemon stop
+openclaw daemon restart
+openclaw daemon uninstall
+```
+
+## 子命令
+
+- `status`：显示服务安装状态并探测 Gateway 健康状况
+- `install`：安装服务（`launchd`/`systemd`/`schtasks`）
+- `uninstall`：移除服务
+- `start`：启动服务
+- `stop`：停止服务
+- `restart`：重启服务
+
+## 常用选项
+
+- `status`：`--url`、`--token`、`--password`、`--timeout`、`--no-probe`、`--deep`、`--json`
+- `install`：`--port`、`--runtime <node|bun>`、`--token`、`--force`、`--json`
+- 生命周期命令（`uninstall|start|stop|restart`）：`--json`
+
+## 推荐
+
+请使用 [`openclaw gateway`](/cli/gateway) 查看最新文档和示例。

--- a/docs/zh-CN/cli/qr.md
+++ b/docs/zh-CN/cli/qr.md
@@ -1,0 +1,42 @@
+---
+summary: "`openclaw qr` CLI 参考（生成 iOS 配对二维码和设置码）"
+read_when:
+  - 想要快速将 iOS 应用与 Gateway 配对
+  - 需要设置码输出用于远程/手动分享
+title: "qr"
+---
+
+# `openclaw qr`
+
+根据当前 Gateway 配置生成 iOS 配对二维码和设置码。
+
+## 用法
+
+```bash
+openclaw qr
+openclaw qr --setup-code-only
+openclaw qr --json
+openclaw qr --remote
+openclaw qr --url wss://gateway.example/ws --token '<token>'
+```
+
+## 选项
+
+- `--remote`：使用配置中的 `gateway.remote.url` 及远程 token/password
+- `--url <url>`：覆盖载荷中使用的 Gateway URL
+- `--public-url <url>`：覆盖载荷中使用的公共 URL
+- `--token <token>`：覆盖载荷中的 Gateway token
+- `--password <password>`：覆盖载荷中的 Gateway password
+- `--setup-code-only`：仅打印设置码
+- `--no-ascii`：跳过 ASCII 二维码渲染
+- `--json`：输出 JSON（`setupCode`、`gatewayUrl`、`auth`、`urlSource`）
+
+## 说明
+
+- `--token` 和 `--password` 互斥。
+- 使用 `--remote` 时，如果有效的远程凭证配置为 SecretRef 且未传入 `--token` 或 `--password`，命令会从活动的 Gateway 快照解析。如果 Gateway 不可用，命令会快速失败。
+- 不使用 `--remote` 时，当密码认证可以胜出（显式 `gateway.auth.mode="password"` 或推断的密码模式且无来自 auth/env 的胜出 token）且未传入 CLI 认证覆盖时，会解析本地 `gateway.auth.password` SecretRef。
+- Gateway 版本差异注意：此命令路径需要支持 `secrets.resolve` 的 Gateway；旧版 Gateway 会返回未知方法错误。
+- 扫描后，通过以下命令批准设备配对：
+  - `openclaw devices list`
+  - `openclaw devices approve <requestId>`

--- a/docs/zh-CN/cli/secrets.md
+++ b/docs/zh-CN/cli/secrets.md
@@ -1,0 +1,168 @@
+---
+summary: "`openclaw secrets` CLI 参考（重载、审计、配置、应用）"
+read_when:
+  - 运行时重新解析 SecretRef
+  - 审计明文残留和未解析引用
+  - 配置 SecretRef 并执行单向清理
+title: "secrets"
+---
+
+# `openclaw secrets`
+
+使用 `openclaw secrets` 管理 SecretRef，保持运行时快照健康。
+
+命令角色：
+
+- `reload`：Gateway RPC（`secrets.reload`），重新解析引用并在完全成功时原子交换运行时快照（不写入配置文件）。
+- `audit`：只读扫描配置/认证存储中的明文、未解析引用和优先级偏移。
+- `configure`：交互式规划器，用于 Provider 设置、目标映射和预检（需要 TTY）。
+- `apply`：执行保存的计划（`--dry-run` 仅验证），然后清理目标明文残留。
+
+推荐操作流程：
+
+```bash
+openclaw secrets audit --check
+openclaw secrets configure
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --dry-run
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json
+openclaw secrets audit --check
+openclaw secrets reload
+```
+
+CI/门控退出码说明：
+
+- `audit --check` 有发现时返回 `1`。
+- 未解析引用返回 `2`。
+
+相关文档：
+
+- 密钥管理指南：[Secrets Management](/gateway/secrets)
+- 凭证范围：[SecretRef Credential Surface](/reference/secretref-credential-surface)
+- 安全指南：[Security](/gateway/security)
+
+## 重载运行时快照
+
+重新解析 SecretRef 并原子交换运行时快照。
+
+```bash
+openclaw secrets reload
+openclaw secrets reload --json
+```
+
+说明：
+
+- 使用 Gateway RPC 方法 `secrets.reload`。
+- 如果解析失败，Gateway 保留上一个正常快照并返回错误（不会部分激活）。
+- JSON 响应包含 `warningCount`。
+
+## 审计
+
+扫描 OpenClaw 状态中的：
+
+- 明文密钥存储
+- 未解析引用
+- 优先级偏移（`auth-profiles.json` 凭证覆盖 `openclaw.json` 引用）
+- 旧版残留（旧版认证存储条目、OAuth 提醒）
+
+```bash
+openclaw secrets audit
+openclaw secrets audit --check
+openclaw secrets audit --json
+```
+
+退出行为：
+
+- `--check` 有发现时以非零退出。
+- 未解析引用以更高优先级非零码退出。
+
+报告结构要点：
+
+- `status`：`clean | findings | unresolved`
+- `summary`：`plaintextCount`、`unresolvedRefCount`、`shadowedRefCount`、`legacyResidueCount`
+- 发现代码：
+  - `PLAINTEXT_FOUND`
+  - `REF_UNRESOLVED`
+  - `REF_SHADOWED`
+  - `LEGACY_RESIDUE`
+
+## 配置（交互式助手）
+
+交互式构建 Provider 和 SecretRef 变更，运行预检，可选应用：
+
+```bash
+openclaw secrets configure
+openclaw secrets configure --plan-out /tmp/openclaw-secrets-plan.json
+openclaw secrets configure --apply --yes
+openclaw secrets configure --providers-only
+openclaw secrets configure --skip-provider-setup
+openclaw secrets configure --agent ops
+openclaw secrets configure --json
+```
+
+流程：
+
+- 首先设置 Provider（对 `secrets.providers` 别名执行 `add/edit/remove`）。
+- 其次映射凭证（选择字段并分配 `{source, provider, id}` 引用）。
+- 最后预检和可选应用。
+
+参数：
+
+- `--providers-only`：仅配置 `secrets.providers`，跳过凭证映射。
+- `--skip-provider-setup`：跳过 Provider 设置，将凭证映射到已有 Provider。
+- `--agent <id>`：将 `auth-profiles.json` 目标发现和写入限定到单个 Agent 存储。
+
+说明：
+
+- 需要交互式 TTY。
+- 不能同时使用 `--providers-only` 和 `--skip-provider-setup`。
+- `configure` 针对 `openclaw.json` 中的密钥字段以及所选 Agent 范围内的 `auth-profiles.json`。
+- 支持在选择器流程中直接创建新的 `auth-profiles.json` 映射。
+- 规范支持范围：[SecretRef Credential Surface](/reference/secretref-credential-surface)。
+- 应用前执行预检解析。
+- 生成的计划默认启用清理选项（`scrubEnv`、`scrubAuthProfilesForProviderTargets`、`scrubLegacyAuthJson` 均启用）。
+- 应用路径对已清理的明文值是单向的。
+- 不加 `--apply` 时，CLI 在预检后仍会提示 `Apply this plan now?`。
+- 加 `--apply`（不加 `--yes`）时，CLI 会额外提示不可逆确认。
+
+Exec Provider 安全说明：
+
+- Homebrew 安装通常在 `/opt/homebrew/bin/*` 下暴露符号链接。
+- 仅在需要可信包管理器路径时设置 `allowSymlinkCommand: true`，并配合 `trustedDirs`（例如 `["/opt/homebrew"]`）。
+- 在 Windows 上，如果 ACL 验证对 Provider 路径不可用，OpenClaw 会安全失败。仅对可信路径设置 `allowInsecurePath: true` 以绕过路径安全检查。
+
+## 应用保存的计划
+
+应用或预检之前生成的计划：
+
+```bash
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --dry-run
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --json
+```
+
+计划契约详情（允许的目标路径、验证规则和失败语义）：
+
+- [Secrets Apply Plan Contract](/gateway/secrets-plan-contract)
+
+`apply` 可能更新的内容：
+
+- `openclaw.json`（SecretRef 目标 + Provider 更新/删除）
+- `auth-profiles.json`（Provider 目标清理）
+- 旧版 `auth.json` 残留
+- `~/.openclaw/.env` 中已迁移值的已知密钥
+
+## 为什么没有回滚备份
+
+`secrets apply` 故意不写入包含旧明文值的回滚备份。
+
+安全性来自严格预检 + 原子式应用，失败时进行尽力内存恢复。
+
+## 示例
+
+```bash
+openclaw secrets audit --check
+openclaw secrets configure
+openclaw secrets audit --check
+```
+
+如果 `audit --check` 仍报告明文发现，更新报告中剩余的目标路径并重新运行审计。


### PR DESCRIPTION
## Summary

Adds Chinese (zh-CN) translations for 5 missing CLI reference pages:

- `cli/clawbot.md` — legacy alias namespace
- `cli/completion.md` — shell completion scripts  
- `cli/daemon.md` — legacy gateway alias
- `cli/qr.md` — iOS pairing QR generation
- `cli/secrets.md` — secrets management (reload/audit/configure/apply)

## Context

Found these 5 pages missing from `docs/zh-CN/cli/` while the English versions exist in `docs/cli/`. Translations follow the same style and terminology as existing zh-CN docs.

## AI-assisted 🤖

- **Degree of AI assistance:** Translations generated and reviewed with AI
- **Testing:** Verified structure matches English source, links preserved
- **Understanding:** Translator understands all content — these are CLI reference docs for commands we use daily

## Checklist

- [x] Translations match English source structure
- [x] YAML frontmatter preserved with translated summaries
- [x] Internal links kept as-is (English paths)
- [x] Consistent terminology with existing zh-CN translations