### PR TITLE
fix(google): patch gaxios fetch fallback and vertex payload wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dist/",
     "docs/",
     "extensions/",
+    "scripts/patch-gaxios-fetch.mjs",
     "skills/"
   ],
   "type": "module",
@@ -154,6 +155,7 @@
     "openclaw": "node scripts/run-node.mjs",
     "openclaw:rpc": "node scripts/run-node.mjs agent --mode rpc --json",
     "plugins:sync": "node --import tsx scripts/sync-plugin-versions.ts",
+    "postinstall": "node scripts/patch-gaxios-fetch.mjs",
     "prepack": "pnpm build && pnpm ui:build",
     "prepare": "command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath git-hooks || exit 0",
     "protocol:check": "pnpm protocol:gen && pnpm protocol:gen:swift && git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift",

--- a/scripts/patch-gaxios-fetch.mjs
+++ b/scripts/patch-gaxios-fetch.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+
+const BROKEN_IMPORT_PATTERNS = [
+  ": (await import('node-fetch')).default;",
+  ': (await import("node-fetch")).default;',
+];
+const FIXED_IMPORT =
+  ": (typeof globalThis.fetch === 'function' ? globalThis.fetch : (await import('node-fetch')).default);";
+
+function resolveGaxiosRoot() {
+  try {
+    const gaxiosEntry = require.resolve("gaxios");
+    return path.resolve(path.dirname(gaxiosEntry), "../../..");
+  } catch {
+    return null;
+  }
+}
+
+function patchFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return "missing";
+  }
+  const source = fs.readFileSync(filePath, "utf8");
+  if (source.includes("typeof globalThis.fetch === 'function'")) {
+    return "already";
+  }
+
+  for (const brokenPattern of BROKEN_IMPORT_PATTERNS) {
+    if (!source.includes(brokenPattern)) {
+      continue;
+    }
+    fs.writeFileSync(filePath, source.replace(brokenPattern, FIXED_IMPORT), "utf8");
+    return "patched";
+  }
+
+  return "pattern-missing";
+}
+
+function run() {
+  const root = resolveGaxiosRoot();
+  if (!root) {
+    console.log("[patch-gaxios-fetch] gaxios not found, skipping.");
+    return;
+  }
+
+  const files = [
+    path.join(root, "build/cjs/src/gaxios.js"),
+    path.join(root, "build/esm/src/gaxios.js"),
+  ];
+
+  const outcomes = files.map((filePath) => ({ filePath, result: patchFile(filePath) }));
+  const patchedCount = outcomes.filter((item) => item.result === "patched").length;
+
+  if (patchedCount > 0) {
+    console.log(`[patch-gaxios-fetch] patched ${patchedCount} gaxios runtime file(s).`);
+    return;
+  }
+
+  const alreadyCount = outcomes.filter((item) => item.result === "already").length;
+  if (alreadyCount === outcomes.length) {
+    console.log("[patch-gaxios-fetch] already patched.");
+    return;
+  }
+
+  const details = outcomes
+    .map((item) => `${path.basename(item.filePath)}=${item.result}`)
+    .join(", ");
+  console.log(`[patch-gaxios-fetch] no patch applied (${details}).`);
+}
+
+run();

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -593,6 +593,76 @@ describe("applyExtraParamsToAgent", () => {
       },
     });
   });
+
+  it("sanitizes invalid negative Google thinkingBudget for google-vertex models", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        config: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingBudget: -1,
+          },
+        },
+      };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "google-vertex",
+      "gemini-3.1-pro-preview",
+      undefined,
+      "high",
+    );
+
+    const model = {
+      api: "google-vertex",
+      provider: "google-vertex",
+      id: "gemini-3.1-pro-preview",
+    } as Model<"google-vertex">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.config).toEqual({
+      thinkingConfig: {
+        includeThoughts: true,
+        thinkingLevel: "HIGH",
+      },
+    });
+  });
+
+  it("does not wrap payload callback for non-Google APIs", () => {
+    let forwardedOnPayload: ((payload: unknown) => void) | undefined;
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      forwardedOnPayload = options?.onPayload;
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "anthropic", "claude-sonnet-4-6");
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+    const originalOnPayload = () => {
+      // noop
+    };
+    void agent.streamFn?.(model, context, {
+      onPayload: originalOnPayload,
+    });
+
+    expect(forwardedOnPayload).toBe(originalOnPayload);
+  });
+
   it("adds OpenRouter attribution headers to stream options", () => {
     const { calls, agent } = createOptionsCaptureAgent();
 

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -802,17 +802,18 @@ function createGoogleThinkingPayloadWrapper(
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
+    if (model.api !== "google-generative-ai" && model.api !== "google-vertex") {
+      return underlying(model, context, options);
+    }
     const onPayload = options?.onPayload;
     return underlying(model, context, {
       ...options,
       onPayload: (payload) => {
-        if (model.api === "google-generative-ai") {
-          sanitizeGoogleThinkingPayload({
-            payload,
-            modelId: model.id,
-            thinkingLevel,
-          });
-        }
+        sanitizeGoogleThinkingPayload({
+          payload,
+          modelId: model.id,
+          thinkingLevel,
+        });
         onPayload?.(payload);
       },
     });

--- a/src/infra/gaxios-fetch-regression.test.ts
+++ b/src/infra/gaxios-fetch-regression.test.ts
@@ -1,0 +1,13 @@
+import { request } from "gaxios";
+import { describe, expect, it } from "vitest";
+
+describe("gaxios fetch fallback regression", () => {
+  it("can issue requests without node-fetch import crashes", async () => {
+    const response = await request<string>({
+      url: "data:text/plain,ok",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes Vertex/Google auth crashes with `Cannot convert undefined or null to object` by adding an install-time `gaxios` patch that prefers `globalThis.fetch` before `node-fetch` dynamic import.
- Hardens the embedded runner Google thinking payload wrapper to handle `google-vertex` (not just `google-generative-ai`) and skip wrapping for non-Google APIs.
- Adds focused regression tests for both paths.

## Why this PR is needed

Related PRs exist, but no single acceptable PR currently covers the full regression path:

- #33116 introduces a `gaxios` patch but only targets one runtime artifact and uses a module path resolution approach that can fail under package `exports` constraints.
- #33428 hardens the Google wrapper path, but does not address the `gaxios` fetch-import crash seen in #32245/#33256.

This PR combines both required fixes and validates them together with local full-suite testing.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Auth / tokens
- [x] Integrations
- [x] Skills / tool execution

## Linked Issue/PR

- Fixes #32245
- Fixes #33392
- Related #33256
- Related #33468
- Related #33116
- Related #33428

## User-visible Changes

- Vertex-backed embedded runs no longer fail on Node 22+/24+/25 with `Cannot convert undefined or null to object` from the auth stack.
- `google-vertex` thinking payloads now receive the same sanitization behavior as `google-generative-ai`.

## Verification

- `pnpm check`
- `pnpm build`
- `pnpm test`

All passed locally.

## Files changed

- `package.json`
- `scripts/patch-gaxios-fetch.mjs`
- `src/infra/gaxios-fetch-regression.test.ts`
- `src/agents/pi-embedded-runner/extra-params.ts`
- `src/agents/pi-embedded-runner-extraparams.test.ts`
