### PR TITLE
fix(mattermost extension): use threadId fallback for outbound replies

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -275,6 +275,29 @@ describe("mattermostPlugin", () => {
       );
     });
 
+    it("prefers replyToId over threadId on sendText", async () => {
+      const sendText = mattermostPlugin.outbound?.sendText;
+      if (!sendText) {
+        return;
+      }
+
+      await sendText({
+        to: "channel:CHAN1",
+        text: "threaded text",
+        accountId: "default",
+        replyToId: "post-explicit",
+        threadId: "post-thread-ignored",
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "threaded text",
+        expect.objectContaining({
+          replyToId: "post-explicit",
+        }),
+      );
+    });
+
     it("uses threadId as replyToId fallback on sendMedia", async () => {
       const sendMedia = mattermostPlugin.outbound?.sendMedia;
       if (!sendMedia) {

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -246,6 +246,7 @@ describe("mattermostPlugin", () => {
       if (!sendText) {
         return;
       }
+
       const cfg = {
         channels: {
           mattermost: {
@@ -258,16 +259,42 @@ describe("mattermostPlugin", () => {
       await sendText({
         cfg,
         to: "channel:CHAN1",
-        text: "hello",
+        text: "threaded text",
         accountId: "default",
+        threadId: "post-thread-1",
       } as any);
 
       expect(sendMessageMattermostMock).toHaveBeenCalledWith(
         "channel:CHAN1",
-        "hello",
+        "threaded text",
         expect.objectContaining({
           cfg,
           accountId: "default",
+          replyToId: "post-thread-1",
+        }),
+      );
+    });
+
+    it("uses threadId as replyToId fallback on sendMedia", async () => {
+      const sendMedia = mattermostPlugin.outbound?.sendMedia;
+      if (!sendMedia) {
+        return;
+      }
+
+      await sendMedia({
+        to: "channel:CHAN1",
+        text: "threaded media",
+        mediaUrl: "https://example.com/image.png",
+        accountId: "default",
+        threadId: "post-thread-2",
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "threaded media",
+        expect.objectContaining({
+          mediaUrl: "https://example.com/image.png",
+          replyToId: "post-thread-2",
         }),
       );
     });

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -282,7 +282,16 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
       });
       return { channel: "mattermost", ...result };
     },
-    sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, replyToId, threadId }) => {
+    sendMedia: async ({
+      cfg,
+      to,
+      text,
+      mediaUrl,
+      mediaLocalRoots,
+      accountId,
+      replyToId,
+      threadId,
+    }) => {
       const replyToIdValue = replyToId ?? threadId;
       const result = await sendMessageMattermost(to, text, {
         cfg,

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -273,21 +273,23 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
       }
       return { ok: true, to: trimmed };
     },
-    sendText: async ({ cfg, to, text, accountId, replyToId }) => {
+    sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) => {
+      const replyToIdValue = replyToId ?? threadId;
       const result = await sendMessageMattermost(to, text, {
         cfg,
         accountId: accountId ?? undefined,
-        replyToId: replyToId ?? undefined,
+        replyToId: replyToIdValue != null ? String(replyToIdValue) : undefined,
       });
       return { channel: "mattermost", ...result };
     },
-    sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, replyToId }) => {
+    sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, replyToId, threadId }) => {
+      const replyToIdValue = replyToId ?? threadId;
       const result = await sendMessageMattermost(to, text, {
         cfg,
         accountId: accountId ?? undefined,
         mediaUrl,
         mediaLocalRoots,
-        replyToId: replyToId ?? undefined,
+        replyToId: replyToIdValue != null ? String(replyToIdValue) : undefined,
       });
       return { channel: "mattermost", ...result };
     },


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `extensions/mattermost` outbound adapter ignored `threadId` and only forwarded `replyToId`.
- Why it matters: when only `threadId` is present in outbound context, threaded sends fall back to root posts instead of replying in-thread.
- What changed: added `replyToId ?? threadId` fallback for Mattermost extension `sendText` and `sendMedia`.
- What did NOT change (scope boundary): no monitor/session routing changes, no API contract changes, no dependency changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33561
- Related #29897

## User-visible / Behavior Changes

Mattermost extension outbound sends now use `threadId` as a fallback reply target when `replyToId` is not provided, improving thread delivery consistency.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Mattermost extension (`extensions/mattermost`)
- Relevant config (redacted): N/A (unit-level adapter repro)

### Steps

1. Call Mattermost extension `sendText`/`sendMedia` with `threadId` set and no `replyToId`.
2. Inspect options passed to `sendMessageMattermost`.
3. In pre-fix code, `replyToId` is `undefined`.

### Expected

- `threadId` is used as fallback and forwarded as `replyToId`.

### Actual

- `threadId` is ignored; `replyToId` remains undefined.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Failing before fix:

- `pnpm test extensions/mattermost/src/channel.test.ts`
- New fallback tests failed due `replyToId: undefined`.

Passing after fix:

- `pnpm test extensions/mattermost/src/channel.test.ts`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `threadId` fallback behavior on both text and media outbound paths.
- Edge cases checked: existing `mediaLocalRoots` forwarding test still passes.
- What you did **not** verify: live Mattermost post delivery against a real server/workspace.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `c46f48cdf0`.
- Files/config to restore: `extensions/mattermost/src/channel.ts`, `extensions/mattermost/src/channel.test.ts`.
- Known bad symptoms reviewers should watch for: Mattermost thread replies posting to channel root when only `threadId` is available.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: low risk of reply-target precedence confusion.
  - Mitigation: explicit fallback order (`replyToId` first, then `threadId`) covered by regression tests.
