### PR TITLE
fix(mac): default release app builds to universal binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - TUI: infer the active agent from the current workspace when launched inside a configured agent workspace, while preserving explicit `agent:` session targets. (#39591) thanks @arceus77-7.
 - Tools/Brave web search: add opt-in `tools.web.search.brave.mode: "llm-context"` so `web_search` can call Brave's LLM Context endpoint and return extracted grounding snippets with source metadata, plus config/docs/test coverage. (#33383) Thanks @thirumaleshp.
+
 ### Fixes
 
 - macOS app/chat UI: route browser proxy through the local node browser service, preserve plain-text paste semantics, strip completed assistant trace/debug wrapper noise from transcripts, refresh permission state after returning from System Settings, and tolerate malformed cron rows in the macOS tab. (#39516) Thanks @Imhermes1.
@@ -16,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Android/Play distribution: remove self-update, background location, `screen.record`, and background mic capture from the Android app, narrow the foreground service to `dataSync` only, and clean up the legacy `location.enabledMode=always` preference migration. (#39660) Thanks @obviyus.
 - macOS overlays: fix VoiceWake, Talk, and Notify overlay exclusivity crashes by removing shared `inout` visibility mutation from `OverlayPanelFactory.present`, and add a repeated Talk overlay smoke test. (#39275, #39321) Thanks @fellanH.
 - macOS Talk Mode: set the speech recognition request `taskHint` to `.dictation` for mic capture, and add regression coverage for the request defaults. (#38445) Thanks @dmiv.
+- macOS release packaging: default `scripts/package-mac-app.sh` to universal binaries for `BUILD_CONFIG=release`, and clarify that `scripts/package-mac-dist.sh` already produces the release zip + DMG. (#33891) Thanks @cgdusek.
 
 ## 2026.3.7
 

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -44,10 +44,12 @@ BUILD_CONFIG=release \
 SIGN_IDENTITY="Developer ID Application: <Developer Name> (<TEAMID>)" \
 scripts/package-mac-dist.sh
 
-# Zip for distribution (includes resource forks for Sparkle delta support)
+# `package-mac-dist.sh` already creates the zip + DMG.
+# If you used `package-mac-app.sh` directly instead, create them manually:
+# If you want notarization/stapling in this step, use the NOTARIZE command below.
 ditto -c -k --sequesterRsrc --keepParent dist/OpenClaw.app dist/OpenClaw-2026.3.8.zip
 
-# Optional: also build a styled DMG for humans (drag to /Applications)
+# Optional: build a styled DMG for humans (drag to /Applications)
 scripts/create-dmg.sh dist/OpenClaw.app dist/OpenClaw-2026.3.8.dmg
 
 # Recommended: build + notarize/staple zip + DMG

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -40,7 +40,7 @@ BUNDLE_ID=ai.openclaw.mac \
 APP_VERSION=2026.3.8 \
 BUILD_CONFIG=release \
 SIGN_IDENTITY="Developer ID Application: <Developer Name> (<TEAMID>)" \
-scripts/package-mac-app.sh
+scripts/package-mac-dist.sh
 
 # Zip for distribution (includes resource forks for Sparkle delta support)
 ditto -c -k --sequesterRsrc --keepParent dist/OpenClaw.app dist/OpenClaw-2026.3.8.zip

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -34,8 +34,10 @@ Notes:
 
 ```bash
 # From repo root; set release IDs so Sparkle feed is enabled.
+# This command builds release artifacts without notarization.
 # APP_BUILD must be numeric + monotonic for Sparkle compare.
 # Default is auto-derived from APP_VERSION when omitted.
+SKIP_NOTARIZE=1 \
 BUNDLE_ID=ai.openclaw.mac \
 APP_VERSION=2026.3.8 \
 BUILD_CONFIG=release \

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -29,7 +29,7 @@ Notes:
 - `APP_BUILD` maps to `CFBundleVersion`/`sparkle:version`; keep it numeric + monotonic (no `-beta`), or Sparkle compares it as equal.
 - If `APP_BUILD` is omitted, `scripts/package-mac-app.sh` derives a Sparkle-safe default from `APP_VERSION` (`YYYYMMDDNN`: stable defaults to `90`, prereleases use a suffix-derived lane) and uses the higher of that value and git commit count.
 - You can still override `APP_BUILD` explicitly when release engineering needs a specific monotonic value.
-- Defaults to the current architecture (`$(uname -m)`). For release/universal builds, set `BUILD_ARCHS="arm64 x86_64"` (or `BUILD_ARCHS=all`).
+- For `BUILD_CONFIG=release`, `scripts/package-mac-app.sh` now defaults to universal (`arm64 x86_64`) automatically. You can still override with `BUILD_ARCHS=arm64` or `BUILD_ARCHS=x86_64`. For local/dev builds (`BUILD_CONFIG=debug`), it defaults to the current architecture (`$(uname -m)`).
 - Use `scripts/package-mac-dist.sh` for release artifacts (zip + DMG + notarization). Use `scripts/package-mac-app.sh` for local/dev packaging.
 
 ```bash

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -16,7 +16,14 @@ GIT_BUILD_NUMBER=$(cd "$ROOT_DIR" && git rev-list --count HEAD 2>/dev/null || ec
 APP_VERSION="${APP_VERSION:-$PKG_VERSION}"
 APP_BUILD="${APP_BUILD:-}"
 BUILD_CONFIG="${BUILD_CONFIG:-debug}"
-BUILD_ARCHS_VALUE="${BUILD_ARCHS:-$(uname -m)}"
+if [[ -n "${BUILD_ARCHS:-}" ]]; then
+  BUILD_ARCHS_VALUE="${BUILD_ARCHS}"
+elif [[ "$BUILD_CONFIG" == "release" ]]; then
+  # Release packaging should be universal unless explicitly overridden.
+  BUILD_ARCHS_VALUE="all"
+else
+  BUILD_ARCHS_VALUE="$(uname -m)"
+fi
 if [[ "${BUILD_ARCHS_VALUE}" == "all" ]]; then
   BUILD_ARCHS_VALUE="arm64 x86_64"
 fi


### PR DESCRIPTION
## Summary
- default `scripts/package-mac-app.sh` to universal arch builds (`BUILD_ARCHS=all`) when `BUILD_CONFIG=release` and `BUILD_ARCHS` is unset
- keep explicit overrides intact (`BUILD_ARCHS` still wins)
- fix `docs/platforms/mac/release.md` release command to use `scripts/package-mac-dist.sh` (the release packaging path)
- closes #28877 and addresses the duplicate regression report in #28376

## Why
Release artifacts were repeatedly built arm64-only from Apple Silicon hosts. This blocks Intel Macs at launch time. The fix hardens the build script so release builds are universal by default even when operators invoke `package-mac-app.sh` directly.

## Local Validation
- `pnpm check`
- `pnpm test`

Both passed locally on this branch.
