### PR TITLE
fix: stabilize telegram streaming draft routing id (closes #33856)

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -91,6 +91,9 @@ export const dispatchTelegramMessage = async ({
   const isPrivateChat = msg.chat.type === "private";
   const draftThreadId = threadSpec.id;
   const draftMaxChars = Math.min(textLimit, 4096);
+  const sidDraftId = Number.parseInt(ctxPayload.MessageSid ?? "", 10);
+  const draftId =
+    Number.isFinite(sidDraftId) && sidDraftId > 0 ? sidDraftId : (msg.message_id ?? Date.now());
   const canStreamDraft =
     streamMode !== "off" &&
     isPrivateChat &&
@@ -100,7 +103,7 @@ export const dispatchTelegramMessage = async ({
     ? createTelegramDraftStream({
         api: bot.api,
         chatId,
-        draftId: msg.message_id || Date.now(),
+        draftId,
         maxChars: draftMaxChars,
         thread: threadSpec,
         log: logVerbose,


### PR DESCRIPTION
Closes #33856

## Problem
Telegram draft streaming keyed updates by msg.message_id, while downstream/final routing can rely on MessageSid (including override paths). That mismatch can make streaming edits and final send target different message identities in shared/main DM routing scenarios.

## Fix
Use ctxPayload.MessageSid as the primary draft stream id (with fallback to msg.message_id or timestamp). This keeps the streaming lifecycle on a stable message key from first delta through final delivery.