### PR TITLE
test(openai-codex): cover numeric, zero, and null credits balance in fetchCodexUsage

### DIFF
--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -80,6 +80,63 @@ describe("fetchCodexUsage", () => {
     ]);
   });
 
+  it("handles numeric credits balance", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          primary_window: {
+            limit_window_seconds: 10_800,
+            used_percent: 10,
+            reset_at: 1_700_000_000,
+          },
+        },
+        plan_type: "Pro",
+        credits: { balance: 5.75 },
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+    expect(result.plan).toBe("Pro ($5.75)");
+  });
+
+  it("handles zero credits balance without hiding the plan", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          primary_window: {
+            limit_window_seconds: 10_800,
+            used_percent: 0,
+            reset_at: 1_700_000_000,
+          },
+        },
+        plan_type: "Plus",
+        credits: { balance: 0 },
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+    expect(result.plan).toBe("Plus ($0.00)");
+  });
+
+  it("handles null credits balance gracefully", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          primary_window: {
+            limit_window_seconds: 10_800,
+            used_percent: 5,
+            reset_at: 1_700_000_000,
+          },
+        },
+        plan_type: "Free",
+        credits: { balance: null },
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+    expect(result.plan).toBe("Free");
+  });
+
   it("labels secondary window as Week when reset cadence clearly exceeds one day", async () => {
     const primaryReset = 1_700_000_000;
     const weeklyLikeSecondaryReset = primaryReset + 5 * 24 * 60 * 60;


### PR DESCRIPTION
## Problem

The existing test for `fetchCodexUsage` only exercised `credits.balance` as a **string** (`"12.5"`). The production code has three distinct branches for this field:

```ts
const balance =
  typeof data.credits.balance === "number"
    ? data.credits.balance                          // ← not tested
    : parseFloat(data.credits.balance) || 0;        // ← "|| 0" hides zero balance
```

Two real-world edge cases were uncovered:
1. **Numeric balance** — API returns `5.75` (number, not string) → was handled correctly but never tested.
2. **Zero balance** — API returns `0` → the `|| 0` short-circuit means `parseFloat("0") || 0` still works, but the intent wasn't verified.
3. **Null balance** — explicitly allowed by the `CodexUsageResponse` type → production skips the block but no test confirmed this.

## Solution

Add three focused test cases to `provider-usage.fetch.codex.test.ts`:

| Case | Input | Expected plan |
|---|---|---|
| Numeric balance | `{ balance: 5.75 }` | `"Pro ($5.75)"` |
| Zero balance | `{ balance: 0 }` | `"Plus ($0.00)"` |
| Null balance | `{ balance: null }` | `"Free"` (balance omitted) |

No production code is changed.