### PR TITLE
fix(browser): use wsUrl when available for extension snapshots

### DIFF
--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -6,10 +6,9 @@ This iPhone app is super-alpha and internal-use only. It connects to an OpenClaw
 
 ## Distribution Status
 
-NO TEST FLIGHT AVAILABLE AT THIS POINT
-
-- Current distribution: local/manual deploy from source via Xcode.
-- App Store flow is not part of the current internal development path.
+- Current default distribution: local/manual deploy from source via Xcode.
+- Repo maintainers do not publish an official TestFlight channel.
+- You can upload your own TestFlight build from your Apple Developer account via `apps/ios/fastlane` (see `apps/ios/fastlane/SETUP.md`).
 
 ## Super-Alpha Disclaimer
 

--- a/apps/ios/ShareExtension/Info.plist
+++ b/apps/ios/ShareExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.23</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>20260223</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>ai.openclaw.ios.bgrefresh</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -19,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.23</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20260223</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoadsInWebContent</key>
@@ -63,10 +67,6 @@
 	<array>
 		<string>audio</string>
 		<string>remote-notification</string>
-	</array>
-	<key>BGTaskSchedulerPermittedIdentifiers</key>
-	<array>
-		<string>ai.openclaw.ios.bgrefresh</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>OpenClaw</string>
+	<string>HS OpenClaw</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconName</key>

