### PR TITLE
fix(agents): strip dangling tool_use blocks from errored/aborted assistant messages

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -207,6 +207,72 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(result.added[0]?.toolCallId).toBe("call_normal");
   });
 
+  it("strips tool_use blocks from errored assistant messages to prevent Anthropic rejection", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check that for you." },
+          { type: "toolCall", id: "call_err1", name: "exec", arguments: {} },
+        ],
+        stopReason: "error",
+      },
+      { role: "user", content: "what happened?" },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.added).toHaveLength(0);
+    const assistantMsg = result.messages[0] as { role: string; content?: unknown[] };
+    expect(assistantMsg.role).toBe("assistant");
+    const hasToolCall = assistantMsg.content?.some(
+      (b: { type?: string }) => b.type === "toolCall" || b.type === "toolUse",
+    );
+    expect(hasToolCall).toBeFalsy();
+  });
+
+  it("strips tool_use blocks from aborted assistant messages preserving text", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Working on it..." },
+          { type: "toolCall", id: "call_ab1", name: "Bash", arguments: {} },
+          { type: "toolCall", id: "call_ab2", name: "read", arguments: {} },
+        ],
+        stopReason: "aborted",
+      },
+      { role: "user", content: "retry" },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    const assistantMsg = result.messages[0] as { role: string; content?: unknown[] };
+    expect(assistantMsg.role).toBe("assistant");
+    expect(assistantMsg.content).toHaveLength(1);
+    expect((assistantMsg.content![0] as { type: string }).type).toBe("text");
+  });
+
+  it("replaces errored assistant with only tool_use blocks with fallback text", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_only", name: "exec", arguments: {} },
+        ],
+        stopReason: "error",
+      },
+      { role: "user", content: "what now?" },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    const assistantMsg = result.messages[0] as { role: string; content?: unknown[] };
+    expect(assistantMsg.role).toBe("assistant");
+    expect(assistantMsg.content).toHaveLength(1);
+    expect((assistantMsg.content![0] as { text: string }).text).toBe("(tool calls removed)");
+  });
+
   it("drops orphan tool results that follow an aborted assistant message", () => {
     // When an assistant message is aborted, any tool results that follow should be
     // dropped as orphans (since we skip extracting tool calls from aborted messages).

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -257,9 +257,7 @@ describe("sanitizeToolUseResultPairing", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
-        content: [
-          { type: "toolCall", id: "call_only", name: "exec", arguments: {} },
-        ],
+        content: [{ type: "toolCall", id: "call_only", name: "exec", arguments: {} }],
         stopReason: "error",
       },
       { role: "user", content: "what now?" },

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -339,6 +339,27 @@ export type ToolUseRepairReport = {
   moved: boolean;
 };
 
+function stripDanglingToolUseBlocks(
+  assistant: Extract<AgentMessage, { role: "assistant" }>,
+): AgentMessage | null {
+  const content = (assistant as { content?: unknown[] }).content;
+  if (!Array.isArray(content)) {
+    return assistant;
+  }
+  const filtered = content.filter((block) => !isRawToolCallBlock(block));
+  if (filtered.length === content.length) {
+    return assistant;
+  }
+  if (filtered.length === 0) {
+    const hasText = (assistant as { text?: unknown }).text;
+    if (typeof hasText === "string" && hasText.trim().length > 0) {
+      return { ...assistant, content: undefined } as unknown as AgentMessage;
+    }
+    return { ...assistant, content: [{ type: "text", text: "(tool calls removed)" }] } as unknown as AgentMessage;
+  }
+  return { ...assistant, content: filtered } as unknown as AgentMessage;
+}
+
 export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRepairReport {
   // Anthropic (and Cloud Code Assist) reject transcripts where assistant tool calls are not
   // immediately followed by matching tool results. Session files can end up with results
@@ -398,7 +419,15 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
     // See: https://github.com/openclaw/openclaw/issues/4597
     const stopReason = (assistant as { stopReason?: string }).stopReason;
     if (stopReason === "error" || stopReason === "aborted") {
-      out.push(msg);
+      const stripped = stripDanglingToolUseBlocks(assistant);
+      if (stripped) {
+        out.push(stripped);
+        if (stripped !== msg) {
+          changed = true;
+        }
+      } else {
+        changed = true;
+      }
       continue;
     }
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -355,7 +355,10 @@ function stripDanglingToolUseBlocks(
     if (typeof hasText === "string" && hasText.trim().length > 0) {
       return { ...assistant, content: undefined } as unknown as AgentMessage;
     }
-    return { ...assistant, content: [{ type: "text", text: "(tool calls removed)" }] } as unknown as AgentMessage;
+    return {
+      ...assistant,
+      content: [{ type: "text", text: "(tool calls removed)" }],
+    } as unknown as AgentMessage;
   }
   return { ...assistant, content: filtered } as unknown as AgentMessage;
 }


### PR DESCRIPTION
## Summary

- **Problem:** When an assistant turn ends with `stopReason: "error"` or `"aborted"`, the message may contain `tool_use` / `toolCall` content blocks without matching `tool_result` blocks in the next user message. Anthropic's API rejects transcripts with unpaired tool calls, crashing session repair.
- **Why it matters:** Sessions that encounter errors or aborts become permanently stuck — no further turns can be sent because the API always rejects the malformed transcript.
- **What changed:** `src/agents/session-transcript-repair.ts` — added `stripDanglingToolUseBlocks` helper; called from `repairToolUseResultPairing` for errored/aborted assistant messages. `src/agents/session-transcript-repair.test.ts` — three new test cases.
- **What did NOT change:** Normal (non-errored) assistant messages, existing tool-result pairing logic, and the rest of the repair pipeline remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33621

## User-visible / Behavior Changes

- Sessions that previously got stuck after an error or abort can now self-heal on the next turn.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Any channel using Anthropic provider

### Steps

1. Trigger an agent error mid-tool-call (e.g., timeout or sandbox crash)
2. Attempt to send a follow-up message in the same session

### Expected

- The session repairs the transcript and the follow-up message is processed normally

### Actual

- Before fix: Anthropic API rejects with "tool_use without matching tool_result"
- After fix: Dangling tool_use blocks are stripped; session continues

## Evidence

Three new unit tests:
- `strips tool_use blocks from errored assistant messages to prevent Anthropic rejection`
- `strips tool_use blocks from aborted assistant messages preserving text`
- `replaces errored assistant with only tool_use blocks with fallback text`

## Human Verification (required)

- Verified scenarios: errored message with tool_use + text, aborted message with text, errored message with only tool_use blocks
- Edge cases checked: assistant message with no content array, message with mixed block types
- What I did **not** verify: Real Anthropic API end-to-end (unit tests mock the transcript)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; sessions would revert to the stuck behavior
- Files/config to restore: `src/agents/session-transcript-repair.ts`
- Known bad symptoms: If the stripping logic is too aggressive, non-errored messages might lose tool blocks (mitigated by the stopReason guard)

## Risks and Mitigations

The stopReason guard ensures only truly errored/aborted messages are modified. Normal tool-call flows are untouched.
