### PR TITLE
fix(workspace): auto-create memory/ directory during bootstrap

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -141,6 +141,15 @@ describe("ensureAgentWorkspace", () => {
     expect(memoryContent).toBe("# Long-term memory\nImportant stuff");
   });
 
+  it("creates memory/ directory automatically during bootstrap", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    const stat = await fs.stat(path.join(tempDir, "memory"));
+    expect(stat.isDirectory()).toBe(true);
+  });
+
   it("treats git-backed workspaces as existing even when template files are missing", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await fs.mkdir(path.join(tempDir, ".git"), { recursive: true });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -446,6 +446,10 @@ export async function ensureAgentWorkspace(params?: {
   }
   await ensureGitRepo(dir, isBrandNewWorkspace);
 
+  // Ensure the memory/ directory exists so memory tools work immediately
+  // without requiring a prior write operation to create it.
+  await fs.mkdir(path.join(dir, "memory"), { recursive: true });
+
   return {
     dir,
     agentsPath,


### PR DESCRIPTION
## Problem

When a new workspace is bootstrapped via `ensureAgentWorkspace`, the `memory/` directory is never explicitly created. Memory tools (`memory_search`, `memory_get`) and file writes to `memory/` can fail on fresh workspaces until some other operation happens to create the directory.

Reported in #33773.

## Fix

Add `fs.mkdir(path.join(dir, "memory"), { recursive: true })` at the end of `ensureAgentWorkspace` — safe, idempotent, and ensures the directory exists from the start.

## Test

Added a test verifying `memory/` is created automatically during workspace bootstrap.

All 16 workspace tests pass.