### PR TITLE
fix: load workspace skills from real workspace in embedded runner (closes #33354)

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -190,8 +190,10 @@ export async function compactEmbeddedPiSessionDirect(
   process.chdir(effectiveWorkspace);
   try {
     const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+    // Keep skill discovery anchored to the real workspace when sandbox cwd differs.
+    const skillWorkspace = resolvedWorkspace;
     const skillEntries = shouldLoadSkillEntries
-      ? loadWorkspaceSkillEntries(effectiveWorkspace)
+      ? loadWorkspaceSkillEntries(skillWorkspace, { config: params.config })
       : [];
     restoreSkillEnv = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({
@@ -206,7 +208,7 @@ export async function compactEmbeddedPiSessionDirect(
       skillsSnapshot: params.skillsSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
-      workspaceDir: effectiveWorkspace,
+      workspaceDir: skillWorkspace,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -168,8 +168,11 @@ export async function runEmbeddedAttempt(
   process.chdir(effectiveWorkspace);
   try {
     const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+    // Always discover skills from the real agent workspace, not the sandbox cwd.
+    // In read-only sandbox mode, the sandbox workspace may not contain workspace skills.
+    const skillWorkspace = resolvedWorkspace;
     const skillEntries = shouldLoadSkillEntries
-      ? loadWorkspaceSkillEntries(effectiveWorkspace)
+      ? loadWorkspaceSkillEntries(skillWorkspace, { config: params.config })
       : [];
     restoreSkillEnv = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({
@@ -185,7 +188,7 @@ export async function runEmbeddedAttempt(
       skillsSnapshot: params.skillsSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
-      workspaceDir: effectiveWorkspace,
+      workspaceDir: skillWorkspace,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;


### PR DESCRIPTION
Closes #33354

## Problem
Agent session startup could discover skills from the sandbox working directory when sandbox workspace access was read-only. That directory can miss the workspace skills folder, so only bundled/managed skills appeared.

## Fix
Use the resolved agent workspace (not sandbox cwd) as the source for skill discovery and skills prompt construction in embedded run and compaction paths. This keeps skill precedence and ensures workspace-installed skills are visible at startup.