### PR TITLE
fix(feishu): add replyTarget config to control topic threading behavior

### DIFF
--- a/changelog/fragments/pr-feishu-reply-target.md
+++ b/changelog/fragments/pr-feishu-reply-target.md
@@ -1,0 +1,1 @@
+- Feishu/reply target: add `replyTarget` config (`"message"` | `"root"`, default `"message"`) to control whether bot replies target the triggering message or the topic root. Fixes #29968 regression where bot replies in normal group chats silently entered topic threads when users quote-replied.

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1489,6 +1489,7 @@ describe("handleFeishuMessage command authorization", () => {
             "oc-group": {
               requireMention: false,
               replyInThread: "enabled",
+              replyTarget: "root",
             },
           },
         },
@@ -1513,6 +1514,42 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         replyToMessageId: "om_root_topic",
         rootId: "om_root_topic",
+      }),
+    );
+  });
+
+  it("replies to the triggering message by default (replyTarget=message) even when root_id is present", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-quote-user" } },
+      message: {
+        message_id: "om_user_reply",
+        root_id: "om_original_msg",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "quote reply in normal group" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_user_reply",
       }),
     );
   });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1337,7 +1337,12 @@ export async function handleFeishuMessage(params: {
     const messageCreateTimeMs = event.message.create_time
       ? parseInt(event.message.create_time, 10)
       : undefined;
-    const replyTargetMessageId = ctx.rootId ?? ctx.messageId;
+    // Resolve reply target strategy: per-group config > global feishu config > default ("message").
+    // "message": reply to the triggering message (visible in main chat view).
+    // "root": reply to topic root message (stays within the topic thread).
+    const replyTargetStrategy = groupConfig?.replyTarget ?? feishuCfg?.replyTarget ?? "message";
+    const replyTargetMessageId =
+      replyTargetStrategy === "root" ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 
     if (broadcastAgents) {

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -128,6 +128,15 @@ const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();
  */
 const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 
+/**
+ * Reply target strategy for group chats.
+ * - "message" (default): Reply to the triggering message itself (pre-#29968 behavior).
+ *   Best for normal group chats where replies should stay visible in the main chat view.
+ * - "root": Reply to the topic root message (ctx.rootId ?? ctx.messageId).
+ *   Best for groups with topic mode enabled where replies should stay within the topic thread.
+ */
+const ReplyTargetSchema = z.enum(["message", "root"]).optional();
+
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
@@ -139,6 +148,7 @@ export const FeishuGroupSchema = z
     groupSessionScope: GroupSessionScopeSchema,
     topicSessionMode: TopicSessionModeSchema,
     replyInThread: ReplyInThreadSchema,
+    replyTarget: ReplyTargetSchema,
   })
   .strict();
 
@@ -167,6 +177,7 @@ const FeishuSharedConfigShape = {
   streaming: StreamingModeSchema,
   tools: FeishuToolsConfigSchema,
   replyInThread: ReplyInThreadSchema,
+  replyTarget: ReplyTargetSchema,
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),


### PR DESCRIPTION
## Problem

PR #29968 (commit `1234cc4c3`, 2026-03-02) changed the Feishu reply target from `ctx.messageId` to `ctx.rootId ?? ctx.messageId`. The intention was to keep replies within topic threads for groups using topic mode.

However, this introduced a regression in **normal group chats** (without topic mode): when a user quote-replies to @bot, Feishu attaches a `root_id` to the message. After #29968, the bot reply is directed to the `root_id` (the quoted message), causing it to **silently enter a topic thread** that is invisible in the main chat view.

From the user's perspective, the bot appears to not respond at all.

## Solution

Add a new `replyTarget` config option (`"message" | "root"`, default `"message"`) that can be set per-group or globally in the Feishu channel config:

- `"message"` (default): Reply to the triggering message itself — the pre-#29968 behavior. Best for normal group chats.
- `"root"`: Reply to the topic root message (`ctx.rootId ?? ctx.messageId`) — the post-#29968 behavior. Best for groups with topic mode enabled.

The default is `"message"` to restore the previous behavior, which is more appropriate for the majority of group chats.

### Configuration example

```json
{
  "channels": {
    "feishu": {
      "replyTarget": "message",
      "groups": {
        "oc_topic_group_id": {
          "replyTarget": "root"
        }
      }
    }
  }
}
```

## Changes

- `extensions/feishu/src/config-schema.ts`: Add `ReplyTargetSchema` (`"message" | "root"`) to `FeishuGroupSchema` and `FeishuSharedConfigShape`
- `extensions/feishu/src/bot.ts`: Resolve `replyTarget` from per-group config → global feishu config → default `"message"`, and use it to compute `replyTargetMessageId`
- `extensions/feishu/src/bot.test.ts`: Update existing topic-root-reply test to use `replyTarget: "root"`, add new test for the default `"message"` behavior
- `changelog/fragments/pr-feishu-reply-target.md`: Changelog entry

## Testing

- All 49 Feishu bot tests pass
- Verified that existing topic thread behavior is preserved when `replyTarget: "root"` is set
- Verified that quote-reply in normal groups correctly replies to the triggering message with the default config

This fix addresses real user feedback where bot replies were invisible in normal group chats after #29968.