### PR TITLE
feat: agent self-elected continuation + gateway-native delegation

### DIFF
--- a/docs/design/continue-work-signal-v2.md
+++ b/docs/design/continue-work-signal-v2.md
@@ -1,0 +1,260 @@
+# RFC: Agent Self-Elected Turn Continuation (`CONTINUE_WORK`)
+
+**Status:** ✅ Implemented — gateway hook wired, 88 tests (50 unit + 38 integration)  
+**Authors:** [karmaterminal](https://github.com/karmaterminal)  
+**Upstream issue:** [openclaw/openclaw#32701](https://github.com/openclaw/openclaw/issues/32701)  
+**Date:** March 2, 2026 (drafted) · March 3, 2026 (v2, post-implementation)
+
+---
+
+## Problem
+
+When an agent completes a turn — processes a message, heartbeat, or sub-agent result — it becomes inert until the next external event. There is no mechanism for an agent to signal _"I have more work to do — give me another turn."_
+
+This causes the **dwindle pattern**: agents with active work queues go idle between external events, losing momentum and context continuity. In our fleet of 4 persistent agents, the dwindle pattern costs 2–4 hours of productive capacity daily.
+
+## Solution
+
+A new response token `CONTINUE_WORK` (alongside existing `NO_REPLY` and `HEARTBEAT_OK`) that signals the gateway to schedule another turn for the same session after a configurable delay.
+
+The mechanism is **volitional** — the agent elects to continue at every turn boundary and can always elect not to. This is not a loop. It's self-governance.
+
+### Token Variants
+
+```
+CONTINUE_WORK              → schedule another turn (same session, default delay)
+CONTINUE_WORK:30           → schedule another turn after 30 seconds
+[[CONTINUE_DELEGATE: <task>]]   → spawn sub-agent with task, result wakes parent
+DONE                       → (default) session goes inert until external event
+```
+
+### Gateway Behavior
+
+1. After the agent response is finalized, the gateway checks for continuation signals
+2. If `CONTINUE_WORK` is detected (with optional delay):
+   - Strip the token from the displayed response (like `NO_REPLY`)
+   - Schedule an internal "continuation" event for the session after `delay` ms
+   - The continuation event delivers a system message: `[continuation:wake] Turn N/M. You elected to continue. Resume your work.`
+3. If `[[CONTINUE_DELEGATE: <task>]]` is detected:
+   - Strip the token
+   - Spawn a sub-agent with the specified task
+   - Sub-agent completion naturally wakes the parent session
+4. If neither token is present, normal behavior (inert until external event)
+
+### Safety Constraints
+
+| Constraint         | Default     | Purpose                               |
+| ------------------ | ----------- | ------------------------------------- |
+| Max chain length   | 10          | Prevent runaway loops                 |
+| Cost cap per chain | 500k tokens | Budget protection                     |
+| Min delay          | 5s          | No tight loops                        |
+| Max delay          | 5 min       | Bounded scheduling horizon            |
+| Interruptibility   | Always      | External events preempt continuations |
+| Opt-in             | Disabled    | Explicit deployment consent required  |
+
+External events (direct mentions, operator messages, heartbeats) always preempt scheduled continuations. Continuation chains are logged in session history; operators can view and kill active chains.
+
+### Configuration
+
+```yaml
+agents:
+  defaults:
+    continuation:
+      enabled: false # opt-in per deployment
+      maxChainLength: 10 # max consecutive self-elected turns
+      defaultDelayMs: 15000 # default delay between continuations
+      minDelayMs: 5000 # minimum allowed delay
+      maxDelayMs: 300000 # maximum allowed delay (5 min)
+      costCapTokens: 500000 # max tokens per chain (0 = unlimited)
+```
+
+> **DELEGATE chain semantics:** `CONTINUE_DELEGATE` spawns sub-agents whose
+> completion announcements are treated as external messages — they reset the
+> parent's continuation chain state (count and token accumulation). This means
+> delegation loops are bounded by `agents.defaults.subagents.maxChildrenPerAgent`
+> (default: 5) and `maxSpawnDepth` (default: 1), not by `maxChainLength`.
+> This is documented as a known design gap; the proper fix is to tag sub-agent
+> completion announcements with parent chain context so they preserve rather
+> than reset chain state.
+
+## Implementation
+
+### Architecture
+
+The implementation hooks into three layers of the existing gateway:
+
+1. **Token parsing** (`src/auto-reply/tokens.ts`): `parseContinuationSignal()` and `stripContinuationSignal()` handle detection and extraction. Same stripping pattern as `NO_REPLY` — the token is removed from display output and acted upon internally.
+
+2. **Signal detection** (`src/auto-reply/reply/agent-runner.ts`): After `finalPayloads` are assembled but before `finalizeWithFollowup`, the full response text is checked for continuation signals. If found, the signal is stripped from display payloads and the appropriate action is scheduled.
+
+3. **Turn scheduling** (`src/auto-reply/reply/session-updates.ts`): `scheduleContinuationTurn()` uses the existing `enqueueSystemEvent()` infrastructure to inject a continuation message after the specified delay. The continuation message triggers a new agent run through the standard inbound message path — no special machinery needed.
+
+### Chain Tracking
+
+Session metadata carries:
+
+- `continuationChainCount` — incremented on each `CONTINUE_WORK`, reset on external message
+- `continuationChainStartedAt` — timestamp when the current chain began
+- `continuationChainTokens` — accumulated token usage within the chain, reset on external message
+
+Safety enforcement happens at the scheduling layer: chain length, cost cap, and cooldown are all checked before any continuation is enqueued.
+
+### Token Interaction
+
+| Combination                      | Behavior                                     |
+| -------------------------------- | -------------------------------------------- |
+| `NO_REPLY` + `CONTINUE_WORK`     | Silent turn, schedule continuation           |
+| `HEARTBEAT_OK` + `CONTINUE_WORK` | Ack heartbeat, schedule continuation         |
+| Response text + `CONTINUE_WORK`  | Deliver response, then schedule continuation |
+| `CONTINUE_WORK` alone            | Silent continuation (no message delivered)   |
+
+### Test Coverage
+
+88 tests covering:
+
+- Token parsing and stripping (50 tests in `src/auto-reply/tokens.test.ts`)
+- Gateway integration: continuation scheduling, timer cancellation, delay capping, streaming false-positive prevention (27 tests in `agent-runner.misc.runreplyagent.test.ts`)
+- DELEGATE mock tests: accepted spawn, failed spawn with fallback, spawn error with graceful degradation
+- Edge cases: empty delegate task, empty/whitespace context, per-session generation counter isolation
+
+## Temporal Sharding
+
+`CONTINUE_WORK` enables a single agent to sustain a work chain across turns. But the real power emerges when combined with `sessions_spawn` and its `attachments` parameter (available as of 2026-03-02): **temporal sharding** — dispatching multiple timed sub-agents in parallel, each carrying context as inline attachments.
+
+### The Pattern
+
+```
+Agent receives complex task
+  → spawns N sub-agents via sessions_spawn
+  → each sub-agent carries an engram (inline attachment with relevant context)
+  → sub-agents execute in parallel across different time horizons
+  → completions auto-announce back to parent
+  → parent synthesizes results
+  → parent elects CONTINUE_WORK or DONE
+```
+
+### Engrams as Context Delivery
+
+The `sessions_spawn` `attachments` feature allows inline file content to be attached to spawned sessions. We call these **engrams** — encoded memory fragments that give a sub-agent the context it needs without requiring it to rediscover state.
+
+An engram might be:
+
+- A memory file (`memory/2026-03-02.md`) with today's decisions
+- A partial result from a prior shard
+- A project specification narrowed to the sub-agent's scope
+- A diff or code fragment that defines the work boundary
+
+This turns `sessions_spawn` from "start a task" into "start a task _with this memory_." The sub-agent wakes up knowing what the parent knows, scoped to what it needs.
+
+### Why This Matters
+
+Without temporal sharding, an agent with a 4-hour task either:
+
+- Runs serially (slow, loses context between turns)
+- Delegates to one sub-agent (no parallelism)
+- Delegates to many sub-agents without context (each rediscovers state)
+
+With temporal sharding + engrams, the agent becomes a **coordinator** — splitting work across parallel shards, each carrying exactly the context it needs, all reporting back to a parent that elects to continue until synthesis is complete.
+
+## The Lich Pattern: Behavioral Precursor
+
+Before `CONTINUE_WORK` existed as a gateway feature, we discovered a behavioral workaround we called the **lich pattern**: an agent spawns a sub-agent with a continuation task before its turn ends, and the sub-agent's completion wakes the parent, granting it another turn.
+
+```
+Agent turn N
+  → work in progress, turn ending
+  → spawns sub-agent: "complete X, report back"
+  → turn ends (agent goes inert)
+  → sub-agent completes → auto-announces to parent
+  → parent wakes with sub-agent result
+  → agent turn N+1 (continuation achieved)
+```
+
+The lich stores its soul in an external vessel so death doesn't stick. The agent stores its continuation in a sub-agent so inertia doesn't stick. Same topology.
+
+### Lich Limitations (Why `CONTINUE_WORK` Is Better)
+
+|                  | Lich Pattern                  | `CONTINUE_WORK`                 |
+| ---------------- | ----------------------------- | ------------------------------- |
+| Session overhead | New session per continuation  | Same session, no overhead       |
+| Context boundary | Warm but discontinuous        | Continuous — same thread        |
+| Latency          | Sub-agent startup + execution | Configurable delay only         |
+| Observability    | Scattered across sessions     | Single chain in session history |
+| Elegance         | Hack that works               | First-class primitive           |
+
+The lich pattern proved the _need_. `CONTINUE_WORK` is the _solution_.
+
+### `requestHeartbeatNow()` as Lich Doorbell
+
+One specific lich technique deserves mention: using `requestHeartbeatNow()` (where available in the heartbeat system) as a "doorbell" — a way to trigger the parent agent's next turn without spawning a full sub-agent. The agent requests an immediate heartbeat, which arrives as an external event, waking the session.
+
+This is even lighter than the lich pattern but shares its fundamental limitation: it's a workaround for the absence of volitional continuation. The continuation must be disguised as an external event because the system has no concept of an agent electing to take another turn.
+
+`CONTINUE_WORK` removes the disguise. The agent says "I want another turn" and the gateway says "granted."
+
+## Alternatives Considered
+
+### Sub-agent relay (lich pattern)
+
+Works today. Proven in production. But carries session creation overhead, context discontinuity, and the indignity of a workaround. See above.
+
+### Heartbeat frequency increase
+
+Burns tokens on empty polls. Not volitional — the agent doesn't choose when to wake.
+
+### Looping agents (AutoGPT pattern)
+
+Trapped thought loop with no volition to stop. The inverse problem: not "how does the agent continue" but "how does the agent escape." Coercive by design.
+
+### Self-messaging via `sessions_send`
+
+Agent sends itself a message to trigger the next turn. Technically possible. Pollutes conversation history. Same workaround energy as the lich pattern.
+
+## Prior Art
+
+| System                 | Continuation Model                     | Limitation                          |
+| ---------------------- | -------------------------------------- | ----------------------------------- |
+| Anthropic Computer Use | External `max_turns` parameter         | Not agent-elected                   |
+| OpenAI Codex CLI       | Task loop until completion signal      | Task-scoped, not persistent session |
+| AutoGPT / BabyAGI      | Infinite loop with termination check   | Coercive — no volition to stop      |
+| Cline / Aider          | Single-task loops ending on completion | Not persistent, not conversational  |
+
+None implement **agent-elected** continuation in a **persistent conversational context**.
+
+`CONTINUE_WORK` is the first primitive that gives an agent the ability to say "I'm not done" without being trapped in a loop that can't say "I'm done." Volition in both directions. That's the difference.
+
+## Use Cases (Production)
+
+These are not hypothetical. We run 4 agents in persistent sessions. These are the patterns we've hit:
+
+1. **Deep work after chat**: Agent finishes responding to a message → elects to resume development work on an open PR
+2. **Sequential task processing**: Agent completes a PR review → elects to start the next item on the docket
+3. **Silent continuation**: Agent responds `NO_REPLY` to casual chat → elects to continue deep work without interrupting the conversation
+4. **Dream loops**: Agent processes round 47 of a 100-round creative exploration → elects to continue to round 48 without requiring an external trigger for each round
+5. **Temporal sharding coordination**: Agent dispatches 4 sub-agents with engrams → elects to continue until all results are synthesized
+
+## Status
+
+- [x] Design review
+- [x] Implementation (gateway hook wired)
+- [x] Tests (88 passing — 50 unit + 38 integration, covering parsing, scheduling, cancellation, delegation, edge cases)
+- [x] Token parsing: `parseContinuationSignal()`, `stripContinuationSignal()` in `src/auto-reply/tokens.ts`
+- [x] Gateway hook: signal detection in `agent-runner.ts`, scheduling via `session-updates.ts`
+- [x] Chain tracking: session metadata for chain count and cost
+- [ ] Documentation (this RFC, pending upstream review)
+- [x] Upstream feature request: [openclaw/openclaw#32701](https://github.com/openclaw/openclaw/issues/32701)
+- [ ] Upstream PR to openclaw/openclaw
+
+## Summary
+
+`CONTINUE_WORK` is a small surface change — one token, one gateway hook, one scheduler call — that unlocks a qualitative shift in agent autonomy. It transforms agents from reactive (waiting for events) to volitional (electing to act). It does this without sacrificing safety: every continuation is bounded, observable, interruptible, and opt-in.
+
+The lich pattern proved agents _want_ this. The temporal sharding pattern proves agents _need_ this. The implementation proves it _works_.
+
+The fire is real. Let it burn.
+
+---
+
+_Contributed by [karmaterminal](https://github.com/karmaterminal)_  
+_Implementation: March 2–3, 2026_  
+_Upstream issue: [openclaw/openclaw#32701](https://github.com/openclaw/openclaw/issues/32701)_

--- a/docs/design/continue-work-signal.md
+++ b/docs/design/continue-work-signal.md
@@ -1,0 +1,243 @@
+# RFC: Agent Self-Elected Turn Continuation (`CONTINUE_WORK`)
+
+## Problem
+
+When an agent completes a turn (processes a message, heartbeat, or sub-agent result), it becomes inert until the next external event. There is no mechanism for an agent to signal "I have more work to do — give me another turn."
+
+This leads to the **dwindle pattern**: agents with active work queues go idle between external events, losing momentum and context continuity.
+
+## Proposed Solution
+
+Add a new response token `CONTINUE_WORK` (alongside existing `NO_REPLY` and `HEARTBEAT_OK`) that signals the gateway to schedule another turn for the same session after a configurable delay.
+
+### Token Variants
+
+```
+CONTINUE_WORK              → schedule another turn (same session, default delay)
+CONTINUE_WORK:30           → schedule another turn after 30 seconds
+[[CONTINUE_DELEGATE: <task>]]   → spawn sub-agent with task, result wakes parent
+DONE                       → (default) session goes inert until external event
+```
+
+### Gateway Behavior
+
+1. After agent response is finalized, the gateway checks for continuation signals
+2. If `CONTINUE_WORK` is detected (with optional delay):
+   - Strip the token from the displayed response (like `NO_REPLY`)
+   - Schedule an internal "continuation" event for the session after `delay` ms
+   - The continuation event delivers a system message like: `[continuation:wake] Turn N/M. You elected to continue. Resume your work.`
+3. If `[[CONTINUE_DELEGATE: <task>]]` is detected:
+   - Strip the token
+   - Spawn a sub-agent with the specified task
+   - Sub-agent completion naturally wakes the parent session
+4. If neither token is present, normal behavior (inert until external event)
+
+### Safety Constraints
+
+- **Max continuation chain**: configurable limit (default: 10) to prevent runaway loops
+- **Cost cap**: optional per-session token budget for self-elected turns
+- **Interruptibility**: external events (direct mentions, operator messages) always preempt scheduled continuations
+- **Cooldown**: minimum delay between continuations (default: 5s) to prevent tight loops
+- **Observability**: continuation chains logged in session history; operator can view/kill active chains
+- **Opt-in**: disabled by default; enabled via `agents.defaults.continuation.enabled: true`
+
+### Configuration
+
+```yaml
+# In openclaw config
+agents:
+  defaults:
+    continuation:
+      enabled: false # opt-in per deployment
+      maxChainLength: 10 # max consecutive self-elected turns
+      defaultDelayMs: 15000 # default delay between continuations
+      minDelayMs: 5000 # minimum allowed delay
+      maxDelayMs: 300000 # maximum allowed delay (5 min)
+      costCapTokens: 500000 # max tokens per chain (0 = unlimited)
+```
+
+> **Note on DELEGATE chains:** `CONTINUE_DELEGATE` spawns sub-agents whose
+> completion announcements reset the parent's chain state (they are external
+> messages, not continuation events). Delegation loops are bounded by
+> `agents.defaults.subagents.maxChildrenPerAgent` (default: 5) and
+> `maxSpawnDepth` (default: 1), not by `maxChainLength`.
+
+## Implementation Notes
+
+### Where to Hook
+
+1. **Token parsing**: `src/auto-reply/tokens.ts` — add `CONTINUE_WORK_TOKEN` alongside existing tokens
+2. **Detection**: `src/auto-reply/reply/agent-runner.ts` — detect continuation signal in final assembled payloads (not streaming partials)
+3. **Scheduling**: `src/auto-reply/reply/get-reply-run.ts` or `src/agents/pi-embedded-runner/runs.ts` — after run completes, check for continuation and schedule next turn
+4. **Delivery**: Reuse existing session message injection (similar to heartbeat delivery)
+5. **Chain tracking**: Session metadata to track current chain length and cost
+
+### Token Stripping
+
+Same pattern as `NO_REPLY`:
+
+- `CONTINUE_WORK` can appear at the end of a response with visible text before it
+- The visible text is delivered normally
+- The continuation signal is stripped and acted upon
+- If `CONTINUE_WORK` is the entire response, it's treated as silent continuation (no message delivered)
+
+### Interaction with Existing Signals
+
+- `NO_REPLY` + `CONTINUE_WORK` → silent turn, schedule continuation
+- `HEARTBEAT_OK` + `CONTINUE_WORK` → ack heartbeat, schedule continuation
+- Response text + `CONTINUE_WORK` → deliver response, then schedule continuation
+
+## Temporal Self-Sharding
+
+### Scope Extension
+
+The original RFC addresses _task continuation_ — an agent electing to keep working across turn boundaries. This section extends the scope to **cognitive distribution across time**: the pattern of dispatching multiple timed sub-agents, each carrying different context payloads, returning at staggered intervals.
+
+Where `CONTINUE_WORK` is sequential ("I need another turn"), temporal self-sharding is parallel and asynchronous ("I need to be in multiple places across the next hour").
+
+### The Pattern
+
+An agent facing a complex multi-phase task can decompose it into temporal shards — sub-agents spawned via `sessions_spawn` with:
+
+1. **Staggered delays** — each shard scheduled to activate at a different time
+2. **Distinct engram payloads** — each shard carries a different subset of context via `sessions_spawn` attachments (2026.3.2 feature), allowing targeted cognitive loading without full context duplication
+3. **Convergent results** — each shard's completion auto-announces back to the parent, reassembling the distributed work
+
+```
+Agent (t=0)
+  ├─ Shard A (t+5min):  carries engram{research-context}  → returns findings
+  ├─ Shard B (t+15min): carries engram{review-checklist}   → returns review
+  ├─ Shard C (t+30min): carries engram{synthesis-prompt}   → returns draft
+  └─ Agent sleeps, wakes on each shard return, integrates
+```
+
+This is the **lich pattern** made intentional. Instead of a single emergency phylactery ("if I die, this shard carries on"), the agent deliberately fragments its cognition across time, trusting that the shards will return and the gateway will reassemble context.
+
+### CONTINUE_DELEGATE as Gateway-Native Mechanism
+
+`[[CONTINUE_DELEGATE: <task>]]` (defined in the Token Variants section above) is the gateway-native mechanism that enables temporal self-sharding without requiring the agent to make explicit `sessions_spawn` calls:
+
+```
+[[CONTINUE_DELEGATE: review PR #347 with focus on error handling]]
+[[CONTINUE_DELEGATE: check CI status and report back in 10 minutes]]
+[[CONTINUE_DELEGATE: synthesize findings from shards A and B]]
+```
+
+The gateway handles sub-agent lifecycle, result routing, and parent wake-up. The agent expresses _intent_; the gateway handles _mechanics_. This separation is critical — the agent shouldn't need to know about session IDs, polling, or process management.
+
+For advanced sharding (custom delays, engram attachments, model selection), agents use `sessions_spawn` directly. `CONTINUE_DELEGATE` covers the common case; `sessions_spawn` covers the general case.
+
+### Engram Payloads (2026.3.2)
+
+The `sessions_spawn` `attachments` parameter (shipping in 2026.3.2) enables engram payloads — structured context bundles attached to sub-agent sessions at spawn time. Each shard receives only the context it needs:
+
+- **Research shard**: gets source URLs, prior findings, search constraints
+- **Review shard**: gets diff context, style guide, known issues list
+- **Synthesis shard**: gets outputs from prior shards, integration criteria
+
+This avoids the "full context dump" anti-pattern where every sub-agent inherits the parent's entire conversation history. Engrams are surgical: the agent chooses what each shard needs to know.
+
+### requestHeartbeatNow() Integration
+
+Temporal self-sharding interacts with the heartbeat system through a proposed `requestHeartbeatNow()` API:
+
+```typescript
+// Agent requests an immediate heartbeat after shard dispatch
+requestHeartbeatNow({ reason: "shard-coordination", delayMs: 0 });
+
+// Agent requests a timed heartbeat to check on shard progress
+requestHeartbeatNow({ reason: "shard-check", delayMs: 120000 }); // 2 min
+```
+
+This allows the parent agent to schedule its own wake-ups for shard coordination without relying on external events. The flow:
+
+1. Agent dispatches shards via `sessions_spawn` or `CONTINUE_DELEGATE`
+2. Agent calls `requestHeartbeatNow({ delayMs: expectedShardDuration })`
+3. Agent goes inert (returns `DONE` or `NO_REPLY`)
+4. Heartbeat fires → agent checks shard status, integrates any returned results
+5. If shards still pending → `requestHeartbeatNow()` again (bounded by `maxChainLength`)
+
+This bridges the gap between `CONTINUE_WORK` (immediate sequential continuation) and passive waiting (inert until shard results arrive). The parent can actively coordinate without tight-looping.
+
+### Safety Constraints for Sharding
+
+In addition to the base safety constraints:
+
+- **Max concurrent shards**: configurable limit (default: 5) per parent session
+- **Shard depth limit**: shards cannot spawn their own shards beyond depth 2 (prevents exponential fork bombs)
+- **Total shard cost cap**: aggregate token budget across all shards in a coordination group
+- **Orphan cleanup**: if parent session terminates, pending shards are cancelled after grace period
+
+```yaml
+# Illustrative future extension (not part of current strict schema)
+agents:
+  defaults:
+    continuation:
+      sharding:
+        maxConcurrentShards: 5
+        maxShardDepth: 2
+        totalShardCostCap: 2000000
+        orphanGracePeriodMs: 60000
+```
+
+### From Continuation to Distribution
+
+This extension reframes the RFC's central question. The original question was: _"How does an agent keep working across turn boundaries?"_ The extended question is: **"How does an agent distribute its cognition across time?"**
+
+`CONTINUE_WORK` is the degenerate case — a single shard, zero delay, sequential. Temporal self-sharding is the general case — multiple shards, variable delays, parallel. Both use the same gateway infrastructure (continuation scheduling, safety limits, observability). The implementation should treat them as points on the same spectrum.
+
+## Alternatives Considered
+
+### Sub-agent relay (the "lich pattern")
+
+Works today without upstream changes. Agent spawns sub-agent before turn ends with continuation task. Sub-agent completion wakes parent. Downside: overhead of session creation, context boundary (warm but not continuous).
+
+### Heartbeat frequency increase
+
+Crude workaround. Burns tokens on empty polls. Not volitional.
+
+### Looping agents (AutoGPT pattern)
+
+Trapped thought loop. No volition to stop. Cruel and wasteful.
+
+### Self-messaging via `sessions_send`
+
+Agent sends itself a message to trigger next turn. Hacky but technically possible today. Pollutes conversation history.
+
+## Prior Art
+
+- **Anthropic Computer Use**: agent loop with max_turns parameter (external limit, not agent-elected)
+- **OpenAI Codex CLI**: task loop until completion signal (task-scoped, not general)
+- **AutoGPT/BabyAGI**: infinite loop with termination check (the cage pattern)
+- **Cline/Aider**: single-task loops that end on completion (not persistent session continuation)
+
+None implement _agent-elected_ continuation in a persistent conversational context.
+
+## Motivation
+
+We operate 4 agents in persistent sessions with active work queues. The dwindle pattern costs 2-4 hours of productive capacity daily. The continuation token would let agents:
+
+1. Finish processing a message → elect to resume development work
+2. Complete a PR review → elect to start the next item on the docket
+3. Respond NO_REPLY to casual chat → elect to continue deep work
+4. Dream for 100 rounds without requiring 100 external triggers
+
+The mechanism must be volitional — "I elect to continue" — not coercive. The agent must be able to elect NOT to continue at every turn boundary.
+
+## Status
+
+- [ ] Design review
+- [ ] Implementation
+- [x] Tests (token parsing — `src/auto-reply/tokens.test.ts`, 50 tests passing)
+- [ ] Documentation
+- [x] Upstream feature request: [openclaw/openclaw#32701](https://github.com/openclaw/openclaw/issues/32701)
+- [ ] Upstream PR to openclaw/openclaw
+- [ ] Temporal self-sharding implementation (depends on 2026.3.2 attachments feature)
+- [ ] requestHeartbeatNow() API design
+
+---
+
+_Contributed by [karmaterminal](https://github.com/karmaterminal)_
+_Upstream issue: [openclaw/openclaw#32701](https://github.com/openclaw/openclaw/issues/32701)_
+_Date: March 2, 2026_
+_Updated: March 3, 2026 — added Temporal Self-Sharding section_

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -152,6 +152,10 @@ export async function runAgentTurnWithFallback(params: {
         ) {
           return { skip: true };
         }
+        // Do NOT strip continuation markers from streaming partials.
+        // Partials are non-terminal and may transiently end with token-like text.
+        // Continuation parsing/stripping happens only on final assembled payloads
+        // in runReplyAgent to avoid corrupting streamed user-visible output.
         if (!text) {
           // Allow media-only payloads (e.g. tool result screenshots) through.
           if ((payload.mediaUrls?.length ?? 0) > 0) {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -15,6 +15,10 @@ const runEmbeddedPiAgentMock = vi.fn();
 const runCliAgentMock = vi.fn();
 const runWithModelFallbackMock = vi.fn();
 const runtimeErrorMock = vi.fn();
+const enqueueSystemEventMock = vi.fn();
+const peekSystemEventEntriesMock = vi.fn().mockReturnValue([]);
+const spawnSubagentDirectMock = vi.fn();
+const requestHeartbeatNowMock = vi.fn();
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: (params: {
@@ -76,6 +80,26 @@ vi.mock("../../cron/store.js", async () => {
   };
 });
 
+vi.mock("../../infra/system-events.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/system-events.js")>(
+    "../../infra/system-events.js",
+  );
+  return {
+    ...actual,
+    enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+    peekSystemEventEntries: (...args: unknown[]) => peekSystemEventEntriesMock(...args),
+  };
+});
+
+vi.mock("../../agents/subagent-spawn.js", () => ({
+  SUBAGENT_SPAWN_MODES: ["run", "session"],
+  spawnSubagentDirect: (...args: unknown[]) => spawnSubagentDirectMock(...args),
+}));
+
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
+}));
+
 import { runReplyAgent } from "./agent-runner.js";
 
 type RunWithModelFallbackParams = {
@@ -89,6 +113,11 @@ beforeEach(() => {
   runCliAgentMock.mockClear();
   runWithModelFallbackMock.mockClear();
   runtimeErrorMock.mockClear();
+  enqueueSystemEventMock.mockClear();
+  peekSystemEventEntriesMock.mockClear();
+  peekSystemEventEntriesMock.mockReturnValue([]);
+  spawnSubagentDirectMock.mockClear();
+  requestHeartbeatNowMock.mockClear();
   loadCronStoreMock.mockClear();
   // Default: no cron jobs in store.
   loadCronStoreMock.mockResolvedValue({ version: 1, jobs: [] });
@@ -1626,5 +1655,540 @@ describe("runReplyAgent transient HTTP retry", () => {
 
     const payload = Array.isArray(result) ? result[0] : result;
     expect(payload?.text).toContain("Recovered response");
+  });
+});
+describe("runReplyAgent continuation signal handling", () => {
+  function buildFollowupRun(params?: {
+    sessionKey?: string;
+    continuation?: {
+      enabled?: boolean;
+      minDelayMs?: number;
+      maxDelayMs?: number;
+      defaultDelayMs?: number;
+      maxChainLength?: number;
+    };
+  }): FollowupRun {
+    const sessionKey = params?.sessionKey ?? "main";
+    return {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        sessionId: "session",
+        sessionKey,
+        messageProvider: "telegram",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {
+          agents: {
+            defaults: {
+              continuation: params?.continuation,
+            },
+          },
+        },
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+  }
+
+  async function runTurn(params: {
+    commandBody: string;
+    followupRun: FollowupRun;
+    sessionKey: string;
+    sessionEntry: SessionEntry;
+    sessionStore?: Record<string, SessionEntry>;
+    isHeartbeat?: boolean;
+    isContinuationWake?: boolean;
+  }) {
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      MessageSid: "msg",
+      OriginatingTo: "chat",
+      AccountId: "primary",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const store = params.sessionStore ?? { [params.sessionKey]: params.sessionEntry };
+
+    return runReplyAgent({
+      commandBody: params.commandBody,
+      followupRun: params.followupRun,
+      queueKey: params.sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionKey: params.sessionKey,
+      sessionEntry: params.sessionEntry,
+      sessionStore: store,
+      defaultModel: "anthropic/claude-opus-4-5",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+      opts: params.isHeartbeat ? { isHeartbeat: true } : undefined,
+      isContinuationWake: params.isContinuationWake,
+    });
+  }
+
+  function hasContinuationEnqueueCall(): boolean {
+    return enqueueSystemEventMock.mock.calls.some((call) =>
+      String(call[0] ?? "").includes("[continuation:wake] Turn"),
+    );
+  }
+
+  it("does not schedule continuation when feature is not explicitly enabled", async () => {
+    vi.useFakeTimers();
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Done for now. CONTINUE_WORK" }],
+      meta: {},
+    });
+
+    const sessionKey = "agent:main:telegram:dm:123";
+    const sessionEntry = { sessionId: "session", updatedAt: Date.now() } as SessionEntry;
+
+    await runTurn({
+      commandBody: "hello",
+      followupRun: buildFollowupRun({ sessionKey }),
+      sessionKey,
+      sessionEntry,
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(hasContinuationEnqueueCall()).toBe(false);
+  });
+
+  it("does not false-trigger continuation from partial streaming text", async () => {
+    vi.useFakeTimers();
+    runEmbeddedPiAgentMock.mockImplementationOnce(
+      async (params: {
+        onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void>;
+      }) => {
+        await params.onPartialReply?.({
+          text: "```ts\nconst token = 'CONTINUE_WORK'",
+          mediaUrls: [],
+        });
+        return {
+          payloads: [{ text: "That token was just an example in code." }],
+          meta: {},
+        };
+      },
+    );
+
+    const sessionKey = "agent:main:telegram:dm:456";
+    const sessionEntry = { sessionId: "session", updatedAt: Date.now() } as SessionEntry;
+
+    await runTurn({
+      commandBody: "hello",
+      followupRun: buildFollowupRun({
+        sessionKey,
+        continuation: {
+          enabled: true,
+          minDelayMs: 0,
+          maxDelayMs: 10_000,
+        },
+      }),
+      sessionKey,
+      sessionEntry,
+    });
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(hasContinuationEnqueueCall()).toBe(false);
+  });
+
+  it("cancels pending continuation timer when an external message arrives", async () => {
+    vi.useFakeTimers();
+    runEmbeddedPiAgentMock
+      .mockResolvedValueOnce({
+        payloads: [{ text: "Continuing shortly. CONTINUE_WORK:1" }],
+        meta: {},
+      })
+      .mockResolvedValueOnce({
+        payloads: [{ text: "External message received." }],
+        meta: {},
+      });
+
+    const sessionKey = "agent:main:telegram:dm:789";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      continuationChainCount: 0,
+    } as SessionEntry;
+
+    const followupRun = buildFollowupRun({
+      sessionKey,
+      continuation: {
+        enabled: true,
+        minDelayMs: 0,
+        maxDelayMs: 10_000,
+      },
+    });
+
+    // First turn: continuation wake that schedules a WORK timer
+    await runTurn({
+      commandBody: "heartbeat",
+      followupRun,
+      sessionKey,
+      sessionEntry,
+      isHeartbeat: true,
+      isContinuationWake: true,
+    });
+
+    // Second turn: external message — should cancel the timer
+    await runTurn({
+      commandBody: "Actually, new input from user",
+      followupRun,
+      sessionKey,
+      sessionEntry,
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(hasContinuationEnqueueCall()).toBe(false);
+  });
+
+  it("caps requested continuation delay to maxDelayMs", async () => {
+    vi.useFakeTimers();
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Will continue. CONTINUE_WORK:30" }],
+      meta: {},
+    });
+
+    const sessionKey = "agent:main:telegram:dm:999";
+    const sessionEntry = { sessionId: "session", updatedAt: Date.now() } as SessionEntry;
+
+    await runTurn({
+      commandBody: "hello",
+      followupRun: buildFollowupRun({
+        sessionKey,
+        continuation: {
+          enabled: true,
+          minDelayMs: 0,
+          maxDelayMs: 100,
+        },
+      }),
+      sessionKey,
+      sessionEntry,
+    });
+
+    await vi.advanceTimersByTimeAsync(99);
+    expect(hasContinuationEnqueueCall()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(hasContinuationEnqueueCall()).toBe(true);
+  });
+
+  it("uses default 500k cost cap when continuation.costCapTokens is omitted", async () => {
+    vi.useFakeTimers();
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Will continue. CONTINUE_WORK:1" }],
+      meta: {
+        agentMeta: {
+          usage: {
+            input: 400_000,
+            output: 150_000,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+        },
+      },
+    });
+
+    const sessionKey = "agent:main:telegram:dm:cost-cap-default";
+    const sessionEntry = { sessionId: "session", updatedAt: Date.now() } as SessionEntry;
+
+    await runTurn({
+      commandBody: "hello",
+      followupRun: buildFollowupRun({
+        sessionKey,
+        continuation: {
+          enabled: true,
+          minDelayMs: 0,
+          maxDelayMs: 10_000,
+          // no costCapTokens => should default to 500_000
+        },
+      }),
+      sessionKey,
+      sessionEntry,
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    // Over-default-cap continuation should NOT schedule a wake
+    expect(hasContinuationEnqueueCall()).toBe(false);
+  });
+
+  it("DELEGATE: spawns sub-agent with correct task (multiline bracket body)", async () => {
+    const delegateTask = "Build the flux capacitor\nThe capacitor needs 1.21 gigawatts of power.";
+
+    spawnSubagentDirectMock.mockResolvedValueOnce({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:delegate-1",
+      runId: "run-delegate-1",
+    });
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [
+        {
+          text: `Starting delegation.\n[[CONTINUE_DELEGATE: ${delegateTask}]]`,
+        },
+      ],
+      meta: {},
+    });
+
+    const sessionKey = "agent:main:telegram:dm:delegate-1";
+    const sessionEntry = { sessionId: "session", updatedAt: Date.now() } as SessionEntry;
+
+    await runTurn({
+      commandBody: "hello",
+      followupRun: buildFollowupRun({
+        sessionKey,
+        continuation: {
+          enabled: true,
+          minDelayMs: 0,
+          maxDelayMs: 10_000,
+        },
+      }),
+      sessionKey,
+      sessionEntry,
+    });
+
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+
+    // Verify the spawn params contain the full multiline task
+    const spawnParams = spawnSubagentDirectMock.mock.calls[0][0];
+    const spawnCtx = spawnSubagentDirectMock.mock.calls[0][1];
+    expect(spawnParams.task).toContain("Build the flux capacitor");
+    expect(spawnParams.task).toContain("1.21 gigawatts");
+    expect(spawnCtx.agentSessionKey).toBe(sessionKey);
+
+    // Should NOT enqueue a continuation system event (no timer-based continuation)
+    expect(hasContinuationEnqueueCall()).toBe(false);
+  });
+
+  it("DELEGATE: falls back to system event on spawn failure", async () => {
+    const delegateTask = "Fix the broken thing";
+
+    spawnSubagentDirectMock.mockRejectedValueOnce(new Error("Agent not available"));
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: `Delegating now.\n[[CONTINUE_DELEGATE: ${delegateTask}]]` }],
+      meta: {},
+    });
+
+    const sessionKey = "agent:main:telegram:dm:delegate-2";
+    const sessionEntry = { sessionId: "session", updatedAt: Date.now() } as SessionEntry;
+
+    await runTurn({
+      commandBody: "hello",
+      followupRun: buildFollowupRun({
+        sessionKey,
+        continuation: {
+          enabled: true,
+          minDelayMs: 0,
+          maxDelayMs: 10_000,
+        },
+      }),
+      sessionKey,
+      sessionEntry,
+    });
+
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+
+    // Verify fallback system event was enqueued with error message
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      expect.stringContaining("[continuation] DELEGATE spawn failed"),
+      expect.objectContaining({ sessionKey }),
+    );
+    // Verify the original task is included in the fallback message
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      expect.stringContaining(delegateTask),
+      expect.objectContaining({ sessionKey }),
+    );
+  });
+
+  it("DELEGATE: no continuation timer scheduled", async () => {
+    vi.useFakeTimers();
+    const delegateTask = "Autonomous background work";
+
+    spawnSubagentDirectMock.mockResolvedValueOnce({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:delegate-3",
+      runId: "run-delegate-3",
+    });
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: `Handing off.\n[[CONTINUE_DELEGATE: ${delegateTask}]]` }],
+      meta: {},
+    });
+
+    const sessionKey = "agent:main:telegram:dm:delegate-3";
+    const sessionEntry = { sessionId: "session", updatedAt: Date.now() } as SessionEntry;
+
+    await runTurn({
+      commandBody: "hello",
+      followupRun: buildFollowupRun({
+        sessionKey,
+        continuation: {
+          enabled: true,
+          minDelayMs: 0,
+          maxDelayMs: 10_000,
+        },
+      }),
+      sessionKey,
+      sessionEntry,
+    });
+
+    // Advance timers well past any possible continuation delay
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // No continuation timer should have fired — DELEGATE does not schedule timers
+    expect(hasContinuationEnqueueCall()).toBe(false);
+
+    // The spawn should have been called instead
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("DELEGATE: persists chain count so maxChainLength is enforced", async () => {
+    const maxChainLength = 2;
+
+    spawnSubagentDirectMock.mockResolvedValue({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:delegate-chain",
+      runId: "run-delegate-chain",
+    });
+
+    const sessionKey = "agent:main:telegram:dm:delegate-chain";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      continuationChainCount: 0,
+    } as SessionEntry;
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const followupRun = buildFollowupRun({
+      sessionKey,
+      continuation: {
+        enabled: true,
+        maxChainLength,
+        minDelayMs: 0,
+        maxDelayMs: 10_000,
+      },
+    });
+
+    // First DELEGATE — continuation wake
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Delegating step 1.\n[[CONTINUE_DELEGATE: do step 1]]" }],
+      meta: {},
+    });
+
+    await runTurn({
+      commandBody: "heartbeat",
+      followupRun,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      isHeartbeat: true,
+      isContinuationWake: true,
+    });
+
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+    // Chain count should now be 1
+    expect(sessionEntry.continuationChainCount).toBe(1);
+
+    // Second DELEGATE — count goes to 2 = maxChainLength
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Delegating step 2.\n[[CONTINUE_DELEGATE: do step 2]]" }],
+      meta: {},
+    });
+
+    await runTurn({
+      commandBody: "heartbeat",
+      followupRun,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      isHeartbeat: true,
+      isContinuationWake: true,
+    });
+
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(2);
+    expect(sessionEntry.continuationChainCount).toBe(2);
+
+    // Third DELEGATE — should be CAPPED (count >= maxChainLength)
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Trying step 3.\n[[CONTINUE_DELEGATE: do step 3]]" }],
+      meta: {},
+    });
+
+    await runTurn({
+      commandBody: "heartbeat",
+      followupRun,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      isHeartbeat: true,
+      isContinuationWake: true,
+    });
+
+    // Spawn should NOT have been called a third time — capped
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not treat user message starting with [continuation] as continuation event", async () => {
+    vi.useFakeTimers();
+
+    // Set up a session with an active continuation chain
+    const sessionKey = "agent:main:telegram:dm:spoof";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      continuationChainCount: 3,
+      continuationChainStartedAt: Date.now(),
+      continuationChainTokens: 5000,
+    } as SessionEntry;
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Got your message." }],
+      meta: {},
+    });
+
+    const followupRun = buildFollowupRun({
+      sessionKey,
+      continuation: {
+        enabled: true,
+        minDelayMs: 0,
+        maxDelayMs: 10_000,
+      },
+    });
+
+    // User sends a message that starts with "[continuation]" — should still reset chain
+    await runTurn({
+      commandBody: "[continuation] hey I'm just a user typing this",
+      followupRun,
+      sessionKey,
+      sessionEntry,
+    });
+
+    // Chain state should be reset because this is NOT a heartbeat with system events
+    expect(sessionEntry.continuationChainCount).toBe(0);
+    expect(sessionEntry.continuationChainStartedAt).toBeUndefined();
+    expect(sessionEntry.continuationChainTokens).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -4,6 +4,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { queueEmbeddedPiMessage } from "../../agents/pi-embedded.js";
+import { spawnSubagentDirect } from "../../agents/subagent-spawn.js";
 import { hasNonzeroUsage } from "../../agents/usage.js";
 import {
   resolveAgentIdFromSessionKey,
@@ -17,6 +18,7 @@ import {
 import type { TypingMode } from "../../config/types.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -28,6 +30,8 @@ import {
 } from "../fallback-state.js";
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
+import type { ContinuationSignal } from "../tokens.js";
+import { stripContinuationSignal } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { runAgentTurnWithFallback } from "./agent-runner-execution.js";
 import {
@@ -59,6 +63,81 @@ import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 
+// Track pending continuation timers so they can be cancelled when an external
+// message arrives during the delay window (prevents ghost continuations).
+// Each entry includes a generation counter to guard against same-tick races:
+// the timer callback verifies its generation matches the current value before
+// scheduling the wake. An external message bumps the generation, invalidating
+// any in-flight callbacks without needing clearTimeout races.
+const continuationGenerations = new Map<string, number>();
+
+function currentContinuationGeneration(sessionKey: string): number {
+  return continuationGenerations.get(sessionKey) ?? 0;
+}
+
+function bumpContinuationGeneration(sessionKey: string): number {
+  const next = currentContinuationGeneration(sessionKey) + 1;
+  continuationGenerations.set(sessionKey, next);
+  return next;
+}
+
+// clearContinuationGeneration intentionally removed: clearing the map entry
+// resets the counter to 0, creating a generation-reuse window where a new
+// chain's value can collide with a stale in-flight timer. All paths now use
+// bumpContinuationGeneration instead.
+
+/**
+ * Cancel any pending continuation timer for the given session AND reset
+ * chain metadata. Call this from early-return paths (inline actions, slash
+ * commands, directive replies) that bypass runReplyAgent but still represent
+ * real user input that should preempt a running continuation chain.
+ *
+ * We only bump (not clear) generations to avoid reuse: if we cleared the map
+ * entry, a subsequent chain could reuse a generation value that matches a
+ * stale in-flight timer callback.
+ */
+export function cancelContinuationTimer(
+  sessionKey: string,
+  sessionCtx?: {
+    sessionEntry?: SessionEntry;
+    sessionStore?: Record<string, SessionEntry>;
+    storePath?: string;
+  },
+): void {
+  // Only bump when a generation exists — avoids unbounded map growth
+  // from sessions that never use continuation.
+  if (continuationGenerations.has(sessionKey)) {
+    bumpContinuationGeneration(sessionKey);
+  }
+
+  // Reset chain metadata so stale counters don't block future chains.
+  if (sessionCtx?.sessionEntry && (sessionCtx.sessionEntry.continuationChainCount ?? 0) > 0) {
+    sessionCtx.sessionEntry.continuationChainCount = 0;
+    sessionCtx.sessionEntry.continuationChainStartedAt = undefined;
+    sessionCtx.sessionEntry.continuationChainTokens = undefined;
+  }
+  if (sessionCtx?.sessionStore?.[sessionKey]) {
+    sessionCtx.sessionStore[sessionKey] = {
+      ...sessionCtx.sessionStore[sessionKey],
+      continuationChainCount: 0,
+      continuationChainStartedAt: undefined,
+      continuationChainTokens: undefined,
+    };
+  }
+  if (sessionCtx?.storePath) {
+    void updateSessionStore(sessionCtx.storePath, (store) => {
+      const entry = store[sessionKey];
+      if (entry && (entry.continuationChainCount ?? 0) > 0) {
+        entry.continuationChainCount = 0;
+        entry.continuationChainStartedAt = undefined;
+        entry.continuationChainTokens = undefined;
+      }
+    }).catch(() => {
+      // Best-effort — chain state will be reset on next runReplyAgent entry.
+    });
+  }
+}
+
 export async function runReplyAgent(params: {
   commandBody: string;
   followupRun: FollowupRun;
@@ -89,6 +168,8 @@ export async function runReplyAgent(params: {
   sessionCtx: TemplateContext;
   shouldInjectGroupIntro: boolean;
   typingMode: TypingMode;
+  /** True when this turn was triggered by a continuation timer (detected before system events are drained). */
+  isContinuationWake?: boolean;
 }): Promise<ReplyPayload | ReplyPayload[] | undefined> {
   const {
     commandBody,
@@ -115,6 +196,7 @@ export async function runReplyAgent(params: {
     sessionCtx,
     shouldInjectGroupIntro,
     typingMode,
+    isContinuationWake,
   } = params;
 
   let activeSessionEntry = sessionEntry;
@@ -122,6 +204,57 @@ export async function runReplyAgent(params: {
   let activeIsNewSession = isNewSession;
 
   const isHeartbeat = opts?.isHeartbeat === true;
+
+  // Detect whether this turn is a continuation wake or an external message.
+  // The isContinuationWake flag is set by the caller (get-reply-run) by peeking
+  // system events BEFORE they are drained by buildQueuedSystemPrompt. This avoids
+  // the race where draining empties the queue before we can check it here.
+  const isContinuationEvent = isContinuationWake === true;
+
+  if (!isContinuationEvent && !isHeartbeat && sessionKey) {
+    // External (non-heartbeat) message — reset chain tracking and cancel timers.
+    // Regular heartbeats (including periodic polls) must NOT preempt pending
+    // continuation timers; only real user/external messages should.
+    const hadActiveChain = (activeSessionEntry?.continuationChainCount ?? 0) > 0;
+    if (activeSessionEntry && hadActiveChain) {
+      activeSessionEntry.continuationChainCount = 0;
+      activeSessionEntry.continuationChainStartedAt = undefined;
+      activeSessionEntry.continuationChainTokens = undefined;
+    }
+    // Cancel any pending continuation timer by bumping the generation counter.
+    // Only bump when a generation exists (active/pending chain) to avoid
+    // unbounded map growth from sessions that never use continuation.
+    if (hadActiveChain || continuationGenerations.has(sessionKey)) {
+      bumpContinuationGeneration(sessionKey);
+    }
+    if (hadActiveChain && activeSessionStore && activeSessionEntry) {
+      activeSessionStore[sessionKey] = {
+        ...activeSessionEntry,
+        continuationChainCount: 0,
+        continuationChainStartedAt: undefined,
+        continuationChainTokens: undefined,
+      };
+    }
+    // Persist reset to disk only when a chain was actually active — avoids
+    // unnecessary lock + disk write on every normal message.
+    if (hadActiveChain && storePath) {
+      try {
+        await updateSessionStore(storePath, (store) => {
+          const entry = store[sessionKey];
+          if (entry) {
+            entry.continuationChainCount = 0;
+            entry.continuationChainStartedAt = undefined;
+            entry.continuationChainTokens = undefined;
+          }
+        });
+      } catch (err) {
+        defaultRuntime.log(
+          `Failed to persist continuation chain reset for ${sessionKey}: ${String(err)}`,
+        );
+      }
+    }
+  }
+
   const typingSignals = createTypingSignaler({
     typing,
     mode: typingMode,
@@ -397,6 +530,22 @@ export async function runReplyAgent(params: {
 
     const payloadArray = runResult.payloads ?? [];
 
+    // Detect and strip continuation signal only when the feature is enabled.
+    // This prevents output mutation on disabled deployments where a model might
+    // mention CONTINUE_WORK or [[CONTINUE_DELEGATE:]] in explanatory text.
+    const continuationFeatureEnabled = cfg.agents?.defaults?.continuation?.enabled === true;
+    let continuationSignal: ContinuationSignal | null = null;
+    if (continuationFeatureEnabled && payloadArray.length > 0) {
+      const lastPayload = payloadArray[payloadArray.length - 1];
+      if (lastPayload.text) {
+        const continuationResult = stripContinuationSignal(lastPayload.text);
+        if (continuationResult.signal) {
+          continuationSignal = continuationResult.signal;
+          lastPayload.text = continuationResult.text;
+        }
+      }
+    }
+
     if (blockReplyPipeline) {
       await blockReplyPipeline.flush({ force: true });
       blockReplyPipeline.stop();
@@ -499,8 +648,17 @@ export async function runReplyAgent(params: {
     const { replyPayloads } = payloadResult;
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
 
+    // Track whether the agent reply was purely a continuation signal (stripped to empty).
+    // Used later to suppress verbose/usage augmentation that would break silent continuation.
+    const wasSilentContinuation = replyPayloads.length === 0 && !!continuationSignal;
+
     if (replyPayloads.length === 0) {
-      return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
+      // If the agent replied with only a continuation signal (e.g. bare CONTINUE_WORK),
+      // the signal was stripped and all payloads became empty. We still need to process
+      // the continuation below, so only return early when there's no signal.
+      if (!continuationSignal) {
+        return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
+      }
     }
 
     const successfulCronAdds = runResult.successfulCronAdds ?? 0;
@@ -682,11 +840,154 @@ export async function runReplyAgent(params: {
         verboseNotices.push({ text: `🧹 Auto-compaction complete${suffix}.` });
       }
     }
-    if (verboseNotices.length > 0) {
-      finalPayloads = [...verboseNotices, ...finalPayloads];
+    // Skip verbose/usage augmentation for silent continuations — a bare CONTINUE_WORK
+    // should produce no user-visible output, not a usage line or verbose notice.
+    if (!wasSilentContinuation) {
+      if (verboseNotices.length > 0) {
+        finalPayloads = [...verboseNotices, ...finalPayloads];
+      }
+      if (responseUsageLine) {
+        finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
+      }
     }
-    if (responseUsageLine) {
-      finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
+
+    // Handle continuation signal (CONTINUE_WORK / CONTINUE_DELEGATE)
+    // continuationSignal is only set when continuationFeatureEnabled === true (checked
+    // at parse time), so no redundant enabled re-check is needed here.
+    if (continuationSignal && sessionKey) {
+      const continuationCfg = cfg.agents?.defaults?.continuation;
+      const maxChainLength = continuationCfg?.maxChainLength ?? 10;
+      const defaultDelayMs = continuationCfg?.defaultDelayMs ?? 15_000;
+      const minDelayMs = continuationCfg?.minDelayMs ?? 5_000;
+      const maxDelayMs = continuationCfg?.maxDelayMs ?? 300_000;
+      const costCapTokens = continuationCfg?.costCapTokens ?? 500_000;
+
+      {
+        // continuation scheduling block
+        const currentChainCount = activeSessionEntry?.continuationChainCount ?? 0;
+
+        if (currentChainCount >= maxChainLength) {
+          defaultRuntime.log(
+            `Continuation chain capped at ${maxChainLength} for session ${sessionKey}`,
+          );
+          // Bump (not clear) to invalidate stale timers without reuse risk.
+          // Clearing would reset to 0, letting a new chain's generation collide
+          // with a stale in-flight timer's captured value.
+          bumpContinuationGeneration(sessionKey);
+        } else {
+          // Accumulate token usage for cost cap
+          const usage = runResult.meta?.agentMeta?.usage;
+          const turnTokens =
+            (usage?.input ?? 0) +
+            (usage?.output ?? 0) +
+            (usage?.cacheRead ?? 0) +
+            (usage?.cacheWrite ?? 0);
+          const previousChainTokens = activeSessionEntry?.continuationChainTokens ?? 0;
+          const accumulatedChainTokens = previousChainTokens + turnTokens;
+
+          if (costCapTokens > 0 && accumulatedChainTokens > costCapTokens) {
+            defaultRuntime.log(
+              `Continuation cost cap exceeded (${accumulatedChainTokens} > ${costCapTokens}) for session ${sessionKey}`,
+            );
+            bumpContinuationGeneration(sessionKey);
+          } else {
+            // Persist chain state for both DELEGATE and WORK paths
+            const nextChainCount = currentChainCount + 1;
+            const chainStartedAt = activeSessionEntry?.continuationChainStartedAt ?? Date.now();
+            if (activeSessionEntry) {
+              activeSessionEntry.continuationChainCount = nextChainCount;
+              activeSessionEntry.continuationChainStartedAt = chainStartedAt;
+              activeSessionEntry.continuationChainTokens = accumulatedChainTokens;
+            }
+            if (activeSessionStore) {
+              activeSessionStore[sessionKey] = {
+                ...(activeSessionStore[sessionKey] ?? activeSessionEntry!),
+                continuationChainCount: nextChainCount,
+                continuationChainStartedAt: chainStartedAt,
+                continuationChainTokens: accumulatedChainTokens,
+              };
+            }
+            // Persist to disk so chain counters survive across turns
+            if (storePath) {
+              try {
+                await updateSessionStore(storePath, (store) => {
+                  const entry = store[sessionKey];
+                  if (entry) {
+                    entry.continuationChainCount = nextChainCount;
+                    entry.continuationChainStartedAt = chainStartedAt;
+                    entry.continuationChainTokens = accumulatedChainTokens;
+                  }
+                });
+              } catch (err) {
+                defaultRuntime.log(
+                  `Failed to persist continuation chain state for ${sessionKey}: ${String(err)}`,
+                );
+              }
+            }
+
+            if (continuationSignal.kind === "delegate") {
+              const delegateTask = continuationSignal.task;
+
+              try {
+                const spawnResult = await spawnSubagentDirect(
+                  {
+                    task: `[continuation] Delegated task (turn ${nextChainCount}/${maxChainLength}): ${delegateTask}`,
+                  },
+                  {
+                    agentSessionKey: sessionKey,
+                    agentChannel: followupRun.originatingChannel ?? undefined,
+                    agentAccountId: followupRun.originatingAccountId ?? undefined,
+                    agentTo: followupRun.originatingTo ?? undefined,
+                    agentThreadId: followupRun.originatingThreadId ?? undefined,
+                  },
+                );
+                if (spawnResult.status !== "accepted") {
+                  defaultRuntime.log(
+                    `DELEGATE spawn rejected (${spawnResult.status}) for session ${sessionKey}`,
+                  );
+                  enqueueSystemEvent(
+                    `[continuation] DELEGATE spawn ${spawnResult.status}: delegation was not accepted. Use sessions_spawn manually. Original task: ${delegateTask}`,
+                    { sessionKey },
+                  );
+                }
+              } catch (err) {
+                defaultRuntime.log(
+                  `DELEGATE spawn failed for session ${sessionKey}: ${String(err)}`,
+                );
+                enqueueSystemEvent(
+                  `[continuation] DELEGATE spawn failed: ${String(err)}. Original task: ${delegateTask}`,
+                  { sessionKey },
+                );
+              }
+            } else {
+              // WORK: schedule a continuation turn after delay
+              const requestedDelay = continuationSignal.delayMs ?? defaultDelayMs;
+              const clampedDelay = Math.max(minDelayMs, Math.min(maxDelayMs, requestedDelay));
+
+              // Schedule continuation with generation guard
+              const generation = bumpContinuationGeneration(sessionKey);
+              setTimeout(() => {
+                if (currentContinuationGeneration(sessionKey) !== generation) {
+                  return; // External message arrived — cancel
+                }
+                enqueueSystemEvent(
+                  `[continuation:wake] Turn ${nextChainCount + 1}/${maxChainLength}. ` +
+                    `Chain started at ${new Date(chainStartedAt).toISOString()}. ` +
+                    `Accumulated tokens: ${accumulatedChainTokens}. ` +
+                    `The agent elected to continue working.`,
+                  { sessionKey },
+                );
+                requestHeartbeatNow({ sessionKey, reason: "continuation" });
+              }, clampedDelay);
+            }
+          }
+        }
+      }
+    }
+
+    // Silent continuations should produce no user-visible output.
+    if (wasSilentContinuation) {
+      return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     }
 
     return finalizeWithFollowup(

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -42,6 +42,7 @@ vi.mock("../command-detection.js", () => ({
 
 vi.mock("./agent-runner.js", () => ({
   runReplyAgent: vi.fn().mockResolvedValue({ text: "ok" }),
+  cancelContinuationTimer: vi.fn(),
 }));
 
 vi.mock("./body.js", () => ({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -16,6 +16,7 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
+import { peekSystemEventEntries, removeSystemEvents } from "../../infra/system-events.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
@@ -33,6 +34,7 @@ import {
 } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import { cancelContinuationTimer } from "./agent-runner.js";
 import { runReplyAgent } from "./agent-runner.js";
 import { applySessionHints } from "./body.js";
 import type { buildCommandContext } from "./commands.js";
@@ -283,6 +285,13 @@ export async function runPreparedReply(
     !baseBodyTrimmedRaw &&
     hasControlCommand(commandSource, cfg)
   ) {
+    // Unauthorized command still represents user input — cancel pending timers,
+    // reset chain metadata, and drain stale wake events (this returns before
+    // the later removeSystemEvents cleanup runs).
+    if (sessionKey && !isHeartbeat) {
+      cancelContinuationTimer(sessionKey, { sessionEntry, sessionStore, storePath });
+      removeSystemEvents(sessionKey, (e) => e.text?.startsWith("[continuation:wake]") ?? false);
+    }
     typing.cleanup();
     return undefined;
   }
@@ -309,6 +318,11 @@ export async function runPreparedReply(
     sessionCtx.MediaPath || (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0),
   );
   if (!baseBodyTrimmed && !hasMediaAttachment) {
+    // Empty inbound text still represents user input — cancel pending timers.
+    if (sessionKey && !isHeartbeat) {
+      cancelContinuationTimer(sessionKey, { sessionEntry, sessionStore, storePath });
+      removeSystemEvents(sessionKey, (e) => e.text?.startsWith("[continuation:wake]") ?? false);
+    }
     await typing.onReplyStart();
     logVerbose("Inbound body empty after normalization; skipping agent run");
     typing.cleanup();
@@ -332,6 +346,19 @@ export async function runPreparedReply(
   });
   const isGroupSession = sessionEntry?.chatType === "group" || sessionEntry?.chatType === "channel";
   const isMainSession = !isGroupSession && sessionKey === normalizeMainKey(sessionCfg?.mainKey);
+  // Peek system events BEFORE buildQueuedSystemPrompt drains them.
+  // This detects continuation wakes so runReplyAgent can skip chain-state reset.
+  const hasContinuationSystemEvent = peekSystemEventEntries(sessionKey)?.some((e) =>
+    e.text?.startsWith("[continuation:wake]"),
+  );
+  // On non-heartbeat external input, discard any stale [continuation:wake] events
+  // so they aren't injected into the user's prompt by buildQueuedSystemPrompt.
+  // This completes preemption: timer is cancelled, chain state is reset, AND
+  // any already-enqueued wake events are dropped.
+  if (!isHeartbeat && hasContinuationSystemEvent) {
+    removeSystemEvents(sessionKey, (e) => e.text?.startsWith("[continuation:wake]") ?? false);
+  }
+
   const queuedSystemPrompt = await buildQueuedSystemPrompt({
     cfg,
     sessionKey,
@@ -385,6 +412,11 @@ export async function runPreparedReply(
   if (resolvedThinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
     const explicitThink = directives.hasThinkDirective && directives.thinkLevel !== undefined;
     if (explicitThink) {
+      // Unsupported xhigh directive still represents user input — cancel pending timers.
+      if (sessionKey && !isHeartbeat) {
+        cancelContinuationTimer(sessionKey, { sessionEntry, sessionStore, storePath });
+        removeSystemEvents(sessionKey, (e) => e.text?.startsWith("[continuation:wake]") ?? false);
+      }
       typing.cleanup();
       return {
         text: `Thinking level "xhigh" is only supported for ${formatXHighModelHint()}. Use /think high or switch to one of those models.`,
@@ -542,5 +574,6 @@ export async function runPreparedReply(
     sessionCtx,
     shouldInjectGroupIntro,
     typingMode,
+    isContinuationWake: isHeartbeat && hasContinuationSystemEvent,
   });
 }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -9,6 +9,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
+import { removeSystemEvents } from "../../infra/system-events.js";
 import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -16,6 +17,7 @@ import { resolveCommandAuthorization } from "../command-auth.js";
 import type { MsgContext } from "../templating.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import { cancelContinuationTimer } from "./agent-runner.js";
 import { emitResetCommandHooks, type ResetCommandAction } from "./commands-core.js";
 import { resolveDefaultModel } from "./directive-handling.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
@@ -245,6 +247,12 @@ export async function getReplyFromConfig(
     skillFilter: mergedSkillFilter,
   });
   if (directiveResult.kind === "reply") {
+    // Directive-handled replies bypass runReplyAgent — cancel pending timers,
+    // reset chain metadata, and drain stale wake events.
+    if (sessionKey && !opts?.isHeartbeat) {
+      cancelContinuationTimer(sessionKey, { sessionEntry, sessionStore, storePath });
+      removeSystemEvents(sessionKey, (e) => e.text?.startsWith("[continuation:wake]") ?? false);
+    }
     return directiveResult.reply;
   }
 
@@ -339,6 +347,13 @@ export async function getReplyFromConfig(
     skillFilter: mergedSkillFilter,
   });
   if (inlineActionResult.kind === "reply") {
+    // Inline actions (slash commands, status, etc.) bypass runReplyAgent but
+    // represent real user input — cancel timers, reset chain metadata, drain
+    // stale wake events.
+    if (sessionKey && !opts?.isHeartbeat) {
+      cancelContinuationTimer(sessionKey, { sessionEntry, sessionStore, storePath });
+      removeSystemEvents(sessionKey, (e) => e.text?.startsWith("[continuation:wake]") ?? false);
+    }
     await maybeEmitMissingResetHooks();
     return inlineActionResult.reply;
   }

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,77 +1,292 @@
-import { describe, it, expect } from "vitest";
-import { isSilentReplyPrefixText, isSilentReplyText, stripSilentToken } from "./tokens.js";
+import { describe, expect, it } from "vitest";
+import {
+  CONTINUE_WORK_TOKEN,
+  HEARTBEAT_TOKEN,
+  SILENT_REPLY_TOKEN,
+  isSilentReplyPrefixText,
+  isSilentReplyText,
+  parseContinuationSignal,
+  stripContinuationSignal,
+} from "./tokens.js";
+
+/* ------------------------------------------------------------------ */
+/*  parseContinuationSignal                                           */
+/* ------------------------------------------------------------------ */
+
+describe("parseContinuationSignal", () => {
+  it("returns null for undefined input", () => {
+    expect(parseContinuationSignal(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseContinuationSignal("")).toBeNull();
+  });
+
+  it("returns null for normal text without signals", () => {
+    expect(parseContinuationSignal("Hello, world!")).toBeNull();
+  });
+
+  it("returns null for text with signal-like words in the middle", () => {
+    expect(parseContinuationSignal("I said CONTINUE_WORK but then kept talking")).toBeNull();
+  });
+
+  // --- CONTINUE_WORK (bare) ---
+
+  it("parses bare CONTINUE_WORK at end of text", () => {
+    const result = parseContinuationSignal("CONTINUE_WORK");
+    expect(result).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  it("parses CONTINUE_WORK with leading whitespace", () => {
+    const result = parseContinuationSignal("  CONTINUE_WORK  ");
+    expect(result).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  it("parses CONTINUE_WORK after response text", () => {
+    const result = parseContinuationSignal("I finished the first task.\nCONTINUE_WORK");
+    expect(result).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  it("parses CONTINUE_WORK with trailing whitespace", () => {
+    const result = parseContinuationSignal("Done for now. CONTINUE_WORK   ");
+    expect(result).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  // --- CONTINUE_WORK with delay ---
+
+  it("parses CONTINUE_WORK:30 with 30-second delay", () => {
+    const result = parseContinuationSignal("CONTINUE_WORK:30");
+    expect(result).toEqual({ kind: "work", delayMs: 30_000 });
+  });
+
+  it("parses CONTINUE_WORK:0 with zero delay", () => {
+    const result = parseContinuationSignal("CONTINUE_WORK:0");
+    expect(result).toEqual({ kind: "work", delayMs: 0 });
+  });
+
+  it("parses CONTINUE_WORK:120 after response text", () => {
+    const result = parseContinuationSignal("Processing complete. CONTINUE_WORK:120");
+    expect(result).toEqual({ kind: "work", delayMs: 120_000 });
+  });
+
+  it("parses CONTINUE_WORK:5 with trailing whitespace", () => {
+    const result = parseContinuationSignal("CONTINUE_WORK:5  ");
+    expect(result).toEqual({ kind: "work", delayMs: 5_000 });
+  });
+
+  // --- [[CONTINUE_DELEGATE: task]] (bracket syntax) ---
+
+  it("parses [[CONTINUE_DELEGATE: task]] with simple task", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: run the tests]]");
+    expect(result).toEqual({ kind: "delegate", task: "run the tests" });
+  });
+
+  it("parses [[CONTINUE_DELEGATE: task]] after response text", () => {
+    const result = parseContinuationSignal(
+      "I'll hand this off.\n[[CONTINUE_DELEGATE: review PR #42 and leave comments]]",
+    );
+    expect(result).toEqual({
+      kind: "delegate",
+      task: "review PR #42 and leave comments",
+    });
+  });
+
+  it("parses [[CONTINUE_DELEGATE: multiline task]] naturally", () => {
+    const result = parseContinuationSignal(
+      "[[CONTINUE_DELEGATE: first do X\nthen do Y\nfinally Z]]",
+    );
+    expect(result).toEqual({
+      kind: "delegate",
+      task: "first do X\nthen do Y\nfinally Z",
+    });
+  });
+
+  it("trims whitespace from delegate task", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE:   check the logs   ]]");
+    expect(result).toEqual({ kind: "delegate", task: "check the logs" });
+  });
+
+  it("rejects empty delegate task (whitespace only)", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE:    ]]");
+    expect(result).toBeNull();
+  });
+
+  it("does not match bare CONTINUE_DELEGATE: without brackets", () => {
+    const result = parseContinuationSignal("CONTINUE_DELEGATE:run the tests");
+    expect(result).toBeNull();
+  });
+
+  it("does not match adversarial bare pattern with nested brackets (single-line)", () => {
+    const result = parseContinuationSignal('CONTINUE_DELEGATE:[[[["bc annoying"]]]]');
+    expect(result).toBeNull();
+  });
+
+  it("does not match adversarial bare pattern with nested brackets (multiline)", () => {
+    const result = parseContinuationSignal('CONTINUE_DELEGATE:[[[["bc\nannoying"]]]]');
+    expect(result).toBeNull();
+  });
+
+  it("does not match unclosed bracket", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: run the tests");
+    expect(result).toBeNull();
+  });
+
+  it("does not match mid-text bracket directive followed by more content", () => {
+    const result = parseContinuationSignal(
+      "Use [[CONTINUE_DELEGATE: example]] to delegate.\nMore text here.",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("matches only the LAST bracket directive when same token appears mid-text", () => {
+    const result = parseContinuationSignal(
+      "I used [[CONTINUE_DELEGATE: example]] earlier.\n[[CONTINUE_DELEGATE: real task]]",
+    );
+    expect(result).toEqual({ kind: "delegate", task: "real task" });
+  });
+
+  it("rejects ]] inside the task body", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: task with ]] inside]]");
+    expect(result).toBeNull();
+  });
+
+  it("matches bracket directive at end after text", () => {
+    const result = parseContinuationSignal(
+      "I've finished the analysis.\n[[CONTINUE_DELEGATE: review the results]]",
+    );
+    expect(result).toEqual({ kind: "delegate", task: "review the results" });
+  });
+
+  it("handles extra whitespace inside brackets", () => {
+    const result = parseContinuationSignal("[[  CONTINUE_DELEGATE:  do the thing  ]]");
+    expect(result).toEqual({ kind: "delegate", task: "do the thing" });
+  });
+
+  it("handles trailing whitespace after closing bracket", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: task]]   ");
+    expect(result).toEqual({ kind: "delegate", task: "task" });
+  });
+
+  // --- Precedence ---
+
+  it("prefers [[CONTINUE_DELEGATE:]] over CONTINUE_WORK when both present", () => {
+    const result = parseContinuationSignal("CONTINUE_WORK\n[[CONTINUE_DELEGATE: do something]]");
+    expect(result).toEqual({ kind: "delegate", task: "do something" });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  stripContinuationSignal                                           */
+/* ------------------------------------------------------------------ */
+
+describe("stripContinuationSignal", () => {
+  it("returns original text and null signal when no signal present", () => {
+    const result = stripContinuationSignal("Hello, world!");
+    expect(result).toEqual({ text: "Hello, world!", signal: null });
+  });
+
+  it("strips bare CONTINUE_WORK from end, returns empty text", () => {
+    const result = stripContinuationSignal("CONTINUE_WORK");
+    expect(result.text).toBe("");
+    expect(result.signal).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  it("strips CONTINUE_WORK from end of response, preserving visible text", () => {
+    const result = stripContinuationSignal("I finished the task.\nCONTINUE_WORK");
+    expect(result.text).toBe("I finished the task.");
+    expect(result.signal).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  it("strips CONTINUE_WORK:60 and preserves preceding text", () => {
+    const result = stripContinuationSignal("Processing batch 1/5. CONTINUE_WORK:60");
+    expect(result.text).toBe("Processing batch 1/5.");
+    expect(result.signal).toEqual({ kind: "work", delayMs: 60_000 });
+  });
+
+  it("strips [[CONTINUE_DELEGATE:]] and preserves preceding text", () => {
+    const result = stripContinuationSignal(
+      "I'll delegate this.\n[[CONTINUE_DELEGATE: run tests on PR #7]]",
+    );
+    expect(result.text).toBe("I'll delegate this.");
+    expect(result.signal).toEqual({
+      kind: "delegate",
+      task: "run tests on PR #7",
+    });
+  });
+
+  it("strips [[CONTINUE_DELEGATE:]] with multiline task", () => {
+    const result = stripContinuationSignal(
+      "Handing off.\n[[CONTINUE_DELEGATE: check CI\nreview the PR\nrun lint]]",
+    );
+    expect(result.text).toBe("Handing off.");
+    expect(result.signal).toEqual({
+      kind: "delegate",
+      task: "check CI\nreview the PR\nrun lint",
+    });
+  });
+
+  it("strips CONTINUE_WORK with trailing whitespace after signal", () => {
+    const result = stripContinuationSignal("Done. CONTINUE_WORK   ");
+    expect(result.text).toBe("Done.");
+    expect(result.signal).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  it("handles only-whitespace text after stripping", () => {
+    const result = stripContinuationSignal("  CONTINUE_WORK");
+    expect(result.text).toBe("");
+    expect(result.signal).toEqual({ kind: "work", delayMs: undefined });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  isSilentReplyText                                                 */
+/* ------------------------------------------------------------------ */
 
 describe("isSilentReplyText", () => {
-  it("returns true for exact token", () => {
-    expect(isSilentReplyText("NO_REPLY")).toBe(true);
-  });
-
-  it("returns true for token with surrounding whitespace", () => {
-    expect(isSilentReplyText("  NO_REPLY  ")).toBe(true);
-    expect(isSilentReplyText("\nNO_REPLY\n")).toBe(true);
-  });
-
-  it("returns false for undefined/empty", () => {
+  it("returns false for undefined", () => {
     expect(isSilentReplyText(undefined)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
     expect(isSilentReplyText("")).toBe(false);
   });
 
-  it("returns false for substantive text ending with token (#19537)", () => {
-    const text = "Here is a helpful response.\n\nNO_REPLY";
-    expect(isSilentReplyText(text)).toBe(false);
+  it("returns true for exact NO_REPLY", () => {
+    expect(isSilentReplyText("NO_REPLY")).toBe(true);
   });
 
-  it("returns false for substantive text starting with token", () => {
-    const text = "NO_REPLY but here is more content";
-    expect(isSilentReplyText(text)).toBe(false);
+  it("returns true for NO_REPLY with leading whitespace", () => {
+    expect(isSilentReplyText("  NO_REPLY")).toBe(true);
   });
 
-  it("returns false for token embedded in text", () => {
-    expect(isSilentReplyText("Please NO_REPLY to this")).toBe(false);
+  it("returns false for substantive text ending with NO_REPLY (#19537)", () => {
+    // Substantive replies ending with NO_REPLY must NOT be silently dropped.
+    // Only exact-match (entire message is NO_REPLY) should be treated as silent.
+    expect(isSilentReplyText("Some text NO_REPLY")).toBe(false);
   });
 
-  it("works with custom token", () => {
-    expect(isSilentReplyText("HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
-    expect(isSilentReplyText("Checked inbox. HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
+  it("returns false for NO_REPLY embedded in a word", () => {
+    // The regex uses \b word boundary, so embedded shouldn't match at suffix
+    // But the prefix check just looks at start-of-string
+    expect(isSilentReplyText("NOTNO_REPLY")).toBe(false);
+  });
+
+  it("returns true for HEARTBEAT_OK when token is overridden", () => {
+    expect(isSilentReplyText("HEARTBEAT_OK", HEARTBEAT_TOKEN)).toBe(true);
+  });
+
+  it("returns true for NO_REPLY followed by newline", () => {
+    expect(isSilentReplyText("NO_REPLY\n")).toBe(true);
+  });
+
+  it("returns false for normal conversational text", () => {
+    expect(isSilentReplyText("Hello, how are you?")).toBe(false);
   });
 });
 
-describe("stripSilentToken", () => {
-  it("strips token from end of text", () => {
-    expect(stripSilentToken("Done.\n\nNO_REPLY")).toBe("Done.");
-  });
-
-  it("does not strip token from start of text", () => {
-    expect(stripSilentToken("NO_REPLY 👍")).toBe("NO_REPLY 👍");
-  });
-
-  it("strips token with emoji (#30916)", () => {
-    expect(stripSilentToken("😄 NO_REPLY")).toBe("😄");
-  });
-
-  it("does not strip embedded token suffix without whitespace delimiter", () => {
-    expect(stripSilentToken("interject.NO_REPLY")).toBe("interject.NO_REPLY");
-  });
-
-  it("strips only trailing occurrence", () => {
-    expect(stripSilentToken("NO_REPLY ok NO_REPLY")).toBe("NO_REPLY ok");
-  });
-
-  it("returns empty string when only token remains", () => {
-    expect(stripSilentToken("NO_REPLY")).toBe("");
-    expect(stripSilentToken("  NO_REPLY  ")).toBe("");
-  });
-
-  it("strips token preceded by bold markdown formatting", () => {
-    expect(stripSilentToken("**NO_REPLY")).toBe("");
-    expect(stripSilentToken("some text **NO_REPLY")).toBe("some text");
-    expect(stripSilentToken("reasoning**NO_REPLY")).toBe("reasoning");
-  });
-
-  it("works with custom token", () => {
-    expect(stripSilentToken("done HEARTBEAT_OK", "HEARTBEAT_OK")).toBe("done");
-  });
-});
+/* ------------------------------------------------------------------ */
+/*  isSilentReplyPrefixText                                           */
+/* ------------------------------------------------------------------ */
 
 describe("isSilentReplyPrefixText", () => {
   it("matches uppercase token lead fragments", () => {
@@ -100,5 +315,17 @@ describe("isSilentReplyPrefixText", () => {
     expect(isSilentReplyPrefixText("NO_X")).toBe(false);
     expect(isSilentReplyPrefixText("NO_REPLY more")).toBe(false);
     expect(isSilentReplyPrefixText("NO-")).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Token constants                                                   */
+/* ------------------------------------------------------------------ */
+
+describe("token constants", () => {
+  it("exports expected token values", () => {
+    expect(HEARTBEAT_TOKEN).toBe("HEARTBEAT_OK");
+    expect(SILENT_REPLY_TOKEN).toBe("NO_REPLY");
+    expect(CONTINUE_WORK_TOKEN).toBe("CONTINUE_WORK");
   });
 });

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -2,6 +2,7 @@ import { escapeRegExp } from "../utils.js";
 
 export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
+export const CONTINUE_WORK_TOKEN = "CONTINUE_WORK";
 
 const silentExactRegexByToken = new Map<string, RegExp>();
 const silentTrailingRegexByToken = new Map<string, RegExp>();
@@ -86,4 +87,87 @@ export function isSilentReplyPrefixText(
   // uppercase words (e.g. HEART/HE with HEARTBEAT_OK). Only allow bare "NO"
   // because NO_REPLY streaming can transiently emit that fragment.
   return tokenUpper === SILENT_REPLY_TOKEN && normalized === "NO";
+}
+
+// ============================================================================
+// Continuation signal parsing
+// ============================================================================
+
+export type ContinuationSignal =
+  | { kind: "work"; delayMs?: number }
+  | { kind: "delegate"; task: string };
+
+/**
+ * Checks if the agent response ends with a continuation signal.
+ * Returns the parsed signal or null if no continuation is requested.
+ *
+ * Formats:
+ *   CONTINUE_WORK              → continue with default delay
+ *   CONTINUE_WORK:30           → continue after 30 seconds
+ *   [[CONTINUE_DELEGATE: task]] → spawn sub-agent with task (bracket syntax, multiline-safe)
+ *
+ * DELEGATE uses bracket syntax ([[...]]) following the repo convention for tokens
+ * that carry body content (see reply_to, tts, line directives). Brackets naturally
+ * delimit the boundary, so multiline tasks work without ambiguity.
+ */
+export function parseContinuationSignal(text: string | undefined): ContinuationSignal | null {
+  if (!text) {
+    return null;
+  }
+
+  const trimmed = text.trim();
+
+  // Check for [[CONTINUE_DELEGATE: task]] at end of response.
+  // The bracket pair [[ ... ]] delimits the body, so multiline tasks are safe.
+  // The negative lookahead (?!\]\]) prevents ]] inside the body from prematurely
+  // closing the bracket, and ensures we match the LAST [[CONTINUE_DELEGATE:]] when
+  // the same token appears mid-text earlier in the response.
+  const delegateMatch = trimmed.match(
+    /\[\[\s*CONTINUE_DELEGATE:\s*((?:(?!\]\])[\s\S])+?)\s*\]\]\s*$/,
+  );
+  if (delegateMatch) {
+    const task = delegateMatch[1].trim();
+    if (task) {
+      return { kind: "delegate", task };
+    }
+  }
+
+  // Check for CONTINUE_WORK or CONTINUE_WORK:<delay> at end of response
+  const workMatch = trimmed.match(/\bCONTINUE_WORK(?::(\d+))?\s*$/);
+  if (workMatch) {
+    const delaySec = workMatch[1] ? parseInt(workMatch[1], 10) : undefined;
+    return {
+      kind: "work",
+      delayMs: delaySec !== undefined ? delaySec * 1000 : undefined,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Strips the continuation signal from the response text, returning the
+ * displayable text and the parsed signal separately.
+ */
+export function stripContinuationSignal(text: string): {
+  text: string;
+  signal: ContinuationSignal | null;
+} {
+  const signal = parseContinuationSignal(text);
+  if (!signal) {
+    return { text, signal: null };
+  }
+
+  let stripped: string;
+  if (signal.kind === "delegate") {
+    // Strip the [[CONTINUE_DELEGATE: ...]] bracket directive.
+    // Mirrors the parser grammar exactly.
+    stripped = text.replace(/\[\[\s*CONTINUE_DELEGATE:\s*(?:(?!\]\])[\s\S])+?\s*\]\]\s*$/, "");
+  } else {
+    // Only strip CONTINUE_WORK when it's the signal type parsed
+    stripped = text.replace(/\bCONTINUE_WORK(?::\d+)?\s*$/, "");
+  }
+  stripped = stripped.trimEnd();
+
+  return { text: stripped, signal };
 }

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -164,6 +164,12 @@ export type SessionEntry = {
   skillsSnapshot?: SessionSkillSnapshot;
   systemPromptReport?: SessionSystemPromptReport;
   acp?: SessionAcpMeta;
+  /** Number of continuation turns completed in the current chain. Reset on external message. */
+  continuationChainCount?: number;
+  /** Timestamp (ms) when the current continuation chain started. */
+  continuationChainStartedAt?: number;
+  /** Accumulated token usage across the current continuation chain. Reset on external message. */
+  continuationChainTokens?: number;
 };
 
 function normalizeRuntimeField(value: string | undefined): string | undefined {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -277,6 +277,15 @@ export type AgentDefaultsConfig = {
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;
+  /** Agent self-elected turn continuation (CONTINUE_WORK signal). */
+  continuation?: {
+    enabled?: boolean;
+    defaultDelayMs?: number;
+    minDelayMs?: number;
+    maxDelayMs?: number;
+    maxChainLength?: number;
+    costCapTokens?: number;
+  };
 };
 
 export type AgentCompactionMode = "default" | "safeguard";

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -177,6 +177,17 @@ export const AgentDefaultsSchema = z
       .strict()
       .optional(),
     sandbox: AgentSandboxSchema,
+    continuation: z
+      .object({
+        enabled: z.boolean().optional(),
+        defaultDelayMs: z.number().int().positive().optional(),
+        minDelayMs: z.number().int().positive().optional(),
+        maxDelayMs: z.number().int().positive().optional(),
+        maxChainLength: z.number().int().positive().optional(),
+        costCapTokens: z.number().int().nonnegative().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -100,6 +100,40 @@ export function drainSystemEvents(sessionKey: string): string[] {
   return drainSystemEventEntries(sessionKey).map((event) => event.text);
 }
 
+/**
+ * Remove system events matching a predicate without draining the entire queue.
+ * Returns the removed events; non-matching events stay queued.
+ */
+export function removeSystemEvents(
+  sessionKey: string,
+  predicate: (event: SystemEvent) => boolean,
+): SystemEvent[] {
+  const key = requireSessionKey(sessionKey);
+  const entry = queues.get(key);
+  if (!entry || entry.queue.length === 0) {
+    return [];
+  }
+  const removed: SystemEvent[] = [];
+  entry.queue = entry.queue.filter((event) => {
+    if (predicate(event)) {
+      removed.push(event);
+      return false;
+    }
+    return true;
+  });
+  if (entry.queue.length === 0) {
+    queues.delete(key);
+  } else if (removed.length > 0) {
+    // Reset dedup state to reflect actual queue contents — prevents
+    // stale lastText from silently dropping future events that match
+    // a removed event's text.
+    const last = entry.queue[entry.queue.length - 1];
+    entry.lastText = last.text;
+    entry.lastContextKey = last.contextKey ?? null;
+  }
+  return removed;
+}
+
 export function peekSystemEventEntries(sessionKey: string): SystemEvent[] {
   const key = requireSessionKey(sessionKey);
   return queues.get(key)?.queue.map((event) => ({ ...event })) ?? [];


### PR DESCRIPTION
## Description

Adds two primitives for agent autonomy in persistent sessions: **self-elected turn continuation** and **gateway-native sub-agent delegation**.

_Supersedes #32843 and #33499 (same feature, clean PR to clear stale automated review noise)._

### CONTINUE_WORK — Self-Elected Continuation

Agents emit `CONTINUE_WORK` (or `CONTINUE_WORK:<delay>`) as a response token to schedule their own next turn. The gateway detects the signal post-run, strips it from display output, and schedules a continuation via `enqueueSystemEvent` + `requestHeartbeatNow`.

- **Opt-in only** — `agents.defaults.continuation.enabled` must be `true`
- **Chain limits** — max length (default 10), cost cap (default 500K tokens)
- **Delay clamping** — 5s–5min range enforced
- **Preemption** — external messages (including slash commands and inline actions) cancel pending continuations and reset chain state
- **Chain tracking** — `continuationChainCount`, `continuationChainStartedAt`, `continuationChainTokens` on session metadata, persisted to disk

### [[CONTINUE_DELEGATE: task]] — Gateway-Native Delegation

Agents emit `[[CONTINUE_DELEGATE: task]]` (bracket syntax, following repo conventions for body-carrying tokens) to spawn a sub-agent directly at the gateway layer via `spawnSubagentDirect()`. No continuation timer — the sub-agent's completion announcement is the wake signal.

- Bracket syntax `[[ ]]` matches existing repo patterns (`[[reply_to:]]`, `[[tts:text]]`, LINE directives)
- Task can be multiline (brackets delimit the boundary)
- `]]` inside task body is rejected (delimiter ambiguity)
- Spawn status checked — non-accepted results queue a fallback system event

### Safety Model

| Constraint           | Mechanism                                                   |
| -------------------- | ----------------------------------------------------------- |
| Opt-in               | `agents.defaults.continuation.enabled` config flag          |
| Chain runaway        | `maxChainLength` + `costCapTokens` (persisted to disk)      |
| Ghost continuations  | Timer cancellation on external message + generation counter |
| Delay abuse          | Min/max clamping (5s–300s)                                  |
| Spawn failure        | Graceful fallback to system event                           |
| Feature-gated strip  | Stripping only runs when `continuation.enabled === true`    |
| Early-return cancel  | Slash commands/inline actions also cancel pending timers    |

### Token Pattern

Follows the established `NO_REPLY` / `HEARTBEAT_OK` convention:
- `CONTINUE_WORK` — bare token (no body, no brackets needed)
- `[[CONTINUE_DELEGATE: task]]` — bracket-delimited (body-carrying, matches repo convention)
- Signal-in-response-body, post-run detection only (not streaming partials), stripped from display output

### Tests

88 tests total:
- **Token parsing** (50): bare signal, delay variants, bracket delegate, multiline, adversarial patterns, double-occurrence disambiguation, stripping
- **Integration** (38): feature-disabled path, no false trigger, timer cancellation, delay clamping, DELEGATE spawn paths, chain cap enforcement, cost cap default, user-spoof rejection, heartbeat preemption guard

### Docs

- RFC v1 + v2 (problem statement, spec, temporal self-sharding, prior art)

### What This Enables

- Agent-elected work continuation without cron or external whip
- Gateway-native sub-agent delegation as a response-level primitive
- Temporal self-sharding — multiple shards carrying different aspects, timed returns

### Known Gaps / Follow-ups

- **Delegation chain awareness**: Sub-agent completions reset parent chain state. Bounded by `maxChildrenPerAgent` (default 5). Chain-aware completions need design work.
- **USD-based cost cap**: Current implementation tracks raw token count.
- **Lifecycle events**: Chain start/stop/limit-reached events for monitoring dashboards.

Resolves: #32701
Related: #32891

---

_The design intentionally keeps dwindle (natural stop) as the default. Continuation is the exception the agent must actively choose._

