### PR TITLE
ui(cron): render run history newest-first by timestamp

### DIFF
--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -360,7 +360,7 @@ export function renderCron(props: CronProps) {
     props.runsScope === "all"
       ? t("cron.jobList.allJobs")
       : (selectedJob?.name ?? props.runsJobId ?? t("cron.jobList.selectJob"));
-  const runs = props.runs;
+  const runs = [...props.runs].toSorted((a, b) => (b.ts ?? 0) - (a.ts ?? 0));
   const runStatusOptions = getRunStatusOptions();
   const runDeliveryOptions = getRunDeliveryOptions();
   const selectedStatusLabels = runStatusOptions


### PR DESCRIPTION
## Summary
- sort displayed cron run entries by descending `ts` before rendering
- ensures newest run appears first in the Run history panel

## Validation
- matches existing UI expectation for newest-first history ordering