### PR TITLE
refactor: extract magic number timeout constants

### DIFF
--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -37,6 +37,8 @@ import { appendWorkspaceMountArgs } from "./workspace-mounts.js";
 
 const HOT_BROWSER_WINDOW_MS = 5 * 60 * 1000;
 const CDP_SOURCE_RANGE_ENV_KEY = "OPENCLAW_BROWSER_CDP_SOURCE_RANGE";
+const CDP_POLL_TIMEOUT_MS = 1000;
+const CDP_RETRY_DELAY_MS = 150;
 
 async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number }): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, params.timeoutMs);
@@ -44,7 +46,7 @@ async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number })
   while (Date.now() < deadline) {
     try {
       const ctrl = new AbortController();
-      const t = setTimeout(ctrl.abort.bind(ctrl), 1000);
+      const t = setTimeout(ctrl.abort.bind(ctrl), CDP_POLL_TIMEOUT_MS);
       try {
         const res = await fetch(url, { signal: ctrl.signal });
         if (res.ok) {
@@ -56,7 +58,7 @@ async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number })
     } catch {
       // ignore
     }
-    await new Promise((r) => setTimeout(r, 150));
+    await new Promise((r) => setTimeout(r, CDP_RETRY_DELAY_MS));
   }
   return false;
 }

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -51,6 +51,8 @@ import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
 import { autoMigrateLegacyStateDir } from "./doctor-state-migrations.js";
 
+const TELEGRAM_CHAT_ID_FETCH_TIMEOUT_MS = 4000;
+
 type UnrecognizedKeysIssue = ZodIssue & {
   code: "unrecognized_keys";
   keys: PropertyKey[];
@@ -500,7 +502,7 @@ async function maybeRepairTelegramAllowFromUsernames(cfg: OpenClawConfig): Promi
     const username = stripped.startsWith("@") ? stripped : `@${stripped}`;
     for (const token of tokens) {
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 4000);
+      const timeout = setTimeout(() => controller.abort(), TELEGRAM_CHAT_ID_FETCH_TIMEOUT_MS);
       try {
         const id = await fetchTelegramChatId({
           token,

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -7,6 +7,8 @@ import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { colorize, isRich, theme } from "../terminal/theme.js";
 import { ensureBinary } from "./binaries.js";
 
+const TAILSCALE_BINARY_CHECK_TIMEOUT_MS = 3000;
+
 function parsePossiblyNoisyJsonObject(stdout: string): Record<string, unknown> {
   const trimmed = stdout.trim();
   const start = trimmed.indexOf("{");
@@ -35,8 +37,10 @@ export async function findTailscaleBinary(): Promise<string | null> {
     try {
       // Use Promise.race with runExec to implement timeout
       await Promise.race([
-        runExec(path, ["--version"], { timeoutMs: 3000 }),
-        new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), 3000)),
+        runExec(path, ["--version"], { timeoutMs: TAILSCALE_BINARY_CHECK_TIMEOUT_MS }),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("timeout")), TAILSCALE_BINARY_CHECK_TIMEOUT_MS),
+        ),
       ]);
       return true;
     } catch {

--- a/src/providers/github-copilot-auth.ts
+++ b/src/providers/github-copilot-auth.ts
@@ -9,6 +9,7 @@ import { stylePromptTitle } from "../terminal/prompt-style.js";
 const CLIENT_ID = "Iv1.b507a08c87ecfe98";
 const DEVICE_CODE_URL = "https://github.com/login/device/code";
 const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const GITHUB_SLOW_DOWN_EXTRA_DELAY_MS = 2000;
 
 type DeviceCodeResponse = {
   device_code: string;
@@ -99,7 +100,7 @@ async function pollForAccessToken(params: {
       continue;
     }
     if (err === "slow_down") {
-      await new Promise((r) => setTimeout(r, params.intervalMs + 2000));
+      await new Promise((r) => setTimeout(r, params.intervalMs + GITHUB_SLOW_DOWN_EXTRA_DELAY_MS));
       continue;
     }
     if (err === "expired_token") {


### PR DESCRIPTION
## Summary

This PR improves code maintainability by replacing hardcoded timeout values with named constants.

## Changes

Replace magic number timeouts with descriptive constants in:

- `src/agents/sandbox/browser.ts`: 
  - `CDP_POLL_TIMEOUT_MS` (1000ms) - timeout for CDP endpoint polling
  - `CDP_RETRY_DELAY_MS` (150ms) - delay between CDP connection retries

- `src/commands/doctor-config-flow.ts`:
  - `TELEGRAM_CHAT_ID_FETCH_TIMEOUT_MS` (4000ms) - timeout for fetching Telegram chat IDs

- `src/infra/tailscale.ts`:
  - `TAILSCALE_BINARY_CHECK_TIMEOUT_MS` (3000ms) - timeout for verifying Tailscale binary

- `src/providers/github-copilot-auth.ts`:
  - `GITHUB_SLOW_DOWN_EXTRA_DELAY_MS` (2000ms) - extra delay when GitHub requests slowdown

## Benefits

✅ Improved code readability - timeout values are self-documenting
✅ Easier maintenance - centralized timeout definitions
✅ No behavior changes - purely refactoring
✅ Tests passing - verified with `pnpm test`

## Testing

- ✅ Existing tests pass (`src/infra/tailscale.test.ts`)
- ✅ No functional changes, only constant extraction
