### PR TITLE
fix(control-ui): allow hardlinks for pnpm installations

### DIFF
--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -262,6 +262,7 @@ function resolveSafeControlUiFile(
     rootRealPath: rootReal,
     boundaryLabel: "control ui root",
     skipLexicalRootCheck: true,
+    rejectHardlinks: false,
   });
   if (!opened.ok) {
     if (opened.reason === "io") {


### PR DESCRIPTION
## Summary

The Control UI returns 404 when OpenClaw is installed globally via pnpm because pnpm uses content-addressable storage and creates hardlinks (nlink >= 2). The openBoundaryFileSync function rejects hardlinks by default, causing the file open to fail.

This change adds rejectHardlinks: false to the openBoundaryFileSync call in resolveSafeControlUiFile, allowing Control UI assets to be served correctly when installed via pnpm.

## Root Cause

When files are hardlinked (as pnpm does), they have nlink >= 2. The openBoundaryFileSync function in src/infra/boundary-file-read.ts by default rejects hardlinks as a security measure. This is appropriate for user-generated content but unnecessary for shipped static assets.

## Fix

Add rejectHardlinks: false to the openBoundaryFileSync call in resolveSafeControlUiFile.

## Testing

pnpm test src/gateway/control-ui.http.test.ts passes (18 tests)

## Related Issue

Fixes #33454