### PR TITLE
ui(navigation): use title case for tab group labels

### DIFF
--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -2,13 +2,13 @@ import { t } from "../i18n/index.ts";
 import type { IconName } from "./icons.js";
 
 export const TAB_GROUPS = [
-  { label: "chat", tabs: ["chat"] },
+  { label: "Chat", tabs: ["chat"] },
   {
-    label: "control",
+    label: "Control",
     tabs: ["overview", "channels", "instances", "sessions", "usage", "cron"],
   },
-  { label: "agent", tabs: ["agents", "skills", "nodes"] },
-  { label: "settings", tabs: ["config", "debug", "logs"] },
+  { label: "Agent", tabs: ["agents", "skills", "nodes"] },
+  { label: "Settings", tabs: ["config", "debug", "logs"] },
 ] as const;
 
 export type Tab =


### PR DESCRIPTION
## Summary
- update `TAB_GROUPS` labels to Title Case (`Chat`, `Control`, `Agent`, `Settings`)
- aligns runtime labels with existing navigation tests and UI naming conventions

## Risk
Low, label-only UI text change.