### PR TITLE
fix(config): preserve custom API keys in secrets section

### DIFF
--- a/src/config/config.secrets-schema.test.ts
+++ b/src/config/config.secrets-schema.test.ts
@@ -173,4 +173,24 @@ describe("config secret refs schema", () => {
       ).toBe(true);
     }
   });
+
+  it("preserves custom user-defined keys in secrets section (#33623)", () => {
+    const result = validateConfigObjectRaw({
+      secrets: {
+        providers: {
+          default: { source: "env" },
+        },
+        brave_api_key: "test-brave-key-123",
+        custom_news_token: "tok_abc",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const secrets = result.config.secrets as Record<string, unknown>;
+      expect(secrets.brave_api_key).toBe("test-brave-key-123");
+      expect(secrets.custom_news_token).toBe("tok_abc");
+      expect(secrets.providers).toEqual({ default: { source: "env" } });
+    }
+  });
 });

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -177,7 +177,7 @@ export const SecretsConfigSchema = z
       .strict()
       .optional(),
   })
-  .strict()
+  .passthrough()
   .optional();
 
 export const ModelApiSchema = z.enum(MODEL_APIS);


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw doctor --fix` deletes custom API keys from the secrets section because `SecretsConfigSchema` uses `.strict()` which strips unknown keys.
- **Why it matters:** Users store custom API keys (e.g., `brave_news_api_key`) directly in secrets and lose them after doctor runs.
- **What changed:** Changed `.strict()` to `.passthrough()` on the top-level `SecretsConfigSchema` in `src/config/zod-schema.core.ts`. Added test.
- **What did NOT change:** Nested schemas (`defaults`, `resolution`) retain `.strict()` for their own keys. Known keys are still validated.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33623

## User-visible / Behavior Changes

- Custom keys in the secrets section are preserved during doctor --fix/--repair runs

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes` — custom keys are now preserved instead of stripped
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: CLI (doctor)

### Steps

1. Add custom keys to secrets: `"secrets": { "brave_api_key": "BSACsc..." }`
2. Run `openclaw doctor --fix`
3. Check config

### Expected

- Custom keys preserved

### Actual

- Before fix: Secrets section cleared to `{}`
- After fix: Custom keys preserved

## Evidence

Test: `preserves custom user-defined keys in secrets section (#33623)` validates custom keys survive schema parsing.

## Human Verification (required)

- Verified scenarios: Custom keys with known keys present
- Edge cases checked: Empty secrets, only custom keys, only known keys
- What I did **not** verify: Full doctor --fix flow end-to-end

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Change `.passthrough()` back to `.strict()`
- Files/config to restore: `src/config/zod-schema.core.ts`
- Known bad symptoms: Unknown keys in secrets section might cause confusion

## Risks and Mitigations

- Risk: Typos in known key names won't be caught by strict validation. Mitigation: Known keys (`providers`, `defaults`, `resolution`) are still explicitly validated by their own schemas.
