### PR TITLE
fix: default supportsReasoningEffort to false for custom providers

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -296,6 +296,21 @@ describe("normalizeModelCompat — supportsReasoningEffort guard (#33272)", () =
     expect(supportsReasoningEffort(normalized)).toBe(false);
   });
 
+  it("applies reasoning guard even when supportsDeveloperRole is already false", () => {
+    // Regression test: a user with compat: { supportsDeveloperRole: false }
+    // on a custom endpoint should still get supportsReasoningEffort defaulted
+    // to false — the early return must not bypass the reasoning guard.
+    const model = {
+      ...baseModel(),
+      provider: "custom-ollama",
+      baseUrl: "https://ollama.example.com/v1",
+      compat: { supportsDeveloperRole: false },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+    expect(supportsReasoningEffort(normalized)).toBe(false);
+  });
+
   it("does not touch supportsReasoningEffort for models with empty baseUrl", () => {
     const model = {
       ...baseModel(),

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -23,6 +23,11 @@ function supportsDeveloperRole(model: Model<Api>): boolean | undefined {
   return (model.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole;
 }
 
+function supportsReasoningEffort(model: Model<Api>): boolean | undefined {
+  return (model.compat as { supportsReasoningEffort?: boolean } | undefined)
+    ?.supportsReasoningEffort;
+}
+
 function createTemplateModel(provider: string, id: string): Model<Api> {
   return {
     id,
@@ -231,6 +236,75 @@ describe("normalizeModelCompat", () => {
     model.compat = { supportsDeveloperRole: false };
     const normalized = normalizeModelCompat(model);
     expect(supportsDeveloperRole(normalized)).toBe(false);
+  });
+});
+
+describe("normalizeModelCompat — supportsReasoningEffort guard (#33272)", () => {
+  it("defaults supportsReasoningEffort to false for custom provider endpoints", () => {
+    const model = {
+      ...baseModel(),
+      provider: "custom-ollama",
+      baseUrl: "https://ollama.example.com/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(supportsReasoningEffort(normalized)).toBe(false);
+  });
+
+  it("defaults supportsReasoningEffort to false for Ollama endpoints", () => {
+    const model = {
+      ...baseModel(),
+      provider: "ollama",
+      baseUrl: "http://localhost:11434/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(supportsReasoningEffort(normalized)).toBe(false);
+  });
+
+  it("preserves supportsReasoningEffort for native OpenAI endpoint", () => {
+    const model = {
+      ...baseModel(),
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    // Should not force supportsReasoningEffort off for native OpenAI
+    expect(supportsReasoningEffort(normalized)).toBeUndefined();
+  });
+
+  it("respects explicit supportsReasoningEffort: true from user config", () => {
+    const model = {
+      ...baseModel(),
+      provider: "custom-gemini-proxy",
+      baseUrl: "https://proxy.example.com/v1",
+      compat: { supportsReasoningEffort: true },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(supportsReasoningEffort(normalized)).toBe(true);
+  });
+
+  it("respects explicit supportsReasoningEffort: false from user config", () => {
+    const model = {
+      ...baseModel(),
+      provider: "custom-provider",
+      baseUrl: "https://proxy.example.com/v1",
+      compat: { supportsReasoningEffort: false },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(supportsReasoningEffort(normalized)).toBe(false);
+  });
+
+  it("does not touch supportsReasoningEffort for models with empty baseUrl", () => {
+    const model = {
+      ...baseModel(),
+      provider: "openai",
+    };
+    delete (model as { baseUrl?: unknown }).baseUrl;
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(supportsReasoningEffort(normalized)).toBeUndefined();
   });
 });
 

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -75,7 +75,9 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   // whose baseUrl is not a known native OpenAI endpoint, unless the caller
   // has already pinned the value explicitly.
   const compat = model.compat ?? undefined;
-  if (compat?.supportsDeveloperRole === false) {
+  // Only skip when both compat properties are already handled — otherwise
+  // the reasoning guard below would be bypassed (#33272 regression).
+  if (compat?.supportsDeveloperRole === false && compat?.supportsReasoningEffort !== undefined) {
     return model;
   }
   // When baseUrl is empty the pi-ai library defaults to api.openai.com, so

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -20,6 +20,23 @@ function isOpenAINativeEndpoint(baseUrl: string): boolean {
   }
 }
 
+/**
+ * Returns true for endpoints known to accept the `reasoning_effort` parameter.
+ * Only native OpenAI endpoints are confirmed to support it. OpenRouter handles
+ * reasoning via its own nested `reasoning.effort` format (injected separately).
+ * All other openai-completions backends (Ollama, vLLM, custom proxies, etc.)
+ * may reject or misinterpret the parameter, causing 400 errors or broken tool
+ * calling. See: openclaw/openclaw#33272
+ */
+function isReasoningEffortEndpoint(baseUrl: string): boolean {
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return host === "api.openai.com";
+  } catch {
+    return false;
+  }
+}
+
 function isAnthropicMessagesModel(model: Model<Api>): model is Model<"anthropic-messages"> {
   return model.api === "anthropic-messages";
 }
@@ -67,13 +84,31 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   // here for non-native endpoints — those backends would return a 400 if we
   // sent `developer`, so safety takes precedence over the caller's hint.
   const needsForce = baseUrl ? !isOpenAINativeEndpoint(baseUrl) : false;
-  if (!needsForce) {
+
+  // Default supportsReasoningEffort to false for non-OpenAI endpoints.
+  // pi-ai defaults supportsReasoningEffort to true for all unknown providers,
+  // which causes reasoning_effort to be injected into requests to backends
+  // that don't support it (Ollama, vLLM proxies, Kimi, etc.), breaking tool
+  // calling or causing 400 errors. Only override when the user has not
+  // explicitly set supportsReasoningEffort in their config.
+  // See: openclaw/openclaw#33272
+  const needsReasoningGuard =
+    baseUrl && !isReasoningEffortEndpoint(baseUrl) && compat?.supportsReasoningEffort === undefined;
+
+  if (!needsForce && !needsReasoningGuard) {
     return model;
   }
 
   // Return a new object — do not mutate the caller's model reference.
+  const compatPatch: Record<string, unknown> = {};
+  if (needsForce) {
+    compatPatch.supportsDeveloperRole = false;
+  }
+  if (needsReasoningGuard) {
+    compatPatch.supportsReasoningEffort = false;
+  }
   return {
     ...model,
-    compat: compat ? { ...compat, supportsDeveloperRole: false } : { supportsDeveloperRole: false },
+    compat: compat ? { ...compat, ...compatPatch } : compatPatch,
   } as typeof model;
 }


### PR DESCRIPTION
Fixes #33272 — Custom providers with api openai-completions no longer receive reasoning_effort in request payloads by default.

## Problem

pi-ai defaults supportsReasoningEffort to true for all openai-completions providers except xAI and Z.AI. Custom providers (Ollama proxies, vLLM, Kimi K2.5, etc.) get reasoning_effort injected, causing 400 errors or silent tool calling failures.

## Fix

Extends normalizeModelCompat() to default supportsReasoningEffort: false for any openai-completions model whose baseUrl is not a known native OpenAI endpoint (api.openai.com). Follows the same pattern as the existing supportsDeveloperRole guard.

Users can still explicitly set supportsReasoningEffort: true in their compat config.

## Tests

6 new test cases covering custom providers, Ollama, native OpenAI, explicit overrides, and empty baseUrl. All 31 tests pass.

---

🤖 **AI-assisted PR** (Claude, via OpenClaw agent)
- Testing: Fully tested locally with vitest; all relevant test suites pass
- The contributor understands what this code does