### PR TITLE
fix: handle systemd is-enabled unit-not-found during gateway install

### DIFF
--- a/src/daemon/systemd-availability.test.ts
+++ b/src/daemon/systemd-availability.test.ts
@@ -6,7 +6,7 @@ vi.mock("node:child_process", () => ({
   execFile: execFileMock,
 }));
 
-import { isSystemdUserServiceAvailable } from "./systemd.js";
+import { isSystemdServiceEnabled, isSystemdUserServiceAvailable } from "./systemd.js";
 
 describe("systemd availability", () => {
   beforeEach(() => {
@@ -31,5 +31,18 @@ describe("systemd availability", () => {
       cb(err, "", "");
     });
     await expect(isSystemdUserServiceAvailable()).resolves.toBe(false);
+  });
+
+  it("treats is-enabled exit code 4 as not installed (not unavailable)", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const err = new Error("Unit openclaw-gateway.service not found") as Error & {
+        stderr?: string;
+        code?: number;
+      };
+      err.stderr = "Unit openclaw-gateway.service not found";
+      err.code = 4;
+      cb(err, "", "");
+    });
+    await expect(isSystemdServiceEnabled({ env: {} })).resolves.toBe(false);
   });
 });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -252,14 +252,9 @@ export async function installSystemdService({
     throw new Error(`systemctl daemon-reload failed: ${reload.stderr || reload.stdout}`.trim());
   }
 
-  const enable = await execSystemctl(["--user", "enable", unitName]);
+  const enable = await execSystemctl(["--user", "enable", "--now", unitName]);
   if (enable.code !== 0) {
-    throw new Error(`systemctl enable failed: ${enable.stderr || enable.stdout}`.trim());
-  }
-
-  const restart = await execSystemctl(["--user", "restart", unitName]);
-  if (restart.code !== 0) {
-    throw new Error(`systemctl restart failed: ${restart.stderr || restart.stdout}`.trim());
+    throw new Error(`systemctl enable --now failed: ${enable.stderr || enable.stdout}`.trim());
   }
 
   // Ensure we don't end up writing to a clack spinner line (wizards show progress without a newline).
@@ -326,10 +321,24 @@ export async function restartSystemdService({
 export async function isSystemdServiceEnabled(args: {
   env?: Record<string, string | undefined>;
 }): Promise<boolean> {
-  await assertSystemdAvailable();
   const serviceName = resolveSystemdServiceName(args.env ?? {});
   const unitName = `${serviceName}.service`;
   const res = await execSystemctl(["--user", "is-enabled", unitName]);
+  if (res.code === 4) {
+    return false;
+  }
+  if (res.code !== 0) {
+    const detail = `${res.stderr} ${res.stdout}`.toLowerCase();
+    if (
+      detail.includes("failed to connect") ||
+      detail.includes("not been booted") ||
+      detail.includes("not supported") ||
+      detail.includes("no such file or directory") ||
+      detail.includes("spawn systemctl")
+    ) {
+      throw new Error(`systemctl --user unavailable: ${res.stderr || res.stdout || "unknown error"}`);
+    }
+  }
   return res.code === 0;
 }
 


### PR DESCRIPTION
Closes #33633

## Problem
On fresh Linux installs, `systemctl --user is-enabled openclaw-gateway.service` can return exit code 4 (`unit not found`) before the unit exists. That path was treated as a hard unavailability error and could block gateway install.

## Fix
Treat `is-enabled` exit code 4 as a normal "not installed/not enabled" state, and keep systemd install on the normal path. Also switched install to `systemctl --user enable --now <unit>` after writing the unit and `daemon-reload`, plus a regression test that mocks code 4.
