### PR TITLE
refactor: extract Telegram config repair logic to separate module

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -2,11 +2,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { ZodIssue } from "zod";
 import { normalizeChatChannelId } from "../channels/registry.js";
-import {
-  isNumericTelegramUserId,
-  normalizeTelegramAllowFromEntry,
-} from "../channels/telegram/allow-from.js";
-import { fetchTelegramChatId } from "../channels/telegram/api.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { CONFIG_PATH, migrateLegacyConfig, readConfigFileSnapshot } from "../config/config.js";
@@ -44,9 +39,12 @@ import {
   isMattermostMutableAllowEntry,
   isSlackMutableAllowEntry,
 } from "../security/mutable-allowlist-detectors.js";
-import { listTelegramAccountIds, resolveTelegramAccount } from "../telegram/accounts.js";
 import { note } from "../terminal/note.js";
 import { isRecord, resolveHomeDir } from "../utils.js";
+import {
+  maybeRepairTelegramAllowFromUsernames,
+  scanTelegramAllowFromUsernameEntries,
+} from "./doctor-config-telegram.js";
 import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
 import { autoMigrateLegacyStateDir } from "./doctor-state-migrations.js";
@@ -201,14 +199,6 @@ function noteIncludeConfinementWarning(snapshot: {
   );
 }
 
-type TelegramAllowFromUsernameHit = { path: string; entry: string };
-
-type TelegramAllowFromListRef = {
-  pathLabel: string;
-  holder: Record<string, unknown>;
-  key: "allowFrom" | "groupAllowFrom";
-};
-
 function asObjectRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
@@ -357,234 +347,6 @@ export function collectMissingExplicitDefaultAccountWarnings(cfg: OpenClawConfig
   }
 
   return warnings;
