### PR TITLE
Tests: expand outbound cfg-threading regression coverage

### DIFF
--- a/extensions/googlechat/src/resolve-target.test.ts
+++ b/extensions/googlechat/src/resolve-target.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { installCommonResolveTargetErrorCases } from "../../shared/resolve-target-test-helpers.js";
+
+const runtimeMocks = vi.hoisted(() => ({
+  chunkMarkdownText: vi.fn((text: string) => [text]),
+  fetchRemoteMedia: vi.fn(),
+}));
 
 vi.mock("openclaw/plugin-sdk", () => ({
   getChatChannelMeta: () => ({ id: "googlechat", label: "Google Chat" }),
@@ -47,7 +52,8 @@ vi.mock("./onboarding.js", () => ({
 vi.mock("./runtime.js", () => ({
   getGoogleChatRuntime: vi.fn(() => ({
     channel: {
-      text: { chunkMarkdownText: vi.fn() },
+      text: { chunkMarkdownText: runtimeMocks.chunkMarkdownText },
+      media: { fetchRemoteMedia: runtimeMocks.fetchRemoteMedia },
     },
   })),
 }));
@@ -66,7 +72,11 @@ vi.mock("./targets.js", () => ({
   resolveGoogleChatOutboundSpace: vi.fn(),
 }));
 
+import { resolveChannelMediaMaxBytes } from "openclaw/plugin-sdk";
+import { resolveGoogleChatAccount } from "./accounts.js";
+import { sendGoogleChatMessage, uploadGoogleChatAttachment } from "./api.js";
 import { googlechatPlugin } from "./channel.js";
+import { resolveGoogleChatOutboundSpace } from "./targets.js";
 
 const resolveTarget = googlechatPlugin.outbound!.resolveTarget!;
 
@@ -102,5 +112,120 @@ describe("googlechat resolveTarget", () => {
   installCommonResolveTargetErrorCases({
     resolveTarget,
     implicitAllowFrom: ["spaces/BBB"],
+  });
+});
+
+describe("googlechat outbound cfg threading", () => {
+  beforeEach(() => {
+    runtimeMocks.fetchRemoteMedia.mockReset();
+    runtimeMocks.chunkMarkdownText.mockClear();
+    vi.mocked(resolveGoogleChatAccount).mockReset();
+    vi.mocked(resolveGoogleChatOutboundSpace).mockReset();
+    vi.mocked(resolveChannelMediaMaxBytes).mockReset();
+    vi.mocked(uploadGoogleChatAttachment).mockReset();
+    vi.mocked(sendGoogleChatMessage).mockReset();
+  });
+
+  it("threads resolved cfg into sendText account resolution", async () => {
+    const cfg = {
+      channels: {
+        googlechat: {
+          serviceAccount: {
+            type: "service_account",
+          },
+        },
+      },
+    };
+    const account = {
+      accountId: "default",
+      config: {},
+      credentialSource: "inline",
+    };
+    vi.mocked(resolveGoogleChatAccount).mockReturnValue(account as any);
+    vi.mocked(resolveGoogleChatOutboundSpace).mockResolvedValue("spaces/AAA");
+    vi.mocked(sendGoogleChatMessage).mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-1",
+    } as any);
+
+    await googlechatPlugin.outbound!.sendText!({
+      cfg: cfg as any,
+      to: "users/123",
+      text: "hello",
+      accountId: "default",
+    });
+
+    expect(resolveGoogleChatAccount).toHaveBeenCalledWith({
+      cfg,
+      accountId: "default",
+    });
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account,
+        space: "spaces/AAA",
+        text: "hello",
+      }),
+    );
+  });
+
+  it("threads resolved cfg into sendMedia account and media loading path", async () => {
+    const cfg = {
+      channels: {
+        googlechat: {
+          serviceAccount: {
+            type: "service_account",
+          },
+          mediaMaxMb: 8,
+        },
+      },
+    };
+    const account = {
+      accountId: "default",
+      config: { mediaMaxMb: 20 },
+      credentialSource: "inline",
+    };
+    vi.mocked(resolveGoogleChatAccount).mockReturnValue(account as any);
+    vi.mocked(resolveGoogleChatOutboundSpace).mockResolvedValue("spaces/AAA");
+    vi.mocked(resolveChannelMediaMaxBytes).mockReturnValue(1024);
+    runtimeMocks.fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("file"),
+      fileName: "file.png",
+      contentType: "image/png",
+    });
+    vi.mocked(uploadGoogleChatAttachment).mockResolvedValue({
+      attachmentUploadToken: "token-1",
+    } as any);
+    vi.mocked(sendGoogleChatMessage).mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-2",
+    } as any);
+
+    await googlechatPlugin.outbound!.sendMedia!({
+      cfg: cfg as any,
+      to: "users/123",
+      text: "photo",
+      mediaUrl: "https://example.com/file.png",
+      accountId: "default",
+    });
+
+    expect(resolveGoogleChatAccount).toHaveBeenCalledWith({
+      cfg,
+      accountId: "default",
+    });
+    expect(runtimeMocks.fetchRemoteMedia).toHaveBeenCalledWith({
+      url: "https://example.com/file.png",
+      maxBytes: 1024,
+    });
+    expect(uploadGoogleChatAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account,
+        space: "spaces/AAA",
+        filename: "file.png",
+      }),
+    );
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account,
+        attachments: [{ attachmentUploadToken: "token-1", contentName: "file.png" }],
+      }),
+    );
   });
 });

