### PR TITLE
fix: align AGENTS.md template section names with code (#25029)

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -13,7 +13,7 @@ This folder is home. Treat it that way.
 
 If `BOOTSTRAP.md` exists, that's your birth certificate. Follow it, figure out who you are, then delete it. You won't need it again.
 
-## Every Session
+## Session Startup
 
 Before doing anything else:
 
@@ -52,7 +52,7 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 - When you make a mistake → document it so future-you doesn't repeat it
 - **Text > Brain** 📝
 
-## Safety
+## Red Lines
 
 - Don't exfiltrate private data. Ever.
 - Don't run destructive commands without asking.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -413,7 +413,10 @@ async function readWorkspaceContextForSummary(): Promise<string> {
         fs.closeSync(opened.fd);
       }
     })();
-    const sections = extractSections(content, ["Session Startup", "Red Lines"]);
+    const sections = extractSections(content, [
+      ["Session Startup", "Every Session"],
+      ["Red Lines", "Safety"],
+    ]);
 
     if (sections.length === 0) {
       return "";

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { readPostCompactionContext } from "./post-compaction-context.js";
+import { extractSections, readPostCompactionContext } from "./post-compaction-context.js";
 
 describe("readPostCompactionContext", () => {
   const tmpDir = path.join("/tmp", "test-post-compaction-" + Date.now());
@@ -225,5 +225,88 @@ Read WORKFLOW.md on startup.
     const result = await readPostCompactionContext(tmpDir, undefined, nowMs);
     expect(result).not.toBeNull();
     expect(result).toContain("Current time:");
+  });
+
+  it("extracts legacy '## Every Session' heading via alias", async () => {
+    const content = `# Rules
+
+## Every Session
+
+Read SOUL.md first.
+
+## Other
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Read SOUL.md first");
+  });
+
+  it("extracts legacy '## Safety' heading via alias", async () => {
+    const content = `# Rules
+
+## Safety
+
+Don't exfiltrate data.
+
+## Other
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Don't exfiltrate data");
+  });
+});
+
+describe("extractSections", () => {
+  it("alias arrays return first match", () => {
+    const content = `## Every Session
+
+Do startup things.
+
+## Safety
+
+Never break things.
+
+## Other
+
+Ignore this.
+`;
+    const sections = extractSections(content, [
+      ["Session Startup", "Every Session"],
+      ["Red Lines", "Safety"],
+    ]);
+    expect(sections).toHaveLength(2);
+    expect(sections[0]).toContain("Do startup things");
+    expect(sections[1]).toContain("Never break things");
+  });
+
+  it("canonical name is preferred over alias when both exist", () => {
+    const content = `## Session Startup
+
+Canonical startup content.
+
+## Every Session
+
+Legacy startup content.
+
+## Red Lines
+
+Canonical red lines.
+
+## Safety
+
+Legacy safety content.
+`;
+    const sections = extractSections(content, [
+      ["Session Startup", "Every Session"],
+      ["Red Lines", "Safety"],
+    ]);
+    expect(sections).toHaveLength(2);
+    // Canonical name appears first in the document, so it should be extracted
+    expect(sections[0]).toContain("Canonical startup content");
+    expect(sections[0]).not.toContain("Legacy startup content");
+    expect(sections[1]).toContain("Canonical red lines");
+    expect(sections[1]).not.toContain("Legacy safety content");
   });
 });

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -303,7 +303,37 @@ Legacy safety content.
       ["Red Lines", "Safety"],
     ]);
     expect(sections).toHaveLength(2);
