### PR TITLE
fix: treat systemctl is-enabled not-found state as disabled

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,6 +79,19 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false when systemctl writes not-found to stdout but stderr has generic exec error", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error("Command failed: systemctl --user is-enabled openclaw-gateway.service") as Error & {
+        code?: number;
+      };
+      err.code = 1;
+      cb(err, "not-found", "Command failed: systemctl --user is-enabled openclaw-gateway.service");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
   it("throws when systemctl is-enabled fails for non-state errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -143,7 +143,7 @@ async function execSystemctl(
 }
 
 function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
-  return (result.stderr || result.stdout || "").trim();
+  return [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
 }
 
 function isSystemctlMissing(detail: string): boolean {


### PR DESCRIPTION
## Summary

Handle `systemctl --user is-enabled` failures where stderr is a generic exec error but stdout contains unit state (`not-found`, `disabled`, etc.).

## Changes

- Update `readSystemctlDetail()` to combine both stderr and stdout instead of choosing only one.
- Add regression test for the case where stderr is generic (`Command failed ...`) and stdout is `not-found`.

## Testing

- Unable to run tests in this environment because `vitest`/pnpm dependencies are not installed (`npx vitest` fails with ERR_MODULE_NOT_FOUND).

Fixes openclaw/openclaw#33633
