### PR TITLE
fix(telegram): coalesce DM streaming into single message in partial mode

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -311,7 +311,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(loadSessionStore).toHaveBeenCalledWith("/tmp/sessions.json", { skipCache: true });
   });
 
-  it("does not overwrite finalized preview when additional final payloads are sent", async () => {
+  it("does not overwrite finalized preview when additional final payloads are sent (block mode)", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
@@ -325,7 +325,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     deliverReplies.mockResolvedValue({ delivered: true });
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(editMessageTelegram).toHaveBeenCalledTimes(1);
     expect(editMessageTelegram).toHaveBeenCalledWith(
@@ -400,27 +400,47 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it.each(["block", "partial"] as const)(
-    "forces new message when assistant message restarts (%s mode)",
-    async (streamMode) => {
-      const draftStream = createDraftStream(999);
-      createTelegramDraftStream.mockReturnValue(draftStream);
-      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-        async ({ dispatcherOptions, replyOptions }) => {
-          await replyOptions?.onPartialReply?.({ text: "First response" });
-          await replyOptions?.onAssistantMessageStart?.();
-          await replyOptions?.onPartialReply?.({ text: "After tool call" });
-          await dispatcherOptions.deliver({ text: "After tool call" }, { kind: "final" });
-          return { queuedFinal: true };
-        },
-      );
-      deliverReplies.mockResolvedValue({ delivered: true });
+  it("forces new message when assistant message restarts in block mode", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "First response" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "After tool call" });
+        await dispatcherOptions.deliver({ text: "After tool call" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
 
-      await dispatchWithContext({ context: createContext(), streamMode });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
-      expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
-    },
-  );
+    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not force new message in partial mode — coalesces across turns", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "First response" });
+        await dispatcherOptions.deliver({ text: "First response" }, { kind: "final" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "After tool call" });
+        await dispatcherOptions.deliver({ text: "After tool call" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+    // Stream revived after first finalization to allow continued editing
+    expect(draftStream.revive).toHaveBeenCalled();
+  });
 
   it("materializes boundary preview and keeps it when no matching final arrives", async () => {
     const answerDraftStream = createDraftStream(999);
@@ -436,7 +456,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     const bot = createBot();
-    await dispatchWithContext({ context: createContext(), streamMode: "partial", bot });
+    await dispatchWithContext({ context: createContext(), streamMode: "block", bot });
 
     expect(answerDraftStream.materialize).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
@@ -476,7 +496,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     deliverReplies.mockResolvedValue({ delivered: true });
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(editMessageTelegram).toHaveBeenCalledTimes(2);
@@ -507,7 +527,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     const bot = createBot();
-    await dispatchWithContext({ context: createContext(), streamMode: "partial", bot });
+    await dispatchWithContext({ context: createContext(), streamMode: "block", bot });
 
     expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
     const deleteMessageCalls = (
@@ -543,7 +563,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       return { queuedFinal: false };
     });
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.materialize).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
@@ -575,7 +595,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     deliverReplies.mockResolvedValue({ delivered: true });
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(editMessageTelegram).toHaveBeenNthCalledWith(
@@ -637,7 +657,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     deliverReplies.mockResolvedValue({ delivered: true });
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Message B early");
@@ -684,7 +704,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
     const bot = createBot();
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial", bot });
+    await dispatchWithContext({ context: createContext(), streamMode: "block", bot });
 
     // Early pre-rotation could not force (no streamed partials yet), so the
     // real assistant message_start must still rotate once.
@@ -766,7 +786,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     deliverReplies.mockResolvedValue({ delivered: true });
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(2);
     expect(editMessageTelegram).toHaveBeenNthCalledWith(
@@ -1186,7 +1206,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
-        previewTransport: "auto",
+        previewTransport: "message",
       }),
     );
     expect(createTelegramDraftStream.mock.calls[1]?.[0]).toEqual(

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -180,6 +180,8 @@ export const dispatchTelegramMessage = async ({
   const forceBlockStreamingForReasoning = resolvedReasoningLevel === "on";
   const streamReasoningDraft = resolvedReasoningLevel === "stream";
   const previewStreamingEnabled = streamMode !== "off";
+  const shouldSplitPreviewMessages = streamMode !== "partial";
+  const useDmMessageTransport = threadSpec?.scope === "dm";
   const canStreamAnswerDraft =
     previewStreamingEnabled && !accountBlockStreamingEnabled && !forceBlockStreamingForReasoning;
   const canStreamReasoningDraft = canStreamAnswerDraft || streamReasoningDraft;
@@ -190,15 +192,16 @@ export const dispatchTelegramMessage = async ({
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
-    const useMessagePreviewTransportForDmReasoning =
-      laneName === "reasoning" && threadSpec?.scope === "dm" && canStreamAnswerDraft;
+    const useMessagePreviewTransportForDm =
+      useDmMessageTransport ||
+      (laneName === "reasoning" && threadSpec?.scope === "dm" && canStreamAnswerDraft);
     const stream = enabled
       ? createTelegramDraftStream({
           api: bot.api,
           chatId,
           maxChars: draftMaxChars,
           thread: threadSpec,
-          previewTransport: useMessagePreviewTransportForDmReasoning ? "message" : "auto",
+          previewTransport: useMessagePreviewTransportForDm ? "message" : "auto",
           replyToMessageId: draftReplyToMessageId,
           minInitialChars: draftMinInitialChars,
           renderText: renderDraftPreview,
@@ -325,10 +328,15 @@ export const dispatchTelegramMessage = async ({
     const split = splitTextIntoLaneSegments(text);
     const hasAnswerSegment = split.segments.some((segment) => segment.lane === "answer");
     if (hasAnswerSegment && finalizedPreviewByLane.answer) {
-      // Some providers can emit the first partial of a new assistant message before
-      // onAssistantMessageStart() arrives. Rotate preemptively so we do not edit
-      // the previously finalized preview message with the next message's text.
-      skipNextAnswerMessageStartRotation = await rotateAnswerLaneForNewAssistantMessage();
+      if (shouldSplitPreviewMessages) {
+        // Some providers can emit the first partial of a new assistant message before
+        // onAssistantMessageStart() arrives. Rotate preemptively so we do not edit
+        // the previously finalized preview message with the next message's text.
+        skipNextAnswerMessageStartRotation = await rotateAnswerLaneForNewAssistantMessage();
+      } else {
+        // In partial (coalesced) mode, allow continued editing of the same message.
+        finalizedPreviewByLane.answer = false;
+      }
     }
     for (const segment of split.segments) {
       if (segment.lane === "reasoning") {
@@ -515,6 +523,7 @@ export const dispatchTelegramMessage = async ({
             // Assistant callbacks are fire-and-forget; ensure queued boundary
             // rotations/partials are applied before final delivery mapping.
             await enqueueDraftLaneEvent(async () => {});
+            // In partial mode, if a message-start boundary has been seen
           }
           const previewButtons = (
             payload.channelData?.telegram as { buttons?: TelegramInlineButtons } | undefined
@@ -562,6 +571,10 @@ export const dispatchTelegramMessage = async ({
               infoKind: info.kind,
               previewButtons,
               allowPreviewUpdateForNonFinal: segment.lane === "reasoning",
+              // In partial mode, allow re-editing a finalized preview when the
+              // stream has been revived. This lets subsequent finals in a batch
+              // (from buffered block dispatcher) coalesce into the same message.
+              allowRefinalize: !shouldSplitPreviewMessages && segment.lane === "answer",
             });
             if (segment.lane === "reasoning") {
               if (result !== "skipped") {
@@ -575,6 +588,12 @@ export const dispatchTelegramMessage = async ({
                 finalizedPreviewByLane.reasoning = true;
               }
               reasoningStepState.resetForNextStep();
+              // In partial (coalesced) mode, keep the stream alive after
+              // finalization so the next tool-call turn can continue editing
+              // the same message. The finally block will stop it for good.
+              if (!shouldSplitPreviewMessages && result === "preview-finalized") {
+                answerLane.stream?.revive?.();
+              }
             }
           }
           if (segments.length > 0) {
@@ -649,8 +668,17 @@ export const dispatchTelegramMessage = async ({
               enqueueDraftLaneEvent(async () => {
                 reasoningStepState.resetForNextStep();
                 if (skipNextAnswerMessageStartRotation) {
+                  // Block-mode pre-rotation already handled this boundary — do not
+                  // reset lane state here as that would clear hasStreamedMessage
+                  // set by the partial that triggered the pre-rotation.
                   skipNextAnswerMessageStartRotation = false;
                   finalizedPreviewByLane.answer = false;
+                  return;
+                }
+                if (!shouldSplitPreviewMessages) {
+                  // In partial (coalesced) mode, reset lane tracking state but keep
+                  // the same stream message — allowing continued editing in place.
+                  resetDraftLaneState(answerLane);
                   return;
                 }
                 await rotateAnswerLaneForNewAssistantMessage();

--- a/src/telegram/draft-stream.test-helpers.ts
+++ b/src/telegram/draft-stream.test-helpers.ts
@@ -13,6 +13,7 @@ export type TestDraftStream = {
   stop: ReturnType<typeof vi.fn<() => Promise<void>>>;
   materialize: ReturnType<typeof vi.fn<() => Promise<number | undefined>>>;
   forceNewMessage: ReturnType<typeof vi.fn<() => void>>;
+  revive: ReturnType<typeof vi.fn<() => void>>;
   setMessageId: (value: number | undefined) => void;
 };
 
@@ -47,6 +48,7 @@ export function createTestDraftStream(params?: {
         messageId = undefined;
       }
     }),
+    revive: vi.fn(),
     setMessageId: (value: number | undefined) => {
       messageId = value;
     },
@@ -77,6 +79,7 @@ export function createSequencedTestDraftStream(startMessageId = 1001): TestDraft
     forceNewMessage: vi.fn().mockImplementation(() => {
       activeMessageId = undefined;
     }),
+    revive: vi.fn(),
     setMessageId: (value: number | undefined) => {
       activeMessageId = value;
     },

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -66,6 +66,8 @@ export type TelegramDraftStream = {
   materialize?: () => Promise<number | undefined>;
   /** Reset internal state so the next update creates a new message instead of editing. */
   forceNewMessage: () => void;
+  /** Re-open the stream lifecycle without clearing messageId or incrementing generation. */
+  revive?: () => void;
 };
 
 type TelegramDraftPreview = {
@@ -337,6 +339,7 @@ export function createTelegramDraftStream(params: {
   const forceNewMessage = () => {
     // Boundary rotation may call stop() to finalize the previous draft.
     // Re-open the stream lifecycle for the next assistant segment.
+    streamState.stopped = false;
     streamState.final = false;
     generation += 1;
     streamMessageId = undefined;
@@ -401,5 +404,11 @@ export function createTelegramDraftStream(params: {
     stop,
     materialize,
     forceNewMessage,
+    /** Re-open the stream lifecycle without clearing messageId or incrementing generation.
+     *  Used after a flush-stop to keep editing the same message. */
+    revive: () => {
+      streamState.stopped = false;
+      streamState.final = false;
+    },
   };
 }

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -81,6 +81,10 @@ type DeliverLaneTextParams = {
   infoKind: string;
   previewButtons?: TelegramInlineButtons;
   allowPreviewUpdateForNonFinal?: boolean;
+  /** When true, ignore the finalizedPreviewByLane guard and allow re-editing
+   *  a previously finalized preview. Used in partial (coalesced) streaming mode
+   *  where multiple finals should edit the same message. */
+  allowRefinalize?: boolean;
 };
 
 type TryUpdatePreviewParams = {
@@ -330,6 +334,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     infoKind,
     previewButtons,
     allowPreviewUpdateForNonFinal = false,
+    allowRefinalize = false,
   }: DeliverLaneTextParams): Promise<LaneDeliveryResult> => {
     const lane = params.lanes[laneName];
     const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
@@ -349,7 +354,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           return archivedResult;
         }
       }
-      if (canEditViaPreview && !params.finalizedPreviewByLane[laneName]) {
+      if (canEditViaPreview && (allowRefinalize || !params.finalizedPreviewByLane[laneName])) {
         await params.flushDraftLane(lane);
         if (laneName === "answer") {
           const archivedResultAfterFlush = await consumeArchivedAnswerPreviewForFinal({


### PR DESCRIPTION
## Summary

When streaming mode is `partial`, responses with multiple tool-call round-trips now coalesce into a single progressively-edited Telegram message instead of sending separate message fragments. Aligns Telegram DM behavior with Discord's existing `shouldSplitPreviewMessages` pattern.

## Three bugs fixed

### 1. `draft-stream.ts` — stream dies at tool-call boundaries
`forceNewMessage()` didn't reset `streamState.stopped`. Added `revive()` method that re-opens the stream lifecycle without clearing `messageId` or incrementing generation — allowing continued editing of the same message.

### 2. `bot-message-dispatch.ts` — no mode gating on rotation
`rotateAnswerLane` was called unconditionally on assistant message boundaries. Now gated behind `shouldSplitPreviewMessages` (block mode only). In partial mode, `resetDraftLaneState()` is called instead, keeping the same stream message. After preview finalization, `revive()` re-opens the stream for subsequent finals.

### 3. `lane-delivery.ts` — finalized guard blocks subsequent finals
`finalizedPreviewByLane.answer = true` blocked ALL subsequent finals from editing preview. Added `allowRefinalize` parameter that bypasses the guard in partial mode while preserving cleanup behavior (the flag stays `true` so the `finally` block correctly skips `clear()`).

### DM transport
Forces `message` transport (`sendMessage`+`editMessageText`) for all DM lanes, not just reasoning. The `sendMessageDraft` transport has no real `messageId`, preventing edits.

## Testing
- Existing tests that tested rotation behavior updated to explicitly use `streamMode: "block"`
- New test: `does not force new message in partial mode — coalesces across turns`
- All 6562 tests passing
- Live-tested on Telegram DM: responses with 2-8 tool calls consistently coalesce into single message

Closes #32535
Fixes #33492