### PR TITLE
fix(cron): return error when payload model is not allowed instead of silent fallback

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -223,13 +223,7 @@ export async function runCronIsolatedAgentTurn(params: {
       defaultModel: resolvedDefault.model,
     });
     if ("error" in resolvedOverride) {
-      if (resolvedOverride.error.startsWith("model not allowed:")) {
-        logWarn(
-          `cron: payload.model '${modelOverride}' not allowed, falling back to agent defaults`,
-        );
-      } else {
-        return { status: "error", error: resolvedOverride.error };
-      }
+      return { status: "error", error: resolvedOverride.error };
     } else {
       provider = resolvedOverride.ref.provider;
       model = resolvedOverride.ref.model;


### PR DESCRIPTION
## Summary
- Make `resolveAllowedModelRef` "model not allowed" error a hard error return instead of silent fallback to agent defaults
- Prevents cron jobs from silently running on expensive default models when `payload.model` is set to a disallowed model

## Root cause
`run.ts:225` had a special case for `error.startsWith("model not allowed:")` that logged a warning and fell through. All other `resolveAllowedModelRef` errors already returned early with `status: "error"`. The "not allowed" branch was the only one that silently continued, causing the job to run on the agent's default model (e.g. `gpt-5.3-codex`) while the user expected their configured model (e.g. `ollama/qwen3.5:4b`).

## Changes
- 1 file, +1/-7 lines (net -6)
- Remove the special-case `startsWith("model not allowed:")" branch
- All `resolveAllowedModelRef` errors now consistently return early

## Test plan
- [x] `pnpm vitest run src/cron/isolated-agent/run.cron-model-override.test.ts` — 6/6 pass
- [x] Existing test at line 169 already asserts `status: "error"" for disallowed models

Closes #33577

lobster-biscuit