### PR TITLE
feat(hooks): bridge subagent lifecycle events to internal hook system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ dist/protocol.schema.json
 
 # Synthing
 **/.stfolder/
+openclaw-*.tgz

--- a/src/agents/subagent-registry-completion.ts
+++ b/src/agents/subagent-registry-completion.ts
@@ -1,3 +1,4 @@
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { SubagentRunOutcome } from "./subagent-announce.js";
 import {
@@ -9,6 +10,28 @@ import {
   type SubagentLifecycleEndedReason,
 } from "./subagent-lifecycle-events.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+/**
+ * Map a SubagentLifecycleEndedReason to an internal hook action string.
+ * This bridges plugin-level lifecycle reasons to the simpler internal hook
+ * action vocabulary that user-authored `.js` hooks subscribe to.
+ */
+function reasonToInternalAction(reason: SubagentLifecycleEndedReason): string {
+  switch (reason) {
+    case "subagent-complete":
+      return "complete";
+    case "subagent-error":
+      return "error";
+    case "subagent-killed":
+      return "killed";
+    case "session-reset":
+      return "reset";
+    case "session-delete":
+      return "delete";
+    default:
+      return "complete";
+  }
+}
 
 export function runOutcomesEqual(
   a: SubagentRunOutcome | undefined,
@@ -85,6 +108,23 @@ export async function emitSubagentEndedHookOnce(params: {
         },
       );
     }
+    // Bridge to internal hook system so user-authored .js hooks can observe
+    // subagent lifecycle events without writing a full plugin.
+    const internalAction = reasonToInternalAction(params.reason);
+    const startedAt = (params.entry as Record<string, unknown>).startedAt as number | undefined;
+    void triggerInternalHook(
+      createInternalHookEvent("subagent", internalAction, params.entry.requesterSessionKey, {
+        childSessionKey: params.entry.childSessionKey,
+        runId: params.entry.runId,
+        reason: params.reason,
+        outcome: params.outcome,
+        error: params.error,
+        endedAt: params.entry.endedAt,
+        startedAt,
+        runtimeMs: params.entry.endedAt && startedAt ? params.entry.endedAt - startedAt : undefined,
+      }),
+    );
+
     params.entry.endedHookEmittedAt = Date.now();
     params.persist();
     return true;

--- a/src/agents/subagent-registry-completion.ts
+++ b/src/agents/subagent-registry-completion.ts
@@ -111,8 +111,7 @@ export async function emitSubagentEndedHookOnce(params: {
     // Bridge to internal hook system so user-authored .js hooks can observe
     // subagent lifecycle events without writing a full plugin.
     const internalAction = reasonToInternalAction(params.reason);
-    const startedAt = (params.entry as Record<string, unknown>).startedAt as number | undefined;
-    void triggerInternalHook(
+    await triggerInternalHook(
       createInternalHookEvent("subagent", internalAction, params.entry.requesterSessionKey, {
         childSessionKey: params.entry.childSessionKey,
         runId: params.entry.runId,
@@ -120,8 +119,11 @@ export async function emitSubagentEndedHookOnce(params: {
         outcome: params.outcome,
         error: params.error,
         endedAt: params.entry.endedAt,
-        startedAt,
-        runtimeMs: params.entry.endedAt && startedAt ? params.entry.endedAt - startedAt : undefined,
+        startedAt: params.entry.startedAt,
+        runtimeMs:
+          params.entry.endedAt && params.entry.startedAt
+            ? params.entry.endedAt - params.entry.startedAt
+            : undefined,
       }),
     );
 

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -10,7 +10,13 @@ import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "message"
+  | "subagent";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -18,6 +18,30 @@ export type InternalHookEventType =
   | "message"
   | "subagent";
 
+// ============================================================================
+// Subagent Hook Events
+// ============================================================================
+
+export type SubagentEndedHookContext = {
+  childSessionKey: string;
+  runId: string;
+  reason: string;
+  outcome?: string;
+  error?: string;
+  startedAt?: number;
+  endedAt?: number;
+  runtimeMs?: number;
+};
+
+export type SubagentEndedHookEvent = InternalHookEvent & {
+  type: "subagent";
+  context: SubagentEndedHookContext;
+};
+
+// ============================================================================
+// Agent Hook Events
+// ============================================================================
+
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
   bootstrapFiles: WorkspaceBootstrapFile[];
@@ -451,4 +475,17 @@ export function isMessagePreprocessedEvent(
     return false;
   }
   return hasStringContextField(context, "channelId");
+}
+
+export function isSubagentEndedEvent(event: InternalHookEvent): event is SubagentEndedHookEvent {
+  if (event.type !== "subagent") {
+    return false;
+  }
+  const context = getHookContext<SubagentEndedHookContext>(event);
+  if (!context) {
+    return false;
+  }
+  return (
+    hasStringContextField(context, "childSessionKey") && hasStringContextField(context, "runId")
+  );
 }


### PR DESCRIPTION
## Summary

Adds `"subagent"` to `InternalHookEventType` and bridges plugin-level subagent lifecycle events into the internal hook system. This lets users write simple `.js` hook files in their `hooks/` directory to track subagent completions, errors, timeouts, and kills — without needing to write a full plugin.

## Problem

OpenClaw has two hook systems:

1. **Plugin hooks** (`src/plugins/`) — Full lifecycle coverage including `subagent_ended`, `subagent_spawned`, `subagent_spawning`. Requires writing a TypeScript plugin.

2. **Internal hooks** (`src/hooks/`) — Simple `.js` files dropped into a `hooks/` directory. Currently supports `command`, `session`, `agent`, `gateway`, `message` event types. **Does not support `subagent` events.**

Users who want to track subagent lifecycle via simple hook files cannot do so. The only option is writing a full plugin or parsing JSONL logs.

### Production evidence

We run 30+ cron jobs with heavy sub-agent usage (parallel spawns, research pipelines, monitoring). We wrote 3 internal hooks for subagent reliability:

- **delivery tracker** — logs completions, seeds pickup state
- **pickup enforcer** — injects main-agent follow-up on completion
- **complete tracker** — watchdog with retry, stale detection, state machine

These hooks listen for `subagent:complete` events. After the plugin hook system landed, they stopped receiving events because `InternalHookEventType` does not include `"subagent"`. The plugin hooks fire correctly, but the internal hook bridge is missing.

### Open question

Was excluding `subagent` from `InternalHookEventType` intentional (to keep internal hooks simple), or was it an oversight during the plugin hook migration? Happy to adjust the approach based on maintainer preference.

## Changes

### `src/hooks/internal-hooks.ts`
- Add `"subagent"` to `InternalHookEventType` union type

### `src/agents/subagent-registry-completion.ts`
- Import `createInternalHookEvent` and `triggerInternalHook`
- Add `reasonToInternalAction()` helper that maps `SubagentLifecycleEndedReason` to internal hook actions
- After emitting the `subagent_ended` plugin hook, also emit an internal hook event via `triggerInternalHook`
- Include full context in payload: `childSessionKey`, `runId`, `reason`, `outcome`, `error`, `startedAt`, `endedAt`, `runtimeMs`
- Internal hook actions: `complete`, `error`, `killed`, `reset`, `delete`

## Example hook usage

```javascript
// hooks/my-subagent-tracker/handler.js
export default {
  events: ["subagent:complete", "subagent:error", "subagent:killed"],
  async handler(event) {
    console.log(`Subagent ${event.context.runId} ${event.action}:`);
    console.log(`  outcome: ${event.context.outcome}`);
    console.log(`  runtime: ${event.context.runtimeMs}ms`);
    // Log to SQLite, send webhook, trigger retry, etc.
  }
};
```

## Context

- Discussion: #20205 (original proposal for `subagent:complete` hook event)
- Previous PRs: #20268, #24925 (closed — plugin hooks landed but internal hook bridge was not added)
- Community feedback: https://github.com/openclaw/openclaw/discussions/20205#discussioncomment-15989503