### PR TITLE
fix(config): normalize groupPolicy aliases so "allow" maps to "open"

### DIFF
--- a/src/config/runtime-group-policy.test.ts
+++ b/src/config/runtime-group-policy.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   GROUP_POLICY_BLOCKED_LABEL,
+  normalizeGroupPolicy,
   resetMissingProviderGroupPolicyFallbackWarningsForTesting,
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
@@ -71,6 +72,44 @@ describe("resolveDefaultGroupPolicy", () => {
       channels: { defaults: { groupPolicy: "disabled" } },
     });
     expect(resolved).toBe("disabled");
+  });
+});
+
+describe("normalizeGroupPolicy", () => {
+  it.each([
+    ["open", "open"],
+    ["disabled", "disabled"],
+    ["allowlist", "allowlist"],
+    ["allow", "open"],
+    ["allowed", "open"],
+    ["enabled", "open"],
+    ["deny", "disabled"],
+    ["denied", "disabled"],
+    ["block", "disabled"],
+    ["blocked", "disabled"],
+    ["whitelist", "allowlist"],
+  ])("normalizes %s → %s", (input, expected) => {
+    expect(normalizeGroupPolicy(input)).toBe(expected);
+  });
+
+  it("is case-insensitive", () => {
+    expect(normalizeGroupPolicy("Allow")).toBe("open");
+    expect(normalizeGroupPolicy("OPEN")).toBe("open");
+    expect(normalizeGroupPolicy("Disabled")).toBe("disabled");
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(normalizeGroupPolicy(undefined)).toBeUndefined();
+  });
+});
+
+describe("resolveRuntimeGroupPolicy with aliases", () => {
+  it("normalizes 'allow' to 'open' when provider config is present", () => {
+    const resolved = resolveRuntimeGroupPolicy({
+      providerConfigPresent: true,
+      groupPolicy: "allow" as never,
+    });
+    expect(resolved.groupPolicy).toBe("open");
   });
 });
 

--- a/src/config/runtime-group-policy.ts
+++ b/src/config/runtime-group-policy.ts
@@ -1,5 +1,27 @@
 import type { GroupPolicy } from "./types.base.js";
 
+const GROUP_POLICY_ALIASES: Record<string, GroupPolicy> = {
+  allow: "open",
+  allowed: "open",
+  enabled: "open",
+  deny: "disabled",
+  denied: "disabled",
+  block: "disabled",
+  blocked: "disabled",
+  whitelist: "allowlist",
+};
+
+export function normalizeGroupPolicy(raw: string | undefined): GroupPolicy | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  const lower = raw.trim().toLowerCase();
+  if (lower === "open" || lower === "disabled" || lower === "allowlist") {
+    return lower;
+  }
+  return GROUP_POLICY_ALIASES[lower] ?? (raw as GroupPolicy);
+}
+
 export type RuntimeGroupPolicyResolution = {
   groupPolicy: GroupPolicy;
   providerMissingFallbackApplied: boolean;
@@ -18,9 +40,11 @@ export function resolveRuntimeGroupPolicy(
 ): RuntimeGroupPolicyResolution {
   const configuredFallbackPolicy = params.configuredFallbackPolicy ?? "open";
   const missingProviderFallbackPolicy = params.missingProviderFallbackPolicy ?? "allowlist";
+  const normalized = normalizeGroupPolicy(params.groupPolicy);
+  const normalizedDefault = normalizeGroupPolicy(params.defaultGroupPolicy);
   const groupPolicy = params.providerConfigPresent
-    ? (params.groupPolicy ?? params.defaultGroupPolicy ?? configuredFallbackPolicy)
-    : (params.groupPolicy ?? missingProviderFallbackPolicy);
+    ? (normalized ?? normalizedDefault ?? configuredFallbackPolicy)
+    : (normalized ?? missingProviderFallbackPolicy);
   const providerMissingFallbackApplied =
     !params.providerConfigPresent && params.groupPolicy === undefined;
   return { groupPolicy, providerMissingFallbackApplied };


### PR DESCRIPTION
## Summary

- **Problem:** Users configure `groupPolicy: "allow"` expecting it to permit all group messages. Since `"allow"` is not a valid `GroupPolicy` enum value (`"open" | "disabled" | "allowlist"`), it falls through to the allowlist branch and silently rejects all groups with `"group not in groupAllowFrom (groupPolicy=allow)"`.
- **Why it matters:** Reported for Feishu on Windows, but this affects ALL channels using `resolveRuntimeGroupPolicy` — a common alias silently breaks group messaging.
- **What changed:** Added `normalizeGroupPolicy()` that maps common aliases (`allow`/`allowed`/`enabled` → `open`, `deny`/`denied`/`block`/`blocked` → `disabled`, `whitelist` → `allowlist`) and applied it inside `resolveRuntimeGroupPolicy` so all channels benefit.
- **What did NOT change:** GroupPolicy type, Zod schema validation, individual channel policy evaluation functions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33862

## User-visible / Behavior Changes

- `groupPolicy: "allow"` now behaves identically to `groupPolicy: "open"` (allows all groups)
- Other common aliases also work: `"enabled"`, `"deny"`, `"blocked"`, `"whitelist"`
- Case-insensitive: `"Allow"`, `"OPEN"` etc. all work

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — only normalizes existing policy values, no new access paths

## Repro + Verification

### Environment

- OS: Windows 11 / any (the fix is platform-independent)
- Channel: Feishu (and all other channels)

### Steps

1. Configure `channels.feishu.groupPolicy: "allow"`
2. Send a message in a Feishu group

### Expected

- Group message accepted

### Actual

- Before: `"group not in groupAllowFrom (groupPolicy=allow)"` — message rejected
- After: Normalized to `"open"` — message accepted

## Evidence

- [x] 21 vitest tests pass in `src/config/runtime-group-policy.test.ts`:
  - 11 alias → canonical mappings
  - Case-insensitivity tests
  - undefined input handling
  - Integration test: `"allow"` resolves to `"open"` in `resolveRuntimeGroupPolicy`
  - All pre-existing tests still pass

## Human Verification (required)

- Verified scenarios: All alias mappings, case normalization, undefined passthrough
- Edge cases checked: Whitespace trimming, mixed case, unknown values pass through unchanged
- What I did **not** verify: Live Feishu group messaging on Windows

## Compatibility / Migration

- Backward compatible? `Yes` — canonical values (`open`, `disabled`, `allowlist`) are unaffected; only adds support for aliases
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; users must use canonical values
- Files/config to restore: `src/config/runtime-group-policy.ts`

## Risks and Mitigations

- Risk: Typos in config values might accidentally match an alias
  - Mitigation: Only well-known synonyms are mapped; unknown values pass through unchanged to preserve existing behavior