### PR TITLE
fix(status): cap cache hit rate at 100% and use inputTokens as denominator

### DIFF
--- a/src/commands/status.format.test.ts
+++ b/src/commands/status.format.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { formatTokensCompact } from "./status.format.js";
+
+describe("formatTokensCompact", () => {
+  it("shows token usage without cache info when cacheRead is absent", () => {
+    const result = formatTokensCompact({
+      totalTokens: 10_000,
+      contextTokens: 100_000,
+      percentUsed: 10,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      inputTokens: undefined,
+    });
+    expect(result).toBe("10k/100k (10%)");
+    expect(result).not.toContain("cached");
+  });
+
+  it("shows correct cache hit rate using inputTokens as denominator", () => {
+    // inputTokens = 10k total input (5k fresh + 5k cache read)
+    // cacheRead = 5k  →  50% hit rate
+    const result = formatTokensCompact({
+      totalTokens: 8_000,
+      contextTokens: 100_000,
+      percentUsed: 8,
+      cacheRead: 5_000,
+      cacheWrite: 0,
+      inputTokens: 10_000,
+    });
+    expect(result).toContain("50% cached");
+  });
+
+  it("never reports cache hit rate above 100% even if cacheRead exceeds totalTokens", () => {
+    // Reproduces the real-world "199% cached" bug:
+    // cron sessions accumulate large cacheRead over time while totalTokens
+    // (input + output) can be much smaller than cacheRead alone.
+    const result = formatTokensCompact({
+      totalTokens: 43_000,
+      contextTokens: 200_000,
+      percentUsed: 21,
+      cacheRead: 86_000, // cache reads > total tokens → old code showed 199%
+      cacheWrite: 0,
+      inputTokens: undefined, // inputTokens not available → falls back to cache-only denominator
+    });
+    const match = result.match(/(\d+)% cached/);
+    expect(match).not.toBeNull();
+    const pct = parseInt(match![1], 10);
+    expect(pct).toBeLessThanOrEqual(100);
+  });
+
+  it("falls back to cache-only denominator when inputTokens is unavailable", () => {
+    // cacheRead = 6k, cacheWrite = 2k → denominator = 8k → 75% hit rate
+    const result = formatTokensCompact({
+      totalTokens: 10_000,
+      contextTokens: 100_000,
+      percentUsed: 10,
+      cacheRead: 6_000,
+      cacheWrite: 2_000,
+      inputTokens: undefined,
+    });
+    expect(result).toContain("75% cached");
+  });
+
+  it("shows unknown usage when totalTokens is null", () => {
+    const result = formatTokensCompact({
+      totalTokens: null,
+      contextTokens: 100_000,
+      percentUsed: null,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      inputTokens: undefined,
+    });
+    expect(result).toContain("unknown");
+  });
+});

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -16,7 +16,7 @@ export const formatDuration = (ms: number | null | undefined) => {
 export const formatTokensCompact = (
   sess: Pick<
     SessionStatus,
-    "totalTokens" | "contextTokens" | "percentUsed" | "cacheRead" | "cacheWrite"
+    "totalTokens" | "contextTokens" | "percentUsed" | "cacheRead" | "cacheWrite" | "inputTokens"
   >,
 ) => {
   const used = sess.totalTokens;
@@ -34,13 +34,19 @@ export const formatTokensCompact = (
     result = `${formatKTokens(used)}/${formatKTokens(ctx)} (${pctLabel})`;
   }
 
-  // Add cache hit rate if there are cached reads
+  // Add cache hit rate if there are cached reads.
+  // The denominator must be the total *input* volume (fresh input + cache reads),
+  // not the session's net token spend.  Using totalTokens (which includes output
+  // tokens) produces rates above 100% when cache reads are large relative to
+  // fresh input — e.g. a long-running cron session that re-reads the same
+  // context repeatedly can show "199% cached".
   if (typeof cacheRead === "number" && cacheRead > 0) {
-    const total =
-      typeof used === "number"
-        ? used
-        : cacheRead + (typeof cacheWrite === "number" ? cacheWrite : 0);
-    const hitRate = Math.round((cacheRead / total) * 100);
+    const inputTokens = sess.inputTokens;
+    const denominator =
+      typeof inputTokens === "number" && inputTokens > 0
+        ? inputTokens // preferred: fresh+cached input
+        : cacheRead + (typeof cacheWrite === "number" ? cacheWrite : 0); // fallback: cache tokens only
+    const hitRate = Math.min(100, Math.round((cacheRead / denominator) * 100));
     result += ` · 🗄️ ${hitRate}% cached`;
   }
 


### PR DESCRIPTION
## Bug

`openclaw status` and `openclaw sessions` display cache hit rates above 100%:

```
43k/200k (21%) · 🗄️ 199% cached
```

## Root Cause

The percentage is calculated as:
```ts
Math.round((cacheRead / totalTokens) * 100)
```

`totalTokens` is the session's **net spend** (input + output tokens). For long-running cron sessions that repeatedly re-read the same cached context, `cacheRead` can far exceed `totalTokens`, producing rates well above 100%.

## Fix

1. **Use `inputTokens` as the denominator** when available. `inputTokens` represents the total input volume (fresh input + cached reads), which is the correct semantic base for a cache hit rate.
2. **Fall back to `(cacheRead + cacheWrite)`** when `inputTokens` is absent — a conservative lower-bound estimate.
3. **Clamp to 100** with `Math.min()` as a final safety net.

## Tests

Adds `status.format.test.ts` with dedicated unit tests for `formatTokensCompact`:

| Case | Expected |
|---|---|
| No cache data | No "cached" label |
| Normal hit rate with `inputTokens` | Correct percentage |
| `cacheRead > totalTokens` (the overflow case) | ≤ 100% |
| Fallback denominator (no `inputTokens`) | Correct percentage from cache tokens |
| Null `totalTokens` | "unknown" label |

## Reproduction

Run OpenClaw with an active cron agent that uses context caching. Check `openclaw sessions` — any session where `cacheRead > totalTokens` (common for gemini/claude cron workers) will show a rate above 100%.