### PR TITLE
fix(cron): manual run no longer shifts every-schedule timing

### DIFF
--- a/src/cron/service.manual-run-preserves-schedule.test.ts
+++ b/src/cron/service.manual-run-preserves-schedule.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { computeJobNextRunAtMs } from "./service/jobs.js";
+import type { CronJob } from "./types.js";
+
+const EVERY_24H_MS = 24 * 60 * 60_000;
+const ANCHOR_7AM = Date.parse("2026-03-04T07:00:00.000Z");
+
+function createDailyJob(state: CronJob["state"]): CronJob {
+  return {
+    id: "morning-affirmation",
+    name: "Morning Affirmation",
+    enabled: true,
+    createdAtMs: ANCHOR_7AM,
+    updatedAtMs: ANCHOR_7AM,
+    schedule: { kind: "every", everyMs: EVERY_24H_MS, anchorMs: ANCHOR_7AM },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "morning check" },
+    delivery: { mode: "none" },
+    state,
+  };
+}
+
+describe("Cron issue #33940: manual run should not shift every schedule", () => {
+  it("without skipLastRunAnchor, next run anchors to lastRunAtMs (broken behavior)", () => {
+    const manualRunAt = Date.parse("2026-03-04T13:00:00.000Z");
+    const job = createDailyJob({ lastRunAtMs: manualRunAt });
+    const nowMs = manualRunAt + 1000;
+
+    const next = computeJobNextRunAtMs(job, nowMs);
+    expect(next).toBe(manualRunAt + EVERY_24H_MS);
+  });
+
+  it("with skipLastRunAnchor, next run uses anchor (correct behavior)", () => {
+    const manualRunAt = Date.parse("2026-03-04T13:00:00.000Z");
+    const job = createDailyJob({ lastRunAtMs: manualRunAt });
+    const nowMs = manualRunAt + 1000;
+
+    const next = computeJobNextRunAtMs(job, nowMs, { skipLastRunAnchor: true });
+    expect(next).toBe(Date.parse("2026-03-05T07:00:00.000Z"));
+  });
+
+  it("scheduled run still uses lastRunAtMs anchor (no regression)", () => {
+    const scheduledRunAt = Date.parse("2026-03-04T07:00:00.000Z");
+    const job = createDailyJob({ lastRunAtMs: scheduledRunAt });
+    const nowMs = scheduledRunAt + 1000;
+
+    const next = computeJobNextRunAtMs(job, nowMs);
+    expect(next).toBe(scheduledRunAt + EVERY_24H_MS);
+  });
+
+  it("skipLastRunAnchor with no lastRunAtMs falls back to anchor", () => {
+    const job = createDailyJob({ lastRunAtMs: undefined });
+    const nowMs = Date.parse("2026-03-04T10:00:00.000Z");
+
+    const next = computeJobNextRunAtMs(job, nowMs, { skipLastRunAnchor: true });
+    expect(next).toBe(Date.parse("2026-03-05T07:00:00.000Z"));
+  });
+
+  it("cron schedule is unaffected by skipLastRunAnchor", () => {
+    const job: CronJob = {
+      id: "cron-7am",
+      name: "Daily 7am cron",
+      enabled: true,
+      createdAtMs: Date.parse("2026-03-01T00:00:00.000Z"),
+      updatedAtMs: Date.parse("2026-03-01T00:00:00.000Z"),
+      schedule: { kind: "cron", expr: "0 7 * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "check" },
+      delivery: { mode: "none" },
+      state: { lastRunAtMs: Date.parse("2026-03-04T13:00:00.000Z") },
+    };
+    const nowMs = Date.parse("2026-03-04T13:01:00.000Z");
+
+    const withFlag = computeJobNextRunAtMs(job, nowMs, { skipLastRunAnchor: true });
+    const without = computeJobNextRunAtMs(job, nowMs);
+    expect(withFlag).toBe(without);
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -196,14 +196,22 @@ export function findJobOrThrow(state: CronServiceState, id: string) {
   return job;
 }
 
-export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | undefined {
+export function computeJobNextRunAtMs(
+  job: CronJob,
+  nowMs: number,
+  opts?: { skipLastRunAnchor?: boolean },
+): number | undefined {
   if (!job.enabled) {
     return undefined;
   }
   if (job.schedule.kind === "every") {
     const everyMs = Math.max(1, Math.floor(job.schedule.everyMs));
     const lastRunAtMs = job.state.lastRunAtMs;
-    if (typeof lastRunAtMs === "number" && Number.isFinite(lastRunAtMs)) {
+    if (
+      !opts?.skipLastRunAnchor &&
+      typeof lastRunAtMs === "number" &&
+      Number.isFinite(lastRunAtMs)
+    ) {
       const nextFromLastRun = Math.floor(lastRunAtMs) + everyMs;
       if (nextFromLastRun > nowMs) {
         return nextFromLastRun;

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -404,6 +404,7 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
       delivered: coreResult.delivered,
       startedAt,
       endedAt,
+      triggeredBy: "manual",
     });
 
     emit(state, {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -285,8 +285,10 @@ export function applyJobResult(
     delivered?: boolean;
     startedAt: number;
     endedAt: number;
+    triggeredBy?: "scheduled" | "manual";
   },
 ): boolean {
+  const isManual = result.triggeredBy === "manual";
   job.state.runningAtMs = undefined;
   job.state.lastRunAtMs = result.startedAt;
   job.state.lastRunStatus = result.status;
@@ -382,9 +384,10 @@ export function applyJobResult(
     } else if (result.status === "error" && job.enabled) {
       // Apply exponential backoff for errored jobs to prevent retry storms.
       const backoff = errorBackoffMs(job.state.consecutiveErrors ?? 1);
+      const nextRunOpts = isManual ? { skipLastRunAnchor: true } : undefined;
       let normalNext: number | undefined;
       try {
-        normalNext = computeJobNextRunAtMs(job, result.endedAt);
+        normalNext = computeJobNextRunAtMs(job, result.endedAt, nextRunOpts);
       } catch (err) {
         // If the schedule expression/timezone throws (croner edge cases),
         // record the schedule error (auto-disables after repeated failures)
@@ -405,9 +408,10 @@ export function applyJobResult(
         "cron: applying error backoff",
       );
     } else if (job.enabled) {
+      const nextRunOpts = isManual ? { skipLastRunAnchor: true } : undefined;
       let naturalNext: number | undefined;
       try {
-        naturalNext = computeJobNextRunAtMs(job, result.endedAt);
+        naturalNext = computeJobNextRunAtMs(job, result.endedAt, nextRunOpts);
       } catch (err) {
         // If the schedule expression/timezone throws (croner edge cases),
         // record the schedule error (auto-disables after repeated failures)


### PR DESCRIPTION
## Summary

- **Problem:** When a user manually triggers a recurring `every`-schedule cron job via `openclaw cron run <id>`, the system updates `lastRunAtMs` to the manual execution time. Since `computeJobNextRunAtMs` calculates the next run as `lastRunAtMs + everyMs`, a daily 7am job manually run at 1pm becomes a daily 1pm job.
- **Fix:** Added `skipLastRunAnchor` option to `computeJobNextRunAtMs()` and `triggeredBy: "manual"` to `applyJobResult()`. Manual runs now use the anchor-based schedule computation (preserving the original cadence) instead of the `lastRunAtMs`-based shortcut.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33940

## User-visible / Behavior Changes

- Manual `openclaw cron run <id>` on `every`-schedule jobs no longer shifts the next scheduled run
- Example: daily 7am job manually run at 1pm → next auto-run still at 7am (was: 1pm next day)
- `cron` expression schedules were never affected (they compute from the expression, not `lastRunAtMs`)
- `lastRunAtMs` is still updated for display/status purposes

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- OpenClaw: 2026.3.2+

### Steps

1. Create a daily cron job: `every 1d` with `anchorMs` at 7am
2. Run it manually at 1pm: `openclaw cron run <id>`
3. Check next scheduled run: `openclaw cron list`

### Expected

- Next run: 7am tomorrow

### Actual (before fix)

- Next run: 1pm tomorrow (24h after manual execution)

## Evidence

- [x] 5 new vitest tests pass in `src/cron/service.manual-run-preserves-schedule.test.ts`
  - `without skipLastRunAnchor, next run anchors to lastRunAtMs` (baseline)
  - `with skipLastRunAnchor, next run uses anchor` (core fix)
  - `scheduled run still uses lastRunAtMs anchor` (no regression)
  - `skipLastRunAnchor with no lastRunAtMs falls back to anchor`
  - `cron schedule is unaffected by skipLastRunAnchor`
- [x] All 383 existing cron tests pass (52 test files, 0 failures)

## Human Verification (required)

- Verified scenarios: daily every-schedule + manual run, cron expression unaffected, no lastRunAtMs fallback
- Edge cases checked: undefined lastRunAtMs, cron-kind schedule ignores flag
- What I did **not** verify: Live gateway runtime with manual cron trigger

## Compatibility / Migration

- Backward compatible? `Yes` — scheduled (non-manual) runs are unchanged
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; manual runs will again shift schedule
- Files/config to restore: `src/cron/service/jobs.ts`, `src/cron/service/timer.ts`, `src/cron/service/ops.ts`

## Risks and Mitigations

- Risk: Manual runs during error-backoff might compute a too-early next run
  - Mitigation: The error-backoff branch uses `Math.max(normalNext, backoffNext)`, so the backoff floor is always respected