### PR TITLE
fix(line): prefer caller cfg in send helpers, forward from extension outbound

### DIFF
--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -114,10 +114,11 @@ describe("linePlugin outbound.sendPayload", () => {
     });
 
     expect(mocks.pushFlexMessage).toHaveBeenCalledTimes(1);
-    expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:group:1", "Now playing:", {
-      verbose: false,
-      accountId: "default",
-    });
+    expect(mocks.pushMessageLine).toHaveBeenCalledWith(
+      "line:group:1",
+      "Now playing:",
+      expect.objectContaining({ verbose: false, accountId: "default", cfg }),
+    );
   });
 
   it("sends template message without dropping text", async () => {
@@ -151,10 +152,11 @@ describe("linePlugin outbound.sendPayload", () => {
 
     expect(mocks.buildTemplateMessageFromPayload).toHaveBeenCalledTimes(1);
     expect(mocks.pushTemplateMessage).toHaveBeenCalledTimes(1);
-    expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:user:1", "Choose one:", {
-      verbose: false,
-      accountId: "default",
-    });
+    expect(mocks.pushMessageLine).toHaveBeenCalledWith(
+      "line:user:1",
+      "Choose one:",
+      expect.objectContaining({ verbose: false, accountId: "default", cfg }),
+    );
   });
 
   it("attaches quick replies when no text chunks are present", async () => {
@@ -193,7 +195,7 @@ describe("linePlugin outbound.sendPayload", () => {
           quickReply: { items: ["One", "Two"] },
         },
       ],
-      { verbose: false, accountId: "default" },
+      expect.objectContaining({ verbose: false, accountId: "default", cfg }),
     );
     expect(mocks.createQuickReplyItems).toHaveBeenCalledWith(["One", "Two"]);
   });
@@ -221,20 +223,50 @@ describe("linePlugin outbound.sendPayload", () => {
       cfg,
     });
 
-    expect(mocks.sendMessageLine).toHaveBeenCalledWith("line:user:3", "", {
-      verbose: false,
-      mediaUrl: "https://example.com/img.jpg",
-      accountId: "default",
-    });
+    expect(mocks.sendMessageLine).toHaveBeenCalledWith(
+      "line:user:3",
+      "",
+      expect.objectContaining({
+        verbose: false,
+        mediaUrl: "https://example.com/img.jpg",
+        accountId: "default",
+        cfg,
+      }),
+    );
     expect(mocks.pushTextMessageWithQuickReplies).toHaveBeenCalledWith(
       "line:user:3",
       "Hello",
       ["One", "Two"],
-      { verbose: false, accountId: "default" },
+      expect.objectContaining({ verbose: false, accountId: "default", cfg }),
     );
     const mediaOrder = mocks.sendMessageLine.mock.invocationCallOrder[0];
     const quickReplyOrder = mocks.pushTextMessageWithQuickReplies.mock.invocationCallOrder[0];
     expect(mediaOrder).toBeLessThan(quickReplyOrder);
+  });
+
+  it("forwards caller cfg to all LINE send helpers", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const callerCfg = { channels: { line: { accountId: "caller-account" } } } as OpenClawConfig;
+
+    const payload = {
+      text: "Hello",
+      channelData: { line: {} },
+    };
+
+    await linePlugin.outbound!.sendPayload!({
+      to: "line:user:U1",
+      text: payload.text,
+      payload,
+      accountId: "acc1",
+      cfg: callerCfg,
+    });
+
+    expect(mocks.pushMessageLine).toHaveBeenCalledWith(
+      "line:user:U1",
+      "Hello",
+      expect.objectContaining({ cfg: callerCfg }),
+    );
   });
 
   it("uses configured text chunk limit for payloads", async () => {

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -47,6 +47,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       }
       await line.pushMessageLine(id, "OpenClaw: your access has been approved.", {
         channelAccessToken: account.channelAccessToken,
+        cfg,
       });
     },
   },
@@ -357,6 +358,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       const buildTemplate = runtime.channel.line.buildTemplateMessageFromPayload;
       const createQuickReplyItems = runtime.channel.line.createQuickReplyItems;
 
+      const sendOpts = { verbose: false, accountId: accountId ?? undefined, cfg };
       let lastResult: { messageId: string; chatId: string } | null = null;
       const quickReplies = lineData.quickReplies ?? [];
       const hasQuickReplies = quickReplies.length > 0;
@@ -370,10 +372,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
         for (let i = 0; i < messages.length; i += 5) {
           // LINE SDK expects Message[] but we build dynamically
           const batch = messages.slice(i, i + 5) as unknown as Parameters<typeof sendBatch>[1];
-          const result = await sendBatch(to, batch, {
-            verbose: false,
-            accountId: accountId ?? undefined,
-          });
+          const result = await sendBatch(to, batch, sendOpts);
           lastResult = { messageId: result.messageId, chatId: result.chatId };
         }
       };
