### PR TITLE
fix(mattermost): honor resolved cfg in outbound sends

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -216,13 +216,57 @@ describe("mattermostPlugin", () => {
   });
 
   describe("outbound", () => {
+    it("forwards cfg on sendText", async () => {
+      const sendText = mattermostPlugin.outbound?.sendText;
+      if (!sendText) {
+        return;
+      }
+      const cfg: OpenClawConfig = {
+        channels: {
+          mattermost: {
+            enabled: true,
+            botToken: "resolved-token",
+            baseUrl: "https://chat.example.com",
+          },
+        },
+      };
+
+      await sendText({
+        cfg,
+        to: "channel:CHAN1",
+        text: "hello",
+        accountId: "default",
+        replyToId: "post-root",
+      });
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({
+          cfg,
+          accountId: "default",
+          replyToId: "post-root",
+        }),
+      );
+    });
+
     it("forwards mediaLocalRoots on sendMedia", async () => {
       const sendMedia = mattermostPlugin.outbound?.sendMedia;
       if (!sendMedia) {
         return;
       }
+      const cfg: OpenClawConfig = {
+        channels: {
+          mattermost: {
+            enabled: true,
+            botToken: "resolved-token",
+            baseUrl: "https://chat.example.com",
+          },
+        },
+      };
 
       await sendMedia({
+        cfg,
         to: "channel:CHAN1",
         text: "hello",
         mediaUrl: "/tmp/workspace/image.png",
@@ -235,6 +279,7 @@ describe("mattermostPlugin", () => {
         "channel:CHAN1",
         "hello",
         expect.objectContaining({
+          cfg,
           mediaUrl: "/tmp/workspace/image.png",
           mediaLocalRoots: ["/tmp/workspace"],
         }),

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -273,15 +273,17 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
       }
       return { ok: true, to: trimmed };
     },
-    sendText: async ({ to, text, accountId, replyToId }) => {
+    sendText: async ({ cfg, to, text, accountId, replyToId }) => {
       const result = await sendMessageMattermost(to, text, {
+        cfg,
         accountId: accountId ?? undefined,
         replyToId: replyToId ?? undefined,
       });
       return { channel: "mattermost", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, mediaLocalRoots, accountId, replyToId }) => {
+    sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, replyToId }) => {
       const result = await sendMessageMattermost(to, text, {
+        cfg,
         accountId: accountId ?? undefined,
         mediaUrl,
         mediaLocalRoots,

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -1,3 +1,4 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sendMessageMattermost } from "./send.js";
 
@@ -10,6 +11,8 @@ const mockState = vi.hoisted(() => ({
   fetchMattermostUserByUsername: vi.fn(),
   normalizeMattermostBaseUrl: vi.fn((input: string | undefined) => input?.trim() ?? ""),
   uploadMattermostFile: vi.fn(),
+  resolveMattermostAccount: vi.fn(),
+  loadConfig: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk", () => ({
@@ -17,11 +20,7 @@ vi.mock("openclaw/plugin-sdk", () => ({
 }));
 
 vi.mock("./accounts.js", () => ({
-  resolveMattermostAccount: () => ({
-    accountId: "default",
-    botToken: "bot-token",
-    baseUrl: "https://mattermost.example.com",
-  }),
+  resolveMattermostAccount: mockState.resolveMattermostAccount,
 }));
 
 vi.mock("./client.js", () => ({
@@ -37,7 +36,7 @@ vi.mock("./client.js", () => ({
 vi.mock("../runtime.js", () => ({
   getMattermostRuntime: () => ({
     config: {
-      loadConfig: () => ({}),
+      loadConfig: mockState.loadConfig,
     },
     logging: {
       shouldLogVerbose: () => false,
@@ -64,9 +63,17 @@ describe("sendMessageMattermost", () => {
     mockState.fetchMattermostMe.mockReset();
     mockState.fetchMattermostUserByUsername.mockReset();
     mockState.uploadMattermostFile.mockReset();
+    mockState.resolveMattermostAccount.mockReset();
+    mockState.loadConfig.mockReset();
     mockState.createMattermostClient.mockReturnValue({});
     mockState.createMattermostPost.mockResolvedValue({ id: "post-1" });
     mockState.uploadMattermostFile.mockResolvedValue({ id: "file-1" });
+    mockState.loadConfig.mockReturnValue({});
+    mockState.resolveMattermostAccount.mockReturnValue({
+      accountId: "default",
+      botToken: "bot-token",
+      baseUrl: "https://mattermost.example.com",
+    });
   });
 
   it("loads outbound media with trusted local roots before upload", async () => {
@@ -96,5 +103,25 @@ describe("sendMessageMattermost", () => {
         contentType: "image/png",
       }),
     );
+  });
+
+  it("prefers opts.cfg over runtime loadConfig when resolving account", async () => {
+    const resolvedCfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          enabled: true,
+          botToken: "resolved-token",
+          baseUrl: "https://mattermost.example.com",
+        },
+      },
+    };
+
+    await sendMessageMattermost("channel:town-square", "hello", { cfg: resolvedCfg });
+
+    expect(mockState.loadConfig).not.toHaveBeenCalled();
+    expect(mockState.resolveMattermostAccount).toHaveBeenCalledWith({
+      cfg: resolvedCfg,
+      accountId: undefined,
+    });
   });
 });

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -1,4 +1,5 @@
 import { loadOutboundMediaFromUrl } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { getMattermostRuntime } from "../runtime.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import {
@@ -13,6 +14,7 @@ import {
 } from "./client.js";
 
 export type MattermostSendOpts = {
+  cfg?: OpenClawConfig;
   botToken?: string;
   baseUrl?: string;
   accountId?: string;
@@ -146,7 +148,7 @@ export async function sendMessageMattermost(
 ): Promise<MattermostSendResult> {
   const core = getCore();
   const logger = core.logging.getChildLogger({ module: "mattermost" });
-  const cfg = core.config.loadConfig();
+  const cfg = opts.cfg ?? core.config.loadConfig();
   const account = resolveMattermostAccount({
     cfg,
     accountId: opts.accountId,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Mattermost outbound adapter called `sendMessageMattermost` without forwarding caller `cfg`.
- Why it matters: SecretRef-backed bot tokens can fail/regress when helper always resolves from runtime `loadConfig()` snapshot.
- What changed: Mattermost outbound `sendText/sendMedia` now pass `cfg`; helper now uses `opts.cfg ?? core.config.loadConfig()`.
- What did NOT change (scope boundary): No monitor/inbound flow changes and no behavior changes outside Mattermost outbound helper path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33599
- Related #33573

## User-visible / Behavior Changes

- Mattermost outbound send path now respects caller-provided resolved config.
- `openclaw message send --channel mattermost` preserves command-time secret resolution through outbound helper boundary.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (development)
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a
- Integration/channel (if any): Mattermost extension outbound adapter
- Relevant config (redacted): `channels.mattermost.botToken` passed through resolved `cfg`

### Steps

1. Configure Mattermost bot token as SecretRef-backed credential.
2. Trigger outbound send via command path where resolved `cfg` is already available.
3. Observe pre-fix helper uses runtime `loadConfig()` snapshot instead of caller cfg.

### Expected

- Helper resolves account credentials from caller-provided `cfg` when present.

### Actual

- Pre-fix helper ignored caller cfg and always reloaded runtime config.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Extended channel and helper tests to assert cfg threading and reran both suites.
- Edge cases checked: Verified helper bypasses `loadConfig()` when `opts.cfg` is supplied.
- What you did **not** verify: Live Mattermost server send using real SecretRef provider.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `extensions/mattermost/src/channel.ts`, `extensions/mattermost/src/mattermost/send.ts`
- Known bad symptoms reviewers should watch for: Outbound path unexpectedly resolving from stale runtime config instead of caller cfg.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Existing callers relying on implicit runtime config load may be affected.
  - Mitigation: Runtime fallback remains intact (`opts.cfg ?? core.config.loadConfig()`), preserving compatibility.
