### PR TITLE
fix: guard googlechat config normalization and webhook bearer parsing (closes #33256)

### DIFF
--- a/extensions/googlechat/src/accounts.ts
+++ b/extensions/googlechat/src/accounts.ts
@@ -17,9 +17,16 @@ export type ResolvedGoogleChatAccount = {
 const ENV_SERVICE_ACCOUNT = "GOOGLE_CHAT_SERVICE_ACCOUNT";
 const ENV_SERVICE_ACCOUNT_FILE = "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE";
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
 function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
-  const accounts = cfg.channels?.["googlechat"]?.accounts;
-  if (!accounts || typeof accounts !== "object") {
+  const accounts = asRecord(cfg.channels?.["googlechat"]?.accounts);
+  if (!accounts) {
     return [];
   }
   return Object.keys(accounts).filter(Boolean);
@@ -49,20 +56,17 @@ function resolveAccountConfig(
   cfg: OpenClawConfig,
   accountId: string,
 ): GoogleChatAccountConfig | undefined {
-  const accounts = cfg.channels?.["googlechat"]?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return undefined;
-  }
-  return accounts[accountId];
+  const accounts = asRecord(cfg.channels?.["googlechat"]?.accounts);
+  return asRecord(accounts?.[accountId]) as GoogleChatAccountConfig | undefined;
 }
 
 function mergeGoogleChatAccountConfig(
   cfg: OpenClawConfig,
   accountId: string,
 ): GoogleChatAccountConfig {
-  const raw = cfg.channels?.["googlechat"] ?? {};
+  const raw = asRecord(cfg.channels?.["googlechat"]) ?? {};
   const { accounts: _ignored, defaultAccount: _ignored2, ...base } = raw;
-  const account = resolveAccountConfig(cfg, accountId) ?? {};
+  const account = asRecord(resolveAccountConfig(cfg, accountId)) ?? {};
   return { ...base, ...account } as GoogleChatAccountConfig;
 }
 

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -155,6 +155,11 @@ function normalizeAudienceType(value?: string | null): GoogleChatAudienceType | 
   return undefined;
 }
 
+function parseBearer(value: unknown): string {
+  const header = typeof value === "string" ? value : "";
+  return header.toLowerCase().startsWith("bearer ") ? header.slice("bearer ".length).trim() : "";
+}
+
 export async function handleGoogleChatWebhookRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -173,10 +178,7 @@ export async function handleGoogleChatWebhookRequest(
     return true;
   }
 
-  const authHeader = String(req.headers.authorization ?? "");
-  const bearer = authHeader.toLowerCase().startsWith("bearer ")
-    ? authHeader.slice("bearer ".length)
-    : "";
+  let effectiveBearer = parseBearer(req.headers?.authorization);
 
   const body = await readJsonBody(req, 1024 * 1024);
   if (!body.ok) {
@@ -215,9 +217,9 @@ export async function handleGoogleChatWebhookRequest(
     };
 
     // For Add-ons, the bearer token may be in authorizationEventObject.systemIdToken
-    const systemIdToken = rawObj.authorizationEventObject?.systemIdToken;
-    if (!bearer && systemIdToken) {
-      Object.assign(req.headers, { authorization: `Bearer ${systemIdToken}` });
+    const systemIdToken = rawObj.authorizationEventObject?.systemIdToken?.trim();
+    if (!effectiveBearer && systemIdToken) {
+      effectiveBearer = systemIdToken;
     }
   }
 
@@ -242,12 +244,6 @@ export async function handleGoogleChatWebhookRequest(
       return true;
     }
   }
-
-  // Re-extract bearer in case it was updated from Add-on format
-  const authHeaderNow = String(req.headers.authorization ?? "");
-  const effectiveBearer = authHeaderNow.toLowerCase().startsWith("bearer ")
-    ? authHeaderNow.slice("bearer ".length)
-    : bearer;
 
   let selected: WebhookTarget | undefined;
   for (const target of targets) {


### PR DESCRIPTION
Closes #33256

## Problem
Google Chat startup/status-probe paths could touch channel config as objects even when config nodes were null/invalid, causing runtime object-conversion failures. In Add-ons webhook flow, bearer extraction also depended on mutating request headers, which could cascade into false 401 outcomes.

## Fix
- Added strict object guards before Google Chat account/config key iteration and merge.
- Unified bearer parsing in webhook handler and read Add-ons systemIdToken directly without header mutation.
- Kept behavior unchanged for valid configs while preventing null/undefined object conversion crashes.