### PR TITLE
fix(webchat): render image blocks with direct base64 data in chat UI

### DIFF
--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -40,6 +40,12 @@ function extractImages(message: unknown): ImageBlock[] {
           // If data is already a data URL, use it directly
           const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
           images.push({ url });
+        } else if (typeof b.data === "string") {
+          // Handle tool-result image blocks serialized as { type: "image", data, mimeType }
+          const data = b.data;
+          const mediaType = (b.mimeType as string) || "image/png";
+          const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
+          images.push({ url });
         } else if (typeof b.url === "string") {
           images.push({ url: b.url });
         }


### PR DESCRIPTION
Potential fix for #33119.

Webchat image extraction handled image.source.base64 and image_url formats, but missed tool-result image blocks serialized as {type:'image', data, mimeType}. As a result, some AI-sent image attachments were not rendered.

This patch adds direct data/mimeType handling and converts to data URL for display.

1 file changed, small focused fix.

---

🤖 AI-assisted PR (Claude via OpenClaw agent)
- Testing: ui/src/ui/controllers/chat.test.ts passes locally
- I understand what this code does