### PR TITLE
fix: fast-fail cooldown after rate_limit and move slug generator to cron lane

### DIFF
--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.test.ts
@@ -15,14 +15,18 @@ vi.mock("./pi-embedded-runner/run/attempt.js", () => ({
 }));
 
 let runEmbeddedPiAgent: typeof import("./pi-embedded-runner.js").runEmbeddedPiAgent;
+let resetProviderRateLimitCooldown: typeof import("./pi-embedded-runner.js").__resetProviderRateLimitCooldownForTests =
+  () => {};
 
 beforeAll(async () => {
-  ({ runEmbeddedPiAgent } = await import("./pi-embedded-runner.js"));
+  ({ runEmbeddedPiAgent, __resetProviderRateLimitCooldownForTests: resetProviderRateLimitCooldown } =
+    await import("./pi-embedded-runner.js"));
 });
 
 beforeEach(() => {
   vi.useRealTimers();
   runEmbeddedAttemptMock.mockReset();
+  resetProviderRateLimitCooldown();
 });
 
 const baseUsage = {
@@ -473,6 +477,58 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
       } else {
         process.env.OPENAI_API_KEY = previousOpenAiKey;
       }
+      await fs.rm(agentDir, { recursive: true, force: true });
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fast-fails repeated provider calls after a rate limit", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-agent-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-workspace-"));
+    try {
+      await writeAuthStore(agentDir);
+
+      runEmbeddedAttemptMock.mockResolvedValueOnce(
+        makeAttempt({
+          assistantTexts: [],
+          lastAssistant: buildAssistant({
+            stopReason: "error",
+            errorMessage: "API rate limit reached. Please try again later.",
+          }),
+        }),
+      );
+
+      const baseParams = {
+        sessionId: "session:test",
+        sessionKey: "agent:test:provider-rate-limit-fast-fail",
+        sessionFile: path.join(workspaceDir, "session.jsonl"),
+        workspaceDir,
+        agentDir,
+        config: makeConfig({ fallbacks: ["anthropic/mock-fallback"] }),
+        prompt: "hello",
+        provider: "openai",
+        model: "mock-1",
+        authProfileId: "openai:p1",
+        authProfileIdSource: "user" as const,
+        timeoutMs: 5_000,
+      };
+
+      await expect(
+        runEmbeddedPiAgent({
+          ...baseParams,
+          runId: "run:first-rate-limit",
+        }),
+      ).rejects.toMatchObject({ name: "FailoverError", reason: "rate_limit" });
+
+      await expect(
+        runEmbeddedPiAgent({
+          ...baseParams,
+          runId: "run:fast-fail",
+        }),
+      ).rejects.toMatchObject({ name: "FailoverError", reason: "rate_limit" });
+
+      expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(1);
+    } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -8,7 +8,10 @@ export {
   limitHistoryTurns,
 } from "./pi-embedded-runner/history.js";
 export { resolveEmbeddedSessionLane } from "./pi-embedded-runner/lanes.js";
