### PR TITLE
fix(delivery): move permanently failing messages (HTTP 4xx) to failed/ immediately

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -11626,6 +11626,15 @@
         "line_number": 277
       }
     ],
+    "src/agents/tools/web-fetch.cf-markdown.test.ts": [
+      {
+        "filename": "src/agents/tools/web-fetch.cf-markdown.test.ts",
+        "line_number": 117,
+        "type": "Secret Keyword",
+        "hashed_secret": "86bc57c4a7bfc76cf9a86d57e9b6daeefecdc056",
+        "is_verified": false
+      }
+    ],
     "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11676,6 +11685,15 @@
         "hashed_secret": "d0ffd81d6d7ad1bc3c365660fe8882480c9a986e",
         "is_verified": false,
         "line_number": 187
+      }
+    ],
+    "src/agents/tools/web-tools.enabled-defaults.test.ts": [
+      {
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "line_number": 655,
+        "type": "Secret Keyword",
+        "hashed_secret": "354a920b3d519d11b737695308dab1bfcf77dbb3",
+        "is_verified": false
       }
     ],
     "src/agents/tools/web-tools.fetch.e2e.test.ts": [
@@ -12887,6 +12905,38 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 357
+      }
+    ],
+    "src/secrets/runtime-web-tools.test.ts": [
+      {
+        "filename": "src/secrets/runtime-web-tools.test.ts",
+        "line_number": 187,
+        "type": "Secret Keyword",
+        "hashed_secret": "2a2e0606a243ecec6a676d214897ad9d930a2dd8",
+        "is_verified": false
+      },
+      {
+        "filename": "src/secrets/runtime-web-tools.test.ts",
+        "line_number": 228,
+        "type": "Secret Keyword",
+        "hashed_secret": "5de8028632e69ea765cf8bfaf0e32a441103de12",
+        "is_verified": false
+      },
+      {
+        "filename": "src/secrets/runtime-web-tools.test.ts",
+        "line_number": 400,
+        "type": "Secret Keyword",
+        "hashed_secret": "4a9927de9f7d1779bc0ed9ac46bfbb033b5cd837",
+        "is_verified": false
+      }
+    ],
+    "src/secrets/runtime-web-tools.ts": [
+      {
+        "filename": "src/secrets/runtime-web-tools.ts",
+        "line_number": 21,
+        "type": "Secret Keyword",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false
       }
     ],
     "src/security/audit.test.ts": [

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12624,7 +12624,7 @@
         "filename": "src/infra/outbound/outbound.test.ts",
         "hashed_secret": "804ec071803318791b835cffd6e509c8d32239db",
         "is_verified": false,
-        "line_number": 896
+        "line_number": 928
       }
     ],
     "src/infra/provider-usage.auth.normalizes-keys.test.ts": [

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -159,8 +159,15 @@ export async function ackDelivery(id: string, stateDir?: string): Promise<void> 
   await unlinkBestEffort(deliveredPath);
 }
 
-/** Update a queue entry after a failed delivery attempt. */
+/** Update a queue entry after a failed delivery attempt.
+ * If the error matches a known permanent failure pattern (e.g. HTTP 4xx),
+ * the entry is moved to failed/ immediately instead of being retried.
+ */
 export async function failDelivery(id: string, error: string, stateDir?: string): Promise<void> {
+  if (isPermanentDeliveryError(error)) {
+    await moveToFailed(id, stateDir);
+    return;
+  }
   const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
   const raw = await fs.promises.readFile(filePath, "utf-8");
   const entry: QueuedDelivery = JSON.parse(raw);
@@ -429,6 +436,12 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  // HTTP 4xx client errors — the request itself is invalid and will never succeed on retry.
+  // Excludes 429 (rate-limiting) which is transient.
+  /\b(?:400|403|404|405|410|413|415|422)\b/i,
+  /message is too long/i,
+  /request entity too large/i,
+  /bad request:/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -164,10 +164,6 @@ export async function ackDelivery(id: string, stateDir?: string): Promise<void> 
  * the entry is moved to failed/ immediately instead of being retried.
  */
 export async function failDelivery(id: string, error: string, stateDir?: string): Promise<void> {
-  if (isPermanentDeliveryError(error)) {
-    await moveToFailed(id, stateDir);
-    return;
-  }
   const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
   const raw = await fs.promises.readFile(filePath, "utf-8");
   const entry: QueuedDelivery = JSON.parse(raw);
@@ -180,6 +176,13 @@ export async function failDelivery(id: string, error: string, stateDir?: string)
     mode: 0o600,
   });
   await fs.promises.rename(tmp, filePath);
