### PR TITLE
plugins: avoid peer auto-install dependency bloat

### DIFF
--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -10,6 +10,11 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.2"
   },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -7,6 +7,11 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.2"
   },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -126,7 +126,7 @@ export async function installPackageDir(params: {
     await sanitizeManifestForNpmInstall(params.targetDir);
     params.logger?.info?.(params.depsLogMessage);
     const npmRes = await runCommandWithTimeout(
-      ["npm", "install", "--omit=dev", "--silent", "--ignore-scripts"],
+      ["npm", "install", "--omit=dev", "--omit=peer", "--silent", "--ignore-scripts"],
       {
         timeoutMs: Math.max(params.timeoutMs, 300_000),
         cwd: params.targetDir,

--- a/src/test-utils/exec-assertions.ts
+++ b/src/test-utils/exec-assertions.ts
@@ -11,7 +11,14 @@ export function expectSingleNpmInstallIgnoreScriptsCall(params: {
     throw new Error("expected npm install call");
   }
   const [argv, opts] = first;
-  expect(argv).toEqual(["npm", "install", "--omit=dev", "--silent", "--ignore-scripts"]);
+  expect(argv).toEqual([
+    "npm",
+    "install",
+    "--omit=dev",
+    "--omit=peer",
+    "--silent",
+    "--ignore-scripts",
+  ]);
   expect(opts?.cwd).toBe(params.expectedCwd);
 }
 


### PR DESCRIPTION
## Summary

- Problem: plugin installs ran `npm install --omit=dev`, which can still auto-install peers and pull `openclaw` + large transitive trees.
- Why it matters: plugin builds/install can become unexpectedly heavy and slow.
- What changed: plugin dependency install now uses `--omit=peer`; test assertions updated; `openclaw` peer marked optional in Google Chat + Memory Core plugin manifests.
- What did NOT change (scope boundary): no plugin runtime loading behavior changes; no channel behavior changes.

## Change Type (select all)

- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #N/A
- Related #N/A

## User-visible / Behavior Changes

- Plugin dependency installs avoid peer auto-installs and no longer drag `openclaw` peer trees by default.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): plugin install path
- Relevant config (redacted): default repo config

### Steps

1. Run `pnpm vitest run src/plugins/install.test.ts`.
2. Confirm installer command assertion expects `--omit=peer`.

### Expected

- Plugin install test suite passes and validates peer omission.

### Actual

- `src/plugins/install.test.ts` passed (20/20).

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: plugin install command and assertion update; peer optional metadata for two extensions.
- Edge cases checked: existing ignore-scripts install path remains in place.
- What you did **not** verify: full repo test suite.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/infra/install-package-dir.ts`, `src/test-utils/exec-assertions.ts`, `extensions/googlechat/package.json`, `extensions/memory-core/package.json`.
- Known bad symptoms reviewers should watch for: plugin packages relying on peer auto-install side effects instead of declaring runtime deps.

## Risks and Mitigations

- Risk: a plugin that relied on peer auto-install may reveal missing direct deps.
  - Mitigation: plugin should declare true runtime deps in `dependencies`; OpenClaw runtime still provides `openclaw/plugin-sdk` aliasing.
