### PR TITLE
fix(agents): correct subagent model resolution priority

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -12,6 +12,7 @@ import {
   modelKey,
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
+  resolveSubagentConfiguredModelSelection,
   resolveThinkingDefault,
   resolveModelRefFromString,
 } from "./model-selection.js";
@@ -566,5 +567,76 @@ describe("normalizeModelSelection", () => {
     expect(normalizeModelSelection(undefined)).toBeUndefined();
     expect(normalizeModelSelection(null)).toBeUndefined();
     expect(normalizeModelSelection(42)).toBeUndefined();
+  });
+});
+
+describe("resolveSubagentConfiguredModelSelection", () => {
+  it("agent-level model takes priority over global defaults.subagents.model", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          subagents: { model: "anthropic/claude-sonnet-4-6" },
+        },
+        list: [{ id: "imagegen", model: "google/gemini-3.1-flash-image-preview" }],
+      },
+    } as OpenClawConfig;
+    expect(resolveSubagentConfiguredModelSelection({ cfg, agentId: "imagegen" })).toBe(
+      "google/gemini-3.1-flash-image-preview",
+    );
+  });
+
+  it("agent-level subagents.model takes highest priority", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          subagents: { model: "anthropic/claude-sonnet-4-6" },
+        },
+        list: [
+          {
+            id: "imagegen",
+            model: "google/gemini-3.1-flash-image-preview",
+            subagents: { model: "openai/gpt-5.2" },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    expect(resolveSubagentConfiguredModelSelection({ cfg, agentId: "imagegen" })).toBe(
+      "openai/gpt-5.2",
+    );
+  });
+
+  it("falls back to global defaults.subagents.model when agent has no model", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          subagents: { model: "anthropic/claude-sonnet-4-6" },
+        },
+        list: [{ id: "helper" }],
+      },
+    } as OpenClawConfig;
+    expect(resolveSubagentConfiguredModelSelection({ cfg, agentId: "helper" })).toBe(
+      "anthropic/claude-sonnet-4-6",
+    );
+  });
+
+  it("returns undefined when no model is configured at any level", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "bare" }],
+      },
+    } as OpenClawConfig;
+    expect(resolveSubagentConfiguredModelSelection({ cfg, agentId: "bare" })).toBeUndefined();
+  });
+
+  it("returns undefined for unknown agent", () => {
+    const cfg = {
+      agents: {
+        defaults: { subagents: { model: "anthropic/claude-sonnet-4-6" } },
+        list: [],
+      },
+    } as OpenClawConfig;
+    expect(resolveSubagentConfiguredModelSelection({ cfg, agentId: "missing" })).toBe(
+      "anthropic/claude-sonnet-4-6",
+    );
   });
 });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -357,8 +357,8 @@ export function resolveSubagentConfiguredModelSelection(params: {
   const agentConfig = resolveAgentConfig(params.cfg, params.agentId);
   return (
     normalizeModelSelection(agentConfig?.subagents?.model) ??
-    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model) ??
-    normalizeModelSelection(agentConfig?.model)
+    normalizeModelSelection(agentConfig?.model) ??
+    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model)
   );
 }
 


### PR DESCRIPTION
## Summary

- Problem: When `defaults.subagents.model` is set globally, agent-level `model` config is silently ignored for subagent spawns because the global default has higher priority in the resolution chain.
- Why it matters: Users configuring specialized agents (e.g. `imagegen` with `google/gemini-3.1-flash-image-preview`) see their model overridden by the global default when spawned as subagents, with no warning.
- What changed: Reordered the `??` fallback chain in `resolveSubagentConfiguredModelSelection` so `agentConfig.model` is checked before `defaults.subagents.model`.
- What did NOT change (scope boundary): `agentConfig.subagents.model` still has the highest priority. `resolveSubagentSpawnModelSelection` and runtime model override logic are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34065

## User-visible / Behavior Changes

Subagents now respect agent-level `model` config when `defaults.subagents.model` is also set. Previously, the global default always won.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22+

### Steps

1. Configure an agent `imagegen` with `model: "google/gemini-3.1-flash-image-preview"` and a global `defaults.subagents.model: "anthropic/claude-sonnet-4-6"`
2. Spawn `imagegen` as a subagent
3. Observe the session transcript `model_change` entry

### Expected

- Model resolves to `google/gemini-3.1-flash-image-preview` (agent config)

### Actual

- Before: Model resolves to `anthropic/claude-sonnet-4-6` (global default, wrong)
- After: Model resolves to `google/gemini-3.1-flash-image-preview` (agent config, correct)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

5 new vitest tests covering:
- Agent model priority over global default
- Agent subagents.model as highest priority
- Fallback to global default when agent has no model
- Undefined when nothing configured
- Unknown agent still gets global default

## Human Verification (required)

- Verified scenarios: Agent with explicit model spawned as subagent; agent with subagents.model override; bare agent with no model config
- Edge cases checked: Unknown/missing agent ID; empty agents list; no defaults configured
- What you did **not** verify: Live multi-agent gateway setup (tested via unit tests only)

## Compatibility / Migration

- Backward compatible? Yes — agents that previously relied on `defaults.subagents.model` overriding `agentConfig.model` were misconfigured; the new behavior matches documented intent
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; or explicitly set `subagents.model` on each agent entry to match the previous global default behavior
- Files/config to restore: `src/agents/model-selection.ts`

## Risks and Mitigations

- Risk: Users who unknowingly depended on the broken priority (global default overriding agent model) may see model changes
  - Mitigation: This matches the documented config hierarchy and the fix is a 1-line reorder; `agentConfig.subagents.model` remains the highest-priority escape hatch