### PR TITLE
docs(zh-CN): add Chinese translations for gateway and channel docs

### DIFF
--- a/docs/zh-CN/channels/irc.md
+++ b/docs/zh-CN/channels/irc.md
@@ -1,0 +1,241 @@
+---
+title: IRC
+description: 将 OpenClaw 连接到 IRC 频道和私信。
+summary: "IRC 插件设置、访问控制和故障排除"
+read_when:
+  - 你想将 OpenClaw 连接到 IRC 频道或私信
+  - 你正在配置 IRC 白名单、群组策略或提及门控
+---
+
+当你想让 OpenClaw 在经典频道（`#room`）和私信中运行时，使用 IRC。
+IRC 作为扩展插件提供，但在主配置的 `channels.irc` 下进行配置。
+
+## 快速开始
+
+1. 在 `~/.openclaw/openclaw.json` 中启用 IRC 配置。
+2. 至少设置以下内容：
+
+```json
+{
+  "channels": {
+    "irc": {
+      "enabled": true,
+      "host": "irc.libera.chat",
+      "port": 6697,
+      "tls": true,
+      "nick": "openclaw-bot",
+      "channels": ["#openclaw"]
+    }
+  }
+}
+```
+
+3. 启动/重启 Gateway 网关：
+
+```bash
+openclaw gateway run
+```
+
+## 安全默认值
+
+- `channels.irc.dmPolicy` 默认为 `"pairing"`。
+- `channels.irc.groupPolicy` 默认为 `"allowlist"`。
+- 当 `groupPolicy="allowlist"` 时，设置 `channels.irc.groups` 来定义允许的频道。
+- 除非你有意接受明文传输，否则使用 TLS（`channels.irc.tls=true`）。
+
+## 访问控制
+
+IRC 频道有两个独立的"门控"：
+
+1. **频道访问**（`groupPolicy` + `groups`）：机器人是否完全接受来自某个频道的消息。
+2. **发送者访问**（`groupAllowFrom` / 每频道 `groups["#channel"].allowFrom`）：谁被允许在该频道内触发机器人。
+
+配置键：
+
+- 私信白名单（私信发送者访问）：`channels.irc.allowFrom`
+- 群组发送者白名单（频道发送者访问）：`channels.irc.groupAllowFrom`
+- 每频道控制（频道 + 发送者 + 提及规则）：`channels.irc.groups["#channel"]`
+- `channels.irc.groupPolicy="open"` 允许未配置的频道（**默认仍受提及门控**）
+
+白名单条目应使用稳定的发送者身份（`nick!user@host`）。
+裸昵称匹配是可变的，仅在 `channels.irc.dangerouslyAllowNameMatching: true` 时启用。
+
+### 常见误区：`allowFrom` 用于私信，而非频道
+
+如果你看到类似这样的日志：
+
+- `irc: drop group sender alice!ident@host (policy=allowlist)`
+
+……这意味着发送者在**群组/频道**消息中未被允许。通过以下方式修复：
+
+- 设置 `channels.irc.groupAllowFrom`（全局适用于所有频道），或
+- 设置每频道发送者白名单：`channels.irc.groups["#channel"].allowFrom`
+
+示例（允许 `#tuirc-dev` 中的任何人与机器人对话）：
+
+```json5
+{
+  channels: {
+    irc: {
+      groupPolicy: "allowlist",
+      groups: {
+        "#tuirc-dev": { allowFrom: ["*"] },
+      },
+    },
+  },
+}
+```
+
+## 回复触发（提及）
+
+即使频道已允许（通过 `groupPolicy` + `groups`）且发送者已允许，OpenClaw 在群组上下文中默认使用**提及门控**。
+
+这意味着你可能会看到类似 `drop channel … (missing-mention)` 的日志，除非消息包含与机器人匹配的提及模式。
+
+要使机器人在 IRC 频道中**无需提及即可回复**，请为该频道禁用提及门控：
+
+```json5
+{
+  channels: {
+    irc: {
+      groupPolicy: "allowlist",
+      groups: {
+        "#tuirc-dev": {
+          requireMention: false,
+          allowFrom: ["*"],
+        },
+      },
+    },
+  },
+}
+```
+
+或者允许**所有** IRC 频道（无每频道白名单）并且无需提及即可回复：
+
+```json5
+{
+  channels: {
+    irc: {
+      groupPolicy: "open",
+      groups: {
+        "*": { requireMention: false, allowFrom: ["*"] },
+      },
+    },
+  },
+}
+```
+
+## 安全说明（推荐用于公共频道）
+
+如果你在公共频道中允许 `allowFrom: ["*"]`，任何人都可以向机器人发送提示。
+为降低风险，请限制该频道可用的工具。
+
+### 频道中所有人使用相同工具
+
+```json5
+{
+  channels: {
+    irc: {
+      groups: {
+        "#tuirc-dev": {
+          allowFrom: ["*"],
+          tools: {
+            deny: ["group:runtime", "group:fs", "gateway", "nodes", "cron", "browser"],
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+### 按发送者分配不同工具（所有者获得更多权限）
+
+使用 `toolsBySender` 对 `"*"` 应用更严格的策略，对你的昵称应用更宽松的策略：
+
+```json5
+{
+  channels: {
+    irc: {
+      groups: {
+        "#tuirc-dev": {
+          allowFrom: ["*"],
+          toolsBySender: {
+            "*": {
+              deny: ["group:runtime", "group:fs", "gateway", "nodes", "cron", "browser"],
+            },
+            "id:eigen": {
+              deny: ["gateway", "nodes", "cron"],
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+注意事项：
+
+- `toolsBySender` 键应使用 `id:` 前缀表示 IRC 发送者身份值：
+  `id:eigen` 或 `id:eigen!~eigen@174.127.248.171` 以获得更强的匹配。
+- 遗留的无前缀键仍然被接受，并仅作为 `id:` 匹配。
+- 第一个匹配的发送者策略生效；`"*"` 是通配符回退。
+
+有关群组访问与提及门控（以及它们如何交互）的更多信息，请参阅：[/channels/groups](/channels/groups)。
+
+## NickServ
+
+要在连接后向 NickServ 认证：
+
+```json
+{
+  "channels": {
+    "irc": {
+      "nickserv": {
+        "enabled": true,
+        "service": "NickServ",
+        "password": "your-nickserv-password"
+      }
+    }
+  }
+}
+```
+
+可选的首次连接注册：
+
+```json
+{
+  "channels": {
+    "irc": {
+      "nickserv": {
+        "register": true,
+        "registerEmail": "bot@example.com"
+      }
+    }
+  }
+}
+```
+
+昵称注册后禁用 `register`，以避免重复的 REGISTER 尝试。
+
+## 环境变量
+
+默认账户支持以下环境变量：
+
+- `IRC_HOST`
+- `IRC_PORT`
+- `IRC_TLS`
+- `IRC_NICK`
+- `IRC_USERNAME`
+- `IRC_REALNAME`
+- `IRC_PASSWORD`
+- `IRC_CHANNELS`（逗号分隔）
+- `IRC_NICKSERV_PASSWORD`
+- `IRC_NICKSERV_REGISTER_EMAIL`
+
+## 故障排除
+
+- 如果机器人连接成功但从不在频道中回复，请验证 `channels.irc.groups` **以及**提及门控是否在丢弃消息（`missing-mention`）。如果你希望它无需 ping 即可回复，请为该频道设置 `requireMention:false`。
+- 如果登录失败，请验证昵称可用性和服务器密码。
+- 如果在自定义网络上 TLS 失败，请验证主机/端口和证书设置。

--- a/docs/zh-CN/gateway/secrets-plan-contract.md
+++ b/docs/zh-CN/gateway/secrets-plan-contract.md
@@ -1,0 +1,106 @@
+---
+summary: "`secrets apply` 计划契约：目标验证、路径匹配和 `auth-profiles.json` 目标范围"
+read_when:
+  - 生成或审查 `openclaw secrets apply` 计划
+  - 调试 `Invalid plan target path` 错误
+  - 了解目标类型和路径验证行为
+title: "Secrets Apply 计划契约"
+---
+
+# Secrets Apply 计划契约
+
+本页定义 `openclaw secrets apply` 执行的严格契约。
+
+如果目标不符合这些规则，apply 会在修改配置之前失败。
+
+## 计划文件结构
+
+`openclaw secrets apply --from <plan.json>` 期望一个包含 `targets` 数组的计划文件：
+
+```json5
+{
+  version: 1,
+  protocolVersion: 1,
+  targets: [
+    {
+      type: "models.providers.apiKey",
+      path: "models.providers.openai.apiKey",
+      pathSegments: ["models", "providers", "openai", "apiKey"],
+      providerId: "openai",
+      ref: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+    },
+    {
+      type: "auth-profiles.api_key.key",
+      path: "profiles.openai:default.key",
+      pathSegments: ["profiles", "openai:default", "key"],
+      agentId: "main",
+      ref: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+    },
+  ],
+}
+```
+
+## 支持的目标范围
+
+计划目标适用于以下位置的受支持凭证路径：
+
+- [SecretRef 凭证范围](/reference/secretref-credential-surface)
+
+## 目标类型行为
+
+通用规则：
+
+- `target.type` 必须是已识别的类型，且必须与规范化的 `target.path` 形状匹配。
+
+为兼容现有计划保留的别名：
+
+- `models.providers.apiKey`
+- `skills.entries.apiKey`
+- `channels.googlechat.serviceAccount`
+
+## 路径验证规则
+
+每个目标按以下规则全部验证：
+
+- `type` 必须是已识别的目标类型。
+- `path` 必须是非空的点分路径。
+- `pathSegments` 可省略。如果提供，必须规范化为与 `path` 完全相同的路径。
+- 禁止的段会被拒绝：`__proto__`、`prototype`、`constructor`。
+- 规范化路径必须匹配目标类型注册的路径形状。
+- 如果设置了 `providerId` 或 `accountId`，必须与路径中编码的 id 匹配。
+- `auth-profiles.json` 目标需要 `agentId`。
+- 创建新的 `auth-profiles.json` 映射时，需包含 `authProfileProvider`。
+
+## 失败行为
+
+如果目标验证失败，apply 会输出类似错误退出：
+
+```text
+Invalid plan target path for models.providers.apiKey: models.providers.openai.baseUrl
+```
+
+无效计划不会提交任何写入。
+
+## 运行时和审计范围说明
+
+- 仅引用的 `auth-profiles.json` 条目（`keyRef`/`tokenRef`）包含在运行时解析和审计覆盖范围内。
+- `secrets apply` 写入受支持的 `openclaw.json` 目标、受支持的 `auth-profiles.json` 目标和可选的清理目标。
+
+## 操作检查
+
+```bash
+# 验证计划但不写入
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --dry-run
+
+# 然后实际应用
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json
+```
+
+如果 apply 因无效目标路径消息失败，使用 `openclaw secrets configure` 重新生成计划，或将目标路径修复为上述支持的形状。
+
+## 相关文档
+
+- [密钥管理](/gateway/secrets)
+- [CLI `secrets`](/cli/secrets)
+- [SecretRef 凭证范围](/reference/secretref-credential-surface)
+- [配置参考](/gateway/configuration-reference)

--- a/docs/zh-CN/gateway/secrets.md
+++ b/docs/zh-CN/gateway/secrets.md
@@ -1,0 +1,427 @@
+---
+summary: "密钥管理：SecretRef 契约、运行时快照行为和安全的单向清除"
+read_when:
+  - 为提供商凭证和 `auth-profiles.json` 引用配置 SecretRef
+  - 在生产环境中操作密钥的重载、审计、配置和安全应用
+  - 了解启动快速失败、非活动表面过滤和最后已知良好行为
+title: "Secrets Management"
+---
+
+# 密钥管理
+
+OpenClaw 支持增量式 SecretRef，使受支持的凭证无需以明文形式存储在配置中。
+
+明文方式仍然可用。SecretRef 是按凭证选择性启用的。
+
+## 目标和运行时模型
+
+密钥在激活期间被解析为内存中的运行时快照。
+
+- 解析在激活时是即时完成的，而非在请求路径上延迟执行。
+- 当有效活跃的 SecretRef 无法解析时，启动会快速失败。
+- 重载使用原子交换：完全成功，或保留最后已知良好的快照。
+- 运行时请求仅从活跃的内存快照中读取。
+
+这使得密钥提供商的中断不会影响热请求路径。
+
+## 活跃表面过滤
+
+SecretRef 仅在有效活跃的表面上进行验证。
+
+- 已启用的表面：未解析的引用会阻止启动/重载。
+- 非活跃表面：未解析的引用不会阻止启动/重载。
+- 非活跃引用会发出非致命诊断信息，代码为 `SECRETS_REF_IGNORED_INACTIVE_SURFACE`。
+
+非活跃表面的示例：
+
+- 已禁用的渠道/账户条目。
+- 没有已启用账户继承的顶级渠道凭证。
+- 已禁用的工具/功能表面。
+- 未被 `tools.web.search.provider` 选中的 Web 搜索提供商特定密钥。
+  在 auto 模式下（未设置 provider），提供商特定密钥也会因提供商自动检测而处于活跃状态。
+- `gateway.remote.token` / `gateway.remote.password` SecretRef 在 `gateway.remote.enabled` 不为 `false` 且满足以下条件之一时处于活跃状态：
+  - `gateway.mode=remote`
+  - 已配置 `gateway.remote.url`
+  - `gateway.tailscale.mode` 为 `serve` 或 `funnel`
+    在没有这些远程表面的本地模式下：
+  - `gateway.remote.token` 在 token 认证可以胜出且未配置环境变量/auth token 时处于活跃状态。
+  - `gateway.remote.password` 仅在密码认证可以胜出且未配置环境变量/auth 密码时处于活跃状态。
+
+## Gateway 网关认证表面诊断
+
+当在 `gateway.auth.password`、`gateway.remote.token` 或 `gateway.remote.password` 上配置了 SecretRef 时，Gateway 网关启动/重载会明确记录表面状态：
+
+- `active`：该 SecretRef 是有效认证表面的一部分，必须解析。
+- `inactive`：该 SecretRef 在此运行时中被忽略，因为另一个认证表面胜出，或者远程认证已禁用/未激活。
+
+这些条目以 `SECRETS_GATEWAY_AUTH_SURFACE` 记录，并包含活跃表面策略使用的原因，以便你了解凭证被视为活跃或非活跃的原因。
+
+## 新手引导引用预检
+
+当新手引导以交互模式运行并选择 SecretRef 存储时，OpenClaw 会在保存前运行预检验证：
+
+- Env 引用：验证环境变量名称并确认在新手引导期间可见非空值。
+- 提供商引用（`file` 或 `exec`）：验证提供商选择，解析 `id`，并检查解析后的值类型。
+
+如果验证失败，新手引导会显示错误并允许你重试。
+
+## SecretRef 契约
+
+在所有地方使用统一的对象格式：
+
+```json5
+{ source: "env" | "file" | "exec", provider: "default", id: "..." }
+```
+
+### `source: "env"`
+
+```json5
+{ source: "env", provider: "default", id: "OPENAI_API_KEY" }
+```
+
+验证规则：
+
+- `provider` 必须匹配 `^[a-z][a-z0-9_-]{0,63}$`
+- `id` 必须匹配 `^[A-Z][A-Z0-9_]{0,127}$`
+
+### `source: "file"`
+
+```json5
+{ source: "file", provider: "filemain", id: "/providers/openai/apiKey" }
+```
+
+验证规则：
+
+- `provider` 必须匹配 `^[a-z][a-z0-9_-]{0,63}$`
+- `id` 必须是绝对 JSON 指针（`/...`）
+- 段中的 RFC6901 转义：`~` => `~0`，`/` => `~1`
+
+### `source: "exec"`
+
+```json5
+{ source: "exec", provider: "vault", id: "providers/openai/apiKey" }
+```
+
+验证规则：
+
+- `provider` 必须匹配 `^[a-z][a-z0-9_-]{0,63}$`
+- `id` 必须匹配 `^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$`
+
+## 提供商配置
+
+在 `secrets.providers` 下定义提供商：
+
+```json5
+{
+  secrets: {
+    providers: {
+      default: { source: "env" },
+      filemain: {
+        source: "file",
+        path: "~/.openclaw/secrets.json",
+        mode: "json", // or "singleValue"
+      },
+      vault: {
+        source: "exec",
+        command: "/usr/local/bin/openclaw-vault-resolver",
+        args: ["--profile", "prod"],
+        passEnv: ["PATH", "VAULT_ADDR"],
+        jsonOnly: true,
+      },
+    },
+    defaults: {
+      env: "default",
+      file: "filemain",
+      exec: "vault",
+    },
+    resolution: {
+      maxProviderConcurrency: 4,
+      maxRefsPerProvider: 512,
+      maxBatchBytes: 262144,
+    },
+  },
+}
+```
+
+### Env 提供商
+
+- 可通过 `allowlist` 配置可选的白名单。
+- 缺失/空的环境变量值会导致解析失败。
+
+### File 提供商
+
+- 从 `path` 读取本地文件。
+- `mode: "json"` 期望 JSON 对象负载，并将 `id` 作为指针解析。
+- `mode: "singleValue"` 期望引用 id 为 `"value"` 并返回文件内容。
+- 路径必须通过所有权/权限检查。
+- Windows 安全关闭说明：如果某路径的 ACL 验证不可用，解析将失败。对于受信任的路径，可在该提供商上设置 `allowInsecurePath: true` 以绕过路径安全检查。
+
+### Exec 提供商
+
+- 运行配置的绝对二进制路径，不使用 shell。
+- 默认情况下，`command` 必须指向常规文件（非符号链接）。
+- 设置 `allowSymlinkCommand: true` 以允许符号链接命令路径（例如 Homebrew shim）。OpenClaw 会验证解析后的目标路径。
+- 将 `allowSymlinkCommand` 与 `trustedDirs` 配合使用以支持包管理器路径（例如 `["/opt/homebrew"]`）。
+- 支持超时、无输出超时、输出字节限制、环境变量白名单和受信任目录。
+- Windows 安全关闭说明：如果命令路径的 ACL 验证不可用，解析将失败。对于受信任的路径，可在该提供商上设置 `allowInsecurePath: true` 以绕过路径安全检查。
+
+请求负载（stdin）：
+
+```json
+{ "protocolVersion": 1, "provider": "vault", "ids": ["providers/openai/apiKey"] }
+```
+
+响应负载（stdout）：
+
+```json
+{ "protocolVersion": 1, "values": { "providers/openai/apiKey": "sk-..." } }
+```
+
+可选的按 id 错误：
+
+```json
+{
+  "protocolVersion": 1,
+  "values": {},
+  "errors": { "providers/openai/apiKey": { "message": "not found" } }
+}
+```
+
+## Exec 集成示例
+
+### 1Password CLI
+
+```json5
+{
+  secrets: {
+    providers: {
+      onepassword_openai: {
+        source: "exec",
+        command: "/opt/homebrew/bin/op",
+        allowSymlinkCommand: true, // required for Homebrew symlinked binaries
+        trustedDirs: ["/opt/homebrew"],
+        args: ["read", "op://Personal/OpenClaw QA API Key/password"],
+        passEnv: ["HOME"],
+        jsonOnly: false,
+      },
+    },
+  },
+  models: {
+    providers: {
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+        models: [{ id: "gpt-5", name: "gpt-5" }],
+        apiKey: { source: "exec", provider: "onepassword_openai", id: "value" },
+      },
+    },
+  },
+}
+```
+
+### HashiCorp Vault CLI
+
+```json5
+{
+  secrets: {
+    providers: {
+      vault_openai: {
+        source: "exec",
+        command: "/opt/homebrew/bin/vault",
+        allowSymlinkCommand: true, // required for Homebrew symlinked binaries
+        trustedDirs: ["/opt/homebrew"],
+        args: ["kv", "get", "-field=OPENAI_API_KEY", "secret/openclaw"],
+        passEnv: ["VAULT_ADDR", "VAULT_TOKEN"],
+        jsonOnly: false,
+      },
+    },
+  },
+  models: {
+    providers: {
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+        models: [{ id: "gpt-5", name: "gpt-5" }],
+        apiKey: { source: "exec", provider: "vault_openai", id: "value" },
+      },
+    },
+  },
+}
+```
+
+### `sops`
+
+```json5
+{
+  secrets: {
+    providers: {
+      sops_openai: {
+        source: "exec",
+        command: "/opt/homebrew/bin/sops",
+        allowSymlinkCommand: true, // required for Homebrew symlinked binaries
+        trustedDirs: ["/opt/homebrew"],
+        args: ["-d", "--extract", '["providers"]["openai"]["apiKey"]', "/path/to/secrets.enc.json"],
+        passEnv: ["SOPS_AGE_KEY_FILE"],
+        jsonOnly: false,
+      },
+    },
+  },
+  models: {
+    providers: {
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+        models: [{ id: "gpt-5", name: "gpt-5" }],
+        apiKey: { source: "exec", provider: "sops_openai", id: "value" },
+      },
+    },
+  },
+}
+```
+
+## 支持的凭证表面
+
+规范的受支持和不受支持的凭证列在：
+
+- [SecretRef 凭证表面](/reference/secretref-credential-surface)
+
+运行时生成或轮换的凭证以及 OAuth 刷新材料被有意排除在只读 SecretRef 解析之外。
+
+## 必要行为和优先级
+
+- 没有引用的字段：保持不变。
+- 有引用的字段：在激活期间对活跃表面是必需的。
+- 如果同时存在明文和引用，引用在支持的优先级路径上优先。
+
+警告和审计信号：
+
+- `SECRETS_REF_OVERRIDES_PLAINTEXT`（运行时警告）
+- `REF_SHADOWED`（当 `auth-profiles.json` 凭证优先于 `openclaw.json` 引用时的审计发现）
+
+Google Chat 兼容性行为：
+
+- `serviceAccountRef` 优先于明文 `serviceAccount`。
+- 当设置了同级引用时，明文值被忽略。
+
+## 激活触发器
+
+密钥激活在以下情况运行：
+
+- 启动（预检加最终激活）
+- 配置重载热应用路径
+- 配置重载重启检查路径
+- 通过 `secrets.reload` 手动重载
+
+激活契约：
+
+- 成功时原子交换快照。
+- 启动失败会中止 Gateway 网关启动。
+- 运行时重载失败会保留最后已知良好的快照。
+
+## 降级和恢复信号
+
+当重载时激活在健康状态后失败时，OpenClaw 进入密钥降级状态。
+
+一次性系统事件和日志代码：
+
+- `SECRETS_RELOADER_DEGRADED`
+- `SECRETS_RELOADER_RECOVERED`
+
+行为：
+
+- 降级：运行时保留最后已知良好的快照。
+- 恢复：在下一次成功激活后发出一次。
+- 在已降级状态下重复失败会记录警告，但不会重复发送事件。
+- 启动快速失败不会发出降级事件，因为运行时从未变为活跃状态。
+
+## 命令路径解析
+
+选择性启用的凭证敏感命令路径（例如 `openclaw memory` 远程内存路径和 `openclaw qr --remote`）可以通过 Gateway 网关快照 RPC 解析受支持的 SecretRef。
+
+- 当 Gateway 网关运行时，这些命令路径从活跃快照中读取。
+- 如果需要已配置的 SecretRef 但 Gateway 网关不可用，命令解析会快速失败并提供可操作的诊断信息。
+- 后端密钥轮换后的快照刷新由 `openclaw secrets reload` 处理。
+- 这些命令路径使用的 Gateway 网关 RPC 方法：`secrets.resolve`。
+
+## 审计和配置工作流
+
+默认操作流程：
+
+```bash
+openclaw secrets audit --check
+openclaw secrets configure
+openclaw secrets audit --check
+```
+
+### `secrets audit`
+
+审计发现包括：
+
+- 静态存储的明文值（`openclaw.json`、`auth-profiles.json`、`.env`）
+- 未解析的引用
+- 优先级遮蔽（`auth-profiles.json` 优先于 `openclaw.json` 引用）
+- 遗留残留（`auth.json`、OAuth 提醒）
+
+### `secrets configure`
+
+交互式助手，功能包括：
+
+- 首先配置 `secrets.providers`（`env`/`file`/`exec`，添加/编辑/删除）
+- 允许你在 `openclaw.json` 和 `auth-profiles.json` 中为一个智能体范围选择受支持的密钥承载字段
+- 可以在目标选择器中直接创建新的 `auth-profiles.json` 映射
+- 捕获 SecretRef 详情（`source`、`provider`、`id`）
+- 运行预检解析
+- 可以立即应用
+
+实用模式：
+
+- `openclaw secrets configure --providers-only`
+- `openclaw secrets configure --skip-provider-setup`
+- `openclaw secrets configure --agent <id>`
+
+`configure` 应用默认行为：
+
+- 从 `auth-profiles.json` 中清除目标提供商的匹配静态凭证
+- 从 `auth.json` 中清除遗留的静态 `api_key` 条目
+- 从 `<config-dir>/.env` 中清除匹配的已知密钥行
+
+### `secrets apply`
+
+应用已保存的计划：
+
+```bash
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --dry-run
+```
+
+有关严格的目标/路径契约详情和精确的拒绝规则，请参阅：
+
+- [Secrets Apply 计划契约](/gateway/secrets-plan-contract)
+
+## 单向安全策略
+
+OpenClaw 有意不写入包含历史明文密钥值的回滚备份。
+
+安全模型：
+
+- 预检必须在写入模式之前成功
+- 运行时激活在提交之前经过验证
+- apply 使用原子文件替换更新文件，并在失败时尽最大努力恢复
+
+## 遗留认证兼容性说明
+
+对于静态凭证，运行时不再依赖明文遗留认证存储。
+
+- 运行时凭证来源是解析后的内存快照。
+- 发现遗留的静态 `api_key` 条目时会被清除。
+- OAuth 相关的兼容性行为保持独立。
+
+## Web UI 说明
+
+某些 SecretInput 联合类型在原始编辑器模式下比表单模式更容易配置。
+
+## 相关文档
+
+- CLI 命令：[secrets](/cli/secrets)
+- 计划契约详情：[Secrets Apply 计划契约](/gateway/secrets-plan-contract)
+- 凭证表面：[SecretRef 凭证表面](/reference/secretref-credential-surface)
+- 认证设置：[认证](/gateway/authentication)
+- 安全态势：[安全](/gateway/security)
+- 环境变量优先级：[环境变量](/help/environment)

--- a/docs/zh-CN/gateway/trusted-proxy-auth.md
+++ b/docs/zh-CN/gateway/trusted-proxy-auth.md
@@ -1,0 +1,325 @@
+---
+summary: "将 Gateway 网关认证委托给受信任的反向代理（Pomerium、Caddy、nginx + OAuth）"
+read_when:
+  - 在身份感知代理后面运行 OpenClaw
+  - 在 OpenClaw 前面设置 Pomerium、Caddy 或 nginx + OAuth
+  - 修复反向代理设置中的 WebSocket 1008 未授权错误
+  - 决定在哪里设置 HSTS 和其他 HTTP 加固头
+---
+
+# Trusted Proxy Auth
+
+> ⚠️ **安全敏感功能。** 此模式将认证完全委托给你的反向代理。错误配置可能会使你的 Gateway 网关暴露于未授权访问。启用前请仔细阅读本页。
+
+## 何时使用
+
+在以下情况使用 `trusted-proxy` 认证模式：
+
+- 你在**身份感知代理**（Pomerium、Caddy + OAuth、nginx + oauth2-proxy、Traefik + forward auth）后面运行 OpenClaw
+- 你的代理处理所有认证并通过头传递用户身份
+- 你在 Kubernetes 或容器环境中，代理是到达 Gateway 网关的唯一路径
+- 你遇到 WebSocket `1008 unauthorized` 错误，因为浏览器无法在 WS 负载中传递 token
+
+## 何时不使用
+
+- 如果你的代理不认证用户（仅作为 TLS 终止器或负载均衡器）
+- 如果存在任何绕过代理到达 Gateway 网关的路径（防火墙漏洞、内部网络访问）
+- 如果你不确定你的代理是否正确剥离/覆写转发头
+- 如果你只需要个人单用户访问（考虑使用 Tailscale Serve + loopback 获得更简单的设置）
+
+## 工作原理
+
+1. 你的反向代理认证用户（OAuth、OIDC、SAML 等）
+2. 代理添加包含已认证用户身份的头（例如 `x-forwarded-user: nick@example.com`）
+3. OpenClaw 检查请求是否来自**受信任的代理 IP**（在 `gateway.trustedProxies` 中配置）
+4. OpenClaw 从配置的头中提取用户身份
+5. 如果所有检查通过，请求被授权
+
+## 控制台 UI 配对行为
+
+当 `gateway.auth.mode = "trusted-proxy"` 处于活跃状态且请求通过了受信任代理检查时，控制台 UI WebSocket 会话可以在没有设备配对身份的情况下连接。
+
+影响：
+
+- 在此模式下，配对不再是控制台 UI 访问的主要门控。
+- 你的反向代理认证策略和 `allowUsers` 成为有效的访问控制。
+- 将 Gateway 网关入口锁定为仅限受信任代理 IP（`gateway.trustedProxies` + 防火墙）。
+
+## 配置
+
+```json5
+{
+  gateway: {
+    // 对于同主机代理设置使用 loopback；对于远程代理主机使用 lan/custom
+    bind: "loopback",
+
+    // 重要：仅在此处添加你的代理 IP
+    trustedProxies: ["10.0.0.1", "172.17.0.1"],
+
+    auth: {
+      mode: "trusted-proxy",
+      trustedProxy: {
+        // 包含已认证用户身份的头（必需）
+        userHeader: "x-forwarded-user",
+
+        // 可选：必须存在的头（代理验证）
+        requiredHeaders: ["x-forwarded-proto", "x-forwarded-host"],
+
+        // 可选：限制为特定用户（空 = 允许所有）
+        allowUsers: ["nick@example.com", "admin@company.org"],
+      },
+    },
+  },
+}
+```
+
+如果 `gateway.bind` 为 `loopback`，请在 `gateway.trustedProxies` 中包含一个 loopback 代理地址（`127.0.0.1`、`::1` 或等效的 loopback CIDR）。
+
+### 配置参考
+
+| 字段                                        | 必需 | 描述                                                                     |
+| ------------------------------------------- | ---- | ------------------------------------------------------------------------ |
+| `gateway.trustedProxies`                    | 是   | 要信任的代理 IP 地址数组。来自其他 IP 的请求将被拒绝。                   |
+| `gateway.auth.mode`                         | 是   | 必须为 `"trusted-proxy"`                                                 |
+| `gateway.auth.trustedProxy.userHeader`      | 是   | 包含已认证用户身份的头名称                                               |
+| `gateway.auth.trustedProxy.requiredHeaders` | 否   | 请求被信任时必须存在的额外头                                             |
+| `gateway.auth.trustedProxy.allowUsers`      | 否   | 用户身份白名单。空值表示允许所有已认证用户。                             |
+
+## TLS 终止和 HSTS
+
+使用一个 TLS 终止点并在该处应用 HSTS。
+
+### 推荐模式：代理 TLS 终止
+
+当你的反向代理处理 `https://control.example.com` 的 HTTPS 时，在代理端为该域名设置 `Strict-Transport-Security`。
+
+- 适合面向互联网的部署。
+- 将证书 + HTTP 加固策略集中在一个地方。
+- OpenClaw 可以在代理后面保持 loopback HTTP。
+
+示例头值：
+
+```text
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+```
+
+### Gateway 网关 TLS 终止
+
+如果 OpenClaw 自身直接提供 HTTPS（没有 TLS 终止代理），请设置：
+
+```json5
+{
+  gateway: {
+    tls: { enabled: true },
+    http: {
+      securityHeaders: {
+        strictTransportSecurity: "max-age=31536000; includeSubDomains",
+      },
+    },
+  },
+}
+```
+
+`strictTransportSecurity` 接受字符串头值，或 `false` 以显式禁用。
+
+### 推出指导
+
+- 在验证流量时先从较短的 max age 开始（例如 `max-age=300`）。
+- 确信无误后再增加到长期值（例如 `max-age=31536000`）。
+- 仅在所有子域名都已准备好 HTTPS 时才添加 `includeSubDomains`。
+- 仅在你有意满足完整域名集的 preload 要求时才使用 preload。
+- 仅 loopback 的本地开发不会从 HSTS 中受益。
+
+## 代理设置示例
+
+### Pomerium
+
+Pomerium 在 `x-pomerium-claim-email`（或其他 claim 头）中传递身份，并在 `x-pomerium-jwt-assertion` 中传递 JWT。
+
+```json5
+{
+  gateway: {
+    bind: "lan",
+    trustedProxies: ["10.0.0.1"], // Pomerium's IP
+    auth: {
+      mode: "trusted-proxy",
+      trustedProxy: {
+        userHeader: "x-pomerium-claim-email",
+        requiredHeaders: ["x-pomerium-jwt-assertion"],
+      },
+    },
+  },
+}
+```
+
+Pomerium 配置片段：
+
+```yaml
+routes:
+  - from: https://openclaw.example.com
+    to: http://openclaw-gateway:18789
+    policy:
+      - allow:
+          or:
+            - email:
+                is: nick@example.com
+    pass_identity_headers: true
+```
+
+### Caddy + OAuth
+
+Caddy 配合 `caddy-security` 插件可以认证用户并传递身份头。
+
+```json5
+{
+  gateway: {
+    bind: "lan",
+    trustedProxies: ["127.0.0.1"], // Caddy's IP (if on same host)
+    auth: {
+      mode: "trusted-proxy",
+      trustedProxy: {
+        userHeader: "x-forwarded-user",
+      },
+    },
+  },
+}
+```
+
+Caddyfile 片段：
+
+```
+openclaw.example.com {
+    authenticate with oauth2_provider
+    authorize with policy1
+
+    reverse_proxy openclaw:18789 {
+        header_up X-Forwarded-User {http.auth.user.email}
+    }
+}
+```
+
+### nginx + oauth2-proxy
+
+oauth2-proxy 认证用户并在 `x-auth-request-email` 中传递身份。
+
+```json5
+{
+  gateway: {
+    bind: "lan",
+    trustedProxies: ["10.0.0.1"], // nginx/oauth2-proxy IP
+    auth: {
+      mode: "trusted-proxy",
+      trustedProxy: {
+        userHeader: "x-auth-request-email",
+      },
+    },
+  },
+}
+```
+
+nginx 配置片段：
+
+```nginx
+location / {
+    auth_request /oauth2/auth;
+    auth_request_set $user $upstream_http_x_auth_request_email;
+
+    proxy_pass http://openclaw:18789;
+    proxy_set_header X-Auth-Request-Email $user;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+}
+```
+
+### Traefik + Forward Auth
+
+```json5
+{
+  gateway: {
+    bind: "lan",
+    trustedProxies: ["172.17.0.1"], // Traefik container IP
+    auth: {
+      mode: "trusted-proxy",
+      trustedProxy: {
+        userHeader: "x-forwarded-user",
+      },
+    },
+  },
+}
+```
+
+## 安全检查清单
+
+启用 trusted-proxy 认证前，请验证：
+
+- [ ] **代理是唯一路径**：Gateway 网关端口已通过防火墙隔离，仅允许你的代理访问
+- [ ] **trustedProxies 最小化**：仅包含你实际的代理 IP，而非整个子网
+- [ ] **代理剥离头**：你的代理覆写（而非追加）来自客户端的 `x-forwarded-*` 头
+- [ ] **TLS 终止**：你的代理处理 TLS；用户通过 HTTPS 连接
+- [ ] **已设置 allowUsers**（推荐）：限制为已知用户，而非允许任何已认证用户
+
+## 安全审计
+
+`openclaw security audit` 会将 trusted-proxy 认证标记为**严重**级别的发现。这是有意为之——它提醒你正在将安全性委托给你的代理设置。
+
+审计检查以下内容：
+
+- 缺少 `trustedProxies` 配置
+- 缺少 `userHeader` 配置
+- 空的 `allowUsers`（允许任何已认证用户）
+
+## 故障排除
+
+### "trusted_proxy_untrusted_source"
+
+请求不是来自 `gateway.trustedProxies` 中的 IP。请检查：
+
+- 代理 IP 是否正确？（Docker 容器 IP 可能会变化）
+- 你的代理前面是否有负载均衡器？
+- 使用 `docker inspect` 或 `kubectl get pods -o wide` 查找实际 IP
+
+### "trusted_proxy_user_missing"
+
+用户头为空或缺失。请检查：
+
+- 你的代理是否配置为传递身份头？
+- 头名称是否正确？（不区分大小写，但拼写很重要）
+- 用户是否确实在代理端完成了认证？
+
+### "trusted_proxy_missing_header_\*"
+
+必需的头不存在。请检查：
+
+- 你的代理配置中是否包含这些特定的头
+- 头是否在链路中的某处被剥离
+
+### "trusted_proxy_user_not_allowed"
+
+用户已认证但不在 `allowUsers` 中。请添加该用户或移除白名单。
+
+### WebSocket 仍然失败
+
+确保你的代理：
+
+- 支持 WebSocket 升级（`Upgrade: websocket`、`Connection: upgrade`）
+- 在 WebSocket 升级请求（不仅仅是 HTTP）上传递身份头
+- 没有为 WebSocket 连接设置单独的认证路径
+
+## 从 Token 认证迁移
+
+如果你正在从 token 认证迁移到 trusted-proxy：
+
+1. 配置你的代理以认证用户并传递头
+2. 独立测试代理设置（使用 curl 带头测试）
+3. 更新 OpenClaw 配置为 trusted-proxy 认证
+4. 重启 Gateway 网关
+5. 从控制台 UI 测试 WebSocket 连接
+6. 运行 `openclaw security audit` 并审查发现
+
+## 相关文档
+
+- [安全](/gateway/security) — 完整安全指南
+- [配置](/gateway/configuration) — 配置参考
+- [远程访问](/gateway/remote) — 其他远程访问模式
+- [Tailscale](/gateway/tailscale) — 仅限 tailnet 访问的更简单替代方案

--- a/docs/zh-CN/gateway/trusted-proxy-auth.md
+++ b/docs/zh-CN/gateway/trusted-proxy-auth.md
@@ -77,13 +77,13 @@ read_when:
 
 ### 配置参考
 
-| 字段                                        | 必需 | 描述                                                                     |
-| ------------------------------------------- | ---- | ------------------------------------------------------------------------ |
-| `gateway.trustedProxies`                    | 是   | 要信任的代理 IP 地址数组。来自其他 IP 的请求将被拒绝。                   |
-| `gateway.auth.mode`                         | 是   | 必须为 `"trusted-proxy"`                                                 |
-| `gateway.auth.trustedProxy.userHeader`      | 是   | 包含已认证用户身份的头名称                                               |
-| `gateway.auth.trustedProxy.requiredHeaders` | 否   | 请求被信任时必须存在的额外头                                             |
-| `gateway.auth.trustedProxy.allowUsers`      | 否   | 用户身份白名单。空值表示允许所有已认证用户。                             |
+| 字段                                        | 必需 | 描述                                                   |
+| ------------------------------------------- | ---- | ------------------------------------------------------ |
+| `gateway.trustedProxies`                    | 是   | 要信任的代理 IP 地址数组。来自其他 IP 的请求将被拒绝。 |
+| `gateway.auth.mode`                         | 是   | 必须为 `"trusted-proxy"`                               |
+| `gateway.auth.trustedProxy.userHeader`      | 是   | 包含已认证用户身份的头名称                             |
+| `gateway.auth.trustedProxy.requiredHeaders` | 否   | 请求被信任时必须存在的额外头                           |
+| `gateway.auth.trustedProxy.allowUsers`      | 否   | 用户身份白名单。空值表示允许所有已认证用户。           |
 
 ## TLS 终止和 HSTS
 
@@ -287,7 +287,7 @@ location / {
 - 头名称是否正确？（不区分大小写，但拼写很重要）
 - 用户是否确实在代理端完成了认证？
 
-### "trusted_proxy_missing_header_\*"
+### "trusted*proxy_missing_header*\*"
 
 必需的头不存在。请检查：
 


### PR DESCRIPTION
## Summary
Adds Chinese translations for 4 missing docs:
- `gateway/secrets.md` — secrets management guide
- `gateway/secrets-plan-contract.md` — apply plan contract  
- `gateway/trusted-proxy-auth.md` — trusted proxy authentication
- `channels/irc.md` — IRC channel setup

AI-assisted 🤖 — translations verified for technical accuracy and terminology consistency with existing zh-CN docs.