### PR TITLE
security: disable X-Powered-By in browser control servers

### DIFF
--- a/src/browser/server-middleware.ts
+++ b/src/browser/server-middleware.ts
@@ -4,6 +4,7 @@ import { browserMutationGuardMiddleware } from "./csrf.js";
 import { isAuthorizedBrowserRequest } from "./http-auth.js";
 
 export function installBrowserCommonMiddleware(app: Express) {
+  app.disable("x-powered-by");
   app.use((req, res, next) => {
     const ctrl = new AbortController();
     const abort = () => ctrl.abort(new Error("request aborted"));


### PR DESCRIPTION
The browser control server and bridge server both use Express but do not disable the default `X-Powered-By: Express` header, leaking framework details.

Adds `app.disable("x-powered-by")` inside `installBrowserCommonMiddleware` so both the control server (`src/browser/server.ts`) and bridge server (`src/browser/bridge-server.ts`) benefit from the fix.

Same pattern as the gateway's main HTTP handler which already omits this header.