### PR TITLE
fix(feishu): deduplicate partially overlapping chunks in streaming card

### DIFF
--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -15,4 +15,10 @@ describe("mergeStreamingText", () => {
     expect(mergeStreamingText("hello wor", "ld")).toBe("hello world");
     expect(mergeStreamingText("line1", "line2")).toBe("line1line2");
   });
+
+  it("deduplicates partially overlapping chunks", () => {
+    expect(mergeStreamingText("第1条", "1条 - 08")).toBe("第1条 - 08");
+    expect(mergeStreamingText("hello wo", "wo rld")).toBe("hello wo rld");
+    expect(mergeStreamingText("abcdef", "defghi")).toBe("abcdefghi");
+  });
 });

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -100,7 +100,15 @@ export function mergeStreamingText(
   if (previous.includes(next)) {
     return previous;
   }
-  // Fallback for fragmented partial chunks: append as-is to avoid losing tokens.
+  // Find the longest suffix of `previous` that matches a prefix of `next` to avoid duplication.
+  // e.g. previous="第1条", next="1条 - 08" → overlap="1条" → merged="第1条 - 08"
+  const maxOverlap = Math.min(previous.length, next.length);
+  for (let i = maxOverlap; i > 0; i--) {
+    if (previous.endsWith(next.slice(0, i))) {
+      return previous + next.slice(i);
+    }
+  }
+  // No overlap found: append as-is.
   return `${previous}${next}`;
 }
 


### PR DESCRIPTION
Fixes #33751

## Problem
When streaming text arrives as partially overlapping fragments (e.g. previous=`第1条`, next=`1条 - 08`), `mergeStreamingText` fell back to naive concatenation, producing visible duplication like `第1条1条 - 08`.

## Fix
Detect the longest suffix-prefix overlap between previous and next text, and merge on that boundary instead of concatenating blindly.

## Tests
Added test case for partial overlap deduplication — all existing tests continue to pass.