### PR TITLE
fix(discord): handle threadId in outbound sendText/sendMedia/sendPoll

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -302,9 +302,10 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
     textChunkLimit: 2000,
     pollMaxOptions: 10,
     resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
-    sendText: async ({ to, text, accountId, deps, replyToId, silent }) => {
+    sendText: async ({ to, text, accountId, deps, replyToId, threadId, silent }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(to, text, {
+      const target = threadId ? `channel:${String(threadId).trim()}` : to;
+      const result = await send(target, text, {
         verbose: false,
         replyTo: replyToId ?? undefined,
         accountId: accountId ?? undefined,
@@ -320,10 +321,12 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       accountId,
       deps,
       replyToId,
+      threadId,
       silent,
     }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(to, text, {
+      const target = threadId ? `channel:${String(threadId).trim()}` : to;
+      const result = await send(target, text, {
         verbose: false,
         mediaUrl,
         mediaLocalRoots,
@@ -333,11 +336,13 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       });
       return { channel: "discord", ...result };
     },
-    sendPoll: async ({ to, poll, accountId, silent }) =>
-      await getDiscordRuntime().channel.discord.sendPollDiscord(to, poll, {
+    sendPoll: async ({ to, poll, accountId, threadId, silent }) => {
+      const target = threadId ? `channel:${String(threadId).trim()}` : to;
+      return await getDiscordRuntime().channel.discord.sendPollDiscord(target, poll, {
         accountId: accountId ?? undefined,
         silent: silent ?? undefined,
-      }),
+      });
+    },
   },
   status: {
     defaultRuntime: {


### PR DESCRIPTION
## Summary

Discord extension outbound adapter ignores `threadId` for sendText, sendMedia, and sendPoll.

## Fix

Add `threadId` parameter to the outbound functions and resolve the target using `channel:<threadId>` format when threadId is provided. This matches the behavior of the core Discord adapter in `src/channels/plugins/outbound/discord.ts`.

## Changes

- `extensions/discord/src/channel.ts`: 
  - Added `threadId` parameter to `sendText`, `sendMedia`, and `sendPoll`
  - Use `channel:<threadId>` format when threadId is provided

## Testing

- Verified code compiles correctly
- Pattern matches core adapter implementation

Fixes #33554