### PR TITLE
fix(tui): prefer assistant text over stale NO_REPLY content

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -88,6 +88,22 @@ describe("extractTextFromMessage", () => {
     expect(text).toBe("[thinking]\nponder\n\nhello");
   });
 
+  it("keeps thinking while replacing stale NO_REPLY content with top-level assistant text", () => {
+    const text = extractTextFromMessage(
+      {
+        role: "assistant",
+        text: "real text field reply",
+        content: [
+          { type: "thinking", thinking: "ponder" },
+          { type: "text", text: "NO_REPLY" },
+        ],
+      },
+      { includeThinking: true },
+    );
+
+    expect(text).toBe("[thinking]\nponder\n\nreal text field reply");
+  });
+
   it("sanitizes ANSI and control chars from string content", () => {
     const text = extractTextFromMessage({
       role: "assistant",
@@ -218,6 +234,16 @@ describe("extractContentFromMessage", () => {
       role: "assistant",
       text: "real text field reply",
       content: [{ type: "text", text: "NO_REPLY" }],
+    });
+
+    expect(text).toBe("real text field reply");
+  });
+
+  it("falls back to assistant text field when string content is stale NO_REPLY", () => {
+    const text = extractContentFromMessage({
+      role: "assistant",
+      text: "real text field reply",
+      content: "NO_REPLY",
     });
 
     expect(text).toBe("real text field reply");

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -45,6 +45,16 @@ describe("extractTextFromMessage", () => {
     expect(text).toBe("first\nsecond");
   });
 
+  it("prefers assistant text field over stale NO_REPLY content", () => {
+    const text = extractTextFromMessage({
+      role: "assistant",
+      text: "real text field reply",
+      content: [{ type: "text", text: "NO_REPLY" }],
+    });
+
+    expect(text).toBe("real text field reply");
+  });
+
   it("preserves internal newlines for string content", () => {
     const text = extractTextFromMessage({
       role: "assistant",
@@ -201,6 +211,16 @@ describe("extractContentFromMessage", () => {
     });
 
     expect(text).toContain("HTTP 429");
+  });
+
+  it("falls back to assistant text field when content only carries NO_REPLY", () => {
+    const text = extractContentFromMessage({
+      role: "assistant",
+      text: "real text field reply",
+      content: [{ type: "text", text: "NO_REPLY" }],
+    });
+
+    expect(text).toBe("real text field reply");
   });
 });
 

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -1,5 +1,6 @@
 import { formatRawAssistantErrorForUi } from "../agents/pi-embedded-helpers.js";
 import { stripLeadingInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { stripAnsi } from "../terminal/ansi.js";
 import { formatTokenCount } from "../utils/usage-format.js";
 
@@ -199,6 +200,27 @@ function formatAssistantErrorFromRecord(record: Record<string, unknown>): string
   return formatRawAssistantErrorForUi(errorMessage);
 }
 
+function extractTopLevelText(record: Record<string, unknown>): string {
+  return typeof record.text === "string" ? sanitizeRenderableText(record.text).trim() : "";
+}
+
+function resolveAssistantTopLevelTextOverride(params: {
+  record: Record<string, unknown>;
+  extractedText: string;
+}): string {
+  if (params.record.role !== "assistant") {
+    return "";
+  }
+  const topLevelText = extractTopLevelText(params.record);
+  if (!topLevelText) {
+    return "";
+  }
+  if (!params.extractedText || isSilentReplyText(params.extractedText, SILENT_REPLY_TOKEN)) {
+    return topLevelText;
+  }
+  return "";
+}
+
 function collectSanitizedBlockStrings(params: {
   content: unknown;
   blockType: "text" | "thinking";
@@ -261,8 +283,16 @@ export function extractContentFromMessage(message: unknown): string {
     blockType: "text",
     valueKey: "text",
   });
-  if (parts.length > 0) {
-    return parts.join("\n").trim();
+  const extractedText = parts.join("\n").trim();
+  const topLevelTextOverride = resolveAssistantTopLevelTextOverride({
+    record,
+    extractedText,
+  });
+  if (topLevelTextOverride) {
+    return topLevelTextOverride;
+  }
+  if (extractedText) {
+    return extractedText;
   }
   return formatAssistantErrorFromRecord(record);
 }
@@ -306,10 +336,25 @@ export function extractTextFromMessage(
   }
   const text = extractTextBlocks(record.content, opts);
   if (text) {
+    const topLevelTextOverride = resolveAssistantTopLevelTextOverride({
+      record,
+      extractedText: text,
+    });
+    if (topLevelTextOverride) {
+      return topLevelTextOverride;
+    }
     if (record.role === "user") {
       return stripLeadingInboundMetadata(text);
     }
     return text;
+  }
+
+  const fallbackText = extractTopLevelText(record);
+  if (fallbackText) {
+    if (record.role === "user") {
+      return stripLeadingInboundMetadata(fallbackText);
+    }
+    return fallbackText;
   }
 
   const errorText = formatAssistantErrorFromRecord(record);

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -242,6 +242,27 @@ function collectSanitizedBlockStrings(params: {
   return parts;
 }
 
+function extractSanitizedContentText(content: unknown): string {
+  if (typeof content === "string") {
+    return sanitizeRenderableText(content).trim();
+  }
+  const parts = collectSanitizedBlockStrings({
+    content,
+    blockType: "text",
+    valueKey: "text",
+  });
+  return parts.join("\n").trim();
+}
+
+function extractSanitizedThinkingText(content: unknown): string {
+  const parts = collectSanitizedBlockStrings({
+    content,
+    blockType: "thinking",
+    valueKey: "thinking",
+  });
+  return parts.join("\n").trim();
+}
+
 /**
  * Extract ONLY thinking blocks from message content.
  * Model-agnostic: returns empty string if no thinking blocks exist.
@@ -255,12 +276,7 @@ export function extractThinkingFromMessage(message: unknown): string {
   if (typeof content === "string") {
     return "";
   }
-  const parts = collectSanitizedBlockStrings({
-    content,
-    blockType: "thinking",
-    valueKey: "thinking",
-  });
-  return parts.join("\n").trim();
+  return extractSanitizedThinkingText(content);
 }
 
 /**
@@ -273,17 +289,7 @@ export function extractContentFromMessage(message: unknown): string {
     return "";
   }
   const { record, content } = resolved;
-
-  if (typeof content === "string") {
-    return sanitizeRenderableText(content).trim();
-  }
-
-  const parts = collectSanitizedBlockStrings({
-    content,
-    blockType: "text",
-    valueKey: "text",
-  });
-  const extractedText = parts.join("\n").trim();
+  const extractedText = extractSanitizedContentText(content);
   const topLevelTextOverride = resolveAssistantTopLevelTextOverride({
     record,
     extractedText,
@@ -297,35 +303,6 @@ export function extractContentFromMessage(message: unknown): string {
   return formatAssistantErrorFromRecord(record);
 }
 
-function extractTextBlocks(content: unknown, opts?: { includeThinking?: boolean }): string {
-  if (typeof content === "string") {
-    return sanitizeRenderableText(content).trim();
-  }
-  if (!Array.isArray(content)) {
-    return "";
-  }
-
-  const textParts = collectSanitizedBlockStrings({
-    content,
-    blockType: "text",
-    valueKey: "text",
-  });
-  const thinkingParts =
-    opts?.includeThinking === true
-      ? collectSanitizedBlockStrings({
-          content,
-          blockType: "thinking",
-          valueKey: "thinking",
-        })
-      : [];
-
-  return composeThinkingAndContent({
-    thinkingText: thinkingParts.join("\n").trim(),
-    contentText: textParts.join("\n").trim(),
-    showThinking: opts?.includeThinking ?? false,
-  });
-}
-
 export function extractTextFromMessage(
   message: unknown,
   opts?: { includeThinking?: boolean },
@@ -334,15 +311,18 @@ export function extractTextFromMessage(
   if (!record) {
     return "";
   }
-  const text = extractTextBlocks(record.content, opts);
+  const extractedContentText = extractSanitizedContentText(record.content);
+  const topLevelTextOverride = resolveAssistantTopLevelTextOverride({
+    record,
+    extractedText: extractedContentText,
+  });
+  const text = composeThinkingAndContent({
+    thinkingText:
+      opts?.includeThinking === true ? extractSanitizedThinkingText(record.content) : "",
+    contentText: topLevelTextOverride || extractedContentText,
+    showThinking: opts?.includeThinking ?? false,
+  });
   if (text) {
-    const topLevelTextOverride = resolveAssistantTopLevelTextOverride({
-      record,
-      extractedText: text,
-    });
-    if (topLevelTextOverride) {
-      return topLevelTextOverride;
-    }
     if (record.role === "user") {
       return stripLeadingInboundMetadata(text);
     }


### PR DESCRIPTION
## Summary

- Problem: some assistant messages carried real reply text in the top-level `text` field while `content` still contained stale `NO_REPLY` blocks
- Why it matters: TUI formatters preferred the stale `content` blocks and rendered `NO_REPLY` instead of the actual assistant reply
- What changed: `extractTextFromMessage()` and `extractContentFromMessage()` now prefer top-level assistant text when the extracted content is empty or resolves to the silent reply token
- What did NOT change (scope boundary): this does not alter gateway message shapes or transcript persistence; it only changes TUI rendering precedence

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #33768
- Related #33758

## User-visible / Behavior Changes

- TUI now shows the actual assistant reply when transcript/message payloads carry reply text in `message.text` but stale `NO_REPLY` remains in `content`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v20.17.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): TUI
- Relevant config (redacted): default local test harness

### Steps

1. Feed an assistant message whose top-level `text` contains the real reply.
2. Keep `content` populated with stale `NO_REPLY` text blocks.
3. Render the message through TUI formatter helpers.

### Expected

- TUI should render the real top-level assistant reply, not `NO_REPLY`.

### Actual

- Before this fix, TUI returned `NO_REPLY` because it always preferred `content` blocks.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm vitest run src/tui/tui-formatters.test.ts src/tui/tui-event-handlers.test.ts src/tui/tui-session-actions.test.ts`
- Edge cases checked: `pnpm exec oxfmt --check src/tui/tui-formatters.ts src/tui/tui-formatters.test.ts`
- What you did **not** verify: live provider-specific reproduction against MiniMax or a real gateway session

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `306453971`
- Files/config to restore: `src/tui/tui-formatters.ts`, `src/tui/tui-formatters.test.ts`
- Known bad symptoms reviewers should watch for: assistant messages unexpectedly preferring top-level `text` when `content` already contains real visible text

## Risks and Mitigations

- Risk: top-level assistant text could override legitimate block content in unexpected mixed-shape payloads
  - Mitigation: override only applies when extracted content is empty or resolves to the silent reply token

🤖 Generated with Codex
