### PR TITLE
fix(matrix): use main plugin-sdk export for KeyedAsyncQueue

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 


### PR DESCRIPTION
Fixes #33266 — Matrix plugin fails to load on Docker.

## Problem

`send-queue.ts` imports `KeyedAsyncQueue` from the subpath `openclaw/plugin-sdk/keyed-async-queue`, which does not resolve in the Docker image where Rolldown bundles plugin-sdk into a single `index.js`. All Matrix users on Docker are affected — the plugin fails silently on startup.

## Fix

**1 file, 1 line changed.**

```diff
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
```

`KeyedAsyncQueue` is already re-exported from `plugin-sdk/index.ts`.

---

🤖 **AI-assisted PR** (Claude, via OpenClaw agent)
- Testing: Verified export exists in plugin-sdk/index.ts
- The contributor understands what this code does