### PR TITLE
fix(cron): manual run no longer drifts every-interval schedule

### DIFF
--- a/src/cron/service.issue-22895-every-next-run.test.ts
+++ b/src/cron/service.issue-22895-every-next-run.test.ts
@@ -48,4 +48,51 @@ describe("Cron issue #22895 interval scheduling", () => {
     const next = computeJobNextRunAtMs(job, nowMs);
     expect(next).toBe(Date.parse("2026-02-22T10:44:00.000Z"));
   });
+
+  it("ignoreLastRun skips lastRunAtMs cadence and uses anchor-based scheduling", () => {
+    const nowMs = Date.parse("2026-02-22T10:10:00.000Z");
+    const job = createEveryJob({
+      lastRunAtMs: Date.parse("2026-02-22T10:04:00.000Z"),
+    });
+
+    // Without ignoreLastRun: cadence-based (lastRun + interval)
+    const cadenceNext = computeJobNextRunAtMs(job, nowMs);
+    expect(cadenceNext).toBe(job.state.lastRunAtMs! + EVERY_30_MIN_MS);
+
+    // With ignoreLastRun: anchor-based (next anchor slot after now)
+    const anchorNext = computeJobNextRunAtMs(job, nowMs, { ignoreLastRun: true });
+    expect(anchorNext).toBe(Date.parse("2026-02-22T10:14:00.000Z"));
+  });
+
+  it("manual run of daily job does not drift schedule from anchor (#33940)", () => {
+    const EVERY_DAY_MS = 24 * 60 * 60_000;
+    const anchorMs = Date.parse("2026-03-04T07:00:00.000Z"); // 7am anchor
+
+    const job: CronJob = {
+      id: "issue-33940",
+      name: "daily-affirmation",
+      enabled: true,
+      createdAtMs: anchorMs,
+      updatedAtMs: anchorMs,
+      schedule: { kind: "every", everyMs: EVERY_DAY_MS, anchorMs },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "morning affirmation" },
+      delivery: { mode: "none" },
+      state: {
+        // Simulates a manual run at 1pm (6 hours after anchor)
+        lastRunAtMs: Date.parse("2026-03-04T13:00:00.000Z"),
+      },
+    };
+
+    const nowMs = Date.parse("2026-03-04T13:00:05.000Z");
+
+    // Default: drifts to 1pm tomorrow (lastRun + 24h)
+    const drifted = computeJobNextRunAtMs(job, nowMs);
+    expect(drifted).toBe(Date.parse("2026-03-05T13:00:00.000Z"));
+
+    // With ignoreLastRun (forced/manual run): stays at 7am tomorrow
+    const anchored = computeJobNextRunAtMs(job, nowMs, { ignoreLastRun: true });
+    expect(anchored).toBe(Date.parse("2026-03-05T07:00:00.000Z"));
+  });
 });

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -196,17 +196,26 @@ export function findJobOrThrow(state: CronServiceState, id: string) {
   return job;
 }
 
