### PR TITLE
security: apply default security headers to extension relay server

### DIFF
--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -3,6 +3,7 @@ import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { Duplex } from "node:stream";
 import WebSocket, { WebSocketServer } from "ws";
+import { setDefaultSecurityHeaders } from "../gateway/http-common.js";
 import { isLoopbackAddress, isLoopbackHost } from "../gateway/net.js";
 import { rawDataToString } from "../infra/ws.js";
 import {
@@ -525,6 +526,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
     };
 
     const server = createServer((req, res) => {
+      setDefaultSecurityHeaders(res);
       const url = new URL(req.url ?? "/", info.baseUrl);
       const path = url.pathname;
       const origin = getHeader(req, "origin");


### PR DESCRIPTION
## Summary

- Call `setDefaultSecurityHeaders()` in the browser extension relay HTTP server
- The relay creates its own `http.createServer()` outside the gateway, so responses lack the baseline headers the gateway applies
- Adds `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, and `Permissions-Policy` to all relay responses

## Test plan

- [x] `src/browser/extension-relay.test.ts` passes (28 tests)
- [ ] Verify headers present on relay HTTP responses