### PR TITLE
fix(nextcloud-talk): honor resolved cfg in outbound sends

### DIFF
--- a/extensions/nextcloud-talk/src/channel.outbound.test.ts
+++ b/extensions/nextcloud-talk/src/channel.outbound.test.ts
@@ -1,0 +1,77 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMessageNextcloudTalkMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./send.js", () => ({
+  sendMessageNextcloudTalk: sendMessageNextcloudTalkMock,
+}));
+
+import { nextcloudTalkPlugin } from "./channel.js";
+
+describe("nextcloudTalkPlugin outbound cfg forwarding", () => {
+  beforeEach(() => {
+    sendMessageNextcloudTalkMock.mockReset();
+    sendMessageNextcloudTalkMock.mockResolvedValue({
+      messageId: "m-1",
+      roomToken: "room-1",
+    });
+  });
+
+  it("forwards cfg to sendText adapter path", async () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        "nextcloud-talk": {
+          enabled: true,
+          baseUrl: "https://cloud.example.com",
+          botSecret: "resolved-secret",
+        },
+      },
+    };
+
+    await nextcloudTalkPlugin.outbound?.sendText?.({
+      cfg,
+      to: "room:room-1",
+      text: "hello",
+      accountId: "default",
+    });
+
+    expect(sendMessageNextcloudTalkMock).toHaveBeenCalledWith(
+      "room:room-1",
+      "hello",
+      expect.objectContaining({
+        cfg,
+        accountId: "default",
+      }),
+    );
+  });
+
+  it("forwards cfg to sendMedia adapter path", async () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        "nextcloud-talk": {
+          enabled: true,
+          baseUrl: "https://cloud.example.com",
+          botSecret: "resolved-secret",
+        },
+      },
+    };
+
+    await nextcloudTalkPlugin.outbound?.sendMedia?.({
+      cfg,
+      to: "room:room-1",
+      text: "hello",
+      mediaUrl: "https://example.com/image.png",
+      accountId: "default",
+    });
+
+    expect(sendMessageNextcloudTalkMock).toHaveBeenCalledWith(
+      "room:room-1",
+      expect.stringContaining("Attachment: https://example.com/image.png"),
+      expect.objectContaining({
+        cfg,
+        accountId: "default",
+      }),
+    );
+  });
+});

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -262,16 +262,18 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> = 
     chunker: (text, limit) => getNextcloudTalkRuntime().channel.text.chunkMarkdownText(text, limit),
     chunkerMode: "markdown",
     textChunkLimit: 4000,
