### PR TITLE
ci: fix security labeler glob to match actual docs path

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -194,7 +194,8 @@
   - changed-files:
       - any-glob-to-any-file:
           - "docs/cli/security.md"
-          - "docs/gateway/security.md"
+          - "docs/gateway/security/**"
+          - "SECURITY.md"
 
 "extensions: copilot-proxy":
   - changed-files:


### PR DESCRIPTION
## Summary

- Fix `security` label glob: `docs/gateway/security.md` does not exist; the actual path is `docs/gateway/security/` (directory with `index.md`)
- Change to `docs/gateway/security/**` to match all files in the security docs directory
- Also add `SECURITY.md` (repo root) to the security label

## Test plan

- [ ] Verify PRs touching `docs/gateway/security/index.md` now get the `security` label