### PR TITLE
fix(matrix): correct plugin-sdk import path for Docker bundle

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 


### PR DESCRIPTION
## Summary

- Problem: The Matrix plugin fails to load on Docker because `send-queue.ts` imports `KeyedAsyncQueue` from a subpath (`openclaw/plugin-sdk/keyed-async-queue`) that doesn't exist in the bundled Docker image.
- Why it matters: Every Matrix user on Docker is broken silently — the container starts healthy but can't send or receive Matrix messages.
- What changed: Updated the import to use the main `openclaw/plugin-sdk` export, where `KeyedAsyncQueue` is already re-exported.
- What did NOT change: Runtime behavior is identical; the import resolves to the same class.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #33266

## User-visible / Behavior Changes

Matrix plugin loads correctly on Docker. No behavior change for non-Docker installs.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux x86_64
- Runtime/container: Docker (`ghcr.io/openclaw/openclaw:latest`)
- Integration/channel: Matrix

### Steps

1. Pull `ghcr.io/openclaw/openclaw:latest`
2. Configure a Matrix homeserver
3. Start the gateway — Matrix plugin fails to load with `Cannot find module '/app/dist/plugin-sdk/index.js/keyed-async-queue'`

### Expected

Matrix plugin loads and connects.

### Actual

Plugin fails silently, Matrix messages don't work.

## Evidence

- [x] Trace/log snippets (from issue #33266)

Error before fix:
```
[plugins] matrix failed to load from /app/extensions/matrix/index.ts:
  Error: Cannot find module '/app/dist/plugin-sdk/index.js/keyed-async-queue'
  - /app/extensions/matrix/src/matrix/send-queue.ts
```

`KeyedAsyncQueue` is exported from `plugin-sdk/index.js` — verified in the built bundle.

## Human Verification (required)

- Verified `KeyedAsyncQueue` is exported from the main `openclaw/plugin-sdk` entry before changing the import.
- Confirmed the only occurrence of the broken subpath in the matrix extension is this one line.
- What I did not verify: full Docker build + runtime test (no Docker environment available locally).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert is a one-line change back to `"openclaw/plugin-sdk/keyed-async-queue"`.
- Symptom to watch: Matrix plugin fails to load on any environment.

## Risks and Mitigations

- Risk: `KeyedAsyncQueue` export removed from main `plugin-sdk` index in a future change.
  - Mitigation: Low risk — it's a core utility. Would be caught immediately by build/typecheck.