### PR TITLE
fix(media): resolve relative local media paths using explicit roots

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -61,7 +61,7 @@ runs:
       if: inputs.install-bun == 'true'
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: "1.3.9+cf6cdbbba"
+        bun-version: "1.3.9"
 
     - name: Runtime versions
       shell: bash

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -10,11 +10,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.2"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -7,11 +7,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.2"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -361,6 +361,20 @@ describe("local media root guard", () => {
     expect(result.kind).toBe("image");
   });
 
+  it("resolves relative local paths against explicit local roots", async () => {
+    const relPath = path.relative(resolvePreferredOpenClawTmpDir(), tinyPngFile);
+    const cwd = process.cwd();
+    process.chdir(path.parse(cwd).root);
+    try {
+      const result = await loadWebMedia(relPath, 1024 * 1024, {
+        localRoots: [resolvePreferredOpenClawTmpDir()],
+      });
+      expect(result.kind).toBe("image");
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
   it("accepts win32 dev=0 stat mismatch for local file loads", async () => {
     const actualLstat = await fs.lstat(tinyPngFile);
     const actualStat = await fs.stat(tinyPngFile);

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -81,56 +81,75 @@ export function getDefaultLocalRoots(): readonly string[] {
 async function assertLocalMediaAllowed(
   mediaPath: string,
   localRoots: readonly string[] | "any" | undefined,
-): Promise<void> {
+): Promise<string> {
   if (localRoots === "any") {
-    return;
+    return mediaPath;
   }
   const roots = localRoots ?? getDefaultLocalRoots();
-  // Resolve symlinks so a symlink under /tmp pointing to /etc/passwd is caught.
-  let resolved: string;
-  try {
-    resolved = await fs.realpath(mediaPath);
-  } catch {
-    resolved = path.resolve(mediaPath);
+
+  const resolvedRoots = await Promise.all(
+    roots.map(async (root) => {
+      try {
+        const resolvedRoot = await fs.realpath(root);
+        return { raw: root, resolved: resolvedRoot };
+      } catch {
+        return { raw: root, resolved: path.resolve(root) };
+      }
+    }),
+  );
+
+  for (const root of resolvedRoots) {
+    if (root.resolved === path.parse(root.resolved).root) {
+      throw new LocalMediaAccessError(
+        "invalid-root",
+        `Invalid localRoots entry (refuses filesystem root): ${root.raw}. Pass a narrower directory.`,
+      );
+    }
   }
 
-  // Hardening: the default allowlist includes the OpenClaw temp dir, and tests/CI may
-  // override the state dir into tmp. Avoid accidentally allowing per-agent
-  // `workspace-*` state roots via the temp-root prefix match; require explicit
-  // localRoots for those.
-  if (localRoots === undefined) {
-    const workspaceRoot = roots.find((root) => path.basename(root) === "workspace");
-    if (workspaceRoot) {
-      const stateDir = path.dirname(workspaceRoot);
-      const rel = path.relative(stateDir, resolved);
-      if (rel && !rel.startsWith("..") && !path.isAbsolute(rel)) {
-        const firstSegment = rel.split(path.sep)[0] ?? "";
-        if (firstSegment.startsWith("workspace-")) {
-          throw new LocalMediaAccessError(
-            "path-not-allowed",
-            `Local media path is not under an allowed directory: ${mediaPath}`,
-          );
+  const candidates = [mediaPath];
+  const hasUrlScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(mediaPath);
+  if (!path.isAbsolute(mediaPath) && !hasUrlScheme) {
+    for (const root of resolvedRoots) {
+      candidates.push(path.join(root.resolved, mediaPath));
+    }
+  }
+
+  for (const candidate of candidates) {
+    let resolved: string;
+    try {
+      resolved = await fs.realpath(candidate);
+    } catch {
+      resolved = path.resolve(candidate);
+    }
+
+    // Hardening: the default allowlist includes the OpenClaw temp dir, and tests/CI may
+    // override the state dir into tmp. Avoid accidentally allowing per-agent
+    // `workspace-*` state roots via the temp-root prefix match; require explicit
+    // localRoots for those.
+    if (localRoots === undefined) {
+      const workspaceRoot = resolvedRoots.find(
+        (root) => path.basename(root.resolved) === "workspace",
+      );
+      if (workspaceRoot) {
+        const stateDir = path.dirname(workspaceRoot.resolved);
+        const rel = path.relative(stateDir, resolved);
+        if (rel && !rel.startsWith("..") && !path.isAbsolute(rel)) {
+          const firstSegment = rel.split(path.sep)[0] ?? "";
+          if (firstSegment.startsWith("workspace-")) {
+            continue;
+          }
         }
       }
     }
-  }
-  for (const root of roots) {
-    let resolvedRoot: string;
-    try {
-      resolvedRoot = await fs.realpath(root);
-    } catch {
-      resolvedRoot = path.resolve(root);
-    }
-    if (resolvedRoot === path.parse(resolvedRoot).root) {
-      throw new LocalMediaAccessError(
-        "invalid-root",
-        `Invalid localRoots entry (refuses filesystem root): ${root}. Pass a narrower directory.`,
-      );
-    }
-    if (resolved === resolvedRoot || resolved.startsWith(resolvedRoot + path.sep)) {
-      return;
+
+    for (const root of resolvedRoots) {
+      if (resolved === root.resolved || resolved.startsWith(root.resolved + path.sep)) {
+        return candidate;
+      }
     }
   }
+
   throw new LocalMediaAccessError(
     "path-not-allowed",
     `Local media path is not under an allowed directory: ${mediaPath}`,
@@ -349,44 +368,46 @@ async function loadWebMediaInternal(
     );
   }
 
+  let localPath = mediaUrl;
+
   // Guard local reads against allowed directory roots to prevent file exfiltration.
   if (!(sandboxValidated || localRoots === "any")) {
-    await assertLocalMediaAllowed(mediaUrl, localRoots);
+    localPath = await assertLocalMediaAllowed(mediaUrl, localRoots);
   }
 
   // Local path
   let data: Buffer;
   if (readFileOverride) {
-    data = await readFileOverride(mediaUrl);
+    data = await readFileOverride(localPath);
   } else {
     try {
-      data = (await readLocalFileSafely({ filePath: mediaUrl })).buffer;
+      data = (await readLocalFileSafely({ filePath: localPath })).buffer;
     } catch (err) {
       if (err instanceof SafeOpenError) {
         if (err.code === "not-found") {
-          throw new LocalMediaAccessError("not-found", `Local media file not found: ${mediaUrl}`, {
+          throw new LocalMediaAccessError("not-found", `Local media file not found: ${localPath}`, {
             cause: err,
           });
         }
         if (err.code === "not-file") {
           throw new LocalMediaAccessError(
             "not-file",
-            `Local media path is not a file: ${mediaUrl}`,
+            `Local media path is not a file: ${localPath}`,
             { cause: err },
           );
         }
         throw new LocalMediaAccessError(
           "invalid-path",
-          `Local media path is not safe to read: ${mediaUrl}`,
+          `Local media path is not safe to read: ${localPath}`,
           { cause: err },
         );
       }
       throw err;
     }
   }
-  const mime = await detectMime({ buffer: data, filePath: mediaUrl });
-  const kind = kindFromMime(mime);
-  let fileName = path.basename(mediaUrl) || undefined;
+  const mime = await detectMime({ buffer: data, filePath: localPath });
+  const kind = mediaKindFromMime(mime);
+  let fileName = path.basename(localPath) || undefined;
   if (fileName && !path.extname(fileName) && mime) {
     const ext = extensionForMime(mime);
     if (ext) {

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -406,7 +406,7 @@ async function loadWebMediaInternal(
     }
   }
   const mime = await detectMime({ buffer: data, filePath: localPath });
-  const kind = mediaKindFromMime(mime);
+  const kind = kindFromMime(mime);
   let fileName = path.basename(localPath) || undefined;
   if (fileName && !path.extname(fileName) && mime) {
     const ext = extensionForMime(mime);

--- a/test/media-relative-local-root.e2e.test.ts
+++ b/test/media-relative-local-root.e2e.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadWebMedia } from "../src/web/media.js";
+
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    cleanup.splice(0).map(async (dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("media local roots e2e", () => {
+  it("loads relative media paths from explicit local root even when cwd is unrelated", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-root-"));
+    cleanup.push(root);
+    const deliverablesDir = path.join(root, "deliverables");
+    await fs.mkdir(deliverablesDir, { recursive: true });
+    const filePath = path.join(deliverablesDir, "hello.txt");
+    await fs.writeFile(filePath, "hello", "utf8");
+
+    const relPath = "deliverables/hello.txt";
+    const originalCwd = process.cwd();
+    process.chdir(path.parse(originalCwd).root);
+    try {
+      const media = await loadWebMedia(relPath, {
+        maxBytes: 1024 * 1024,
+        localRoots: [root],
+      });
+      expect(media.kind).toBe("document");
+      expect(media.buffer.toString("utf8")).toBe("hello");
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- resolve relative local media paths against explicit `localRoots` before safe-read checks
- keep URL-like inputs (e.g. `rtsp://`) out of local-root candidate expansion
- preserve default hardening for `workspace-*` state directories

## Tests
- `pnpm --dir . exec vitest run src/web/media.test.ts`
- `pnpm --dir . exec vitest run --config vitest.e2e.config.ts test/media-relative-local-root.e2e.test.ts`

Refs: #33358
