### PR TITLE
fix(failover): recognize weekly/monthly quota errors as rate limits

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -22,6 +22,20 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 529 })).toBe("rate_limit");
   });
 
+  it("infers rate_limit from weekly/monthly quota exhausted (zhipuai 1310)", () => {
+    // Full error as logged by zhipuai
+    expect(
+      resolveFailoverReasonFromError({
+        message:
+          "LLM error 1310: Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-03-06 22:19:54",
+      }),
+    ).toBe("rate_limit");
+    // Generic "limit exhausted" phrase from other providers
+    expect(
+      resolveFailoverReasonFromError({ message: "API limit exhausted, please try again later" }),
+    ).toBe("rate_limit");
+  });
+
   it("infers format errors from error messages", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -10,6 +10,8 @@ const ERROR_PATTERNS = {
     "quota exceeded",
     "resource_exhausted",
     "usage limit",
+    "limit exhausted",
+    "weekly/monthly limit",
     /\btpm\b/i,
     "tokens per minute",
   ],


### PR DESCRIPTION
## Summary

- **Problem:** When zhipuai (GLM-5) returns error 1310 `"Weekly/Monthly Limit Exhausted"`, the failover system does not recognize the phrase and silently gives up instead of rotating to the next model.
- **Why it matters:** Users with fallback models configured see every request fail for the duration of the quota window (17+ hours observed), even though healthy fallback models are available.
- **What changed:** Added `"limit exhausted"` and `"weekly/monthly limit"` to `ERROR_PATTERNS.rateLimit` in `failover-matches.ts` so `classifyFailoverReason()` returns `"rate_limit"` and `shouldRotate` is set to `true`.
- **What did NOT change:** No failover routing logic changed. All other providers and patterns untouched.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #33785

## User-visible / Behavior Changes

When zhipuai returns a weekly/monthly quota error, fallback models are now tried automatically instead of the run ending with an error.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: any
- Runtime/container: any
- Model/provider: zhipuai / GLM-5

### Steps

1. Configure zhipuai as primary model with fallback models
2. Exhaust the zhipuai weekly/monthly quota
3. Send a message

### Expected

- Fallback model is used automatically

### Actual (before fix)

- Run ends with `LLM error 1310: Weekly/Monthly Limit Exhausted`, no fallback attempted

## Evidence

- [x] Failing test/log before + passing after

Added two test cases to `failover-error.test.ts` covering the exact error string from the reporter's logs and a generic `"API limit exhausted"` variant. All 18 tests pass.

## Human Verification (required)

- Verified scenarios: traced `classifyFailoverReason()` → `isRateLimitErrorMessage()` → `matchesErrorPatterns()` call path; confirmed the new patterns match the logged error after `toLowerCase()`
- Edge cases checked: pattern specificity (won't false-positive on unrelated error messages), case insensitivity already handled by `matchesErrorPatterns`
- What you did **not** verify: live zhipuai quota exhaustion (requires an actual account in quota)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert quickly: revert `src/agents/pi-embedded-helpers/failover-matches.ts`, remove the two added strings from `rateLimit`
- Files/config to restore: `failover-matches.ts` only
- Known bad symptoms: none expected; worst case is a pattern matching too broadly, which would cause unexpected failover (recoverable by removing the pattern)

## Risks and Mitigations

- Risk: `"limit exhausted"` could match unrelated error messages from other providers
  - Mitigation: phrase is specific enough to quota scenarios; the matching function lowercases input so partial false matches are unlikely