### PR TITLE
docs: replace em-dashes with hyphens in headings

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -487,7 +487,7 @@ Treat the snippet above as **secure DM mode**:
 
 If you run multiple accounts on the same channel, use `per-account-channel-peer` instead. If the same person contacts you on multiple channels, use `session.identityLinks` to collapse those DM sessions into one canonical identity. See [Session Management](/concepts/session) and [Configuration](/gateway/configuration).
 
-## Allowlists (DM + groups) — terminology
+## Allowlists (DM + groups) - terminology
 
 OpenClaw has two separate “who can trigger me?” layers:
 

--- a/docs/install/migrating.md
+++ b/docs/install/migrating.md
@@ -67,7 +67,7 @@ Those live under `$OPENCLAW_STATE_DIR`.
 
 ## Migration steps (recommended)
 
-### Step 0 — Make a backup (old machine)
+### Step 0 - Make a backup (old machine)
 
 On the **old** machine, stop the gateway first so files aren’t changing mid-copy:
 
@@ -87,7 +87,7 @@ tar -czf openclaw-workspace.tgz .openclaw/workspace
 
 If you have multiple profiles/state dirs (e.g. `~/.openclaw-main`, `~/.openclaw-work`), archive each.
 
-### Step 1 — Install OpenClaw on the new machine
+### Step 1 - Install OpenClaw on the new machine
 
 On the **new** machine, install the CLI (and Node if needed):
 
@@ -95,7 +95,7 @@ On the **new** machine, install the CLI (and Node if needed):
 
 At this stage, it’s OK if onboarding creates a fresh `~/.openclaw/` — you will overwrite it in the next step.
 
-### Step 2 — Copy the state dir + workspace to the new machine
+### Step 2 - Copy the state dir + workspace to the new machine
 
 Copy **both**:
 
@@ -113,7 +113,7 @@ After copying, ensure:
 - Hidden directories were included (e.g. `.openclaw/`)
 - File ownership is correct for the user running the gateway
 
-### Step 3 — Run Doctor (migrations + service repair)
+### Step 3 - Run Doctor (migrations + service repair)
 
 On the **new** machine:
 

--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -5,7 +5,7 @@ read_when:
 title: "Audio and Voice Notes"
 ---
 
-# Audio / Voice Notes — 2026-01-17
+# Audio / Voice Notes - 2026-01-17
 
 ## What works
 

--- a/docs/nodes/images.md
+++ b/docs/nodes/images.md
@@ -5,7 +5,7 @@ read_when:
 title: "Image and Media Support"
 ---
 
-# Image & Media Support — 2025-12-05
+# Image & Media Support - 2025-12-05
 
 The WhatsApp channel runs via **Baileys Web**. This document captures the current media handling rules for send, gateway, and agent replies.
 

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -6,7 +6,7 @@ read_when:
 title: "Media Understanding"
 ---
 
-# Media Understanding (Inbound) — 2026-01-17
+# Media Understanding (Inbound) - 2026-01-17
 
 OpenClaw can **summarize inbound media** (image/audio/video) before the reply pipeline runs. It auto‑detects when local tools or provider keys are available, and can be disabled or customized. If understanding is off, models still receive the original files/URLs as usual.
 

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -36,7 +36,7 @@ MiniMax highlights these improvements in M2.5:
 
 ## Choose a setup
 
-### MiniMax OAuth (Coding Plan) — recommended
+### MiniMax OAuth (Coding Plan) - recommended
 
 **Best for:** quick setup with MiniMax Coding Plan via OAuth, no API key required.
 

--- a/docs/providers/venice.md
+++ b/docs/providers/venice.md
@@ -125,7 +125,7 @@ openclaw models list | grep venice
 
 ## Available Models (25 Total)
 
-### Private Models (15) — Fully Private, No Logging
+### Private Models (15) - Fully Private, No Logging
 
 | Model ID                         | Name                    | Context (tokens) | Features                |
 | -------------------------------- | ----------------------- | ---------------- | ----------------------- |
@@ -145,7 +145,7 @@ openclaw models list | grep venice
 | `openai-gpt-oss-120b`            | OpenAI GPT OSS 120B     | 131k             | General                 |
 | `zai-org-glm-4.7`                | GLM 4.7                 | 202k             | Reasoning, multilingual |
 
-### Anonymized Models (10) — Via Venice Proxy
+### Anonymized Models (10) - Via Venice Proxy
 
 | Model ID                 | Original          | Context (tokens) | Features          |
 | ------------------------ | ----------------- | ---------------- | ----------------- |

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -115,12 +115,12 @@ If you see `!`:
 
 ## Remote Gateway (use a node host)
 
-### Local Gateway (same machine as Chrome) — usually **no extra steps**
+### Local Gateway (same machine as Chrome) - usually **no extra steps**
 
 If the Gateway runs on the same machine as Chrome, it starts the browser control service on loopback
 and auto-starts the relay server. The extension talks to the local relay; the CLI/tool calls go to the Gateway.
 
-### Remote Gateway (Gateway runs elsewhere) — **run a node host**
+### Remote Gateway (Gateway runs elsewhere) - **run a node host**
 
 If your Gateway runs on another machine, start a node host on the machine that runs Chrome.
 The Gateway will proxy browser actions to that node; the extension + relay stay local to the browser machine.


### PR DESCRIPTION
## Summary

- Replace em-dashes (—) with hyphens (-) in doc headings across 8 files
- Em-dashes in headings break Mintlify anchor link generation

Affected files: `migrating.md`, `chrome-extension.md`, `media-understanding.md`, `audio.md`, `images.md`, `security/index.md`, `minimax.md`, `venice.md`

## Test plan

- [ ] Verify heading anchors resolve correctly on docs site
- [ ] Confirm no em-dashes remain in English doc headings