### PR TITLE
fix(config): hot-reload agents.defaults.models allowlist changes

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -56,6 +56,11 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     actions: ["restart-heartbeat"],
   },
   {
+    prefix: "agents.defaults.models",
+    kind: "hot",
+    actions: ["restart-heartbeat"],
+  },
+  {
     prefix: "models",
     kind: "hot",
     actions: ["restart-heartbeat"],

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -159,6 +159,14 @@ describe("buildGatewayReloadPlan", () => {
     );
   });
 
+  it("hot-reloads when agents.defaults.models allowlist changes (#33600)", () => {
+    const plan = buildGatewayReloadPlan(["agents.defaults.models.openrouter/minimax/minimax-m2.5"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartHeartbeat).toBe(true);
+    expect(plan.noopPaths).toEqual([]);
+    expect(plan.hotReasons).toContain("agents.defaults.models.openrouter/minimax/minimax-m2.5");
+  });
+
   it("hot-reloads health monitor when channelHealthCheckMinutes changes", () => {
     const plan = buildGatewayReloadPlan(["gateway.channelHealthCheckMinutes"]);
     expect(plan.restartGateway).toBe(false);


### PR DESCRIPTION
## Problem

`agents.defaults.models` changes (adding/removing models from the allowlist) were silently ignored during config hot-reload. The prefix fell through to the catch-all `agents` rule with `kind: "none"`, so the gateway never picked up allowlist edits without a full restart.

Root cause: `agents.defaults.model` (singular) had a reload rule, but `agents.defaults.models` (plural, the allowlist map) did not.

## Fix

Add an explicit hot-reload rule for `agents.defaults.models` that triggers heartbeat restart, same as the existing `agents.defaults.model` rule.

## Test

Added regression test confirming `agents.defaults.models.*` paths are hot-reloaded (not silently dropped).

Closes #33600