### PR TITLE
fix(sandbox): allow write tool mkdirp for valid workspace paths

### DIFF
--- a/src/agents/sandbox/fs-bridge.test.ts
+++ b/src/agents/sandbox/fs-bridge.test.ts
@@ -272,6 +272,55 @@ describe("sandbox fs bridge shell compatibility", () => {
     await expectMkdirpAllowsExistingDirectory({ forceBoundaryIoFallback: true });
   });
 
+  it("allows mkdirp when boundary open fails and host path does not exist yet", async () => {
+    await withTempDir("openclaw-fs-bridge-mkdirp-new-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      mockedOpenBoundaryFile.mockImplementationOnce(async () => ({
+        ok: false,
+        reason: "io",
+        error: Object.assign(new Error("EISDIR"), { code: "EISDIR" }),
+      }));
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      await expect(bridge.mkdirp({ filePath: "new-subdir/nested" })).resolves.toBeUndefined();
+
+      const mkdirCall = findCallByScriptFragment('mkdir -p -- "$1"');
+      expect(mkdirCall).toBeDefined();
+      const mkdirPath = mkdirCall ? getDockerPathArg(mkdirCall[0]) : "";
+      expect(mkdirPath).toBe("/workspace/new-subdir/nested");
+    });
+  });
+
+  it("allows mkdirp for workspace root when boundary open returns io error", async () => {
+    await withTempDir("openclaw-fs-bridge-mkdirp-root-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      mockedOpenBoundaryFile.mockImplementationOnce(async () => ({
+        ok: false,
+        reason: "validation",
+        error: new Error("platform open failed"),
+      }));
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      await expect(bridge.mkdirp({ filePath: "." })).resolves.toBeUndefined();
+    });
+  });
+
   it("rejects mkdirp when target exists as a file", async () => {
     await withTempDir("openclaw-fs-bridge-mkdirp-file-", async (stateDir) => {
       const workspaceDir = path.join(stateDir, "workspace");

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
 import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../../infra/path-alias-guards.js";
 import type { SafeOpenSyncAllowedType } from "../../infra/safe-open-sync.js";
@@ -333,11 +334,17 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     if (!guarded.ok) {
       if (guarded.reason !== "path") {
         // Some platforms cannot open directories via openSync(O_RDONLY), even when
-        // the path is a valid in-boundary directory. Allow mkdirp to proceed in that
-        // narrow case by verifying the host path is an existing directory.
-        const canFallbackToDirectoryStat =
-          options.allowedType === "directory" && this.pathIsExistingDirectory(target.hostPath);
-        if (!canFallbackToDirectoryStat) {
+        // the path is a valid in-boundary directory. Allow mkdirp to proceed when:
+        // (a) the host path is an existing directory (original fallback), or
+        // (b) the host path does not exist yet AND resolves lexically inside the
+        //     mount root — the actual mkdir -p runs inside the container so the
+        //     host-side open check is not required for non-existent paths.
+        const canFallbackToDirectoryCheck =
+          options.allowedType === "directory" &&
+          (this.pathIsExistingDirectory(target.hostPath) ||
+            (!this.hostPathExists(target.hostPath) &&
+              this.hostPathIsInsideMount(target.hostPath, lexicalMount)));
+        if (!canFallbackToDirectoryCheck) {
           throw guarded.error instanceof Error
             ? guarded.error
             : new Error(
@@ -372,6 +379,22 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     } catch {
       return false;
     }
+  }
+
+  private hostPathExists(hostPath: string): boolean {
+    try {
+      fs.lstatSync(hostPath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Check if host path is the mount root itself or a descendant of it. */
+  private hostPathIsInsideMount(hostPath: string, mount: SandboxFsMount): boolean {
+    const resolved = path.resolve(hostPath);
+    const root = path.resolve(mount.hostRoot);
+    return resolved === root || resolved.startsWith(root + path.sep);
   }
 
   private resolveMountByContainerPath(containerPath: string): SandboxFsMount | null {


### PR DESCRIPTION
## Summary

- Problem: The sandbox `write` tool rejects valid `/workspace` paths with "Sandbox boundary checks failed; cannot create directories" even though `read`, `edit`, and `exec` work correctly on the same paths.
- Why it matters: Sandboxed worker agents cannot create or overwrite files via the `write` tool, breaking artifact generation workflows.
- What changed: Extended the mkdirp boundary-check fallback in `assertPathSafety` to also allow paths that do not yet exist on the host but resolve lexically inside the mount root. The actual `mkdir -p` runs inside the container, so the host-side `openSync` check is not required for non-existent directories.
- What did NOT change (scope boundary): Read, edit, stat, and remove path checks are untouched. Paths that exist as files on the host are still rejected. Symlink/hardlink escape detection is unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34072

## User-visible / Behavior Changes

- `write /workspace/file.txt` and `write /workspace/tmp/new.txt` now succeed in sandboxed worker agents with `workspaceAccess: rw`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No — the fallback only applies when `allowedType === "directory"`, the host path does not exist, and the path is lexically inside the mount root. Symlink/hardlink escape detection and canonical container path validation remain unchanged.
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Docker sandbox)
- Runtime: Node.js 22+

### Steps

1. Configure a sandbox worker with `mode: all`, `workspaceAccess: rw`, `scope: agent`
2. Run `write /workspace/case1_existing.txt` with content
3. Run `write /workspace/tmp/new-write-test.txt` with content

### Expected

- Both write operations succeed

### Actual

- Before: "Sandbox boundary checks failed; cannot create directories: /workspace"
- After: Both writes succeed

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

2 new vitest tests:
1. `allows mkdirp when boundary open fails and host path does not exist yet` — simulates EISDIR on openBoundaryFile for a new subdirectory
2. `allows mkdirp for workspace root when boundary open returns io error` — simulates platform open failure for the workspace root itself

## Human Verification (required)

- Verified scenarios: mkdirp for existing directories, new subdirectories, workspace root, bind-mounted directories
- Edge cases checked: Target is a file (still rejected), symlink escape (still blocked), hardlink escape (still blocked), read-only mounts (still blocked)
- What you did **not** verify: Live Docker sandbox on different storage drivers (overlayfs, btrfs, zfs)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/sandbox/fs-bridge.ts`

## Risks and Mitigations

- Risk: Slightly relaxed host-side boundary check for mkdirp on non-existent paths
  - Mitigation: The fallback only triggers when (1) `allowedType === "directory"`, (2) host path does not exist, and (3) path is lexically inside mount root. The canonical container-path check still runs after the boundary check, and the mount root was already validated by `resolveMountByContainerPath`.