### PR TITLE
fix(gateway): avoid stale-socket false positives for idle channels (#34052)

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -456,7 +456,7 @@ describe("channel-health-monitor", () => {
   describe("stale socket detection", () => {
     const STALE_THRESHOLD = 30 * 60_000;
 
-    it("restarts a channel with no events past the stale threshold", async () => {
+    it("restarts a channel whose events stopped arriving past the stale threshold", async () => {
       const now = Date.now();
       const manager = createSlackSnapshotManager(
         runningConnectedSlackAccount({
@@ -489,14 +489,14 @@ describe("channel-health-monitor", () => {
       await expectNoRestart(manager);
     });
 
-    it("restarts a channel that never received any event past the stale threshold", async () => {
+    it("does not restart a channel that never received any event (avoids false stale-socket)", async () => {
       const now = Date.now();
       const manager = createSlackSnapshotManager(
         runningConnectedSlackAccount({
           lastStartAt: now - STALE_THRESHOLD - 60_000,
         }),
       );
-      await expectRestartedChannel(manager, "slack");
+      await expectNoRestart(manager);
     });
 
     it("respects custom staleEventThresholdMs", async () => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -98,7 +98,7 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: false, reason: "disconnected" });
   });
 
-  it("flags stale sockets when no events arrive beyond threshold", () => {
+  it("treats channels that never received events as healthy (no false stale-socket)", () => {
     const evaluation = evaluateChannelHealth(
       {
         running: true,
@@ -107,6 +107,25 @@ describe("evaluateChannelHealth", () => {
         configured: true,
         lastStartAt: 0,
         lastEventAt: null,
+      },
+      {
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("flags stale sockets when events have been received but stopped arriving", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: 10_000,
       },
       {
         now: 100_000,

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -96,8 +96,13 @@ export function evaluateChannelHealth(
     const upSince = snapshot.lastStartAt ?? 0;
     const upDuration = policy.now - upSince;
     if (upDuration > policy.staleEventThresholdMs) {
-      const lastEvent = snapshot.lastEventAt ?? 0;
-      const eventAge = policy.now - lastEvent;
+      if (snapshot.lastEventAt == null) {
+        // Channel has never received an event — cannot determine staleness.
+        // Treat as healthy to avoid false-positive restarts in low-traffic
+        // or multi-account setups where some channels are idle.
+        return { healthy: true, reason: "healthy" };
+      }
+      const eventAge = policy.now - snapshot.lastEventAt;
       if (eventAge > policy.staleEventThresholdMs) {
         return { healthy: false, reason: "stale-socket" };
       }


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the `channel-health-monitor` where it would incorrectly flag healthy but idle channels as `stale-socket` in multi-account setups, leading to cascading restarts, memory leaks, and gateway instability.

The fix prevents the health monitor from restarting a channel that has never received an event.

## Problem

The root cause was in `evaluateChannelHealth` (`src/gateway/channel-health-policy.ts`). When a channel had `lastEventAt: null`, the nullish coalescing operator (`??`) would default `lastEvent` to `0`. This caused the `eventAge` to be calculated as `now - 0`, which was always greater than the `staleEventThresholdMs`, triggering a false-positive restart for any channel that had been running for more than 30 minutes without receiving its first event.

This was particularly problematic in multi-account, low-traffic environments, where it is common for some channels to remain idle for extended periods.

## Fix

- The `evaluateChannelHealth` function is modified to first check if `snapshot.lastEventAt` is `null`.
- If it is `null`, the channel is now considered healthy, as its staleness cannot be determined. The function returns early, preventing the false-positive stale-socket evaluation.
- The logic to flag genuinely stale channels (those that have received events but then stopped) remains unchanged.

## Testing

- Updated `channel-health-policy.test.ts` to assert that a channel with `lastEventAt: null` is evaluated as healthy.
- Added a new test to confirm that a channel that *has* received events but then goes stale is still correctly flagged.
- Updated `channel-health-monitor.test.ts` to assert that the monitor does *not* restart a channel that has never received an event.

This directly addresses the scenario described in the issue and aligns with the suggested fix from `mdlmarkham`.

Fixes #34052