@@ -397,36 +396,24 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
         if (lineData.flexMessage) {
           // LINE SDK expects FlexContainer but we receive contents as unknown
           const flexContents = lineData.flexMessage.contents as Parameters<typeof sendFlex>[2];
-          lastResult = await sendFlex(to, lineData.flexMessage.altText, flexContents, {
-            verbose: false,
-            accountId: accountId ?? undefined,
-          });
+          lastResult = await sendFlex(to, lineData.flexMessage.altText, flexContents, sendOpts);
         }
 
         if (lineData.templateMessage) {
           const template = buildTemplate(lineData.templateMessage);
           if (template) {
-            lastResult = await sendTemplate(to, template, {
-              verbose: false,
-              accountId: accountId ?? undefined,
-            });
+            lastResult = await sendTemplate(to, template, sendOpts);
           }
         }
 
         if (lineData.location) {
-          lastResult = await sendLocation(to, lineData.location, {
-            verbose: false,
-            accountId: accountId ?? undefined,
-          });
+          lastResult = await sendLocation(to, lineData.location, sendOpts);
         }
 
         for (const flexMsg of processed.flexMessages) {
           // LINE SDK expects FlexContainer but we receive contents as unknown
           const flexContents = flexMsg.contents as Parameters<typeof sendFlex>[2];
-          lastResult = await sendFlex(to, flexMsg.altText, flexContents, {
-            verbose: false,
-            accountId: accountId ?? undefined,
-          });
+          lastResult = await sendFlex(to, flexMsg.altText, flexContents, sendOpts);
         }
       }
 
@@ -434,9 +421,8 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       if (mediaUrls.length > 0 && !shouldSendQuickRepliesInline && !sendMediaAfterText) {
         for (const url of mediaUrls) {
           lastResult = await runtime.channel.line.sendMessageLine(to, "", {
-            verbose: false,
+            ...sendOpts,
             mediaUrl: url,
-            accountId: accountId ?? undefined,
           });
         }
       }
@@ -445,15 +431,9 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
         for (let i = 0; i < chunks.length; i += 1) {
           const isLast = i === chunks.length - 1;
           if (isLast && hasQuickReplies) {
-            lastResult = await sendQuickReplies(to, chunks[i], quickReplies, {
-              verbose: false,
-              accountId: accountId ?? undefined,
-            });
+            lastResult = await sendQuickReplies(to, chunks[i], quickReplies, sendOpts);
           } else {
-            lastResult = await sendText(to, chunks[i], {
-              verbose: false,
-              accountId: accountId ?? undefined,
-            });
+            lastResult = await sendText(to, chunks[i], sendOpts);
           }
         }
       } else if (shouldSendQuickRepliesInline) {
@@ -511,9 +491,8 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       if (mediaUrls.length > 0 && !shouldSendQuickRepliesInline && sendMediaAfterText) {
         for (const url of mediaUrls) {
           lastResult = await runtime.channel.line.sendMessageLine(to, "", {
-            verbose: false,
+            ...sendOpts,
             mediaUrl: url,
-            accountId: accountId ?? undefined,
           });
         }
       }
@@ -523,10 +502,11 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       }
       return { channel: "line", messageId: "empty", chatId: to };
     },
-    sendText: async ({ to, text, accountId }) => {
+    sendText: async ({ to, text, accountId, cfg }) => {
       const runtime = getLineRuntime();
       const sendText = runtime.channel.line.pushMessageLine;
       const sendFlex = runtime.channel.line.pushFlexMessage;
+      const sendOpts = { verbose: false, accountId: accountId ?? undefined, cfg };
 
       // Process markdown: extract tables/code blocks, strip formatting
       const processed = processLineMessage(text);
@@ -534,10 +514,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       // Send cleaned text first (if non-empty)
       let result: { messageId: string; chatId: string };
       if (processed.text.trim()) {
-        result = await sendText(to, processed.text, {
-          verbose: false,
-          accountId: accountId ?? undefined,
-        });
+        result = await sendText(to, processed.text, sendOpts);
       } else {
         // If text is empty after processing, still need a result
         result = { messageId: "processed", chatId: to };
@@ -547,20 +524,18 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       for (const flexMsg of processed.flexMessages) {
         // LINE SDK expects FlexContainer but we receive contents as unknown
         const flexContents = flexMsg.contents as Parameters<typeof sendFlex>[2];
-        await sendFlex(to, flexMsg.altText, flexContents, {
-          verbose: false,
-          accountId: accountId ?? undefined,
-        });
+        await sendFlex(to, flexMsg.altText, flexContents, sendOpts);
       }
 
       return { channel: "line", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId }) => {
+    sendMedia: async ({ to, text, mediaUrl, accountId, cfg }) => {
       const send = getLineRuntime().channel.line.sendMessageLine;
       const result = await send(to, text, {
         verbose: false,
         mediaUrl,
         accountId: accountId ?? undefined,
+        cfg,
       });
       return { channel: "line", ...result };
     },

--- a/src/line/send.test.ts
+++ b/src/line/send.test.ts
@@ -225,4 +225,30 @@ describe("LINE send helpers", () => {
     ];
     expect(firstCall[0].messages[0].quickReply?.items).toHaveLength(13);
   });
+
+  it("uses caller cfg when provided, does not call loadConfig", async () => {
+    const callerCfg = { channels: { line: { channelAccessToken: "caller-token" } } } as never;
+    resolveLineAccountMock.mockImplementation(({ cfg }) => {
+      expect(cfg).toBe(callerCfg);
+      return { accountId: "default" };
+    });
+
+    await sendModule.pushMessageLine("U123", "hello", { cfg: callerCfg });
+
+    expect(loadConfigMock).not.toHaveBeenCalled();
+    expect(resolveLineAccountMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: callerCfg }),
+    );
+  });
+
+  it("falls back to loadConfig when cfg is not provided", async () => {
+    loadConfigMock.mockReturnValue({ channels: { line: {} } } as never);
+
+    await sendModule.pushMessageLine("U123", "hello", {});
+
+    expect(loadConfigMock).toHaveBeenCalled();
+    expect(resolveLineAccountMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: { channels: { line: {} } } }),
+    );
+  });
 });

