### PR TITLE
Deps: fix pnpm audit vulnerabilities in Google extension path

### DIFF
--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -8,7 +8,7 @@
     "google-auth-library": "^10.6.1"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.3.1"
+    "openclaw": ">=2026.3.2"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -5,7 +5,7 @@
   "description": "OpenClaw core memory search plugin",
   "type": "module",
   "peerDependencies": {
-    "openclaw": ">=2026.3.1"
+    "openclaw": ">=2026.3.2"
   },
   "openclaw": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -260,7 +260,7 @@
     "minimumReleaseAge": 2880,
     "overrides": {
       "hono": "4.11.10",
-      "fast-xml-parser": "5.3.6",
+      "fast-xml-parser": "5.3.8",
       "request": "npm:@cypress/request@3.0.10",
       "request-promise": "npm:@cypress/request-promise@5.0.0",
       "form-data": "2.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   hono: 4.11.10
-  fast-xml-parser: 5.3.6
+  fast-xml-parser: 5.3.8
   request: npm:@cypress/request@3.0.10
   request-promise: npm:@cypress/request-promise@5.0.0
   form-data: 2.5.4
@@ -347,8 +347,8 @@ importers:
         specifier: ^10.6.1
         version: 10.6.1
       openclaw:
-        specifier: '>=2026.3.1'
-        version: 2026.3.1(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
+        specifier: '>=2026.3.2'
+        version: 2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/imessage: {}
 
@@ -383,8 +383,8 @@ importers:
   extensions/memory-core:
     dependencies:
       openclaw:
-        specifier: '>=2026.3.1'
-        version: 2026.3.1(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
+        specifier: '>=2026.3.2'
+        version: 2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/memory-lancedb:
     dependencies:
@@ -3963,8 +3963,8 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-parser@5.3.6:
-    resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
+  fast-xml-parser@5.3.8:
+    resolution: {integrity: sha512-53jIF4N6u/pxvaL1eb/hEZts/cFLWZ92eCfLrNyCI0k38lettCG/Bs40W9pPwoPXyHQlKu2OUbQtiEIZK/J6Vw==}
     hasBin: true
 
   fd-slicer@1.1.0:
@@ -4942,8 +4942,8 @@ packages:
       zod:
         optional: true
 
-  openclaw@2026.3.1:
-    resolution: {integrity: sha512-7Pt5ykhaYa8TYpLWnBhaMg6Lp6kfk3rMKgqJ3WWESKM9BizYu1fkH/rF9BLeXlsNASgZdLp4oR8H0XfvIIoXIg==}
+  openclaw@2026.3.2:
+    resolution: {integrity: sha512-Gkqx24m7PF1DUXPI968DuC9n52lTZ5hI3X5PIi0HosC7J7d6RLkgVppj1mxvgiQAWMp41E41elvoi/h4KBjFcQ==}
     engines: {node: '>=22.12.0'}
     hasBin: true
     peerDependencies:
@@ -6711,7 +6711,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.8':
     dependencies:
       '@smithy/types': 4.13.0
-      fast-xml-parser: 5.3.6
+      fast-xml-parser: 5.3.8
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -10082,7 +10082,7 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-parser@5.3.6:
+  fast-xml-parser@5.3.8:
     dependencies:
       strnum: 2.2.0
 
@@ -11154,7 +11154,7 @@ snapshots:
       ws: 8.19.0
       zod: 4.3.6
 
-  openclaw@2026.3.1(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
+  openclaw@2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
       '@aws-sdk/client-bedrock': 3.1000.0
@@ -11209,6 +11209,7 @@ snapshots:
       qrcode-terminal: 0.12.0
       sharp: 0.34.5
       sqlite-vec: 0.1.7-alpha.2
+      strip-ansi: 7.2.0
       tar: 7.5.9
       tslog: 4.10.2
       undici: 7.22.0


### PR DESCRIPTION
## Summary

- Problem: `pnpm audit` flagged multiple advisories through `extensions/googlechat -> openclaw@2026.3.1` plus one low advisory on `fast-xml-parser@5.3.6` via `@aws-sdk/client-bedrock`.
- Why it matters: security audit was failing and dependency graph included known vulnerable ranges.
- What changed: raised extension peer floor to `openclaw>=2026.3.2`, bumped pnpm override `fast-xml-parser` to `5.3.8`, regenerated lockfile.
- What did NOT change (scope boundary): no runtime logic changes outside dependency constraints/resolution.

## Change Type (select all)

- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #N/A
- Related #N/A

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Google Chat extension dependency path
- Relevant config (redacted): default repo config

### Steps

1. Run `pnpm audit` on current branch.
2. Confirm no vulnerabilities remain.

### Expected

- `pnpm audit` reports no known vulnerabilities.

### Actual

- `pnpm audit` reports no known vulnerabilities.

## Evidence

- [x] Failing test/log before + passing after

Before:
- `pnpm audit` reported advisories on `extensions__googlechat>openclaw` (vulnerable `<=2026.3.1`) and low advisory on `fast-xml-parser`.

After:
- `pnpm audit` -> `No known vulnerabilities found`.

## Human Verification (required)

- Verified scenarios: reproduced audit findings, applied dependency fixes, re-ran audit clean.
- Edge cases checked: lockfile resolution for extension peers moved to `openclaw@2026.3.2`.
- What you did **not** verify: full test suite/build.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `extensions/googlechat/package.json`, `extensions/memory-core/package.json`, `package.json`, `pnpm-lock.yaml`.
- Known bad symptoms reviewers should watch for: plugin install requiring older `openclaw` versions than `2026.3.2`.

## Risks and Mitigations

- Risk: forcing newer peer floor could affect environments pinned below `openclaw 2026.3.2`.
  - Mitigation: aligns with patched advisory baseline and lockfile now resolves to safe versions.
