### PR TITLE
fix(discord): resolve threadId in extension outbound sendText/sendMedia/sendPoll

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -3,16 +3,20 @@ import { describe, expect, it, vi } from "vitest";
 import { discordPlugin } from "./channel.js";
 import { setDiscordRuntime } from "./runtime.js";
 
+function stubRuntime() {
+  const sendMessageDiscord = vi.fn(async () => ({ messageId: "m1" }));
+  const sendPollDiscord = vi.fn(async () => ({ messageId: "p1", channelId: "789" }));
+  setDiscordRuntime({
+    channel: {
+      discord: { sendMessageDiscord, sendPollDiscord },
+    },
+  } as unknown as PluginRuntime);
+  return { sendMessageDiscord, sendPollDiscord };
+}
+
 describe("discordPlugin outbound", () => {
   it("forwards mediaLocalRoots to sendMessageDiscord", async () => {
-    const sendMessageDiscord = vi.fn(async () => ({ messageId: "m1" }));
-    setDiscordRuntime({
-      channel: {
-        discord: {
-          sendMessageDiscord,
-        },
-      },
-    } as unknown as PluginRuntime);
+    const { sendMessageDiscord } = stubRuntime();
 
     const result = await discordPlugin.outbound!.sendMedia!({
       cfg: {} as OpenClawConfig,
@@ -32,5 +36,73 @@ describe("discordPlugin outbound", () => {
       }),
     );
     expect(result).toMatchObject({ channel: "discord", messageId: "m1" });
+  });
+
+  it("sendText resolves threadId into target", async () => {
+    const { sendMessageDiscord } = stubRuntime();
+
+    await discordPlugin.outbound!.sendText!({
+      cfg: {} as OpenClawConfig,
+      to: "channel:100",
+      text: "thread msg",
+      threadId: "555",
+    });
+
+    expect(sendMessageDiscord).toHaveBeenCalledWith(
+      "channel:555",
+      "thread msg",
+      expect.objectContaining({ verbose: false }),
+    );
+  });
+
+  it("sendText uses original target when threadId is absent", async () => {
+    const { sendMessageDiscord } = stubRuntime();
+
+    await discordPlugin.outbound!.sendText!({
+      cfg: {} as OpenClawConfig,
+      to: "channel:100",
+      text: "no thread",
+    });
+
+    expect(sendMessageDiscord).toHaveBeenCalledWith(
+      "channel:100",
+      "no thread",
+      expect.objectContaining({ verbose: false }),
+    );
+  });
+
+  it("sendMedia resolves threadId into target", async () => {
+    const { sendMessageDiscord } = stubRuntime();
+
+    await discordPlugin.outbound!.sendMedia!({
+      cfg: {} as OpenClawConfig,
+      to: "channel:200",
+      text: "media in thread",
+      mediaUrl: "/img.png",
+      threadId: "777",
+    });
+
+    expect(sendMessageDiscord).toHaveBeenCalledWith(
+      "channel:777",
+      "media in thread",
+      expect.objectContaining({ mediaUrl: "/img.png" }),
+    );
+  });
+
+  it("sendPoll resolves threadId into target", async () => {
+    const { sendPollDiscord } = stubRuntime();
+
+    await discordPlugin.outbound!.sendPoll!({
+      cfg: {} as OpenClawConfig,
+      to: "channel:300",
+      poll: { question: "Q?" } as never,
+      threadId: "999",
+    });
+
+    expect(sendPollDiscord).toHaveBeenCalledWith(
+      "channel:999",
+      expect.objectContaining({ question: "Q?" }),
+      expect.any(Object),
+    );
   });
 });

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -48,6 +48,12 @@ const discordMessageActions: ChannelMessageActionAdapter = {
   },
 };
 
