### PR TITLE
fix(daemon): handle systemctl is-enabled exit code 4 (unit not-found)

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,6 +79,21 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false when systemctl exits with code 4 (unit not-found on stdout)", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      // systemctl is-enabled prints "not-found" on stdout and exits 4 when the unit does not exist.
+      // Node wraps this in an Error whose message is the command string, not the stdout content.
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & { code?: number };
+      err.code = 4;
+      cb(err, "not-found\n", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
   it("throws when systemctl is-enabled fails for non-state errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -143,7 +143,9 @@ async function execSystemctl(
 }
 
 function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
-  return (result.stderr || result.stdout || "").trim();
+  // Combine both streams: systemctl may report state on stdout (e.g. "not-found")
+  // while execFileUtf8 fills stderr with the Node error message on non-zero exit.
+  return `${result.stderr} ${result.stdout}`.trim();
 }
 
 function isSystemctlMissing(detail: string): boolean {


### PR DESCRIPTION
## Summary

- **Problem:** On Ubuntu 24.04, `openclaw gateway install` fails with `systemctl is-enabled unavailable` when the service unit does not yet exist. `systemctl --user is-enabled` exits with code 4 and prints `not-found` on **stdout**, but the code only checked stderr.
- **Why it matters:** Blocks fresh Linux installs from setting up the gateway systemd service — a first-run experience failure.
- **What changed:** `readSystemctlDetail` now combines both stderr and stdout (matching the pattern already used in `isSystemdUserServiceAvailable`), so `not-found` from stdout is visible to `isSystemdUnitNotEnabled`.
- **What did NOT change (scope boundary):** `execFileUtf8`, `isSystemctlMissing`, `isSystemdUnitNotEnabled`, `assertSystemdAvailable`, and all other systemd functions are untouched. No runtime behavior change for macOS/Windows or for units that already exist.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33633
- Related #N/A

## User-visible / Behavior Changes

`openclaw gateway install` now succeeds on Linux when the systemd unit does not yet exist (exit code 4 / `not-found`), instead of throwing `systemctl is-enabled unavailable`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: fresh install, no existing systemd unit

### Steps

1. Fresh install OpenClaw on Ubuntu 24.04
2. Run `openclaw gateway install`
3. Observe error: `systemctl is-enabled unavailable`

### Expected

- Gateway install succeeds and creates the systemd unit file

### Actual

- Throws `systemctl is-enabled unavailable` because exit code 4 output on stdout is hidden by Node error message in stderr

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

New test reproduces exit code 4 with `not-found` on stdout and empty stderr. All 20 existing systemd tests pass.

## Human Verification (required)

- Verified scenarios: exit code 0 (enabled), exit code 1 (disabled), exit code 4 (not-found), EACCES (systemctl missing), non-state errors (bus failure)
- Edge cases checked: `readSystemctlDetail` combining both streams when both non-empty (extra whitespace handled by `.trim()`)
- What you did **not** verify: live Ubuntu 24.04 install (verified via unit test mocking `execFile` to reproduce exact Node.js behavior)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert single-line change in `readSystemctlDetail` back to `(result.stderr || result.stdout || "").trim()`
- Files/config to restore: `src/daemon/systemd.ts`
- Known bad symptoms: `isSystemctlMissing` false positive if stdout contains "not found" (with space) — verified impossible since systemctl outputs "not-found" (with hyphen)

## Risks and Mitigations

None — the fix aligns `readSystemctlDetail` with the identical pattern already proven in `isSystemdUserServiceAvailable` (same file, line 183).
