### PR TITLE
fix(googlechat): respect replyToMode in DM reply delivery

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -375,6 +375,12 @@ async function deliverGoogleChatReply(params: {
 }): Promise<void> {
   const { payload, account, spaceId, runtime, core, config, statusSink, typingMessageName } =
     params;
+
+  // Respect replyToMode: when "off" (default for DMs), do not pass thread
+  // to avoid creating threaded replies in direct messages (#33370).
+  const replyToMode = config.channels?.["googlechat"]?.replyToMode ?? "off";
+  const thread = replyToMode !== "off" ? payload.replyToId : undefined;
+
   const mediaList = payload.mediaUrls?.length
     ? payload.mediaUrls
     : payload.mediaUrl
@@ -431,7 +437,7 @@ async function deliverGoogleChatReply(params: {
           account,
           space: spaceId,
           text: caption,
-          thread: payload.replyToId,
+          thread,
           attachments: [
             { attachmentUploadToken: upload.attachmentUploadToken, contentName: loaded.fileName },
           ],
@@ -463,7 +469,7 @@ async function deliverGoogleChatReply(params: {
             account,
             space: spaceId,
             text: chunk,
-            thread: payload.replyToId,
+            thread,
           });
         }
         statusSink?.({ lastOutboundAt: Date.now() });


### PR DESCRIPTION
Fixes #33370

Google Chat DM replies were always sent as threaded responses because deliverGoogleChatReply unconditionally passed payload.replyToId as the thread parameter, ignoring the replyToMode config setting (default: off).

Now the function reads replyToMode from config and only passes thread when the mode is not off.

1 file, +8/-2.

---

AI-assisted PR (Claude via OpenClaw agent). I understand what this code does.