### PR TITLE
WhatsApp: separate outbound allowSendTo from inbound allowFrom

### DIFF
--- a/docs/plans/2026-03-03-whatsapp-separate-outbound-allowlist.md
+++ b/docs/plans/2026-03-03-whatsapp-separate-outbound-allowlist.md
@@ -1,0 +1,578 @@
+# WhatsApp: Separate Outbound `allowSendTo` from Inbound `allowFrom`
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Allow WhatsApp outbound sends to any number while keeping inbound restricted via `allowFrom` — by adding a new `allowSendTo` config field.
+
+**Architecture (Approach A — Generic):** Add `allowSendTo` as a first-class concept in the outbound adapter pipeline, not a WhatsApp-only hack. The `ChannelOutboundAdapter.resolveTarget` interface gains an optional `allowSendTo` parameter. The generic `resolveOutboundTarget` resolves it via a new `resolveAllowSendTo` config adapter method. WhatsApp is the first (and only for now) channel to implement it. Other channels ignore it — fully backward compatible.
+
+**Tech Stack:** TypeScript, Vitest
+
+**Fixes:** GitHub issues #30087, #25039
+
+**Key design decision:** When `allowSendTo` is defined, it completely **replaces** `allowFrom` for outbound checks. When undefined, behavior is identical to current (uses `allowFrom`). This means `allowSendTo: ["*"]` = unrestricted outbound, `allowSendTo: []` = block all outbound.
+
+---
+
+## Files touched (complete list)
+
+| File                                             | Change                                                                               |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `src/config/types.whatsapp.ts`                   | Add `allowSendTo` field                                                              |
+| `src/web/accounts.ts`                            | Add to `ResolvedWhatsAppAccount` type + resolution                                   |
+| `src/plugin-sdk/channel-config-helpers.ts`       | Add `resolveWhatsAppConfigAllowSendTo` helper                                        |
+| `src/whatsapp/resolve-outbound-target.ts`        | Accept + use `allowSendTo`                                                           |
+| `src/whatsapp/resolve-outbound-target.test.ts`   | New tests for `allowSendTo`                                                          |
+| `src/channels/plugins/types.adapters.ts`         | Add `allowSendTo` to `resolveTarget` params + `resolveAllowSendTo` to config adapter |
+| `src/channels/plugins/outbound/whatsapp.ts`      | Pass `allowSendTo` through                                                           |
+| `src/infra/outbound/targets.ts`                  | Resolve + pass `allowSendTo` in generic pipeline                                     |
+| `src/channels/dock.ts`                           | Wire `resolveAllowSendTo` for WhatsApp dock + update Pick type                       |
+| `src/agents/tools/whatsapp-target-auth.ts`       | Pass `allowSendTo` from account config                                               |
+| `src/cron/isolated-agent/delivery-target.ts`     | Pass `allowSendTo` in cron delivery                                                  |
+| `extensions/whatsapp/src/channel.ts`             | Pass `allowSendTo` in plugin adapter                                                 |
+| `extensions/whatsapp/src/resolve-target.test.ts` | Update plugin adapter tests                                                          |
+
+---
+
+## Task 1: Add `allowSendTo` to config types + account resolution
+
+**Files:**
+
+- Modify: `src/config/types.whatsapp.ts`
+- Modify: `src/web/accounts.ts`
+- Modify: `src/plugin-sdk/channel-config-helpers.ts`
+
+**Step 1: Add field to `WhatsAppSharedConfig`**
+
+In `src/config/types.whatsapp.ts`, in `WhatsAppSharedConfig` after `allowFrom` (line 46), add:
+
+```typescript
+/** Optional allowlist for outbound WhatsApp sends (E.164). When set, overrides allowFrom for outbound target resolution. Use ["*"] for unrestricted outbound. */
+allowSendTo?: string[];
+```
+
+**Step 2: Add to `ResolvedWhatsAppAccount` type**
+
+In `src/web/accounts.ts`, after `allowFrom?: string[]` (line 21), add:
+
+```typescript
+allowSendTo?: string[];
+```
+
+**Step 3: Add to `resolveWhatsAppAccount` return**
+
+In `src/web/accounts.ts`, after line 137 (`allowFrom: ...`), add:
+
+```typescript
+allowSendTo: accountCfg?.allowSendTo ?? rootCfg?.allowSendTo,
+```
+
+**Step 4: Add config helper**
+
+In `src/plugin-sdk/channel-config-helpers.ts`, after `resolveWhatsAppConfigAllowFrom` function, add:
+
+```typescript
+export function resolveWhatsAppConfigAllowSendTo(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): string[] | undefined {
+  return resolveWhatsAppAccount(params).allowSendTo;
+}
+```
+
+**Step 5: Commit**
+
+```bash
+scripts/committer "WhatsApp: add allowSendTo config type and account resolution" src/config/types.whatsapp.ts src/web/accounts.ts src/plugin-sdk/channel-config-helpers.ts
+```
+
+---
+
+## Task 2: Update the core outbound resolver (TDD)
+
+**Files:**
+
+- Modify: `src/whatsapp/resolve-outbound-target.ts`
+- Modify: `src/whatsapp/resolve-outbound-target.test.ts`
+
+**Step 1: Write failing tests**
+
+Update test helpers `expectAllowedForTarget` and `expectDeniedForTarget` to accept optional `allowSendTo`:
+
+```typescript
+function expectAllowedForTarget(params: {
+  allowFrom: ResolveParams["allowFrom"];
+  mode: ResolveParams["mode"];
+  to?: string;
+  allowSendTo?: ResolveParams["allowSendTo"];
+}) {
+  const to = params.to ?? PRIMARY_TARGET;
+  expectResolutionOk(
+    { to, allowFrom: params.allowFrom, mode: params.mode, allowSendTo: params.allowSendTo },
+    to,
+  );
+}
+
+function expectDeniedForTarget(params: {
+  allowFrom: ResolveParams["allowFrom"];
+  mode: ResolveParams["mode"];
+  to?: string;
+  allowSendTo?: ResolveParams["allowSendTo"];
+}) {
+  expectResolutionError({
+    to: params.to ?? PRIMARY_TARGET,
+    allowFrom: params.allowFrom,
+    mode: params.mode,
+    allowSendTo: params.allowSendTo,
+  });
+}
+```
+
+Add new `describe` block:
+
+```typescript
+describe("allowSendTo override", () => {
+  it("allows message when target is in allowSendTo even if not in allowFrom", () => {
+    mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET, PRIMARY_TARGET);
+    expectAllowedForTarget({
+      allowFrom: [SECONDARY_TARGET],
+      mode: "implicit",
+      allowSendTo: [PRIMARY_TARGET],
+    });
+  });
+
+  it("denies message when target is not in allowSendTo even if in allowFrom", () => {
+    mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET, SECONDARY_TARGET);
+    expectDeniedForTarget({
+      allowFrom: [PRIMARY_TARGET],
+      mode: "implicit",
+      allowSendTo: [SECONDARY_TARGET],
+    });
+  });
+
+  it("allows any target when allowSendTo contains wildcard", () => {
+    mockNormalizedDirectMessage(PRIMARY_TARGET);
+    expectAllowedForTarget({
+      allowFrom: [SECONDARY_TARGET],
+      mode: "implicit",
+      allowSendTo: ["*"],
+    });
+  });
+
+  it("falls back to allowFrom when allowSendTo is undefined", () => {
+    mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
+    expectAllowedForTarget({
+      allowFrom: [PRIMARY_TARGET],
+      mode: "implicit",
+      allowSendTo: undefined,
+    });
+  });
+
+  it("falls back to allowFrom when allowSendTo is undefined and target not in list", () => {
+    mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
+    expectDeniedForTarget({
+      allowFrom: [SECONDARY_TARGET],
+      mode: "implicit",
+      allowSendTo: undefined,
+    });
+  });
+
+  it("blocks all outbound when allowSendTo is empty array", () => {
+    mockNormalizedDirectMessage(PRIMARY_TARGET);
+    expectDeniedForTarget({
+      allowFrom: ["*"],
+      mode: "implicit",
+      allowSendTo: [],
+    });
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+pnpm vitest run src/whatsapp/resolve-outbound-target.test.ts
+```
+
+Expected: FAIL (allowSendTo not in params type yet)
+
+**Step 3: Implement the change**
+
+Replace `resolveWhatsAppOutboundTarget` in `src/whatsapp/resolve-outbound-target.ts`:
+
+```typescript
+export function resolveWhatsAppOutboundTarget(params: {
+  to: string | null | undefined;
+  allowFrom: Array<string | number> | null | undefined;
+  allowSendTo?: Array<string | number> | null | undefined;
+  mode: string | null | undefined;
+}): WhatsAppOutboundTargetResolution {
+  const trimmed = params.to?.trim() ?? "";
+
+  // When allowSendTo is explicitly defined, use it for outbound checks.
+  // Otherwise fall back to allowFrom (legacy behavior).
+  const outboundListRaw = (
+    params.allowSendTo !== undefined && params.allowSendTo !== null
+      ? params.allowSendTo
+      : (params.allowFrom ?? [])
+  )
+    .map((entry) => String(entry).trim())
+    .filter(Boolean);
+  const hasWildcard = outboundListRaw.includes("*");
+  const outboundList = outboundListRaw
+    .filter((entry) => entry !== "*")
+    .map((entry) => normalizeWhatsAppTarget(entry))
+    .filter((entry): entry is string => Boolean(entry));
+
+  if (trimmed) {
+    const normalizedTo = normalizeWhatsAppTarget(trimmed);
+    if (!normalizedTo) {
+      return {
+        ok: false,
+        error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+      };
+    }
+    if (isWhatsAppGroupJid(normalizedTo)) {
+      return { ok: true, to: normalizedTo };
+    }
+    if (hasWildcard || outboundList.length === 0) {
+      return { ok: true, to: normalizedTo };
+    }
+    if (outboundList.includes(normalizedTo)) {
+      return { ok: true, to: normalizedTo };
+    }
+    return {
+      ok: false,
+      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+    };
+  }
+
+  return {
+    ok: false,
+    error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+  };
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+pnpm vitest run src/whatsapp/resolve-outbound-target.test.ts
+```
+
+Expected: ALL PASS
+
+**Step 5: Commit**
+
+```bash
+scripts/committer "WhatsApp: support allowSendTo in outbound target resolver" src/whatsapp/resolve-outbound-target.ts src/whatsapp/resolve-outbound-target.test.ts
+```
+
+---
+
+## Task 3: Wire `allowSendTo` through the generic outbound adapter interface
+
+**Files:**
+
+- Modify: `src/channels/plugins/types.adapters.ts`
+- Modify: `src/infra/outbound/targets.ts`
+- Modify: `src/channels/dock.ts`
+
+**Step 1: Update `resolveTarget` params in adapter interface**
+
+In `src/channels/plugins/types.adapters.ts`, inside `ChannelOutboundAdapter.resolveTarget` params (line 116), after `allowFrom?: string[];`:
+
+```typescript
+allowSendTo?: string[];
+```
+
+**Step 2: Add `resolveAllowSendTo` to `ChannelConfigAdapter`**
+
+In `src/channels/plugins/types.adapters.ts`, inside `ChannelConfigAdapter` type (after `resolveAllowFrom`), add:
+
+```typescript
+resolveAllowSendTo?: (params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}) => string[] | undefined;
+```
+
+**Step 3: Update `ChannelDock` Pick type**
+
+In `src/channels/dock.ts` line 65-68, update the Pick:
+
+```typescript
+config?: Pick<
+  ChannelConfigAdapter<unknown>,
+  "resolveAllowFrom" | "resolveAllowSendTo" | "formatAllowFrom" | "resolveDefaultTo"
+>;
+```
+
+**Step 4: Wire `resolveAllowSendTo` for WhatsApp in dock.ts**
+
+In `src/channels/dock.ts`, in the WhatsApp dock entry, after `resolveAllowFrom` (line 297), add:
+
+```typescript
+resolveAllowSendTo: ({ cfg, accountId }) => resolveWhatsAppConfigAllowSendTo({ cfg, accountId }),
+```
+
+Add the import for `resolveWhatsAppConfigAllowSendTo` from `../plugin-sdk/channel-config-helpers.js`.
+
+**Step 5: Update `resolveOutboundTarget` in targets.ts**
+
+In `src/infra/outbound/targets.ts`, function `resolveOutboundTarget` (line 170):
+
+Add `allowSendTo?: string[];` to the params type.
+
+After the `allowFrom` resolution block (lines 198-206), add:
+
+```typescript
+const allowSendToRaw =
+  params.allowSendTo ??
+  (params.cfg && plugin.config.resolveAllowSendTo
+    ? plugin.config.resolveAllowSendTo({
+        cfg: params.cfg,
+        accountId: params.accountId ?? undefined,
+      })
+    : undefined);
+const allowSendTo = allowSendToRaw?.map((entry) => String(entry));
+```
+
+Update the `resolveTarget` call (lines 220-226) to pass `allowSendTo`:
+
+```typescript
+return resolveTarget({
+  cfg: params.cfg,
+  to: effectiveTo,
+  allowFrom,
+  allowSendTo,
+  accountId: params.accountId ?? undefined,
+  mode: params.mode ?? "explicit",
+});
+```
+
+**Step 6: Commit**
+
+```bash
+scripts/committer "WhatsApp: wire allowSendTo through generic outbound adapter pipeline" src/channels/plugins/types.adapters.ts src/infra/outbound/targets.ts src/channels/dock.ts
+```
+
+---
+
+## Task 4: Update WhatsApp outbound adapters (core + extension plugin)
+
+**Files:**
+
+- Modify: `src/channels/plugins/outbound/whatsapp.ts`
+- Modify: `extensions/whatsapp/src/channel.ts`
+- Modify: `extensions/whatsapp/src/resolve-target.test.ts`
+
+**Step 1: Update core outbound adapter**
+
+In `src/channels/plugins/outbound/whatsapp.ts` line 14-15:
+
+```typescript
+resolveTarget: ({ to, allowFrom, allowSendTo, mode }) =>
+  resolveWhatsAppOutboundTarget({ to, allowFrom, allowSendTo, mode }),
+```
+
+**Step 2: Update extension plugin adapter**
+
+In `extensions/whatsapp/src/channel.ts` line 287-288:
+
+```typescript
+resolveTarget: ({ to, allowFrom, allowSendTo, mode }) =>
+  resolveWhatsAppOutboundTarget({ to, allowFrom, allowSendTo, mode }),
+```
+
+**Step 3: Update extension plugin tests**
+
+In `extensions/whatsapp/src/resolve-target.test.ts`, add test cases for `allowSendTo` behavior (mirroring the core tests from Task 2). At minimum add a test that `allowSendTo: ["*"]` allows any target even when `allowFrom` is restrictive.
+
+**Step 4: Commit**
+
+```bash
+scripts/committer "WhatsApp: pass allowSendTo in core and extension outbound adapters" src/channels/plugins/outbound/whatsapp.ts extensions/whatsapp/src/channel.ts extensions/whatsapp/src/resolve-target.test.ts
+```
+
+---
+
+## Task 5: Wire `allowSendTo` in agent tool authorization
+
+**Files:**
+
+- Modify: `src/agents/tools/whatsapp-target-auth.ts`
+
+**Step 1: Pass `allowSendTo` from account config**
+
+Replace `resolveAuthorizedWhatsAppOutboundTarget`:
+
+```typescript
+export function resolveAuthorizedWhatsAppOutboundTarget(params: {
+  cfg: OpenClawConfig;
+  chatJid: string;
+  accountId?: string;
+  actionLabel: string;
+}): { to: string; accountId: string } {
+  const account = resolveWhatsAppAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  const resolution = resolveWhatsAppOutboundTarget({
+    to: params.chatJid,
+    allowFrom: account.allowFrom ?? [],
+    allowSendTo: account.allowSendTo,
+    mode: "implicit",
+  });
+  if (!resolution.ok) {
+    throw new ToolAuthorizationError(
+      `WhatsApp ${params.actionLabel} blocked: chatJid "${params.chatJid}" is not in the configured allowSendTo/allowFrom list for account "${account.accountId}".`,
+    );
+  }
+  return { to: resolution.to, accountId: account.accountId };
+}
+```
+
+**Step 2: Commit**
+
+```bash
+scripts/committer "WhatsApp: wire allowSendTo in agent tool authorization" src/agents/tools/whatsapp-target-auth.ts
+```
+
+---
+
+## Task 6: Wire `allowSendTo` in cron delivery
+
+**Files:**
+
+- Modify: `src/cron/isolated-agent/delivery-target.ts`
+
+**Step 1: Resolve and pass `allowSendTo`**
+
+In the WhatsApp-specific block (lines 151-172), after line 164 (`allowFromOverride = [...]`), add:
+
+```typescript
+const allowSendToRaw = resolveWhatsAppAccount({ cfg, accountId: resolvedAccountId }).allowSendTo;
+```
+
+In the `resolveOutboundTarget` call (lines 174-181), add `allowSendTo`:
+
+```typescript
+const docked = resolveOutboundTarget({
+  channel,
+  to: toCandidate,
+  cfg,
+  accountId,
+  mode,
+  allowFrom: allowFromOverride,
+  allowSendTo: allowSendToRaw,
+});
+```
+
+**Step 2: Commit**
+
+```bash
+scripts/committer "WhatsApp: wire allowSendTo in cron delivery target" src/cron/isolated-agent/delivery-target.ts
+```
+
+---
+
+## Task 7: Type-check + lint + full test suite
+
+**Step 1: Type-check**
+
+```bash
+pnpm tsgo
+```
+
+Expected: PASS
+
+**Step 2: Lint + format**
+
+```bash
+pnpm check
+pnpm format:fix
+```
+
+Expected: PASS (fix formatting if needed)
+
+**Step 3: Run full test suite**
+
+```bash
+pnpm test
+```
+
+Expected: ALL PASS
+
+**Step 4: Fix any issues and commit**
+
+---
+
+## Task 8: Manual integration test
+
+**Step 1: Apply config**
+
+In `~/.openclaw/openclaw.json`, on the `default` account:
+
+```json
+{
+  "dmPolicy": "allowlist",
+  "allowFrom": ["+886920010612"],
+  "allowSendTo": ["*"]
+}
+```
+
+Meaning: only owner can DM in, agent can send to anyone.
+
+**Step 2: Rebuild dist**
+
+```bash
+pnpm build
+```
+
+**Step 3: Restart gateway**
+
+```bash
+pkill -9 -f openclaw-gateway || true
+nohup openclaw gateway run --bind loopback --port 18789 --force > /tmp/openclaw-gateway.log 2>&1 &
+```
+
+**Step 4: Test outbound send to external number**
+
+```bash
+openclaw message send --channel whatsapp --target "<OTHER_PHONE_E164>" --message "Test allowSendTo"
+```
+
+Expected: Message delivered successfully (no "requires target" error).
+
+**Step 5: Test inbound still blocked**
+
+Send a WhatsApp message from a number NOT in `allowFrom`. Expected: silently dropped.
+
+**Step 6: Test backward compatibility**
+
+Remove `allowSendTo` from config, restart gateway. Verify behavior is identical to before (outbound restricted to `allowFrom`).
+
+---
+
+## Verification Checklist
+
+- [ ] `pnpm tsgo` passes
+- [ ] `pnpm check` passes
+- [ ] `pnpm test` passes (all existing + new outbound resolver tests)
+- [ ] Extension plugin tests pass (`extensions/whatsapp`)
+- [ ] Outbound to non-allowFrom number succeeds when `allowSendTo: ["*"]`
+- [ ] Outbound blocked when target not in `allowSendTo` (if set)
+- [ ] Inbound from non-allowFrom number still blocked
+- [ ] Behavior unchanged when `allowSendTo` is not set (backward compatible)
+- [ ] Cron delivery uses `allowSendTo` when set
+- [ ] Agent tool send uses `allowSendTo` when set
+- [ ] `allowSendTo: []` blocks all outbound (empty = nobody)
+
+---
+
+## PR info
+
+**Branch:** `fix/whatsapp-separate-outbound-allowlist`
+**Title:** `WhatsApp: separate outbound allowSendTo from inbound allowFrom`
+**Closes:** #30087, #25039

