### PR TITLE
fix(gateway): clarify control-ui device identity secure-context guidance

### DIFF
--- a/src/gateway/server/ws-connection/auth-messages.test.ts
+++ b/src/gateway/server/ws-connection/auth-messages.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { formatControlUiDeviceIdentityRequiredMessage } from "./auth-messages.js";
+
+describe("formatControlUiDeviceIdentityRequiredMessage", () => {
+  it("returns actionable guidance for insecure control-ui connections", () => {
+    const message = formatControlUiDeviceIdentityRequiredMessage();
+    expect(message).toContain("control ui requires device identity");
+    expect(message).toContain("HTTPS/WSS on remote hosts");
+    expect(message).toContain("localhost secure context");
+    expect(message).toContain("gateway.controlUi.allowInsecureAuth=true");
+  });
+});

--- a/src/gateway/server/ws-connection/auth-messages.test.ts
+++ b/src/gateway/server/ws-connection/auth-messages.test.ts
@@ -17,6 +17,7 @@ describe("formatControlUiDeviceIdentityRequiredMessage", () => {
   it("returns a close reason that fits within websocket limits", () => {
     const closeReason = formatControlUiDeviceIdentityRequiredCloseReason();
     expect(closeReason).toContain("control ui requires device identity");
+    expect(closeReason).toContain("gateway.controlUi.allowInsecureAuth=true");
     expect(Buffer.byteLength(closeReason, "utf8")).toBeLessThanOrEqual(120);
   });
 });

--- a/src/gateway/server/ws-connection/auth-messages.test.ts
+++ b/src/gateway/server/ws-connection/auth-messages.test.ts
@@ -1,5 +1,9 @@
+import { Buffer } from "node:buffer";
 import { describe, expect, it } from "vitest";
