### PR TITLE
fix(outbound): multi-layer deduplication for all channels

### DIFF
--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,5 +1,6 @@
 import type { TypingCallbacks } from "../../channels/typing.js";
 import type { HumanDelayConfig } from "../../config/types.js";
+import { buildOutboundDedupeKey } from "../../infra/outbound/outbound-dedupe.js";
 import { sleep } from "../../utils.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { registerDispatcher } from "./dispatcher-registry.js";
@@ -113,6 +114,10 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
   let completeCalled = false;
   // Track whether we've sent a block reply (for human delay - skip delay on first block).
   let sentFirstBlock = false;
+  // Layer 3: per-dispatch-lifecycle dedup set.
+  // Catches duplicates within a single dispatch cycle (e.g. multi-tool sequence
+  // emitting the same text block multiple times).
+  const deliveredPayloadKeys = new Set<string>();
   // Serialize outbound replies to preserve tool/block/final order.
   const queuedCounts: Record<ReplyDispatchKind, number> = {
     tool: 0,
@@ -137,6 +142,21 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     if (!normalized) {
       return false;
     }
+
+    // Layer 3: per-dispatch-lifecycle dedup — skip if this exact payload
+    // was already enqueued during this dispatcher's lifetime.
+    const dedupeKey = buildOutboundDedupeKey({
+      channel: "dispatch",
+      to: "dispatch",
+      payload: normalized,
+    });
+    if (dedupeKey) {
+      if (deliveredPayloadKeys.has(dedupeKey)) {
+        return false;
+      }
+      deliveredPayloadKeys.add(dedupeKey);
+    }
+
     queuedCounts[kind] += 1;
     pending += 1;
 

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -143,10 +143,10 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
       return false;
     }
 
