### PR TITLE
fix(llm-task): correct fallback import path for npm builds

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -25,7 +25,7 @@ async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
   }
 
   // Bundled install (built)
-  const mod = await import("../../../src/agents/pi-embedded-runner.js");
+  const mod = await import("../../../dist/extensionAPI.js");
   if (typeof mod.runEmbeddedPiAgent !== "function") {
     throw new Error("Internal error: runEmbeddedPiAgent not available");
   }


### PR DESCRIPTION
## Summary

- **Problem:** `llm-task` plugin fails on npm installs — `loadRunEmbeddedPiAgent()` fallback import uses the same `src/` path as the dev try block
- **Why it matters:** Plugin is completely broken for all npm users on 2026.3.2
- **What changed:** Fallback import path (line 28) changed from `src/agents/pi-embedded-runner.js` to `dist/extensionAPI.js`
- **What did NOT change:** Dev/source try block (line 17) still uses `src/` path — only the fallback for built installs is fixed

> **⚠️ Note:** This fix resolves the module resolution error, but there is a second issue: `runEmbeddedPiAgent()` crashes the gateway when invoked from the extension context. The dynamic import resolves, but the embedded runner appears to have runtime dependency issues when called from an extension vs core gateway. See [#33892 comment](https://github.com/openclaw/openclaw/issues/33892#issuecomment-3995174131) for details. This PR is still correct and necessary — the fallback path must point to `dist/` — but a follow-up fix may be needed for the runtime invocation.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #33892

## User-visible / Behavior Changes

`llm-task` plugin resolves the correct module on npm installs. Full end-to-end execution requires a follow-up fix for the embedded runner context.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 26.3 (arm64)
- Runtime/container: Node 25.6.1
- Model/provider: telnyx-litellm/Kimi-K2.5-drop
- Integration/channel: N/A
- Relevant config: `plugins.entries.llm-task.enabled: true`, `tools.alsoAllow: ["llm-task"]`

### Steps

1. Install OpenClaw 2026.3.2 via npm
2. Enable llm-task plugin in openclaw.json
3. Call the llm-task tool

### Expected

- Tool resolves `runEmbeddedPiAgent` from dist and executes the LLM task

### Actual (before this fix)

- `Cannot find module '../../../src/agents/pi-embedded-runner.js'`

### Actual (after this fix)

- Module resolves correctly ✅
- `runEmbeddedPiAgent()` crashes gateway on invocation ❌ (separate issue — extension runtime context incompatibility)

## Evidence

- [x] Trace/log snippets

Error before fix:
```
Cannot find module '../../../src/agents/pi-embedded-runner.js'
```

After fix — module resolves but runtime crashes:
```
[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair
```

Verified `runEmbeddedPiAgent` is exported from `dist/extensionAPI.js`:
```js
export { ..., runEmbeddedPiAgent, ... };
```

## Human Verification (required)

- Verified scenarios: Module resolution fixed — plugin loads without import error
- Edge cases checked: Dev path (line 17, `src/`) untouched, dev/source builds unaffected
- What you did **not** verify: Full end-to-end LLM task execution — runtime crash occurs after import succeeds (tracked in #33892)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Disable llm-task plugin (`enabled: false`)
- Files/config to restore: Revert `extensions/llm-task/src/llm-task-tool.ts` line 28
- Known bad symptoms: If `dist/extensionAPI.js` export name changes, fallback fails with `runEmbeddedPiAgent not available`

## Risks and Mitigations

- Risk: `dist/extensionAPI.js` export structure changes in future builds
  - Mitigation: Export is used by the gateway itself — unlikely to change without broader breakage
- Risk: Runtime crash persists after this fix
  - Mitigation: This PR is a prerequisite fix; the runtime issue needs a separate investigation into how extensions invoke the embedded agent runner