### PR TITLE
feat(hooks): add memory:retrieved hook event for retrieval observability

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   clearInternalHooks,
   isMemoryRetrievedEvent,
@@ -142,13 +142,13 @@ describe("resolveBootstrapContextForRun", () => {
     await resolveBootstrapContextForRun({ workspaceDir, sessionKey: "test-session" });
 
     expect(captured).toHaveLength(1);
-    const event = captured[0]!;
+    const event = captured[0];
     expect(isMemoryRetrievedEvent(event)).toBe(true);
 
     const context = event.context as MemoryRetrievedHookContext;
     expect(context.workspaceDir).toBe(workspaceDir);
-    expect(context.tokenBudget.bootstrapFiles).toBeGreaterThan(0);
-    expect(context.tokenBudget.memoryRetrieved).toBeGreaterThanOrEqual(0);
+    expect(context.tokenBudget.limit).toBeGreaterThan(0);
+    expect(context.tokenBudget.used).toBeGreaterThanOrEqual(0);
 
     const soulResult = context.results.find((r) => r.path.endsWith("SOUL.md"));
     expect(soulResult).toBeDefined();
@@ -166,8 +166,8 @@ describe("resolveBootstrapContextForRun", () => {
     await resolveBootstrapContextForRun({ workspaceDir });
 
     expect(captured).toHaveLength(1);
-    const context = captured[0]!.context as MemoryRetrievedHookContext;
+    const context = captured[0].context as MemoryRetrievedHookContext;
     expect(context.results).toEqual([]);
-    expect(typeof context.tokenBudget.memoryRetrieved).toBe("number");
+    expect(typeof context.tokenBudget.used).toBe("number");
   });
 });

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -1,10 +1,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearInternalHooks,
+  isMemoryRetrievedEvent,
   registerInternalHook,
   type AgentBootstrapHookContext,
+  type InternalHookEvent,
+  type MemoryRetrievedHookContext,
 } from "../hooks/internal-hooks.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import { resolveBootstrapContextForRun, resolveBootstrapFilesForRun } from "./bootstrap-files.js";
@@ -125,5 +128,46 @@ describe("resolveBootstrapContextForRun", () => {
     });
 
     expect(files).toEqual([]);
+  });
+
+  it("emits memory:retrieved hook event with bootstrap file results", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "persona content", "utf8");
+
+    const captured: InternalHookEvent[] = [];
+    registerInternalHook("memory:retrieved", (event) => {
+      captured.push(event);
+    });
+
+    await resolveBootstrapContextForRun({ workspaceDir, sessionKey: "test-session" });
+
+    expect(captured).toHaveLength(1);
+    const event = captured[0]!;
+    expect(isMemoryRetrievedEvent(event)).toBe(true);
+
+    const context = event.context as MemoryRetrievedHookContext;
+    expect(context.workspaceDir).toBe(workspaceDir);
+    expect(context.tokenBudget.bootstrapFiles).toBeGreaterThan(0);
+    expect(context.tokenBudget.memoryRetrieved).toBeGreaterThanOrEqual(0);
+
+    const soulResult = context.results.find((r) => r.path.endsWith("SOUL.md"));
+    expect(soulResult).toBeDefined();
+    expect(soulResult!.source).toBe("bootstrap");
+  });
+
+  it("emits memory:retrieved with empty results when no bootstrap files exist", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-empty-");
+
+    const captured: InternalHookEvent[] = [];
+    registerInternalHook("memory:retrieved", (event) => {
+      captured.push(event);
+    });
+
+    await resolveBootstrapContextForRun({ workspaceDir });
+
+    expect(captured).toHaveLength(1);
+    const context = captured[0]!.context as MemoryRetrievedHookContext;
+    expect(context.results).toEqual([]);
+    expect(typeof context.tokenBudget.memoryRetrieved).toBe("number");
   });
 });

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -124,18 +124,16 @@ export async function resolveBootstrapContextForRun(params: {
   });
 
   const sessionKey = params.sessionKey ?? params.sessionId ?? "unknown";
