### PR TITLE
security: add Permissions-Policy to diffs viewer responses

### DIFF
--- a/extensions/diffs/src/http.test.ts
+++ b/extensions/diffs/src/http.test.ts
@@ -42,6 +42,7 @@ describe("createDiffsHttpHandler", () => {
     expect(res.statusCode).toBe(200);
     expect(res.body).toBe("<html>viewer</html>");
     expect(res.getHeader("content-security-policy")).toContain("default-src 'none'");
+    expect(res.getHeader("permissions-policy")).toBe("camera=(), microphone=(), geolocation=()");
   });
 
   it("rejects invalid tokens", async () => {

--- a/extensions/diffs/src/http.ts
+++ b/extensions/diffs/src/http.ts
@@ -170,6 +170,7 @@ function setSharedHeaders(res: ServerResponse, contentType: string): void {
   res.setHeader("content-type", contentType);
   res.setHeader("x-content-type-options", "nosniff");
   res.setHeader("referrer-policy", "no-referrer");
+  res.setHeader("permissions-policy", "camera=(), microphone=(), geolocation=()");
 }
 
 function normalizeRemoteClientKey(remoteAddress: string | undefined): string {


### PR DESCRIPTION
## Summary

- Add `Permissions-Policy: camera=(), microphone=(), geolocation=()` to diffs extension `setSharedHeaders`
- Aligns with the gateway-level header added in #30186
- Includes test assertion

## Test plan

- [x] `extensions/diffs/src/http.test.ts` passes (8 tests)
- [ ] Verify header present in diffs viewer responses