### PR TITLE
fix(runner): skip overflow compaction when assistant reports zero input tokens

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -335,4 +335,35 @@ describe("overflow compaction in run loop", () => {
     expect(result.meta.agentMeta?.usage?.input).toBe(4_000);
     expect(result.meta.agentMeta?.promptTokens).toBe(2_000);
   });
+
+  it("does not trigger overflow compaction when input tokens are zero (e.g. provider-side Jinja template error)", async () => {
+    // Simulate a provider error that superficially resembles an overflow message
+    // but occurred before the model processed any tokens (input=0). This is the
+    // failure mode for LM Studio + Qwen3 Jinja template errors.
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        lastAssistant: {
+          stopReason: "error",
+          // Use a message that genuinely matches isLikelyContextOverflowError to
+          // confirm the guard prevents compaction even when the pattern fires.
+          errorMessage:
+            'Error rendering prompt with jinja template: "No user query found in messages." prompt is too long',
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 0,
+          },
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    await runEmbeddedPiAgent(baseParams);
+
+    // Compaction must NOT have been attempted — the error is not a real overflow.
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(log.warn).not.toHaveBeenCalledWith(expect.stringContaining("context overflow detected"));
+  });
 });

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -46,7 +46,8 @@ describe("overflow compaction in run loop", () => {
         lower.includes("request_too_large") ||
         lower.includes("request size exceeds") ||
         lower.includes("context window exceeded") ||
-        lower.includes("prompt too large")
+        lower.includes("prompt too large") ||
+        lower.includes("prompt is too long")
       );
     });
     mockedCompactDirect.mockResolvedValue({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -838,7 +838,17 @@ export async function runEmbeddedPiAgent(
                   // inspect prior assistant errors from history for this attempt.
                   return null;
                 }
-                if (assistantErrorText && isLikelyContextOverflowError(assistantErrorText)) {
+                // If the model reported zero input tokens, it never processed the
+                // prompt — so the error cannot be a context overflow regardless of
+                // the error message. This guards against provider errors like Jinja
+                // template failures that superficially resemble overflow messages.
+                const zeroInputTokens =
+                  lastAssistantUsage !== undefined && (lastAssistantUsage.input ?? 0) === 0;
+                if (
+                  assistantErrorText &&
+                  !zeroInputTokens &&
+                  isLikelyContextOverflowError(assistantErrorText)
+                ) {
                   return { text: assistantErrorText, source: "assistantError" as const };
                 }
                 return null;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -843,7 +843,7 @@ export async function runEmbeddedPiAgent(
                 // the error message. This guards against provider errors like Jinja
                 // template failures that superficially resemble overflow messages.
                 const zeroInputTokens =
-                  lastAssistantUsage !== undefined && (lastAssistantUsage.input ?? 0) === 0;
+                  lastAssistantUsage !== undefined && lastAssistantUsage.input === 0;
                 if (
                   assistantErrorText &&
                   !zeroInputTokens &&


### PR DESCRIPTION
## Summary

- **Problem:** LM Studio with Qwen3 models raises a Jinja template exception (`"No user query found in messages."`) before processing any tokens. `isLikelyContextOverflowError` can match this error message, triggering auto-compaction which immediately cancels (no real messages to summarize), which re-raises the same error — an infinite loop that blocks the agent.
- **Why it matters:** 100% reproducible on every message for LM Studio + Qwen3 users; agent becomes completely unresponsive.
- **What changed:** Added a `zeroInputTokens` guard in `run.ts`: when `lastAssistantUsage` is defined and `input === 0`, skip the overflow detection path. A model that processed zero input tokens cannot have a context overflow.
- **What did NOT change:** The `promptError` overflow path is untouched. All other providers and overflow detection logic unchanged.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Fixes #32936

## User-visible / Behavior Changes

LM Studio + Qwen3 users no longer get stuck in a compaction loop. The actual provider error is surfaced directly instead of being misclassified as context overflow.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 22+, LM Studio with Qwen3.x model
- Model/provider: LM Studio (OpenAI-compatible)
- Integration/channel: Telegram

### Steps

1. Configure LM Studio with a Qwen3.x model
2. Send any message to the agent
3. Observe repeated `context-overflow-diag: source=assistantError` in logs with zero-token usage

### Expected

- Error is surfaced as a provider-side template error, not a context overflow

### Actual (before fix)

- Infinite compaction loop: overflow detected → compaction cancelled → overflow detected again

## Evidence

- [x] Failing test/log before + passing after

Added a regression test in `run.overflow-compaction.loop.test.ts`: error message includes `"prompt is too long"` (which genuinely matches `isLikelyContextOverflowError`) combined with `usage.input = 0`. Test asserts compaction is never attempted. All 16 overflow tests pass.

## Human Verification (required)

- Verified scenarios: traced `applyJobResult` → `lastAssistantUsage` → guard condition; confirmed `input === 0` (strict equality) correctly distinguishes "zero tokens reported" from "input field absent"
- Edge cases checked: providers that omit `input` from usage payload — `input === undefined` does not trigger the guard (unlike the previous `?? 0` approach which would have suppressed legitimate overflow detection)
- What you did **not** verify: live LM Studio + Qwen3 end-to-end (requires specific local model setup)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert quickly: revert the `zeroInputTokens` guard in `src/agents/pi-embedded-runner/run.ts` (3 lines)
- Files/config to restore: `run.ts` only
- Known bad symptoms: if reverted, LM Studio + Qwen3 users return to the compaction loop

## Risks and Mitigations

- Risk: a provider might legitimately report `input = 0` alongside a real overflow message
  - Mitigation: impossible by definition — context overflow requires tokens to have been processed; `input = 0` means the model never received the prompt