### PR TITLE
fix(tui): normalize session key to lowercase to match gateway canonicalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI/session-key canonicalization: normalize `openclaw tui --session` values to lowercase so uppercase session names no longer drop real-time streaming updates due to gateway/TUI key mismatches. (#33866, #34013) thanks @lynnzc.
 - Outbound/send config threading: pass resolved SecretRef config through outbound adapters and helper send paths so send flows do not reload unresolved runtime config. (#33987) Thanks @joshavant.
 - Sessions/subagent attachments: remove `attachments[].content.maxLength` from `sessions_spawn` schema to avoid llama.cpp GBNF repetition overflow, and preflight UTF-8 byte size before buffer allocation while keeping runtime file-size enforcement unchanged. (#33648) Thanks @anisoptera.
 - Runtime/tool-state stability: recover from dangling Anthropic `tool_use` after compaction, serialize long-running Discord handler runs without blocking new inbound events, and prevent stale busy snapshots from suppressing stuck-channel recovery. (from #33630, #33583) Thanks @kevinWangSheng and @theotarr.

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -74,6 +74,27 @@ describe("resolveTuiSessionKey", () => {
       }),
     ).toBe("agent:ops:incident");
   });
+
+  it("lowercases session keys with uppercase characters", () => {
+    // Uppercase in agent-prefixed form
+    expect(
+      resolveTuiSessionKey({
+        raw: "agent:main:Test1",
+        sessionScope: "global",
+        currentAgentId: "main",
+        sessionMainKey: "agent:main:main",
+      }),
+    ).toBe("agent:main:test1");
+    // Uppercase in bare form (prefixed by currentAgentId)
+    expect(
+      resolveTuiSessionKey({
+        raw: "Test1",
+        sessionScope: "global",
+        currentAgentId: "main",
+        sessionMainKey: "agent:main:main",
+      }),
+    ).toBe("agent:main:test1");
+  });
 });
 
 describe("resolveGatewayDisconnectState", () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -203,9 +203,9 @@ export function resolveTuiSessionKey(params: {
     return trimmed;
   }
   if (trimmed.startsWith("agent:")) {
-    return trimmed;
+    return trimmed.toLowerCase();
   }
-  return `agent:${params.currentAgentId}:${trimmed}`;
+  return `agent:${params.currentAgentId}:${trimmed.toLowerCase()}`;
 }
 
 export function resolveGatewayDisconnectState(reason?: string): {


### PR DESCRIPTION
Fixes #33866

## What's happening

Launching the TUI with an uppercase session name (e.g. `--session agent:main:Test1`) causes all real-time events to be silently dropped. The screen stays blank while the agent processes the message, but history shows up correctly on restart.

The root cause is a mismatch between two functions:

- `resolveSessionStoreKey` (gateway side) always canonicalizes keys to lowercase before storing and emitting events
- `resolveTuiSessionKey` (TUI side) was returning the raw user input unchanged, preserving original casing

So the TUI subscribes under `"agent:main:Test1"` while the gateway emits under `"agent:main:test1"` — no match, no events.

Messages were saved correctly because the write path also goes through `resolveSessionStoreKey`, which is why history appeared on restart. Only the live event stream was broken.

## Fix

Lowercase the returned key on the two return paths in `resolveTuiSessionKey` that previously preserved original casing. The empty-input path via `buildAgentMainSessionKey` already normalizes through `normalizeAgentId`/`normalizeMainKey`, so that path is unchanged.

## Testing

Added two test cases to `tui.test.ts` covering the exact scenario from the issue report — both the `agent:`-prefixed form and the bare form with uppercase characters.

All 20 tests pass.