### PR TITLE
fix(sandbox): add ssrfPolicy default to allow localhost access

### DIFF
--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -87,6 +87,8 @@ function buildSandboxBrowserResolvedConfig(params: {
     attachOnly: true,
     defaultProfile: DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
     extraArgs: [],
+    // Default to trusted-network mode (same as normal browser) to allow localhost access
+    ssrfPolicy: { dangerouslyAllowPrivateNetwork: true },
     profiles: {
       [DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME]: {
         cdpPort: params.cdpPort,

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -74,6 +74,34 @@ describe("resolveTuiSessionKey", () => {
       }),
     ).toBe("agent:ops:incident");
   });
+
+  it("canonicalizes uppercase session keys to lowercase (regression #33866)", () => {
+    // Session keys should be lowercase to match gateway's resolveSessionStoreKey
+    expect(
+      resolveTuiSessionKey({
+        raw: "Test1",
+        sessionScope: "global",
+        currentAgentId: "main",
+        sessionMainKey: "agent:main:main",
+      }),
+    ).toBe("agent:main:test1");
+    expect(
+      resolveTuiSessionKey({
+        raw: "agent:main:Test1",
+        sessionScope: "global",
+        currentAgentId: "main",
+        sessionMainKey: "agent:main:main",
+      }),
+    ).toBe("agent:main:test1");
+    expect(
+      resolveTuiSessionKey({
+        raw: "agent:ops:UPPER",
+        sessionScope: "global",
+        currentAgentId: "main",
+        sessionMainKey: "agent:main:main",
+      }),
+    ).toBe("agent:ops:upper");
+  });
 });
 
 describe("resolveGatewayDisconnectState", () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -199,13 +199,14 @@ export function resolveTuiSessionKey(params: {
       mainKey: params.sessionMainKey,
     });
   }
-  if (trimmed === "global" || trimmed === "unknown") {
-    return trimmed;
+  const lowered = trimmed.toLowerCase();
+  if (lowered === "global" || lowered === "unknown") {
+    return lowered;
   }
   if (trimmed.startsWith("agent:")) {
-    return trimmed;
+    return lowered;
   }
-  return `agent:${params.currentAgentId}:${trimmed}`;
+  return `agent:${params.currentAgentId}:${lowered}`;
 }
 
 export function resolveGatewayDisconnectState(reason?: string): {


### PR DESCRIPTION
## Summary

The sandbox browser was blocking localhost/loopback access because `buildSandboxBrowserResolvedConfig()` did not include `ssrfPolicy` in its returned config. This caused the SSRF guard to default to strict mode, blocking localhost access.

## Root Cause

1. **Normal browser path:** `resolveBrowserSsrFPolicy()` → no explicit setting → `{ dangerouslyAllowPrivateNetwork: true }` → localhost allowed

2. **Sandbox browser path:** `buildSandboxBrowserResolvedConfig()` → ssrfPolicy field missing → undefined → `isPrivateNetworkAllowedByPolicy(undefined)` → false → `BLOCKED_HOSTNAMES.has(localhost)` → BLOCKED

## Fix

Add `ssrfPolicy: { dangerouslyAllowPrivateNetwork: true }` to `buildSandboxBrowserResolvedConfig()` to match the normal browser default behavior.

Note: Sandbox browser containers are already network-isolated by Docker, so allowing loopback access inside the container does not compromise host security.

## Testing

- [ ] Enable sandbox with browser: `sandbox: { mode: "all", browser: { enabled: true } }`
- [ ] Start a dev server inside the sandbox (e.g., `npm run dev` on port 3000)
- [ ] Use browser tool to navigate to `http://localhost:3000`
- [ ] Verify navigation succeeds (previously blocked)

## Related Issue

Fixes #33989