### PR TITLE
fix(memory): replace glob patterns with directory paths for chokidar v5

### DIFF
--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -367,7 +367,7 @@ export abstract class MemoryManagerSyncOps {
     const watchPaths = new Set<string>([
       path.join(this.workspaceDir, "MEMORY.md"),
       path.join(this.workspaceDir, "memory.md"),
-      path.join(this.workspaceDir, "memory", "**", "*.md"),
+      path.join(this.workspaceDir, "memory"),
     ]);
     const additionalPaths = normalizeExtraMemoryPaths(this.workspaceDir, this.settings.extraPaths);
     for (const entry of additionalPaths) {
@@ -377,7 +377,7 @@ export abstract class MemoryManagerSyncOps {
           continue;
         }
         if (stat.isDirectory()) {
-          watchPaths.add(path.join(entry, "**", "*.md"));
+          watchPaths.add(entry);
           continue;
         }
         if (stat.isFile() && entry.toLowerCase().endsWith(".md")) {
@@ -389,7 +389,23 @@ export abstract class MemoryManagerSyncOps {
     }
     this.watcher = chokidar.watch(Array.from(watchPaths), {
       ignoreInitial: true,
-      ignored: (watchPath) => shouldIgnoreMemoryWatchPath(String(watchPath)),
+      ignored: (watchPath, stats) => {
+        if (shouldIgnoreMemoryWatchPath(String(watchPath))) {
+          return true;
+        }
+        // chokidar v5 recurses directories natively; filter non-.md files.
+        // When stats are available, only filter known files; otherwise use
+        // the extension to catch non-.md paths even on unlink events where
+        // chokidar may not provide stats.
+        const isMd = String(watchPath).toLowerCase().endsWith(".md");
+        if (stats?.isFile() && !isMd) {
+          return true;
+        }
+        if (!stats && !isMd && path.extname(String(watchPath)) !== "") {
+          return true;
+        }
+        return false;
+      },
       awaitWriteFinish: {
         stabilityThreshold: this.settings.sync.watchDebounceMs,
         pollInterval: 100,

--- a/src/memory/manager.watcher-config.test.ts
+++ b/src/memory/manager.watcher-config.test.ts
@@ -91,19 +91,37 @@ describe("memory watcher config", () => {
       expect.arrayContaining([
         path.join(workspaceDir, "MEMORY.md"),
         path.join(workspaceDir, "memory.md"),
-        path.join(workspaceDir, "memory", "**", "*.md"),
-        path.join(extraDir, "**", "*.md"),
+        path.join(workspaceDir, "memory"),
+        extraDir,
       ]),
     );
     expect(options.ignoreInitial).toBe(true);
     expect(options.awaitWriteFinish).toEqual({ stabilityThreshold: 25, pollInterval: 100 });
 
-    const ignored = options.ignored as ((watchPath: string) => boolean) | undefined;
+    const ignored = options.ignored as
+      | ((watchPath: string, stats?: { isFile(): boolean }) => boolean)
+      | undefined;
     expect(ignored).toBeTypeOf("function");
+    // Ignored directories still filtered by name
     expect(ignored?.(path.join(workspaceDir, "memory", "node_modules", "pkg", "index.md"))).toBe(
       true,
     );
     expect(ignored?.(path.join(workspaceDir, "memory", ".venv", "lib", "python.md"))).toBe(true);
+    // .md files in valid directories are accepted
     expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.md"))).toBe(false);
+    // Non-.md files are filtered when stats indicate a file
+    const fileStats = { isFile: () => true };
+    expect(ignored?.(path.join(workspaceDir, "memory", "project", "image.png"), fileStats)).toBe(
+      true,
+    );
+    expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.md"), fileStats)).toBe(
+      false,
+    );
+    // Case-insensitive .md check (e.g. README.MD on macOS/Windows)
+    expect(ignored?.(path.join(workspaceDir, "memory", "NOTES.MD"), fileStats)).toBe(false);
+    // Non-.md files without stats (e.g. unlink events) are still filtered
+    expect(ignored?.(path.join(workspaceDir, "memory", "project", "image.png"))).toBe(true);
+    // Directories (no extension, no stats) are allowed through
+    expect(ignored?.(path.join(workspaceDir, "memory", "project"))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Chokidar v5 removed built-in glob support (picomatch/anymatch). Paths like `memory/**/*.md` are now treated as **literal file paths**, causing the memory file watcher to silently miss all changes.

## Changes

- Replace glob patterns (`memory/**/*.md`) with plain directory paths (`memory`) in `ensureWatcher()`
- Add `.md` extension filter in the `ignored` callback so chokidar recurses directories natively while only processing markdown files
- Update watcher config tests to match new behavior

## Test plan

- [x] `pnpm vitest run src/memory/manager.watcher-config.test.ts` — 1/1 pass
- [x] Verified `ignored` callback filters non-.md files when `stats.isFile()` is true
- [x] Verified dependency directories (`node_modules`, `.venv`) are still ignored

Fixes #33585

lobster-biscuit