### PR TITLE
fix(memory): include agent sessions directory in topic transcript search

### DIFF
--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveStateDir } from "../../../config/paths.js";
+import { resolveSessionTranscriptsDirForAgent } from "../../../config/sessions/paths.js";
 import { writeFileWithinRoot } from "../../../infra/fs-safe.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
@@ -209,6 +210,14 @@ const saveSessionToMemory: HookHandler = async (event) => {
         sessionsDirs.add(path.dirname(currentSessionFile));
       }
       sessionsDirs.add(path.join(workspaceDir, "sessions"));
+      // Also search the agent's actual sessions directory, where topic
+      // transcripts (e.g. {sessionId}-topic-{topicId}.jsonl) are stored.
+      const agentId = resolveAgentIdFromSessionKey(event.sessionKey);
+      try {
+        sessionsDirs.add(resolveSessionTranscriptsDirForAgent(agentId));
+      } catch {
+        // Ignore resolution failures.
+      }
 
       for (const sessionsDir of sessionsDirs) {
         const recoveredSessionFile = await findPreviousSessionFile({


### PR DESCRIPTION
## Summary

- **Problem:** The session-memory hook (`saveSessionToMemory`) searches for session transcript files to summarize into daily notes. When the current session file is missing or has been reset, it falls back to scanning `workspace/sessions/`. However, Telegram Group Topic transcripts are stored in the agent's dedicated sessions directory (`agents/{id}/sessions/`) under names like `{sessionId}-topic-{topicId}.jsonl`, which is not in the search path.
- **Why it matters:** Conversations in Telegram Group Topics are silently excluded from daily memory notes, causing agents to lose context from topic-based discussions.
- **What changed:** `src/hooks/bundled/session-memory/handler.ts` — imported `resolveSessionTranscriptsDirForAgent`, added the agent's sessions directory to the `sessionsDirs` search set alongside `workspace/sessions/`.
- **What did NOT change:** The summarization logic, daily note format, and the primary session file resolution path are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33568

## User-visible / Behavior Changes

- Telegram Group Topic conversations are now included in daily memory notes when `/new` or `/reset` is triggered.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Telegram Group Topics

### Steps

1. Have an agent connected to a Telegram Group with Topics enabled
2. Conduct a conversation in a topic
3. Run `/new` or `/reset`
4. Check `memory/YYYY-MM-DD.md`

### Expected

- Topic conversation is summarized in the daily note

### Actual

- Before fix: Topic conversations are missing from daily notes
- After fix: Topic conversations are included

## Evidence

The fix adds the agent sessions directory to the search set. The `resolveSessionTranscriptsDirForAgent` function is an existing, tested utility that correctly resolves to `~/.config/openclaw/agents/{id}/sessions/`.

## Human Verification (required)

- Verified scenarios: topic transcript in agent sessions dir, no topic transcripts (no change), resolution failure (caught and ignored)
- Edge cases checked: `resolveSessionTranscriptsDirForAgent` throwing (wrapped in try-catch), duplicate directory entries in Set
- What I did **not** verify: Real Telegram Group with Topics end-to-end

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; topic transcripts would be excluded from daily notes again
- Files/config to restore: `src/hooks/bundled/session-memory/handler.ts`
- Known bad symptoms: If the agent sessions directory contains unexpected files, they might be scanned (mitigated by the existing session file filter logic)

## Risks and Mitigations

The added directory is only scanned when the primary session file is missing or reset — a narrow fallback path. The `try-catch` guard prevents resolution failures from breaking the entire hook.
