### PR TITLE
feat: inject system event on model fallback

### DIFF
--- a/src/agents/model-fallback.fallback-event.test.ts
+++ b/src/agents/model-fallback.fallback-event.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from "vitest";
+import { drainSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
+import { runWithModelFallback } from "./model-fallback.js";
+import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
+
+const SESSION_KEY = "test:fallback-event";
+const makeCfg = makeModelFallbackCfg;
+
+describe("runWithModelFallback – system event injection", () => {
+  it("enqueues a system event when fallback succeeds", async () => {
+    resetSystemEventsForTest();
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("rate limited"), { status: 429 }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      sessionKey: SESSION_KEY,
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-haiku-3-5");
+
+    const events = drainSystemEvents(SESSION_KEY);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toContain("Model fallback:");
+    expect(events[0]).toContain("openai/gpt-4.1-mini");
+    expect(events[0]).toContain("anthropic/claude-haiku-3-5");
+    expect(events[0]).toContain("rate_limit");
+  });
+
+  it("does not enqueue event when primary succeeds (no fallback)", async () => {
+    resetSystemEventsForTest();
+    const cfg = makeCfg();
+    const run = vi.fn().mockResolvedValueOnce("ok");
+
+    await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      sessionKey: SESSION_KEY,
+      run,
+    });
+
+    const events = drainSystemEvents(SESSION_KEY);
+    expect(events).toHaveLength(0);
+  });
+
+  it("does not enqueue event when sessionKey is not provided", async () => {
+    resetSystemEventsForTest();
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("rate limited"), { status: 429 }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    // No sessionKey → no event
+    const events = drainSystemEvents(SESSION_KEY);
+    expect(events).toHaveLength(0);
+  });
+
+  it("includes auth reason when fallback is due to auth error", async () => {
+    resetSystemEventsForTest();
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("unauthorized"), { status: 401 }))
+      .mockResolvedValueOnce("ok");
+
+    await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      sessionKey: SESSION_KEY,
+      run,
+    });
+
+    const events = drainSystemEvents(SESSION_KEY);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toContain("(reason: auth)");
+  });
+
+  it("includes timeout reason when fallback is due to timeout", async () => {
+    resetSystemEventsForTest();
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("gateway timeout"), { status: 504 }))
+      .mockResolvedValueOnce("ok");
+
+    await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      sessionKey: SESSION_KEY,
+      run,
+    });
+
+    const events = drainSystemEvents(SESSION_KEY);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toContain("(reason: timeout)");
+  });
+
+  it("includes unknown reason for unrecognized errors", async () => {
+    resetSystemEventsForTest();
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("something weird"))
+      .mockResolvedValueOnce("ok");
+
+    await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      sessionKey: SESSION_KEY,
+      run,
+    });
+
+    const events = drainSystemEvents(SESSION_KEY);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toContain("(reason: unknown)");
+  });
+
+  it("enqueues event with correct models for custom fallback chain", async () => {
+    resetSystemEventsForTest();
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: ["anthropic/claude-haiku-3-5", "openrouter/deepseek-chat"],
+          },
+        },
+      },
+    });
+
+    // Primary fails, first fallback fails, second fallback succeeds.
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("rate limited"), { status: 429 }))
+      .mockRejectedValueOnce(Object.assign(new Error("billing"), { status: 402 }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      sessionKey: SESSION_KEY,
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(result.provider).toBe("openrouter");
+    expect(result.model).toBe("openrouter/deepseek-chat");
+
+    const events = drainSystemEvents(SESSION_KEY);
+    expect(events).toHaveLength(1);
+    // Event should reference the primary and the successful fallback
+    expect(events[0]).toContain("openai/gpt-4.1-mini");
+    expect(events[0]).toContain("openrouter/deepseek-chat");
+  });
+
+  it("does not enqueue event when all candidates fail", async () => {
+    resetSystemEventsForTest();
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("rate limited"), { status: 429 }))
+      .mockRejectedValueOnce(Object.assign(new Error("also down"), { status: 503 }));
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        sessionKey: SESSION_KEY,
+        fallbacksOverride: [],
+        run,
+      }),
+    ).rejects.toThrow();
+
+    const events = drainSystemEvents(SESSION_KEY);
+    expect(events).toHaveLength(0);
+  });
+});

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -3,6 +3,7 @@ import {
   resolveAgentModelFallbackValues,
   resolveAgentModelPrimaryValue,
 } from "../config/model-input.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
 import {
   ensureAuthProfileStore,
   getSoonestCooldownExpiry,
@@ -457,6 +458,8 @@ export async function runWithModelFallback<T>(params: {
   fallbacksOverride?: string[];
   run: ModelFallbackRunFn<T>;
   onError?: ModelFallbackErrorHandler;
+  /** When provided, a system event is enqueued on successful fallback so the agent is aware of the model switch. */
+  sessionKey?: string;
 }): Promise<ModelFallbackRunResult<T>> {
   const candidates = resolveFallbackCandidates({
     cfg: params.cfg,
@@ -527,6 +530,15 @@ export async function runWithModelFallback<T>(params: {
       options: runOptions,
     });
     if ("success" in attemptRun) {
+      if (i > 0 && params.sessionKey) {
+        const primary = candidates[0];
+        const lastAttempt = attempts[attempts.length - 1];
+        const reason = lastAttempt?.reason ?? "unknown";
+        enqueueSystemEvent(
+          `Model fallback: ${primary.provider}/${primary.model} → ${candidate.provider}/${candidate.model} (reason: ${reason})`,
+          { sessionKey: params.sessionKey },
+        );
+      }
       return attemptRun.success;
     }
     const err = attemptRun.error;

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -157,6 +157,7 @@ export function resolveModelFallbackOptions(run: FollowupRun["run"]) {
       agentId: run.agentId,
       sessionKey: run.sessionKey,
     }),
+    sessionKey: run.sessionKey,
   };
 }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -157,6 +157,7 @@ export function createFollowupRunner(params: {
             agentId: queued.run.agentId,
             sessionKey: queued.run.sessionKey,
           }),
+          sessionKey: queued.run.sessionKey,
           run: async (provider, model, runOptions) => {
             const authProfile = resolveRunAuthProfile(queued.run, provider);
             const result = await runEmbeddedPiAgent({

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -840,6 +840,7 @@ async function agentCommandInternal(
         model,
         agentDir,
         fallbacksOverride: effectiveFallbacksOverride,
+        sessionKey,
         run: (providerOverride, modelOverride, runOptions) => {
           const isFallbackRetry = fallbackAttemptIndex > 0;
           fallbackAttemptIndex += 1;

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -468,6 +468,7 @@ export async function runCronIsolatedAgentTurn(params: {
         agentDir,
         fallbacksOverride:
           payloadFallbacks ?? resolveAgentModelFallbacksOverride(params.cfg, agentId),
+        sessionKey: agentSessionKey,
         run: async (providerOverride, modelOverride, runOptions) => {
           if (abortSignal?.aborted) {
             throw new Error(abortReason());


### PR DESCRIPTION
Closes #32910

## Summary
- When `runWithModelFallback` succeeds on a non-primary candidate, enqueue a lightweight system event via `enqueueSystemEvent` so the agent knows which model is responding
- Event format: `Model fallback: openai/gpt-4.1-mini → anthropic/claude-haiku-3-5 (reason: rate_limit)`
- Added optional `sessionKey` param to `runWithModelFallback`; all production callers now pass it
- The event includes the failover reason from the last failed attempt (`rate_limit`, `auth`, `timeout`, `billing`, `unknown`, etc.)

## What did NOT change
- No new config flags — the event is always emitted when `sessionKey` is provided (ephemeral, in-memory only)
- `runWithImageModelFallback` is unchanged (image fallbacks don't run inside agent sessions)
- No schema or Zod changes required
- Existing callers without `sessionKey` still work (the param is optional)

## Test plan
- [x] 8 new tests in `model-fallback.fallback-event.test.ts`:
  - Event enqueued on successful fallback
  - No event when primary succeeds
  - No event when sessionKey is absent
  - Auth, timeout, and unknown reasons
  - Multi-hop fallback chain (primary → fallback1 → fallback2)
  - No event when all candidates fail
- [x] 50 existing `model-fallback.test.ts` tests pass
- [x] 12 existing `model-fallback.probe.test.ts` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)