### PR TITLE
fix: filter delivery-mirror entries from webchat chat history

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -225,6 +225,19 @@ function extractAssistantTextForSilentCheck(message: unknown): string | undefine
   return texts.length > 0 ? texts.join("\n") : undefined;
 }
 
+/**
+ * Returns true for assistant messages written by the delivery-mirror subsystem.
+ * These entries record outbound sends for transcript completeness but should not
+ * be surfaced in the webchat UI (the real model response is already present).
+ */
+function isDeliveryMirrorMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const msg = message as Record<string, unknown>;
+  return msg.role === "assistant" && msg.model === "delivery-mirror";
+}
+
 function sanitizeChatHistoryMessages(messages: unknown[]): unknown[] {
   if (messages.length === 0) {
     return messages;
@@ -237,6 +250,14 @@ function sanitizeChatHistoryMessages(messages: unknown[]): unknown[] {
     // Drop assistant messages whose entire visible text is the silent reply token.
     const text = extractAssistantTextForSilentCheck(res.message);
     if (text !== undefined && isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+      changed = true;
+      continue;
+    }
+    // Drop delivery-mirror transcript entries — these are internal bookkeeping
+    // for outbound messages sent via channel plugins and should not appear in
+    // the webchat UI (the real assistant message is already in the transcript).
+    // See: openclaw/openclaw#33263
+    if (isDeliveryMirrorMessage(res.message)) {
       changed = true;
       continue;
     }


### PR DESCRIPTION
Fixes #33263

## Problem

When outbound messages are sent via channel plugins (Telegram, Discord, etc.), a `delivery-mirror` assistant message is appended to the session transcript for bookkeeping:

```json
{"role": "assistant", "provider": "openclaw", "model": "delivery-mirror", "usage": {"totalTokens": 0}}
```

This internal entry was being surfaced in the webchat Control UI chat history alongside the real model response, causing **duplicate assistant messages** for every turn.

## Fix

**1 file, 21 lines added**

Filter `delivery-mirror` messages in `sanitizeChatHistoryMessages()`, using the same pattern as the existing silent-reply-token filter. The helper checks `role === "assistant" && model === "delivery-mirror"`.

The delivery-mirror entries remain in the session JSONL transcript (they are useful for debugging and transcript completeness). Only the webchat UI history endpoint filters them out.

---

🤖 **AI-assisted PR** (Claude, via OpenClaw agent)
- Testing: Lightly tested (no existing test file for chat.ts server methods; logic follows established filter pattern)
- The contributor understands what this code does