### PR TITLE
fix(gateway): improve version resolution with config fallback

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1032,7 +1032,11 @@ export function attachGatewayWsMessageHandler(params: {
           type: "hello-ok",
           protocol: PROTOCOL_VERSION,
           server: {
-            version: resolveRuntimeServiceVersion(process.env),
+            version: resolveRuntimeServiceVersion(
+              process.env,
+              undefined,
+              loadConfig()?.wizard?.lastRunVersion,
+            ),
             connId,
           },
           features: { methods: gatewayMethods, events },

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -153,6 +153,46 @@ describe("version resolution", () => {
     expect(resolveUsableRuntimeVersion(" 2026.3.2 ")).toBe("2026.3.2");
   });
 
+  it("uses configVersionHint when all env and runtime candidates are empty", () => {
+    expect(
+      resolveRuntimeServiceVersion(
+        {
+          OPENCLAW_VERSION: "",
+          OPENCLAW_SERVICE_VERSION: "",
+          npm_package_version: "",
+        },
+        "unknown",
+        "2026.1.5",
+      ),
+    ).toBe(VERSION === "0.0.0" ? "2026.1.5" : VERSION);
+  });
+
+  it("ignores configVersionHint when a higher-priority candidate is available", () => {
+    expect(
+      resolveRuntimeServiceVersion(
+        {
+          OPENCLAW_VERSION: "9.0.0",
+        },
+        "unknown",
+        "2026.1.5",
+      ),
+    ).toBe("9.0.0");
+  });
+
+  it("ignores blank configVersionHint and falls back to fallback", () => {
+    expect(
+      resolveRuntimeServiceVersion(
+        {
+          OPENCLAW_VERSION: "",
+          OPENCLAW_SERVICE_VERSION: "",
+          npm_package_version: "",
+        },
+        "my-fallback",
+        "   ",
+      ),
+    ).toBe(VERSION === "0.0.0" ? "my-fallback" : VERSION);
+  });
+
   it("prefers runtime VERSION over service/package markers and ignores blank env values", () => {
     expect(
       resolveRuntimeServiceVersion({

--- a/src/version.ts
+++ b/src/version.ts
@@ -105,6 +105,7 @@ export function resolveUsableRuntimeVersion(version: string | undefined): string
 export function resolveRuntimeServiceVersion(
   env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
   fallback = RUNTIME_SERVICE_VERSION_FALLBACK,
+  configVersionHint?: string,
 ): string {
   const runtimeVersion = resolveUsableRuntimeVersion(VERSION);
 
@@ -114,6 +115,7 @@ export function resolveRuntimeServiceVersion(
       runtimeVersion,
       env["OPENCLAW_SERVICE_VERSION"],
       env["npm_package_version"],
+      configVersionHint,
     ) ?? fallback
   );
 }


### PR DESCRIPTION
## Summary

- **Problem:** In bundled or Docker environments, `resolveBinaryVersion()` may return `"0.0.0"` when package.json is not found at module resolution time, causing the WebUI to show "unknown" instead of the actual version.
- **Why it matters:** Users cannot tell what version they are running from the WebUI.
- **What changed:** Added `configVersionHint` parameter to `resolveRuntimeServiceVersion` as a last-resort fallback. The gateway passes `wizard.lastRunVersion` from the loaded config when assembling the hello-ok response. Modified 3 files.
- **What did NOT change:** The existing version resolution priority (env vars, package.json, build-info) is unchanged. The hint is only used when all other sources fail.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33639

## User-visible / Behavior Changes

- WebUI version pill shows the wizard-recorded version as fallback instead of "unknown"

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (or any Docker/bundled environment)
- Runtime: Node.js
- Integration/channel: webchat (Control UI)

### Steps

1. Install OpenClaw in a bundled/Docker environment where package.json may not be accessible
2. Run `openclaw configure` (sets wizard.lastRunVersion)
3. Open WebUI

### Expected

- Version pill shows the installed version

### Actual

- Before fix: Shows "unknown" or "0.0.0"
- After fix: Shows the wizard-recorded version as fallback

## Evidence

3 new tests in `version.test.ts`: configVersionHint used as fallback, ignored when higher-priority available, blank hint falls through.

## Human Verification (required)

- Verified scenarios: Fallback chain with and without hint
- Edge cases checked: Blank hint, empty string, higher-priority override
- What I did **not** verify: Live Docker/bundled build testing

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove configVersionHint parameter
- Files/config to restore: `src/version.ts`, `src/gateway/server/ws-connection/message-handler.ts`
- Known bad symptoms: None — just reverts to "unknown" behavior

## Risks and Mitigations

- Risk: wizard.lastRunVersion could be stale if user updates but doesn't re-run configure. Mitigation: This is a last-resort fallback; all other resolution methods take priority.
