### PR TITLE
fix(slack extension): forward mediaLocalRoots in sendMedia

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -108,6 +108,33 @@ describe("slackPlugin outbound", () => {
     );
     expect(result).toEqual({ channel: "slack", messageId: "m-media" });
   });
+
+  it("forwards mediaLocalRoots for sendMedia", async () => {
+    const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-media-local" });
+    const sendMedia = slackPlugin.outbound?.sendMedia;
+    expect(sendMedia).toBeDefined();
+    const mediaLocalRoots = ["/tmp/workspace"];
+
+    const result = await sendMedia!({
+      cfg,
+      to: "C999",
+      text: "caption",
+      mediaUrl: "/tmp/workspace/image.png",
+      mediaLocalRoots,
+      accountId: "default",
+      deps: { sendSlack },
+    });
+
+    expect(sendSlack).toHaveBeenCalledWith(
+      "C999",
+      "caption",
+      expect.objectContaining({
+        mediaUrl: "/tmp/workspace/image.png",
+        mediaLocalRoots,
+      }),
+    );
+    expect(result).toEqual({ channel: "slack", messageId: "m-media-local" });
+  });
 });
 
 describe("slackPlugin config", () => {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -371,7 +371,17 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
       });
       return { channel: "slack", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId, threadId, cfg }) => {
+    sendMedia: async ({
+      to,
+      text,
+      mediaUrl,
+      mediaLocalRoots,
+      accountId,
+      deps,
+      replyToId,
+      threadId,
+      cfg,
+    }) => {
       const { send, threadTsValue, tokenOverride } = resolveSlackSendContext({
         cfg,
         accountId: accountId ?? undefined,
@@ -381,6 +391,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
       });
       const result = await send(to, text, {
         mediaUrl,
+        mediaLocalRoots,
         threadTs: threadTsValue != null ? String(threadTsValue) : undefined,
         accountId: accountId ?? undefined,
         ...(tokenOverride ? { token: tokenOverride } : {}),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `extensions/slack` outbound `sendMedia` dropped `mediaLocalRoots` before calling `sendMessageSlack`.
- Why it matters: local media sends that rely on workspace/agent root allowlists need `mediaLocalRoots` to resolve safely.
- What changed: added `mediaLocalRoots` forwarding in Slack extension `outbound.sendMedia` and added regression coverage.
- What did NOT change (scope boundary): no Slack monitor flow changes, no action handler changes, no dependency/config changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33542
- Related #

## User-visible / Behavior Changes

Slack extension media sends now preserve `mediaLocalRoots` in outbound `sendMedia`, so local media paths allowed by workspace roots are forwarded to `sendMessageSlack`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Slack extension (`extensions/slack`)
- Relevant config (redacted): N/A (unit-level adapter repro)

### Steps

1. Call `slackPlugin.outbound.sendMedia(...)` with non-empty `mediaLocalRoots`.
2. Observe options passed to `sendSlack` in `extensions/slack/src/channel.ts`.
3. In pre-fix code, verify `mediaLocalRoots` is omitted.

### Expected

- `sendSlack` receives `mediaLocalRoots` from outbound `sendMedia`.

### Actual

- `mediaLocalRoots` is dropped by the extension adapter.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Failing before fix:

- `pnpm test extensions/slack/src/channel.test.ts`
- Failure showed missing `mediaLocalRoots` in `sendSlack` call payload.

Passing after fix:

- `pnpm test extensions/slack/src/channel.test.ts`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: regression test asserts `mediaLocalRoots` forwarding on Slack extension `sendMedia`.
- Edge cases checked: existing thread/reply routing tests remain passing (`threadTs` behavior unchanged).
- What you did **not** verify: live Slack upload send with a real workspace/token.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `0014af7552`.
- Files/config to restore: `extensions/slack/src/channel.ts`, `extensions/slack/src/channel.test.ts`.
- Known bad symptoms reviewers should watch for: local-media Slack sends failing where workspace roots are required.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: low risk of future adapter payload drift.
  - Mitigation: regression test pins the expected Slack send payload.
