### PR TITLE
fix(tui): lowercase session key to match gateway canonical format

### DIFF
--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -199,13 +199,16 @@ export function resolveTuiSessionKey(params: {
       mainKey: params.sessionMainKey,
     });
   }
-  if (trimmed === "global" || trimmed === "unknown") {
-    return trimmed;
+  // Lowercase to match gateway's canonical session key format (resolveSessionStoreKey).
+  // Without this, uppercase session names silently break real-time event routing (#33866).
+  const lower = trimmed.toLowerCase();
+  if (lower === "global" || lower === "unknown") {
+    return lower;
   }
-  if (trimmed.startsWith("agent:")) {
-    return trimmed;
+  if (lower.startsWith("agent:")) {
+    return lower;
   }
-  return `agent:${params.currentAgentId}:${trimmed}`;
+  return `agent:${params.currentAgentId}:${lower}`;
 }
 
 export function resolveGatewayDisconnectState(reason?: string): {


### PR DESCRIPTION
Fixes #33866

`resolveTuiSessionKey` preserved the original case of `--session` input, but the gateway canonicalizes all session keys to lowercase via `resolveSessionStoreKey`. This mismatch caused the TUI to silently drop all real-time streaming events when the session name contained uppercase characters — the screen appears to hang while the agent processes, and replies only show after relaunch.

The fix lowercases the input before constructing the session key.

1 file, +8/-5. All 156 TUI tests pass.

---

AI-assisted PR (Claude via OpenClaw agent). I understand what this code does.