### PR TITLE
feat: expand iOS platform default commands for openclaw-app

### DIFF
--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -329,6 +329,25 @@ describe("resolveNodeCommandAllowlist", () => {
     expect(allow.has("photos.latest")).toBe(true);
     expect(allow.has("motion.activity")).toBe(true);
 
+    // Extended iOS node commands (openclaw-app)
+    expect(allow.has("location.get")).toBe(true);
+    expect(allow.has("location.geocode")).toBe(true);
+    expect(allow.has("location.status")).toBe(true);
+    expect(allow.has("device.battery")).toBe(true);
+    expect(allow.has("device.network")).toBe(true);
+    expect(allow.has("device.storage")).toBe(true);
+    expect(allow.has("contacts.get")).toBe(true);
+    expect(allow.has("contacts.count")).toBe(true);
+    expect(allow.has("calendar.today")).toBe(true);
+    expect(allow.has("calendar.upcoming")).toBe(true);
+    expect(allow.has("calendar.status")).toBe(true);
+    expect(allow.has("health.steps")).toBe(true);
+    expect(allow.has("health.heartRate")).toBe(true);
+    expect(allow.has("health.sleep")).toBe(true);
+    expect(allow.has("health.summary")).toBe(true);
+    expect(allow.has("motion.altitude")).toBe(true);
+    expect(allow.has("motion.pedometer")).toBe(true);
+
     for (const cmd of DEFAULT_DANGEROUS_NODE_COMMANDS) {
       expect(allow.has(cmd)).toBe(false);
     }

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -329,24 +329,44 @@ describe("resolveNodeCommandAllowlist", () => {
     expect(allow.has("photos.latest")).toBe(true);
     expect(allow.has("motion.activity")).toBe(true);
 
-    // Extended iOS node commands (openclaw-app)
+    // Extended iOS node commands (openclaw-app) — full set
+    // Location
     expect(allow.has("location.get")).toBe(true);
     expect(allow.has("location.geocode")).toBe(true);
+    expect(allow.has("location.search")).toBe(true);
+    expect(allow.has("location.distance")).toBe(true);
+    expect(allow.has("location.monitor.start")).toBe(true);
+    expect(allow.has("location.monitor.stop")).toBe(true);
     expect(allow.has("location.status")).toBe(true);
+    // Device
     expect(allow.has("device.battery")).toBe(true);
     expect(allow.has("device.network")).toBe(true);
     expect(allow.has("device.storage")).toBe(true);
+    expect(allow.has("device.screen")).toBe(true);
+    expect(allow.has("device.display")).toBe(true);
+    expect(allow.has("device.locale")).toBe(true);
+    // Contacts
     expect(allow.has("contacts.get")).toBe(true);
     expect(allow.has("contacts.count")).toBe(true);
+    expect(allow.has("contacts.status")).toBe(true);
+    // Calendar
     expect(allow.has("calendar.today")).toBe(true);
     expect(allow.has("calendar.upcoming")).toBe(true);
+    expect(allow.has("calendar.search")).toBe(true);
+    expect(allow.has("calendar.calendars")).toBe(true);
     expect(allow.has("calendar.status")).toBe(true);
+    // Health
     expect(allow.has("health.steps")).toBe(true);
     expect(allow.has("health.heartRate")).toBe(true);
     expect(allow.has("health.sleep")).toBe(true);
+    expect(allow.has("health.workouts")).toBe(true);
+    expect(allow.has("health.energy")).toBe(true);
     expect(allow.has("health.summary")).toBe(true);
-    expect(allow.has("motion.altitude")).toBe(true);
+    expect(allow.has("health.status")).toBe(true);
+    // Motion
     expect(allow.has("motion.pedometer")).toBe(true);
+    expect(allow.has("motion.altitude")).toBe(true);
+    expect(allow.has("motion.status")).toBe(true);
 
     for (const cmd of DEFAULT_DANGEROUS_NODE_COMMANDS) {
       expect(allow.has(cmd)).toBe(false);

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -43,6 +43,52 @@ const PHOTOS_COMMANDS = ["photos.latest"];
 
 const MOTION_COMMANDS = ["motion.activity", "motion.pedometer"];
 
+// Extended iOS node commands. The OpenClaw iOS app (openclaw-app) registers
+// additional read-only commands beyond the base set shared with other platforms.
+// These are safe by default — all read-only, consent-gated on the device side.
+const IOS_LOCATION_COMMANDS = [
+  ...LOCATION_COMMANDS,
+  "location.geocode",
+  "location.search",
+  "location.distance",
+  "location.monitor.start",
+  "location.monitor.stop",
+  "location.status",
+];
+const IOS_DEVICE_COMMANDS = [
+  ...DEVICE_COMMANDS,
+  "device.battery",
+  "device.network",
+  "device.storage",
+  "device.screen",
+  "device.display",
+  "device.locale",
+];
+const IOS_CONTACTS_COMMANDS = [
+  ...CONTACTS_COMMANDS,
+  "contacts.get",
+  "contacts.count",
+  "contacts.status",
+];
+const IOS_CALENDAR_COMMANDS = [
+  ...CALENDAR_COMMANDS,
+  "calendar.today",
+  "calendar.upcoming",
+  "calendar.search",
+  "calendar.calendars",
+  "calendar.status",
+];
+const IOS_HEALTH_COMMANDS = [
+  "health.steps",
+  "health.heartRate",
+  "health.sleep",
+  "health.workouts",
+  "health.energy",
+  "health.summary",
+  "health.status",
+];
+const IOS_MOTION_COMMANDS = [...MOTION_COMMANDS, "motion.altitude", "motion.status"];
+
 const SMS_DANGEROUS_COMMANDS = ["sms.send"];
 
 // iOS nodes don't implement system.run/which, but they do support notifications.
@@ -75,13 +121,14 @@ const PLATFORM_DEFAULTS: Record<string, string[]> = {
   ios: [
     ...CANVAS_COMMANDS,
     ...CAMERA_COMMANDS,
-    ...LOCATION_COMMANDS,
-    ...DEVICE_COMMANDS,
-    ...CONTACTS_COMMANDS,
-    ...CALENDAR_COMMANDS,
+    ...IOS_LOCATION_COMMANDS,
+    ...IOS_DEVICE_COMMANDS,
+    ...IOS_CONTACTS_COMMANDS,
+    ...IOS_CALENDAR_COMMANDS,
+    ...IOS_HEALTH_COMMANDS,
     ...REMINDERS_COMMANDS,
     ...PHOTOS_COMMANDS,
-    ...MOTION_COMMANDS,
+    ...IOS_MOTION_COMMANDS,
     ...IOS_SYSTEM_COMMANDS,
   ],
   android: [


### PR DESCRIPTION
## Summary

Expands `PLATFORM_DEFAULTS.ios` in `node-command-policy.ts` to include all 36 commands registered by the OpenClaw iOS app (`openclaw-app`). This allows iOS nodes to work out of the box without requiring `gateway.nodes.allowCommands` configuration.

### Problem

The iOS app registers commands like `health.steps`, `calendar.today`, `contacts.count`, `device.battery`, etc., but the gateway's iOS platform defaults only include the base set (`location.get`, `device.info`, `contacts.search`, `calendar.events`, `motion.activity`, `motion.pedometer`). Users connecting an iPhone must manually add 25+ commands to their gateway config for full functionality.

### Solution

Add iOS-specific extended command arrays that build on the shared base sets:

| Array | New commands |
|-------|-------------|
| `IOS_LOCATION_COMMANDS` | `geocode`, `search`, `distance`, `monitor.start`, `monitor.stop`, `status` |
| `IOS_DEVICE_COMMANDS` | `battery`, `network`, `storage`, `screen`, `display`, `locale` |
| `IOS_CONTACTS_COMMANDS` | `get`, `count`, `status` |
| `IOS_CALENDAR_COMMANDS` | `today`, `upcoming`, `search`, `calendars`, `status` |
| `IOS_HEALTH_COMMANDS` | `steps`, `heartRate`, `sleep`, `workouts`, `energy`, `summary`, `status` |
| `IOS_MOTION_COMMANDS` | `altitude`, `status` |

All commands are **read-only** and **consent-gated on the device side** (the iOS app checks per-capability user consent before executing any command).

### Impact

- **iOS platform**: All 36 commands now allowed by default
- **Other platforms**: No change — android, macos, linux, windows defaults are untouched
- **Existing configs**: Users with `allowCommands` already set will see no difference (the allowlist is a union of defaults + config)

## Test plan

- [x] Updated `gateway-misc.test.ts` — added assertions for all new iOS commands in the "includes iOS service commands by default" test
- [ ] Verify `resolveNodeCommandAllowlist` returns the full set for `platform: "ios"`
- [ ] Connect an iOS node and confirm `calendar.today`, `health.steps`, `contacts.count`, etc. are no longer rejected


---
*Generated with [Claude Code](https://claude.ai/code)*