### PR TITLE
fix: add ssrfPolicy to sandbox browser config to allow localhost access

### DIFF
--- a/src/agents/sandbox/browser.test.ts
+++ b/src/agents/sandbox/browser.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isPrivateNetworkAllowedByPolicy } from "../../infra/net/ssrf.js";
+import { buildSandboxBrowserResolvedConfig } from "./browser.js";
+
+describe("buildSandboxBrowserResolvedConfig", () => {
+  it("includes ssrfPolicy that allows private network (trusted-network mode)", () => {
+    const config = buildSandboxBrowserResolvedConfig({
+      controlPort: 9222,
+      cdpPort: 9223,
+      headless: true,
+      evaluateEnabled: false,
+    });
+
+    expect(config.ssrfPolicy).toBeDefined();
+    expect(config.ssrfPolicy?.dangerouslyAllowPrivateNetwork).toBe(true);
+  });
+
+  it("ssrfPolicy passes isPrivateNetworkAllowedByPolicy check", () => {
+    const config = buildSandboxBrowserResolvedConfig({
+      controlPort: 9222,
+      cdpPort: 9223,
+      headless: true,
+      evaluateEnabled: false,
+    });
+
+    expect(isPrivateNetworkAllowedByPolicy(config.ssrfPolicy)).toBe(true);
+  });
+});

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -61,7 +61,8 @@ async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number })
   return false;
 }
 
-function buildSandboxBrowserResolvedConfig(params: {
+/** @internal Exported for testing. */
+export function buildSandboxBrowserResolvedConfig(params: {
   controlPort: number;
   cdpPort: number;
   headless: boolean;
@@ -93,6 +94,8 @@ function buildSandboxBrowserResolvedConfig(params: {
         color: DEFAULT_OPENCLAW_BROWSER_COLOR,
       },
     },
+    // Default to trusted-network mode (same as normal browser) to allow localhost access
+    ssrfPolicy: { dangerouslyAllowPrivateNetwork: true },
   };
 }
 


### PR DESCRIPTION
## Summary

- Problem: `buildSandboxBrowserResolvedConfig()` does not include `ssrfPolicy`, causing the SSRF guard to block localhost/loopback access in sandbox browser
- Why it matters: Cannot use browser tool to access dev servers running inside the sandbox (e.g., `localhost:3000`), forcing users toward insecure workarounds like external tunnels
- What changed: Added `ssrfPolicy: { dangerouslyAllowPrivateNetwork: true }` to sandbox browser config + exported the function for testing + added tests
- What did NOT change (scope boundary): No changes to SSRF guard logic, normal browser config, or sandbox networking

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33989

## User-visible / Behavior Changes

Sandbox browser can now navigate to `localhost` / `127.0.0.1` URLs, matching the normal browser's default trusted-network behavior.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — sandbox browser can now reach loopback addresses
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: Sandbox browser containers are already Docker network-isolated. Allowing loopback within the container does not expose host services. This matches the normal browser's existing default (`dangerouslyAllowPrivateNetwork: true` via `resolveBrowserSsrFPolicy()`).

## Repro + Verification

### Environment

- OS: Amazon Linux 2023 (EC2)
- Runtime/container: Docker sandbox with browser enabled
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `sandbox: { mode: "all", browser: { enabled: true } }`

### Steps

1. Enable sandbox with browser: `sandbox.browser.enabled: true`
2. Inside sandbox, start a dev server (e.g., `npm run dev` on port 3000)
3. Use browser tool to navigate to `http://localhost:3000`

### Expected

- Browser navigates to `localhost:3000` and renders the page

### Actual

- Navigation blocked by SSRF guard (`BLOCKED_HOSTNAMES.has("localhost")`)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test `src/agents/sandbox/browser.test.ts` verifies ssrfPolicy is present and passes `isPrivateNetworkAllowedByPolicy()` check.

## Human Verification (required)

- Verified scenarios: Test confirms config includes correct ssrfPolicy; `pnpm check` passes
- Edge cases checked: Verified that normal browser path is unaffected (separate code path via `resolveBrowserSsrFPolicy()`)
- What you did **not** verify: Live sandbox environment end-to-end test

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the one-line addition of `ssrfPolicy` in `buildSandboxBrowserResolvedConfig()`
- Files/config to restore: `src/agents/sandbox/browser.ts`
- Known bad symptoms reviewers should watch for: If reverted, sandbox browser returns to blocking localhost

## Risks and Mitigations

None — this aligns sandbox browser with the normal browser's existing default behavior.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)