### PR TITLE
docs: standardize GitHub label casing in maintainers list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,9 @@ Welcome to the lobster tank! 🦞
   - GitHub: [@joshavant](https://github.com/joshavant) · X: [@joshavant](https://x.com/joshavant)
 
 - **Jonathan Taylor** - ACP subsystem, Gateway features/bugs, Gog/Mog/Sog CLI's, SEDMAT
-  - Github [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
+  - GitHub: [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
 - **Josh Lehman** - Compaction, Tlon/Urbit subsystem
-  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman\_](https://x.com/jlehman_)
+  - GitHub: [@jalehman](https://github.com/jalehman) · X: [@jlehman\_](https://x.com/jlehman_)
 
 ## How to Contribute
 


### PR DESCRIPTION
## Summary
- standardize two maintainer bullets in `CONTRIBUTING.md` from `Github` to `GitHub:`
- keeps wording consistent with the rest of the maintainer list

## Type
- docs

## Risk
- low (documentation-only)

## Validation
- baseline gates were run in this session (existing unrelated UI test failures on main); this change is docs-only and does not touch runtime code