### PR TITLE
fix(discord): pass resolved cfg to send functions for SecretRef support

### DIFF
--- a/src/channels/plugins/outbound/discord.test.ts
+++ b/src/channels/plugins/outbound/discord.test.ts
@@ -126,6 +126,43 @@ describe("discordOutbound", () => {
     hoisted.getThreadBindingManagerMock.mockClear().mockReturnValue(null);
   });
 
+  it("passes cfg from context to sendMessageDiscord in sendText", async () => {
+    const cfg = {} as Record<string, unknown>;
+    await discordOutbound.sendText?.({
+      cfg,
+      to: "channel:123",
+      text: "hello",
+    });
+
+    const opts = hoisted.sendMessageDiscordMock.mock.calls[0][2];
+    expect(opts.cfg).toBe(cfg);
+  });
+
+  it("passes cfg from context to sendMessageDiscord in sendMedia", async () => {
+    const cfg = {} as Record<string, unknown>;
+    await discordOutbound.sendMedia?.({
+      cfg,
+      to: "channel:123",
+      text: "cap",
+      mediaUrl: "https://example.com/a.jpg",
+    });
+
+    const opts = hoisted.sendMessageDiscordMock.mock.calls[0][2];
+    expect(opts.cfg).toBe(cfg);
+  });
+
+  it("passes cfg from context to sendPollDiscord in sendPoll", async () => {
+    const cfg = {} as Record<string, unknown>;
+    await discordOutbound.sendPoll?.({
+      cfg,
+      to: "channel:123",
+      poll: { question: "Q?", options: ["a", "b"] },
+    });
+
+    const opts = hoisted.sendPollDiscordMock.mock.calls[0][2];
+    expect(opts.cfg).toBe(cfg);
+  });
+
   it("routes text sends to thread target when threadId is provided", async () => {
     const result = await discordOutbound.sendText?.({
       cfg: {},

--- a/src/channels/plugins/outbound/discord.ts
+++ b/src/channels/plugins/outbound/discord.ts
@@ -83,7 +83,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
   resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
   sendPayload: async (ctx) =>
     await sendTextMediaPayload({ channel: "discord", ctx, adapter: discordOutbound }),
-  sendText: async ({ to, text, accountId, deps, replyToId, threadId, identity, silent }) => {
+  sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, identity, silent }) => {
     if (!silent) {
       const webhookResult = await maybeSendDiscordWebhookText({
         text,
@@ -103,10 +103,12 @@ export const discordOutbound: ChannelOutboundAdapter = {
       replyTo: replyToId ?? undefined,
       accountId: accountId ?? undefined,
       silent: silent ?? undefined,
+      cfg,
     });
     return { channel: "discord", ...result };
   },
   sendMedia: async ({
+    cfg,
     to,
     text,
     mediaUrl,
@@ -126,14 +128,16 @@ export const discordOutbound: ChannelOutboundAdapter = {
       replyTo: replyToId ?? undefined,
       accountId: accountId ?? undefined,
       silent: silent ?? undefined,
+      cfg,
     });
     return { channel: "discord", ...result };
   },
-  sendPoll: async ({ to, poll, accountId, threadId, silent }) => {
+  sendPoll: async ({ cfg, to, poll, accountId, threadId, silent }) => {
     const target = resolveDiscordOutboundTarget({ to, threadId });
     return await sendPollDiscord(target, poll, {
       accountId: accountId ?? undefined,
       silent: silent ?? undefined,
+      cfg,
     });
   },
 };

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -4,8 +4,7 @@ import path from "node:path";
 import { serializePayload, type MessagePayloadObject, type RequestClient } from "@buape/carbon";
 import { ChannelType, Routes } from "discord-api-types/v10";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
-import { loadConfig } from "../config/config.js";
-import type { OpenClawConfig } from "../config/config.js";
+import { loadConfig, type OpenClawConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
 import type { RetryConfig } from "../infra/retry.js";
@@ -125,7 +124,7 @@ async function resolveDiscordSendTarget(
 ): Promise<{ rest: RequestClient; request: DiscordClientRequest; channelId: string }> {
   const cfg = opts.cfg ?? loadConfig();
   const { rest, request } = createDiscordClient(opts, cfg);
-  const recipient = await parseAndResolveRecipient(to, opts.accountId);
+  const recipient = await parseAndResolveRecipient(to, opts.accountId, cfg);
   const { channelId } = await resolveChannelId(rest, recipient, request);
   return { rest, request, channelId };
 }
@@ -151,7 +150,7 @@ export async function sendMessageDiscord(
     accountId: accountInfo.accountId,
   });
   const { token, rest, request } = createDiscordClient(opts, cfg);
-  const recipient = await parseAndResolveRecipient(to, opts.accountId);
+  const recipient = await parseAndResolveRecipient(to, opts.accountId, cfg);
   const { channelId } = await resolveChannelId(rest, recipient, request);
 
   // Forum/Media channels reject POST /messages; auto-create a thread post instead.
@@ -520,7 +519,7 @@ export async function sendVoiceMessageDiscord(
     token = client.token;
     rest = client.rest;
     const request = client.request;
-    const recipient = await parseAndResolveRecipient(to, opts.accountId);
+    const recipient = await parseAndResolveRecipient(to, opts.accountId, cfg);
     channelId = (await resolveChannelId(rest, recipient, request)).channelId;
 
     // Convert to OGG/Opus if needed

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -5,6 +5,7 @@ import { serializePayload, type MessagePayloadObject, type RequestClient } from 
 import { ChannelType, Routes } from "discord-api-types/v10";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
 import { loadConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
 import type { RetryConfig } from "../infra/retry.js";
@@ -44,6 +45,7 @@ import {
 } from "./voice-message.js";
 
 type DiscordSendOpts = {
+  cfg?: OpenClawConfig;
   token?: string;
   accountId?: string;
   mediaUrl?: string;
@@ -121,7 +123,7 @@ async function resolveDiscordSendTarget(
   to: string,
   opts: DiscordSendOpts,
 ): Promise<{ rest: RequestClient; request: DiscordClientRequest; channelId: string }> {
-  const cfg = loadConfig();
+  const cfg = opts.cfg ?? loadConfig();
   const { rest, request } = createDiscordClient(opts, cfg);
   const recipient = await parseAndResolveRecipient(to, opts.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
@@ -133,7 +135,7 @@ export async function sendMessageDiscord(
   text: string,
   opts: DiscordSendOpts = {},
 ): Promise<DiscordSendResult> {
-  const cfg = loadConfig();
+  const cfg = opts.cfg ?? loadConfig();
   const accountInfo = resolveDiscordAccount({
     cfg,
     accountId: opts.accountId,

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -10,7 +10,7 @@ import { PollLayoutType } from "discord-api-types/payloads/v10";
 import type { RESTAPIPoll } from "discord-api-types/rest/v10";
 import { Routes, type APIChannel, type APIEmbed } from "discord-api-types/v10";
 import type { ChunkMode } from "../auto-reply/chunk.js";
-import { loadConfig } from "../config/config.js";
+import { loadConfig, type OpenClawConfig } from "../config/config.js";
 import type { RetryRunner } from "../infra/retry-policy.js";
 import { buildOutboundMediaLoadOptions } from "../media/load-options.js";
 import { normalizePollDurationHours, normalizePollInput, type PollInput } from "../polls.js";
@@ -80,9 +80,10 @@ function parseRecipient(raw: string): DiscordRecipient {
 export async function parseAndResolveRecipient(
   raw: string,
   accountId?: string,
+  cfg?: OpenClawConfig,
 ): Promise<DiscordRecipient> {
-  const cfg = loadConfig();
-  const accountInfo = resolveDiscordAccount({ cfg, accountId });
+  const resolvedCfg = cfg ?? loadConfig();
+  const accountInfo = resolveDiscordAccount({ cfg: resolvedCfg, accountId });
 
   // First try to resolve using directory lookup (handles usernames)
   const trimmed = raw.trim();
@@ -93,7 +94,7 @@ export async function parseAndResolveRecipient(
   const resolved = await resolveDiscordTarget(
     raw,
     {
-      cfg,
+      cfg: resolvedCfg,
       accountId: accountInfo.accountId,
     },
     parseOptions,


### PR DESCRIPTION
## Summary

- Problem: `openclaw message send` fails with "unresolved SecretRef" when `channels.discord.token` is a file-based SecretRef. The CLI correctly resolves the SecretRef via `resolveCommandSecretRefsViaGateway()`, but the resolved config is discarded at the final step: `sendMessageDiscord` calls `loadConfig()` to load a fresh unresolved config from disk instead of using the resolved config threaded through the delivery pipeline.
- Why it matters: All CLI-based Discord message delivery fails when channel tokens use SecretRef. Interactive runs show a terminal error; unattended cron jobs and scripts exit with code 1, causing silent message loss.
- What changed: The Discord outbound adapter now passes `cfg` from its context to `sendMessageDiscord` and `sendPollDiscord`. `sendMessageDiscord`, `resolveDiscordSendTarget`, and `sendPollDiscord` accept an optional `cfg` in their opts and prefer it over `loadConfig()`. `parseAndResolveRecipient` also accepts an optional `cfg` parameter so the resolved config reaches recipient resolution too.
- What did NOT change (scope boundary): No changes to the resolution chain (`resolveCommandSecretRefsViaGateway`), config loading (`loadConfig`), Zod schema, gateway RPC, or any other channel's outbound adapter. Other channels (Telegram, Slack) have the same `loadConfig()` pattern in their send functions but are out of scope for this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33573
- Related #29580 (feat: expand SecretRef coverage - added resolution to `message.ts`)
- Related #33070 (same error class for `openclaw status`)

## User-visible / Behavior Changes

`openclaw message send --channel discord` now works when `channels.discord.token` is a SecretRef. Previously it always failed with "unresolved SecretRef".

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes - resolved token is now passed through to the send function rather than re-reading from disk. The token value itself is identical; only the source of the config object changes (resolved in-memory config vs fresh disk read).
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Debian Linux (6.12.63+deb13-amd64)
- Runtime/container: Node 22.22.0, npm global install
- Model/provider: N/A (bug is in config threading, not model interaction)
- Integration/channel: Discord
- Relevant config (redacted):
  ```json
  {
    "channels": {
      "discord": {
        "enabled": true,
        "token": { "source": "file", "provider": "filemain", "id": "/channels/discord/token" }
      }
    },
    "secrets": {
      "defaults": { "file": "filemain" },
      "providers": { "filemain": { "source": "file", "path": "..." } }
    }
  }
  ```

### Steps

1. Set `channels.discord.token` to a file SecretRef (with the actual token stored in the secrets file)
2. Run `openclaw message send --channel discord --target "channel:XXXX" --message "test"`
3. Observe error

### Expected

Message delivered to Discord channel.

### Actual

```
Error: channels.discord.token: unresolved SecretRef "file:filemain:/channels/discord/token".
Resolve this command against an active gateway runtime snapshot before reading it.
```

## Evidence

- [x] Failing test/log before + passing after (see regression tests below)
- [x] Trace/log snippets (reproduction output in bug report)
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

### Regression tests added

Three tests in `src/channels/plugins/outbound/discord.test.ts`:

1. **`passes cfg from context to sendMessageDiscord in sendText`** - verifies `sendText` handler passes the context `cfg` object (by reference) to `sendMessageDiscord` opts.
2. **`passes cfg from context to sendMessageDiscord in sendMedia`** - verifies `sendMedia` handler passes `cfg` through to `sendMessageDiscord` opts.
3. **`passes cfg from context to sendPollDiscord in sendPoll`** - verifies `sendPoll` handler passes `cfg` through to `sendPollDiscord` opts.

All three tests fail before the fix (cfg not present in opts) and pass after.

### Test results

- `src/channels/plugins/outbound/discord.test.ts`: 15/15 pass (12 existing + 3 new cfg passthrough)
- `src/channels/plugins/outbound/discord.sendpayload.test.ts`: 5/5 pass (unchanged)
- `src/discord/send.components.test.ts`: 1/1 pass (unchanged)
- Related Discord send suites (`send.sends-basic-channel-messages`, `send.creates-thread`, `send.webhook-activity`, `accounts`, `token`): 63/63 pass (no regressions)
- `pnpm tsgo`: pre-existing extension errors remain (`extensions/diagnostics-otel`, `extensions/diffs`, `extensions/tlon`); no additional errors from this change

## Human Verification (required)

- Verified scenarios: adapter passes cfg for sendText, sendMedia, sendPoll; existing thread/webhook/silent tests still pass
- Edge cases checked: sendPayload path (routes through adapter sendText/sendMedia, so cfg is passed transitively); deps override path (sendDiscord mock receives cfg); parseAndResolveRecipient receives cfg from all call sites in send.outbound.ts
- What you did **not** verify: Other channels (Telegram, Slack) - they have the same `loadConfig()` pattern but are not changed in this PR. `sendDiscordComponentMessage` (`send.components.ts:61`) still calls `loadConfig()` directly (not in the outbound adapter path). Live end-to-end with real SecretRef on Discord (requires gateway with SecretRef config).

## Compatibility / Migration

- Backward compatible? Yes - `loadConfig()` is still called as fallback when `opts.cfg` is not provided. All existing callers that don't pass `cfg` continue to work identically.
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the PR. Or use plaintext tokens as workaround.
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Discord messages sent with wrong config state (stale resolved config vs fresh disk config). In practice this should not happen because the CLI resolves config once at command start.

## Risks and Mitigations

- Risk: Other callers of `sendMessageDiscord` (gateway runtime, monitor, bot handlers) currently rely on `loadConfig()` to get the latest config. Passing `cfg` from the outbound adapter context means the send uses the config snapshot from command start, not the latest on disk.
  - Mitigation: Only the outbound adapter path passes `cfg`. All other callers (gateway runtime, monitor) continue to omit `cfg` and get `loadConfig()` as before. The outbound adapter already operates on a fixed config snapshot throughout the request lifecycle.

## Files Changed

| File | Change |
|------|--------|
| `src/discord/send.outbound.ts` | Add optional `cfg` to `DiscordSendOpts`; use `opts.cfg ?? loadConfig()` in `sendMessageDiscord`, `resolveDiscordSendTarget`; pass `cfg` to `parseAndResolveRecipient` at all call sites; merge duplicate config import |
| `src/discord/send.shared.ts` | Add optional `cfg` parameter to `parseAndResolveRecipient`; use `cfg ?? loadConfig()` internally |
| `src/channels/plugins/outbound/discord.ts` | Destructure `cfg` from outbound context; pass it to `sendMessageDiscord` and `sendPollDiscord` in `sendText`, `sendMedia`, and `sendPoll` handlers |

## Status

- Implemented. Three source files changed, three regression tests added. All tests pass (84/84 across 8 test files). `pnpm tsgo` has pre-existing extension errors only; no additional errors from this change.

## Notes

- Other channels (Telegram `send.ts:1191`, Slack `send.ts:265`) have the same pattern of calling `loadConfig()` in their send functions. These should be audited and fixed separately.
- The Telegram send function already accepts `opts.cfg` in some paths (`send.ts:328`: `const cfg = opts.cfg ?? loadConfig()`), showing the intended pattern.
- The `sendPayload` path in the Discord adapter (`line 84-85`) calls `sendTextMediaPayload`, which routes back through the adapter's `sendText`/`sendMedia` handlers. These now pass `cfg`, so the sendPayload path is also fixed.
- `sendDiscordComponentMessage` (`src/discord/send.components.ts:61`) still calls `loadConfig()` directly and passes the result to both `resolveDiscordAccount` and `parseAndResolveRecipient`. This function is not called from the outbound adapter path and is out of scope for this PR.

## AI Disclosure

AI-assisted. Root cause analysis, bug reproduction, code changes, and regression tests were developed with Claude Opus 4.6 (Claude Code). Drafts reviewed and validated by Codex 5.3. Human verified reproduction on live system and reviewed all changes.
