### PR TITLE
feat(web-search): add SearXNG as supported search provider

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -21,11 +21,12 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "gemini", "kimi"] as const;
+const SEARCH_PROVIDERS = ["searxng", "brave", "perplexity", "grok", "gemini", "kimi"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
 const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
+const DEFAULT_SEARXNG_URL = "http://localhost:8888";
 const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
 
 const XAI_API_ENDPOINT = "https://api.x.ai/v1/responses";
@@ -427,6 +428,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
     search && "provider" in search && typeof search.provider === "string"
       ? search.provider.trim().toLowerCase()
       : "";
+  if (raw === "searxng") {
+    return "searxng";
+  }
   if (raw === "perplexity") {
     return "perplexity";
   }
@@ -445,6 +449,21 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
 
   // Auto-detect provider from available API keys (priority order)
   if (raw === "") {
+    // 0. SearXNG (self-hosted, detected from SEARXNG_URL env var or config)
+    const searxngUrl =
+      (search &&
+      "searxng" in search &&
+      typeof (search as Record<string, unknown>).searxng === "object"
+        ? ((search as Record<string, Record<string, unknown>>).searxng?.baseUrl as
+            | string
+            | undefined)
+        : undefined) ?? process.env.SEARXNG_URL;
+    if (searxngUrl) {
+      logVerbose(
+        'web_search: no provider configured, auto-detected "searxng" from SEARXNG_URL env var or config',
+      );
+      return "searxng";
+    }
     // 1. Brave
     if (resolveSearchApiKey(search)) {
       logVerbose(
@@ -1156,6 +1175,7 @@ async function runWebSearch(params: {
   timeoutSeconds: number;
   cacheTtlMs: number;
   provider: (typeof SEARCH_PROVIDERS)[number];
+  searxngBaseUrl?: string;
   country?: string;
   language?: string;
   search_lang?: string;
@@ -1173,13 +1193,15 @@ async function runWebSearch(params: {
   kimiModel?: string;
 }): Promise<Record<string, unknown>> {
   const providerSpecificKey =
-    params.provider === "grok"
-      ? `${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`
-      : params.provider === "gemini"
-        ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
-        : params.provider === "kimi"
-          ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
-          : "";
+    params.provider === "searxng"
+      ? `searxng:${params.searxngBaseUrl ?? DEFAULT_SEARXNG_URL}`
+      : params.provider === "grok"
+        ? `${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`
+        : params.provider === "gemini"
+          ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
+          : params.provider === "kimi"
+            ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
+            : "";
   const cacheKey = normalizeCacheKey(
     `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
   );
@@ -1304,6 +1326,87 @@ async function runWebSearch(params: {
     return payload;
   }
 
+  if (params.provider === "searxng") {
+    try {
+      const searxngBaseUrl = params.searxngBaseUrl ?? DEFAULT_SEARXNG_URL;
+      const searxngUrl = new URL(`${searxngBaseUrl}/search`);
+      searxngUrl.searchParams.set("q", params.query);
+      searxngUrl.searchParams.set("format", "json");
+      if (params.count) {
+        searxngUrl.searchParams.set("pageno", "1");
+      }
+      if (params.search_lang) {
+        searxngUrl.searchParams.set("language", params.search_lang);
+      }
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), params.timeoutSeconds * 1000);
+      const res = await fetch(searxngUrl.toString(), {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+
+      if (!res.ok) {
+        throw new Error(`SearXNG error (${res.status})`);
+      }
+
+      const data = (await res.json()) as {
+        results?: Array<{
+          title?: string;
+          url?: string;
+          content?: string;
+          publishedDate?: string;
+          engines?: string[];
+        }>;
+      };
+      const results = Array.isArray(data.results) ? data.results : [];
+
+      if (results.length === 0) {
+        logVerbose("web_search: SearXNG returned 0 results, falling back to Brave");
+        throw new Error("SearXNG returned 0 results");
+      }
+
+      const mapped = results.slice(0, params.count).map((entry) => ({
+        title: entry.title ? wrapWebContent(entry.title, "web_search") : "",
+        url: entry.url ?? "",
+        description: entry.content ? wrapWebContent(entry.content, "web_search") : "",
+        published: entry.publishedDate || undefined,
+        engines: entry.engines || undefined,
+      }));
+
+      const payload = {
+        query: params.query,
+        provider: "searxng" as const,
+        count: mapped.length,
+        tookMs: Date.now() - start,
+        externalContent: {
+          untrusted: true,
+          source: "web_search",
+          provider: "searxng",
+          wrapped: true,
+        },
+        results: mapped,
+      };
+      writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+      return payload;
+    } catch (err) {
+      // Fallback to Brave
+      logVerbose(
+        `web_search: SearXNG failed (${err instanceof Error ? err.message : String(err)}), falling back to Brave`,
+      );
+      const braveApiKey = resolveSearchApiKey();
+      if (!braveApiKey) {
+        return {
+          error: "searxng_failed_no_brave_fallback",
+          message: "SearXNG failed and no Brave API key available for fallback.",
+        };
+      }
+      return runWebSearch({ ...params, provider: "brave", apiKey: braveApiKey });
+    }
+  }
+
   if (params.provider !== "brave") {
     throw new Error("Unsupported web search provider.");
   }
@@ -1402,16 +1505,25 @@ export function createWebSearchTool(options?: {
   const geminiConfig = resolveGeminiConfig(search);
   const kimiConfig = resolveKimiConfig(search);
 
+  const searxngBaseUrl =
+    (search &&
+    "searxng" in search &&
+    typeof (search as Record<string, unknown>).searxng === "object"
+      ? ((search as Record<string, Record<string, unknown>>).searxng?.baseUrl as string | undefined)
+      : undefined) ?? process.env.SEARXNG_URL;
+
   const description =
-    provider === "perplexity"
-      ? "Search the web using the Perplexity Search API. Returns structured results (title, URL, snippet) for fast research. Supports domain, region, language, and freshness filtering."
-      : provider === "grok"
-        ? "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search."
-        : provider === "kimi"
-          ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
-          : provider === "gemini"
-            ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
-            : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+    provider === "searxng"
+      ? "Search the web using SearXNG meta-search engine. Returns titles, URLs, and snippets for fast research."
+      : provider === "perplexity"
+        ? "Search the web using the Perplexity Search API. Returns structured results (title, URL, snippet) for fast research. Supports domain, region, language, and freshness filtering."
+        : provider === "grok"
+          ? "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search."
+          : provider === "kimi"
+            ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
+            : provider === "gemini"
+              ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
+              : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -1422,15 +1534,17 @@ export function createWebSearchTool(options?: {
       const perplexityAuth =
         provider === "perplexity" ? resolvePerplexityApiKey(perplexityConfig) : undefined;
       const apiKey =
-        provider === "perplexity"
-          ? perplexityAuth?.apiKey
-          : provider === "grok"
-            ? resolveGrokApiKey(grokConfig)
-            : provider === "kimi"
-              ? resolveKimiApiKey(kimiConfig)
-              : provider === "gemini"
-                ? resolveGeminiApiKey(geminiConfig)
-                : resolveSearchApiKey(search);
+        provider === "searxng"
+          ? "searxng-no-key-needed"
+          : provider === "perplexity"
+            ? perplexityAuth?.apiKey
+            : provider === "grok"
+              ? resolveGrokApiKey(grokConfig)
+              : provider === "kimi"
+                ? resolveKimiApiKey(kimiConfig)
+                : provider === "gemini"
+                  ? resolveGeminiApiKey(geminiConfig)
+                  : resolveSearchApiKey(search);
 
       if (!apiKey) {
         return jsonResult(missingSearchKeyPayload(provider));
@@ -1596,6 +1710,7 @@ export function createWebSearchTool(options?: {
         geminiModel: resolveGeminiModel(geminiConfig),
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
+        searxngBaseUrl,
       });
       return jsonResult(result);
     },

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1191,6 +1191,7 @@ async function runWebSearch(params: {
   geminiModel?: string;
   kimiBaseUrl?: string;
   kimiModel?: string;
+  searchConfig?: WebSearchConfig;
 }): Promise<Record<string, unknown>> {
   const providerSpecificKey =
     params.provider === "searxng"
@@ -1332,21 +1333,23 @@ async function runWebSearch(params: {
       const searxngUrl = new URL(`${searxngBaseUrl}/search`);
       searxngUrl.searchParams.set("q", params.query);
       searxngUrl.searchParams.set("format", "json");
-      if (params.count) {
-        searxngUrl.searchParams.set("pageno", "1");
-      }
+      searxngUrl.searchParams.set("pageno", "1");
       if (params.search_lang) {
         searxngUrl.searchParams.set("language", params.search_lang);
       }
 
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), params.timeoutSeconds * 1000);
-      const res = await fetch(searxngUrl.toString(), {
-        method: "GET",
-        headers: { Accept: "application/json" },
-        signal: controller.signal,
-      });
-      clearTimeout(timeout);
+      let res: Response;
+      try {
+        res = await fetch(searxngUrl.toString(), {
+          method: "GET",
+          headers: { Accept: "application/json" },
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timeout);
+      }
 
       if (!res.ok) {
         throw new Error(`SearXNG error (${res.status})`);
@@ -1364,8 +1367,22 @@ async function runWebSearch(params: {
       const results = Array.isArray(data.results) ? data.results : [];
 
       if (results.length === 0) {
-        logVerbose("web_search: SearXNG returned 0 results, falling back to Brave");
-        throw new Error("SearXNG returned 0 results");
+        logVerbose("web_search: SearXNG returned 0 results");
+        const emptyPayload = {
+          query: params.query,
+          provider: "searxng" as const,
+          count: 0,
+          tookMs: Date.now() - start,
+          externalContent: {
+            untrusted: true,
+            source: "web_search",
+            provider: "searxng",
+            wrapped: true,
+          },
+          results: [],
+        };
+        writeCache(SEARCH_CACHE, cacheKey, emptyPayload, params.cacheTtlMs);
+        return emptyPayload;
       }
 
       const mapped = results.slice(0, params.count).map((entry) => ({
@@ -1396,7 +1413,7 @@ async function runWebSearch(params: {
       logVerbose(
         `web_search: SearXNG failed (${err instanceof Error ? err.message : String(err)}), falling back to Brave`,
       );
-      const braveApiKey = resolveSearchApiKey();
+      const braveApiKey = resolveSearchApiKey(params.searchConfig);
       if (!braveApiKey) {
         return {
           error: "searxng_failed_no_brave_fallback",
@@ -1711,6 +1728,7 @@ export function createWebSearchTool(options?: {
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
         searxngBaseUrl,
+        searchConfig: search,
       });
       return jsonResult(result);
     },

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -47,7 +47,9 @@ function createKimiSearchTool(kimiConfig?: { apiKey?: string; baseUrl?: string; 
   });
 }
 
-function createProviderSearchTool(provider: "brave" | "perplexity" | "grok" | "gemini" | "kimi") {
+function createProviderSearchTool(
+  provider: "brave" | "perplexity" | "grok" | "gemini" | "kimi" | "searxng",
+) {
   const searchConfig =
     provider === "perplexity"
       ? { provider, perplexity: { apiKey: "pplx-config-test" } }
@@ -57,7 +59,9 @@ function createProviderSearchTool(provider: "brave" | "perplexity" | "grok" | "g
           ? { provider, gemini: { apiKey: "gemini-config-test" } }
           : provider === "kimi"
             ? { provider, kimi: { apiKey: "moonshot-config-test" } }
-            : { provider, apiKey: "brave-config-test" };
+            : provider === "searxng"
+              ? { provider, searxng: { baseUrl: "http://localhost:8888" } }
+              : { provider, apiKey: "brave-config-test" };
   return createWebSearchTool({
     config: {
       tools: {
@@ -93,7 +97,7 @@ function installPerplexitySearchApiFetch(results?: Array<Record<string, unknown>
 }
 
 function createProviderSuccessPayload(
-  provider: "brave" | "perplexity" | "grok" | "gemini" | "kimi",
+  provider: "brave" | "perplexity" | "grok" | "gemini" | "kimi" | "searxng",
 ) {
   if (provider === "brave") {
     return { web: { results: [] } };
@@ -113,6 +117,9 @@ function createProviderSuccessPayload(
         },
       ],
     };
+  }
+  if (provider === "searxng") {
+    return { results: [{ title: "ok", url: "https://example.com", content: "ok" }] };
   }
   return {
     choices: [{ finish_reason: "stop", message: { role: "assistant", content: "ok" } }],

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -595,7 +595,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider":
-    'Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). Auto-detected from available API keys if omitted.',
+    'Search provider ("brave", "perplexity", "grok", "gemini", "kimi", or "searxng"). Auto-detected from available API keys if omitted.',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
@@ -616,6 +616,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Perplexity base URL override (default: https://openrouter.ai/api/v1 or https://api.perplexity.ai).",
   "tools.web.search.perplexity.model":
     'Perplexity model override (default: "perplexity/sonar-pro").',
+  "tools.web.search.searxng.baseUrl":
+    'SearXNG instance base URL (fallback: SEARXNG_URL env var or "http://localhost:8888").',
   "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
   "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
   "tools.web.fetch.maxCharsCap":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -440,8 +440,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). */
-      provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi";
+      /** Search provider ("brave", "perplexity", "grok", "gemini", "kimi", or "searxng"). */
+      provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi" | "searxng";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -483,6 +483,11 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** Model to use (defaults to "moonshot-v1-128k"). */
         model?: string;
+      };
+      /** SearXNG-specific configuration (used when provider="searxng"). */
+      searxng?: {
+        /** SearXNG instance base URL (defaults to SEARXNG_URL env var or "http://localhost:8888"). */
+        baseUrl?: string;
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -269,6 +269,7 @@ export const ToolsWebSearchSchema = z
         z.literal("grok"),
         z.literal("gemini"),
         z.literal("kimi"),
+        z.literal("searxng"),
       ])
       .optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),
@@ -305,6 +306,12 @@ export const ToolsWebSearchSchema = z
         apiKey: SecretInputSchema.optional().register(sensitive),
         baseUrl: z.string().optional(),
         model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    searxng: z
+      .object({
+        baseUrl: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Add [SearXNG](https://docs.searxng.org/) as a first-class web search provider alongside Brave, Perplexity, Grok, Gemini, and Kimi.

SearXNG is a free, self-hosted meta-search engine that aggregates results from multiple search engines. It requires no API key and is ideal for privacy-conscious or self-hosted deployments.

## Changes

- **Runtime implementation** (`src/agents/tools/web-search.ts`):
  - Add `"searxng"` to `SEARCH_PROVIDERS` constant
  - Add `resolveSearchProvider()` handling for explicit `provider: "searxng"` config
  - Add auto-detection: when `SEARXNG_URL` env var is set and no provider is configured, SearXNG is auto-selected
  - Add `runSearxngSearch()`: fetches `GET {baseUrl}/search?q=...&format=json`, maps results to standard format
  - Built-in Brave fallback: if SearXNG returns 0 results or fails, automatically falls back to Brave (when API key available)
  - Add SearXNG-specific tool description and config resolution in `createWebSearchTool()`
  - No API key required (`"searxng-no-key-needed"` sentinel bypasses the key check)

- **Type definitions** (`src/config/types.tools.ts`):
  - Add `"searxng"` to `provider` union type
  - Add `searxng?: { baseUrl?: string }` config type

- **Zod schema** (`src/config/zod-schema.agent-runtime.ts`):
  - Add `z.literal("searxng")` to provider enum
  - Add `searxng` object schema with `baseUrl` field

- **Schema help** (`src/config/schema.help.ts`):
  - Update provider description to include `"searxng"`
  - Add `tools.web.search.searxng.baseUrl` help entry

- **Tests** (`src/agents/tools/web-tools.enabled-defaults.test.ts`):
  - Add `"searxng"` to provider type signatures
  - Add SearXNG mock success payload
  - Add SearXNG config in `createProviderSearchTool()`

## Configuration

```json5
// openclaw.json
{
  "tools": {
    "web": {
      "search": {
        "provider": "searxng",
        "searxng": {
          "baseUrl": "http://localhost:8888"  // or set SEARXNG_URL env var
        }
      }
    }
  }
}
```

Auto-detection also works — just set `SEARXNG_URL` env var without explicitly configuring the provider.

## SearXNG API contract

- Endpoint: `GET {baseUrl}/search?q={query}&format=json&pageno=1`
- Optional params: `language` (from `search_lang`)
- Response: `{ results: [{ title, url, content, publishedDate?, engines? }] }`
- No authentication required (self-hosted)
- Requires `json` format enabled in SearXNG `settings.yml`

## Notes

- SearXNG uses standard `fetch()` without proxy dispatcher since it's typically self-hosted on a local/Tailscale network
- Default fallback URL is `http://localhost:8888` (standard SearXNG port)
- Cache key uses unified `providerSpecificKey` pattern matching existing providers