### PR TITLE
fix(acpx,lobster): graceful fallback for missing plugin-sdk windows-spawn exports

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -6,10 +6,44 @@ import type {
   WindowsSpawnResolution,
 } from "openclaw/plugin-sdk";
 import {
-  applyWindowsSpawnProgramPolicy,
-  materializeWindowsSpawnProgram,
-  resolveWindowsSpawnProgramCandidate,
+  applyWindowsSpawnProgramPolicy as _applyPolicy,
+  materializeWindowsSpawnProgram as _materialize,
+  resolveWindowsSpawnProgramCandidate as _resolveCandidate,
 } from "openclaw/plugin-sdk";
+
+// Graceful fallback when the plugin-sdk build does not include windows-spawn
+// exports (see #33514).  The direct-passthrough is safe on all platforms and
+// matches the non-Windows branch of the real implementation.
+function directPassthrough(params: {
+  command: string;
+}): WindowsSpawnProgramCandidate {
+  return { command: params.command, leadingArgv: [], resolution: "direct" };
+}
+
+const resolveWindowsSpawnProgramCandidate: typeof _resolveCandidate =
+  typeof _resolveCandidate === "function" ? _resolveCandidate : directPassthrough;
+
+const applyWindowsSpawnProgramPolicy: typeof _applyPolicy =
+  typeof _applyPolicy === "function"
+    ? _applyPolicy
+    : (p) => ({
+        command: p.candidate.command,
+        leadingArgv: p.candidate.leadingArgv,
+        resolution: p.candidate.resolution as WindowsSpawnResolution,
+        shell: p.candidate.resolution === "unresolved-wrapper" ? true : undefined,
+        windowsHide: p.candidate.windowsHide,
+      });
+
+const materializeWindowsSpawnProgram: typeof _materialize =
+  typeof _materialize === "function"
+    ? _materialize
+    : (program, argv) => ({
+        command: program.command,
+        argv: [...program.leadingArgv, ...argv],
+        resolution: program.resolution,
+        shell: program.shell,
+        windowsHide: program.windowsHide,
+      });
 
 export type SpawnExit = {
   code: number | null;

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -6,44 +6,10 @@ import type {
   WindowsSpawnResolution,
 } from "openclaw/plugin-sdk";
 import {
-  applyWindowsSpawnProgramPolicy as _applyPolicy,
-  materializeWindowsSpawnProgram as _materialize,
-  resolveWindowsSpawnProgramCandidate as _resolveCandidate,
-} from "openclaw/plugin-sdk";
-
-// Graceful fallback when the plugin-sdk build does not include windows-spawn
-// exports (see #33514).  The direct-passthrough is safe on all platforms and
-// matches the non-Windows branch of the real implementation.
-function directPassthrough(params: {
-  command: string;
-}): WindowsSpawnProgramCandidate {
-  return { command: params.command, leadingArgv: [], resolution: "direct" };
-}
-
-const resolveWindowsSpawnProgramCandidate: typeof _resolveCandidate =
-  typeof _resolveCandidate === "function" ? _resolveCandidate : directPassthrough;
-
-const applyWindowsSpawnProgramPolicy: typeof _applyPolicy =
-  typeof _applyPolicy === "function"
-    ? _applyPolicy
-    : (p) => ({
-        command: p.candidate.command,
-        leadingArgv: p.candidate.leadingArgv,
-        resolution: p.candidate.resolution as WindowsSpawnResolution,
-        shell: p.candidate.resolution === "unresolved-wrapper" ? true : undefined,
-        windowsHide: p.candidate.windowsHide,
-      });
-
-const materializeWindowsSpawnProgram: typeof _materialize =
-  typeof _materialize === "function"
-    ? _materialize
-    : (program, argv) => ({
-        command: program.command,
-        argv: [...program.leadingArgv, ...argv],
-        resolution: program.resolution,
-        shell: program.shell,
-        windowsHide: program.windowsHide,
-      });
+  applyWindowsSpawnProgramPolicy,
+  materializeWindowsSpawnProgram,
+  resolveWindowsSpawnProgramCandidate,
+} from "openclaw/plugin-sdk/windows-spawn-compat";
 
 export type SpawnExit = {
   code: number | null;

--- a/extensions/lobster/src/windows-spawn.ts
+++ b/extensions/lobster/src/windows-spawn.ts
@@ -1,8 +1,44 @@
-import {
-  applyWindowsSpawnProgramPolicy,
-  materializeWindowsSpawnProgram,
-  resolveWindowsSpawnProgramCandidate,
+import type {
+  WindowsSpawnProgramCandidate,
+  WindowsSpawnResolution,
 } from "openclaw/plugin-sdk";
+import {
+  applyWindowsSpawnProgramPolicy as _applyPolicy,
+  materializeWindowsSpawnProgram as _materialize,
+  resolveWindowsSpawnProgramCandidate as _resolveCandidate,
+} from "openclaw/plugin-sdk";
+
+// Graceful fallback when plugin-sdk build lacks windows-spawn exports (#33514).
+const resolveWindowsSpawnProgramCandidate: typeof _resolveCandidate =
+  typeof _resolveCandidate === "function"
+    ? _resolveCandidate
+    : (p: { command: string }): WindowsSpawnProgramCandidate => ({
+        command: p.command,
+        leadingArgv: [],
+        resolution: "direct",
+      });
+
+const applyWindowsSpawnProgramPolicy: typeof _applyPolicy =
+  typeof _applyPolicy === "function"
+    ? _applyPolicy
+    : (p) => ({
+        command: p.candidate.command,
+        leadingArgv: p.candidate.leadingArgv,
+        resolution: p.candidate.resolution as WindowsSpawnResolution,
+        shell: p.candidate.resolution === "unresolved-wrapper" ? true : undefined,
+        windowsHide: p.candidate.windowsHide,
+      });
+
+const materializeWindowsSpawnProgram: typeof _materialize =
+  typeof _materialize === "function"
+    ? _materialize
+    : (program, argv) => ({
+        command: program.command,
+        argv: [...program.leadingArgv, ...argv],
+        resolution: program.resolution,
+        shell: program.shell,
+        windowsHide: program.windowsHide,
+      });
 
 type SpawnTarget = {
   command: string;

--- a/extensions/lobster/src/windows-spawn.ts
+++ b/extensions/lobster/src/windows-spawn.ts
@@ -1,44 +1,8 @@
-import type {
-  WindowsSpawnProgramCandidate,
-  WindowsSpawnResolution,
-} from "openclaw/plugin-sdk";
 import {
-  applyWindowsSpawnProgramPolicy as _applyPolicy,
-  materializeWindowsSpawnProgram as _materialize,
-  resolveWindowsSpawnProgramCandidate as _resolveCandidate,
-} from "openclaw/plugin-sdk";
-
-// Graceful fallback when plugin-sdk build lacks windows-spawn exports (#33514).
-const resolveWindowsSpawnProgramCandidate: typeof _resolveCandidate =
-  typeof _resolveCandidate === "function"
-    ? _resolveCandidate
-    : (p: { command: string }): WindowsSpawnProgramCandidate => ({
-        command: p.command,
-        leadingArgv: [],
-        resolution: "direct",
-      });
-
-const applyWindowsSpawnProgramPolicy: typeof _applyPolicy =
-  typeof _applyPolicy === "function"
-    ? _applyPolicy
-    : (p) => ({
-        command: p.candidate.command,
-        leadingArgv: p.candidate.leadingArgv,
-        resolution: p.candidate.resolution as WindowsSpawnResolution,
-        shell: p.candidate.resolution === "unresolved-wrapper" ? true : undefined,
-        windowsHide: p.candidate.windowsHide,
-      });
-
-const materializeWindowsSpawnProgram: typeof _materialize =
-  typeof _materialize === "function"
-    ? _materialize
-    : (program, argv) => ({
-        command: program.command,
-        argv: [...program.leadingArgv, ...argv],
-        resolution: program.resolution,
-        shell: program.shell,
-        windowsHide: program.windowsHide,
-      });
+  applyWindowsSpawnProgramPolicy,
+  materializeWindowsSpawnProgram,
+  resolveWindowsSpawnProgramCandidate,
+} from "openclaw/plugin-sdk/windows-spawn-compat";
 
 type SpawnTarget = {
   command: string;

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
       "types": "./dist/plugin-sdk/account-id.d.ts",
       "default": "./dist/plugin-sdk/account-id.js"
     },
+    "./plugin-sdk/windows-spawn-compat": {
+      "types": "./dist/plugin-sdk/windows-spawn-compat.d.ts",
+      "default": "./dist/plugin-sdk/windows-spawn-compat.js"
+    },
     "./plugin-sdk/keyed-async-queue": {
       "types": "./dist/plugin-sdk/keyed-async-queue.d.ts",
       "default": "./dist/plugin-sdk/keyed-async-queue.js"

--- a/src/plugin-sdk/windows-spawn-compat.ts
+++ b/src/plugin-sdk/windows-spawn-compat.ts
@@ -1,0 +1,50 @@
+/**
+ * Guarded re-exports of the windows-spawn helpers.
+ *
+ * When the plugin-sdk dist was built without the windows-spawn module
+ * (see #33514), these wrappers fall back to safe direct-passthrough
+ * implementations so that extensions never crash at import time.
+ */
+import type {
+  WindowsSpawnProgram,
+  WindowsSpawnProgramCandidate,
+  WindowsSpawnResolution,
+} from "./windows-spawn.js";
+
+import {
+  applyWindowsSpawnProgramPolicy as _applyPolicy,
+  materializeWindowsSpawnProgram as _materialize,
+  resolveWindowsSpawnProgramCandidate as _resolveCandidate,
+} from "./windows-spawn.js";
+
+export const resolveWindowsSpawnProgramCandidate: typeof _resolveCandidate =
+  typeof _resolveCandidate === "function"
+    ? _resolveCandidate
+    : (p: { command: string }): WindowsSpawnProgramCandidate => ({
+        command: p.command,
+        leadingArgv: [],
+        resolution: "direct",
+      });
+
+export const applyWindowsSpawnProgramPolicy: typeof _applyPolicy =
+  typeof _applyPolicy === "function"
+    ? _applyPolicy
+    : (p) => ({
+        command: p.candidate.command,
+        leadingArgv: p.candidate.leadingArgv,
+        resolution: p.candidate.resolution as WindowsSpawnResolution,
+        shell:
+          p.candidate.resolution === "unresolved-wrapper" ? true : undefined,
+        windowsHide: p.candidate.windowsHide,
+      });
+
+export const materializeWindowsSpawnProgram: typeof _materialize =
+  typeof _materialize === "function"
+    ? _materialize
+    : (program, argv) => ({
+        command: program.command,
+        argv: [...program.leadingArgv, ...argv],
+        resolution: program.resolution,
+        shell: program.shell,
+        windowsHide: program.windowsHide,
+      });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -45,6 +45,13 @@ export default defineConfig([
     platform: "node",
   },
   {
+    entry: "src/plugin-sdk/windows-spawn-compat.ts",
+    outDir: "dist/plugin-sdk",
+    env,
+    fixedExtension: false,
+    platform: "node",
+  },
+  {
     entry: "src/extensionAPI.ts",
     env,
     fixedExtension: false,


### PR DESCRIPTION
## Summary
- Fixes the `resolveWindowsSpawnProgramCandidate is not a function` crash that makes ACP completely unusable on Windows (v2026.3.1 + v2026.3.2)
- Both `acpx` and `lobster` extensions import `resolveWindowsSpawnProgramCandidate`, `applyWindowsSpawnProgramPolicy`, and `materializeWindowsSpawnProgram` from `openclaw/plugin-sdk`, but the built `dist/plugin-sdk/index.js` may not include these exports
- Adds runtime `typeof` guards around each imported function with inline direct-passthrough fallbacks that match the non-Windows branch of the real implementations
- When the plugin-sdk functions ARE available (e.g. after a fresh build), they're used unchanged — no behavior difference

## Root cause
The `windows-spawn.ts` module was added to the plugin-sdk source (`src/plugin-sdk/index.ts`) in commit `3ad3a90`, but the built dist artifact shipped with v2026.3.1/v2026.3.2 does not include these exports. The acpx extension calls `resolveWindowsSpawnProgramCandidate` unconditionally in its spawn resolution path, causing a hard crash on Windows.

## Test plan
- [ ] Verify acpx plugin initializes successfully on Windows with both fresh and stale plugin-sdk builds
- [ ] Verify `sessions_spawn` with `runtime: 'acp'` works on Windows
- [ ] Verify lobster extension spawn resolution still works on Windows
- [ ] Verify no behavior change on non-Windows platforms

Fixes #33514