### PR TITLE
fix(whatsapp): store post-conversion text in echo tracker to prevent self-chat loops

### DIFF
--- a/src/web/auto-reply/deliver-reply.test.ts
+++ b/src/web/auto-reply/deliver-reply.test.ts
@@ -283,6 +283,48 @@ describe("deliverWebReply", () => {
     );
   });
 
+  it("returns sentChunks with WhatsApp-converted text for echo tracking", async () => {
+    const msg = makeMsg();
+    const { sentChunks } = await deliverWebReply({
+      replyResult: { text: "aaaaaa" },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 3,
+      replyLogger,
+      skipLog: true,
+    });
+    expect(sentChunks).toEqual(["aaa", "aaa"]);
+    expect(sentChunks).toHaveLength(2);
+  });
+
+  it("returns empty sentChunks when reasoning payload is suppressed", async () => {
+    const msg = makeMsg();
+    const { sentChunks } = await deliverWebReply({
+      replyResult: { text: "Reasoning:\nhidden", isReasoning: true },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+    expect(sentChunks).toEqual([]);
+    expect(msg.reply).not.toHaveBeenCalled();
+  });
+
+  it("includes media caption in sentChunks", async () => {
+    const msg = makeMsg();
+    mockLoadedImageMedia();
+    const { sentChunks } = await deliverWebReply({
+      replyResult: { text: "caption text", mediaUrl: "http://example.com/img.jpg" },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+    expect(sentChunks).toEqual(["caption text"]);
+  });
+
   it("sends non-audio/image/video media as document", async () => {
     const msg = makeMsg();
     (

--- a/src/web/auto-reply/deliver-reply.ts
+++ b/src/web/auto-reply/deliver-reply.ts
@@ -39,12 +39,13 @@ export async function deliverWebReply(params: {
   connectionId?: string;
   skipLog?: boolean;
   tableMode?: MarkdownTableMode;
-}) {
+}): Promise<{ sentChunks: string[] }> {
   const { replyResult, msg, maxMediaBytes, textLimit, replyLogger, connectionId, skipLog } = params;
+  const sentChunks: string[] = [];
   const replyStarted = Date.now();
   if (shouldSuppressReasoningReply(replyResult)) {
     whatsappOutboundLog.debug(`Suppressed reasoning payload to ${msg.from}`);
-    return;
+    return { sentChunks };
   }
   const tableMode = params.tableMode ?? "code";
   const chunkMode = params.chunkMode ?? "length";
@@ -87,6 +88,7 @@ export async function deliverWebReply(params: {
     for (const [index, chunk] of textChunks.entries()) {
       const chunkStarted = Date.now();
       await sendWithRetry(() => msg.reply(chunk), "text");
+      sentChunks.push(chunk);
       if (!skipLog) {
         const durationMs = Date.now() - chunkStarted;
         whatsappOutboundLog.debug(
@@ -108,7 +110,7 @@ export async function deliverWebReply(params: {
       },
       "auto-reply sent (text)",
     );
-    return;
+    return { sentChunks };
   }
 
   const remainingText = [...textChunks];
@@ -172,6 +174,9 @@ export async function deliverWebReply(params: {
           "media:document",
         );
       }
+      if (caption) {
+        sentChunks.push(caption);
+      }
       whatsappOutboundLog.info(
         `Sent media reply to ${msg.from} (${(media.buffer.length / (1024 * 1024)).toFixed(2)}MB)`,
       );
@@ -200,6 +205,7 @@ export async function deliverWebReply(params: {
         if (fallbackText) {
           whatsappOutboundLog.warn(`Media skipped; sent text-only to ${msg.from}`);
           await msg.reply(fallbackText);
+          sentChunks.push(fallbackText);
         }
       }
     }
@@ -208,5 +214,8 @@ export async function deliverWebReply(params: {
   // Remaining text chunks after media
   for (const chunk of remainingText) {
     await msg.reply(chunk);
+    sentChunks.push(chunk);
   }
+
+  return { sentChunks };
 }

--- a/src/web/auto-reply/monitor/echo.test.ts
+++ b/src/web/auto-reply/monitor/echo.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { createEchoTracker } from "./echo.js";
+
+describe("createEchoTracker", () => {
+  it("remembers and matches plain text", () => {
+    const tracker = createEchoTracker({});
+    tracker.rememberText("hello world", {});
+    expect(tracker.has("hello world")).toBe(true);
+    expect(tracker.has("other text")).toBe(false);
+  });
+
+  it("forgets text after explicit forget()", () => {
+    const tracker = createEchoTracker({});
+    tracker.rememberText("hello", {});
+    expect(tracker.has("hello")).toBe(true);
+    tracker.forget("hello");
+    expect(tracker.has("hello")).toBe(false);
+  });
+
+  it("evicts oldest entries when exceeding maxItems", () => {
+    const tracker = createEchoTracker({ maxItems: 3 });
+    tracker.rememberText("a", {});
+    tracker.rememberText("b", {});
+    tracker.rememberText("c", {});
+    tracker.rememberText("d", {});
+    // "a" should be evicted
+    expect(tracker.has("a")).toBe(false);
+    expect(tracker.has("b")).toBe(true);
+    expect(tracker.has("d")).toBe(true);
+  });
+
+  it("ignores undefined/empty text", () => {
+    const tracker = createEchoTracker({});
+    tracker.rememberText(undefined, {});
+    tracker.rememberText("", {});
+    expect(tracker.has("")).toBe(false);
+    expect(tracker.has("undefined")).toBe(false);
+  });
+
+  it("stores combined body key when provided", () => {
+    const tracker = createEchoTracker({});
+    tracker.rememberText("chunk 1", {
+      combinedBody: "chunk 1\nchunk 2",
+      combinedBodySessionKey: "session:abc",
+    });
+    const key = tracker.buildCombinedKey({
+      sessionKey: "session:abc",
+      combinedBody: "chunk 1\nchunk 2",
+    });
+    expect(tracker.has(key)).toBe(true);
+  });
+});
+
+describe("echo tracker: self-chat echo loop prevention", () => {
+  it("matches WhatsApp-converted chunks, not just raw markdown", () => {
+    // Simulates the fix: each converted chunk is stored individually.
+    // When WhatsApp echoes back the converted text, it matches.
+    const tracker = createEchoTracker({});
+
+    // Raw markdown (what used to be stored):
+    const rawMarkdown = "**Important**: Check the _docs_ for details.";
+    // WhatsApp-converted (what actually gets echoed back):
+    const whatsappFormatted = "*Important*: Check the _docs_ for details.";
+
+    // Store the converted text (post-fix behavior)
+    tracker.rememberText(whatsappFormatted, {});
+
+    // Echo arrives as WhatsApp-formatted text
+    expect(tracker.has(whatsappFormatted)).toBe(true);
+    // Raw markdown would NOT match if only it was stored
+    expect(tracker.has(rawMarkdown)).toBe(false);
+  });
+
+  it("matches individual chunks when text is split", () => {
+    const tracker = createEchoTracker({});
+
+    // Long text gets chunked before sending
+    const chunk1 = "First part of the response that was sent.";
+    const chunk2 = "Second part of the response that was sent.";
+    const fullText = `${chunk1}\n${chunk2}`;
+
+    // Each chunk is stored individually (post-fix behavior)
+    tracker.rememberText(chunk1, {});
+    tracker.rememberText(chunk2, {});
+
+    // WhatsApp echoes back each chunk as a separate message
+    expect(tracker.has(chunk1)).toBe(true);
+    expect(tracker.has(chunk2)).toBe(true);
+    // Full text is NOT stored (so no false match on combined echo)
+    expect(tracker.has(fullText)).toBe(false);
+  });
+});

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -401,7 +401,7 @@ export async function processMessage(params: {
           // web UI only; sending them here leaks chain-of-thought to end users.
           return;
         }
-        await deliverWebReply({
+        const { sentChunks } = await deliverWebReply({
           replyResult: payload,
           msg: params.msg,
           mediaLocalRoots,
@@ -414,12 +414,23 @@ export async function processMessage(params: {
           tableMode,
         });
         didSendReply = true;
-        const shouldLog = payload.text ? true : undefined;
-        params.rememberSentText(payload.text, {
-          combinedBody,
-          combinedBodySessionKey: params.route.sessionKey,
-          logVerboseMessage: shouldLog,
-        });
+        // Register each sent chunk (post-markdown-conversion) for echo detection.
+        // Previously only the raw pre-conversion text was stored, causing mismatches
+        // when WhatsApp echoed back the converted text in self-chat mode.
+        for (const chunk of sentChunks) {
+          params.rememberSentText(chunk, {
+            combinedBody,
+            combinedBodySessionKey: params.route.sessionKey,
+            logVerboseMessage: true,
+          });
+        }
+        // Also store the raw text as a fallback for channels that don't convert markdown.
+        if (payload.text && !sentChunks.includes(payload.text)) {
+          params.rememberSentText(payload.text, {
+            combinedBody,
+            combinedBodySessionKey: params.route.sessionKey,
+          });
+        }
         const fromDisplay =
           params.msg.chatType === "group" ? conversationId : (params.msg.from ?? "unknown");
         const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);


### PR DESCRIPTION
## Summary / What changed

- `deliverWebReply` now returns `sentChunks` — the actual WhatsApp-formatted text chunks that were sent
- `processMessage` registers each post-conversion chunk in the echo tracker (instead of the raw pre-conversion markdown)
- Raw text is also stored as a fallback for non-converting channels
- Added unit tests for `createEchoTracker` and `sentChunks` return value

## Why

In self-chat mode, the echo tracker stored the **raw markdown** text (`payload.text`), but WhatsApp echoes back the **post-conversion** text (after `markdownToWhatsApp()` + chunking). Since these don't match, the echo slips through detection and gets processed as a new inbound message — triggering a fresh agent run. This creates an infinite loop that fires every `~timeoutSeconds` (typically 120s), repeating the same response indefinitely.

The `fromMe` filter in `access-control.ts` intentionally allows `fromMe` messages when `isSamePhone` is true (self-chat mode), because the user's own typed messages also have `fromMe=true`. So the echo tracker is the correct defense layer — it just needs to store the right text.

## Tests

```bash
npx vitest run src/web/auto-reply/monitor/echo.test.ts src/web/auto-reply/deliver-reply.test.ts src/web/inbound/access-control.test.ts
```

- 7 new tests (echo tracker basics + self-chat echo loop scenarios + sentChunks return)
- 21 existing tests pass unchanged
- `pnpm build` succeeds (DTS failure is pre-existing `@discordjs/voice`)

## Real-world validation

Observed in production: WhatsApp bot in self-chat mode sent the same response 4-5 times at exactly `timeoutSeconds` intervals. Gateway logs showed each echo being processed as a new inbound message with incrementing idle time.

## Issue

Fixes #26770

---

AI-assisted (Claude), fully tested, all code reviewed and understood.