-export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | undefined {
+export function computeJobNextRunAtMs(
+  job: CronJob,
+  nowMs: number,
+  opts?: { ignoreLastRun?: boolean },
+): number | undefined {
   if (!job.enabled) {
     return undefined;
   }
   if (job.schedule.kind === "every") {
     const everyMs = Math.max(1, Math.floor(job.schedule.everyMs));
-    const lastRunAtMs = job.state.lastRunAtMs;
-    if (typeof lastRunAtMs === "number" && Number.isFinite(lastRunAtMs)) {
-      const nextFromLastRun = Math.floor(lastRunAtMs) + everyMs;
-      if (nextFromLastRun > nowMs) {
-        return nextFromLastRun;
+    // When ignoreLastRun is set (manual/forced runs), skip the lastRunAtMs
+    // cadence shortcut so the schedule stays anchored to its original time
+    // instead of drifting to the manual execution time (#33940).
+    if (!opts?.ignoreLastRun) {
+      const lastRunAtMs = job.state.lastRunAtMs;
+      if (typeof lastRunAtMs === "number" && Number.isFinite(lastRunAtMs)) {
+        const nextFromLastRun = Math.floor(lastRunAtMs) + everyMs;
+        if (nextFromLastRun > nowMs) {
+          return nextFromLastRun;
+        }
       }
     }
     const fallbackAnchorMs = isFiniteTimestamp(job.createdAtMs) ? job.createdAtMs : nowMs;

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -404,6 +404,7 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
       delivered: coreResult.delivered,
       startedAt,
       endedAt,
+      forced: mode === "force",
     });
 
     emit(state, {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -285,6 +285,7 @@ export function applyJobResult(
     delivered?: boolean;
     startedAt: number;
     endedAt: number;
+    forced?: boolean;
   },
 ): boolean {
   job.state.runningAtMs = undefined;
@@ -382,9 +383,10 @@ export function applyJobResult(
     } else if (result.status === "error" && job.enabled) {
       // Apply exponential backoff for errored jobs to prevent retry storms.
       const backoff = errorBackoffMs(job.state.consecutiveErrors ?? 1);
+      const nextRunOpts = result.forced ? { ignoreLastRun: true } : undefined;
       let normalNext: number | undefined;
       try {
-        normalNext = computeJobNextRunAtMs(job, result.endedAt);
+        normalNext = computeJobNextRunAtMs(job, result.endedAt, nextRunOpts);
       } catch (err) {
         // If the schedule expression/timezone throws (croner edge cases),
         // record the schedule error (auto-disables after repeated failures)
@@ -405,9 +407,10 @@ export function applyJobResult(
         "cron: applying error backoff",
       );
     } else if (job.enabled) {
+      const nextRunOpts = result.forced ? { ignoreLastRun: true } : undefined;
       let naturalNext: number | undefined;
       try {
-        naturalNext = computeJobNextRunAtMs(job, result.endedAt);
+        naturalNext = computeJobNextRunAtMs(job, result.endedAt, nextRunOpts);
       } catch (err) {
         // If the schedule expression/timezone throws (croner edge cases),
         // record the schedule error (auto-disables after repeated failures)

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1047,7 +1047,7 @@ export async function executeJob(
   state: CronServiceState,
   job: CronJob,
   _nowMs: number,
-  _opts: { forced: boolean },
+  opts: { forced: boolean },
 ) {
   if (!job.state) {
     job.state = {};
@@ -1075,6 +1075,7 @@ export async function executeJob(
     delivered: coreResult.delivered,
     startedAt,
     endedAt,
+    forced: opts.forced,
   });
 
   emitJobFinished(state, job, coreResult, startedAt);


### PR DESCRIPTION
## Summary

- **Problem:** When a user manually executes an `every`-kind cron job via `openclaw cron run <id>`, the next scheduled run drifts to `manualRunTime + interval` instead of staying anchored to the original schedule. For example, a daily 7am job manually run at 1pm would next fire at 1pm the following day instead of 7am.
- **Why it matters:** Users lose their carefully configured schedules whenever they debug/test a cron job manually. This affects any `every`-kind cron job (daily affirmations, periodic checks, etc.).
- **What changed:** `computeJobNextRunAtMs` accepts an optional `{ ignoreLastRun }` flag that skips the `lastRunAtMs` cadence shortcut for `every` schedules. `applyJobResult` receives a `forced` flag from the manual-run path and forwards it. `executeJob` now also forwards its `opts.forced` instead of discarding it.
- **What did NOT change (scope boundary):** Scheduled (non-forced) runs retain the existing cadence behaviour from #22895. `cron` and `at` schedule kinds are entirely unaffected. Timer-tick path (`applyOutcomeToStoredJob`) does not pass `forced`, preserving existing behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33940
- Related #22895 (cadence shortcut for `every` schedules — preserved for non-forced runs)

## User-visible / Behavior Changes

`openclaw cron run <id>` (manual/force mode) no longer shifts the next scheduled fire time for `every`-kind jobs. The schedule stays anchored to the original time.

Before: daily 7am job → manual run at 1pm → next fire at 1pm tomorrow
After: daily 7am job → manual run at 1pm → next fire at 7am tomorrow

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (reported), any OS
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: any `every`-kind cron job

### Steps

1. Create a daily cron job anchored at 7am: `every 1d`
2. Verify next run shows ~7am tomorrow
3. Manually execute: `openclaw cron run <id>`
4. Check next run time

### Expected

- Next run stays at 7am tomorrow

### Actual

- Next run shifts to current time + 24h (e.g., 1pm tomorrow if run at 1pm)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

Two new regression tests:
1. `ignoreLastRun` flag skips cadence shortcut and uses anchor-based scheduling
2. Daily 7am job manually run at 1pm → next fire stays 7am tomorrow (not 1pm)

All 83 existing cron tests pass unchanged.

## Human Verification (required)

- Verified scenarios: forced run with `every` schedule (daily, 30-min intervals), non-forced scheduled runs (cadence preserved), error paths with backoff
- Edge cases checked: `ignoreLastRun` only affects `every` branch (not `cron`/`at`), `executeJob` now forwards `opts.forced` instead of discarding
- What you did **not** verify: live gateway cron manual execution (verified via unit tests with exact timestamp assertions)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: remove `ignoreLastRun` option from `computeJobNextRunAtMs` and `forced` from `applyJobResult`
- Files/config to restore: `src/cron/service/jobs.ts`, `src/cron/service/timer.ts`, `src/cron/service/ops.ts`
- Known bad symptoms: if a forced run somehow doesn't set `forced: true`, the old drift behavior returns (safe fallback)

## Risks and Mitigations

- Risk: Anchor-based next-run could fire sooner than `everyMs` after a manual run (e.g., manual run at 6:50am → next anchor at 7am = 10 min gap for a 24h interval)
  - Mitigation: This is the expected behavior — the anchor schedule is authoritative. The `lastRunAtMs` cadence shortcut is only a convenience for scheduled runs, not a hard constraint. Users manually running a job accept that it is "extra" and does not replace the next scheduled fire.