### PR TITLE
fix(cron): infer payload from top-level fields and migrate legacy timeout

### DIFF
--- a/src/cron/service.store.migration.test.ts
+++ b/src/cron/service.store.migration.test.ts
@@ -225,4 +225,62 @@ describe("cron store migration", () => {
       await store.cleanup();
     }
   });
+
+  it("infers payload from top-level command when payload exists but is empty", async () => {
+    const store = await makeStorePath();
+    try {
+      await writeLegacyStore(store.storePath, {
+        id: "legacy-empty-payload",
+        name: "Legacy Empty",
+        enabled: true,
+        createdAtMs: 1_700_000_000_000,
+        updatedAtMs: 1_700_000_000_000,
+        schedule: { kind: "cron", expr: "0 6 * * *" },
+        command: "echo hello",
+        payload: {},
+        state: {},
+      });
+
+      await migrateAndLoadFirstJob(store.storePath);
+      const loaded = await loadCronStore(store.storePath);
+      const migrated = loaded.jobs[0] as Record<string, unknown>;
+
+      expect(migrated.payload).toEqual({
+        kind: "systemEvent",
+        text: "echo hello",
+      });
+      expect("command" in migrated).toBe(false);
+    } finally {
+      await store.cleanup();
+    }
+  });
+
+  it("migrates legacy timeout into agentTurn payload timeoutSeconds", async () => {
+    const store = await makeStorePath();
+    try {
+      await writeLegacyStore(store.storePath, {
+        id: "legacy-timeout-migration",
+        name: "Legacy Timeout",
+        enabled: true,
+        createdAtMs: 1_700_000_000_000,
+        updatedAtMs: 1_700_000_000_000,
+        schedule: "30 8 * * *",
+        message: "run morning check",
+        timeout: 300,
+        state: {},
+      });
+
+      await migrateAndLoadFirstJob(store.storePath);
+      const loaded = await loadCronStore(store.storePath);
+      const migrated = loaded.jobs[0] as Record<string, unknown>;
+      const payload = migrated.payload as Record<string, unknown>;
+
+      expect(payload.kind).toBe("agentTurn");
+      expect(payload.message).toBe("run morning check");
+      expect(payload.timeoutSeconds).toBe(300);
+      expect("timeout" in migrated).toBe(false);
+    } finally {
+      await store.cleanup();
+    }
+  });
 });

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -350,6 +350,10 @@ export async function ensureLoaded(
         } else if (typeof payloadRecord.text === "string" && payloadRecord.text.trim()) {
           payloadRecord.kind = "systemEvent";
           mutated = true;
+        } else if (inferPayloadIfMissing(raw)) {
+          // Payload exists but is empty/invalid — re-infer from top-level
+          // legacy fields (command, message, text) that may still be present.
+          mutated = true;
         }
       }
       if (payloadRecord.kind === "agentTurn") {
@@ -357,6 +361,22 @@ export async function ensureLoaded(
           mutated = true;
         }
       }
+    }
+
+    // Migrate legacy top-level `timeout` (seconds) into the payload before
+    // stripping.  Only applies to agentTurn payloads that lack timeoutSeconds.
+    const currentPayload =
+      raw.payload && typeof raw.payload === "object" && !Array.isArray(raw.payload)
+        ? (raw.payload as Record<string, unknown>)
+        : null;
+    if (
+      currentPayload?.kind === "agentTurn" &&
+      typeof currentPayload.timeoutSeconds !== "number" &&
+      typeof raw.timeout === "number" &&
+      Number.isFinite(raw.timeout as number)
+    ) {
+      currentPayload.timeoutSeconds = Math.max(0, Math.floor(raw.timeout as number));
+      mutated = true;
     }
 
     const hadLegacyTopLevelFields =

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -373,9 +373,9 @@ export async function ensureLoaded(
       currentPayload?.kind === "agentTurn" &&
       typeof currentPayload.timeoutSeconds !== "number" &&
       typeof raw.timeout === "number" &&
-      Number.isFinite(raw.timeout as number)
+      Number.isFinite(raw.timeout)
     ) {
-      currentPayload.timeoutSeconds = Math.max(0, Math.floor(raw.timeout as number));
+      currentPayload.timeoutSeconds = Math.max(0, Math.floor(raw.timeout));
       mutated = true;
     }
 


### PR DESCRIPTION
## Summary

- **Problem:** Legacy cron jobs with an empty `payload` object but a top-level `command` field are not properly migrated — the `command` is silently dropped. Similarly, a top-level `timeout` field (seconds) is stripped during migration without being preserved in the payload's `timeoutSeconds`.
- **Why it matters:** Users upgrading from older OpenClaw versions lose cron job commands and timeout settings, causing silent job failures.
- **What changed:** `src/cron/service/store.ts` — calls `inferPayloadIfMissing` when payload exists but has no valid `kind`; migrates legacy `timeout` into `payload.timeoutSeconds` for agentTurn payloads. `src/cron/service.store.migration.test.ts` — two new test cases.
- **What did NOT change:** Jobs with a valid `payload.kind` are unaffected. The `stripLegacyTopLevelFields` logic continues to remove migrated fields after they're copied.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #33451

## User-visible / Behavior Changes

- Legacy cron jobs with empty payloads now correctly infer their payload from top-level `command`/`message` fields.
- Legacy top-level `timeout` values are preserved as `payload.timeoutSeconds`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Cron service

### Steps

1. Create a cron job store file with `payload: {}` and `command: "echo hello"`
2. Load the cron store (triggers migration)

### Expected

- `payload` is inferred as `{ kind: "systemEvent", text: "echo hello" }`
- Top-level `command` is stripped

### Actual

- Before fix: `payload` stays `{}`, command is lost
- After fix: payload is correctly inferred

## Evidence

Two new unit tests:
- `infers payload from top-level command when payload exists but is empty`
- `migrates legacy timeout into agentTurn payload timeoutSeconds`

## Human Verification (required)

- Verified scenarios: empty payload + command, empty payload + message, payload with timeout migration
- Edge cases checked: payload with valid kind (not modified), non-finite timeout values, non-agentTurn payloads (timeout not migrated)
- What I did **not** verify: Real production store files from very old OpenClaw versions

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No` (this IS the migration fix)

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; legacy jobs would still lose data on migration
- Files/config to restore: `src/cron/service/store.ts`
- Known bad symptoms: If inference logic is wrong, jobs might get incorrect payload kinds

## Risks and Mitigations

The inference logic (`inferPayloadIfMissing`) is existing and well-tested — we only extend when it's called. The timeout migration is guarded by `kind === "agentTurn"` and `Number.isFinite`.
