### PR TITLE
feat(config): add fallbackNotify option for model fallback notices

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -615,7 +615,8 @@ export async function runReplyAgent(params: {
           attempts: fallbackAttempts,
         },
       });
-      if (verboseEnabled) {
+      const shouldNotifyFallback = verboseEnabled || cfg?.agents?.defaults?.fallbackNotify === true;
+      if (shouldNotifyFallback) {
         const fallbackNotice = buildFallbackNotice({
           selectedProvider,
           selectedModel,
@@ -642,7 +643,7 @@ export async function runReplyAgent(params: {
           previousActiveModel: fallbackTransition.previousState.activeModel,
         },
       });
-      if (verboseEnabled) {
+      if (verboseEnabled || cfg?.agents?.defaults?.fallbackNotify === true) {
         verboseNotices.push({
           text: buildFallbackClearedNotice({
             selectedProvider,

--- a/src/config/config.fallback-notify.test.ts
+++ b/src/config/config.fallback-notify.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { OpenClawSchema } from "./zod-schema.js";
 import { loadConfig } from "./config.js";
 import { withTempHome, writeOpenClawConfig } from "./test-helpers.js";
+import { OpenClawSchema } from "./zod-schema.js";
 
 describe("fallbackNotify config option", () => {
   it("accepts fallbackNotify: true", () => {

--- a/src/config/config.fallback-notify.test.ts
+++ b/src/config/config.fallback-notify.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+import { loadConfig } from "./config.js";
+import { withTempHome, writeOpenClawConfig } from "./test-helpers.js";
+
+describe("fallbackNotify config option", () => {
+  it("accepts fallbackNotify: true", () => {
+    const parsed = OpenClawSchema.parse({
+      agents: { defaults: { fallbackNotify: true } },
+    });
+    expect(parsed.agents?.defaults?.fallbackNotify).toBe(true);
+  });
+
+  it("accepts fallbackNotify: false", () => {
+    const parsed = OpenClawSchema.parse({
+      agents: { defaults: { fallbackNotify: false } },
+    });
+    expect(parsed.agents?.defaults?.fallbackNotify).toBe(false);
+  });
+
+  it("defaults to undefined when omitted", () => {
+    const parsed = OpenClawSchema.parse({
+      agents: { defaults: {} },
+    });
+    expect(parsed.agents?.defaults?.fallbackNotify).toBeUndefined();
+  });
+
+  it("loads correctly from config file", async () => {
+    await withTempHome(async (home) => {
+      await writeOpenClawConfig(home, {
+        agents: { defaults: { fallbackNotify: true } },
+      });
+
+      const cfg = loadConfig();
+      expect(cfg.agents?.defaults?.fallbackNotify).toBe(true);
+    });
+  });
+});

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -187,6 +187,8 @@ export type AgentDefaultsConfig = {
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on" | "full";
+  /** Emit a visible notice when the model fallback chain activates (even when verbose is off). */
+  fallbackNotify?: boolean;
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
   /** Default block streaming level when no override is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -135,6 +135,7 @@ export const AgentDefaultsSchema = z
       ])
       .optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
+    fallbackNotify: z.boolean().optional(),
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),


### PR DESCRIPTION
## Summary

- **Problem:** Model fallback notices are only visible when verbose mode is on. Silent fallbacks make it difficult to track usage across providers and understand unexpected behavior.
- **Why it matters:** Users can accumulate unexpected costs on secondary providers without realizing the primary was throttled.
- **What changed:** Added `agents.defaults.fallbackNotify` boolean config option. When true, fallback transition and cleared notices are emitted regardless of verbose level. Modified `src/auto-reply/reply/agent-runner.ts`, `src/config/zod-schema.agent-defaults.ts`, `src/config/types.agent-defaults.ts`.
- **What did NOT change:** Existing verbose mode behavior is unchanged. Lifecycle events are always emitted regardless of this setting.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33654

## User-visible / Behavior Changes

- New config option `agents.defaults.fallbackNotify: true` shows model fallback notices even when verbose is off
- Example notice: `↪️ Model Fallback: openai/gpt-5 (selected anthropic/claude-opus-4-6; rate limit)`

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Any

### Steps

1. Set `agents.defaults.fallbackNotify: true` in config
2. Set `agents.defaults.model.fallbacks` with a fallback model
3. Trigger a rate limit on the primary model

### Expected

- Fallback notice appears even without verbose mode

### Actual

- Before fix: No notice unless verbose is on
- After fix: Notice appears when fallbackNotify is true

## Evidence

Config validation test: `src/config/config.fallback-notify.test.ts` — 4 tests validating schema acceptance and defaults.

## Human Verification (required)

- Verified scenarios: Config schema validation, fallback notice emission logic
- Edge cases checked: fallbackNotify undefined (defaults to off), false, true
- What I did **not** verify: Live multi-provider fallback scenario

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` (new optional field, defaults to undefined/off)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `fallbackNotify` from config or set to false
- Files/config to restore: `src/config/zod-schema.agent-defaults.ts`, `src/config/types.agent-defaults.ts`, `src/auto-reply/reply/agent-runner.ts`
- Known bad symptoms: Extra verbose-style notices appearing unexpectedly

## Risks and Mitigations

None — additive config option with no impact when unset.
