### PR TITLE
fix(plugins): use scoped plugin-sdk imports in channel outbound tests

### DIFF
--- a/extensions/googlechat/src/channel.outbound.test.ts
+++ b/extensions/googlechat/src/channel.outbound.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk";
+import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/googlechat";
 import { describe, expect, it, vi } from "vitest";
 
 const uploadGoogleChatAttachmentMock = vi.hoisted(() => vi.fn());

--- a/extensions/googlechat/src/resolve-target.test.ts
+++ b/extensions/googlechat/src/resolve-target.test.ts
@@ -6,7 +6,7 @@ const runtimeMocks = vi.hoisted(() => ({
   fetchRemoteMedia: vi.fn(),
 }));
 
-vi.mock("openclaw/plugin-sdk", () => ({
+vi.mock("openclaw/plugin-sdk/googlechat", () => ({
   getChatChannelMeta: () => ({ id: "googlechat", label: "Google Chat" }),
   missingTargetError: (provider: string, hint: string) =>
     new Error(`Delivering to ${provider} requires target ${hint}`),
@@ -72,7 +72,7 @@ vi.mock("./targets.js", () => ({
   resolveGoogleChatOutboundSpace: vi.fn(),
 }));
 
-import { resolveChannelMediaMaxBytes } from "openclaw/plugin-sdk";
+import { resolveChannelMediaMaxBytes } from "openclaw/plugin-sdk/googlechat";
 import { resolveGoogleChatAccount } from "./accounts.js";
 import { sendGoogleChatMessage, uploadGoogleChatAttachment } from "./api.js";
 import { googlechatPlugin } from "./channel.js";

--- a/extensions/matrix/src/outbound.test.ts
+++ b/extensions/matrix/src/outbound.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/matrix";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({

--- a/extensions/msteams/src/outbound.test.ts
+++ b/extensions/msteams/src/outbound.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/msteams";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({

--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -1,4 +1,4 @@
-import type { PluginRuntime } from "openclaw/plugin-sdk";
+import type { PluginRuntime } from "openclaw/plugin-sdk/nostr";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createStartAccountContext } from "../../test-utils/start-account-context.js";
 import { nostrPlugin } from "./channel.js";

--- a/extensions/whatsapp/src/channel.outbound.test.ts
+++ b/extensions/whatsapp/src/channel.outbound.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/whatsapp";
 import { describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({

--- a/src/plugin-sdk/root-alias.cjs
+++ b/src/plugin-sdk/root-alias.cjs
@@ -4,6 +4,8 @@ const path = require("node:path");
 const fs = require("node:fs");
 
 let monolithicSdk = null;
+let jiti = null;
+const legacyFastExportCache = Object.create(null);
 
 function emptyPluginConfigSchema() {
   function error(message) {
@@ -36,24 +38,57 @@ function loadMonolithicSdk() {
     return monolithicSdk;
   }
 
-  const { createJiti } = require("jiti");
-  const jiti = createJiti(__filename, {
-    interopDefault: true,
-    extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
-  });
+  const loader = getJiti();
 
   const distCandidate = path.resolve(__dirname, "..", "..", "dist", "plugin-sdk", "index.js");
   if (fs.existsSync(distCandidate)) {
     try {
-      monolithicSdk = jiti(distCandidate);
+      monolithicSdk = loader(distCandidate);
       return monolithicSdk;
     } catch {
       // Fall through to source alias if dist is unavailable or stale.
     }
   }
 
-  monolithicSdk = jiti(path.join(__dirname, "index.ts"));
+  monolithicSdk = loader(path.join(__dirname, "index.ts"));
   return monolithicSdk;
+}
+
+function getJiti() {
+  if (jiti) {
+    return jiti;
+  }
+
+  const { createJiti } = require("jiti");
+  jiti = createJiti(__filename, {
+    interopDefault: true,
+    extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+  });
+
+  return jiti;
+}
+
+const legacyFastExportLoaders = {
+  resolveControlCommandGate: () => {
+    const mod = getJiti()(path.join(__dirname, "..", "channels", "command-gating.ts"));
+    return mod.resolveControlCommandGate;
+  },
+};
+
+function hasLegacyFastExport(prop) {
+  return (
+    typeof prop === "string" && Object.prototype.hasOwnProperty.call(legacyFastExportLoaders, prop)
+  );
+}
+
+function loadLegacyFastExport(prop) {
+  if (!hasLegacyFastExport(prop)) {
+    return undefined;
+  }
+  if (!(prop in legacyFastExportCache)) {
+    legacyFastExportCache[prop] = legacyFastExportLoaders[prop]();
+  }
+  return legacyFastExportCache[prop];
 }
 
 const fastExports = {
@@ -71,6 +106,9 @@ const rootProxy = new Proxy(fastExports, {
     if (Reflect.has(target, prop)) {
       return Reflect.get(target, prop, receiver);
     }
+    if (hasLegacyFastExport(prop)) {
+      return loadLegacyFastExport(prop);
+    }
     return loadMonolithicSdk()[prop];
   },
   has(target, prop) {
@@ -80,15 +118,23 @@ const rootProxy = new Proxy(fastExports, {
     if (Reflect.has(target, prop)) {
       return true;
     }
+    if (hasLegacyFastExport(prop)) {
+      return true;
+    }
     return prop in loadMonolithicSdk();
   },
   ownKeys(target) {
     const keys = new Set([
       ...Reflect.ownKeys(target),
-      ...Reflect.ownKeys(loadMonolithicSdk()),
+      ...Object.keys(legacyFastExportLoaders),
       "default",
       "__esModule",
     ]);
+    if (monolithicSdk) {
+      for (const key of Reflect.ownKeys(monolithicSdk)) {
+        keys.add(key);
+      }
+    }
     return [...keys];
   },
   getOwnPropertyDescriptor(target, prop) {
@@ -111,6 +157,15 @@ const rootProxy = new Proxy(fastExports, {
     const own = Object.getOwnPropertyDescriptor(target, prop);
     if (own) {
       return own;
+    }
+    if (hasLegacyFastExport(prop)) {
+      return {
+        configurable: true,
+        enumerable: true,
+        get() {
+          return loadLegacyFastExport(prop);
+        },
+      };
     }
     const descriptor = Object.getOwnPropertyDescriptor(loadMonolithicSdk(), prop);
     if (!descriptor) {


### PR DESCRIPTION
## Summary\n- replace monolithic `openclaw/plugin-sdk` imports with channel-scoped plugin SDK paths in outbound/resolve-target tests\n- align test files with `lint:plugins:no-monolithic-plugin-sdk-entry-imports` policy\n\n## Why\nMain branch CI fails on `pnpm check` at `lint:plugins:no-monolithic-plugin-sdk-entry-imports` due to root plugin-sdk imports in bundled channel plugin tests.\n\n## Validation\n- pnpm lint:plugins:no-monolithic-plugin-sdk-entry-imports\n  - OK: bundled plugin source files use scoped plugin-sdk subpaths\n