### PR TITLE
fix: prevent webchat replies from routing to external channels

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -6,6 +6,7 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import {
   logMessageProcessed,
   logMessageQueued,
@@ -207,8 +208,12 @@ export async function dispatchReplyFromConfig(params: {
   const originatingChannel = ctx.OriginatingChannel;
   const originatingTo = ctx.OriginatingTo;
   const currentSurface = (ctx.Surface ?? ctx.Provider)?.toLowerCase();
+  const isWebchatSurface = currentSurface === INTERNAL_MESSAGE_CHANNEL;
   const shouldRouteToOriginating =
-    isRoutableChannel(originatingChannel) && originatingTo && originatingChannel !== currentSurface;
+    !isWebchatSurface &&
+    isRoutableChannel(originatingChannel) &&
+    originatingTo &&
+    originatingChannel !== currentSurface;
   const ttsChannel = shouldRouteToOriginating ? originatingChannel : currentSurface;
 
   /**


### PR DESCRIPTION
Closes #33522

## Problem
After the 2026.3.2 routing changes, Control UI (webchat) runs could still carry stale external origin metadata. That allowed reply dispatch to route UI replies to external channels (e.g. iMessage) when origin differed from webchat surface.

## Fix
Add a webchat-only guard in reply dispatch routing. When current surface is `webchat`, cross-channel `routeReply` is disabled, so UI replies stay in webchat and are not forwarded to external transports.
