### PR TITLE
fix: sanitize unclassified agent errors before forwarding to channels

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -159,10 +159,13 @@ describe("formatAssistantErrorText", () => {
   });
 });
 
-describe("isJsonParseError", () => {
-  it("detects 'Bad control character' errors", () => {
-    expect(
-      isJsonParseError(
+  it("detects 'Unterminated' string errors", () => {
+    expect(isJsonParseError("Unterminated string in JSON at position 42")).toBe(true);
+  });
+
+  it("detects 'Unexpected end of JSON input'", () => {
+    expect(isJsonParseError("Unexpected end of JSON input")).toBe(true);
+  });
         "Bad control character in string literal in JSON at position 144 (line 1 column 145)",
       ),
     ).toBe(true);

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -137,11 +137,11 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
-  it("returns a friendly message for 'Unexpected' JSON parse errors", () => {
+  it("returns a friendly message for 'Unexpected end of JSON input'", () => {
     const msg = makeAssistantError("Unexpected end of JSON input");
-    // This doesn't match "in JSON at position" — it's a different variant.
-    // The generic fallback catches it instead.
-    expect(formatAssistantErrorText(msg)).toBe("An unexpected error occurred. Please try again.");
+    expect(formatAssistantErrorText(msg)).toBe(
+      "The AI service returned a malformed response. Please try again.",
+    );
   });
 
   it("never returns raw unclassified error text to users", () => {

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -5,6 +5,7 @@ import {
   formatBillingErrorMessage,
   formatAssistantErrorText,
   formatRawAssistantErrorForUi,
+  isJsonParseError,
 } from "./pi-embedded-helpers.js";
 import { makeAssistantMessageFixture } from "./test-helpers/assistant-message-fixtures.js";
 
@@ -116,6 +117,84 @@ describe("formatAssistantErrorText", () => {
   it("returns a friendly message for empty stream chunk errors", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");
+  });
+
+  it("returns a friendly message for JSON parse errors from SSE stream corruption", () => {
+    const msg = makeAssistantError(
+      "Bad control character in string literal in JSON at position 144 (line 1 column 145)",
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "The AI service returned a malformed response. Please try again.",
+    );
+  });
+
+  it("returns a friendly message for 'Expected' JSON parse errors", () => {
+    const msg = makeAssistantError(
+      "Expected ':' after property name in JSON at position 87 (line 1 column 88)",
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "The AI service returned a malformed response. Please try again.",
+    );
+  });
+
+  it("returns a friendly message for 'Unexpected' JSON parse errors", () => {
+    const msg = makeAssistantError("Unexpected end of JSON input");
+    // This doesn't match "in JSON at position" — it's a different variant.
+    // The generic fallback catches it instead.
+    expect(formatAssistantErrorText(msg)).toBe("An unexpected error occurred. Please try again.");
+  });
+
+  it("never returns raw unclassified error text to users", () => {
+    const msg = makeAssistantError("some completely unknown error that no pattern matches");
+    const result = formatAssistantErrorText(msg);
+    expect(result).not.toContain("some completely unknown error");
+    expect(result).toBe("An unexpected error occurred. Please try again.");
+  });
+
+  it("never leaks long raw error text to users", () => {
+    const msg = makeAssistantError("x".repeat(1000));
+    const result = formatAssistantErrorText(msg);
+    expect(result.length).toBeLessThan(100);
+    expect(result).toBe("An unexpected error occurred. Please try again.");
+  });
+});
+
+describe("isJsonParseError", () => {
+  it("detects 'Bad control character' errors", () => {
+    expect(
+      isJsonParseError(
+        "Bad control character in string literal in JSON at position 144 (line 1 column 145)",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects 'Expected' errors", () => {
+    expect(
+      isJsonParseError(
+        "Expected ',' or '}' after property value in JSON at position 91 (line 1 column 92)",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects 'Unexpected' token errors", () => {
+    expect(isJsonParseError("Unexpected token < in JSON at position 0")).toBe(true);
+  });
+
+  it("detects 'Unterminated' string errors", () => {
+    expect(isJsonParseError("Unterminated string in JSON at position 42")).toBe(true);
+  });
+
+  it("detects SyntaxError wrapping", () => {
+    expect(isJsonParseError("SyntaxError: Unexpected token in JSON")).toBe(true);
+  });
+
+  it("returns false for empty input", () => {
+    expect(isJsonParseError("")).toBe(false);
+  });
+
+  it("returns false for non-JSON errors", () => {
+    expect(isJsonParseError("Connection refused")).toBe(false);
+    expect(isJsonParseError("rate limit exceeded")).toBe(false);
   });
 });
 

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -31,6 +31,7 @@ export {
   isFailoverErrorMessage,
   isImageDimensionErrorMessage,
   isImageSizeError,
+  isJsonParseError,
   isOverloadedErrorMessage,
   isRawApiErrorPayload,
   isRateLimitAssistantError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -625,6 +625,12 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
       }
       return formatRawAssistantErrorForUi(trimmed);
     }
+
+    // Generic fallback for errorContext — never forward raw unclassified error text.
+    // This mirrors the catch-all in formatAssistantErrorText and closes the gap for
+    // exception-path errors that bypass formatAssistantErrorText entirely.
+    log.warn(`Unclassified caught error (not forwarded verbatim): ${trimmed.slice(0, 300)}`);
+    return "An unexpected error occurred. Please try again.";
   }
 
   // Strip leading blank lines (including whitespace-only lines) without clobbering indentation on
@@ -657,7 +663,7 @@ const IMAGE_SIZE_ERROR_RE = /image exceeds\s*(\d+(?:\.\d+)?)\s*mb/i;
  * never be forwarded verbatim to user-facing channels.
  */
 const JSON_PARSE_ERROR_RE =
-  /(?:Expected|Unexpected|Bad control character|Unterminated).*in JSON at position/i;
+  /(?:Expected|Unexpected|Bad control character|Unterminated).*(?:in JSON(?: at position)?|JSON input)/i;
 const SYNTAX_ERROR_JSON_RE = /SyntaxError.*JSON/i;
 
 export function isJsonParseError(raw: string): boolean {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -560,11 +560,18 @@ export function formatAssistantErrorText(
     return formatRawAssistantErrorForUi(raw);
   }
 
-  // Never return raw unhandled errors - log for debugging but return safe message
-  if (raw.length > 600) {
-    log.warn(`Long error truncated: ${raw.slice(0, 200)}`);
+  // Catch JSON parse errors from malformed LLM streaming responses (SSE chunk corruption).
+  // These occur when the provider SDK fails to parse a streamed response chunk and surface
+  // native Node.js JSON.parse() errors like "Expected ':' after property name in JSON at
+  // position 87" or "Bad control character in string literal in JSON at position 144".
+  if (isJsonParseError(raw)) {
+    return "The AI service returned a malformed response. Please try again.";
   }
-  return raw.length > 600 ? `${raw.slice(0, 600)}…` : raw;
+
+  // Never forward raw unclassified error text to user-facing channels.
+  // Log for debugging but return a generic safe message.
+  log.warn(`Unclassified agent error (not forwarded verbatim): ${raw.slice(0, 300)}`);
+  return "An unexpected error occurred. Please try again.";
 }
 
 export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boolean }): string {
@@ -597,6 +604,11 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
 
     if (isBillingErrorMessage(trimmed)) {
       return BILLING_ERROR_USER_MESSAGE;
+    }
+
+    // Catch JSON parse errors from malformed LLM streaming responses (defense-in-depth).
+    if (isJsonParseError(trimmed)) {
+      return "The AI service returned a malformed response. Please try again.";
     }
 
     if (isRawApiErrorPayload(trimmed) || isLikelyHttpErrorText(trimmed)) {
@@ -637,6 +649,23 @@ const IMAGE_DIMENSION_ERROR_RE =
   /image dimensions exceed max allowed size for many-image requests:\s*(\d+)\s*pixels/i;
 const IMAGE_DIMENSION_PATH_RE = /messages\.(\d+)\.content\.(\d+)\.image/i;
 const IMAGE_SIZE_ERROR_RE = /image exceeds\s*(\d+(?:\.\d+)?)\s*mb/i;
+
+/**
+ * Detect JSON parse errors from malformed LLM streaming responses. These occur when the
+ * provider SDK's SSE parser encounters corrupt chunks — e.g., truncated deltas, bad control
+ * characters, or partial JSON payloads. The resulting native `JSON.parse()` errors should
+ * never be forwarded verbatim to user-facing channels.
+ */
+const JSON_PARSE_ERROR_RE =
+  /(?:Expected|Unexpected|Bad control character|Unterminated).*in JSON at position/i;
+const SYNTAX_ERROR_JSON_RE = /SyntaxError.*JSON/i;
+
+export function isJsonParseError(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  return JSON_PARSE_ERROR_RE.test(raw) || SYNTAX_ERROR_JSON_RE.test(raw);
+}
 
 export function isMissingToolCallInputError(raw: string): boolean {
   if (!raw) {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -567,9 +567,7 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
-      const safeMessage = isTransientHttp
-        ? sanitizeUserFacingText(message, { errorContext: true })
-        : message;
+      const safeMessage = sanitizeUserFacingText(message, { errorContext: true });
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
       const fallbackText = isContextOverflow
         ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."


### PR DESCRIPTION
## Summary

Unclassified agent errors (JSON parse errors from SSE stream corruption, unrecognized error payloads) are currently forwarded verbatim to user-facing channels (Discord, Slack, etc.). Users see raw Node.js error messages like:

> Bad control character in string literal in JSON at position 144 (line 1 column 145)

or

> Expected ':' after property name in JSON at position 87 (line 1 column 88)

These occur when the LLM provider SDK fails to parse a streamed response chunk — the SSE delta contains malformed JSON (truncated deltas, bad control characters, partial payloads). The error propagates through `formatAssistantErrorText()` without matching any existing pattern, hitting the raw-text fallthrough at the end.

### Changes

**`src/agents/pi-embedded-helpers/errors.ts`:**
- Add `isJsonParseError()` — detects native `JSON.parse()` errors from malformed streaming responses
- Add JSON parse error pattern to `formatAssistantErrorText()` → returns "The AI service returned a malformed response. Please try again."
- Replace the raw-text fallthrough with a generic safe message: "An unexpected error occurred. Please try again." (logged for debugging, never forwarded)
- Add defense-in-depth JSON parse check in `sanitizeUserFacingText()` errorContext branch

**`src/auto-reply/reply/agent-runner-execution.ts`:**
- Always sanitize error messages in the catch block (previously only sanitized for `isTransientHttp` errors, allowing non-transient errors like JSON parse errors through verbatim)

**`src/agents/pi-embedded-helpers.ts`:**
- Export `isJsonParseError` from barrel

### Error patterns caught

| Error | Source | Previously |
|-------|--------|-----------|
| `Bad control character in string literal in JSON at position N` | SSE chunk corruption | Forwarded verbatim |
| `Expected ':' after property name in JSON at position N` | SSE chunk corruption | Forwarded verbatim |
| `Expected ',' or '}' after property value in JSON at position N` | SSE chunk corruption | Forwarded verbatim |
| `Unterminated string in JSON at position N` | SSE chunk corruption | Forwarded verbatim |
| `SyntaxError: Unexpected token in JSON` | JSON.parse failure | Forwarded verbatim |
| Any unclassified error text | Various | Forwarded verbatim (up to 600 chars) |

### Impact

- **All channels** (Discord, Slack, Telegram, etc.): No more raw error text in user-facing messages
- **Debugging**: Unclassified errors are logged with `log.warn()` for debugging — not lost, just not forwarded
- **Existing error handling**: All existing classified errors (context overflow, rate limit, billing, etc.) are unchanged

## Test plan

- [x] 13 new tests in `pi-embedded-helpers.formatassistanterrortext.test.ts` (33 total, all passing)
  - JSON parse error variants (Bad control character, Expected, Unexpected, Unterminated, SyntaxError)
  - `isJsonParseError()` helper (7 tests: positive matches, negative matches, empty input)
  - Generic fallback: unclassified errors never leak raw text
  - Long error truncation: 1000-char errors produce short safe messages
- [x] Lint passes (`prek` hooks clean)
- [ ] Manual verification: trigger SSE corruption by interrupting a streaming response mid-chunk


---
*Generated with [Claude Code](https://claude.ai/code)*