### PR TITLE
fix(discord): warn when groupPolicy=allowlist with no guilds configured

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1406,6 +1406,16 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
         }
       }
     }
+
+    if (groupPolicy === "allowlist" && channelName === "discord") {
+      const guilds = asObjectRecord(account.guilds) ?? asObjectRecord(parent?.guilds);
+      const hasGuilds = guilds !== null && Object.keys(guilds).length > 0;
+      if (!hasGuilds) {
+        warnings.push(
+          `- ${prefix}.groupPolicy is "allowlist" but no guilds are configured — all guild messages will be silently dropped. Add guild entries to ${prefix}.guilds, or set groupPolicy to "open".`,
+        );
+      }
+    }
   };
 
   for (const [channelName, channelConfig] of Object.entries(

--- a/src/discord/accounts.test.ts
+++ b/src/discord/accounts.test.ts
@@ -55,4 +55,50 @@ describe("resolveDiscordAccount allowFrom precedence", () => {
 
     expect(resolved.config.allowFrom).toBeUndefined();
   });
+
+  it("inherits base guilds when account sets groupPolicy=allowlist without own guilds", () => {
+    const resolved = resolveDiscordAccount({
+      cfg: {
+        channels: {
+          discord: {
+            guilds: {
+              "guild-1": { requireMention: false },
+            },
+            accounts: {
+              default: { groupPolicy: "allowlist", token: "token-default" },
+            },
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(resolved.config.groupPolicy).toBe("allowlist");
+    expect(resolved.config.guilds).toEqual({ "guild-1": { requireMention: false } });
+  });
+
+  it("uses account guilds when account overrides guilds", () => {
+    const resolved = resolveDiscordAccount({
+      cfg: {
+        channels: {
+          discord: {
+            guilds: {
+              "guild-1": { requireMention: false },
+            },
+            accounts: {
+              default: {
+                groupPolicy: "allowlist",
+                guilds: { "guild-2": { requireMention: true } },
+                token: "token-default",
+              },
+            },
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(resolved.config.groupPolicy).toBe("allowlist");
+    expect(resolved.config.guilds).toEqual({ "guild-2": { requireMention: true } });
+  });
 });

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -728,6 +728,153 @@ describe("preflightDiscordMessage", () => {
     expect(result?.hasAnyMention).toBe(false);
   });
 
+  it("drops guild messages when groupPolicy=allowlist and no guilds configured", async () => {
+    const channelId = "channel-allowlist-no-guilds";
+    const guildId = "guild-allowlist-no-guilds";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          return {
+            id: channelId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-allowlist-no-guilds",
+      content: "hello world",
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "allowlist",
+      threadBindings: createNoopThreadBindingManager("default"),
+      data: {
+        channel_id: channelId,
+        guild_id: guildId,
+        guild: {
+          id: guildId,
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("allows guild messages when groupPolicy=allowlist and guild is in allowlist", async () => {
+    const channelId = "channel-allowlist-with-guild";
+    const guildId = "guild-allowlist-with-guild";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          return {
+            id: channelId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-allowlist-with-guild",
+      content: "hello world",
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "allowlist",
+      threadBindings: createNoopThreadBindingManager("default"),
+      guildEntries: {
+        [guildId]: {
+          requireMention: false,
+        },
+      },
+      data: {
+        channel_id: channelId,
+        guild_id: guildId,
+        guild: {
+          id: guildId,
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(result).not.toBeNull();
+  });
+
   it("uses attachment content_type for guild audio preflight mention detection", async () => {
     transcribeFirstAudioMock.mockResolvedValue("hey openclaw");
 

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -474,6 +474,16 @@ export async function preflightDiscordMessage(
   const channelAllowed = channelConfig?.allowed !== false;
   if (
     isGuildMessage &&
+    params.groupPolicy === "allowlist" &&
+    (!params.guildEntries || Object.keys(params.guildEntries).length === 0)
+  ) {
+    logger.warn(
+      { guildId: params.data.guild_id },
+      "Discord groupPolicy is 'allowlist' but no guilds are configured — all guild messages will be dropped",
+    );
+  }
+  if (
+    isGuildMessage &&
     !isDiscordGroupAllowedByPolicy({
       groupPolicy: params.groupPolicy,
       guildAllowlisted: Boolean(guildInfo),


### PR DESCRIPTION
## Summary

- **Problem:** When `discord.accounts.default.groupPolicy` is `"allowlist"` without account-level guild entries, all group messages are silently dropped with no warning.
- **Why it matters:** Users expect the account policy to inherit guild entries from the parent config, but the silent drop gives no diagnostic clue.
- **What changed:** Added runtime warning in preflight check, doctor validation diagnostic, and guild inheritance tests. Modified 4 files.
- **What did NOT change:** Account merge behavior (base guilds are already inherited via shallow merge), existing allowlist evaluation logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33569

## User-visible / Behavior Changes

- Runtime warning when Discord groupPolicy=allowlist but no guilds configured
- Doctor diagnostic warning for the same condition

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Discord

### Steps

1. Set `discord.accounts.default.groupPolicy: "allowlist"` without account-level guilds
2. Send a Discord group message
3. Run `openclaw doctor`

### Expected

- Runtime warning in logs about empty allowlist
- Doctor diagnostic warning

### Actual

- Before fix: Silent drop with no warning
- After fix: Clear warning in logs and doctor output

## Evidence

4 new tests: preflight drops with empty guilds, preflight allows with listed guild, base guild inheritance, account guild override.

## Human Verification (required)

- Verified scenarios: Empty guilds, inherited guilds, overridden guilds
- Edge cases checked: Account with explicit empty guilds object
- What I did **not** verify: Live Discord group messaging

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the warning additions
- Files/config to restore: `src/discord/monitor/message-handler.preflight.ts`, `src/commands/doctor-config-flow.ts`
- Known bad symptoms: None — only adds diagnostic output

## Risks and Mitigations

None — purely diagnostic additions.
