### PR TITLE
fix(device-pair): guard malformed pending payload in notifier poll

### DIFF
--- a/extensions/device-pair/notify.test.ts
+++ b/extensions/device-pair/notify.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { coercePendingPairingRequests } from "./notify.js";
+
+describe("coercePendingPairingRequests", () => {
+  it("returns empty array for non-array payloads", () => {
+    expect(coercePendingPairingRequests(undefined)).toEqual([]);
+    expect(coercePendingPairingRequests(null)).toEqual([]);
+    expect(coercePendingPairingRequests({ pending: [] })).toEqual([]);
+  });
+
+  it("keeps only well-formed pending entries", () => {
+    expect(
+      coercePendingPairingRequests([
+        { requestId: "r1", deviceId: "d1", displayName: "Phone" },
+        { requestId: "r2" },
+        { deviceId: "d3" },
+        null,
+      ]),
+    ).toEqual([{ requestId: "r1", deviceId: "d1", displayName: "Phone" }]);
+  });
+});

--- a/extensions/device-pair/notify.ts
+++ b/extensions/device-pair/notify.ts
@@ -427,7 +427,7 @@ export async function handleNotifyCommand(params: {
         `Pair request notifications: ${enabled ? "enabled" : "disabled"} for this chat.`,
         `Mode: ${mode}`,
         `Subscribers: ${state.subscribers.length}`,
-        `Pending requests: ${pending.pending.length}`,
+        `Pending requests: ${coercePendingPairingRequests(pending.pending).length}`,
         "",
         "Use /pair notify on|off|once",
       ].join("\n"),

--- a/extensions/device-pair/notify.ts
+++ b/extensions/device-pair/notify.ts
@@ -29,6 +29,19 @@ export type PendingPairingRequest = {
   ts?: number;
 };
 
+export function coercePendingPairingRequests(input: unknown): PendingPairingRequest[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  return input.filter((entry): entry is PendingPairingRequest => {
+    if (!entry || typeof entry !== "object") {
+      return false;
+    }
+    const record = entry as Record<string, unknown>;
+    return typeof record.requestId === "string" && typeof record.deviceId === "string";
+  });
+}
+
 export function formatPendingRequests(pending: PendingPairingRequest[]): string {
   if (pending.length === 0) {
     return "No pending device pairing requests.";
@@ -253,7 +266,7 @@ async function notifyPendingPairingRequests(params: {
 }): Promise<void> {
   const state = await readNotifyState(params.statePath);
   const pairing = await listDevicePairing();
-  const pending = pairing.pending as PendingPairingRequest[];
+  const pending = coercePendingPairingRequests(pairing.pending);
   const now = Date.now();
   const pendingIds = new Set(pending.map((entry) => entry.requestId));
   let changed = false;


### PR DESCRIPTION
## Summary
- guard `listDevicePairing().pending` with a shape-safe coercion before iterating
- drop malformed entries instead of throwing during notifier polling
- add unit tests for non-array and mixed payloads

## Why
If a runtime or transport returns a malformed `pending` payload, notifier polling can throw and stop notifications. This keeps polling resilient and avoids a full service interruption for bad payload shapes.

## Testing
- added `extensions/device-pair/notify.test.ts` (not run locally in this environment because vitest is unavailable without installing workspace deps)