### PR TITLE
fix(matrix): resolve keyed-async-queue module resolution regression

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 

--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/matrix";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 

--- a/src/plugin-sdk/matrix.ts
+++ b/src/plugin-sdk/matrix.ts
@@ -90,6 +90,8 @@ export {
 export { formatDocsLink } from "../terminal/links.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
 export { createScopedPairingAccess } from "./pairing-access.js";
+export { enqueueKeyedTask, KeyedAsyncQueue } from "./keyed-async-queue.js";
+export type { KeyedAsyncQueueHooks } from "./keyed-async-queue.js";
 export { formatResolvedUnresolvedNote } from "./resolution-notes.js";
 export { runPluginCommandWithTimeout } from "./run-command.js";
 export { createLoggerBackedRuntime } from "./runtime.js";


### PR DESCRIPTION
## Problem\nMatrix plugin fails to load on 2026.3.2 with:\n\nCannot find module '.../dist/plugin-sdk/index.js/keyed-async-queue'\n\n## Root cause\nThe Matrix extension imported  from a package subpath:\n\n- \n\nIn packaged dist/runtime this subpath can be resolved as , which is invalid.\n\n## Fix\nImport  from the plugin-sdk entrypoint export instead:\n\n- \n\n## Validation\n- 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/home/kkk/.openclaw/workspace-web3/openclaw[39m

 [32m✓[39m extensions/matrix/src/matrix/send-queue.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m extensions/matrix/src/matrix/send.test.ts [2m([22m[2m5 tests[22m[2m)[22m[33m 9161[2mms[22m[39m

[2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[32m10 passed[39m[22m[90m (10)[39m
[2m   Start at [22m 03:53:47
[2m   Duration [22m 9.48s[2m (transform 12.35s, setup 408ms, import 9.16s, tests 9.17s, environment 0ms)[22m\n\n## Scope\n- Matrix extension import path only.\n- No behavior changes to send queue logic.