### PR TITLE
fix(sessions-spawn): fix llama.cpp GBNF grammar overflow regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sessions/subagent attachments: remove `attachments[].content.maxLength` from `sessions_spawn` schema to avoid llama.cpp GBNF repetition overflow, and preflight UTF-8 byte size before buffer allocation while keeping runtime file-size enforcement unchanged. (#33648) Thanks @anisoptera.
 - Runtime/tool-state stability: recover from dangling Anthropic `tool_use` after compaction, serialize long-running Discord handler runs without blocking new inbound events, and prevent stale busy snapshots from suppressing stuck-channel recovery. (from #33630, #33583) Thanks @kevinWangSheng and @theotarr.
 - Extensions/media local-root propagation: consistently forward `mediaLocalRoots` through extension `sendMedia` adapters (Google Chat, Slack, iMessage, Signal, WhatsApp), preserving non-local media behavior while restoring local attachment resolution from configured roots. Synthesis of #33581, #33545, #33540, #33536, #33528. Thanks @bmendonca3.
 - Gateway/security default response headers: add `Permissions-Policy: camera=(), microphone=(), geolocation=()` to baseline gateway HTTP security headers for all responses. (#30186) thanks @habakan.

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -611,13 +611,14 @@ export async function spawnSubagentDirect(
           }
           buf = strictBuf;
         } else {
-          buf = Buffer.from(contentVal, "utf8");
-          const estimatedBytes = buf.byteLength;
+          // Avoid allocating oversized UTF-8 buffers before enforcing file limits.
+          const estimatedBytes = Buffer.byteLength(contentVal, "utf8");
           if (estimatedBytes > maxFileBytes) {
             fail(
               `attachments_file_bytes_exceeded (name=${name} bytes=${estimatedBytes} maxFileBytes=${maxFileBytes})`,
             );
           }
+          buf = Buffer.from(contentVal, "utf8");
         }
 
         const bytes = buf.byteLength;

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -164,4 +164,26 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
+
+  it("keeps attachment content schema unconstrained for llama.cpp grammar safety", () => {
+    const tool = createSessionsSpawnTool();
+    const schema = tool.parameters as {
+      properties?: {
+        attachments?: {
+          items?: {
+            properties?: {
+              content?: {
+                type?: string;
+                maxLength?: number;
+              };
+            };
+          };
+        };
+      };
+    };
+
+    const contentSchema = schema.properties?.attachments?.items?.properties?.content;
+    expect(contentSchema?.type).toBe("string");
+    expect(contentSchema?.maxLength).toBeUndefined();
+  });
 });

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -41,7 +41,7 @@ const SessionsSpawnToolSchema = Type.Object({
     Type.Array(
       Type.Object({
         name: Type.String(),
-        content: Type.String({ maxLength: 6_700_000 }),
+        content: Type.String(),
         encoding: Type.Optional(optionalStringEnum(["utf8", "base64"] as const)),
         mimeType: Type.Optional(Type.String()),
       }),


### PR DESCRIPTION
... by removing maxLength from attachment content schema

## Summary
Describe the problem and fix in 2–5 bullets:
- Problem: `maxLength: 6_700_000` on the `attachments[].content` field in the `sessions_spawn` tool schema causes llama.cpp to reject the entire GBNF grammar (`char{0,6700000}` exceeds its repetition sanity limit), breaking all tool calling for local model users.
- Why it matters: Any llama.cpp user on 2026.3.2 cannot use tools at all — the grammar failure is total, not just for `sessions_spawn`.
- What changed: Removed `maxLength: 6_700_000` from `Type.String()` in the schema definition (`sessions-spawn-tool.ts:44`).
- What did NOT change (scope boundary): `maxItems: 50` on the attachments array stays (under llama.cpp's 2000 limit). Server-side byte-limit enforcement in `subagent-spawn.ts` is untouched and remains the real validation gate.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #32916
- Related #16761

## User-visible / Behavior Changes
llama.cpp backend can parse the tool grammar again. No config or default changes.

## Security Impact (required)
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification
### Environment
- OS: Ubuntu 24.04 (reporter), Ubuntu 24.04 (dev)
- Runtime/container: Node 22+, llama-server with Qwen 3.5 35B-A3B / 122B
- Model/provider: llama.cpp (OpenAI-compatible API)
- Integration/channel (if any): Telegram (reporter/dev)
- Relevant config (redacted): default

### Steps
1. Start llama-server with `--jinja` and a Qwen 3.5 model
2. Send any message that triggers tool use via OpenClaw 2026.3.2
3. Observe llama-server logs

### Expected
- Grammar parses successfully, tool calls work

### Actual
- `parse: error parsing grammar: number of repetitions exceeds sane defaults` in llama-server logs
- "Invalid diff: now finding less tool calls!" returned to user
- All tool calling broken

## Evidence
- [x] Trace/log snippets

Reporter's grammar dump shows the offending rule:
`tool-sessions-spawn-arg-attachments-schema-item-content ::= """ char{0,6700000} """ space`
After fix, `maxLength` is absent from the JSON Schema and this rule is no longer generated.

## Human Verification (required)
- Verified scenarios: build passes, `sessions-spawn-tool.test.ts` passes (3 tests), confirmed end-to-end with a live llama.cpp server
- Edge cases checked: kinda just worked
- What you did **not** verify: Ollama grammar path

## Compatibility / Migration
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly: Revert the one-line change in `sessions-spawn-tool.ts:44`, re-add `{ maxLength: 6_700_000 }` to `Type.String()`
- Files/config to restore: `src/agents/tools/sessions-spawn-tool.ts`
- Known bad symptoms reviewers should watch for: If a model somehow generates an absurdly large `content` string that bypasses server-side validation — extremely unlikely since `subagent-spawn.ts` enforces `maxFileBytes` (default 1MB) before materialization

## Risks and Mitigations
- Risk: Schema no longer hints content size to the LLM, could theoretically lead to oversized payloads in model output.
  - Mitigation: Server-side validation in `subagent-spawn.ts:516-629` enforces `maxFileBytes` (default 1MB) and `maxTotalBytes` (default 5MB) independently; the schema hint was never the enforcement mechanism.