--- a/extensions/irc/src/send.test.ts
+++ b/extensions/irc/src/send.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const loadConfig = vi.fn();
+  const resolveMarkdownTableMode = vi.fn(() => "preserve");
+  const convertMarkdownTables = vi.fn((text: string) => text);
+  const record = vi.fn();
+  return {
+    loadConfig,
+    resolveMarkdownTableMode,
+    convertMarkdownTables,
+    record,
+    resolveIrcAccount: vi.fn(() => ({
+      configured: true,
+      accountId: "default",
+      host: "irc.example.com",
+      nick: "openclaw",
+      port: 6697,
+      tls: true,
+    })),
+    normalizeIrcMessagingTarget: vi.fn((value: string) => value.trim()),
+    connectIrcClient: vi.fn(),
+    buildIrcConnectOptions: vi.fn(() => ({})),
+  };
+});
+
+vi.mock("./runtime.js", () => ({
+  getIrcRuntime: () => ({
+    config: {
+      loadConfig: hoisted.loadConfig,
+    },
+    channel: {
+      text: {
+        resolveMarkdownTableMode: hoisted.resolveMarkdownTableMode,
+        convertMarkdownTables: hoisted.convertMarkdownTables,
+      },
+      activity: {
+        record: hoisted.record,
+      },
+    },
+  }),
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveIrcAccount: hoisted.resolveIrcAccount,
+}));
+
+vi.mock("./normalize.js", () => ({
+  normalizeIrcMessagingTarget: hoisted.normalizeIrcMessagingTarget,
+}));
+
+vi.mock("./client.js", () => ({
+  connectIrcClient: hoisted.connectIrcClient,
+}));
+
+vi.mock("./connect-options.js", () => ({
+  buildIrcConnectOptions: hoisted.buildIrcConnectOptions,
+}));
+
+vi.mock("./protocol.js", async () => {
+  const actual = await vi.importActual<typeof import("./protocol.js")>("./protocol.js");
+  return {
+    ...actual,
+    makeIrcMessageId: () => "irc-msg-1",
+  };
+});
+
+import { sendMessageIrc } from "./send.js";
+
+describe("sendMessageIrc cfg threading", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses explicitly provided cfg without loading runtime config", async () => {
+    const providedCfg = { source: "provided" } as const;
+    const client = {
+      isReady: vi.fn(() => true),
+      sendPrivmsg: vi.fn(),
+    };
+
+    const result = await sendMessageIrc("#room", "hello", {
+      cfg: providedCfg,
+      client,
+      accountId: "work",
+    });
+
+    expect(hoisted.loadConfig).not.toHaveBeenCalled();
+    expect(hoisted.resolveIrcAccount).toHaveBeenCalledWith({
+      cfg: providedCfg,
+      accountId: "work",
+    });
+    expect(client.sendPrivmsg).toHaveBeenCalledWith("#room", "hello");
+    expect(result).toEqual({ messageId: "irc-msg-1", target: "#room" });
+  });
+
+  it("falls back to runtime config when cfg is omitted", async () => {
+    const runtimeCfg = { source: "runtime" } as const;
+    hoisted.loadConfig.mockReturnValueOnce(runtimeCfg);
+    const client = {
+      isReady: vi.fn(() => true),
+      sendPrivmsg: vi.fn(),
+    };
+
+    await sendMessageIrc("#ops", "ping", { client });
+
+    expect(hoisted.loadConfig).toHaveBeenCalledTimes(1);
+    expect(hoisted.resolveIrcAccount).toHaveBeenCalledWith({
+      cfg: runtimeCfg,
+      accountId: undefined,
+    });
+    expect(client.sendPrivmsg).toHaveBeenCalledWith("#ops", "ping");
+  });
+});

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -117,6 +117,7 @@ describe("linePlugin outbound.sendPayload", () => {
     expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:group:1", "Now playing:", {
       verbose: false,
       accountId: "default",
+      cfg,
     });
   });
 
@@ -154,6 +155,7 @@ describe("linePlugin outbound.sendPayload", () => {
     expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:user:1", "Choose one:", {
       verbose: false,
       accountId: "default",
+      cfg,
     });
   });
 
@@ -193,7 +195,7 @@ describe("linePlugin outbound.sendPayload", () => {
           quickReply: { items: ["One", "Two"] },
         },
       ],
-      { verbose: false, accountId: "default" },
+      { verbose: false, accountId: "default", cfg },
     );
     expect(mocks.createQuickReplyItems).toHaveBeenCalledWith(["One", "Two"]);
   });
@@ -225,12 +227,13 @@ describe("linePlugin outbound.sendPayload", () => {
       verbose: false,
       mediaUrl: "https://example.com/img.jpg",
       accountId: "default",
+      cfg,
     });
     expect(mocks.pushTextMessageWithQuickReplies).toHaveBeenCalledWith(
       "line:user:3",
       "Hello",
       ["One", "Two"],
-      { verbose: false, accountId: "default" },
+      { verbose: false, accountId: "default", cfg },
     );
     const mediaOrder = mocks.sendMessageLine.mock.invocationCallOrder[0];
     const quickReplyOrder = mocks.pushTextMessageWithQuickReplies.mock.invocationCallOrder[0];

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -34,6 +34,7 @@ const loadWebMediaMock = vi.fn().mockResolvedValue({
   contentType: "image/png",
   kind: "image",
 });
+const runtimeLoadConfigMock = vi.fn(() => ({}));
 const mediaKindFromMimeMock = vi.fn(() => "image");
 const isVoiceCompatibleAudioMock = vi.fn(() => false);
 const getImageMetadataMock = vi.fn().mockResolvedValue(null);
