### PR TITLE
fix(whatsapp extension): forward mediaLocalRoots in sendMedia

### DIFF
--- a/extensions/whatsapp/src/channel.test.ts
+++ b/extensions/whatsapp/src/channel.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { whatsappPlugin } from "./channel.js";
+
+describe("whatsappPlugin outbound sendMedia", () => {
+  it("forwards mediaLocalRoots to sendMessageWhatsApp", async () => {
+    const sendWhatsApp = vi.fn(async () => ({
+      messageId: "msg-1",
+      toJid: "15551234567@s.whatsapp.net",
+    }));
+    const mediaLocalRoots = ["/tmp/workspace"];
+
+    const outbound = whatsappPlugin.outbound;
+    if (!outbound?.sendMedia) {
+      throw new Error("whatsapp outbound sendMedia is unavailable");
+    }
+
+    const result = await outbound.sendMedia({
+      cfg: {} as never,
+      to: "whatsapp:+15551234567",
+      text: "photo",
+      mediaUrl: "/tmp/workspace/photo.png",
+      mediaLocalRoots,
+      accountId: "default",
+      deps: { sendWhatsApp },
+      gifPlayback: false,
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledWith(
+      "whatsapp:+15551234567",
+      "photo",
+      expect.objectContaining({
+        verbose: false,
+        mediaUrl: "/tmp/workspace/photo.png",
+        mediaLocalRoots,
+        accountId: "default",
+        gifPlayback: false,
+      }),
+    );
+    expect(result).toMatchObject({ channel: "whatsapp", messageId: "msg-1" });
+  });
+});

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -295,11 +295,12 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       });
       return { channel: "whatsapp", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback }) => {
+    sendMedia: async ({ to, text, mediaUrl, mediaLocalRoots, accountId, deps, gifPlayback }) => {
       const send = deps?.sendWhatsApp ?? getWhatsAppRuntime().channel.whatsapp.sendMessageWhatsApp;
       const result = await send(to, text, {
         verbose: false,
         mediaUrl,
+        mediaLocalRoots,
         accountId: accountId ?? undefined,
         gifPlayback,
       });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `extensions/whatsapp` plugin `outbound.sendMedia` did not forward `mediaLocalRoots` to `sendWhatsApp`.
- Why it matters: workspace/local media paths depend on `mediaLocalRoots` for allowlisted local-file resolution; dropping it can block agent media delivery.
- What changed: threaded `mediaLocalRoots` through the extension adapter's `sendMedia` path and added a regression test that asserts forwarding.
- What did NOT change (scope boundary): no core channel routing changes, no auth/session changes, no dependency changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33504
- Related #

## User-visible / Behavior Changes

WhatsApp extension media sends now preserve `mediaLocalRoots` when calling outbound `sendMedia`, so local media paths allowed by workspace roots resolve correctly instead of being dropped at the plugin boundary.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): WhatsApp extension (`extensions/whatsapp`)
- Relevant config (redacted): N/A (unit-level adapter repro)

### Steps

1. On `upstream/main`, inspect `extensions/whatsapp/src/channel.ts` `outbound.sendMedia` and note `mediaLocalRoots` is not passed into `sendWhatsApp` options.
2. Call `whatsappPlugin.outbound.sendMedia(...)` with a non-empty `mediaLocalRoots` array and a local `mediaUrl`.
3. Observe the outbound dependency call receives options without `mediaLocalRoots`.

### Expected

- `sendWhatsApp` receives `mediaLocalRoots` unchanged from `outbound.sendMedia` input.

### Actual

- `mediaLocalRoots` is dropped in the extension adapter, so local-root context does not reach `sendWhatsApp`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing after fix:

- `pnpm test extensions/whatsapp/src/channel.test.ts extensions/whatsapp/src/resolve-target.test.ts`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added/ran regression test that invokes `whatsappPlugin.outbound.sendMedia` and asserts `sendWhatsApp` receives `mediaLocalRoots`.
- Edge cases checked: validated no change to other outbound option fields (`mediaUrl`, `accountId`, `gifPlayback`, `verbose`).
- What you did **not** verify: live WhatsApp network send against a real account/session.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `f05b1b3344`.
- Files/config to restore: `extensions/whatsapp/src/channel.ts`, `extensions/whatsapp/src/channel.test.ts`.
- Known bad symptoms reviewers should watch for: if reverted or regressed, outbound local-media sends may fail where workspace roots are required.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: low risk of option-payload drift between extension and core adapters.
  - Mitigation: regression test asserts forwarded payload shape for `sendMedia`.
