### PR TITLE
fix(routing): prevent duplicate delivery in dmScope=main sessions

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -30,7 +30,7 @@ vi.mock("../session-utils.js", async (importOriginal) => {
   const original = await importOriginal<typeof import("../session-utils.js")>();
   return {
     ...original,
-    loadSessionEntry: () => ({
+    loadSessionEntry: (rawKey: string) => ({
       cfg: {},
       storePath: path.join(path.dirname(mockState.transcriptPath), "sessions.json"),
       entry: {
@@ -38,7 +38,7 @@ vi.mock("../session-utils.js", async (importOriginal) => {
         sessionFile: mockState.transcriptPath,
         ...mockState.sessionEntry,
       },
-      canonicalKey: "main",
+      canonicalKey: rawKey || "main",
     }),
   };
 });
@@ -147,12 +147,13 @@ async function runNonStreamingChatSend(params: {
   respond: ReturnType<typeof vi.fn>;
   idempotencyKey: string;
   message?: string;
+  sessionKey?: string;
   client?: unknown;
   expectBroadcast?: boolean;
 }) {
   await chatHandlers["chat.send"]({
     params: {
-      sessionKey: "main",
+      sessionKey: params.sessionKey ?? "main",
       message: params.message ?? "hello",
       idempotencyKey: params.idempotencyKey,
     },
@@ -367,6 +368,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       context,
       respond,
       idempotencyKey: "idem-origin-routing",
+      // Use a per-channel session key so delivery context is inherited.
+      sessionKey: "agent:main:telegram:direct:6812765697",
       expectBroadcast: false,
     });
 
@@ -400,6 +403,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       context,
       respond,
       idempotencyKey: "idem-feishu-origin-routing",
+      // Use a per-channel session key so delivery context is inherited.
+      sessionKey: "agent:main:feishu:direct:ou_feishu_direct_123",
       expectBroadcast: false,
     });
 
@@ -408,6 +413,40 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         OriginatingChannel: "feishu",
         OriginatingTo: "ou_feishu_direct_123",
         AccountId: "default",
+      }),
+    );
+  });
+
+  it("chat.send does NOT inherit delivery context for shared main sessions (dmScope=main)", async () => {
+    createTranscriptFixture("openclaw-chat-send-main-no-cross-route-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "discord",
+        to: "discord:1234567890",
+        accountId: "default",
+      },
+      lastChannel: "discord",
+      lastTo: "discord:1234567890",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-main-no-cross-route",
+      // Use a shared main session key (dmScope=main).
+      sessionKey: "main",
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        AccountId: undefined,
       }),
     );
   });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -847,7 +847,16 @@ export const chatHandlers: GatewayRequestHandlers = {
       const routeAccountIdCandidate =
         entry?.deliveryContext?.accountId ?? entry?.lastAccountId ?? undefined;
       const routeThreadIdCandidate = entry?.deliveryContext?.threadId ?? entry?.lastThreadId;
+      // Shared main sessions (dmScope=main/per-peer) don't embed a channel in
+      // the session key, so their lastChannel/deliveryContext may refer to any
+      // previously-used external channel — not the user's current WebChat intent.
+      // Only inherit for channel-specific sessions (per-channel-peer, groups)
+      // to avoid duplicate cross-channel delivery (#33619).
+      const keyParts = sessionKey.split(":");
+      const isChannelAgnosticSession =
+        keyParts.length <= 3 || (keyParts.length === 4 && keyParts[2] === "direct");
       const hasDeliverableRoute =
+        !isChannelAgnosticSession &&
         routeChannelCandidate &&
         routeChannelCandidate !== INTERNAL_MESSAGE_CHANNEL &&
         typeof routeToCandidate === "string" &&


### PR DESCRIPTION
## Summary

Fixes #33619

Commit 050e928 (#29328) changed `chat.send` to inherit `OriginatingChannel` from the session's delivery context. This correctly enables cross-channel routing for per-channel sessions (e.g., Feishu) but causes duplicate message delivery for `dmScope=main` users who share a single session across all channels.

When a user chats on Discord then switches to WebChat, the shared main session's `lastChannel` ("discord") is inherited as `OriginatingChannel`, triggering cross-channel routing and delivering responses to both Discord and WebChat.

### Fix

Check if the session key is channel-agnostic (shared main session or per-peer session) before inheriting the delivery context:

- **Channel-specific sessions** (per-channel-peer, groups): inherit delivery context (correct behavior for Feishu routing)
- **Shared sessions** (dmScope=main, per-peer): use `INTERNAL_MESSAGE_CHANNEL` to prevent cross-channel delivery

The check is based on session key structure — main sessions have `<=3` colon segments (`agent:main:main`), per-peer has 4 with `direct` at index 2, while per-channel sessions have 5+ segments with an embedded channel name.

## Test plan

- [x] `pnpm tsgo` passes
- [x] `pnpm check` passes
- [x] Updated existing Telegram/Feishu routing tests to use per-channel session keys
- [x] Added new test: shared main session does NOT inherit delivery context
- [x] All 9 chat directive-tags tests pass
- [x] All 55 dispatch-from-config + session-key tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)