### PR TITLE
refactor(gateway): improve type safety in tools-invoke-http

### DIFF
--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -266,10 +266,8 @@ export async function handleToolsInvokeHttpRequest(
   });
 
   const subagentFiltered = applyToolPolicyPipeline({
-    // oxlint-disable-next-line typescript/no-explicit-any
-    tools: allTools as any,
-    // oxlint-disable-next-line typescript/no-explicit-any
-    toolMeta: (tool) => getPluginToolMeta(tool as any),
+    tools: allTools,
+    toolMeta: (tool) => getPluginToolMeta(tool),
     warn: logWarn,
     steps: [
       ...buildDefaultToolPolicyPipelineSteps({
@@ -310,13 +308,11 @@ export async function handleToolsInvokeHttpRequest(
 
   try {
     const toolArgs = mergeActionIntoArgsIfSupported({
-      // oxlint-disable-next-line typescript/no-explicit-any
-      toolSchema: (tool as any).parameters,
+      toolSchema: tool.parameters,
       action,
       args,
     });
-    // oxlint-disable-next-line typescript/no-explicit-any
-    const result = await (tool as any).execute?.(`http-${Date.now()}`, toolArgs);
+    const result = await tool.execute(`http-${Date.now()}`, toolArgs);
     sendJson(res, 200, { ok: true, result });
   } catch (err) {
     const inputStatus = resolveToolInputErrorStatus(err);


### PR DESCRIPTION
## Changes

This PR improves type safety in `tools-invoke-http.ts` by removing unnecessary `as any` type assertions.

### What was changed:
- Removed 4 `as any` type assertions in production code
- Removed unnecessary `oxlint-disable` comments
- Directly access `tool.parameters` and `tool.execute` without type casts
- Simplified `toolMeta` callback by removing type assertion

### Why:
- Improves type safety and reduces potential runtime errors
- Makes the code easier to maintain and refactor
- Eliminates technical debt from unsafe type assertions

### Testing:
- ✅ Oxlint passes with no warnings or errors
- Code follows existing patterns in the codebase

## Type Safety Improvements
Before: `(tool as any).execute?.(\`http-${Date.now()}\`, toolArgs)`
After: `tool.execute(\`http-${Date.now()}\`, toolArgs)`

The TypeScript compiler now correctly infers the tool type from the pipeline, providing better type checking and IDE support.