### PR TITLE
fix(irc): honor resolved cfg in outbound sends

### DIFF
--- a/extensions/irc/src/channel.outbound.test.ts
+++ b/extensions/irc/src/channel.outbound.test.ts
@@ -1,0 +1,79 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMessageIrcMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./send.js", () => ({
+  sendMessageIrc: sendMessageIrcMock,
+}));
+
+import { ircPlugin } from "./channel.js";
+
+describe("ircPlugin outbound cfg forwarding", () => {
+  beforeEach(() => {
+    sendMessageIrcMock.mockReset();
+    sendMessageIrcMock.mockResolvedValue({
+      messageId: "irc-msg-1",
+      target: "#general",
+    });
+  });
+
+  it("forwards cfg to sendText adapter path", async () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        irc: {
+          enabled: true,
+          host: "irc.example.com",
+          nick: "openclaw",
+          password: "resolved-secret",
+        },
+      },
+    };
+
+    await ircPlugin.outbound?.sendText?.({
+      cfg,
+      to: "#general",
+      text: "hello",
+      accountId: "default",
+    });
+
+    expect(sendMessageIrcMock).toHaveBeenCalledWith(
+      "#general",
+      "hello",
+      expect.objectContaining({
+        cfg,
+        accountId: "default",
+      }),
+    );
+  });
+
+  it("forwards cfg to sendMedia adapter path", async () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        irc: {
+          enabled: true,
+          host: "irc.example.com",
+          nick: "openclaw",
+          password: "resolved-secret",
+        },
+      },
+    };
+
+    await ircPlugin.outbound?.sendMedia?.({
+      cfg,
+      to: "#general",
+      text: "hello",
+      mediaUrl: "https://example.com/image.png",
+      accountId: "default",
+    });
+
+    expect(sendMessageIrcMock).toHaveBeenCalledWith(
+      "#general",
+      expect.stringContaining("Attachment: https://example.com/image.png"),
+      expect.objectContaining({
+        cfg,
+        accountId: "default",
+      }),
+    );
+  });
+});

--- a/extensions/irc/src/channel.ts
+++ b/extensions/irc/src/channel.ts
@@ -296,16 +296,18 @@ export const ircPlugin: ChannelPlugin<ResolvedIrcAccount, IrcProbe> = {
     chunker: (text, limit) => getIrcRuntime().channel.text.chunkMarkdownText(text, limit),
     chunkerMode: "markdown",
     textChunkLimit: 350,
-    sendText: async ({ to, text, accountId, replyToId }) => {
+    sendText: async ({ cfg, to, text, accountId, replyToId }) => {
       const result = await sendMessageIrc(to, text, {
+        cfg: cfg as CoreConfig,
         accountId: accountId ?? undefined,
         replyTo: replyToId ?? undefined,
       });
       return { channel: "irc", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, replyToId }) => {
+    sendMedia: async ({ cfg, to, text, mediaUrl, accountId, replyToId }) => {
       const combined = mediaUrl ? `${text}\n\nAttachment: ${mediaUrl}` : text;
       const result = await sendMessageIrc(to, combined, {
+        cfg: cfg as CoreConfig,
         accountId: accountId ?? undefined,
         replyTo: replyToId ?? undefined,
       });

--- a/extensions/irc/src/send.test.ts
+++ b/extensions/irc/src/send.test.ts
@@ -91,4 +91,27 @@ describe("sendMessageIrc cfg threading", () => {
       accountId: undefined,
     });
   });
+
+  it("falls back to runtime loadConfig when opts.cfg is omitted", async () => {
+    const client = {
+      isReady: () => true,
+      sendPrivmsg: vi.fn(),
+      quit: vi.fn(),
+    };
+
+    await sendMessageIrc("#general", "hello", { client } as never);
+
+    expect(loadConfigMock).toHaveBeenCalledOnce();
+    expect(resolveIrcAccountMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: expect.objectContaining({
+          channels: expect.objectContaining({
+            irc: expect.objectContaining({
+              host: "runtime.example.com",
+            }),
+          }),
+        }),
+      }),
+    );
+  });
 });

