### PR TITLE
fix(signal extension): forward mediaLocalRoots in sendMedia

### DIFF
--- a/extensions/signal/src/channel.test.ts
+++ b/extensions/signal/src/channel.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { signalPlugin } from "./channel.js";
+
+describe("signalPlugin outbound sendMedia", () => {
+  it("forwards mediaLocalRoots to sendMessageSignal", async () => {
+    const sendSignal = vi.fn(async () => ({ messageId: "m1" }));
+    const mediaLocalRoots = ["/tmp/workspace"];
+
+    const sendMedia = signalPlugin.outbound?.sendMedia;
+    if (!sendMedia) {
+      throw new Error("signal outbound sendMedia is unavailable");
+    }
+
+    await sendMedia({
+      cfg: {} as never,
+      to: "signal:+15551234567",
+      text: "photo",
+      mediaUrl: "/tmp/workspace/photo.png",
+      mediaLocalRoots,
+      accountId: "default",
+      deps: { sendSignal },
+    });
+
+    expect(sendSignal).toHaveBeenCalledWith(
+      "signal:+15551234567",
+      "photo",
+      expect.objectContaining({
+        mediaUrl: "/tmp/workspace/photo.png",
+        mediaLocalRoots,
+        accountId: "default",
+      }),
+    );
+  });
+});

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -68,6 +68,7 @@ async function sendSignalOutbound(params: {
   to: string;
   text: string;
   mediaUrl?: string;
+  mediaLocalRoots?: readonly string[];
   accountId?: string;
   deps?: { sendSignal?: SignalSendFn };
 }) {
@@ -80,6 +81,7 @@ async function sendSignalOutbound(params: {
   });
   return await send(params.to, params.text, {
     ...(params.mediaUrl ? { mediaUrl: params.mediaUrl } : {}),
+    ...(params.mediaLocalRoots?.length ? { mediaLocalRoots: params.mediaLocalRoots } : {}),
     maxBytes,
     accountId: params.accountId ?? undefined,
   });
@@ -270,12 +272,13 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
       });
       return { channel: "signal", ...result };
     },
-    sendMedia: async ({ cfg, to, text, mediaUrl, accountId, deps }) => {
+    sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps }) => {
       const result = await sendSignalOutbound({
         cfg,
         to,
         text,
         mediaUrl,
+        mediaLocalRoots,
         accountId: accountId ?? undefined,
         deps,
       });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `extensions/signal` outbound `sendMedia` dropped `mediaLocalRoots` before calling `sendMessageSignal`.
- Why it matters: local media resolution for agent/workspace paths relies on `mediaLocalRoots`; dropping it can block media sends.
- What changed: threaded `mediaLocalRoots` through `sendSignalOutbound` and extension `outbound.sendMedia`, plus a regression test.
- What did NOT change (scope boundary): no Signal monitor/routing changes, no config schema changes, no dependency changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33533
- Related #

## User-visible / Behavior Changes

Signal extension media sends now preserve `mediaLocalRoots` in outbound `sendMedia`, so local media paths allowed by workspace roots are no longer dropped at the plugin adapter boundary.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Signal extension (`extensions/signal`)
- Relevant config (redacted): N/A (unit-level adapter repro)

### Steps

1. Call `signalPlugin.outbound.sendMedia(...)` with non-empty `mediaLocalRoots` and a local `mediaUrl`.
2. Observe the dependency call (`sendSignal`) options payload from `extensions/signal/src/channel.ts`.
3. Verify `mediaLocalRoots` is missing in the pre-fix implementation.

### Expected

- `sendSignal` receives `mediaLocalRoots` from outbound `sendMedia`.

### Actual

- `mediaLocalRoots` is dropped in the extension adapter and not passed to `sendSignal`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Failing before fix:

- `pnpm test extensions/signal/src/channel.test.ts`
- Failure showed `mediaLocalRoots` missing in `sendSignal` call args.

Passing after fix:

- `pnpm test extensions/signal/src/channel.test.ts`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: regression test invokes `signalPlugin.outbound.sendMedia` and asserts `sendSignal` receives `mediaLocalRoots`.
- Edge cases checked: ensured existing outbound options (`mediaUrl`, `accountId`, `maxBytes`) are still passed.
- What you did **not** verify: live Signal network send against a real Signal account/provider.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `dd0a6248ca`.
- Files/config to restore: `extensions/signal/src/channel.ts`, `extensions/signal/src/channel.test.ts`.
- Known bad symptoms reviewers should watch for: local media sends failing when path allowlists are required.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: low risk of outbound option drift between extension adapter and core send function.
  - Mitigation: regression test locks expected `sendSignal` call payload.
