### PR TITLE
fix(gateway): prevent health monitor stale-socket restart loop in multi-account setups

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -499,6 +499,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         webhookPath: account.config.webhookPath,
         webhookHost: account.config.webhookHost,
         webhookPort: account.config.webhookPort,
+        setStatus: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
       });
     },
     logoutAccount: async ({ accountId, cfg }) => {

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -489,14 +489,18 @@ describe("channel-health-monitor", () => {
       await expectNoRestart(manager);
     });
 
-    it("restarts a channel that never received any event past the stale threshold", async () => {
+    it("does not restart a channel that never received any event (quiet channel)", async () => {
+      // A channel that has been running past the stale threshold but never
+      // received any events (lastEventAt is undefined/null) should NOT be
+      // restarted. This prevents a restart loop for quiet-but-healthy channels:
+      //   restart → grace expires → null treated as stale → restart again.
       const now = Date.now();
       const manager = createSlackSnapshotManager(
         runningConnectedSlackAccount({
           lastStartAt: now - STALE_THRESHOLD - 60_000,
         }),
       );
-      await expectRestartedChannel(manager, "slack");
+      await expectNoRestart(manager);
     });
 
     it("respects custom staleEventThresholdMs", async () => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -98,7 +98,11 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: false, reason: "disconnected" });
   });
 
