### PR TITLE
fix(imessage extension): forward mediaLocalRoots in sendMedia

### DIFF
--- a/extensions/imessage/src/channel.outbound.test.ts
+++ b/extensions/imessage/src/channel.outbound.test.ts
@@ -63,4 +63,33 @@ describe("imessagePlugin outbound", () => {
     );
     expect(result).toEqual({ channel: "imessage", messageId: "m-media" });
   });
+
+  it("forwards mediaLocalRoots on direct sendMedia adapter path", async () => {
+    const sendIMessage = vi.fn().mockResolvedValue({ messageId: "m-media-local" });
+    const sendMedia = imessagePlugin.outbound?.sendMedia;
+    expect(sendMedia).toBeDefined();
+    const mediaLocalRoots = ["/tmp/workspace"];
+
+    const result = await sendMedia!({
+      cfg,
+      to: "chat_id:88",
+      text: "caption",
+      mediaUrl: "/tmp/workspace/pic.png",
+      mediaLocalRoots,
+      accountId: "acct-1",
+      deps: { sendIMessage },
+    });
+
+    expect(sendIMessage).toHaveBeenCalledWith(
+      "chat_id:88",
+      "caption",
+      expect.objectContaining({
+        mediaUrl: "/tmp/workspace/pic.png",
+        mediaLocalRoots,
+        accountId: "acct-1",
+        maxBytes: 3 * 1024 * 1024,
+      }),
+    );
+    expect(result).toEqual({ channel: "imessage", messageId: "m-media-local" });
+  });
 });

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -54,6 +54,7 @@ async function sendIMessageOutbound(params: {
   to: string;
   text: string;
   mediaUrl?: string;
+  mediaLocalRoots?: readonly string[];
   accountId?: string;
   deps?: { sendIMessage?: IMessageSendFn };
   replyToId?: string;
@@ -69,6 +70,7 @@ async function sendIMessageOutbound(params: {
   });
   return await send(params.to, params.text, {
     ...(params.mediaUrl ? { mediaUrl: params.mediaUrl } : {}),
+    ...(params.mediaLocalRoots?.length ? { mediaLocalRoots: params.mediaLocalRoots } : {}),
     maxBytes,
     accountId: params.accountId ?? undefined,
     replyToId: params.replyToId ?? undefined,
@@ -239,12 +241,13 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount> = {
       });
       return { channel: "imessage", ...result };
     },
-    sendMedia: async ({ cfg, to, text, mediaUrl, accountId, deps, replyToId }) => {
+    sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps, replyToId }) => {
       const result = await sendIMessageOutbound({
         cfg,
         to,
         text,
         mediaUrl,
+        mediaLocalRoots,
         accountId: accountId ?? undefined,
         deps,
         replyToId: replyToId ?? undefined,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `extensions/imessage` outbound `sendMedia` dropped `mediaLocalRoots` before calling `sendMessageIMessage`.
- Why it matters: local media path resolution for agent/workspace roots depends on `mediaLocalRoots`; dropping it can block media delivery.
- What changed: threaded `mediaLocalRoots` through `sendIMessageOutbound` and extension `outbound.sendMedia`, and added regression coverage.
- What did NOT change (scope boundary): no iMessage monitor/routing changes, no config schema changes, no dependency changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33537
- Related #

## User-visible / Behavior Changes

iMessage extension media sends now preserve `mediaLocalRoots` in outbound `sendMedia`, so local media paths allowed by workspace roots are forwarded to `sendMessageIMessage`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): iMessage extension (`extensions/imessage`)
- Relevant config (redacted): N/A (unit-level adapter repro)

### Steps

1. Call `imessagePlugin.outbound.sendMedia(...)` with non-empty `mediaLocalRoots` and a local-path `mediaUrl`.
2. Observe options passed to `sendIMessage` from `extensions/imessage/src/channel.ts`.
3. Verify `mediaLocalRoots` is missing in the pre-fix implementation.

### Expected

- `sendIMessage` receives `mediaLocalRoots` provided by outbound `sendMedia`.

### Actual

- `mediaLocalRoots` is dropped in the extension adapter.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Failing before fix:

- `pnpm test extensions/imessage/src/channel.outbound.test.ts`
- Failure showed `mediaLocalRoots` absent in `sendIMessage` call payload.

Passing after fix:

- `pnpm test extensions/imessage/src/channel.outbound.test.ts`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: regression test now asserts `mediaLocalRoots` is forwarded on direct `sendMedia` adapter path.
- Edge cases checked: existing `replyToId` coverage remains passing; existing `maxBytes`/`accountId` forwarding unchanged.
- What you did **not** verify: live iMessage send against a real iMessage account/CLI runtime.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `0e8950b091`.
- Files/config to restore: `extensions/imessage/src/channel.ts`, `extensions/imessage/src/channel.outbound.test.ts`.
- Known bad symptoms reviewers should watch for: local media sends may fail where workspace roots are required.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: low risk of adapter payload drift in future edits.
  - Mitigation: outbound regression test now enforces expected call payload including `mediaLocalRoots`.
