### PR TITLE
feat: support sampling params (frequency_penalty, presence_penalty, top_p, top_k) in model extra params

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.sampling-params.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.sampling-params.test.ts
@@ -1,0 +1,315 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { applyExtraParamsToAgent, collectSamplingParams } from "./extra-params.js";
+
+// Mock streamSimple for testing
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: vi.fn(() => ({
+    push: vi.fn(),
+    result: vi.fn(),
+  })),
+}));
+
+type SamplingCase = {
+  applyProvider: string;
+  applyModelId: string;
+  model: Model<"openai-completions">;
+  cfg?: Parameters<typeof applyExtraParamsToAgent>[1];
+  options?: SimpleStreamOptions;
+};
+
+function runSamplingCase(params: SamplingCase) {
+  const payload: Record<string, unknown> = { model: params.model.id, messages: [] };
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    options?.onPayload?.(payload);
+    return {} as ReturnType<StreamFn>;
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(agent, params.cfg, params.applyProvider, params.applyModelId);
+
+  const context: Context = { messages: [] };
+  void agent.streamFn?.(params.model, context, params.options ?? {});
+
+  return payload;
+}
+
+const defaultModel = {
+  api: "openai-completions",
+  provider: "openai",
+  id: "gpt-5",
+} as Model<"openai-completions">;
+
+describe("collectSamplingParams", () => {
+  it("returns undefined when no sampling params are present", () => {
+    expect(collectSamplingParams({ temperature: 0.7 })).toBeUndefined();
+    expect(collectSamplingParams(undefined)).toBeUndefined();
+    expect(collectSamplingParams({})).toBeUndefined();
+  });
+
+  it("collects snake_case params", () => {
+    expect(
+      collectSamplingParams({
+        frequency_penalty: 0.5,
+        presence_penalty: 0.3,
+      }),
+    ).toEqual({
+      frequency_penalty: 0.5,
+      presence_penalty: 0.3,
+    });
+  });
+
+  it("normalises camelCase to snake_case", () => {
+    expect(
+      collectSamplingParams({
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.3,
+        topP: 0.9,
+        topK: 40,
+        repetitionPenalty: 1.1,
+      }),
+    ).toEqual({
+      frequency_penalty: 0.5,
+      presence_penalty: 0.3,
+      top_p: 0.9,
+      top_k: 40,
+      repetition_penalty: 1.1,
+    });
+  });
+
+  it("ignores non-numeric values", () => {
+    expect(
+      collectSamplingParams({
+        frequency_penalty: "high",
+        presence_penalty: true,
+        top_p: null,
+        top_k: 40,
+      }),
+    ).toEqual({ top_k: 40 });
+  });
+
+  it("ignores NaN and Infinity", () => {
+    expect(
+      collectSamplingParams({
+        frequency_penalty: NaN,
+        presence_penalty: Infinity,
+        top_p: 0.9,
+      }),
+    ).toEqual({ top_p: 0.9 });
+  });
+
+  it("snake_case takes last-wins when both aliases are present", () => {
+    // Both camelCase and snake_case are present — last-wins per iteration
+    // order, but both map to the same key so the final value wins.
+    const result = collectSamplingParams({
+      frequencyPenalty: 0.5,
+      frequency_penalty: 0.8,
+    });
+    expect(result).toHaveProperty("frequency_penalty");
+    expect(typeof result!.frequency_penalty).toBe("number");
+  });
+});
+
+describe("extra-params: sampling parameter injection", () => {
+  it("injects frequency_penalty into payload", () => {
+    const payload = runSamplingCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: defaultModel,
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5": {
+                params: {
+                  frequency_penalty: 0.5,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(payload.frequency_penalty).toBe(0.5);
+  });
+
+  it("injects multiple sampling params into payload", () => {
+    const payload = runSamplingCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: defaultModel,
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5": {
+                params: {
+                  frequency_penalty: 0.5,
+                  presence_penalty: 0.3,
+                  top_p: 0.9,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(payload.frequency_penalty).toBe(0.5);
+    expect(payload.presence_penalty).toBe(0.3);
+    expect(payload.top_p).toBe(0.9);
+  });
+
+  it("normalises camelCase config keys to snake_case in payload", () => {
+    const payload = runSamplingCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: defaultModel,
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5": {
+                params: {
+                  frequencyPenalty: 0.5,
+                  presencePenalty: 0.3,
+                  topP: 0.9,
+                  topK: 40,
+                  repetitionPenalty: 1.1,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(payload.frequency_penalty).toBe(0.5);
+    expect(payload.presence_penalty).toBe(0.3);
+    expect(payload.top_p).toBe(0.9);
+    expect(payload.top_k).toBe(40);
+    expect(payload.repetition_penalty).toBe(1.1);
+  });
+
+  it("does not inject sampling params when none are configured", () => {
+    const payload = runSamplingCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: defaultModel,
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5": {
+                params: {
+                  temperature: 0.7,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(payload).not.toHaveProperty("frequency_penalty");
+    expect(payload).not.toHaveProperty("presence_penalty");
+    expect(payload).not.toHaveProperty("top_p");
+    expect(payload).not.toHaveProperty("top_k");
+    expect(payload).not.toHaveProperty("repetition_penalty");
+  });
+
+  it("chains with existing onPayload callback", () => {
+    const existingOnPayload = vi.fn();
+    const payload: Record<string, unknown> = { model: "gpt-5", messages: [] };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5": {
+                params: {
+                  frequency_penalty: 0.5,
+                },
+              },
+            },
+          },
+        },
+      },
+      "openai",
+      "gpt-5",
+    );
+
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(defaultModel, context, { onPayload: existingOnPayload });
+
+    // Sampling params should be injected
+    expect(payload.frequency_penalty).toBe(0.5);
+    // Original onPayload should still be called
+    expect(existingOnPayload).toHaveBeenCalledWith(payload);
+  });
+
+  it("works with non-OpenAI providers", () => {
+    const zaiModel = {
+      api: "openai-completions",
+      provider: "zai",
+      id: "glm-5",
+    } as Model<"openai-completions">;
+
+    const payload = runSamplingCase({
+      applyProvider: "zai",
+      applyModelId: "glm-5",
+      model: zaiModel,
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "zai/glm-5": {
+                params: {
+                  frequency_penalty: 0.5,
+                  repetition_penalty: 1.1,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(payload.frequency_penalty).toBe(0.5);
+    expect(payload.repetition_penalty).toBe(1.1);
+  });
+
+  it("ignores non-numeric sampling param values", () => {
+    const payload = runSamplingCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: defaultModel,
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5": {
+                params: {
+                  frequency_penalty: "high",
+                  presence_penalty: 0.3,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(payload).not.toHaveProperty("frequency_penalty");
+    expect(payload.presence_penalty).toBe(0.3);
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -50,6 +50,51 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
 };
 
 /**
+ * Sampling parameter names that can be forwarded to the API via onPayload.
+ * These are not part of pi-ai's SimpleStreamOptions, so they must be injected
+ * directly into the request body using the onPayload callback.
+ *
+ * Accepts both camelCase (config convention) and snake_case (API convention).
+ * Snake_case is what ends up in the payload; camelCase is normalised on read.
+ */
+const SAMPLING_PARAM_ALIASES: Record<string, string> = {
+  frequency_penalty: "frequency_penalty",
+  frequencyPenalty: "frequency_penalty",
+  presence_penalty: "presence_penalty",
+  presencePenalty: "presence_penalty",
+  repetition_penalty: "repetition_penalty",
+  repetitionPenalty: "repetition_penalty",
+  top_p: "top_p",
+  topP: "top_p",
+  top_k: "top_k",
+  topK: "top_k",
+};
+
+/**
+ * Collect sampling parameters (frequency_penalty, presence_penalty, top_p,
+ * top_k, repetition_penalty) from extraParams. Returns a map of snake_case
+ * API field names to numeric values, or undefined when none are set.
+ *
+ * @internal Exported for testing only
+ */
+export function collectSamplingParams(
+  extraParams: Record<string, unknown> | undefined,
+): Record<string, number> | undefined {
+  if (!extraParams) {
+    return undefined;
+  }
+  let result: Record<string, number> | undefined;
+  for (const [configKey, apiKey] of Object.entries(SAMPLING_PARAM_ALIASES)) {
+    const value = extraParams[configKey];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      result ??= {};
+      result[apiKey] = value;
+    }
+  }
+  return result;
+}
+
+/**
  * Resolve cacheRetention from extraParams, supporting both new `cacheRetention`
  * and legacy `cacheControlTtl` values for backwards compatibility.
  *
@@ -146,13 +191,20 @@ function createStreamFnWithExtraParams(
       ? (extraParams.provider as Record<string, unknown>)
       : undefined;
 
-  if (Object.keys(streamParams).length === 0 && !providerRouting) {
+  // Collect sampling parameters that are not part of SimpleStreamOptions.
+  // These are injected directly into the API request body via onPayload.
+  const samplingParams = collectSamplingParams(extraParams);
+
+  if (Object.keys(streamParams).length === 0 && !providerRouting && !samplingParams) {
     return undefined;
   }
 
   log.debug(`creating streamFn wrapper with params: ${JSON.stringify(streamParams)}`);
   if (providerRouting) {
     log.debug(`OpenRouter provider routing: ${JSON.stringify(providerRouting)}`);
+  }
+  if (samplingParams) {
+    log.debug(`sampling params: ${JSON.stringify(samplingParams)}`);
   }
 
   const underlying = baseStreamFn ?? streamSimple;
@@ -165,10 +217,31 @@ function createStreamFnWithExtraParams(
           compat: { ...model.compat, openRouterRouting: providerRouting },
         } as unknown as typeof model)
       : model;
-    return underlying(effectiveModel, context, {
-      ...streamParams,
-      ...options,
-    });
+
+    // When sampling parameters are configured, inject them into the API
+    // request body via onPayload. pi-ai does not expose these in
+    // SimpleStreamOptions, so we write them directly into the payload
+    // object that the provider sends to the API.
+    const mergedOptions = samplingParams
+      ? {
+          ...streamParams,
+          ...options,
+          onPayload: (payload: unknown) => {
+            if (payload && typeof payload === "object") {
+              const payloadObj = payload as Record<string, unknown>;
+              for (const [key, value] of Object.entries(samplingParams)) {
+                payloadObj[key] = value;
+              }
+            }
+            options?.onPayload?.(payload);
+          },
+        }
+      : {
+          ...streamParams,
+          ...options,
+        };
+
+    return underlying(effectiveModel, context, mergedOptions);
   };
 
   return wrappedStreamFn;


### PR DESCRIPTION
## Summary

Fixes #32496.

`createStreamFnWithExtraParams` only processes `temperature` and `maxTokens` — sampling parameters like `frequency_penalty`, `presence_penalty`, `top_p`, `top_k`, and `repetition_penalty` are silently ignored. This causes issues with models prone to repetitive output (e.g., GLM-5) when penalty parameters are not applied.

**Fix:** Collect sampling parameters from `extraParams` and inject them directly into the API request body via the `onPayload` callback. This follows the same pattern as Z.AI `tool_stream` injection — these parameters are not part of pi-ai's `SimpleStreamOptions`, so they must be written into the payload object that the provider sends to the API.

Supports both camelCase and snake_case in config:

```jsonc
{
  "agents": {
    "defaults": {
      "models": {
        "zai/glm-5": {
          "params": {
            "frequency_penalty": 0.5,
            "presence_penalty": 0.3,
            "top_p": 0.9,
            "top_k": 40,
            "repetition_penalty": 1.1
          }
        }
      }
    }
  }
}
```

camelCase alternatives (`frequencyPenalty`, `presencePenalty`, `topP`, `topK`, `repetitionPenalty`) are also accepted and normalised to snake_case in the payload.

## What did NOT change

- `temperature` / `maxTokens` passthrough — unchanged (still uses SimpleStreamOptions)
- `transport` / `openaiWsWarmup` / `cacheRetention` handling — unchanged
- OpenRouter provider routing — unchanged
- All existing provider-specific wrappers (Anthropic betas, Moonshot thinking, SiliconFlow, Google, Z.AI) — unchanged
- Zod schema — already accepts arbitrary `params` via `z.record(z.string(), z.unknown())`

## Implementation

- Added `collectSamplingParams()` helper that extracts numeric sampling params from config, normalising camelCase → snake_case
- `createStreamFnWithExtraParams` now wraps `onPayload` to inject sampling params into the request body when present
- Existing `onPayload` callbacks are chained (not replaced)

## Test plan

- [x] 13 new tests in `extra-params.sampling-params.test.ts`
  - collectSamplingParams: no params, snake_case, camelCase normalisation, non-numeric rejection, NaN/Infinity rejection, alias dedup
  - Integration: frequency_penalty injection, multiple params, camelCase→snake_case, no injection when absent, onPayload chaining, non-OpenAI providers, non-numeric ignored
- [x] All 27 extra-params tests pass (13 new + 14 existing)
- [x] All 677 config tests pass