### PR TITLE
fix(tools): warn when configured tools are hidden by tools.profile

### DIFF
--- a/src/agents/pi-tools.profile-warning.test.ts
+++ b/src/agents/pi-tools.profile-warning.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { __test__ } from "./pi-tools.js";
+
+const { warnConfiguredToolsHiddenByProfile } = __test__;
+
+vi.mock("../logger.js", () => ({
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+}));
+
+import { logWarn } from "../logger.js";
+
+function fakeTool(name: string) {
+  return { name, description: "", parameters: {} } as never;
+}
+
+describe("warnConfiguredToolsHiddenByProfile", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("warns when exec is configured but hidden by messaging profile", () => {
+    warnConfiguredToolsHiddenByProfile({
+      profile: "messaging",
+      before: [fakeTool("exec"), fakeTool("sessions_list"), fakeTool("session_status")],
+      after: [fakeTool("sessions_list"), fakeTool("session_status")],
+      cfg: { tools: { exec: { security: "full" } } } as never,
+    });
+    expect(logWarn).toHaveBeenCalledOnce();
+    expect(vi.mocked(logWarn).mock.calls[0]?.[0]).toMatch(/tools\.profile "messaging" hides.*exec/);
+  });
+
+  it("does not warn when profile is full", () => {
+    warnConfiguredToolsHiddenByProfile({
+      profile: "full",
+      before: [fakeTool("exec")],
+      after: [],
+      cfg: { tools: { exec: { security: "full" } } } as never,
+    });
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when no configured tools are hidden", () => {
+    warnConfiguredToolsHiddenByProfile({
+      profile: "messaging",
+      before: [fakeTool("sessions_list")],
+      after: [fakeTool("sessions_list")],
+      cfg: { tools: { exec: { security: "full" } } } as never,
+    });
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when hidden tools have no explicit config", () => {
+    warnConfiguredToolsHiddenByProfile({
+      profile: "messaging",
+      before: [fakeTool("exec"), fakeTool("sessions_list")],
+      after: [fakeTool("sessions_list")],
+      cfg: {} as never,
+    });
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it("warns when fs tools are configured but hidden by minimal profile", () => {
+    warnConfiguredToolsHiddenByProfile({
+      profile: "minimal",
+      before: [fakeTool("read"), fakeTool("write"), fakeTool("session_status")],
+      after: [fakeTool("session_status")],
+      cfg: { tools: { fs: { workspaceOnly: true } } } as never,
+    });
+    expect(logWarn).toHaveBeenCalledOnce();
+    expect(vi.mocked(logWarn).mock.calls[0]?.[0]).toMatch(/read, write/);
+  });
+
+  it("suggests tools.alsoAllow in the warning message", () => {
+    warnConfiguredToolsHiddenByProfile({
+      profile: "messaging",
+      before: [fakeTool("exec"), fakeTool("sessions_list")],
+      after: [fakeTool("sessions_list")],
+      cfg: { tools: { exec: { security: "full" } } } as never,
+    });
+    expect(vi.mocked(logWarn).mock.calls[0]?.[0]).toMatch(/tools\.alsoAllow/);
+  });
+
+  it("does not warn when profile is unset", () => {
+    warnConfiguredToolsHiddenByProfile({
+      profile: undefined,
+      before: [fakeTool("exec")],
+      after: [],
+      cfg: { tools: { exec: { security: "full" } } } as never,
+    });
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -57,6 +57,69 @@ import {
 } from "./tool-policy.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
+const TOOL_CONFIG_KEYS: Record<string, string> = {
+  exec: "tools.exec",
+  read: "tools.fs",
+  write: "tools.fs",
+  edit: "tools.fs",
+  apply_patch: "tools.fs",
+};
+
+function warnConfiguredToolsHiddenByProfile(params: {
+  profile?: string;
+  before: AnyAgentTool[];
+  after: AnyAgentTool[];
+  cfg?: OpenClawConfig;
+  agentId?: string;
+}) {
+  const { profile, before, after, cfg } = params;
+  if (!profile || profile === "full") {
+    return;
+  }
+
+  const afterNames = new Set(after.map((t) => t.name));
+  const hidden = before.filter((t) => !afterNames.has(t.name));
+  if (hidden.length === 0) {
+    return;
+  }
+
+  const globalTools = cfg?.tools;
+  const agentTools =
+    cfg && params.agentId ? resolveAgentConfig(cfg, params.agentId)?.tools : undefined;
+
+  const configured: string[] = [];
+  for (const tool of hidden) {
+    const cfgKey = TOOL_CONFIG_KEYS[tool.name];
+    if (!cfgKey) {
+      continue;
+    }
+    const hasGlobal =
+      cfgKey === "tools.exec"
+        ? globalTools?.exec != null
+        : cfgKey === "tools.fs"
+          ? globalTools?.fs != null
+          : false;
+    const hasAgent =
+      cfgKey === "tools.exec"
+        ? agentTools?.exec != null
+        : cfgKey === "tools.fs"
+          ? agentTools?.fs != null
+          : false;
+    if (hasGlobal || hasAgent) {
+      configured.push(tool.name);
+    }
+  }
+
+  if (configured.length === 0) {
+    return;
+  }
+
+  logWarn(
+    `tools.profile "${profile}" hides configured tool(s): ${configured.join(", ")}. ` +
+      `Change tools.profile to "coding" or "full", or add these tools to tools.alsoAllow to make them available.`,
+  );
+}
+
 function isOpenAIProvider(provider?: string) {
   const normalized = provider?.trim().toLowerCase();
   return normalized === "openai" || normalized === "openai-codex";
@@ -525,6 +588,15 @@ export function createOpenClawCodingTools(options?: {
       { policy: subagentPolicy, label: "subagent tools.allow" },
     ],
   });
+
+  warnConfiguredToolsHiddenByProfile({
+    profile,
+    before: toolsByAuthorization,
+    after: subagentFiltered,
+    cfg: options?.config,
+    agentId,
+  });
+
   // Always normalize tool JSON Schemas before handing them to pi-agent/pi-ai.
   // Without this, some providers (notably OpenAI) will reject root-level union schemas.
   // Provider-specific cleaning: Gemini needs constraint keywords stripped, but Anthropic expects them.
@@ -552,3 +624,7 @@ export function createOpenClawCodingTools(options?: {
   // on the wire and maps them back for tool dispatch.
   return withAbort;
 }
+
+export const __test__ = {
+  warnConfiguredToolsHiddenByProfile,
+};


### PR DESCRIPTION
## Summary

- **Problem:** When `tools.profile=messaging` (or `minimal`), the `exec` tool (and other non-messaging tools) are silently excluded from the agent's tool list — even when the user has explicitly configured `tools.exec.security`, `tools.exec.ask`, etc. There is no indication that the config is being ignored, leading to confusion ("the agent says it has no exec tool").
- **Fix:** After the tool policy pipeline runs, a new `warnConfiguredToolsHiddenByProfile()` function compares the pre-filter and post-filter tool lists. If any tools that have explicit configuration (e.g. `tools.exec`, `tools.fs`) were removed by the profile, a warning is logged naming the hidden tools and suggesting `tools.alsoAllow` or a profile change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33871

## User-visible / Behavior Changes

- A warning is now logged when configured tools are hidden by `tools.profile`:
  ```
  tools.profile "messaging" hides configured tool(s): exec. Change tools.profile to "coding" or "full", or add these tools to tools.alsoAllow to make them available.
  ```
- No behavior change for existing profiles — tools are still filtered the same way; this only adds diagnostic visibility

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — no tools are added/removed, only a warning is logged
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Config: `tools.profile: "messaging"`, `tools.exec.security: "full"`

### Steps

1. Set `tools.profile: "messaging"` and `tools.exec.security: "full"`
2. Start the gateway
3. Check logs for the new warning

### Expected

- Warning in logs: `tools.profile "messaging" hides configured tool(s): exec...`

### Actual (before fix)

- No warning; exec silently unavailable

## Evidence

- [x] 7 new vitest tests pass in `src/agents/pi-tools.profile-warning.test.ts`
  - `warns when exec is configured but hidden by messaging profile`
  - `does not warn when profile is full`
  - `does not warn when no configured tools are hidden`
  - `does not warn when hidden tools have no explicit config`
  - `warns when fs tools are configured but hidden by minimal profile`
  - `suggests tools.alsoAllow in the warning message`
  - `does not warn when profile is unset`
- [x] 48 existing pi-tools tests pass (3 test files)

## Human Verification (required)

- Verified scenarios: messaging profile + exec config, minimal profile + fs config, full profile (no warn), unset profile (no warn)
- Edge cases checked: No config → no warning, tools not hidden → no warning
- What I did **not** verify: Live gateway runtime (only unit tested)

## Compatibility / Migration

- Backward compatible? `Yes` — only adds a log warning, no behavior change
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; warnings will no longer appear
- Files/config to restore: `src/agents/pi-tools.ts`

## Risks and Mitigations

- Risk: Warning fires on every tool resolution call (could be noisy in high-throughput scenarios)
  - Mitigation: Only fires when both (a) a restrictive profile is set and (b) configured tools are actually hidden — this is an unusual and likely unintentional configuration