### PR TITLE
fix(telegram): case-insensitive botUsername in hasBotMention (#19883)

### DIFF
--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -300,7 +300,7 @@ async function resolveImagesForRequest(
   for (const url of urls) {
     const source = parseImageUrlToSource(url);
     if (source.type === "base64") {
-      totalBytes += estimateBase64DecodedBytes(source.data);
+      totalBytes += estimateBase64DecodedBytes(source.data ?? "");
       if (totalBytes > limits.maxTotalImageBytes) {
         throw new Error(
           `Total image payload too large (${totalBytes}; limit ${limits.maxTotalImageBytes})`,

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   buildTypingThreadParams,
   describeReplyTarget,
   expandTextLinks,
+  hasBotMention,
   normalizeForwardedContext,
   resolveTelegramDirectPeerId,
   resolveTelegramForumThreadId,
@@ -393,5 +394,50 @@ describe("expandTextLinks", () => {
     const text = " Hello world";
     const entities = [{ type: "text_link", offset: 1, length: 5, url: "https://example.com" }];
     expect(expandTextLinks(text, entities)).toBe(" [Hello](https://example.com) world");
+  });
+});
+
+describe("hasBotMention (issue #19883: forum topic mention detection)", () => {
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const forumMsg = (text: string, entities?: unknown[]): any => ({
+    text,
+    entities,
+    chat: { id: -1001234567890, type: "supergroup", is_forum: true },
+    message_thread_id: 42,
+  });
+
+  it("detects mention when text uses lowercase but botUsername has mixed case", () => {
+    // User types '@mybot' (lowercase) in a forum topic; API registers botUsername as 'MyBot'.
+    // text.includes(`@${'MyBot'}`) compares 'hello @mybot' against '@MyBot' → false on buggy main.
+    const msg = forumMsg("hello @mybot can you help?");
+    expect(hasBotMention(msg, "MyBot")).toBe(true);
+  });
+
+  it("detects mention via entity when entity slice has different case than botUsername", () => {
+    // User types '@MYBOT' (all caps). text lowercased ('@mybot') vs '@MyBot' → false.
+    // Entity slice '.slice(6,12)' = '@MYBOT', lowercased = '@mybot', vs '@MyBot' → false on buggy main.
+    const msg = forumMsg("hello @MYBOT here", [{ type: "mention", offset: 6, length: 6 }]);
+    expect(hasBotMention(msg, "MyBot")).toBe(true);
+  });
+
+  it("returns false when bot is not mentioned at all", () => {
+    const msg = forumMsg("just chatting here");
+    expect(hasBotMention(msg, "MyBot")).toBe(false);
+  });
+
+  it("detects mention when both text and botUsername are already lowercase", () => {
+    const msg = forumMsg("hello @mybot please answer");
+    expect(hasBotMention(msg, "mybot")).toBe(true);
+  });
+
+  it("uses caption when text is absent (forum photo message)", () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const msg: any = {
+      caption: "@mybot please describe this image",
+      caption_entities: [{ type: "mention", offset: 0, length: 6 }],
+      chat: { id: -1001234567890, type: "supergroup", is_forum: true },
+      message_thread_id: 42,
+    };
+    expect(hasBotMention(msg, "MyBot")).toBe(true);
   });
 });

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -281,8 +281,9 @@ export function buildGroupLabel(msg: Message, chatId: number | string, messageTh
 }
 
 export function hasBotMention(msg: Message, botUsername: string) {
+  const lowerUsername = botUsername.toLowerCase();
   const text = (msg.text ?? msg.caption ?? "").toLowerCase();
-  if (text.includes(`@${botUsername}`)) {
+  if (text.includes(`@${lowerUsername}`)) {
     return true;
   }
   const entities = msg.entities ?? msg.caption_entities ?? [];
@@ -291,7 +292,7 @@ export function hasBotMention(msg: Message, botUsername: string) {
       continue;
     }
     const slice = (msg.text ?? msg.caption ?? "").slice(ent.offset, ent.offset + ent.length);
-    if (slice.toLowerCase() === `@${botUsername}`) {
+    if (slice.toLowerCase() === `@${lowerUsername}`) {
       return true;
     }
   }


### PR DESCRIPTION
## Problem

In Telegram forum topics, messages that mention the bot via `@BotUsername` are silently ignored. The bot never responds even though the mention is present in the text. The issue also affects captions in photo/video messages sent to forum topics.

## Root Cause

`hasBotMention()` in `src/telegram/bot/helpers.ts` lowercases the message text but **does not lowercase `botUsername`** before comparison. Both the text-includes check and the entity-slice check compare against the raw (potentially mixed-case) `botUsername`, causing a case mismatch failure for any user who types the mention in a different case than the API-registered username.

```typescript
// BEFORE (buggy):
const text = (msg.text ?? ...).toLowerCase();
if (text.includes(`@${botUsername}`)) { ... }  // botUsername not lowercased!
```

## Fix

Compute `lowerUsername = botUsername.toLowerCase()` once at function entry and substitute it in both comparison sites.

```typescript
// AFTER (fixed):
const lowerUsername = botUsername.toLowerCase();
const text = (msg.text ?? ...).toLowerCase();
if (text.includes(`@${lowerUsername}`)) { ... }
```

## Verification

- **Test:** `src/telegram/bot/helpers.test.ts` — 5 new tests in `describe("hasBotMention (issue #19883)")` covering lowercase text vs mixed-case username, entity-based detection, caption detection, and negative case
- **Fails on main:** `test-fail-on-main.log` shows 3 failures confirming the bug
- **Passes on fix:** `test-pass-on-fix.log` shows all 44 tests passing
- **Build:** clean compile (`build-output.log`)
- **Test suite:** no regressions (`test-output.log`)
- **Code proof:** old pattern removed, new pattern confirmed (`step6-verify.log`)

Closes #19883