### PR TITLE
fix(googlechat): handle Add-on non-MESSAGE events (ADDED_TO_SPACE, REMOVED_FROM_SPACE)

### DIFF
--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -24,7 +24,7 @@ function extractBearerToken(header: unknown): string {
 
 type ParsedGoogleChatInboundPayload =
   | { ok: true; event: GoogleChatEvent; addOnBearerToken: string }
-  | { ok: false };
+  | { ok: false; unknownAddonEvent?: boolean; addOnBearerToken?: string }
 
 function parseGoogleChatInboundPayload(
   raw: unknown,
@@ -84,11 +84,9 @@ function parseGoogleChatInboundPayload(
         eventTime: chat.eventTime,
       };
     } else {
-      // Unknown Add-on event type — respond 200 to avoid error logs
-      res.statusCode = 200;
-      res.setHeader("Content-Type", "application/json");
-      res.end("{}");
-      return { ok: false };
+      // Unknown Add-on event type — return flag so caller can respond 200
+      // after verifying the token (avoid auth bypass by not responding here)
+      return { ok: false, unknownAddonEvent: true, addOnBearerToken };
     }
   }
 
@@ -192,10 +190,9 @@ export function createGoogleChatWebhookRequestHandler(params: {
         }
 
         const parsed = parseGoogleChatInboundPayload(body.value, res);
-        if (!parsed.ok) {
+        if (!parsed.ok && !parsed.unknownAddonEvent) {
           return true;
         }
-        parsedEvent = parsed.event;
 
         if (!parsed.addOnBearerToken) {
           res.statusCode = 401;
@@ -208,7 +205,7 @@ export function createGoogleChatWebhookRequestHandler(params: {
           res,
           isMatch: async (target) => {
             const verification = await verifyGoogleChatRequest({
-              bearer: parsed.addOnBearerToken,
+              bearer: parsed.addOnBearerToken!,
               audienceType: target.audienceType,
               audience: target.audience,
             });
@@ -218,6 +215,16 @@ export function createGoogleChatWebhookRequestHandler(params: {
         if (!selectedTarget) {
           return true;
         }
+
+        // Unknown Add-on event type: respond 200 after auth passes
+        if (parsed.unknownAddonEvent) {
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "application/json");
+          res.end("{}");
+          return true;
+        }
+
+        parsedEvent = (parsed as { ok: true; event: GoogleChatEvent }).event;
       }
 
       if (!selectedTarget || !parsedEvent) {

--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -1,0 +1,245 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  beginWebhookRequestPipelineOrReject,
+  readJsonWebhookBodyOrReject,
+  resolveWebhookTargetWithAuthOrReject,
+  resolveWebhookTargets,
+  type WebhookInFlightLimiter,
+} from "openclaw/plugin-sdk";
+import { verifyGoogleChatRequest } from "./auth.js";
+import type { WebhookTarget } from "./monitor-types.js";
+import type {
+  GoogleChatEvent,
+  GoogleChatMessage,
+  GoogleChatSpace,
+  GoogleChatUser,
+} from "./types.js";
+
+function extractBearerToken(header: unknown): string {
+  const authHeader = Array.isArray(header) ? String(header[0] ?? "") : String(header ?? "");
+  return authHeader.toLowerCase().startsWith("bearer ")
+    ? authHeader.slice("bearer ".length).trim()
+    : "";
+}
+
+type ParsedGoogleChatInboundPayload =
+  | { ok: true; event: GoogleChatEvent; addOnBearerToken: string }
+  | { ok: false };
+
+function parseGoogleChatInboundPayload(
+  raw: unknown,
+  res: ServerResponse,
+): ParsedGoogleChatInboundPayload {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    res.statusCode = 400;
+    res.end("invalid payload");
+    return { ok: false };
+  }
+
+  let eventPayload = raw;
+  let addOnBearerToken = "";
+
+  // Transform Google Workspace Add-on format to standard Chat API format.
+  const rawObj = raw as {
+    commonEventObject?: { hostApp?: string };
+    chat?: {
+      messagePayload?: { space?: GoogleChatSpace; message?: GoogleChatMessage };
+      user?: GoogleChatUser;
+      eventTime?: string;
+    };
+    authorizationEventObject?: { systemIdToken?: string };
+  };
+
+  if (rawObj.commonEventObject?.hostApp === "CHAT") {
+    const chat = rawObj.chat as (typeof rawObj.chat & {
+      addedToSpacePayload?: { space?: GoogleChatSpace };
+      removedFromSpacePayload?: { space?: GoogleChatSpace };
+    }) | undefined;
+    addOnBearerToken = String(rawObj.authorizationEventObject?.systemIdToken ?? "").trim();
+
+    if (chat?.messagePayload) {
+      // MESSAGE event
+      const messagePayload = chat.messagePayload;
+      eventPayload = {
+        type: "MESSAGE",
+        space: messagePayload?.space,
+        message: messagePayload?.message,
+        user: chat.user,
+        eventTime: chat.eventTime,
+      };
+    } else if (chat?.addedToSpacePayload) {
+      // ADDED_TO_SPACE event
+      eventPayload = {
+        type: "ADDED_TO_SPACE",
+        space: chat.addedToSpacePayload.space,
+        user: chat.user,
+        eventTime: chat.eventTime,
+      };
+    } else if (chat?.removedFromSpacePayload) {
+      // REMOVED_FROM_SPACE event
+      eventPayload = {
+        type: "REMOVED_FROM_SPACE",
+        space: chat.removedFromSpacePayload.space,
+        user: chat.user,
+        eventTime: chat.eventTime,
+      };
+    } else {
+      // Unknown Add-on event type — respond 200 to avoid error logs
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end("{}");
+      return { ok: false };
+    }
+  }
+
+  const event = eventPayload as GoogleChatEvent;
+  const eventType = event.type ?? (eventPayload as { eventType?: string }).eventType;
+  if (typeof eventType !== "string") {
+    res.statusCode = 400;
+    res.end("invalid payload");
+    return { ok: false };
+  }
+
+  if (!event.space || typeof event.space !== "object" || Array.isArray(event.space)) {
+    res.statusCode = 400;
+    res.end("invalid payload");
+    return { ok: false };
+  }
+
+  if (eventType === "MESSAGE") {
+    if (!event.message || typeof event.message !== "object" || Array.isArray(event.message)) {
+      res.statusCode = 400;
+      res.end("invalid payload");
+      return { ok: false };
+    }
+  }
+
+  return { ok: true, event, addOnBearerToken };
+}
+
+export function createGoogleChatWebhookRequestHandler(params: {
+  webhookTargets: Map<string, WebhookTarget[]>;
+  webhookInFlightLimiter: WebhookInFlightLimiter;
+  processEvent: (event: GoogleChatEvent, target: WebhookTarget) => Promise<void>;
+}): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
+  return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
+    const resolved = resolveWebhookTargets(req, params.webhookTargets);
+    if (!resolved) {
+      return false;
+    }
+    const { path, targets } = resolved;
+
+    const requestLifecycle = beginWebhookRequestPipelineOrReject({
+      req,
+      res,
+      allowMethods: ["POST"],
+      requireJsonContentType: true,
+      inFlightLimiter: params.webhookInFlightLimiter,
+      inFlightKey: `${path}:${req.socket?.remoteAddress ?? "unknown"}`,
+    });
+    if (!requestLifecycle.ok) {
+      return true;
+    }
+
+    try {
+      const headerBearer = extractBearerToken(req.headers.authorization);
+      let selectedTarget: WebhookTarget | null = null;
+      let parsedEvent: GoogleChatEvent | null = null;
+
+      if (headerBearer) {
+        selectedTarget = await resolveWebhookTargetWithAuthOrReject({
+          targets,
+          res,
+          isMatch: async (target) => {
+            const verification = await verifyGoogleChatRequest({
+              bearer: headerBearer,
+              audienceType: target.audienceType,
+              audience: target.audience,
+            });
+            return verification.ok;
+          },
+        });
+        if (!selectedTarget) {
+          return true;
+        }
+
+        const body = await readJsonWebhookBodyOrReject({
+          req,
+          res,
+          profile: "post-auth",
+          emptyObjectOnEmpty: false,
+          invalidJsonMessage: "invalid payload",
+        });
+        if (!body.ok) {
+          return true;
+        }
+
+        const parsed = parseGoogleChatInboundPayload(body.value, res);
+        if (!parsed.ok) {
+          return true;
+        }
+        parsedEvent = parsed.event;
+      } else {
+        const body = await readJsonWebhookBodyOrReject({
+          req,
+          res,
+          profile: "pre-auth",
+          emptyObjectOnEmpty: false,
+          invalidJsonMessage: "invalid payload",
+        });
+        if (!body.ok) {
+          return true;
+        }
+
+        const parsed = parseGoogleChatInboundPayload(body.value, res);
+        if (!parsed.ok) {
+          return true;
+        }
+        parsedEvent = parsed.event;
+
+        if (!parsed.addOnBearerToken) {
+          res.statusCode = 401;
+          res.end("unauthorized");
+          return true;
+        }
+
+        selectedTarget = await resolveWebhookTargetWithAuthOrReject({
+          targets,
+          res,
+          isMatch: async (target) => {
+            const verification = await verifyGoogleChatRequest({
+              bearer: parsed.addOnBearerToken,
+              audienceType: target.audienceType,
+              audience: target.audience,
+            });
+            return verification.ok;
+          },
+        });
+        if (!selectedTarget) {
+          return true;
+        }
+      }
+
+      if (!selectedTarget || !parsedEvent) {
+        res.statusCode = 401;
+        res.end("unauthorized");
+        return true;
+      }
+
+      const dispatchTarget = selectedTarget;
+      dispatchTarget.statusSink?.({ lastInboundAt: Date.now() });
+      params.processEvent(parsedEvent, dispatchTarget).catch((err) => {
+        dispatchTarget.runtime.error?.(
+          `[${dispatchTarget.account.accountId}] Google Chat webhook failed: ${String(err)}`,
+        );
+      });
+
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end("{}");
+      return true;
+    } finally {
+      requestLifecycle.release();
+    }
+  };
+}


### PR DESCRIPTION
## Problem

When the Chat app is configured as a **Google Workspace Add-on**, Google Chat sends events in the Add-on format (`commonEventObject.hostApp === "CHAT"`).

Previously, only MESSAGE events (`chat.messagePayload`) were transformed correctly. Other event types like `ADDED_TO_SPACE` and `REMOVED_FROM_SPACE` were **not handled**, causing:
- `400 'invalid payload'` responses from OpenClaw
- Google Chat entering a backoff/suspended state and **completely stopping event delivery** to the endpoint

## Fix

In `monitor-webhook.ts`:
- Handle `ADDED_TO_SPACE` events via `chat.addedToSpacePayload`
- Handle `REMOVED_FROM_SPACE` events via `chat.removedFromSpacePayload`
- Respond `200 {}` for unknown Add-on event types to avoid error loops
- Move `addOnBearerToken` extraction before event-type branching (applies to all Add-on events, not just MESSAGE)

## How to reproduce

1. Configure a Chat app as a Google Workspace Add-on (HTTP endpoint)
2. Add the bot to a Google Chat space
3. Google sends `ADDED_TO_SPACE` in Add-on format → OpenClaw returns 400
4. Google Chat stops sending any further events to the endpoint

## Reference

- Google Workspace Add-ons Chat events: https://developers.google.com/workspace/add-ons/chat/build#actions