### PR TITLE
Gateway: guard startup config writes against stale snapshots

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,5 +1,6 @@
 export {
   clearConfigCache,
+  ConfigWriteConflictError,
   clearRuntimeConfigSnapshot,
   createConfigIO,
   getRuntimeConfigSnapshot,

--- a/src/config/env-preserve-io.test.ts
+++ b/src/config/env-preserve-io.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, it, expect } from "vitest";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
+  ConfigWriteConflictError,
   createConfigIO,
   readConfigFileSnapshotForWrite,
   writeConfigFile as writeConfigFileViaWrapper,
@@ -144,6 +145,26 @@ describe("env snapshot TOCTOU via wrapper APIs", () => {
       });
 
       expect(await readGatewayToken(configPath)).toBe("original-key-123");
+    });
+  });
+});
+
+describe("expected config hash guard", () => {
+  it("rejects writes when the on-disk config changed after the caller snapshot", async () => {
+    await withGatewayTokenTempConfig(async (configPath) => {
+      const io = createConfigIO({ configPath });
+      const firstRead = await io.readConfigFileSnapshotForWrite();
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ gateway: { remote: { token: "mutated-on-disk" } } }, null, 2),
+      );
+
+      await expect(
+        io.writeConfigFile(firstRead.snapshot.config, {
+          ...firstRead.writeOptions,
+          expectedConfigHash: firstRead.snapshot.hash,
+        }),
+      ).rejects.toBeInstanceOf(ConfigWriteConflictError);
     });
   });
 });

--- a/src/config/io.runtime-snapshot-write.test.ts
+++ b/src/config/io.runtime-snapshot-write.test.ts
@@ -3,9 +3,11 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withTempHome } from "./home-env.test-harness.js";
 import {
+  ConfigWriteConflictError,
   clearConfigCache,
   clearRuntimeConfigSnapshot,
   loadConfig,
+  readConfigFileSnapshot,
   setRuntimeConfigSnapshot,
   writeConfigFile,
 } from "./io.js";
