### PR TITLE
fix: add EADDRINUSE retry and TIME_WAIT port-bind checks for gateway startup

### DIFF
--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -12,6 +12,7 @@ const forceFreePortAndWait = vi.fn(async (_port: number, _opts: unknown) => ({
   waitedMs: 0,
   escalatedToSigkill: false,
 }));
+const waitForPortBindable = vi.fn(async (_port: number, _opts?: unknown) => 0);
 const ensureDevGatewayConfig = vi.fn(async (_opts?: unknown) => {});
 const runGatewayLoop = vi.fn(async ({ start }: { start: () => Promise<unknown> }) => {
   await start();
@@ -80,6 +81,7 @@ vi.mock("../command-format.js", () => ({
 
 vi.mock("../ports.js", () => ({
   forceFreePortAndWait: (port: number, opts: unknown) => forceFreePortAndWait(port, opts),
+  waitForPortBindable: (port: number, opts?: unknown) => waitForPortBindable(port, opts),
 }));
 
 vi.mock("./dev.js", () => ({
@@ -108,6 +110,7 @@ describe("gateway run option collisions", () => {
     setGatewayWsLogStyle.mockClear();
     setVerbose.mockClear();
     forceFreePortAndWait.mockClear();
+    waitForPortBindable.mockClear();
     ensureDevGatewayConfig.mockClear();
     runGatewayLoop.mockClear();
   });
@@ -140,6 +143,7 @@ describe("gateway run option collisions", () => {
     ]);
 
     expect(forceFreePortAndWait).toHaveBeenCalledWith(18789, expect.anything());
+    expect(waitForPortBindable).toHaveBeenCalledWith(18789, expect.anything());
     expect(setGatewayWsLogStyle).toHaveBeenCalledWith("full");
     expect(startGatewayServer).toHaveBeenCalledWith(
       18789,

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -21,7 +21,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
 import { inheritOptionFromParent } from "../command-options.js";
-import { forceFreePortAndWait } from "../ports.js";
+import { forceFreePortAndWait, waitForPortBindable } from "../ports.js";
 import { ensureDevGatewayConfig } from "./dev.js";
 import { runGatewayLoop } from "./run-loop.js";
 import {
@@ -207,6 +207,14 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
         if (waitedMs > 0) {
           gatewayLog.info(`force: waited ${waitedMs}ms for port ${port} to free`);
         }
+      }
+      // After killing, verify the port is actually bindable (handles TIME_WAIT).
+      const bindWaitMs = await waitForPortBindable(port, {
+        timeoutMs: 3000,
+        intervalMs: 150,
+      });
+      if (bindWaitMs > 0) {
+        gatewayLog.info(`force: waited ${bindWaitMs}ms for port ${port} to become bindable`);
       }
     } catch (err) {
       defaultRuntime.error(`Force: ${String(err)}`);

--- a/src/cli/ports.test.ts
+++ b/src/cli/ports.test.ts
@@ -1,0 +1,97 @@
+import { EventEmitter } from "node:events";
+import net from "node:net";
+import { describe, expect, it, vi } from "vitest";
+
+// Hoist the factory so vi.mock can access it.
+const mockCreateServer = vi.hoisted(() => vi.fn());
+
+vi.mock("node:net", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:net")>();
+  return { ...actual, createServer: mockCreateServer };
+});
+
+import { probePortFree, waitForPortBindable } from "./ports.js";
+
+/** Build a minimal fake net.Server that emits a given error code on listen(). */
+function makeErrServer(code: string): net.Server {
+  const err = Object.assign(new Error(`bind error: ${code}`), {
+    code,
+  }) as NodeJS.ErrnoException;
+
+  const fake = new EventEmitter() as unknown as net.Server;
+  (fake as unknown as { close: (cb?: () => void) => net.Server }).close = (cb?: () => void) => {
+    cb?.();
+    return fake;
+  };
+  (fake as unknown as { unref: () => net.Server }).unref = () => fake;
+  (fake as unknown as { listen: (...args: unknown[]) => net.Server }).listen = (
+    ..._args: unknown[]
+  ) => {
+    setImmediate(() => fake.emit("error", err));
+    return fake;
+  };
+  return fake;
+}
+
+describe("probePortFree", () => {
+  it("resolves false (not rejects) when bind returns EADDRINUSE", async () => {
+    mockCreateServer.mockReturnValue(makeErrServer("EADDRINUSE"));
+    await expect(probePortFree(9999, "127.0.0.1")).resolves.toBe(false);
+  });
+
+  it("rejects immediately for EADDRNOTAVAIL (non-retryable: host address not on any interface)", async () => {
+    mockCreateServer.mockReturnValue(makeErrServer("EADDRNOTAVAIL"));
+    await expect(probePortFree(9999, "192.0.2.1")).rejects.toMatchObject({ code: "EADDRNOTAVAIL" });
+  });
+
+  it("rejects immediately for EACCES (non-retryable bind error)", async () => {
+    mockCreateServer.mockReturnValue(makeErrServer("EACCES"));
+    await expect(probePortFree(80, "0.0.0.0")).rejects.toMatchObject({ code: "EACCES" });
+  });
+
+  it("rejects immediately for other non-retryable errors", async () => {
+    mockCreateServer.mockReturnValue(makeErrServer("EINVAL"));
+    await expect(probePortFree(9999, "0.0.0.0")).rejects.toMatchObject({ code: "EINVAL" });
+  });
+
+  it("resolves true when the port is free", async () => {
+    // Mock a successful bind: the "listening" event fires immediately without
+    // acquiring a real socket, making this deterministic and avoiding TOCTOU races.
+    // (A real-socket approach would bind to :0, release, then reprobe — the OS can
+    // reassign the ephemeral port in between, causing a flaky EADDRINUSE failure.)
+    const fakeServer = new EventEmitter() as unknown as net.Server;
+    (fakeServer as unknown as { close: (cb?: () => void) => net.Server }).close = (
+      cb?: () => void,
+    ) => {
+      cb?.();
+      return fakeServer;
+    };
+    (fakeServer as unknown as { unref: () => net.Server }).unref = () => fakeServer;
+    (fakeServer as unknown as { listen: (...args: unknown[]) => net.Server }).listen = (
+      ..._args: unknown[]
+    ) => {
+      // Simulate a successful bind by firing the "listening" callback.
+      const callback = _args.find((a) => typeof a === "function") as (() => void) | undefined;
+      setImmediate(() => callback?.());
+      return fakeServer;
+    };
+    mockCreateServer.mockReturnValue(fakeServer);
+
+    const result = await probePortFree(9999, "127.0.0.1");
+    expect(result).toBe(true);
+  });
+});
+
+describe("waitForPortBindable", () => {
+  it("propagates EACCES rejection immediately without retrying", async () => {
+    // Every call to createServer will emit EACCES — so if waitForPortBindable retried,
+    // mockCreateServer would be called many times. We assert it's called exactly once.
+    mockCreateServer.mockClear();
+    mockCreateServer.mockReturnValue(makeErrServer("EACCES"));
+    await expect(
+      waitForPortBindable(80, { timeoutMs: 5000, intervalMs: 50 }),
+    ).rejects.toMatchObject({ code: "EACCES" });
+    // Only one probe should have been attempted — no spinning through the retry loop.
+    expect(mockCreateServer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -329,13 +329,30 @@ export async function forceFreePortAndWait(
 /**
  * Attempt a real TCP bind to verify the port is available at the OS level.
  * Catches TIME_WAIT / kernel-level holds that lsof won't show.
+ *
+ * Resolves false only for EADDRINUSE — a genuinely transient condition
+ * (port still in TIME_WAIT after a --force kill) that the caller should retry.
+ *
+ * All other errors are non-retryable and are rejected immediately:
+ * - EADDRNOTAVAIL: the host address doesn't exist on any local interface
+ *   (hard misconfiguration, not a transient kernel hold).
+ * - EACCES: bind to a privileged port as non-root.
+ * - EINVAL, etc.: other unrecoverable OS errors.
  */
 export function probePortFree(port: number, host = "0.0.0.0"): Promise<boolean> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const srv = createServer();
     srv.unref();
-    srv.once("error", () => {
-      resolve(false);
+    srv.once("error", (err: NodeJS.ErrnoException) => {
+      srv.close();
+      if (err.code === "EADDRINUSE") {
+        // Genuinely transient — port still in use or TIME_WAIT after a --force kill.
+        resolve(false);
+      } else {
+        // Non-retryable: EADDRNOTAVAIL (bad host address), EACCES (privileged port),
+        // EINVAL, and any other OS errors. Surface immediately; no retry loop.
+        reject(err);
+      }
     });
     srv.listen(port, host, () => {
       srv.close(() => resolve(true));

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createServer } from "node:net";
 import { resolveLsofCommandSync } from "../infra/ports-lsof.js";
 import { tryListenOnPort } from "../infra/ports-probe.js";
 import { sleep } from "../utils.js";
@@ -323,4 +324,46 @@ export async function forceFreePortAndWait(
   throw new Error(
     `port ${port} still has listeners after --force: ${still.map((p) => p.pid).join(", ")}`,
   );
+}
+
+/**
+ * Attempt a real TCP bind to verify the port is available at the OS level.
+ * Catches TIME_WAIT / kernel-level holds that lsof won't show.
+ */
+export function probePortFree(port: number, host = "0.0.0.0"): Promise<boolean> {
+  return new Promise((resolve) => {
+    const srv = createServer();
+    srv.unref();
+    srv.once("error", () => {
+      resolve(false);
+    });
+    srv.listen(port, host, () => {
+      srv.close(() => resolve(true));
+    });
+  });
+}
+
+/**
+ * Poll until a real test-bind succeeds, up to `timeoutMs`.
+ * Returns the number of ms waited, or throws if the port never freed.
+ */
+export async function waitForPortBindable(
+  port: number,
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<number> {
+  const timeoutMs = Math.max(opts.timeoutMs ?? 3000, 0);
+  const intervalMs = Math.max(opts.intervalMs ?? 150, 1);
+  let waited = 0;
+  while (waited < timeoutMs) {
+    if (await probePortFree(port)) {
+      return waited;
+    }
+    await sleep(intervalMs);
+    waited += intervalMs;
+  }
+  // Final attempt
+  if (await probePortFree(port)) {
+    return waited;
+  }
+  throw new Error(`port ${port} still not bindable after ${waited}ms (TIME_WAIT or kernel hold)`);
 }

--- a/src/gateway/server/http-listen.ts
+++ b/src/gateway/server/http-listen.ts
@@ -1,5 +1,9 @@
 import type { Server as HttpServer } from "node:http";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
+import { sleep } from "../../utils.js";
+
+const EADDRINUSE_MAX_RETRIES = 4;
+const EADDRINUSE_RETRY_INTERVAL_MS = 500;
 
 export async function listenGatewayHttpServer(params: {
   httpServer: HttpServer;
@@ -7,31 +11,40 @@ export async function listenGatewayHttpServer(params: {
   port: number;
 }) {
   const { httpServer, bindHost, port } = params;
-  try {
-    await new Promise<void>((resolve, reject) => {
-      const onError = (err: NodeJS.ErrnoException) => {
-        httpServer.off("listening", onListening);
-        reject(err);
-      };
-      const onListening = () => {
-        httpServer.off("error", onError);
-        resolve();
-      };
-      httpServer.once("error", onError);
-      httpServer.once("listening", onListening);
-      httpServer.listen(port, bindHost);
-    });
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "EADDRINUSE") {
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (err: NodeJS.ErrnoException) => {
+          httpServer.off("listening", onListening);
+          reject(err);
+        };
+        const onListening = () => {
+          httpServer.off("error", onError);
+          resolve();
+        };
+        httpServer.once("error", onError);
+        httpServer.once("listening", onListening);
+        httpServer.listen(port, bindHost);
+      });
+      return; // bound successfully
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EADDRINUSE" && attempt < EADDRINUSE_MAX_RETRIES) {
+        // Port may still be in TIME_WAIT after a recent process exit; retry.
+        await sleep(EADDRINUSE_RETRY_INTERVAL_MS);
+        continue;
+      }
+      if (code === "EADDRINUSE") {
+        throw new GatewayLockError(
+          `another gateway instance is already listening on ws://${bindHost}:${port}`,
+          err,
+        );
+      }
       throw new GatewayLockError(
-        `another gateway instance is already listening on ws://${bindHost}:${port}`,
+        `failed to bind gateway socket on ws://${bindHost}:${port}: ${String(err)}`,
         err,
       );
     }
-    throw new GatewayLockError(
-      `failed to bind gateway socket on ws://${bindHost}:${port}: ${String(err)}`,
-      err,
-    );
   }
 }


### PR DESCRIPTION
## Problem

When a gateway process is killed and immediately restarted, the TCP port can be in `TIME_WAIT` state: the kernel holds the socket in a 2-minute cleanup window even though the listening process is gone. `lsof` (and `fuser`) only report actively-listening sockets; they cannot see `TIME_WAIT` entries, so `--force` would succeed and report "no listeners" yet the subsequent `httpServer.listen()` would still fail with `EADDRINUSE`.

This caused intermittent gateway startup failures on restart in CI and on developer machines running hot-reload cycles.

## Two-layer fix

### Layer 1 — retry loop in `src/gateway/server/http-listen.ts`

`listenGatewayHttpServer` now retries up to `EADDRINUSE_MAX_RETRIES` (4) times at `EADDRINUSE_RETRY_INTERVAL_MS` (500 ms) intervals before throwing `GatewayLockError`. This handles the general case where any gateway restart hits a transiently-occupied port. Total retry budget: 2 seconds.

### Layer 2 — TCP bind probe in `src/cli/ports.ts` (only with `--force`)

Two new exports:

- `probePortFree(port, host)` — creates a `net.Server`, binds it, closes it, and resolves `true` if that succeeded. Unlike `lsof`, a real bind attempt is rejected by the kernel if the port has a `TIME_WAIT` entry.
- `waitForPortBindable(port, opts)` — polls `probePortFree` up to `timeoutMs` (default 3 s) with `intervalMs` (default 150 ms) between probes.

`runGatewayCommand` now calls `waitForPortBindable` after `forceFreePortAndWait` when `--force` is used.

## Test plan

- [x] `pnpm build` — clean build
- [x] `pnpm check` — lint/format pass
- [x] `pnpm test` — full test suite passes
- [x] `run.option-collisions.test.ts` updated to mock `waitForPortBindable`
- Manual: stop gateway, kill process, run `openclaw gateway run --force` immediately — gateway starts without EADDRINUSE error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