-import { formatControlUiDeviceIdentityRequiredMessage } from "./auth-messages.js";
+import {
+  formatControlUiDeviceIdentityRequiredCloseReason,
+  formatControlUiDeviceIdentityRequiredMessage,
+} from "./auth-messages.js";
 
 describe("formatControlUiDeviceIdentityRequiredMessage", () => {
   it("returns actionable guidance for insecure control-ui connections", () => {
@@ -8,5 +12,11 @@ describe("formatControlUiDeviceIdentityRequiredMessage", () => {
     expect(message).toContain("HTTPS/WSS on remote hosts");
     expect(message).toContain("localhost secure context");
     expect(message).toContain("gateway.controlUi.allowInsecureAuth=true");
+  });
+
+  it("returns a close reason that fits within websocket limits", () => {
+    const closeReason = formatControlUiDeviceIdentityRequiredCloseReason();
+    expect(closeReason).toContain("control ui requires device identity");
+    expect(Buffer.byteLength(closeReason, "utf8")).toBeLessThanOrEqual(120);
   });
 });

--- a/src/gateway/server/ws-connection/auth-messages.ts
+++ b/src/gateway/server/ws-connection/auth-messages.ts
@@ -4,6 +4,13 @@ import { GATEWAY_CLIENT_IDS } from "../../protocol/client-info.js";
 
 export type AuthProvidedKind = "token" | "device-token" | "password" | "none";
 
+export function formatControlUiDeviceIdentityRequiredMessage(): string {
+  return (
+    "control ui requires device identity " +
+    "(use HTTPS/WSS on remote hosts, or localhost secure context; local HTTP dev-only fallback: gateway.controlUi.allowInsecureAuth=true)"
+  );
+}
+
 export function formatGatewayAuthFailureMessage(params: {
   authMode: ResolvedGatewayAuth["mode"];
   authProvided: AuthProvidedKind;

--- a/src/gateway/server/ws-connection/auth-messages.ts
+++ b/src/gateway/server/ws-connection/auth-messages.ts
@@ -1,6 +1,7 @@
 import { isGatewayCliClient, isWebchatClient } from "../../../utils/message-channel.js";
 import type { ResolvedGatewayAuth } from "../../auth.js";
 import { GATEWAY_CLIENT_IDS } from "../../protocol/client-info.js";
+import { truncateCloseReason } from "../close-reason.js";
 
 export type AuthProvidedKind = "token" | "device-token" | "password" | "none";
 
@@ -9,6 +10,10 @@ export function formatControlUiDeviceIdentityRequiredMessage(): string {
     "control ui requires device identity " +
     "(use HTTPS/WSS on remote hosts, or localhost secure context; local HTTP dev-only fallback: gateway.controlUi.allowInsecureAuth=true)"
   );
+}
+
+export function formatControlUiDeviceIdentityRequiredCloseReason(): string {
+  return truncateCloseReason(formatControlUiDeviceIdentityRequiredMessage());
 }
 
 export function formatGatewayAuthFailureMessage(params: {

--- a/src/gateway/server/ws-connection/auth-messages.ts
+++ b/src/gateway/server/ws-connection/auth-messages.ts
@@ -12,8 +12,11 @@ export function formatControlUiDeviceIdentityRequiredMessage(): string {
   );
 }
 
+const CONTROL_UI_DEVICE_IDENTITY_REQUIRED_CLOSE_REASON =
+  "control ui requires device identity; use HTTPS/WSS or localhost; dev fallback: gateway.controlUi.allowInsecureAuth=true";
+
 export function formatControlUiDeviceIdentityRequiredCloseReason(): string {
-  return truncateCloseReason(formatControlUiDeviceIdentityRequiredMessage());
+  return truncateCloseReason(CONTROL_UI_DEVICE_IDENTITY_REQUIRED_CLOSE_REASON);
 }
 
 export function formatGatewayAuthFailureMessage(params: {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -77,7 +77,11 @@ import {
 } from "../health-state.js";
 import type { GatewayWsClient } from "../ws-types.js";
 import { resolveConnectAuthDecision, resolveConnectAuthState } from "./auth-context.js";
-import { formatGatewayAuthFailureMessage, type AuthProvidedKind } from "./auth-messages.js";
+import {
+  formatControlUiDeviceIdentityRequiredMessage,
+  formatGatewayAuthFailureMessage,
+  type AuthProvidedKind,
+} from "./auth-messages.js";
 import {
   evaluateMissingDeviceIdentity,
   isTrustedProxyControlUiOperatorAuth,
@@ -631,8 +635,7 @@ export function attachGatewayWsMessageHandler(params: {
           }
 
           if (decision.kind === "reject-control-ui-insecure-auth") {
-            const errorMessage =
-              "control ui requires device identity (use HTTPS or localhost secure context)";
+            const errorMessage = formatControlUiDeviceIdentityRequiredMessage();
             markHandshakeFailure("control-ui-insecure-auth", {
               insecureAuthConfigured: controlUiAuthPolicy.allowInsecureAuthConfigured,
             });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -78,6 +78,7 @@ import {
 import type { GatewayWsClient } from "../ws-types.js";
 import { resolveConnectAuthDecision, resolveConnectAuthState } from "./auth-context.js";
 import {
+  formatControlUiDeviceIdentityRequiredCloseReason,
   formatControlUiDeviceIdentityRequiredMessage,
   formatGatewayAuthFailureMessage,
   type AuthProvidedKind,
@@ -642,7 +643,7 @@ export function attachGatewayWsMessageHandler(params: {
             sendHandshakeErrorResponse(ErrorCodes.INVALID_REQUEST, errorMessage, {
               details: { code: ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED },
             });
-            close(1008, errorMessage);
+            close(1008, formatControlUiDeviceIdentityRequiredCloseReason());
             return false;
           }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the control-ui insecure-auth rejection message tells users to use HTTPS or localhost, but does not explain the remote-host WSS requirement or the explicit local-only dev fallback.
- Why it matters: operators on remote hosts can hit the error and still not know the valid secure-context path to recover.
- What changed: centralized the message in a formatter and updated it to mention HTTPS/WSS for remote hosts, localhost secure context, and the `gateway.controlUi.allowInsecureAuth=true` dev-only fallback.
- What did NOT change (scope boundary): this does not relax device identity requirements or change gateway auth behavior; it only improves the rejection guidance text.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32473
- Related #20401

## User-visible / Behavior Changes

The gateway now returns a more actionable control-ui device-identity error message for insecure remote connections.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.3.1 (dev), issue report on Ubuntu 25 / Docker
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Control UI gateway websocket
- Relevant config (redacted): remote host without secure control-ui device identity context

### Steps

1. Start the gateway with control UI enabled on a remote host without HTTPS/WSS secure context.
2. Attempt to connect the control UI from that remote host.
3. Observe the rejected handshake error text.

### Expected

- The rejection explains the valid recovery paths for remote hosts and local-only dev fallback.

### Actual

- The rejection only said `use HTTPS or localhost secure context`, which left the remote-host WSS path and explicit insecure dev override unclear.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: exercised `formatControlUiDeviceIdentityRequiredMessage()` via unit test and confirmed the websocket handler now uses the shared formatter.
- Edge cases checked: message includes remote-host guidance, localhost guidance, and the explicit dev-only fallback flag.
- What you did **not** verify: a live remote Docker deployment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restore the previous hardcoded message.
- Files/config to restore: `src/gateway/server/ws-connection/auth-messages.ts`, `src/gateway/server/ws-connection/message-handler.ts`
- Known bad symptoms reviewers should watch for: missing or misleading control-ui insecure-auth recovery guidance.

## Risks and Mitigations

- Risk: the message could over-emphasize the local dev fallback.
  - Mitigation: it is labeled `dev-only` and behavior remains unchanged.
