### PR TITLE
refactor(command-auth): canonical commands.allowFrom enforcement foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,13 @@
 - Signal: "update fly" => `fly ssh console -a flawd-bot -C "bash -lc 'cd /data/clawd/openclaw && git pull --rebase origin main'"` then `fly machines restart e825232f34d058 -a flawd-bot`.
 - When working on a GitHub Issue or PR, print the full URL at the end of the task.
 - When answering questions, respond with high-confidence answers only: verify in code; do not guess.
+- Command auth canonicalization (`commands.allowFrom`) rules:
+  - Canonical final-auth helpers live in `src/auto-reply/command-auth.ts`: `resolveCommandSenderCandidates(...)` and `resolveCanonicalCommandSenderAuthorization(...)`.
+  - Handler contract (all channels, native/slash/text/plugin paths): compute channel-local fallback auth first, then compute final auth via canonical helper before any deny/drop and before writing `CommandAuthorized` into context.
+  - Precedence contract: `commands.allowFrom.<provider>` overrides `commands.allowFrom["*"]`; fallback auth applies only when neither provider-specific nor `*` list is configured.
+  - Explicit-empty provider list rule: `commands.allowFrom.<provider>: []` is a deliberate deny-all override for that provider (it does not fall back to `commands.allowFrom["*"]`).
+  - Do not reimplement precedence logic in channel monitors, plugin SDK helpers, or security helpers; route all final privileged-command auth through the canonical helper.
+  - Required parity tests for any auth-path change: global override, provider-specific override, provider-over-global precedence, explicit-empty provider deny-all semantics, prefixed identity normalization, and fallback parity when no applicable `commands.allowFrom` list exists.
 - Never update the Carbon dependency.
 - Any dependency with `pnpm.patchedDependencies` must use an exact version (no `^`/`~`).
 - Patching dependencies (pnpm patches, overrides, or vendored changes) requires explicit approval; do not do this by default.

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -144,7 +144,10 @@ function resolveOwnerAllowFromList(params: {
 /**
  * Resolves the commands.allowFrom list for a given provider.
  * Returns the provider-specific list if defined, otherwise the "*" global list.
- * Returns null if commands.allowFrom is not configured at all (fall back to channel allowFrom).
+ * Returns null only when neither provider-specific nor "*" list is configured.
+ *
+ * Important: an explicit provider list of [] is treated as an explicit deny-all
+ * override for that provider (it does not fall back to "*").
  */
 function resolveCommandsAllowFromList(params: {
   dock?: ChannelDock;
@@ -158,7 +161,7 @@ function resolveCommandsAllowFromList(params: {
     return null; // Not configured, fall back to channel allowFrom
   }
 
-  // Check provider-specific list first, then fall back to global "*"
+  // Provider-specific list (including an explicit empty array) overrides global "*".
   const providerKey = providerId ?? "";
   const providerList = commandsAllowFrom[providerKey];
   const globalList = commandsAllowFrom["*"];
@@ -250,6 +253,69 @@ function resolveSenderCandidates(params: {
   return normalized;
 }
 
+/**
+ * Canonical sender normalization for command authorization across all ingress paths.
+ *
+ * Channel handlers should pass raw sender identity fields and use the returned
+ * candidates as the single input to final command auth resolution.
+ */
+export function resolveCommandSenderCandidates(params: {
+  dock?: ChannelDock;
+  cfg: OpenClawConfig;
+  providerId?: ChannelId;
+  accountId?: string | null;
+  senderId?: string | null;
+  senderE164?: string | null;
+  from?: string | null;
+  chatType?: string | null;
+}): string[] {
+  const dock = params.dock ?? (params.providerId ? getChannelDock(params.providerId) : undefined);
+  return resolveSenderCandidates({
+    dock,
+    providerId: params.providerId,
+    cfg: params.cfg,
+    accountId: params.accountId,
+    senderId: params.senderId,
+    senderE164: params.senderE164,
+    from: params.from,
+    chatType: params.chatType,
+  });
+}
+
+/**
+ * Canonical final authorization for privileged commands.
+ *
+ * Precedence:
+ * 1) commands.allowFrom.<provider>
+ * 2) commands.allowFrom["*"]
+ * 3) fallbackAuthorized (only when neither provider nor "*" commands.allowFrom list is configured)
+ */
+export function resolveCanonicalCommandSenderAuthorization(params: {
+  dock?: ChannelDock;
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  providerId?: ChannelId;
+  senderCandidates: string[];
+  fallbackAuthorized: boolean;
+}): boolean {
+  const dock = params.dock ?? (params.providerId ? getChannelDock(params.providerId) : undefined);
+  const commandsAllowFromList = resolveCommandsAllowFromList({
+    dock,
+    cfg: params.cfg,
+    accountId: params.accountId,
+    providerId: params.providerId,
+  });
+  if (commandsAllowFromList === null) {
+    // Preserve current channel behavior when command-specific allowFrom is not configured.
+    return params.fallbackAuthorized;
+  }
+  const commandsAllowAll = commandsAllowFromList.some((entry) => entry.trim() === "*");
+  if (commandsAllowAll) {
+    return true;
+  }
+  return params.senderCandidates.some((candidate) => commandsAllowFromList.includes(candidate));
+}
+
 export function resolveCommandAuthorization(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
@@ -260,14 +326,6 @@ export function resolveCommandAuthorization(params: {
   const dock = providerId ? getChannelDock(providerId) : undefined;
   const from = (ctx.From ?? "").trim();
   const to = (ctx.To ?? "").trim();
-
-  // Check if commands.allowFrom is configured (separate command authorization)
-  const commandsAllowFromList = resolveCommandsAllowFromList({
-    dock,
-    cfg,
-    accountId: ctx.AccountId,
-    providerId,
-  });
 
   const allowFromRaw = dock?.config?.resolveAllowFrom
     ? dock.config.resolveAllowFrom({ cfg, accountId: ctx.AccountId })
@@ -322,7 +380,7 @@ export function resolveCommandAuthorization(params: {
     ),
   );
 
-  const senderCandidates = resolveSenderCandidates({
+  const senderCandidates = resolveCommandSenderCandidates({
     dock,
     providerId,
     cfg,
@@ -351,21 +409,15 @@ export function resolveCommandAuthorization(params: {
       : ownerAllowlistConfigured
         ? senderIsOwner
         : allowAll || ownerCandidatesForCommands.length === 0 || Boolean(matchedCommandOwner);
-
-  // If commands.allowFrom is configured, use it for command authorization
-  // Otherwise, fall back to existing behavior (channel allowFrom + owner checks)
-  let isAuthorizedSender: boolean;
-  if (commandsAllowFromList !== null) {
-    // commands.allowFrom is configured - use it for authorization
-    const commandsAllowAll = commandsAllowFromList.some((entry) => entry.trim() === "*");
-    const matchedCommandsAllowFrom = commandsAllowFromList.length
-      ? senderCandidates.find((candidate) => commandsAllowFromList.includes(candidate))
-      : undefined;
-    isAuthorizedSender = commandsAllowAll || Boolean(matchedCommandsAllowFrom);
-  } else {
-    // Fall back to existing behavior
-    isAuthorizedSender = commandAuthorized && isOwnerForCommands;
-  }
+  // Keep channel-specific fallback logic above, but always finalize with canonical precedence.
+  const isAuthorizedSender = resolveCanonicalCommandSenderAuthorization({
+    dock,
+    cfg,
+    accountId: ctx.AccountId,
+    providerId,
+    senderCandidates,
+    fallbackAuthorized: commandAuthorized && isOwnerForCommands,
+  });
 
   return {
     providerId,

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -296,6 +296,33 @@ describe("resolveCommandAuthorization", () => {
       expect(whatsappAuth.isAuthorizedSender).toBe(true);
     });
 
+    it("treats empty provider-specific commands.allowFrom as explicit deny-all", () => {
+      const cfg = {
+        commands: {
+          allowFrom: {
+            "*": ["globaluser"],
+            whatsapp: [],
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+      } as OpenClawConfig;
+
+      const globalUserCtx = {
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        From: "whatsapp:globaluser",
+        SenderId: "globaluser",
+      } as MsgContext;
+
+      const auth = resolveCommandAuthorization({
+        ctx: globalUserCtx,
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(auth.isAuthorizedSender).toBe(false);
+    });
+
     it("falls back to channel allowFrom when commands.allowFrom not set", () => {
       const cfg = {
         channels: { whatsapp: { allowFrom: ["+15551234567"] } },

--- a/src/telegram/bot-native-commands.plugin-auth.test.ts
+++ b/src/telegram/bot-native-commands.plugin-auth.test.ts
@@ -23,6 +23,77 @@ vi.mock("../pairing/pairing-store.js", () => ({
 }));
 
 describe("registerTelegramNativeCommands (plugin auth)", () => {
+  function registerPluginCommandHandler(params: {
+    cfg: OpenClawConfig;
+    allowFrom?: string[];
+    groupAllowFrom?: string[];
+    useAccessGroups?: boolean;
+    telegramCfg?: TelegramAccountConfig;
+    resolveGroupPolicy?: (chatId: string | number) => ChannelGroupPolicy;
+  }): {
+    handler: ((ctx: unknown) => Promise<void>) | undefined;
+    sendMessage: ReturnType<typeof vi.fn>;
+  } {
+    getPluginCommandSpecs.mockClear();
+    matchPluginCommand.mockClear();
+    executePluginCommand.mockClear();
+    deliverReplies.mockClear();
+
+    const command = {
+      name: "plugin",
+      description: "Plugin command",
+      requireAuth: true,
+      handler: vi.fn(),
+    } as const;
+
+    getPluginCommandSpecs.mockReturnValue([{ name: "plugin", description: "Plugin command" }]);
+    matchPluginCommand.mockReturnValue({ command, args: undefined });
+    executePluginCommand.mockResolvedValue({ text: "ok" });
+
+    const handlers: Record<string, (ctx: unknown) => Promise<void>> = {};
+    const sendMessage = vi.fn();
+    const bot = {
+      api: {
+        setMyCommands: vi.fn().mockResolvedValue(undefined),
+        sendMessage,
+      },
+      command: (name: string, handler: (ctx: unknown) => Promise<void>) => {
+        handlers[name] = handler;
+      },
+    } as const;
+
+    registerTelegramNativeCommands({
+      bot: bot as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+      cfg: params.cfg,
+      runtime: {} as unknown as RuntimeEnv,
+      accountId: "default",
+      telegramCfg: params.telegramCfg ?? ({} as TelegramAccountConfig),
+      allowFrom: params.allowFrom ?? [],
+      groupAllowFrom: params.groupAllowFrom ?? [],
+      replyToMode: "off",
+      textLimit: 4000,
+      useAccessGroups: params.useAccessGroups ?? false,
+      nativeEnabled: false,
+      nativeSkillsEnabled: false,
+      nativeDisabledExplicit: false,
+      resolveGroupPolicy:
+        params.resolveGroupPolicy ??
+        (() =>
+          ({
+            allowlistEnabled: false,
+            allowed: true,
+          }) as ChannelGroupPolicy),
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: undefined,
+        topicConfig: undefined,
+      }),
+      shouldSkipUpdate: () => false,
+      opts: { token: "token" },
+    });
+
+    return { handler: handlers.plugin, sendMessage };
+  }
+
   it("does not register plugin commands in menu when native=false but keeps handlers available", () => {
     const specs = Array.from({ length: 101 }, (_, i) => ({
       name: `cmd_${i}`,
@@ -153,5 +224,275 @@ describe("registerTelegramNativeCommands (plugin auth)", () => {
       }),
     );
     expect(bot.api.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("allows native group plugin commands via commands.allowFrom global override", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {
+        commands: {
+          allowFrom: {
+            "*": ["111"],
+          },
+        },
+      } as OpenClawConfig,
+      allowFrom: ["999"],
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: -100123, type: "supergroup" },
+        from: { id: 111, username: "allowed" },
+        message_id: 10,
+        date: 123456,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalledWith(
+      -100123,
+      "You are not authorized to use this command.",
+    );
+  });
+
+  it("allows native group plugin commands when commands.allowFrom uses telegram prefix", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {
+        commands: {
+          allowFrom: {
+            "*": ["telegram:111"],
+          },
+        },
+      } as OpenClawConfig,
+      allowFrom: ["999"],
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: -100124, type: "supergroup" },
+        from: { id: 111, username: "allowed" },
+        message_id: 14,
+        date: 123460,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalledWith(
+      -100124,
+      "You are not authorized to use this command.",
+    );
+  });
+
+  it("allows native group plugin commands via commands.allowFrom provider-specific override", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {
+        commands: {
+          allowFrom: {
+            "*": ["global-user"],
+            telegram: ["111"],
+          },
+        },
+      } as OpenClawConfig,
+      allowFrom: ["999"],
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: -100456, type: "supergroup" },
+        from: { id: 111, username: "allowed" },
+        message_id: 11,
+        date: 123457,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalledWith(
+      -100456,
+      "You are not authorized to use this command.",
+    );
+  });
+
+  it("keeps native fallback authorization when commands.allowFrom is not configured", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {} as OpenClawConfig,
+      allowFrom: ["999"],
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: -100789, type: "supergroup" },
+        from: { id: 111, username: "denied" },
+        message_id: 12,
+        date: 123458,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      -100789,
+      "You are not authorized to use this command.",
+    );
+  });
+
+  it("applies commands.allowFrom override on the direct-message path", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {
+        commands: {
+          allowFrom: {
+            telegram: ["111"],
+          },
+        },
+      } as OpenClawConfig,
+      allowFrom: ["999"],
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: 12345, type: "private" },
+        from: { id: 111, username: "dm-allowed" },
+        message_id: 18,
+        date: 123464,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalledWith(
+      12345,
+      "You are not authorized to use this command.",
+    );
+  });
+
+  it("prefers provider-specific commands.allowFrom over global for native auth", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {
+        commands: {
+          allowFrom: {
+            "*": ["111"],
+            telegram: ["222"],
+          },
+        },
+      } as OpenClawConfig,
+      allowFrom: ["999"],
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: -100987, type: "supergroup" },
+        from: { id: 111, username: "global-only" },
+        message_id: 13,
+        date: 123459,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      -100987,
+      "You are not authorized to use this command.",
+    );
+  });
+
+  it("treats empty telegram-specific commands.allowFrom as explicit deny-all for native auth", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {
+        commands: {
+          allowFrom: {
+            "*": ["111"],
+            telegram: [],
+          },
+        },
+      } as OpenClawConfig,
+      allowFrom: ["111"],
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: -100111, type: "supergroup" },
+        from: { id: 111, username: "globally-and-locally-allowed" },
+        message_id: 15,
+        date: 123461,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      -100111,
+      "You are not authorized to use this command.",
+    );
+  });
+
+  it("applies canonical commands.allowFrom before policy-based unauthorized returns", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {
+        commands: {
+          allowFrom: {
+            telegram: ["111"],
+          },
+        },
+      } as OpenClawConfig,
+      allowFrom: ["999"],
+      useAccessGroups: true,
+      telegramCfg: {
+        groupPolicy: "allowlist",
+      } as TelegramAccountConfig,
+      resolveGroupPolicy: () =>
+        ({
+          allowlistEnabled: true,
+          allowed: true,
+        }) as ChannelGroupPolicy,
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: -100121, type: "supergroup" },
+        from: { id: 111, username: "canonical-override" },
+        message_id: 16,
+        date: 123462,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalledWith(
+      -100121,
+      "You are not authorized to use this command.",
+    );
+  });
+
+  it("keeps policy fallback behavior when commands.allowFrom is not configured", async () => {
+    const { handler, sendMessage } = registerPluginCommandHandler({
+      cfg: {} as OpenClawConfig,
+      allowFrom: ["999"],
+      useAccessGroups: true,
+      telegramCfg: {
+        groupPolicy: "allowlist",
+      } as TelegramAccountConfig,
+      resolveGroupPolicy: () =>
+        ({
+          allowlistEnabled: true,
+          allowed: true,
+        }) as ChannelGroupPolicy,
+    });
+
+    await handler?.({
+      message: {
+        chat: { id: -100122, type: "supergroup" },
+        from: { id: 111, username: "fallback-denied" },
+        message_id: 17,
+        date: 123463,
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      -100122,
+      "You are not authorized to use this command.",
+    );
   });
 });

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -1,5 +1,9 @@
 import type { Bot, Context } from "grammy";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
+import {
+  resolveCanonicalCommandSenderAuthorization,
+  resolveCommandSenderCandidates,
+} from "../auto-reply/command-auth.js";
 import type { CommandArgs } from "../auto-reply/commands-registry.js";
 import {
   buildCommandTextFromArgs,
@@ -13,6 +17,7 @@ import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
 import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 import { resolveCommandAuthorizedFromAuthorizers } from "../channels/command-gating.js";
+import { getChannelDock } from "../channels/dock.js";
 import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 import { recordInboundSessionMetaSafe } from "../channels/session-meta.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -233,7 +238,6 @@ async function resolveTelegramCommandAuth(params: {
     if (baseAccess.reason === "topic-disabled") {
       return await sendAuthMessage("This topic is disabled.");
     }
-    return await rejectNotAuthorized();
   }
 
   const policyAccess = evaluateTelegramGroupPolicyAccess({
@@ -258,12 +262,6 @@ async function resolveTelegramCommandAuth(params: {
     if (policyAccess.reason === "group-policy-disabled") {
       return await sendAuthMessage("Telegram group commands are disabled.");
     }
-    if (
-      policyAccess.reason === "group-policy-allowlist-no-sender" ||
-      policyAccess.reason === "group-policy-allowlist-unauthorized"
-    ) {
-      return await rejectNotAuthorized();
-    }
     if (policyAccess.reason === "group-chat-not-allowed") {
       return await sendAuthMessage("This group is not allowed.");
     }
@@ -284,7 +282,39 @@ async function resolveTelegramCommandAuth(params: {
     authorizers: [{ configured: dmAllow.hasEntries, allowed: senderAllowed }],
     modeWhenAccessGroupsOff: "configured",
   });
-  if (requireAuth && !commandAuthorized) {
+  // Keep Telegram-local auth signals as fallback; canonical commands.allowFrom
+  // finalization can override sender-authorization denies only.
+  const baseAuthorized = baseAccess.allowed
+    ? true
+    : baseAccess.reason !== "group-override-unauthorized";
+  const policyAuthorized = policyAccess.allowed
+    ? true
+    : policyAccess.reason !== "group-policy-allowlist-no-sender" &&
+      policyAccess.reason !== "group-policy-allowlist-unauthorized";
+  const fallbackAuthorized = baseAuthorized && policyAuthorized && commandAuthorized;
+  const telegramDock = getChannelDock("telegram");
+  const senderCandidates = resolveCommandSenderCandidates({
+    dock: telegramDock,
+    cfg,
+    providerId: "telegram",
+    accountId,
+    senderId,
+    from: isGroup ? buildTelegramGroupFrom(chatId, resolvedThreadId) : `telegram:${chatId}`,
+    chatType: isGroup ? "group" : "direct",
+  });
+  // Two-step auth contract:
+  // 1) keep Telegram-local checks as fallbackAuthorized
+  // 2) finalize through canonical commands.allowFrom precedence
+  // Use this final result for both deny/drop and CommandAuthorized context.
+  const commandAuthorizedWithOverrides = resolveCanonicalCommandSenderAuthorization({
+    dock: telegramDock,
+    cfg,
+    accountId,
+    providerId: "telegram",
+    senderCandidates,
+    fallbackAuthorized,
+  });
+  if (requireAuth && !commandAuthorizedWithOverrides) {
     return await rejectNotAuthorized();
   }
 
@@ -297,7 +327,7 @@ async function resolveTelegramCommandAuth(params: {
     senderUsername,
     groupConfig,
     topicConfig,
-    commandAuthorized,
+    commandAuthorized: commandAuthorizedWithOverrides,
   };
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: command authorization for privileged commands is decided in multiple ingress paths, so `commands.allowFrom` precedence can drift by channel/path.
- Why it matters: same config can authorize in one path and deny in another, which is a recurring security and reliability bug class.
- What changed: introduced canonical command-auth foundation helpers, documented the enforcement contract/contributor rules, and migrated the first channel slice (Telegram native commands) to the canonical final decision model.
- What did NOT change (scope boundary): this PR does not migrate Discord/Slack/Signal/iMessage/extensions yet; it establishes the base contract and proves the migration pattern with one channel.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #33156 (superseded by this PR)
- Related discussion #33590

## User-visible / Behavior Changes

- Privileged Telegram native command auth now finalizes through canonical `commands.allowFrom` precedence.
- With `commands.allowFrom` configured, authorization follows canonical provider/`*` resolution instead of path-local drift.
- Without `commands.allowFrom` configured, existing channel-local fallback behavior is preserved.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 + pnpm + Vitest
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted):

### Steps

1. Configure Telegram command authorization scenarios with `commands.allowFrom` variants (`*`, provider-specific, prefixed IDs, unset).
2. Run focused regression coverage for canonical helpers and Telegram native command auth.
3. Confirm final auth decision uses canonical resolver and fallback behavior is unchanged when unset.

### Expected

- Canonical precedence is enforced when configured.
- Fallback path remains unchanged when not configured.

### Actual

- Matches expected in covered scenarios.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: canonical helper behavior (`*`, provider override, prefixed normalization, unset fallback) and Telegram native command auth finalization.
- Edge cases checked: provider-specific list precedence over global list; no-config fallback preservation.
- What you did **not** verify: full cross-channel migration in this PR (Discord/Slack/Signal/iMessage/extensions remain follow-up).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commits (foundation + docs + Telegram slice) or temporarily unset `commands.allowFrom` to force fallback semantics while investigating.
- Files/config to restore: `src/auto-reply/command-auth.ts`, `src/telegram/bot-native-commands.ts`, `src/telegram/bot-native-commands.plugin-auth.test.ts`, `AGENTS.md`.
- Known bad symptoms reviewers should watch for: Telegram privileged command allow/deny mismatches against configured `commands.allowFrom`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: canonical helper contract could be misapplied in future channel migrations.
  - Mitigation: AGENTS guidance now defines the required two-step pattern (channel fallback + canonical finalization) and Telegram serves as reference implementation.
- Risk: partial rollout leaves other channels with legacy drift until follow-up PRs land.
  - Mitigation: this PR intentionally scopes to foundation + first migrated slice; discussion #33590 documents phased rollout for remaining channels.
