### PR TITLE
fix(discord): disable carbon listener timeout to prevent stuck health-monitor cycle

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1420,7 +1420,7 @@ export const FIELD_HELP: Record<string, string> = {
   "channels.discord.retry.jitter": "Jitter factor (0-1) applied to Discord retry delays.",
   "channels.discord.maxLinesPerMessage": "Soft max line count per Discord message (default: 17).",
   "channels.discord.eventQueue.listenerTimeout":
-    "Canonical Discord listener timeout control in ms for gateway event handlers. Default is 120000 in OpenClaw; set per account via channels.discord.accounts.<id>.eventQueue.listenerTimeout.",
+    "Canonical Discord listener timeout control in ms for gateway event handlers. Default is 0 (disabled) in OpenClaw — DiscordMessageListener.handle() is fire-and-forget so no timeout is needed. Set to a positive ms value to re-enable Carbon's built-in timeout. Configure per account via channels.discord.accounts.<id>.eventQueue.listenerTimeout.",
   "channels.discord.eventQueue.maxQueueSize":
     "Optional Discord EventQueue capacity override (max queued events before backpressure). Set per account via channels.discord.accounts.<id>.eventQueue.maxQueueSize.",
   "channels.discord.eventQueue.maxConcurrency":

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -332,12 +332,13 @@ export type DiscordAccountConfig = {
   activityUrl?: string;
   /**
    * Carbon EventQueue configuration. Controls how Discord gateway events are processed.
-   * The most important option is `listenerTimeout` which defaults to 30s in Carbon --
-   * too short for LLM calls with extended thinking. Set a higher value (e.g. 120000)
-   * to prevent the event queue from killing long-running message handlers.
+   * `listenerTimeout` defaults to 0 (disabled) in OpenClaw because
+   * DiscordMessageListener.handle() is fire-and-forget and returns immediately —
+   * a timeout only causes false kills and health-monitor stuck cycles on long agent runs.
+   * Set to a positive value (ms) to re-enable Carbon's built-in timeout if needed.
    */
   eventQueue?: {
-    /** Max time (ms) a single listener can run before being killed. Default: 120000. */
+    /** Max time (ms) a single listener can run before being killed. Default: 0 (disabled). */
     listenerTimeout?: number;
     /** Max events queued before backpressure is applied. Default: 10000. */
     maxQueueSize?: number;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -529,7 +529,7 @@ export const DiscordAccountSchema = z
     activityUrl: z.string().url().optional(),
     eventQueue: z
       .object({
-        listenerTimeout: z.number().int().positive().optional(),
+        listenerTimeout: z.number().int().min(0).optional(),
         maxQueueSize: z.number().int().positive().optional(),
         maxConcurrency: z.number().int().positive().optional(),
       })

--- a/src/discord/monitor/provider.test.ts
+++ b/src/discord/monitor/provider.test.ts
@@ -392,7 +392,7 @@ describe("monitorDiscordProvider", () => {
     expect(String(lifecycleArgs.pendingGatewayErrors?.[0])).toContain("4014");
   });
 
-  it("passes default eventQueue.listenerTimeout of 120s to Carbon Client", async () => {
+  it("passes default eventQueue.listenerTimeout of 0 (disabled) to Carbon Client", async () => {
     const { monitorDiscordProvider } = await import("./provider.js");
 
     await monitorDiscordProvider({
@@ -402,7 +402,7 @@ describe("monitorDiscordProvider", () => {
 
     const eventQueue = getConstructedEventQueue();
     expect(eventQueue).toBeDefined();
-    expect(eventQueue?.listenerTimeout).toBe(120_000);
+    expect(eventQueue?.listenerTimeout).toBe(0);
   });
 
   it("forwards custom eventQueue config from discord config to Carbon Client", async () => {

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -516,9 +516,13 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       clientPlugins.push(new VoicePlugin());
     }
     // Pass eventQueue config to Carbon so the listener timeout can be tuned.
-    // Default listenerTimeout is 120s (Carbon defaults to 30s which is too short for LLM calls).
+    // DiscordMessageListener.handle() is fire-and-forget (uses `void` internally),
+    // so it returns almost immediately regardless of how long the agent run takes.
+    // Setting listenerTimeout to 0 disables Carbon's timeout so it never falsely
+    // kills the Discord connection mid-run and triggers the health-monitor stuck cycle.
+    // See: https://github.com/openclaw/openclaw/issues/33452
     const eventQueueOpts = {
-      listenerTimeout: 120_000,
+      listenerTimeout: 0,
       ...discordCfg.eventQueue,
     };
     const client = new Client(


### PR DESCRIPTION
Fixes #33452

## Root Cause

After digging into the source, the actual root cause is in `@buape/carbon`'s `EventQueue.processListener()`, which `await`s `listener.handle()` with a configurable timeout (`listenerTimeout`).

`DiscordMessageListener.handle()` is fire-and-forget internally:
```typescript
async handle(data, client) {
  this.onEvent?.();
  void this.channelQueue.enqueue(channelId, () => runDiscordListenerWithSlowLog(...));
  // returns immediately
}
```

However, carbon's `EventQueue` races the `handle()` call against a timeout. Previously this was 120s (bumped from carbon's 30s default). When agent runs take longer than 120s — common for multi-step coding tasks with sequential exec calls — carbon's timeout fires, which:

1. Carbon logs a timeout error for the listener
2. The Discord health monitor sees `lastInboundAt` not updating (messages are stuck waiting for the timed-out slot)
3. Health monitor detects "stuck" → restarts Discord provider
4. Discord reconnects, but the next long agent run triggers the same cycle

## The Fix

Set `listenerTimeout: 0` to disable the timeout entirely. Since `handle()` returns immediately by design, the timeout adds no safety value — it only causes harm when agent runs exceed the threshold.

The `discordCfg.eventQueue` spread still allows users to override this if needed.

## Verification

Reproduced on:
- OpenClaw 2026.3.1 and 2026.3.2
- Multiple Discord channels with concurrent agent runs

The `Slow listener detected` warnings (from OpenClaw's own `runDiscordListenerWithSlowLog`) are a separate monitoring concern and are working correctly — they log async task duration, not event loop blocking.

## Impact

Multi-channel Discord setups where agents run long tasks (coding, multi-step tool loops) no longer experience the stuck/restart cycle that makes all Discord channels unresponsive.