### PR TITLE
fix: persist moonshot cn endpoint selection (closes #33637)

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -53,6 +53,7 @@ const XIAOMI_DEFAULT_COST = {
 };
 
 const MOONSHOT_BASE_URL = "https://api.moonshot.ai/v1";
+const MOONSHOT_CN_BASE_URL = "https://api.moonshot.cn/v1";
 const MOONSHOT_DEFAULT_MODEL_ID = "kimi-k2.5";
 const MOONSHOT_DEFAULT_CONTEXT_WINDOW = 256000;
 const MOONSHOT_DEFAULT_MAX_TOKENS = 8192;
@@ -209,6 +210,23 @@ function resolveApiKeyFromProfiles(params: {
     }
   }
   return undefined;
+}
+
+function resolveMoonshotFromProfiles(store: ReturnType<typeof ensureAuthProfileStore>): {
+  apiKey?: string;
+  baseUrl: string;
+} {
+  const ids = listProfilesForProvider(store, "moonshot");
+  for (const id of ids) {
+    const cred = store.profiles[id];
+    if (!cred || cred.type !== "api_key") {
+      continue;
+    }
+    const endpoint =
+      typeof cred.metadata?.endpoint === "string" ? cred.metadata.endpoint.trim().toLowerCase() : "";
+    return { apiKey: cred.key, baseUrl: endpoint === "cn" ? MOONSHOT_CN_BASE_URL : MOONSHOT_BASE_URL };
+  }
+  return { baseUrl: MOONSHOT_BASE_URL };
 }
 
 export function normalizeGoogleModelId(id: string): string {
@@ -496,11 +514,15 @@ export async function resolveImplicitProviders(params: {
     };
   }
 
-  const moonshotKey =
-    resolveEnvApiKeyVarName("moonshot") ??
-    resolveApiKeyFromProfiles({ provider: "moonshot", store: authStore });
+  const moonshotEnvKey = resolveEnvApiKeyVarName("moonshot");
+  const moonshotFromProfile = resolveMoonshotFromProfiles(authStore);
+  const moonshotKey = moonshotEnvKey ?? moonshotFromProfile.apiKey;
   if (moonshotKey) {
-    providers.moonshot = { ...buildMoonshotProvider(), apiKey: moonshotKey };
+    providers.moonshot = {
+      ...buildMoonshotProvider(),
+      baseUrl: moonshotEnvKey ? MOONSHOT_BASE_URL : moonshotFromProfile.baseUrl,
+      apiKey: moonshotKey,
+    };
   }
 
   const syntheticKey =

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -468,7 +468,7 @@ export async function applyAuthChoiceApiProviders(
     let hasCredential = false;
 
     if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "moonshot") {
-      await setMoonshotApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir);
+      await setMoonshotApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir, "cn");
       hasCredential = true;
     }
 
@@ -479,7 +479,7 @@ export async function applyAuthChoiceApiProviders(
         initialValue: true,
       });
       if (useExisting) {
-        await setMoonshotApiKey(envKey.apiKey, params.agentDir);
+        await setMoonshotApiKey(envKey.apiKey, params.agentDir, "cn");
         hasCredential = true;
       }
     }
@@ -488,7 +488,7 @@ export async function applyAuthChoiceApiProviders(
         message: "Enter Moonshot API key (.cn)",
         validate: validateApiKeyInput,
       });
-      await setMoonshotApiKey(normalizeApiKeyInput(String(key)), params.agentDir);
+      await setMoonshotApiKey(normalizeApiKeyInput(String(key)), params.agentDir, "cn");
     }
     nextConfig = applyAuthProfileConfig(nextConfig, {
       profileId: "moonshot:default",

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -63,7 +63,11 @@ export async function setMinimaxApiKey(key: string, agentDir?: string) {
   });
 }
 
-export async function setMoonshotApiKey(key: string, agentDir?: string) {
+export async function setMoonshotApiKey(
+  key: string,
+  agentDir?: string,
+  endpoint?: "ai" | "cn",
+) {
   // Write to resolved agent dir so gateway finds credentials on startup.
   upsertAuthProfile({
     profileId: "moonshot:default",
@@ -71,6 +75,7 @@ export async function setMoonshotApiKey(key: string, agentDir?: string) {
       type: "api_key",
       provider: "moonshot",
       key,
+      ...(endpoint ? { metadata: { endpoint } } : {}),
     },
     agentDir: resolveAuthAgentDir(agentDir),
   });

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -419,7 +419,7 @@ export async function applyNonInteractiveAuthChoice(params: {
       return null;
     }
     if (resolved.source !== "profile") {
-      await setMoonshotApiKey(resolved.key);
+      await setMoonshotApiKey(resolved.key, undefined, "cn");
     }
     nextConfig = applyAuthProfileConfig(nextConfig, {
       profileId: "moonshot:default",


### PR DESCRIPTION
Closes #33637

## Problem
Moonshot .cn onboarding could still resolve to the default Moonshot .ai endpoint at runtime when provider config was reconstructed from auth profiles, causing valid platform.moonshot.cn keys to fail with HTTP 401.

## Fix
Persist the Moonshot endpoint selection (cn) in auth profile metadata during onboarding, and use that metadata when resolving implicit Moonshot provider config so .cn selections map to https://api.moonshot.cn/v1 consistently.
