### PR TITLE
feat(discord): support applied_tags in channel-edit for forum threads

### DIFF
--- a/src/agents/tools/discord-actions-guild.ts
+++ b/src/agents/tools/discord-actions-guild.ts
@@ -327,6 +327,7 @@ export async function handleDiscordGuildAction(
         integer: true,
       });
       const availableTags = parseAvailableTags(params.availableTags);
+      const appliedTags = readStringArrayParam(params, "appliedTags");
       const editPayload = {
         channelId,
         name: name ?? undefined,
@@ -339,6 +340,7 @@ export async function handleDiscordGuildAction(
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
         availableTags,
+        appliedTags: appliedTags ?? undefined,
       };
       const channel = accountId
         ? await editChannelDiscord(editPayload, { accountId })

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -390,6 +390,11 @@ function buildChannelManagementSchema() {
         description: "Clear the parent/category when supported by the provider.",
       }),
     ),
+    appliedTags: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Tag IDs to apply to a forum/media thread (Discord only, max 5).",
+      }),
+    ),
   };
 }
 

--- a/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
+++ b/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
@@ -197,6 +197,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
       integer: true,
     });
     const availableTags = parseAvailableTags(actionParams.availableTags);
+    const appliedTags = readStringArrayParam(actionParams, "appliedTags");
     return await handleDiscordAction(
       {
         action: "channelEdit",
@@ -212,6 +213,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
         availableTags,
+        appliedTags: appliedTags ?? undefined,
       },
       cfg,
     );

--- a/src/discord/send.channels.test.ts
+++ b/src/discord/send.channels.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const patchMock = vi.fn();
+
+vi.mock("./client.js", () => ({
+  resolveDiscordRest: () => ({ patch: patchMock }),
+}));
+
+const { editChannelDiscord } = await import("./send.channels.js");
+
+describe("editChannelDiscord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes applied_tags in request body when appliedTags is provided", async () => {
+    patchMock.mockResolvedValueOnce({
+      id: "thread-1",
+      type: 11,
+      applied_tags: ["tag-a", "tag-b"],
+    });
+
+    const result = await editChannelDiscord({
+      channelId: "thread-1",
+      appliedTags: ["tag-a", "tag-b"],
+    });
+
+    const body = patchMock.mock.calls[0]?.[1]?.body as Record<string, unknown>;
+    expect(body).toEqual({ applied_tags: ["tag-a", "tag-b"] });
+    expect(result).toMatchObject({ id: "thread-1" });
+  });
+
+  it("omits applied_tags when not provided", async () => {
+    patchMock.mockResolvedValueOnce({ id: "ch-1" });
+
+    await editChannelDiscord({ channelId: "ch-1", name: "renamed" });
+
+    const body = patchMock.mock.calls[0]?.[1]?.body as Record<string, unknown>;
+    expect(body.name).toBe("renamed");
+    expect(body).not.toHaveProperty("applied_tags");
+  });
+
+  it("sends both availableTags and appliedTags when both provided", async () => {
+    patchMock.mockResolvedValueOnce({ id: "forum-1" });
+
+    await editChannelDiscord({
+      channelId: "forum-1",
+      availableTags: [{ name: "Bug" }],
+      appliedTags: ["tag-1"],
+    });
+
+    const body = patchMock.mock.calls[0]?.[1]?.body as Record<string, unknown>;
+    expect(body.available_tags).toEqual([{ name: "Bug" }]);
+    expect(body.applied_tags).toEqual(["tag-1"]);
+  });
+});

--- a/src/discord/send.channels.ts
+++ b/src/discord/send.channels.ts
@@ -79,6 +79,9 @@ export async function editChannelDiscord(
       ...(t.emoji_name !== undefined && { emoji_name: t.emoji_name }),
     }));
   }
+  if (payload.appliedTags !== undefined) {
+    body.applied_tags = payload.appliedTags;
+  }
   return (await rest.patch(Routes.channel(payload.channelId), {
     body,
   })) as APIChannel;

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -156,6 +156,7 @@ export type DiscordChannelEdit = {
   locked?: boolean;
   autoArchiveDuration?: number;
   availableTags?: DiscordForumTag[];
+  appliedTags?: string[];
 };
 
 export type DiscordChannelMove = {


### PR DESCRIPTION
## Summary

- **Problem:** Discord forum/media threads support `applied_tags` (array of tag IDs) on `PATCH /channels/{id}`, but the `channel-edit` action did not pass this field through. `thread-create` already supports it, creating an inconsistency where tags can be set on creation but never modified afterward.
- **Why it matters:** Users cannot programmatically tag/untag forum threads after creation, breaking automated workflows (auto-tagging based on content, updating status tags like "Resolved").
- **What changed:** Added `appliedTags` to `DiscordChannelEdit` type, `editChannelDiscord` function, both action handler paths (plugin actions and agent tools), and the channel management tool schema.
- **What did NOT change:** `thread-create` behavior (already supports `appliedTags`), `availableTags` handling, other channel-edit fields.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33691

## User-visible / Behavior Changes

- `channel-edit` action now accepts `appliedTags` parameter (array of Discord tag ID strings)
- Message tool schema exposes `appliedTags` with description: "Tag IDs to apply to a forum/media thread (Discord only, max 5)."
- Agents and plugins can now modify forum thread tags after creation

## Security Impact (required)

- New permissions/capabilities? `No` — uses existing Discord bot permissions (MANAGE_THREADS)
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — same PATCH endpoint, just includes new field in body
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+
- Discord: Bot with MANAGE_THREADS permission in a forum channel

### Steps

1. Create a forum thread with tags using `thread-create` (already works)
2. Use `channel-edit` with `appliedTags: ["tag-id-1", "tag-id-2"]` to modify tags

### Expected

- Thread tags are updated on Discord

### Actual

- Before: `appliedTags` parameter ignored, tags unchanged
- After: Tags correctly sent via `applied_tags` in PATCH body

## Evidence

- [x] 3 vitest unit tests in `src/discord/send.channels.test.ts`:
  - `applied_tags` included in request body when `appliedTags` provided
  - `applied_tags` omitted when `appliedTags` not provided
  - Both `availableTags` and `appliedTags` sent together correctly

## Human Verification (required)

- Verified scenarios: appliedTags provided, omitted, combined with availableTags
- Edge cases checked: Empty array, undefined vs not provided
- What I did **not** verify: Live Discord API call (unit tests mock the REST client)

## Compatibility / Migration

- Backward compatible? `Yes` — `appliedTags` is optional, existing callers unaffected
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; `channel-edit` stops accepting `appliedTags`
- Files/config to restore: 6 files listed in the commit

## Risks and Mitigations

- Risk: Discord API may reject `applied_tags` on non-forum/non-media threads
  - Mitigation: Discord returns a clear error in this case, matching behavior of `thread-create` which also doesn't guard against this