-    // Layer 3: per-dispatch-lifecycle dedup — skip if this exact payload
-    // was already enqueued during this dispatcher's lifetime.
-    // The key is computed here but only registered after successful delivery
-    // so that failed sends can be retried within the same dispatch cycle.
+    // Layer 3: per-dispatch-lifecycle dedup — atomically claim a slot for
+    // this payload at enqueue time so that back-to-back synchronous
+    // emissions of the same content within one dispatch cycle are blocked.
+    // On delivery failure the key is removed so the payload can be retried.
     const dedupeKey = buildOutboundDedupeKey({
       channel: "dispatch",
       to: "dispatch",
@@ -156,6 +156,8 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
       if (deliveredPayloadKeys.has(dedupeKey)) {
         return false;
       }
+      // Claim immediately to block concurrent/synchronous duplicates.
+      deliveredPayloadKeys.add(dedupeKey);
     }
 
     queuedCounts[kind] += 1;
@@ -179,12 +181,12 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         // Safe: deliver is called inside an async .then() callback, so even a synchronous
         // throw becomes a rejection that flows through .catch()/.finally(), ensuring cleanup.
         await options.deliver(normalized, { kind });
-        // Register the key only after successful delivery so failures can retry.
-        if (dedupeKey) {
-          deliveredPayloadKeys.add(dedupeKey);
-        }
       })
       .catch((err) => {
+        // Rollback the dedup claim on failure so the payload can be retried.
+        if (dedupeKey) {
+          deliveredPayloadKeys.delete(dedupeKey);
+        }
         options.onError?.(err, { kind });
       })
       .finally(() => {

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -145,6 +145,8 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
 
     // Layer 3: per-dispatch-lifecycle dedup — skip if this exact payload
     // was already enqueued during this dispatcher's lifetime.
+    // The key is computed here but only registered after successful delivery
+    // so that failed sends can be retried within the same dispatch cycle.
     const dedupeKey = buildOutboundDedupeKey({
       channel: "dispatch",
       to: "dispatch",
@@ -154,7 +156,6 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
       if (deliveredPayloadKeys.has(dedupeKey)) {
         return false;
       }
-      deliveredPayloadKeys.add(dedupeKey);
     }
 
     queuedCounts[kind] += 1;
@@ -178,6 +179,10 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         // Safe: deliver is called inside an async .then() callback, so even a synchronous
         // throw becomes a rejection that flows through .catch()/.finally(), ensuring cleanup.
         await options.deliver(normalized, { kind });
+        // Register the key only after successful delivery so failures can retry.
+        if (dedupeKey) {
+          deliveredPayloadKeys.add(dedupeKey);
+        }
       })
       .catch((err) => {
         options.onError?.(err, { kind });

--- a/src/infra/dedupe.ts
+++ b/src/infra/dedupe.ts
@@ -3,6 +3,8 @@ import { pruneMapToMaxSize } from "./map-size.js";
 export type DedupeCache = {
   check: (key: string | undefined | null, now?: number) => boolean;
   peek: (key: string | undefined | null, now?: number) => boolean;
+  /** Remove a key from the cache (e.g. to rollback a claim on failure). */
+  remove: (key: string) => void;
   clear: () => void;
   size: () => number;
 };
@@ -70,6 +72,9 @@ export function createDedupeCache(options: DedupeCacheOptions): DedupeCache {
         return false;
       }
       return hasUnexpired(key, now, false);
+    },
+    remove: (key: string) => {
+      cache.delete(key);
     },
     clear: () => {
       cache.clear();

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -12,6 +12,7 @@ import { withEnvAsync } from "../../test-utils/env.js";
 import { createIMessageTestPlugin } from "../../test-utils/imessage-test-plugin.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
 import { resolvePreferredOpenClawTmpDir } from "../tmp-openclaw-dir.js";
+import { resetOutboundDedupe } from "./outbound-dedupe.js";
 
 const mocks = vi.hoisted(() => ({
   appendAssistantMessageToSessionTranscript: vi.fn(async () => ({ ok: true, sessionFile: "x" })),
@@ -207,6 +208,7 @@ describe("deliverOutboundPayloads", () => {
 
   afterEach(() => {
     setActivePluginRegistry(emptyRegistry);
+    resetOutboundDedupe();
   });
   it("chunks telegram markdown and passes through accountId", async () => {
     const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "c1" });
@@ -888,6 +890,100 @@ describe("deliverOutboundPayloads", () => {
       }),
     );
     expect(results).toEqual([{ channel: "line", messageId: "ln-1" }]);
+  });
+
+  it("skips duplicate payload on second delivery (cross-turn dedup)", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    const first = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+    });
+    const second = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(0);
+  });
+
+  it("allows delivery to different recipients", async () => {
+    const sendWhatsApp = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "w1", toJid: "jid1" })
+      .mockResolvedValueOnce({ messageId: "w2", toJid: "jid2" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+    });
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1666",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not register failed delivery (allows retry)", async () => {
+    const sendWhatsApp = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce({ messageId: "w1", toJid: "jid" });
+
+    // First attempt fails.
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "whatsapp",
+        to: "+1555",
+        payloads: [{ text: "retry me" }],
+        deps: { sendWhatsApp },
+      }),
+    ).rejects.toThrow("network error");
+
+    // Retry succeeds because the failed send was not registered.
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "retry me" }],
+      deps: { sendWhatsApp },
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledTimes(2);
+    expect(results).toHaveLength(1);
+  });
+
+  it("fixes self-duplicated text before delivery", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    const paragraph = "This is a paragraph that is long enough to trigger dedup detection.";
+    const duplicated = `${paragraph}\n\n${paragraph}`;
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: duplicated }],
+      deps: { sendWhatsApp },
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    expect(sendWhatsApp).toHaveBeenCalledWith("+1555", paragraph, expect.anything());
   });
 
   it("emits message_sent failure when delivery errors", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -38,9 +38,11 @@ import type { sendMessageWhatsApp } from "../../web/outbound.js";
 import { throwIfAborted } from "./abort.js";
 import { ackDelivery, enqueueDelivery, failDelivery } from "./delivery-queue.js";
 import type { OutboundIdentity } from "./identity.js";
+import { isOutboundDuplicate, registerOutboundDelivered } from "./outbound-dedupe.js";
 import type { NormalizedOutboundPayload } from "./payloads.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
 import { isPlainTextSurface, sanitizeForPlainText } from "./sanitize-text.js";
+import { deduplicateText } from "./self-dedup.js";
 import type { OutboundSessionContext } from "./session-context.js";
 import type { OutboundChannel } from "./targets.js";
 
@@ -296,6 +298,13 @@ function normalizePayloadsForChannelDelivery(
       // Telegram sendPayload uses textMode:"html". Preserve raw HTML in this path.
       if (!(channel === "telegram" && payload.channelData)) {
         sanitizedPayload = { ...payload, text: sanitizeForPlainText(payload.text) };
+      }
+    }
+    // Layer 2: fix self-duplicated text (e.g. BlueBubbles streaming concatenation bug).
+    if (sanitizedPayload.text) {
+      const deduplicated = deduplicateText(sanitizedPayload.text);
+      if (deduplicated != null) {
+        sanitizedPayload = { ...sanitizedPayload, text: deduplicated };
       }
     }
     const normalized = normalizePayloadForChannelDelivery(sanitizedPayload, channel);
@@ -675,6 +684,25 @@ async function deliverOutboundPayloadsCore(
     try {
       throwIfAborted(abortSignal);
 
+      // Layer 1: cross-turn TTL dedup — skip if an identical payload was
+      // recently delivered to the same recipient.
+      const dedupeParams = {
+        channel,
+        to,
+        accountId,
+        threadId: params.threadId,
+        resolvedReplyToId: params.replyToId,
+        payload,
+      };
+      if (isOutboundDuplicate(dedupeParams)) {
+        log.info("outbound dedup: skipping duplicate payload", {
+          channel,
+          to,
+          text: payloadSummary.text.slice(0, 80),
+        });
+        continue;
+      }
+
       // Run message_sending plugin hook (may modify content or cancel)
       const hookResult = await applyMessageSendingHook({
         hookRunner,
@@ -699,6 +727,7 @@ async function deliverOutboundPayloadsCore(
       if (handler.sendPayload && effectivePayload.channelData) {
         const delivery = await handler.sendPayload(effectivePayload, sendOverrides);
         results.push(delivery);
+        registerOutboundDelivered(dedupeParams);
         emitMessageSent({
           success: true,
           content: payloadSummary.text,
@@ -714,6 +743,7 @@ async function deliverOutboundPayloadsCore(
           await sendTextChunks(payloadSummary.text, sendOverrides);
         }
         const messageId = results.at(-1)?.messageId;
+        registerOutboundDelivered(dedupeParams);
         emitMessageSent({
           success: results.length > beforeCount,
           content: payloadSummary.text,
@@ -738,6 +768,7 @@ async function deliverOutboundPayloadsCore(
           lastMessageId = delivery.messageId;
         }
       }
+      registerOutboundDelivered(dedupeParams);
       emitMessageSent({
         success: true,
         content: payloadSummary.text,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -38,7 +38,11 @@ import type { sendMessageWhatsApp } from "../../web/outbound.js";
 import { throwIfAborted } from "./abort.js";
 import { ackDelivery, enqueueDelivery, failDelivery } from "./delivery-queue.js";
 import type { OutboundIdentity } from "./identity.js";
-import { isOutboundDuplicate, registerOutboundDelivered } from "./outbound-dedupe.js";
+import {
+  buildOutboundDedupeKey,
+  claimOutboundDelivery,
+  rollbackOutboundClaim,
+} from "./outbound-dedupe.js";
 import type { NormalizedOutboundPayload } from "./payloads.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
 import { isPlainTextSurface, sanitizeForPlainText } from "./sanitize-text.js";
@@ -681,29 +685,14 @@ async function deliverOutboundPayloadsCore(
   }
   for (const payload of normalizedPayloads) {
     let payloadSummary = buildPayloadSummary(payload);
+    // Track the dedup claim key so we can rollback on failure.
+    let dedupeClaimKey: string | null = null;
     try {
       throwIfAborted(abortSignal);
 
-      // Layer 1: cross-turn TTL dedup — skip if an identical payload was
-      // recently delivered to the same recipient.
-      const dedupeParams = {
-        channel,
-        to,
-        accountId,
-        threadId: params.threadId,
-        resolvedReplyToId: params.replyToId,
-        payload,
-      };
-      if (isOutboundDuplicate(dedupeParams)) {
-        log.info("outbound dedup: skipping duplicate payload", {
-          channel,
-          to,
-          text: payloadSummary.text.slice(0, 80),
-        });
-        continue;
-      }
-
-      // Run message_sending plugin hook (may modify content or cancel)
+      // Run message_sending plugin hook (may modify content or cancel).
+      // Hooks run BEFORE dedup so the key is built from the effective
+      // (post-hook) payload — the content that is actually delivered.
       const hookResult = await applyMessageSendingHook({
         hookRunner,
         enabled: hasMessageSendingHooks,
@@ -719,6 +708,33 @@ async function deliverOutboundPayloadsCore(
       const effectivePayload = hookResult.payload;
       payloadSummary = hookResult.payloadSummary;
 
+      // Layer 1: cross-turn TTL dedup — atomically claim a slot for this
+      // payload. If it was recently delivered to the same recipient the
+      // claim returns null and we skip. On delivery failure the claim is
+      // rolled back so the payload can be retried.
+      const dedupeParams = {
+        channel,
+        to,
+        accountId,
+        threadId: params.threadId,
+        resolvedReplyToId: params.replyToId ?? undefined,
+        payload: effectivePayload,
+      };
+      dedupeClaimKey = claimOutboundDelivery(dedupeParams);
+      if (dedupeClaimKey === null) {
+        // claimOutboundDelivery returns null for both duplicates AND empty
+        // payloads. Only skip if the key is non-null (true duplicate).
+        const key = buildOutboundDedupeKey(dedupeParams);
+        if (key !== null) {
+          log.info("outbound dedup: skipping duplicate payload", {
+            channel,
+            to,
+            text: payloadSummary.text.slice(0, 80),
+          });
+          continue;
+        }
+      }
+
       params.onPayload?.(payloadSummary);
       const sendOverrides = {
         replyToId: effectivePayload.replyToId ?? params.replyToId ?? undefined,
@@ -727,7 +743,6 @@ async function deliverOutboundPayloadsCore(
       if (handler.sendPayload && effectivePayload.channelData) {
         const delivery = await handler.sendPayload(effectivePayload, sendOverrides);
         results.push(delivery);
-        registerOutboundDelivered(dedupeParams);
         emitMessageSent({
           success: true,
           content: payloadSummary.text,
@@ -743,7 +758,6 @@ async function deliverOutboundPayloadsCore(
           await sendTextChunks(payloadSummary.text, sendOverrides);
         }
         const messageId = results.at(-1)?.messageId;
-        registerOutboundDelivered(dedupeParams);
         emitMessageSent({
           success: results.length > beforeCount,
           content: payloadSummary.text,
@@ -768,13 +782,17 @@ async function deliverOutboundPayloadsCore(
           lastMessageId = delivery.messageId;
         }
       }
-      registerOutboundDelivered(dedupeParams);
       emitMessageSent({
         success: true,
         content: payloadSummary.text,
         messageId: lastMessageId,
       });
     } catch (err) {
+      // Rollback the dedup claim so the payload can be retried.
+      if (dedupeClaimKey) {
+        rollbackOutboundClaim(dedupeClaimKey);
+        dedupeClaimKey = null;
+      }
       emitMessageSent({
         success: false,
         content: payloadSummary.text,

--- a/src/infra/outbound/outbound-dedupe.test.ts
+++ b/src/infra/outbound/outbound-dedupe.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildOutboundDedupeKey,
+  isOutboundDuplicate,
+  registerOutboundDelivered,
+  resetOutboundDedupe,
+} from "./outbound-dedupe.js";
+import type { OutboundDedupeKeyParams } from "./outbound-dedupe.js";
+
+function makeParams(overrides?: Partial<OutboundDedupeKeyParams>): OutboundDedupeKeyParams {
+  return {
+    channel: "telegram",
+    to: "123",
+    payload: { text: "Hello, world!" },
+    ...overrides,
+  };
+}
+
+describe("buildOutboundDedupeKey", () => {
+  it("returns null for empty payload", () => {
+    expect(buildOutboundDedupeKey(makeParams({ payload: {} }))).toBeNull();
+    expect(buildOutboundDedupeKey(makeParams({ payload: { text: "  " } }))).toBeNull();
+    expect(buildOutboundDedupeKey(makeParams({ payload: { text: "" } }))).toBeNull();
+  });
+
+  it("normalizes text for comparison", () => {
+    const key1 = buildOutboundDedupeKey(makeParams({ payload: { text: "Hello, world!" } }));
+    const key2 = buildOutboundDedupeKey(makeParams({ payload: { text: "  hello,  world!  " } }));
+    expect(key1).toBe(key2);
+  });
+
+  it("includes channel and to in the key", () => {
+    const key1 = buildOutboundDedupeKey(makeParams({ channel: "telegram" }));
+    const key2 = buildOutboundDedupeKey(makeParams({ channel: "whatsapp" }));
+    expect(key1).not.toBe(key2);
+  });
+
+  it("includes accountId in the key", () => {
+    const key1 = buildOutboundDedupeKey(makeParams({ accountId: "acc1" }));
+    const key2 = buildOutboundDedupeKey(makeParams({ accountId: "acc2" }));
+    expect(key1).not.toBe(key2);
+  });
+
+  it("includes threadId in the key", () => {
+    const key1 = buildOutboundDedupeKey(makeParams({ threadId: "t1" }));
+    const key2 = buildOutboundDedupeKey(makeParams({ threadId: "t2" }));
+    expect(key1).not.toBe(key2);
+  });
+
+  it("excludes audioAsVoice from the key", () => {
+    const key1 = buildOutboundDedupeKey(
+      makeParams({ payload: { text: "hi", audioAsVoice: true } }),
+    );
+    const key2 = buildOutboundDedupeKey(
+      makeParams({ payload: { text: "hi", audioAsVoice: false } }),
+    );
+    expect(key1).toBe(key2);
+  });
+
+  it("sorts media URLs for stable key", () => {
+    const key1 = buildOutboundDedupeKey(
+      makeParams({ payload: { text: "hi", mediaUrls: ["b.jpg", "a.jpg"] } }),
+    );
+    const key2 = buildOutboundDedupeKey(
+      makeParams({ payload: { text: "hi", mediaUrls: ["a.jpg", "b.jpg"] } }),
+    );
+    expect(key1).toBe(key2);
+  });
+
+  it("returns non-null for channelData-only payload", () => {
+    const key = buildOutboundDedupeKey(makeParams({ payload: { channelData: { mode: "flex" } } }));
+    expect(key).not.toBeNull();
+  });
+
+  it("differentiates distinct channelData payloads", () => {
+    const key1 = buildOutboundDedupeKey(
+      makeParams({ payload: { channelData: { mode: "flex", layout: "carousel" } } }),
+    );
+    const key2 = buildOutboundDedupeKey(
+      makeParams({ payload: { channelData: { mode: "flex", layout: "list" } } }),
+    );
+    expect(key1).not.toBe(key2);
+  });
+
+  it("produces same key for identical channelData regardless of insertion order", () => {
+    const key1 = buildOutboundDedupeKey(makeParams({ payload: { channelData: { a: 1, b: 2 } } }));
+    const key2 = buildOutboundDedupeKey(makeParams({ payload: { channelData: { b: 2, a: 1 } } }));
+    expect(key1).toBe(key2);
+  });
+
+  it("includes replyToId in the key", () => {
+    const key1 = buildOutboundDedupeKey(makeParams({ payload: { text: "hi", replyToId: "1" } }));
+    const key2 = buildOutboundDedupeKey(makeParams({ payload: { text: "hi", replyToId: "2" } }));
+    expect(key1).not.toBe(key2);
+  });
+
+  it("uses resolvedReplyToId when payload.replyToId is unset", () => {
+    const key1 = buildOutboundDedupeKey(
+      makeParams({ resolvedReplyToId: "r1", payload: { text: "hi" } }),
+    );
+    const key2 = buildOutboundDedupeKey(
+      makeParams({ resolvedReplyToId: "r2", payload: { text: "hi" } }),
+    );
+    expect(key1).not.toBe(key2);
+  });
+
+  it("payload.replyToId takes precedence over resolvedReplyToId", () => {
+    const key1 = buildOutboundDedupeKey(
+      makeParams({ resolvedReplyToId: "r1", payload: { text: "hi", replyToId: "p1" } }),
+    );
+    const key2 = buildOutboundDedupeKey(
+      makeParams({ resolvedReplyToId: "r2", payload: { text: "hi", replyToId: "p1" } }),
+    );
+    expect(key1).toBe(key2);
+  });
+
+  it("handles field values containing special characters without collision", () => {
+    // Ensure JSON serialization prevents delimiter-based collisions
+    const key1 = buildOutboundDedupeKey(
+      makeParams({ to: "a|b", threadId: "", payload: { text: "hi" } }),
+    );
+    const key2 = buildOutboundDedupeKey(
+      makeParams({ to: "a", threadId: "b", payload: { text: "hi" } }),
+    );
+    expect(key1).not.toBe(key2);
+  });
+
+  it("uses mediaUrl when mediaUrls is not set", () => {
+    const key1 = buildOutboundDedupeKey(makeParams({ payload: { text: "hi", mediaUrl: "a.jpg" } }));
+    const key2 = buildOutboundDedupeKey(
+      makeParams({ payload: { text: "hi", mediaUrls: ["a.jpg"] } }),
+    );
+    expect(key1).toBe(key2);
+  });
+});
+
+describe("isOutboundDuplicate / registerOutboundDelivered", () => {
+  afterEach(() => {
+    resetOutboundDedupe();
+  });
+
+  it("returns false on first encounter", () => {
+    expect(isOutboundDuplicate(makeParams())).toBe(false);
+  });
+
+  it("returns true after registration within TTL", () => {
+    const now = Date.now();
+    registerOutboundDelivered(makeParams(), now);
+    expect(isOutboundDuplicate(makeParams(), now + 100)).toBe(true);
+  });
+
+  it("returns false after TTL expires", () => {
+    const now = Date.now();
+    registerOutboundDelivered(makeParams(), now);
+    // TTL is 30s, check at 31s
+    expect(isOutboundDuplicate(makeParams(), now + 31_000)).toBe(false);
+  });
+
+  it("returns false for different recipient", () => {
+    const now = Date.now();
+    registerOutboundDelivered(makeParams({ to: "123" }), now);
+    expect(isOutboundDuplicate(makeParams({ to: "456" }), now + 100)).toBe(false);
+  });
+
+  it("returns false for different channel", () => {
+    const now = Date.now();
+    registerOutboundDelivered(makeParams({ channel: "telegram" }), now);
+    expect(isOutboundDuplicate(makeParams({ channel: "whatsapp" }), now + 100)).toBe(false);
+  });
+
+  it("does not register on peek (isOutboundDuplicate)", () => {
+    const now = Date.now();
+    // Peek only — should not register
+    isOutboundDuplicate(makeParams(), now);
+    // Should still be false since peek doesn't register
+    expect(isOutboundDuplicate(makeParams(), now + 100)).toBe(false);
+  });
+
+  it("handles empty payload gracefully", () => {
+    expect(isOutboundDuplicate(makeParams({ payload: {} }))).toBe(false);
+    // Should not throw
+    registerOutboundDelivered(makeParams({ payload: {} }));
+  });
+});

--- a/src/infra/outbound/outbound-dedupe.test.ts
+++ b/src/infra/outbound/outbound-dedupe.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   buildOutboundDedupeKey,
+  claimOutboundDelivery,
   isOutboundDuplicate,
   registerOutboundDelivered,
   resetOutboundDedupe,
+  rollbackOutboundClaim,
 } from "./outbound-dedupe.js";
 import type { OutboundDedupeKeyParams } from "./outbound-dedupe.js";
 
@@ -82,9 +84,33 @@ describe("buildOutboundDedupeKey", () => {
     expect(key1).not.toBe(key2);
   });
 
+  it("differentiates nested channelData payloads", () => {
+    const key1 = buildOutboundDedupeKey(
+      makeParams({
+        payload: { channelData: { template: { type: "carousel", items: [1, 2, 3] } } },
+      }),
+    );
+    const key2 = buildOutboundDedupeKey(
+      makeParams({
+        payload: { channelData: { template: { type: "bubble", items: [4, 5, 6] } } },
+      }),
+    );
+    expect(key1).not.toBe(key2);
+  });
+
   it("produces same key for identical channelData regardless of insertion order", () => {
     const key1 = buildOutboundDedupeKey(makeParams({ payload: { channelData: { a: 1, b: 2 } } }));
     const key2 = buildOutboundDedupeKey(makeParams({ payload: { channelData: { b: 2, a: 1 } } }));
+    expect(key1).toBe(key2);
+  });
+
+  it("produces same key for deeply nested channelData regardless of insertion order", () => {
+    const key1 = buildOutboundDedupeKey(
+      makeParams({ payload: { channelData: { outer: { z: 3, a: 1 } } } }),
+    );
+    const key2 = buildOutboundDedupeKey(
+      makeParams({ payload: { channelData: { outer: { a: 1, z: 3 } } } }),
+    );
     expect(key1).toBe(key2);
   });
 
@@ -115,7 +141,6 @@ describe("buildOutboundDedupeKey", () => {
   });
 
   it("handles field values containing special characters without collision", () => {
-    // Ensure JSON serialization prevents delimiter-based collisions
     const key1 = buildOutboundDedupeKey(
       makeParams({ to: "a|b", threadId: "", payload: { text: "hi" } }),
     );
@@ -131,6 +156,17 @@ describe("buildOutboundDedupeKey", () => {
       makeParams({ payload: { text: "hi", mediaUrls: ["a.jpg"] } }),
     );
     expect(key1).toBe(key2);
+  });
+
+  it("differentiates distinct emoji-only messages", () => {
+    const key1 = buildOutboundDedupeKey(makeParams({ payload: { text: "\u{1F600}" } }));
+    const key2 = buildOutboundDedupeKey(makeParams({ payload: { text: "\u{1F622}" } }));
+    expect(key1).not.toBe(key2);
+  });
+
+  it("returns non-null key for emoji-only text", () => {
+    const key = buildOutboundDedupeKey(makeParams({ payload: { text: "\u{1F600}" } }));
+    expect(key).not.toBeNull();
   });
 });
 
@@ -152,7 +188,6 @@ describe("isOutboundDuplicate / registerOutboundDelivered", () => {
   it("returns false after TTL expires", () => {
     const now = Date.now();
     registerOutboundDelivered(makeParams(), now);
-    // TTL is 30s, check at 31s
     expect(isOutboundDuplicate(makeParams(), now + 31_000)).toBe(false);
   });
 
@@ -170,15 +205,58 @@ describe("isOutboundDuplicate / registerOutboundDelivered", () => {
 
   it("does not register on peek (isOutboundDuplicate)", () => {
     const now = Date.now();
-    // Peek only — should not register
     isOutboundDuplicate(makeParams(), now);
-    // Should still be false since peek doesn't register
     expect(isOutboundDuplicate(makeParams(), now + 100)).toBe(false);
   });
 
   it("handles empty payload gracefully", () => {
     expect(isOutboundDuplicate(makeParams({ payload: {} }))).toBe(false);
-    // Should not throw
     registerOutboundDelivered(makeParams({ payload: {} }));
+  });
+});
+
+describe("claimOutboundDelivery / rollbackOutboundClaim", () => {
+  afterEach(() => {
+    resetOutboundDedupe();
+  });
+
+  it("returns key string on first claim", () => {
+    const key = claimOutboundDelivery(makeParams());
+    expect(key).not.toBeNull();
+    expect(typeof key).toBe("string");
+  });
+
+  it("returns null on second claim (duplicate)", () => {
+    claimOutboundDelivery(makeParams());
+    const second = claimOutboundDelivery(makeParams());
+    expect(second).toBeNull();
+  });
+
+  it("returns null for empty payload", () => {
+    const key = claimOutboundDelivery(makeParams({ payload: {} }));
+    expect(key).toBeNull();
+  });
+
+  it("allows retry after rollback", () => {
+    const key = claimOutboundDelivery(makeParams());
+    expect(key).not.toBeNull();
+    rollbackOutboundClaim(key!);
+    const retry = claimOutboundDelivery(makeParams());
+    expect(retry).not.toBeNull();
+  });
+
+  it("blocks concurrent claims for same payload", () => {
+    const now = Date.now();
+    const key1 = claimOutboundDelivery(makeParams(), now);
+    const key2 = claimOutboundDelivery(makeParams(), now + 1);
+    expect(key1).not.toBeNull();
+    expect(key2).toBeNull();
+  });
+
+  it("allows claims for different recipients", () => {
+    const key1 = claimOutboundDelivery(makeParams({ to: "123" }));
+    const key2 = claimOutboundDelivery(makeParams({ to: "456" }));
+    expect(key1).not.toBeNull();
+    expect(key2).not.toBeNull();
   });
 });

--- a/src/infra/outbound/outbound-dedupe.ts
+++ b/src/infra/outbound/outbound-dedupe.ts
@@ -75,7 +75,7 @@ export function buildOutboundDedupeKey(params: OutboundDedupeKeyParams): string 
   // Fallback to trimmed raw text when normalization produces empty string
   // (e.g. emoji-only messages where normalizeTextForComparison strips all emoji).
   const effectiveText = normalizedText || rawText.trim();
-  const sortedMediaUrls = mediaUrls.toSorted().join(",");
+  const sortedMediaUrls = JSON.stringify(mediaUrls.toSorted());
   // Use the resolved replyToId (payload-level takes precedence, then dispatch-level fallback).
   const replyTo = payload.replyToId ?? resolvedReplyToId ?? "";
   const thread = threadId != null ? String(threadId) : "";

--- a/src/infra/outbound/outbound-dedupe.ts
+++ b/src/infra/outbound/outbound-dedupe.ts
@@ -1,0 +1,107 @@
+import { normalizeTextForComparison } from "../../agents/pi-embedded-helpers/messaging-dedupe.js";
+import { createDedupeCache } from "../dedupe.js";
+
+const OUTBOUND_DEDUPE_TTL_MS = 30_000;
+const OUTBOUND_DEDUPE_MAX_SIZE = 500;
+
+const dedupeCache = createDedupeCache({
+  ttlMs: OUTBOUND_DEDUPE_TTL_MS,
+  maxSize: OUTBOUND_DEDUPE_MAX_SIZE,
+});
+
+export type OutboundDedupeKeyParams = {
+  channel: string;
+  to: string;
+  accountId?: string;
+  threadId?: string | number | null;
+  /** Fallback replyToId from dispatch params (used when payload.replyToId is unset). */
+  resolvedReplyToId?: string;
+  payload: {
+    text?: string;
+    mediaUrl?: string;
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+    replyToId?: string;
+    channelData?: Record<string, unknown>;
+  };
+};
+
+/**
+ * Build a deduplication key for an outbound payload.
+ *
+ * Returns null when the payload is empty (nothing to deduplicate).
+ * The key is a JSON array of [channel, account, to, thread, normalizedText,
+ * sortedMediaUrls, resolvedReplyToId, channelDataFingerprint] to avoid
+ * ambiguity from delimiter collisions. `audioAsVoice` is intentionally
+ * excluded so that voice/audio variants of the same content are
+ * caught as duplicates (aligned with PR #30478 reasoning).
+ */
+export function buildOutboundDedupeKey(params: OutboundDedupeKeyParams): string | null {
+  const { channel, to, accountId, threadId, resolvedReplyToId, payload } = params;
+  const rawText = payload.text ?? "";
+  const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+  const hasChannelData = Boolean(
+    payload.channelData && Object.keys(payload.channelData).length > 0,
+  );
+
+  // Nothing to deduplicate for empty payloads.
+  if (!rawText.trim() && mediaUrls.length === 0 && !hasChannelData) {
+    return null;
+  }
+
+  const normalizedText = rawText ? normalizeTextForComparison(rawText) : "";
+  const sortedMediaUrls = mediaUrls.toSorted().join(",");
+  // Use the resolved replyToId (payload-level takes precedence, then dispatch-level fallback).
+  const replyTo = payload.replyToId ?? resolvedReplyToId ?? "";
+  const thread = threadId != null ? String(threadId) : "";
+  const account = accountId ?? "";
+  // Include channelData fingerprint so distinct structured payloads are not
+  // collapsed into the same key (e.g. different Telegram flex layouts).
+  const channelDataFp = hasChannelData
+    ? JSON.stringify(payload.channelData, Object.keys(payload.channelData!).sort())
+    : "";
+
+  // Use JSON array serialization to avoid delimiter collision issues.
+  return JSON.stringify([
+    "out",
+    channel,
+    account,
+    to,
+    thread,
+    normalizedText,
+    sortedMediaUrls,
+    replyTo,
+    channelDataFp,
+  ]);
+}
+
+/**
+ * Check whether an identical outbound payload was recently delivered.
+ * Peek only — does not register the key.
+ */
+export function isOutboundDuplicate(params: OutboundDedupeKeyParams, now?: number): boolean {
+  const key = buildOutboundDedupeKey(params);
+  if (!key) {
+    return false;
+  }
+  return dedupeCache.peek(key, now);
+}
+
+/**
+ * Register a successfully delivered outbound payload in the dedup cache.
+ * Should be called only after successful delivery so that failed sends
+ * can be retried.
+ */
+export function registerOutboundDelivered(params: OutboundDedupeKeyParams, now?: number): void {
+  const key = buildOutboundDedupeKey(params);
+  if (!key) {
+    return;
+  }
+  // `check()` registers the key and returns false (not a duplicate) on first call.
+  dedupeCache.check(key, now);
+}
+
+/** Reset the dedup cache. Intended for tests only. */
+export function resetOutboundDedupe(): void {
+  dedupeCache.clear();
+}

--- a/src/infra/outbound/outbound-dedupe.ts
+++ b/src/infra/outbound/outbound-dedupe.ts
@@ -27,10 +27,32 @@ export type OutboundDedupeKeyParams = {
 };
 
 /**
+ * Recursively serialize an object with sorted keys for stable fingerprinting.
+ * Unlike `JSON.stringify(obj, sortedTopLevelKeys)`, this correctly handles
+ * nested objects by sorting keys at every depth level.
+ */
+function stableStringify(obj: unknown): string {
+  if (obj === null || obj === undefined) {
+    return JSON.stringify(obj);
+  }
+  if (typeof obj !== "object") {
+    return JSON.stringify(obj);
+  }
+  if (Array.isArray(obj)) {
+    return `[${obj.map(stableStringify).join(",")}]`;
+  }
+  const sorted = Object.keys(obj as Record<string, unknown>).toSorted();
+  const entries = sorted.map(
+    (k) => `${JSON.stringify(k)}:${stableStringify((obj as Record<string, unknown>)[k])}`,
+  );
+  return `{${entries.join(",")}}`;
+}
+
+/**
  * Build a deduplication key for an outbound payload.
  *
  * Returns null when the payload is empty (nothing to deduplicate).
- * The key is a JSON array of [channel, account, to, thread, normalizedText,
+ * The key is a JSON array of [channel, account, to, thread, effectiveText,
  * sortedMediaUrls, resolvedReplyToId, channelDataFingerprint] to avoid
  * ambiguity from delimiter collisions. `audioAsVoice` is intentionally
  * excluded so that voice/audio variants of the same content are
@@ -50,6 +72,9 @@ export function buildOutboundDedupeKey(params: OutboundDedupeKeyParams): string 
   }
 
   const normalizedText = rawText ? normalizeTextForComparison(rawText) : "";
+  // Fallback to trimmed raw text when normalization produces empty string
+  // (e.g. emoji-only messages where normalizeTextForComparison strips all emoji).
+  const effectiveText = normalizedText || rawText.trim();
   const sortedMediaUrls = mediaUrls.toSorted().join(",");
   // Use the resolved replyToId (payload-level takes precedence, then dispatch-level fallback).
   const replyTo = payload.replyToId ?? resolvedReplyToId ?? "";
@@ -57,9 +82,8 @@ export function buildOutboundDedupeKey(params: OutboundDedupeKeyParams): string 
   const account = accountId ?? "";
   // Include channelData fingerprint so distinct structured payloads are not
   // collapsed into the same key (e.g. different Telegram flex layouts).
-  const channelDataFp = hasChannelData
-    ? JSON.stringify(payload.channelData, Object.keys(payload.channelData!).sort())
-    : "";
+  // Uses recursive stable stringify to correctly handle nested objects.
+  const channelDataFp = hasChannelData ? stableStringify(payload.channelData) : "";
 
   // Use JSON array serialization to avoid delimiter collision issues.
   return JSON.stringify([
@@ -68,11 +92,45 @@ export function buildOutboundDedupeKey(params: OutboundDedupeKeyParams): string 
     account,
     to,
     thread,
-    normalizedText,
+    effectiveText,
     sortedMediaUrls,
     replyTo,
     channelDataFp,
   ]);
+}
+
+/**
+ * Atomically claim a dedup slot before delivery. Returns the key string
+ * as a claim token if the payload is new, or null if it is a duplicate
+ * (or an empty payload with nothing to deduplicate).
+ *
+ * This immediately registers the key in the cache so that concurrent
+ * deliveries of the same payload will see the claim and be skipped.
+ * On delivery failure, call `rollbackOutboundClaim(key)` to remove
+ * the claim and allow retry.
+ */
+export function claimOutboundDelivery(
+  params: OutboundDedupeKeyParams,
+  now?: number,
+): string | null {
+  const key = buildOutboundDedupeKey(params);
+  if (!key) {
+    return null;
+  }
+  // `check()` returns true if the key already exists (duplicate), false if new (and registers it).
+  const isDuplicate = dedupeCache.check(key, now);
+  if (isDuplicate) {
+    return null;
+  }
+  return key;
+}
+
+/**
+ * Rollback a previously claimed dedup key (e.g. when delivery fails).
+ * This allows the same payload to be retried.
+ */
+export function rollbackOutboundClaim(key: string): void {
+  dedupeCache.remove(key);
 }
 
 /**

--- a/src/infra/outbound/self-dedup.test.ts
+++ b/src/infra/outbound/self-dedup.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  deduplicateText,
+  detectFullTextRepetition,
+  detectTextSelfDuplication,
+} from "./self-dedup.js";
+
+describe("detectTextSelfDuplication", () => {
+  it("returns null for short text", () => {
+    expect(detectTextSelfDuplication("short")).toBeNull();
+    expect(detectTextSelfDuplication("ok\n\nok")).toBeNull();
+  });
+
+  it("returns null for non-duplicate text", () => {
+    const text =
+      "This is paragraph one with enough text.\n\nThis is paragraph two, totally different.";
+    expect(detectTextSelfDuplication(text)).toBeNull();
+  });
+
+  it("removes duplicate paragraphs", () => {
+    const paragraph = "This is a paragraph that is long enough to trigger dedup.";
+    const text = `${paragraph}\n\n${paragraph}`;
+    const result = detectTextSelfDuplication(text);
+    expect(result).toBe(paragraph);
+  });
+
+  it("handles BlueBubbles-style duplication", () => {
+    const content =
+      "Here is a detailed response with enough text to qualify for deduplication checks.";
+    const text = `${content}\n\n${content}`;
+    const result = detectTextSelfDuplication(text);
+    expect(result).toBe(content);
+  });
+
+  it("handles three-way repetition", () => {
+    const paragraph = "This paragraph is repeated three times and is long enough.";
+    const text = `${paragraph}\n\n${paragraph}\n\n${paragraph}`;
+    const result = detectTextSelfDuplication(text);
+    expect(result).toBe(paragraph);
+  });
+
+  it("preserves non-duplicate paragraphs in order", () => {
+    const para1 = "First paragraph with enough text to qualify for checks.";
+    const para2 = "Second paragraph that is different from the first one.";
+    const text = `${para1}\n\n${para2}\n\n${para1}`;
+    const result = detectTextSelfDuplication(text);
+    expect(result).toBe(`${para1}\n\n${para2}`);
+  });
+
+  it("returns null for single paragraph", () => {
+    expect(
+      detectTextSelfDuplication(
+        "Just one long paragraph with no double-newline breaks at all, long enough text.",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("detectFullTextRepetition", () => {
+  it("returns null for short text", () => {
+    expect(detectFullTextRepetition("short")).toBeNull();
+    expect(detectFullTextRepetition("a".repeat(38))).toBeNull();
+  });
+
+  it("returns null for non-repeated text", () => {
+    const text = "A".repeat(30) + "B".repeat(30);
+    expect(detectFullTextRepetition(text)).toBeNull();
+  });
+
+  it("detects exact full-text duplication", () => {
+    const half = "This is a message that got duplicated by streaming buffer bug.";
+    const text = half + half;
+    const result = detectFullTextRepetition(text);
+    expect(result).toBe(half);
+  });
+
+  it("detects duplication with whitespace normalization", () => {
+    const half = "Hello  world  this  is  a  test  message  with  spaces";
+    // Slightly different spacing — normalization should still match.
+    const text = `${half}${half}`;
+    const result = detectFullTextRepetition(text);
+    expect(result).toBe(half);
+  });
+});
+
+describe("deduplicateText", () => {
+  it("returns null for clean text", () => {
+    expect(
+      deduplicateText(
+        "This is a normal message without any duplication at all. It is long enough.",
+      ),
+    ).toBeNull();
+  });
+
+  it("prefers full-text repetition detection", () => {
+    const half = "This is a duplicated message from streaming buffer.";
+    const text = half + half;
+    const result = deduplicateText(text);
+    expect(result).toBe(half);
+  });
+
+  it("falls back to paragraph deduplication", () => {
+    const paragraph = "A paragraph with enough content for deduplication to engage.";
+    const text = `${paragraph}\n\n${paragraph}`;
+    const result = deduplicateText(text);
+    expect(result).toBe(paragraph);
+  });
+});

--- a/src/infra/outbound/self-dedup.ts
+++ b/src/infra/outbound/self-dedup.ts
@@ -1,0 +1,93 @@
+import { normalizeTextForComparison } from "../../agents/pi-embedded-helpers/messaging-dedupe.js";
+
+const MIN_SELF_DEDUP_LENGTH = 20;
+
+/**
+ * Detect paragraph-level self-duplication within a single text.
+ *
+ * Splits on double-newline boundaries and removes duplicate paragraphs
+ * (keeping the first occurrence). Returns the deduplicated text, or null
+ * if no duplication was found.
+ *
+ * Short texts (< MIN_SELF_DEDUP_LENGTH) are skipped to avoid false
+ * positives on intentional repetition like "ok\n\nok".
+ */
+export function detectTextSelfDuplication(text: string): string | null {
+  if (!text || text.length < MIN_SELF_DEDUP_LENGTH) {
+    return null;
+  }
+
+  const paragraphs = text.split(/\n\n+/);
+  if (paragraphs.length < 2) {
+    return null;
+  }
+
+  const seen = new Set<string>();
+  const deduplicated: string[] = [];
+  let foundDuplicate = false;
+
+  for (const paragraph of paragraphs) {
+    const normalized = normalizeTextForComparison(paragraph);
+    // Keep empty/whitespace-only paragraphs (formatting).
+    if (!normalized) {
+      deduplicated.push(paragraph);
+      continue;
+    }
+    if (seen.has(normalized)) {
+      foundDuplicate = true;
+      continue;
+    }
+    seen.add(normalized);
+    deduplicated.push(paragraph);
+  }
+
+  return foundDuplicate ? deduplicated.join("\n\n") : null;
+}
+
+/**
+ * Detect full-text repetition: the text is the same content repeated
+ * back-to-back (e.g., streaming concatenation bug where the buffer
+ * is appended to itself).
+ *
+ * Checks whether the first half of the text equals the second half
+ * after normalization. Returns the first half (original) if a match
+ * is found, or null otherwise.
+ */
+export function detectFullTextRepetition(text: string): string | null {
+  if (!text || text.length < MIN_SELF_DEDUP_LENGTH * 2) {
+    return null;
+  }
+
+  const trimmed = text.trim();
+  if (trimmed.length < MIN_SELF_DEDUP_LENGTH * 2) {
+    return null;
+  }
+
+  const mid = Math.floor(trimmed.length / 2);
+  const firstHalf = trimmed.slice(0, mid);
+  const secondHalf = trimmed.slice(mid);
+
+  const normalizedFirst = normalizeTextForComparison(firstHalf);
+  const normalizedSecond = normalizeTextForComparison(secondHalf);
+
+  if (normalizedFirst && normalizedFirst === normalizedSecond) {
+    return firstHalf.trim();
+  }
+
+  return null;
+}
+
+/**
+ * Apply all self-deduplication heuristics to a text.
+ * Returns the cleaned text if any duplication was found, or null if the
+ * text is clean.
+ *
+ * Order: full-text repetition first (more aggressive), then paragraph-level.
+ */
+export function deduplicateText(text: string): string | null {
+  const fullRepetition = detectFullTextRepetition(text);
+  if (fullRepetition != null) {
+    return fullRepetition;
+  }
+  return detectTextSelfDuplication(text);
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -19,6 +19,7 @@ import type {
 } from "../src/channels/plugins/types.js";
 import type { OpenClawConfig } from "../src/config/config.js";
 import type { OutboundSendDeps } from "../src/infra/outbound/deliver.js";
+import { resetOutboundDedupe } from "../src/infra/outbound/outbound-dedupe.js";
 import { withIsolatedTestHome } from "./test-env.js";
 
 // Set HOME/state isolation before importing any runtime OpenClaw modules.
@@ -191,4 +192,9 @@ afterEach(() => {
   if (vi.isFakeTimers()) {
     vi.useRealTimers();
   }
+  // Reset outbound dedup cache between tests to prevent cross-test pollution.
+  // The dedup cache is a process-level singleton; without this reset, heartbeat
+  // and cron tests can fail when a prior test in the same worker claimed a key
+  // that blocks delivery in a subsequent test (observed on Windows CI shards).
+  resetOutboundDedupe();
 });


### PR DESCRIPTION
## Summary

- Add three layers of channel-agnostic outbound message deduplication to fix duplicate message delivery across Telegram, WhatsApp, and all other channels
- **Layer 1 (Cross-turn TTL dedup):** Process-level 30s TTL cache in `deliverOutboundPayloadsCore` skips identical payloads recently sent to the same recipient — covers queue race conditions, cron announce repeats, and tool execution races (#25192, #33150, #27921, #20740)
- **Layer 2 (Text self-duplication):** Normalization step detects and fixes paragraph-level and full-text repetition before delivery — covers BlueBubbles streaming concatenation bug (#30316 comment)

Fixes #30316, #25192
Supersedes #30478

> **Note:** #33150 describes duplicated *inbound* messages during agent busy states. This PR addresses *outbound* deduplication only. PR #33168 handles the inbound queue drain dedup and is complementary to this PR.

## Changes in v2 (review feedback)

Addressed all review feedback from @greptile-apps and @chatgpt-codex-connector:

- **`channelData` included in dedup key:** Sorted JSON fingerprint of `channelData` is now part of the composite key, so distinct structured payloads (e.g. different Telegram flex layouts) are no longer silently suppressed as false duplicates
- **Resolved `replyToId`:** Dedup key now uses the resolved reply target (`payload.replyToId ?? params.replyToId`) matching actual send behavior, preventing legitimate threaded replies from being dropped
- **JSON array key format:** Replaced pipe-delimited key with `JSON.stringify([...])` to eliminate delimiter collision risk when field values contain `|`
- **5 new tests:** channelData differentiation, key order stability, resolvedReplyToId, payload replyToId precedence, special character collision resistance

## Test plan

- [x] `outbound-dedupe.test.ts`: 22 unit tests (was 17) — key building, TTL behavior, peek vs register, channelData fingerprinting, resolvedReplyToId, delimiter collision resistance
- [x] `self-dedup.test.ts`: 14 unit tests — short text, paragraph dedup, BlueBubbles pattern, three-way repetition, full-text repetition
- [x] `deliver.test.ts`: 4 integration tests — cross-turn dedup skip, different recipients allowed, failed delivery retryable, self-duplicated text auto-fixed
- [x] TypeScript type check passes (`pnpm tsgo`)
- [x] Lint/format passes (`pnpm check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)