### PR TITLE
fix(daemon): handle systemctl exit code 4 as unit-not-found

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,6 +79,28 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false when systemctl exits with code 4 (unit not found)", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error("not-found") as Error & { code?: number };
+      err.code = 4;
+      cb(err, "", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
+  it("returns false when exit code 4 has empty output", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error("") as Error & { code?: number };
+      err.code = 4;
+      cb(err, "", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
   it("throws when systemctl is-enabled fails for non-state errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -351,6 +351,11 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
   if (res.code === 0) {
     return true;
   }
+  // Exit code 4 means "no such unit" — the service hasn't been installed yet.
+  // Treat this the same as "disabled" so gateway install can proceed.
+  if (res.code === 4) {
+    return false;
+  }
   const detail = readSystemctlDetail(res);
   if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
     return false;


### PR DESCRIPTION
## Summary

- **Problem:** `systemctl --user is-enabled` returns exit code 4 when the service unit file does not exist. The current handler does not distinguish exit code 4 from other non-zero codes, so `isSystemdServiceEnabled` throws an `unavailable` error instead of returning `false`, aborting gateway installation.
- **Why it matters:** First-time installs on systems where the systemd unit has never been created fail with a confusing error, even though the correct behavior is to create the unit.
- **What changed:** `src/daemon/systemd.ts` — added explicit check for `res.code === 4` before the keyword-based fallback parsing. `src/daemon/systemd.test.ts` — added two unit tests covering exit code 4 with and without stderr output.
- **What did NOT change:** All other exit codes, the `isSystemctlMissing` / `isSystemdUnitNotEnabled` keyword checks, and the error throw path remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #33512

## User-visible / Behavior Changes

- Gateway installation on fresh systems with systemd no longer throws `systemctl is-enabled unavailable` when the unit file has not yet been created.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (systemd-based)
- Runtime: Node.js
- Integration/channel: Gateway daemon

### Steps

1. Start with a clean system where the openclaw systemd unit has never been installed
2. Run the gateway installation / auto-setup

### Expected

- `isSystemdServiceEnabled` returns `false`, installation proceeds to create the unit

### Actual

- Before fix: throws `systemctl is-enabled unavailable: not-found`
- After fix: returns `false`, installation proceeds normally

## Evidence

Two new unit tests:
- `returns false when systemctl exits with code 4 (unit not found)` — mocks exit code 4 with stderr "not-found"
- `returns false when exit code 4 has empty output` — mocks exit code 4 with empty stderr

## Human Verification (required)

- Verified scenarios: exit code 0 (enabled), exit code 4 (not found), exit code 1 with "disabled" keyword
- Edge cases checked: exit code 4 with empty output, exit code 4 with non-standard stderr text
- What I did **not** verify: Real systemd environment on all distros

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; the original keyword parsing handles most cases
- Files/config to restore: `src/daemon/systemd.ts`
- Known bad symptoms: Installation would fail on clean systems again

## Risks and Mitigations

None — exit code 4 is documented by systemd as "no such unit" and is a strict superset of the keyword check it precedes.
