### PR TITLE
fix(sandbox): preserve global sandbox config for webhook/cron agent runs

### DIFF
--- a/src/cron/isolated-agent/run.sandbox-config-preserved.test.ts
+++ b/src/cron/isolated-agent/run.sandbox-config-preserved.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearFastTestEnv,
+  loadRunCronIsolatedAgentTurn,
+  makeCronSession,
+  resolveAgentConfigMock,
+  resolveAllowedModelRefMock,
+  resolveConfiguredModelRefMock,
+  resolveCronSessionMock,
+  resetRunCronIsolatedAgentTurnHarness,
+  restoreFastTestEnv,
+  runWithModelFallbackMock,
+  updateSessionStoreMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+// ---------- helpers ----------
+
+function makeJob(overrides?: Record<string, unknown>) {
+  return {
+    id: "webhook-job",
+    agentId: "test_agent",
+    name: "Webhook Test",
+    schedule: { kind: "at", at: new Date().toISOString() },
+    sessionTarget: "isolated",
+    payload: {
+      kind: "agentTurn",
+      message: "test message",
+    },
+    state: { nextRunAtMs: Date.now() },
+    ...overrides,
+  } as never;
+}
+
+function makeParams(overrides?: Record<string, unknown>) {
+  return {
+    cfg: {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all" },
+        },
+        entries: [{ id: "test_agent" }],
+      },
+    },
+    deps: {} as never,
+    job: makeJob(),
+    message: "test message",
+    sessionKey: "webhook:test",
+    ...overrides,
+  };
+}
+
+// ---------- tests ----------
+
+describe("runCronIsolatedAgentTurn — sandbox config preserved (#33349)", () => {
+  let previousFastTestEnv: string | undefined;
+
+  beforeEach(() => {
+    previousFastTestEnv = clearFastTestEnv();
+    resetRunCronIsolatedAgentTurnHarness();
+
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "openai",
+      model: "gpt-4",
+    });
+    resolveAllowedModelRefMock.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-4" },
+    });
+
+    updateSessionStoreMock.mockResolvedValue(undefined);
+    resolveCronSessionMock.mockReturnValue(makeCronSession());
+  });
+
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("preserves agents.defaults.sandbox when agent entry has no sandbox config", async () => {
+    // Agent entry exists but has no sandbox config → resolveAgentConfig returns
+    // { sandbox: undefined, ... }. Before the fix, Object.assign would overwrite
+    // the global sandbox config with undefined, causing sandbox mode to be "off".
+    resolveAgentConfigMock.mockReturnValue({
+      name: "Test Agent",
+      sandbox: undefined,
+      tools: undefined,
+      heartbeat: undefined,
+      identity: undefined,
+      groupChat: undefined,
+      memorySearch: undefined,
+      humanDelay: undefined,
+      skills: undefined,
+      workspace: undefined,
+      agentDir: undefined,
+      subagents: undefined,
+    });
+
+    const params = makeParams();
+
+    await runCronIsolatedAgentTurn(params);
+
+    // runWithModelFallback receives cfgWithAgentDefaults as `cfg`.
+    // Verify that agents.defaults.sandbox.mode is still "all".
+    const call = runWithModelFallbackMock.mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    expect(call.cfg.agents.defaults.sandbox).toEqual({ mode: "all" });
+  });
+
+  it("preserves sandbox config when agent entry is not found", async () => {
+    // No agent entry → resolveAgentConfig returns undefined → agentOverrideRest is {}
+    resolveAgentConfigMock.mockReturnValue(undefined);
+
+    const params = makeParams();
+
+    await runCronIsolatedAgentTurn(params);
+
+    const call = runWithModelFallbackMock.mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    expect(call.cfg.agents.defaults.sandbox).toEqual({ mode: "all" });
+  });
+
+  it("applies agent-specific sandbox override when explicitly set", async () => {
+    // Agent has explicit sandbox config → should override the global
+    resolveAgentConfigMock.mockReturnValue({
+      name: "Sandbox Agent",
+      sandbox: { mode: "non-main" },
+      tools: undefined,
+      heartbeat: undefined,
+      identity: undefined,
+      groupChat: undefined,
+      memorySearch: undefined,
+      humanDelay: undefined,
+      skills: undefined,
+      workspace: undefined,
+      agentDir: undefined,
+      subagents: undefined,
+    });
+
+    const params = makeParams();
+
+    await runCronIsolatedAgentTurn(params);
+
+    const call = runWithModelFallbackMock.mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    expect(call.cfg.agents.defaults.sandbox).toEqual({ mode: "non-main" });
+  });
+
+  it("preserves other global defaults when agent entry has partial overrides", async () => {
+    // Agent entry sets heartbeat but not sandbox → sandbox should survive
+    resolveAgentConfigMock.mockReturnValue({
+      name: "Partial Agent",
+      heartbeat: { enabled: true },
+      sandbox: undefined,
+      tools: undefined,
+      identity: undefined,
+      groupChat: undefined,
+      memorySearch: undefined,
+      humanDelay: undefined,
+      skills: undefined,
+      workspace: undefined,
+      agentDir: undefined,
+      subagents: undefined,
+    });
+
+    const params = makeParams({
+      cfg: {
+        agents: {
+          defaults: {
+            sandbox: { mode: "all" },
+            heartbeat: { enabled: false },
+          },
+          entries: [{ id: "test_agent" }],
+        },
+      },
+    });
+
+    await runCronIsolatedAgentTurn(params);
+
+    const call = runWithModelFallbackMock.mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    // Sandbox preserved from global defaults
+    expect(call.cfg.agents.defaults.sandbox).toEqual({ mode: "all" });
+    // Heartbeat overridden by agent config
+    expect(call.cfg.agents.defaults.heartbeat).toEqual({ enabled: true });
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -125,10 +125,18 @@ export async function runCronIsolatedAgentTurn(params: {
   // This ensures auth-profiles, workspace, and agentDir all resolve to the
   // correct per-agent paths (e.g. ~/.openclaw/agents/<agentId>/agent/).
   const agentId = normalizedRequested ?? defaultAgentId;
+  // Strip undefined values so per-agent overrides don't wipe global defaults.
+  // resolveAgentConfig() returns explicit `sandbox: undefined` (and similar)
+  // when the agent entry doesn't set those fields; Object.assign would copy
+  // that `undefined` over the global agents.defaults.sandbox, causing sandbox
+  // mode to fall back to "off".  See: #33349
+  const definedOverrides = Object.fromEntries(
+    Object.entries(agentOverrideRest).filter(([, v]) => v !== undefined),
+  ) as Partial<AgentDefaultsConfig>;
   const agentCfg: AgentDefaultsConfig = Object.assign(
     {},
     params.cfg.agents?.defaults,
-    agentOverrideRest as Partial<AgentDefaultsConfig>,
+    definedOverrides,
   );
   // Merge agent model override with defaults instead of replacing, so that
   // `fallbacks` from `agents.defaults.model` are preserved when the agent


### PR DESCRIPTION
## Summary

- **Root cause**: `runCronIsolatedAgentTurn` merges per-agent config overrides into `agents.defaults` via `Object.assign`. `resolveAgentConfig()` returns an object with explicit `sandbox: undefined` (and similar) when the agent entry doesn't define those fields. `Object.assign` copies `undefined` values, wiping the global `agents.defaults.sandbox` and causing `resolveSandboxConfigForAgent` to default to `mode: "off"`.
- **Fix**: Filter out `undefined` values from the agent override object before the merge so global defaults survive.
- Adds 4 targeted tests verifying sandbox config preservation across agent-override scenarios.

## What did NOT change

- `resolveAgentConfig()` return shape is unchanged — callers that check for the *presence* of a key (e.g., `"sandbox" in agentConfig`) are not affected.
- `resolveSandboxConfigForAgent()` and the full sandbox resolution chain are untouched; the fix is solely in the config merge step inside `runCronIsolatedAgentTurn`.
- Agents that explicitly set `sandbox` in their per-agent entry still correctly override the global defaults.
- The model merge logic (which already had its own special handling) is unaffected.

## Test plan

- [x] New test file `run.sandbox-config-preserved.test.ts` (4 tests):
  - Preserves `agents.defaults.sandbox` when agent entry has no sandbox config
  - Preserves sandbox config when agent entry is not found
  - Applies agent-specific sandbox override when explicitly set
  - Preserves other global defaults when agent entry has partial overrides
- [x] All 26 existing `run.*.test.ts` tests pass
- [x] All 146 sandbox tests pass (1 pre-existing failure in `sandbox-paths.test.ts` unrelated to this change)

Fixes #33349

🤖 Generated with [Claude Code](https://claude.com/claude-code)