### PR TITLE
Discord extension: honor threadId for outbound sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Discord/Agent-scoped media roots: pass `mediaLocalRoots` through Discord monitor reply delivery (message + component interaction paths) so local media attachments honor per-agent workspace roots instead of falling back to default global roots. Thanks @thewilloftheshadow.
 - Discord/slash command handling: intercept text-based slash commands in channels, register plugin commands as native, and send fallback acknowledgments for empty slash runs so interactions do not hang. Thanks @thewilloftheshadow.
 - Discord/thread session lifecycle: reset thread-scoped sessions when a thread is archived so reopening a thread starts fresh without deleting transcript history. Thanks @thewilloftheshadow.
+- Discord/extension outbound thread routing: honor `threadId` in extension `sendText`, `sendMedia`, and `sendPoll` by resolving thread sends to `channel:<threadId>` targets instead of parent channel ids. (#33554) Thanks @bmendonca3.
 - Discord/presence defaults: send an online presence update on ready when no custom presence is configured so bots no longer appear offline by default. Thanks @thewilloftheshadow.
 - Discord/typing cleanup: stop typing indicators after silent/NO_REPLY runs by marking the run complete before dispatch idle cleanup. Thanks @thewilloftheshadow.
 - Discord/voice messages: request upload slots with JSON fetch calls so voice message uploads no longer fail with content-type errors. Thanks @thewilloftheshadow.

--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -33,4 +33,80 @@ describe("discordPlugin outbound", () => {
     );
     expect(result).toMatchObject({ channel: "discord", messageId: "m1" });
   });
+
+  it("uses threadId as target for sendText", async () => {
+    const sendMessageDiscord = vi.fn(async () => ({ messageId: "m2" }));
+    setDiscordRuntime({
+      channel: {
+        discord: {
+          sendMessageDiscord,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    await discordPlugin.outbound!.sendText!({
+      cfg: {} as OpenClawConfig,
+      to: "channel:123",
+      text: "hello",
+      threadId: "456",
+      accountId: "work",
+    });
+
+    expect(sendMessageDiscord).toHaveBeenCalledWith(
+      "channel:456",
+      "hello",
+      expect.objectContaining({ accountId: "work" }),
+    );
+  });
+
+  it("uses threadId as target for sendMedia", async () => {
+    const sendMessageDiscord = vi.fn(async () => ({ messageId: "m3" }));
+    setDiscordRuntime({
+      channel: {
+        discord: {
+          sendMessageDiscord,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    await discordPlugin.outbound!.sendMedia!({
+      cfg: {} as OpenClawConfig,
+      to: "channel:123",
+      text: "photo",
+      mediaUrl: "https://example.com/a.png",
+      threadId: "456",
+      accountId: "work",
+    });
+
+    expect(sendMessageDiscord).toHaveBeenCalledWith(
+      "channel:456",
+      "photo",
+      expect.objectContaining({ mediaUrl: "https://example.com/a.png", accountId: "work" }),
+    );
+  });
+
+  it("uses threadId as target for sendPoll", async () => {
+    const sendPollDiscord = vi.fn(async () => ({ messageId: "p1", channelId: "456" }));
+    setDiscordRuntime({
+      channel: {
+        discord: {
+          sendPollDiscord,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    await discordPlugin.outbound!.sendPoll!({
+      cfg: {} as OpenClawConfig,
+      to: "channel:123",
+      poll: { question: "Q", options: ["A", "B"] },
+      threadId: "456",
+      accountId: "work",
+    });
+
+    expect(sendPollDiscord).toHaveBeenCalledWith(
+      "channel:456",
+      { question: "Q", options: ["A", "B"] },
+      expect.objectContaining({ accountId: "work" }),
+    );
+  });
 });

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -34,6 +34,20 @@ import { getDiscordRuntime } from "./runtime.js";
 
 const meta = getChatChannelMeta("discord");
 
+function resolveDiscordOutboundTarget(params: {
+  to: string;
+  threadId?: string | number | null;
+}): string {
+  if (params.threadId == null) {
+    return params.to;
+  }
+  const threadId = String(params.threadId).trim();
+  if (!threadId) {
+    return params.to;
+  }
+  return `channel:${threadId}`;
+}
+
 const discordMessageActions: ChannelMessageActionAdapter = {
   listActions: (ctx) =>
     getDiscordRuntime().channel.discord.messageActions?.listActions?.(ctx) ?? [],
@@ -302,9 +316,10 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
     textChunkLimit: 2000,
     pollMaxOptions: 10,
     resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
-    sendText: async ({ to, text, accountId, deps, replyToId, silent }) => {
+    sendText: async ({ to, text, accountId, deps, replyToId, threadId, silent }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(to, text, {
+      const target = resolveDiscordOutboundTarget({ to, threadId });
+      const result = await send(target, text, {
         verbose: false,
         replyTo: replyToId ?? undefined,
         accountId: accountId ?? undefined,
@@ -320,10 +335,12 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       accountId,
       deps,
       replyToId,
+      threadId,
       silent,
     }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(to, text, {
+      const target = resolveDiscordOutboundTarget({ to, threadId });
+      const result = await send(target, text, {
         verbose: false,
         mediaUrl,
         mediaLocalRoots,
@@ -333,11 +350,13 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       });
       return { channel: "discord", ...result };
     },
-    sendPoll: async ({ to, poll, accountId, silent }) =>
-      await getDiscordRuntime().channel.discord.sendPollDiscord(to, poll, {
+    sendPoll: async ({ to, poll, accountId, threadId, silent }) => {
+      const target = resolveDiscordOutboundTarget({ to, threadId });
+      return await getDiscordRuntime().channel.discord.sendPollDiscord(target, poll, {
         accountId: accountId ?? undefined,
         silent: silent ?? undefined,
-      }),
+      });
+    },
   },
   status: {
     defaultRuntime: {


### PR DESCRIPTION
## Summary
- fix `extensions/discord` outbound adapter to resolve `threadId` to `channel:<threadId>` for `sendText`, `sendMedia`, and `sendPoll`
- add outbound regression tests covering thread-target routing for all three methods
- add changelog entry under `2026.3.3` Fixes

Fixes #33554

## Testing
- `pnpm test extensions/discord/src/channel.test.ts`
