### PR TITLE
fix(slack extension): forward outbound identity in sendText/sendMedia

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -114,6 +114,33 @@ describe("slackPlugin outbound", () => {
     expect(result).toEqual({ channel: "slack", messageId: "m-text-identity" });
   });
 
+  it("normalizes partially wrapped emoji shortcodes", async () => {
+    const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-text-emoji-normalized" });
+    const sendText = slackPlugin.outbound?.sendText;
+    expect(sendText).toBeDefined();
+
+    await sendText!({
+      cfg,
+      to: "C123",
+      text: "hello",
+      accountId: "default",
+      identity: {
+        emoji: ":zap",
+      },
+      deps: { sendSlack },
+    });
+
+    expect(sendSlack).toHaveBeenCalledWith(
+      "C123",
+      "hello",
+      expect.objectContaining({
+        identity: {
+          iconEmoji: ":zap:",
+        },
+      }),
+    );
+  });
+
   it("prefers replyToId over threadId for sendMedia", async () => {
     const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-media" });
     const sendMedia = slackPlugin.outbound?.sendMedia;
@@ -200,6 +227,36 @@ describe("slackPlugin outbound", () => {
       }),
     );
     expect(result).toEqual({ channel: "slack", messageId: "m-media-identity" });
+  });
+
+  it("does not fabricate iconEmoji from non-shortcode emoji values", async () => {
+    const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-text-unicode-emoji" });
+    const sendText = slackPlugin.outbound?.sendText;
+    expect(sendText).toBeDefined();
+
+    await sendText!({
+      cfg,
+      to: "C123",
+      text: "hello",
+      accountId: "default",
+      identity: {
+        name: "OpenClaw Agent",
+        emoji: "🦞",
+      },
+      deps: { sendSlack },
+    });
+
+    expect(sendSlack).toHaveBeenCalledWith(
+      "C123",
+      "hello",
+      expect.objectContaining({
+        identity: {
+          username: "OpenClaw Agent",
+          iconUrl: undefined,
+          iconEmoji: undefined,
+        },
+      }),
+    );
   });
 });
 

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -82,6 +82,38 @@ describe("slackPlugin outbound", () => {
     expect(result).toEqual({ channel: "slack", messageId: "m-text" });
   });
 
+  it("forwards mapped identity for sendText", async () => {
+    const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-text-identity" });
+    const sendText = slackPlugin.outbound?.sendText;
+    expect(sendText).toBeDefined();
+
+    const result = await sendText!({
+      cfg,
+      to: "C123",
+      text: "hello",
+      accountId: "default",
+      identity: {
+        name: "OpenClaw Agent",
+        avatarUrl: "https://example.com/agent.png",
+        emoji: "zap",
+      },
+      deps: { sendSlack },
+    });
+
+    expect(sendSlack).toHaveBeenCalledWith(
+      "C123",
+      "hello",
+      expect.objectContaining({
+        identity: {
+          username: "OpenClaw Agent",
+          iconUrl: "https://example.com/agent.png",
+          iconEmoji: ":zap:",
+        },
+      }),
+    );
+    expect(result).toEqual({ channel: "slack", messageId: "m-text-identity" });
+  });
+
   it("prefers replyToId over threadId for sendMedia", async () => {
     const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-media" });
     const sendMedia = slackPlugin.outbound?.sendMedia;
@@ -134,6 +166,40 @@ describe("slackPlugin outbound", () => {
       }),
     );
     expect(result).toEqual({ channel: "slack", messageId: "m-media-local" });
+  });
+
+  it("forwards mapped identity for sendMedia", async () => {
+    const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-media-identity" });
+    const sendMedia = slackPlugin.outbound?.sendMedia;
+    expect(sendMedia).toBeDefined();
+
+    const result = await sendMedia!({
+      cfg,
+      to: "C999",
+      text: "caption",
+      mediaUrl: "https://example.com/image.png",
+      accountId: "default",
+      identity: {
+        name: "OpenClaw Agent",
+        avatarUrl: "https://example.com/agent.png",
+        emoji: "zap",
+      },
+      deps: { sendSlack },
+    });
+
+    expect(sendSlack).toHaveBeenCalledWith(
+      "C999",
+      "caption",
+      expect.objectContaining({
+        mediaUrl: "https://example.com/image.png",
+        identity: {
+          username: "OpenClaw Agent",
+          iconUrl: "https://example.com/agent.png",
+          iconEmoji: ":zap:",
+        },
+      }),
+    );
+    expect(result).toEqual({ channel: "slack", messageId: "m-media-identity" });
   });
 });
 

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -71,6 +71,20 @@ type SlackOutboundIdentity = {
   iconEmoji?: string;
 };
 
