### PR TITLE
fix(cron): ensure nextRunAtMs is always after lastRunAtMs for cron jobs

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1592,4 +1592,41 @@ describe("Cron issue regressions", () => {
     expect(job?.state.lastStatus).toBe("error");
     expect(job?.state.lastError).toContain("timed out");
   });
+
+  it("computes nextRunAtMs after lastRunAtMs for daily cron jobs that run late (#33126)", () => {
+    // Bug: When a daily cron job runs past its scheduled time, nextRunAtMs was
+    // incorrectly set to the same day's scheduled time (which has already passed)
+    // instead of the next day's scheduled time.
+    //
+    // Schedule: 03:00 UTC daily with Asia/Shanghai timezone
+    // Job ran at: 06:01:44 UTC on 2026-03-03 (past the 03:00 UTC schedule)
+    // Expected next: 03:00 UTC on 2026-03-04
+    // Buggy next: 03:00 UTC on 2026-03-03 (same day, already passed)
+    const lastRunAtMs = Date.parse("2026-03-03T06:01:44.233Z");
+    const job: CronJob = {
+      id: "git-sync",
+      name: "Git Sync",
+      enabled: true,
+      createdAtMs: Date.parse("2026-01-01T00:00:00.000Z"),
+      updatedAtMs: lastRunAtMs,
+      schedule: { kind: "cron", expr: "0 3 * * *", tz: "Asia/Shanghai" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "sync" },
+      delivery: { mode: "main" },
+      state: {
+        lastRunAtMs,
+        lastStatus: "ok",
+      },
+    };
+
+    const next = computeJobNextRunAtMs(job, lastRunAtMs);
+
+    // Should be scheduled for the next day, not the same day
+    expect(next).toBeDefined();
+    expect(next).toBeGreaterThan(lastRunAtMs);
+    // Should be around 03:00 UTC on 2026-03-04 (which is 2026-03-03 19:00 UTC in Asia/Shanghai)
+    // or later depending on timezone handling
+    expect(new Date(next ?? 0).getTime()).toBeGreaterThan(lastRunAtMs);
+  });
 });

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -204,6 +204,18 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
     const nextSecondMs = Math.floor(nowMs / 1000) * 1000 + 1000;
     return computeStaggeredCronNextRunAtMs(job, nextSecondMs);
   }
+  // Guard against scheduling next run in the past (before lastRunAtMs).
+  // This can happen when a job runs late and croner returns the same-day
+  // scheduled time which has already passed (#33126).
+  const lastRunAtMs = job.state.lastRunAtMs;
+  if (isFiniteTimestamp(next) && isFiniteTimestamp(lastRunAtMs) && next <= lastRunAtMs) {
+    // Retry calculation starting from lastRunAtMs + 1 second
+    const afterLastRunMs = lastRunAtMs + 1000;
+    const corrected = computeStaggeredCronNextRunAtMs(job, afterLastRunMs);
+    if (isFiniteTimestamp(corrected) && corrected > lastRunAtMs) {
+      return corrected;
+    }
+  }
   return isFiniteTimestamp(next) ? next : undefined;
 }
 


### PR DESCRIPTION
## Problem

When a daily cron job runs past its scheduled time (e.g., due to system load or long execution), `nextRunAtMs` was incorrectly calculated as the same day's scheduled time which has already passed.

Example:
- Schedule: `0 3 * * *` (03:00 UTC daily) with tz: Asia/Shanghai
- Job ran at: 06:01:44 UTC on 2026-03-03 (past the scheduled 03:00 UTC)
- Expected `nextRunAtMs`: 03:00 UTC on 2026-03-04 (next day)
- Actual `nextRunAtMs`: 03:00 UTC on 2026-03-03 (same day, already passed)

This caused the scheduler to think the job was overdue and could trigger immediate re-execution.

## Fix

Add a defensive check in `computeJobNextRunAtMs`: if the calculated next run time is less than or equal to `lastRunAtMs`, retry the calculation starting from after the last run time.

### Changes
- `src/cron/service/jobs.ts`: Add guard to ensure `nextRunAtMs` is always after `lastRunAtMs`
- `src/cron/service.issue-regressions.test.ts`: Add regression test for #33126

Closes #33126