+
+  // Permanent errors (e.g. HTTP 4xx) will never succeed on retry — move to
+  // failed/ immediately after persisting diagnostic fields so operators can
+  // inspect lastError/lastAttemptAt in the failed entry.
+  if (isPermanentDeliveryError(error)) {
+    await moveToFailed(id, stateDir);
+  }
 }
 
 /** Load all pending delivery entries from the queue directory. */

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -188,6 +188,24 @@ describe("delivery-queue", () => {
       expect(entry.lastAttemptAt).toBeGreaterThan(0);
       expect(entry.lastError).toBe("connection refused");
     });
+
+    it("moves entry to failed/ immediately for permanent errors", async () => {
+      const id = await enqueueDelivery(
+        {
+          channel: "telegram",
+          to: "123",
+          payloads: [{ text: "x".repeat(5000) }],
+        },
+        tmpDir,
+      );
+
+      await failDelivery(id, "400: Bad Request: message is too long", tmpDir);
+
+      const queueDir = path.join(tmpDir, "delivery-queue");
+      const failedDir = path.join(queueDir, "failed");
+      expect(fs.existsSync(path.join(queueDir, `${id}.json`))).toBe(false);
+      expect(fs.existsSync(path.join(failedDir, `${id}.json`))).toBe(true);
+    });
   });
 
   describe("moveToFailed", () => {
@@ -219,6 +237,13 @@ describe("delivery-queue", () => {
       "Forbidden: bot was kicked from the group chat",
       "chat_id is empty",
       "Outbound not configured for channel: msteams",
+      "400: Bad Request: message is too long",
+      "Request to sendMessage API failed. (413: Request Entity Too Large)",
+      "bad request: can't parse entities",
+      "403 Forbidden",
+      "404 Not Found",
+      "message is too long",
+      "request entity too large",
     ])("returns true for permanent error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(true);
     });
@@ -229,6 +254,7 @@ describe("delivery-queue", () => {
       "socket hang up",
       "rate limited",
       "500 Internal Server Error",
+      "429 Too Many Requests",
     ])("returns false for transient error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(false);
     });

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -189,7 +189,7 @@ describe("delivery-queue", () => {
       expect(entry.lastError).toBe("connection refused");
     });
 