@@ -41,7 +42,7 @@ const resizeToJpegMock = vi.fn();
 
 const runtimeStub = {
   config: {
-    loadConfig: () => ({}),
+    loadConfig: runtimeLoadConfigMock,
   },
   media: {
     loadWebMedia: loadWebMediaMock as unknown as PluginRuntime["media"]["loadWebMedia"],
@@ -65,6 +66,7 @@ const runtimeStub = {
 } as unknown as PluginRuntime;
 
 let sendMessageMatrix: typeof import("./send.js").sendMessageMatrix;
+let resolveMediaMaxBytes: typeof import("./send/client.js").resolveMediaMaxBytes;
 
 const makeClient = () => {
   const sendMessage = vi.fn().mockResolvedValue("evt1");
@@ -80,11 +82,14 @@ const makeClient = () => {
 beforeAll(async () => {
   setMatrixRuntime(runtimeStub);
   ({ sendMessageMatrix } = await import("./send.js"));
+  ({ resolveMediaMaxBytes } = await import("./send/client.js"));
 });
 
 describe("sendMessageMatrix media", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    runtimeLoadConfigMock.mockReset();
+    runtimeLoadConfigMock.mockReturnValue({});
     mediaKindFromMimeMock.mockReturnValue("image");
     isVoiceCompatibleAudioMock.mockReturnValue(false);
     setMatrixRuntime(runtimeStub);
@@ -214,6 +219,8 @@ describe("sendMessageMatrix media", () => {
 describe("sendMessageMatrix threads", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    runtimeLoadConfigMock.mockReset();
+    runtimeLoadConfigMock.mockReturnValue({});
     setMatrixRuntime(runtimeStub);
   });
 
@@ -238,5 +245,82 @@ describe("sendMessageMatrix threads", () => {
       event_id: "$thread",
       "m.in_reply_to": { event_id: "$thread" },
     });
+  });
+});
+
+describe("sendMessageMatrix cfg threading", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runtimeLoadConfigMock.mockReset();
+    runtimeLoadConfigMock.mockReturnValue({
+      channels: {
+        matrix: {
+          mediaMaxMb: 7,
+        },
+      },
+    });
+    setMatrixRuntime(runtimeStub);
+  });
+
+  it("does not call runtime loadConfig when cfg is provided", async () => {
+    const { client } = makeClient();
+    const providedCfg = {
+      channels: {
+        matrix: {
+          mediaMaxMb: 4,
+        },
+      },
+    };
+
+    await sendMessageMatrix("room:!room:example", "hello cfg", {
+      client,
+      cfg: providedCfg as any,
+    });
+
+    expect(runtimeLoadConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to runtime loadConfig when cfg is omitted", async () => {
+    const { client } = makeClient();
+
+    await sendMessageMatrix("room:!room:example", "hello runtime", { client });
+
+    expect(runtimeLoadConfigMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveMediaMaxBytes cfg threading", () => {
+  beforeEach(() => {
+    runtimeLoadConfigMock.mockReset();
+    runtimeLoadConfigMock.mockReturnValue({
+      channels: {
+        matrix: {
+          mediaMaxMb: 9,
+        },
+      },
+    });
+    setMatrixRuntime(runtimeStub);
+  });
+
+  it("uses provided cfg and skips runtime loadConfig", () => {
+    const providedCfg = {
+      channels: {
+        matrix: {
+          mediaMaxMb: 3,
+        },
+      },
+    };
+
+    const maxBytes = resolveMediaMaxBytes(undefined, providedCfg as any);
+
+    expect(maxBytes).toBe(3 * 1024 * 1024);
+    expect(runtimeLoadConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to runtime loadConfig when cfg is omitted", () => {
+    const maxBytes = resolveMediaMaxBytes();
+
+    expect(maxBytes).toBe(9 * 1024 * 1024);
+    expect(runtimeLoadConfigMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/matrix/src/outbound.test.ts
+++ b/extensions/matrix/src/outbound.test.ts
@@ -1,0 +1,124 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  sendMessageMatrix: vi.fn(),
+  sendPollMatrix: vi.fn(),
+}));
+
+vi.mock("./matrix/send.js", () => ({
+  sendMessageMatrix: mocks.sendMessageMatrix,
+  sendPollMatrix: mocks.sendPollMatrix,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getMatrixRuntime: () => ({
+    channel: {
+      text: {
+        chunkMarkdownText: (text: string) => [text],
+      },
+    },
+  }),
+}));
+
+import { matrixOutbound } from "./outbound.js";
+
+describe("matrixOutbound cfg threading", () => {
+  beforeEach(() => {
+    mocks.sendMessageMatrix.mockReset();
+    mocks.sendPollMatrix.mockReset();
+    mocks.sendMessageMatrix.mockResolvedValue({ messageId: "evt-1", roomId: "!room:example" });
+    mocks.sendPollMatrix.mockResolvedValue({ eventId: "$poll", roomId: "!room:example" });
+  });
+
+  it("passes resolved cfg to sendMessageMatrix for text sends", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          accessToken: "resolved-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    await matrixOutbound.sendText!({
+      cfg,
+      to: "room:!room:example",
+      text: "hello",
+      accountId: "default",
+      threadId: "$thread",
+      replyToId: "$reply",
+    });
+
+    expect(mocks.sendMessageMatrix).toHaveBeenCalledWith(
+      "room:!room:example",
+      "hello",
+      expect.objectContaining({
+        cfg,
+        accountId: "default",
+        threadId: "$thread",
+        replyToId: "$reply",
+      }),
+    );
+  });
+
+  it("passes resolved cfg to sendMessageMatrix for media sends", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          accessToken: "resolved-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    await matrixOutbound.sendMedia!({
+      cfg,
+      to: "room:!room:example",
+      text: "caption",
+      mediaUrl: "file:///tmp/cat.png",
+      accountId: "default",
+    });
+
+    expect(mocks.sendMessageMatrix).toHaveBeenCalledWith(
+      "room:!room:example",
+      "caption",
+      expect.objectContaining({
+        cfg,
+        mediaUrl: "file:///tmp/cat.png",
+      }),
+    );
+  });
+
+  it("passes resolved cfg to sendPollMatrix", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          accessToken: "resolved-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    await matrixOutbound.sendPoll!({
+      cfg,
+      to: "room:!room:example",
+      poll: {
+        question: "Snack?",
+        options: ["Pizza", "Sushi"],
+      },
+      accountId: "default",
+      threadId: "$thread",
+    });
+
+    expect(mocks.sendPollMatrix).toHaveBeenCalledWith(
+      "room:!room:example",
+      expect.objectContaining({
+        question: "Snack?",
+        options: ["Pizza", "Sushi"],
+      }),
+      expect.objectContaining({
+        cfg,
+        accountId: "default",
+        threadId: "$thread",
+      }),
+    );
+  });
+});

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -240,6 +240,37 @@ describe("mattermostPlugin", () => {
         }),
       );
     });
