### PR TITLE
feat(onboarding): add web search to onboarding flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine plugin interface: add `ContextEngine` plugin slot with full lifecycle hooks (`bootstrap`, `ingest`, `assemble`, `compact`, `afterTurn`, `prepareSubagentSpawn`, `onSubagentEnded`), slot-based registry with config-driven resolution, `LegacyContextEngine` wrapper preserving existing compaction behavior, scoped subagent runtime for plugin runtimes via `AsyncLocalStorage`, and `sessions.get` gateway method. Enables plugins like `lossless-claw` to provide alternative context management strategies without modifying core compaction logic. Zero behavior change when no context engine plugin is configured. (#22201) thanks @jalehman.
 - CLI: make read-only SecretRef status flows degrade safely (#37023) thanks @joshavant.
 - Docker/Podman extension dependency baking: add `OPENCLAW_EXTENSIONS` so container builds can preinstall selected bundled extension npm dependencies into the image for faster and more reproducible startup in container deployments. (#32223) Thanks @sallyom.
+- Onboarding/web search: add provider selection step and full provider list in configure wizard, with SecretRef ref-mode support during onboarding. (#34009) Thanks @kesku and @thewilloftheshadow.
 
 ### Breaking
 

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -75,12 +75,15 @@ You can keep it local with `memorySearch.provider = "local"` (no API usage).
 
 See [Memory](/concepts/memory).
 
-### 4) Web search tool (Brave / Perplexity via OpenRouter)
+### 4) Web search tool
 
-`web_search` uses API keys and may incur usage charges:
+`web_search` uses API keys and may incur usage charges depending on your provider:
 
+- **Perplexity Search API**: `PERPLEXITY_API_KEY`
 - **Brave Search API**: `BRAVE_API_KEY` or `tools.web.search.apiKey`
-- **Perplexity** (via OpenRouter): `PERPLEXITY_API_KEY` or `OPENROUTER_API_KEY`
+- **Gemini (Google Search)**: `GEMINI_API_KEY`
+- **Grok (xAI)**: `XAI_API_KEY`
+- **Kimi (Moonshot)**: `KIMI_API_KEY` or `MOONSHOT_API_KEY`
 
 See [Web tools](/tools/web).
 

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -94,6 +94,12 @@ For a high-level overview, see [Onboarding Wizard](/start/wizard).
     - [iMessage](/channels/imessage): legacy `imsg` CLI path + DB access.
     - DM security: default is pairing. First DM sends a code; approve via `openclaw pairing approve <channel> <code>` or use allowlists.
   </Step>
+  <Step title="Web search">
+    - Pick a provider: Perplexity, Brave, Gemini, Grok, or Kimi (or skip).
+    - Paste your API key (QuickStart auto-detects keys from env vars or existing config).
+    - Skip with `--skip-search`.
+    - Configure later: `openclaw configure --section web`.
+  </Step>
   <Step title="Daemon install">
     - macOS: LaunchAgent
       - Requires a logged-in user session; for headless, use a custom LaunchDaemon (not shipped).

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -35,9 +35,10 @@ openclaw agents add <name>
 </Note>
 
 <Tip>
-Recommended: set up a Brave Search API key so the agent can use `web_search`
-(`web_fetch` works without a key). Easiest path: `openclaw configure --section web`
-which stores `tools.web.search.apiKey`. Docs: [Web tools](/tools/web).
+The onboarding wizard includes a web search step where you can pick a provider
+(Perplexity, Brave, Gemini, Grok, or Kimi) and paste your API key so the agent
+can use `web_search`. You can also configure this later with
+`openclaw configure --section web`. Docs: [Web tools](/tools/web).
 </Tip>
 
 ## QuickStart vs Advanced

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -256,7 +256,7 @@ Enable with `tools.loopDetection.enabled: true` (default is `false`).
 
 ### `web_search`
 
-Search the web using Brave Search API.
+Search the web using Perplexity, Brave, Gemini, Grok, or Kimi.
 
 Core parameters:
 
@@ -265,7 +265,7 @@ Core parameters:
 
 Notes:
 
-- Requires a Brave API key (recommended: `openclaw configure --section web`, or set `BRAVE_API_KEY`).
+- Requires an API key for the chosen provider (recommended: `openclaw configure --section web`).
 - Enable via `tools.web.search.enabled`.
 - Responses are cached (default 15 min).
 - See [Web tools](/tools/web) for setup.

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -505,30 +505,7 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
 
   // Auto-detect provider from available API keys (priority order)
   if (raw === "") {
-    // 1. Brave
-    if (resolveSearchApiKey(search)) {
-      logVerbose(
-        'web_search: no provider configured, auto-detected "brave" from available API keys',
-      );
-      return "brave";
-    }
-    // 2. Gemini
-    const geminiConfig = resolveGeminiConfig(search);
-    if (resolveGeminiApiKey(geminiConfig)) {
-      logVerbose(
-        'web_search: no provider configured, auto-detected "gemini" from available API keys',
-      );
-      return "gemini";
-    }
-    // 3. Kimi
-    const kimiConfig = resolveKimiConfig(search);
-    if (resolveKimiApiKey(kimiConfig)) {
-      logVerbose(
-        'web_search: no provider configured, auto-detected "kimi" from available API keys',
-      );
-      return "kimi";
-    }
-    // 4. Perplexity
+    // 1. Perplexity
     const perplexityConfig = resolvePerplexityConfig(search);
     const { apiKey: perplexityKey } = resolvePerplexityApiKey(perplexityConfig);
     if (perplexityKey) {
@@ -537,7 +514,22 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
       );
       return "perplexity";
     }
-    // 5. Grok
+    // 2. Brave
+    if (resolveSearchApiKey(search)) {
+      logVerbose(
+        'web_search: no provider configured, auto-detected "brave" from available API keys',
+      );
+      return "brave";
+    }
+    // 3. Gemini
+    const geminiConfig = resolveGeminiConfig(search);
+    if (resolveGeminiApiKey(geminiConfig)) {
+      logVerbose(
+        'web_search: no provider configured, auto-detected "gemini" from available API keys',
+      );
+      return "gemini";
+    }
+    // 4. Grok
     const grokConfig = resolveGrokConfig(search);
     if (resolveGrokApiKey(grokConfig)) {
       logVerbose(
@@ -545,9 +537,17 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
       );
       return "grok";
     }
+    // 5. Kimi
+    const kimiConfig = resolveKimiConfig(search);
+    if (resolveKimiApiKey(kimiConfig)) {
+      logVerbose(
+        'web_search: no provider configured, auto-detected "kimi" from available API keys',
+      );
+      return "kimi";
+    }
   }
 
-  return "brave";
+  return "perplexity";
 }
 
 function resolvePerplexityConfig(search?: WebSearchConfig): PerplexityConfig {

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -119,6 +119,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--daemon-runtime <runtime>", "Daemon runtime: node|bun")
     .option("--skip-channels", "Skip channel setup")
     .option("--skip-skills", "Skip skills setup")
+    .option("--skip-search", "Skip search provider setup")
     .option("--skip-health", "Skip health check")
     .option("--skip-ui", "Skip Control UI/TUI prompts")
     .option("--node-manager <name>", "Node manager for skills: npm|pnpm|bun")
@@ -193,6 +194,7 @@ export function registerOnboardCommand(program: Command) {
           daemonRuntime: opts.daemonRuntime as GatewayDaemonRuntime | undefined,
           skipChannels: Boolean(opts.skipChannels),
           skipSkills: Boolean(opts.skipSkills),
+          skipSearch: Boolean(opts.skipSearch),
           skipHealth: Boolean(opts.skipHealth),
           skipUi: Boolean(opts.skipUi),
           nodeManager: opts.nodeManager as NodeManagerChoice | undefined,

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -166,18 +166,36 @@ async function promptWebToolsConfig(
 ): Promise<OpenClawConfig> {
   const existingSearch = nextConfig.tools?.web?.search;
   const existingFetch = nextConfig.tools?.web?.fetch;
-  const existingProvider = existingSearch?.provider ?? "brave";
-  const hasPerplexityKey = Boolean(
-    existingSearch?.perplexity?.apiKey || process.env.PERPLEXITY_API_KEY,
-  );
-  const hasBraveKey = Boolean(existingSearch?.apiKey || process.env.BRAVE_API_KEY);
-  const hasSearchKey = existingProvider === "perplexity" ? hasPerplexityKey : hasBraveKey;
+  const existingProvider = existingSearch?.provider ?? "perplexity";
+
+  const { SEARCH_PROVIDER_OPTIONS } = await import("./onboard-search.js");
+
+  const hasKeyForProvider = (provider: string): boolean => {
+    const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === provider);
+    if (!entry) {
+      return false;
+    }
+    const envAvailable = entry.envKeys.some((k) => Boolean(process.env[k]?.trim()));
+    switch (provider) {
+      case "brave":
+        return Boolean(existingSearch?.apiKey) || envAvailable;
+      case "perplexity":
+        return Boolean(existingSearch?.perplexity?.apiKey) || envAvailable;
+      case "gemini":
+        return Boolean(existingSearch?.gemini?.apiKey) || envAvailable;
+      case "grok":
+        return Boolean(existingSearch?.grok?.apiKey) || envAvailable;
+      case "kimi":
+        return Boolean(existingSearch?.kimi?.apiKey) || envAvailable;
+      default:
+        return false;
+    }
+  };
 
   note(
     [
       "Web search lets your agent look things up online using the `web_search` tool.",
-      "Choose a provider: Perplexity Search (recommended) or Brave Search.",
-      "Both return structured results (title, URL, snippet) for fast research.",
+      "Choose a provider and paste your API key.",
       "Docs: https://docs.openclaw.ai/tools/web",
     ].join("\n"),
     "Web search",
@@ -186,30 +204,30 @@ async function promptWebToolsConfig(
   const enableSearch = guardCancel(
     await confirm({
       message: "Enable web_search?",
-      initialValue: existingSearch?.enabled ?? hasSearchKey,
+      initialValue: existingSearch?.enabled ?? hasKeyForProvider(existingProvider),
     }),
     runtime,
   );
 
-  let nextSearch = {
+  let nextSearch: Record<string, unknown> = {
     ...existingSearch,
     enabled: enableSearch,
   };
 
   if (enableSearch) {
+    const providerOptions = SEARCH_PROVIDER_OPTIONS.map((entry) => {
+      const configured = hasKeyForProvider(entry.value);
+      return {
+        value: entry.value,
+        label: entry.label,
+        hint: configured ? `${entry.hint} · configured` : entry.hint,
+      };
+    });
+
     const providerChoice = guardCancel(
       await select({
         message: "Choose web search provider",
-        options: [
-          {
-            value: "perplexity",
-            label: "Perplexity Search",
-          },
-          {
-            value: "brave",
-            label: "Brave Search",
-          },
-        ],
+        options: providerOptions,
         initialValue: existingProvider,
       }),
       runtime,
@@ -217,59 +235,79 @@ async function promptWebToolsConfig(
 
     nextSearch = { ...nextSearch, provider: providerChoice };
 
-    if (providerChoice === "perplexity") {
-      const hasKey = Boolean(existingSearch?.perplexity?.apiKey);
-      const keyInput = guardCancel(
-        await text({
-          message: hasKey
-            ? "Perplexity API key (leave blank to keep current or use PERPLEXITY_API_KEY)"
-            : "Perplexity API key (paste it here; leave blank to use PERPLEXITY_API_KEY)",
-          placeholder: hasKey ? "Leave blank to keep current" : "pplx-...",
-        }),
-        runtime,
-      );
-      const key = String(keyInput ?? "").trim();
-      if (key) {
-        nextSearch = {
-          ...nextSearch,
-          perplexity: { ...existingSearch?.perplexity, apiKey: key },
-        };
-      } else if (!hasKey && !process.env.PERPLEXITY_API_KEY) {
-        note(
-          [
-            "No key stored yet, so web_search will stay unavailable.",
-            "Store a key here or set PERPLEXITY_API_KEY in the Gateway environment.",
-            "Get your API key at: https://www.perplexity.ai/settings/api",
-            "Docs: https://docs.openclaw.ai/tools/web",
-          ].join("\n"),
-          "Web search",
-        );
+    const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === providerChoice)!;
+    const existingKey = (() => {
+      switch (providerChoice) {
+        case "brave":
+          return existingSearch?.apiKey;
+        case "perplexity":
+          return existingSearch?.perplexity?.apiKey;
+        case "gemini":
+          return existingSearch?.gemini?.apiKey;
+        case "grok":
+          return existingSearch?.grok?.apiKey;
+        case "kimi":
+          return existingSearch?.kimi?.apiKey;
+        default:
+          return undefined;
       }
-    } else {
-      const hasKey = Boolean(existingSearch?.apiKey);
-      const keyInput = guardCancel(
-        await text({
-          message: hasKey
-            ? "Brave Search API key (leave blank to keep current or use BRAVE_API_KEY)"
-            : "Brave Search API key (paste it here; leave blank to use BRAVE_API_KEY)",
-          placeholder: hasKey ? "Leave blank to keep current" : "BSA...",
-        }),
-        runtime,
-      );
-      const key = String(keyInput ?? "").trim();
-      if (key) {
-        nextSearch = { ...nextSearch, apiKey: key };
-      } else if (!hasKey && !process.env.BRAVE_API_KEY) {
-        note(
-          [
-            "No key stored yet, so web_search will stay unavailable.",
-            "Store a key here or set BRAVE_API_KEY in the Gateway environment.",
-            "Get your API key at: https://brave.com/search/api/",
-            "Docs: https://docs.openclaw.ai/tools/web",
-          ].join("\n"),
-          "Web search",
-        );
+    })();
+    const hasKey = Boolean(existingKey);
+    const envAvailable = entry.envKeys.some((k) => Boolean(process.env[k]?.trim()));
+    const envVarNames = entry.envKeys.join(" / ");
+
+    const keyInput = guardCancel(
+      await text({
+        message: hasKey
+          ? `${entry.label} API key (leave blank to keep current or use ${envVarNames})`
+          : `${entry.label} API key (paste it here; leave blank to use ${envVarNames})`,
+        placeholder: hasKey ? "Leave blank to keep current" : entry.placeholder,
+      }),
+      runtime,
+    );
+    const key = String(keyInput ?? "").trim();
+
+    if (key || hasKey) {
+      const apiKey = key || existingKey;
+      switch (providerChoice) {
+        case "brave":
+          nextSearch = { ...nextSearch, apiKey };
+          break;
+        case "perplexity":
+          nextSearch = {
+            ...nextSearch,
+            perplexity: { ...existingSearch?.perplexity, apiKey },
+          };
+          break;
+        case "gemini":
+          nextSearch = {
+            ...nextSearch,
+            gemini: { ...existingSearch?.gemini, apiKey },
+          };
+          break;
+        case "grok":
+          nextSearch = {
+            ...nextSearch,
+            grok: { ...existingSearch?.grok, apiKey },
+          };
+          break;
+        case "kimi":
+          nextSearch = {
+            ...nextSearch,
+            kimi: { ...existingSearch?.kimi, apiKey },
+          };
+          break;
       }
+    } else if (!envAvailable) {
+      note(
+        [
+          "No key stored yet, so web_search will stay unavailable.",
+          `Store a key here or set ${envVarNames} in the Gateway environment.`,
+          `Get your API key at: ${entry.signupUrl}`,
+          "Docs: https://docs.openclaw.ai/tools/web",
+        ].join("\n"),
+        "Web search",
+      );
     }
   }
 

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -168,7 +168,8 @@ async function promptWebToolsConfig(
   const existingFetch = nextConfig.tools?.web?.fetch;
   const existingProvider = existingSearch?.provider ?? "perplexity";
 
-  const { SEARCH_PROVIDER_OPTIONS, resolveExistingKey } = await import("./onboard-search.js");
+  const { SEARCH_PROVIDER_OPTIONS, resolveExistingKey, applySearchKey, hasKeyInEnv } =
+    await import("./onboard-search.js");
   type SP = (typeof SEARCH_PROVIDER_OPTIONS)[number]["value"];
 
   const hasKeyForProvider = (provider: string): boolean => {
@@ -176,8 +177,7 @@ async function promptWebToolsConfig(
     if (!entry) {
       return false;
     }
-    const envAvailable = entry.envKeys.some((k) => Boolean(process.env[k]?.trim()));
-    return Boolean(resolveExistingKey(nextConfig, provider as SP)) || envAvailable;
+    return Boolean(resolveExistingKey(nextConfig, provider as SP)) || hasKeyInEnv(entry);
   };
 
   note(
@@ -242,36 +242,8 @@ async function promptWebToolsConfig(
     const key = String(keyInput ?? "").trim();
 
     if (key || hasKey) {
-      const apiKey = key || existingKey;
-      switch (providerChoice) {
-        case "brave":
-          nextSearch = { ...nextSearch, apiKey };
-          break;
-        case "perplexity":
-          nextSearch = {
-            ...nextSearch,
-            perplexity: { ...existingSearch?.perplexity, apiKey },
-          };
-          break;
-        case "gemini":
-          nextSearch = {
-            ...nextSearch,
-            gemini: { ...existingSearch?.gemini, apiKey },
-          };
-          break;
-        case "grok":
-          nextSearch = {
-            ...nextSearch,
-            grok: { ...existingSearch?.grok, apiKey },
-          };
-          break;
-        case "kimi":
-          nextSearch = {
-            ...nextSearch,
-            kimi: { ...existingSearch?.kimi, apiKey },
-          };
-          break;
-      }
+      const applied = applySearchKey(nextConfig, providerChoice as SP, (key || existingKey)!);
+      nextSearch = { ...applied.tools?.web?.search };
     } else if (!envAvailable) {
       nextSearch = { ...nextSearch, enabled: false };
       note(

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -244,7 +244,9 @@ async function promptWebToolsConfig(
     const keyInput = guardCancel(
       await text({
         message: keyConfigured
-          ? `${entry.label} API key (leave blank to keep current or use ${envVarNames})`
+          ? envAvailable
+            ? `${entry.label} API key (leave blank to keep current or use ${envVarNames})`
+            : `${entry.label} API key (leave blank to keep current)`
           : envAvailable
             ? `${entry.label} API key (paste it here; leave blank to use ${envVarNames})`
             : `${entry.label} API key`,

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -168,7 +168,8 @@ async function promptWebToolsConfig(
   const existingFetch = nextConfig.tools?.web?.fetch;
   const existingProvider = existingSearch?.provider ?? "perplexity";
 
-  const { SEARCH_PROVIDER_OPTIONS } = await import("./onboard-search.js");
+  const { SEARCH_PROVIDER_OPTIONS, resolveExistingKey } = await import("./onboard-search.js");
+  type SP = (typeof SEARCH_PROVIDER_OPTIONS)[number]["value"];
 
   const hasKeyForProvider = (provider: string): boolean => {
     const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === provider);
@@ -176,20 +177,7 @@ async function promptWebToolsConfig(
       return false;
     }
     const envAvailable = entry.envKeys.some((k) => Boolean(process.env[k]?.trim()));
-    switch (provider) {
-      case "brave":
-        return Boolean(existingSearch?.apiKey) || envAvailable;
-      case "perplexity":
-        return Boolean(existingSearch?.perplexity?.apiKey) || envAvailable;
-      case "gemini":
-        return Boolean(existingSearch?.gemini?.apiKey) || envAvailable;
-      case "grok":
-        return Boolean(existingSearch?.grok?.apiKey) || envAvailable;
-      case "kimi":
-        return Boolean(existingSearch?.kimi?.apiKey) || envAvailable;
-      default:
-        return false;
-    }
+    return Boolean(resolveExistingKey(nextConfig, provider as SP)) || envAvailable;
   };
 
   note(
@@ -236,22 +224,7 @@ async function promptWebToolsConfig(
     nextSearch = { ...nextSearch, provider: providerChoice };
 
     const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === providerChoice)!;
-    const existingKey = (() => {
-      switch (providerChoice) {
-        case "brave":
-          return existingSearch?.apiKey;
-        case "perplexity":
-          return existingSearch?.perplexity?.apiKey;
-        case "gemini":
-          return existingSearch?.gemini?.apiKey;
-        case "grok":
-          return existingSearch?.grok?.apiKey;
-        case "kimi":
-          return existingSearch?.kimi?.apiKey;
-        default:
-          return undefined;
-      }
-    })();
+    const existingKey = resolveExistingKey(nextConfig, providerChoice as SP);
     const hasKey = Boolean(existingKey);
     const envAvailable = entry.envKeys.some((k) => Boolean(process.env[k]?.trim()));
     const envVarNames = entry.envKeys.join(" / ");
@@ -299,6 +272,7 @@ async function promptWebToolsConfig(
           break;
       }
     } else if (!envAvailable) {
+      nextSearch = { ...nextSearch, enabled: false };
       note(
         [
           "No key stored yet, so web_search will stay unavailable.",

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -192,7 +192,8 @@ async function promptWebToolsConfig(
   const enableSearch = guardCancel(
     await confirm({
       message: "Enable web_search?",
-      initialValue: existingSearch?.enabled ?? hasKeyForProvider(existingProvider),
+      initialValue:
+        existingSearch?.enabled ?? SEARCH_PROVIDER_OPTIONS.some((e) => hasKeyForProvider(e.value)),
     }),
     runtime,
   );

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -252,7 +252,6 @@ async function promptWebToolsConfig(
       }),
       runtime,
     );
-    );
     const key = String(keyInput ?? "").trim();
 
     if (key || existingKey) {

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -166,8 +166,13 @@ async function promptWebToolsConfig(
 ): Promise<OpenClawConfig> {
   const existingSearch = nextConfig.tools?.web?.search;
   const existingFetch = nextConfig.tools?.web?.fetch;
-  const { SEARCH_PROVIDER_OPTIONS, resolveExistingKey, applySearchKey, hasKeyInEnv } =
-    await import("./onboard-search.js");
+  const {
+    SEARCH_PROVIDER_OPTIONS,
+    resolveExistingKey,
+    hasExistingKey,
+    applySearchKey,
+    hasKeyInEnv,
+  } = await import("./onboard-search.js");
   type SP = (typeof SEARCH_PROVIDER_OPTIONS)[number]["value"];
 
   const hasKeyForProvider = (provider: string): boolean => {
@@ -175,7 +180,7 @@ async function promptWebToolsConfig(
     if (!entry) {
       return false;
     }
-    return Boolean(resolveExistingKey(nextConfig, provider as SP)) || hasKeyInEnv(entry);
+    return hasExistingKey(nextConfig, provider as SP) || hasKeyInEnv(entry);
   };
 
   const existingProvider: string =
@@ -229,25 +234,27 @@ async function promptWebToolsConfig(
 
     const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === providerChoice)!;
     const existingKey = resolveExistingKey(nextConfig, providerChoice as SP);
-    const hasKey = Boolean(existingKey);
+    const keyConfigured = hasExistingKey(nextConfig, providerChoice as SP);
     const envAvailable = entry.envKeys.some((k) => Boolean(process.env[k]?.trim()));
     const envVarNames = entry.envKeys.join(" / ");
 
     const keyInput = guardCancel(
       await text({
-        message: hasKey
+        message: keyConfigured
           ? `${entry.label} API key (leave blank to keep current or use ${envVarNames})`
           : `${entry.label} API key (paste it here; leave blank to use ${envVarNames})`,
-        placeholder: hasKey ? "Leave blank to keep current" : entry.placeholder,
+        placeholder: keyConfigured ? "Leave blank to keep current" : entry.placeholder,
       }),
       runtime,
     );
     const key = String(keyInput ?? "").trim();
 
-    if (key || hasKey) {
+    if (key || existingKey) {
       const applied = applySearchKey(nextConfig, providerChoice as SP, (key || existingKey)!);
       nextSearch = { ...applied.tools?.web?.search };
-    } else if (!envAvailable) {
+    } else if (keyConfigured || envAvailable) {
+      nextSearch = { ...nextSearch };
+    } else {
       nextSearch = { ...nextSearch, enabled: false };
       note(
         [

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -166,8 +166,6 @@ async function promptWebToolsConfig(
 ): Promise<OpenClawConfig> {
   const existingSearch = nextConfig.tools?.web?.search;
   const existingFetch = nextConfig.tools?.web?.fetch;
-  const existingProvider = existingSearch?.provider ?? "perplexity";
-
   const { SEARCH_PROVIDER_OPTIONS, resolveExistingKey, applySearchKey, hasKeyInEnv } =
     await import("./onboard-search.js");
   type SP = (typeof SEARCH_PROVIDER_OPTIONS)[number]["value"];
@@ -179,6 +177,11 @@ async function promptWebToolsConfig(
     }
     return Boolean(resolveExistingKey(nextConfig, provider as SP)) || hasKeyInEnv(entry);
   };
+
+  const existingProvider: string =
+    existingSearch?.provider ??
+    SEARCH_PROVIDER_OPTIONS.find((e) => hasKeyForProvider(e.value))?.value ??
+    "perplexity";
 
   note(
     [

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -262,10 +262,9 @@ async function promptWebToolsConfig(
     } else if (keyConfigured || envAvailable) {
       nextSearch = { ...nextSearch };
     } else {
-      nextSearch = { ...nextSearch, enabled: false };
       note(
         [
-          "No key stored yet, so web_search will stay unavailable.",
+          "No key stored yet — web_search won't work until a key is available.",
           `Store a key here or set ${envVarNames} in the Gateway environment.`,
           `Get your API key at: ${entry.signupUrl}`,
           "Docs: https://docs.openclaw.ai/tools/web",

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -245,10 +245,13 @@ async function promptWebToolsConfig(
       await text({
         message: keyConfigured
           ? `${entry.label} API key (leave blank to keep current or use ${envVarNames})`
-          : `${entry.label} API key (paste it here; leave blank to use ${envVarNames})`,
+          : envAvailable
+            ? `${entry.label} API key (paste it here; leave blank to use ${envVarNames})`
+            : `${entry.label} API key`,
         placeholder: keyConfigured ? "Leave blank to keep current" : entry.placeholder,
       }),
       runtime,
+    );
     );
     const key = String(keyInput ?? "").trim();
 

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -183,10 +183,13 @@ async function promptWebToolsConfig(
     return hasExistingKey(nextConfig, provider as SP) || hasKeyInEnv(entry);
   };
 
-  const existingProvider: string =
-    existingSearch?.provider ??
-    SEARCH_PROVIDER_OPTIONS.find((e) => hasKeyForProvider(e.value))?.value ??
-    "perplexity";
+  const existingProvider: string = (() => {
+    const stored = existingSearch?.provider;
+    if (stored && SEARCH_PROVIDER_OPTIONS.some((e) => e.value === stored)) {
+      return stored;
+    }
+    return SEARCH_PROVIDER_OPTIONS.find((e) => hasKeyForProvider(e.value))?.value ?? "perplexity";
+  })();
 
   note(
     [

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -156,6 +156,17 @@ describe("setupSearch", () => {
     expect(prompter.text).not.toHaveBeenCalled();
   });
 
+  it("quickstart falls through to key prompt when no key and no env var", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter } = createPrompter({ selectValue: "grok", textValue: "" });
+    const result = await setupSearch(cfg, runtime, prompter, {
+      quickstartDefaults: true,
+    });
+    expect(prompter.text).toHaveBeenCalled();
+    expect(result.tools?.web?.search?.provider).toBe("grok");
+    expect(result.tools?.web?.search?.enabled).toBe(false);
+  });
+
   it("quickstart skips key prompt when env var is available", async () => {
     const orig = process.env.BRAVE_API_KEY;
     process.env.BRAVE_API_KEY = "env-brave-key";

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -110,7 +110,7 @@ describe("setupSearch", () => {
     });
     const result = await setupSearch(cfg, runtime, prompter);
     expect(result.tools?.web?.search?.provider).toBe("brave");
-    expect(result.tools?.web?.search?.enabled).toBe(false);
+    expect(result.tools?.web?.search?.enabled).toBeUndefined();
     const missingNote = notes.find((n) => n.message.includes("No API key stored"));
     expect(missingNote).toBeDefined();
   });
@@ -207,7 +207,7 @@ describe("setupSearch", () => {
     });
     expect(prompter.text).toHaveBeenCalled();
     expect(result.tools?.web?.search?.provider).toBe("grok");
-    expect(result.tools?.web?.search?.enabled).toBe(false);
+    expect(result.tools?.web?.search?.enabled).toBeUndefined();
   });
 
   it("quickstart skips key prompt when env var is available", async () => {

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -233,10 +233,7 @@ describe("setupSearch", () => {
 
   it("stores env-backed SecretRef when secretInputMode=ref for perplexity", async () => {
     const cfg: OpenClawConfig = {};
-    const { prompter } = createPrompter({
-      selectValue: "perplexity",
-      textValue: "pplx-test-key",
-    });
+    const { prompter } = createPrompter({ selectValue: "perplexity" });
     const result = await setupSearch(cfg, runtime, prompter, {
       secretInputMode: "ref",
     });
@@ -246,14 +243,12 @@ describe("setupSearch", () => {
       provider: "default",
       id: "PERPLEXITY_API_KEY",
     });
+    expect(prompter.text).not.toHaveBeenCalled();
   });
 
   it("stores env-backed SecretRef when secretInputMode=ref for brave", async () => {
     const cfg: OpenClawConfig = {};
-    const { prompter } = createPrompter({
-      selectValue: "brave",
-      textValue: "BSA-test-key",
-    });
+    const { prompter } = createPrompter({ selectValue: "brave" });
     const result = await setupSearch(cfg, runtime, prompter, {
       secretInputMode: "ref",
     });
@@ -263,6 +258,7 @@ describe("setupSearch", () => {
       provider: "default",
       id: "BRAVE_API_KEY",
     });
+    expect(prompter.text).not.toHaveBeenCalled();
   });
 
   it("stores plaintext key when secretInputMode is unset", async () => {

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -156,6 +156,28 @@ describe("setupSearch", () => {
     expect(prompter.text).not.toHaveBeenCalled();
   });
 
+  it("quickstart preserves enabled:false when search was intentionally disabled", async () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        web: {
+          search: {
+            provider: "perplexity",
+            enabled: false,
+            perplexity: { apiKey: "stored-pplx-key" },
+          },
+        },
+      },
+    };
+    const { prompter } = createPrompter({ selectValue: "perplexity" });
+    const result = await setupSearch(cfg, runtime, prompter, {
+      quickstartDefaults: true,
+    });
+    expect(result.tools?.web?.search?.provider).toBe("perplexity");
+    expect(result.tools?.web?.search?.perplexity?.apiKey).toBe("stored-pplx-key");
+    expect(result.tools?.web?.search?.enabled).toBe(false);
+    expect(prompter.text).not.toHaveBeenCalled();
+  });
+
   it("quickstart falls through to key prompt when no key and no env var", async () => {
     const cfg: OpenClawConfig = {};
     const { prompter } = createPrompter({ selectValue: "grok", textValue: "" });

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -231,6 +231,50 @@ describe("setupSearch", () => {
     }
   });
 
+  it("stores env-backed SecretRef when secretInputMode=ref for perplexity", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter } = createPrompter({
+      selectValue: "perplexity",
+      textValue: "pplx-test-key",
+    });
+    const result = await setupSearch(cfg, runtime, prompter, {
+      secretInputMode: "ref",
+    });
+    expect(result.tools?.web?.search?.provider).toBe("perplexity");
+    expect(result.tools?.web?.search?.perplexity?.apiKey).toEqual({
+      source: "env",
+      provider: "default",
+      id: "PERPLEXITY_API_KEY",
+    });
+  });
+
+  it("stores env-backed SecretRef when secretInputMode=ref for brave", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter } = createPrompter({
+      selectValue: "brave",
+      textValue: "BSA-test-key",
+    });
+    const result = await setupSearch(cfg, runtime, prompter, {
+      secretInputMode: "ref",
+    });
+    expect(result.tools?.web?.search?.provider).toBe("brave");
+    expect(result.tools?.web?.search?.apiKey).toEqual({
+      source: "env",
+      provider: "default",
+      id: "BRAVE_API_KEY",
+    });
+  });
+
+  it("stores plaintext key when secretInputMode is unset", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter } = createPrompter({
+      selectValue: "brave",
+      textValue: "BSA-plain",
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search?.apiKey).toBe("BSA-plain");
+  });
+
   it("exports all 5 providers in SEARCH_PROVIDER_OPTIONS", () => {
     expect(SEARCH_PROVIDER_OPTIONS).toHaveLength(5);
     const values = SEARCH_PROVIDER_OPTIONS.map((e) => e.value);

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -106,6 +106,7 @@ describe("setupSearch", () => {
     });
     const result = await setupSearch(cfg, runtime, prompter);
     expect(result.tools?.web?.search?.provider).toBe("brave");
+    expect(result.tools?.web?.search?.enabled).toBe(false);
     const missingNote = notes.find((n) => n.message.includes("No API key stored"));
     expect(missingNote).toBeDefined();
   });

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -62,6 +62,7 @@ describe("setupSearch", () => {
     });
     const result = await setupSearch(cfg, runtime, prompter);
     expect(result.tools?.web?.search?.provider).toBe("brave");
+    expect(result.tools?.web?.search?.enabled).toBe(true);
     expect(result.tools?.web?.search?.apiKey).toBe("BSA-test-key");
   });
 
@@ -73,6 +74,7 @@ describe("setupSearch", () => {
     });
     const result = await setupSearch(cfg, runtime, prompter);
     expect(result.tools?.web?.search?.provider).toBe("gemini");
+    expect(result.tools?.web?.search?.enabled).toBe(true);
     expect(result.tools?.web?.search?.gemini?.apiKey).toBe("AIza-test");
   });
 
@@ -84,6 +86,7 @@ describe("setupSearch", () => {
     });
     const result = await setupSearch(cfg, runtime, prompter);
     expect(result.tools?.web?.search?.provider).toBe("grok");
+    expect(result.tools?.web?.search?.enabled).toBe(true);
     expect(result.tools?.web?.search?.grok?.apiKey).toBe("xai-test");
   });
 
@@ -95,6 +98,7 @@ describe("setupSearch", () => {
     });
     const result = await setupSearch(cfg, runtime, prompter);
     expect(result.tools?.web?.search?.provider).toBe("kimi");
+    expect(result.tools?.web?.search?.enabled).toBe(true);
     expect(result.tools?.web?.search?.kimi?.apiKey).toBe("sk-moonshot");
   });
 
@@ -128,6 +132,7 @@ describe("setupSearch", () => {
     });
     const result = await setupSearch(cfg, runtime, prompter);
     expect(result.tools?.web?.search?.perplexity?.apiKey).toBe("existing-key");
+    expect(result.tools?.web?.search?.enabled).toBe(true);
   });
 
   it("quickstart skips key prompt when env var is available", async () => {
@@ -140,6 +145,7 @@ describe("setupSearch", () => {
         quickstartDefaults: true,
       });
       expect(result.tools?.web?.search?.provider).toBe("brave");
+      expect(result.tools?.web?.search?.enabled).toBe(true);
       expect(prompter.text).not.toHaveBeenCalled();
     } finally {
       if (orig === undefined) {

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { SEARCH_PROVIDER_OPTIONS, setupSearch } from "./onboard-search.js";
+
+const runtime: RuntimeEnv = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: ((code: number) => {
+    throw new Error(`unexpected exit ${code}`);
+  }) as RuntimeEnv["exit"],
+};
+
+function createPrompter(params: { selectValue?: string; textValue?: string }): {
+  prompter: WizardPrompter;
+  notes: Array<{ title?: string; message: string }>;
+} {
+  const notes: Array<{ title?: string; message: string }> = [];
+  const prompter: WizardPrompter = {
+    intro: vi.fn(async () => {}),
+    outro: vi.fn(async () => {}),
+    note: vi.fn(async (message: string, title?: string) => {
+      notes.push({ title, message });
+    }),
+    select: vi.fn(
+      async () => params.selectValue ?? "perplexity",
+    ) as unknown as WizardPrompter["select"],
+    multiselect: vi.fn(async () => []) as unknown as WizardPrompter["multiselect"],
+    text: vi.fn(async () => params.textValue ?? ""),
+    confirm: vi.fn(async () => true),
+    progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+  };
+  return { prompter, notes };
+}
+
+describe("setupSearch", () => {
+  it("returns config unchanged when user skips", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter } = createPrompter({ selectValue: "__skip__" });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result).toBe(cfg);
+  });
+
+  it("sets provider and key for perplexity", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter } = createPrompter({
+      selectValue: "perplexity",
+      textValue: "pplx-test-key",
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search?.provider).toBe("perplexity");
+    expect(result.tools?.web?.search?.perplexity?.apiKey).toBe("pplx-test-key");
+    expect(result.tools?.web?.search?.enabled).toBe(true);
+  });
+
+  it("sets provider and key for brave", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter } = createPrompter({
+      selectValue: "brave",
+      textValue: "BSA-test-key",
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search?.provider).toBe("brave");
+    expect(result.tools?.web?.search?.apiKey).toBe("BSA-test-key");
+  });
+
+  it("sets provider and key for gemini", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter } = createPrompter({
+      selectValue: "gemini",
+      textValue: "AIza-test",
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search?.provider).toBe("gemini");
+    expect(result.tools?.web?.search?.gemini?.apiKey).toBe("AIza-test");
+  });
+
+  it("sets provider and key for grok", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter } = createPrompter({
+      selectValue: "grok",
+      textValue: "xai-test",
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search?.provider).toBe("grok");
+    expect(result.tools?.web?.search?.grok?.apiKey).toBe("xai-test");
+  });
+
+  it("sets provider and key for kimi", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter } = createPrompter({
+      selectValue: "kimi",
+      textValue: "sk-moonshot",
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search?.provider).toBe("kimi");
+    expect(result.tools?.web?.search?.kimi?.apiKey).toBe("sk-moonshot");
+  });
+
+  it("shows missing-key note when no key is provided and no env var", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter, notes } = createPrompter({
+      selectValue: "brave",
+      textValue: "",
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search?.provider).toBe("brave");
+    const missingNote = notes.find((n) => n.message.includes("No API key stored"));
+    expect(missingNote).toBeDefined();
+  });
+
+  it("keeps existing key when user leaves input blank", async () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        web: {
+          search: {
+            provider: "perplexity",
+            perplexity: { apiKey: "existing-key" },
+          },
+        },
+      },
+    };
+    const { prompter } = createPrompter({
+      selectValue: "perplexity",
+      textValue: "",
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search?.perplexity?.apiKey).toBe("existing-key");
+  });
+
+  it("quickstart skips key prompt when env var is available", async () => {
+    const orig = process.env.BRAVE_API_KEY;
+    process.env.BRAVE_API_KEY = "env-brave-key";
+    try {
+      const cfg: OpenClawConfig = {};
+      const { prompter } = createPrompter({ selectValue: "brave" });
+      const result = await setupSearch(cfg, runtime, prompter, {
+        quickstartDefaults: true,
+      });
+      expect(result.tools?.web?.search?.provider).toBe("brave");
+      expect(prompter.text).not.toHaveBeenCalled();
+    } finally {
+      if (orig === undefined) {
+        delete process.env.BRAVE_API_KEY;
+      } else {
+        process.env.BRAVE_API_KEY = orig;
+      }
+    }
+  });
+
+  it("exports all 5 providers in SEARCH_PROVIDER_OPTIONS", () => {
+    expect(SEARCH_PROVIDER_OPTIONS).toHaveLength(5);
+    const values = SEARCH_PROVIDER_OPTIONS.map((e) => e.value);
+    expect(values).toEqual(["perplexity", "brave", "gemini", "grok", "kimi"]);
+  });
+});

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -135,6 +135,27 @@ describe("setupSearch", () => {
     expect(result.tools?.web?.search?.enabled).toBe(true);
   });
 
+  it("advanced preserves enabled:false when keeping existing key", async () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        web: {
+          search: {
+            provider: "perplexity",
+            enabled: false,
+            perplexity: { apiKey: "existing-key" },
+          },
+        },
+      },
+    };
+    const { prompter } = createPrompter({
+      selectValue: "perplexity",
+      textValue: "",
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search?.perplexity?.apiKey).toBe("existing-key");
+    expect(result.tools?.web?.search?.enabled).toBe(false);
+  });
+
   it("quickstart skips key prompt when config key exists", async () => {
     const cfg: OpenClawConfig = {
       tools: {

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -135,6 +135,27 @@ describe("setupSearch", () => {
     expect(result.tools?.web?.search?.enabled).toBe(true);
   });
 
+  it("quickstart skips key prompt when config key exists", async () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        web: {
+          search: {
+            provider: "perplexity",
+            perplexity: { apiKey: "stored-pplx-key" },
+          },
+        },
+      },
+    };
+    const { prompter } = createPrompter({ selectValue: "perplexity" });
+    const result = await setupSearch(cfg, runtime, prompter, {
+      quickstartDefaults: true,
+    });
+    expect(result.tools?.web?.search?.provider).toBe("perplexity");
+    expect(result.tools?.web?.search?.perplexity?.apiKey).toBe("stored-pplx-key");
+    expect(result.tools?.web?.search?.enabled).toBe(true);
+    expect(prompter.text).not.toHaveBeenCalled();
+  });
+
   it("quickstart skips key prompt when env var is available", async () => {
     const orig = process.env.BRAVE_API_KEY;
     process.env.BRAVE_API_KEY = "env-brave-key";

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
-import { normalizeSecretInputString } from "../config/types.secrets.js";
+import { hasConfiguredSecretInput, normalizeSecretInputString } from "../config/types.secrets.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 
@@ -61,23 +61,33 @@ export function hasKeyInEnv(entry: SearchProviderEntry): boolean {
   return entry.envKeys.some((k) => Boolean(process.env[k]?.trim()));
 }
 
+function rawKeyValue(config: OpenClawConfig, provider: SearchProvider): unknown {
+  const search = config.tools?.web?.search;
+  switch (provider) {
+    case "brave":
+      return search?.apiKey;
+    case "perplexity":
+      return search?.perplexity?.apiKey;
+    case "gemini":
+      return search?.gemini?.apiKey;
+    case "grok":
+      return search?.grok?.apiKey;
+    case "kimi":
+      return search?.kimi?.apiKey;
+  }
+}
+
+/** Returns the plaintext key string, or undefined for SecretRefs/missing. */
 export function resolveExistingKey(
   config: OpenClawConfig,
   provider: SearchProvider,
 ): string | undefined {
-  const search = config.tools?.web?.search;
-  switch (provider) {
-    case "brave":
-      return normalizeSecretInputString(search?.apiKey);
-    case "perplexity":
-      return normalizeSecretInputString(search?.perplexity?.apiKey);
-    case "gemini":
-      return normalizeSecretInputString(search?.gemini?.apiKey);
-    case "grok":
-      return normalizeSecretInputString(search?.grok?.apiKey);
-    case "kimi":
-      return normalizeSecretInputString(search?.kimi?.apiKey);
-  }
+  return normalizeSecretInputString(rawKeyValue(config, provider));
+}
+
+/** Returns true if a key is configured (plaintext string or SecretRef). */
+export function hasExistingKey(config: OpenClawConfig, provider: SearchProvider): boolean {
+  return hasConfiguredSecretInput(rawKeyValue(config, provider));
 }
 
 export function applySearchKey(
@@ -151,7 +161,7 @@ export async function setupSearch(
   const existingProvider = config.tools?.web?.search?.provider;
 
   const options = SEARCH_PROVIDER_OPTIONS.map((entry) => {
-    const configured = Boolean(resolveExistingKey(config, entry.value)) || hasKeyInEnv(entry);
+    const configured = hasExistingKey(config, entry.value) || hasKeyInEnv(entry);
     const hint = configured ? `${entry.hint} · configured` : entry.hint;
     return { value: entry.value, label: entry.label, hint };
   });
@@ -161,7 +171,7 @@ export async function setupSearch(
       return existingProvider;
     }
     const detected = SEARCH_PROVIDER_OPTIONS.find(
-      (e) => Boolean(resolveExistingKey(config, e.value)) || hasKeyInEnv(e),
+      (e) => hasExistingKey(config, e.value) || hasKeyInEnv(e),
     );
     if (detected) {
       return detected.value;
@@ -189,9 +199,10 @@ export async function setupSearch(
 
   const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === choice)!;
   const existingKey = resolveExistingKey(config, choice);
+  const keyConfigured = hasExistingKey(config, choice);
   const envAvailable = hasKeyInEnv(entry);
 
-  if (opts?.quickstartDefaults && (existingKey || envAvailable)) {
+  if (opts?.quickstartDefaults && (keyConfigured || envAvailable)) {
     const wasDisabled = config.tools?.web?.search?.enabled === false;
     let result = existingKey
       ? applySearchKey(config, choice, existingKey)
@@ -209,12 +220,12 @@ export async function setupSearch(
   }
 
   const keyInput = await prompter.text({
-    message: existingKey
+    message: keyConfigured
       ? `${entry.label} API key (leave blank to keep current)`
       : envAvailable
         ? `${entry.label} API key (leave blank to use env var)`
         : `${entry.label} API key`,
-    placeholder: existingKey ? "Leave blank to keep current" : entry.placeholder,
+    placeholder: keyConfigured ? "Leave blank to keep current" : entry.placeholder,
   });
 
   const key = keyInput?.trim() ?? "";
@@ -226,7 +237,7 @@ export async function setupSearch(
     return applySearchKey(config, choice, existingKey);
   }
 
-  if (envAvailable) {
+  if (keyConfigured || envAvailable) {
     return applyProviderOnly(config, choice);
   }
 

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -192,9 +192,20 @@ export async function setupSearch(
   const envAvailable = hasKeyInEnv(entry);
 
   if (opts?.quickstartDefaults && (existingKey || envAvailable)) {
-    return existingKey
+    const wasDisabled = config.tools?.web?.search?.enabled === false;
+    let result = existingKey
       ? applySearchKey(config, choice, existingKey)
       : applyProviderOnly(config, choice);
+    if (wasDisabled) {
+      result = {
+        ...result,
+        tools: {
+          ...result.tools,
+          web: { ...result.tools?.web, search: { ...result.tools?.web?.search, enabled: false } },
+        },
+      };
+    }
+    return result;
   }
 
   const keyInput = await prompter.text({

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -2,7 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 
-type SearchProvider = "perplexity" | "brave" | "gemini" | "grok" | "kimi";
+export type SearchProvider = "perplexity" | "brave" | "gemini" | "grok" | "kimi";
 
 type SearchProviderEntry = {
   value: SearchProvider;
@@ -60,7 +60,10 @@ function hasKeyInEnv(entry: SearchProviderEntry): boolean {
   return entry.envKeys.some((k) => Boolean(process.env[k]?.trim()));
 }
 
-function resolveExistingKey(config: OpenClawConfig, provider: SearchProvider): string | undefined {
+export function resolveExistingKey(
+  config: OpenClawConfig,
+  provider: SearchProvider,
+): string | undefined {
   const search = config.tools?.web?.search;
   switch (provider) {
     case "brave":
@@ -226,5 +229,18 @@ export async function setupSearch(
     "Web search",
   );
 
-  return applyProviderOnly(config, choice);
+  return {
+    ...config,
+    tools: {
+      ...config.tools,
+      web: {
+        ...config.tools?.web,
+        search: {
+          ...config.tools?.web?.search,
+          provider: choice,
+          enabled: false,
+        },
+      },
+    },
+  };
 }

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -254,6 +254,23 @@ export async function setupSearch(
     return preserveDisabledState(config, result);
   }
 
+  if (opts?.secretInputMode === "ref") {
+    if (keyConfigured) {
+      return preserveDisabledState(config, applyProviderOnly(config, choice));
+    }
+    const ref = buildSearchEnvRef(choice);
+    await prompter.note(
+      [
+        "Secret references enabled — OpenClaw will store a reference instead of the API key.",
+        `Env var: ${ref.id}${envAvailable ? " (detected)" : ""}.`,
+        ...(envAvailable ? [] : [`Set ${ref.id} in the Gateway environment.`]),
+        "Docs: https://docs.openclaw.ai/tools/web",
+      ].join("\n"),
+      "Web search",
+    );
+    return applySearchKey(config, choice, ref);
+  }
+
   const keyInput = await prompter.text({
     message: keyConfigured
       ? `${entry.label} API key (leave blank to keep current)`

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -56,7 +56,7 @@ export const SEARCH_PROVIDER_OPTIONS: readonly SearchProviderEntry[] = [
   },
 ] as const;
 
-function hasKeyInEnv(entry: SearchProviderEntry): boolean {
+export function hasKeyInEnv(entry: SearchProviderEntry): boolean {
   return entry.envKeys.some((k) => Boolean(process.env[k]?.trim()));
 }
 
@@ -79,7 +79,7 @@ export function resolveExistingKey(
   }
 }
 
-function applySearchKey(
+export function applySearchKey(
   config: OpenClawConfig,
   provider: SearchProvider,
   key: string,

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -159,13 +159,11 @@ export async function setupSearch(
     if (existingProvider) {
       return existingProvider;
     }
-    if (opts?.quickstartDefaults) {
-      const detected = SEARCH_PROVIDER_OPTIONS.find(
-        (e) => Boolean(resolveExistingKey(config, e.value)) || hasKeyInEnv(e),
-      );
-      if (detected) {
-        return detected.value;
-      }
+    const detected = SEARCH_PROVIDER_OPTIONS.find(
+      (e) => Boolean(resolveExistingKey(config, e.value)) || hasKeyInEnv(e),
+    );
+    if (detected) {
+      return detected.value;
     }
     return "perplexity";
   })();

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -100,7 +100,7 @@ export function hasExistingKey(config: OpenClawConfig, provider: SearchProvider)
 /** Build an env-backed SecretRef for a search provider. */
 function buildSearchEnvRef(provider: SearchProvider): SecretRef {
   const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === provider);
-  const envVar = entry?.envKeys[0];
+  const envVar = entry?.envKeys.find((k) => Boolean(process.env[k]?.trim())) ?? entry?.envKeys[0];
   if (!envVar) {
     throw new Error(
       `No env var mapping for search provider "${provider}" in secret-input-mode=ref.`,

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -139,6 +139,19 @@ function applyProviderOnly(config: OpenClawConfig, provider: SearchProvider): Op
   };
 }
 
+function preserveDisabledState(original: OpenClawConfig, result: OpenClawConfig): OpenClawConfig {
+  if (original.tools?.web?.search?.enabled !== false) {
+    return result;
+  }
+  return {
+    ...result,
+    tools: {
+      ...result.tools,
+      web: { ...result.tools?.web, search: { ...result.tools?.web?.search, enabled: false } },
+    },
+  };
+}
+
 export type SetupSearchOptions = {
   quickstartDefaults?: boolean;
 };
@@ -203,20 +216,10 @@ export async function setupSearch(
   const envAvailable = hasKeyInEnv(entry);
 
   if (opts?.quickstartDefaults && (keyConfigured || envAvailable)) {
-    const wasDisabled = config.tools?.web?.search?.enabled === false;
-    let result = existingKey
+    const result = existingKey
       ? applySearchKey(config, choice, existingKey)
       : applyProviderOnly(config, choice);
-    if (wasDisabled) {
-      result = {
-        ...result,
-        tools: {
-          ...result.tools,
-          web: { ...result.tools?.web, search: { ...result.tools?.web?.search, enabled: false } },
-        },
-      };
-    }
-    return result;
+    return preserveDisabledState(config, result);
   }
 
   const keyInput = await prompter.text({
@@ -234,11 +237,11 @@ export async function setupSearch(
   }
 
   if (existingKey) {
-    return applySearchKey(config, choice, existingKey);
+    return preserveDisabledState(config, applySearchKey(config, choice, existingKey));
   }
 
   if (keyConfigured || envAvailable) {
-    return applyProviderOnly(config, choice);
+    return preserveDisabledState(config, applyProviderOnly(config, choice));
   }
 
   await prompter.note(

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -1,0 +1,230 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+
+type SearchProvider = "perplexity" | "brave" | "gemini" | "grok" | "kimi";
+
+type SearchProviderEntry = {
+  value: SearchProvider;
+  label: string;
+  hint: string;
+  envKeys: string[];
+  placeholder: string;
+  signupUrl: string;
+};
+
+export const SEARCH_PROVIDER_OPTIONS: readonly SearchProviderEntry[] = [
+  {
+    value: "perplexity",
+    label: "Perplexity Search",
+    hint: "Structured results · domain/language/freshness filters",
+    envKeys: ["PERPLEXITY_API_KEY"],
+    placeholder: "pplx-...",
+    signupUrl: "https://www.perplexity.ai/settings/api",
+  },
+  {
+    value: "brave",
+    label: "Brave Search",
+    hint: "Structured results · region-specific",
+    envKeys: ["BRAVE_API_KEY"],
+    placeholder: "BSA...",
+    signupUrl: "https://brave.com/search/api/",
+  },
+  {
+    value: "gemini",
+    label: "Gemini (Google Search)",
+    hint: "Google Search grounding · AI-synthesized",
+    envKeys: ["GEMINI_API_KEY"],
+    placeholder: "AIza...",
+    signupUrl: "https://aistudio.google.com/apikey",
+  },
+  {
+    value: "grok",
+    label: "Grok (xAI)",
+    hint: "xAI web-grounded responses",
+    envKeys: ["XAI_API_KEY"],
+    placeholder: "xai-...",
+    signupUrl: "https://console.x.ai/",
+  },
+  {
+    value: "kimi",
+    label: "Kimi (Moonshot)",
+    hint: "Moonshot web search",
+    envKeys: ["KIMI_API_KEY", "MOONSHOT_API_KEY"],
+    placeholder: "sk-...",
+    signupUrl: "https://platform.moonshot.cn/",
+  },
+] as const;
+
+function hasKeyInEnv(entry: SearchProviderEntry): boolean {
+  return entry.envKeys.some((k) => Boolean(process.env[k]?.trim()));
+}
+
+function resolveExistingKey(config: OpenClawConfig, provider: SearchProvider): string | undefined {
+  const search = config.tools?.web?.search;
+  switch (provider) {
+    case "brave":
+      return search?.apiKey?.trim() || undefined;
+    case "perplexity":
+      return search?.perplexity?.apiKey?.trim() || undefined;
+    case "gemini":
+      return search?.gemini?.apiKey?.trim() || undefined;
+    case "grok":
+      return search?.grok?.apiKey?.trim() || undefined;
+    case "kimi":
+      return search?.kimi?.apiKey?.trim() || undefined;
+  }
+}
+
+function applySearchKey(
+  config: OpenClawConfig,
+  provider: SearchProvider,
+  key: string,
+): OpenClawConfig {
+  const search = { ...config.tools?.web?.search, provider, enabled: true };
+  switch (provider) {
+    case "brave":
+      search.apiKey = key;
+      break;
+    case "perplexity":
+      search.perplexity = { ...search.perplexity, apiKey: key };
+      break;
+    case "gemini":
+      search.gemini = { ...search.gemini, apiKey: key };
+      break;
+    case "grok":
+      search.grok = { ...search.grok, apiKey: key };
+      break;
+    case "kimi":
+      search.kimi = { ...search.kimi, apiKey: key };
+      break;
+  }
+  return {
+    ...config,
+    tools: {
+      ...config.tools,
+      web: { ...config.tools?.web, search },
+    },
+  };
+}
+
+function applyProviderOnly(config: OpenClawConfig, provider: SearchProvider): OpenClawConfig {
+  return {
+    ...config,
+    tools: {
+      ...config.tools,
+      web: {
+        ...config.tools?.web,
+        search: {
+          ...config.tools?.web?.search,
+          provider,
+          enabled: true,
+        },
+      },
+    },
+  };
+}
+
+export type SetupSearchOptions = {
+  quickstartDefaults?: boolean;
+};
+
+export async function setupSearch(
+  config: OpenClawConfig,
+  _runtime: RuntimeEnv,
+  prompter: WizardPrompter,
+  opts?: SetupSearchOptions,
+): Promise<OpenClawConfig> {
+  await prompter.note(
+    [
+      "Web search lets your agent look things up online.",
+      "Choose a provider and paste your API key.",
+      "Docs: https://docs.openclaw.ai/tools/web",
+    ].join("\n"),
+    "Web search",
+  );
+
+  const existingProvider = config.tools?.web?.search?.provider;
+
+  const options = SEARCH_PROVIDER_OPTIONS.map((entry) => {
+    const configured = Boolean(resolveExistingKey(config, entry.value)) || hasKeyInEnv(entry);
+    const hint = configured ? `${entry.hint} · configured` : entry.hint;
+    return { value: entry.value, label: entry.label, hint };
+  });
+
+  const defaultProvider: SearchProvider = (() => {
+    if (existingProvider) {
+      return existingProvider;
+    }
+    if (opts?.quickstartDefaults) {
+      const detected = SEARCH_PROVIDER_OPTIONS.find(
+        (e) => Boolean(resolveExistingKey(config, e.value)) || hasKeyInEnv(e),
+      );
+      if (detected) {
+        return detected.value;
+      }
+    }
+    return "perplexity";
+  })();
+
+  type PickerValue = SearchProvider | "__skip__";
+  const choice = await prompter.select<PickerValue>({
+    message: "Search provider",
+    options: [
+      ...options,
+      {
+        value: "__skip__" as const,
+        label: "Skip for now",
+        hint: "Configure later with openclaw configure --section web",
+      },
+    ],
+    initialValue: defaultProvider as PickerValue,
+  });
+
+  if (choice === "__skip__") {
+    return config;
+  }
+
+  const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === choice)!;
+  const existingKey = resolveExistingKey(config, choice);
+  const envAvailable = hasKeyInEnv(entry);
+
+  if (opts?.quickstartDefaults && (existingKey || envAvailable)) {
+    return existingKey
+      ? applySearchKey(config, choice, existingKey)
+      : applyProviderOnly(config, choice);
+  }
+
+  const keyInput = await prompter.text({
+    message: existingKey
+      ? `${entry.label} API key (leave blank to keep current)`
+      : envAvailable
+        ? `${entry.label} API key (leave blank to use env var)`
+        : `${entry.label} API key`,
+    placeholder: existingKey ? "Leave blank to keep current" : entry.placeholder,
+  });
+
+  const key = keyInput?.trim() ?? "";
+  if (key) {
+    return applySearchKey(config, choice, key);
+  }
+
+  if (existingKey) {
+    return applySearchKey(config, choice, existingKey);
+  }
+
+  if (envAvailable) {
+    return applyProviderOnly(config, choice);
+  }
+
+  await prompter.note(
+    [
+      "No API key stored — web_search will stay unavailable until you add one.",
+      `Get your key at: ${entry.signupUrl}`,
+      "Docs: https://docs.openclaw.ai/tools/web",
+    ].join("\n"),
+    "Web search",
+  );
+
+  return applyProviderOnly(config, choice);
+}

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -180,7 +180,7 @@ export async function setupSearch(
   });
 
   const defaultProvider: SearchProvider = (() => {
-    if (existingProvider) {
+    if (existingProvider && SEARCH_PROVIDER_OPTIONS.some((e) => e.value === existingProvider)) {
       return existingProvider;
     }
     const detected = SEARCH_PROVIDER_OPTIONS.find(

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { normalizeSecretInputString } from "../config/types.secrets.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 
@@ -67,15 +68,15 @@ export function resolveExistingKey(
   const search = config.tools?.web?.search;
   switch (provider) {
     case "brave":
-      return search?.apiKey?.trim() || undefined;
+      return normalizeSecretInputString(search?.apiKey);
     case "perplexity":
-      return search?.perplexity?.apiKey?.trim() || undefined;
+      return normalizeSecretInputString(search?.perplexity?.apiKey);
     case "gemini":
-      return search?.gemini?.apiKey?.trim() || undefined;
+      return normalizeSecretInputString(search?.gemini?.apiKey);
     case "grok":
-      return search?.grok?.apiKey?.trim() || undefined;
+      return normalizeSecretInputString(search?.grok?.apiKey);
     case "kimi":
-      return search?.kimi?.apiKey?.trim() || undefined;
+      return normalizeSecretInputString(search?.kimi?.apiKey);
   }
 }
 

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -279,7 +279,7 @@ export async function setupSearch(
 
   await prompter.note(
     [
-      "No API key stored — web_search will stay unavailable until you add one.",
+      "No API key stored — web_search won't work until a key is available.",
       `Get your key at: ${entry.signupUrl}`,
       "Docs: https://docs.openclaw.ai/tools/web",
     ].join("\n"),
@@ -295,7 +295,6 @@ export async function setupSearch(
         search: {
           ...config.tools?.web?.search,
           provider: choice,
-          enabled: false,
         },
       },
     },

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -1,7 +1,14 @@
 import type { OpenClawConfig } from "../config/config.js";
-import { hasConfiguredSecretInput, normalizeSecretInputString } from "../config/types.secrets.js";
+import {
+  DEFAULT_SECRET_PROVIDER_ALIAS,
+  type SecretInput,
+  type SecretRef,
+  hasConfiguredSecretInput,
+  normalizeSecretInputString,
+} from "../config/types.secrets.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
+import type { SecretInputMode } from "./onboard-types.js";
 
 export type SearchProvider = "perplexity" | "brave" | "gemini" | "grok" | "kimi";
 
@@ -90,10 +97,34 @@ export function hasExistingKey(config: OpenClawConfig, provider: SearchProvider)
   return hasConfiguredSecretInput(rawKeyValue(config, provider));
 }
 
+/** Build an env-backed SecretRef for a search provider. */
+function buildSearchEnvRef(provider: SearchProvider): SecretRef {
+  const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === provider);
+  const envVar = entry?.envKeys[0];
+  if (!envVar) {
+    throw new Error(
+      `No env var mapping for search provider "${provider}" in secret-input-mode=ref.`,
+    );
+  }
+  return { source: "env", provider: DEFAULT_SECRET_PROVIDER_ALIAS, id: envVar };
+}
+
+/** Resolve a plaintext key into the appropriate SecretInput based on mode. */
+function resolveSearchSecretInput(
+  provider: SearchProvider,
+  key: string,
+  secretInputMode?: SecretInputMode,
+): SecretInput {
+  if (secretInputMode === "ref") {
+    return buildSearchEnvRef(provider);
+  }
+  return key;
+}
+
 export function applySearchKey(
   config: OpenClawConfig,
   provider: SearchProvider,
-  key: string,
+  key: SecretInput,
 ): OpenClawConfig {
   const search = { ...config.tools?.web?.search, provider, enabled: true };
   switch (provider) {
@@ -154,6 +185,7 @@ function preserveDisabledState(original: OpenClawConfig, result: OpenClawConfig)
 
 export type SetupSearchOptions = {
   quickstartDefaults?: boolean;
+  secretInputMode?: SecretInputMode;
 };
 
 export async function setupSearch(
@@ -233,7 +265,8 @@ export async function setupSearch(
 
   const key = keyInput?.trim() ?? "";
   if (key) {
-    return applySearchKey(config, choice, key);
+    const secretInput = resolveSearchSecretInput(choice, key, opts?.secretInputMode);
+    return applySearchKey(config, choice, secretInput);
   }
 
   if (existingKey) {

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -154,6 +154,7 @@ export type OnboardOptions = {
   /** @deprecated Legacy alias for `skipChannels`. */
   skipProviders?: boolean;
   skipSkills?: boolean;
+  skipSearch?: boolean;
   skipHealth?: boolean;
   skipUi?: boolean;
   nodeManager?: NodeManagerChoice;

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -70,8 +70,8 @@ describe("web search provider auto-detection", () => {
     vi.restoreAllMocks();
   });
 
-  it("falls back to brave when no keys available", () => {
-    expect(resolveSearchProvider({})).toBe("brave");
+  it("falls back to perplexity when no keys available", () => {
+    expect(resolveSearchProvider({})).toBe("perplexity");
   });
 
   it("auto-detects brave when only BRAVE_API_KEY is set", () => {
@@ -109,17 +109,19 @@ describe("web search provider auto-detection", () => {
     expect(resolveSearchProvider({})).toBe("kimi");
   });
 
-  it("follows priority order — brave wins when multiple keys available", () => {
+  it("follows priority order — perplexity wins when multiple keys available", () => {
+    process.env.PERPLEXITY_API_KEY = "test-perplexity-key";
+    process.env.BRAVE_API_KEY = "test-brave-key";
+    process.env.GEMINI_API_KEY = "test-gemini-key";
+    process.env.XAI_API_KEY = "test-xai-key";
+    expect(resolveSearchProvider({})).toBe("perplexity");
+  });
+
+  it("brave wins over gemini and grok when perplexity unavailable", () => {
     process.env.BRAVE_API_KEY = "test-brave-key";
     process.env.GEMINI_API_KEY = "test-gemini-key";
     process.env.XAI_API_KEY = "test-xai-key";
     expect(resolveSearchProvider({})).toBe("brave");
-  });
-
-  it("gemini wins over perplexity and grok when brave unavailable", () => {
-    process.env.GEMINI_API_KEY = "test-gemini-key";
-    process.env.PERPLEXITY_API_KEY = "test-perplexity-key";
-    expect(resolveSearchProvider({})).toBe("gemini");
   });
 
   it("explicit provider always wins regardless of keys", () => {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -444,7 +444,7 @@ export type ToolsConfig = {
       /** Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). */
       provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
-      apiKey?: string;
+      apiKey?: SecretInput;
       /** Default search results count (1-10). */
       maxResults?: number;
       /** Timeout in seconds for search requests. */
@@ -454,7 +454,7 @@ export type ToolsConfig = {
       /** Perplexity-specific configuration (used when provider="perplexity"). */
       perplexity?: {
         /** API key for Perplexity (defaults to PERPLEXITY_API_KEY env var). */
-        apiKey?: string;
+        apiKey?: SecretInput;
         /** @deprecated Legacy Sonar/OpenRouter field. Ignored by Search API. */
         baseUrl?: string;
         /** @deprecated Legacy Sonar/OpenRouter field. Ignored by Search API. */
@@ -463,7 +463,7 @@ export type ToolsConfig = {
       /** Grok-specific configuration (used when provider="grok"). */
       grok?: {
         /** API key for xAI (defaults to XAI_API_KEY env var). */
-        apiKey?: string;
+        apiKey?: SecretInput;
         /** Model to use (defaults to "grok-4-1-fast"). */
         model?: string;
         /** Include inline citations in response text as markdown links (default: false). */
@@ -472,14 +472,14 @@ export type ToolsConfig = {
       /** Gemini-specific configuration (used when provider="gemini"). */
       gemini?: {
         /** Gemini API key (defaults to GEMINI_API_KEY env var). */
-        apiKey?: string;
+        apiKey?: SecretInput;
         /** Model to use for grounded search (defaults to "gemini-2.5-flash"). */
         model?: string;
       };
       /** Kimi-specific configuration (used when provider="kimi"). */
       kimi?: {
         /** Moonshot/Kimi API key (defaults to KIMI_API_KEY or MOONSHOT_API_KEY env var). */
-        apiKey?: string;
+        apiKey?: SecretInput;
         /** Base URL for API requests (defaults to "https://api.moonshot.ai/v1"). */
         baseUrl?: string;
         /** Model to use (defaults to "moonshot-v1-128k"). */

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -481,23 +481,38 @@ export async function finalizeOnboardingWizard(
     const label = entry?.label ?? webSearchProvider;
     const storedKey = resolveExistingKey(nextConfig, webSearchProvider);
     const envAvailable = entry ? hasKeyInEnv(entry) : false;
+    const hasKey = Boolean(storedKey) || envAvailable;
     const keySource = storedKey
       ? "API key: stored in config."
       : envAvailable
         ? `API key: provided via ${entry?.envKeys.join(" / ")} env var.`
         : undefined;
-    await prompter.note(
-      [
-        "Web search is enabled, so your agent can look things up online when needed.",
-        "",
-        `Provider: ${label}`,
-        keySource,
-        "Docs: https://docs.openclaw.ai/tools/web",
-      ]
-        .filter(Boolean)
-        .join("\n"),
-      "Web search",
-    );
+    if (hasKey) {
+      await prompter.note(
+        [
+          "Web search is enabled, so your agent can look things up online when needed.",
+          "",
+          `Provider: ${label}`,
+          keySource,
+          "Docs: https://docs.openclaw.ai/tools/web",
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        "Web search",
+      );
+    } else {
+      await prompter.note(
+        [
+          `Provider ${label} is selected but no API key was found.`,
+          "web_search will not work until a key is added.",
+          `  ${formatCliCommand("openclaw configure --section web")}`,
+          "",
+          `Get your key at: ${entry?.signupUrl ?? "https://docs.openclaw.ai/tools/web"}`,
+          "Docs: https://docs.openclaw.ai/tools/web",
+        ].join("\n"),
+        "Web search",
+      );
+    }
   } else {
     await prompter.note(
       [

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -472,39 +472,22 @@ export async function finalizeOnboardingWizard(
     );
   }
 
-  const webSearchProvider = nextConfig.tools?.web?.search?.provider ?? "brave";
-  const webSearchKey =
-    webSearchProvider === "perplexity"
-      ? (nextConfig.tools?.web?.search?.perplexity?.apiKey ?? "").trim()
-      : (nextConfig.tools?.web?.search?.apiKey ?? "").trim();
-  const webSearchEnv =
-    webSearchProvider === "perplexity"
-      ? (process.env.PERPLEXITY_API_KEY ?? "").trim()
-      : (process.env.BRAVE_API_KEY ?? "").trim();
-  const hasWebSearchKey = Boolean(webSearchKey || webSearchEnv);
-  await prompter.note(
-    hasWebSearchKey
-      ? [
-          "Web search is enabled, so your agent can look things up online when needed.",
-          "",
-          `Provider: ${webSearchProvider === "perplexity" ? "Perplexity Search" : "Brave Search"}`,
-          webSearchKey
-            ? `API key: stored in config (tools.web.search.${webSearchProvider === "perplexity" ? "perplexity.apiKey" : "apiKey"}).`
-            : `API key: provided via ${webSearchProvider === "perplexity" ? "PERPLEXITY_API_KEY" : "BRAVE_API_KEY"} env var (Gateway environment).`,
-          "Docs: https://docs.openclaw.ai/tools/web",
-        ].join("\n")
-      : [
-          "To enable web search, your agent will need an API key for either Perplexity Search or Brave Search.",
-          "",
-          "Set it up interactively:",
-          `- Run: ${formatCliCommand("openclaw configure --section web")}`,
-          "- Choose a provider and paste your API key",
-          "",
-          "Alternative: set PERPLEXITY_API_KEY or BRAVE_API_KEY in the Gateway environment (no config changes).",
-          "Docs: https://docs.openclaw.ai/tools/web",
-        ].join("\n"),
-    "Web search (optional)",
-  );
+  const webSearchProvider = nextConfig.tools?.web?.search?.provider;
+  const webSearchEnabled = nextConfig.tools?.web?.search?.enabled;
+  if (webSearchProvider && webSearchEnabled !== false) {
+    const { SEARCH_PROVIDER_OPTIONS } = await import("../commands/onboard-search.js");
+    const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === webSearchProvider);
+    const label = entry?.label ?? webSearchProvider;
+    await prompter.note(
+      [
+        "Web search is enabled, so your agent can look things up online when needed.",
+        "",
+        `Provider: ${label}`,
+        "Docs: https://docs.openclaw.ai/tools/web",
+      ].join("\n"),
+      "Web search",
+    );
+  }
 
   await prompter.note(
     'What now: https://openclaw.ai/showcase ("What People Are Building").',

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -496,11 +496,9 @@ export async function finalizeOnboardingWizard(
           "Web search is enabled, so your agent can look things up online when needed.",
           "",
           `Provider: ${label}`,
-          keySource,
+          ...(keySource ? [keySource] : []),
           "Docs: https://docs.openclaw.ai/tools/web",
-        ]
-          .filter(Boolean)
-          .join("\n"),
+        ].join("\n"),
         "Web search",
       );
     } else if (!hasKey) {

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -527,15 +527,32 @@ export async function finalizeOnboardingWizard(
       );
     }
   } else {
-    await prompter.note(
-      [
-        "Web search was skipped. You can enable it later:",
-        `  ${formatCliCommand("openclaw configure --section web")}`,
-        "",
-        "Docs: https://docs.openclaw.ai/tools/web",
-      ].join("\n"),
-      "Web search",
+    // Legacy configs may have a working key (e.g. apiKey or BRAVE_API_KEY) without
+    // an explicit provider. Runtime auto-detects these, so avoid saying "skipped".
+    const { SEARCH_PROVIDER_OPTIONS, hasExistingKey, hasKeyInEnv } =
+      await import("../commands/onboard-search.js");
+    const legacyDetected = SEARCH_PROVIDER_OPTIONS.find(
+      (e) => hasExistingKey(nextConfig, e.value) || hasKeyInEnv(e),
     );
+    if (legacyDetected) {
+      await prompter.note(
+        [
+          `Web search is available via ${legacyDetected.label} (auto-detected).`,
+          "Docs: https://docs.openclaw.ai/tools/web",
+        ].join("\n"),
+        "Web search",
+      );
+    } else {
+      await prompter.note(
+        [
+          "Web search was skipped. You can enable it later:",
+          `  ${formatCliCommand("openclaw configure --section web")}`,
+          "",
+          "Docs: https://docs.openclaw.ai/tools/web",
+        ].join("\n"),
+        "Web search",
+      );
+    }
   }
 
   await prompter.note(

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -475,18 +475,21 @@ export async function finalizeOnboardingWizard(
   const webSearchProvider = nextConfig.tools?.web?.search?.provider;
   const webSearchEnabled = nextConfig.tools?.web?.search?.enabled;
   if (webSearchProvider && webSearchEnabled !== false) {
-    const { SEARCH_PROVIDER_OPTIONS, resolveExistingKey, hasKeyInEnv } =
+    const { SEARCH_PROVIDER_OPTIONS, resolveExistingKey, hasExistingKey, hasKeyInEnv } =
       await import("../commands/onboard-search.js");
     const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === webSearchProvider);
     const label = entry?.label ?? webSearchProvider;
     const storedKey = resolveExistingKey(nextConfig, webSearchProvider);
+    const keyConfigured = hasExistingKey(nextConfig, webSearchProvider);
     const envAvailable = entry ? hasKeyInEnv(entry) : false;
-    const hasKey = Boolean(storedKey) || envAvailable;
+    const hasKey = keyConfigured || envAvailable;
     const keySource = storedKey
       ? "API key: stored in config."
-      : envAvailable
-        ? `API key: provided via ${entry?.envKeys.join(" / ")} env var.`
-        : undefined;
+      : keyConfigured
+        ? "API key: configured via secret reference."
+        : envAvailable
+          ? `API key: provided via ${entry?.envKeys.join(" / ")} env var.`
+          : undefined;
     if (hasKey) {
       await prompter.note(
         [

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -487,6 +487,16 @@ export async function finalizeOnboardingWizard(
       ].join("\n"),
       "Web search",
     );
+  } else {
+    await prompter.note(
+      [
+        "Web search was skipped. You can enable it later:",
+        `  ${formatCliCommand("openclaw configure --section web")}`,
+        "",
+        "Docs: https://docs.openclaw.ai/tools/web",
+      ].join("\n"),
+      "Web search",
+    );
   }
 
   await prompter.note(

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -474,7 +474,7 @@ export async function finalizeOnboardingWizard(
 
   const webSearchProvider = nextConfig.tools?.web?.search?.provider;
   const webSearchEnabled = nextConfig.tools?.web?.search?.enabled;
-  if (webSearchProvider && webSearchEnabled !== false) {
+  if (webSearchProvider) {
     const { SEARCH_PROVIDER_OPTIONS, resolveExistingKey, hasExistingKey, hasKeyInEnv } =
       await import("../commands/onboard-search.js");
     const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === webSearchProvider);
@@ -490,7 +490,7 @@ export async function finalizeOnboardingWizard(
         : envAvailable
           ? `API key: provided via ${entry?.envKeys.join(" / ")} env var.`
           : undefined;
-    if (hasKey) {
+    if (webSearchEnabled !== false && hasKey) {
       await prompter.note(
         [
           "Web search is enabled, so your agent can look things up online when needed.",
@@ -503,7 +503,7 @@ export async function finalizeOnboardingWizard(
           .join("\n"),
         "Web search",
       );
-    } else {
+    } else if (!hasKey) {
       await prompter.note(
         [
           `Provider ${label} is selected but no API key was found.`,
@@ -511,6 +511,16 @@ export async function finalizeOnboardingWizard(
           `  ${formatCliCommand("openclaw configure --section web")}`,
           "",
           `Get your key at: ${entry?.signupUrl ?? "https://docs.openclaw.ai/tools/web"}`,
+          "Docs: https://docs.openclaw.ai/tools/web",
+        ].join("\n"),
+        "Web search",
+      );
+    } else {
+      await prompter.note(
+        [
+          `Web search (${label}) is configured but disabled.`,
+          `Re-enable: ${formatCliCommand("openclaw configure --section web")}`,
+          "",
           "Docs: https://docs.openclaw.ai/tools/web",
         ].join("\n"),
         "Web search",

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -475,16 +475,27 @@ export async function finalizeOnboardingWizard(
   const webSearchProvider = nextConfig.tools?.web?.search?.provider;
   const webSearchEnabled = nextConfig.tools?.web?.search?.enabled;
   if (webSearchProvider && webSearchEnabled !== false) {
-    const { SEARCH_PROVIDER_OPTIONS } = await import("../commands/onboard-search.js");
+    const { SEARCH_PROVIDER_OPTIONS, resolveExistingKey, hasKeyInEnv } =
+      await import("../commands/onboard-search.js");
     const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === webSearchProvider);
     const label = entry?.label ?? webSearchProvider;
+    const storedKey = resolveExistingKey(nextConfig, webSearchProvider);
+    const envAvailable = entry ? hasKeyInEnv(entry) : false;
+    const keySource = storedKey
+      ? "API key: stored in config."
+      : envAvailable
+        ? `API key: provided via ${entry?.envKeys.join(" / ")} env var.`
+        : undefined;
     await prompter.note(
       [
         "Web search is enabled, so your agent can look things up online when needed.",
         "",
         `Provider: ${label}`,
+        keySource,
         "Docs: https://docs.openclaw.ai/tools/web",
-      ].join("\n"),
+      ]
+        .filter(Boolean)
+        .join("\n"),
       "Web search",
     );
   } else {

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -31,8 +31,8 @@ const configureGatewayForOnboarding = vi.hoisted(() =>
 );
 const finalizeOnboardingWizard = vi.hoisted(() =>
   vi.fn(async (options) => {
-    if (!process.env.BRAVE_API_KEY) {
-      await options.prompter.note("hint", "Web search (optional)");
+    if (!options.nextConfig?.tools?.web?.search?.provider) {
+      await options.prompter.note("Web search was skipped.", "Web search");
     }
 
     if (options.opts.skipUi) {
@@ -263,6 +263,7 @@ describe("runOnboardingWizard", () => {
           installDaemon: false,
           skipProviders: true,
           skipSkills: true,
+          skipSearch: true,
           skipHealth: true,
           skipUi: true,
         },
@@ -291,6 +292,7 @@ describe("runOnboardingWizard", () => {
         installDaemon: false,
         skipProviders: true,
         skipSkills: true,
+        skipSearch: true,
         skipHealth: true,
         skipUi: true,
       },
@@ -335,6 +337,7 @@ describe("runOnboardingWizard", () => {
         authChoice: "skip",
         skipProviders: true,
         skipSkills: true,
+        skipSearch: true,
         skipHealth: true,
         installDaemon: false,
       },
@@ -375,6 +378,7 @@ describe("runOnboardingWizard", () => {
           installDaemon: false,
           skipProviders: true,
           skipSkills: true,
+          skipSearch: true,
           skipHealth: true,
           skipUi: true,
         },
@@ -384,7 +388,7 @@ describe("runOnboardingWizard", () => {
 
       const calls = (note as unknown as { mock: { calls: unknown[][] } }).mock.calls;
       expect(calls.length).toBeGreaterThan(0);
-      expect(calls.some((call) => call?.[1] === "Web search (optional)")).toBe(true);
+      expect(calls.some((call) => call?.[1] === "Web search")).toBe(true);
     } finally {
       if (prevBraveKey === undefined) {
         delete process.env.BRAVE_API_KEY;
@@ -440,6 +444,7 @@ describe("runOnboardingWizard", () => {
           installDaemon: false,
           skipProviders: true,
           skipSkills: true,
+          skipSearch: true,
           skipHealth: true,
           skipUi: true,
         },
@@ -476,6 +481,7 @@ describe("runOnboardingWizard", () => {
         installDaemon: false,
         skipProviders: true,
         skipSkills: true,
+        skipSearch: true,
         skipHealth: true,
         skipUi: true,
         secretInputMode: "ref",

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -512,6 +512,15 @@ export async function runOnboardingWizard(
     skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
   });
 
+  if (opts.skipSearch) {
+    await prompter.note("Skipping search setup.", "Search");
+  } else {
+    const { setupSearch } = await import("../commands/onboard-search.js");
+    nextConfig = await setupSearch(nextConfig, runtime, prompter, {
+      quickstartDefaults: flow === "quickstart",
+    });
+  }
+
   if (opts.skipSkills) {
     await prompter.note("Skipping skills setup.", "Skills");
   } else {

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -518,6 +518,7 @@ export async function runOnboardingWizard(
     const { setupSearch } = await import("../commands/onboard-search.js");
     nextConfig = await setupSearch(nextConfig, runtime, prompter, {
       quickstartDefaults: flow === "quickstart",
+      secretInputMode: opts.secretInputMode,
     });
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** Onboarding wizard had no search provider step, users had to run `openclaw configure --section web` post-setup, and even that only offered Perplexity and Brave despite 5 providers being supported.
- **Why it matters:** Search is a core agent capability; it should be a first-class onboarding step like model and channel selection.
- **What changed:** Added a search provider selection step (Perplexity, Brave, Gemini, Grok, Kimi) to both QuickStart and Advanced onboarding flows; updated the configure wizard to show all 5 providers. Runtime search provider auto-detection priority updated to match onboarding UI order
- **What did NOT change (scope boundary):** Tool execution logic, config schema, and existing provider implementations are untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Comments from https://github.com/openclaw/openclaw/pull/33822, this is a follow up PR

## User-visible / Behavior Changes

- Onboarding now prompts for a search provider between the channel and skills steps.
- All 5 supported providers shown
- QuickStart auto-detects provider from env vars and skips key prompt if a key is already available.
- `openclaw configure --section web` now shows all 5 providers instead of just Brave and Perplexity.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`: same pattern as existing key prompts (plaintext text input, stored in config)
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.3.0)
- Runtime/container: Node 20 / Bun

### Steps

1. `pnpm openclaw onboard --reset` → verify search step appears after channels
2. Select a provider → enter key → confirm it's stored in config
3. `pnpm openclaw configure --section web` → verify all 5 providers listed

### Expected

- Search provider picker with 5 options + Skip
- Key stored under the correct config path per provider

### Actual

- Matches expected

## Evidence

- [x] Failing test/log before + passing after
- 10 new tests in `onboard-search.test.ts` (all pass)
- 2 existing `configure.wizard.test.ts` tests still pass
- `pnpm build` + `pnpm check` clean

## Human Verification (required)

| Screenshots |  |
|---|---|
| ![](https://github.com/user-attachments/assets/cea9e8f6-0852-4c43-9c84-78296bc42dff) | ![](https://github.com/user-attachments/assets/2223db69-c97b-4231-9bfc-82510108090a) |
| ![](https://github.com/user-attachments/assets/92596748-dd7d-4dd3-bb0c-ef0f005bdbe9) | ![](https://github.com/user-attachments/assets/75a77f16-2a57-4ab3-bba7-c06a487b80ab) |
| ![](https://github.com/user-attachments/assets/1c77c1a7-608c-456e-86ac-f9e71945a0b3) |  |

- Verified scenarios: Build, lint, all affected tests pass
- Edge cases checked: Skip flow, blank key with existing key, env var auto-detect in quickstart
- What you did **not** verify: Full interactive onboarding end-to-end on a fresh machine

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`: uses existing config paths and env vars
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit or pass `--skip-search` (new flag on `OnboardOptions`) to skip the step
- Files/config to restore: `src/wizard/onboarding.ts`, `src/commands/configure.wizard.ts`
- Known bad symptoms reviewers should watch for: Onboarding hanging at search step, config file missing `tools.web.search` after selection

## Risks and Mitigations

- Risk: Onboarding flow is slightly longer
  - Mitigation: "Skip for now" option always available, not a concern