### PR TITLE
fix(streaming): suppress NO_REPLY prefix tokens in partial replies

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -1,6 +1,6 @@
 import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { isSilentReplyPrefixText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import {
@@ -232,10 +232,12 @@ export function handleMessageUpdate(
       });
       ctx.state.emittedAssistantUpdate = true;
       if (ctx.params.onPartialReply && ctx.state.shouldEmitPartialReplies) {
-        void ctx.params.onPartialReply({
-          text: cleanedText,
-          mediaUrls: hasMedia ? mediaUrls : undefined,
-        });
+        if (!isSilentReplyPrefixText(cleanedText, SILENT_REPLY_TOKEN)) {
+          void ctx.params.onPartialReply({
+            text: cleanedText,
+            mediaUrls: hasMedia ? mediaUrls : undefined,
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- **Problem:** With `streaming: partial` enabled, the first streamed tokens of `NO_REPLY` (e.g., `"NO"`) are emitted to clients via `onPartialReply` before the full directive is recognized. Channels like Telegram briefly display "NO" as a visible message to the user before the reply is suppressed.
- **Why it matters:** Users see confusing partial text ("NO") flash briefly in their chat before it disappears, degrading the user experience.
- **What changed:** `src/agents/pi-embedded-subscribe.handlers.messages.ts` — imported `isSilentReplyPrefixText` and `SILENT_REPLY_TOKEN`; added a check before `onPartialReply` that suppresses emission when the accumulated text matches a known silent reply prefix.
- **What did NOT change:** The final `NO_REPLY` detection, non-streaming paths, and the `isSilentReplyPrefixText` utility itself are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33544

## User-visible / Behavior Changes

- Channels with streaming enabled no longer flash partial "NO" text before suppressing NO_REPLY directives.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Telegram with `streaming: partial`

### Steps

1. Configure an agent with `streaming: partial` and connect via Telegram
2. Trigger a scenario where the agent responds with `NO_REPLY`
3. Observe the Telegram chat

### Expected

- No visible message is sent (the directive is fully suppressed)

### Actual

- Before fix: "NO" briefly appears then vanishes
- After fix: No partial text is emitted

## Evidence

The `isSilentReplyPrefixText` utility is already well-tested in `src/auto-reply/tokens.test.ts`. The change adds a single guard clause that leverages this existing utility.

## Human Verification (required)

- Verified scenarios: NO_REPLY token, normal reply text, partial NO_REPLY prefix
- Edge cases checked: text starting with "NO" that is NOT a NO_REPLY directive (handled by the existing prefix check logic)
- What I did **not** verify: Real Telegram streaming end-to-end

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; partial "NO" would reappear
- Files/config to restore: `src/agents/pi-embedded-subscribe.handlers.messages.ts`
- Known bad symptoms: If the prefix check is too broad, legitimate messages starting with "NO" might be delayed (mitigated by `isSilentReplyPrefixText` only matching exact NO_REPLY prefixes)

## Risks and Mitigations

`isSilentReplyPrefixText` is a narrow check — it only suppresses text that is an exact prefix of the configured `SILENT_REPLY_TOKEN`. Normal messages starting with "No" or "Not" are unaffected.
