### PR TITLE
feat(telegram): send authorization hint when bot is @mentioned but unauthorized

### DIFF
--- a/extensions/telegram/src/bot-handlers.ts
+++ b/extensions/telegram/src/bot-handlers.ts
@@ -62,6 +62,7 @@ import {
   buildTelegramParentPeer,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
+  hasBotMention,
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import { resolveTelegramConversationRoute } from "./conversation-route.js";
@@ -1642,20 +1643,32 @@ export const registerTelegramHandlers = ({
         return;
       }
 
-      if (
-        shouldSkipGroupMessage({
-          isGroup: event.isGroup,
-          chatId: event.chatId,
-          chatTitle: event.msg.chat.title,
-          resolvedThreadId,
-          senderId: event.senderId,
-          senderUsername: event.senderUsername,
-          effectiveGroupAllow,
-          hasGroupAllowOverride,
-          groupConfig,
-          topicConfig,
-        })
-      ) {
+      const shouldSkip = shouldSkipGroupMessage({
+        isGroup: event.isGroup,
+        chatId: event.chatId,
+        chatTitle: event.msg.chat.title,
+        resolvedThreadId,
+        senderId: event.senderId,
+        senderUsername: event.senderUsername,
+        effectiveGroupAllow,
+        hasGroupAllowOverride,
+        groupConfig,
+        topicConfig,
+      });
+      
+      if (shouldSkip) {
+        // Check if bot was @mentioned - if so, send authorization hint
+        const botUsername = event.ctx.me?.username;
+        if (botUsername && hasBotMention(event.msg, botUsername)) {
+          await withTelegramApiErrorLogging({
+            operation: "sendMessage",
+            runtime,
+            fn: () => bot.api.sendMessage(
+              event.chatId,
+              "⚠️ I received your message, but I'm not authorized to respond in this group. Please check the group configuration.",
+            ),
+          }).catch(() => {}); // Silently ignore errors
+        }
         return;
       }
 

--- a/extensions/telegram/src/bot-handlers.ts
+++ b/extensions/telegram/src/bot-handlers.ts
@@ -559,7 +559,7 @@ export const registerTelegramHandlers = ({
     if (!baseAccess.allowed) {
       if (baseAccess.reason === "group-disabled") {
         logVerbose(`Blocked telegram group ${chatId} (group disabled)`);
-        return { skip: true, reason: 'group-disabled' };
+        return { skip: true, reason: "group-disabled" };
       }
       if (baseAccess.reason === "topic-disabled") {
         logVerbose(
@@ -1655,7 +1655,7 @@ export const registerTelegramHandlers = ({
         groupConfig,
         topicConfig,
       });
-      
+
       if (shouldSkip) {
         // Only send hint for unconfigured groups (not intentionally disabled)
         if (skipReason === "group-policy-allowlist-empty") {
@@ -1664,11 +1664,12 @@ export const registerTelegramHandlers = ({
             await withTelegramApiErrorLogging({
               operation: "sendMessage",
               runtime,
-              fn: () => bot.api.sendMessage(
-                event.chatId,
-                "⚠️ I received your message, but I'm not authorized to respond in this group. Please check the group configuration.",
-                resolvedThreadId != null ? { message_thread_id: resolvedThreadId } : undefined,
-              ),
+              fn: () =>
+                bot.api.sendMessage(
+                  event.chatId,
+                  "⚠️ I received your message, but I'm not authorized to respond in this group. Please check the group configuration.",
+                  resolvedThreadId != null ? { message_thread_id: resolvedThreadId } : undefined,
+                ),
             }).catch(() => {}); // Silently ignore errors
           }
         }

--- a/extensions/telegram/src/bot-handlers.ts
+++ b/extensions/telegram/src/bot-handlers.ts
@@ -532,7 +532,7 @@ export const registerTelegramHandlers = ({
     hasGroupAllowOverride: boolean;
     groupConfig?: TelegramGroupConfig;
     topicConfig?: TelegramTopicConfig;
-  }) => {
+  }): { skip: boolean; reason?: string } => {
     const {
       isGroup,
       chatId,
@@ -559,21 +559,21 @@ export const registerTelegramHandlers = ({
     if (!baseAccess.allowed) {
       if (baseAccess.reason === "group-disabled") {
         logVerbose(`Blocked telegram group ${chatId} (group disabled)`);
-        return true;
+        return { skip: true, reason: 'group-disabled' };
       }
       if (baseAccess.reason === "topic-disabled") {
         logVerbose(
           `Blocked telegram topic ${chatId} (${resolvedThreadId ?? "unknown"}) (topic disabled)`,
         );
-        return true;
+        return { skip: true, reason: "topic-disabled" };
       }
       logVerbose(
         `Blocked telegram group sender ${senderId || "unknown"} (group allowFrom override)`,
       );
-      return true;
+      return { skip: true, reason: "allowfrom-override" };
     }
     if (!isGroup) {
-      return false;
+      return { skip: false };
     }
     const policyAccess = evaluateTelegramGroupPolicyAccess({
       isGroup,
@@ -596,26 +596,26 @@ export const registerTelegramHandlers = ({
     if (!policyAccess.allowed) {
       if (policyAccess.reason === "group-policy-disabled") {
         logVerbose("Blocked telegram group message (groupPolicy: disabled)");
-        return true;
+        return { skip: true, reason: "group-policy-disabled" };
       }
       if (policyAccess.reason === "group-policy-allowlist-no-sender") {
         logVerbose("Blocked telegram group message (no sender ID, groupPolicy: allowlist)");
-        return true;
+        return { skip: true, reason: "group-policy-allowlist-no-sender" };
       }
       if (policyAccess.reason === "group-policy-allowlist-empty") {
         logVerbose(
           "Blocked telegram group message (groupPolicy: allowlist, no group allowlist entries)",
         );
-        return true;
+        return { skip: true, reason: "group-policy-allowlist-empty" };
       }
       if (policyAccess.reason === "group-policy-allowlist-unauthorized") {
         logVerbose(`Blocked telegram group message from ${senderId} (groupPolicy: allowlist)`);
-        return true;
+        return { skip: true, reason: "group-policy-allowlist-unauthorized" };
       }
       logger.info({ chatId, title: chatTitle, reason: "not-allowed" }, "skipping group message");
-      return true;
+      return { skip: true, reason: "not-allowed" };
     }
-    return false;
+    return { skip: false };
   };
 
   type TelegramGroupAllowContext = Awaited<ReturnType<typeof resolveTelegramGroupAllowFromContext>>;
@@ -1643,7 +1643,7 @@ export const registerTelegramHandlers = ({
         return;
       }
 
-      const shouldSkip = shouldSkipGroupMessage({
+      const { skip: shouldSkip, reason: skipReason } = shouldSkipGroupMessage({
         isGroup: event.isGroup,
         chatId: event.chatId,
         chatTitle: event.msg.chat.title,
@@ -1657,17 +1657,20 @@ export const registerTelegramHandlers = ({
       });
       
       if (shouldSkip) {
-        // Check if bot was @mentioned - if so, send authorization hint
-        const botUsername = event.ctx.me?.username;
-        if (botUsername && hasBotMention(event.msg, botUsername)) {
-          await withTelegramApiErrorLogging({
-            operation: "sendMessage",
-            runtime,
-            fn: () => bot.api.sendMessage(
-              event.chatId,
-              "⚠️ I received your message, but I'm not authorized to respond in this group. Please check the group configuration.",
-            ),
-          }).catch(() => {}); // Silently ignore errors
+        // Only send hint for unconfigured groups (not intentionally disabled)
+        if (skipReason === "group-policy-allowlist-empty") {
+          const botUsername = event.ctx.me?.username;
+          if (botUsername && hasBotMention(event.msg, botUsername)) {
+            await withTelegramApiErrorLogging({
+              operation: "sendMessage",
+              runtime,
+              fn: () => bot.api.sendMessage(
+                event.chatId,
+                "⚠️ I received your message, but I'm not authorized to respond in this group. Please check the group configuration.",
+                resolvedThreadId != null ? { message_thread_id: resolvedThreadId } : undefined,
+              ),
+            }).catch(() => {}); // Silently ignore errors
+          }
         }
         return;
       }

--- a/extensions/telegram/src/bot-handlers.ts
+++ b/extensions/telegram/src/bot-handlers.ts
@@ -721,7 +721,7 @@ export const registerTelegramHandlers = ({
         hasGroupAllowOverride,
         groupConfig,
         topicConfig,
-      })
+      }).skip
     ) {
       return { allowed: false, reason: "group-policy" };
     }


### PR DESCRIPTION
feat(telegram): send authorization hint when bot is @mentioned but unauthorized

Fixes #34056

- Check if bot was @mentioned when group message is rejected
- Send user-friendly authorization hint message
- Reuse existing hasBotMention() helper and withTelegramApiErrorLogging()
- Helps users debug group configuration issues

When a bot is added to a group but not authorized (e.g., groupPolicy:
'allowlist' but no allowFrom configured), @mentions now get a response
instead of being silently dropped.

Message: '⚠️ I received your message, but I'm not authorized to respond
in this group. Please check the group configuration.'

## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** When bot is in unauthorized group, @mentions are silently dropped with no feedback, making debugging difficult
- **Why it matters:** Users can't distinguish "bot didn't receive message" vs "bot received but rejected"; poor debugging experience
- **What changed:** Added @mention detection and authorization hint (27 lines, 1 file)
- **What did NOT change (scope boundary):** No changes to authorization logic, just adds user feedback. Commands already had feedback via sendAuthMessage().

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations (Telegram channel)
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #34056

## User-visible / Behavior Changes

**Before:**
- Bot in unauthorized group: @mentions silently dropped
- No way to know if bot received the message
- Users must check logs or guess configuration issues

**After:**
- Bot in unauthorized group: @mentions get authorization hint
- Clear message: "⚠️ I received your message, but I'm not authorized to respond in this group. Please check the group configuration."
- Immediate feedback for debugging configuration
- Non-@mention messages still silently dropped (no spam)

**Example scenario:**
```
User adds bot to group with groupPolicy: "allowlist"
User: @mybot hello
Bot: ⚠️ I received your message, but I'm not authorized to respond in this group. Please check the group configuration.
User: [realizes need to configure allowFrom]
```

No config changes required. Works immediately after deployment.

## Security Impact (required)

- New permissions/capabilities? **No** - Just adds informational message
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** - Uses existing Telegram API sendMessage
- Command/tool execution surface changed? **No**
- Data access scope changed? **No** - Only sends message to chat where bot already is
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (dev environment)
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel: Telegram
- Relevant config (redacted): Telegram bot with groupPolicy: "allowlist" but no allowFrom

### Steps

**Before fix:**
1. Add bot to Telegram group
2. Configure groupPolicy: "allowlist" but don't add any allowFrom entries
3. Send message: "@mybot hello"
4. Observe: No response, message silently dropped

**After fix:**
1. Add bot to Telegram group
2. Configure groupPolicy: "allowlist" but don't add any allowFrom entries
3. Send message: "@mybot hello"
4. Observe: Authorization hint message

### Expected

- @mention in unauthorized group → authorization hint
- Regular message in unauthorized group → silently dropped (no spam)

### Actual

- **UNVERIFIED** - Could not test with live Telegram bot
- Code logic follows issue requirements
- Reuses existing helpers (hasBotMention, withTelegramApiErrorLogging)
- Manual testing recommended before merge

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Code diff review (27 lines added, 14 modified)

**Code changes:**
```
src/telegram/bot-handlers.ts | 27 insertions(+), 14 deletions(-)
```

**Key changes:**
1. Added `hasBotMention` import
2. Modified `shouldSkipGroupMessage` call to store result
3. Added @mention check and authorization hint before return

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios:** 
  - ✅ Code syntax is valid (TypeScript patterns correct)
  - ✅ Logic flow: check skip → check @mention → send hint → return
  - ✅ Reuses existing helpers (hasBotMention, withTelegramApiErrorLogging)
  - ✅ Message text is clear and user-friendly
  - ✅ Error handling with .catch(() => {}) prevents crashes
  
- **Edge cases checked:**
  - ✅ No botUsername → no hint (graceful degradation)
  - ✅ Not @mentioned → no hint (no spam)
  - ✅ Send message fails → silently ignored (no crash)
  - ✅ Regular messages → still silently dropped (maintains current behavior)
  
- **What you did NOT verify:**
  - ❌ Live Telegram bot testing
  - ❌ Multi-account scenarios
  - ❌ Forum/topic scenarios
  - ❌ Full build/test suite

## Compatibility / Migration

- Backward compatible? **Yes** - Purely additive, adds user feedback
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- **How to disable/revert this change quickly:** 
  - Revert commit `08a7979`
  - Or remove @mention check block (lines ~1427-1438)
  
- **Files/config to restore:** None needed - single-file change

- **Known bad symptoms reviewers should watch for:**
  - Bot responding to all unauthorized messages (check hasBotMention logic)
  - Send message errors flooding logs (check .catch handling)
  - Bot crashes on messages (check error handling)

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write None.

- **Risk:** Bot might send authorization hints to groups where it shouldn't
  - **Mitigation:** Only triggers on @mention + unauthorized; regular messages still silent; message is informational only
  
- **Risk:** Message send failures could cause issues
  - **Mitigation:** Wrapped in .catch(() => {}) to silently ignore errors; uses existing withTelegramApiErrorLogging

- **Risk:** Message text might need localization
  - **Mitigation:** Text is simple and clear; can be extracted to i18n later without breaking change

---

**AI-Assisted PR 🤖**
- Tool: Claude AI
- Testing: Untested (no live bot environment)
- Code understanding: ✅ Confirmed