-  const results: MemoryRetrievalResult[] = bootstrapFiles
-    .filter((file) => !file.missing)
-    .map((file) => ({
-      path: file.path,
-      source: "bootstrap",
-    }));
-  const memoryRetrieved = contextFiles.reduce((sum, file) => sum + file.content.length, 0);
+  const results: MemoryRetrievalResult[] = contextFiles.map((file) => ({
+    path: file.path,
+    source: "bootstrap",
+  }));
+  const used = contextFiles.reduce((sum, file) => sum + file.content.length, 0);
   const hookContext: MemoryRetrievedHookContext = {
     results,
     tokenBudget: {
-      bootstrapFiles: totalMaxChars,
-      memoryRetrieved,
+      limit: totalMaxChars,
+      used,
     },
     workspaceDir: params.workspaceDir,
   };

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -1,4 +1,10 @@
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  createInternalHookEvent,
+  triggerInternalHook,
+  type MemoryRetrievedHookContext,
+  type MemoryRetrievalResult,
+} from "../hooks/internal-hooks.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
@@ -109,10 +115,32 @@ export async function resolveBootstrapContextForRun(params: {
   contextFiles: EmbeddedContextFile[];
 }> {
   const bootstrapFiles = await resolveBootstrapFilesForRun(params);
+  const maxChars = resolveBootstrapMaxChars(params.config);
+  const totalMaxChars = resolveBootstrapTotalMaxChars(params.config);
   const contextFiles = buildBootstrapContextFiles(bootstrapFiles, {
-    maxChars: resolveBootstrapMaxChars(params.config),
-    totalMaxChars: resolveBootstrapTotalMaxChars(params.config),
+    maxChars,
+    totalMaxChars,
     warn: params.warn,
   });
+
+  const sessionKey = params.sessionKey ?? params.sessionId ?? "unknown";
+  const results: MemoryRetrievalResult[] = bootstrapFiles
+    .filter((file) => !file.missing)
+    .map((file) => ({
+      path: file.path,
+      source: "bootstrap",
+    }));
+  const memoryRetrieved = contextFiles.reduce((sum, file) => sum + file.content.length, 0);
+  const hookContext: MemoryRetrievedHookContext = {
+    results,
+    tokenBudget: {
+      bootstrapFiles: totalMaxChars,
+      memoryRetrieved,
+    },
+    workspaceDir: params.workspaceDir,
+  };
+  const event = createInternalHookEvent("memory", "retrieved", sessionKey, hookContext);
+  await triggerInternalHook(event);
+
   return { bootstrapFiles, contextFiles };
 }

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -7,7 +7,6 @@ import {
   isGatewayStartupEvent,
   isMessageReceivedEvent,
   isMemoryRetrievedEvent,
-  isMessageReceivedEvent,
   isMessageSentEvent,
   registerInternalHook,
   triggerInternalHook,
@@ -482,7 +481,7 @@ describe("hooks", () => {
     it("returns true for memory:retrieved events with expected context", () => {
       const event = createInternalHookEvent("memory", "retrieved", "test-session", {
         results: [{ path: "/tmp/SOUL.md", source: "bootstrap" }],
-        tokenBudget: { bootstrapFiles: 50000, memoryRetrieved: 1200 },
+        tokenBudget: { limit: 50000, used: 1200 },
         workspaceDir: "/tmp",
       } satisfies MemoryRetrievedHookContext);
       expect(isMemoryRetrievedEvent(event)).toBe(true);
@@ -491,7 +490,7 @@ describe("hooks", () => {
     it("returns true when results array is empty", () => {
       const event = createInternalHookEvent("memory", "retrieved", "test-session", {
         results: [],
-        tokenBudget: { bootstrapFiles: 50000, memoryRetrieved: 0 },
+        tokenBudget: { limit: 50000, used: 0 },
         workspaceDir: "/tmp",
       } satisfies MemoryRetrievedHookContext);
       expect(isMemoryRetrievedEvent(event)).toBe(true);
@@ -512,7 +511,7 @@ describe("hooks", () => {
     it("returns false when results is not an array", () => {
       const event = createInternalHookEvent("memory", "retrieved", "test-session", {
         results: "not-an-array",
-        tokenBudget: { bootstrapFiles: 50000, memoryRetrieved: 0 },
+        tokenBudget: { limit: 50000, used: 0 },
         workspaceDir: "/tmp",
       });
       expect(isMemoryRetrievedEvent(event)).toBe(false);
@@ -521,7 +520,7 @@ describe("hooks", () => {
     it("returns false when workspaceDir is missing", () => {
       const event = createInternalHookEvent("memory", "retrieved", "test-session", {
         results: [],
-        tokenBudget: { bootstrapFiles: 50000, memoryRetrieved: 0 },
+        tokenBudget: { limit: 50000, used: 0 },
       });
       expect(isMemoryRetrievedEvent(event)).toBe(false);
     });
@@ -534,7 +533,7 @@ describe("hooks", () => {
 
       const context: MemoryRetrievedHookContext = {
         results: [{ path: "/workspace/SOUL.md", source: "bootstrap" }],
-        tokenBudget: { bootstrapFiles: 50000, memoryRetrieved: 1200 },
+        tokenBudget: { limit: 50000, used: 1200 },
         workspaceDir: "/workspace",
       };
       const event = createInternalHookEvent("memory", "retrieved", "test-session", context);
@@ -550,7 +549,7 @@ describe("hooks", () => {
 
       const context: MemoryRetrievedHookContext = {
         results: [],
-        tokenBudget: { bootstrapFiles: 50000, memoryRetrieved: 0 },
+        tokenBudget: { limit: 50000, used: 0 },
         workspaceDir: "/workspace",
       };
       const event = createInternalHookEvent("memory", "retrieved", "test-session", context);

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -6,12 +6,15 @@ import {
   isAgentBootstrapEvent,
   isGatewayStartupEvent,
   isMessageReceivedEvent,
+  isMemoryRetrievedEvent,
+  isMessageReceivedEvent,
   isMessageSentEvent,
   registerInternalHook,
   triggerInternalHook,
   unregisterInternalHook,
   type AgentBootstrapHookContext,
   type GatewayStartupHookContext,
+  type MemoryRetrievedHookContext,
   type MessageReceivedHookContext,
   type MessageSentHookContext,
 } from "./internal-hooks.js";
@@ -472,6 +475,88 @@ describe("hooks", () => {
 
       const keys = getRegisteredEventKeys();
       expect(keys).toEqual([]);
+    });
+  });
+
+  describe("isMemoryRetrievedEvent", () => {
+    it("returns true for memory:retrieved events with expected context", () => {
+      const event = createInternalHookEvent("memory", "retrieved", "test-session", {
+        results: [{ path: "/tmp/SOUL.md", source: "bootstrap" }],
+        tokenBudget: { bootstrapFiles: 50000, memoryRetrieved: 1200 },
+        workspaceDir: "/tmp",
+      } satisfies MemoryRetrievedHookContext);
+      expect(isMemoryRetrievedEvent(event)).toBe(true);
+    });
+
+    it("returns true when results array is empty", () => {
+      const event = createInternalHookEvent("memory", "retrieved", "test-session", {
+        results: [],
+        tokenBudget: { bootstrapFiles: 50000, memoryRetrieved: 0 },
+        workspaceDir: "/tmp",
+      } satisfies MemoryRetrievedHookContext);
+      expect(isMemoryRetrievedEvent(event)).toBe(true);
+    });
+
+    it("returns false for non-memory events", () => {
+      const event = createInternalHookEvent("command", "new", "test-session");
+      expect(isMemoryRetrievedEvent(event)).toBe(false);
+    });
+
+    it("returns false for memory events with a different action", () => {
+      const event = createInternalHookEvent("memory", "indexed", "test-session", {
+        workspaceDir: "/tmp",
+      });
+      expect(isMemoryRetrievedEvent(event)).toBe(false);
+    });
+
+    it("returns false when results is not an array", () => {
+      const event = createInternalHookEvent("memory", "retrieved", "test-session", {
+        results: "not-an-array",
+        tokenBudget: { bootstrapFiles: 50000, memoryRetrieved: 0 },
+        workspaceDir: "/tmp",
+      });
+      expect(isMemoryRetrievedEvent(event)).toBe(false);
+    });
+
+    it("returns false when workspaceDir is missing", () => {
+      const event = createInternalHookEvent("memory", "retrieved", "test-session", {
+        results: [],
+        tokenBudget: { bootstrapFiles: 50000, memoryRetrieved: 0 },
+      });
+      expect(isMemoryRetrievedEvent(event)).toBe(false);
+    });
+  });
+
+  describe("memory hooks", () => {
+    it("should trigger memory:retrieved handlers", async () => {
+      const handler = vi.fn();
+      registerInternalHook("memory:retrieved", handler);
+
+      const context: MemoryRetrievedHookContext = {
+        results: [{ path: "/workspace/SOUL.md", source: "bootstrap" }],
+        tokenBudget: { bootstrapFiles: 50000, memoryRetrieved: 1200 },
+        workspaceDir: "/workspace",
+      };
+      const event = createInternalHookEvent("memory", "retrieved", "test-session", context);
+      await triggerInternalHook(event);
+
+      expect(handler).toHaveBeenCalledWith(event);
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it("should trigger general memory handlers", async () => {
+      const handler = vi.fn();
+      registerInternalHook("memory", handler);
+
+      const context: MemoryRetrievedHookContext = {
+        results: [],
+        tokenBudget: { bootstrapFiles: 50000, memoryRetrieved: 0 },
+        workspaceDir: "/workspace",
+      };
+      const event = createInternalHookEvent("memory", "retrieved", "test-session", context);
+      await triggerInternalHook(event);
+
+      expect(handler).toHaveBeenCalledWith(event);
     });
   });
 });

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -10,7 +10,13 @@ import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "memory"
+  | "message";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -203,10 +209,10 @@ export type MemoryRetrievedHookContext = {
   results: MemoryRetrievalResult[];
   /** Token budget breakdown for memory retrieval */
   tokenBudget: {
-    /** Characters allocated to bootstrap files */
-    bootstrapFiles: number;
-    /** Characters used by memory-retrieved content */
-    memoryRetrieved: number;
+    /** Character budget cap for bootstrap files */
+    limit: number;
+    /** Characters actually injected into the agent context */
+    used: number;
   };
   /** Workspace directory that scoped this retrieval */
   workspaceDir: string;

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -183,6 +183,41 @@ export type MessagePreprocessedHookEvent = InternalHookEvent & {
   context: MessagePreprocessedHookContext;
 };
 
+// ============================================================================
+// Memory Hook Events
+// ============================================================================
+
+export type MemoryRetrievalResult = {
+  /** Relative or absolute path to the retrieved file */
+  path: string;
+  /** Start line of the relevant chunk (1-indexed), if applicable */
+  startLine?: number;
+  /** End line of the relevant chunk (1-indexed), if applicable */
+  endLine?: number;
+  /** Source that produced this result (e.g., "bootstrap", "memory-search") */
+  source: string;
+};
+
+export type MemoryRetrievedHookContext = {
+  /** Items selected for injection into agent context */
+  results: MemoryRetrievalResult[];
+  /** Token budget breakdown for memory retrieval */
+  tokenBudget: {
+    /** Characters allocated to bootstrap files */
+    bootstrapFiles: number;
+    /** Characters used by memory-retrieved content */
+    memoryRetrieved: number;
+  };
+  /** Workspace directory that scoped this retrieval */
+  workspaceDir: string;
+};
+
+export type MemoryRetrievedHookEvent = InternalHookEvent & {
+  type: "memory";
+  action: "retrieved";
+  context: MemoryRetrievedHookContext;
+};
+
 export interface InternalHookEvent {
   /** The type of event (command, session, agent, gateway, etc.) */
   type: InternalHookEventType;
@@ -445,4 +480,17 @@ export function isMessagePreprocessedEvent(
     return false;
   }
   return hasStringContextField(context, "channelId");
+}
+
+export function isMemoryRetrievedEvent(
+  event: InternalHookEvent,
+): event is MemoryRetrievedHookEvent {
+  if (!isHookEventTypeAndAction(event, "memory", "retrieved")) {
+    return false;
+  }
+  const context = getHookContext<MemoryRetrievedHookContext>(event);
+  if (!context) {
+    return false;
+  }
+  return Array.isArray(context.results) && hasStringContextField(context, "workspaceDir");
 }


### PR DESCRIPTION
## Summary

- **Problem:** Memory retrieval pipeline is a black box to hook authors. No way to see what was selected, excluded, or how tokens were allocated.
- **Why it matters:** Users building structured knowledge systems cannot debug retrieval quality or tune extraPaths configuration.
- **What changed:** Added `memory:retrieved` internal hook event with `MemoryRetrievedHookContext` type, `isMemoryRetrievedEvent` type guard, and emission from `resolveBootstrapContextForRun`. Modified 4 files.
- **What did NOT change:** Retrieval logic, bootstrap file loading, existing hook events.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33503

## User-visible / Behavior Changes

- New `memory:retrieved` hook event fires after bootstrap files are loaded
- Hook payload includes retrieved file paths, sources, and token budget breakdown

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Any

### Steps

1. Register a hook handler for `memory:retrieved`
2. Start a session
3. Observe the hook event payload

### Expected

- Hook fires with retrieved file paths and token budget

### Actual

- Before fix: No hook event for memory retrieval
- After fix: `memory:retrieved` event fires with full context

## Evidence

10 new tests: 8 in `internal-hooks.test.ts` (type guard, handler triggering), 2 in `bootstrap-files.test.ts` (hook emission with and without files).

## Human Verification (required)

- Verified scenarios: Hook event emission, type guard validation
- Edge cases checked: Empty workspace, missing files, wrong event types
- What I did **not** verify: Full hook pipeline with external handlers

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the hook emission in bootstrap-files.ts
- Files/config to restore: `src/agents/bootstrap-files.ts`, `src/hooks/internal-hooks.ts`
- Known bad symptoms: None — hook events are additive

## Risks and Mitigations

None — additive hook event with no impact on existing functionality.
