### PR TITLE
fix(tui): normalize session key to lowercase to match Gateway behavior

### DIFF
--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -74,6 +74,36 @@ describe("resolveTuiSessionKey", () => {
       }),
     ).toBe("agent:ops:incident");
   });
+
+  it("normalizes session keys to lowercase to match Gateway behavior", () => {
+    // Fixes #33866 - TUI real-time events dropped for uppercase session names
+    expect(
+      resolveTuiSessionKey({
+        raw: "Test1",
+        sessionScope: "global",
+        currentAgentId: "main",
+        sessionMainKey: "agent:main:main",
+      }),
+    ).toBe("agent:main:test1");
+
+    expect(
+      resolveTuiSessionKey({
+        raw: "agent:main:Test1",
+        sessionScope: "global",
+        currentAgentId: "main",
+        sessionMainKey: "agent:main:main",
+      }),
+    ).toBe("agent:main:test1");
+
+    expect(
+      resolveTuiSessionKey({
+        raw: "UPPERCASE",
+        sessionScope: "global",
+        currentAgentId: "MyAgent",
+        sessionMainKey: "agent:myagent:main",
+      }),
+    ).toBe("agent:myagent:uppercase");
+  });
 });
 
 describe("resolveGatewayDisconnectState", () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -199,13 +199,15 @@ export function resolveTuiSessionKey(params: {
       mainKey: params.sessionMainKey,
     });
   }
-  if (trimmed === "global" || trimmed === "unknown") {
-    return trimmed;
+  // Normalize to lowercase to match Gateway's resolveSessionStoreKey behavior
+  const lowered = trimmed.toLowerCase();
+  if (lowered === "global" || lowered === "unknown") {
+    return lowered;
   }
-  if (trimmed.startsWith("agent:")) {
-    return trimmed;
+  if (lowered.startsWith("agent:")) {
+    return lowered;
   }
-  return `agent:${params.currentAgentId}:${trimmed}`;
+  return `agent:${params.currentAgentId.toLowerCase()}:${lowered}`;
 }
 
 export function resolveGatewayDisconnectState(reason?: string): {


### PR DESCRIPTION
## Summary

- Fixes #33866
- TUI real-time events were dropped for session names with uppercase characters
- `resolveTuiSessionKey` now normalizes to lowercase to match Gateway's `resolveSessionStoreKey`

## Problem

When launching TUI with a session name containing uppercase letters (e.g., `agent:main:Test1`), the TUI silently dropped all real-time chat events. This was because:

1. `resolveTuiSessionKey` preserved the original case
2. Gateway canonicalizes session keys to lowercase via `resolveSessionStoreKey`
3. Event routing failed due to case mismatch

## Solution

Normalize session keys to lowercase in `resolveTuiSessionKey` to match Gateway behavior:

- `Test1` → `agent:main:test1`
- `agent:main:Test1` → `agent:main:test1`
- `UPPERCASE` → `agent:main:uppercase`

## Test Coverage

Added test cases for:
- Simple uppercase session name
- Agent-prefixed uppercase session name
- Fully uppercase session name

## Impact

- Low risk: Single-line change in core logic
- High impact: Fixes critical TUI regression for all users with uppercase session names
- No breaking changes: Case normalization is idempotent

Fixes #33866