### PR TITLE
fix(imessage): normalize camelCase RPC keys to prevent outbound echo

### DIFF
--- a/src/imessage/monitor/parse-notification.test.ts
+++ b/src/imessage/monitor/parse-notification.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveIMessageInboundDecision } from "./inbound-processing.js";
 import { parseIMessageNotification } from "./parse-notification.js";
 
 describe("parseIMessageNotification", () => {
@@ -128,8 +130,10 @@ describe("parseIMessageNotification", () => {
   });
 });
 
-describe("parseIMessageNotification + inbound filtering integration", () => {
-  it("isFromMe message is correctly identified for drop", () => {
+describe("parseIMessageNotification + resolveIMessageInboundDecision integration", () => {
+  const cfg = {} as OpenClawConfig;
+
+  it("camelCase isFromMe payload is dropped as 'from me' by inbound filter", () => {
     const payload = {
       message: {
         id: 100,
@@ -138,8 +142,27 @@ describe("parseIMessageNotification + inbound filtering integration", () => {
         isFromMe: true,
       },
     };
-    const result = parseIMessageNotification(payload);
-    expect(result).not.toBeNull();
-    expect(result!.is_from_me).toBe(true);
+    const message = parseIMessageNotification(payload);
+    expect(message).not.toBeNull();
+
+    const decision = resolveIMessageInboundDecision({
+      cfg,
+      accountId: "default",
+      message: message!,
+      opts: undefined,
+      messageText: message!.text ?? "",
+      bodyText: message!.text ?? "",
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+      echoCache: undefined,
+      logVerbose: undefined,
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "from me" });
   });
 });

--- a/src/imessage/monitor/parse-notification.test.ts
+++ b/src/imessage/monitor/parse-notification.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { parseIMessageNotification } from "./parse-notification.js";
+
+describe("parseIMessageNotification", () => {
+  it("returns null for non-object input", () => {
+    expect(parseIMessageNotification(null)).toBeNull();
+    expect(parseIMessageNotification("string")).toBeNull();
+    expect(parseIMessageNotification(42)).toBeNull();
+  });
+
+  it("returns null when .message is missing", () => {
+    expect(parseIMessageNotification({})).toBeNull();
+    expect(parseIMessageNotification({ other: 1 })).toBeNull();
+  });
+
+  it("parses standard snake_case payload", () => {
+    const payload = {
+      message: {
+        id: 1,
+        sender: "+15551234567",
+        text: "hello",
+        is_from_me: false,
+        is_group: false,
+        chat_id: 10,
+      },
+    };
+    const result = parseIMessageNotification(payload);
+    expect(result).not.toBeNull();
+    expect(result!.is_from_me).toBe(false);
+    expect(result!.is_group).toBe(false);
+    expect(result!.chat_id).toBe(10);
+  });
+
+  it("normalizes camelCase isFromMe to is_from_me", () => {
+    const payload = {
+      message: {
+        id: 2,
+        sender: "+15551234567",
+        text: "outbound echo",
+        isFromMe: true,
+        is_group: false,
+      },
+    };
+    const result = parseIMessageNotification(payload);
+    expect(result).not.toBeNull();
+    expect(result!.is_from_me).toBe(true);
+  });
+
+  it("normalizes camelCase isGroup to is_group", () => {
+    const payload = {
+      message: {
+        id: 3,
+        sender: "+15551234567",
+        text: "group msg",
+        is_from_me: false,
+        isGroup: true,
+        chatId: 42,
+      },
+    };
+    const result = parseIMessageNotification(payload);
+    expect(result).not.toBeNull();
+    expect(result!.is_group).toBe(true);
+    expect(result!.chat_id).toBe(42);
+  });
+
+  it("normalizes all known camelCase keys", () => {
+    const payload = {
+      message: {
+        id: 4,
+        sender: "+15551234567",
+        text: "full camel",
+        isFromMe: false,
+        isGroup: true,
+        chatId: 99,
+        chatGuid: "iMessage;-;+1555",
+        chatName: "Test Group",
+        chatIdentifier: "+1555",
+        replyToId: "prev-1",
+        replyToText: "earlier message",
+        replyToSender: "+15559999999",
+        createdAt: "2026-03-04T12:00:00Z",
+      },
+    };
+    const result = parseIMessageNotification(payload);
+    expect(result).not.toBeNull();
+    expect(result!.is_from_me).toBe(false);
+    expect(result!.is_group).toBe(true);
+    expect(result!.chat_id).toBe(99);
+    expect(result!.chat_guid).toBe("iMessage;-;+1555");
+    expect(result!.chat_name).toBe("Test Group");
+    expect(result!.chat_identifier).toBe("+1555");
+    expect(result!.reply_to_id).toBe("prev-1");
+    expect(result!.reply_to_text).toBe("earlier message");
+    expect(result!.reply_to_sender).toBe("+15559999999");
+    expect(result!.created_at).toBe("2026-03-04T12:00:00Z");
+  });
+
+  it("does not overwrite existing snake_case with camelCase", () => {
+    const payload = {
+      message: {
+        id: 5,
+        sender: "+15551234567",
+        text: "both",
+        is_from_me: false,
+        isFromMe: true,
+      },
+    };
+    const result = parseIMessageNotification(payload);
+    expect(result).not.toBeNull();
+    expect(result!.is_from_me).toBe(false);
+  });
+
+  it("normalizes camelCase in nested attachments", () => {
+    const payload = {
+      message: {
+        id: 6,
+        sender: "+15551234567",
+        text: "",
+        is_from_me: false,
+        attachments: [{ originalPath: "/tmp/photo.jpg", mimeType: "image/jpeg" }],
+      },
+    };
+    const result = parseIMessageNotification(payload);
+    expect(result).not.toBeNull();
+    expect(result!.attachments).toHaveLength(1);
+    expect(result!.attachments![0].original_path).toBe("/tmp/photo.jpg");
+    expect(result!.attachments![0].mime_type).toBe("image/jpeg");
+  });
+});
+
+describe("parseIMessageNotification + inbound filtering integration", () => {
+  it("isFromMe message is correctly identified for drop", () => {
+    const payload = {
+      message: {
+        id: 100,
+        sender: "+15551234567",
+        text: "my own message",
+        isFromMe: true,
+      },
+    };
+    const result = parseIMessageNotification(payload);
+    expect(result).not.toBeNull();
+    expect(result!.is_from_me).toBe(true);
+  });
+});

--- a/src/imessage/monitor/parse-notification.ts
+++ b/src/imessage/monitor/parse-notification.ts
@@ -49,6 +49,44 @@ function isOptionalAttachments(value: unknown): value is IMessagePayload["attach
   });
 }
 
+const CAMEL_TO_SNAKE: ReadonlyArray<[string, string]> = [
+  ["isFromMe", "is_from_me"],
+  ["isGroup", "is_group"],
+  ["chatId", "chat_id"],
+  ["chatGuid", "chat_guid"],
+  ["chatName", "chat_name"],
+  ["chatIdentifier", "chat_identifier"],
+  ["replyToId", "reply_to_id"],
+  ["replyToText", "reply_to_text"],
+  ["replyToSender", "reply_to_sender"],
+  ["createdAt", "created_at"],
+  ["mimeType", "mime_type"],
+  ["originalPath", "original_path"],
+];
+
+/**
+ * Some imsg CLI versions send camelCase keys (e.g. `isFromMe`) instead of
+ * the snake_case variants (`is_from_me`) that IMessagePayload declares.
+ * Copy any camelCase value into the expected snake_case slot when the
+ * snake_case key is absent so downstream filters see a consistent shape.
+ */
+function normalizeCamelCaseKeys(record: Record<string, unknown>): void {
+  for (const [camel, snake] of CAMEL_TO_SNAKE) {
+    if (record[camel] !== undefined && record[snake] === undefined) {
+      record[snake] = record[camel];
+    }
+  }
+
+  const attachments = record.attachments;
+  if (Array.isArray(attachments)) {
+    for (const att of attachments) {
+      if (isRecord(att)) {
+        normalizeCamelCaseKeys(att);
+      }
+    }
+  }
+}
+
 export function parseIMessageNotification(raw: unknown): IMessagePayload | null {
   if (!isRecord(raw)) {
     return null;
@@ -58,6 +96,7 @@ export function parseIMessageNotification(raw: unknown): IMessagePayload | null 
     return null;
   }
 
+  normalizeCamelCaseKeys(maybeMessage);
   const message: IMessagePayload = maybeMessage;
   if (
     !isOptionalNumber(message.id) ||


### PR DESCRIPTION
## Summary

Some `imsg` CLI versions emit camelCase keys (`isFromMe`, `isGroup`, `chatId`, etc.) instead of the snake_case variants (`is_from_me`, `is_group`, `chat_id`) that `IMessagePayload` declares. When `is_from_me` is absent, the outbound-echo filter in `resolveIMessageInboundDecision` never triggers, so every sent message is echoed back as an inbound message in the session.

## Changes

- **`src/imessage/monitor/parse-notification.ts`**: Added `normalizeCamelCaseKeys()` that copies camelCase values into their snake_case slots when the snake_case key is absent. Runs on the raw message object (and nested `attachments`) before the `IMessagePayload` type assertion. Does not overwrite existing snake_case values.
- **`src/imessage/monitor/parse-notification.test.ts`** (new): 9 unit tests covering standard snake_case, camelCase normalization for all known keys, precedence (snake_case wins over camelCase), nested attachment normalization, and integration with the inbound filtering path.

## How It Works

Before:
```
RPC: { isFromMe: true, ... }
→ parseIMessageNotification casts to IMessagePayload
→ message.is_from_me === undefined
→ filter at line 111 does NOT drop
→ message echoed as inbound
```

After:
```
RPC: { isFromMe: true, ... }
→ normalizeCamelCaseKeys copies isFromMe → is_from_me
→ message.is_from_me === true
→ filter drops with reason "from me"
```

## Test Plan

- [x] `npx vitest run src/imessage/monitor/parse-notification.test.ts` — 9 tests pass
- [x] Existing `inbound-processing.test.ts` tests still pass (no changes to that module)
- [ ] Manual: send iMessage with an imsg CLI that emits camelCase — verify sent messages are no longer echoed

## Security Impact

- Does this change handle user input? **No** — normalizes internal RPC keys only
- Does this change affect authentication/authorization? **No**
- Does this change expose new endpoints or APIs? **No**
- Does this change modify data storage or retrieval? **No**
- Does this change affect cryptographic operations? **No**

## Human Verification

1. Send a message via iMessage channel
2. Verify the sent message does NOT appear as a new inbound message
3. Verify inbound messages from other users still process normally
4. Verify attachments with camelCase keys (`originalPath`, `mimeType`) are still resolved

## Failure Recovery

Revert this single commit — the only change is additive normalization in the parse step.

## Risks and Mitigations

- **Risk**: A future imsg CLI version adds new camelCase keys not in the mapping → those keys pass through unnormalized (same as current behavior, not a regression).
- **Risk**: Both camelCase and snake_case present with different values → snake_case wins, preserving current behavior.