@@ -59,6 +61,40 @@ describe("runtime config snapshot writes", () => {
         clearRuntimeConfigSnapshot();
         clearConfigCache();
       }
+    });
+  });
+
+  it("forwards expectedConfigHash through the public writeConfigFile wrapper", async () => {
+    await withTempHome("openclaw-config-runtime-write-", async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const initialConfig: OpenClawConfig = {
+        gateway: {
+          mode: "local",
+        },
+      };
+
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, `${JSON.stringify(initialConfig, null, 2)}\n`, "utf8");
+
+      const snapshot = await readConfigFileSnapshot();
+      const nextConfig: OpenClawConfig = {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+          },
+        },
+      };
+
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify({ gateway: { mode: "remote" } }, null, 2)}\n`,
+        "utf8",
+      );
+
+      await expect(
+        writeConfigFile(nextConfig, { expectedConfigHash: snapshot.hash }),
+      ).rejects.toBeInstanceOf(ConfigWriteConflictError);
     });
   });
 });

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1425,6 +1425,7 @@ export async function writeConfigFile(
     options.expectedConfigPath === undefined || options.expectedConfigPath === io.configPath;
   await io.writeConfigFile(nextCfg, {
     envSnapshotForRestore: sameConfigPath ? options.envSnapshotForRestore : undefined,
+    expectedConfigHash: options.expectedConfigHash,
     unsetPaths: options.unsetPaths,
   });
 }

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -127,11 +127,33 @@ export type ConfigWriteOptions = {
    */
   expectedConfigPath?: string;
   /**
+   * Optional optimistic-concurrency guard. When provided, the write is
+   * rejected if the on-disk config hash no longer matches the caller's
+   * read-time snapshot.
+   */
+  expectedConfigHash?: string;
+  /**
    * Paths that must be explicitly removed from the persisted file payload,
    * even if schema/default normalization reintroduces them.
    */
   unsetPaths?: string[][];
 };
+
+export class ConfigWriteConflictError extends Error {
+  readonly configPath: string;
+  readonly expectedHash: string;
+  readonly actualHash: string | null;
+
+  constructor(params: { configPath: string; expectedHash: string; actualHash: string | null }) {
+    super(
+      `Config changed on disk since it was loaded; refusing to overwrite newer edits at ${params.configPath}.`,
+    );
+    this.name = "ConfigWriteConflictError";
+    this.configPath = params.configPath;
+    this.expectedHash = params.expectedHash;
+    this.actualHash = params.actualHash;
+  }
+}
 
 export type ReadConfigFileSnapshotForWriteResult = {
   snapshot: ConfigFileSnapshot;
@@ -1037,6 +1059,15 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     clearConfigCache();
     let persistCandidate: unknown = cfg;
     const { snapshot } = await readConfigFileSnapshotInternal();
+    const currentHash = resolveConfigSnapshotHash(snapshot);
+    const expectedHash = options.expectedConfigHash?.trim();
+    if (expectedHash && currentHash !== expectedHash) {
+      throw new ConfigWriteConflictError({
+        configPath,
+        expectedHash,
+        actualHash: currentHash,
+      });
+    }
     let envRefMap: Map<string, string> | null = null;
     let changedPaths: Set<string> | null = null;
     if (snapshot.valid && snapshot.exists) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -414,6 +414,11 @@ export async function startGatewayServer(
         "Gateway auth token was missing. Generated a new token and saved it to config (gateway.auth.token).",
       );
     } else {
+      if (authBootstrap.persistConflictPath) {
+        log.warn(
+          `gateway: startup auth token not persisted because ${authBootstrap.persistConflictPath} changed on disk during startup.`,
+        );
+      }
       log.warn(
         "Gateway auth token was missing. Generated a runtime token for this startup without changing config; restart will generate a different token. Persist one with `openclaw config set gateway.auth.mode token` and `openclaw config set gateway.auth.token <token>`.",
       );

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -396,8 +396,8 @@ export async function startGatewayServer(
     });
   }
 
+  cfgAtStart = loadConfig();
   const authSnapshot = await readConfigFileSnapshot();
-  cfgAtStart = authSnapshot.config;
   const authBootstrap = await ensureGatewayStartupAuth({
     cfg: cfgAtStart,
     env: process.env,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -439,6 +439,7 @@ export async function startGatewayServer(
   const controlUiSeedSnapshot = await readConfigFileSnapshot();
   await maybeSeedControlUiAllowedOriginsAtStartup({
     config: controlUiSeedSnapshot.config,
+    configPath: controlUiSeedSnapshot.path,
     writeConfig: async (nextCfg) =>
       await writeConfigFile(nextCfg, { expectedConfigHash: controlUiSeedSnapshot.hash }),
     log,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -11,6 +11,7 @@ import { createDefaultDeps } from "../cli/deps.js";
 import { isRestartEnabled } from "../config/commands.js";
 import {
   CONFIG_PATH,
+  ConfigWriteConflictError,
   type OpenClawConfig,
   isNixMode,
   loadConfig,
@@ -18,6 +19,7 @@ import {
   readConfigFileSnapshot,
   writeConfigFile,
 } from "../config/config.js";
+import { ensureControlUiAllowedOriginsForNonLoopbackBind } from "../config/gateway-control-ui-origins.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
@@ -260,12 +262,21 @@ export async function startGatewayServer(
         "gateway: legacy config entries detected but no auto-migration changes were produced; continuing with validation.",
       );
     } else {
-      await writeConfigFile(migrated);
-      if (changes.length > 0) {
-        log.info(
-          `gateway: migrated legacy config entries:\n${changes
-            .map((entry) => `- ${entry}`)
-            .join("\n")}`,
+      try {
+        await writeConfigFile(migrated, { expectedConfigHash: configSnapshot.hash });
+        if (changes.length > 0) {
+          log.info(
+            `gateway: migrated legacy config entries:\n${changes
+              .map((entry) => `- ${entry}`)
+              .join("\n")}`,
+          );
+        }
+      } catch (err) {
+        if (!(err instanceof ConfigWriteConflictError)) {
+          throw err;
+        }
+        log.warn(
+          `gateway: skipped legacy auto-migration because ${configSnapshot.path} changed on disk during startup.`,
         );
       }
     }
@@ -285,14 +296,20 @@ export async function startGatewayServer(
   const autoEnable = applyPluginAutoEnable({ config: configSnapshot.config, env: process.env });
   if (autoEnable.changes.length > 0) {
     try {
-      await writeConfigFile(autoEnable.config);
+      await writeConfigFile(autoEnable.config, { expectedConfigHash: configSnapshot.hash });
       log.info(
         `gateway: auto-enabled plugins:\n${autoEnable.changes
           .map((entry) => `- ${entry}`)
           .join("\n")}`,
       );
     } catch (err) {
-      log.warn(`gateway: failed to persist plugin auto-enable changes: ${String(err)}`);
+      if (err instanceof ConfigWriteConflictError) {
+        log.warn(
+          `gateway: skipped plugin auto-enable persistence because ${configSnapshot.path} changed on disk during startup.`,
+        );
+      } else {
+        log.warn(`gateway: failed to persist plugin auto-enable changes: ${String(err)}`);
+      }
     }
   }
 
@@ -379,13 +396,16 @@ export async function startGatewayServer(
     });
   }
 
-  cfgAtStart = loadConfig();
+  const authSnapshot = await readConfigFileSnapshot();
+  cfgAtStart = authSnapshot.config;
   const authBootstrap = await ensureGatewayStartupAuth({
     cfg: cfgAtStart,
     env: process.env,
     authOverride: opts.auth,
     tailscaleOverride: opts.tailscale,
     persist: true,
+    writeConfig: async (nextCfg) =>
+      await writeConfigFile(nextCfg, { expectedConfigHash: authSnapshot.hash }),
   });
   cfgAtStart = authBootstrap.cfg;
   if (authBootstrap.generatedToken) {
@@ -415,9 +435,12 @@ export async function startGatewayServer(
   );
   // Unconditional startup migration: seed gateway.controlUi.allowedOrigins for existing
   // non-loopback installs that upgraded to v2026.2.26+ without required origins.
-  cfgAtStart = await maybeSeedControlUiAllowedOriginsAtStartup({
-    config: cfgAtStart,
-    writeConfig: writeConfigFile,
+  cfgAtStart = ensureControlUiAllowedOriginsForNonLoopbackBind(cfgAtStart).config;
+  const controlUiSeedSnapshot = await readConfigFileSnapshot();
+  await maybeSeedControlUiAllowedOriginsAtStartup({
+    config: controlUiSeedSnapshot.config,
+    writeConfig: async (nextCfg) =>
+      await writeConfigFile(nextCfg, { expectedConfigHash: controlUiSeedSnapshot.hash }),
     log,
   });
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -12,6 +12,7 @@ import { isRestartEnabled } from "../config/commands.js";
 import {
   CONFIG_PATH,
   ConfigWriteConflictError,
+  applyConfigOverrides,
   type OpenClawConfig,
   isNixMode,
   loadConfig,
@@ -396,8 +397,12 @@ export async function startGatewayServer(
     });
   }
 
-  cfgAtStart = loadConfig();
+  // Preserve loadConfig side effects (env var hydration and runtime overrides)
+  // before startup auth bootstrap, but use a single snapshot for cfg+hash so
+  // optimistic write guards can't pair a stale cfg with a newer expected hash.
+  void loadConfig();
   const authSnapshot = await readConfigFileSnapshot();
+  cfgAtStart = applyConfigOverrides(authSnapshot.config);
   const authBootstrap = await ensureGatewayStartupAuth({
     cfg: cfgAtStart,
     env: process.env,

--- a/src/gateway/startup-auth.load-config-env.test.ts
+++ b/src/gateway/startup-auth.load-config-env.test.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "../config/home-env.test-harness.js";
+import { createConfigIO } from "../config/io.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { ensureGatewayStartupAuth } from "./startup-auth.js";
+
+describe("gateway startup auth config loading", () => {
+  it("preserves config env vars when startup auth boots from loadConfig", async () => {
+    await withTempHome("openclaw-startup-auth-load-config-", async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const config: OpenClawConfig = {
+        env: {
+          vars: {
+            OPENCLAW_GATEWAY_TOKEN: "token-from-config-env",
+          },
+        },
+      };
+
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+
+      const env = { HOME: home } as NodeJS.ProcessEnv;
+      const io = createConfigIO({ env, homedir: () => home });
+      const loaded = io.loadConfig();
+
+      expect(env.OPENCLAW_GATEWAY_TOKEN).toBe("token-from-config-env");
+
+      const loadedResult = await ensureGatewayStartupAuth({
+        cfg: loaded,
+        env,
+        persist: false,
+      });
+      expect(loadedResult.generatedToken).toBeUndefined();
+      expect(loadedResult.auth.mode).toBe("token");
+      expect(loadedResult.auth.token).toBe("token-from-config-env");
+
+      const snapshot = await io.readConfigFileSnapshot();
+      const rawEnv = { HOME: home } as NodeJS.ProcessEnv;
+      const snapshotResult = await ensureGatewayStartupAuth({
+        cfg: snapshot.config,
+        env: rawEnv,
+        persist: false,
+      });
+      expect(snapshotResult.generatedToken).toMatch(/^[0-9a-f]{48}$/);
+    });
+  });
+});

--- a/src/gateway/startup-auth.test.ts
+++ b/src/gateway/startup-auth.test.ts
@@ -89,6 +89,7 @@ describe("ensureGatewayStartupAuth", () => {
 
     expect(result.generatedToken).toMatch(/^[0-9a-f]{48}$/);
     expect(result.persistedGeneratedToken).toBe(false);
+    expect(result.persistConflictPath).toBe("/tmp/openclaw.json");
     expect(result.auth.mode).toBe("token");
     expect(result.auth.token).toBe(result.generatedToken);
     expect(writeConfig).toHaveBeenCalledTimes(1);

--- a/src/gateway/startup-auth.test.ts
+++ b/src/gateway/startup-auth.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../config/config.js";
+import { ConfigWriteConflictError, type OpenClawConfig } from "../config/config.js";
 import { expectGeneratedTokenPersistedToGatewayAuth } from "../test-utils/auth-token-assertions.js";
 
 const mocks = vi.hoisted(() => ({
@@ -69,6 +69,30 @@ describe("ensureGatewayStartupAuth", () => {
       authToken: result.auth.token,
       persistedConfig: mocks.writeConfigFile.mock.calls[0]?.[0],
     });
+  });
+
+  it("keeps a generated token ephemeral when the config changed before startup persistence", async () => {
+    const writeConfig = vi.fn(async () => {
+      throw new ConfigWriteConflictError({
+        configPath: "/tmp/openclaw.json",
+        expectedHash: "before",
+        actualHash: "after",
+      });
+    });
+
+    const result = await ensureGatewayStartupAuth({
+      cfg: {},
+      env: {} as NodeJS.ProcessEnv,
+      persist: true,
+      writeConfig,
+    });
+
+    expect(result.generatedToken).toMatch(/^[0-9a-f]{48}$/);
+    expect(result.persistedGeneratedToken).toBe(false);
+    expect(result.auth.mode).toBe("token");
+    expect(result.auth.token).toBe(result.generatedToken);
+    expect(writeConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.writeConfigFile).not.toHaveBeenCalled();
   });
 
   it("does not generate when token already exists", async () => {

--- a/src/gateway/startup-auth.ts
+++ b/src/gateway/startup-auth.ts
@@ -200,6 +200,7 @@ export async function ensureGatewayStartupAuth(params: {
   auth: ReturnType<typeof resolveGatewayAuth>;
   generatedToken?: string;
   persistedGeneratedToken: boolean;
+  persistConflictPath?: string;
 }> {
   const env = params.env ?? process.env;
   const persistRequested = params.persist === true;
@@ -232,6 +233,7 @@ export async function ensureGatewayStartupAuth(params: {
     resolvedAuth: resolved,
   });
   let persistedGeneratedToken = false;
+  let persistConflictPath: string | undefined;
   if (persist) {
     const persistConfig = params.writeConfig ?? writeConfigFile;
     try {
@@ -241,6 +243,7 @@ export async function ensureGatewayStartupAuth(params: {
       if (!(err instanceof ConfigWriteConflictError)) {
         throw err;
       }
+      persistConflictPath = err.configPath;
     }
   }
 
@@ -256,6 +259,7 @@ export async function ensureGatewayStartupAuth(params: {
     auth: nextAuth,
     generatedToken,
     persistedGeneratedToken,
+    persistConflictPath,
   };
 }
 

--- a/src/gateway/startup-auth.ts
+++ b/src/gateway/startup-auth.ts
@@ -4,7 +4,7 @@ import type {
   GatewayTailscaleConfig,
   OpenClawConfig,
 } from "../config/config.js";
-import { writeConfigFile } from "../config/config.js";
+import { ConfigWriteConflictError, writeConfigFile } from "../config/config.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { secretRefKey } from "../secrets/ref-contract.js";
 import { resolveSecretRefValues } from "../secrets/resolve.js";
@@ -194,6 +194,7 @@ export async function ensureGatewayStartupAuth(params: {
   authOverride?: GatewayAuthConfig;
   tailscaleOverride?: GatewayTailscaleConfig;
   persist?: boolean;
+  writeConfig?: (cfg: OpenClawConfig) => Promise<void>;
 }): Promise<{
   cfg: OpenClawConfig;
   auth: ReturnType<typeof resolveGatewayAuth>;
@@ -230,8 +231,17 @@ export async function ensureGatewayStartupAuth(params: {
     persistRequested,
     resolvedAuth: resolved,
   });
+  let persistedGeneratedToken = false;
   if (persist) {
-    await writeConfigFile(nextCfg);
+    const persistConfig = params.writeConfig ?? writeConfigFile;
+    try {
+      await persistConfig(nextCfg);
+      persistedGeneratedToken = true;
+    } catch (err) {
+      if (!(err instanceof ConfigWriteConflictError)) {
+        throw err;
+      }
+    }
   }
 
   const nextAuth = resolveGatewayAuthFromConfig({
@@ -245,7 +255,7 @@ export async function ensureGatewayStartupAuth(params: {
     cfg: nextCfg,
     auth: nextAuth,
     generatedToken,
-    persistedGeneratedToken: persist,
+    persistedGeneratedToken,
   };
 }
 

--- a/src/gateway/startup-control-ui-origins.test.ts
+++ b/src/gateway/startup-control-ui-origins.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { ConfigWriteConflictError } from "../config/io.js";
+import { maybeSeedControlUiAllowedOriginsAtStartup } from "./startup-control-ui-origins.js";
+
+describe("maybeSeedControlUiAllowedOriginsAtStartup", () => {
+  it("logs a startup-skip warning on config write conflicts", async () => {
+    const info = vi.fn();
+    const warn = vi.fn();
+
+    const result = await maybeSeedControlUiAllowedOriginsAtStartup({
+      config: {
+        gateway: {
+          bind: "lan",
+          port: 18789,
+        },
+      },
+      configPath: "/tmp/openclaw.json",
+      writeConfig: async () => {
+        throw new ConfigWriteConflictError({
+          configPath: "/tmp/openclaw.json",
+          expectedHash: "old",
+          actualHash: "new",
+        });
+      },
+      log: { info, warn },
+    });
+
+    expect(result).toBeTruthy();
+    expect(info).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "gateway: skipped gateway.controlUi.allowedOrigins seed because /tmp/openclaw.json changed on disk during startup.",
+    );
+  });
+});

--- a/src/gateway/startup-control-ui-origins.ts
+++ b/src/gateway/startup-control-ui-origins.ts
@@ -3,9 +3,11 @@ import {
   ensureControlUiAllowedOriginsForNonLoopbackBind,
   type GatewayNonLoopbackBindMode,
 } from "../config/gateway-control-ui-origins.js";
+import { ConfigWriteConflictError } from "../config/io.js";
 
 export async function maybeSeedControlUiAllowedOriginsAtStartup(params: {
   config: OpenClawConfig;
+  configPath?: string;
   writeConfig: (config: OpenClawConfig) => Promise<void>;
   log: { info: (msg: string) => void; warn: (msg: string) => void };
 }): Promise<OpenClawConfig> {
@@ -17,6 +19,12 @@ export async function maybeSeedControlUiAllowedOriginsAtStartup(params: {
     await params.writeConfig(seeded.config);
     params.log.info(buildSeededOriginsInfoLog(seeded.seededOrigins, seeded.bind));
   } catch (err) {
+    if (err instanceof ConfigWriteConflictError) {
+      params.log.warn(
+        `gateway: skipped gateway.controlUi.allowedOrigins seed because ${params.configPath ?? err.configPath} changed on disk during startup.`,
+      );
+      return seeded.config;
+    }
     params.log.warn(
       `gateway: failed to persist gateway.controlUi.allowedOrigins seed: ${String(err)}. The gateway will start with the in-memory value but config was not saved.`,
     );


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: several gateway startup paths can persist a config object that was computed from an older snapshot, overwriting newer edits made to `openclaw.json` during restart.
- Why it matters: restart-time writes are supposed to be narrow startup repairs, but they can silently clobber active user edits and even re-persist runtime-only startup state.
- What changed: startup writes now use an optimistic hash guard, auth-token bootstrap falls back to runtime-only when the file changed on disk, and Control UI origin seeding persists from a fresh disk snapshot instead of the whole in-memory runtime config.
- What did NOT change (scope boundary): normal user-initiated config writes (`config.patch`, CLI config commands, etc.) still use the existing write path without the startup-only conflict guard.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33310
- Related #23846

## User-visible / Behavior Changes

- Gateway startup now skips stale auto-persist writes instead of overwriting newer on-disk config edits during restart.
- If startup auth token persistence races with a newer on-disk config edit, the token stays runtime-only for that boot rather than clobbering the file.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: any gateway host where startup persistence runs during restart
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): config missing a startup-persisted field such as `gateway.controlUi.allowedOrigins` on non-loopback bind, or missing `gateway.auth.token`

### Steps

1. Start with a config that triggers a startup write path (for example non-loopback bind without `gateway.controlUi.allowedOrigins`).
2. Restart the gateway so it loads `openclaw.json` and begins startup migration/seed logic.
3. Modify `openclaw.json` on disk before the startup write completes.
4. Observe the pre-fix startup path can write the older snapshot back over the newer edit.

### Expected

- Startup should not overwrite a newer on-disk config edit with an older in-memory snapshot.

### Actual

- The stale startup snapshot can be written back to disk, silently discarding the newer edit.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: confirmed the config writer rejects stale-snapshot writes when the on-disk file hash changes; confirmed startup auth keeps generated tokens ephemeral on write conflicts.
- Edge cases checked: startup Control UI origin seeding now derives persisted config from a fresh disk snapshot, so it no longer piggybacks unrelated runtime-only startup state into the file.
- What you did **not** verify: a live launchd/systemd restart race on a real host.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR to restore the previous startup persistence behavior.
- Files/config to restore: `src/config/config.ts`, `src/config/io.ts`, `src/gateway/server.impl.ts`, `src/gateway/startup-auth.ts`
- Known bad symptoms reviewers should watch for: startup repair writes being skipped unexpectedly when another process intentionally edits the config during startup.

## Risks and Mitigations

- Risk: a legitimate startup auto-migration/auto-enable write may now be skipped when the config file changes concurrently.
  - Mitigation: the gateway logs a warning instead of overwriting newer edits, and the user can retry once the concurrent edit is complete.
