### PR TITLE
security: add Permissions-Policy header to Control UI responses

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -114,6 +114,10 @@ describe("handleControlUiHttpRequest", () => {
         );
         expect(handled).toBe(true);
         expect(setHeader).toHaveBeenCalledWith("X-Frame-Options", "DENY");
+        expect(setHeader).toHaveBeenCalledWith(
+          "Permissions-Policy",
+          "camera=(), microphone=(), geolocation=()",
+        );
         const csp = setHeader.mock.calls.find((call) => call[0] === "Content-Security-Policy")?.[1];
         expect(typeof csp).toBe("string");
         expect(String(csp)).toContain("frame-ancestors 'none'");

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -111,6 +111,7 @@ function applyControlUiSecurityHeaders(res: ServerResponse) {
   res.setHeader("Content-Security-Policy", buildControlUiCspHeader());
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("Referrer-Policy", "no-referrer");
+  res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
 }
 
 function sendJson(res: ServerResponse, status: number, body: unknown) {


### PR DESCRIPTION
#30186 added the `Permissions-Policy` header to `setDefaultSecurityHeaders` for gateway API responses, but the Control UI has its own `applyControlUiSecurityHeaders` function that was not updated.

This adds the same `Permissions-Policy: camera=(), microphone=(), geolocation=()` header to the Control UI security headers for consistency, and extends the existing test to assert its presence.