### PR TITLE
fix(discord): fall back to DM channel when user ID is misrouted as channel

### DIFF
--- a/src/discord/send.dm-fallback.test.ts
+++ b/src/discord/send.dm-fallback.test.ts
@@ -1,0 +1,114 @@
+import { Routes } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetDiscordDirectoryCacheForTest } from "./directory-cache.js";
+import { sendMessageDiscord } from "./send.js";
+import { makeDiscordRest } from "./send.test-harness.js";
+
+vi.mock("../web/media.js", async () => {
+  const { discordWebMediaMockFactory } = await import("./send.test-harness.js");
+  return discordWebMediaMockFactory();
+});
+
+describe("sendMessageDiscord DM fallback on Unknown Channel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetDiscordDirectoryCacheForTest();
+  });
+
+  function unknownChannelError() {
+    const err: Record<string, unknown> = new Error("Unknown Channel");
+    err.code = 10003;
+    return err;
+  }
+
+  it("retries as DM when channel:userId returns Unknown Channel (text)", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const userId = "111222333444555666";
+    const dmChannelId = "dm-999888777";
+
+    postMock
+      .mockRejectedValueOnce(unknownChannelError())
+      .mockResolvedValueOnce({ id: dmChannelId })
+      .mockResolvedValueOnce({ id: "msg-1", channel_id: dmChannelId });
+
+    const result = await sendMessageDiscord(`channel:${userId}`, "hello", {
+      rest,
+      token: "t",
+    });
+
+    expect(result.messageId).toBe("msg-1");
+    expect(result.channelId).toBe(dmChannelId);
+
+    expect(postMock).toHaveBeenCalledTimes(3);
+    expect(postMock.mock.calls[0][0]).toBe(Routes.channelMessages(userId));
+    expect(postMock.mock.calls[1][0]).toBe(Routes.userChannels());
+    expect(
+      (postMock.mock.calls[1][1] as { body: { recipient_id: string } }).body.recipient_id,
+    ).toBe(userId);
+    expect(postMock.mock.calls[2][0]).toBe(Routes.channelMessages(dmChannelId));
+  });
+
+  it("retries as DM when channel:userId returns Unknown Channel (media)", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const userId = "111222333444555666";
+    const dmChannelId = "dm-999888777";
+
+    postMock
+      .mockRejectedValueOnce(unknownChannelError())
+      .mockResolvedValueOnce({ id: dmChannelId })
+      .mockResolvedValueOnce({ id: "msg-2", channel_id: dmChannelId });
+
+    const result = await sendMessageDiscord(`channel:${userId}`, "file here", {
+      rest,
+      token: "t",
+      mediaUrl: "https://example.com/test.pdf",
+    });
+
+    expect(result.messageId).toBe("msg-2");
+    expect(result.channelId).toBe(dmChannelId);
+    expect(postMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry when error is not Unknown Channel", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const permErr: Record<string, unknown> = new Error("Missing Permissions");
+    permErr.code = 50013;
+
+    postMock.mockRejectedValueOnce(permErr);
+
+    await expect(
+      sendMessageDiscord("channel:789", "hello", { rest, token: "t" }),
+    ).rejects.toThrow();
+
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry for user: targets (already resolved)", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const dmChannelId = "dm-123";
+
+    postMock
+      .mockResolvedValueOnce({ id: dmChannelId })
+      .mockResolvedValueOnce({ id: "msg-3", channel_id: dmChannelId });
+
+    const result = await sendMessageDiscord("user:555", "hello", {
+      rest,
+      token: "t",
+    });
+
+    expect(result.messageId).toBe("msg-3");
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(postMock.mock.calls[0][0]).toBe(Routes.userChannels());
+  });
+
+  it("does not retry for non-numeric channel IDs", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockRejectedValueOnce(unknownChannelError());
+
+    await expect(
+      sendMessageDiscord("channel:not-numeric", "hello", { rest, token: "t" }),
+    ).rejects.toThrow();
+
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -22,6 +22,7 @@ import {
   buildDiscordSendError,
   buildDiscordTextChunks,
   createDiscordClient,
+  getDiscordErrorCode,
   normalizeDiscordPollInput,
   normalizeStickerIds,
   parseAndResolveRecipient,
@@ -262,11 +263,12 @@ export async function sendMessageDiscord(
   }
 
   let result: { id: string; channel_id: string } | { id: string | null; channel_id: string };
+  let effectiveChannelId = channelId;
   try {
     if (opts.mediaUrl) {
       result = await sendDiscordMedia(
         rest,
-        channelId,
+        effectiveChannelId,
         textWithMentions,
         opts.mediaUrl,
         opts.mediaLocalRoots,
@@ -281,7 +283,7 @@ export async function sendMessageDiscord(
     } else {
       result = await sendDiscordText(
         rest,
-        channelId,
+        effectiveChannelId,
         textWithMentions,
         opts.replyTo,
         request,
@@ -293,12 +295,61 @@ export async function sendMessageDiscord(
       );
     }
   } catch (err) {
-    throw await buildDiscordSendError(err, {
-      channelId,
-      rest,
-      token,
-      hasMedia: Boolean(opts.mediaUrl),
-    });
+    const DISCORD_UNKNOWN_CHANNEL = 10003;
+    if (
+      getDiscordErrorCode(err) === DISCORD_UNKNOWN_CHANNEL &&
+      recipient.kind === "channel" &&
+      /^\d+$/.test(recipient.id)
+    ) {
+      const dmRecipient = { kind: "user" as const, id: recipient.id };
+      const { channelId: dmChannelId } = await resolveChannelId(rest, dmRecipient, request);
+      effectiveChannelId = dmChannelId;
+      try {
+        if (opts.mediaUrl) {
+          result = await sendDiscordMedia(
+            rest,
+            effectiveChannelId,
+            textWithMentions,
+            opts.mediaUrl,
+            opts.mediaLocalRoots,
+            opts.replyTo,
+            request,
+            accountInfo.config.maxLinesPerMessage,
+            opts.components,
+            opts.embeds,
+            chunkMode,
+            opts.silent,
+          );
+        } else {
+          result = await sendDiscordText(
+            rest,
+            effectiveChannelId,
+            textWithMentions,
+            opts.replyTo,
+            request,
+            accountInfo.config.maxLinesPerMessage,
+            opts.components,
+            opts.embeds,
+            chunkMode,
+            opts.silent,
+          );
+        }
+      } catch (retryErr) {
+        throw await buildDiscordSendError(retryErr, {
+          channelId: effectiveChannelId,
+          rest,
+          token,
+          hasMedia: Boolean(opts.mediaUrl),
+        });
+      }
+    } else {
+      throw await buildDiscordSendError(err, {
+        channelId: effectiveChannelId,
+        rest,
+        token,
+        hasMedia: Boolean(opts.mediaUrl),
+      });
+    }
   }
 
   recordChannelActivity({

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -492,6 +492,7 @@ export {
   buildReactionIdentifier,
   createDiscordClient,
   formatReactionEmoji,
+  getDiscordErrorCode,
   normalizeDiscordPollInput,
   normalizeEmojiName,
   normalizeReactionEmoji,


### PR DESCRIPTION
## Summary

When sending media/files to a Discord user DM via `openclaw message send --target <userId> --media <file>`, the outbound target normalizer converts bare numeric IDs to `channel:<userId>`. Since user IDs are not channel IDs, the Discord API returns error 10003 (Unknown Channel). Text replies to DMs work because the reply path already stores the resolved DM channel ID.

## Changes

- **`src/discord/send.shared.ts`**: Exported `getDiscordErrorCode` so callers can inspect Discord API error codes.
- **`src/discord/send.outbound.ts`**: Added DM fallback logic in `sendMessageDiscord`. When the Discord API returns 10003 (Unknown Channel) for a numeric `channel:` target, the function retries by creating a DM channel from the same ID via `POST /users/@me/channels`, then resends to the resolved DM channel. Non-numeric targets and non-10003 errors are unaffected.
- **`src/discord/send.dm-fallback.test.ts`** (new): 5 unit tests covering: text DM fallback, media DM fallback, no retry on other error codes, no retry for `user:` targets (already resolved), no retry for non-numeric channel IDs.

## How It Works

Before:
```
--target 111222333 → normalizeDiscordOutboundTarget → channel:111222333
→ POST /channels/111222333/messages → 10003 Unknown Channel → error
```

After:
```
--target 111222333 → normalizeDiscordOutboundTarget → channel:111222333
→ POST /channels/111222333/messages → 10003 Unknown Channel
→ fallback: POST /users/@me/channels { recipient_id: 111222333 } → dm-999888
→ POST /channels/dm-999888/messages → success
```

## Test Plan

- [x] `npx vitest run src/discord/send.dm-fallback.test.ts` — 5 tests pass
- [x] Existing `send.sends-basic-channel-messages.test.ts` tests still pass
- [ ] Manual: `openclaw message send --channel discord --target <userId> --media <file>` should succeed
- [ ] Manual: `openclaw message send --channel discord --target <channelId> --media <file>` still works (no regression)

## Security Impact

- Does this change handle user input? **No** — uses existing parsed target IDs
- Does this change affect authentication/authorization? **No**
- Does this change expose new endpoints or APIs? **No**
- Does this change modify data storage or retrieval? **No**
- Does this change affect cryptographic operations? **No**

## Human Verification

1. Send a media file to a Discord user ID via CLI → should succeed (creates DM channel automatically)
2. Send a media file to a Discord channel ID → should still work (no fallback triggered)
3. Send text to a Discord user ID → should work (may also use fallback)
4. Verify error messages are clear when both channel and DM resolution fail

## Failure Recovery

Revert this single commit. The fallback only adds an extra API call on error, so reverting restores the original "Unknown Channel" error behavior.

## Risks and Mitigations

- **Risk**: Extra API call on every Unknown Channel error for numeric targets. **Mitigation**: Only triggers after a 10003 error, not on the happy path. The DM channel creation call is lightweight.
- **Risk**: User ID that coincidentally matches a deleted channel ID could be misrouted. **Mitigation**: Creating a DM channel for a valid user ID is always safe; for invalid user IDs, Discord returns a clear error.