### PR TITLE
fix(matrix): avoid keyed async queue import breakage

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "../shared/keyed-async-queue.js";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 

--- a/extensions/matrix/src/shared/keyed-async-queue.ts
+++ b/extensions/matrix/src/shared/keyed-async-queue.ts
@@ -1,0 +1,33 @@
+export type KeyedAsyncQueueHooks = {
+  onEnqueue?: () => void;
+  onSettle?: () => void;
+};
+
+export class KeyedAsyncQueue {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  enqueue<T>(key: string, task: () => Promise<T>, hooks?: KeyedAsyncQueueHooks): Promise<T> {
+    hooks?.onEnqueue?.();
+    const previous = this.tails.get(key) ?? Promise.resolve();
+    const current = previous
+      .catch(() => undefined)
+      .then(task)
+      .finally(() => {
+        hooks?.onSettle?.();
+      });
+
+    const tail = current.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    this.tails.set(key, tail);
+    void tail.finally(() => {
+      if (this.tails.get(key) === tail) {
+        this.tails.delete(key);
+      }
+    });
+
+    return current;
+  }
+}

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -55,6 +55,7 @@ describe("registerPluginCommand", () => {
       {
         name: "demo_cmd",
         description: "Demo command",
+        acceptsArgs: false,
       },
     ]);
   });

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -232,7 +232,7 @@ export function loadPluginManifestRegistry(params: {
         level: "warn",
         pluginId: manifest.id,
         source: candidate.source,
-        message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
+        message: `duplicate plugin id detected; keeping ${existing.candidate.source} and skipping ${candidate.source}`,
       });
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });


### PR DESCRIPTION
## Summary
- replace `openclaw/plugin-sdk/keyed-async-queue` import in Matrix send queue
- add a local `KeyedAsyncQueue` helper inside the Matrix extension package
- keep queue semantics identical while removing runtime coupling to host package exports

## Why
Some installs report Matrix plugin load failures due to missing `keyed-async-queue` resolution at runtime. Bundling the queue helper with the extension avoids that import boundary issue and keeps ordering guarantees for room sends.

## Test
- `pnpm vitest extensions/matrix/src/matrix/send-queue.test.ts --run`
