### PR TITLE
fix(line): honor resolved cfg in outbound sends

### DIFF
--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -88,6 +88,26 @@ function createRuntime(): { runtime: PluginRuntime; mocks: LineRuntimeMocks } {
 }
 
 describe("linePlugin outbound.sendPayload", () => {
+  it("forwards cfg into line send helper options", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+
+    await linePlugin.outbound!.sendPayload!({
+      to: "line:user:cfg",
+      text: "hello",
+      payload: { text: "hello" },
+      accountId: "default",
+      cfg,
+    });
+
+    expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:user:cfg", "hello", {
+      verbose: false,
+      cfg,
+      accountId: "default",
+    });
+  });
+
   it("sends flex message without dropping text", async () => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);
@@ -116,6 +136,7 @@ describe("linePlugin outbound.sendPayload", () => {
     expect(mocks.pushFlexMessage).toHaveBeenCalledTimes(1);
     expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:group:1", "Now playing:", {
       verbose: false,
+      cfg,
       accountId: "default",
     });
   });
@@ -153,6 +174,7 @@ describe("linePlugin outbound.sendPayload", () => {
     expect(mocks.pushTemplateMessage).toHaveBeenCalledTimes(1);
     expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:user:1", "Choose one:", {
       verbose: false,
+      cfg,
       accountId: "default",
     });
   });
@@ -193,7 +215,7 @@ describe("linePlugin outbound.sendPayload", () => {
           quickReply: { items: ["One", "Two"] },
         },
       ],
-      { verbose: false, accountId: "default" },
+      { verbose: false, cfg, accountId: "default" },
     );
     expect(mocks.createQuickReplyItems).toHaveBeenCalledWith(["One", "Two"]);
   });
@@ -224,13 +246,14 @@ describe("linePlugin outbound.sendPayload", () => {
     expect(mocks.sendMessageLine).toHaveBeenCalledWith("line:user:3", "", {
       verbose: false,
       mediaUrl: "https://example.com/img.jpg",
+      cfg,
       accountId: "default",
     });
     expect(mocks.pushTextMessageWithQuickReplies).toHaveBeenCalledWith(
       "line:user:3",
       "Hello",
       ["One", "Two"],
-      { verbose: false, accountId: "default" },
+      { verbose: false, cfg, accountId: "default" },
     );
     const mediaOrder = mocks.sendMessageLine.mock.invocationCallOrder[0];
     const quickReplyOrder = mocks.pushTextMessageWithQuickReplies.mock.invocationCallOrder[0];

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -372,6 +372,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           const batch = messages.slice(i, i + 5) as unknown as Parameters<typeof sendBatch>[1];
           const result = await sendBatch(to, batch, {
             verbose: false,
+            cfg,
             accountId: accountId ?? undefined,
           });
           lastResult = { messageId: result.messageId, chatId: result.chatId };
@@ -399,6 +400,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           const flexContents = lineData.flexMessage.contents as Parameters<typeof sendFlex>[2];
           lastResult = await sendFlex(to, lineData.flexMessage.altText, flexContents, {
             verbose: false,
+            cfg,
             accountId: accountId ?? undefined,
           });
         }
@@ -408,6 +410,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           if (template) {
             lastResult = await sendTemplate(to, template, {
               verbose: false,
+              cfg,
               accountId: accountId ?? undefined,
             });
           }
@@ -416,6 +419,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
         if (lineData.location) {
           lastResult = await sendLocation(to, lineData.location, {
             verbose: false,
+            cfg,
             accountId: accountId ?? undefined,
           });
         }
@@ -425,6 +429,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           const flexContents = flexMsg.contents as Parameters<typeof sendFlex>[2];
           lastResult = await sendFlex(to, flexMsg.altText, flexContents, {
             verbose: false,
+            cfg,
             accountId: accountId ?? undefined,
           });
         }
@@ -436,6 +441,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           lastResult = await runtime.channel.line.sendMessageLine(to, "", {
             verbose: false,
             mediaUrl: url,
+            cfg,
             accountId: accountId ?? undefined,
           });
         }
@@ -447,11 +453,13 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           if (isLast && hasQuickReplies) {
             lastResult = await sendQuickReplies(to, chunks[i], quickReplies, {
               verbose: false,
+              cfg,
               accountId: accountId ?? undefined,
             });
           } else {
             lastResult = await sendText(to, chunks[i], {
               verbose: false,
+              cfg,
               accountId: accountId ?? undefined,
             });
           }
@@ -513,6 +521,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           lastResult = await runtime.channel.line.sendMessageLine(to, "", {
             verbose: false,
             mediaUrl: url,
+            cfg,
             accountId: accountId ?? undefined,
           });
         }
@@ -523,7 +532,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       }
       return { channel: "line", messageId: "empty", chatId: to };
     },
