### PR TITLE
ci: add npm publish workflow on version tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,6 +61,6 @@ jobs:
           fi
 
       - name: Publish to npm
-        run: pnpm publish --no-git-checks --ignore-scripts --access public --tag ${{ steps.dist-tag.outputs.tag }}
+        run: pnpm publish --no-git-checks --ignore-scripts --access public --tag "${{ steps.dist-tag.outputs.tag }}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,7 +48,19 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Resolve npm dist-tag
+        id: dist-tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF#refs/tags/v}"
+          if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=next" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
-        run: pnpm publish --no-git-checks --ignore-scripts --access public
+        run: pnpm publish --no-git-checks --ignore-scripts --access public --tag ${{ steps.dist-tag.outputs.tag }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Build UI assets
+        run: pnpm run ui:build
+
       - name: Configure npm authentication
         run: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > "$HOME/.npmrc"
         env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,12 +14,22 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: false
+
+      - name: Validate tag matches package.json version
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF#refs/tags/v}"
+          pkg_version="$(node -p 'require("./package.json").version')"
+          if [[ "$tag_version" != "$pkg_version" ]]; then
+            echo "::error::Tag version ($tag_version) does not match package.json version ($pkg_version)"
+            exit 1
+          fi
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -33,25 +43,12 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - name: Resolve version from tag
-        id: version
-        shell: bash
-        run: |
-          set -euo pipefail
-          tag_version="${GITHUB_REF#refs/tags/v}"
-          pkg_version="$(node -p 'require("./package.json").version')"
-          if [[ "$tag_version" != "$pkg_version" ]]; then
-            echo "::error::Tag version ($tag_version) does not match package.json version ($pkg_version)"
-            exit 1
-          fi
-          echo "version=$tag_version" >> "$GITHUB_OUTPUT"
-
       - name: Configure npm authentication
         run: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > "$HOME/.npmrc"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
-        run: pnpm publish --no-git-checks --access public
+        run: pnpm publish --no-git-checks --ignore-scripts --access public
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,57 @@
+name: npm Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: npm-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          use-sticky-disk: "true"
+
+      - name: Pre-release checks
+        run: pnpm run release:check
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Resolve version from tag
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF#refs/tags/v}"
+          pkg_version="$(node -p 'require("./package.json").version')"
+          if [[ "$tag_version" != "$pkg_version" ]]; then
+            echo "::error::Tag version ($tag_version) does not match package.json version ($pkg_version)"
+            exit 1
+          fi
+          echo "version=$tag_version" >> "$GITHUB_OUTPUT"
+
+      - name: Configure npm authentication
+        run: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > "$HOME/.npmrc"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        run: pnpm publish --no-git-checks --access public
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`.github/workflows/npm-publish.yml`) that publishes to npm when a `v*` tag is pushed
- Root cause of #31442: the npm `latest` dist-tag was stuck at `2026.2.26` because no workflow existed to publish new versions to the npm registry
- The workflow validates tag version matches `package.json`, runs `release:check` + `build`, then publishes via `pnpm publish`
- Follows existing repo patterns (blacksmith runners, `setup-node-env` composite action, tag trigger convention from `docker-release.yml`)

## Setup required
- An `NPM_TOKEN` repository secret must be configured with a valid npm access token that has publish permissions for the `openclaw` package

## Test plan
- [ ] Verify workflow syntax is valid (`gh workflow view npm-publish.yml`)
- [ ] Configure `NPM_TOKEN` secret and push a test tag to confirm end-to-end publish
- [ ] Verify `npm info openclaw` shows updated version after publish

Fixes #31442