--- a/docs/plans/2026-03-03-whatsapp-separate-outbound-allowlist.md
+++ b/docs/plans/2026-03-03-whatsapp-separate-outbound-allowlist.md
@@ -519,7 +519,7 @@ In `~/.openclaw/openclaw.json`, on the `default` account:
 ```json
 {
   "dmPolicy": "allowlist",
-  "allowFrom": ["+886920010612"],
+  "allowFrom": ["+1555XXXXXXX"],
   "allowSendTo": ["*"]
 }
 ```

--- a/docs/plans/2026-03-03-whatsapp-separate-outbound-allowlist.md
+++ b/docs/plans/2026-03-03-whatsapp-separate-outbound-allowlist.md
@@ -31,6 +31,8 @@
 | `src/cron/isolated-agent/delivery-target.ts`     | Pass `allowSendTo` in cron delivery                                                  |
 | `extensions/whatsapp/src/channel.ts`             | Pass `allowSendTo` in plugin adapter                                                 |
 | `extensions/whatsapp/src/resolve-target.test.ts` | Update plugin adapter tests                                                          |
+| `src/plugin-sdk/index.ts`                        | Export `resolveWhatsAppConfigAllowSendTo` from barrel                                |
+| `src/config/zod-schema.providers-whatsapp.ts`    | Add `allowSendTo` to WhatsApp config validation schema                               |
 
 ---
 

