### PR TITLE
feat(skills): support context: fork (subagent execution)

### DIFF
--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -214,12 +214,22 @@ export function resolveOpenClawMetadata(
 export function resolveSkillInvocationPolicy(
   frontmatter: ParsedSkillFrontmatter,
 ): SkillInvocationPolicy {
+  const contextRaw = (frontmatter?.["context"] ?? frontmatter?.["execution-context"] ?? "")
+    .trim()
+    .toLowerCase();
+  const context: SkillInvocationPolicy["context"] =
+    contextRaw === "fork" ? "fork" : contextRaw === "inline" ? "inline" : undefined;
+
+  const agentType = (frontmatter?.["agent-type"] ?? frontmatter?.["agentType"] ?? "").trim();
+
   return {
     userInvocable: parseFrontmatterBool(getFrontmatterString(frontmatter, "user-invocable"), true),
     disableModelInvocation: parseFrontmatterBool(
       getFrontmatterString(frontmatter, "disable-model-invocation"),
       false,
     ),
+    context,
+    agentType: agentType || undefined,
   };
 }
 

--- a/src/agents/skills/placeholders.test.ts
+++ b/src/agents/skills/placeholders.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { applyPlaceholders, type PlaceholderContext } from "./placeholders.js";
+
+describe("applyPlaceholders", () => {
+  it("replaces simple placeholders", () => {
+    const template = "Working directory: {{CWD}}";
+    const context: PlaceholderContext = { CWD: "/home/user/project" };
+    expect(applyPlaceholders(template, context)).toBe("Working directory: /home/user/project");
+  });
+
+  it("uses default values when placeholder is missing", () => {
+    const template = "Args: {{ARGS|none provided}}";
+    const context: PlaceholderContext = {};
+    expect(applyPlaceholders(template, context)).toBe("Args: none provided");
+  });
+
+  it("uses default values when placeholder is empty", () => {
+    const template = "Args: {{ARGS|none provided}}";
+    const context: PlaceholderContext = { ARGS: "" };
+    expect(applyPlaceholders(template, context)).toBe("Args: none provided");
+  });
+
+  it("prefers actual value over default", () => {
+    const template = "Args: {{ARGS|none}}";
+    const context: PlaceholderContext = { ARGS: "test" };
+    expect(applyPlaceholders(template, context)).toBe("Args: test");
+  });
+
+  it("leaves empty when no value and no default", () => {
+    const template = "Args: {{ARGS}}";
+    const context: PlaceholderContext = {};
+    expect(applyPlaceholders(template, context)).toBe("Args: ");
+  });
+
+  it("handles conditional blocks with truthy values", () => {
+    const template = "{{#if SELECTION}}Selected: {{SELECTION}}{{/if}}";
+    const context: PlaceholderContext = { SELECTION: "some text" };
+    expect(applyPlaceholders(template, context)).toBe("Selected: some text");
+  });
+
+  it("hides conditional blocks with falsy values", () => {
+    const template = "{{#if SELECTION}}Selected: {{SELECTION}}{{/if}}";
+    const context: PlaceholderContext = {};
+    expect(applyPlaceholders(template, context)).toBe("");
+  });
+
+  it("handles nested placeholders in conditionals", () => {
+    const template = "{{#if ARGS}}Run with: {{ARGS}}{{/if}}";
+    const context: PlaceholderContext = { ARGS: "--verbose" };
+    expect(applyPlaceholders(template, context)).toBe("Run with: --verbose");
+  });
+
+  it("handles multiple conditionals", () => {
+    const template = "{{#if CWD}}CWD: {{CWD}}{{/if}} {{#if ARGS}}ARGS: {{ARGS}}{{/if}}";
+    const context: PlaceholderContext = { CWD: "/tmp", ARGS: "test" };
+    expect(applyPlaceholders(template, context)).toBe("CWD: /tmp ARGS: test");
+  });
+
+  it("handles mixed content", () => {
+    const template = `
+# Skill Example
+
+Working in: {{CWD}}
+
+{{#if ARGS}}
+Arguments provided: {{ARGS}}
+{{/if}}
+
+{{#if SELECTION}}
+Selected text:
+{{SELECTION}}
+{{/if}}
+
+Default behavior: {{MODE|auto}}
+`;
+    const context: PlaceholderContext = {
+      CWD: "/workspace",
+      ARGS: "--flag",
+      MODE: undefined,
+    };
+    const result = applyPlaceholders(template, context);
+    expect(result).toContain("Working in: /workspace");
+    expect(result).toContain("Arguments provided: --flag");
+    expect(result).not.toContain("Selected text:");
+    expect(result).toContain("Default behavior: auto");
+  });
+
+  it("treats whitespace-only values as falsy", () => {
+    const template = "{{#if ARGS}}Has args{{/if}}";
+    const context: PlaceholderContext = { ARGS: "   " };
+    expect(applyPlaceholders(template, context)).toBe("");
+  });
+
+  it("treats 'false' string as falsy", () => {
+    const template = "{{#if FLAG}}Enabled{{/if}}";
+    const context: PlaceholderContext = { FLAG: "false" };
+    expect(applyPlaceholders(template, context)).toBe("");
+  });
+});

--- a/src/agents/skills/placeholders.ts
+++ b/src/agents/skills/placeholders.ts
@@ -1,0 +1,102 @@
+/**
+ * Dynamic placeholder expansion for OpenClaw Skills.
+ * Supports {{KEY}}, {{KEY|default}}, and {{#if KEY}}...{{/if}} syntax.
+ */
+
+export type PlaceholderContext = {
+  CWD?: string;
+  ARGS?: string;
+  SELECTION?: string;
+  [key: string]: string | undefined;
+};
+
+type Token =
+  | { kind: "text"; value: string }
+  | { kind: "placeholder"; key: string; defaultValue?: string }
+  | { kind: "if"; key: string }
+  | { kind: "endif" };
+
+function tokenize(template: string): Token[] {
+  const tokens: Token[] = [];
+  const regex = /\{\{([^}]+)\}\}/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(template)) !== null) {
+    // Add text before the match
+    if (match.index > lastIndex) {
+      tokens.push({ kind: "text", value: template.slice(lastIndex, match.index) });
+    }
+
+    const content = match[1]?.trim() ?? "";
+
+    // Check for conditional: {{#if KEY}} or {{/if}}
+    if (content.startsWith("#if ")) {
+      const key = content.slice(4).trim();
+      tokens.push({ kind: "if", key });
+    } else if (content === "/if") {
+      tokens.push({ kind: "endif" });
+    } else {
+      // Placeholder: {{KEY}} or {{KEY|default}}
+      const parts = content.split("|");
+      const key = parts[0]?.trim() ?? "";
+      const defaultValue = parts[1]?.trim();
+      tokens.push({ kind: "placeholder", key, defaultValue });
+    }
+
+    lastIndex = regex.lastIndex;
+  }
+
+  // Add remaining text
+  if (lastIndex < template.length) {
+    tokens.push({ kind: "text", value: template.slice(lastIndex) });
+  }
+
+  return tokens;
+}
+
+function isTruthy(value: string | undefined): boolean {
+  if (!value) return false;
+  const trimmed = value.trim();
+  return trimmed.length > 0 && trimmed.toLowerCase() !== "false";
+}
+
+export function applyPlaceholders(template: string, context: PlaceholderContext): string {
+  const tokens = tokenize(template);
+  const output: string[] = [];
+  const conditionStack: Array<{ key: string; enabled: boolean }> = [];
+
+  for (const token of tokens) {
+    const currentlyEnabled = conditionStack.every((frame) => frame.enabled);
+
+    if (token.kind === "if") {
+      const value = context[token.key];
+      const enabled = isTruthy(value);
+      conditionStack.push({ key: token.key, enabled });
+      continue;
+    }
+
+    if (token.kind === "endif") {
+      conditionStack.pop();
+      continue;
+    }
+
+    if (!currentlyEnabled) {
+      continue;
+    }
+
+    if (token.kind === "text") {
+      output.push(token.value);
+    } else if (token.kind === "placeholder") {
+      const value = context[token.key];
+      if (value !== undefined && value.trim().length > 0) {
+        output.push(value);
+      } else if (token.defaultValue !== undefined) {
+        output.push(token.defaultValue);
+      }
+      // If no value and no default, leave empty (don't output the placeholder)
+    }
+  }
+
+  return output.join("");
+}

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -35,6 +35,10 @@ export type OpenClawSkillMetadata = {
 export type SkillInvocationPolicy = {
   userInvocable: boolean;
   disableModelInvocation: boolean;
+  /** Execution context: "inline" (default) or "fork" (spawn subagent) */
+  context?: "inline" | "fork";
+  /** Agent type for fork context (e.g., "codex", "claude-code") */
+  agentType?: string;
 };
 
 export type SkillCommandDispatchSpec = {
@@ -54,6 +58,10 @@ export type SkillCommandSpec = {
   description: string;
   /** Optional deterministic dispatch behavior for this command. */
   dispatch?: SkillCommandDispatchSpec;
+  /** Execution context from skill frontmatter */
+  context?: "inline" | "fork";
+  /** Agent type for fork context */
+  agentType?: string;
 };
 
 export type SkillsInstallPreferences = {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -754,6 +754,8 @@ export function buildWorkspaceSkillCommandSpecs(
       skillName: rawName,
       description,
       ...(dispatch ? { dispatch } : {}),
+      ...(entry.invocation?.context ? { context: entry.invocation.context } : {}),
+      ...(entry.invocation?.agentType ? { agentType: entry.invocation.agentType } : {}),
     });
   }
   return specs;

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -238,6 +238,90 @@ export async function handleInlineActions(params: {
       }
     }
 
+    // Check if skill should be executed in fork context (subagent)
+    const shouldFork = skillInvocation.command.context === "fork";
+
+    if (shouldFork) {
+      // Spawn subagent to execute the skill
+      const skillEntries = loadWorkspaceSkillEntries(workspaceDir, { config: cfg });
+      const matchedEntry = skillEntries.find(
+        (entry) => entry.skill.name === skillInvocation.command.skillName,
+      );
+
+      let skillContent = "";
+      if (matchedEntry) {
+        try {
+          skillContent = fs.readFileSync(matchedEntry.skill.filePath, "utf-8");
+          const placeholderContext: PlaceholderContext = {
+            CWD: workspaceDir,
+            ARGS: skillInvocation.args ?? "",
+            SELECTION: ctx.ReplyToBody ?? "",
+          };
+          skillContent = applyPlaceholders(skillContent, placeholderContext);
+        } catch {
+          skillContent = "";
+        }
+      }
+
+      const taskPrompt = [
+        `Execute the "${skillInvocation.command.skillName}" skill.`,
+        skillContent ? `\n\nSkill instructions:\n\n${skillContent}` : null,
+        skillInvocation.args ? `\n\nUser input:\n${skillInvocation.args}` : null,
+      ]
+        .filter((entry): entry is string => Boolean(entry))
+        .join("\n\n");
+
+      const channel =
+        resolveGatewayMessageChannel(ctx.Surface) ??
+        resolveGatewayMessageChannel(ctx.Provider) ??
+        undefined;
+
+      const tools = createOpenClawTools({
+        agentSessionKey: sessionKey,
+        agentChannel: channel,
+        agentAccountId: (ctx as { AccountId?: string }).AccountId,
+        agentTo: ctx.OriginatingTo ?? ctx.To,
+        agentThreadId: ctx.MessageThreadId ?? undefined,
+        agentDir,
+        workspaceDir,
+        config: cfg,
+      });
+      const authorizedTools = applyOwnerOnlyToolPolicy(tools, command.senderIsOwner);
+
+      const sessionsSpawnTool = authorizedTools.find((tool) => tool.name === "sessions_spawn");
+      if (!sessionsSpawnTool) {
+        typing.cleanup();
+        return {
+          kind: "reply",
+          reply: { text: `❌ Subagent execution not available (sessions_spawn tool missing)` },
+        };
+      }
+
+      const toolCallId = `fork_${generateSecureToken(8)}`;
+      try {
+        const spawnParams: Record<string, unknown> = {
+          task: taskPrompt,
+          label: `Skill: ${skillInvocation.command.skillName}`,
+        };
+        if (skillInvocation.command.agentType) {
+          spawnParams.agentId = skillInvocation.command.agentType;
+        }
+        await sessionsSpawnTool.execute(toolCallId, spawnParams);
+        typing.cleanup();
+        return {
+          kind: "reply",
+          reply: {
+            text: `🚀 Spawned subagent to execute "${skillInvocation.command.skillName}" skill. Results will be announced when complete.`,
+          },
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        typing.cleanup();
+        return { kind: "reply", reply: { text: `❌ Failed to spawn subagent: ${message}` } };
+      }
+    }
+
+    // Inline execution (default)
     // Load skill entries to access SKILL.md content for placeholder expansion
     const skillEntries = loadWorkspaceSkillEntries(workspaceDir, { config: cfg });
     const matchedEntry = skillEntries.find(

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -1,6 +1,9 @@
+import fs from "node:fs";
 import { collectTextContentBlocks } from "../../agents/content-blocks.js";
 import { createOpenClawTools } from "../../agents/openclaw-tools.js";
 import type { SkillCommandSpec } from "../../agents/skills.js";
+import { loadWorkspaceSkillEntries } from "../../agents/skills.js";
+import { applyPlaceholders, type PlaceholderContext } from "../../agents/skills/placeholders.js";
 import { applyOwnerOnlyToolPolicy } from "../../agents/tool-policy.js";
 import { getChannelDock } from "../../channels/dock.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -235,9 +238,33 @@ export async function handleInlineActions(params: {
       }
     }
 
+    // Load skill entries to access SKILL.md content for placeholder expansion
+    const skillEntries = loadWorkspaceSkillEntries(workspaceDir, { config: cfg });
+    const matchedEntry = skillEntries.find(
+      (entry) => entry.skill.name === skillInvocation.command.skillName,
+    );
+
+    let skillContent = "";
+    if (matchedEntry) {
+      try {
+        skillContent = fs.readFileSync(matchedEntry.skill.filePath, "utf-8");
+        // Apply placeholder expansion
+        const placeholderContext: PlaceholderContext = {
+          CWD: workspaceDir,
+          ARGS: skillInvocation.args ?? "",
+          SELECTION: ctx.ReplyToBody ?? "",
+        };
+        skillContent = applyPlaceholders(skillContent, placeholderContext);
+      } catch {
+        // If we can't read the skill file, fall back to basic prompt
+        skillContent = "";
+      }
+    }
+
     const promptParts = [
       `Use the "${skillInvocation.command.skillName}" skill for this request.`,
-      skillInvocation.args ? `User input:\n${skillInvocation.args}` : null,
+      skillContent ? `\n\nSkill instructions (expanded):\n\n${skillContent}` : null,
+      skillInvocation.args ? `\n\nUser input:\n${skillInvocation.args}` : null,
     ].filter((entry): entry is string => Boolean(entry));
     const rewrittenBody = promptParts.join("\n\n");
     ctx.Body = rewrittenBody;


### PR DESCRIPTION
### What
Adds a skill execution mode that spawns a subagent instead of executing inline.

### How to use
In `SKILL.md` frontmatter:
```yaml
context: fork
agent-type: <agentId> # optional; defaults to the current agent
```

### Behavior
- `context: fork` spawns a subagent via `sessions_spawn` and passes the expanded SKILL.md as the task prompt.
- Inline execution remains the default.

### Implementation
- Extend skill frontmatter parsing to read `context` and `agent-type`
- Thread the fields through `SkillCommandSpec`
- Add fork-mode handling in `get-reply-inline-actions.ts`

### Depends on
This PR is stacked on #33899 (dynamic placeholders) and is marked draft for easier review.
