### PR TITLE
fix: preserve external session labels over internal client names (closes #33534)

### DIFF
--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -15,8 +15,15 @@ const mergeOrigin = (
     return undefined;
   }
   const merged: SessionOrigin = existing ? { ...existing } : {};
+  const existingProvider = existing?.provider?.trim().toLowerCase();
+  const nextProvider = next?.provider?.trim().toLowerCase();
+  const nextIsInternal = nextProvider === "internal";
+  const existingIsExternal = Boolean(existingProvider && existingProvider !== "internal");
   if (next?.label) {
-    merged.label = next.label;
+    // Keep channel/user labels when an internal transport reconnects (e.g. TUI).
+    if (!(nextIsInternal && existingIsExternal && existing?.label)) {
+      merged.label = next.label;
+    }
   }
   if (next?.provider) {
     merged.provider = next.provider;


### PR DESCRIPTION
Closes #33534

## Problem
When chat traffic comes through an internal client (for example TUI with ), session origin metadata could overwrite an existing external conversation label. That caused Control UI session rows to show the transport client name for unrelated sessions.

## Fix
Hardened session-origin merge logic to avoid replacing an existing external-channel label with an internal-origin label. This preserves session-specific names (for example Telegram DM contact names) while still allowing internal labels when no external label exists.