### PR TITLE
fix(feishu): preserve Chinese filenames in file uploads instead of percent-encoding

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -340,7 +340,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(messageResourceGetMock).not.toHaveBeenCalled();
   });
 
-  it("encodes Chinese filenames for file uploads", async () => {
+  it("preserves Chinese filenames for file uploads", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -349,8 +349,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     });
 
     const createCall = fileCreateMock.mock.calls[0][0];
-    expect(createCall.data.file_name).not.toBe("测试文档.pdf");
-    expect(createCall.data.file_name).toBe(encodeURIComponent("测试文档") + ".pdf");
+    expect(createCall.data.file_name).toBe("测试文档.pdf");
   });
 
   it("preserves ASCII filenames unchanged for file uploads", async () => {
@@ -365,7 +364,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(createCall.data.file_name).toBe("report-2026.pdf");
   });
 
-  it("encodes special characters (em-dash, full-width brackets) in filenames", async () => {
+  it("preserves special characters (em-dash, full-width brackets) in filenames", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -374,9 +373,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     });
 
     const createCall = fileCreateMock.mock.calls[0][0];
-    expect(createCall.data.file_name).toMatch(/\.md$/);
-    expect(createCall.data.file_name).not.toContain("—");
-    expect(createCall.data.file_name).not.toContain("（");
+    expect(createCall.data.file_name).toBe("报告—详情（2026）.md");
   });
 });
 
@@ -386,56 +383,44 @@ describe("sanitizeFileNameForUpload", () => {
     expect(sanitizeFileNameForUpload("my-file_v2.txt")).toBe("my-file_v2.txt");
   });
 
