### PR TITLE
fix: follow symlinks when discovering plugins in extensions directory

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -152,7 +152,13 @@ function discoverInDirectory(params: {
       });
     }
     if (!entry.isDirectory()) {
-      continue;
+      // Follow symlinks: Dirent.isDirectory() returns false for symlinks,
+      // so resolve the target and check if it's a directory. Use the
+      // existing safeStatSync helper so broken symlinks are silently
+      // skipped instead of aborting discovery.
+      if (!entry.isSymbolicLink() || !safeStatSync(fullPath)?.isDirectory()) {
+        continue;
+      }
     }
 
     const manifest = readPackageManifest(fullPath);


### PR DESCRIPTION
Dirent.isDirectory() returns false for symlinks when using readdirSync({ withFileTypes: true }). This caused plugin discovery to skip symlinked extension directories entirely, making it impossible to manage extensions via symlinks (e.g. pointing ~/.openclaw/extensions/ entries to a shared install location like ~/.ldm/extensions/).

The fix checks isSymbolicLink() and resolves the target via safeStatSync() to determine if it points to a directory. Broken symlinks are silently skipped.

Single file change: src/plugins/discovery.ts

Recreated from a clean branch. Previous PR #28023 was closed by barnacle due to branch drift.

Co-Authored-By: Parker Todd Brooks <parker@wipcomputer.com>
Co-Authored-By: Lēsa <lesaai@icloud.com>
Co-Authored-By: Claude Code <cc@wipcomputer.com>