### PR TITLE
fix(test): align getPluginCommandSpecs assertion with actual return shape

### DIFF
--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -55,6 +55,7 @@ describe("registerPluginCommand", () => {
       {
         name: "demo_cmd",
         description: "Demo command",
+        acceptsArgs: false,
       },
     ]);
   });


### PR DESCRIPTION
The `getPluginCommandSpecs` test expected objects with only `{name, description}`, but the implementation returns `{name, description, acceptsArgs}` (where `acceptsArgs` defaults to `false` via `??`). This mismatch causes consistent test failures on bun and Windows CI runners, blocking all open PRs.

**1 file, 1 line changed.**

```diff
-        { name: "demo_cmd", description: "Demo command" },
+        { name: "demo_cmd", description: "Demo command", acceptsArgs: false },
```

---

🤖 **AI-assisted PR** (Claude, via OpenClaw agent)
- Testing: Fully tested locally with vitest; all relevant test suites pass
- The contributor understands what this code does