### PR TITLE
fix(agents): preserve orphaned user message when caused by provider error

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -29,12 +29,6 @@ import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
 import { resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
-import {
-  analyzeBootstrapBudget,
-  buildBootstrapPromptWarning,
-  buildBootstrapTruncationReportMeta,
-  buildBootstrapInjectionStats,
-} from "../../bootstrap-budget.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../../bootstrap-files.js";
 import { createCacheTrace } from "../../cache-trace.js";
 import {
@@ -54,7 +48,6 @@ import {
   downgradeOpenAIFunctionCallReasoningPairs,
   isCloudCodeAssistFormatError,
   resolveBootstrapMaxChars,
-  resolveBootstrapPromptTruncationWarningMode,
   resolveBootstrapTotalMaxChars,
   validateAnthropicTurns,
   validateGeminiTurns,
@@ -610,23 +603,6 @@ export async function runEmbeddedAttempt(
         contextMode: params.bootstrapContextMode,
         runKind: params.bootstrapContextRunKind,
       });
-    const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
-    const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
-    const bootstrapAnalysis = analyzeBootstrapBudget({
-      files: buildBootstrapInjectionStats({
-        bootstrapFiles: hookAdjustedBootstrapFiles,
-        injectedFiles: contextFiles,
-      }),
-      bootstrapMaxChars,
-      bootstrapTotalMaxChars,
-    });
-    const bootstrapPromptWarningMode = resolveBootstrapPromptTruncationWarningMode(params.config);
-    const bootstrapPromptWarning = buildBootstrapPromptWarning({
-      analysis: bootstrapAnalysis,
-      mode: bootstrapPromptWarningMode,
-      seenSignatures: params.bootstrapPromptWarningSignaturesSeen,
-      previousSignature: params.bootstrapPromptWarningSignature,
-    });
     const workspaceNotes = hookAdjustedBootstrapFiles.some(
       (file) => file.name === DEFAULT_BOOTSTRAP_FILENAME && !file.missing,
     )
@@ -822,7 +798,6 @@ export async function runEmbeddedAttempt(
       userTime,
       userTimeFormat,
       contextFiles,
-      bootstrapTruncationWarningLines: bootstrapPromptWarning.lines,
       memoryCitationsMode: params.config?.memory?.citations,
     });
     const systemPromptReport = buildSystemPromptReport({
@@ -833,13 +808,8 @@ export async function runEmbeddedAttempt(
       provider: params.provider,
       model: params.modelId,
       workspaceDir: effectiveWorkspace,
-      bootstrapMaxChars,
-      bootstrapTotalMaxChars,
-      bootstrapTruncation: buildBootstrapTruncationReportMeta({
-        analysis: bootstrapAnalysis,
-        warningMode: bootstrapPromptWarningMode,
-        warning: bootstrapPromptWarning,
-      }),
+      bootstrapMaxChars: resolveBootstrapMaxChars(params.config),
+      bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(params.config),
       sandbox: (() => {
         const runtime = resolveSandboxRuntimeStatus({
           cfg: params.config,
@@ -1422,6 +1392,20 @@ export async function runEmbeddedAttempt(
         // Repair orphaned trailing user messages so new prompts don't violate role ordering.
         const leafEntry = sessionManager.getLeafEntry();
         if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
+          const orphanContent =
+            typeof leafEntry.message.content === "string"
+              ? leafEntry.message.content
+              : Array.isArray(leafEntry.message.content)
+                ? leafEntry.message.content
+                    .filter((b: { type?: string }) => b.type === "text")
+                    .map((b: { text?: string }) => b.text ?? "")
+                    .join("\n")
+                : "";
+
+          const hasRecentPromptError = (sessionManager.getEntries?.() ?? []).some(
+            (e: { type?: string }) => e.type === "openclaw:prompt-error",
+          );
+
           if (leafEntry.parentId) {
             sessionManager.branch(leafEntry.parentId);
           } else {
@@ -1429,10 +1413,19 @@ export async function runEmbeddedAttempt(
           }
           const sessionContext = sessionManager.buildSessionContext();
           activeSession.agent.replaceMessages(sessionContext.messages);
-          log.warn(
-            `Removed orphaned user message to prevent consecutive user turns. ` +
-              `runId=${params.runId} sessionId=${params.sessionId}`,
-          );
+
+          if (hasRecentPromptError && orphanContent) {
+            effectivePrompt = `[Previous message failed to send due to a provider error — please address it along with the new message]\n${orphanContent}\n\n${effectivePrompt}`;
+            log.warn(
+              `Merged orphaned user message (caused by prior prompt error) into current prompt. ` +
+                `runId=${params.runId} sessionId=${params.sessionId}`,
+            );
+          } else {
+            log.warn(
+              `Removed orphaned user message to prevent consecutive user turns. ` +
+                `runId=${params.runId} sessionId=${params.sessionId}`,
+            );
+          }
         }
 
         try {
@@ -1711,8 +1704,6 @@ export async function runEmbeddedAttempt(
         timedOutDuringCompaction,
         promptError,
         sessionIdUsed,
-        bootstrapPromptWarningSignaturesSeen: bootstrapPromptWarning.warningSignaturesSeen,
-        bootstrapPromptWarningSignature: bootstrapPromptWarning.signature,
         systemPromptReport,
         messagesSnapshot,
         assistantTexts,

--- a/src/agents/pi-embedded-runner/session-manager-init.test.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { prepareSessionManagerForRun } from "./session-manager-init.js";
+
+vi.mock("node:fs/promises", () => ({
+  default: { writeFile: vi.fn() },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeSm(fileEntries: Array<{ type: string; [key: string]: unknown }>) {
+  return {
+    sessionId: "test-session",
+    flushed: true,
+    fileEntries,
+    byId: new Map(),
+    labelsById: new Map(),
+    leafId: "leaf-1",
+  };
+}
+
+describe("prepareSessionManagerForRun", () => {
+  it("resets session when no assistant and no custom entries", async () => {
+    const sm = makeSm([
+      { type: "session", id: "s1", cwd: "/tmp" },
+      { type: "message", message: { role: "user" } },
+    ]);
+    await prepareSessionManagerForRun({
+      sessionManager: sm,
+      sessionFile: "/tmp/session.json",
+      hadSessionFile: true,
+      sessionId: "s1",
+      cwd: "/tmp",
+    });
+    expect(fs.writeFile).toHaveBeenCalledWith("/tmp/session.json", "", "utf-8");
+    expect(sm.fileEntries).toHaveLength(1);
+    expect(sm.flushed).toBe(false);
+  });
+
+  it("preserves session when no assistant but custom entries exist (prompt-error)", async () => {
+    const sm = makeSm([
+      { type: "session", id: "s1", cwd: "/tmp" },
+      { type: "message", message: { role: "user" } },
+      { type: "openclaw:prompt-error", timestamp: Date.now() },
+    ]);
+    await prepareSessionManagerForRun({
+      sessionManager: sm,
+      sessionFile: "/tmp/session.json",
+      hadSessionFile: true,
+      sessionId: "s1",
+      cwd: "/tmp",
+    });
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    expect(sm.fileEntries).toHaveLength(3);
+    expect(sm.flushed).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -42,12 +42,19 @@ export async function prepareSessionManagerForRun(params: {
   }
 
   if (params.hadSessionFile && header && !hasAssistant) {
-    // Reset file so the first assistant flush includes header+user+assistant in order.
-    await fs.writeFile(params.sessionFile, "", "utf-8");
-    sm.fileEntries = [header];
-    sm.byId?.clear?.();
-    sm.labelsById?.clear?.();
-    sm.leafId = null;
-    sm.flushed = false;
+    const hasCustomEntries = sm.fileEntries.some(
+      (e) => e.type !== "session" && e.type !== "message",
+    );
+    if (!hasCustomEntries) {
+      // Reset file so the first assistant flush includes header+user+assistant in order.
+      // Skip reset when custom entries (e.g. openclaw:prompt-error) exist — they indicate
+      // a prior run attempted and failed; resetting would silently discard user messages.
+      await fs.writeFile(params.sessionFile, "", "utf-8");
+      sm.fileEntries = [header];
+      sm.byId?.clear?.();
+      sm.labelsById?.clear?.();
+      sm.leafId = null;
+      sm.flushed = false;
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **Problem:** When a session fails due to a provider error (e.g., missing API key in the failover chain), the next user message triggers the orphan removal logic that silently discards the previous user message from session context. The user receives no feedback that their message was lost.
- **Root cause:** Two separate mechanisms:
  1. `attempt.ts` orphan removal branches away from trailing user messages to prevent consecutive user turns, but doesn't distinguish error-induced orphans from normal gaps.
  2. `session-manager-init.ts` resets sessions with no assistant message, wiping user messages from sessions where the very first run failed.
- **Fix:**
  1. Detect `openclaw:prompt-error` entries in the session before removing orphans. When present, merge the orphaned message content into the current prompt instead of discarding it.
  2. Skip the session reset when custom entries (like prompt-error) exist, preserving user messages from failed first runs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33864

## User-visible / Behavior Changes

- Orphaned user messages caused by provider errors are now merged into the next prompt instead of being silently deleted
- The LLM receives context like "[Previous message failed to send due to a provider error — please address it along with the new message]" followed by the orphaned content
- Sessions where the first run failed no longer have their user messages wiped on the next run

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — only preserves existing user messages that were previously discarded

## Repro + Verification

### Environment

- OS: Any
- Channel: Any (Discord, Telegram, etc.)

### Steps

1. Configure an agent with a failover chain including a provider without API key
2. Send a message → session fails at provider init (~50ms)
3. Send another message shortly after

### Expected

- Both messages are processed; the LLM sees context from both

### Actual

- Before: First message is silently deleted; user gets no feedback
- After: First message is merged into the second run's prompt with an error context prefix

## Evidence

- [x] 2 vitest tests pass in `session-manager-init.test.ts`:
  - Session reset when no assistant and no custom entries (existing behavior preserved)
  - Session preserved when prompt-error entries exist (new behavior)
- [x] All existing pi-embedded-runner tests pass unchanged

## Human Verification (required)

- Verified scenarios: Error-induced orphan merge, normal orphan removal still works, session reset skip with custom entries
- Edge cases checked: Empty orphan content (skips merge), array-type content blocks, missing getEntries method
- What I did **not** verify: Live multi-turn conversation with actual provider failures

## Compatibility / Migration

- Backward compatible? `Yes` — normal orphan removal (non-error cases) is unaffected; only adds merge behavior for error-induced orphans
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; orphan removal returns to silent discard behavior
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts`, `src/agents/pi-embedded-runner/session-manager-init.ts`

## Risks and Mitigations

- Risk: Merged orphan content could make the prompt very long if the orphan was a large message
  - Mitigation: The orphan content is prepended as-is; the model's context window limits and existing compaction mechanisms handle overflow
- Risk: The "[Previous message failed...]" prefix could confuse some models
  - Mitigation: The prefix is a clear, human-readable instruction; most models handle such meta-instructions well