### PR TITLE
fix: resolve relative media paths against localRoots before access check

### DIFF
--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -342,6 +342,23 @@ async function loadWebMediaInternal(
     mediaUrl = resolveUserPath(mediaUrl);
   }
 
+  // Resolve relative paths (e.g., ./deliverables/file.png) against localRoots.
+  // Agents write files relative to their workspace, but the media delivery context
+  // may have a different process.cwd(). Try each allowed root to find the file.
+  if (!path.isAbsolute(mediaUrl) && localRoots !== "any" && !sandboxValidated) {
+    const roots = localRoots ?? getDefaultLocalRoots();
+    for (const root of roots) {
+      const candidate = path.resolve(root, mediaUrl);
+      try {
+        await fs.access(candidate);
+        mediaUrl = candidate;
+        break;
+      } catch {
+        // File not found under this root, try next
+      }
+    }
+  }
+
   if ((sandboxValidated || localRoots === "any") && !readFileOverride) {
     throw new LocalMediaAccessError(
       "unsafe-bypass",


### PR DESCRIPTION
## Problem

When an agent outputs `MEDIA:./deliverables/file.png`, the relative path is resolved against `process.cwd()` in `assertLocalMediaAllowed()`. During Telegram (or other channel) reply delivery, `process.cwd()` may differ from the agent's workspace directory. This causes a `LocalMediaAccessError` ("Local media path is not under an allowed directory") even when the file exists under a configured local root like `~/.openclaw/workspace/deliverables/`.

## Fix

Before calling `assertLocalMediaAllowed()`, try resolving relative paths against each configured `localRoot` directory using `fs.access()` to find the first existing match. This converts the relative path to an absolute path that will pass the subsequent access check.

**Before:** `./deliverables/file.png` → `path.resolve(cwd, './deliverables/file.png')` → fails if cwd ≠ workspace  
**After:** `./deliverables/file.png` → tries each localRoot → finds `~/.openclaw/workspace/deliverables/file.png` → passes check

## Scope

- Only applies to relative paths (not absolute, http, file://, or tilde paths)
- Only when `localRoots !== "any"` and `!sandboxValidated` (doesn't interfere with bypass paths)
- Falls through gracefully to existing behavior if file isn't found in any root

Fixes #33358