### PR TITLE
test: align commands.test.ts with acceptsArgs field in getPluginCommandSpecs

### DIFF
--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -55,6 +55,7 @@ describe("registerPluginCommand", () => {
       {
         name: "demo_cmd",
         description: "Demo command",
+        acceptsArgs: false,
       },
     ]);
   });


### PR DESCRIPTION
## Summary

`getPluginCommandSpecs()` now returns an `acceptsArgs` boolean for each command spec, but the unit test assertion was not updated to include the new field, causing CI failures across all open PRs.

## Changes

- Added `acceptsArgs: false` to the expected output in the `getPluginCommandSpecs()` test assertion

## Test

This fixes the failing `src/plugins/commands.test.ts` test on `main`.