### PR TITLE
fix: forward tool_choice from options for openai-codex-responses provider

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.codex-tool-choice.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.codex-tool-choice.test.ts
@@ -1,0 +1,112 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+// Mock streamSimple for testing
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: vi.fn(() => ({
+    push: vi.fn(),
+    result: vi.fn(),
+  })),
+}));
+
+type CodexToolChoiceCase = {
+  applyProvider: string;
+  applyModelId: string;
+  model: Model<"openai-codex-responses">;
+  cfg?: Parameters<typeof applyExtraParamsToAgent>[1];
+  options?: SimpleStreamOptions;
+};
+
+function runCodexToolChoiceCase(params: CodexToolChoiceCase) {
+  const payload: Record<string, unknown> = {
+    model: params.model.id,
+    messages: [],
+    tool_choice: "auto", // This is what the pi-ai provider hardcodes
+  };
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    options?.onPayload?.(payload);
+    return {} as ReturnType<StreamFn>;
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(agent, params.cfg, params.applyProvider, params.applyModelId);
+
+  const context: Context = { messages: [] };
+  void agent.streamFn?.(params.model, context, params.options ?? {});
+
+  return payload;
+}
+
+describe("extra-params: Codex tool_choice support", () => {
+  it("forwards tool_choice from options to payload for openai-codex provider", () => {
+    const payload = runCodexToolChoiceCase({
+      applyProvider: "openai-codex",
+      applyModelId: "gpt-5.1-codex",
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.1-codex",
+      } as Model<"openai-codex-responses">,
+      options: {
+        toolChoice: "required",
+      },
+    });
+
+    // The wrapper should override the hardcoded "auto" with "required"
+    expect(payload.tool_choice).toBe("required");
+  });
+
+  it("does not override tool_choice when not provided in options", () => {
+    const payload = runCodexToolChoiceCase({
+      applyProvider: "openai-codex",
+      applyModelId: "gpt-5.1-codex",
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.1-codex",
+      } as Model<"openai-codex-responses">,
+      options: {}, // No toolChoice provided
+    });
+
+    // Should remain as "auto" (the hardcoded value from the provider)
+    expect(payload.tool_choice).toBe("auto");
+  });
+
+  it("does not apply tool_choice wrapper for non-codex providers", () => {
+    const payload = runCodexToolChoiceCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-4.1",
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-4.1",
+      } as unknown as Model<"openai-codex-responses">,
+      options: {
+        toolChoice: "required",
+      },
+    });
+
+    // The openai provider should NOT have the wrapper, so tool_choice stays "auto"
+    // (this test verifies the wrapper is only applied to openai-codex)
+    expect(payload.tool_choice).toBe("auto");
+  });
+
+  it("supports tool_choice as object with function name", () => {
+    const payload = runCodexToolChoiceCase({
+      applyProvider: "openai-codex",
+      applyModelId: "gpt-5.1-codex",
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.1-codex",
+      } as Model<"openai-codex-responses">,
+      options: {
+        toolChoice: { type: "function", function: { name: "my_tool" } },
+      },
+    });
+
+    expect(payload.tool_choice).toEqual({ type: "function", function: { name: "my_tool" } });
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -853,6 +853,36 @@ function createZaiToolStreamWrapper(
 }
 
 /**
+ * Create a streamFn wrapper that forwards tool_choice from options to the payload.
+ *
+ * The openai-codex-responses provider in pi-ai hardcodes tool_choice to "auto",
+ * ignoring any tool_choice passed in options. This wrapper works around that by
+ * injecting tool_choice from options into the payload after the provider builds it.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/33421
+ */
+function createCodexToolChoiceWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          const payloadObj = payload as Record<string, unknown>;
+          const opts = options as { toolChoice?: unknown } | undefined;
+          // Only override if toolChoice is explicitly provided in options
+          if (opts?.toolChoice !== undefined) {
+            payloadObj.tool_choice = opts.toolChoice;
+          }
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
+/**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also adds OpenRouter app attribution headers when using the OpenRouter provider.
  *
@@ -876,6 +906,10 @@ export function applyExtraParamsToAgent(
   if (provider === "openai-codex") {
     // Default Codex to WebSocket-first when nothing else specifies transport.
     agent.streamFn = createCodexDefaultTransportWrapper(agent.streamFn);
+    // Work around upstream pi-ai hardcoding tool_choice to "auto" for openai-codex-responses.
+    // Forward tool_choice from options to the payload so callers can control tool behavior.
+    // See: https://github.com/openclaw/openclaw/issues/33421
+    agent.streamFn = createCodexToolChoiceWrapper(agent.streamFn);
   } else if (provider === "openai") {
     // Default OpenAI Responses to WebSocket-first with transparent SSE fallback.
     agent.streamFn = createOpenAIDefaultTransportWrapper(agent.streamFn);


### PR DESCRIPTION
Fixes #33421

## Problem
The `openai-codex-responses` provider hardcodes `tool_choice` to `"auto"`, ignoring any `tool_choice` passed in options.

## Solution
Added `createCodexToolChoiceWrapper` in `extra-params.ts` that intercepts the payload and injects `tool_choice` from options when explicitly provided.

## Files Changed
- `src/agents/pi-embedded-runner/extra-params.ts` - Added tool_choice wrapper
- `src/agents/pi-embedded-runner/extra-params.codex-tool-choice.test.ts` - Unit tests

## Behavior
- Forwards `tool_choice` from options to payload for openai-codex provider
- Does not override when not provided (keeps hardcoded "auto")
- Supports `tool_choice` as string or object with function name