### PR TITLE
fix(daemon): handle systemctl is-enabled exit code 4 (not-found) on Ubuntu 24.04

### DIFF
--- a/src/daemon/exec-file.ts
+++ b/src/daemon/exec-file.ts
@@ -19,12 +19,22 @@ export async function execFileUtf8(
       }
 
       const e = error as { code?: unknown; message?: unknown };
+      const stdoutText = String(stdout ?? "");
       const stderrText = String(stderr ?? "");
       resolve({
-        stdout: String(stdout ?? ""),
+        stdout: stdoutText,
         stderr:
           stderrText ||
-          (typeof e.message === "string" ? e.message : typeof error === "string" ? error : ""),
+          // Only fall back to the Node.js error message when the child
+          // produced no output at all — otherwise callers lose the real
+          // stdout/stderr in favour of Node's "Command failed: …" wrapper.
+          (stdoutText
+            ? ""
+            : typeof e.message === "string"
+              ? e.message
+              : typeof error === "string"
+                ? error
+                : ""),
         code: typeof e.code === "number" ? e.code : 1,
       });
     });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,6 +79,19 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false when systemctl exits 4 with stdout 'not-found' (Ubuntu 24.04)", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & { code?: number };
+      err.code = 4;
+      cb(err, "not-found\n", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
   it("throws when systemctl is-enabled fails for non-state errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -143,7 +143,11 @@ async function execSystemctl(
 }
 
 function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
-  return (result.stderr || result.stdout || "").trim();
+  // Combine both streams so patterns like "not-found" (stdout) or
+  // "Failed to get unit file state" (stderr) are detected regardless
+  // of which stream systemctl writes to.
+  const parts = [result.stderr, result.stdout].filter(Boolean);
+  return parts.join("\n").trim();
 }
 
 function isSystemctlMissing(detail: string): boolean {


### PR DESCRIPTION
## Problem

On Ubuntu 24.04, `systemctl --user is-enabled openclaw-gateway.service` exits with code 4 and prints `not-found` to **stdout** when the unit doesn't exist yet. `openclaw gateway install` then fails with:

```
Error: systemctl is-enabled unavailable: Command failed: systemctl --user is-enabled openclaw-gateway.service
```

### Root cause

1. **`execFileUtf8`** fell back to Node's `error.message` (`"Command failed: …"`) as stderr when real stderr was empty — even though stdout contained the actual `not-found` output.
2. **`readSystemctlDetail`** used `stderr || stdout`, so the polluted stderr took precedence and the `not-found` pattern in stdout was never checked.

## Fix

1. `readSystemctlDetail` now combines both streams (`stderr + stdout`) so patterns in either are detected.
2. `execFileUtf8` no longer falls back to `error.message` when the child produced real stdout, keeping original output intact.

## Test

Added a test reproducing the exact Ubuntu 24.04 scenario (exit code 4, stdout `not-found\n`, empty stderr). All 20 systemd tests pass.

Closes #33633