### PR TITLE
fix(gateway): stop forcing low thinking on voice transcripts

### DIFF
--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -338,6 +338,8 @@ describe("voice transcript events", () => {
         sourceTool: "gateway.voice.transcript",
       },
     });
+    expect(opts.thinking).toBeUndefined();
+    expect(opts.thinkingOnce).toBeUndefined();
   });
 
   it("does not block agent dispatch when session-store touch fails", async () => {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -308,7 +308,6 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
           message: text,
           sessionId,
           sessionKey: canonicalKey,
-          thinking: "low",
           deliver: false,
           messageChannel: "node",
           inputProvenance: {


### PR DESCRIPTION
## Summary
- Remove forced `thinking: "low"` override from gateway `voice.transcript` ingress.
- Let voice transcripts inherit the target session's configured/default thinking level.
- Add regression assertions to ensure no `thinking` or `thinkingOnce` override is injected by this path.

## Problem
`voice.transcript` currently passes `thinking: "low"` into `agentCommandFromIngress`.
That can persist as session-level thinking in downstream handling, which unexpectedly downgrades sessions (e.g., `agent:main:main`) after voice traffic.

## Root Cause
`src/gateway/server-node-events.ts` hardcodes `thinking: "low"` in the `voice.transcript` handler.

## Fix
- Remove the forced thinking override in `voice.transcript` dispatch.
- Keep existing dedupe, session-store touch, and provenance behavior unchanged.

## Tests
- Updated `src/gateway/server-node-events.test.ts` to explicitly assert:
  - `opts.thinking` is `undefined`
  - `opts.thinkingOnce` is `undefined`
- Ran targeted test:
  - `corepack pnpm test:gateway src/gateway/server-node-events.test.ts`
  - Result: `20 passed`.

## Notes
This change is intentionally narrow: it only removes thinking override injection at gateway ingress and does not alter voice-call extension response-generator behavior.
