### PR TITLE
fix: use overflow-wrap break-word for chat text (#25013)

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1843,8 +1843,8 @@
 
 /* Chat text */
 .chat-text {
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  overflow-wrap: break-word;
+  word-break: normal;
   color: var(--chat-text);
   line-height: 1.5;
 }


### PR DESCRIPTION
## Summary

- Problem: `.chat-text` in `components.css` uses `overflow-wrap: anywhere` which breaks words mid-character in the Control UI chat view. The correct definition in `ui/src/styles/chat/text.css` uses `overflow-wrap: break-word` but gets overridden by the `components.css` rule later in the cascade.
- Why it matters: Chat messages display with ugly mid-word breaks, degrading readability.
- What changed: Changed `.chat-text` in `components.css` from `overflow-wrap: anywhere; word-break: break-word` to `overflow-wrap: break-word; word-break: normal`.
- What did NOT change (scope boundary): The other 3 usages of `overflow-wrap: anywhere` in `components.css` (cron payloads, session keys, agent KV) are left untouched — those are correct for unbreakable identifier strings.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #25013

## User-visible / Behavior Changes

Chat text in the Control UI no longer breaks words mid-character. Long words now only break at natural word boundaries or when absolutely necessary to prevent overflow.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any (browser)
- Runtime/container: Control UI

### Steps

1. Open the Control UI chat view
2. Send or receive a message with long words or URLs
3. Observe that words no longer break mid-character

### Expected

- Words break only at natural boundaries (spaces, hyphens) or as a last resort

### Actual

- Before fix: words broke mid-character due to `overflow-wrap: anywhere`

## Evidence

- [x] Trace/log snippets

CSS inspection: `overflow-wrap: break-word` and `word-break: normal` now apply to `.chat-text`.

## Human Verification (required)

- Verified scenarios: CSS property values changed as expected; no other `overflow-wrap: anywhere` rules affected
- Edge cases checked: RTL text, long URLs, code blocks (handled by separate `pre` overflow-x rules)
- What you did **not** verify: Visual rendering in all browsers (CSS-only change, standard properties)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit
- Files/config to restore: `ui/src/styles/components.css`
- Known bad symptoms reviewers should watch for: Text overflow in narrow chat containers

## Risks and Mitigations

None — this restores the intended CSS behavior that `text.css` already defines but was being overridden.
