### PR TITLE
fix(whatsapp): honor resolved cfg in outbound sends

### DIFF
--- a/src/channels/plugins/outbound/whatsapp.sendpayload.test.ts
+++ b/src/channels/plugins/outbound/whatsapp.sendpayload.test.ts
@@ -15,6 +15,49 @@ function baseCtx(payload: ReplyPayload) {
 }
 
 describe("whatsappOutbound sendPayload", () => {
+  it("forwards cfg on sendText", async () => {
+    const cfg = {
+      channels: { whatsapp: { enabled: true } },
+    };
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "wa-1" });
+    const sendText = whatsappOutbound.sendText!;
+
+    await sendText({
+      cfg,
+      to: "5511999999999@c.us",
+      text: "hello",
+      deps: { sendWhatsApp },
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledWith(
+      "5511999999999@c.us",
+      "hello",
+      expect.objectContaining({ cfg }),
+    );
+  });
+
+  it("forwards cfg on sendMedia", async () => {
+    const cfg = {
+      channels: { whatsapp: { enabled: true } },
+    };
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "wa-1" });
+    const sendMedia = whatsappOutbound.sendMedia!;
+
+    await sendMedia({
+      cfg,
+      to: "5511999999999@c.us",
+      text: "caption",
+      mediaUrl: "https://example.com/a.jpg",
+      deps: { sendWhatsApp },
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledWith(
+      "5511999999999@c.us",
+      "caption",
+      expect.objectContaining({ cfg, mediaUrl: "https://example.com/a.jpg" }),
+    );
+  });
+
   it("text-only delegates to sendText", async () => {
     const ctx = baseCtx({ text: "hello" });
     const result = await whatsappOutbound.sendPayload!(ctx);

--- a/src/channels/plugins/outbound/whatsapp.ts
+++ b/src/channels/plugins/outbound/whatsapp.ts
@@ -15,21 +15,23 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
     resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
   sendPayload: async (ctx) =>
     await sendTextMediaPayload({ channel: "whatsapp", ctx, adapter: whatsappOutbound }),
-  sendText: async ({ to, text, accountId, deps, gifPlayback }) => {
+  sendText: async ({ cfg, to, text, accountId, deps, gifPlayback }) => {
     const send =
       deps?.sendWhatsApp ?? (await import("../../../web/outbound.js")).sendMessageWhatsApp;
     const result = await send(to, text, {
       verbose: false,
+      cfg,
       accountId: accountId ?? undefined,
       gifPlayback,
     });
     return { channel: "whatsapp", ...result };
   },
-  sendMedia: async ({ to, text, mediaUrl, mediaLocalRoots, accountId, deps, gifPlayback }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId, deps, gifPlayback }) => {
     const send =
       deps?.sendWhatsApp ?? (await import("../../../web/outbound.js")).sendMessageWhatsApp;
     const result = await send(to, text, {
       verbose: false,
+      cfg,
       mediaUrl,
       mediaLocalRoots,
       accountId: accountId ?? undefined,

--- a/src/web/outbound.test.ts
+++ b/src/web/outbound.test.ts
@@ -7,6 +7,11 @@ import { resetLogger, setLoggerOverride } from "../logging.js";
 import { redactIdentifier } from "../logging/redact-identifier.js";
 import { setActiveWebListener } from "./active-listener.js";
 
+const loadConfigMock = vi.fn(() => ({}));
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => loadConfigMock(),
+}));
+
 const loadWebMediaMock = vi.fn();
 vi.mock("./media.js", () => ({
   loadWebMedia: (...args: unknown[]) => loadWebMediaMock(...args),
@@ -22,6 +27,8 @@ describe("web outbound", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    loadConfigMock.mockReset();
+    loadConfigMock.mockReturnValue({});
     setActiveWebListener({
       sendComposingTo,
       sendMessage,
@@ -44,6 +51,18 @@ describe("web outbound", () => {
     });
     expect(sendComposingTo).toHaveBeenCalledWith("+1555");
     expect(sendMessage).toHaveBeenCalledWith("+1555", "hi", undefined, undefined);
+  });
+
+  it("prefers caller cfg over loadConfig when provided", async () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          enabled: true,
+        },
+      },
+    };
+    await sendMessageWhatsApp("+1555", "hi", { verbose: false, cfg } as never);
+    expect(loadConfigMock).not.toHaveBeenCalled();
   });
 
   it("throws a helpful error when no active listener exists", async () => {

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -1,5 +1,6 @@
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { generateSecureUuid } from "../infra/secure-random.js";
 import { getChildLogger } from "../logging/logger.js";
 import { redactIdentifier } from "../logging/redact-identifier.js";
@@ -18,6 +19,7 @@ export async function sendMessageWhatsApp(
   body: string,
   options: {
     verbose: boolean;
+    cfg?: OpenClawConfig;
     mediaUrl?: string;
     mediaLocalRoots?: readonly string[];
     gifPlayback?: boolean;
@@ -30,7 +32,7 @@ export async function sendMessageWhatsApp(
   const { listener: active, accountId: resolvedAccountId } = requireActiveWebListener(
     options.accountId,
   );
-  const cfg = loadConfig();
+  const cfg = options.cfg ?? loadConfig();
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "whatsapp",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: WhatsApp outbound helper (`sendMessageWhatsApp`) always called `loadConfig()` and ignored caller config context.
- Why it matters: Outbound adapter flows with an already-resolved `cfg` could still use stale/runtime config snapshots.
- What changed: Added optional `cfg` to `sendMessageWhatsApp` options and switched to `options.cfg ?? loadConfig()`; WhatsApp outbound adapter now forwards `cfg` in sendText/sendMedia.
- What did NOT change (scope boundary): No changes to listener/session lifecycle, poll/reaction behavior, or non-WhatsApp adapters.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33604
- Related #33573

## User-visible / Behavior Changes

- WhatsApp outbound helper now respects caller-provided cfg context when present.
- WhatsApp outbound adapter now threads cfg into send options for text/media sends.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (development)
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a
- Integration/channel (if any): WhatsApp outbound adapter + web outbound helper
- Relevant config (redacted): caller-provided `cfg` in outbound context

### Steps

1. Call WhatsApp outbound adapter with a populated `cfg` in context.
2. Observe pre-fix helper still calls `loadConfig()`.
3. Verify caller cfg is not used in helper path pre-fix.

### Expected

- Helper should use caller cfg when provided and fallback to `loadConfig()` only when absent.

### Actual

- Pre-fix helper always used `loadConfig()`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Added regression tests in `src/web/outbound.test.ts` and `src/channels/plugins/outbound/whatsapp.sendpayload.test.ts`; confirmed fail-before/pass-after.
- Edge cases checked: Verified adapter forwards cfg for both text and media paths.
- What you did **not** verify: Live WhatsApp send against real active listener with non-default config divergence.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/web/outbound.ts`, `src/channels/plugins/outbound/whatsapp.ts`
- Known bad symptoms reviewers should watch for: Outbound path unexpectedly ignoring caller cfg and reverting to runtime config snapshot.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Callers may pass malformed cfg objects.
  - Mitigation: Existing fallback and existing table-mode resolution behavior remain unchanged; cfg path is optional and additive.
