### PR TITLE
fix(infra): increase launchctl timeout and avoid duplicate process on restart

### DIFF
--- a/src/infra/restart.launchctl.test.ts
+++ b/src/infra/restart.launchctl.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  spawnSync: (...args: unknown[]) => spawnSyncMock(...args),
+}));
+
+vi.mock("./restart-stale-pids.js", () => ({
+  cleanStaleGatewayProcessesSync: vi.fn(() => []),
+  findGatewayPidsOnPortSync: vi.fn(() => []),
+}));
+
+vi.mock("../daemon/constants.js", () => ({
+  resolveGatewayLaunchAgentLabel: () => "com.openclaw.gateway",
+  resolveGatewaySystemdServiceName: () => "openclaw-gateway",
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { triggerOpenClawRestart } from "./restart.js";
+
+describe.runIf(process.platform === "darwin")("triggerOpenClawRestart (macOS)", () => {
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+    delete process.env.VITEST;
+    delete process.env.NODE_ENV;
+    process.env.HOME = "/Users/test";
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, origEnv);
+  });
+
+  it("returns ok when kickstart succeeds", () => {
+    spawnSyncMock.mockReturnValue({ error: undefined, status: 0, stdout: "", stderr: "" });
+
+    const result = triggerOpenClawRestart();
+    expect(result.ok).toBe(true);
+    expect(result.method).toBe("launchctl");
+  });
+
+  it("returns ok when bootstrap succeeds even if retry kickstart times out", () => {
+    let callIdx = 0;
+    spawnSyncMock.mockImplementation((_cmd: string, args: string[]) => {
+      callIdx++;
+      if (callIdx === 1) {
+        return { error: new Error("spawnSync launchctl ETIMEDOUT"), status: null };
+      }
+      if (args[0] === "bootstrap") {
+        return { error: undefined, status: 0, stdout: "", stderr: "" };
+      }
+      return { error: new Error("spawnSync launchctl ETIMEDOUT"), status: null };
+    });
+
+    const result = triggerOpenClawRestart();
+    expect(result.ok).toBe(true);
+    expect(result.method).toBe("launchctl");
+  });
+
+  it("returns not-ok when both kickstart and bootstrap fail", () => {
+    spawnSyncMock.mockReturnValue({
+      error: new Error("spawnSync launchctl ETIMEDOUT"),
+      status: null,
+    });
+
+    const result = triggerOpenClawRestart();
+    expect(result.ok).toBe(false);
+  });
+
+  it("uses 15s timeout for spawnSync calls", () => {
+    spawnSyncMock.mockReturnValue({ error: undefined, status: 0, stdout: "", stderr: "" });
+
+    triggerOpenClawRestart();
+
+    const timeoutArg = spawnSyncMock.mock.calls[0]?.[2]?.timeout;
+    expect(timeoutArg).toBe(15_000);
+  });
+});

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -15,7 +15,7 @@ export type RestartAttempt = {
   tried?: string[];
 };
 
-const SPAWN_TIMEOUT_MS = 2000;
+const SPAWN_TIMEOUT_MS = 15_000;
 const SIGUSR1_AUTH_GRACE_MS = 5000;
 const DEFAULT_DEFERRAL_POLL_MS = 500;
 const DEFAULT_DEFERRAL_MAX_WAIT_MS = 30_000;
@@ -377,12 +377,15 @@ export function triggerOpenClawRestart(): RestartAttempt {
   if (!retry.error && retry.status === 0) {
     return { ok: true, method: "launchctl", tried };
   }
-  return {
-    ok: false,
-    method: "launchctl",
-    detail: formatSpawnDetail(retry),
-    tried,
-  };
+  // bootstrap succeeded → launchd has loaded the service and KeepAlive
+  // will start it. Treat this as a successful supervised restart even
+  // if the follow-up kickstart timed out, to avoid spawning a duplicate
+  // in-process gateway that conflicts with the launchd-managed process.
+  restartLog.warn(
+    `launchctl bootstrap succeeded but kickstart timed out (${formatSpawnDetail(retry)}); ` +
+      `relying on launchd KeepAlive to start the service`,
+  );
+  return { ok: true, method: "launchctl", tried };
 }
 
 export type ScheduledRestart = {


### PR DESCRIPTION
## Summary

- **Problem:** The gateway restart mechanism uses `spawnSync("launchctl", ...)` with a 2-second timeout (`SPAWN_TIMEOUT_MS = 2000`). On macOS, `launchctl bootstrap` can take longer, causing ETIMEDOUT. When `bootstrap` succeeds but the follow-up `kickstart` times out, the code returns `{ ok: false }`, triggering an in-process restart fallback. Meanwhile, launchd's `KeepAlive: true` also starts a new process — creating two gateway processes on the same port. Both receive SIGTERM shortly after, the LaunchAgent ends up unloaded, and the gateway stays down.
- **Fix:** (1) Increased `SPAWN_TIMEOUT_MS` from 2s to 15s. (2) When `bootstrap` succeeds but `kickstart` times out, return `{ ok: true }` instead of `{ ok: false }` — launchd will handle the restart via `KeepAlive`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #33947

## User-visible / Behavior Changes

- Gateway restarts via launchctl are more reliable (15s timeout instead of 2s)
- When `launchctl bootstrap` succeeds, no duplicate process is spawned — the caller exits and lets launchd handle the restart
- Log message when relying on KeepAlive: `launchctl bootstrap succeeded but kickstart timed out; relying on launchd KeepAlive to start the service`

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Gateway mode: LaunchAgent with KeepAlive: true

### Steps

1. Modify a config key that triggers full restart (e.g. `auth.profiles`)
2. Observe restart behavior

### Expected

- Clean restart: one gateway process, no duplicate

### Actual (before fix)

- spawnSync times out at 2s → in-process restart + launchd KeepAlive → two processes → both SIGTERM → gateway down

## Evidence

- [x] 4 new vitest tests pass in `src/infra/restart.launchctl.test.ts`
  - `returns ok when kickstart succeeds`
  - `returns ok when bootstrap succeeds even if retry kickstart times out`
  - `returns not-ok when both kickstart and bootstrap fail`
  - `uses 15s timeout for spawnSync calls`
- [x] All 54 existing restart tests pass (4 test files, 0 failures)

## Human Verification (required)

- Verified scenarios: kickstart success, bootstrap success + kickstart timeout, both fail
- Edge cases checked: ETIMEDOUT error handling, timeout value propagation
- What I did **not** verify: Live macOS LaunchAgent restart (only unit tested with mocked spawnSync)

## Compatibility / Migration

- Backward compatible? `Yes` — timeout increase and better fallback handling
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; timeout returns to 2s and duplicate-process issue resurfaces
- Files/config to restore: `src/infra/restart.ts`

## Risks and Mitigations

- Risk: 15s timeout may be too long for some environments, delaying restart detection
  - Mitigation: 15s is still well under the 30s drain timeout; the previous 2s was demonstrably too short
- Risk: Relying on KeepAlive after bootstrap may not start the process if KeepAlive is disabled
  - Mitigation: Gateway LaunchAgent always sets KeepAlive: true; users who disable it are expected to manage restarts manually