### PR TITLE
cron: preserve global defaults when agent overrides are unset

### DIFF
--- a/src/cron/isolated-agent/run.agent-defaults-merge.test.ts
+++ b/src/cron/isolated-agent/run.agent-defaults-merge.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  makeIsolatedAgentTurnParams,
+  setupRunCronIsolatedAgentTurnSuite,
+} from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  resolveAgentConfigMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+describe("runCronIsolatedAgentTurn — defaults merge", () => {
+  setupRunCronIsolatedAgentTurnSuite();
+
+  function getMergedDefaults(): Record<string, unknown> {
+    expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
+    const cfg = runWithModelFallbackMock.mock.calls[0]?.[0]?.cfg as
+      | { agents?: { defaults?: Record<string, unknown> } }
+      | undefined;
+    return cfg?.agents?.defaults ?? {};
+  }
+
+  it("preserves global defaults when per-agent fields are unset", async () => {
+    const globalDefaults = {
+      model: {
+        primary: "openai/gpt-4.1",
+        fallbacks: ["anthropic/claude-sonnet-4"],
+      },
+      workspace: "/tmp/global-workspace",
+      thinkingDefault: "medium",
+      memorySearch: { enabled: true },
+      humanDelay: { enabled: true, baseMs: 500 },
+      heartbeat: { every: "30m" },
+      subagents: { maxSpawnDepth: 3 },
+      sandbox: { enabled: true },
+      tools: { web_search: { enabled: true } },
+    };
+
+    resolveAgentConfigMock.mockReturnValue({
+      workspace: undefined,
+      thinkingDefault: undefined,
+      memorySearch: undefined,
+      humanDelay: undefined,
+      heartbeat: undefined,
+      subagents: undefined,
+      sandbox: undefined,
+      tools: undefined,
+    });
+
+    await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        agentId: "ops",
+        cfg: {
+          agents: {
+            defaults: globalDefaults,
+            list: [{ id: "ops" }],
+          },
+        },
+      }),
+    );
+
+    const mergedDefaults = getMergedDefaults();
+    expect(mergedDefaults.model).toEqual(globalDefaults.model);
+    expect(mergedDefaults.workspace).toBe(globalDefaults.workspace);
+    expect(mergedDefaults.thinkingDefault).toBe(globalDefaults.thinkingDefault);
+    expect(mergedDefaults.memorySearch).toEqual(globalDefaults.memorySearch);
+    expect(mergedDefaults.humanDelay).toEqual(globalDefaults.humanDelay);
+    expect(mergedDefaults.heartbeat).toEqual(globalDefaults.heartbeat);
+    expect(mergedDefaults.subagents).toEqual(globalDefaults.subagents);
+    expect(mergedDefaults.sandbox).toEqual(globalDefaults.sandbox);
+    expect(mergedDefaults.tools).toEqual(globalDefaults.tools);
+  });
+
+  it("still applies explicit per-agent defaults when provided", async () => {
+    resolveAgentConfigMock.mockReturnValue({
+      workspace: "/tmp/agent-workspace",
+      thinkingDefault: "off",
+      heartbeat: { every: "10m" },
+    });
+
+    await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        agentId: "ops",
+        cfg: {
+          agents: {
+            defaults: {
+              workspace: "/tmp/global-workspace",
+              thinkingDefault: "high",
+              heartbeat: { every: "30m" },
+            },
+            list: [{ id: "ops" }],
+          },
+        },
+      }),
+    );
+
+    const mergedDefaults = getMergedDefaults();
+    expect(mergedDefaults.workspace).toBe("/tmp/agent-workspace");
+    expect(mergedDefaults.thinkingDefault).toBe("off");
+    expect(mergedDefaults.heartbeat).toEqual({ every: "10m" });
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -121,6 +121,13 @@ export async function runCronIsolatedAgentTurn(params: {
     ? resolveAgentConfig(params.cfg, normalizedRequested)
     : undefined;
   const { model: overrideModel, ...agentOverrideRest } = agentConfigOverride ?? {};
+  // Do not let absent per-agent fields clear global defaults during merge.
+  // `Object.assign` would treat `{ field: undefined }` as an explicit override.
+  const agentOverrideDefaults = Object.fromEntries(
+    Object.entries(agentOverrideRest as Partial<AgentDefaultsConfig>).filter(
+      ([, value]) => value !== undefined,
+    ),
+  ) as Partial<AgentDefaultsConfig>;
   // Use the requested agentId even when there is no explicit agent config entry.
   // This ensures auth-profiles, workspace, and agentDir all resolve to the
   // correct per-agent paths (e.g. ~/.openclaw/agents/<agentId>/agent/).
@@ -128,7 +135,7 @@ export async function runCronIsolatedAgentTurn(params: {
   const agentCfg: AgentDefaultsConfig = Object.assign(
     {},
     params.cfg.agents?.defaults,
-    agentOverrideRest as Partial<AgentDefaultsConfig>,
+    agentOverrideDefaults,
   );
   // Merge agent model override with defaults instead of replacing, so that
   // `fallbacks` from `agents.defaults.model` are preserved when the agent


### PR DESCRIPTION
## Summary
Fix isolated cron agent default merging so absent per-agent fields do not clobber global `agents.defaults` values.

Before this patch, `runCronIsolatedAgentTurn` merged `resolveAgentConfig(...)` into `agents.defaults` with `Object.assign(...)`. Since `resolveAgentConfig` includes keys with `undefined` values, those `undefined` keys overwrote configured global defaults.

This affected all overlapping fields currently returned by `resolveAgentConfig` and consumed by cron defaults merge:
- `workspace`
- `thinkingDefault`
- `memorySearch`
- `humanDelay`
- `heartbeat`
- `subagents`
- `sandbox`
- `tools`

## Changes
- Inlined filtering of `undefined` keys from per-agent overrides before merging into cron `agentCfg`.
- Added regression coverage to ensure global defaults remain intact when per-agent values are unset, while explicit per-agent values still override.

## Validation
- `pnpm test src/cron/isolated-agent/run.agent-defaults-merge.test.ts`
- `pnpm test src/cron/isolated-agent/run.skill-filter.test.ts src/cron/isolated-agent/run.cron-model-override.test.ts`
