### PR TITLE
perf(telegram): lazy-load sticker cache into memory with debounced writes

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -22,6 +22,15 @@ async function loadSlackPrepareModules() {
   createSlackTestAccount = helpers.createSlackTestAccount;
 }
 
+vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
+  return {
+    ...actual,
+    resolveStorePath: vi.fn(() => "/tmp/openclaw-test-sessions.json"),
+    readSessionUpdatedAt: vi.fn(() => undefined),
+  };
+});
+
 function buildCtx(overrides?: { replyToMode?: "all" | "first" | "off" }) {
   const replyToMode = overrides?.replyToMode ?? "all";
   return createInboundSlackTestContext({

--- a/extensions/telegram/src/sticker-cache.test.ts
+++ b/extensions/telegram/src/sticker-cache.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -20,7 +21,13 @@ vi.mock("openclaw/plugin-sdk/media-understanding-runtime", () => ({
   describeImageFileWithModel: vi.fn(),
 }));
 
-const TEST_CACHE_DIR = "/tmp/openclaw-test-sticker-cache/telegram";
+const TEST_STATE_DIR = path.join(os.tmpdir(), "openclaw-test-sticker-cache");
+
+vi.mock("openclaw/plugin-sdk/state-paths", () => ({
+  STATE_DIR: path.join(os.tmpdir(), "openclaw-test-sticker-cache"),
+}));
+
+const TEST_CACHE_DIR = path.join(TEST_STATE_DIR, "telegram");
 const TEST_CACHE_FILE = path.join(TEST_CACHE_DIR, "sticker-cache.json");
 
 type StickerCacheModule = typeof import("./sticker-cache.js");
@@ -29,15 +36,15 @@ let stickerCache: StickerCacheModule;
 
 describe("sticker-cache", () => {
   beforeEach(async () => {
-    process.env.OPENCLAW_STATE_DIR = "/tmp/openclaw-test-sticker-cache";
-    fs.rmSync("/tmp/openclaw-test-sticker-cache", { recursive: true, force: true });
+    process.env.OPENCLAW_STATE_DIR = TEST_STATE_DIR;
+    fs.rmSync(TEST_STATE_DIR, { recursive: true, force: true });
     fs.mkdirSync(TEST_CACHE_DIR, { recursive: true });
     vi.resetModules();
     stickerCache = await import("./sticker-cache.js");
   });
 
   afterEach(() => {
-    fs.rmSync("/tmp/openclaw-test-sticker-cache", { recursive: true, force: true });
+    fs.rmSync(TEST_STATE_DIR, { recursive: true, force: true });
     delete process.env.OPENCLAW_STATE_DIR;
   });
 

--- a/extensions/telegram/src/sticker-cache.test.ts
+++ b/extensions/telegram/src/sticker-cache.test.ts
@@ -70,7 +70,7 @@ describe("sticker-cache", () => {
       expect(result).toEqual(sticker);
     });
 
-    it("returns null after cache is cleared", () => {
+    it("returns null after cache is cleared", async () => {
       const sticker = {
         fileId: "file123",
         fileUniqueId: "unique123",
@@ -81,8 +81,10 @@ describe("sticker-cache", () => {
       stickerCache.cacheSticker(sticker);
       expect(stickerCache.getCachedSticker("unique123")).not.toBeNull();
 
-      // Manually clear the cache file
+      // Delete cache file and re-import to clear in-memory state
       fs.rmSync(TEST_CACHE_FILE, { force: true });
+      vi.resetModules();
+      stickerCache = await import("./sticker-cache.js");
 
       expect(stickerCache.getCachedSticker("unique123")).toBeNull();
     });

--- a/extensions/telegram/src/sticker-cache.ts
+++ b/extensions/telegram/src/sticker-cache.ts
@@ -17,6 +17,7 @@ import { STATE_DIR } from "openclaw/plugin-sdk/state-paths";
 
 const CACHE_FILE = path.join(STATE_DIR, "telegram", "sticker-cache.json");
 const CACHE_VERSION = 1;
+const SAVE_DEBOUNCE_MS = 2_000;
 
 export interface CachedSticker {
   fileId: string;
@@ -33,45 +34,55 @@ interface StickerCache {
   stickers: Record<string, CachedSticker>;
 }
 
-function loadCache(): StickerCache {
+// In-memory cache: lazily loaded from disk on first access, written back with debounce.
+let memCache: StickerCache | null = null;
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+function getCache(): StickerCache {
+  if (memCache) {
+    return memCache;
+  }
   const data = loadJsonFile(CACHE_FILE);
-  if (!data || typeof data !== "object") {
-    return { version: CACHE_VERSION, stickers: {} };
+  if (data && typeof data === "object" && (data as StickerCache).version === CACHE_VERSION) {
+    memCache = data as StickerCache;
+  } else {
+    memCache = { version: CACHE_VERSION, stickers: {} };
   }
-  const cache = data as StickerCache;
-  if (cache.version !== CACHE_VERSION) {
-    // Future: handle migration if needed
-    return { version: CACHE_VERSION, stickers: {} };
-  }
-  return cache;
+  return memCache;
 }
 
-function saveCache(cache: StickerCache): void {
-  saveJsonFile(CACHE_FILE, cache);
+function scheduleSave(): void {
+  if (saveTimer) {
+    return;
+  }
+  saveTimer = setTimeout(() => {
+    saveTimer = null;
+    if (memCache) {
+      saveJsonFile(CACHE_FILE, memCache);
+    }
+  }, SAVE_DEBOUNCE_MS);
 }
 
 /**
  * Get a cached sticker by its unique ID.
  */
 export function getCachedSticker(fileUniqueId: string): CachedSticker | null {
-  const cache = loadCache();
-  return cache.stickers[fileUniqueId] ?? null;
+  return getCache().stickers[fileUniqueId] ?? null;
 }
 
 /**
  * Add or update a sticker in the cache.
  */
 export function cacheSticker(sticker: CachedSticker): void {
-  const cache = loadCache();
-  cache.stickers[sticker.fileUniqueId] = sticker;
-  saveCache(cache);
+  getCache().stickers[sticker.fileUniqueId] = sticker;
+  scheduleSave();
 }
 
 /**
  * Search cached stickers by text query (fuzzy match on description + emoji + setName).
  */
 export function searchStickers(query: string, limit = 10): CachedSticker[] {
-  const cache = loadCache();
+  const cache = getCache();
   const queryLower = query.toLowerCase();
   const results: Array<{ sticker: CachedSticker; score: number }> = [];
 
@@ -118,15 +129,14 @@ export function searchStickers(query: string, limit = 10): CachedSticker[] {
  * Get all cached stickers (for debugging/listing).
  */
 export function getAllCachedStickers(): CachedSticker[] {
-  const cache = loadCache();
-  return Object.values(cache.stickers);
+  return Object.values(getCache().stickers);
 }
 
 /**
  * Get cache statistics.
  */
 export function getCacheStats(): { count: number; oldestAt?: string; newestAt?: string } {
-  const cache = loadCache();
+  const cache = getCache();
   const stickers = Object.values(cache.stickers);
   if (stickers.length === 0) {
     return { count: 0 };


### PR DESCRIPTION
## Summary
- Every `getCachedSticker`, `cacheSticker`, `searchStickers`, `getAllCachedStickers`, and `getCacheStats` call was reading the entire JSON cache file from disk synchronously. `cacheSticker` also wrote back the full file on every call.
- Now the cache is lazily loaded into memory on first access and kept resident. Disk writes are debounced (2s), so rapid `cacheSticker` calls batch into a single write.

## Test plan
- [ ] Verify sticker caching and search still work correctly on Telegram
- [ ] Verify cache persists across gateway restarts
- [ ] Run `pnpm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)