### PR TITLE
fix: treat systemd unit not-found as disabled

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,6 +79,19 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false when systemctl reports not-found on stdout", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & { code?: number };
+      err.code = 4;
+      cb(err, "not-found", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
   it("throws when systemctl is-enabled fails for non-state errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1,14 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import {
-  LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
-  resolveGatewayServiceDescription,
-  resolveGatewaySystemdServiceName,
-} from "./constants.js";
-import { execFileUtf8 } from "./exec-file.js";
-import { formatLine, toPosixPath, writeFormattedLines } from "./output.js";
-import { resolveHomeDir } from "./paths.js";
-import { parseKeyValueOutput } from "./runtime-parse.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
 import type {
   GatewayServiceCommandConfig,
@@ -18,6 +9,15 @@ import type {
   GatewayServiceInstallArgs,
   GatewayServiceManageArgs,
 } from "./service-types.js";
+import {
+  LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
+  resolveGatewayServiceDescription,
+  resolveGatewaySystemdServiceName,
+} from "./constants.js";
+import { execFileUtf8 } from "./exec-file.js";
+import { formatLine, toPosixPath, writeFormattedLines } from "./output.js";
+import { resolveHomeDir } from "./paths.js";
+import { parseKeyValueOutput } from "./runtime-parse.js";
 import {
   enableSystemdUserLinger,
   readSystemdUserLingerStatus,
@@ -143,7 +143,12 @@ async function execSystemctl(
 }
 
 function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
-  return (result.stderr || result.stdout || "").trim();
+  const stderr = result.stderr.trim();
+  const stdout = result.stdout.trim();
+  if (stderr && stdout && stderr !== stdout) {
+    return `${stderr} ${stdout}`.trim();
+  }
+  return (stderr || stdout || "").trim();
 }
 
 function isSystemctlMissing(detail: string): boolean {


### PR DESCRIPTION
Fixes #33633.

## Summary
- preserve `stdout` detail when `execFileUtf8` falls back to a generic command-failed message
- treat `systemctl --user is-enabled ...` returning `not-found` as a disabled/missing unit instead of an unavailable systemctl error
- add a regression test for the Ubuntu `exit 4 + stdout=not-found` case

## Testing
- `pnpm vitest run src/daemon/systemd.test.ts`

## AI-assisted
- AI-assisted: yes
- Testing: targeted regression test run locally
- I verified the code path and understand the change