### PR TITLE
fix(feishu): refresh typing indicator on keepalive instead of skipping re-adds

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -8,7 +8,9 @@ const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 const resolveReceiveIdTypeMock = vi.hoisted(() => vi.fn());
 const createReplyDispatcherWithTypingMock = vi.hoisted(() => vi.fn());
-const addTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => ({ messageId: "om_msg" })));
+const addTypingIndicatorMock = vi.hoisted(() =>
+  vi.fn(async () => ({ messageId: "om_msg", reactionId: "rc_typing_1" })),
+);
 const removeTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => {}));
 const streamingInstances = vi.hoisted(() => [] as any[]);
 
@@ -167,6 +169,93 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         messageId: "om_parent",
       }),
     );
+  });
+
+  it("refreshes typing indicator on keepalive by removing then re-adding", async () => {
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      replyToMessageId: "om_parent",
+      messageCreateTimeMs: Date.now() - 30_000,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    // First call: initial add
+    await options.onReplyStart?.();
+    expect(addTypingIndicatorMock).toHaveBeenCalledTimes(1);
+    expect(removeTypingIndicatorMock).not.toHaveBeenCalled();
+
+    // Second call (keepalive): should remove then re-add
+    await options.onReplyStart?.();
+    expect(removeTypingIndicatorMock).toHaveBeenCalledTimes(1);
+    expect(addTypingIndicatorMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not orphan a reaction when stop() races with keepalive start()", async () => {
+    // Simulate stop() running during the addTypingIndicator await by having
+    // the mock trigger the onIdle (stop) callback mid-flight.
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      replyToMessageId: "om_parent",
+      messageCreateTimeMs: Date.now() - 30_000,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+
+    // First call: initial add — sets typingState
+    await options.onReplyStart?.();
+    expect(addTypingIndicatorMock).toHaveBeenCalledTimes(1);
+
+    // On the next add call, simulate stop() firing during the async gap
+    addTypingIndicatorMock.mockImplementationOnce(async () => {
+      // onIdle fires while addTypingIndicator is in-flight
+      await options.onIdle?.();
+      return { messageId: "om_msg", reactionId: "rc_orphan" };
+    });
+
+    // Second call (keepalive): remove + add, but onIdle runs mid-add.
+    // The typingStopped flag prevents the orphaned reaction from sticking:
+    // start() detects the flag after add returns and removes rc_orphan.
+    await options.onReplyStart?.();
+
+    // rc_orphan should have been cleaned up. removeTypingIndicator is called:
+    // 1. keepalive remove (old reaction)
+    // 2. stop() — no-op since typingState was null
+    // 3. post-add cleanup (rc_orphan)
+    expect(removeTypingIndicatorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: expect.objectContaining({ reactionId: "rc_orphan" }),
+      }),
+    );
+  });
+
+  it("skips start after stop has been called", async () => {
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      replyToMessageId: "om_parent",
+      messageCreateTimeMs: Date.now() - 30_000,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+
+    // Initial add
+    await options.onReplyStart?.();
+    expect(addTypingIndicatorMock).toHaveBeenCalledTimes(1);
+
+    // Stop
+    await options.onIdle?.();
+
+    // Try to start again after stop — should be no-op
+    await options.onReplyStart?.();
+    expect(addTypingIndicatorMock).toHaveBeenCalledTimes(1); // still 1, not 2
   });
 
   it("keeps auto mode plain text on non-streaming send path", async () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -76,38 +76,76 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
   let typingState: TypingIndicatorState | null = null;
+  let typingStopped = false;
+  // Serialize start() calls so concurrent keepalive ticks (fire-and-forget
+  // onReplyStart) don't interleave and orphan reactions.
+  let startChain: Promise<void> = Promise.resolve();
   const typingCallbacks = createTypingCallbacks({
-    start: async () => {
-      // Check if typing indicator is enabled (default: true)
+    start: (): Promise<void> | void => {
+      // Quick synchronous bail-outs — avoid chaining no-op promises.
       if (!(account.config.typingIndicator ?? true)) {
         return;
       }
-      if (!replyToMessageId) {
+      if (!replyToMessageId || typingStopped) {
         return;
       }
-      // Skip typing indicator for old messages — likely replays after context
-      // compaction that would flood users with stale notifications (#30418).
-      const messageCreateTimeMs = normalizeEpochMs(params.messageCreateTimeMs);
-      if (
-        messageCreateTimeMs !== undefined &&
-        Date.now() - messageCreateTimeMs > TYPING_INDICATOR_MAX_AGE_MS
-      ) {
-        return;
-      }
-      // Feishu reactions persist until explicitly removed, so skip keepalive
-      // re-adds when a reaction already exists. Re-adding the same emoji
-      // triggers a new push notification for every call (#28660).
-      if (typingState?.reactionId) {
-        return;
-      }
-      typingState = await addTypingIndicator({
-        cfg,
-        messageId: replyToMessageId,
-        accountId,
-        runtime: params.runtime,
+      startChain = startChain.then(async () => {
+        if (typingStopped) {
+          return;
+        }
+        // Skip typing indicator for old messages — likely replays after context
+        // compaction that would flood users with stale notifications (#30418).
+        const messageCreateTimeMs = normalizeEpochMs(params.messageCreateTimeMs);
+        if (
+          messageCreateTimeMs !== undefined &&
+          Date.now() - messageCreateTimeMs > TYPING_INDICATOR_MAX_AGE_MS
+        ) {
+          return;
+        }
+        // Feishu reactions persist until explicitly removed, so the initial add
+        // is sufficient. However, the Feishu client stops displaying the typing
+        // animation after a short period even though the reaction remains. To
+        // keep the indicator visible during long inference runs we must remove
+        // and re-add the reaction instead of calling addReaction again (which
+        // would trigger a duplicate push notification per #28660).
+        if (typingState?.reactionId) {
+          await removeTypingIndicator({
+            cfg,
+            state: typingState,
+            accountId,
+            runtime: params.runtime,
+          });
+          typingState = null;
+        }
+        // Recheck after the async gap — stop() may have run while we awaited.
+        if (typingStopped) {
+          return;
+        }
+        typingState = await addTypingIndicator({
+          cfg,
+          messageId: replyToMessageId,
+          accountId,
+          runtime: params.runtime,
+        });
+        // Final recheck — if stop() ran during addTypingIndicator, clean up the
+        // freshly-added reaction so it doesn't stick on the message.
+        if (typingStopped && typingState) {
+          await removeTypingIndicator({
+            cfg,
+            state: typingState,
+            accountId,
+            runtime: params.runtime,
+          });
+          typingState = null;
+        }
       });
+      return startChain;
     },
     stop: async () => {
+      typingStopped = true;
+      // Wait for any in-flight start() to finish before cleaning up, so we
+      // don't race with its state mutations.
+      await startChain;
       if (!typingState) {
         return;
       }


### PR DESCRIPTION
## Problem

The #31580 fix correctly prevented duplicate notification pushes by skipping typing reaction re-adds when the indicator was already active. However, this caused the Feishu client to stop displaying the typing animation after a short period — the reaction remained on the message but the visual indicator disappeared.

**Observed behavior after v2026.2.28+:**
- `typing TTL reached (2m); stopping typing indicator` in logs but no `added typing indicator reaction` entries
- Users no longer see the "..." typing animation in Feishu
- The inline emoji reaction appears briefly then animation stops

## Root Cause

The `start` callback in the Feishu reply dispatcher is called both for the initial typing indicator add AND for keepalive refreshes. The #31580 fix added an early return when `typingState?.reactionId` exists, which correctly prevented duplicate adds but also prevented ALL keepalive refreshes.

Feishu reactions persist until explicitly removed (unlike Telegram which auto-expires). But the Feishu client UI stops rendering the typing animation after a short period unless the reaction is refreshed.

## Fix

Instead of skipping re-adds entirely, **remove the existing reaction first, then re-add it**. This:
1. Refreshes the visual typing indicator animation
2. Avoids duplicate push notifications (since the reaction is removed before re-adding, Feishu treats it as a new reaction, not a duplicate)
3. Maintains the original #28660 fix intent

## Changes

- `extensions/feishu/src/reply-dispatcher.ts`: Replace early `return` with remove-then-re-add cycle
- `extensions/feishu/src/reply-dispatcher.test.ts`: Add regression test for keepalive refresh behavior; fix mock to return `reactionId`

## Testing

- Unit test added: verifies second `onReplyStart` call triggers remove → add cycle
- Manually verified on Feishu with long inference runs