-    it("moves entry to failed/ immediately for permanent errors", async () => {
+    it("moves entry to failed/ immediately for permanent errors with diagnostic fields", async () => {
       const id = await enqueueDelivery(
         {
           channel: "telegram",
@@ -205,6 +205,12 @@ describe("delivery-queue", () => {
       const failedDir = path.join(queueDir, "failed");
       expect(fs.existsSync(path.join(queueDir, `${id}.json`))).toBe(false);
       expect(fs.existsSync(path.join(failedDir, `${id}.json`))).toBe(true);
+
+      // Verify diagnostic fields are persisted so operators can inspect the cause.
+      const failedEntry = JSON.parse(fs.readFileSync(path.join(failedDir, `${id}.json`), "utf-8"));
+      expect(failedEntry.lastError).toBe("400: Bad Request: message is too long");
+      expect(failedEntry.lastAttemptAt).toBeGreaterThan(0);
+      expect(failedEntry.retryCount).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary

- Problem: Messages that fail delivery with HTTP 400 (or other client errors) get permanently stuck in `~/.openclaw/delivery-queue/`. Every gateway restart retries them, but since 4xx errors are client errors, the request will never succeed — creating an infinite retry loop.
- Why it matters: Users must manually delete stuck queue entries (`rm ~/.openclaw/delivery-queue/*.json`). Without intervention, every gateway restart fires off the same failing messages.
- What changed: (1) `failDelivery` now checks `isPermanentDeliveryError` and moves permanent failures to `failed/` immediately on first attempt, instead of just incrementing retry count. (2) Added HTTP 4xx status code patterns and common message-level permanent errors (`message is too long`, `request entity too large`, `bad request:`) to `PERMANENT_ERROR_PATTERNS`.
- What did NOT change (scope boundary): The recovery-on-restart path (`recoverPendingDeliveries`) already had permanent error detection — that logic is unchanged. Transient errors (429, 5xx, network timeouts) still retry with backoff as before. `MAX_RETRIES` and backoff timing are unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #33403

## User-visible / Behavior Changes

- Messages that fail with HTTP 4xx client errors (400, 403, 404, 413, etc.) are now immediately moved to `failed/` instead of being retried indefinitely.
- Messages exceeding Telegram's 4096 char limit (or similar channel-specific limits) are moved to `failed/` on first attempt.
- Transient errors (429 rate limiting, 5xx server errors, network timeouts) continue to retry with exponential backoff as before.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OS: macOS
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): Any (Telegram in the reported case)
- Relevant config (redacted): Default delivery queue settings

### Steps
1. Queue a message that triggers a 400 from Telegram (e.g. message body > 4096 chars)
2. Observe it is moved to `failed/` immediately after the first attempt
3. Restart the gateway
4. Message is no longer retried

### Expected
HTTP 4xx errors are treated as permanent failures and moved to `failed/` immediately.

### Actual (before fix)
4xx errors left the entry in the queue with an incremented retry count, to be retried on every restart until `MAX_RETRIES` was reached (5 restarts).

## Evidence

- [x] Failing test/log before + passing after

```
Test Files  1 passed (1)
     Tests  67 passed (67)
```

New test: `failDelivery > moves entry to failed/ immediately for permanent errors` — verifies that an entry with a "400: Bad Request: message is too long" error is moved to `failed/` instead of staying in the queue.

New `isPermanentDeliveryError` test cases: `400: Bad Request: message is too long`, `413: Request Entity Too Large`, `bad request: can't parse entities`, `403 Forbidden`, `404 Not Found`, `message is too long`, `request entity too large`.

Confirmed `429 Too Many Requests` correctly returns `false` (transient).

Full test suite: 802 test files passed, 6494 tests passed (2 pre-existing unrelated failures in commands.test.ts).

## Human Verification (required)

- Verified scenarios: Local test suite passes (`pnpm build && pnpm check && pnpm test`)
- Edge cases checked:
  - HTTP 400 (Bad Request) → permanent, moved to `failed/`
  - HTTP 403/404/413 → permanent, moved to `failed/`
  - HTTP 429 (rate limit) → transient, retried with backoff
  - HTTP 500 → transient, retried with backoff
  - Network errors (ETIMEDOUT, socket hang up) → transient, retried
  - Existing permanent patterns (chat not found, bot blocked) → still work correctly
  - `failDelivery` called from `deliver.ts` initial delivery path → permanent errors now caught
  - `recoverPendingDeliveries` on restart → permanent error check still works (redundant but safe)
- What you did **not** verify: Live/integration testing with real Telegram/Discord/Slack delivery failures

> **Note:** This PR was created with AI assistance (Claude Code). The code changes have been reviewed and understood.

## Compatibility / Migration

- Backward compatible? Yes — messages that previously got stuck will now be moved to `failed/` (an improvement, not a breaking change)
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: `git revert <commit-hash>`
- Files/config to restore: `src/infra/outbound/delivery-queue.ts`
- Known bad symptoms: If pattern matching is too aggressive, legitimate transient errors could be incorrectly classified as permanent. Symptom: messages moved to `failed/` that should have been retried. Mitigation: patterns are targeted (specific status codes excluding 429, specific error messages).

## Risks and Mitigations

- Risk: The regex `\b(?:400|403|404|405|410|413|415|422)\b` could match numbers in non-HTTP-status contexts (e.g., a chat ID containing "400").
  - Mitigation: Combined with other permanent patterns, and the error string is from the delivery pipeline (not user content), so false matches are unlikely. The `bad request:` pattern requires the colon to avoid matching casual mentions.
- Risk: Some APIs might return 400 for recoverable situations (e.g., temporary server misconfiguration).
  - Mitigation: HTTP 400 is defined as "client error" — the request itself is malformed. If the payload hasn't changed, retrying won't help.
