### PR TITLE
fix(skills): probe sandbox container binaries for skill eligibility checks

### DIFF
--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -91,6 +91,8 @@ export function shouldIncludeSkill(params: {
     hasBin: hasBinary,
     hasRemoteBin: eligibility?.remote?.hasBin,
     hasAnyRemoteBin: eligibility?.remote?.hasAnyBin,
+    hasSandboxBin: eligibility?.sandbox?.hasBin,
+    hasAnySandboxBin: eligibility?.sandbox?.hasAnyBin,
     hasEnv: (envName) =>
       Boolean(
         process.env[envName] ||

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -8,7 +8,7 @@ import { resolvePluginSkillDirs } from "./plugin-skills.js";
 
 type SkillsChangeEvent = {
   workspaceDir?: string;
-  reason: "watch" | "manual" | "remote-node";
+  reason: "watch" | "manual" | "remote-node" | "sandbox-bins";
   changedPath?: string;
 };
 

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -77,6 +77,11 @@ export type SkillEligibilityContext = {
     hasAnyBin: (bins: string[]) => boolean;
     note?: string;
   };
+  sandbox?: {
+    hasBin: (bin: string) => boolean;
+    hasAnyBin: (bins: string[]) => boolean;
+    image?: string;
+  };
 };
 
 export type SkillSnapshot = {

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -12,6 +12,7 @@ import { buildAgentSystemPrompt } from "../../agents/system-prompt.js";
 import { buildToolSummaryMap } from "../../agents/tool-summaries.js";
 import type { WorkspaceBootstrapFile } from "../../agents/workspace.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../../infra/skills-sandbox.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
@@ -38,7 +39,7 @@ export async function resolveCommandsSystemPromptBundle(
     try {
       return buildWorkspaceSkillSnapshot(workspaceDir, {
         config: params.cfg,
-        eligibility: { remote: getRemoteSkillEligibility() },
+        eligibility: { remote: getRemoteSkillEligibility(), sandbox: getSandboxSkillEligibility() },
         snapshotVersion: getSkillsSnapshotVersion(workspaceDir),
       });
     } catch {

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -11,6 +11,7 @@ import {
   formatZonedTimestamp,
 } from "../../infra/format-time/format-datetime.ts";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../../infra/skills-sandbox.js";
 import { drainSystemEventEntries } from "../../infra/system-events.js";
 
 export async function buildQueuedSystemPrompt(params: {
@@ -155,6 +156,7 @@ export async function ensureSkillSnapshot(params: {
   let nextEntry = sessionEntry;
   let systemSent = sessionEntry?.systemSent ?? false;
   const remoteEligibility = getRemoteSkillEligibility();
+  const sandboxEligibility = getSandboxSkillEligibility();
   const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   ensureSkillsWatcher({ workspaceDir, config: cfg });
   const shouldRefreshSnapshot =
@@ -171,7 +173,7 @@ export async function ensureSkillSnapshot(params: {
         ? buildWorkspaceSkillSnapshot(workspaceDir, {
             config: cfg,
             skillFilter,
-            eligibility: { remote: remoteEligibility },
+            eligibility: { remote: remoteEligibility, sandbox: sandboxEligibility },
             snapshotVersion,
           })
         : current.skillsSnapshot;
@@ -195,7 +197,7 @@ export async function ensureSkillSnapshot(params: {
     ? buildWorkspaceSkillSnapshot(workspaceDir, {
         config: cfg,
         skillFilter,
-        eligibility: { remote: remoteEligibility },
+        eligibility: { remote: remoteEligibility, sandbox: sandboxEligibility },
         snapshotVersion,
       })
     : (nextEntry?.skillsSnapshot ??
@@ -204,7 +206,7 @@ export async function ensureSkillSnapshot(params: {
         : buildWorkspaceSkillSnapshot(workspaceDir, {
             config: cfg,
             skillFilter,
-            eligibility: { remote: remoteEligibility },
+            eligibility: { remote: remoteEligibility, sandbox: sandboxEligibility },
             snapshotVersion,
           })));
   if (

--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -8,6 +8,7 @@ import { buildWorkspaceSkillCommandSpecs, type SkillCommandSpec } from "../agent
 import type { OpenClawConfig } from "../config/config.js";
 import { logVerbose } from "../globals.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../infra/skills-sandbox.js";
 import { listChatCommands } from "./commands-registry.js";
 
 export function listReservedChatSlashCommandNames(extraNames: string[] = []): Set<string> {
@@ -41,7 +42,7 @@ export function listSkillCommandsForWorkspace(params: {
   return buildWorkspaceSkillCommandSpecs(params.workspaceDir, {
     config: params.cfg,
     skillFilter: params.skillFilter,
-    eligibility: { remote: getRemoteSkillEligibility() },
+    eligibility: { remote: getRemoteSkillEligibility(), sandbox: getSandboxSkillEligibility() },
     reservedNames: listReservedChatSlashCommandNames(),
   });
 }
@@ -101,7 +102,7 @@ export function listSkillCommandsForAgents(params: {
     const commands = buildWorkspaceSkillCommandSpecs(workspaceDir, {
       config: params.cfg,
       skillFilter,
-      eligibility: { remote: getRemoteSkillEligibility() },
+      eligibility: { remote: getRemoteSkillEligibility(), sandbox: getSandboxSkillEligibility() },
       reservedNames: used,
     });
     for (const command of commands) {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -69,6 +69,7 @@ import {
 } from "../infra/agent-events.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../infra/skills-sandbox.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { applyVerboseOverride } from "../sessions/level-overrides.js";
@@ -600,7 +601,10 @@ async function agentCommandInternal(
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {
           config: cfg,
-          eligibility: { remote: getRemoteSkillEligibility() },
+          eligibility: {
+            remote: getRemoteSkillEligibility(),
+            sandbox: getSandboxSkillEligibility(),
+          },
           snapshotVersion: skillsSnapshotVersion,
           skillFilter,
         })

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -18,6 +18,7 @@ import { resolveOsSummary } from "../infra/os-summary.js";
 import { inspectPortUsage } from "../infra/ports.js";
 import { readRestartSentinel } from "../infra/restart-sentinel.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../infra/skills-sandbox.js";
 import { readTailscaleStatusJson } from "../infra/tailscale.js";
 import { normalizeUpdateChannel, resolveUpdateChannelDisplay } from "../infra/update-channels.js";
 import { checkUpdateStatus, formatGitInstallLabel } from "../infra/update-check.js";
@@ -221,7 +222,10 @@ export async function statusAllCommand(
             try {
               return buildWorkspaceSkillStatus(defaultWorkspace, {
                 config: cfg,
-                eligibility: { remote: getRemoteSkillEligibility() },
+                eligibility: {
+                  remote: getRemoteSkillEligibility(),
+                  sandbox: getSandboxSkillEligibility(),
+                },
               });
             } catch {
               return null;

--- a/src/cron/isolated-agent/skills-snapshot.test.ts
+++ b/src/cron/isolated-agent/skills-snapshot.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  buildWorkspaceSkillSnapshot: vi.fn(),
+  getRemoteSkillEligibility: vi.fn(),
+  getSandboxSkillEligibility: vi.fn(),
+}));
+
+vi.mock("../../agents/skills.js", () => ({
+  buildWorkspaceSkillSnapshot: mocks.buildWorkspaceSkillSnapshot,
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentSkillsFilter: () => undefined,
+}));
+
+vi.mock("../../agents/skills/filter.js", () => ({
+  matchesSkillFilter: () => false,
+}));
+
+vi.mock("../../agents/skills/refresh.js", () => ({
+  getSkillsSnapshotVersion: () => 1,
+}));
+
+vi.mock("../../infra/skills-remote.js", () => ({
+  getRemoteSkillEligibility: mocks.getRemoteSkillEligibility,
+}));
+
+vi.mock("../../infra/skills-sandbox.js", () => ({
+  getSandboxSkillEligibility: mocks.getSandboxSkillEligibility,
+}));
+
+import { resolveCronSkillsSnapshot } from "./skills-snapshot.js";
+
+describe("resolveCronSkillsSnapshot", () => {
+  beforeEach(() => {
+    mocks.buildWorkspaceSkillSnapshot.mockReset();
+    mocks.getRemoteSkillEligibility.mockReset();
+    mocks.getSandboxSkillEligibility.mockReset();
+  });
+
+  it("passes sandbox eligibility into cron snapshot build", () => {
+    const remote = { platforms: ["darwin"] };
+    const sandbox = { image: "sandbox:latest" };
+    mocks.getRemoteSkillEligibility.mockReturnValue(remote);
+    mocks.getSandboxSkillEligibility.mockReturnValue(sandbox);
+    mocks.buildWorkspaceSkillSnapshot.mockReturnValue({ prompt: "", skills: [] });
+
+    resolveCronSkillsSnapshot({
+      workspaceDir: "/tmp/workspace",
+      config: {} as never,
+      agentId: "a1",
+      isFastTestEnv: false,
+    });
+
+    expect(mocks.buildWorkspaceSkillSnapshot).toHaveBeenCalledWith("/tmp/workspace", {
+      config: {},
+      skillFilter: undefined,
+      eligibility: {
+        remote,
+        sandbox,
+      },
+      snapshotVersion: 1,
+    });
+  });
+});

--- a/src/cron/isolated-agent/skills-snapshot.ts
+++ b/src/cron/isolated-agent/skills-snapshot.ts
@@ -4,6 +4,7 @@ import { matchesSkillFilter } from "../../agents/skills/filter.js";
 import { getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../../infra/skills-sandbox.js";
 
 export function resolveCronSkillsSnapshot(params: {
   workspaceDir: string;
@@ -31,7 +32,7 @@ export function resolveCronSkillsSnapshot(params: {
   return buildWorkspaceSkillSnapshot(params.workspaceDir, {
     config: params.config,
     skillFilter,
-    eligibility: { remote: getRemoteSkillEligibility() },
+    eligibility: { remote: getRemoteSkillEligibility(), sandbox: getSandboxSkillEligibility() },
     snapshotVersion,
   });
 }

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -10,6 +10,7 @@ import { listAgentWorkspaceDirs } from "../../agents/workspace-dirs.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig, writeConfigFile } from "../../config/config.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../../infra/skills-sandbox.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import {
@@ -84,7 +85,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     const report = buildWorkspaceSkillStatus(workspaceDir, {
       config: cfg,
-      eligibility: { remote: getRemoteSkillEligibility() },
+      eligibility: { remote: getRemoteSkillEligibility(), sandbox: getSandboxSkillEligibility() },
     });
     respond(true, report, undefined);
   },

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -40,6 +40,7 @@ import {
   refreshRemoteBinsForConnectedNodes,
   setSkillsRemoteRegistry,
 } from "../infra/skills-remote.js";
+import { refreshSandboxBinsCache } from "../infra/skills-sandbox.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scheduleGatewayUpdateCheck } from "../infra/update-startup.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
@@ -616,6 +617,7 @@ export async function startGatewayServer(
   if (!minimalTestGateway) {
     setSkillsRemoteRegistry(nodeRegistry);
     void primeRemoteSkillsCache();
+    void refreshSandboxBinsCache(cfgAtStart);
   }
   // Debounce skills-triggered node probes to avoid feedback loops and rapid-fire invokes.
   // Skills changes can happen in bursts (e.g., file watcher events), and each probe
@@ -635,6 +637,7 @@ export async function startGatewayServer(
           skillsRefreshTimer = null;
           const latest = loadConfig();
           void refreshRemoteBinsForConnectedNodes(latest);
+          void refreshSandboxBinsCache(latest);
         }, skillsRefreshDelayMs);
       });
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -627,7 +627,7 @@ export async function startGatewayServer(
   const skillsChangeUnsub = minimalTestGateway
     ? () => {}
     : registerSkillsChangeListener((event) => {
-        if (event.reason === "remote-node") {
+        if (event.reason === "remote-node" || event.reason === "sandbox-bins") {
           return;
         }
         if (skillsRefreshTimer) {

--- a/src/infra/skills-sandbox.ts
+++ b/src/infra/skills-sandbox.ts
@@ -1,0 +1,148 @@
+import type { SkillEligibilityContext, SkillEntry } from "../agents/skills.js";
+import { loadWorkspaceSkillEntries } from "../agents/skills.js";
+import { bumpSkillsSnapshotVersion } from "../agents/skills/refresh.js";
+import { listAgentWorkspaceDirs } from "../agents/workspace-dirs.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
+import { execDockerRaw } from "../agents/sandbox/docker.js";
+import { DEFAULT_SANDBOX_IMAGE } from "../agents/sandbox/constants.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("gateway/skills-sandbox");
+
+let cachedBins: Set<string> | null = null;
+let cachedImage: string | null = null;
+
+/**
+ * Collect all bins required by skills that could run in the sandbox.
+ */
+function collectRequiredBins(entries: SkillEntry[]): string[] {
+  const bins = new Set<string>();
+  for (const entry of entries) {
+    for (const bin of entry.metadata?.requires?.bins ?? []) {
+      if (bin.trim()) bins.add(bin.trim());
+    }
+    for (const bin of entry.metadata?.requires?.anyBins ?? []) {
+      if (bin.trim()) bins.add(bin.trim());
+    }
+  }
+  return [...bins];
+}
+
+function buildBinProbeScript(bins: string[]): string {
+  const escaped = bins.map((b) => `'${b.replace(/'/g, `'\\''`)}'`).join(" ");
+  return `for b in ${escaped}; do if command -v "$b" >/dev/null 2>&1; then echo "$b"; fi; done`;
+}
+
+/**
+ * Try to probe bins inside a running sandbox container first (cheapest).
+ * Falls back to `docker run --rm` on the sandbox image.
+ */
+async function probeSandboxBins(
+  image: string,
+  bins: string[],
+  containerName?: string,
+): Promise<string[]> {
+  if (bins.length === 0) return [];
+
+  const script = buildBinProbeScript(bins);
+
+  // Try running container first (no startup cost)
+  if (containerName) {
+    try {
+      const result = await execDockerRaw(
+        ["exec", "-i", containerName, "sh", "-c", script],
+        { allowFailure: true },
+      );
+      if (result.code === 0) {
+        return result.stdout
+          .toString()
+          .split(/\r?\n/)
+          .map((l) => l.trim())
+          .filter(Boolean);
+      }
+    } catch {
+      // container not running, fall through to image probe
+    }
+  }
+
+  // Fall back to image probe
+  try {
+    const result = await execDockerRaw(
+      ["run", "--rm", "--entrypoint", "sh", image, "-c", script],
+      { allowFailure: true },
+    );
+    if (result.code === 0) {
+      return result.stdout
+        .toString()
+        .split(/\r?\n/)
+        .map((l) => l.trim())
+        .filter(Boolean);
+    }
+  } catch (err) {
+    log.warn(`sandbox bin probe failed for image ${image}: ${String(err)}`);
+  }
+
+  return [];
+}
+
+/**
+ * Resolve the sandbox image from config (agent-level or global default).
+ */
+function resolveSandboxImage(cfg: OpenClawConfig, agentId?: string): string | undefined {
+  const sandboxCfg = resolveSandboxConfigForAgent(cfg, agentId);
+  if (sandboxCfg.mode === "off") return undefined;
+  return sandboxCfg.docker?.image ?? DEFAULT_SANDBOX_IMAGE;
+}
+
+/**
+ * Refresh the cached set of binaries available in the sandbox image.
+ * Call this on gateway startup and when sandbox config changes.
+ */
+export async function refreshSandboxBinsCache(cfg: OpenClawConfig, agentId?: string) {
+  const image = resolveSandboxImage(cfg, agentId);
+  if (!image) {
+    cachedBins = null;
+    cachedImage = null;
+    return;
+  }
+
+  const workspaceDirs = listAgentWorkspaceDirs(cfg);
+  const allBins = new Set<string>();
+  for (const dir of workspaceDirs) {
+    const entries = loadWorkspaceSkillEntries(dir, { config: cfg });
+    for (const bin of collectRequiredBins(entries)) {
+      allBins.add(bin);
+    }
+  }
+  if (allBins.size === 0) {
+    cachedBins = new Set();
+    cachedImage = image;
+    return;
+  }
+
+  const found = await probeSandboxBins(image, [...allBins]);
+  const nextBins = new Set(found);
+  const changed = cachedImage !== image || !areSetsEqual(cachedBins, nextBins);
+  cachedBins = nextBins;
+  cachedImage = image;
+  if (changed) {
+    bumpSkillsSnapshotVersion({ reason: "sandbox-bins" });
+  }
+}
+
+function areSetsEqual(a: Set<string> | null, b: Set<string>): boolean {
+  if (!a) return false;
+  if (a.size !== b.size) return false;
+  for (const v of b) { if (!a.has(v)) return false; }
+  return true;
+}
+
+export function getSandboxSkillEligibility(): SkillEligibilityContext["sandbox"] | undefined {
+  if (!cachedBins || cachedBins.size === 0) return undefined;
+  return {
+    hasBin: (bin) => cachedBins!.has(bin),
+    hasAnyBin: (bins) => bins.some((b) => cachedBins!.has(b)),
+    image: cachedImage ?? undefined,
+  };
+}

--- a/src/shared/config-eval.ts
+++ b/src/shared/config-eval.ts
@@ -136,6 +136,8 @@ export function evaluateRuntimeEligibility(
     hasBin: params.hasBin,
     hasRemoteBin: params.hasRemoteBin,
     hasAnyRemoteBin: params.hasAnyRemoteBin,
+    hasSandboxBin: params.hasSandboxBin,
+    hasAnySandboxBin: params.hasAnySandboxBin,
     hasEnv: params.hasEnv,
     isConfigPathTruthy: params.isConfigPathTruthy,
   });

--- a/src/shared/config-eval.ts
+++ b/src/shared/config-eval.ts
@@ -53,6 +53,8 @@ type RuntimeRequirementEvalParams = {
   hasBin: (bin: string) => boolean;
   hasAnyRemoteBin?: (bins: string[]) => boolean;
   hasRemoteBin?: (bin: string) => boolean;
+  hasSandboxBin?: (bin: string) => boolean;
+  hasAnySandboxBin?: (bins: string[]) => boolean;
   hasEnv: (envName: string) => boolean;
   isConfigPathTruthy: (pathStr: string) => boolean;
 };
@@ -72,6 +74,9 @@ export function evaluateRuntimeRequires(params: RuntimeRequirementEvalParams): b
       if (params.hasRemoteBin?.(bin)) {
         continue;
       }
+      if (params.hasSandboxBin?.(bin)) {
+        continue;
+      }
       return false;
     }
   }
@@ -80,7 +85,9 @@ export function evaluateRuntimeRequires(params: RuntimeRequirementEvalParams): b
   if (requiredAnyBins.length > 0) {
     const anyFound = requiredAnyBins.some((bin) => params.hasBin(bin));
     if (!anyFound && !params.hasAnyRemoteBin?.(requiredAnyBins)) {
-      return false;
+      if (!params.hasAnySandboxBin?.(requiredAnyBins)) {
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- probe sandbox container/image binaries when evaluating skill requires.bins
- pass hasSandboxBin/hasAnySandboxBin through runtime eligibility evaluation
- propagate sandbox eligibility to skill command discovery paths

## Context
This PR supersedes #29303 by rebasing the same fix set onto a clean branch for current main.

## Tests
- added sandbox eligibility unit coverage and snapshot-related tests in the touched areas

Signed-off-by: sxu75374 <imshuaixu@gmail.com>
