### PR TITLE
CLI: resolve exec SecretRefs before security audit in status command

### DIFF
--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -1,4 +1,6 @@
 import { formatCliCommand } from "../cli/command-format.js";
+import { resolveCommandSecretRefsViaGateway } from "../cli/command-secret-gateway.js";
+import { getStatusCommandSecretTargetIds } from "../cli/command-secret-targets.js";
 import { withProgress } from "../cli/progress.js";
 import { loadConfig, resolveGatewayPort } from "../config/config.js";
 import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
@@ -81,11 +83,18 @@ export async function statusCommand(
     return;
   }
 
+  const loadedRaw = loadConfig();
+  const { resolvedConfig: resolvedCfg } = await resolveCommandSecretRefsViaGateway({
+    config: loadedRaw,
+    commandName: "status",
+    targetIds: getStatusCommandSecretTargetIds(),
+  });
+
   const [scan, securityAudit] = opts.json
     ? await Promise.all([
         scanStatus({ json: opts.json, timeoutMs: opts.timeoutMs, all: opts.all }, runtime),
         runSecurityAudit({
-          config: loadConfig(),
+          config: resolvedCfg,
           deep: false,
           includeFilesystem: true,
           includeChannelSecurity: true,
@@ -101,7 +110,7 @@ export async function statusCommand(
           },
           async () =>
             await runSecurityAudit({
-              config: loadConfig(),
+              config: resolvedCfg,
               deep: false,
               includeFilesystem: true,
               includeChannelSecurity: true,


### PR DESCRIPTION
## Summary

- `openclaw status` crashes with `unresolved SecretRef` error when channel credentials use exec SecretRefs (e.g. Slack tokens via 1Password)
- Root cause: `statusCommand()` passes raw `loadConfig()` directly to `runSecurityAudit()`, which walks into `resolveSlackBotToken()` → `assertSecretInputResolved()` and throws
- Fix: call `resolveCommandSecretRefsViaGateway()` before the audit, matching the existing pattern in `status-all.ts` and `message.ts`

## Test plan

- [x] `pnpm build` passes (type-check)
- [ ] `openclaw status` no longer crashes with exec SecretRefs configured
- [ ] `openclaw status --json` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)