### PR TITLE
fix(signal): use JSON-RPC version as primary probe instead of REST check

### DIFF
--- a/src/signal/probe.test.ts
+++ b/src/signal/probe.test.ts
@@ -30,18 +30,47 @@ describe("probeSignal", () => {
     expect(res.status).toBe(200);
   });
 
-  it("returns ok=false when /check fails", async () => {
+  it("returns ok=true when /check fails but JSON-RPC version succeeds", async () => {
     signalCheckMock.mockResolvedValueOnce({
       ok: false,
-      status: 503,
-      error: "HTTP 503",
+      status: 404,
+      error: "HTTP 404",
     });
+    signalRpcRequestMock.mockResolvedValueOnce({ version: "0.13.24" });
+
+    const res = await probeSignal("http://127.0.0.1:8080", 1000);
+
+    expect(res.ok).toBe(true);
+    expect(res.version).toBe("0.13.24");
+  });
+
+  it("returns ok=false when both /check and JSON-RPC fail", async () => {
+    signalCheckMock.mockResolvedValueOnce({
+      ok: false,
+      status: null,
+      error: "fetch failed",
+    });
+    signalRpcRequestMock.mockRejectedValueOnce(new Error("connection refused"));
 
     const res = await probeSignal("http://127.0.0.1:8080", 1000);
 
     expect(res.ok).toBe(false);
-    expect(res.status).toBe(503);
+    expect(res.error).toBe("fetch failed");
+  });
+
+  it("returns ok=true with error when /check passes but JSON-RPC fails", async () => {
+    signalCheckMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      error: null,
+    });
+    signalRpcRequestMock.mockRejectedValueOnce(new Error("rpc timeout"));
+
+    const res = await probeSignal("http://127.0.0.1:8080", 1000);
+
+    expect(res.ok).toBe(true);
     expect(res.version).toBe(null);
+    expect(res.error).toBe("rpc timeout");
   });
 });
 

--- a/src/signal/probe.ts
+++ b/src/signal/probe.ts
@@ -29,8 +29,32 @@ export async function probeSignal(baseUrl: string, timeoutMs: number): Promise<S
     elapsedMs: 0,
     version: null,
   };
+
   const check = await signalCheck(baseUrl, timeoutMs);
-  if (!check.ok) {
+  const restOk = check.ok;
+
+  try {
+    const version = await signalRpcRequest("version", undefined, {
+      baseUrl,
+      timeoutMs,
+    });
+    result.version = parseSignalVersion(version);
+    return {
+      ...result,
+      ok: true,
+      status: check.status ?? 200,
+      elapsedMs: Date.now() - started,
+    };
+  } catch (rpcErr) {
+    if (restOk) {
+      return {
+        ...result,
+        ok: true,
+        status: check.status ?? null,
+        error: rpcErr instanceof Error ? rpcErr.message : String(rpcErr),
+        elapsedMs: Date.now() - started,
+      };
+    }
     return {
       ...result,
       status: check.status ?? null,
@@ -38,19 +62,4 @@ export async function probeSignal(baseUrl: string, timeoutMs: number): Promise<S
       elapsedMs: Date.now() - started,
     };
   }
-  try {
-    const version = await signalRpcRequest("version", undefined, {
-      baseUrl,
-      timeoutMs,
-    });
-    result.version = parseSignalVersion(version);
-  } catch (err) {
-    result.error = err instanceof Error ? err.message : String(err);
-  }
-  return {
-    ...result,
-    ok: true,
-    status: check.status ?? null,
-    elapsedMs: Date.now() - started,
-  };
 }


### PR DESCRIPTION
## Summary

- **Problem:** `probeSignal` uses `GET /api/v1/check` as a gating health check. In JSON-RPC-only signal-cli daemon mode, this endpoint returns 404, causing the probe to report `ok=false` (false-negative) even when the daemon is fully operational and processing messages.
- **Why it matters:** False alarms in `openclaw channels status --probe` and `doctor`, confusing operators who see Signal reported as failed while it's working fine.
- **What changed:** Probe now always attempts the JSON-RPC `version` call regardless of the REST check result. If the RPC call succeeds, the daemon is healthy. Only reports failure when both REST check AND JSON-RPC call fail.
- **What did NOT change:** `signalCheck` and `signalRpcRequest` internals, signal event streaming, message sending/receiving.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33841

## User-visible / Behavior Changes

- `openclaw channels status --probe` now correctly reports Signal as healthy when running in JSON-RPC daemon mode (even if `/api/v1/check` returns 404)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — same endpoints, just changed evaluation order
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+
- signal-cli: 0.13.x in daemon mode (`--http 127.0.0.1:8080`)

### Steps

1. Start signal-cli in JSON-RPC daemon mode
2. Run `openclaw channels status --probe`

### Expected

- Signal reported as healthy (JSON-RPC version responds)

### Actual

- Before: `ok=false`, error "HTTP 404" (REST check fails, probe exits early)
- After: `ok=true`, version "0.13.24" (JSON-RPC succeeds, REST failure ignored)

## Evidence

- [x] 4 vitest unit tests covering all probe scenarios:
  - REST ok + RPC ok → `ok=true` with version
  - REST fail + RPC ok → `ok=true` with version (the fixed scenario)
  - REST fail + RPC fail → `ok=false` with error
  - REST ok + RPC fail → `ok=true` with error (degraded but reachable)

## Human Verification (required)

- Verified scenarios: All 4 combinations of REST/RPC success/failure
- Edge cases checked: Version parsing from nested `{version: "..."}` objects, empty responses
- What I did **not** verify: Live signal-cli daemon in JSON-RPC mode

## Compatibility / Migration

- Backward compatible? `Yes` — REST+RPC both succeeding still works identically; the change only affects the REST-fail case
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; probe reverts to strict REST check gating
- Files/config to restore: `src/signal/probe.ts`

## Risks and Mitigations

- Risk: JSON-RPC `version` call may succeed on a partially broken daemon
  - Mitigation: If `version` responds correctly, the JSON-RPC transport is functional — this is the same transport used for actual message sending/receiving