+function resolveThreadTarget(to: string, threadId?: string | number | null): string {
+  if (threadId == null) return to;
+  const id = String(threadId).trim();
+  return id ? `channel:${id}` : to;
+}
+
 export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
   id: "discord",
   meta: {
@@ -302,9 +308,10 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
     textChunkLimit: 2000,
     pollMaxOptions: 10,
     resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
-    sendText: async ({ to, text, accountId, deps, replyToId, silent }) => {
+    sendText: async ({ to, text, accountId, deps, replyToId, threadId, silent }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(to, text, {
+      const target = resolveThreadTarget(to, threadId);
+      const result = await send(target, text, {
         verbose: false,
         replyTo: replyToId ?? undefined,
         accountId: accountId ?? undefined,
@@ -320,10 +327,12 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       accountId,
       deps,
       replyToId,
+      threadId,
       silent,
     }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(to, text, {
+      const target = resolveThreadTarget(to, threadId);
+      const result = await send(target, text, {
         verbose: false,
         mediaUrl,
         mediaLocalRoots,
@@ -333,11 +342,15 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       });
       return { channel: "discord", ...result };
     },
-    sendPoll: async ({ to, poll, accountId, silent }) =>
-      await getDiscordRuntime().channel.discord.sendPollDiscord(to, poll, {
-        accountId: accountId ?? undefined,
-        silent: silent ?? undefined,
-      }),
+    sendPoll: async ({ to, poll, accountId, threadId, silent }) =>
+      await getDiscordRuntime().channel.discord.sendPollDiscord(
+        resolveThreadTarget(to, threadId),
+        poll,
+        {
+          accountId: accountId ?? undefined,
+          silent: silent ?? undefined,
+        },
+      ),
   },
   status: {
     defaultRuntime: {


### PR DESCRIPTION
## Summary

- **Problem:** The Discord extension outbound adapter (`extensions/discord/src/channel.ts`) ignores the `threadId` field from the delivery context. When an outbound message targets a thread, the extension sends it to the parent channel instead.
- **Why it matters:** Messages intended for Discord threads (forum posts, thread replies) end up in the wrong channel, breaking threaded conversation flows.
- **What changed:** Added `resolveThreadTarget` helper that maps `threadId` to `channel:<threadId>` (matching the core plugin's `resolveDiscordOutboundTarget` logic). Applied it to `sendText`, `sendMedia`, and `sendPoll` in the extension outbound adapter.
- **What did NOT change:** Core outbound plugin logic, inbound handling, webhook routing, account resolution.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33554

## User-visible / Behavior Changes

- Discord extension outbound messages now correctly target threads when `threadId` is provided in the delivery context
- `sendPoll` also respects `threadId`

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — same Discord API endpoints, just different channel target
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+

### Steps

1. Configure Discord extension with a forum channel or thread target
2. Trigger outbound message delivery with `threadId` in the context

### Expected

- Message is sent to `channel:<threadId>`

### Actual

- Before: Message is sent to the parent `to` target, ignoring `threadId`
- After: Message is routed to `channel:<threadId>` when threadId is present

## Evidence

- [x] 5 vitest unit tests in `extensions/discord/src/channel.test.ts`:
  - `sendText resolves threadId into target`
  - `sendText uses original target when threadId is absent`
  - `sendMedia resolves threadId into target`
  - `sendPoll resolves threadId into target`
  - Existing `forwards mediaLocalRoots` test still passes

## Human Verification (required)

- Verified scenarios: threadId present → target rewritten; threadId absent → original target used; null/empty threadId → no-op
- Edge cases checked: numeric threadId (auto-stringified), empty string threadId (treated as absent), null threadId
- What I did **not** verify: Live Discord API delivery with forum/media channels

## Compatibility / Migration

- Backward compatible? `Yes` — threadId is optional; without it, behavior is identical to before
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; extension falls back to previous behavior (threadId ignored)
- Files/config to restore: `extensions/discord/src/channel.ts`

## Risks and Mitigations

- Risk: `None` — the fix aligns extension behavior with the core outbound plugin, which has been stable