### PR TITLE
docs: fix trailing slash in formal-verification link

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -25,7 +25,7 @@ This page explains hardening **within that model**. It does not claim hostile mu
 
 ## Quick check: `openclaw security audit`
 
-See also: [Formal Verification (Security Models)](/security/formal-verification/)
+See also: [Formal Verification (Security Models)](/security/formal-verification)
 
 Run this regularly (especially after changing config or exposing network surfaces):
 


### PR DESCRIPTION
The security overview page links to `/security/formal-verification/` (with trailing slash), but the actual doc is at `/security/formal-verification` (no trailing slash).

While Mintlify may handle the redirect, the canonical path should not have a trailing slash per the repo's doc linking conventions.