### PR TITLE
fix(gateway): skip stale-socket check for channels without event tracking

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -489,14 +489,14 @@ describe("channel-health-monitor", () => {
       await expectNoRestart(manager);
     });
 
-    it("restarts a channel that never received any event past the stale threshold", async () => {
+    it("skips channels that never set lastEventAt (no false-positive stale-socket)", async () => {
       const now = Date.now();
       const manager = createSlackSnapshotManager(
         runningConnectedSlackAccount({
           lastStartAt: now - STALE_THRESHOLD - 60_000,
         }),
       );
-      await expectRestartedChannel(manager, "slack");
+      await expectNoRestart(manager);
     });
 
     it("respects custom staleEventThresholdMs", async () => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -98,7 +98,26 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: false, reason: "disconnected" });
   });
 
-  it("flags stale sockets when no events arrive beyond threshold", () => {
+  it("flags stale sockets when lastEventAt is set and exceeds threshold", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: 10_000,
+      },
+      {
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
+  });
+
+  it("treats channels without lastEventAt as healthy (no false-positive stale-socket)", () => {
     const evaluation = evaluateChannelHealth(
       {
         running: true,
@@ -114,7 +133,44 @@ describe("evaluateChannelHealth", () => {
         staleEventThresholdMs: 30_000,
       },
     );
-    expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("treats channels that never set lastEventAt as healthy", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+      },
+      {
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("reports healthy when lastEventAt is recent", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: 85_000,
+      },
+      {
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
 });
 

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -92,12 +92,16 @@ export function evaluateChannelHealth(
   if (snapshot.connected === false) {
     return { healthy: false, reason: "disconnected" };
   }
-  if (snapshot.lastEventAt != null || snapshot.lastStartAt != null) {
+  // Stale-socket detection: only evaluate channels that actively track event
+  // liveness via lastEventAt (e.g. Slack, Discord).  Channels that never set
+  // lastEventAt (Telegram, Signal, etc.) would always appear stale after the
+  // threshold because `lastEventAt ?? 0` produces epoch-zero — triggering
+  // false-positive restarts every 30 minutes.
+  if (snapshot.lastEventAt != null) {
     const upSince = snapshot.lastStartAt ?? 0;
     const upDuration = policy.now - upSince;
     if (upDuration > policy.staleEventThresholdMs) {
-      const lastEvent = snapshot.lastEventAt ?? 0;
-      const eventAge = policy.now - lastEvent;
+      const eventAge = policy.now - snapshot.lastEventAt;
       if (eventAge > policy.staleEventThresholdMs) {
         return { healthy: false, reason: "stale-socket" };
       }


### PR DESCRIPTION
### Context

The stale-socket detection in `evaluateChannelHealth` (added in #30153 for Slack's half-dead WebSocket scenario) uses `lastEventAt` to decide if a channel has gone silent. However, only Slack and Discord actively set `lastEventAt` via their `setStatus` callback. All other channels (Telegram, Signal, WhatsApp, etc.) never set it.

### Problem

The guard condition was:

```typescript
if (snapshot.lastEventAt != null || snapshot.lastStartAt != null)
```

Since `lastStartAt` is always set by the gateway for every channel, this condition is always true. Then `lastEventAt ?? 0` falls back to epoch zero, making `eventAge = now - 0` which always exceeds the 30-minute threshold. Result: every non-Slack/Discord channel gets false-positive stale-socket restarts every 30 minutes, indefinitely.

In practice this meant Telegram, WhatsApp, and Signal providers were being torn down and restarted every ~30 minutes for no reason -- causing brief message delivery gaps on each cycle.

### Fix

Only enter the stale-socket check when `lastEventAt != null` -- i.e., when the channel has actually opted in to event liveness tracking. Channels that don't track events skip this check entirely and remain healthy.

One-line condition change (`||` to just `lastEventAt != null`), plus the `?? 0` fallback is no longer needed since we've already confirmed the value is non-null.

### Tests

- Updated the existing policy test that asserted the false-positive behavior
- Added 3 new test cases: channels with null lastEventAt, channels that never set lastEventAt, and channels with recent events
- Updated the integration test to expect no restart for channels without event tracking
- All 31 tests pass