-    sendText: async ({ to, text, accountId }) => {
+    sendText: async ({ cfg, to, text, accountId }) => {
       const runtime = getLineRuntime();
       const sendText = runtime.channel.line.pushMessageLine;
       const sendFlex = runtime.channel.line.pushFlexMessage;
@@ -536,6 +545,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       if (processed.text.trim()) {
         result = await sendText(to, processed.text, {
           verbose: false,
+          cfg,
           accountId: accountId ?? undefined,
         });
       } else {
@@ -549,17 +559,19 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
         const flexContents = flexMsg.contents as Parameters<typeof sendFlex>[2];
         await sendFlex(to, flexMsg.altText, flexContents, {
           verbose: false,
+          cfg,
           accountId: accountId ?? undefined,
         });
       }
 
       return { channel: "line", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId }) => {
+    sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
       const send = getLineRuntime().channel.line.sendMessageLine;
       const result = await send(to, text, {
         verbose: false,
         mediaUrl,
+        cfg,
         accountId: accountId ?? undefined,
       });
       return { channel: "line", ...result };

--- a/src/line/send.test.ts
+++ b/src/line/send.test.ts
@@ -159,6 +159,24 @@ describe("LINE send helpers", () => {
     expect(result).toEqual({ messageId: "reply", chatId: "C1" });
   });
 
+  it("prefers caller cfg over loadConfig when provided", async () => {
+    const cfg = {
+      channels: {
+        line: {
+          enabled: true,
+        },
+      },
+    };
+
+    await sendModule.pushMessageLine("line:user:U-cfg", "Hello", { cfg } as never);
+
+    expect(loadConfigMock).not.toHaveBeenCalled();
+    expect(resolveLineAccountMock).toHaveBeenCalledWith({
+      cfg,
+      accountId: undefined,
+    });
+  });
+
   it("throws when push messages are empty", async () => {
     await expect(sendModule.pushMessagesLine("U123", [])).rejects.toThrow(
       "Message must be non-empty for LINE sends",

--- a/src/line/send.ts
+++ b/src/line/send.ts
@@ -1,5 +1,6 @@
 import { messagingApi } from "@line/bot-sdk";
 import { loadConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logVerbose } from "../globals.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
 import { resolveLineAccount } from "./accounts.js";
@@ -25,6 +26,7 @@ const userProfileCache = new Map<
 const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 interface LineSendOpts {
+  cfg?: OpenClawConfig;
   channelAccessToken?: string;
   accountId?: string;
   verbose?: boolean;
@@ -32,8 +34,8 @@ interface LineSendOpts {
   replyToken?: string;
 }
 
-type LineClientOpts = Pick<LineSendOpts, "channelAccessToken" | "accountId">;
-type LinePushOpts = Pick<LineSendOpts, "channelAccessToken" | "accountId" | "verbose">;
+type LineClientOpts = Pick<LineSendOpts, "cfg" | "channelAccessToken" | "accountId">;
+type LinePushOpts = Pick<LineSendOpts, "cfg" | "channelAccessToken" | "accountId" | "verbose">;
 
 interface LinePushBehavior {
   errorContext?: string;
@@ -68,7 +70,7 @@ function createLineMessagingClient(opts: LineClientOpts): {
   account: ReturnType<typeof resolveLineAccount>;
   client: messagingApi.MessagingApiClient;
 } {
-  const cfg = loadConfig();
+  const cfg = opts.cfg ?? loadConfig();
   const account = resolveLineAccount({
     cfg,
     accountId: opts.accountId,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: LINE send helpers always loaded config via `loadConfig()` and ignored caller context.
- Why it matters: Extension outbound flow had resolved `cfg` available but helper calls reloaded config snapshot instead.
- What changed: Added optional `cfg` to LINE send options and switched helper resolution to `opts.cfg ?? loadConfig()`; LINE extension outbound now threads `cfg` into helper calls.
- What did NOT change (scope boundary): No changes to LINE webhook/inbound processing or non-LINE channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33611
- Related #33573

## User-visible / Behavior Changes

- LINE outbound helper path now respects caller-provided cfg when present.
- LINE extension outbound send flow threads cfg through text/media/batch helper calls.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (development)
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a
- Integration/channel (if any): LINE extension outbound + core LINE send helpers
- Relevant config (redacted): caller `cfg` passed to outbound context

### Steps

1. Execute LINE outbound send via extension path with `cfg` provided in context.
2. Observe pre-fix helper still resolves config through `loadConfig()`.
3. Verify helper ignores caller cfg pre-fix.

### Expected

- LINE helper should use caller cfg when provided.

### Actual

- Pre-fix LINE helper always used `loadConfig()`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Added failing-first regression tests in `src/line/send.test.ts` and `extensions/line/src/channel.sendPayload.test.ts`, then validated pass-after.
- Edge cases checked: Verified cfg threading for text/media/quick-reply/batch helper options in extension outbound flow.
- What you did **not** verify: Live LINE API send with divergent on-disk vs caller config.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/line/send.ts`, `extensions/line/src/channel.ts`
- Known bad symptoms reviewers should watch for: LINE sends unexpectedly resolving config from stale runtime snapshot instead of caller cfg.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Additional optional `cfg` path could be misused by malformed callers.
  - Mitigation: Fallback behavior remains unchanged (`opts.cfg ?? loadConfig()`), and existing callers remain compatible.
