### PR TITLE
security: apply default security headers to canvas host server

### DIFF
--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -7,6 +7,7 @@ import type { Duplex } from "node:stream";
 import chokidar from "chokidar";
 import { type WebSocket, WebSocketServer } from "ws";
 import { resolveStateDir } from "../config/paths.js";
+import { setDefaultSecurityHeaders } from "../gateway/http-common.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { detectMime } from "../media/mime.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -417,6 +418,7 @@ export async function startCanvasHost(opts: CanvasHostServerOpts): Promise<Canva
     if (String(req.headers.upgrade ?? "").toLowerCase() === "websocket") {
       return;
     }
+    setDefaultSecurityHeaders(res);
     void (async () => {
       if (await handleA2uiHttpRequest(req, res)) {
         return;


### PR DESCRIPTION
## Summary

- Call `setDefaultSecurityHeaders()` in the canvas host standalone HTTP server
- The canvas host creates its own `http.createServer()` outside the gateway, so requests bypass the gateway's `handleRequest` which applies these headers
- Adds `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, and `Permissions-Policy` to all canvas host responses
- Does not add `X-Frame-Options` or CSP (intentionally omitted for canvas host per `http-common.ts` design)

## Test plan

- [x] `src/canvas-host/server.test.ts` passes (7 tests)
- [ ] Verify headers present on canvas host responses