-}
-
-function collectTelegramAccountScopes(
-  cfg: OpenClawConfig,
-): Array<{ prefix: string; account: Record<string, unknown> }> {
-  const scopes: Array<{ prefix: string; account: Record<string, unknown> }> = [];
-  const telegram = asObjectRecord(cfg.channels?.telegram);
-  if (!telegram) {
-    return scopes;
-  }
-
-  scopes.push({ prefix: "channels.telegram", account: telegram });
-  const accounts = asObjectRecord(telegram.accounts);
-  if (!accounts) {
-    return scopes;
-  }
-  for (const key of Object.keys(accounts)) {
-    const account = asObjectRecord(accounts[key]);
-    if (!account) {
-      continue;
-    }
-    scopes.push({ prefix: `channels.telegram.accounts.${key}`, account });
-  }
-
-  return scopes;
-}
-
-function collectTelegramAllowFromLists(
-  prefix: string,
-  account: Record<string, unknown>,
-): TelegramAllowFromListRef[] {
-  const refs: TelegramAllowFromListRef[] = [
-    { pathLabel: `${prefix}.allowFrom`, holder: account, key: "allowFrom" },
-    { pathLabel: `${prefix}.groupAllowFrom`, holder: account, key: "groupAllowFrom" },
-  ];
-  const groups = asObjectRecord(account.groups);
-  if (!groups) {
-    return refs;
-  }
-
-  for (const groupId of Object.keys(groups)) {
-    const group = asObjectRecord(groups[groupId]);
-    if (!group) {
-      continue;
-    }
-    refs.push({
-      pathLabel: `${prefix}.groups.${groupId}.allowFrom`,
-      holder: group,
-      key: "allowFrom",
-    });
-    const topics = asObjectRecord(group.topics);
-    if (!topics) {
-      continue;
-    }
-    for (const topicId of Object.keys(topics)) {
-      const topic = asObjectRecord(topics[topicId]);
-      if (!topic) {
-        continue;
-      }
-      refs.push({
-        pathLabel: `${prefix}.groups.${groupId}.topics.${topicId}.allowFrom`,
-        holder: topic,
-        key: "allowFrom",
-      });
-    }
-  }
-  return refs;
-}
-
-function scanTelegramAllowFromUsernameEntries(cfg: OpenClawConfig): TelegramAllowFromUsernameHit[] {
-  const hits: TelegramAllowFromUsernameHit[] = [];
-
-  const scanList = (pathLabel: string, list: unknown) => {
-    if (!Array.isArray(list)) {
-      return;
-    }
-    for (const entry of list) {
-      const normalized = normalizeTelegramAllowFromEntry(entry);
-      if (!normalized || normalized === "*") {
-        continue;
-      }
-      if (isNumericTelegramUserId(normalized)) {
-        continue;
-      }
-      hits.push({ path: pathLabel, entry: String(entry).trim() });
-    }
-  };
-
-  for (const scope of collectTelegramAccountScopes(cfg)) {
-    for (const ref of collectTelegramAllowFromLists(scope.prefix, scope.account)) {
-      scanList(ref.pathLabel, ref.holder[ref.key]);
-    }
-  }
-
-  return hits;
-}
-
-async function maybeRepairTelegramAllowFromUsernames(cfg: OpenClawConfig): Promise<{
-  config: OpenClawConfig;
-  changes: string[];
-}> {
-  const hits = scanTelegramAllowFromUsernameEntries(cfg);
-  if (hits.length === 0) {
-    return { config: cfg, changes: [] };
-  }
-
-  const tokens = Array.from(
-    new Set(
-      listTelegramAccountIds(cfg)
-        .map((accountId) => resolveTelegramAccount({ cfg, accountId }))
-        .map((account) => (account.tokenSource === "none" ? "" : account.token))
-        .map((token) => token.trim())
-        .filter(Boolean),
-    ),
-  );
-
-  if (tokens.length === 0) {
-    return {
-      config: cfg,
-      changes: [
-        `- Telegram allowFrom contains @username entries, but no Telegram bot token is configured; cannot auto-resolve (run onboarding or replace with numeric sender IDs).`,
-      ],
-    };
-  }
-
-  const resolveUserId = async (raw: string): Promise<string | null> => {
-    const trimmed = raw.trim();
-    if (!trimmed) {
-      return null;
-    }
-    const stripped = normalizeTelegramAllowFromEntry(trimmed);
-    if (!stripped || stripped === "*") {
-      return null;
-    }
-    if (isNumericTelegramUserId(stripped)) {
-      return stripped;
-    }
-    if (/\s/.test(stripped)) {
-      return null;
-    }
-    const username = stripped.startsWith("@") ? stripped : `@${stripped}`;
-    for (const token of tokens) {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 4000);
-      try {
-        const id = await fetchTelegramChatId({
-          token,
-          chatId: username,
-          signal: controller.signal,
-        });
-        if (id) {
-          return id;
-        }
-      } catch {
-        // ignore and try next token
-      } finally {
-        clearTimeout(timeout);
-      }
-    }
-    return null;
-  };
-
-  const changes: string[] = [];
-  const next = structuredClone(cfg);
-
-  const repairList = async (pathLabel: string, holder: Record<string, unknown>, key: string) => {
-    const raw = holder[key];
-    if (!Array.isArray(raw)) {
-      return;
-    }
-    const out: Array<string | number> = [];
-    const replaced: Array<{ from: string; to: string }> = [];
-    for (const entry of raw) {
-      const normalized = normalizeTelegramAllowFromEntry(entry);
-      if (!normalized) {
-        continue;
-      }
-      if (normalized === "*") {
-        out.push("*");
-        continue;
-      }
-      if (isNumericTelegramUserId(normalized)) {
-        out.push(normalized);
-        continue;
-      }
-      const resolved = await resolveUserId(String(entry));
-      if (resolved) {
-        out.push(resolved);
-        replaced.push({ from: String(entry).trim(), to: resolved });
-      } else {
-        out.push(String(entry).trim());
-      }
-    }
-    const deduped: Array<string | number> = [];
-    const seen = new Set<string>();
-    for (const entry of out) {
-      const k = String(entry).trim();
-      if (!k || seen.has(k)) {
-        continue;
-      }
-      seen.add(k);
-      deduped.push(entry);
-    }
-    holder[key] = deduped;
-    if (replaced.length > 0) {
-      for (const rep of replaced.slice(0, 5)) {
-        changes.push(`- ${pathLabel}: resolved ${rep.from} -> ${rep.to}`);
-      }
-      if (replaced.length > 5) {
-        changes.push(`- ${pathLabel}: resolved ${replaced.length - 5} more @username entries`);
-      }
-    }
-  };
-
-  const repairAccount = async (prefix: string, account: Record<string, unknown>) => {
-    for (const ref of collectTelegramAllowFromLists(prefix, account)) {
-      await repairList(ref.pathLabel, ref.holder, ref.key);
-    }
-  };
-
-  for (const scope of collectTelegramAccountScopes(next)) {
-    await repairAccount(scope.prefix, scope.account);
-  }
-
-  if (changes.length === 0) {
-    return { config: cfg, changes: [] };
-  }
-  return { config: next, changes };
 }
 
 type DiscordNumericIdHit = { path: string; entry: number };

