### PR TITLE
ci: add missing labeler entries for synology-chat, diffs, and thread-ownership

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -104,6 +104,11 @@
       - any-glob-to-any-file:
           - "extensions/zalo/**"
           - "docs/channels/zalo.md"
+"channel: synology-chat":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/synology-chat/**"
+          - "docs/channels/synology-chat.md"
 "channel: zalouser":
   - changed-files:
       - any-glob-to-any-file:
@@ -256,3 +261,12 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/talk-voice/**"
+"extensions: diffs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/diffs/**"
+          - "docs/tools/diffs.md"
+"extensions: thread-ownership":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/thread-ownership/**"


### PR DESCRIPTION
## Summary

- Add `channel: synology-chat` labeler entry with extension + docs glob
- Add `extensions: diffs` labeler entry with extension + docs glob
- Add `extensions: thread-ownership` labeler entry

These three extensions exist under `extensions/` but had no matching entries in `.github/labeler.yml`, so PRs touching them would not get auto-labeled.

## Test plan

- [ ] Verify labeler YAML syntax is valid
- [ ] Confirm PRs touching these extensions get labeled correctly