### PR TITLE
fix(googlechat extension): honor mediaLocalRoots in sendMedia

### DIFF
--- a/extensions/googlechat/src/channel.outbound.test.ts
+++ b/extensions/googlechat/src/channel.outbound.test.ts
@@ -69,6 +69,7 @@ describe("googlechatPlugin outbound sendMedia", () => {
         localRoots: ["/tmp/workspace"],
       }),
     );
+    expect(fetchRemoteMedia).not.toHaveBeenCalled();
     expect(uploadGoogleChatAttachmentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         space: "spaces/AAA",

--- a/extensions/googlechat/src/channel.outbound.test.ts
+++ b/extensions/googlechat/src/channel.outbound.test.ts
@@ -1,0 +1,91 @@
+import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+
+const uploadGoogleChatAttachmentMock = vi.hoisted(() => vi.fn());
+const sendGoogleChatMessageMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./api.js", () => ({
+  sendGoogleChatMessage: sendGoogleChatMessageMock,
+  uploadGoogleChatAttachment: uploadGoogleChatAttachmentMock,
+}));
+
+import { googlechatPlugin } from "./channel.js";
+import { setGoogleChatRuntime } from "./runtime.js";
+
+describe("googlechatPlugin outbound sendMedia", () => {
+  it("loads local media with mediaLocalRoots via runtime media loader", async () => {
+    const loadWebMedia = vi.fn(async () => ({
+      buffer: Buffer.from("image-bytes"),
+      fileName: "image.png",
+      contentType: "image/png",
+    }));
+    const fetchRemoteMedia = vi.fn(async () => ({
+      buffer: Buffer.from("remote-bytes"),
+      fileName: "remote.png",
+      contentType: "image/png",
+    }));
+
+    setGoogleChatRuntime({
+      media: { loadWebMedia },
+      channel: {
+        media: { fetchRemoteMedia },
+        text: { chunkMarkdownText: (text: string) => [text] },
+      },
+    } as unknown as PluginRuntime);
+
+    uploadGoogleChatAttachmentMock.mockResolvedValue({
+      attachmentUploadToken: "token-1",
+    });
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-1",
+    });
+
+    const cfg: OpenClawConfig = {
+      channels: {
+        googlechat: {
+          enabled: true,
+          serviceAccount: {
+            type: "service_account",
+            client_email: "bot@example.com",
+            private_key: "test-key",
+            token_uri: "https://oauth2.googleapis.com/token",
+          },
+        },
+      },
+    };
+
+    const result = await googlechatPlugin.outbound?.sendMedia?.({
+      cfg,
+      to: "spaces/AAA",
+      text: "caption",
+      mediaUrl: "/tmp/workspace/image.png",
+      mediaLocalRoots: ["/tmp/workspace"],
+      accountId: "default",
+    });
+
+    expect(loadWebMedia).toHaveBeenCalledWith(
+      "/tmp/workspace/image.png",
+      expect.objectContaining({
+        localRoots: ["/tmp/workspace"],
+      }),
+    );
+    expect(uploadGoogleChatAttachmentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        filename: "image.png",
+        contentType: "image/png",
+      }),
+    );
+    expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "caption",
+      }),
+    );
+    expect(result).toEqual({
+      channel: "googlechat",
+      messageId: "spaces/AAA/messages/msg-1",
+      chatId: "spaces/AAA",
+    });
+  });
+});

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -421,7 +421,16 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         chatId: space,
       };
     },
-    sendMedia: async ({ cfg, to, text, mediaUrl, accountId, replyToId, threadId }) => {
+    sendMedia: async ({
+      cfg,
+      to,
+      text,
+      mediaUrl,
+      mediaLocalRoots,
+      accountId,
+      replyToId,
+      threadId,
+    }) => {
       if (!mediaUrl) {
         throw new Error("Google Chat mediaUrl is required.");
       }
@@ -443,9 +452,9 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
           (cfg.channels?.["googlechat"] as { mediaMaxMb?: number } | undefined)?.mediaMaxMb,
         accountId,
       });
-      const loaded = await runtime.channel.media.fetchRemoteMedia({
-        url: mediaUrl,
+      const loaded = await runtime.media.loadWebMedia(mediaUrl, {
         maxBytes: maxBytes ?? (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
+        localRoots: mediaLocalRoots?.length ? mediaLocalRoots : undefined,
       });
       const upload = await uploadGoogleChatAttachment({
         account,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `extensions/googlechat` outbound `sendMedia` ignored `mediaLocalRoots` and used remote-only media fetch.
- Why it matters: local workspace media paths could not be resolved under allowlisted roots in Google Chat outbound sends.
- What changed: switched media loading to `runtime.media.loadWebMedia(..., { localRoots })` and threaded `mediaLocalRoots` through.
- What did NOT change (scope boundary): no Google Chat auth/probe behavior changes, no API endpoint changes, no dependency changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33580
- Related #

## User-visible / Behavior Changes

Google Chat extension outbound media sends now honor `mediaLocalRoots`, enabling local media path resolution under workspace allowlists instead of remote-only fetch behavior.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Google Chat extension (`extensions/googlechat`)
- Relevant config (redacted): inline service account object in unit test

### Steps

1. Call Google Chat extension `sendMedia` with local-path `mediaUrl` and `mediaLocalRoots`.
2. Observe media loading path in `extensions/googlechat/src/channel.ts`.
3. In pre-fix code, loader path is remote-only and ignores local roots.

### Expected

- Media is loaded via runtime web-media loader with `localRoots` from `mediaLocalRoots`.

### Actual

- Local roots are ignored and remote-only fetch path is used.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Failing before fix:

- `pnpm test extensions/googlechat/src/channel.outbound.test.ts`
- Test failed because `loadWebMedia(..., { localRoots })` was never called.

Passing after fix:

- `pnpm test extensions/googlechat/src/channel.outbound.test.ts`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: local-media send path now calls runtime loader with local roots and uploads loaded bytes.
- Edge cases checked: upload/send call flow preserved and message result mapping unchanged.
- What you did **not** verify: live Google Chat send with a real service account and space.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `3da1e55df4`.
- Files/config to restore: `extensions/googlechat/src/channel.ts`, `extensions/googlechat/src/channel.outbound.test.ts`.
- Known bad symptoms reviewers should watch for: Google Chat media upload failures for local paths.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: low risk of media loader behavior drift for remote URLs.
  - Mitigation: loader/output path remains identical after load; regression test guards local-roots usage.