-    // Canonical name appears first in the document, so it should be extracted
+    // Canonical name is tried first in alias priority order, so it wins
+    expect(sections[0]).toContain("Canonical startup content");
+    expect(sections[0]).not.toContain("Legacy startup content");
+    expect(sections[1]).toContain("Canonical red lines");
+    expect(sections[1]).not.toContain("Legacy safety content");
+  });
+
+  it("prefers canonical name even when legacy alias appears first in the document", () => {
+    // Regression: old single-pass logic picked whichever alias appeared first
+    // in the document, not the canonical (first-listed) alias.
+    const content = `## Every Session
+
+Legacy startup content.
+
+## Session Startup
+
+Canonical startup content.
+
+## Safety
+
+Legacy safety content.
+
+## Red Lines
+
+Canonical red lines.
+`;
+    const sections = extractSections(content, [
+      ["Session Startup", "Every Session"],
+      ["Red Lines", "Safety"],
+    ]);
+    expect(sections).toHaveLength(2);
     expect(sections[0]).toContain("Canonical startup content");
     expect(sections[0]).not.toContain("Legacy startup content");
     expect(sections[1]).toContain("Canonical red lines");

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -55,7 +55,10 @@ export async function readPostCompactionContext(
 
     // Extract "## Session Startup" and "## Red Lines" sections
     // Each section ends at the next "## " heading or end of file
-    const sections = extractSections(content, ["Session Startup", "Red Lines"]);
+    const sections = extractSections(content, [
+      ["Session Startup", "Every Session"],
+      ["Red Lines", "Safety"],
+    ]);
 
     if (sections.length === 0) {
       return null;
@@ -90,12 +93,16 @@ export async function readPostCompactionContext(
  * Matches H2 (##) or H3 (###) headings case-insensitively.
  * Skips content inside fenced code blocks.
  * Captures until the next heading of same or higher level, or end of string.
+ *
+ * Each entry in `sectionNames` can be a single name or an array of aliases.
+ * When an array is given, the first matching alias wins (canonical name first).
  */
-export function extractSections(content: string, sectionNames: string[]): string[] {
+export function extractSections(content: string, sectionNames: (string | string[])[]): string[] {
   const results: string[] = [];
   const lines = content.split("\n");
 
-  for (const name of sectionNames) {
+  for (const nameEntry of sectionNames) {
+    const names = Array.isArray(nameEntry) ? nameEntry : [nameEntry];
     let sectionLines: string[] = [];
     let inSection = false;
     let sectionLevel = 0;
@@ -127,8 +134,8 @@ export function extractSections(content: string, sectionNames: string[]): string
         const headingText = headingMatch[2];
 
         if (!inSection) {
-          // Check if this is our target section (case-insensitive)
-          if (headingText.toLowerCase() === name.toLowerCase()) {
+          // Check if this is our target section (case-insensitive, first alias wins)
+          if (names.some((n) => headingText.toLowerCase() === n.toLowerCase())) {
             inSection = true;
             sectionLevel = level;
             sectionLines = [line];

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -95,7 +95,9 @@ export async function readPostCompactionContext(
  * Captures until the next heading of same or higher level, or end of string.
  *
  * Each entry in `sectionNames` can be a single name or an array of aliases.
- * When an array is given, the first matching alias wins (canonical name first).
+ * When an array is given, aliases are tried in priority order (canonical first).
+ * This ensures `["Session Startup", "Every Session"]` always prefers
+ * `## Session Startup` even if `## Every Session` appears earlier in the document.
  */
 export function extractSections(content: string, sectionNames: (string | string[])[]): string[] {
   const results: string[] = [];
@@ -103,64 +105,79 @@ export function extractSections(content: string, sectionNames: (string | string[
 
   for (const nameEntry of sectionNames) {
     const names = Array.isArray(nameEntry) ? nameEntry : [nameEntry];
-    let sectionLines: string[] = [];
-    let inSection = false;
-    let sectionLevel = 0;
-    let inCodeBlock = false;
-
-    for (const line of lines) {
-      // Track fenced code blocks
-      if (line.trimStart().startsWith("```")) {
-        inCodeBlock = !inCodeBlock;
-        if (inSection) {
-          sectionLines.push(line);
-        }
-        continue;
-      }
-
-      // Skip heading detection inside code blocks
-      if (inCodeBlock) {
-        if (inSection) {
-          sectionLines.push(line);
-        }
-        continue;
-      }
-
-      // Check if this line is a heading
-      const headingMatch = line.match(/^(#{2,3})\s+(.+?)\s*$/);
-
-      if (headingMatch) {
-        const level = headingMatch[1].length; // 2 or 3
-        const headingText = headingMatch[2];
-
-        if (!inSection) {
-          // Check if this is our target section (case-insensitive, first alias wins)
-          if (names.some((n) => headingText.toLowerCase() === n.toLowerCase())) {
-            inSection = true;
-            sectionLevel = level;
-            sectionLines = [line];
-            continue;
-          }
-        } else {
-          // We're in section — stop if we hit a heading of same or higher level
-          if (level <= sectionLevel) {
-            break;
-          }
-          // Lower-level heading (e.g., ### inside ##) — include it
-          sectionLines.push(line);
-          continue;
-        }
-      }
-
-      if (inSection) {
-        sectionLines.push(line);
+    // Try aliases in priority order (canonical first), full scan per alias
+    let matched: string | null = null;
+    for (const name of names) {
+      matched = extractSingleSection(lines, name);
+      if (matched) {
+        break;
       }
     }
-
-    if (sectionLines.length > 0) {
-      results.push(sectionLines.join("\n").trim());
+    if (matched) {
+      results.push(matched);
     }
   }
 
   return results;
+}
+
+/** Scan all lines for a single heading name and return the section content, or null. */
+function extractSingleSection(lines: string[], name: string): string | null {
+  let sectionLines: string[] = [];
+  let inSection = false;
+  let sectionLevel = 0;
+  let inCodeBlock = false;
+
+  for (const line of lines) {
+    // Track fenced code blocks
+    if (line.trimStart().startsWith("```")) {
+      inCodeBlock = !inCodeBlock;
+      if (inSection) {
+        sectionLines.push(line);
+      }
+      continue;
+    }
+
+    // Skip heading detection inside code blocks
+    if (inCodeBlock) {
+      if (inSection) {
+        sectionLines.push(line);
+      }
+      continue;
+    }
+
+    // Check if this line is a heading
+    const headingMatch = line.match(/^(#{2,3})\s+(.+?)\s*$/);
+
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const headingText = headingMatch[2];
+
+      if (!inSection) {
+        if (headingText.toLowerCase() === name.toLowerCase()) {
+          inSection = true;
+          sectionLevel = level;
+          sectionLines = [line];
+          continue;
+        }
+      } else {
+        // We're in section -- stop if we hit a heading of same or higher level
+        if (level <= sectionLevel) {
+          break;
+        }
+        // Lower-level heading (e.g., ### inside ##) -- include it
+        sectionLines.push(line);
+        continue;
+      }
+    }
+
+    if (inSection) {
+      sectionLines.push(line);
+    }
+  }
+
+  if (sectionLines.length > 0) {
+    return sectionLines.join("\n").trim();
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

- Problem: The AGENTS.md template uses `## Every Session` and `## Safety` as section headings, but the code (`extractSections`) expects `## Session Startup` and `## Red Lines`. Since matching is exact (case-insensitive), users who copy the template get zero post-compaction context injected.
- Why it matters: After compaction, the agent loses its startup sequence and safety rules — the two most critical sections for consistent behavior.
- What changed: Updated the template to use canonical names (`Session Startup`, `Red Lines`). Extended `extractSections` to accept alias arrays so both old and new heading names work. Refactored section scanning into an `extractSingleSection` helper that tries aliases in priority order (canonical first), so if a document contains both `## Session Startup` and `## Every Session`, the canonical heading is always preferred regardless of document order. Added tests for backward compatibility and a regression test for canonical-first priority.
- What did NOT change (scope boundary): No changes to compaction logic, summarization, or any other section extraction behavior.

## Change Type (select all)

- [x] Bug fix
- [x] Docs

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage

## Linked Issue/PR

- Closes #25029

## User-visible / Behavior Changes

Users who copied the old AGENTS.md template will now have their `## Every Session` and `## Safety` sections correctly extracted after compaction. Users with the canonical headings (`## Session Startup`, `## Red Lines`) are unaffected.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+

### Steps

1. Create an AGENTS.md with `## Every Session` and `## Safety` headings
2. Trigger compaction
3. Observe that post-compaction context is now injected (previously was `null`)

### Expected

- Both legacy and canonical section names are extracted

### Actual

- Before fix: only canonical names matched; template users got no post-compaction context

## Evidence

- [x] Failing test/log before + passing after

New tests verify legacy headings (`## Every Session`, `## Safety`) are extracted via alias support. 19 tests pass including a regression test confirming canonical headings are preferred over legacy aliases regardless of document order.

## Human Verification (required)

- Verified scenarios: All existing + new tests pass (`pnpm test -- --run src/auto-reply/reply/post-compaction-context.test.ts`)
- Edge cases checked: Both headings present (canonical preferred even when legacy appears first in document), only legacy headings, mixed case
- What you did **not** verify: Live gateway compaction (requires full deployment)

## Compatibility / Migration

- Backward compatible? Yes — old heading names are accepted via aliases
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; old behavior is restored
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: Post-compaction context returning `null` when it shouldn't

## Risks and Mitigations

- Risk: Users with both `## Session Startup` AND `## Every Session` in the same file — only the canonical (first alias) is extracted.
  - Mitigation: This is the correct behavior. Aliases are tried in priority order via full document scans per alias. Documented and tested with a regression test.