-    sendText: async ({ to, text, accountId, replyToId }) => {
+    sendText: async ({ cfg, to, text, accountId, replyToId }) => {
       const result = await sendMessageNextcloudTalk(to, text, {
+        cfg: cfg as CoreConfig,
         accountId: accountId ?? undefined,
         replyTo: replyToId ?? undefined,
       });
       return { channel: "nextcloud-talk", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, replyToId }) => {
+    sendMedia: async ({ cfg, to, text, mediaUrl, accountId, replyToId }) => {
       const messageWithMedia = mediaUrl ? `${text}\n\nAttachment: ${mediaUrl}` : text;
       const result = await sendMessageNextcloudTalk(to, messageWithMedia, {
+        cfg: cfg as CoreConfig,
         accountId: accountId ?? undefined,
         replyTo: replyToId ?? undefined,
       });

--- a/extensions/nextcloud-talk/src/send.test.ts
+++ b/extensions/nextcloud-talk/src/send.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CoreConfig } from "./types.js";
+
+const loadConfigMock = vi.hoisted(() => vi.fn());
+const resolveNextcloudTalkAccountMock = vi.hoisted(() => vi.fn());
+const recordActivityMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./runtime.js", () => ({
+  getNextcloudTalkRuntime: () => ({
+    config: {
+      loadConfig: loadConfigMock,
+    },
+    channel: {
+      text: {
+        resolveMarkdownTableMode: () => "off",
+        convertMarkdownTables: (text: string) => text,
+      },
+      activity: {
+        record: recordActivityMock,
+      },
+    },
+  }),
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveNextcloudTalkAccount: resolveNextcloudTalkAccountMock,
+}));
+
+vi.mock("./signature.js", () => ({
+  generateNextcloudTalkSignature: vi.fn(() => ({
+    random: "random",
+    signature: "signature",
+  })),
+}));
+
+import { sendMessageNextcloudTalk } from "./send.js";
+
+describe("sendMessageNextcloudTalk cfg threading", () => {
+  beforeEach(() => {
+    loadConfigMock.mockReset();
+    resolveNextcloudTalkAccountMock.mockReset();
+    recordActivityMock.mockReset();
+
+    const runtimeCfg: CoreConfig = {
+      channels: {
+        "nextcloud-talk": {
+          enabled: true,
+          baseUrl: "https://runtime.example.com",
+          botSecret: "runtime-secret",
+        },
+      },
+    };
+    loadConfigMock.mockReturnValue(runtimeCfg);
+
+    resolveNextcloudTalkAccountMock.mockReturnValue({
+      accountId: "default",
+      enabled: true,
+      baseUrl: "https://resolved.example.com",
+      secret: "resolved-secret",
+      secretSource: "config",
+      config: {},
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          ocs: {
+            data: {
+              id: "msg-1",
+              timestamp: 1700000000,
+            },
+          },
+        }),
+      })),
+    );
+  });
+
+  it("prefers opts.cfg over runtime loadConfig when resolving account", async () => {
+    const resolvedCfg: CoreConfig = {
+      channels: {
+        "nextcloud-talk": {
+          enabled: true,
+          baseUrl: "https://resolved.example.com",
+          botSecret: "resolved-secret",
+        },
+      },
+    };
+
+    await sendMessageNextcloudTalk("room:test", "hello", { cfg: resolvedCfg });
+
+    expect(loadConfigMock).not.toHaveBeenCalled();
+    expect(resolveNextcloudTalkAccountMock).toHaveBeenCalledWith({
+      cfg: resolvedCfg,
+      accountId: undefined,
+    });
+  });
+});

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -4,6 +4,7 @@ import { generateNextcloudTalkSignature } from "./signature.js";
 import type { CoreConfig, NextcloudTalkSendResult } from "./types.js";
 
 type NextcloudTalkSendOpts = {
+  cfg?: CoreConfig;
   baseUrl?: string;
   secret?: string;
   accountId?: string;
@@ -60,7 +61,7 @@ export async function sendMessageNextcloudTalk(
   text: string,
   opts: NextcloudTalkSendOpts = {},
 ): Promise<NextcloudTalkSendResult> {
-  const cfg = getNextcloudTalkRuntime().config.loadConfig() as CoreConfig;
+  const cfg = (opts.cfg ?? getNextcloudTalkRuntime().config.loadConfig()) as CoreConfig;
   const account = resolveNextcloudTalkAccount({
     cfg,
     accountId: opts.accountId,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Nextcloud Talk outbound adapter discarded resolved command config and called `sendMessageNextcloudTalk` without `cfg`, so send helper always reloaded config via `runtime.config.loadConfig()`.
- Why it matters: SecretRef-backed `channels.nextcloud-talk.botSecret` can fail in `openclaw message send` despite upstream command-time SecretRef resolution.
- What changed: `outbound.sendText/sendMedia` now forward `cfg`; `sendMessageNextcloudTalk` now prefers `opts.cfg ?? runtime.config.loadConfig()`.
- What did NOT change (scope boundary): No behavior changes to monitor/webhook flow, pairing, policies, or non-Nextcloud channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33589
- Related #33573

## User-visible / Behavior Changes

- Nextcloud Talk outbound send path now uses resolved config provided by caller instead of always reloading on-disk config.
- `openclaw message send --channel nextcloud-talk` now preserves command-level secret resolution through outbound helper boundaries.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (development)
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a
- Integration/channel (if any): Nextcloud Talk extension outbound adapter
- Relevant config (redacted): `channels.nextcloud-talk.botSecret` passed through command-resolved cfg

### Steps

1. Configure Nextcloud Talk with SecretRef-backed `botSecret` in config.
2. Invoke outbound adapter path via `openclaw message send --channel nextcloud-talk` (resolved cfg available upstream).
3. Observe pre-fix helper path uses `loadConfig()` snapshot instead of resolved cfg.

### Expected

- Outbound send helper resolves account secrets from the resolved `cfg` passed by caller.

### Actual

- Pre-fix helper ignored caller `cfg` and resolved from `loadConfig()` snapshot.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Added and ran regression tests for cfg threading at outbound adapter boundary and send helper boundary.
- Edge cases checked: Verified send helper avoids calling `loadConfig()` when `opts.cfg` is provided.
- What you did **not** verify: Live Nextcloud server round-trip with real SecretRef provider.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `extensions/nextcloud-talk/src/channel.ts`, `extensions/nextcloud-talk/src/send.ts`
- Known bad symptoms reviewers should watch for: Outbound sends unexpectedly resolving credentials from stale runtime config instead of command-resolved cfg.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Some existing callers might rely on implicit runtime `loadConfig()` behavior.
  - Mitigation: Change preserves fallback (`opts.cfg ?? loadConfig()`), so existing callers remain unchanged.