--- a/extensions/irc/src/send.test.ts
+++ b/extensions/irc/src/send.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CoreConfig } from "./types.js";
+
+const loadConfigMock = vi.hoisted(() => vi.fn());
+const resolveIrcAccountMock = vi.hoisted(() => vi.fn());
+const recordActivityMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./runtime.js", () => ({
+  getIrcRuntime: () => ({
+    config: {
+      loadConfig: loadConfigMock,
+    },
+    channel: {
+      text: {
+        resolveMarkdownTableMode: () => "off",
+        convertMarkdownTables: (text: string) => text,
+      },
+      activity: {
+        record: recordActivityMock,
+      },
+    },
+  }),
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveIrcAccount: resolveIrcAccountMock,
+}));
+
+vi.mock("./protocol.js", () => ({
+  makeIrcMessageId: () => "irc-msg-1",
+}));
+
+import { sendMessageIrc } from "./send.js";
+
+describe("sendMessageIrc cfg threading", () => {
+  beforeEach(() => {
+    loadConfigMock.mockReset();
+    resolveIrcAccountMock.mockReset();
+    recordActivityMock.mockReset();
+
+    const runtimeCfg: CoreConfig = {
+      channels: {
+        irc: {
+          enabled: true,
+          host: "runtime.example.com",
+          nick: "runtime-bot",
+          password: "runtime-secret",
+        },
+      },
+    };
+    loadConfigMock.mockReturnValue(runtimeCfg);
+
+    resolveIrcAccountMock.mockReturnValue({
+      accountId: "default",
+      enabled: true,
+      configured: true,
+      host: "resolved.example.com",
+      port: 6697,
+      tls: true,
+      nick: "resolved-bot",
+      username: "resolved-bot",
+      realname: "OpenClaw",
+      password: "resolved-secret",
+      passwordSource: "config",
+      config: {},
+    });
+  });
+
+  it("prefers opts.cfg over runtime loadConfig when resolving account", async () => {
+    const resolvedCfg: CoreConfig = {
+      channels: {
+        irc: {
+          enabled: true,
+          host: "resolved.example.com",
+          nick: "resolved-bot",
+          password: "resolved-secret",
+        },
+      },
+    };
+    const client = {
+      isReady: () => true,
+      sendPrivmsg: vi.fn(),
+      quit: vi.fn(),
+    };
+
+    await sendMessageIrc("#general", "hello", { cfg: resolvedCfg, client } as never);
+
+    expect(loadConfigMock).not.toHaveBeenCalled();
+    expect(resolveIrcAccountMock).toHaveBeenCalledWith({
+      cfg: resolvedCfg,
+      accountId: undefined,
+    });
+  });
+});

--- a/extensions/irc/src/send.ts
+++ b/extensions/irc/src/send.ts
@@ -8,6 +8,7 @@ import { getIrcRuntime } from "./runtime.js";
 import type { CoreConfig } from "./types.js";
 
 type SendIrcOptions = {
+  cfg?: CoreConfig;
   accountId?: string;
   replyTo?: string;
   target?: string;
@@ -37,7 +38,7 @@ export async function sendMessageIrc(
   opts: SendIrcOptions = {},
 ): Promise<SendIrcResult> {
   const runtime = getIrcRuntime();
-  const cfg = runtime.config.loadConfig() as CoreConfig;
+  const cfg = (opts.cfg ?? runtime.config.loadConfig()) as CoreConfig;
   const account = resolveIrcAccount({
     cfg,
     accountId: opts.accountId,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: IRC outbound adapter discarded caller-provided `cfg` and called `sendMessageIrc` without it.
- Why it matters: SecretRef-backed IRC credentials can fail in command-driven sends when helper re-resolves from runtime config snapshot.
- What changed: IRC outbound `sendText/sendMedia` now forward `cfg`; `sendMessageIrc` now uses `opts.cfg ?? runtime.config.loadConfig()`.
- What did NOT change (scope boundary): No monitor/inbound behavior changes and no changes outside IRC extension outbound helper path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33596
- Related #33573

## User-visible / Behavior Changes

- IRC outbound send helper now respects resolved config passed by caller.
- `openclaw message send --channel irc` keeps command-level config/secret resolution through adapter boundaries.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (development)
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a
- Integration/channel (if any): IRC extension outbound adapter
- Relevant config (redacted): `channels.irc.password` passed via command-resolved cfg

### Steps

1. Configure IRC password as SecretRef-backed credential.
2. Invoke outbound IRC send via command path with resolved `cfg` available.
3. Observe pre-fix helper uses runtime `loadConfig()` snapshot instead of provided cfg.

### Expected

- IRC helper resolves account credentials from caller-provided `cfg` when present.

### Actual

- Pre-fix helper ignored caller cfg and reloaded runtime config.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Added/ran adapter-level and helper-level cfg-threading regression tests.
- Edge cases checked: Verified `sendMessageIrc` avoids `loadConfig()` when `opts.cfg` is supplied.
- What you did **not** verify: Live IRC server send with real SecretRef provider.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `extensions/irc/src/channel.ts`, `extensions/irc/src/send.ts`
- Known bad symptoms reviewers should watch for: IRC outbound helper unexpectedly resolving from stale runtime config instead of caller cfg.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Existing callers relying on implicit runtime config load may be affected.
  - Mitigation: Fallback behavior is preserved (`opts.cfg ?? loadConfig()`), so existing callers remain compatible.
