### PR TITLE
fix(embedded): merge orphaned user message into prompt instead of removing

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1390,8 +1390,24 @@ export async function runEmbeddedAttempt(
         });
 
         // Repair orphaned trailing user messages so new prompts don't violate role ordering.
+        // Merge the orphaned message content into the current prompt to preserve context (#33549).
         const leafEntry = sessionManager.getLeafEntry();
         if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
+          const orphanedContent =
+            typeof leafEntry.message.content === "string"
+              ? leafEntry.message.content
+              : Array.isArray(leafEntry.message.content)
+                ? leafEntry.message.content
+                    .filter(
+                      (block: { type?: string; text?: string }) =>
+                        block.type === "text" && typeof block.text === "string",
+                    )
+                    .map((block: { text: string }) => block.text)
+                    .join("\n")
+                : "";
+          if (orphanedContent) {
+            effectivePrompt = `${orphanedContent}\n\n${effectivePrompt}`;
+          }
           if (leafEntry.parentId) {
             sessionManager.branch(leafEntry.parentId);
           } else {
@@ -1400,7 +1416,7 @@ export async function runEmbeddedAttempt(
           const sessionContext = sessionManager.buildSessionContext();
           activeSession.agent.replaceMessages(sessionContext.messages);
           log.warn(
-            `Removed orphaned user message to prevent consecutive user turns. ` +
+            `Merged orphaned user message into current prompt to prevent consecutive user turns. ` +
               `runId=${params.runId} sessionId=${params.sessionId}`,
           );
         }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1384,13 +1384,11 @@ export async function runEmbeddedAttempt(
         }
 
         log.debug(`embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId}`);
-        cacheTrace?.recordStage("prompt:before", {
-          prompt: effectivePrompt,
-          messages: activeSession.messages,
-        });
 
         // Repair orphaned trailing user messages so new prompts don't violate role ordering.
         // Merge the orphaned message content into the current prompt to preserve context (#33549).
+        // Insert orphaned text between any hook prependContext and the raw prompt so that
+        // before_prompt_build hooks keep their expected position at the top of the prompt.
         const leafEntry = sessionManager.getLeafEntry();
         if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
           const orphanedContent =
@@ -1406,7 +1404,15 @@ export async function runEmbeddedAttempt(
                     .join("\n")
                 : "";
           if (orphanedContent) {
-            effectivePrompt = `${orphanedContent}\n\n${effectivePrompt}`;
+            // Reconstruct effectivePrompt preserving hook prependContext ordering:
+            // [prependContext] | orphanedContent | params.prompt
+            const parts: string[] = [];
+            if (hookResult?.prependContext) {
+              parts.push(hookResult.prependContext);
+            }
+            parts.push(orphanedContent);
+            parts.push(params.prompt);
+            effectivePrompt = parts.join("\n\n");
           }
           if (leafEntry.parentId) {
             sessionManager.branch(leafEntry.parentId);
@@ -1420,6 +1426,11 @@ export async function runEmbeddedAttempt(
               `runId=${params.runId} sessionId=${params.sessionId}`,
           );
         }
+
+        cacheTrace?.recordStage("prompt:before", {
+          prompt: effectivePrompt,
+          messages: activeSession.messages,
+        });
 
         try {
           // Idempotent cleanup for legacy sessions with persisted image payloads.


### PR DESCRIPTION
## Summary
- Fixes user messages disappearing from the webchat UI during long agent operations
- Root cause: the orphan repair logic at `attempt.ts:1392` removed trailing user messages from the session transcript via `branch()` + `replaceMessages()`, but these messages had already been broadcast to connected webchat clients
- Fix: extract the orphaned message's text content and merge it into `effectivePrompt` before branching, so the model still receives the user's content and no visible data is lost

## What changed
- **Before**: Orphaned user messages were silently deleted from the session transcript, causing them to vanish from the webchat UI mid-conversation
- **After**: Orphaned user message text is prepended to the current prompt. The session tree is still branched to maintain role ordering, but the content is preserved in the new prompt to the model

## Files changed
- `src/agents/pi-embedded-runner/run/attempt.ts` — orphan repair block now extracts text content (handles both string and content-block array formats) and merges into `effectivePrompt`

## Test plan
- [ ] Start a long-running agent operation (2+ min) with webchat
- [ ] Verify user messages remain visible in the webchat UI throughout
- [ ] Verify no `Removed orphaned user message` warnings in logs (replaced with `Merged orphaned user message`)
- [ ] Verify the model still receives the orphaned message content in its prompt
- [ ] Verify boot-hook sessions with consecutive user turns don't break role ordering

Fixes #33549