### PR TITLE
security: harden media server response headers

### DIFF
--- a/src/media/server.test.ts
+++ b/src/media/server.test.ts
@@ -62,6 +62,9 @@ describe("media server", () => {
     const res = await fetch(mediaUrl("file1"));
     expect(res.status).toBe(200);
     expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(res.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(res.headers.get("x-powered-by")).toBeNull();
     expect(await res.text()).toBe("hello");
     await waitForFileRemoval(file);
   });

--- a/src/media/server.ts
+++ b/src/media/server.ts
@@ -34,6 +34,8 @@ export function attachMediaRoutes(
 
   app.get("/media/:id", async (req, res) => {
     res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Referrer-Policy", "no-referrer");
+    res.setHeader("Cache-Control", "no-store, must-revalidate");
     const id = req.params.id;
     if (!isValidMediaId(id)) {
       res.status(400).send("invalid path");
@@ -106,6 +108,7 @@ export async function startMediaServer(
   runtime: RuntimeEnv = defaultRuntime,
 ): Promise<Server> {
   const app = express();
+  app.disable("x-powered-by");
   attachMediaRoutes(app, ttlMs, runtime);
   return await new Promise((resolve, reject) => {
     const server = app.listen(port, "127.0.0.1");


### PR DESCRIPTION
The standalone media server (`src/media/server.ts`) currently only sets `X-Content-Type-Options: nosniff`.  This leaves a few defensive-header gaps compared to the main gateway handler.

Changes:

- Add `Referrer-Policy: no-referrer` to prevent referrer leakage on media requests
- Add `Cache-Control: no-store, must-revalidate` so proxies/browsers don't cache single-use ephemeral media files
- Disable Express `X-Powered-By` header to avoid disclosing framework details
- Extend existing test to assert the new headers and verify `X-Powered-By` is absent

All three follow OWASP baseline header recommendations and match what `setDefaultSecurityHeaders()` already applies to gateway responses.