### PR TITLE
feat(workspace): auto-load most recent daily note on session boot

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -72,12 +72,13 @@ export async function resolveBootstrapFilesForRun(params: {
   runKind?: BootstrapContextRunKind;
 }): Promise<WorkspaceBootstrapFile[]> {
   const sessionKey = params.sessionKey ?? params.sessionId;
+  const autoLoadDailyNote = params.config?.agents?.defaults?.autoLoadDailyNote === true;
   const rawFiles = params.sessionKey
     ? await getOrLoadBootstrapFiles({
         workspaceDir: params.workspaceDir,
         sessionKey: params.sessionKey,
       })
-    : await loadWorkspaceBootstrapFiles(params.workspaceDir);
+    : await loadWorkspaceBootstrapFiles(params.workspaceDir, { autoLoadDailyNote });
   const bootstrapFiles = applyContextModeFilter({
     files: filterBootstrapFilesForSession(rawFiles, sessionKey),
     contextMode: params.contextMode,

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -258,7 +258,7 @@ describe("filterBootstrapFilesForSession", () => {
 
 describe("loadWorkspaceBootstrapFiles with autoLoadDailyNote", () => {
   it("includes most recent daily note when autoLoadDailyNote is true", async () => {
-    const { dir, cleanup } = await makeTempWorkspace();
+    const dir = await makeTempWorkspace();
     try {
       const memoryDir = path.join(dir, "memory");
       await fs.mkdir(memoryDir, { recursive: true });
@@ -267,28 +267,28 @@ describe("loadWorkspaceBootstrapFiles with autoLoadDailyNote", () => {
       await fs.writeFile(path.join(memoryDir, "2026-02-28.md"), "feb note");
 
       const files = await loadWorkspaceBootstrapFiles(dir, { autoLoadDailyNote: true });
-      const dailyNote = files.find((f) => f.name === "2026-03-02.md");
+      const dailyNote = files.find((f) => (f.name as string) === "2026-03-02.md");
 
       expect(dailyNote).toBeDefined();
       expect(dailyNote?.missing).toBe(false);
       expect(dailyNote?.content).toBe("day 2 note");
     } finally {
-      await cleanup();
+      await fs.rm(dir, { recursive: true, force: true });
     }
   });
 
   it("does not include daily note when autoLoadDailyNote is false", async () => {
-    const { dir, cleanup } = await makeTempWorkspace();
+    const dir = await makeTempWorkspace();
     try {
       const memoryDir = path.join(dir, "memory");
       await fs.mkdir(memoryDir, { recursive: true });
       await fs.writeFile(path.join(memoryDir, "2026-03-02.md"), "note");
 
       const files = await loadWorkspaceBootstrapFiles(dir, { autoLoadDailyNote: false });
-      const dailyNote = files.find((f) => f.name === "2026-03-02.md");
+      const dailyNote = files.find((f) => (f.name as string) === "2026-03-02.md");
       expect(dailyNote).toBeUndefined();
     } finally {
-      await cleanup();
+      await fs.rm(dir, { recursive: true, force: true });
     }
   });
 });

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -255,3 +255,40 @@ describe("filterBootstrapFilesForSession", () => {
     expectSubagentAllowedBootstrapNames(result);
   });
 });
+
+describe("loadWorkspaceBootstrapFiles with autoLoadDailyNote", () => {
+  it("includes most recent daily note when autoLoadDailyNote is true", async () => {
+    const { dir, cleanup } = await makeTempWorkspace();
+    try {
+      const memoryDir = path.join(dir, "memory");
+      await fs.mkdir(memoryDir, { recursive: true });
+      await fs.writeFile(path.join(memoryDir, "2026-03-01.md"), "day 1 note");
+      await fs.writeFile(path.join(memoryDir, "2026-03-02.md"), "day 2 note");
+      await fs.writeFile(path.join(memoryDir, "2026-02-28.md"), "feb note");
+
+      const files = await loadWorkspaceBootstrapFiles(dir, { autoLoadDailyNote: true });
+      const dailyNote = files.find((f) => f.name === "2026-03-02.md");
+
+      expect(dailyNote).toBeDefined();
+      expect(dailyNote?.missing).toBe(false);
+      expect(dailyNote?.content).toBe("day 2 note");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("does not include daily note when autoLoadDailyNote is false", async () => {
+    const { dir, cleanup } = await makeTempWorkspace();
+    try {
+      const memoryDir = path.join(dir, "memory");
+      await fs.mkdir(memoryDir, { recursive: true });
+      await fs.writeFile(path.join(memoryDir, "2026-03-02.md"), "note");
+
+      const files = await loadWorkspaceBootstrapFiles(dir, { autoLoadDailyNote: false });
+      const dailyNote = files.find((f) => f.name === "2026-03-02.md");
+      expect(dailyNote).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -458,6 +458,32 @@ export async function ensureAgentWorkspace(params?: {
   };
 }
 
+const DAILY_NOTE_RE = /^\d{4}-\d{2}-\d{2}\.md$/;
+
+async function resolveDailyNoteEntry(
+  resolvedDir: string,
+): Promise<{ name: WorkspaceBootstrapFileName; filePath: string } | null> {
+  const memoryDir = path.join(resolvedDir, "memory");
+  let entries: string[];
+  try {
+    entries = await fs.readdir(memoryDir);
+  } catch {
+    return null;
+  }
+  const dailyNotes = entries
+    .filter((name) => DAILY_NOTE_RE.test(name))
+    .sort()
+    .reverse();
+  if (dailyNotes.length === 0) {
+    return null;
+  }
+  const latest = dailyNotes[0]!;
+  return {
+    name: latest as WorkspaceBootstrapFileName,
+    filePath: path.join(memoryDir, latest),
+  };
+}
+
 async function resolveMemoryBootstrapEntries(
   resolvedDir: string,
 ): Promise<Array<{ name: WorkspaceBootstrapFileName; filePath: string }>> {
@@ -495,7 +521,10 @@ async function resolveMemoryBootstrapEntries(
   return deduped;
 }
 
-export async function loadWorkspaceBootstrapFiles(dir: string): Promise<WorkspaceBootstrapFile[]> {
+export async function loadWorkspaceBootstrapFiles(
+  dir: string,
+  opts?: { autoLoadDailyNote?: boolean },
+): Promise<WorkspaceBootstrapFile[]> {
   const resolvedDir = resolveUserPath(dir);
 
   const entries: Array<{
@@ -533,6 +562,13 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
   ];
 
   entries.push(...(await resolveMemoryBootstrapEntries(resolvedDir)));
+
+  if (opts?.autoLoadDailyNote) {
+    const dailyNote = await resolveDailyNoteEntry(resolvedDir);
+    if (dailyNote) {
+      entries.push(dailyNote);
+    }
+  }
 
   const result: WorkspaceBootstrapFile[] = [];
   for (const entry of entries) {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -134,6 +134,8 @@ export type AgentDefaultsConfig = {
   workspace?: string;
   /** Optional repository root for system prompt runtime line (overrides auto-detect). */
   repoRoot?: string;
+  /** Auto-load the most recent memory/YYYY-MM-DD.md daily note into session context. */
+  autoLoadDailyNote?: boolean;
   /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
   skipBootstrap?: boolean;
   /** Max chars for injected bootstrap files before truncation (default: 20000). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -37,6 +37,7 @@ export const AgentDefaultsSchema = z
       .optional(),
     workspace: z.string().optional(),
     repoRoot: z.string().optional(),
+    autoLoadDailyNote: z.boolean().optional(),
     skipBootstrap: z.boolean().optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
     bootstrapTotalMaxChars: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary

- **Problem:** Users who maintain daily notes in `memory/YYYY-MM-DD.md` must manually reference them in the system prompt or AGENTS.md. There is no way to automatically inject the most recent daily note into the agent's context at session boot.
- **Why it matters:** Daily notes contain critical operational context (yesterday's decisions, ongoing tasks, blockers). Without auto-loading, agents start each session without this context, leading to repeated questions and lost continuity.
- **What changed:** `src/config/zod-schema.agent-defaults.ts` and `src/config/types.agent-defaults.ts` — added `autoLoadDailyNote` boolean config option. `src/agents/workspace.ts` — added `resolveDailyNoteEntry` helper and integrated it into `loadWorkspaceBootstrapFiles`. `src/agents/bootstrap-files.ts` — passes the config flag through. `src/agents/workspace.test.ts` — two new tests.
- **What did NOT change:** Existing bootstrap file loading (AGENTS.md, SOUL.md, MEMORY.md), memory directory structure, and session key behavior are unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33532

## User-visible / Behavior Changes

- New config option `agents.defaults.autoLoadDailyNote: true` causes the most recent `memory/YYYY-MM-DD.md` file to be automatically loaded at session boot.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Any

### Steps

1. Create `memory/2026-03-02.md` in the workspace
2. Set `agents.defaults.autoLoadDailyNote: true` in config
3. Start a new session

### Expected

- The content of `2026-03-02.md` is included in the bootstrap context

### Actual

- Before: Daily note is not loaded unless explicitly referenced
- After: Most recent daily note is auto-loaded

## Evidence

Two new unit tests:
- `includes most recent daily note when autoLoadDailyNote is true`
- `does not include daily note when autoLoadDailyNote is false`

## Human Verification (required)

- Verified scenarios: multiple daily notes (picks most recent by filename sort), single note, no notes
- Edge cases checked: empty memory directory, files that don't match YYYY-MM-DD.md pattern, flag disabled
- What I did **not** verify: Real production workspace with many daily notes

## Compatibility / Migration

- Backward compatible? `Yes` (opt-in, defaults to `undefined`/`false`)
- Config/env changes? New optional config key `agents.defaults.autoLoadDailyNote`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Set `autoLoadDailyNote: false` or remove the key; or revert this commit
- Files/config to restore: `src/agents/workspace.ts`, `src/agents/bootstrap-files.ts`, config schema files
- Known bad symptoms: If the daily note is very large, it could consume context budget (mitigated by existing context window management)

## Risks and Mitigations

The feature is opt-in and defaults to off. The daily note is appended to the existing bootstrap files list, so existing context budget limits apply.
