### PR TITLE
feat(tools): add allowedRoots to whitelist directories outside workspace

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -350,8 +350,12 @@ async function normalizeReadImageResult(
   return { ...result, content: nextContent };
 }
 
-export function wrapToolWorkspaceRootGuard(tool: AnyAgentTool, root: string): AnyAgentTool {
-  return wrapToolWorkspaceRootGuardWithOptions(tool, root);
+export function wrapToolWorkspaceRootGuard(
+  tool: AnyAgentTool,
+  root: string,
+  options?: { additionalRoots?: string[] },
+): AnyAgentTool {
+  return wrapToolWorkspaceRootGuardWithOptions(tool, root, options);
 }
 
 function mapContainerPathToWorkspaceRoot(params: {
@@ -411,6 +415,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
   root: string,
   options?: {
     containerWorkdir?: string;
+    additionalRoots?: string[];
   },
 ): AnyAgentTool {
   return {
@@ -427,7 +432,12 @@ export function wrapToolWorkspaceRootGuardWithOptions(
           root,
           containerWorkdir: options?.containerWorkdir,
         });
-        await assertSandboxPath({ filePath: sandboxPath, cwd: root, root });
+        await assertSandboxPath({
+          filePath: sandboxPath,
+          cwd: root,
+          root,
+          additionalRoots: options?.additionalRoots,
+        });
       }
       return tool.execute(toolCallId, normalized ?? args, signal, onUpdate);
     },

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -308,12 +308,14 @@ export function createOpenClawCodingTools(options?: {
   const fsConfig = resolveToolFsConfig({ cfg: options?.config, agentId });
   const fsPolicy = createToolFsPolicy({
     workspaceOnly: fsConfig.workspaceOnly,
+    allowedRoots: fsConfig.allowedRoots,
   });
   const sandboxRoot = sandbox?.workspaceDir;
   const sandboxFsBridge = sandbox?.fsBridge;
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
   const workspaceRoot = resolveWorkspaceRoot(options?.workspaceDir);
   const workspaceOnly = fsPolicy.workspaceOnly;
+  const allowedRoots = fsPolicy.allowedRoots;
   const applyPatchConfig = execConfig.applyPatch;
   // Secure by default: apply_patch is workspace-contained unless explicitly disabled.
   // (tools.fs.workspaceOnly is a separate umbrella flag for read/write/edit/apply_patch.)
@@ -345,6 +347,7 @@ export function createOpenClawCodingTools(options?: {
           workspaceOnly
             ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
                 containerWorkdir: sandbox.containerWorkdir,
+                additionalRoots: allowedRoots,
               })
             : sandboxed,
         ];
@@ -354,7 +357,11 @@ export function createOpenClawCodingTools(options?: {
         modelContextWindowTokens: options?.modelContextWindowTokens,
         imageSanitization,
       });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      return [
+        workspaceOnly
+          ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot, { additionalRoots: allowedRoots })
+          : wrapped,
+      ];
     }
     if (tool.name === "bash" || tool.name === execToolName) {
       return [];
@@ -364,14 +371,22 @@ export function createOpenClawCodingTools(options?: {
         return [];
       }
       const wrapped = createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      return [
+        workspaceOnly
+          ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot, { additionalRoots: allowedRoots })
+          : wrapped,
+      ];
     }
     if (tool.name === "edit") {
       if (sandboxRoot) {
         return [];
       }
       const wrapped = createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      return [
+        workspaceOnly
+          ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot, { additionalRoots: allowedRoots })
+          : wrapped,
+      ];
     }
     return [tool];
   });

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
-import { resolveSandboxedMediaSource } from "./sandbox-paths.js";
+import { resolveSandboxPath, resolveSandboxedMediaSource } from "./sandbox-paths.js";
 
 async function withSandboxRoot<T>(run: (sandboxDir: string) => Promise<T>) {
   const sandboxDir = await fs.mkdtemp(path.join(os.tmpdir(), "sandbox-media-"));
@@ -276,5 +276,62 @@ describe("resolveSandboxedMediaSource", () => {
       sandboxRoot: "/any/path",
     });
     expect(result).toBe("");
+  });
+});
+
+describe("resolveSandboxPath with additionalRoots", () => {
+  it("accepts a path inside an additionalRoot", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      const extraRoot = path.join(os.tmpdir(), "extra-allowed-root");
+      const targetFile = path.join(extraRoot, "data", "file.txt");
+      const result = resolveSandboxPath({
+        filePath: targetFile,
+        cwd: sandboxDir,
+        root: sandboxDir,
+        additionalRoots: [extraRoot],
+      });
+      expect(result.resolved).toBe(path.resolve(targetFile));
+      expect(result.relative).toBe(path.join("data", "file.txt"));
+    });
+  });
+
+  it("rejects a path outside all roots", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      const extraRoot = path.join(os.tmpdir(), "extra-allowed-root");
+      expect(() =>
+        resolveSandboxPath({
+          filePath: "/etc/passwd",
+          cwd: sandboxDir,
+          root: sandboxDir,
+          additionalRoots: [extraRoot],
+        }),
+      ).toThrow(/sandbox/i);
+    });
+  });
+
+  it("works correctly when no additionalRoots are provided", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      const inside = path.join(sandboxDir, "child.txt");
+      const result = resolveSandboxPath({
+        filePath: inside,
+        cwd: sandboxDir,
+        root: sandboxDir,
+      });
+      expect(result.resolved).toBe(path.resolve(inside));
+      expect(result.relative).toBe("child.txt");
+    });
+  });
+
+  it("still rejects escaping paths when additionalRoots is empty", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      expect(() =>
+        resolveSandboxPath({
+          filePath: "/etc/passwd",
+          cwd: sandboxDir,
+          root: sandboxDir,
+          additionalRoots: [],
+        }),
+      ).toThrow(/sandbox/i);
+    });
   });
 });

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -41,7 +41,12 @@ export function resolveSandboxInputPath(filePath: string, cwd: string): string {
   return resolveToCwd(filePath, cwd);
 }
 
