### PR TITLE
fix(tui): canonicalize session keys to lowercase (regression #33866)

### DIFF
--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -74,6 +74,34 @@ describe("resolveTuiSessionKey", () => {
       }),
     ).toBe("agent:ops:incident");
   });
+
+  it("canonicalizes uppercase session keys to lowercase (regression #33866)", () => {
+    // Session keys should be lowercase to match gateway's resolveSessionStoreKey
+    expect(
+      resolveTuiSessionKey({
+        raw: "Test1",
+        sessionScope: "global",
+        currentAgentId: "main",
+        sessionMainKey: "agent:main:main",
+      }),
+    ).toBe("agent:main:test1");
+    expect(
+      resolveTuiSessionKey({
+        raw: "agent:main:Test1",
+        sessionScope: "global",
+        currentAgentId: "main",
+        sessionMainKey: "agent:main:main",
+      }),
+    ).toBe("agent:main:test1");
+    expect(
+      resolveTuiSessionKey({
+        raw: "agent:ops:UPPER",
+        sessionScope: "global",
+        currentAgentId: "main",
+        sessionMainKey: "agent:main:main",
+      }),
+    ).toBe("agent:ops:upper");
+  });
 });
 
 describe("resolveGatewayDisconnectState", () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -199,13 +199,14 @@ export function resolveTuiSessionKey(params: {
       mainKey: params.sessionMainKey,
     });
   }
-  if (trimmed === "global" || trimmed === "unknown") {
-    return trimmed;
+  const lowered = trimmed.toLowerCase();
+  if (lowered === "global" || lowered === "unknown") {
+    return lowered;
   }
   if (trimmed.startsWith("agent:")) {
-    return trimmed;
+    return lowered;
   }
-  return `agent:${params.currentAgentId}:${trimmed}`;
+  return `agent:${params.currentAgentId}:${lowered}`;
 }
 
 export function resolveGatewayDisconnectState(reason?: string): {


### PR DESCRIPTION
## Summary

TUI silently drops all real-time chat events (deltas and finals) when the `--session` name contains uppercase characters, because `resolveTuiSessionKey` preserves the original case while the Gateway canonicalizes session keys to lowercase via `resolveSessionStoreKey`.

## Fix

Modified `resolveTuiSessionKey` to convert session keys to lowercase, matching the gateway's behavior.

## Changes

- `src/tui/tui.ts`: Convert session keys to lowercase in `resolveTuiSessionKey`
- `src/tui/tui.test.ts`: Added 3 test cases for uppercase session key scenarios

## Testing

All 20 tests in tui.test.ts pass.

Closes #33866