+function normalizeSlackIconEmoji(rawEmoji?: string): string | undefined {
+  const trimmed = rawEmoji?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (/^:[a-z0-9_+-]+:$/i.test(trimmed)) {
+    return trimmed;
+  }
+  if (/^:?[a-z0-9_+-]+:?$/i.test(trimmed)) {
+    return `:${trimmed.replace(/^:|:$/g, "")}:`;
+  }
+  return undefined;
+}
+
 function resolveSlackSendIdentity(identity?: {
   name?: string | null;
   avatarUrl?: string | null;
@@ -81,8 +95,7 @@ function resolveSlackSendIdentity(identity?: {
   }
   const username = identity.name?.trim() || undefined;
   const iconUrl = identity.avatarUrl?.trim() || undefined;
-  const rawEmoji = identity.emoji?.trim();
-  const iconEmoji = rawEmoji ? (rawEmoji.startsWith(":") ? rawEmoji : `:${rawEmoji}:`) : undefined;
+  const iconEmoji = normalizeSlackIconEmoji(identity.emoji ?? undefined);
   if (!username && !iconUrl && !iconEmoji) {
     return undefined;
   }

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -65,6 +65,30 @@ function isSlackAccountConfigured(account: ResolvedSlackAccount): boolean {
 
 type SlackSendFn = ReturnType<typeof getSlackRuntime>["channel"]["slack"]["sendMessageSlack"];
 
+type SlackOutboundIdentity = {
+  username?: string;
+  iconUrl?: string;
+  iconEmoji?: string;
+};
+
+function resolveSlackSendIdentity(identity?: {
+  name?: string | null;
+  avatarUrl?: string | null;
+  emoji?: string | null;
+}): SlackOutboundIdentity | undefined {
+  if (!identity) {
+    return undefined;
+  }
+  const username = identity.name?.trim() || undefined;
+  const iconUrl = identity.avatarUrl?.trim() || undefined;
+  const rawEmoji = identity.emoji?.trim();
+  const iconEmoji = rawEmoji ? (rawEmoji.startsWith(":") ? rawEmoji : `:${rawEmoji}:`) : undefined;
+  if (!username && !iconUrl && !iconEmoji) {
+    return undefined;
+  }
+  return { username, iconUrl, iconEmoji };
+}
+
 function resolveSlackSendContext(params: {
   cfg: Parameters<typeof resolveSlackAccount>[0]["cfg"];
   accountId?: string;
@@ -356,7 +380,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
     deliveryMode: "direct",
     chunker: null,
     textChunkLimit: 4000,
-    sendText: async ({ to, text, accountId, deps, replyToId, threadId, cfg }) => {
+    sendText: async ({ to, text, accountId, deps, replyToId, threadId, identity, cfg }) => {
       const { send, threadTsValue, tokenOverride } = resolveSlackSendContext({
         cfg,
         accountId: accountId ?? undefined,
@@ -364,10 +388,12 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         replyToId,
         threadId,
       });
+      const slackIdentity = resolveSlackSendIdentity(identity);
       const result = await send(to, text, {
         cfg,
         threadTs: threadTsValue != null ? String(threadTsValue) : undefined,
         accountId: accountId ?? undefined,
+        ...(slackIdentity ? { identity: slackIdentity } : {}),
         ...(tokenOverride ? { token: tokenOverride } : {}),
       });
       return { channel: "slack", ...result };
@@ -381,6 +407,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
       deps,
       replyToId,
       threadId,
+      identity,
       cfg,
     }) => {
       const { send, threadTsValue, tokenOverride } = resolveSlackSendContext({
@@ -390,12 +417,14 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         replyToId,
         threadId,
       });
+      const slackIdentity = resolveSlackSendIdentity(identity);
       const result = await send(to, text, {
         cfg,
         mediaUrl,
         mediaLocalRoots,
         threadTs: threadTsValue != null ? String(threadTsValue) : undefined,
         accountId: accountId ?? undefined,
+        ...(slackIdentity ? { identity: slackIdentity } : {}),
         ...(tokenOverride ? { token: tokenOverride } : {}),
       });
       return { channel: "slack", ...result };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `extensions/slack` outbound `sendText`/`sendMedia` ignored `identity`, so custom sender identity was not passed to Slack sends.
- Why it matters: outbound identity controls username/icon customization and should be consistent with core Slack outbound behavior.
- What changed: added identity mapping (`name/avatarUrl/emoji` -> `username/iconUrl/iconEmoji`) and forwarded identity in Slack extension outbound paths.
- What did NOT change (scope boundary): no monitor reply flow changes, no token scope logic changes, no dependency/config changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33548
- Related #27130

## User-visible / Behavior Changes

Slack extension outbound sends now preserve sender identity metadata (`name/avatarUrl/emoji`) by mapping it to Slack identity fields (`username/iconUrl/iconEmoji`) for both text and media sends.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Slack extension (`extensions/slack`)
- Relevant config (redacted): N/A (unit-level adapter repro)

### Steps

1. Call `slackPlugin.outbound.sendText(...)` or `sendMedia(...)` with `identity` set.
2. Observe options passed to `sendSlack` from `extensions/slack/src/channel.ts`.
3. In pre-fix code, verify `identity` is absent.

### Expected

- Outbound adapter forwards mapped Slack identity values (`username`, `iconUrl`, `iconEmoji`).

### Actual

- Extension adapter drops `identity` entirely.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Failing before fix:

- `pnpm test extensions/slack/src/channel.test.ts`
- New tests failed because `identity` was missing in `sendSlack` call payload.

Passing after fix:

- `pnpm test extensions/slack/src/channel.test.ts`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: outbound text/media identity forwarding with expected Slack field mapping.
- Edge cases checked: emoji normalization (`zap` -> `:zap:`) and existing thread/reply behavior tests still pass.
- What you did **not** verify: live Slack send against a real workspace/token.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `729a097e7e`.
- Files/config to restore: `extensions/slack/src/channel.ts`, `extensions/slack/src/channel.test.ts`.
- Known bad symptoms reviewers should watch for: custom outbound Slack identity not applied.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: identity mapping divergence between extension and core adapter.
  - Mitigation: tests assert mapped payload shape for both `sendText` and `sendMedia`.
