### PR TITLE
feat(telegram): default to sendMessageDraft for all chat types

### DIFF
--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -384,7 +384,6 @@ describe("createTelegramDraftStream", () => {
       api: api as unknown as Bot["api"],
       chatId: 123,
       previewTransport: "message",
-      previewTransport: "message",
       onSupersededPreview,
     });
 
@@ -413,7 +412,6 @@ describe("createTelegramDraftStream", () => {
     const stream = createTelegramDraftStream({
       api: api as unknown as Bot["api"],
       chatId: 123,
-      previewTransport: "message",
       previewTransport: "message",
       renderText: (text) => ({ text: `<i>${text}</i>`, parseMode: "HTML" }),
     });

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -13,8 +13,11 @@ function createMockDraftApi(sendMessageImpl?: () => Promise<{ message_id: number
   };
 }
 
-function createForumDraftStream(api: ReturnType<typeof createMockDraftApi>) {
-  return createThreadedDraftStream(api, { id: 99, scope: "forum" });
+function createForumMessageStream(api: ReturnType<typeof createMockDraftApi>) {
+  return createDraftStream(api, {
+    thread: { id: 99, scope: "forum" },
+    previewTransport: "message",
+  });
 }
 
 function createThreadedDraftStream(
@@ -57,17 +60,17 @@ function createForceNewMessageHarness(params: { throttleMs?: number } = {}) {
   api.sendMessage
     .mockResolvedValueOnce({ message_id: 17 })
     .mockResolvedValueOnce({ message_id: 42 });
-  const stream = createDraftStream(
-    api,
-    params.throttleMs != null ? { throttleMs: params.throttleMs } : {},
-  );
+  const stream = createDraftStream(api, {
+    previewTransport: "message",
+    ...(params.throttleMs != null ? { throttleMs: params.throttleMs } : {}),
+  });
   return { api, stream };
 }
 
 describe("createTelegramDraftStream", () => {
   it("sends stream preview message with message_thread_id when provided", async () => {
     const api = createMockDraftApi();
-    const stream = createForumDraftStream(api);
+    const stream = createForumMessageStream(api);
 
     stream.update("Hello");
     await expectInitialForumSend(api);
@@ -75,7 +78,7 @@ describe("createTelegramDraftStream", () => {
 
   it("edits existing stream preview message on subsequent updates", async () => {
     const api = createMockDraftApi();
-    const stream = createForumDraftStream(api);
+    const stream = createForumMessageStream(api);
 
     stream.update("Hello");
     await expectInitialForumSend(api);
@@ -93,7 +96,7 @@ describe("createTelegramDraftStream", () => {
       resolveSend = resolve;
     });
     const api = createMockDraftApi(() => firstSend);
-    const stream = createForumDraftStream(api);
+    const stream = createForumMessageStream(api);
 
     stream.update("Hello");
     await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledTimes(1));
@@ -109,7 +112,10 @@ describe("createTelegramDraftStream", () => {
 
   it("omits message_thread_id for general topic id", async () => {
     const api = createMockDraftApi();
-    const stream = createThreadedDraftStream(api, { id: 1, scope: "forum" });
+    const stream = createDraftStream(api, {
+      thread: { id: 1, scope: "forum" },
+      previewTransport: "message",
+    });
 
     stream.update("Hello");
 
@@ -131,6 +137,56 @@ describe("createTelegramDraftStream", () => {
     await stream.clear();
 
     expect(api.deleteMessage).not.toHaveBeenCalled();
+  });
+
+
+  it("uses sendMessageDraft for forum threads by default (Bot API 9.5)", async () => {
+    const api = createMockDraftApi();
+    const stream = createThreadedDraftStream(api, { id: 99, scope: "forum" });
+
+    stream.update("Hello");
+    await vi.waitFor(() =>
+      expect(api.sendMessageDraft).toHaveBeenCalledWith(123, expect.any(Number), "Hello", {
+        message_thread_id: 99,
+      }),
+    );
+    expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(api.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("uses sendMessageDraft for subsequent forum updates without editing", async () => {
+    const api = createMockDraftApi();
+    const stream = createThreadedDraftStream(api, { id: 99, scope: "forum" });
+
+    stream.update("Hello");
+    await vi.waitFor(() => expect(api.sendMessageDraft).toHaveBeenCalledTimes(1));
+
+    stream.update("Hello again");
+    await stream.flush();
+
+    expect(api.sendMessageDraft).toHaveBeenCalledTimes(2);
+    expect(api.sendMessageDraft).toHaveBeenLastCalledWith(
+      123,
+      expect.any(Number),
+      "Hello again",
+      { message_thread_id: 99 },
+    );
+    expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(api.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("supports forcing message transport in forum threads", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      thread: { id: 99, scope: "forum" },
+      previewTransport: "message",
+    });
+
+    stream.update("Hello");
+    await vi.waitFor(() =>
+      expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", { message_thread_id: 99 }),
+    );
+    expect(api.sendMessageDraft).not.toHaveBeenCalled();
   });
 
   it("supports forcing message transport in dm threads", async () => {
@@ -327,6 +383,7 @@ describe("createTelegramDraftStream", () => {
     const stream = createTelegramDraftStream({
       api: api as unknown as Bot["api"],
       chatId: 123,
+      previewTransport: "message",
       onSupersededPreview,
     });
 
@@ -355,6 +412,7 @@ describe("createTelegramDraftStream", () => {
     const stream = createTelegramDraftStream({
       api: api as unknown as Bot["api"],
       chatId: 123,
+      previewTransport: "message",
       renderText: (text) => ({ text: `<i>${text}</i>`, parseMode: "HTML" }),
     });
 

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -384,6 +384,7 @@ describe("createTelegramDraftStream", () => {
       api: api as unknown as Bot["api"],
       chatId: 123,
       previewTransport: "message",
+      previewTransport: "message",
       onSupersededPreview,
     });
 
@@ -413,6 +414,7 @@ describe("createTelegramDraftStream", () => {
       api: api as unknown as Bot["api"],
       chatId: 123,
       previewTransport: "message",
+      previewTransport: "message",
       renderText: (text) => ({ text: `<i>${text}</i>`, parseMode: "HTML" }),
     });
 
@@ -433,6 +435,7 @@ describe("createTelegramDraftStream", () => {
     const stream = createTelegramDraftStream({
       api: api as unknown as Bot["api"],
       chatId: 123,
+      previewTransport: "message",
       maxChars: 100,
       renderText: () => ({ text: `<b>${"<".repeat(120)}</b>`, parseMode: "HTML" }),
       warn,
@@ -460,6 +463,7 @@ describe("draft stream initial message debounce", () => {
     return createTelegramDraftStream({
       api: api as unknown as Bot["api"],
       chatId: 123,
+      previewTransport: "message",
       minInitialChars,
     });
   }
@@ -554,6 +558,7 @@ describe("draft stream initial message debounce", () => {
       const stream = createTelegramDraftStream({
         api: api as unknown as Bot["api"],
         chatId: 123,
+      previewTransport: "message",
         // no minInitialChars (backward-compatible behavior)
       });
 

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -102,12 +102,15 @@ export function createTelegramDraftStream(params: {
   const minInitialChars = params.minInitialChars;
   const chatId = params.chatId;
   const requestedPreviewTransport = params.previewTransport ?? "auto";
+  // Bot API 9.5 (March 2026) opened sendMessageDraft to all bots and
+  // chat types.  Default to draft transport everywhere ("auto") and let
+  // the runtime fallback handle older servers gracefully.
   const prefersDraftTransport =
     requestedPreviewTransport === "draft"
       ? true
       : requestedPreviewTransport === "message"
         ? false
-        : params.thread?.scope === "dm";
+        : true;
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyParams =
     params.replyToMessageId != null


### PR DESCRIPTION
## Summary
- Migrates Telegram streaming preview from `sendMessage`+`editMessageText` to native `sendMessageDraft` for **all** chat types (forums, groups, DMs)
- Bot API 9.5 (March 1, 2026) [opened `sendMessageDraft` to all bots](https://core.telegram.org/bots/api#march-1-2026), removing the previous DM-only restriction that caused `TEXTDRAFT_PEER_INVALID` errors (#7803)
- The `"auto"` preview transport now defaults to draft everywhere instead of only for DM threads
- Runtime fallback to `sendMessage`+`editMessageText` is fully preserved for older Bot API servers

## UX improvements
- No push notification before content is ready (draft is not a real message)
- No "Edited" tag on the final message
- Higher update frequency possible (draft API is designed for streaming)
- Eliminates race conditions between error notifications and streaming updates (#19001)
- Eliminates group chat throttling issues with apiThrottler (#29822)

## Changes
- `src/telegram/draft-stream.ts`: Change `prefersDraftTransport` default from `params.thread?.scope === "dm"` to `true`
- `src/telegram/draft-stream.test.ts`: Update existing message-transport tests to use explicit `previewTransport: "message"`, add 3 new tests for forum draft transport default

## Test plan
- [ ] New tests: forum threads use `sendMessageDraft` by default
- [ ] New tests: forum subsequent updates use `sendMessageDraft` (no `editMessageText`)
- [ ] New tests: forum threads can be forced to message transport via `previewTransport: "message"`
- [ ] Existing tests: all message-transport tests pass with explicit `previewTransport: "message"`
- [ ] Existing tests: DM draft transport, fallback, runtime rejection, forceNewMessage all pass
- [ ] Manual: verify streaming works in a Telegram group/forum with Bot API 9.5+

Closes #32041