### PR TITLE
fix: print Slack manifest as raw JSON

### DIFF
--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -117,11 +117,11 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
       `Docs: ${formatDocsLink("/slack", "slack")}`,
       "",
-      "Manifest (JSON):",
-      manifest,
+      "Slack app manifest JSON is printed below as raw output (copy/paste directly).",
     ].join("\n"),
     "Slack socket mode tokens",
   );
+  process.stdout.write(`${manifest}\n`);
 }
 
 function setSlackGroupPolicy(


### PR DESCRIPTION
Closes #32493

## Problem
Slack channel setup rendered the app manifest through the boxed note renderer, which prefixes lines with pipe characters and makes copied output invalid JSON.

## Fix
Keep setup guidance in the note block, but print the manifest separately as raw stdout JSON so users can copy/paste and parse it directly.