### PR TITLE
fix(telegram): use message transport for DM streaming preview

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -190,15 +190,19 @@ export const dispatchTelegramMessage = async ({
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
-    const useMessagePreviewTransportForDmReasoning =
-      laneName === "reasoning" && threadSpec?.scope === "dm" && canStreamAnswerDraft;
+    // Use message transport (sendMessage + editMessageText) for DM streaming
+    // instead of draft transport (sendMessageDraft). Draft transport does not
+    // track a messageId, so the final delivery cannot edit the preview in place
+    // and falls through to sendPayload, duplicating the message. (#33492)
+    const useMessagePreviewTransportForDm =
+      threadSpec?.scope === "dm" && canStreamAnswerDraft;
     const stream = enabled
       ? createTelegramDraftStream({
           api: bot.api,
           chatId,
           maxChars: draftMaxChars,
           thread: threadSpec,
-          previewTransport: useMessagePreviewTransportForDmReasoning ? "message" : "auto",
+          previewTransport: useMessagePreviewTransportForDm ? "message" : "auto",
           replyToMessageId: draftReplyToMessageId,
           minInitialChars: draftMinInitialChars,
           renderText: renderDraftPreview,


### PR DESCRIPTION
## Summary

Use message transport (`sendMessage` + `editMessageText`) for **all** streaming lanes in Telegram DMs, not just the reasoning lane. This fixes duplicate messages when streaming is enabled in DM conversations.

## Problem

Draft transport (`sendMessageDraft`) does not track a `messageId`. When the final delivery arrives, `resolvePreviewTarget()` cannot find the preview message to edit in place, so `deliverLaneText` falls through to `sendPayload()`, sending a **new message**. The user sees both the streaming preview and a duplicate final message.

Groups are unaffected because they use message transport by default.

## Fix

The reasoning lane already forced message transport for DMs:

```typescript
const useMessagePreviewTransportForDmReasoning =
  laneName === "reasoning" && threadSpec?.scope === "dm" && canStreamAnswerDraft;
```

This PR removes the `laneName === "reasoning"` guard so **all lanes** (including the answer lane) use message transport in DMs:

```typescript
const useMessagePreviewTransportForDm =
  threadSpec?.scope === "dm" && canStreamAnswerDraft;
```

With message transport, `streamMessageId` is properly tracked, and the final delivery edits the preview message in place (returns `"preview-finalized"`) instead of creating a new message.

## Testing

- DM conversation with streaming enabled: single message, no duplicate
- Group conversation: unchanged (already uses message transport via `"auto"`)
- Block streaming: unchanged (separate code path)

Fixes #33492

---

**Also fixes #33453** (same root cause: Telegram DM streaming duplication via draft transport).