--- a/src/commands/doctor-config-telegram.ts
+++ b/src/commands/doctor-config-telegram.ts
@@ -1,0 +1,253 @@
+import {
+  isNumericTelegramUserId,
+  normalizeTelegramAllowFromEntry,
+} from "../channels/telegram/allow-from.js";
+import { fetchTelegramChatId } from "../channels/telegram/api.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { listTelegramAccountIds, resolveTelegramAccount } from "../telegram/accounts.js";
+
+type TelegramAllowFromUsernameHit = { path: string; entry: string };
+
+type TelegramAllowFromListRef = {
+  pathLabel: string;
+  holder: Record<string, unknown>;
+  key: string;
+};
+
+function asObjectRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+export function collectTelegramAccountScopes(
+  cfg: OpenClawConfig,
+): Array<{ prefix: string; account: Record<string, unknown> }> {
+  const scopes: Array<{ prefix: string; account: Record<string, unknown> }> = [];
+  const telegram = asObjectRecord(cfg.channels?.telegram);
+  if (!telegram) {
+    return scopes;
+  }
+
+  scopes.push({ prefix: "channels.telegram", account: telegram });
+  const accounts = asObjectRecord(telegram.accounts);
+  if (!accounts) {
+    return scopes;
+  }
+  for (const key of Object.keys(accounts)) {
+    const account = asObjectRecord(accounts[key]);
+    if (!account) {
+      continue;
+    }
+    scopes.push({ prefix: `channels.telegram.accounts.${key}`, account });
+  }
+
+  return scopes;
+}
+
+export function collectTelegramAllowFromLists(
+  prefix: string,
+  account: Record<string, unknown>,
+): TelegramAllowFromListRef[] {
+  const refs: TelegramAllowFromListRef[] = [
+    { pathLabel: `${prefix}.allowFrom`, holder: account, key: "allowFrom" },
+    { pathLabel: `${prefix}.groupAllowFrom`, holder: account, key: "groupAllowFrom" },
+  ];
+  const groups = asObjectRecord(account.groups);
+  if (!groups) {
+    return refs;
+  }
+
+  for (const groupId of Object.keys(groups)) {
+    const group = asObjectRecord(groups[groupId]);
+    if (!group) {
+      continue;
+    }
+    refs.push({
+      pathLabel: `${prefix}.groups.${groupId}.allowFrom`,
+      holder: group,
+      key: "allowFrom",
+    });
+    const topics = asObjectRecord(group.topics);
+    if (!topics) {
+      continue;
+    }
+    for (const topicId of Object.keys(topics)) {
+      const topic = asObjectRecord(topics[topicId]);
+      if (!topic) {
+        continue;
+      }
+      refs.push({
+        pathLabel: `${prefix}.groups.${groupId}.topics.${topicId}.allowFrom`,
+        holder: topic,
+        key: "allowFrom",
+      });
+    }
+  }
+
+  return refs;
+}
+
+export function scanTelegramAllowFromUsernameEntries(
+  cfg: OpenClawConfig,
+): TelegramAllowFromUsernameHit[] {
+  const hits: TelegramAllowFromUsernameHit[] = [];
+
+  const scanList = (pathLabel: string, list: unknown) => {
+    if (!Array.isArray(list)) {
+      return;
+    }
+    for (const entry of list) {
+      const normalized = normalizeTelegramAllowFromEntry(entry);
+      if (!normalized || normalized === "*") {
+        continue;
+      }
+      if (isNumericTelegramUserId(normalized)) {
+        continue;
+      }
+      hits.push({ path: pathLabel, entry: String(entry).trim() });
+    }
+  };
+
+  for (const scope of collectTelegramAccountScopes(cfg)) {
+    for (const ref of collectTelegramAllowFromLists(scope.prefix, scope.account)) {
+      scanList(ref.pathLabel, ref.holder[ref.key]);
+    }
+  }
+
+  return hits;
+}
+
+export async function maybeRepairTelegramAllowFromUsernames(cfg: OpenClawConfig): Promise<{
+  config: OpenClawConfig;
+  changes: string[];
+}> {
+  const hits = scanTelegramAllowFromUsernameEntries(cfg);
+  if (hits.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+
+  const tokens = Array.from(
+    new Set(
+      listTelegramAccountIds(cfg)
+        .map((accountId) => resolveTelegramAccount({ cfg, accountId }))
+        .map((account) => (account.tokenSource === "none" ? "" : account.token))
+        .map((token) => token.trim())
+        .filter(Boolean),
+    ),
+  );
+
+  if (tokens.length === 0) {
+    return {
+      config: cfg,
+      changes: [
+        `- Telegram allowFrom contains @username entries, but no Telegram bot token is configured; cannot auto-resolve (run onboarding or replace with numeric sender IDs).`,
+      ],
+    };
+  }
+
+  const resolveUserId = async (raw: string): Promise<string | null> => {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const stripped = normalizeTelegramAllowFromEntry(trimmed);
+    if (!stripped || stripped === "*") {
+      return null;
+    }
+    if (isNumericTelegramUserId(stripped)) {
+      return stripped;
+    }
+    if (/\s/.test(stripped)) {
+      return null;
+    }
+    const username = stripped.startsWith("@") ? stripped : `@${stripped}`;
+    for (const token of tokens) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 4000);
+      try {
+        const id = await fetchTelegramChatId({
+          token,
+          chatId: username,
+          signal: controller.signal,
+        });
+        if (id) {
+          return id;
+        }
+      } catch {
+        // ignore and try next token
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+    return null;
+  };
+
+  const changes: string[] = [];
+  const next = structuredClone(cfg);
+
+  const repairList = async (pathLabel: string, holder: Record<string, unknown>, key: string) => {
+    const raw = holder[key];
+    if (!Array.isArray(raw)) {
+      return;
+    }
+    const out: Array<string | number> = [];
+    const replaced: Array<{ from: string; to: string }> = [];
+    for (const entry of raw) {
+      const normalized = normalizeTelegramAllowFromEntry(entry);
+      if (!normalized) {
+        continue;
+      }
+      if (normalized === "*") {
+        out.push("*");
+        continue;
+      }
+      if (isNumericTelegramUserId(normalized)) {
+        out.push(normalized);
+        continue;
+      }
+      const resolved = await resolveUserId(String(entry));
+      if (resolved) {
+        out.push(resolved);
+        replaced.push({ from: String(entry).trim(), to: resolved });
+      } else {
+        out.push(String(entry).trim());
+      }
+    }
+    const deduped: Array<string | number> = [];
+    const seen = new Set<string>();
+    for (const entry of out) {
+      const k = String(entry).trim();
+      if (!k || seen.has(k)) {
+        continue;
+      }
+      seen.add(k);
+      deduped.push(entry);
+    }
+    holder[key] = deduped;
+    if (replaced.length > 0) {
+      for (const rep of replaced.slice(0, 5)) {
+        changes.push(`- ${pathLabel}: resolved ${rep.from} -> ${rep.to}`);
+      }
+      if (replaced.length > 5) {
+        changes.push(`- ${pathLabel}: resolved ${replaced.length - 5} more @username entries`);
+      }
+    }
+  };
+
+  const repairAccount = async (prefix: string, account: Record<string, unknown>) => {
+    for (const ref of collectTelegramAllowFromLists(prefix, account)) {
+      await repairList(ref.pathLabel, ref.holder, ref.key);
+    }
+  };
+
+  for (const scope of collectTelegramAccountScopes(next)) {
+    await repairAccount(scope.prefix, scope.account);
+  }
+
+  if (changes.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+  return { config: next, changes };
+}


### PR DESCRIPTION
## Summary
Extracted Telegram-related config validation and repair functions from the large `doctor-config-flow.ts` file (2106 lines) into a new dedicated module `doctor-config-telegram.ts` (253 lines).

## Changes
- Created `src/commands/doctor-config-telegram.ts` with Telegram-specific functions:
  - `collectTelegramAccountScopes`
  - `collectTelegramAllowFromLists`
  - `scanTelegramAllowFromUsernameEntries`
  - `maybeRepairTelegramAllowFromUsernames`
- Updated `doctor-config-flow.ts` to import and use the extracted functions
- Reduced `doctor-config-flow.ts` from 2106 lines to 1865 lines

## Testing
✅ All existing tests pass without modification

## Impact
- Improved code organization and maintainability
- Easier to navigate and modify Telegram-specific logic
- No functional changes or breaking changes
- First step towards further modularization of the doctor config flow

## Related
This addresses the code quality issue of having an overly large file (>2000 lines) by extracting cohesive, platform-specific logic into dedicated modules.