### PR TITLE
fix: skip tool call ID sanitization for custom openai-completions providers

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -94,7 +94,11 @@ export function resolveTranscriptPolicy(params: {
     (provider === "openrouter" || provider === "opencode" || provider === "kilocode") &&
     modelId.toLowerCase().includes("gemini");
   const isCopilotClaude = provider === "github-copilot" && modelId.toLowerCase().includes("claude");
-  const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
+  // Only sanitize tool call IDs for first-party OpenAI endpoints.
+  // Custom openai-completions providers (e.g. Ollama, vLLM) are excluded
+  // because sanitized IDs can cause models to return empty tool names on turn 2+ (#33438).
+  const requiresOpenAiCompatibleToolIdSanitization =
+    params.modelApi === "openai-completions" && isOpenAi;
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").


### PR DESCRIPTION
Fixes #33438

Tool call ID sanitization (`sanitizeToolCallIdsForCloudCodeAssist`) was applied to **all** `openai-completions` providers, but it was designed for first-party OpenAI endpoints. Custom providers (Ollama, vLLM, etc.) return empty tool names (`name: ""`) on turn 2+ when receiving sanitized IDs, breaking the entire tool loop.

This patch restricts the sanitization guard to first-party OpenAI providers only (`isOpenAi`). Google, Mistral, and Anthropic models still get sanitized via their own dedicated paths.

1 file, +5/-1. Existing tests pass (10/10).

---

AI-assisted PR (Claude via OpenClaw agent). I understand what this code does.