### PR TITLE
fix(config): sanitize API keys to strip smart quotes and non-ASCII artifacts

### DIFF
--- a/src/config/types.secrets.sanitize.test.ts
+++ b/src/config/types.secrets.sanitize.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSecretInputString } from "./types.secrets.js";
+
+describe("normalizeSecretInputString — smart-quote sanitization", () => {
+  it("passes through clean ASCII keys unchanged", () => {
+    expect(normalizeSecretInputString("sk-abc123-XYZ")).toBe("sk-abc123-XYZ");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeSecretInputString("  sk-abc  ")).toBe("sk-abc");
+  });
+
+  it("replaces smart/curly quotes with straight quotes", () => {
+    expect(normalizeSecretInputString("\u2018key\u2019")).toBe("'key'");
+    expect(normalizeSecretInputString("\u201Ckey\u201D")).toBe('"key"');
+  });
+
+  it("replaces em/en dashes with hyphens", () => {
+    expect(normalizeSecretInputString("sk\u2014abc\u2013def")).toBe("sk-abc-def");
+  });
+
+  it("removes BOM and non-breaking spaces", () => {
+    expect(normalizeSecretInputString("\uFEFFsk\u00a0abc")).toBe("sk abc");
+  });
+
+  it("strips non-ASCII characters that would break HTTP headers", () => {
+    // em dash (U+2014) → "-", then any remaining non-ASCII stripped
+    expect(normalizeSecretInputString("sk-abc\u00e9")).toBe("sk-abc");
+  });
+
+  it("returns undefined for empty/whitespace-only strings", () => {
+    expect(normalizeSecretInputString("")).toBeUndefined();
+    expect(normalizeSecretInputString("   ")).toBeUndefined();
+  });
+
+  it("returns undefined for non-string values", () => {
+    expect(normalizeSecretInputString(undefined)).toBeUndefined();
+    expect(normalizeSecretInputString(42)).toBeUndefined();
+    expect(normalizeSecretInputString(null)).toBeUndefined();
+  });
+});

--- a/src/config/types.secrets.ts
+++ b/src/config/types.secrets.ts
@@ -109,8 +109,30 @@ export function normalizeSecretInputString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
-  const trimmed = value.trim();
+  const trimmed = sanitizeSecretString(value.trim());
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Sanitize a secret/API key string by replacing common copy-paste artifacts:
+ * - Smart/curly quotes (\u2018 \u2019 \u201c \u201d) → straight quotes
+ * - Em/en dashes (\u2014 \u2013) → hyphens
+ * - Non-breaking spaces (\u00a0) → regular spaces
+ * - BOM (\uFEFF) → removed
+ * Then strip any remaining non-ASCII characters that would cause HTTP header
+ * ByteString errors (e.g. when used in Authorization or X-Subscription-Token).
+ * See: openclaw/openclaw#33222
+ */
+function sanitizeSecretString(value: string): string {
+  return value
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201c\u201d]/g, '"')
+    .replace(/\u2014/g, "-")
+    .replace(/\u2013/g, "-")
+    .replace(/\u00a0/g, " ")
+    .replace(/\uFEFF/g, "")
+    .replace(/[^\x20-\x7E]/g, "")
+    .trim();
 }
 
 function formatSecretRefLabel(ref: SecretRef): string {


### PR DESCRIPTION
Fixes #33222

API keys pasted from password managers or rich-text editors often contain invisible Unicode artifacts (smart quotes, em dashes, BOM, non-breaking spaces). These cause cryptic ByteString errors when used in HTTP headers like X-Subscription-Token, with no actionable error message.

This patch adds sanitization to normalizeSecretInputString at config parse time:
- Smart/curly quotes -> straight quotes
- Em/en dashes -> hyphens
- Non-breaking spaces -> regular spaces
- BOM removed
- Remaining non-ASCII stripped

Clean ASCII keys pass through unchanged. 8 test cases included.

2 files, +64/-1.

---

AI-assisted PR (Claude via OpenClaw agent). I understand what this code does.