--- a/docs/plans/2026-03-03-whatsapp-separate-outbound-allowlist.md
+++ b/docs/plans/2026-03-03-whatsapp-separate-outbound-allowlist.md
@@ -28,7 +28,7 @@
 | `src/infra/outbound/targets.ts`                  | Resolve + pass `allowSendTo` in generic pipeline                                     |
 | `src/channels/dock.ts`                           | Wire `resolveAllowSendTo` for WhatsApp dock + update Pick type                       |
 | `src/agents/tools/whatsapp-target-auth.ts`       | Pass `allowSendTo` from account config                                               |
-| `src/cron/isolated-agent/delivery-target.ts`     | Pass `allowSendTo` in cron delivery                                                  |
+| `src/cron/isolated-agent/delivery-target.ts`     | Pass `allowSendTo` in cron delivery + fix implicit-mode target substitution          |
 | `extensions/whatsapp/src/channel.ts`             | Pass `allowSendTo` in plugin adapter                                                 |
 | `extensions/whatsapp/src/resolve-target.test.ts` | Update plugin adapter tests                                                          |
 | `src/plugin-sdk/index.ts`                        | Export `resolveWhatsAppConfigAllowSendTo` from barrel                                |

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -22,6 +22,7 @@ import {
   resolveDefaultGroupPolicy,
   resolveWhatsAppAccount,
   resolveWhatsAppConfigAllowFrom,
+  resolveWhatsAppConfigAllowSendTo,
   resolveWhatsAppConfigDefaultTo,
   resolveWhatsAppGroupRequireMention,
   resolveWhatsAppGroupIntroHint,
@@ -116,6 +117,8 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       allowFrom: account.allowFrom,
     }),
     resolveAllowFrom: ({ cfg, accountId }) => resolveWhatsAppConfigAllowFrom({ cfg, accountId }),
