### PR TITLE
feat(acp): add delivery.mode config to suppress ACP session channel delivery

### DIFF
--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -406,6 +406,65 @@ describe("spawnAcpDirect", () => {
     expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
+  it("suppresses delivery when acp.delivery.mode is none", async () => {
+    hoisted.state.cfg = {
+      ...hoisted.state.cfg,
+      acp: {
+        ...hoisted.state.cfg.acp,
+        delivery: { mode: "none" },
+      },
+    };
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Run silently",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+        agentThreadId: "requester-thread",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const agentCall = hoisted.callGatewayMock.mock.calls
+      .map((call: unknown[]) => call[0] as { method?: string; params?: Record<string, unknown> })
+      .find((request) => request.method === "agent");
+    expect(agentCall?.params?.deliver).toBe(false);
+    expect(agentCall?.params?.channel).toBeUndefined();
+    expect(agentCall?.params?.to).toBeUndefined();
+  });
+
+  it("delivers to parent channel when acp.delivery.mode is inherit (default)", async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Run normally",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+        agentThreadId: "requester-thread",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const agentCall = hoisted.callGatewayMock.mock.calls
+      .map((call: unknown[]) => call[0] as { method?: string; params?: Record<string, unknown> })
+      .find((request) => request.method === "agent");
+    expect(agentCall?.params?.deliver).toBe(true);
+    expect(agentCall?.params?.channel).toBe("discord");
+  });
+
   it('forbids sandbox="require" for runtime=acp', async () => {
     const result = await spawnAcpDirect(
       {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -409,7 +409,9 @@ export async function spawnAcpDirect(
   const inferredDeliveryTo = boundThreadId
     ? `channel:${boundThreadId}`
     : requesterOrigin?.to?.trim() || (deliveryThreadId ? `channel:${deliveryThreadId}` : undefined);
-  const hasDeliveryTarget = Boolean(requesterOrigin?.channel && inferredDeliveryTo);
+  const acpDeliveryMode = cfg.acp?.delivery?.mode ?? "inherit";
+  const hasDeliveryTarget =
+    acpDeliveryMode !== "none" && Boolean(requesterOrigin?.channel && inferredDeliveryTo);
   const childIdem = crypto.randomUUID();
   let childRunId: string = childIdem;
   try {

--- a/src/config/types.acp.ts
+++ b/src/config/types.acp.ts
@@ -34,6 +34,13 @@ export type AcpRuntimeConfig = {
   installCommand?: string;
 };
 
+export type AcpDeliveryConfig = {
+  /** Controls whether ACP session output is delivered to the parent channel.
+   *  "inherit" (default): inherit parent session delivery context.
+   *  "none": suppress all channel delivery for ACP sessions. */
+  mode?: "inherit" | "none";
+};
+
 export type AcpConfig = {
   /** Global ACP runtime gate. */
   enabled?: boolean;
@@ -45,4 +52,5 @@ export type AcpConfig = {
   maxConcurrentSessions?: number;
   stream?: AcpStreamConfig;
   runtime?: AcpRuntimeConfig;
+  delivery?: AcpDeliveryConfig;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -404,6 +404,12 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        delivery: z
+          .object({
+            mode: z.union([z.literal("inherit"), z.literal("none")]).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

- **Problem:** ACP sessions spawned via `sessions_spawn` unconditionally inherit the parent session's delivery context and send output to the parent's channel (e.g. Telegram). There is no way to disable this behavior — `acp.delivery.mode` does not exist in the config.
- **Fix:** Added `acp.delivery` config object with a `mode` field (`"inherit"` | `"none"`). When set to `"none"`, `spawnAcpDirect` suppresses all channel delivery params (`channel`, `to`, `accountId`, `threadId`, `deliver`) so ACP session output stays internal.
- **Pattern:** Follows the existing `delivery.mode` pattern used by cron jobs (`src/cron/service/jobs.ts`).

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33859

## User-visible / Behavior Changes

New config option:
```json
{
  "acp": {
    "delivery": {
      "mode": "none"
    }
  }
}
```
- `"inherit"` (default): ACP sessions deliver to the parent session's channel (existing behavior)
- `"none"`: ACP sessions run silently — output stays internal, no channel delivery

## Security Impact (required)

- New permissions/capabilities? `No` — only adds a delivery suppression gate
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — only suppresses the existing delivery params
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Channel: Any (Telegram, Discord, etc.)

### Steps

1. Set `acp.delivery.mode: "none"` in config
2. Spawn an ACP session via `sessions_spawn runtime=acp`

### Expected

- ACP session output should NOT appear in the parent channel

### Actual

- Before: Output always appears in parent channel
- After: Output is suppressed when `mode: "none"`

## Evidence

- [x] 9 vitest tests pass in `src/agents/acp-spawn.test.ts`:
  - New: `suppresses delivery when acp.delivery.mode is none` — verifies `deliver=false` and no channel/to params
  - New: `delivers to parent channel when acp.delivery.mode is inherit (default)` — verifies existing behavior preserved
  - All 7 existing tests pass unchanged
- [x] Schema tests pass (`src/config/schema.test.ts`)

## Human Verification (required)

- Verified scenarios: delivery suppression with `mode: "none"`, default behavior with `mode: "inherit"`, no config (defaults to inherit)
- Edge cases checked: Thread-bound ACP spawns, missing delivery config entirely
- What I did **not** verify: Live ACP session with Telegram delivery suppression

## Compatibility / Migration

- Backward compatible? `Yes` — default is `"inherit"` which preserves existing behavior
- Config/env changes? New optional `acp.delivery.mode` config field
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `acp.delivery` from config or set `mode: "inherit"`; revert this commit
- Files/config to restore: `src/agents/acp-spawn.ts`, `src/config/types.acp.ts`, `src/config/zod-schema.ts`

## Risks and Mitigations

- Risk: Users might set `mode: "none"` and not realize ACP output is being suppressed
  - Mitigation: Default is `"inherit"` (existing behavior); the config key name clearly indicates delivery suppression