### PR TITLE
fix(infra): debounce triggerOpenClawRestart to prevent restart loops

### DIFF
--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -176,6 +176,17 @@ describe("infra runtime", () => {
     });
   });
 
+  describe("triggerOpenClawRestart cooldown", () => {
+    it("coalesces rapid triggerOpenClawRestart calls within cooldown window", () => {
+      const { triggerOpenClawRestart } = require("./restart.js");
+      const first = triggerOpenClawRestart();
+      const second = triggerOpenClawRestart();
+
+      expect(first.detail).toBe("test mode");
+      expect(second.detail).toBe("restart already in progress (coalesced)");
+    });
+  });
+
   describe("pre-restart deferral check", () => {
     setupRestartSignalSuite();
 

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -12,6 +12,7 @@ import {
   scheduleGatewaySigusr1Restart,
   setGatewaySigusr1RestartPolicy,
   setPreRestartDeferralCheck,
+  triggerOpenClawRestart,
 } from "./restart.js";
 import { createTelegramRetryRunner } from "./retry-policy.js";
 import { listTailnetAddresses } from "./tailnet.js";
@@ -178,7 +179,6 @@ describe("infra runtime", () => {
 
   describe("triggerOpenClawRestart cooldown", () => {
     it("coalesces rapid triggerOpenClawRestart calls within cooldown window", () => {
-      const { triggerOpenClawRestart } = require("./restart.js");
       const first = triggerOpenClawRestart();
       const second = triggerOpenClawRestart();
 

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -286,7 +286,19 @@ function normalizeSystemdUnit(raw?: string, profile?: string): string {
   return unit.endsWith(".service") ? unit : `${unit}.service`;
 }
 
+let lastExternalRestartAtMs = 0;
+
 export function triggerOpenClawRestart(): RestartAttempt {
+  const now = Date.now();
+  if (now - lastExternalRestartAtMs < RESTART_COOLDOWN_MS) {
+    return {
+      ok: true,
+      method: "supervisor",
+      detail: "restart already in progress (coalesced)",
+    };
+  }
+  lastExternalRestartAtMs = now;
+
   if (process.env.VITEST || process.env.NODE_ENV === "test") {
     return { ok: true, method: "supervisor", detail: "test mode" };
   }


### PR DESCRIPTION
## Summary

- **Problem:** `triggerOpenClawRestart` can be called in rapid succession (e.g., multiple config changes or webhook events within seconds), each spawning a `launchctl kickstart` or `systemctl restart` subprocess. These concurrent restarts race against each other and can produce a restart loop.
- **Why it matters:** The restart loop causes repeated agent disconnections, lost in-flight messages, and excessive CPU usage until the user manually intervenes.
- **What changed:** `src/infra/restart.ts` — added a `lastExternalRestartAtMs` timestamp and a `RESTART_COOLDOWN_MS` (30s) debounce. Rapid calls within the cooldown window return immediately with `"restart already in progress (coalesced)"`. `src/infra/infra-runtime.test.ts` — new test confirming the cooldown behavior.
- **What did NOT change:** The actual restart mechanisms (`launchctl`, `systemctl`, `cleanStaleGatewayProcessesSync`) are untouched. Single restart calls work identically.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #33459

## User-visible / Behavior Changes

- Rapid restart commands are coalesced into a single restart, preventing restart loops.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js
- Integration/channel: Gateway daemon

### Steps

1. Call `triggerOpenClawRestart()` twice within 1 second

### Expected

- First call executes, second call returns "coalesced" immediately

### Actual

- Before fix: Both calls spawn concurrent restart subprocesses
- After fix: Second call is coalesced

## Evidence

New unit test:
- `coalesces rapid triggerOpenClawRestart calls within cooldown window` — verifies first call returns "test mode", second returns "coalesced"

## Human Verification (required)

- Verified scenarios: two rapid calls, single call (no cooldown hit)
- Edge cases checked: cooldown boundary timing, test mode interaction with cooldown
- What I did **not** verify: Real launchctl/systemctl subprocess behavior under load

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; restarts would fire without debounce again
- Files/config to restore: `src/infra/restart.ts`
- Known bad symptoms: If cooldown is too long, legitimate restarts might be delayed (30s is conservative)

## Risks and Mitigations

30s cooldown is well above the typical restart duration (~5s) but well below user-noticeable delay. The cooldown only applies to `triggerOpenClawRestart`, not to the initial startup path.
