### PR TITLE
fix(gateway): hot-reload agents.defaults.models allowlist changes

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -51,6 +51,11 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     actions: ["restart-heartbeat"],
   },
   {
+    prefix: "agents.defaults.models",
+    kind: "hot",
+    actions: ["restart-heartbeat"],
+  },
+  {
     prefix: "agents.defaults.model",
     kind: "hot",
     actions: ["restart-heartbeat"],

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -159,6 +159,14 @@ describe("buildGatewayReloadPlan", () => {
     );
   });
 
+  it("restarts heartbeat when agents.defaults.models allowlist changes", () => {
+    const plan = buildGatewayReloadPlan(["agents.defaults.models"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartHeartbeat).toBe(true);
+    expect(plan.hotReasons).toContain("agents.defaults.models");
+    expect(plan.noopPaths).toEqual([]);
+  });
+
   it("hot-reloads health monitor when channelHealthCheckMinutes changes", () => {
     const plan = buildGatewayReloadPlan(["gateway.channelHealthCheckMinutes"]);
     expect(plan.restartGateway).toBe(false);


### PR DESCRIPTION
## Summary

`agents.defaults.models` (plural — the allowlist array) had no reload rule. Changes to the model allowlist in `openclaw.json` were silently ignored at runtime because the path fell through to the catch-all `agents` tail rule (`kind=none`).

The existing rule for `agents.defaults.model` (singular) does **not** prefix-match `agents.defaults.models` — the next character is `s`, not `.`.

## Changes

- Add `agents.defaults.models` reload rule with `restart-heartbeat` action
- Add test verifying allowlist changes trigger heartbeat restart (not no-op)

## Test plan

- [x] `pnpm vitest run src/gateway/config-reload.test.ts` — 22/22 pass
- [x] Existing `agents.defaults.model` (singular) test still passes
- [x] New test confirms `agents.defaults.models` → `restartHeartbeat=true`, not `noopPaths`

Fixes #33600

lobster-biscuit