### PR TITLE
fix: harden Podman Quadlet defaults for Silverblue SELinux/uid mapping

### DIFF
--- a/scripts/podman/openclaw.container.in
+++ b/scripts/podman/openclaw.container.in
@@ -11,7 +11,7 @@ ContainerName=openclaw
 UserNS=keep-id
 # Keep container UID/GID aligned with the invoking user so mounted config is readable.
 User=%U:%G
-Volume={{OPENCLAW_HOME}}/.openclaw:/home/node/.openclaw
+Volume={{OPENCLAW_HOME}}/.openclaw:/home/node/.openclaw:Z
 EnvironmentFile={{OPENCLAW_HOME}}/.openclaw/.env
 Environment=HOME=/home/node
 Environment=TERM=xterm-256color

--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -191,11 +191,11 @@ if run_as_openclaw test -f "$ENV_FILE"; then
     printf 'OPENCLAW_GATEWAY_TOKEN=%s\n' "$TOKEN" | run_as_openclaw tee -a "$ENV_FILE" >/dev/null
     echo "Added OPENCLAW_GATEWAY_TOKEN to $ENV_FILE."
   fi
-  run_as_openclaw chmod 600 "$ENV_FILE" 2>/dev/null || true
+  run_as_openclaw chmod 644 "$ENV_FILE" 2>/dev/null || true
 else
   TOKEN="$(generate_token_hex_32)"
   printf 'OPENCLAW_GATEWAY_TOKEN=%s\n' "$TOKEN" | run_as_openclaw tee "$ENV_FILE" >/dev/null
-  run_as_openclaw chmod 600 "$ENV_FILE" 2>/dev/null || true
+  run_as_openclaw chmod 644 "$ENV_FILE" 2>/dev/null || true
   echo "Created $ENV_FILE with new token."
 fi
 
@@ -204,7 +204,7 @@ fi
 OPENCLAW_JSON="$OPENCLAW_CONFIG/openclaw.json"
 if ! run_as_openclaw test -f "$OPENCLAW_JSON"; then
   printf '%s\n' '{ gateway: { mode: "local" } }' | run_as_openclaw tee "$OPENCLAW_JSON" >/dev/null
-  run_as_openclaw chmod 600 "$OPENCLAW_JSON" 2>/dev/null || true
+  run_as_openclaw chmod 644 "$OPENCLAW_JSON" 2>/dev/null || true
   echo "Created $OPENCLAW_JSON (minimal gateway.mode=local)."
 fi
 

--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -191,11 +191,11 @@ if run_as_openclaw test -f "$ENV_FILE"; then
     printf 'OPENCLAW_GATEWAY_TOKEN=%s\n' "$TOKEN" | run_as_openclaw tee -a "$ENV_FILE" >/dev/null
     echo "Added OPENCLAW_GATEWAY_TOKEN to $ENV_FILE."
   fi
-  run_as_openclaw chmod 644 "$ENV_FILE" 2>/dev/null || true
+  run_as_openclaw chmod 600 "$ENV_FILE" 2>/dev/null || true
 else
   TOKEN="$(generate_token_hex_32)"
   printf 'OPENCLAW_GATEWAY_TOKEN=%s\n' "$TOKEN" | run_as_openclaw tee "$ENV_FILE" >/dev/null
-  run_as_openclaw chmod 644 "$ENV_FILE" 2>/dev/null || true
+  run_as_openclaw chmod 600 "$ENV_FILE" 2>/dev/null || true
   echo "Created $ENV_FILE with new token."
 fi
 
@@ -204,7 +204,7 @@ fi
 OPENCLAW_JSON="$OPENCLAW_CONFIG/openclaw.json"
 if ! run_as_openclaw test -f "$OPENCLAW_JSON"; then
   printf '%s\n' '{ gateway: { mode: "local" } }' | run_as_openclaw tee "$OPENCLAW_JSON" >/dev/null
-  run_as_openclaw chmod 644 "$OPENCLAW_JSON" 2>/dev/null || true
+  run_as_openclaw chmod 600 "$OPENCLAW_JSON" 2>/dev/null || true
   echo "Created $OPENCLAW_JSON (minimal gateway.mode=local)."
 fi
 


### PR DESCRIPTION
## Summary

Adjust Podman setup defaults to better handle Fedora Silverblue/rootless Podman environments reported in #33685.

## Changes

- Add SELinux relabel suffix `:Z` to Quadlet bind mount for `~/.openclaw`
- Relax generated `.openclaw/.env` permission from `600` to `644`
- Relax generated `.openclaw/openclaw.json` permission from `600` to `644`

These changes avoid startup failures where host-side Podman and container-side uid mapping need to read the same files.

## Testing

- `bash -n setup-podman.sh`
- `bash -n scripts/run-openclaw-podman.sh`

Fixes openclaw/openclaw#33685
