### PR TITLE
Fix LINE outbound cfg threading for send helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Docs/tool-loop detection config keys: align `docs/tools/loop-detection.md` examples and field names with the current `tools.loopDetection` schema to prevent copy-paste validation failures from outdated keys. (#33182) Thanks @Mylszd.
+- LINE/outbound cfg threading: make LINE send helpers prefer caller-provided `cfg` over reloading config snapshots, and forward `cfg` through LINE extension outbound send paths (`sendPayload`, `sendText`, `sendMedia`) so SecretRef/account resolution stays consistent with adapter context. (#33611) Thanks @bmendonca3.
 - Discord/inbound debouncer: skip bot-own MESSAGE_CREATE events before they reach the debounce queue to avoid self-triggered slowdowns in busy servers. Thanks @thewilloftheshadow.
 - Discord/Agent-scoped media roots: pass `mediaLocalRoots` through Discord monitor reply delivery (message + component interaction paths) so local media attachments honor per-agent workspace roots instead of falling back to default global roots. Thanks @thewilloftheshadow.
 - Discord/slash command handling: intercept text-based slash commands in channels, register plugin commands as native, and send fallback acknowledgments for empty slash runs so interactions do not hang. Thanks @thewilloftheshadow.

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -117,6 +117,7 @@ describe("linePlugin outbound.sendPayload", () => {
     expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:group:1", "Now playing:", {
       verbose: false,
       accountId: "default",
+      cfg,
     });
   });
 
@@ -154,6 +155,7 @@ describe("linePlugin outbound.sendPayload", () => {
     expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:user:1", "Choose one:", {
       verbose: false,
       accountId: "default",
+      cfg,
     });
   });
 
@@ -193,7 +195,7 @@ describe("linePlugin outbound.sendPayload", () => {
           quickReply: { items: ["One", "Two"] },
         },
       ],
-      { verbose: false, accountId: "default" },
+      { verbose: false, accountId: "default", cfg },
     );
     expect(mocks.createQuickReplyItems).toHaveBeenCalledWith(["One", "Two"]);
   });
@@ -225,12 +227,13 @@ describe("linePlugin outbound.sendPayload", () => {
       verbose: false,
       mediaUrl: "https://example.com/img.jpg",
       accountId: "default",
+      cfg,
     });
     expect(mocks.pushTextMessageWithQuickReplies).toHaveBeenCalledWith(
       "line:user:3",
       "Hello",
       ["One", "Two"],
-      { verbose: false, accountId: "default" },
+      { verbose: false, accountId: "default", cfg },
     );
     const mediaOrder = mocks.sendMessageLine.mock.invocationCallOrder[0];
     const quickReplyOrder = mocks.pushTextMessageWithQuickReplies.mock.invocationCallOrder[0];
@@ -266,6 +269,46 @@ describe("linePlugin outbound.sendPayload", () => {
       fallbackLimit: 5000,
     });
     expect(mocks.chunkMarkdownText).toHaveBeenCalledWith("Hello world", 123);
+  });
+
+  it("forwards cfg in outbound.sendText", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+
+    await linePlugin.outbound!.sendText!({
+      to: "line:user:7",
+      text: "hello",
+      accountId: "default",
+      cfg,
+    });
+
+    expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:user:7", "hello", {
+      verbose: false,
+      accountId: "default",
+      cfg,
+    });
+  });
+
+  it("forwards cfg in outbound.sendMedia", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+
+    await linePlugin.outbound!.sendMedia!({
+      to: "line:user:8",
+      text: "caption",
+      mediaUrl: "https://example.com/m.jpg",
+      accountId: "default",
+      cfg,
+    });
+
+    expect(mocks.sendMessageLine).toHaveBeenCalledWith("line:user:8", "caption", {
+      verbose: false,
+      mediaUrl: "https://example.com/m.jpg",
+      accountId: "default",
+      cfg,
+    });
   });
 });
 

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -373,6 +373,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           const result = await sendBatch(to, batch, {
             verbose: false,
             accountId: accountId ?? undefined,
+            cfg,
           });
           lastResult = { messageId: result.messageId, chatId: result.chatId };
         }
@@ -400,6 +401,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           lastResult = await sendFlex(to, lineData.flexMessage.altText, flexContents, {
             verbose: false,
             accountId: accountId ?? undefined,
+            cfg,
           });
         }
 
@@ -409,6 +411,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
             lastResult = await sendTemplate(to, template, {
               verbose: false,
               accountId: accountId ?? undefined,
+              cfg,
             });
           }
         }
@@ -417,6 +420,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           lastResult = await sendLocation(to, lineData.location, {
             verbose: false,
             accountId: accountId ?? undefined,
+            cfg,
           });
         }
 
