### PR TITLE
Export session: restore JS placeholders in template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - LINE/context and routing synthesis: fix group/room peer routing and command-authorization context propagation, and keep processing later events in mixed-success webhook batches. (from #21955, #24475, #27035, #28286) Thanks @lailoo, @mcaxtr, @jervyclaw, @Glucksberg, and @Takhoffman.
 - LINE/status/config/webhook synthesis: fix status false positives from snapshot/config state and accept LINE webhook HEAD probes for compatibility. (from #10487, #25726, #27537, #27908, #31387) Thanks @BlueBirdBack, @stakeswky, @loiie45e, @puritysb, and @mcaxtr.
 - LINE cleanup/test follow-ups: fold cleanup/test learnings into the synthesis review path while keeping runtime changes focused on regression fixes. (from #17630, #17289) Thanks @Clawborn and @davidahmann.
+- Export session HTML/template placeholders: restore literal `{{MARKED_JS}}`, `{{HIGHLIGHT_JS}}`, and `{{JS}}` script placeholders so `/export-session` correctly inlines vendor/runtime scripts instead of emitting broken `ReferenceError` exports. Fixes #22595. Thanks @umiiii.
 
 ## 2026.3.2
 

--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -59,30 +59,12 @@
     </script>
 
     <!-- Vendored libraries -->
-    <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
-    </script>
+    <script>{{MARKED_JS}}</script>
 
     <!-- highlight.js -->
-    <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
-    </script>
+    <script>{{HIGHLIGHT_JS}}</script>
 
     <!-- Main application code -->
-    <script>
-      {
-        {
-          JS;
-        }
-      }
-    </script>
+    <script>{{JS}}</script>
   </body>
 </html>

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -80,6 +80,12 @@ function now() {
 }
 
 describe("export html security hardening", () => {
+  it("keeps vendor script placeholders intact for export-time replacement", () => {
+    expect(templateHtml).toContain("<script>{{MARKED_JS}}</script>");
+    expect(templateHtml).toContain("<script>{{HIGHLIGHT_JS}}</script>");
+    expect(templateHtml).toContain("<script>{{JS}}</script>");
+  });
+
   it("escapes raw HTML from markdown blocks", () => {
     const attack = "<img src=x onerror=alert(1)>";
     const session: SessionData = {


### PR DESCRIPTION
## Summary
- restore literal `{{MARKED_JS}}`, `{{HIGHLIGHT_JS}}`, and `{{JS}}` placeholders in export-session HTML template
- add regression coverage to keep these placeholders intact in `template.security.test.ts`
- document the fix in `CHANGELOG.md`

## Testing
- pnpm vitest src/auto-reply/reply/export-html/template.security.test.ts
- pnpm format:check

Fixes #22595