-  it("flags stale sockets when no events arrive beyond threshold", () => {
+  it("treats channels with no events since start as healthy (quiet channel, not stale)", () => {
+    // A channel that has never received events since starting should NOT be
+    // flagged as stale-socket. This prevents a restart loop where a quiet
+    // channel is repeatedly restarted: restart → grace expires → null treated
+    // as stale → restart again.
     const evaluation = evaluateChannelHealth(
       {
         running: true,
@@ -114,7 +118,75 @@ describe("evaluateChannelHealth", () => {
         staleEventThresholdMs: 30_000,
       },
     );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("flags stale sockets when events were received before but stopped", () => {
+    // If the channel previously received events (lastEventAt is a number)
+    // but hasn't received any beyond the stale threshold, it's a genuine
+    // stale socket (half-dead connection).
+    const now = 100_000;
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: now - 35_000,
+      },
+      {
+        now,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
     expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
+  });
+
+  it("does not flag stale-socket when lastEventAt is recent", () => {
+    const now = 100_000;
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: now - 5_000,
+      },
+      {
+        now,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("does not flag stale-socket for freshly restarted channel with reset lastEventAt", () => {
+    // After a health-monitor restart, lastEventAt is reset to null.
+    // The channel should get a full stale-threshold window before being
+    // flagged again — and only if it receives-then-loses events.
+    // Use lastStartAt past the connect-grace window so the test exercises
+    // the stale-socket path rather than early-returning as grace.
+    const now = 100_000;
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: now - 15_000,
+        lastEventAt: null,
+      },
+      {
+        now,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
 });
 

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -92,12 +92,22 @@ export function evaluateChannelHealth(
   if (snapshot.connected === false) {
     return { healthy: false, reason: "disconnected" };
   }
-  if (snapshot.lastEventAt != null || snapshot.lastStartAt != null) {
+  // Stale-socket detection: catches "half-dead" connections that appear alive
+  // (health checks pass, connected=true) but silently stop delivering events.
+  //
+  // Key distinction:
+  //   lastEventAt == null → channel hasn't received any events since it started
+  //     (normal for quiet channels or freshly restarted ones — skip stale check)
+  //   lastEventAt is a number → channel received events before and may have stopped
+  //     (potential stale socket — check the age)
+  //
+  // Without this distinction, quiet-but-healthy channels enter a restart loop:
+  //   restart → 30 min grace → null/0 treated as stale → restart again.
+  if (snapshot.lastEventAt != null) {
     const upSince = snapshot.lastStartAt ?? 0;
     const upDuration = policy.now - upSince;
     if (upDuration > policy.staleEventThresholdMs) {
-      const lastEvent = snapshot.lastEventAt ?? 0;
-      const eventAge = policy.now - lastEvent;
+      const eventAge = policy.now - snapshot.lastEventAt;
       if (eventAge > policy.staleEventThresholdMs) {
         return { healthy: false, reason: "stale-socket" };
       }

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -217,6 +217,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           running: true,
           lastStartAt: Date.now(),
           lastError: null,
+          // Reset event timestamps so the health monitor doesn't inherit stale
+          // values from the previous lifecycle and immediately flag the channel
+          // as stale-socket after the connect grace window expires.
+          lastEventAt: null,
+          lastInboundAt: null,
           reconnectAttempts: preserveRestartAttempts ? (restartAttempts.get(rKey) ?? 0) : 0,
         });
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -119,6 +119,7 @@ export const registerTelegramHandlers = ({
   shouldSkipUpdate,
   processMessage,
   logger,
+  setStatus,
 }: RegisterTelegramHandlerParams) => {
   const DEFAULT_TEXT_FRAGMENT_MAX_GAP_MS = 1500;
   const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = 4000;
@@ -729,6 +730,11 @@ export const registerTelegramHandlers = ({
       if (shouldSkipUpdate(ctx)) {
         return;
       }
+      // Refresh liveness timestamp so reaction-only traffic is not mistaken for a stale socket.
+      if (setStatus) {
+        const at = Date.now();
+        setStatus({ lastEventAt: at, lastInboundAt: at });
+      }
 
       const chatId = reaction.chat.id;
       const messageId = reaction.message_id;
@@ -1036,6 +1042,11 @@ export const registerTelegramHandlers = ({
     if (shouldSkipUpdate(ctx)) {
       return;
     }
+    // Refresh liveness timestamp so callback-only traffic is not mistaken for a stale socket.
+    if (setStatus) {
+      const at = Date.now();
+      setStatus({ lastEventAt: at, lastInboundAt: at });
+    }
     const answerCallbackQuery =
       typeof (ctx as { answerCallbackQuery?: unknown }).answerCallbackQuery === "function"
         ? () => ctx.answerCallbackQuery()
@@ -1324,6 +1335,11 @@ export const registerTelegramHandlers = ({
       if (shouldSkipUpdate(ctx)) {
         return;
       }
+      // Refresh liveness timestamp so migration events keep the socket alive.
+      if (setStatus) {
+        const at = Date.now();
+        setStatus({ lastEventAt: at, lastInboundAt: at });
+      }
 
       const oldChatId = String(msg.chat.id);
       const newChatId = String(msg.migrate_to_chat_id);
@@ -1386,6 +1402,13 @@ export const registerTelegramHandlers = ({
     try {
       if (shouldSkipUpdate(event.ctxForDedupe)) {
         return;
+      }
+      // Wire up event liveness tracking: update lastEventAt on every inbound event
+      // so the health monitor can detect "half-dead" sockets that pass health checks
+      // but silently stop delivering events.
+      if (setStatus) {
+        const at = Date.now();
+        setStatus({ lastEventAt: at, lastInboundAt: at });
       }
       const eventAuthContext = await resolveTelegramEventAuthorizationContext({
         chatId: event.chatId,

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -112,6 +112,7 @@ export type RegisterTelegramHandlerParams = {
     replyMedia?: TelegramMediaRef[],
   ) => Promise<void>;
   logger: ReturnType<typeof getChildLogger>;
+  setStatus?: (patch: { lastEventAt?: number | null; lastInboundAt?: number | null }) => void;
 };
 
 type RegisterTelegramNativeCommandsParams = {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -56,6 +56,7 @@ export type TelegramBotOptions = {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
   };
+  setStatus?: (patch: { lastEventAt?: number | null; lastInboundAt?: number | null }) => void;
 };
 
 export { getTelegramSequentialKey };
@@ -377,6 +378,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     shouldSkipUpdate,
     processMessage,
     logger,
+    setStatus: opts.setStatus,
   });
 
   return bot;

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -30,6 +30,7 @@ export type MonitorTelegramOpts = {
   webhookHost?: string;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
+  setStatus?: (patch: { lastEventAt?: number | null; lastInboundAt?: number | null }) => void;
 };
 
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
@@ -172,6 +173,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         fetch: proxyFetch,
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
+        setStatus: opts.setStatus,
       });
       await waitForAbortSignal(opts.abortSignal);
       return;
@@ -224,6 +226,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
             lastUpdateId,
             onUpdateId: persistUpdateId,
           },
+          setStatus: opts.setStatus,
         });
       } catch (err) {
         const shouldRetry = await waitBeforeRetryOnRecoverableSetupError(

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -87,6 +87,7 @@ export async function startTelegramWebhook(opts: {
   abortSignal?: AbortSignal;
   healthPath?: string;
   publicUrl?: string;
+  setStatus?: (patch: { lastEventAt?: number | null; lastInboundAt?: number | null }) => void;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -107,6 +108,7 @@ export async function startTelegramWebhook(opts: {
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    setStatus: opts.setStatus,
   });
   await initializeTelegramWebhookBot({
     bot,


### PR DESCRIPTION
fix #34052
## Summary

- **Problem:** Health monitor continuously restarts all channel accounts (Telegram, Discord, Slack) with reason `stale-socket` in multi-account setups, causing memory growth, message drops, and gateway unresponsiveness.
- **Why it matters:** With 9+ channels the gateway peaked at 5.8 GB RAM on a 7.6 GB VPS; 255 restart events per day made the system unusable.
- **What changed:**
  1. Telegram channels now propagate a `setStatus` callback to update `lastEventAt`/`lastInboundAt` on every inbound event, matching Discord and Slack behavior.
  2. `server-channels.ts` explicitly resets `lastEventAt` and `lastInboundAt` to `null` on channel start, preventing stale timestamps from being inherited across restarts.
  3. `evaluateChannelHealth` now distinguishes between "never received events" (`lastEventAt == null`) and "stopped receiving events" (`lastEventAt` is a stale number). Channels that have never received events are no longer flagged as `stale-socket`.
- **What did NOT change (scope boundary):** No Telegram/Discord/Slack API calls are affected. The `setStatus` callback is purely internal (updates an in-memory runtime snapshot). Channel connection logic, reconnect backoff, and webhook handling remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Health monitor restarts ALL channels (stale-socket) in multi-account setup
- Related #31760 (Discord-only stuck-restart loop)
- Related #28622 (lastInboundAt staleness detection proposal)

## User-visible / Behavior Changes

- Quiet channels (channels that have never received an inbound event) are no longer incorrectly restarted every 30 minutes.
- Freshly restarted channels get a full stale-threshold window before being eligible for stale-socket detection — only if they first receive and then stop receiving events.
- Telegram channels now participate in the same liveness tracking that Discord and Slack already use.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 24.04 / AWS EC2) or any
- Runtime/container: Node v22+
- Integration/channel: Telegram, Discord, Slack (multi-account)
- Relevant config: 4 agents, 4 Telegram accounts, 4 Discord accounts, 1 Slack account

### Steps

1. Configure a multi-account gateway with several Telegram/Discord/Slack accounts
2. Start the gateway and let it run for 30+ minutes
3. Observe health monitor logs

### Expected

- Channels that are connected and healthy stay running
- Only channels that genuinely stop receiving events (after previously receiving them) are restarted

### Actual (before fix)

- All channels flagged as `stale-socket` every 5-10 minutes
- 255 restart events per day, memory peaked at 5.8 GB

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Test results:** 37/37 tests pass (10 policy + 27 monitor), including:
- `treats channels with no events since start as healthy (quiet channel, not stale)` — verifies null lastEventAt is not flagged
- `flags stale sockets when events were received before but stopped` — verifies genuine stale detection still works
- `does not flag stale-socket for freshly restarted channel with reset lastEventAt` — verifies restart reset behavior
- `does not restart a channel that never received any event (quiet channel)` — end-to-end monitor test

## Human Verification (required)

- Verified scenarios: All 37 unit tests pass covering policy logic and monitor integration
- Edge cases checked: null vs number lastEventAt, grace period boundary, inherited stale busy flags, custom staleEventThresholdMs
- What you did **not** verify: Live multi-account gateway with real Telegram/Discord/Slack connections

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commits `eb85f0c4c` and `48134ca97`
- Known bad symptoms reviewers should watch for: If a genuinely dead channel with `lastEventAt: null` is never restarted (unlikely — such channels would show `connected: false` and be caught by the disconnected check instead)

## Risks and Mitigations

- Risk: A channel with a truly broken socket that never receives any events AND reports `connected: true` would not be detected by stale-socket (since `lastEventAt` stays `null`).
  - Mitigation: Such channels would eventually be caught by the `disconnected` check when the underlying transport detects the broken connection. All three channel types (Discord gateway heartbeat, Slack Socket Mode ping, Telegram long-poll timeout) have their own connection-level keepalive that flips `connected` to `false` on failure.
