### PR TITLE
fix(googlechat): guard against null channels config in applyAccountConfig

### DIFF
--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -349,7 +349,7 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         return {
           ...next,
           channels: {
-            ...next.channels,
+            ...(next.channels ?? {}),
             googlechat: {
               ...next.channels?.["googlechat"],
               enabled: true,
@@ -361,7 +361,7 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
       return {
         ...next,
         channels: {
-          ...next.channels,
+          ...(next.channels ?? {}),
           googlechat: {
             ...next.channels?.["googlechat"],
             enabled: true,


### PR DESCRIPTION
## Summary
- Fixes the `Cannot convert undefined or null to object` crash when starting the googlechat channel on v2026.3.2
- Root cause: two unguarded spread operators (`...next.channels`) in `applyAccountConfig` at `extensions/googlechat/src/channel.ts` lines 352 and 364 throw when `next.channels` is `undefined` (e.g. fresh installs or minimal configs)
- Fix: wrap both with nullish coalescing — `...(next.channels ?? {})` — matching the optional chaining already used on the nested accesses in the same function

## Test plan
- [ ] Verify googlechat channel starts successfully with a fresh/empty config (no `channels` key)
- [ ] Verify existing configs with populated `channels` still work as before
- [ ] Run `pnpm test` to confirm no regressions

Fixes #33468