### PR TITLE
fix(logging): include profile name in rolling log filename for multi-profile isolation

### DIFF
--- a/src/gateway/server-methods/logs.ts
+++ b/src/gateway/server-methods/logs.ts
@@ -14,7 +14,7 @@ const DEFAULT_LIMIT = 500;
 const DEFAULT_MAX_BYTES = 250_000;
 const MAX_LIMIT = 5000;
 const MAX_BYTES = 1_000_000;
-const ROLLING_LOG_RE = /^openclaw-\d{4}-\d{2}-\d{2}\.log$/;
+const ROLLING_LOG_RE = /^openclaw(?:-[a-zA-Z0-9_-]+)?-\d{4}-\d{2}-\d{2}\.log$/;
 
 function isRollingLogFile(file: string): boolean {
   return ROLLING_LOG_RE.test(path.basename(file));

--- a/src/logging/logger-rolling-profile.test.ts
+++ b/src/logging/logger-rolling-profile.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { __test__ } from "./logger.js";
+
+const { defaultRollingPathForToday, isRollingPath } = __test__;
+
+describe("defaultRollingPathForToday", () => {
+  const origProfile = process.env.OPENCLAW_PROFILE;
+  afterEach(() => {
+    if (origProfile === undefined) {
+      delete process.env.OPENCLAW_PROFILE;
+    } else {
+      process.env.OPENCLAW_PROFILE = origProfile;
+    }
+  });
+
+  it("produces default path when no profile is set", () => {
+    delete process.env.OPENCLAW_PROFILE;
+    const p = defaultRollingPathForToday();
+    expect(p).toMatch(/openclaw-\d{4}-\d{2}-\d{2}\.log$/);
+    expect(p).not.toContain("openclaw-xv-");
+  });
+
+  it("produces default path when profile is 'default'", () => {
+    process.env.OPENCLAW_PROFILE = "default";
+    const p = defaultRollingPathForToday();
+    expect(p).toMatch(/openclaw-\d{4}-\d{2}-\d{2}\.log$/);
+    expect(p).not.toContain("openclaw-default-");
+  });
+
+  it("includes profile tag when OPENCLAW_PROFILE is set", () => {
+    process.env.OPENCLAW_PROFILE = "xv";
+    const p = defaultRollingPathForToday();
+    expect(p).toMatch(/openclaw-xv-\d{4}-\d{2}-\d{2}\.log$/);
+  });
+});
+
+describe("isRollingPath", () => {
+  it("matches default rolling path", () => {
+    expect(isRollingPath("/tmp/openclaw/openclaw-2026-03-04.log")).toBe(true);
+  });
+
+  it("matches profile-specific rolling path", () => {
+    expect(isRollingPath("/tmp/openclaw/openclaw-xv-2026-03-04.log")).toBe(true);
+    expect(isRollingPath("/tmp/openclaw/openclaw-my-profile-2026-03-04.log")).toBe(true);
+  });
+
+  it("rejects non-rolling paths", () => {
+    expect(isRollingPath("/tmp/openclaw/openclaw.log")).toBe(false);
+    expect(isRollingPath("/tmp/openclaw/other-2026-03-04.log")).toBe(false);
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -297,6 +297,8 @@ export function registerLogTransport(transport: LogTransport): () => void {
 
 export const __test__ = {
   shouldSkipLoadConfigFallback,
+  defaultRollingPathForToday,
+  isRollingPath,
 };
 
 function formatLocalDate(date: Date): string {
@@ -306,18 +308,24 @@ function formatLocalDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-function defaultRollingPathForToday(): string {
-  const today = formatLocalDate(new Date());
-  return path.join(DEFAULT_LOG_DIR, `${LOG_PREFIX}-${today}${LOG_SUFFIX}`);
+function resolveLogProfileTag(): string {
+  const profile = process.env.OPENCLAW_PROFILE?.trim();
+  if (!profile || profile === "default") {
+    return "";
+  }
+  return `-${profile}`;
 }
 
+function defaultRollingPathForToday(): string {
+  const today = formatLocalDate(new Date());
+  const tag = resolveLogProfileTag();
+  return path.join(DEFAULT_LOG_DIR, `${LOG_PREFIX}${tag}-${today}${LOG_SUFFIX}`);
+}
+
+const ROLLING_PATH_RE = /^openclaw(?:-[a-zA-Z0-9_-]+)?-\d{4}-\d{2}-\d{2}\.log$/;
+
 function isRollingPath(file: string): boolean {
-  const base = path.basename(file);
-  return (
-    base.startsWith(`${LOG_PREFIX}-`) &&
-    base.endsWith(LOG_SUFFIX) &&
-    base.length === `${LOG_PREFIX}-YYYY-MM-DD${LOG_SUFFIX}`.length
-  );
+  return ROLLING_PATH_RE.test(path.basename(file));
 }
 
 function pruneOldRollingLogs(dir: string): void {


### PR DESCRIPTION
## Summary

- **Problem:** When running multiple OpenClaw profiles on the same host (e.g. default + `--profile xv`), both gateway instances write to the same `/tmp/openclaw/openclaw-YYYY-MM-DD.log` file. Log entries from different profiles are interleaved with no distinguishing metadata, making debugging extremely painful.
- **Fix:** The rolling log filename now includes the profile tag from `OPENCLAW_PROFILE` when set and non-default (e.g. `openclaw-xv-2026-03-04.log`). The `isRollingPath()` check and the gateway `logs.tail` regex are updated to match both default and profile-aware filenames.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #33902

## User-visible / Behavior Changes

- Default profile: no change, still logs to `openclaw-YYYY-MM-DD.log`
- Named profiles: now log to `openclaw-{profile}-YYYY-MM-DD.log` (e.g. `openclaw-xv-2026-03-04.log`)
- `openclaw gateway status` still reports the correct log file path (it reads from the logger settings)
- `logs.tail` API correctly resolves both default and profile-specific rolling files

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Two profiles: default + `--profile xv`

### Steps

1. Start default gateway
2. Start `--profile xv` gateway
3. Observe separate log files in `/tmp/openclaw/`

### Expected

- Default: `openclaw-2026-03-04.log`
- Profile `xv`: `openclaw-xv-2026-03-04.log`

### Actual (before fix)

- Both write to `openclaw-2026-03-04.log`

## Evidence

- [x] 6 new vitest tests pass in `src/logging/logger-rolling-profile.test.ts`
  - `defaultRollingPathForToday`: no profile → default, `"default"` → default, `"xv"` → profile tag
  - `isRollingPath`: matches default, matches profile-specific, rejects non-rolling
- [x] All 68 existing logger tests pass (14 test files, 0 failures)

## Human Verification (required)

- Verified scenarios: Profile tag insertion, rolling path detection, pruning compatibility
- Edge cases checked: `OPENCLAW_PROFILE=default` treated as no-profile, empty string ignored
- What I did **not** verify: Live multi-profile runtime (only unit tested)

## Compatibility / Migration

- Backward compatible? `Yes` — default profile behavior is unchanged
- Config/env changes? `No` — uses existing `OPENCLAW_PROFILE` env var
- Migration needed? `No` — existing log files are not moved; new files appear alongside old ones

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; both profiles will share the log file again
- Files/config to restore: `src/logging/logger.ts`, `src/gateway/server-methods/logs.ts`

## Risks and Mitigations

- Risk: `pruneOldRollingLogs` might miss profile-aware files
  - Mitigation: Pruning already filters by `startsWith("openclaw-")` and `endsWith(".log")`; profile-aware filenames match both conditions
- Risk: External log parsers may not expect profile-tagged filenames
  - Mitigation: Default profile is unchanged; only explicitly named profiles get tagged filenames