### PR TITLE
ui(i18n): preselect persisted locale before lazy translation load

### DIFF
--- a/ui/src/i18n/lib/translate.ts
+++ b/ui/src/i18n/lib/translate.ts
@@ -35,6 +35,8 @@ class I18nManager {
       this.locale = DEFAULT_LOCALE;
       return;
     }
+    // Reflect the persisted startup locale immediately; translation map may still lazy-load.
+    this.locale = initialLocale;
     // Use the normal locale setter so startup locale loading follows the same
     // translation-loading + notify path as manual locale changes.
     void this.setLocale(initialLocale);


### PR DESCRIPTION
## Summary
- set `this.locale` to persisted non-default locale immediately during startup
- continue lazy loading translation map via `setLocale`

## Why
Prevents startup race where `getLocale()` may report `en` briefly even when a saved non-English locale exists.

## Risk
Low. Translation fallback to English remains unchanged until locale map is loaded.