### PR TITLE
fix(feishu extension): forward reply target context in outbound sends

### DIFF
--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -136,6 +136,25 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(result).toEqual(expect.objectContaining({ channel: "feishu", messageId: "card_msg" }));
   });
+
+  it("forwards replyToId as replyToMessageId on sendText", async () => {
+    await sendText({
+      cfg: {} as any,
+      to: "chat_1",
+      text: "hello",
+      replyToId: "om_reply_1",
+      accountId: "main",
+    } as any);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat_1",
+        text: "hello",
+        replyToMessageId: "om_reply_1",
+        accountId: "main",
+      }),
+    );
+  });
 });
 
 describe("feishuOutbound.sendMedia renderMode", () => {
@@ -177,5 +196,25 @@ describe("feishuOutbound.sendMedia renderMode", () => {
     );
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(result).toEqual(expect.objectContaining({ channel: "feishu", messageId: "media_msg" }));
+  });
+
+  it("uses threadId fallback as replyToMessageId on sendMedia", async () => {
+    await feishuOutbound.sendMedia?.({
+      cfg: {} as any,
+      to: "chat_1",
+      text: "caption",
+      mediaUrl: "https://example.com/image.png",
+      threadId: "om_thread_1",
+      accountId: "main",
+    } as any);
+
+    expect(sendMediaFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat_1",
+        mediaUrl: "https://example.com/image.png",
+        replyToMessageId: "om_thread_1",
+        accountId: "main",
+      }),
+    );
   });
 });

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -155,6 +155,26 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
       }),
     );
   });
+
+  it("falls back to threadId when replyToId is empty on sendText", async () => {
+    await sendText({
+      cfg: {} as any,
+      to: "chat_1",
+      text: "hello",
+      replyToId: " ",
+      threadId: "om_thread_2",
+      accountId: "main",
+    } as any);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat_1",
+        text: "hello",
+        replyToMessageId: "om_thread_2",
+        accountId: "main",
+      }),
+    );
+  });
 });
 
 describe("feishuOutbound.sendMedia renderMode", () => {
@@ -212,6 +232,14 @@ describe("feishuOutbound.sendMedia renderMode", () => {
       expect.objectContaining({
         to: "chat_1",
         mediaUrl: "https://example.com/image.png",
+        replyToMessageId: "om_thread_1",
+        accountId: "main",
+      }),
+    );
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat_1",
+        text: "caption",
         replyToMessageId: "om_thread_1",
         accountId: "main",
       }),

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -43,21 +43,34 @@ function shouldUseCard(text: string): boolean {
   return /```[\s\S]*?```/.test(text) || /\|.+\|[\r\n]+\|[-:| ]+\|/.test(text);
 }
 
+function resolveReplyToMessageId(params: {
+  replyToId?: string | null;
+  threadId?: string | number | null;
+}): string | undefined {
+  const replyTarget = params.replyToId ?? params.threadId;
+  if (replyTarget == null) {
+    return undefined;
+  }
+  const trimmed = String(replyTarget).trim();
+  return trimmed || undefined;
+}
+
 async function sendOutboundText(params: {
   cfg: Parameters<typeof sendMessageFeishu>[0]["cfg"];
   to: string;
   text: string;
   accountId?: string;
+  replyToMessageId?: string;
 }) {
-  const { cfg, to, text, accountId } = params;
+  const { cfg, to, text, accountId, replyToMessageId } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   const renderMode = account.config?.renderMode ?? "auto";
 
   if (renderMode === "card" || (renderMode === "auto" && shouldUseCard(text))) {
-    return sendMarkdownCardFeishu({ cfg, to, text, accountId });
+    return sendMarkdownCardFeishu({ cfg, to, text, accountId, replyToMessageId });
   }
 
-  return sendMessageFeishu({ cfg, to, text, accountId });
+  return sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId });
 }
 
 export const feishuOutbound: ChannelOutboundAdapter = {
@@ -65,7 +78,8 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   chunker: (text, limit) => getFeishuRuntime().channel.text.chunkMarkdownText(text, limit),
   chunkerMode: "markdown",
   textChunkLimit: 4000,
-  sendText: async ({ cfg, to, text, accountId }) => {
+  sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) => {
+    const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
     // Scheme A compatibility shim:
     // when upstream accidentally returns a local image path as plain text,
     // auto-upload and send as Feishu image message instead of leaking path text.
@@ -77,6 +91,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           mediaUrl: localImagePath,
           accountId: accountId ?? undefined,
+          replyToMessageId,
         });
         return { channel: "feishu", ...result };
       } catch (err) {
@@ -90,10 +105,21 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       to,
       text,
       accountId: accountId ?? undefined,
+      replyToMessageId,
     });
     return { channel: "feishu", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, mediaLocalRoots }) => {
+  sendMedia: async ({
+    cfg,
+    to,
+    text,
+    mediaUrl,
+    accountId,
+    mediaLocalRoots,
+    replyToId,
+    threadId,
+  }) => {
+    const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
     // Send text first if provided
     if (text?.trim()) {
       await sendOutboundText({
@@ -101,6 +127,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         to,
         text,
         accountId: accountId ?? undefined,
+        replyToMessageId,
       });
     }
 
@@ -113,6 +140,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           mediaUrl,
           accountId: accountId ?? undefined,
           mediaLocalRoots,
+          replyToMessageId,
         });
         return { channel: "feishu", ...result };
       } catch (err) {
@@ -125,6 +153,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           text: fallbackText,
           accountId: accountId ?? undefined,
+          replyToMessageId,
         });
         return { channel: "feishu", ...result };
       }
