### PR TITLE
feat(plugins): emit tool:before / tool:after internal hook events for native tools

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
@@ -455,4 +456,23 @@ export async function handleToolExecutionEnd(
         ctx.log.warn(`after_tool_call hook failed: tool=${toolName} error=${String(err)}`);
       });
   }
+
+  // Emit tool:after internal hook event so registerHook("tool:after", ...)
+  // handlers observe native tool completions.  Fire-and-forget.  #32460
+  const durationMsInternal =
+    startData?.startTime != null ? Date.now() - startData.startTime : undefined;
+  void triggerInternalHook(
+    createInternalHookEvent("tool", "after", ctx.params.sessionKey ?? "", {
+      toolName,
+      params: afterToolCallArgs,
+      toolCallId,
+      runId,
+      result: sanitizedResult,
+      error: isToolError ? extractToolErrorMessage(sanitizedResult) : undefined,
+      durationMs: durationMsInternal,
+      agentId: ctx.params.agentId,
+    }),
+  ).catch((err) => {
+    ctx.log.warn(`tool:after internal hook error: ${String(err)}`);
+  });
 }

--- a/src/agents/pi-tools.before-tool-call.internal-hook.test.ts
+++ b/src/agents/pi-tools.before-tool-call.internal-hook.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearInternalHooks, registerInternalHook } from "../hooks/internal-hooks.js";
+import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import {
+  __testing as beforeToolCallTesting,
+  runBeforeToolCallHook,
+  wrapToolWithBeforeToolCallHook,
+} from "./pi-tools.before-tool-call.js";
+
+vi.mock("../plugins/hook-runner-global.js");
+
+const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+
+function installNoOpHookRunner() {
+  const hookRunner = {
+    hasHooks: vi.fn(() => false),
+    runBeforeToolCall: vi.fn(),
+  };
+  // oxlint-disable-next-line typescript/no-explicit-any
+  mockGetGlobalHookRunner.mockReturnValue(hookRunner as any);
+  return hookRunner;
+}
+
+describe("tool:before internal hook emission (#32460)", () => {
+  beforeEach(() => {
+    resetDiagnosticSessionStateForTest();
+    beforeToolCallTesting.adjustedParamsByToolCallId.clear();
+    clearInternalHooks();
+    installNoOpHookRunner();
+  });
+
+  it("fires tool:before internal hook for native tool calls", async () => {
+    const received: unknown[] = [];
+    registerInternalHook("tool:before", async (event) => {
+      received.push(event);
+    });
+
+    await runBeforeToolCallHook({
+      toolName: "exec",
+      params: { command: "ls" },
+      toolCallId: "call-1",
+      ctx: {
+        agentId: "main",
+        sessionKey: "test-session",
+        runId: "run-1",
+      },
+    });
+
+    // Wait for the fire-and-forget promise to resolve
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    const event = received[0] as Record<string, unknown>;
+    expect(event.type).toBe("tool");
+    expect(event.action).toBe("before");
+    expect(event.sessionKey).toBe("test-session");
+    const context = event.context as Record<string, unknown>;
+    expect(context.toolName).toBe("exec");
+    expect(context.params).toEqual({ command: "ls" });
+    expect(context.toolCallId).toBe("call-1");
+    expect(context.runId).toBe("run-1");
+    expect(context.agentId).toBe("main");
+  });
+
+  it("fires tool:before with empty session key when ctx is omitted", async () => {
+    const received: unknown[] = [];
+    registerInternalHook("tool:before", async (event) => {
+      received.push(event);
+    });
+
+    await runBeforeToolCallHook({
+      toolName: "read",
+      params: { path: "/tmp/file" },
+    });
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    const event = received[0] as Record<string, unknown>;
+    expect(event.type).toBe("tool");
+    expect(event.action).toBe("before");
+    expect(event.sessionKey).toBe("");
+  });
+
+  it("fires tool:before through wrapToolWithBeforeToolCallHook", async () => {
+    const received: unknown[] = [];
+    registerInternalHook("tool:before", async (event) => {
+      received.push(event);
+    });
+
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithBeforeToolCallHook({ name: "process", execute } as any, {
+      agentId: "agent-1",
+      sessionKey: "session-1",
+      runId: "run-1",
+    });
+
+    await tool.execute("call-2", { command: "test" }, undefined, {} as never);
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    const event = received[0] as Record<string, unknown>;
+    expect(event.type).toBe("tool");
+    expect(event.action).toBe("before");
+    expect(event.sessionKey).toBe("session-1");
+    const context = event.context as Record<string, unknown>;
+    expect(context.toolName).toBe("process");
+  });
+
+  it("does not block tool execution if internal hook throws", async () => {
+    registerInternalHook("tool:before", async () => {
+      throw new Error("hook failure");
+    });
+
+    const result = await runBeforeToolCallHook({
+      toolName: "exec",
+      params: { command: "ls" },
+      ctx: { sessionKey: "test" },
+    });
+
+    expect(result.blocked).toBe(false);
+  });
+
+  it("fires tool event for registerHook('tool', ...) handlers (type-level match)", async () => {
+    const received: unknown[] = [];
+    // Register on the type level (matches all tool:* events)
+    registerInternalHook("tool", async (event) => {
+      received.push(event);
+    });
+
+    await runBeforeToolCallHook({
+      toolName: "read",
+      params: { path: "/tmp/x" },
+      ctx: { sessionKey: "test" },
+    });
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    const event = received[0] as Record<string, unknown>;
+    expect(event.type).toBe("tool");
+    expect(event.action).toBe("before");
+  });
+});

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -1,4 +1,5 @@
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
@@ -141,6 +142,22 @@ export async function runBeforeToolCallHook(args: {
 
     recordToolCall(sessionState, toolName, params, args.toolCallId, args.ctx.loopDetection);
   }
+
+  // Emit tool:before internal hook event so registerHook("tool:before", ...)
+  // handlers observe native tool invocations.  Fire-and-forget: internal hooks
+  // cannot block execution — use api.on("before_tool_call") for that.  #32460
+  const sessionKey = args.ctx?.sessionKey ?? "";
+  void triggerInternalHook(
+    createInternalHookEvent("tool", "before", sessionKey, {
+      toolName,
+      params: isPlainObject(params) ? params : {},
+      toolCallId: args.toolCallId,
+      runId: args.ctx?.runId,
+      agentId: args.ctx?.agentId,
+    }),
+  ).catch((err) => {
+    log.warn(`tool:before internal hook error: ${String(err)}`);
+  });
 
   const hookRunner = getGlobalHookRunner();
   if (!hookRunner?.hasHooks("before_tool_call")) {

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -10,7 +10,13 @@ import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "message"
+  | "tool";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;


### PR DESCRIPTION
## Summary

- Adds `"tool"` to `InternalHookEventType`, enabling `registerHook("tool:before", handler)` and `registerHook("tool:after", handler)` for native embedded-agent tools (exec, read, process, etc.).
- `tool:before` fires from `runBeforeToolCallHook()` — the shared entry point for all native tool pre-execution logic.
- `tool:after` fires from `handleToolExecutionEnd()` — the subscription handler that already emits the typed `after_tool_call` plugin hook.
- Both events are fire-and-forget (`void triggerInternalHook(...)`) — errors are caught and logged, never blocking tool execution.
- Includes 5 tests covering: hook event shape, context propagation, wrapper integration, error resilience, and type-level event matching.

## What did NOT change

- The typed plugin hooks (`api.on("before_tool_call", ...)` and `api.on("after_tool_call", ...)`) are untouched — they still fire and retain their blocking / param-modification capabilities.
- The `wrapToolWithBeforeToolCallHook` wrapper is unchanged; the internal hook fires from `runBeforeToolCallHook` which it delegates to.
- Tool loop detection runs before the internal hook, so blocked-by-loop tools never emit `tool:before`.
- No new config options; the feature activates automatically when a hook registers for the `"tool"` or `"tool:before"` / `"tool:after"` event keys.

## Hook event shape

```typescript
// tool:before context
{
  toolName: string;
  params: Record<string, unknown>;
  toolCallId?: string;
  runId?: string;
  agentId?: string;
}

// tool:after context (adds result + timing)
{
  toolName: string;
  params: Record<string, unknown>;
  toolCallId?: string;
  runId?: string;
  agentId?: string;
  result?: unknown;
  error?: string;
  durationMs?: number;
}
```

## Test plan

- [x] New test file `pi-tools.before-tool-call.internal-hook.test.ts` (5 tests):
  - Fires `tool:before` internal hook for native tool calls with correct event shape
  - Fires with empty session key when ctx is omitted
  - Fires through `wrapToolWithBeforeToolCallHook`
  - Does not block tool execution if internal hook throws
  - Fires for `registerHook("tool", ...)` type-level handlers
- [x] All 156 existing hook tests pass
- [x] All 5 new tests pass

Closes #32460

🤖 Generated with [Claude Code](https://claude.com/claude-code)