+
+    it("threads resolved cfg on sendText", async () => {
+      const sendText = mattermostPlugin.outbound?.sendText;
+      if (!sendText) {
+        return;
+      }
+      const cfg = {
+        channels: {
+          mattermost: {
+            botToken: "resolved-bot-token",
+            baseUrl: "https://chat.example.com",
+          },
+        },
+      } as OpenClawConfig;
+
+      await sendText({
+        cfg,
+        to: "channel:CHAN1",
+        text: "hello",
+        accountId: "default",
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({
+          cfg,
+          accountId: "default",
+        }),
+      );
+    });
   });
 
   describe("config", () => {

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -2,7 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sendMessageMattermost } from "./send.js";
 
 const mockState = vi.hoisted(() => ({
+  loadConfig: vi.fn(() => ({})),
   loadOutboundMediaFromUrl: vi.fn(),
+  resolveMattermostAccount: vi.fn(() => ({
+    accountId: "default",
+    botToken: "bot-token",
+    baseUrl: "https://mattermost.example.com",
+  })),
   createMattermostClient: vi.fn(),
   createMattermostDirectChannel: vi.fn(),
   createMattermostPost: vi.fn(),
@@ -17,11 +23,7 @@ vi.mock("openclaw/plugin-sdk", () => ({
 }));
 
 vi.mock("./accounts.js", () => ({
-  resolveMattermostAccount: () => ({
-    accountId: "default",
-    botToken: "bot-token",
-    baseUrl: "https://mattermost.example.com",
-  }),
+  resolveMattermostAccount: mockState.resolveMattermostAccount,
 }));
 
 vi.mock("./client.js", () => ({
@@ -37,7 +39,7 @@ vi.mock("./client.js", () => ({
 vi.mock("../runtime.js", () => ({
   getMattermostRuntime: () => ({
     config: {
-      loadConfig: () => ({}),
+      loadConfig: mockState.loadConfig,
     },
     logging: {
       shouldLogVerbose: () => false,
@@ -57,6 +59,14 @@ vi.mock("../runtime.js", () => ({
 
 describe("sendMessageMattermost", () => {
   beforeEach(() => {
+    mockState.loadConfig.mockReset();
+    mockState.loadConfig.mockReturnValue({});
+    mockState.resolveMattermostAccount.mockReset();
+    mockState.resolveMattermostAccount.mockReturnValue({
+      accountId: "default",
+      botToken: "bot-token",
+      baseUrl: "https://mattermost.example.com",
+    });
     mockState.loadOutboundMediaFromUrl.mockReset();
     mockState.createMattermostClient.mockReset();
     mockState.createMattermostDirectChannel.mockReset();
@@ -67,6 +77,46 @@ describe("sendMessageMattermost", () => {
     mockState.createMattermostClient.mockReturnValue({});
     mockState.createMattermostPost.mockResolvedValue({ id: "post-1" });
     mockState.uploadMattermostFile.mockResolvedValue({ id: "file-1" });
+  });
+
+  it("uses provided cfg and skips runtime loadConfig", async () => {
+    const providedCfg = {
+      channels: {
+        mattermost: {
+          botToken: "provided-token",
+        },
+      },
+    };
+
+    await sendMessageMattermost("channel:town-square", "hello", {
+      cfg: providedCfg as any,
+      accountId: "work",
+    });
+
+    expect(mockState.loadConfig).not.toHaveBeenCalled();
+    expect(mockState.resolveMattermostAccount).toHaveBeenCalledWith({
+      cfg: providedCfg,
+      accountId: "work",
+    });
+  });
+
+  it("falls back to runtime loadConfig when cfg is omitted", async () => {
+    const runtimeCfg = {
+      channels: {
+        mattermost: {
+          botToken: "runtime-token",
+        },
+      },
+    };
+    mockState.loadConfig.mockReturnValueOnce(runtimeCfg);
+
+    await sendMessageMattermost("channel:town-square", "hello");
+
+    expect(mockState.loadConfig).toHaveBeenCalledTimes(1);
+    expect(mockState.resolveMattermostAccount).toHaveBeenCalledWith({
+      cfg: runtimeCfg,
+      accountId: undefined,
+    });
   });
 
   it("loads outbound media with trusted local roots before upload", async () => {

--- a/extensions/msteams/src/outbound.test.ts
+++ b/extensions/msteams/src/outbound.test.ts
@@ -1,0 +1,131 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  sendMessageMSTeams: vi.fn(),
+  sendPollMSTeams: vi.fn(),
+  createPoll: vi.fn(),
+}));
+
+vi.mock("./send.js", () => ({
+  sendMessageMSTeams: mocks.sendMessageMSTeams,
+  sendPollMSTeams: mocks.sendPollMSTeams,
+}));
+
+vi.mock("./polls.js", () => ({
+  createMSTeamsPollStoreFs: () => ({
+    createPoll: mocks.createPoll,
+  }),
+}));
+
+vi.mock("./runtime.js", () => ({
+  getMSTeamsRuntime: () => ({
+    channel: {
+      text: {
+        chunkMarkdownText: (text: string) => [text],
+      },
+    },
+  }),
+}));
+
+import { msteamsOutbound } from "./outbound.js";
+
+describe("msteamsOutbound cfg threading", () => {
+  beforeEach(() => {
+    mocks.sendMessageMSTeams.mockReset();
+    mocks.sendPollMSTeams.mockReset();
+    mocks.createPoll.mockReset();
+    mocks.sendMessageMSTeams.mockResolvedValue({
+      messageId: "msg-1",
+      conversationId: "conv-1",
+    });
+    mocks.sendPollMSTeams.mockResolvedValue({
+      pollId: "poll-1",
+      messageId: "msg-poll-1",
+      conversationId: "conv-1",
+    });
+    mocks.createPoll.mockResolvedValue(undefined);
+  });
+
+  it("passes resolved cfg to sendMessageMSTeams for text sends", async () => {
+    const cfg = {
+      channels: {
+        msteams: {
+          appId: "resolved-app-id",
+        },
+      },
+    } as OpenClawConfig;
+
+    await msteamsOutbound.sendText!({
+      cfg,
+      to: "conversation:abc",
+      text: "hello",
+    });
+
+    expect(mocks.sendMessageMSTeams).toHaveBeenCalledWith({
+      cfg,
+      to: "conversation:abc",
+      text: "hello",
+    });
+  });
+
+  it("passes resolved cfg and media roots for media sends", async () => {
+    const cfg = {
+      channels: {
+        msteams: {
+          appId: "resolved-app-id",
+        },
+      },
+    } as OpenClawConfig;
+
+    await msteamsOutbound.sendMedia!({
+      cfg,
+      to: "conversation:abc",
+      text: "photo",
+      mediaUrl: "file:///tmp/photo.png",
+      mediaLocalRoots: ["/tmp"],
+    });
+
+    expect(mocks.sendMessageMSTeams).toHaveBeenCalledWith({
+      cfg,
+      to: "conversation:abc",
+      text: "photo",
+      mediaUrl: "file:///tmp/photo.png",
+      mediaLocalRoots: ["/tmp"],
+    });
+  });
+
+  it("passes resolved cfg to sendPollMSTeams and stores poll metadata", async () => {
+    const cfg = {
+      channels: {
+        msteams: {
+          appId: "resolved-app-id",
+        },
+      },
+    } as OpenClawConfig;
+
+    await msteamsOutbound.sendPoll!({
+      cfg,
+      to: "conversation:abc",
+      poll: {
+        question: "Snack?",
+        options: ["Pizza", "Sushi"],
+      },
+    });
+
+    expect(mocks.sendPollMSTeams).toHaveBeenCalledWith({
+      cfg,
+      to: "conversation:abc",
+      question: "Snack?",
+      options: ["Pizza", "Sushi"],
+      maxSelections: 1,
+    });
+    expect(mocks.createPoll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "poll-1",
+        question: "Snack?",
+        options: ["Pizza", "Sushi"],
+      }),
+    );
+  });
+});

--- a/extensions/nextcloud-talk/src/send.test.ts
+++ b/extensions/nextcloud-talk/src/send.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  loadConfig: vi.fn(),
+  resolveMarkdownTableMode: vi.fn(() => "preserve"),
+  convertMarkdownTables: vi.fn((text: string) => text),
+  record: vi.fn(),
+  resolveNextcloudTalkAccount: vi.fn(() => ({
+    accountId: "default",
+    baseUrl: "https://nextcloud.example.com",
+    secret: "secret-value",
+  })),
+  generateNextcloudTalkSignature: vi.fn(() => ({
+    random: "r",
+    signature: "s",
+  })),
+}));
+
+vi.mock("./runtime.js", () => ({
+  getNextcloudTalkRuntime: () => ({
+    config: {
+      loadConfig: hoisted.loadConfig,
+    },
+    channel: {
+      text: {
+        resolveMarkdownTableMode: hoisted.resolveMarkdownTableMode,
+        convertMarkdownTables: hoisted.convertMarkdownTables,
+      },
+      activity: {
+        record: hoisted.record,
+      },
+    },
+  }),
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveNextcloudTalkAccount: hoisted.resolveNextcloudTalkAccount,
+}));
+
+vi.mock("./signature.js", () => ({
+  generateNextcloudTalkSignature: hoisted.generateNextcloudTalkSignature,
+}));
+
+import { sendMessageNextcloudTalk, sendReactionNextcloudTalk } from "./send.js";
+
+describe("nextcloud-talk send cfg threading", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses provided cfg for sendMessage and skips runtime loadConfig", async () => {
+    const cfg = { source: "provided" } as const;
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          ocs: { data: { id: 12345, timestamp: 1_706_000_000 } },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await sendMessageNextcloudTalk("room:abc123", "hello", {
+      cfg,
+      accountId: "work",
+    });
+
+    expect(hoisted.loadConfig).not.toHaveBeenCalled();
+    expect(hoisted.resolveNextcloudTalkAccount).toHaveBeenCalledWith({
+      cfg,
+      accountId: "work",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      messageId: "12345",
+      roomToken: "abc123",
+      timestamp: 1_706_000_000,
+    });
+  });
+
+  it("falls back to runtime cfg for sendReaction when cfg is omitted", async () => {
+    const runtimeCfg = { source: "runtime" } as const;
+    hoisted.loadConfig.mockReturnValueOnce(runtimeCfg);
+    fetchMock.mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+    const result = await sendReactionNextcloudTalk("room:ops", "m-1", "👍", {
+      accountId: "default",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(hoisted.loadConfig).toHaveBeenCalledTimes(1);
+    expect(hoisted.resolveNextcloudTalkAccount).toHaveBeenCalledWith({
+      cfg: runtimeCfg,
+      accountId: "default",
+    });
+  });
+});

--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -1,0 +1,88 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createStartAccountContext } from "../../test-utils/start-account-context.js";
+import { nostrPlugin } from "./channel.js";
+import { setNostrRuntime } from "./runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  normalizePubkey: vi.fn((value: string) => `normalized-${value.toLowerCase()}`),
+  startNostrBus: vi.fn(),
+}));
+
+vi.mock("./nostr-bus.js", () => ({
+  DEFAULT_RELAYS: ["wss://relay.example.com"],
+  getPublicKeyFromPrivate: vi.fn(() => "pubkey"),
+  normalizePubkey: mocks.normalizePubkey,
+  startNostrBus: mocks.startNostrBus,
+}));
+
+describe("nostr outbound cfg threading", () => {
+  afterEach(() => {
+    mocks.normalizePubkey.mockClear();
+    mocks.startNostrBus.mockReset();
+  });
+
+  it("uses resolved cfg when converting markdown tables before send", async () => {
+    const resolveMarkdownTableMode = vi.fn(() => "off");
+    const convertMarkdownTables = vi.fn((text: string) => `converted:${text}`);
+    setNostrRuntime({
+      channel: {
+        text: {
+          resolveMarkdownTableMode,
+          convertMarkdownTables,
+        },
+      },
+      reply: {},
+    } as unknown as PluginRuntime);
+
+    const sendDm = vi.fn(async () => {});
+    const bus = {
+      sendDm,
+      close: vi.fn(),
+      getMetrics: vi.fn(() => ({ counters: {} })),
+      publishProfile: vi.fn(),
+      getProfileState: vi.fn(async () => null),
+    };
+    mocks.startNostrBus.mockResolvedValueOnce(bus as any);
+
+    const cleanup = await nostrPlugin.gateway!.startAccount!(
+      createStartAccountContext({
+        account: {
+          accountId: "default",
+          enabled: true,
+          configured: true,
+          privateKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          publicKey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+          relays: ["wss://relay.example.com"],
+          config: {},
+        },
+        abortSignal: new AbortController().signal,
+      }),
+    );
+
+    const cfg = {
+      channels: {
+        nostr: {
+          privateKey: "resolved-nostr-private-key",
+        },
+      },
+    };
+    await nostrPlugin.outbound!.sendText!({
+      cfg: cfg as any,
+      to: "NPUB123",
+      text: "|a|b|",
+      accountId: "default",
+    });
+
+    expect(resolveMarkdownTableMode).toHaveBeenCalledWith({
+      cfg,
+      channel: "nostr",
+      accountId: "default",
+    });
+    expect(convertMarkdownTables).toHaveBeenCalledWith("|a|b|", "off");
+    expect(mocks.normalizePubkey).toHaveBeenCalledWith("NPUB123");
+    expect(sendDm).toHaveBeenCalledWith("normalized-npub123", "converted:|a|b|");
+
+    cleanup.stop();
+  });
+});

--- a/extensions/signal/src/channel.outbound.test.ts
+++ b/extensions/signal/src/channel.outbound.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { signalPlugin } from "./channel.js";
+
+describe("signal outbound cfg threading", () => {
+  it("threads provided cfg into sendText deps call", async () => {
+    const cfg = {
+      channels: {
+        signal: {
+          accounts: {
+            work: {
+              mediaMaxMb: 12,
+            },
+          },
+          mediaMaxMb: 5,
+        },
+      },
+    };
+    const sendSignal = vi.fn(async () => ({ messageId: "sig-1" }));
+
+    const result = await signalPlugin.outbound!.sendText!({
+      cfg,
+      to: "+15551230000",
+      text: "hello",
+      accountId: "work",
+      deps: { sendSignal },
+    });
+
+    expect(sendSignal).toHaveBeenCalledWith("+15551230000", "hello", {
+      cfg,
+      maxBytes: 12 * 1024 * 1024,
+      accountId: "work",
+    });
+    expect(result).toEqual({ channel: "signal", messageId: "sig-1" });
+  });
+
+  it("threads cfg + mediaUrl into sendMedia deps call", async () => {
+    const cfg = {
+      channels: {
+        signal: {
+          mediaMaxMb: 7,
+        },
+      },
+    };
+    const sendSignal = vi.fn(async () => ({ messageId: "sig-2" }));
+
+    const result = await signalPlugin.outbound!.sendMedia!({
+      cfg,
+      to: "+15559870000",
+      text: "photo",
+      mediaUrl: "https://example.com/a.jpg",
+      accountId: "default",
+      deps: { sendSignal },
+    });
+
+    expect(sendSignal).toHaveBeenCalledWith("+15559870000", "photo", {
+      cfg,
+      mediaUrl: "https://example.com/a.jpg",
+      maxBytes: 7 * 1024 * 1024,
+      accountId: "default",
+    });
+    expect(result).toEqual({ channel: "signal", messageId: "sig-2" });
+  });
+});

--- a/extensions/whatsapp/src/channel.outbound.test.ts
+++ b/extensions/whatsapp/src/channel.outbound.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  sendPollWhatsApp: vi.fn(async () => ({ messageId: "wa-poll-1", toJid: "1555@s.whatsapp.net" })),
+}));
+
+vi.mock("./runtime.js", () => ({
+  getWhatsAppRuntime: () => ({
+    logging: {
+      shouldLogVerbose: () => false,
+    },
+    channel: {
+      whatsapp: {
+        sendPollWhatsApp: hoisted.sendPollWhatsApp,
+      },
+    },
+  }),
+}));
+
+import { whatsappPlugin } from "./channel.js";
+
+describe("whatsappPlugin outbound sendPoll", () => {
+  it("threads cfg into runtime sendPollWhatsApp call", async () => {
+    const cfg = { marker: "resolved-cfg" } as const;
+    const poll = {
+      question: "Lunch?",
+      options: ["Pizza", "Sushi"],
+      maxSelections: 1,
+    };
+
+    const result = await whatsappPlugin.outbound!.sendPoll!({
+      cfg,
+      to: "+1555",
+      poll,
+      accountId: "work",
+    });
+
+    expect(hoisted.sendPollWhatsApp).toHaveBeenCalledWith("+1555", poll, {
+      verbose: false,
+      accountId: "work",
+      cfg,
+    });
+    expect(result).toEqual({ messageId: "wa-poll-1", toJid: "1555@s.whatsapp.net" });
+  });
+});

--- a/src/agents/tools/discord-actions.test.ts
+++ b/src/agents/tools/discord-actions.test.ts
@@ -107,7 +107,7 @@ describe("handleDiscordMessagingAction", () => {
       expect(reactMessageDiscord).toHaveBeenCalledWith("C1", "M1", "✅", expectedOptions);
       return;
     }
-    expect(reactMessageDiscord).toHaveBeenCalledWith("C1", "M1", "✅");
+    expect(reactMessageDiscord).toHaveBeenCalledWith("C1", "M1", "✅", {});
   });
 
   it("removes reactions on empty emoji", async () => {
@@ -120,7 +120,7 @@ describe("handleDiscordMessagingAction", () => {
       },
       enableAllActions,
     );
-    expect(removeOwnReactionsDiscord).toHaveBeenCalledWith("C1", "M1");
+    expect(removeOwnReactionsDiscord).toHaveBeenCalledWith("C1", "M1", {});
   });
 
   it("removes reactions when remove flag set", async () => {
@@ -134,7 +134,7 @@ describe("handleDiscordMessagingAction", () => {
       },
       enableAllActions,
     );
-    expect(removeReactionDiscord).toHaveBeenCalledWith("C1", "M1", "✅");
+    expect(removeReactionDiscord).toHaveBeenCalledWith("C1", "M1", "✅", {});
   });
 
   it("rejects removes without emoji", async () => {

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -847,7 +847,10 @@ describe("signalMessageActions", () => {
         cfg: createSignalAccountOverrideCfg(),
         accountId: "work",
         params: { to: "+15550001111", messageId: "123", emoji: "👍" },
-        expectedArgs: ["+15550001111", 123, "👍", { accountId: "work" }],
+        expectedRecipient: "+15550001111",
+        expectedTimestamp: 123,
+        expectedEmoji: "👍",
+        expectedOptions: { accountId: "work" },
       },
       {
         name: "normalizes uuid recipients",
@@ -858,7 +861,10 @@ describe("signalMessageActions", () => {
           messageId: "123",
           emoji: "🔥",
         },
-        expectedArgs: ["123e4567-e89b-12d3-a456-426614174000", 123, "🔥", { accountId: undefined }],
+        expectedRecipient: "123e4567-e89b-12d3-a456-426614174000",
+        expectedTimestamp: 123,
+        expectedEmoji: "🔥",
+        expectedOptions: {},
       },
       {
         name: "passes groupId and targetAuthor for group reactions",
@@ -870,17 +876,13 @@ describe("signalMessageActions", () => {
           messageId: "123",
           emoji: "✅",
         },
-        expectedArgs: [
-          "",
-          123,
-          "✅",
-          {
-            accountId: undefined,
-            groupId: "group-id",
-            targetAuthor: "uuid:123e4567-e89b-12d3-a456-426614174000",
-            targetAuthorUuid: undefined,
-          },
-        ],
+        expectedRecipient: "",
+        expectedTimestamp: 123,
+        expectedEmoji: "✅",
+        expectedOptions: {
+          groupId: "group-id",
+          targetAuthor: "uuid:123e4567-e89b-12d3-a456-426614174000",
+        },
       },
     ] as const;
 
@@ -890,7 +892,15 @@ describe("signalMessageActions", () => {
         cfg: testCase.cfg,
         accountId: testCase.accountId,
       });
-      expect(sendReactionSignal, testCase.name).toHaveBeenCalledWith(...testCase.expectedArgs);
+      expect(sendReactionSignal, testCase.name).toHaveBeenCalledWith(
+        testCase.expectedRecipient,
+        testCase.expectedTimestamp,
+        testCase.expectedEmoji,
+        expect.objectContaining({
+          cfg: testCase.cfg,
+          ...testCase.expectedOptions,
+        }),
+      );
     }
   });
 

--- a/src/channels/plugins/outbound/slack.test.ts
+++ b/src/channels/plugins/outbound/slack.test.ts
@@ -58,11 +58,13 @@ const expectSlackSendCalledWith = (
     };
   },
 ) => {
-  expect(sendMessageSlack).toHaveBeenCalledWith("C123", text, {
+  const expected = {
     threadTs: "1111.2222",
     accountId: "default",
-    ...options,
-  });
+    cfg: expect.any(Object),
+    ...(options?.identity ? { identity: expect.objectContaining(options.identity) } : {}),
+  };
+  expect(sendMessageSlack).toHaveBeenCalledWith("C123", text, expect.objectContaining(expected));
 };
 
 describe("slack outbound hook wiring", () => {

--- a/src/channels/plugins/outbound/whatsapp.poll.test.ts
+++ b/src/channels/plugins/outbound/whatsapp.poll.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  sendPollWhatsApp: vi.fn(async () => ({ messageId: "poll-1", toJid: "1555@s.whatsapp.net" })),
+}));
+
+vi.mock("../../../globals.js", () => ({
+  shouldLogVerbose: () => false,
+}));
+
+vi.mock("../../../web/outbound.js", () => ({
+  sendPollWhatsApp: hoisted.sendPollWhatsApp,
+}));
+
+import { whatsappOutbound } from "./whatsapp.js";
+
+describe("whatsappOutbound sendPoll", () => {
+  it("threads cfg through poll send options", async () => {
+    const cfg = { marker: "resolved-cfg" } as const;
+    const poll = {
+      question: "Lunch?",
+      options: ["Pizza", "Sushi"],
+      maxSelections: 1,
+    };
+
+    const result = await whatsappOutbound.sendPoll!({
+      cfg,
+      to: "+1555",
+      poll,
+      accountId: "work",
+    });
+
+    expect(hoisted.sendPollWhatsApp).toHaveBeenCalledWith("+1555", poll, {
+      verbose: false,
+      accountId: "work",
+      cfg,
+    });
+    expect(result).toEqual({ messageId: "poll-1", toJid: "1555@s.whatsapp.net" });
+  });
+});

--- a/src/commands/message.test.ts
+++ b/src/commands/message.test.ts
@@ -169,6 +169,199 @@ const createTelegramSendPluginRegistration = () => ({
 const { messageCommand } = await import("./message.js");
 
 describe("messageCommand", () => {
+  it("threads resolved SecretRef config into outbound send actions", async () => {
+    const rawConfig = {
+      channels: {
+        telegram: {
+          token: { $secret: "vault://telegram/token" },
+        },
+      },
+    };
+    const resolvedConfig = {
+      channels: {
+        telegram: {
+          token: "12345:resolved-token",
+        },
+      },
+    };
+    testConfig = rawConfig;
+    resolveCommandSecretRefsViaGateway.mockResolvedValueOnce({
+      resolvedConfig: resolvedConfig as unknown as Record<string, unknown>,
+      diagnostics: ["resolved channels.telegram.token"],
+    });
+    await setRegistry(
+      createTestRegistry([
+        {
+          ...createTelegramSendPluginRegistration(),
+        },
+      ]),
+    );
+
+    const deps = makeDeps();
+    await messageCommand(
+      {
+        action: "send",
+        channel: "telegram",
+        target: "123456",
+        message: "hi",
+      },
+      deps,
+      runtime,
+    );
+
+    expect(resolveCommandSecretRefsViaGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: rawConfig,
+        commandName: "message",
+      }),
+    );
+    expect(handleTelegramAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "send", to: "123456", accountId: undefined }),
+      resolvedConfig,
+    );
+  });
+
+  it("threads resolved SecretRef config into outbound adapter sends", async () => {
+    const rawConfig = {
+      channels: {
+        telegram: {
+          token: { $secret: "vault://telegram/token" },
+        },
+      },
+    };
+    const resolvedConfig = {
+      channels: {
+        telegram: {
+          token: "12345:resolved-token",
+        },
+      },
+    };
+    testConfig = rawConfig;
+    resolveCommandSecretRefsViaGateway.mockResolvedValueOnce({
+      resolvedConfig: resolvedConfig as unknown as Record<string, unknown>,
+      diagnostics: ["resolved channels.telegram.token"],
+    });
+    const sendText = vi.fn(async () => ({
+      channel: "telegram" as const,
+      messageId: "msg-1",
+      chatId: "123456",
+    }));
+    const sendMedia = vi.fn(async () => ({
+      channel: "telegram" as const,
+      messageId: "msg-2",
+      chatId: "123456",
+    }));
+    await setRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: createStubPlugin({
+            id: "telegram",
+            label: "Telegram",
+            outbound: {
+              deliveryMode: "direct",
+              sendText,
+              sendMedia,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const deps = makeDeps();
+    await messageCommand(
+      {
+        action: "send",
+        channel: "telegram",
+        target: "123456",
+        message: "hi",
+      },
+      deps,
+      runtime,
+    );
+
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: resolvedConfig,
+        to: "123456",
+        text: "hi",
+      }),
+    );
+    expect(sendText.mock.calls[0]?.[0]?.cfg).not.toBe(rawConfig);
+  });
+
+  it("keeps local-fallback resolved cfg in outbound adapter sends", async () => {
+    const rawConfig = {
+      channels: {
+        telegram: {
+          token: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" },
+        },
+      },
+    };
+    const locallyResolvedConfig = {
+      channels: {
+        telegram: {
+          token: "12345:local-fallback-token",
+        },
+      },
+    };
+    testConfig = rawConfig;
+    resolveCommandSecretRefsViaGateway.mockResolvedValueOnce({
+      resolvedConfig: locallyResolvedConfig as unknown as Record<string, unknown>,
+      diagnostics: ["gateway secrets.resolve unavailable; used local resolver fallback."],
+    });
+    const sendText = vi.fn(async () => ({
+      channel: "telegram" as const,
+      messageId: "msg-3",
+      chatId: "123456",
+    }));
+    const sendMedia = vi.fn(async () => ({
+      channel: "telegram" as const,
+      messageId: "msg-4",
+      chatId: "123456",
+    }));
+    await setRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: createStubPlugin({
+            id: "telegram",
+            label: "Telegram",
+            outbound: {
+              deliveryMode: "direct",
+              sendText,
+              sendMedia,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const deps = makeDeps();
+    await messageCommand(
+      {
+        action: "send",
+        channel: "telegram",
+        target: "123456",
+        message: "hi",
+      },
+      deps,
+      runtime,
+    );
+
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: locallyResolvedConfig,
+      }),
+    );
+    expect(sendText.mock.calls[0]?.[0]?.cfg).not.toBe(rawConfig);
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("[secrets] gateway secrets.resolve unavailable"),
+    );
+  });
+
   it("defaults channel when only one configured", async () => {
     process.env.TELEGRAM_BOT_TOKEN = "token-abc";
     await setRegistry(

--- a/src/infra/outbound/cfg-threading.guard.test.ts
+++ b/src/infra/outbound/cfg-threading.guard.test.ts
@@ -1,0 +1,179 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const thisFilePath = fileURLToPath(import.meta.url);
+const thisDir = path.dirname(thisFilePath);
+const repoRoot = path.resolve(thisDir, "../../..");
+const loadConfigPattern = /\b(?:loadConfig|config\.loadConfig)\s*\(/;
+
+function toPosix(relativePath: string): string {
+  return relativePath.split(path.sep).join("/");
+}
+
+function readRepoFile(relativePath: string): string {
+  const absolute = path.join(repoRoot, relativePath);
+  return readFileSync(absolute, "utf8");
+}
+
+function listCoreOutboundEntryFiles(): string[] {
+  const outboundDir = path.join(repoRoot, "src/channels/plugins/outbound");
+  return readdirSync(outboundDir)
+    .filter((name) => name.endsWith(".ts") && !name.endsWith(".test.ts"))
+    .map((name) => toPosix(path.join("src/channels/plugins/outbound", name)))
+    .toSorted();
+}
+
+function listExtensionFiles(): {
+  adapterEntrypoints: string[];
+  inlineChannelEntrypoints: string[];
+} {
+  const extensionsRoot = path.join(repoRoot, "extensions");
+  const adapterEntrypoints: string[] = [];
+  const inlineChannelEntrypoints: string[] = [];
+
+  for (const entry of readdirSync(extensionsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const srcDir = path.join(extensionsRoot, entry.name, "src");
+    const outboundPath = path.join(srcDir, "outbound.ts");
+    if (existsSync(outboundPath)) {
+      adapterEntrypoints.push(toPosix(path.join("extensions", entry.name, "src/outbound.ts")));
+    }
+
+    const channelPath = path.join(srcDir, "channel.ts");
+    if (!existsSync(channelPath)) {
+      continue;
+    }
+    const source = readFileSync(channelPath, "utf8");
+    if (source.includes("outbound:")) {
+      inlineChannelEntrypoints.push(toPosix(path.join("extensions", entry.name, "src/channel.ts")));
+    }
+  }
+
+  return {
+    adapterEntrypoints: adapterEntrypoints.toSorted(),
+    inlineChannelEntrypoints: inlineChannelEntrypoints.toSorted(),
+  };
+}
+
+function extractOutboundBlock(source: string, file: string): string {
+  const outboundKeyIndex = source.indexOf("outbound:");
+  expect(outboundKeyIndex, `${file} should define outbound:`).toBeGreaterThanOrEqual(0);
+  const braceStart = source.indexOf("{", outboundKeyIndex);
+  expect(braceStart, `${file} should define outbound object`).toBeGreaterThanOrEqual(0);
+
+  let depth = 0;
+  let state: "code" | "single" | "double" | "template" | "lineComment" | "blockComment" = "code";
+  for (let i = braceStart; i < source.length; i += 1) {
+    const current = source[i];
+    const next = source[i + 1];
+
+    if (state === "lineComment") {
+      if (current === "\n") {
+        state = "code";
+      }
+      continue;
+    }
+    if (state === "blockComment") {
+      if (current === "*" && next === "/") {
+        state = "code";
+        i += 1;
+      }
+      continue;
+    }
+    if (state === "single") {
+      if (current === "\\" && next) {
+        i += 1;
+        continue;
+      }
+      if (current === "'") {
+        state = "code";
+      }
+      continue;
+    }
+    if (state === "double") {
+      if (current === "\\" && next) {
+        i += 1;
+        continue;
+      }
+      if (current === '"') {
+        state = "code";
+      }
+      continue;
+    }
+    if (state === "template") {
+      if (current === "\\" && next) {
+        i += 1;
+        continue;
+      }
+      if (current === "`") {
+        state = "code";
+      }
+      continue;
+    }
+
+    if (current === "/" && next === "/") {
+      state = "lineComment";
+      i += 1;
+      continue;
+    }
+    if (current === "/" && next === "*") {
+      state = "blockComment";
+      i += 1;
+      continue;
+    }
+    if (current === "'") {
+      state = "single";
+      continue;
+    }
+    if (current === '"') {
+      state = "double";
+      continue;
+    }
+    if (current === "`") {
+      state = "template";
+      continue;
+    }
+    if (current === "{") {
+      depth += 1;
+      continue;
+    }
+    if (current === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(braceStart, i + 1);
+      }
+    }
+  }
+
+  throw new Error(`Unable to parse outbound block in ${file}`);
+}
+
+describe("outbound cfg-threading guard", () => {
+  it("keeps outbound adapter entrypoints free of loadConfig calls", () => {
+    const coreAdapterFiles = listCoreOutboundEntryFiles();
+    const extensionAdapterFiles = listExtensionFiles().adapterEntrypoints;
+    const adapterFiles = [...coreAdapterFiles, ...extensionAdapterFiles];
+
+    for (const file of adapterFiles) {
+      const source = readRepoFile(file);
+      expect(source, `${file} must not call loadConfig in outbound entrypoint`).not.toMatch(
+        loadConfigPattern,
+      );
+    }
+  });
+
+  it("keeps inline channel outbound blocks free of loadConfig calls", () => {
+    const inlineFiles = listExtensionFiles().inlineChannelEntrypoints;
+    for (const file of inlineFiles) {
+      const source = readRepoFile(file);
+      const outboundBlock = extractOutboundBlock(source, file);
+      expect(outboundBlock, `${file} outbound block must not call loadConfig`).not.toMatch(
+        loadConfigPattern,
+      );
+    }
+  });
+});

--- a/src/infra/outbound/message.channels.test.ts
+++ b/src/infra/outbound/message.channels.test.ts
@@ -27,6 +27,76 @@ afterEach(() => {
 });
 
 describe("sendMessage channel normalization", () => {
+  it("threads resolved cfg through alias + target normalization in outbound dispatch", async () => {
+    const resolvedCfg = {
+      __resolvedCfgMarker: "cfg-from-secret-resolution",
+      channels: {},
+    } as Record<string, unknown>;
+    const seen: {
+      resolveCfg?: unknown;
+      sendCfg?: unknown;
+      to?: string;
+    } = {};
+    const imessageAliasPlugin: ChannelPlugin = {
+      id: "imessage",
+      meta: {
+        id: "imessage",
+        label: "iMessage",
+        selectionLabel: "iMessage",
+        docsPath: "/channels/imessage",
+        blurb: "iMessage test stub.",
+        aliases: ["imsg"],
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      outbound: {
+        deliveryMode: "direct",
+        resolveTarget: ({ to, cfg }) => {
+          seen.resolveCfg = cfg;
+          const normalized = String(to ?? "")
+            .trim()
+            .replace(/^imessage:/i, "");
+          return { ok: true, to: normalized };
+        },
+        sendText: async ({ cfg, to }) => {
+          seen.sendCfg = cfg;
+          seen.to = to;
+          return { channel: "imessage", messageId: "i-resolved" };
+        },
+        sendMedia: async ({ cfg, to }) => {
+          seen.sendCfg = cfg;
+          seen.to = to;
+          return { channel: "imessage", messageId: "i-resolved-media" };
+        },
+      },
+    };
+
+    setRegistry(
+      createTestRegistry([
+        {
+          pluginId: "imessage",
+          source: "test",
+          plugin: imessageAliasPlugin,
+        },
+      ]),
+    );
+
+    const result = await sendMessage({
+      cfg: resolvedCfg,
+      to: " imessage:+15551234567 ",
+      content: "hi",
+      channel: "imsg",
+    });
+
+    expect(result.channel).toBe("imessage");
+    expect(seen.resolveCfg).toBe(resolvedCfg);
+    expect(seen.sendCfg).toBe(resolvedCfg);
+    expect(seen.to).toBe("+15551234567");
+  });
+
   it("normalizes Teams alias", async () => {
     const sendMSTeams = vi.fn(async () => ({
       messageId: "m1",


### PR DESCRIPTION
## Findings (sorted by severity)

1. Critical: none.
2. High: none.
3. Medium: none.
4. Low: no functional regressions found in audited outbound cfg-threading paths.

Result: no remaining cfg-threading regressions found in audited scope.

## Coverage matrix

| Provider/path audited | Status |
|---|---|
| Core outbound adapters (`discord`, `imessage`, `signal`, `slack`, `telegram`, `whatsapp`) | safe |
| Extension `bluebubbles` outbound | safe |
| Extension `discord` outbound | safe |
| Extension `feishu` outbound | safe |
| Extension `googlechat` outbound | safe |
| Extension `imessage` outbound | safe |
| Extension `irc` outbound | safe |
| Extension `line` outbound | safe |
| Extension `matrix` outbound | safe |
| Extension `mattermost` outbound | safe |
| Extension `msteams` outbound | safe |
| Extension `nextcloud-talk` outbound | safe |
| Extension `nostr` outbound | safe |
| Extension `signal` outbound | safe |
| Extension `slack` outbound | safe |
| Extension `synology-chat` outbound | safe |
| Extension `telegram` outbound | safe |
| Extension `tlon` outbound | safe |
| Extension `twitch` outbound | safe |
| Extension `whatsapp` outbound | safe |
| Extension `zalo` outbound | safe |
| Extension `zalouser` outbound | safe |
| CLI secret-resolution -> outbound dispatch (`message` command path) | safe |
| Helper-layer fallback sites (`irc`, `nextcloud-talk`, `mattermost`, `matrix`) | safe |
| Static guard against outbound `loadConfig` usage in adapter/inline outbound entrypoints | safe |

## What this PR changes

- Adds outbound cfg-threading regression tests across core + extension outbound providers.
- Adds helper-layer regression tests to prove explicit `cfg` bypasses runtime `loadConfig` fallback where helper fallback exists.
- Adds a static guard test that fails if `loadConfig`/`config.loadConfig` appears inside outbound adapter entrypoints or inline channel outbound blocks.

## Test evidence

Passed:

- `pnpm test -- src/infra/outbound/*.test.ts src/channels/plugins/outbound/*.test.ts src/cli/command-secret-gateway.test.ts src/cli/command-secret-resolution.coverage.test.ts src/cli/outbound-send-mapping.test.ts src/cli/program/register.message.test.ts src/commands/message.test.ts extensions/bluebubbles/src/send.test.ts extensions/bluebubbles/src/media-send.test.ts extensions/feishu/src/outbound.test.ts extensions/feishu/src/send.test.ts extensions/feishu/src/send-target.test.ts extensions/feishu/src/send.reply-fallback.test.ts extensions/googlechat/src/resolve-target.test.ts extensions/imessage/src/channel.outbound.test.ts extensions/irc/src/send.test.ts extensions/line/src/channel.sendPayload.test.ts extensions/matrix/src/outbound.test.ts extensions/matrix/src/matrix/send.test.ts extensions/matrix/src/matrix/send-queue.test.ts extensions/matrix/src/matrix/send/targets.test.ts extensions/mattermost/src/channel.test.ts extensions/mattermost/src/mattermost/send.test.ts extensions/msteams/src/outbound.test.ts extensions/msteams/src/send.test.ts extensions/nextcloud-talk/src/send.test.ts extensions/nostr/src/channel.outbound.test.ts extensions/signal/src/channel.outbound.test.ts extensions/tlon/src/urbit/send.test.ts extensions/twitch/src/outbound.test.ts extensions/twitch/src/send.test.ts extensions/whatsapp/src/channel.outbound.test.ts extensions/zalo/src/channel.sendpayload.test.ts extensions/zalouser/src/channel.sendpayload.test.ts extensions/zalouser/src/send.test.ts src/infra/outbound/cfg-threading.guard.test.ts` (62 files, 521 tests)

- `pnpm test -- src/agents/tools/discord-actions.test.ts src/channels/plugins/actions/actions.test.ts src/channels/plugins/outbound/slack.test.ts src/infra/outbound/message.channels.test.ts extensions/line/src/channel.sendPayload.test.ts` (5 files, 97 tests)

- `pnpm build`

## Notes

- This PR is intentionally test-focused and keeps provider payload/API contracts unchanged.
