### PR TITLE
fix(gateway): keep Tailscale Serve control UI local behind proxies

### DIFF
--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -42,6 +42,20 @@ function createTailscaleForwardedReq(): never {
   } as never;
 }
 
+function createNonTailscaleForwardedReq(): never {
+  return {
+    socket: { remoteAddress: "127.0.0.1" },
+    headers: {
+      host: "gateway.local",
+      "x-forwarded-for": "203.0.113.10",
+      "x-forwarded-proto": "https",
+      "x-forwarded-host": "ai-hub.bone-egret.ts.net",
+      "tailscale-user-login": "peter",
+      "tailscale-user-name": "Peter",
+    },
+  } as never;
+}
+
 function createTailscaleWhois() {
   return async () => ({ login: "peter", name: "Peter" });
 }
@@ -276,6 +290,10 @@ describe("gateway auth", () => {
 
   it("does not treat proxied tailscale serve requests as direct without trusted proxies", () => {
     expect(isLocalDirectRequest(createTailscaleForwardedReq())).toBe(false);
+  });
+
+  it("does not treat proxied .ts.net requests as direct when forwarded client IP is non-tailscale", () => {
+    expect(isLocalDirectRequest(createNonTailscaleForwardedReq(), ["127.0.0.1"])).toBe(false);
   });
 
   it("does not treat non-tailscale proxied requests as direct when trusted proxies are configured", () => {

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -4,6 +4,7 @@ import {
   authorizeGatewayConnect,
   authorizeHttpGatewayConnect,
   authorizeWsControlUiGatewayConnect,
+  isLocalDirectRequest,
   resolveGatewayAuth,
 } from "./auth.js";
 
@@ -267,6 +268,27 @@ describe("gateway auth", () => {
 
     expect(res.ok).toBe(true);
     expect(res.method).toBe("token");
+  });
+
+  it("treats proxied tailscale serve requests as direct when trusted proxies are configured", () => {
+    expect(isLocalDirectRequest(createTailscaleForwardedReq(), ["127.0.0.1"])).toBe(true);
+  });
+
+  it("does not treat non-tailscale proxied requests as direct when trusted proxies are configured", () => {
+    expect(
+      isLocalDirectRequest(
+        {
+          socket: { remoteAddress: "127.0.0.1" },
+          headers: {
+            host: "gateway.local",
+            "x-forwarded-for": "203.0.113.10",
+            "x-forwarded-proto": "https",
+            "x-forwarded-host": "example.com",
+          },
+        } as never,
+        ["127.0.0.1"],
+      ),
+    ).toBe(false);
   });
 
   it("does not allow tailscale identity to satisfy token mode auth by default", async () => {

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -42,6 +42,20 @@ function createTailscaleForwardedReq(): never {
   } as never;
 }
 
+function createTailscaleForwardedReqWithPortInHost(): never {
+  return {
+    socket: { remoteAddress: "127.0.0.1" },
+    headers: {
+      host: "gateway.local",
+      "x-forwarded-for": "100.64.0.1",
+      "x-forwarded-proto": "https",
+      "x-forwarded-host": "ai-hub.bone-egret.ts.net:443",
+      "tailscale-user-login": "peter",
+      "tailscale-user-name": "Peter",
+    },
+  } as never;
+}
+
 function createNonTailscaleForwardedReq(): never {
   return {
     socket: { remoteAddress: "127.0.0.1" },
@@ -286,6 +300,20 @@ describe("gateway auth", () => {
 
   it("treats proxied tailscale serve requests as direct when trusted proxies are configured", () => {
     expect(isLocalDirectRequest(createTailscaleForwardedReq(), ["127.0.0.1"])).toBe(true);
+  });
+
+  it("treats proxied tailscale serve requests with host:port as direct when trusted proxies are configured", () => {
+    expect(isLocalDirectRequest(createTailscaleForwardedReqWithPortInHost(), ["127.0.0.1"])).toBe(
+      true,
+    );
+  });
+
+  it("does not apply the tailscale local-direct shortcut when explicitly disabled", () => {
+    expect(
+      isLocalDirectRequest(createTailscaleForwardedReq(), ["127.0.0.1"], false, {
+        allowTailscaleServeShortcut: false,
+      }),
+    ).toBe(false);
   });
 
   it("does not treat proxied tailscale serve requests as direct without trusted proxies", () => {

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -274,6 +274,10 @@ describe("gateway auth", () => {
     expect(isLocalDirectRequest(createTailscaleForwardedReq(), ["127.0.0.1"])).toBe(true);
   });
 
+  it("does not treat proxied tailscale serve requests as direct without trusted proxies", () => {
+    expect(isLocalDirectRequest(createTailscaleForwardedReq())).toBe(false);
+  });
+
   it("does not treat non-tailscale proxied requests as direct when trusted proxies are configured", () => {
     expect(
       isLocalDirectRequest(

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -335,6 +335,20 @@ describe("gateway auth", () => {
     });
   });
 
+  it("keeps tailscale header auth enabled when trusted proxies make the request local-direct", async () => {
+    const res = await authorizeWsControlUiGatewayConnect({
+      auth: { mode: "token", token: "secret", allowTailscale: true },
+      connectAuth: null,
+      tailscaleWhois: createTailscaleWhois(),
+      trustedProxies: ["127.0.0.1"],
+      req: createTailscaleForwardedReq(),
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("tailscale");
+    expect(res.user).toBe("peter");
+  });
+
   it("uses proxy-aware request client IP by default for rate-limit checks", async () => {
     const limiter = await expectTokenMismatchWithLimiter({
       reqHeaders: { "x-forwarded-for": "203.0.113.10" },

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -56,6 +56,20 @@ function createTailscaleForwardedReqWithPortInHost(): never {
   } as never;
 }
 
+function createTailscaleForwardedIpv6Req(): never {
+  return {
+    socket: { remoteAddress: "::1" },
+    headers: {
+      host: "gateway.local",
+      "x-forwarded-for": "fd7a:115c:a1e0::1",
+      "x-forwarded-proto": "https",
+      "x-forwarded-host": "ai-hub.bone-egret.ts.net",
+      "tailscale-user-login": "peter",
+      "tailscale-user-name": "Peter",
+    },
+  } as never;
+}
+
 function createNonTailscaleForwardedReq(): never {
   return {
     socket: { remoteAddress: "127.0.0.1" },
@@ -299,13 +313,31 @@ describe("gateway auth", () => {
   });
 
   it("treats proxied tailscale serve requests as direct when trusted proxies are configured", () => {
-    expect(isLocalDirectRequest(createTailscaleForwardedReq(), ["127.0.0.1"])).toBe(true);
+    expect(
+      isLocalDirectRequest(createTailscaleForwardedReq(), ["127.0.0.1"], false, {
+        allowTailscaleServeShortcut: true,
+      }),
+    ).toBe(true);
   });
 
   it("treats proxied tailscale serve requests with host:port as direct when trusted proxies are configured", () => {
-    expect(isLocalDirectRequest(createTailscaleForwardedReqWithPortInHost(), ["127.0.0.1"])).toBe(
-      true,
-    );
+    expect(
+      isLocalDirectRequest(createTailscaleForwardedReqWithPortInHost(), ["127.0.0.1"], false, {
+        allowTailscaleServeShortcut: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats proxied tailscale serve IPv6 requests as direct when trusted proxies are configured", () => {
+    expect(
+      isLocalDirectRequest(createTailscaleForwardedIpv6Req(), ["::1"], false, {
+        allowTailscaleServeShortcut: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps tailscale local-direct shortcut disabled by default", () => {
+    expect(isLocalDirectRequest(createTailscaleForwardedReq(), ["127.0.0.1"])).toBe(false);
   });
 
   it("does not apply the tailscale local-direct shortcut when explicitly disabled", () => {
@@ -321,7 +353,11 @@ describe("gateway auth", () => {
   });
 
   it("does not treat proxied .ts.net requests as direct when forwarded client IP is non-tailscale", () => {
-    expect(isLocalDirectRequest(createNonTailscaleForwardedReq(), ["127.0.0.1"])).toBe(false);
+    expect(
+      isLocalDirectRequest(createNonTailscaleForwardedReq(), ["127.0.0.1"], false, {
+        allowTailscaleServeShortcut: true,
+      }),
+    ).toBe(false);
   });
 
   it("does not treat non-tailscale proxied requests as direct when trusted proxies are configured", () => {

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -129,6 +129,10 @@ export function isLocalDirectRequest(
   if (!req) {
     return false;
   }
+  const forwardedHost = headerValue(req.headers?.["x-forwarded-host"]);
+  if (isTailscaleProxyRequest(req) && forwardedHost?.endsWith(".ts.net")) {
+    return true;
+  }
   const clientIp = resolveRequestClientIp(req, trustedProxies, allowRealIpFallback) ?? "";
   if (!isLoopbackAddress(clientIp)) {
     return false;
@@ -373,6 +377,10 @@ export async function authorizeGatewayConnect(
     trustedProxies,
     params.allowRealIpFallback === true,
   );
+  const allowVerifiedTailscaleHeaderAuth =
+    allowTailscaleHeaderAuth &&
+    auth.allowTailscale &&
+    (!localDirect || isTailscaleProxyRequest(req));
 
   if (auth.mode === "trusted-proxy") {
     if (!auth.trustedProxy) {
@@ -416,7 +424,7 @@ export async function authorizeGatewayConnect(
     }
   }
 
-  if (allowTailscaleHeaderAuth && auth.allowTailscale && !localDirect) {
+  if (allowVerifiedTailscaleHeaderAuth) {
     const tailscaleCheck = await resolveVerifiedTailscaleUser({
       req,
       tailscaleWhois,

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -6,6 +6,7 @@ import type {
 } from "../config/config.js";
 import { readTailscaleWhoisIdentity, type TailscaleWhoisIdentity } from "../infra/tailscale.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
+import { isCarrierGradeNatIpv4Address } from "../shared/net/ip.js";
 import {
   AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
   type AuthRateLimiter,
@@ -131,7 +132,13 @@ export function isLocalDirectRequest(
   }
   const remoteIsTrustedProxy = isTrustedProxyAddress(req.socket?.remoteAddress, trustedProxies);
   const forwardedHost = headerValue(req.headers?.["x-forwarded-host"]);
-  if (remoteIsTrustedProxy && isTailscaleProxyRequest(req) && forwardedHost?.endsWith(".ts.net")) {
+  const tailscaleClientIp = resolveTailscaleClientIp(req);
+  if (
+    remoteIsTrustedProxy &&
+    isTailscaleProxyRequest(req) &&
+    forwardedHost?.endsWith(".ts.net") &&
+    isCarrierGradeNatIpv4Address(tailscaleClientIp)
+  ) {
     return true;
   }
   const clientIp = resolveRequestClientIp(req, trustedProxies, allowRealIpFallback) ?? "";

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -129,8 +129,9 @@ export function isLocalDirectRequest(
   if (!req) {
     return false;
   }
+  const remoteIsTrustedProxy = isTrustedProxyAddress(req.socket?.remoteAddress, trustedProxies);
   const forwardedHost = headerValue(req.headers?.["x-forwarded-host"]);
-  if (isTailscaleProxyRequest(req) && forwardedHost?.endsWith(".ts.net")) {
+  if (remoteIsTrustedProxy && isTailscaleProxyRequest(req) && forwardedHost?.endsWith(".ts.net")) {
     return true;
   }
   const clientIp = resolveRequestClientIp(req, trustedProxies, allowRealIpFallback) ?? "";
@@ -144,7 +145,6 @@ export function isLocalDirectRequest(
     req.headers?.["x-forwarded-host"],
   );
 
-  const remoteIsTrustedProxy = isTrustedProxyAddress(req.socket?.remoteAddress, trustedProxies);
   return isLocalishHost(req.headers?.host) && (!hasForwarded || remoteIsTrustedProxy);
 }
 

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -16,6 +16,7 @@ import { resolveGatewayCredentialsFromValues } from "./credentials.js";
 import {
   isLocalishHost,
   isLoopbackAddress,
+  resolveHostName,
   isTrustedProxyAddress,
   resolveClientIp,
 } from "./net.js";
@@ -122,21 +123,31 @@ function resolveRequestClientIp(
   });
 }
 
+function isTailscaleForwardedHost(value: string | undefined): boolean {
+  const host = resolveHostName(value);
+  return host.toLowerCase().endsWith(".ts.net");
+}
+
 export function isLocalDirectRequest(
   req?: IncomingMessage,
   trustedProxies?: string[],
   allowRealIpFallback = false,
+  options?: {
+    allowTailscaleServeShortcut?: boolean;
+  },
 ): boolean {
   if (!req) {
     return false;
   }
+  const allowTailscaleServeShortcut = options?.allowTailscaleServeShortcut !== false;
   const remoteIsTrustedProxy = isTrustedProxyAddress(req.socket?.remoteAddress, trustedProxies);
   const forwardedHost = headerValue(req.headers?.["x-forwarded-host"]);
   const tailscaleClientIp = resolveTailscaleClientIp(req);
   if (
+    allowTailscaleServeShortcut &&
     remoteIsTrustedProxy &&
     isTailscaleProxyRequest(req) &&
-    forwardedHost?.endsWith(".ts.net") &&
+    isTailscaleForwardedHost(forwardedHost) &&
     isCarrierGradeNatIpv4Address(tailscaleClientIp)
   ) {
     return true;
@@ -383,6 +394,7 @@ export async function authorizeGatewayConnect(
     req,
     trustedProxies,
     params.allowRealIpFallback === true,
+    { allowTailscaleServeShortcut: false },
   );
   const allowVerifiedTailscaleHeaderAuth =
     allowTailscaleHeaderAuth &&

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -6,7 +6,7 @@ import type {
 } from "../config/config.js";
 import { readTailscaleWhoisIdentity, type TailscaleWhoisIdentity } from "../infra/tailscale.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
-import { isCarrierGradeNatIpv4Address } from "../shared/net/ip.js";
+import { isCarrierGradeNatIpv4Address, isIpInCidr } from "../shared/net/ip.js";
 import {
   AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
   type AuthRateLimiter,
@@ -94,6 +94,7 @@ function headerValue(value: string | string[] | undefined): string | undefined {
 }
 
 const TAILSCALE_TRUSTED_PROXIES = ["127.0.0.1", "::1"] as const;
+const TAILSCALE_IPV6_ULA_CIDR = "fd7a:115c:a1e0::/48";
 
 function resolveTailscaleClientIp(req?: IncomingMessage): string | undefined {
   if (!req) {
@@ -128,6 +129,10 @@ function isTailscaleForwardedHost(value: string | undefined): boolean {
   return host.toLowerCase().endsWith(".ts.net");
 }
 
+function isTailscaleServeClientIp(value: string | undefined): boolean {
+  return isCarrierGradeNatIpv4Address(value) || isIpInCidr(value ?? "", TAILSCALE_IPV6_ULA_CIDR);
+}
+
 export function isLocalDirectRequest(
   req?: IncomingMessage,
   trustedProxies?: string[],
@@ -139,7 +144,7 @@ export function isLocalDirectRequest(
   if (!req) {
     return false;
   }
-  const allowTailscaleServeShortcut = options?.allowTailscaleServeShortcut !== false;
+  const allowTailscaleServeShortcut = options?.allowTailscaleServeShortcut === true;
   const remoteIsTrustedProxy = isTrustedProxyAddress(req.socket?.remoteAddress, trustedProxies);
   const forwardedHost = headerValue(req.headers?.["x-forwarded-host"]);
   const tailscaleClientIp = resolveTailscaleClientIp(req);
@@ -148,7 +153,7 @@ export function isLocalDirectRequest(
     remoteIsTrustedProxy &&
     isTailscaleProxyRequest(req) &&
     isTailscaleForwardedHost(forwardedHost) &&
-    isCarrierGradeNatIpv4Address(tailscaleClientIp)
+    isTailscaleServeClientIp(tailscaleClientIp)
   ) {
     return true;
   }

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -12,6 +12,7 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
   onceMessage,
+  openTailscaleWs,
   openWs,
   originForPort,
   readConnectChallengeNonce,
@@ -546,6 +547,48 @@ export function registerControlUiAndPairingSuite(): void {
     );
     expect(await getPairedDevice(identity.deviceId)).toBeNull();
     ws2.close();
+    await server.close();
+    restoreGatewayToken(prevToken);
+  });
+
+  test("auto-approves tailscale serve operator pairing behind trusted proxies", async () => {
+    const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
+    const { writeConfigFile } = await import("../config/config.js");
+    const { server, ws, port, prevToken } = await startServerWithClient("secret");
+    const { identityPath, identity } = await createOperatorIdentityFixture(
+      "openclaw-device-tailscale-",
+    );
+    ws.close();
+    await writeConfigFile({
+      gateway: {
+        trustedProxies: ["127.0.0.1"],
+        controlUi: {
+          allowedOrigins: ["https://gateway.tailnet.ts.net"],
+        },
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+
+    const wsTailscale = await openTailscaleWs(port);
+    const nonce = await readConnectChallengeNonce(wsTailscale);
+    const res = await connectReq(wsTailscale, {
+      token: "secret",
+      scopes: ["operator.read"],
+      client: { ...CONTROL_UI_CLIENT },
+      device: await buildSignedDeviceForIdentity({
+        identityPath,
+        client: { ...CONTROL_UI_CLIENT },
+        scopes: ["operator.read"],
+        nonce,
+      }),
+    });
+    expect(res.ok).toBe(true);
+    await expectStatusAndHealthOk(wsTailscale);
+    expect(await getPairedDevice(identity.deviceId)).not.toBeNull();
+    expect(
+      (await listDevicePairing()).pending.filter((entry) => entry.deviceId === identity.deviceId),
+    ).toHaveLength(0);
+    wsTailscale.close();
     await server.close();
     restoreGatewayToken(prevToken);
   });

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -902,6 +902,40 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
+  test("requires pairing for gateway backend clients behind tailscale serve proxy headers", async () => {
+    const { writeConfigFile } = await import("../config/config.js");
+    const { server, ws, port, prevToken } = await startServerWithClient("secret");
+    ws.close();
+    await writeConfigFile({
+      gateway: {
+        trustedProxies: ["127.0.0.1"],
+        controlUi: {
+          allowedOrigins: ["https://gateway.tailnet.ts.net"],
+        },
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+    const wsTailscaleBackend = await openWs(port, {
+      "x-forwarded-for": "100.64.0.1",
+      "x-forwarded-proto": "https",
+      "x-forwarded-host": "gateway.tailnet.ts.net",
+      "tailscale-user-login": "peter",
+      "tailscale-user-name": "Peter",
+    });
+    try {
+      const tailscaleBackend = await connectReq(wsTailscaleBackend, {
+        token: "secret",
+        client: BACKEND_GATEWAY_CLIENT,
+      });
+      expect(tailscaleBackend.ok).toBe(false);
+      expect(tailscaleBackend.error?.message ?? "").toContain("pairing required");
+    } finally {
+      wsTailscaleBackend.close();
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("requires pairing for gateway backend clients when connection is not local-direct", async () => {
     const { server, ws, port, prevToken } = await startServerWithClient("secret");
     ws.close();

--- a/src/gateway/server/http-auth.ts
+++ b/src/gateway/server/http-auth.ts
@@ -78,7 +78,11 @@ export async function authorizeCanvasRequest(params: {
   if (malformedScopedPath) {
     return { ok: false, reason: "unauthorized" };
   }
-  if (isLocalDirectRequest(req, trustedProxies, allowRealIpFallback)) {
+  if (
+    isLocalDirectRequest(req, trustedProxies, allowRealIpFallback, {
+      allowTailscaleServeShortcut: false,
+    })
+  ) {
     return { ok: true };
   }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -321,7 +321,9 @@ export function attachGatewayWsMessageHandler(params: {
   const remoteIsTrustedProxy = isTrustedProxyAddress(remoteAddr, trustedProxies);
   const hasUntrustedProxyHeaders = hasProxyHeaders && !remoteIsTrustedProxy;
   const hostIsLocalish = isLocalishHost(requestHost);
-  const isLocalClient = isLocalDirectRequest(upgradeReq, trustedProxies, allowRealIpFallback);
+  const isLocalClient = isLocalDirectRequest(upgradeReq, trustedProxies, allowRealIpFallback, {
+    allowTailscaleServeShortcut: true,
+  });
   const reportedClientIp =
     isLocalClient || hasUntrustedProxyHeaders
       ? undefined

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -515,6 +515,7 @@ export function attachGatewayWsMessageHandler(params: {
         const isWebchat = isWebchatConnect(connectParams);
         const isLocalClient =
           isStrictLocalClient || (isProxyTailscaleServeShortcutOnly && (isControlUi || isWebchat));
+        const isPrivilegedLocalClient = isStrictLocalClient;
         if (enforceOriginCheckForAnyClient || isControlUi || isWebchat) {
           const hostHeaderOriginFallbackEnabled =
             configSnapshot.gateway?.controlUi?.dangerouslyAllowHostHeaderOriginFallback === true;
@@ -523,7 +524,7 @@ export function attachGatewayWsMessageHandler(params: {
             origin: requestOrigin,
             allowedOrigins: configSnapshot.gateway?.controlUi?.allowedOrigins,
             allowHostHeaderOriginFallback: hostHeaderOriginFallbackEnabled,
-            isLocalClient,
+            isLocalClient: isPrivilegedLocalClient,
           });
           if (!originCheck.ok) {
             const errorMessage =
@@ -775,7 +776,7 @@ export function attachGatewayWsMessageHandler(params: {
         const skipPairing =
           shouldSkipBackendSelfPairing({
             connectParams,
-            isLocalClient,
+            isLocalClient: isPrivilegedLocalClient,
             hasBrowserOriginHeader,
             sharedAuthOk,
             authMethod,
@@ -828,7 +829,7 @@ export function attachGatewayWsMessageHandler(params: {
             reason: "not-paired" | "role-upgrade" | "scope-upgrade" | "metadata-upgrade",
           ) => {
             const allowSilentLocalPairing = shouldAllowSilentLocalPairing({
-              isLocalClient,
+              isLocalClient: isPrivilegedLocalClient,
               hasBrowserOriginHeader,
               isControlUi,
               isWebchat,
@@ -1017,7 +1018,7 @@ export function attachGatewayWsMessageHandler(params: {
         if (presenceKey) {
           upsertPresence(presenceKey, {
             host: connectParams.client.displayName ?? connectParams.client.id ?? os.hostname(),
-            ip: isLocalClient ? undefined : reportedClientIp,
+            ip: isPrivilegedLocalClient ? undefined : reportedClientIp,
             version: connectParams.client.version,
             platform: connectParams.client.platform,
             deviceFamily: connectParams.client.deviceFamily,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -321,11 +321,26 @@ export function attachGatewayWsMessageHandler(params: {
   const remoteIsTrustedProxy = isTrustedProxyAddress(remoteAddr, trustedProxies);
   const hasUntrustedProxyHeaders = hasProxyHeaders && !remoteIsTrustedProxy;
   const hostIsLocalish = isLocalishHost(requestHost);
-  const isLocalClient = isLocalDirectRequest(upgradeReq, trustedProxies, allowRealIpFallback, {
-    allowTailscaleServeShortcut: true,
-  });
+  const isStrictLocalClient = isLocalDirectRequest(
+    upgradeReq,
+    trustedProxies,
+    allowRealIpFallback,
+    {
+      allowTailscaleServeShortcut: false,
+    },
+  );
+  const isTailscaleServeShortcutLocalClient = isLocalDirectRequest(
+    upgradeReq,
+    trustedProxies,
+    allowRealIpFallback,
+    {
+      allowTailscaleServeShortcut: true,
+    },
+  );
+  const isProxyTailscaleServeShortcutOnly =
+    isTailscaleServeShortcutLocalClient && !isStrictLocalClient;
   const reportedClientIp =
-    isLocalClient || hasUntrustedProxyHeaders
+    isStrictLocalClient || hasUntrustedProxyHeaders
       ? undefined
       : clientIp && !isLoopbackAddress(clientIp)
         ? clientIp
@@ -498,6 +513,8 @@ export function attachGatewayWsMessageHandler(params: {
 
         const isControlUi = connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
         const isWebchat = isWebchatConnect(connectParams);
+        const isLocalClient =
+          isStrictLocalClient || (isProxyTailscaleServeShortcutOnly && (isControlUi || isWebchat));
         if (enforceOriginCheckForAnyClient || isControlUi || isWebchat) {
           const hostHeaderOriginFallbackEnabled =
             configSnapshot.gateway?.controlUi?.dangerouslyAllowHostHeaderOriginFallback === true;


### PR DESCRIPTION
## Summary

- Problem: Webchat/control-ui connections coming through Tailscale Serve can fall back to `pairing required` once `gateway.trustedProxies` is configured, even though the request is still loopback-delivered by Serve.
- Why it matters: the recommended loopback + Tailscale Serve deployment can no longer silently pair the Control UI, so the dashboard becomes unusable behind Serve.
- What changed: treat loopback Tailscale Serve requests (`x-forwarded-*` + `.ts.net`) as local-direct for pairing/origin decisions, while still preserving verified Tailscale header auth.
- What did NOT change (scope boundary): no generic reverse-proxy bypass, no changes to token/password validation, no changes to non-Tailscale proxy handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20401
- Related #

## User-visible / Behavior Changes

- Control UI / webchat connections coming through Tailscale Serve no longer hit `pairing required` just because `gateway.trustedProxies` is configured.
- Existing Tailscale header-auth behavior for Control UI remains intact.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS local test env
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): Gateway Control UI / webchat over Tailscale Serve
- Relevant config (redacted): `gateway.trustedProxies=["127.0.0.1"]`, Control UI origin `https://gateway.tailnet.ts.net`

### Steps

1. Run the gateway behind Tailscale Serve so requests arrive from loopback with `x-forwarded-for`, `x-forwarded-proto`, and `x-forwarded-host` headers.
2. Configure `gateway.trustedProxies` to trust the loopback proxy source.
3. Open the Control UI over the `.ts.net` hostname and connect with a fresh device identity.

### Expected

- The request is still treated as local-direct for Control UI pairing, so first-run pairing is silently approved.

### Actual

- Proxy-aware client IP resolution unwraps to the remote Tailscale client IP first, so the request is treated as remote and the websocket closes with `pairing required`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/gateway/auth.test.ts`
  - `pnpm test src/gateway/server.auth.control-ui.test.ts`
  - `pnpm check`
- Edge cases checked:
  - Non-Tailscale proxied requests with `trustedProxies` configured still stay non-local.
  - Verified Tailscale header auth still works on the WS control-ui auth path.
- What you did **not** verify:
  - End-to-end against a live Tailscale daemon / real browser session.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `ee99709f5c`.
- Files/config to restore:
  - `src/gateway/auth.ts`
  - `src/gateway/auth.test.ts`
  - `src/gateway/server.auth.control-ui.suite.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected local-direct classification for non-Tailscale proxied Control UI requests.

## Risks and Mitigations

- Risk: a loopback proxy that forges Tailscale-style forwarded headers and a `.ts.net` host could be classified as local-direct.
  - Mitigation: the special case is limited to loopback Tailscale proxy header shape plus `.ts.net`, tokenless WS auth still requires verified Tailscale identity, and a regression test keeps generic non-Tailscale proxy traffic remote.