--- a/apps/ios/Tests/Info.plist
+++ b/apps/ios/Tests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-			<string>BNDL</string>
-			<key>CFBundleShortVersionString</key>
-			<string>2026.2.23</string>
-			<key>CFBundleVersion</key>
-			<string>20260223</string>
-		</dict>
-	</plist>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/apps/ios/WatchApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/apps/ios/WatchApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,116 +1,137 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "watch",
-      "role": "notificationCenter",
-      "subtype": "38mm",
-      "size": "24x24",
-      "scale": "2x",
-      "filename": "watch-notification-38@2x.png"
+      "filename" : "watch-notification-38@2x.png",
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "24x24",
+      "subtype" : "38mm"
     },
     {
-      "idiom": "watch",
-      "role": "notificationCenter",
-      "subtype": "42mm",
-      "size": "27.5x27.5",
-      "scale": "2x",
-      "filename": "watch-notification-42@2x.png"
+      "filename" : "watch-notification-42@2x.png",
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "27.5x27.5",
+      "subtype" : "42mm"
     },
     {
-      "idiom": "watch",
-      "role": "companionSettings",
-      "size": "29x29",
-      "scale": "2x",
-      "filename": "watch-companion-29@2x.png"
+      "filename" : "watch-companion-29@2x.png",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
-      "idiom": "watch",
-      "role": "companionSettings",
-      "size": "29x29",
-      "scale": "3x",
-      "filename": "watch-companion-29@3x.png"
+      "filename" : "watch-companion-29@3x.png",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
-      "idiom": "watch",
-      "role": "appLauncher",
-      "subtype": "38mm",
-      "size": "40x40",
-      "scale": "2x",
-      "filename": "watch-app-38@2x.png"
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "33x33",
+      "subtype" : "45mm"
     },
     {
-      "idiom": "watch",
-      "role": "appLauncher",
-      "subtype": "40mm",
-      "size": "44x44",
-      "scale": "2x",
-      "filename": "watch-app-40@2x.png"
+      "filename" : "watch-app-38@2x.png",
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "40x40",
+      "subtype" : "38mm"
     },
     {
-      "idiom": "watch",
-      "role": "appLauncher",
-      "subtype": "41mm",
-      "size": "46x46",
-      "scale": "2x",
-      "filename": "watch-app-41@2x.png"
+      "filename" : "watch-app-40@2x.png",
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "44x44",
+      "subtype" : "40mm"
     },
     {
-      "idiom": "watch",
-      "role": "appLauncher",
-      "subtype": "44mm",
-      "size": "50x50",
-      "scale": "2x",
-      "filename": "watch-app-44@2x.png"
+      "filename" : "watch-app-41@2x.png",
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "46x46",
+      "subtype" : "41mm"
     },
     {
-      "idiom": "watch",
-      "role": "appLauncher",
-      "subtype": "45mm",
-      "size": "51x51",
-      "scale": "2x",
-      "filename": "watch-app-45@2x.png"
+      "filename" : "watch-app-44@2x.png",
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "50x50",
+      "subtype" : "44mm"
     },
     {
-      "idiom": "watch",
-      "role": "quickLook",
-      "subtype": "38mm",
-      "size": "86x86",
-      "scale": "2x",
-      "filename": "watch-quicklook-38@2x.png"
+      "filename" : "watch-app-45@2x.png",
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "51x51",
+      "subtype" : "45mm"
     },
     {
-      "idiom": "watch",
-      "role": "quickLook",
-      "subtype": "42mm",
-      "size": "98x98",
-      "scale": "2x",
-      "filename": "watch-quicklook-42@2x.png"
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "54x54",
+      "subtype" : "49mm"
     },
     {
-      "idiom": "watch",
-      "role": "quickLook",
-      "subtype": "44mm",
-      "size": "108x108",
-      "scale": "2x",
-      "filename": "watch-quicklook-44@2x.png"
+      "filename" : "watch-quicklook-38@2x.png",
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "86x86",
+      "subtype" : "38mm"
     },
     {
-      "idiom": "watch",
-      "role": "quickLook",
-      "subtype": "45mm",
-      "size": "117x117",
-      "scale": "2x",
-      "filename": "watch-quicklook-45@2x.png"
+      "filename" : "watch-quicklook-42@2x.png",
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "98x98",
+      "subtype" : "42mm"
     },
     {
-      "idiom": "watch-marketing",
-      "size": "1024x1024",
-      "scale": "1x",
-      "filename": "watch-marketing-1024.png"
+      "filename" : "watch-quicklook-44@2x.png",
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "108x108",
+      "subtype" : "44mm"
+    },
+    {
+      "filename" : "watch-quicklook-45@2x.png",
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "117x117",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "129x129",
+      "subtype" : "49mm"
+    },
+    {
+      "filename" : "watch-marketing-1024.png",
+      "idiom" : "watch-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/apps/ios/WatchApp/Info.plist
+++ b/apps/ios/WatchApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.23</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>20260223</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>WKCompanionAppBundleIdentifier</key>
 	<string>$(OPENCLAW_APP_BUNDLE_ID)</string>
 	<key>WKWatchKitApp</key>

--- a/apps/ios/WatchExtension/Info.plist
+++ b/apps/ios/WatchExtension/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.23</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>20260223</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/apps/ios/fastlane/.env.example
+++ b/apps/ios/fastlane/.env.example
@@ -15,6 +15,10 @@
 
 # Code signing
 # IOS_DEVELOPMENT_TEAM=XXXXXXXXXX
+# IOS_APP_IDENTIFIER=ai.openclaw.ios
+# IOS_SHARE_IDENTIFIER=ai.openclaw.ios.share
+# IOS_WATCH_APP_IDENTIFIER=ai.openclaw.ios.watchkitapp
+# IOS_WATCH_EXTENSION_IDENTIFIER=ai.openclaw.ios.watchkitapp.extension
 
 # Deliver toggles (off by default)
 # DELIVER_METADATA=1

--- a/apps/ios/fastlane/Appfile
+++ b/apps/ios/fastlane/Appfile
@@ -1,4 +1,4 @@
-app_identifier("bot.molt.ios")
+app_identifier(ENV.fetch("IOS_APP_IDENTIFIER", "ai.openclaw.ios"))
 
 # Auth is expected via App Store Connect API key.
 # Provide either:

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -72,12 +72,27 @@ platform :ios do
     end
     UI.user_error!("Missing IOS_DEVELOPMENT_TEAM (Apple Team ID). Add it to fastlane/.env or export it in your shell.") if team_id.nil? || team_id.strip.empty?
 
+    app_bundle_id = ENV.fetch("IOS_APP_IDENTIFIER", "ai.openclaw.ios")
+    share_bundle_id = ENV.fetch("IOS_SHARE_IDENTIFIER", "#{app_bundle_id}.share")
+    watch_app_bundle_id = ENV.fetch("IOS_WATCH_APP_IDENTIFIER", "#{app_bundle_id}.watchkitapp")
+    watch_extension_bundle_id = ENV.fetch("IOS_WATCH_EXTENSION_IDENTIFIER", "#{watch_app_bundle_id}.extension")
+
     build_app(
       project: "OpenClaw.xcodeproj",
       scheme: "OpenClaw",
       export_method: "app-store",
       clean: true,
-      xcargs: "DEVELOPMENT_TEAM=#{team_id} -allowProvisioningUpdates",
+      xcargs: [
+        "DEVELOPMENT_TEAM=#{team_id}",
+        "OPENCLAW_CODE_SIGN_STYLE=Automatic",
+        "OPENCLAW_APP_PROFILE=",
+        "OPENCLAW_SHARE_PROFILE=",
+        "OPENCLAW_APP_BUNDLE_ID=#{app_bundle_id}",
+        "OPENCLAW_SHARE_BUNDLE_ID=#{share_bundle_id}",
+        "OPENCLAW_WATCH_APP_BUNDLE_ID=#{watch_app_bundle_id}",
+        "OPENCLAW_WATCH_EXTENSION_BUNDLE_ID=#{watch_extension_bundle_id}",
+        "-allowProvisioningUpdates"
+      ].join(" "),
       export_xcargs: "-allowProvisioningUpdates",
       export_options: {
         signingStyle: "automatic"

--- a/apps/ios/fastlane/SETUP.md
+++ b/apps/ios/fastlane/SETUP.md
@@ -20,6 +20,10 @@ ASC_KEY_PATH=/absolute/path/to/AuthKey_XXXXXXXXXX.p8
 
 # Code signing (Apple Team ID / App ID Prefix)
 IOS_DEVELOPMENT_TEAM=YOUR_TEAM_ID
+IOS_APP_IDENTIFIER=com.yourcompany.openclaw
+IOS_SHARE_IDENTIFIER=com.yourcompany.openclaw.share
+IOS_WATCH_APP_IDENTIFIER=com.yourcompany.openclaw.watchkitapp
+IOS_WATCH_EXTENSION_IDENTIFIER=com.yourcompany.openclaw.watchkitapp.extension
 ```
 
 Tip: run `scripts/ios-team-id.sh` from the repo root to print a Team ID to paste into `.env`. The helper prefers the canonical OpenClaw team (`Y5PE65HELJ`) when present locally; otherwise it prefers the first non-personal team from your Xcode account (then personal team if needed). Fastlane uses this helper automatically if `IOS_DEVELOPMENT_TEAM` is missing.
@@ -30,3 +34,7 @@ Run:
 cd apps/ios
 fastlane beta
 ```
+
+Notes:
+- `IOS_APP_IDENTIFIER` and related IDs must match App IDs registered in Apple Developer.
+- The `beta` lane forces automatic signing and clears manual provisioning profile specifiers.

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -8,6 +8,8 @@ options:
 settings:
   base:
     SWIFT_VERSION: "6.0"
+    MARKETING_VERSION: "1.0.0"
+    CURRENT_PROJECT_VERSION: "1"
 
 packages:
   OpenClawKit:
@@ -92,8 +94,8 @@ targets:
           - CFBundleURLName: ai.openclaw.ios
             CFBundleURLSchemes:
               - openclaw
-        CFBundleShortVersionString: "2026.2.23"
-        CFBundleVersion: "20260223"
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         UILaunchScreen: {}
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -146,8 +148,8 @@ targets:
       path: ShareExtension/Info.plist
       properties:
         CFBundleDisplayName: OpenClaw Share
-        CFBundleShortVersionString: "2026.2.23"
-        CFBundleVersion: "20260223"
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.share-services
           NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).ShareViewController"
@@ -176,8 +178,8 @@ targets:
       path: WatchApp/Info.plist
       properties:
         CFBundleDisplayName: OpenClaw
-        CFBundleShortVersionString: "2026.2.23"
-        CFBundleVersion: "20260223"
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         WKCompanionAppBundleIdentifier: "$(OPENCLAW_APP_BUNDLE_ID)"
         WKWatchKitApp: true
 
@@ -200,8 +202,8 @@ targets:
       path: WatchExtension/Info.plist
       properties:
         CFBundleDisplayName: OpenClaw
-        CFBundleShortVersionString: "2026.2.23"
-        CFBundleVersion: "20260223"
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         NSExtension:
           NSExtensionAttributes:
             WKAppBundleIdentifier: "$(OPENCLAW_WATCH_APP_BUNDLE_ID)"
@@ -228,5 +230,5 @@ targets:
       path: Tests/Info.plist
       properties:
         CFBundleDisplayName: OpenClawTests
-        CFBundleShortVersionString: "2026.2.23"
-        CFBundleVersion: "20260223"
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -62,3 +62,14 @@ Use for local dev only; keep off for release builds.
 - `CODESIGN_TIMESTAMP=off` (offline debug)
 - `DISABLE_LIBRARY_VALIDATION=1` (dev-only Sparkle workaround)
 - `SKIP_TEAM_ID_CHECK=1` (bypass audit)
+
+## Tests
+
+```bash
+cd apps/macos
+swift test
+```
+
+When writing tests that mutate process-global state (`setenv`, `unsetenv`, `UserDefaults`),
+use `TestIsolation.withEnvValues` / `TestIsolation.withUserDefaultsValues` so parallel suites
+do not race each other.

--- a/apps/macos/Tests/OpenClawIPCTests/WideAreaGatewayDiscoveryTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WideAreaGatewayDiscoveryTests.swift
@@ -5,7 +5,6 @@ import Testing
 @Suite
 struct WideAreaGatewayDiscoveryTests {
     @Test func discoversBeaconFromTailnetDnsSdFallback() {
-        setenv("OPENCLAW_WIDE_AREA_DOMAIN", "openclaw.internal", 1)
         let statusJson = """
         {
           "Self": { "TailscaleIPs": ["100.69.232.64"] },
@@ -33,14 +32,15 @@ struct WideAreaGatewayDiscoveryTests {
                     return "\"displayName=Peter\\226\\128\\153s Mac Studio (OpenClaw)\" \"gatewayPort=18789\" \"tailnetDns=peters-mac-studio-1.sheep-coho.ts.net\" \"cliPath=/Users/steipete/openclaw/src/entry.ts\""
                 }
                 return ""
-            })
+            },
+            wideAreaDomain: "openclaw.internal")
 
         let beacons = WideAreaGatewayDiscovery.discover(
             timeoutSeconds: 2.0,
             context: context)
 
         #expect(beacons.count == 1)
-        let beacon = beacons[0]
+        guard let beacon = beacons.first else { return }
         let expectedDisplay = "Peter\u{2019}s Mac Studio (OpenClaw)"
         #expect(beacon.displayName == expectedDisplay)
         #expect(beacon.port == 18789)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,12 +322,6 @@ importers:
         specifier: workspace:*
         version: link:../..
 
-  extensions/google-antigravity-auth:
-    devDependencies:
-      openclaw:
-        specifier: workspace:*
-        version: link:../..
-
   extensions/google-gemini-cli-auth:
     devDependencies:
       openclaw:
@@ -6890,7 +6884,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6906,7 +6900,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7095,7 +7089,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 5.0.4
       '@microsoft/agents-activity': 1.3.1
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7997,7 +7991,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8043,7 +8037,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.3.0
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8935,14 +8929,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9511,8 +9497,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/src/browser/routes/agent.snapshot.ts
+++ b/src/browser/routes/agent.snapshot.ts
@@ -298,10 +298,9 @@ export function registerBrowserAgentSnapshotRoutes(
       }
 
       const snap =
-        profileCtx.profile.driver === "extension" || !tab.wsUrl
+        !tab.wsUrl
           ? (() => {
-              // Extension relay doesn't expose per-page WS URLs; run AX snapshot via Playwright CDP session.
-              // Also covers cases where wsUrl is missing/unusable.
+              // Use Playwright CDP sessions only when we lack a per-tab websocket URL.
               return requirePwAi(res, "aria snapshot").then(async (pw) => {
                 if (!pw) {
                   return null;


### PR DESCRIPTION
## Summary\n- prefer per-tab wsUrl for extension relay snapshots when available\n- fall back to Playwright CDP only when wsUrl is missing\n\n## Testing\n- not run (no dedicated snapshot route test found)