### PR TITLE
fix(session): recover continuity when session key lookup misses

### DIFF
--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -8,7 +8,7 @@
     "google-auth-library": "^10.6.1"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.3.1"
+    "openclaw": ">=2026.3.2"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -5,7 +5,7 @@
   "description": "OpenClaw core memory search plugin",
   "type": "module",
   "peerDependencies": {
-    "openclaw": ">=2026.3.1"
+    "openclaw": ">=2026.3.2"
   },
   "openclaw": {
     "extensions": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,13 +29,13 @@ importers:
         version: 3.1000.0
       '@buape/carbon':
         specifier: 0.0.0-beta-20260216184201
-        version: 0.0.0-beta-20260216184201(hono@4.11.10)(opusscript@0.1.1)
+        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
       '@discordjs/voice':
         specifier: ^0.19.0
-        version: 0.19.0(opusscript@0.1.1)
+        version: 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       '@grammyjs/runner':
         specifier: ^2.0.3
         version: 2.0.3(grammy@1.41.0)
@@ -341,8 +341,8 @@ importers:
         specifier: ^10.6.1
         version: 10.6.1
       openclaw:
-        specifier: '>=2026.3.1'
-        version: 2026.3.1(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
+        specifier: '>=2026.3.2'
+        version: 2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/imessage: {}
 
@@ -402,8 +402,8 @@ importers:
   extensions/memory-core:
     dependencies:
       openclaw:
-        specifier: '>=2026.3.1'
-        version: 2026.3.1(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
+        specifier: '>=2026.3.2'
+        version: 2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/memory-lancedb:
     dependencies:
@@ -924,6 +924,10 @@ packages:
   '@discordjs/node-pre-gyp@0.4.5':
     resolution: {integrity: sha512-YJOVVZ545x24mHzANfYoy0BJX5PDyeZlpiJjDkUBM/V/Ao7TFX9lcUvCN4nr0tbr5ubeaXxtEBILUrHtTphVeQ==}
     hasBin: true
+
+  '@discordjs/opus@0.10.0':
+    resolution: {integrity: sha512-HHEnSNrSPmFEyndRdQBJN2YE6egyXS9JUnJWyP6jficK0Y+qKMEZXyYTgmzpjrxXP1exM/hKaNP7BRBUEWkU5w==}
+    engines: {node: '>=12.0.0'}
 
   '@discordjs/voice@0.19.0':
     resolution: {integrity: sha512-UyX6rGEXzVyPzb1yvjHtPfTlnLvB5jX/stAMdiytHhfoydX+98hfympdOwsnTktzr+IRvphxTbdErgYDJkEsvw==}
@@ -4973,8 +4977,8 @@ packages:
       zod:
         optional: true
 
-  openclaw@2026.3.1:
-    resolution: {integrity: sha512-7Pt5ykhaYa8TYpLWnBhaMg6Lp6kfk3rMKgqJ3WWESKM9BizYu1fkH/rF9BLeXlsNASgZdLp4oR8H0XfvIIoXIg==}
+  openclaw@2026.3.2:
+    resolution: {integrity: sha512-Gkqx24m7PF1DUXPI968DuC9n52lTZ5hI3X5PIi0HosC7J7d6RLkgVppj1mxvgiQAWMp41E41elvoi/h4KBjFcQ==}
     engines: {node: '>=22.12.0'}
     hasBin: true
     peerDependencies:
@@ -5185,10 +5189,13 @@ packages:
   prism-media@1.3.5:
     resolution: {integrity: sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==}
     peerDependencies:
+      '@discordjs/opus': '>=0.8.0 <1.0.0'
       ffmpeg-static: ^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0
       node-opus: ^0.3.3
       opusscript: ^0.0.8
     peerDependenciesMeta:
+      '@discordjs/opus':
+        optional: true
       ffmpeg-static:
         optional: true
       node-opus:
@@ -6813,18 +6820,19 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@buape/carbon@0.0.0-beta-20260216184201(hono@4.11.10)(opusscript@0.1.1)':
+  '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)':
     dependencies:
       '@types/node': 25.3.3
       discord-api-types: 0.38.37
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260120.0
-      '@discordjs/voice': 0.19.0(opusscript@0.1.1)
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       '@hono/node-server': 1.19.9(hono@4.11.10)
       '@types/bun': 1.3.9
       '@types/ws': 8.18.1
       ws: 8.19.0
     transitivePeerDependencies:
+      - '@discordjs/opus'
       - bufferutil
       - ffmpeg-static
       - hono
@@ -6959,14 +6967,24 @@ snapshots:
       - supports-color
     optional: true
 
-  '@discordjs/voice@0.19.0(opusscript@0.1.1)':
+  '@discordjs/opus@0.10.0':
+    dependencies:
+      '@discordjs/node-pre-gyp': 0.4.5
+      node-addon-api: 8.5.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  '@discordjs/voice@0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)':
     dependencies:
       '@types/ws': 8.18.1
       discord-api-types: 0.38.40
-      prism-media: 1.3.5(opusscript@0.1.1)
+      prism-media: 1.3.5(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       tslib: 2.8.1
       ws: 8.19.0
     transitivePeerDependencies:
+      - '@discordjs/opus'
       - bufferutil
       - ffmpeg-static
       - node-opus
@@ -11171,13 +11189,13 @@ snapshots:
       ws: 8.19.0
       zod: 4.3.6
 
-  openclaw@2026.3.1(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
+  openclaw@2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
       '@aws-sdk/client-bedrock': 3.1000.0
-      '@buape/carbon': 0.0.0-beta-20260216184201(hono@4.11.10)(opusscript@0.1.1)
+      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
       '@clack/prompts': 1.0.1
-      '@discordjs/voice': 0.19.0(opusscript@0.1.1)
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       '@grammyjs/runner': 2.0.3(grammy@1.41.0)
       '@grammyjs/transformer-throttler': 1.2.1(grammy@1.41.0)
       '@homebridge/ciao': 1.3.5
@@ -11226,12 +11244,15 @@ snapshots:
       qrcode-terminal: 0.12.0
       sharp: 0.34.5
       sqlite-vec: 0.1.7-alpha.2
+      strip-ansi: 7.2.0
       tar: 7.5.9
       tslog: 4.10.2
       undici: 7.22.0
       ws: 8.19.0
       yaml: 2.8.2
       zod: 4.3.6
+    optionalDependencies:
+      '@discordjs/opus': 0.10.0
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - '@types/express'
@@ -11485,8 +11506,9 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
-  prism-media@1.3.5(opusscript@0.1.1):
+  prism-media@1.3.5(@discordjs/opus@0.10.0)(opusscript@0.1.1):
     optionalDependencies:
+      '@discordjs/opus': 0.10.0
       opusscript: 0.1.1
 
   process-nextick-args@2.0.1: {}

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -5,6 +5,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { buildModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.ts";
 import { enqueueSystemEvent, resetSystemEventsForTest } from "../../infra/system-events.js";
 import { applyResetModelOverride } from "./session-reset-model.js";
@@ -492,6 +493,72 @@ describe("initSessionState RawBody", () => {
       expect(result.sessionEntry.sessionId).toBe(sessionId);
       expect(result.sessionEntry.sessionFile).toBe(sessionFile);
       expect(result.storePath).toBe(storePath);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("reuses existing sessions when only a mixed-case key exists in the store", async () => {
+    const root = await makeCaseDir("openclaw-session-case-recovery-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:discord:channel:c123";
+    const legacyStoreKey = "Agent:Main:Discord:Channel:C123";
+    const sessionId = "session-case-recovery";
+
+    await saveSessionStore(storePath, {
+      [legacyStoreKey]: {
+        sessionId,
+        updatedAt: Date.now(),
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: { Body: "hello", SessionKey: sessionKey, Provider: "discord", Surface: "discord" },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionEntry.sessionId).toBe(sessionId);
+    const persistedStore = loadSessionStore(storePath, { skipCache: true });
+    expect(persistedStore[sessionKey]?.sessionId).toBe(sessionId);
+    expect(persistedStore[legacyStoreKey]).toBeUndefined();
+  });
+
+  it("recovers missing session entries from another agent store", async () => {
+    const root = await makeCaseDir("openclaw-session-cross-agent-recovery-");
+    const stateDir = path.join(root, ".openclaw");
+    const sessionKey = "agent:worker1:discord:channel:42";
+    const sessionId = "session-cross-agent-recovery";
+    const misplacedStorePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+    const expectedStorePath = path.join(stateDir, "agents", "worker1", "sessions", "sessions.json");
+
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    try {
+      await fs.mkdir(path.dirname(misplacedStorePath), { recursive: true });
+      await saveSessionStore(misplacedStorePath, {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: Date.now(),
+        },
+      });
+
+      const cfg = {
+        agents: {
+          list: [{ id: "main", default: true }, { id: "worker1" }],
+        },
+      } as OpenClawConfig;
+
+      const result = await initSessionState({
+        ctx: { Body: "hello", SessionKey: sessionKey, Provider: "discord", Surface: "discord" },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.storePath).toBe(expectedStorePath);
+      expect(result.sessionEntry.sessionId).toBe(sessionId);
+      const recoveredStore = loadSessionStore(expectedStorePath, { skipCache: true });
+      expect(recoveredStore[sessionKey]?.sessionId).toBe(sessionId);
     } finally {
       vi.unstubAllEnvs();
     }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -60,8 +60,11 @@ function resolveSessionStoreMatch(
   if (!target) {
     return undefined;
   }
+  const exact = store[target];
+  if (exact) {
+    return { entry: exact, legacyKeys: [] };
+  }
   const normalized = target.toLowerCase();
-  let selectedKey: string | undefined;
   let selectedEntry: SessionEntry | undefined;
   const legacyKeys: string[] = [];
   for (const [key, entry] of Object.entries(store)) {
@@ -70,13 +73,10 @@ function resolveSessionStoreMatch(
     }
     if (!selectedEntry || (entry.updatedAt ?? 0) > (selectedEntry.updatedAt ?? 0)) {
       selectedEntry = entry;
-      selectedKey = key;
     }
-    if (key !== target) {
-      legacyKeys.push(key);
-    }
+    legacyKeys.push(key);
   }
-  if (!selectedEntry || !selectedKey) {
+  if (!selectedEntry) {
     return undefined;
   }
   return { entry: selectedEntry, legacyKeys };

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -86,11 +86,9 @@ function recoverSessionEntryFromOtherAgentStores(params: {
   cfg: OpenClawConfig;
   sessionCfg: OpenClawConfig["session"];
   sessionKey: string;
-  currentAgentId: string;
   currentStorePath: string;
 }): SessionEntry | undefined {
   const candidateAgentIds = new Set<string>([
-    params.currentAgentId,
     resolveDefaultAgentId(params.cfg),
     ...listAgentIds(params.cfg),
   ]);
@@ -269,7 +267,6 @@ export async function initSessionState(params: {
       cfg,
       sessionCfg,
       sessionKey,
-      currentAgentId: agentId,
       currentStorePath: storePath,
     });
     if (recoveredEntry) {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -1,6 +1,10 @@
 import crypto from "node:crypto";
 import path from "node:path";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import {
+  listAgentIds,
+  resolveDefaultAgentId,
+  resolveSessionAgentId,
+} from "../../agents/agent-scope.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
@@ -43,6 +47,75 @@ import { buildSessionEndHookPayload, buildSessionStartHookPayload } from "./sess
 
 const log = createSubsystemLogger("session-init");
 
+type SessionStoreMatch = {
+  entry: SessionEntry;
+  legacyKeys: string[];
+};
+
+function resolveSessionStoreMatch(
+  store: Record<string, SessionEntry>,
+  sessionKey: string,
+): SessionStoreMatch | undefined {
+  const target = sessionKey.trim();
+  if (!target) {
+    return undefined;
+  }
+  const normalized = target.toLowerCase();
+  let selectedKey: string | undefined;
+  let selectedEntry: SessionEntry | undefined;
+  const legacyKeys: string[] = [];
+  for (const [key, entry] of Object.entries(store)) {
+    if (!entry || key.toLowerCase() !== normalized) {
+      continue;
+    }
+    if (!selectedEntry || (entry.updatedAt ?? 0) > (selectedEntry.updatedAt ?? 0)) {
+      selectedEntry = entry;
+      selectedKey = key;
+    }
+    if (key !== target) {
+      legacyKeys.push(key);
+    }
+  }
+  if (!selectedEntry || !selectedKey) {
+    return undefined;
+  }
+  return { entry: selectedEntry, legacyKeys };
+}
+
+function recoverSessionEntryFromOtherAgentStores(params: {
+  cfg: OpenClawConfig;
+  sessionCfg: OpenClawConfig["session"];
+  sessionKey: string;
+  currentAgentId: string;
+  currentStorePath: string;
+}): SessionEntry | undefined {
+  const candidateAgentIds = new Set<string>([
+    params.currentAgentId,
+    resolveDefaultAgentId(params.cfg),
+    ...listAgentIds(params.cfg),
+  ]);
+  let recovered: SessionEntry | undefined;
+  for (const agentId of candidateAgentIds) {
+    const storePath = resolveStorePath(params.sessionCfg?.store, { agentId });
+    if (storePath === params.currentStorePath) {
+      continue;
+    }
+    let candidateStore: Record<string, SessionEntry>;
+    try {
+      candidateStore = loadSessionStore(storePath, { skipCache: true });
+    } catch {
+      continue;
+    }
+    const candidateMatch = resolveSessionStoreMatch(candidateStore, params.sessionKey);
+    if (!candidateMatch) {
+      continue;
+    }
+    if (!recovered || (candidateMatch.entry.updatedAt ?? 0) > (recovered.updatedAt ?? 0)) {
+      recovered = candidateMatch.entry;
+    }
+  }
+  return recovered;
+}
 export type SessionInitResult = {
   sessionCtx: TemplateContext;
   sessionEntry: SessionEntry;
@@ -99,6 +172,7 @@ export async function initSessionState(params: {
   });
   let sessionKey: string | undefined;
   let sessionEntry: SessionEntry;
+  const legacySessionKeysToDelete = new Set<string>();
 
   let sessionId: string | undefined;
   let isNewSession = false;
@@ -185,7 +259,24 @@ export async function initSessionState(params: {
   if (retiredLegacyMainDelivery) {
     sessionStore[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
   }
-  const entry = sessionStore[sessionKey];
+  const localMatch = resolveSessionStoreMatch(sessionStore, sessionKey);
+  let entry = localMatch?.entry;
+  for (const legacyKey of localMatch?.legacyKeys ?? []) {
+    legacySessionKeysToDelete.add(legacyKey);
+  }
+  if (!entry) {
+    const recoveredEntry = recoverSessionEntryFromOtherAgentStores({
+      cfg,
+      sessionCfg,
+      sessionKey,
+      currentAgentId: agentId,
+      currentStorePath: storePath,
+    });
+    if (recoveredEntry) {
+      entry = recoveredEntry;
+      log.warn(`Recovered missing session key from alternate agent store: ${sessionKey}`);
+    }
+  }
   const previousSessionEntry = resetTriggered && entry ? { ...entry } : undefined;
   const now = Date.now();
   const isThread = resolveThreadFlag({
@@ -213,7 +304,7 @@ export async function initSessionState(params: {
     ? evaluateSessionFreshness({ updatedAt: entry.updatedAt, now, policy: resetPolicy }).fresh
     : false;
 
-  if (!isNewSession && freshEntry) {
+  if (!isNewSession && entry && freshEntry) {
     sessionId = entry.sessionId;
     systemSent = entry.systemSent ?? false;
     abortedLastRun = entry.abortedLastRun ?? false;
@@ -391,11 +482,17 @@ export async function initSessionState(params: {
   }
   // Preserve per-session overrides while resetting compaction state on /new.
   sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };
+  for (const legacyKey of legacySessionKeysToDelete) {
+    delete sessionStore[legacyKey];
+  }
   await updateSessionStore(
     storePath,
     (store) => {
       // Preserve per-session overrides while resetting compaction state on /new.
       store[sessionKey] = { ...store[sessionKey], ...sessionEntry };
+      for (const legacyKey of legacySessionKeysToDelete) {
+        delete store[legacyKey];
+      }
       if (retiredLegacyMainDelivery) {
         store[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
       }


### PR DESCRIPTION
## Summary
- recover existing sessions when `initSessionState` cannot find an exact session-key match in the current agent store
- add case-insensitive session-key matching for legacy mixed-case keys
- add a fallback recovery path that scans other agent stores (on miss only) and rehydrates the current agent store with the newest matching entry
- prune legacy mixed-case keys after successful canonical recovery

Fixes #33477

## Why
Discord provider restarts can surface session-key lookup misses in real deployments (legacy mixed-case keys or misplaced entries in another agent store), which causes a new `sessionId` to be generated and context to reset (`messages=0`).

This patch preserves continuity by recovering prior session state before deciding a session is new.

## Tests
- `pnpm -s vitest run src/auto-reply/reply/session.test.ts`
- `pnpm -s check`

## Added regression coverage
- reuses an existing session when only a mixed-case key exists in the store
- recovers a missing session entry from another agent store and persists it into the expected store
