### PR TITLE
fix(discord extension): honor threadId in outbound send paths

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -36,9 +36,11 @@ describe("discordPlugin outbound", () => {
 
   it("routes sendText to thread target when threadId is provided", async () => {
     const sendMessageDiscord = vi.fn(async () => ({ messageId: "m-thread-text" }));
+    const fetchChannel = vi.fn(async () => ({ parent_id: "parent-1" }));
     setDiscordRuntime({
       channel: {
         discord: {
+          fetchChannel,
           sendMessageDiscord,
         },
       },
@@ -62,9 +64,11 @@ describe("discordPlugin outbound", () => {
 
   it("routes sendMedia to thread target when threadId is provided", async () => {
     const sendMessageDiscord = vi.fn(async () => ({ messageId: "m-thread-media" }));
+    const fetchChannel = vi.fn(async () => ({ parent_id: "parent-2" }));
     setDiscordRuntime({
       channel: {
         discord: {
+          fetchChannel,
           sendMessageDiscord,
         },
       },
@@ -92,9 +96,11 @@ describe("discordPlugin outbound", () => {
 
   it("routes sendPoll to thread target when threadId is provided", async () => {
     const sendPollDiscord = vi.fn(async () => ({ messageId: "m-thread-poll" }));
+    const fetchChannel = vi.fn(async () => ({ parent_id: "parent-3" }));
     setDiscordRuntime({
       channel: {
         discord: {
+          fetchChannel,
           sendPollDiscord,
         },
       },
@@ -119,5 +125,29 @@ describe("discordPlugin outbound", () => {
       expect.objectContaining({ accountId: "work" }),
     );
     expect(result).toMatchObject({ messageId: "m-thread-poll" });
+  });
+
+  it("rejects thread targets that do not belong to the provided parent channel", async () => {
+    const sendMessageDiscord = vi.fn(async () => ({ messageId: "m-thread-text" }));
+    const fetchChannel = vi.fn(async () => ({ parent_id: "other-parent" }));
+    setDiscordRuntime({
+      channel: {
+        discord: {
+          fetchChannel,
+          sendMessageDiscord,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    await expect(
+      discordPlugin.outbound!.sendText!({
+        cfg: {} as OpenClawConfig,
+        to: "channel:parent-1",
+        text: "hello thread",
+        threadId: "thread-1",
+        accountId: "work",
+      }),
+    ).rejects.toThrow(/threadId must belong/i);
+    expect(sendMessageDiscord).not.toHaveBeenCalled();
   });
 });

--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -33,4 +33,91 @@ describe("discordPlugin outbound", () => {
     );
     expect(result).toMatchObject({ channel: "discord", messageId: "m1" });
   });
+
+  it("routes sendText to thread target when threadId is provided", async () => {
+    const sendMessageDiscord = vi.fn(async () => ({ messageId: "m-thread-text" }));
+    setDiscordRuntime({
+      channel: {
+        discord: {
+          sendMessageDiscord,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    const result = await discordPlugin.outbound!.sendText!({
+      cfg: {} as OpenClawConfig,
+      to: "channel:parent-1",
+      text: "hello thread",
+      threadId: "thread-1",
+      accountId: "work",
+    });
+
+    expect(sendMessageDiscord).toHaveBeenCalledWith(
+      "channel:thread-1",
+      "hello thread",
+      expect.objectContaining({ accountId: "work" }),
+    );
+    expect(result).toMatchObject({ channel: "discord", messageId: "m-thread-text" });
+  });
+
+  it("routes sendMedia to thread target when threadId is provided", async () => {
+    const sendMessageDiscord = vi.fn(async () => ({ messageId: "m-thread-media" }));
+    setDiscordRuntime({
+      channel: {
+        discord: {
+          sendMessageDiscord,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    const result = await discordPlugin.outbound!.sendMedia!({
+      cfg: {} as OpenClawConfig,
+      to: "channel:parent-2",
+      text: "media thread",
+      mediaUrl: "https://example.com/image.png",
+      threadId: "thread-2",
+      accountId: "work",
+    });
+
+    expect(sendMessageDiscord).toHaveBeenCalledWith(
+      "channel:thread-2",
+      "media thread",
+      expect.objectContaining({
+        mediaUrl: "https://example.com/image.png",
+        accountId: "work",
+      }),
+    );
+    expect(result).toMatchObject({ channel: "discord", messageId: "m-thread-media" });
+  });
+
+  it("routes sendPoll to thread target when threadId is provided", async () => {
+    const sendPollDiscord = vi.fn(async () => ({ messageId: "m-thread-poll" }));
+    setDiscordRuntime({
+      channel: {
+        discord: {
+          sendPollDiscord,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    const result = await discordPlugin.outbound!.sendPoll!({
+      cfg: {} as OpenClawConfig,
+      to: "channel:parent-3",
+      poll: {
+        question: "Deploy?",
+        options: ["yes", "no"],
+      },
+      threadId: "thread-3",
+      accountId: "work",
+    });
+
+    expect(sendPollDiscord).toHaveBeenCalledWith(
+      "channel:thread-3",
+      expect.objectContaining({
+        question: "Deploy?",
+      }),
+      expect.objectContaining({ accountId: "work" }),
+    );
+    expect(result).toMatchObject({ messageId: "m-thread-poll" });
+  });
 });

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -34,10 +34,12 @@ import { getDiscordRuntime } from "./runtime.js";
 
 const meta = getChatChannelMeta("discord");
 
-function resolveDiscordOutboundTarget(params: {
+async function resolveDiscordOutboundTarget(params: {
   to: string;
   threadId?: string | number | null;
-}): string {
+  cfg: Parameters<NonNullable<typeof discordPlugin.outbound>["sendText"]>[0]["cfg"];
+  accountId?: string | null;
+}): Promise<string> {
   if (params.threadId == null) {
     return params.to;
   }
@@ -45,7 +47,38 @@ function resolveDiscordOutboundTarget(params: {
   if (!threadId) {
     return params.to;
   }
+  const parentChannelId = resolveDiscordParentChannelId(params.to);
+  const fetchChannel = getDiscordRuntime().channel.discord.fetchChannel;
+  if (!fetchChannel) {
+    throw new Error("Discord thread routing requires fetchChannel support");
+  }
+  const thread = await fetchChannel(threadId, {
+    cfg: params.cfg,
+    accountId: params.accountId ?? undefined,
+  });
+  const parentId = typeof thread?.parent_id === "string" ? thread.parent_id.trim() : "";
+  if (!parentId || parentId !== parentChannelId) {
+    throw new Error("Discord threadId must belong to the provided parent channel");
+  }
   return `channel:${threadId}`;
+}
+
+function resolveDiscordParentChannelId(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error("Discord channel id is required");
+  }
+  if (trimmed.startsWith("channel:")) {
+    const channelId = trimmed.slice("channel:".length).trim();
+    if (!channelId) {
+      throw new Error("Discord channel id is required");
+    }
+    return channelId;
+  }
+  if (trimmed.startsWith("user:")) {
+    throw new Error("Discord threadId requires a channel target");
+  }
+  return trimmed;
 }
 
 const discordMessageActions: ChannelMessageActionAdapter = {
@@ -318,13 +351,17 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
     resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
     sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, silent }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(resolveDiscordOutboundTarget({ to, threadId }), text, {
-        verbose: false,
-        cfg,
-        replyTo: replyToId ?? undefined,
-        accountId: accountId ?? undefined,
-        silent: silent ?? undefined,
-      });
+      const result = await send(
+        await resolveDiscordOutboundTarget({ to, threadId, cfg, accountId }),
+        text,
+        {
+          verbose: false,
+          cfg,
+          replyTo: replyToId ?? undefined,
+          accountId: accountId ?? undefined,
+          silent: silent ?? undefined,
+        },
+      );
       return { channel: "discord", ...result };
     },
     sendMedia: async ({
@@ -340,20 +377,24 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       silent,
     }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(resolveDiscordOutboundTarget({ to, threadId }), text, {
-        verbose: false,
-        cfg,
-        mediaUrl,
-        mediaLocalRoots,
-        replyTo: replyToId ?? undefined,
-        accountId: accountId ?? undefined,
-        silent: silent ?? undefined,
-      });
+      const result = await send(
+        await resolveDiscordOutboundTarget({ to, threadId, cfg, accountId }),
+        text,
+        {
+          verbose: false,
+          cfg,
+          mediaUrl,
+          mediaLocalRoots,
+          replyTo: replyToId ?? undefined,
+          accountId: accountId ?? undefined,
+          silent: silent ?? undefined,
+        },
+      );
       return { channel: "discord", ...result };
     },
     sendPoll: async ({ cfg, to, poll, accountId, threadId, silent }) =>
       await getDiscordRuntime().channel.discord.sendPollDiscord(
-        resolveDiscordOutboundTarget({ to, threadId }),
+        await resolveDiscordOutboundTarget({ to, threadId, cfg, accountId }),
         poll,
         {
           cfg,

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -34,6 +34,20 @@ import { getDiscordRuntime } from "./runtime.js";
 
 const meta = getChatChannelMeta("discord");
 
+function resolveDiscordOutboundTarget(params: {
+  to: string;
+  threadId?: string | number | null;
+}): string {
+  if (params.threadId == null) {
+    return params.to;
+  }
+  const threadId = String(params.threadId).trim();
+  if (!threadId) {
+    return params.to;
+  }
+  return `channel:${threadId}`;
+}
+
 const discordMessageActions: ChannelMessageActionAdapter = {
   listActions: (ctx) =>
     getDiscordRuntime().channel.discord.messageActions?.listActions?.(ctx) ?? [],
@@ -302,9 +316,9 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
     textChunkLimit: 2000,
     pollMaxOptions: 10,
     resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
-    sendText: async ({ cfg, to, text, accountId, deps, replyToId, silent }) => {
+    sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, silent }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(to, text, {
+      const result = await send(resolveDiscordOutboundTarget({ to, threadId }), text, {
         verbose: false,
         cfg,
         replyTo: replyToId ?? undefined,
@@ -322,10 +336,11 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       accountId,
       deps,
       replyToId,
+      threadId,
       silent,
     }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(to, text, {
+      const result = await send(resolveDiscordOutboundTarget({ to, threadId }), text, {
         verbose: false,
         cfg,
         mediaUrl,
@@ -336,12 +351,16 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       });
       return { channel: "discord", ...result };
     },
-    sendPoll: async ({ cfg, to, poll, accountId, silent }) =>
-      await getDiscordRuntime().channel.discord.sendPollDiscord(to, poll, {
-        cfg,
-        accountId: accountId ?? undefined,
-        silent: silent ?? undefined,
-      }),
+    sendPoll: async ({ cfg, to, poll, accountId, threadId, silent }) =>
+      await getDiscordRuntime().channel.discord.sendPollDiscord(
+        resolveDiscordOutboundTarget({ to, threadId }),
+        poll,
+        {
+          cfg,
+          accountId: accountId ?? undefined,
+          silent: silent ?? undefined,
+        },
+      ),
   },
   status: {
     defaultRuntime: {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `extensions/discord` outbound adapter ignored `threadId` on `sendText`, `sendMedia`, and `sendPoll`.
- Why it matters: thread-targeted outbound sends were routed to parent targets instead of the intended Discord thread.
- What changed: added thread-aware target resolution (`channel:<threadId>`) and applied it across all three Discord extension outbound send paths.
- What did NOT change (scope boundary): no Discord monitor/thread binding logic changes, no webhook identity logic changes, no dependency/config changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33554
- Related #

## User-visible / Behavior Changes

Discord extension outbound sends now honor `threadId` by routing `sendText`, `sendMedia`, and `sendPoll` to `channel:<threadId>` when provided.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Discord extension (`extensions/discord`)
- Relevant config (redacted): N/A (unit-level adapter repro)

### Steps

1. Call Discord extension outbound `sendText`/`sendMedia`/`sendPoll` with `to=channel:<parent>` and `threadId=<thread>`.
2. Inspect the target passed to `sendMessageDiscord` / `sendPollDiscord`.
3. In pre-fix code, target remains the parent `to` value.

### Expected

- Target is resolved to `channel:<threadId>` when `threadId` is provided.

### Actual

- `threadId` is ignored; sends use parent target.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Failing before fix:

- `pnpm test extensions/discord/src/channel.test.ts`
- New tests failed because calls used parent targets instead of `channel:<threadId>`.

Passing after fix:

- `pnpm test extensions/discord/src/channel.test.ts`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: thread routing for text/media/poll outbound adapter paths.
- Edge cases checked: existing mediaLocalRoots forwarding test remains passing.
- What you did **not** verify: live Discord sends against a real bot/token/workspace.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `682cf34e93`.
- Files/config to restore: `extensions/discord/src/channel.ts`, `extensions/discord/src/channel.test.ts`.
- Known bad symptoms reviewers should watch for: outbound thread messages/polls posted to parent channel instead of thread.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: low risk of target normalization drift between extension and core adapters.
  - Mitigation: regression tests cover all outbound methods with thread routing expectations.
