### PR TITLE
feat(ui): paperclip attach button with support for any document type

### DIFF
--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -76,7 +76,7 @@ describe("parseMessageWithAttachments", () => {
     expect(logs).toHaveLength(0);
   });
 
-  it("drops non-image payloads and logs", async () => {
+  it("saves non-image payloads to disk and logs", async () => {
     const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
     const { parsed, logs } = await parseWithWarnings("x", [
       {
@@ -87,8 +87,11 @@ describe("parseMessageWithAttachments", () => {
       },
     ]);
     expect(parsed.images).toHaveLength(0);
+    expect(parsed.files).toHaveLength(1);
+    expect(parsed.files![0].fileName).toBe("not-image.pdf");
+    expect(parsed.message).toMatch(/\[Attached file:.*not-image\.pdf\]/);
     expect(logs).toHaveLength(1);
-    expect(logs[0]).toMatch(/non-image/i);
+    expect(logs[0]).toMatch(/saved non-image/i);
   });
 
   it("prefers sniffed mime type and logs mismatch", async () => {
@@ -106,17 +109,20 @@ describe("parseMessageWithAttachments", () => {
     expect(logs[0]).toMatch(/mime mismatch/i);
   });
 
-  it("drops unknown mime when sniff fails and logs", async () => {
+  it("saves unknown mime files to disk when sniff fails", async () => {
     const unknown = Buffer.from("not an image").toString("base64");
     const { parsed, logs } = await parseWithWarnings("x", [
       { type: "file", fileName: "unknown.bin", content: unknown },
     ]);
     expect(parsed.images).toHaveLength(0);
+    expect(parsed.files).toHaveLength(1);
+    expect(parsed.files![0].fileName).toBe("unknown.bin");
+    expect(parsed.message).toMatch(/\[Attached file:.*unknown\.bin\]/);
     expect(logs).toHaveLength(1);
-    expect(logs[0]).toMatch(/unable to detect image mime type/i);
+    expect(logs[0]).toMatch(/saved non-image/i);
   });
 
-  it("keeps valid images and drops invalid ones", async () => {
+  it("keeps valid images and saves non-images to disk", async () => {
     const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
     const { parsed, logs } = await parseWithWarnings("x", [
       {
@@ -135,7 +141,9 @@ describe("parseMessageWithAttachments", () => {
     expect(parsed.images).toHaveLength(1);
     expect(parsed.images[0]?.mimeType).toBe("image/png");
     expect(parsed.images[0]?.data).toBe(PNG_1x1);
-    expect(logs.some((l) => /non-image/i.test(l))).toBe(true);
+    expect(parsed.files).toHaveLength(1);
+    expect(parsed.files![0].fileName).toBe("not-image.pdf");
+    expect(logs.some((l) => /saved non-image/i.test(l))).toBe(true);
   });
 });
 

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { estimateBase64DecodedBytes } from "../media/base64.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 
@@ -14,10 +16,52 @@ export type ChatImageContent = {
   mimeType: string;
 };
 
+export type ChatFileContent = {
+  type: "file";
+  filePath: string;
+  fileName: string;
+};
+
 export type ParsedMessageWithImages = {
   message: string;
   images: ChatImageContent[];
+  files?: ChatFileContent[];
 };
+
+/** Alias for backwards compatibility */
+export type ParsedMessageWithAttachments = ParsedMessageWithImages;
+
+const UPLOADS_DIR =
+  process.env.OPENCLAW_UPLOADS_DIR ||
+  path.join(process.env.HOME || "/Users/openclaw", ".openclaw", "workspace", "uploads");
+
+function sanitizeFileName(name: string): string {
+  // Remove path separators and other dangerous characters
+  return name
+    .replace(/[/\\:*?"<>|]/g, "_")
+    .replace(/\s+/g, "_")
+    .slice(0, 200);
+}
+
+function saveFileToDisk(
+  base64Data: string,
+  originalName: string,
+  log?: AttachmentLog,
+): string | null {
+  try {
+    fs.mkdirSync(UPLOADS_DIR, { recursive: true, mode: 0o700 });
+    const timestamp = Date.now();
+    const safeName = sanitizeFileName(originalName || "unnamed");
+    const fileName = `${timestamp}-${safeName}`;
+    const filePath = path.join(UPLOADS_DIR, fileName);
+    const buffer = Buffer.from(base64Data, "base64");
+    fs.writeFileSync(filePath, buffer, { mode: 0o600 });
+    return filePath;
+  } catch (err) {
+    log?.warn(`failed to save file ${originalName}: ${String(err)}`);
+    return null;
+  }
+}
 
 type AttachmentLog = {
   warn: (message: string) => void;
@@ -106,6 +150,8 @@ export async function parseMessageWithAttachments(
   }
 
   const images: ChatImageContent[] = [];
+  const files: ChatFileContent[] = [];
+  let parsedMessage = message;
 
   for (const [idx, att] of attachments.entries()) {
     if (!att) {
@@ -120,28 +166,32 @@ export async function parseMessageWithAttachments(
 
     const providedMime = normalizeMime(mime);
     const sniffedMime = normalizeMime(await sniffMimeFromBase64(b64));
-    if (sniffedMime && !isImageMime(sniffedMime)) {
-      log?.warn(`attachment ${label}: detected non-image (${sniffedMime}), dropping`);
-      continue;
-    }
-    if (!sniffedMime && !isImageMime(providedMime)) {
-      log?.warn(`attachment ${label}: unable to detect image mime type, dropping`);
-      continue;
-    }
-    if (sniffedMime && providedMime && sniffedMime !== providedMime) {
-      log?.warn(
-        `attachment ${label}: mime mismatch (${providedMime} -> ${sniffedMime}), using sniffed`,
-      );
-    }
 
-    images.push({
-      type: "image",
-      data: b64,
-      mimeType: sniffedMime ?? providedMime ?? mime,
-    });
+    const isImage = sniffedMime ? isImageMime(sniffedMime) : isImageMime(providedMime);
+
+    if (isImage) {
+      if (sniffedMime && providedMime && sniffedMime !== providedMime) {
+        log?.warn(
+          `attachment ${label}: mime mismatch (${providedMime} -> ${sniffedMime}), using sniffed`,
+        );
+      }
+      images.push({
+        type: "image",
+        data: b64,
+        mimeType: sniffedMime ?? providedMime ?? mime,
+      });
+    } else {
+      // Non-image: save to disk and inject path into message
+      const filePath = saveFileToDisk(b64, att.fileName || label, log);
+      if (filePath) {
+        files.push({ type: "file", filePath, fileName: att.fileName || label });
+        parsedMessage += `\n\n[Attached file: ${filePath}]`;
+        log?.warn(`attachment ${label}: saved non-image to ${filePath}`);
+      }
+    }
   }
 
-  return { message, images };
+  return { message: parsedMessage, images, files };
 }
 
 /**

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -259,6 +259,12 @@
   justify-content: flex-end;
 }
 
+/* Attach button in compose row */
+.chat-compose__attach {
+  flex-shrink: 0;
+  align-self: flex-end;
+}
+
 /* Compose input row - horizontal layout */
 .chat-compose__row {
   display: flex;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -152,13 +152,20 @@ export async function sendChatMessage(
   if (msg) {
     contentBlocks.push({ type: "text", text: msg });
   }
-  // Add image previews to the message for display
+  // Add attachment previews to the message for display
   if (hasAttachments) {
     for (const att of attachments) {
-      contentBlocks.push({
-        type: "image",
-        source: { type: "base64", media_type: att.mimeType, data: att.dataUrl },
-      });
+      if (att.mimeType.startsWith("image/")) {
+        contentBlocks.push({
+          type: "image",
+          source: { type: "base64", media_type: att.mimeType, data: att.dataUrl },
+        });
+      } else {
+        contentBlocks.push({
+          type: "text",
+          text: `[Attached: ${att.fileName || "file"}]`,
+        });
+      }
     }
   }
 
@@ -186,10 +193,12 @@ export async function sendChatMessage(
           if (!parsed) {
             return null;
           }
+          const isImage = att.mimeType.startsWith("image/");
           return {
-            type: "image",
+            type: isImage ? "image" : "file",
             mimeType: parsed.mimeType,
             content: parsed.content,
+            ...(att.fileName ? { fileName: att.fileName } : {}),
           };
         })
         .filter((a): a is NonNullable<typeof a> => a !== null)

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -2,6 +2,7 @@ export type ChatAttachment = {
   id: string;
   dataUrl: string;
   mimeType: string;
+  fileName?: string;
 };
 
 export type ChatQueueItem = {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -162,17 +162,14 @@ function generateAttachmentId(): string {
   return `att-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
-const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10 MB
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
-function addImageFiles(files: File[], props: ChatProps) {
+function addFiles(files: File[], props: ChatProps) {
   if (!props.onAttachmentsChange) {
     return;
   }
   for (const file of files) {
-    if (!file.type.startsWith("image/")) {
-      continue;
-    }
-    if (file.size > MAX_IMAGE_SIZE) {
+    if (file.size > MAX_FILE_SIZE) {
       continue;
     }
     const reader = new FileReader();
@@ -181,7 +178,8 @@ function addImageFiles(files: File[], props: ChatProps) {
       const newAttachment: ChatAttachment = {
         id: generateAttachmentId(),
         dataUrl,
-        mimeType: file.type,
+        mimeType: file.type || "application/octet-stream",
+        fileName: file.name,
       };
       const current = props.attachments ?? [];
       props.onAttachmentsChange?.([...current, newAttachment]);
@@ -196,23 +194,23 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
     return;
   }
 
-  const imageFiles: File[] = [];
+  const pastedFiles: File[] = [];
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
-    if (item.type.startsWith("image/")) {
+    if (item.kind === "file") {
       const file = item.getAsFile();
       if (file) {
-        imageFiles.push(file);
+        pastedFiles.push(file);
       }
     }
   }
 
-  if (imageFiles.length === 0) {
+  if (pastedFiles.length === 0) {
     return;
   }
 
   e.preventDefault();
-  addImageFiles(imageFiles, props);
+  addFiles(pastedFiles, props);
 }
 
 function handleDrop(e: DragEvent, props: ChatProps) {
@@ -222,13 +220,11 @@ function handleDrop(e: DragEvent, props: ChatProps) {
   if (!files || !props.onAttachmentsChange) {
     return;
   }
-  const imageFiles: File[] = [];
+  const droppedFiles: File[] = [];
   for (let i = 0; i < files.length; i++) {
-    if (files[i].type.startsWith("image/")) {
-      imageFiles.push(files[i]);
-    }
+    droppedFiles.push(files[i]);
   }
-  addImageFiles(imageFiles, props);
+  addFiles(droppedFiles, props);
 }
 
 function handleDragOver(e: DragEvent) {
@@ -247,11 +243,15 @@ function renderAttachmentPreview(props: ChatProps) {
       ${attachments.map(
         (att) => html`
           <div class="chat-attachment">
-            <img
-              src=${att.dataUrl}
-              alt="Attachment preview"
-              class="chat-attachment__img"
-            />
+            ${
+              att.mimeType.startsWith("image/")
+                ? html`<img
+                  src=${att.dataUrl}
+                  alt="Attachment preview"
+                  class="chat-attachment__img"
+                />`
+                : html`<div class="chat-attachment__file">${att.fileName || "file"}</div>`
+            }
             <button
               class="chat-attachment__remove"
               type="button"
@@ -285,8 +285,8 @@ export function renderChat(props: ChatProps) {
   const hasAttachments = (props.attachments?.length ?? 0) > 0;
   const composePlaceholder = props.connected
     ? hasAttachments
-      ? "Add a message or paste more images..."
-      : "Message (↩ to send, Shift+↩ for line breaks, paste images)"
+      ? "Add a message or paste more files..."
+      : "Message (↩ to send, Shift+↩ for line breaks, paste or attach files)"
     : "Connect to the gateway to start chatting…";
 
   const splitRatio = props.splitRatio ?? 0.6;
@@ -461,7 +461,6 @@ export function renderChat(props: ChatProps) {
         <div class="chat-compose__row">
           <input
             type="file"
-            accept="image/*"
             multiple
             style="display:none"
             @change=${(e: Event) => {
@@ -472,7 +471,7 @@ export function renderChat(props: ChatProps) {
                 for (let i = 0; i < files.length; i++) {
                   arr.push(files[i]);
                 }
-                addImageFiles(arr, props);
+                addFiles(arr, props);
               }
               input.value = "";
             }}
@@ -481,7 +480,7 @@ export function renderChat(props: ChatProps) {
             class="btn btn--icon chat-compose__attach"
             type="button"
             ?disabled=${!props.connected}
-            title="Attach image"
+            title="Attach file"
             @click=${(e: Event) => {
               const btn = e.currentTarget as HTMLElement;
               const input = btn.previousElementSibling as HTMLInputElement;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -162,32 +162,19 @@ function generateAttachmentId(): string {
   return `att-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
-function handlePaste(e: ClipboardEvent, props: ChatProps) {
-  const items = e.clipboardData?.items;
-  if (!items || !props.onAttachmentsChange) {
+const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+function addImageFiles(files: File[], props: ChatProps) {
+  if (!props.onAttachmentsChange) {
     return;
   }
-
-  const imageItems: DataTransferItem[] = [];
-  for (let i = 0; i < items.length; i++) {
-    const item = items[i];
-    if (item.type.startsWith("image/")) {
-      imageItems.push(item);
-    }
-  }
-
-  if (imageItems.length === 0) {
-    return;
-  }
-
-  e.preventDefault();
-
-  for (const item of imageItems) {
-    const file = item.getAsFile();
-    if (!file) {
+  for (const file of files) {
+    if (!file.type.startsWith("image/")) {
       continue;
     }
-
+    if (file.size > MAX_IMAGE_SIZE) {
+      continue;
+    }
     const reader = new FileReader();
     reader.addEventListener("load", () => {
       const dataUrl = reader.result as string;
@@ -201,6 +188,52 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
     });
     reader.readAsDataURL(file);
   }
+}
+
+function handlePaste(e: ClipboardEvent, props: ChatProps) {
+  const items = e.clipboardData?.items;
+  if (!items || !props.onAttachmentsChange) {
+    return;
+  }
+
+  const imageFiles: File[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (item.type.startsWith("image/")) {
+      const file = item.getAsFile();
+      if (file) {
+        imageFiles.push(file);
+      }
+    }
+  }
+
+  if (imageFiles.length === 0) {
+    return;
+  }
+
+  e.preventDefault();
+  addImageFiles(imageFiles, props);
+}
+
+function handleDrop(e: DragEvent, props: ChatProps) {
+  e.preventDefault();
+  e.stopPropagation();
+  const files = e.dataTransfer?.files;
+  if (!files || !props.onAttachmentsChange) {
+    return;
+  }
+  const imageFiles: File[] = [];
+  for (let i = 0; i < files.length; i++) {
+    if (files[i].type.startsWith("image/")) {
+      imageFiles.push(files[i]);
+    }
+  }
+  addImageFiles(imageFiles, props);
+}
+
+function handleDragOver(e: DragEvent) {
+  e.preventDefault();
+  e.stopPropagation();
 }
 
 function renderAttachmentPreview(props: ChatProps) {
@@ -420,9 +453,43 @@ export function renderChat(props: ChatProps) {
           : nothing
       }
 
-      <div class="chat-compose">
+      <div class="chat-compose"
+        @dragover=${handleDragOver}
+        @drop=${(e: DragEvent) => handleDrop(e, props)}
+      >
         ${renderAttachmentPreview(props)}
         <div class="chat-compose__row">
+          <input
+            type="file"
+            accept="image/*"
+            multiple
+            style="display:none"
+            @change=${(e: Event) => {
+              const input = e.target as HTMLInputElement;
+              const files = input.files;
+              if (files) {
+                const arr: File[] = [];
+                for (let i = 0; i < files.length; i++) {
+                  arr.push(files[i]);
+                }
+                addImageFiles(arr, props);
+              }
+              input.value = "";
+            }}
+          />
+          <button
+            class="btn btn--icon chat-compose__attach"
+            type="button"
+            ?disabled=${!props.connected}
+            title="Attach image"
+            @click=${(e: Event) => {
+              const btn = e.currentTarget as HTMLElement;
+              const input = btn.previousElementSibling as HTMLInputElement;
+              input?.click();
+            }}
+          >
+            ${icons.paperclip}
+          </button>
           <label class="field chat-compose__field">
             <span>Message</span>
             <textarea


### PR DESCRIPTION
## Summary

Adds a paperclip attach button to the Control UI chat compose area with full file type support:

- **Images** → existing base64 vision pipeline (no change)
- **Non-images** (PDF, DOCX, CSV, etc.) → saved to `~/.openclaw/workspace/uploads/`, path injected as `[Attached file: <path>]` so the agent can Read them

### Changes

- Paperclip button opens native file picker (all file types, not just images)
- Drag-and-drop any file onto the compose area
- Paste any file from clipboard
- Non-image attachment preview shows filename instead of `<img>` tag
- Backend: `parseMessageWithAttachments` saves non-images to disk with safe filenames
- New `ChatFileContent` type and `files[]` on the parse result
- 10 MB max file size enforced client-side
- Uploads dir created automatically with 0700 permissions, files written 0600

### Why?

The Control UI only supported pasting images from clipboard. Users need to share documents (PDFs, spreadsheets, etc.) with the agent, not just screenshots.

## Test plan

- [x] Paperclip button visible in compose row, opens file picker on click
- [x] Selected images appear as attachment previews, vision pipeline works
- [x] Non-image files show filename preview, saved to uploads dir
- [x] `[Attached file: <path>]` appears in agent message
- [x] Drag-and-drop works for all file types
- [x] Files > 10 MB are silently ignored
- [x] Clipboard paste works for all file types
- [x] Existing tests updated and passing (10/10)