### PR TITLE
fix(logging): use local timezone for timestamps instead of UTC

### DIFF
--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -7,6 +7,7 @@ import { getConsoleSettings, shouldLogSubsystemToConsole } from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
 import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
+import { formatLocalIsoWithOffset } from "./timestamps.js";
 
 type LogObj = { date?: Date } & Record<string, unknown>;
 
@@ -197,7 +198,7 @@ function formatConsoleLine(opts: {
     opts.style === "json" ? opts.subsystem : formatSubsystemForConsole(opts.subsystem);
   if (opts.style === "json") {
     return JSON.stringify({
-      time: new Date().toISOString(),
+      time: formatLocalIsoWithOffset(new Date()),
       level: opts.level,
       subsystem: displaySubsystem,
       message: opts.message,
@@ -218,10 +219,10 @@ function formatConsoleLine(opts: {
   const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
   const time = (() => {
     if (opts.style === "pretty") {
-      return color.gray(new Date().toISOString().slice(11, 19));
+      return color.gray(formatLocalIsoWithOffset(new Date()).slice(11, 19));
     }
     if (loggingState.consoleTimestampPrefix) {
-      return color.gray(new Date().toISOString());
+      return color.gray(formatLocalIsoWithOffset(new Date()));
     }
     return "";
   })();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: gateway.err.log shows mixed timezone timestamps - some logs are UTC (2026-03-03T16:59:21.820Z), some are local time (2026-03-04T01:04:11.008+08:00)
- Why it matters: Inconsistent log timestamps make troubleshooting difficult and hard to correlate event order
- What changed: Replaced 3 instances of new Date().toISOString() with formatLocalIsoWithOffset(new Date()) in subsystem.ts
- What did NOT change (scope boundary): Only modified log timestamp format, no changes to log content or other logic

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Related 6a3940a

## User-visible / Behavior Changes

None. Log timestamp format changed from UTC to local timezone, no user-facing impact

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22.x
- Model/provider: N/A
- Integration/channel (if any): gateway logging

### Steps

1. Start Gateway
2. Trigger any log output (e.g., Discord connection)
3. Check gateway.err.log or console output

### Expected

All log timestamps use consistent format: 2026-03-04T10:50:00.000+08:00

### Actual

Before fix: mixed UTC and local time

## Evidence

Before fix:
- 2026-03-03T16:59:21.820Z [discord] failed to fetch bot identity
- 2026-03-04T01:04:11.008+08:00 [openclaw] Non-fatal unhandled rejection

After fix:
- All logs use consistent local timezone format

## Human Verification (required)

- Verified scenarios: Local build test, confirmed timestamp format is consistent
- Edge cases checked: JSON format, pretty format, consoleTimestampPrefix - all 3 scenarios
- What you did not verify: Not deployed to production for actual verification

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: git revert
- Files/config to restore: src/logging/subsystem.ts

## Risks and Mitigations

None. Only replaced time formatting function, no business logic changes