### PR TITLE
Auth: force Codex default model when auth choice is openai-codex

### DIFF
--- a/src/commands/auth-choice.apply.openai.ts
+++ b/src/commands/auth-choice.apply.openai.ts
@@ -10,7 +10,7 @@ import { isRemoteEnvironment } from "./oauth-env.js";
 import { applyAuthProfileConfig, setOpenaiApiKey, writeOAuthCredentials } from "./onboard-auth.js";
 import { openUrl } from "./onboard-helpers.js";
 import {
-  applyOpenAICodexModelDefault,
+  applyOpenAICodexModelDefaultWithOptions,
   OPENAI_CODEX_DEFAULT_MODEL,
 } from "./openai-codex-model-default.js";
 import { loginOpenAICodexOAuth } from "./openai-codex-oauth.js";
@@ -103,7 +103,7 @@ export async function applyAuthChoiceOpenAI(
         mode: "oauth",
       });
       if (params.setDefaultModel) {
-        const applied = applyOpenAICodexModelDefault(nextConfig);
+        const applied = applyOpenAICodexModelDefaultWithOptions(nextConfig, { force: true });
         nextConfig = applied.next;
         if (applied.changed) {
           await params.prompter.note(

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -189,6 +189,40 @@ describe("applyAuthChoice", () => {
     });
   });
 
+  it("forces openai-codex as default model when setDefaultModel=true", async () => {
+    await setupTempState();
+
+    loginOpenAICodexOAuth.mockResolvedValueOnce({
+      email: "user@example.com",
+      refresh: "refresh-token",
+      access: "access-token",
+      expires: Date.now() + 60_000,
+    });
+
+    const prompter = createPrompter({});
+    const runtime = createExitThrowingRuntime();
+
+    const result = await applyAuthChoice({
+      authChoice: "openai-codex",
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+            },
+          },
+        },
+      },
+      prompter,
+      runtime,
+      setDefaultModel: true,
+    });
+
+    expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
+      "openai-codex/gpt-5.3-codex",
+    );
+  });
+
   it("prompts and writes provider API key for common providers", async () => {
     const scenarios: Array<{
       authChoice:

--- a/src/commands/openai-codex-model-default.ts
+++ b/src/commands/openai-codex-model-default.ts
@@ -32,8 +32,18 @@ export function applyOpenAICodexModelDefault(cfg: OpenClawConfig): {
   next: OpenClawConfig;
   changed: boolean;
 } {
+  return applyOpenAICodexModelDefaultWithOptions(cfg, {});
+}
+
+export function applyOpenAICodexModelDefaultWithOptions(
+  cfg: OpenClawConfig,
+  opts: { force?: boolean },
+): {
+  next: OpenClawConfig;
+  changed: boolean;
+} {
   const current = resolvePrimaryModel(cfg.agents?.defaults?.model);
-  if (!shouldSetOpenAICodexModel(current)) {
+  if (!opts.force && !shouldSetOpenAICodexModel(current)) {
     return { next: cfg, changed: false };
   }
   return {

--- a/src/commands/openai-model-default.test.ts
+++ b/src/commands/openai-model-default.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./google-gemini-model-default.js";
 import {
   applyOpenAICodexModelDefault,
+  applyOpenAICodexModelDefaultWithOptions,
   OPENAI_CODEX_DEFAULT_MODEL,
 } from "./openai-codex-model-default.js";
 import {
@@ -226,6 +227,14 @@ describe("applyOpenAICodexModelDefault", () => {
     };
     const applied = applyOpenAICodexModelDefault(cfg);
     expectConfigUnchanged(applied, cfg);
+  });
+
+  it("overrides non-openai models when force=true", () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
+    };
+    const applied = applyOpenAICodexModelDefaultWithOptions(cfg, { force: true });
+    expectPrimaryModelChanged(applied, OPENAI_CODEX_DEFAULT_MODEL);
   });
 });
 


### PR DESCRIPTION
## Summary
- fix onboarding behavior for `openai-codex` auth choice when `setDefaultModel=true`
- force default model update to `openai-codex/gpt-5.3-codex` even if `agents.defaults.model.primary` currently points to another provider
- preserve existing non-forced behavior by keeping `applyOpenAICodexModelDefault` unchanged and adding an options-based forced path
- add tests for both forced codex defaulting and auth-choice integration

Closes #33290.

## Validation
- `pnpm exec vitest run src/commands/openai-model-default.test.ts src/commands/auth-choice.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm test` (fails on pre-existing tests outside this change set: `src/memory/batch-voyage.test.ts`, `src/memory/manager.batch.test.ts`, `src/plugins/commands.test.ts`)