@@ -426,6 +430,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           lastResult = await sendFlex(to, flexMsg.altText, flexContents, {
             verbose: false,
             accountId: accountId ?? undefined,
+            cfg,
           });
         }
       }
@@ -437,6 +442,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
             verbose: false,
             mediaUrl: url,
             accountId: accountId ?? undefined,
+            cfg,
           });
         }
       }
@@ -448,11 +454,13 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
             lastResult = await sendQuickReplies(to, chunks[i], quickReplies, {
               verbose: false,
               accountId: accountId ?? undefined,
+              cfg,
             });
           } else {
             lastResult = await sendText(to, chunks[i], {
               verbose: false,
               accountId: accountId ?? undefined,
+              cfg,
             });
           }
         }
@@ -514,6 +522,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
             verbose: false,
             mediaUrl: url,
             accountId: accountId ?? undefined,
+            cfg,
           });
         }
       }
@@ -523,7 +532,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       }
       return { channel: "line", messageId: "empty", chatId: to };
     },
-    sendText: async ({ to, text, accountId }) => {
+    sendText: async ({ to, text, accountId, cfg }) => {
       const runtime = getLineRuntime();
       const sendText = runtime.channel.line.pushMessageLine;
       const sendFlex = runtime.channel.line.pushFlexMessage;
@@ -537,6 +546,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
         result = await sendText(to, processed.text, {
           verbose: false,
           accountId: accountId ?? undefined,
+          cfg,
         });
       } else {
         // If text is empty after processing, still need a result
@@ -550,17 +560,19 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
         await sendFlex(to, flexMsg.altText, flexContents, {
           verbose: false,
           accountId: accountId ?? undefined,
+          cfg,
         });
       }
 
       return { channel: "line", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId }) => {
+    sendMedia: async ({ to, text, mediaUrl, accountId, cfg }) => {
       const send = getLineRuntime().channel.line.sendMessageLine;
       const result = await send(to, text, {
         verbose: false,
         mediaUrl,
         accountId: accountId ?? undefined,
+        cfg,
       });
       return { channel: "line", ...result };
     },

--- a/src/line/send.test.ts
+++ b/src/line/send.test.ts
@@ -159,6 +159,28 @@ describe("LINE send helpers", () => {
     expect(result).toEqual({ messageId: "reply", chatId: "C1" });
   });
 
+  it("prefers caller cfg when building line messaging client", async () => {
+    const cfg = {
+      channels: {
+        line: {
+          channelAccessToken: "cfg-token",
+          channelSecret: "cfg-secret",
+        },
+      },
+    };
+
+    await sendModule.sendMessageLine("line:user:U1", "hello", {
+      cfg,
+      accountId: "default",
+    });
+
+    expect(resolveLineAccountMock).toHaveBeenCalledWith({
+      cfg,
+      accountId: "default",
+    });
+    expect(loadConfigMock).not.toHaveBeenCalled();
+  });
+
   it("throws when push messages are empty", async () => {
     await expect(sendModule.pushMessagesLine("U123", [])).rejects.toThrow(
       "Message must be non-empty for LINE sends",

--- a/src/line/send.ts
+++ b/src/line/send.ts
@@ -25,6 +25,7 @@ const userProfileCache = new Map<
 const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 interface LineSendOpts {
+  cfg?: ReturnType<typeof loadConfig>;
   channelAccessToken?: string;
   accountId?: string;
   verbose?: boolean;
@@ -32,7 +33,7 @@ interface LineSendOpts {
   replyToken?: string;
 }
 
-type LineClientOpts = Pick<LineSendOpts, "channelAccessToken" | "accountId">;
+type LineClientOpts = Pick<LineSendOpts, "cfg" | "channelAccessToken" | "accountId">;
 type LinePushOpts = Pick<LineSendOpts, "channelAccessToken" | "accountId" | "verbose">;
 
 interface LinePushBehavior {
@@ -68,7 +69,7 @@ function createLineMessagingClient(opts: LineClientOpts): {
   account: ReturnType<typeof resolveLineAccount>;
   client: messagingApi.MessagingApiClient;
 } {
-  const cfg = loadConfig();
+  const cfg = opts.cfg ?? loadConfig();
   const account = resolveLineAccount({
     cfg,
     accountId: opts.accountId,


### PR DESCRIPTION
## Summary
- make LINE send helpers prefer caller-provided cfg (`opts.cfg ?? loadConfig()`)
- thread cfg through LINE extension outbound sends (`sendPayload`, `sendText`, `sendMedia`)
- add regression tests for helper cfg precedence and outbound cfg forwarding
- add CHANGELOG fixes entry for #33611

## Testing
- pnpm test src/line/send.test.ts extensions/line/src/channel.sendPayload.test.ts

Closes #33611
