### PR TITLE
fix(discord): await channel queue to prevent listener disablement

### DIFF
--- a/src/discord/monitor/listeners.test.ts
+++ b/src/discord/monitor/listeners.test.ts
@@ -13,56 +13,50 @@ function fakeEvent(channelId: string) {
 }
 
 describe("DiscordMessageListener", () => {
-  it("returns immediately without awaiting handler completion", async () => {
-    let resolveHandler: (() => void) | undefined;
-    const handlerDone = new Promise<void>((resolve) => {
-      resolveHandler = resolve;
-    });
+  it("awaits handler completion before returning", async () => {
+    let handlerFinished = false;
     const handler = vi.fn(async () => {
-      await handlerDone;
+      await new Promise<void>((r) => setTimeout(r, 10));
+      handlerFinished = true;
     });
     const logger = createLogger();
     const listener = new DiscordMessageListener(handler as never, logger as never);
 
-    await expect(listener.handle(fakeEvent("ch-1"), {} as never)).resolves.toBeUndefined();
+    await listener.handle(fakeEvent("ch-1"), {} as never);
+    expect(handlerFinished).toBe(true);
     expect(handler).toHaveBeenCalledTimes(1);
     expect(logger.error).not.toHaveBeenCalled();
-
-    resolveHandler?.();
-    await handlerDone;
   });
 
   it("serializes queued handler runs for the same channel", async () => {
+    const order: string[] = [];
     let firstResolve: (() => void) | undefined;
-    let secondResolve: (() => void) | undefined;
     const firstDone = new Promise<void>((resolve) => {
       firstResolve = resolve;
-    });
-    const secondDone = new Promise<void>((resolve) => {
-      secondResolve = resolve;
     });
     let runCount = 0;
     const handler = vi.fn(async () => {
       runCount += 1;
-      if (runCount === 1) {
+      const n = runCount;
+      order.push(`start:${n}`);
+      if (n === 1) {
         await firstDone;
-        return;
       }
-      await secondDone;
+      order.push(`end:${n}`);
     });
     const listener = new DiscordMessageListener(handler as never, createLogger() as never);
 
-    await expect(listener.handle(fakeEvent("ch-1"), {} as never)).resolves.toBeUndefined();
-    await expect(listener.handle(fakeEvent("ch-1"), {} as never)).resolves.toBeUndefined();
+    const p1 = listener.handle(fakeEvent("ch-1"), {} as never);
+    const p2 = listener.handle(fakeEvent("ch-1"), {} as never);
 
-    expect(handler).toHaveBeenCalledTimes(1);
-    firstResolve?.();
     await vi.waitFor(() => {
-      expect(handler).toHaveBeenCalledTimes(2);
+      expect(order).toContain("start:1");
     });
+    expect(order).not.toContain("start:2");
 
-    secondResolve?.();
-    await secondDone;
+    firstResolve?.();
+    await Promise.all([p1, p2]);
+    expect(order).toEqual(["start:1", "end:1", "start:2", "end:2"]);
   });
 
   it("runs handlers for different channels in parallel", async () => {
@@ -86,8 +80,8 @@ describe("DiscordMessageListener", () => {
     });
     const listener = new DiscordMessageListener(handler as never, createLogger() as never);
 
-    await listener.handle(fakeEvent("ch-a"), {} as never);
-    await listener.handle(fakeEvent("ch-b"), {} as never);
+    const pA = listener.handle(fakeEvent("ch-a"), {} as never);
+    const pB = listener.handle(fakeEvent("ch-b"), {} as never);
 
     await vi.waitFor(() => {
       expect(handler).toHaveBeenCalledTimes(2);
@@ -102,12 +96,11 @@ describe("DiscordMessageListener", () => {
     expect(order).not.toContain("end:ch-a");
 
     resolveA?.();
-    await vi.waitFor(() => {
-      expect(order).toContain("end:ch-a");
-    });
+    await Promise.all([pA, pB]);
+    expect(order).toContain("end:ch-a");
   });
 
-  it("logs async handler failures", async () => {
+  it("logs handler failures without throwing", async () => {
     const handler = vi.fn(async () => {
       throw new Error("boom");
     });
@@ -115,10 +108,27 @@ describe("DiscordMessageListener", () => {
     const listener = new DiscordMessageListener(handler as never, logger as never);
 
     await expect(listener.handle(fakeEvent("ch-1"), {} as never)).resolves.toBeUndefined();
-    await vi.waitFor(() => {
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining("discord handler failed: Error: boom"),
-      );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("discord handler failed: Error: boom"),
+    );
+  });
+
+  it("processes the next message after a handler error on the same channel", async () => {
+    let callCount = 0;
+    const handler = vi.fn(async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        throw new Error("transient failure");
+      }
     });
+    const logger = createLogger();
+    const listener = new DiscordMessageListener(handler as never, logger as never);
+
+    await listener.handle(fakeEvent("ch-1"), {} as never);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+
+    await listener.handle(fakeEvent("ch-1"), {} as never);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(logger.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -143,18 +143,27 @@ export class DiscordMessageListener extends MessageCreateListener {
     // Serialize messages within the same channel to preserve ordering,
     // but allow different channels to proceed in parallel so that
     // channel-bound agents are not blocked by each other.
-    void this.channelQueue.enqueue(channelId, () =>
-      runDiscordListenerWithSlowLog({
-        logger: this.logger,
-        listener: this.constructor.name,
-        event: this.type,
-        run: () => this.handler(data, client),
-        onError: (err) => {
-          const logger = this.logger ?? discordEventQueueLog;
-          logger.error(danger(`discord handler failed: ${String(err)}`));
-        },
-      }),
-    );
+    //
+    // await (not void) so Carbon's event queue tracks when the listener
+    // is truly done — prevents the gateway from disabling the listener
+    // after an API-overload timeout (#33615).
+    try {
+      await this.channelQueue.enqueue(channelId, () =>
+        runDiscordListenerWithSlowLog({
+          logger: this.logger,
+          listener: this.constructor.name,
+          event: this.type,
+          run: () => this.handler(data, client),
+          onError: (err) => {
+            const logger = this.logger ?? discordEventQueueLog;
+            logger.error(danger(`discord handler failed: ${String(err)}`));
+          },
+        }),
+      );
+    } catch {
+      // Swallow unexpected queue errors so Carbon never sees a rejected
+      // listener promise, which would permanently disable the channel.
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** After a slow listener event due to AI provider overload, the Discord channel permanently stops receiving messages until gateway restart.
- **Why it matters:** Channels become silently dead with no recovery path other than a full restart.
- **What changed:** Changed `void` (fire-and-forget) to `await` for the channel queue enqueue in `DiscordMessageListener.handle()`. Added outer try/catch to prevent rejected promises from disabling the listener. Modified 2 files.
- **What did NOT change:** KeyedAsyncQueue behavior, message handler logic, error logging.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33615

## User-visible / Behavior Changes

- Discord channels recover from provider overload timeouts without requiring gateway restart
- Message processing continues after handler errors

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 22.04
- Runtime: Node.js
- Integration/channel: Discord

### Steps

1. Send a message that triggers an AI response
2. If the provider returns overloaded errors causing a slow listener timeout
3. Send another message

### Expected

- Second message is processed normally

### Actual

- Before fix: Channel permanently stops receiving messages
- After fix: Channel recovers after the error

## Evidence

5 tests: handler awaits completion, serialization, parallelism, error logging, and recovery after error on same channel.

## Human Verification (required)

- Verified scenarios: Handler completion awaiting, error recovery, channel serialization
- Edge cases checked: Error on first message, second message on same channel processes
- What I did **not** verify: Live Discord testing with actual provider overload

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Change `await` back to `void` in listeners.ts
- Files/config to restore: `src/discord/monitor/listeners.ts`
- Known bad symptoms: If reverted, the original stuck channel bug returns

## Risks and Mitigations

- Risk: Awaiting the queue task means Carbon's event queue now waits for full processing. Mitigation: The outer try/catch ensures the promise never rejects, preventing Carbon from disabling the listener.
