### PR TITLE
feat(mac): add launchd daemon scope for gateway service

### DIFF
--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -49,7 +49,7 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
     return;
   }
 
-  const service = resolveGatewayService();
+  const service = resolveGatewayService({ scope: opts.scope ?? "agent", env: process.env });
   let loaded = false;
   try {
     loaded = await service.isLoaded({ env: process.env });

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -22,8 +22,8 @@ import type { DaemonLifecycleOptions } from "./types.js";
 const POST_RESTART_HEALTH_ATTEMPTS = DEFAULT_RESTART_HEALTH_ATTEMPTS;
 const POST_RESTART_HEALTH_DELAY_MS = DEFAULT_RESTART_HEALTH_DELAY_MS;
 
-async function resolveGatewayRestartPort() {
-  const service = resolveGatewayService();
+async function resolveGatewayRestartPort(opts?: { scope?: DaemonLifecycleOptions["scope"] }) {
+  const service = resolveGatewayService({ scope: opts?.scope ?? "auto", env: process.env });
   const command = await service.readCommand(process.env).catch(() => null);
   const serviceEnv = command?.environment ?? undefined;
   const mergedEnv = {
@@ -38,7 +38,7 @@ async function resolveGatewayRestartPort() {
 export async function runDaemonUninstall(opts: DaemonLifecycleOptions = {}) {
   return await runServiceUninstall({
     serviceNoun: "Gateway",
-    service: resolveGatewayService(),
+    service: resolveGatewayService({ scope: opts.scope ?? "auto", env: process.env }),
     opts,
     stopBeforeUninstall: true,
     assertNotLoadedAfterUninstall: true,
@@ -48,7 +48,7 @@ export async function runDaemonUninstall(opts: DaemonLifecycleOptions = {}) {
 export async function runDaemonStart(opts: DaemonLifecycleOptions = {}) {
   return await runServiceStart({
     serviceNoun: "Gateway",
-    service: resolveGatewayService(),
+    service: resolveGatewayService({ scope: opts.scope ?? "auto", env: process.env }),
     renderStartHints: renderGatewayServiceStartHints,
     opts,
   });
@@ -57,7 +57,7 @@ export async function runDaemonStart(opts: DaemonLifecycleOptions = {}) {
 export async function runDaemonStop(opts: DaemonLifecycleOptions = {}) {
   return await runServiceStop({
     serviceNoun: "Gateway",
-    service: resolveGatewayService(),
+    service: resolveGatewayService({ scope: opts.scope ?? "auto", env: process.env }),
     opts,
   });
 }
@@ -69,8 +69,8 @@ export async function runDaemonStop(opts: DaemonLifecycleOptions = {}) {
  */
 export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promise<boolean> {
   const json = Boolean(opts.json);
-  const service = resolveGatewayService();
-  const restartPort = await resolveGatewayRestartPort().catch(() =>
+  const service = resolveGatewayService({ scope: opts.scope ?? "auto", env: process.env });
+  const restartPort = await resolveGatewayRestartPort({ scope: opts.scope }).catch(() =>
     resolveGatewayPort(loadConfig(), process.env),
   );
   const restartWaitMs = POST_RESTART_HEALTH_ATTEMPTS * POST_RESTART_HEALTH_DELAY_MS;

--- a/src/cli/daemon-cli/register-service-commands.ts
+++ b/src/cli/daemon-cli/register-service-commands.ts
@@ -17,11 +17,13 @@ function resolveInstallOptions(
   const parentForce = inheritOptionFromParent<boolean>(command, "force");
   const parentPort = inheritOptionFromParent<string>(command, "port");
   const parentToken = inheritOptionFromParent<string>(command, "token");
+  const parentScope = inheritOptionFromParent<string>(command, "scope");
   return {
     ...cmdOpts,
     force: Boolean(cmdOpts.force || parentForce),
     port: cmdOpts.port ?? parentPort,
     token: cmdOpts.token ?? parentToken,
+    scope: cmdOpts.scope ?? parentScope,
   };
 }
 
@@ -39,6 +41,7 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
   parent
     .command("status")
     .description(opts?.statusDescription ?? "Show gateway service status + probe the Gateway")
+    .option("--scope <scope>", "Service scope on macOS launchd: agent|daemon|auto", "auto")
     .option("--url <url>", "Gateway WebSocket URL (defaults to config/remote/local)")
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (password auth)")
@@ -52,12 +55,14 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
         probe: Boolean(cmdOpts.probe),
         deep: Boolean(cmdOpts.deep),
         json: Boolean(cmdOpts.json),
+        scope: cmdOpts.scope,
       });
     });
 
   parent
     .command("install")
     .description("Install the Gateway service (launchd/systemd/schtasks)")
+    .option("--scope <scope>", "Service scope on macOS launchd: agent|daemon", "agent")
     .option("--port <port>", "Gateway port")
     .option("--runtime <runtime>", "Daemon runtime (node|bun). Default: node")
     .option("--token <token>", "Gateway token (token auth)")
@@ -70,6 +75,7 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
   parent
     .command("uninstall")
     .description("Uninstall the Gateway service (launchd/systemd/schtasks)")
+    .option("--scope <scope>", "Service scope on macOS launchd: agent|daemon|auto", "auto")
     .option("--json", "Output JSON", false)
     .action(async (cmdOpts) => {
       await runDaemonUninstall(cmdOpts);
@@ -78,6 +84,7 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
   parent
     .command("start")
     .description("Start the Gateway service (launchd/systemd/schtasks)")
+    .option("--scope <scope>", "Service scope on macOS launchd: agent|daemon|auto", "auto")
     .option("--json", "Output JSON", false)
     .action(async (cmdOpts) => {
       await runDaemonStart(cmdOpts);
@@ -86,6 +93,7 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
   parent
     .command("stop")
     .description("Stop the Gateway service (launchd/systemd/schtasks)")
+    .option("--scope <scope>", "Service scope on macOS launchd: agent|daemon|auto", "auto")
     .option("--json", "Output JSON", false)
     .action(async (cmdOpts) => {
       await runDaemonStop(cmdOpts);
@@ -94,6 +102,7 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
   parent
     .command("restart")
     .description("Restart the Gateway service (launchd/systemd/schtasks)")
+    .option("--scope <scope>", "Service scope on macOS launchd: agent|daemon|auto", "auto")
     .option("--json", "Output JSON", false)
     .action(async (cmdOpts) => {
       await runDaemonRestart(cmdOpts);

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -168,7 +168,7 @@ export async function gatherDaemonStatus(
     deep?: boolean;
   } & FindExtraGatewayServicesOptions,
 ): Promise<DaemonStatus> {
-  const service = resolveGatewayService();
+  const service = resolveGatewayService({ scope: opts.scope ?? "auto", env: process.env });
   const [loaded, command, runtime] = await Promise.all([
     service.isLoaded({ env: process.env }).catch(() => false),
     service.readCommand(process.env).catch(() => null),

--- a/src/cli/daemon-cli/status.ts
+++ b/src/cli/daemon-cli/status.ts
@@ -10,6 +10,7 @@ export async function runDaemonStatus(opts: DaemonStatusOptions) {
       rpc: opts.rpc,
       probe: Boolean(opts.probe),
       deep: Boolean(opts.deep),
+      scope: opts.scope,
     });
     printDaemonStatus(status, { json: Boolean(opts.json) });
   } catch (err) {

--- a/src/cli/daemon-cli/types.ts
+++ b/src/cli/daemon-cli/types.ts
@@ -8,10 +8,13 @@ export type GatewayRpcOpts = {
   json?: boolean;
 };
 
+export type DaemonServiceScope = "agent" | "daemon" | "auto";
+
 export type DaemonStatusOptions = {
   rpc: GatewayRpcOpts;
   probe: boolean;
   json: boolean;
+  scope?: DaemonServiceScope;
 } & FindExtraGatewayServicesOptions;
 
 export type DaemonInstallOptions = {
@@ -20,8 +23,10 @@ export type DaemonInstallOptions = {
   token?: string;
   force?: boolean;
   json?: boolean;
+  scope?: Exclude<DaemonServiceScope, "auto">;
 };
 
 export type DaemonLifecycleOptions = {
   json?: boolean;
+  scope?: DaemonServiceScope;
 };

--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -115,3 +115,35 @@ export function buildLaunchAgentPlist({
   const envXml = renderEnvDict(environment);
   return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ThrottleInterval</key>\n    <integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>\n    <key>Umask</key>\n    <integer>${LAUNCH_AGENT_UMASK_DECIMAL}</integer>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
 }
+
+export function buildLaunchDaemonPlist({
+  label,
+  username,
+  comment,
+  programArguments,
+  workingDirectory,
+  stdoutPath,
+  stderrPath,
+  environment,
+}: {
+  label: string;
+  username: string;
+  comment?: string;
+  programArguments: string[];
+  workingDirectory?: string;
+  stdoutPath: string;
+  stderrPath: string;
+  environment?: Record<string, string | undefined>;
+}): string {
+  const argsXml = programArguments
+    .map((arg) => `\n      <string>${plistEscape(arg)}</string>`)
+    .join("");
+  const workingDirXml = workingDirectory
+    ? `\n    <key>WorkingDirectory</key>\n    <string>${plistEscape(workingDirectory)}</string>`
+    : "";
+  const commentXml = comment?.trim()
+    ? `\n    <key>Comment</key>\n    <string>${plistEscape(comment.trim())}</string>`
+    : "";
+  const envXml = renderEnvDict(environment);
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    <key>UserName</key>\n    <string>${plistEscape(username)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ThrottleInterval</key>\n    <integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
+}

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -9,6 +9,7 @@ import {
 import { execFileUtf8 } from "./exec-file.js";
 import {
   buildLaunchAgentPlist as buildLaunchAgentPlistImpl,
+  buildLaunchDaemonPlist as buildLaunchDaemonPlistImpl,
   readLaunchAgentProgramArgumentsFromFile,
 } from "./launchd-plist.js";
 import { formatLine, toPosixPath, writeFormattedLines } from "./output.js";
@@ -43,6 +44,27 @@ function resolveLaunchAgentPlistPathForLabel(
 export function resolveLaunchAgentPlistPath(env: GatewayServiceEnv): string {
   const label = resolveLaunchAgentLabel({ env });
   return resolveLaunchAgentPlistPathForLabel(env, label);
+}
+
+function resolveLaunchDaemonLabel(args?: { env?: Record<string, string | undefined> }): string {
+  const envLabel = args?.env?.OPENCLAW_LAUNCHD_LABEL?.trim();
+  if (envLabel) {
+    return envLabel;
+  }
+  return resolveGatewayLaunchAgentLabel(args?.env?.OPENCLAW_PROFILE);
+}
+
+function resolveLaunchDaemonPlistPathForLabel(
+  env: Record<string, string | undefined>,
+  label: string,
+): string {
+  void env; // reserved for parity with LaunchAgent resolver
+  return path.posix.join(path.sep, "Library", "LaunchDaemons", `${label}.plist`);
+}
+
+export function resolveLaunchDaemonPlistPath(env: GatewayServiceEnv): string {
+  const label = resolveLaunchDaemonLabel({ env });
+  return resolveLaunchDaemonPlistPathForLabel(env, label);
 }
 
 export function resolveGatewayLogPaths(env: GatewayServiceEnv): {
@@ -95,6 +117,37 @@ export function buildLaunchAgentPlist({
   });
 }
 
+export function buildLaunchDaemonPlist({
+  label = GATEWAY_LAUNCH_AGENT_LABEL,
+  username,
+  comment,
+  programArguments,
+  workingDirectory,
+  stdoutPath,
+  stderrPath,
+  environment,
+}: {
+  label?: string;
+  username: string;
+  comment?: string;
+  programArguments: string[];
+  workingDirectory?: string;
+  stdoutPath: string;
+  stderrPath: string;
+  environment?: Record<string, string | undefined>;
+}): string {
+  return buildLaunchDaemonPlistImpl({
+    label,
+    username,
+    comment,
+    programArguments,
+    workingDirectory,
+    stdoutPath,
+    stderrPath,
+    environment,
+  });
+}
+
 async function execLaunchctl(
   args: string[],
 ): Promise<{ stdout: string; stderr: string; code: number }> {
@@ -109,6 +162,10 @@ function resolveGuiDomain(): string {
     return "gui/501";
   }
   return `gui/${process.getuid()}`;
+}
+
+function resolveSystemDomain(): string {
+  return "system";
 }
 
 export type LaunchctlPrintInfo = {
@@ -488,6 +545,185 @@ export async function restartLaunchAgent({
   }
   try {
     stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+      throw err;
+    }
+  }
+}
+
+// --- LaunchDaemon (system domain) support ---
+
+export async function isLaunchDaemonLoaded(args: GatewayServiceEnvArgs): Promise<boolean> {
+  const domain = resolveSystemDomain();
+  const label = resolveLaunchDaemonLabel({ env: args.env });
+  const res = await execLaunchctl(["print", `${domain}/${label}`]);
+  return res.code === 0;
+}
+
+export async function readLaunchDaemonProgramArguments(
+  env: GatewayServiceEnv,
+): Promise<GatewayServiceCommandConfig | null> {
+  const plistPath = resolveLaunchDaemonPlistPath(env);
+  return readLaunchAgentProgramArgumentsFromFile(plistPath);
+}
+
+export async function readLaunchDaemonRuntime(
+  env: Record<string, string | undefined>,
+): Promise<GatewayServiceRuntime> {
+  const domain = resolveSystemDomain();
+  const label = resolveLaunchDaemonLabel({ env });
+  const res = await execLaunchctl(["print", `${domain}/${label}`]);
+  if (res.code !== 0) {
+    return {
+      status: "unknown",
+      detail: (res.stderr || res.stdout).trim() || undefined,
+      missingUnit: true,
+    };
+  }
+  const parsed = parseLaunchctlPrint(res.stdout || res.stderr || "");
+  // access() is fine for /Library/LaunchDaemons only when readable; treat missing as cached label.
+  let plistExists = true;
+  try {
+    await fs.access(resolveLaunchDaemonPlistPath(env));
+  } catch {
+    plistExists = false;
+  }
+  const state = parsed.state?.toLowerCase();
+  const status = state === "running" || parsed.pid ? "running" : state ? "stopped" : "unknown";
+  return {
+    status,
+    state: parsed.state,
+    pid: parsed.pid,
+    lastExitStatus: parsed.lastExitStatus,
+    lastExitReason: parsed.lastExitReason,
+    cachedLabel: !plistExists,
+  };
+}
+
+export async function uninstallLaunchDaemon({
+  env,
+  stdout,
+}: GatewayServiceManageArgs): Promise<void> {
+  const domain = resolveSystemDomain();
+  const plistPath = resolveLaunchDaemonPlistPath(env);
+  await execLaunchctl(["bootout", domain, plistPath]);
+  await execLaunchctl(["unload", plistPath]);
+  try {
+    await fs.unlink(plistPath);
+  } catch {
+    // ignore
+  }
+  try {
+    stdout.write(`${formatLine("Uninstalled LaunchDaemon", plistPath)}\n`);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+      throw err;
+    }
+  }
+}
+
+export async function stopLaunchDaemon({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
+  const serviceEnv = env ?? (process.env as GatewayServiceEnv);
+  const domain = resolveSystemDomain();
+  const label = resolveLaunchDaemonLabel({ env: serviceEnv });
+  const stop = await execLaunchctl(["bootout", `${domain}/${label}`]);
+  if (stop.code !== 0 && !isLaunchctlNotLoaded(stop)) {
+    throw new Error(`launchctl bootout failed: ${stop.stderr || stop.stdout}`.trim());
+  }
+  try {
+    stdout.write(`${formatLine("Stopped LaunchDaemon", `${domain}/${label}`)}\n`);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+      throw err;
+    }
+  }
+}
+
+export async function installLaunchDaemon({
+  env,
+  stdout,
+  programArguments,
+  workingDirectory,
+  environment,
+  description,
+}: GatewayServiceInstallArgs): Promise<{ plistPath: string }> {
+  const { logDir, stdoutPath, stderrPath } = resolveGatewayLogPaths(env);
+  await fs.mkdir(logDir, { recursive: true });
+
+  const domain = resolveSystemDomain();
+  const label = resolveLaunchDaemonLabel({ env });
+  const plistPath = resolveLaunchDaemonPlistPathForLabel(env, label);
+
+  // LaunchDaemons directory is system-owned; expect EACCES unless elevated.
+  const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
+  const username = env.USER || env.LOGNAME || "openclaw";
+  const plist = buildLaunchDaemonPlist({
+    label,
+    username,
+    comment: serviceDescription,
+    programArguments,
+    workingDirectory,
+    stdoutPath,
+    stderrPath,
+    environment,
+  });
+  await fs.writeFile(plistPath, plist, "utf8");
+
+  await execLaunchctl(["bootout", domain, plistPath]);
+  await execLaunchctl(["unload", plistPath]);
+  await execLaunchctl(["enable", `${domain}/${label}`]);
+  const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
+  if (boot.code !== 0) {
+    const detail = (boot.stderr || boot.stdout).trim();
+    throw new Error(`launchctl bootstrap failed: ${detail}`);
+  }
+  await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
+
+  writeFormattedLines(
+    stdout,
+    [
+      { label: "Installed LaunchDaemon", value: plistPath },
+      { label: "Logs", value: stdoutPath },
+    ],
+    { leadingBlankLine: true },
+  );
+  return { plistPath };
+}
+
+export async function restartLaunchDaemon({
+  stdout,
+  env,
+}: GatewayServiceControlArgs): Promise<void> {
+  const serviceEnv = env ?? (process.env as GatewayServiceEnv);
+  const domain = resolveSystemDomain();
+  const label = resolveLaunchDaemonLabel({ env: serviceEnv });
+  const plistPath = resolveLaunchDaemonPlistPath(serviceEnv);
+
+  const runtime = await execLaunchctl(["print", `${domain}/${label}`]);
+  const previousPid =
+    runtime.code === 0
+      ? parseLaunchctlPrint(runtime.stdout || runtime.stderr || "").pid
+      : undefined;
+
+  const stop = await execLaunchctl(["bootout", `${domain}/${label}`]);
+  if (stop.code !== 0 && !isLaunchctlNotLoaded(stop)) {
+    throw new Error(`launchctl bootout failed: ${stop.stderr || stop.stdout}`.trim());
+  }
+  if (typeof previousPid === "number") {
+    await waitForPidExit(previousPid);
+  }
+
+  const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
+  if (boot.code !== 0) {
+    throw new Error(`launchctl bootstrap failed: ${(boot.stderr || boot.stdout).trim()}`);
+  }
+  const start = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
+  if (start.code !== 0) {
+    throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
+  }
+  try {
+    stdout.write(`${formatLine("Restarted LaunchDaemon", `${domain}/${label}`)}\n`);
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
       throw err;

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -1,11 +1,18 @@
 import {
   installLaunchAgent,
+  installLaunchDaemon,
   isLaunchAgentLoaded,
+  isLaunchDaemonLoaded,
   readLaunchAgentProgramArguments,
   readLaunchAgentRuntime,
+  readLaunchDaemonProgramArguments,
+  readLaunchDaemonRuntime,
   restartLaunchAgent,
+  restartLaunchDaemon,
   stopLaunchAgent,
+  stopLaunchDaemon,
   uninstallLaunchAgent,
+  uninstallLaunchDaemon,
 } from "./launchd.js";
 import {
   installScheduledTask,
@@ -51,6 +58,8 @@ function ignoreInstallResult(
   };
 }
 
+export type GatewayServiceScope = "agent" | "daemon" | "auto";
+
 export type GatewayService = {
   label: string;
   loadedText: string;
@@ -64,9 +73,16 @@ export type GatewayService = {
   readRuntime: (env: GatewayServiceEnv) => Promise<GatewayServiceRuntime>;
 };
 
-export function resolveGatewayService(): GatewayService {
+export function resolveGatewayService(opts?: {
+  scope?: GatewayServiceScope;
+  env?: Record<string, string | undefined>;
+}): GatewayService {
   if (process.platform === "darwin") {
-    return {
+    const env = opts?.env ?? (process.env as Record<string, string | undefined>);
+    const scope =
+      opts?.scope ?? (env.OPENCLAW_LAUNCHD_SCOPE as GatewayServiceScope | undefined) ?? "auto";
+
+    const launchAgentService: GatewayService = {
       label: "LaunchAgent",
       loadedText: "loaded",
       notLoadedText: "not loaded",
@@ -77,6 +93,57 @@ export function resolveGatewayService(): GatewayService {
       isLoaded: isLaunchAgentLoaded,
       readCommand: readLaunchAgentProgramArguments,
       readRuntime: readLaunchAgentRuntime,
+    };
+
+    const launchDaemonService: GatewayService = {
+      label: "LaunchDaemon",
+      loadedText: "loaded",
+      notLoadedText: "not loaded",
+      install: ignoreInstallResult(installLaunchDaemon),
+      uninstall: uninstallLaunchDaemon,
+      stop: stopLaunchDaemon,
+      restart: restartLaunchDaemon,
+      isLoaded: isLaunchDaemonLoaded,
+      readCommand: readLaunchDaemonProgramArguments,
+      readRuntime: readLaunchDaemonRuntime,
+    };
+
+    if (scope === "daemon") {
+      return launchDaemonService;
+    }
+    if (scope === "agent") {
+      return launchAgentService;
+    }
+
+    // auto: prefer daemon if it appears to be running/listed; otherwise use agent
+    // (This prevents misleading "not installed" errors in headless daemon deployments.)
+    return {
+      ...launchAgentService,
+      isLoaded: async (args) => {
+        const daemonLoaded = await launchDaemonService
+          .isLoaded({ env: args.env ?? env })
+          .catch(() => false);
+        if (daemonLoaded) {
+          return true;
+        }
+        return await launchAgentService.isLoaded(args).catch(() => false);
+      },
+      readRuntime: async (e) => {
+        const daemonRuntime = await launchDaemonService
+          .readRuntime(e)
+          .catch(() => ({ status: "unknown" }));
+        if (daemonRuntime?.status && daemonRuntime.status !== "unknown") {
+          return daemonRuntime;
+        }
+        return await launchAgentService.readRuntime(e);
+      },
+      readCommand: async (e) => {
+        const daemonCmd = await launchDaemonService.readCommand(e).catch(() => null);
+        if (daemonCmd) {
+          return daemonCmd;
+        }
+        return await launchAgentService.readCommand(e);
+      },
     };
   }
 

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -115,10 +115,11 @@ export function resolveGatewayService(opts?: {
       return launchAgentService;
     }
 
-    // auto: prefer daemon if it appears to be running/listed; otherwise use agent
-    // (This prevents misleading "not installed" errors in headless daemon deployments.)
+    // auto: prefer daemon when present; otherwise fall back to agent.
+    // (This prevents misleading "LaunchAgent not installed" errors in headless daemon deployments.)
     return {
-      ...launchAgentService,
+      ...launchDaemonService,
+      label: "launchd (auto)",
       isLoaded: async (args) => {
         const daemonLoaded = await launchDaemonService
           .isLoaded({ env: args.env ?? env })


### PR DESCRIPTION
## Summary

Adds first-class support for running the OpenClaw gateway as a macOS **system LaunchDaemon** (`/Library/LaunchDaemons/`), in addition to the existing per-user LaunchAgent scope.

- New `--scope agent|daemon|auto` option on `install`, `uninstall`, `start`, `stop`, `restart`, and `status` commands
- `auto` scope detects whether a daemon-scope plist is loaded and prefers it over agent scope
- New `src/daemon/launchd.ts` implements daemon-scope plist generation, targeting `/Library/LaunchDaemons/` with appropriate `UserName` and working directory
- Updated `launchd-plist.ts` with `buildLaunchDaemonPlist()` for system-level plists
- All existing agent-scope behavior is preserved as the default

### Why?

LaunchAgents only run when a user is logged in via the GUI. For always-on servers (e.g., a Mac Mini running headless), the gateway needs to survive reboots without anyone logging in. LaunchDaemons start at boot and run as a specified user, making them the correct mechanism for server deployments.

## Test plan

- [ ] `openclaw daemon install --scope daemon` creates plist in `/Library/LaunchDaemons/`
- [ ] `openclaw daemon start --scope auto` detects and starts the daemon-scope service
- [ ] `openclaw daemon status --scope auto` correctly reports daemon scope
- [ ] Existing `--scope agent` (default) behavior is unchanged
- [ ] Gateway starts at boot without GUI login on macOS