### PR TITLE
fix: respect user-configured baseUrl for Moonshot provider

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -944,11 +944,16 @@ export async function resolveImplicitProviders(params: {
     };
   }
 
+  const explicitMoonshot = params.explicitProviders?.moonshot;
   const moonshotKey =
     resolveEnvApiKeyVarName("moonshot") ??
     resolveApiKeyFromProfiles({ provider: "moonshot", store: authStore });
   if (moonshotKey) {
-    providers.moonshot = { ...buildMoonshotProvider(), apiKey: moonshotKey };
+    providers.moonshot = {
+      ...buildMoonshotProvider(),
+      ...(explicitMoonshot?.baseUrl ? { baseUrl: explicitMoonshot.baseUrl } : {}),
+      apiKey: moonshotKey,
+    };
   }
 
   const kimiCodingKey =


### PR DESCRIPTION
## Summary

Fixes Moonshot CN API authentication issues by respecting the user-configured `baseUrl` in `explicitProviders`.

## Problem

Users configuring Moonshot CN endpoint (`https://api.moonshot.cn/v1`) were getting HTTP 401 errors because `resolveImplicitProviders` always used the default global endpoint (`https://api.moonshot.ai/v1`), ignoring the user configuration.

## Solution

Check `params.explicitProviders?.moonshot?.baseUrl` before applying the default baseUrl. If the user has configured a custom baseUrl, use it.

## Changes

- `src/agents/models-config.providers.ts`: Add explicit baseUrl check for moonshot provider

## Related Issues

- Fixes #33637

## Testing

- Verified with Moonshot CN API key configuration
- Default global endpoint still works when no custom baseUrl is set