--- a/src/line/send.ts
+++ b/src/line/send.ts
@@ -1,4 +1,5 @@
 import { messagingApi } from "@line/bot-sdk";
+import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import { logVerbose } from "../globals.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
@@ -27,13 +28,14 @@ const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 interface LineSendOpts {
   channelAccessToken?: string;
   accountId?: string;
+  cfg?: OpenClawConfig;
   verbose?: boolean;
   mediaUrl?: string;
   replyToken?: string;
 }
 
-type LineClientOpts = Pick<LineSendOpts, "channelAccessToken" | "accountId">;
-type LinePushOpts = Pick<LineSendOpts, "channelAccessToken" | "accountId" | "verbose">;
+type LineClientOpts = Pick<LineSendOpts, "channelAccessToken" | "accountId" | "cfg">;
+type LinePushOpts = Pick<LineSendOpts, "channelAccessToken" | "accountId" | "cfg" | "verbose">;
 
 interface LinePushBehavior {
   errorContext?: string;
@@ -68,7 +70,7 @@ function createLineMessagingClient(opts: LineClientOpts): {
   account: ReturnType<typeof resolveLineAccount>;
   client: messagingApi.MessagingApiClient;
 } {
-  const cfg = loadConfig();
+  const cfg = opts.cfg ?? loadConfig();
   const account = resolveLineAccount({
     cfg,
     accountId: opts.accountId,
@@ -405,7 +407,12 @@ export function createTextMessageWithQuickReplies(
  */
 export async function showLoadingAnimation(
   chatId: string,
-  opts: { channelAccessToken?: string; accountId?: string; loadingSeconds?: number } = {},
+  opts: {
+    channelAccessToken?: string;
+    accountId?: string;
+    cfg?: OpenClawConfig;
+    loadingSeconds?: number;
+  } = {},
 ): Promise<void> {
   const { client } = createLineMessagingClient(opts);
 
@@ -426,7 +433,12 @@ export async function showLoadingAnimation(
  */
 export async function getUserProfile(
   userId: string,
-  opts: { channelAccessToken?: string; accountId?: string; useCache?: boolean } = {},
+  opts: {
+    channelAccessToken?: string;
+    accountId?: string;
+    cfg?: OpenClawConfig;
+    useCache?: boolean;
+  } = {},
 ): Promise<{ displayName: string; pictureUrl?: string } | null> {
   const useCache = opts.useCache ?? true;
 
@@ -465,7 +477,7 @@ export async function getUserProfile(
  */
 export async function getUserDisplayName(
   userId: string,
-  opts: { channelAccessToken?: string; accountId?: string } = {},
+  opts: { channelAccessToken?: string; accountId?: string; cfg?: OpenClawConfig } = {},
 ): Promise<string> {
   const profile = await getUserProfile(userId, opts);
   return profile?.displayName ?? userId;


### PR DESCRIPTION
## Summary
LINE send helpers in `src/line/send.ts` always called `loadConfig()` via `createLineMessagingClient`, even when the caller had a resolved config context. The LINE extension outbound path also did not pass `cfg` into the send helpers.

## Changes
- Add optional `cfg` to `LineSendOpts`; use `opts.cfg ?? loadConfig()` in `createLineMessagingClient`
- Forward `cfg` from LINE extension `sendPayload`, `sendText`, `sendMedia`, and `pairing.notifyApproval` to all LINE send helper calls
- Add regression tests for helper cfg preference and adapter cfg forwarding

## Impact
Outbound helper config resolution now aligns with caller context, consistent with other channels (e.g. Telegram, Zalo).

Fixes #33611