@@ -136,6 +165,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       to,
       text: text ?? "",
       accountId: accountId ?? undefined,
+      replyToMessageId,
     });
     return { channel: "feishu", ...result };
   },

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -47,11 +47,14 @@ function resolveReplyToMessageId(params: {
   replyToId?: string | null;
   threadId?: string | number | null;
 }): string | undefined {
-  const replyTarget = params.replyToId ?? params.threadId;
-  if (replyTarget == null) {
+  const replyToId = params.replyToId?.trim();
+  if (replyToId) {
+    return replyToId;
+  }
+  if (params.threadId == null) {
     return undefined;
   }
-  const trimmed = String(replyTarget).trim();
+  const trimmed = String(params.threadId).trim();
   return trimmed || undefined;
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `extensions/feishu` outbound `sendText`/`sendMedia` dropped reply target context (`replyToId`/`threadId`).
- Why it matters: replies sent through outbound adapter paths could lose reply threading and post as non-replies.
- What changed: added reply target resolver (`replyToId ?? threadId`) and forwarded `replyToMessageId` through text/media send paths.
- What did NOT change (scope boundary): no Feishu monitor/dispatcher logic changes, no duplicate suppression changes, no dependency changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33572
- Related #32958

## User-visible / Behavior Changes

Feishu extension outbound sends now preserve reply target context by mapping `replyToId`/`threadId` to `replyToMessageId` for both text and media sends.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Feishu extension (`extensions/feishu`)
- Relevant config (redacted): N/A (unit-level adapter repro)

### Steps

1. Call Feishu outbound `sendText` or `sendMedia` with `replyToId` or `threadId` set.
2. Observe args passed to `sendMessageFeishu` / `sendMediaFeishu` in `extensions/feishu/src/outbound.ts`.
3. In pre-fix code, `replyToMessageId` is not forwarded.

### Expected

- Reply target context is forwarded as `replyToMessageId`.

### Actual

- Reply target context is dropped.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Failing before fix:

- `pnpm test extensions/feishu/src/outbound.test.ts`
- New tests failed because `replyToMessageId` was missing.

Passing after fix:

- `pnpm test extensions/feishu/src/outbound.test.ts`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `replyToId` forwarding on `sendText`, `threadId` fallback forwarding on `sendMedia`.
- Edge cases checked: existing local-image auto-convert and renderMode tests remain passing.
- What you did **not** verify: live Feishu delivery against a real tenant/chat.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `c129a691fc`.
- Files/config to restore: `extensions/feishu/src/outbound.ts`, `extensions/feishu/src/outbound.test.ts`.
- Known bad symptoms reviewers should watch for: Feishu outbound replies losing thread/reply target.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: low risk of reply target precedence mismatch.
  - Mitigation: explicit resolver (`replyToId` first, then `threadId`) covered by regression tests.
