### PR TITLE
feat: show configured fallback models in /status

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -357,6 +357,82 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("Fallback:");
   });
 
+  it("shows configured fallback models when no active fallback (#33278)", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: {
+          primary: "anthropic/claude-opus-4-6",
+          fallbacks: ["openai-codex/gpt-5.3-codex", "openai/gpt-4.1"],
+        },
+        contextTokens: 200_000,
+      },
+      sessionEntry: {
+        sessionId: "configured-fallbacks",
+        updatedAt: 0,
+        modelProvider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain(
+      "Fallback: openai-codex/gpt-5.3-codex → openai/gpt-4.1 (configured)",
+    );
+  });
+
+  it("does not show configured fallback line when no fallbacks configured", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: {
+          primary: "anthropic/claude-opus-4-6",
+        },
+        contextTokens: 200_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).not.toContain("Fallback:");
+  });
+
+  it("prefers active fallback line over configured fallbacks", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: {
+          primary: "anthropic/claude-opus-4-6",
+          fallbacks: ["openai/gpt-4.1"],
+        },
+        contextTokens: 200_000,
+      },
+      sessionEntry: {
+        sessionId: "active-fallback",
+        updatedAt: 0,
+        modelProvider: "openai",
+        model: "gpt-4.1",
+        fallbackNoticeSelectedModel: "anthropic/claude-opus-4-6",
+        fallbackNoticeActiveModel: "openai/gpt-4.1",
+        fallbackNoticeReason: "rate limit",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+      activeModelAuth: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("↪️ Fallback:");
+    expect(normalized).toContain("(rate limit)");
+    expect(normalized).not.toContain("(configured)");
+  });
+
   it("keeps provider prefix from configured model", () => {
     const text = buildStatusMessage({
       agent: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -408,6 +408,24 @@ const formatVoiceModeLine = (
   return `🔊 Voice: ${autoMode} · provider=${provider} · limit=${maxLength} · summary=${summarize}`;
 };
 
+/**
+ * Resolve the configured fallback model labels from the agent model config.
+ * Returns a short label for each configured fallback (e.g. "openai/gpt-4o").
+ */
+function resolveConfiguredFallbackLabels(args: StatusArgs): string[] {
+  const modelConfig = args.agent?.model;
+  if (!modelConfig || typeof modelConfig === "string") {
+    return [];
+  }
+  const fallbacks = (modelConfig as Record<string, unknown>).fallbacks;
+  if (!Array.isArray(fallbacks) || fallbacks.length === 0) {
+    return [];
+  }
+  return fallbacks
+    .filter((f): f is string => typeof f === "string" && f.trim().length > 0)
+    .map((f) => f.trim());
+}
+
 export function buildStatusMessage(args: StatusArgs): string {
   const now = args.now ?? Date.now();
   const entry = args.sessionEntry;
@@ -650,11 +668,19 @@ export function buildStatusMessage(args: StatusArgs): string {
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
   const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`;
   const showFallbackAuth = activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;
-  const fallbackLine = fallbackState.active
-    ? `↪️ Fallback: ${activeModelLabel}${
+  const fallbackLine = (() => {
+    if (fallbackState.active) {
+      return `↪️ Fallback: ${activeModelLabel}${
         showFallbackAuth ? ` · 🔑 ${activeAuthLabelValue}` : ""
-      } (${fallbackState.reason ?? "selected model unavailable"})`
-    : null;
+      } (${fallbackState.reason ?? "selected model unavailable"})`;
+    }
+    // Show configured fallbacks even when not actively in use (#33278)
+    const configuredFallbacks = resolveConfiguredFallbackLabels(args);
+    if (configuredFallbacks.length > 0) {
+      return `🔄 Fallback: ${configuredFallbacks.join(" → ")} (configured)`;
+    }
+    return null;
+  })();
   const commit = resolveCommitHash();
   const versionLine = `🦞 OpenClaw ${VERSION}${commit ? ` (${commit})` : ""}`;
   const usagePair = formatUsagePair(inputTokens, outputTokens);


### PR DESCRIPTION
Fixes #33278

## Problem

`/status` only shows fallback information when a fallback is **actively in use** (primary model rate-limited/unavailable). When the primary model is working fine, there is zero indication that fallbacks are configured. Users cannot verify their safety net from `/status` alone.

## Fix

**2 files, ~105 insertions**

When no fallback is actively in use, `/status` now shows configured fallbacks:

```
🧠 Model: anthropic/claude-opus-4-6 · 🔑 api-key
🔄 Fallback: openai-codex/gpt-5.3-codex → openai/gpt-4.1 (configured)
```

Active fallback display is unchanged:
```
↪️ Fallback: openai/gpt-4.1 · 🔑 api-key (rate limit)
```

When no fallbacks are configured, no line is shown (unchanged behavior).

## Tests

3 new test cases:
- Shows configured fallbacks when idle
- Omits line when no fallbacks configured
- Active fallback takes precedence over configured display

All 29 tests pass.

---

🤖 **AI-assisted PR** (Claude, via OpenClaw agent)
- Testing: Fully tested locally with vitest; all relevant test suites pass
- The contributor understands what this code does