-export { runEmbeddedPiAgent } from "./pi-embedded-runner/run.js";
+export {
+  __resetProviderRateLimitCooldownForTests,
+  runEmbeddedPiAgent,
+} from "./pi-embedded-runner/run.js";
 export {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -57,6 +57,8 @@ type ApiKeyInfo = ResolvedProviderAuth;
 // Avoid Anthropic's refusal test token poisoning session transcripts.
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
 const ANTHROPIC_MAGIC_STRING_REPLACEMENT = "ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)";
+const PROVIDER_RATE_LIMIT_FAST_FAIL_MS = 30_000;
+const providerRateLimitUntilByProvider = new Map<string, number>();
 
 function scrubAnthropicRefusalMagic(prompt: string): string {
   if (!prompt.includes(ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL)) return prompt;
@@ -64,6 +66,31 @@ function scrubAnthropicRefusalMagic(prompt: string): string {
     ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL,
     ANTHROPIC_MAGIC_STRING_REPLACEMENT,
   );
+}
+
+function getProviderRateLimitRemainingMs(providerId: string): number {
+  const key = normalizeProviderId(providerId);
+  const until = providerRateLimitUntilByProvider.get(key);
+  if (!until) return 0;
+  const remaining = until - Date.now();
+  if (remaining <= 0) {
+    providerRateLimitUntilByProvider.delete(key);
+    return 0;
+  }
+  return remaining;
+}
+
+function markProviderRateLimited(providerId: string) {
+  const key = normalizeProviderId(providerId);
+  const until = Date.now() + PROVIDER_RATE_LIMIT_FAST_FAIL_MS;
+  const existing = providerRateLimitUntilByProvider.get(key) ?? 0;
+  if (until > existing) {
+    providerRateLimitUntilByProvider.set(key, until);
+  }
+}
+
+export function __resetProviderRateLimitCooldownForTests() {
+  providerRateLimitUntilByProvider.clear();
 }
 
 export async function runEmbeddedPiAgent(
@@ -97,6 +124,24 @@ export async function runEmbeddedPiAgent(
       const fallbackConfigured =
         (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
       await ensureClawdbotModelsJson(params.config, agentDir);
+
+      if (fallbackConfigured) {
+        const remainingMs = getProviderRateLimitRemainingMs(provider);
+        if (remainingMs > 0) {
+          log.warn(
+            `provider cooldown fast-fail: ${provider}/${modelId} retryInMs=${remainingMs}`,
+          );
+          throw new FailoverError(
+            `Provider temporarily rate-limited. Retry in ${Math.ceil(remainingMs / 1000)}s.`,
+            {
+              reason: "rate_limit",
+              provider,
+              model: modelId,
+              status: 429,
+            },
+          );
+        }
+      }
 
       const { model, error, authStorage, modelRegistry } = resolveModel(
         provider,
@@ -441,6 +486,9 @@ export async function runEmbeddedPiAgent(
               };
             }
             const promptFailoverReason = classifyFailoverReason(errorText);
+            if (promptFailoverReason === "rate_limit") {
+              markProviderRateLimited(provider);
+            }
             if (promptFailoverReason && promptFailoverReason !== "timeout" && lastProfileId) {
               await markAuthProfileFailure({
                 store: authStore,
@@ -524,6 +572,9 @@ export async function runEmbeddedPiAgent(
           const shouldRotate = (!aborted && failoverFailure) || timedOut;
 
           if (shouldRotate) {
+            if (assistantFailoverReason === "rate_limit") {
+              markProviderRateLimited(provider);
+            }
             if (lastProfileId) {
               const reason =
                 timedOut || assistantFailoverReason === "timeout"

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import type { ClawdbotConfig } from "../config/config.js";
+import { CommandLane } from "../process/lanes.js";
 import {
   resolveDefaultAgentId,
   resolveAgentWorkspaceDir,
@@ -46,7 +47,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       agentDir,
       config: params.cfg,
       prompt,
-      timeoutMs: 15_000, // 15 second timeout
+      lane: CommandLane.Cron,
+      timeoutMs: 5_000, // Keep slug generation lightweight; fallback timestamp slug handles failures
       runId: `slug-gen-${Date.now()}`,
     });
 


### PR DESCRIPTION
## Summary
Upstream source-only fixes for embedded runner rate-limit thrash and slug generation lane isolation.

### Changes
1. `src/agents/pi-embedded-runner/run.ts`
   - fast-fail cooldown per provider/auth-profile after `rate_limit`
2. `src/agents/pi-embedded-runner.ts`
   - export cooldown reset helper (test support)
3. `src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.test.ts`
   - regression test: repeated calls after `rate_limit` fail fast without a new model call
4. `src/hooks/llm-slug-generator.ts`
   - move to `cron` lane and reduce timeout `15s -> 5s` (fallback unchanged)

### Validation run
```bash
curl -fsSL https://bun.sh/install | bash
export BUN_INSTALL="$HOME/.bun"; export PATH="$BUN_INSTALL/bin:$PATH"
bun --version
bun test src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.test.ts
pnpm exec vitest run src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.test.ts
pnpm lint
```

- `bun --version`: `1.3.10`
- `bun test ...`: executed, but fails in this file due to `vi.setSystemTime` not being available in Bun test runtime
- `pnpm exec vitest run ...`: ✅ 9/9 passed
- `pnpm lint`: ✅ 0 warnings / 0 errors

### Out of scope (not included)
- deploy config (`openclaw.json`)
- compiled/runtime hotfixes (`dist/*`, `pi-embedded-*.js`)