-export function resolveSandboxPath(params: { filePath: string; cwd: string; root: string }): {
+export function resolveSandboxPath(params: {
+  filePath: string;
+  cwd: string;
+  root: string;
+  additionalRoots?: string[];
+}): {
   resolved: string;
   relative: string;
 } {
@@ -52,6 +57,18 @@ export function resolveSandboxPath(params: { filePath: string; cwd: string; root
     return { resolved, relative: "" };
   }
   if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    if (params.additionalRoots?.length) {
+      for (const extraRoot of params.additionalRoots) {
+        const resolvedExtra = path.resolve(extraRoot);
+        const extraRelative = path.relative(resolvedExtra, resolved);
+        if (
+          extraRelative === "" ||
+          (!extraRelative.startsWith("..") && !path.isAbsolute(extraRelative))
+        ) {
+          return { resolved, relative: extraRelative };
+        }
+      }
+    }
     throw new Error(`Path escapes sandbox root (${shortPath(rootResolved)}): ${params.filePath}`);
   }
   return { resolved, relative };
@@ -61,6 +78,7 @@ export async function assertSandboxPath(params: {
   filePath: string;
   cwd: string;
   root: string;
+  additionalRoots?: string[];
   allowFinalSymlinkForUnlink?: boolean;
   allowFinalHardlinkForUnlink?: boolean;
 }) {

--- a/src/agents/tool-fs-policy.ts
+++ b/src/agents/tool-fs-policy.ts
@@ -3,16 +3,22 @@ import { resolveAgentConfig } from "./agent-scope.js";
 
 export type ToolFsPolicy = {
   workspaceOnly: boolean;
+  allowedRoots?: string[];
 };
 
-export function createToolFsPolicy(params: { workspaceOnly?: boolean }): ToolFsPolicy {
+export function createToolFsPolicy(params: {
+  workspaceOnly?: boolean;
+  allowedRoots?: string[];
+}): ToolFsPolicy {
   return {
     workspaceOnly: params.workspaceOnly === true,
+    allowedRoots: params.allowedRoots?.length ? params.allowedRoots : undefined,
   };
 }
 
 export function resolveToolFsConfig(params: { cfg?: OpenClawConfig; agentId?: string }): {
   workspaceOnly?: boolean;
+  allowedRoots?: string[];
 } {
   const cfg = params.cfg;
   const globalFs = cfg?.tools?.fs;
@@ -20,6 +26,7 @@ export function resolveToolFsConfig(params: { cfg?: OpenClawConfig; agentId?: st
     cfg && params.agentId ? resolveAgentConfig(cfg, params.agentId)?.tools?.fs : undefined;
   return {
     workspaceOnly: agentFs?.workspaceOnly ?? globalFs?.workspaceOnly,
+    allowedRoots: agentFs?.allowedRoots ?? globalFs?.allowedRoots,
   };
 }
 

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -279,6 +279,8 @@ export type FsToolsConfig = {
    * Default: false (unrestricted, matches legacy behavior).
    */
   workspaceOnly?: boolean;
+  /** Additional directory roots allowed for fs operations when workspaceOnly is true. */
+  allowedRoots?: string[];
 };
 
 export type AgentToolsConfig = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -422,6 +422,7 @@ const ToolExecSchema = z.object(ToolExecBaseShape).strict().optional();
 const ToolFsSchema = z
   .object({
     workspaceOnly: z.boolean().optional(),
+    allowedRoots: z.array(z.string()).optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

- **Problem:** `tools.fs.workspaceOnly` is binary: restrict to workspace or allow everything. No way to whitelist specific directories outside the workspace.
- **Why it matters:** Common setups have agent workspace separate from user data (notes, projects). Disabling workspaceOnly entirely is too permissive.
- **What changed:** Added `tools.fs.allowedRoots` config field accepting an array of additional allowed path prefixes. Extended sandbox path checking to accept multiple roots. Modified 7 files: config schema, types, sandbox-paths, pi-tools.read, pi-tools, tool-fs-policy, and tests.
- **What did NOT change:** Default behavior unchanged. workspaceOnly without allowedRoots works exactly as before.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33635

## User-visible / Behavior Changes

- New config: `tools.fs.allowedRoots: ["~/notes", "~/projects"]`
- These roots are additive to the workspace root when `workspaceOnly: true`

## Security Impact (required)

- New permissions/capabilities? `Yes` — extends filesystem access to specified additional roots
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `Yes` — additional roots are explicitly user-configured

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Any

### Steps

1. Set `tools.fs.workspaceOnly: true` and `tools.fs.allowedRoots: ["/tmp/test-notes"]`
2. Agent reads a file from `/tmp/test-notes/` — should succeed
3. Agent reads a file from `/etc/` — should fail

### Expected

- Files inside workspace root or any allowedRoot are accessible
- Files outside all roots are rejected

### Actual

- Before fix: Only workspace root is allowed
- After fix: Workspace root + allowedRoots are allowed

## Evidence

4 new tests in `sandbox-paths.test.ts`: path inside additionalRoot accepted, outside all roots rejected, no additionalRoots backward compat, empty array still rejects.

## Human Verification (required)

- Verified scenarios: Single additional root, multiple roots, no roots
- Edge cases checked: Empty array, path at root boundary, symlink traversal
- What I did **not** verify: Integration with Docker sandbox bind mounts

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` (new optional field)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `allowedRoots` from config
- Files/config to restore: Config schema and sandbox-paths.ts
- Known bad symptoms: Unexpected file access errors if allowedRoots paths don't exist

## Risks and Mitigations

- Risk: Users might set overly broad roots like `/`. Mitigation: This is an explicit user choice; the feature is additive only.