-  it("encodes Chinese characters in basename, preserves extension", () => {
-    const result = sanitizeFileNameForUpload("测试文件.md");
-    expect(result).toBe(encodeURIComponent("测试文件") + ".md");
-    expect(result).toMatch(/\.md$/);
+  it("preserves Chinese characters in filenames", () => {
+    expect(sanitizeFileNameForUpload("测试文件.md")).toBe("测试文件.md");
+    expect(sanitizeFileNameForUpload("武汉15座山登山信息汇总.csv")).toBe(
+      "武汉15座山登山信息汇总.csv",
+    );
   });
 
-  it("encodes em-dash and full-width brackets", () => {
-    const result = sanitizeFileNameForUpload("文件—说明（v2）.pdf");
-    expect(result).toMatch(/\.pdf$/);
-    expect(result).not.toContain("—");
-    expect(result).not.toContain("（");
-    expect(result).not.toContain("）");
+  it("preserves em-dash and full-width brackets", () => {
+    expect(sanitizeFileNameForUpload("文件—说明（v2）.pdf")).toBe("文件—说明（v2）.pdf");
   });
 
-  it("encodes single quotes and parentheses per RFC 5987", () => {
-    const result = sanitizeFileNameForUpload("文件'(test).txt");
-    expect(result).toContain("%27");
-    expect(result).toContain("%28");
-    expect(result).toContain("%29");
-    expect(result).toMatch(/\.txt$/);
+  it("preserves single quotes and parentheses", () => {
+    expect(sanitizeFileNameForUpload("file'(test).txt")).toBe("file'(test).txt");
   });
 
-  it("handles filenames without extension", () => {
-    const result = sanitizeFileNameForUpload("测试文件");
-    expect(result).toBe(encodeURIComponent("测试文件"));
+  it("preserves mixed ASCII and non-ASCII", () => {
+    expect(sanitizeFileNameForUpload("Report_报告_2026.xlsx")).toBe("Report_报告_2026.xlsx");
   });
 
-  it("handles mixed ASCII and non-ASCII", () => {
-    const result = sanitizeFileNameForUpload("Report_报告_2026.xlsx");
-    expect(result).toMatch(/\.xlsx$/);
-    expect(result).not.toContain("报告");
+  it("preserves emoji filenames", () => {
+    expect(sanitizeFileNameForUpload("report_😀.txt")).toBe("report_😀.txt");
   });
 
-  it("encodes non-ASCII extensions", () => {
-    const result = sanitizeFileNameForUpload("报告.文档");
-    expect(result).toContain("%E6%96%87%E6%A1%A3");
-    expect(result).not.toContain("文档");
+  it("replaces control characters with underscore", () => {
+    expect(sanitizeFileNameForUpload("file\x00name.txt")).toBe("file_name.txt");
+    expect(sanitizeFileNameForUpload("file\nname.txt")).toBe("file_name.txt");
+    expect(sanitizeFileNameForUpload("file\rname.txt")).toBe("file_name.txt");
+    expect(sanitizeFileNameForUpload("file\tname.txt")).toBe("file_name.txt");
   });
 
-  it("encodes emoji filenames", () => {
-    const result = sanitizeFileNameForUpload("report_😀.txt");
-    expect(result).toContain("%F0%9F%98%80");
-    expect(result).toMatch(/\.txt$/);
+  it("replaces double-quote and backslash with underscore", () => {
+    expect(sanitizeFileNameForUpload('file"name.txt')).toBe("file_name.txt");
+    expect(sanitizeFileNameForUpload("file\\name.txt")).toBe("file_name.txt");
   });
 
-  it("encodes mixed ASCII and non-ASCII extensions", () => {
+  it("preserves mixed ASCII and non-ASCII extensions", () => {
     const result = sanitizeFileNameForUpload("notes_总结.v测试");
-    expect(result).toContain("notes_");
-    expect(result).toContain("%E6%B5%8B%E8%AF%95");
-    expect(result).not.toContain("测试");
+    expect(result).toBe("notes_总结.v测试");
   });
 });
 

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -208,21 +208,16 @@ export async function uploadImageFeishu(params: {
 }
 
 /**
- * Encode a filename for safe use in Feishu multipart/form-data uploads.
- * Non-ASCII characters (Chinese, em-dash, full-width brackets, etc.) cause
- * the upload to silently fail when passed raw through the SDK's form-data
- * serialization.  RFC 5987 percent-encoding keeps headers 7-bit clean while
- * Feishu's server decodes and preserves the original display name.
+ * Sanitize a filename for safe use in Feishu multipart/form-data uploads.
+ * Strip control characters (null, newline, CR, etc.) and characters that
+ * break Content-Disposition headers (double-quote, backslash).  Non-ASCII
+ * characters (Chinese, em-dash, full-width brackets) are preserved as-is
+ * because Feishu displays `file_name` verbatim without any decoding —
+ * percent-encoding them causes garbled filenames in the Feishu UI.
  */
 export function sanitizeFileNameForUpload(fileName: string): string {
-  const ASCII_ONLY = /^[\x20-\x7E]+$/;
-  if (ASCII_ONLY.test(fileName)) {
-    return fileName;
-  }
-  return encodeURIComponent(fileName)
-    .replace(/'/g, "%27")
-    .replace(/\(/g, "%28")
-    .replace(/\)/g, "%29");
+  // eslint-disable-next-line no-control-regex -- intentional: strip C0 control chars + DEL
+  return fileName.replace(/[\x00-\x1F\x7F"\\]/g, "_");
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Problem:** `sanitizeFileNameForUpload()` percent-encodes all non-ASCII characters via `encodeURIComponent`. Feishu's `im.file.create` API displays `file_name` verbatim without decoding, so Chinese filenames (e.g. `武汉15座山登山信息汇总.csv`) appear as `%E6%AD%A6%E6%B1%89...` in the Feishu UI. This is a regression from the #31179 fix introduced in v2026.3.2.
- **Fix:** Changed `sanitizeFileNameForUpload()` to only strip characters that break form-data serialization (control chars `\x00-\x1F`, DEL `\x7F`, double-quote `"`, backslash `\`) by replacing them with underscore. CJK characters, emoji, em-dashes, full-width brackets, and other Unicode characters are now preserved as-is.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33912

## User-visible / Behavior Changes

- Chinese, Japanese, Korean, emoji, and other Unicode filenames now display correctly in Feishu
- ASCII filenames are unaffected
- Control characters and Content-Disposition-breaking characters are still sanitized

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- OpenClaw: 2026.3.2+
- Channel: Feishu

### Steps

1. Send a file with Chinese filename via the `message` tool
2. Check the filename display in Feishu

### Expected

- File displays as `武汉15座山登山信息汇总.csv`

### Actual (before fix)

- File displays as `%E6%AD%A6%E6%B1%8915%E5%BA%A7%E5%B1%B1...csv`

## Evidence

- [x] 26 vitest tests pass in `extensions/feishu/src/media.test.ts`
  - Updated: `preserves Chinese filenames for file uploads` (was: `encodes`)
  - Updated: `preserves special characters (em-dash, full-width brackets)` (was: `encodes`)
  - New: `replaces control characters with underscore`
  - New: `replaces double-quote and backslash with underscore`
  - All 26 tests pass

## Human Verification (required)

- Verified scenarios: Chinese filenames, emoji filenames, mixed ASCII/non-ASCII, control chars, special chars
- Edge cases checked: Null bytes, newlines, double-quotes, backslashes in filenames
- What I did **not** verify: Live Feishu upload (only unit tested)

## Compatibility / Migration

- Backward compatible? `Yes` — files already uploaded with percent-encoded names are not affected
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; filenames will be percent-encoded again
- Files/config to restore: `extensions/feishu/src/media.ts`

## Risks and Mitigations

- Risk: Some edge-case non-ASCII characters may still break form-data serialization
  - Mitigation: The control character + quote/backslash filter covers all known problematic characters; the Feishu SDK's form-data library (v4.x) supports UTF-8 natively
- Risk: Original #31179 issue (upload failing with non-ASCII names) may resurface
  - Mitigation: That issue was likely caused by a now-fixed SDK bug; the `docx.ts` upload path in the same extension already uses raw UTF-8 filenames successfully