### PR TITLE
fix(heartbeat): skip empty followup drains after message-channel delivery

### DIFF
--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -15,6 +15,7 @@ const runEmbeddedPiAgentMock = vi.fn();
 const runCliAgentMock = vi.fn();
 const runWithModelFallbackMock = vi.fn();
 const runtimeErrorMock = vi.fn();
+const scheduleFollowupDrainMock = vi.fn();
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: (params: {
@@ -63,7 +64,7 @@ vi.mock("./queue.js", async () => {
   return {
     ...actual,
     enqueueFollowupRun: vi.fn(),
-    scheduleFollowupDrain: vi.fn(),
+    scheduleFollowupDrain: (...args: unknown[]) => scheduleFollowupDrainMock(...args),
   };
 });
 
@@ -80,6 +81,7 @@ beforeEach(() => {
   runCliAgentMock.mockClear();
   runWithModelFallbackMock.mockClear();
   runtimeErrorMock.mockClear();
+  scheduleFollowupDrainMock.mockClear();
   resetSystemEventsForTest();
 
   // Default: no provider switch; execute the chosen provider+model.
@@ -872,7 +874,7 @@ describe("runReplyAgent claude-cli routing", () => {
 describe("runReplyAgent messaging tool suppression", () => {
   function createRun(
     messageProvider = "slack",
-    opts: { storePath?: string; sessionKey?: string } = {},
+    opts: { storePath?: string; sessionKey?: string; isHeartbeat?: boolean } = {},
   ) {
     const typing = createMockTypingController();
     const sessionKey = opts.sessionKey ?? "main";
@@ -919,6 +921,7 @@ describe("runReplyAgent messaging tool suppression", () => {
       shouldFollowup: false,
       isActive: false,
       isStreaming: false,
+      opts: opts.isHeartbeat ? { isHeartbeat: true } : undefined,
       typing,
       sessionCtx,
       sessionKey,
@@ -944,6 +947,34 @@ describe("runReplyAgent messaging tool suppression", () => {
     const result = await createRun("slack");
 
     expect(result).toBeUndefined();
+  });
+
+  it("does not schedule followup drain for heartbeat runs that only send via messaging tools", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      messagingToolSentTexts: ["status sent"],
+      messagingToolSentTargets: [{ tool: "message", provider: "imessage", to: "+18005551212" }],
+      meta: {},
+    });
+
+    const result = await createRun("imessage", { isHeartbeat: true });
+
+    expect(result).toBeUndefined();
+    expect(scheduleFollowupDrainMock).not.toHaveBeenCalled();
+  });
+
+  it("does not schedule followup drain when heartbeat payloads are fully deduped by messaging tool sends", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      messagingToolSentTexts: ["hello world!"],
+      messagingToolSentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
+      meta: {},
+    });
+
+    const result = await createRun("slack", { isHeartbeat: true });
+
+    expect(result).toBeUndefined();
+    expect(scheduleFollowupDrainMock).not.toHaveBeenCalled();
   });
 
   it("delivers replies when tool provider does not match", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -501,7 +501,12 @@ export async function runReplyAgent(params: {
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and
     // keep the typing indicator stuck.
+    const shouldSkipEmptyHeartbeatFollowupDrain =
+      isHeartbeat && (runResult.messagingToolSentTargets?.length ?? 0) > 0;
     if (payloadArray.length === 0) {
+      if (shouldSkipEmptyHeartbeatFollowupDrain) {
+        return undefined;
+      }
       return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     }
 
@@ -530,6 +535,9 @@ export async function runReplyAgent(params: {
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
 
     if (replyPayloads.length === 0) {
+      if (shouldSkipEmptyHeartbeatFollowupDrain) {
+        return undefined;
+      }
       return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     }
 


### PR DESCRIPTION
## Summary

- Problem: Heartbeat runs that deliver via `messageChannel` can end with no main-session payload, which still triggers followup-drain scheduling.
- Why it matters: This can recurse into duplicate heartbeat followup chains and send repeated outbound messages.
- What changed: `runReplyAgent` now skips empty followup-drain scheduling for heartbeat runs when messaging-tool delivery already happened.
- What did NOT change (scope boundary): Normal non-heartbeat followup behavior and non-messaging heartbeat behavior remain unchanged.

AI-assisted contribution by @jlgrimes (Clawbot workflow).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33677
- Related #25606

## User-visible / Behavior Changes

- Heartbeat runs that route output through a messaging tool no longer schedule empty followup drains in the source session.
- This prevents duplicate heartbeat message bursts caused by followup run chaining.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (Debian)
- Runtime/container: Node + Vitest
- Model/provider: N/A (unit tests)
- Integration/channel (if any): heartbeat + messaging tool paths
- Relevant config (redacted): N/A

### Steps

1. Run a heartbeat turn configured to send via messaging tool (`messageChannel`) and return no renderable payload in main session.
2. Observe whether followup drain is scheduled.
3. Repeat for deduped-to-empty heartbeat payloads.

### Expected

- No empty followup-drain scheduling for heartbeat turns that already delivered via messaging tools.

### Actual

- After this patch, no followup drain is scheduled in those heartbeat messaging-tool cases.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing tests:

- `pnpm test src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- `pnpm test src/auto-reply/reply/agent-runner-payloads.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: heartbeat + messaging-tool + empty payload; heartbeat + deduped-to-empty payload.
- Edge cases checked: non-heartbeat behavior remains unchanged by targeted guard.
- What you did **not** verify: full end-to-end live iMessage heartbeat run in a production gateway.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `fix(heartbeat): skip empty followup drains after message-channel delivery`.
- Files/config to restore: `src/auto-reply/reply/agent-runner.ts` and related tests.
- Known bad symptoms reviewers should watch for: missing expected followups for heartbeat runs that should still queue (non-messaging paths).

## Risks and Mitigations

- Risk: Guard might suppress legitimate heartbeat followups in edge cases where messaging target metadata exists but delivery failed upstream.
  - Mitigation: Guard is narrowly scoped to empty-payload heartbeat turns with recorded messaging-tool sends; existing non-empty and non-heartbeat paths are untouched.
