### PR TITLE
test(memory,plugins): stabilize batch tests and align command spec expectation

### DIFF
--- a/src/memory/batch-voyage.test.ts
+++ b/src/memory/batch-voyage.test.ts
@@ -9,6 +9,17 @@ vi.mock("../infra/retry.js", () => ({
   retryAsync: async <T>(fn: () => Promise<T>) => fn(),
 }));
 
+vi.mock("./remote-http.js", () => ({
+  withRemoteHttpResponse: async <T>(params: {
+    url: string;
+    init?: RequestInit;
+    onResponse: (response: Response) => Promise<T>;
+  }) => {
+    const response = await fetch(params.url, params.init);
+    return await params.onResponse(response);
+  },
+}));
+
 describe("runVoyageEmbeddingBatches", () => {
   let runVoyageEmbeddingBatches: typeof import("./batch-voyage.js").runVoyageEmbeddingBatches;
 

--- a/src/memory/manager.batch.test.ts
+++ b/src/memory/manager.batch.test.ts
@@ -8,6 +8,17 @@ import { getMemorySearchManager, type MemoryIndexManager } from "./index.js";
 import { createOpenAIEmbeddingProviderMock } from "./test-embeddings-mock.js";
 import "./test-runtime-mocks.js";
 
+vi.mock("./remote-http.js", () => ({
+  withRemoteHttpResponse: async <T>(params: {
+    url: string;
+    init?: RequestInit;
+    onResponse: (response: Response) => Promise<T>;
+  }) => {
+    const response = await fetch(params.url, params.init);
+    return await params.onResponse(response);
+  },
+}));
+
 const embedBatch = vi.fn(async (_texts: string[]) => [] as number[][]);
 const embedQuery = vi.fn(async () => [0.5, 0.5, 0.5]);
 


### PR DESCRIPTION
## Problem
`test:fast` currently reports failures in:
- `src/memory/batch-voyage.test.ts`
- `src/memory/manager.batch.test.ts`
- `src/plugins/commands.test.ts`

The memory batch tests can hit SSRF guard behavior through remote HTTP helper wiring in test runtime, and the plugin command test expectation is out of date with normalized metadata output.

## Fix
- Mock `withRemoteHttpResponse` in memory batch tests to keep unit tests on fetch-mocked transport and avoid SSRF guard coupling.
- Align plugin command metadata expectation with current normalized output (`acceptsArgs: false`).

## Validation
- `corepack pnpm -s vitest src/memory/batch-voyage.test.ts src/memory/manager.batch.test.ts src/plugins/commands.test.ts`

## Scope
Test-only stabilization and expectation alignment.
No production runtime logic changes.
