### PR TITLE
fix(plugin-sdk): default includeReadThreadId to true for Slack message reads

### DIFF
--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -20,7 +20,7 @@ export async function handleSlackMessageAction(params: {
   normalizeChannelId?: (channelId: string) => string;
   includeReadThreadId?: boolean;
 }): Promise<AgentToolResult<unknown>> {
-  const { providerId, ctx, invoke, normalizeChannelId, includeReadThreadId = false } = params;
+  const { providerId, ctx, invoke, normalizeChannelId, includeReadThreadId = true } = params;
   const { action, cfg, params: actionParams } = ctx;
   const accountId = ctx.accountId ?? undefined;
   const resolveChannelId = () => {


### PR DESCRIPTION
## Problem

`handleSlackMessageAction` in the plugin-sdk defaults `includeReadThreadId` to `false`. When a caller uses `message action=read threadId=<id>`, the threadId is silently dropped and the read returns the channel's main timeline instead of the thread's replies.

## Context

The built-in Slack plugin (`slack.actions.ts`) already passes `includeReadThreadId: true` explicitly, so this doesn't affect the core Slack integration. However, the plugin-sdk export is the public API for third-party plugins, and the default of `false` is surprising: when a caller explicitly provides a `threadId` parameter, silently ignoring it violates the principle of least surprise.

## Change

One-line change: `includeReadThreadId = false` → `includeReadThreadId = true` in `src/plugin-sdk/slack-message-actions.ts`.

This makes the API behave as callers would expect — if you pass a threadId, it gets used.

## Testing

- **AI-assisted** (Claude). Understanding confirmed.
- **Lightly tested**: Previously applied as a dist patch on our production instance (2026.2.x era, before the built-in plugin passed `true`). Confirmed thread reads work correctly with the default flipped.