### PR TITLE
fix(nextcloud-talk): thread resolved cfg into sendMessageNextcloudTalk to prevent SecretRef failures

### DIFF
--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -262,18 +262,20 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> = 
     chunker: (text, limit) => getNextcloudTalkRuntime().channel.text.chunkMarkdownText(text, limit),
     chunkerMode: "markdown",
     textChunkLimit: 4000,
-    sendText: async ({ to, text, accountId, replyToId }) => {
+    sendText: async ({ cfg, to, text, accountId, replyToId }) => {
       const result = await sendMessageNextcloudTalk(to, text, {
         accountId: accountId ?? undefined,
         replyTo: replyToId ?? undefined,
+        cfg: cfg as CoreConfig,
       });
       return { channel: "nextcloud-talk", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, replyToId }) => {
+    sendMedia: async ({ cfg, to, text, mediaUrl, accountId, replyToId }) => {
       const messageWithMedia = mediaUrl ? `${text}\n\nAttachment: ${mediaUrl}` : text;
       const result = await sendMessageNextcloudTalk(to, messageWithMedia, {
         accountId: accountId ?? undefined,
         replyTo: replyToId ?? undefined,
+        cfg: cfg as CoreConfig,
       });
       return { channel: "nextcloud-talk", ...result };
     },

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -9,6 +9,7 @@ type NextcloudTalkSendOpts = {
   accountId?: string;
   replyTo?: string;
   verbose?: boolean;
+  cfg?: CoreConfig;
 };
 
 function resolveCredentials(
@@ -60,7 +61,7 @@ export async function sendMessageNextcloudTalk(
   text: string,
   opts: NextcloudTalkSendOpts = {},
 ): Promise<NextcloudTalkSendResult> {
-  const cfg = getNextcloudTalkRuntime().config.loadConfig() as CoreConfig;
+  const cfg = (opts.cfg ?? getNextcloudTalkRuntime().config.loadConfig()) as CoreConfig;
   const account = resolveNextcloudTalkAccount({
     cfg,
     accountId: opts.accountId,
@@ -175,7 +176,7 @@ export async function sendReactionNextcloudTalk(
   reaction: string,
   opts: Omit<NextcloudTalkSendOpts, "replyTo"> = {},
 ): Promise<{ ok: true }> {
-  const cfg = getNextcloudTalkRuntime().config.loadConfig() as CoreConfig;
+  const cfg = (opts.cfg ?? getNextcloudTalkRuntime().config.loadConfig()) as CoreConfig;
   const account = resolveNextcloudTalkAccount({
     cfg,
     accountId: opts.accountId,


### PR DESCRIPTION
## Problem

The Nextcloud Talk outbound send path was calling `getNextcloudTalkRuntime().config.loadConfig()` directly inside `sendMessageNextcloudTalk` and `sendReactionNextcloudTalk` instead of using the already-resolved config supplied by the channel adapter.

When `channels.nextcloud-talk.botSecret` is configured as a SecretRef (e.g., a file/provider-backed credential), `loadConfig()` returns the unresolved raw config from disk. This caused unresolved-secret errors at send time — even though command-level resolution had already succeeded upstream — breaking `openclaw message send` for Nextcloud Talk with SecretRef-backed bot secrets.

This is the same class of regression that was fixed in other channel paths (e.g., Discord SecretRef threading).

## Fix

- Add optional `cfg?: CoreConfig` field to `NextcloudTalkSendOpts`
- In both `sendMessageNextcloudTalk` and `sendReactionNextcloudTalk`: use `opts.cfg ?? getNextcloudTalkRuntime().config.loadConfig()` so callers can pass the resolved config directly, while CLI/tool paths that don't have resolved config continue to fall back to `loadConfig()`
- In `channel.ts` `sendText` and `sendMedia` callbacks: destructure `cfg` from the outbound context and forward it into the send helper, mirroring the pattern used by other channel outbound adapters (e.g., `direct-text-media.ts`)

## Testing

- All 15 existing Nextcloud Talk tests pass
- No new TS errors introduced (`pnpm build` + `pnpm check` clean)

Fixes #33589