### PR TITLE
fix(delivery): expand permanent error patterns to stop futile retries

### DIFF
--- a/src/infra/outbound/delivery-queue.permanent-errors.test.ts
+++ b/src/infra/outbound/delivery-queue.permanent-errors.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { isPermanentDeliveryError } from "./delivery-queue.js";
+
+describe("isPermanentDeliveryError", () => {
+  const permanent = [
+    "no conversation reference found",
+    "chat not found",
+    "user not found",
+    "bot was blocked by the user",
+    "Forbidden: bot was kicked from the group",
+    "chat_id is empty",
+    "recipient is not a valid user",
+    "outbound not configured for channel telegram",
+    "ambiguous discord recipient",
+    "400 Bad Request: message text is empty",
+    "Bad Request (400)",
+    "message is not modified",
+    "message to delete not found",
+    "message can't be deleted",
+    "have no rights to send a message",
+    "Unknown Channel",
+    "Missing Access",
+    "Missing Permissions",
+  ];
+
+  for (const msg of permanent) {
+    it(`marks "${msg}" as permanent`, () => {
+      expect(isPermanentDeliveryError(msg)).toBe(true);
+    });
+  }
+
+  const transient = [
+    "ETIMEDOUT",
+    "socket hang up",
+    "500 Internal Server Error",
+    "429 Too Many Requests",
+    "ECONNRESET",
+    "network error",
+  ];
+
+  for (const msg of transient) {
+    it(`does NOT mark "${msg}" as permanent`, () => {
+      expect(isPermanentDeliveryError(msg)).toBe(false);
+    });
+  }
+});

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -387,6 +387,18 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  // HTTP 400 Bad Request is non-transient — retrying won't help (#33403)
+  /\b400\b.*bad request/i,
+  /bad request.*\b400\b/i,
+  // Telegram-specific permanent errors
+  /message is not modified/i,
+  /message to delete not found/i,
+  /message can't be deleted/i,
+  /have no rights to send a message/i,
+  // Discord-specific permanent errors
+  /unknown channel/i,
+  /missing access/i,
+  /missing permissions/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {


### PR DESCRIPTION
Fixes #33403

The delivery queue retried permanently failing messages (HTTP 400, Telegram permission errors, Discord missing access) on every gateway restart, wasting resources and spamming logs.

This patch expands isPermanentDeliveryError with patterns for:
- HTTP 400 Bad Request
- Telegram: message not modified, no rights to send, message can't be deleted
- Discord: unknown channel, missing access/permissions

These are moved to failed/ immediately instead of being retried indefinitely.

2 files, +58/-0. 24 test cases.

---

AI-assisted PR (Claude via OpenClaw agent). I understand what this code does.