+    resolveAllowSendTo: ({ cfg, accountId }) =>
+      resolveWhatsAppConfigAllowSendTo({ cfg, accountId }),
     formatAllowFrom: ({ allowFrom }) => formatWhatsAppConfigAllowFromEntries(allowFrom),
     resolveDefaultTo: ({ cfg, accountId }) => resolveWhatsAppConfigDefaultTo({ cfg, accountId }),
   },
@@ -284,8 +287,8 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
     chunkerMode: "text",
     textChunkLimit: 4000,
     pollMaxOptions: 12,
-    resolveTarget: ({ to, allowFrom, mode }) =>
-      resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+    resolveTarget: ({ to, allowFrom, allowSendTo, mode }) =>
+      resolveWhatsAppOutboundTarget({ to, allowFrom, allowSendTo, mode }),
     sendText: async ({ to, text, accountId, deps, gifPlayback }) => {
       const send = deps?.sendWhatsApp ?? getWhatsAppRuntime().channel.whatsapp.sendMessageWhatsApp;
       const result = await send(to, text, {

--- a/extensions/whatsapp/src/resolve-target.test.ts
+++ b/extensions/whatsapp/src/resolve-target.test.ts
@@ -20,10 +20,12 @@ vi.mock("openclaw/plugin-sdk/whatsapp", async () => {
     resolveWhatsAppOutboundTarget: ({
       to,
       allowFrom,
+      allowSendTo,
       mode,
     }: {
       to?: string;
       allowFrom: string[];
+      allowSendTo?: string[];
       mode: "explicit" | "implicit";
     }) => {
       const raw = typeof to === "string" ? to.trim() : "";
@@ -36,8 +38,10 @@ vi.mock("openclaw/plugin-sdk/whatsapp", async () => {
       }
 
       if (mode === "implicit" && !normalized.endsWith("@g.us")) {
-        const allowAll = allowFrom.includes("*");
-        const allowExact = allowFrom.some((entry) => {
+        // Use allowSendTo if defined, otherwise fall back to allowFrom
+        const effectiveList = allowSendTo ?? allowFrom;
+        const allowAll = effectiveList.includes("*");
+        const allowExact = effectiveList.some((entry) => {
           if (!entry) {
             return false;
           }
@@ -53,6 +57,32 @@ vi.mock("openclaw/plugin-sdk/whatsapp", async () => {
     },
     missingTargetError: (provider: string, hint: string) =>
       new Error(`Delivering to ${provider} requires target ${hint}`),
+    WhatsAppConfigSchema: {},
+    whatsappOnboardingAdapter: {},
+    resolveWhatsAppHeartbeatRecipients: vi.fn(),
+    buildChannelConfigSchema: vi.fn(),
+    collectWhatsAppStatusIssues: vi.fn(),
+    createActionGate: vi.fn(),
+    DEFAULT_ACCOUNT_ID: "default",
+    escapeRegExp: vi.fn(),
+    formatPairingApproveHint: vi.fn(),
+    listWhatsAppAccountIds: vi.fn(),
+    listWhatsAppDirectoryGroupsFromConfig: vi.fn(),
+    listWhatsAppDirectoryPeersFromConfig: vi.fn(),
+    looksLikeWhatsAppTargetId: vi.fn(),
+    migrateBaseNameToDefaultAccount: vi.fn(),
+    normalizeAccountId: vi.fn(),
+    normalizeE164: vi.fn(),
+    normalizeWhatsAppMessagingTarget: vi.fn(),
+    readStringParam: vi.fn(),
+    resolveDefaultWhatsAppAccountId: vi.fn(),
+    resolveWhatsAppAccount: vi.fn(),
+    resolveWhatsAppConfigAllowSendTo: vi.fn(),
+    resolveWhatsAppGroupIntroHint: vi.fn(),
+    resolveWhatsAppGroupRequireMention: vi.fn(),
+    resolveWhatsAppGroupToolPolicy: vi.fn(),
+    resolveWhatsAppMentionStripPatterns: vi.fn(() => []),
+    applyAccountNameToChannelSection: vi.fn(),
   };
 });
 

--- a/src/agents/tools/whatsapp-target-auth.ts
+++ b/src/agents/tools/whatsapp-target-auth.ts
@@ -16,11 +16,12 @@ export function resolveAuthorizedWhatsAppOutboundTarget(params: {
   const resolution = resolveWhatsAppOutboundTarget({
     to: params.chatJid,
     allowFrom: account.allowFrom ?? [],
+    allowSendTo: account.allowSendTo,
     mode: "implicit",
   });
   if (!resolution.ok) {
     throw new ToolAuthorizationError(
-      `WhatsApp ${params.actionLabel} blocked: chatJid "${params.chatJid}" is not in the configured allowFrom list for account "${account.accountId}".`,
+      `WhatsApp ${params.actionLabel} blocked: chatJid "${params.chatJid}" is not in the configured allowSendTo/allowFrom list for account "${account.accountId}".`,
     );
   }
   return { to: resolution.to, accountId: account.accountId };

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -9,6 +9,7 @@ import {
   resolveIMessageConfigAllowFrom,
   resolveIMessageConfigDefaultTo,
   resolveWhatsAppConfigAllowFrom,
+  resolveWhatsAppConfigAllowSendTo,
   resolveWhatsAppConfigDefaultTo,
 } from "../plugin-sdk/channel-config-helpers.js";
 import { requireActivePluginRegistry } from "../plugins/runtime.js";
@@ -64,7 +65,7 @@ export type ChannelDock = {
   elevated?: ChannelElevatedAdapter;
   config?: Pick<
     ChannelConfigAdapter<unknown>,
-    "resolveAllowFrom" | "formatAllowFrom" | "resolveDefaultTo"
+    "resolveAllowFrom" | "resolveAllowSendTo" | "formatAllowFrom" | "resolveDefaultTo"
   >;
   groups?: ChannelGroupAdapter;
   mentions?: ChannelMentionAdapter;
@@ -295,6 +296,8 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
     outbound: DEFAULT_OUTBOUND_TEXT_CHUNK_LIMIT_4000,
     config: {
       resolveAllowFrom: ({ cfg, accountId }) => resolveWhatsAppConfigAllowFrom({ cfg, accountId }),
+      resolveAllowSendTo: ({ cfg, accountId }) =>
+        resolveWhatsAppConfigAllowSendTo({ cfg, accountId }),
       formatAllowFrom: ({ allowFrom }) => formatWhatsAppConfigAllowFromEntries(allowFrom),
       resolveDefaultTo: ({ cfg, accountId }) => resolveWhatsAppConfigDefaultTo({ cfg, accountId }),
     },
@@ -563,6 +566,7 @@ function buildDockFromPlugin(plugin: ChannelPlugin): ChannelDock {
     config: plugin.config
       ? {
           resolveAllowFrom: plugin.config.resolveAllowFrom,
+          resolveAllowSendTo: plugin.config.resolveAllowSendTo,
           formatAllowFrom: plugin.config.formatAllowFrom,
           resolveDefaultTo: plugin.config.resolveDefaultTo,
         }

--- a/src/channels/plugins/outbound/whatsapp.ts
+++ b/src/channels/plugins/outbound/whatsapp.ts
@@ -11,8 +11,8 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
   chunkerMode: "text",
   textChunkLimit: 4000,
   pollMaxOptions: 12,
-  resolveTarget: ({ to, allowFrom, mode }) =>
-    resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+  resolveTarget: ({ to, allowFrom, allowSendTo, mode }) =>
+    resolveWhatsAppOutboundTarget({ to, allowFrom, allowSendTo, mode }),
   sendPayload: async (ctx) =>
     await sendTextMediaPayload({ channel: "whatsapp", ctx, adapter: whatsappOutbound }),
   sendText: async ({ to, text, accountId, deps, gifPlayback }) => {

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -73,6 +73,10 @@ export type ChannelConfigAdapter<ResolvedAccount> = {
     accountId?: string | null;
     allowFrom: Array<string | number>;
   }) => string[];
+  resolveAllowSendTo?: (params: {
+    cfg: OpenClawConfig;
+    accountId?: string | null;
+  }) => Array<string | number> | undefined;
   resolveDefaultTo?: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
@@ -114,6 +118,7 @@ export type ChannelOutboundAdapter = {
     cfg?: OpenClawConfig;
     to?: string;
     allowFrom?: string[];
+    allowSendTo?: string[];
     accountId?: string | null;
     mode?: ChannelOutboundTargetMode;
   }) => { ok: true; to: string } | { ok: false; error: Error };

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -44,6 +44,8 @@ type WhatsAppSharedConfig = {
   selfChatMode?: boolean;
   /** Optional allowlist for WhatsApp direct chats (E.164). */
   allowFrom?: string[];
+  /** Optional allowlist for outbound WhatsApp sends (E.164). When set, overrides allowFrom for outbound target resolution. Use ["*"] for unrestricted outbound. */
+  allowSendTo?: string[];
   /** Default delivery target for CLI `--deliver` when no explicit `--reply-to` is provided (E.164 or group JID). */
   defaultTo?: string;
   /** Optional allowlist for WhatsApp group senders (E.164). */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -42,6 +42,7 @@ const WhatsAppSharedSchema = z.object({
   dmPolicy: DmPolicySchema.optional().default("pairing"),
   selfChatMode: z.boolean().optional(),
   allowFrom: z.array(z.string()).optional(),
+  allowSendTo: z.array(z.string()).optional(),
   defaultTo: z.string().optional(),
   groupAllowFrom: z.array(z.string()).optional(),
   groupPolicy: GroupPolicySchema.optional().default("allowlist"),

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -149,10 +149,11 @@ export async function resolveDeliveryTarget(
   }
 
   let allowFromOverride: string[] | undefined;
+  let allowSendToOverride: string[] | undefined;
   if (channel === "whatsapp") {
     const resolvedAccountId = normalizeAccountId(accountId);
-    const configuredAllowFromRaw =
-      resolveWhatsAppAccount({ cfg, accountId: resolvedAccountId }).allowFrom ?? [];
+    const whatsappAccount = resolveWhatsAppAccount({ cfg, accountId: resolvedAccountId });
+    const configuredAllowFromRaw = whatsappAccount.allowFrom ?? [];
     const configuredAllowFrom = configuredAllowFromRaw
       .map((entry) => String(entry).trim())
       .filter((entry) => entry && entry !== "*")
@@ -162,20 +163,20 @@ export async function resolveDeliveryTarget(
       .map((entry) => normalizeWhatsAppTarget(entry))
       .filter((entry): entry is string => Boolean(entry));
     allowFromOverride = [...new Set([...configuredAllowFrom, ...storeAllowFrom])];
+    allowSendToOverride = whatsappAccount.allowSendTo;
 
-    if (toCandidate && mode === "implicit" && allowFromOverride.length > 0) {
+    // When allowSendTo is defined, use it for implicit-mode target validation
+    // instead of allowFrom. A wildcard bypasses substitution entirely.
+    const effectiveSendList = allowSendToOverride ?? allowFromOverride;
+    const hasWildcard = effectiveSendList.some((e) => e === "*");
+
+    if (toCandidate && mode === "implicit" && effectiveSendList.length > 0 && !hasWildcard) {
       const normalizedCurrentTarget = normalizeWhatsAppTarget(toCandidate);
-      if (!normalizedCurrentTarget || !allowFromOverride.includes(normalizedCurrentTarget)) {
-        toCandidate = allowFromOverride[0];
+      if (!normalizedCurrentTarget || !effectiveSendList.includes(normalizedCurrentTarget)) {
+        toCandidate = effectiveSendList[0];
       }
     }
   }
-
-  // allowSendTo is resolved from config — no pairing-store merge needed.
-  const allowSendToOverride =
-    channel === "whatsapp"
-      ? resolveWhatsAppAccount({ cfg, accountId: normalizeAccountId(accountId) }).allowSendTo
-      : undefined;
 
   const docked = resolveOutboundTarget({
     channel,

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -171,6 +171,12 @@ export async function resolveDeliveryTarget(
     }
   }
 
+  // allowSendTo is resolved from config — no pairing-store merge needed.
+  const allowSendToOverride =
+    channel === "whatsapp"
+      ? resolveWhatsAppAccount({ cfg, accountId: normalizeAccountId(accountId) }).allowSendTo
+      : undefined;
+
   const docked = resolveOutboundTarget({
     channel,
     to: toCandidate,
@@ -178,6 +184,7 @@ export async function resolveDeliveryTarget(
     accountId,
     mode,
     allowFrom: allowFromOverride,
+    allowSendTo: allowSendToOverride,
   });
   if (!docked.ok) {
     return {

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -174,7 +174,9 @@ export async function resolveDeliveryTarget(
       .map((entry) => normalizeWhatsAppTarget(entry))
       .filter((entry): entry is string => Boolean(entry));
     const effectiveSendList = normalizedAllowSendTo ?? allowFromOverride;
-    const hasWildcard = (allowSendToOverride ?? allowFromOverride).includes("*");
+    const hasWildcard = (allowSendToOverride ?? allowFromOverride)?.some(
+      (entry) => String(entry).trim() === "*",
+    );
 
     if (toCandidate && mode === "implicit" && effectiveSendList.length > 0 && !hasWildcard) {
       const normalizedCurrentTarget = normalizeWhatsAppTarget(toCandidate);

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -166,9 +166,15 @@ export async function resolveDeliveryTarget(
     allowSendToOverride = whatsappAccount.allowSendTo;
 
     // When allowSendTo is defined, use it for implicit-mode target validation
-    // instead of allowFrom. A wildcard bypasses substitution entirely.
-    const effectiveSendList = allowSendToOverride ?? allowFromOverride;
-    const hasWildcard = effectiveSendList.some((e) => e === "*");
+    // instead of allowFrom. Normalize entries so comparison with the normalized
+    // toCandidate works regardless of config formatting.
+    const normalizedAllowSendTo = allowSendToOverride
+      ?.map((entry) => String(entry).trim())
+      .filter((entry) => entry && entry !== "*")
+      .map((entry) => normalizeWhatsAppTarget(entry))
+      .filter((entry): entry is string => Boolean(entry));
+    const effectiveSendList = normalizedAllowSendTo ?? allowFromOverride;
+    const hasWildcard = (allowSendToOverride ?? allowFromOverride).includes("*");
 
     if (toCandidate && mode === "implicit" && effectiveSendList.length > 0 && !hasWildcard) {
       const normalizedCurrentTarget = normalizeWhatsAppTarget(toCandidate);

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -171,6 +171,7 @@ export function resolveOutboundTarget(params: {
   channel: GatewayMessageChannel;
   to?: string;
   allowFrom?: string[];
+  allowSendTo?: string[];
   cfg?: OpenClawConfig;
   accountId?: string | null;
   mode?: ChannelOutboundTargetMode;
@@ -205,6 +206,16 @@ export function resolveOutboundTarget(params: {
       : undefined);
   const allowFrom = allowFromRaw?.map((entry) => String(entry));
 
+  const allowSendToRaw =
+    params.allowSendTo ??
+    (params.cfg && plugin.config.resolveAllowSendTo
+      ? plugin.config.resolveAllowSendTo({
+          cfg: params.cfg,
+          accountId: params.accountId ?? undefined,
+        })
+      : undefined);
+  const allowSendTo = allowSendToRaw?.map((entry) => String(entry));
+
   // Fall back to per-channel defaultTo when no explicit target is provided.
   const effectiveTo =
     params.to?.trim() ||
@@ -221,6 +232,7 @@ export function resolveOutboundTarget(params: {
       cfg: params.cfg,
       to: effectiveTo,
       allowFrom,
+      allowSendTo,
       accountId: params.accountId ?? undefined,
       mode: params.mode ?? "explicit",
     });

--- a/src/plugin-sdk/channel-config-helpers.ts
+++ b/src/plugin-sdk/channel-config-helpers.ts
@@ -15,6 +15,13 @@ export function resolveWhatsAppConfigAllowFrom(params: {
   return resolveWhatsAppAccount(params).allowFrom ?? [];
 }
 
+export function resolveWhatsAppConfigAllowSendTo(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): string[] | undefined {
+  return resolveWhatsAppAccount(params).allowSendTo;
+}
+
 export function formatWhatsAppConfigAllowFromEntries(allowFrom: Array<string | number>): string[] {
   return normalizeWhatsAppAllowFromEntries(allowFrom);
 }

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -335,6 +335,7 @@ export {
   resolveIMessageConfigAllowFrom,
   resolveIMessageConfigDefaultTo,
   resolveWhatsAppConfigAllowFrom,
+  resolveWhatsAppConfigAllowSendTo,
   resolveWhatsAppConfigDefaultTo,
 } from "./channel-config-helpers.js";
 export {

--- a/src/plugin-sdk/whatsapp.ts
+++ b/src/plugin-sdk/whatsapp.ts
@@ -24,6 +24,7 @@ export {
 export {
   formatWhatsAppConfigAllowFromEntries,
   resolveWhatsAppConfigAllowFrom,
+  resolveWhatsAppConfigAllowSendTo,
   resolveWhatsAppConfigDefaultTo,
 } from "./channel-config-helpers.js";
 export {

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -19,6 +19,7 @@ export type ResolvedWhatsAppAccount = {
   isLegacyAuthDir: boolean;
   selfChatMode?: boolean;
   allowFrom?: string[];
+  allowSendTo?: string[];
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
   dmPolicy?: DmPolicy;
@@ -135,6 +136,7 @@ export function resolveWhatsAppAccount(params: {
     selfChatMode: accountCfg?.selfChatMode ?? rootCfg?.selfChatMode,
     dmPolicy: accountCfg?.dmPolicy ?? rootCfg?.dmPolicy,
     allowFrom: accountCfg?.allowFrom ?? rootCfg?.allowFrom,
+    allowSendTo: accountCfg?.allowSendTo ?? rootCfg?.allowSendTo,
     groupAllowFrom: accountCfg?.groupAllowFrom ?? rootCfg?.groupAllowFrom,
     groupPolicy: accountCfg?.groupPolicy ?? rootCfg?.groupPolicy,
     textChunkLimit: accountCfg?.textChunkLimit ?? rootCfg?.textChunkLimit,

--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -37,6 +37,7 @@ function expectAllowedForTarget(params: {
   allowFrom: ResolveParams["allowFrom"];
   mode: ResolveParams["mode"];
   to?: string;
+  allowSendTo?: ResolveParams["allowSendTo"];
 }) {
   const to = params.to ?? PRIMARY_TARGET;
   expectResolutionOk(
@@ -44,6 +45,7 @@ function expectAllowedForTarget(params: {
       to,
       allowFrom: params.allowFrom,
       mode: params.mode,
+      allowSendTo: params.allowSendTo,
     },
     to,
   );
@@ -53,11 +55,13 @@ function expectDeniedForTarget(params: {
   allowFrom: ResolveParams["allowFrom"];
   mode: ResolveParams["mode"];
   to?: string;
+  allowSendTo?: ResolveParams["allowSendTo"];
 }) {
   expectResolutionError({
     to: params.to ?? PRIMARY_TARGET,
     allowFrom: params.allowFrom,
     mode: params.mode,
+    allowSendTo: params.allowSendTo,
   });
 }
 
@@ -197,6 +201,64 @@ describe("resolveWhatsAppOutboundTarget", () => {
     it("allows message in custom mode string when target is in allowList", () => {
       mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
       expectAllowedForTarget({ allowFrom: [PRIMARY_TARGET], mode: "broadcast" });
+    });
+  });
+
+  describe("allowSendTo override", () => {
+    it("allows message when target is in allowSendTo even if not in allowFrom", () => {
+      // Mock order: allowSendTo[0] normalize, then 'to' normalize (allowFrom is skipped)
+      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
+      expectAllowedForTarget({
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+        allowSendTo: [PRIMARY_TARGET],
+      });
+    });
+
+    it("denies message when target is not in allowSendTo even if in allowFrom", () => {
+      // Mock order: allowSendTo[0] normalize, then 'to' normalize (allowFrom is skipped)
+      mockNormalizedDirectMessage(SECONDARY_TARGET, PRIMARY_TARGET);
+      expectDeniedForTarget({
+        allowFrom: [PRIMARY_TARGET],
+        mode: "implicit",
+        allowSendTo: [SECONDARY_TARGET],
+      });
+    });
+
+    it("allows any target when allowSendTo contains wildcard", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET);
+      expectAllowedForTarget({
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+        allowSendTo: ["*"],
+      });
+    });
+
+    it("falls back to allowFrom when allowSendTo is undefined", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
+      expectAllowedForTarget({
+        allowFrom: [PRIMARY_TARGET],
+        mode: "implicit",
+        allowSendTo: undefined,
+      });
+    });
+
+    it("falls back to allowFrom when allowSendTo is undefined and target not in list", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
+      expectDeniedForTarget({
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+        allowSendTo: undefined,
+      });
+    });
+
+    it("blocks all outbound when allowSendTo is empty array", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET);
+      expectDeniedForTarget({
+        allowFrom: ["*"],
+        mode: "implicit",
+        allowSendTo: [],
+      });
     });
   });
 

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -33,6 +33,10 @@ export function resolveWhatsAppOutboundTarget(params: {
         error: missingTargetError("WhatsApp", "<E.164|group JID>"),
       };
     }
+    // Group JIDs bypass allowFrom/allowSendTo intentionally: group sends are
+    // governed by the separate groupPolicy/groupAllowFrom axis, not by the
+    // per-DM allowlist.  This matches legacy allowFrom behavior and keeps
+    // allowSendTo semantically consistent as a DM-only outbound gate.
     if (isWhatsAppGroupJid(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -8,14 +8,19 @@ export type WhatsAppOutboundTargetResolution =
 export function resolveWhatsAppOutboundTarget(params: {
   to: string | null | undefined;
   allowFrom: Array<string | number> | null | undefined;
+  allowSendTo?: Array<string | number> | null | undefined;
   mode: string | null | undefined;
 }): WhatsAppOutboundTargetResolution {
   const trimmed = params.to?.trim() ?? "";
-  const allowListRaw = (params.allowFrom ?? [])
+
+  // When allowSendTo is explicitly defined, use it for outbound checks.
+  // Otherwise fall back to allowFrom (legacy behavior).
+  const hasExplicitSendTo = params.allowSendTo !== undefined && params.allowSendTo !== null;
+  const outboundListRaw = (hasExplicitSendTo ? params.allowSendTo! : (params.allowFrom ?? []))
     .map((entry) => String(entry).trim())
     .filter(Boolean);
-  const hasWildcard = allowListRaw.includes("*");
-  const allowList = allowListRaw
+  const hasWildcard = outboundListRaw.includes("*");
+  const outboundList = outboundListRaw
     .filter((entry) => entry !== "*")
     .map((entry) => normalizeWhatsAppTarget(entry))
     .filter((entry): entry is string => Boolean(entry));
@@ -31,12 +36,12 @@ export function resolveWhatsAppOutboundTarget(params: {
     if (isWhatsAppGroupJid(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }
-    // Enforce allowFrom for all direct-message send modes (including explicit).
-    // Group destinations are handled by group policy and are allowed above.
-    if (hasWildcard || allowList.length === 0) {
+    // When allowSendTo is explicitly set, empty means "block all".
+    // Legacy allowFrom behavior: empty means "allow all" (no restrictions).
+    if (hasWildcard || (!hasExplicitSendTo && outboundList.length === 0)) {
       return { ok: true, to: normalizedTo };
     }
-    if (allowList.includes(normalizedTo)) {
+    if (outboundList.includes(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }
     return {


### PR DESCRIPTION
## Summary

- Adds a new `allowSendTo` config field for WhatsApp accounts that decouples outbound send authorization from inbound `allowFrom`
- When `allowSendTo` is set, it completely replaces `allowFrom` for outbound target resolution; when unset, behavior is unchanged (backward compatible)
- Wired through the generic outbound adapter pipeline (`ChannelOutboundAdapter.resolveTarget`, `ChannelConfigAdapter.resolveAllowSendTo`) so other channels can adopt it later
- Covers all outbound paths: direct send, agent tool authorization, and cron delivery

**Fixes:** #30087, #25039

### Key design decisions

- `allowSendTo: ["*"]` = unrestricted outbound (send to anyone)
- `allowSendTo: []` = block all outbound (explicit empty = deny, unlike `allowFrom: []` which means allow all)
- `allowSendTo: undefined` = legacy behavior (uses `allowFrom` for outbound checks)

### Example config

```json
{
  "channels": {
    "whatsapp": {
      "accounts": {
        "default": {
          "dmPolicy": "allowlist",
          "allowFrom": ["+1234567890"],
          "allowSendTo": ["*"]
        }
      }
    }
  }
}
```

Only `+1234567890` can message the bot, but the bot can send outbound to any number.

## Test plan

- [x] 27 unit tests pass for `resolveWhatsAppOutboundTarget` (6 new for `allowSendTo`)
- [x] 9 extension plugin resolve-target tests pass
- [x] Full test suite: 804 files, 6490 tests, 0 failures
- [x] Type-check (`pnpm tsgo`) clean
- [x] Lint/format (`pnpm check`) clean
- [x] Manual verification: gateway starts with `allowSendTo: ["*"]` config, agent can send outbound while inbound is restricted
- [x] Test with `allowSendTo: []` blocks all outbound
- [ ] Test with `allowSendTo: ["+specific"]` restricts outbound to that number

🤖 Generated with [Claude Code](https://claude.com/claude-code)