### PR TITLE
fix(providers): respect configured baseUrl for Moonshot CN users

### DIFF
--- a/src/agents/models-config.providers.moonshot.test.ts
+++ b/src/agents/models-config.providers.moonshot.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { captureEnv } from "../test-utils/env.js";
+import { resolveImplicitProviders } from "./models-config.providers.js";
+
+describe("moonshot implicit provider", () => {
+  const createAgentDir = () => mkdtempSync(join(tmpdir(), "openclaw-test-"));
+
+  it("uses the default api.moonshot.ai baseUrl when none is configured", async () => {
+    const agentDir = createAgentDir();
+    const envSnapshot = captureEnv(["MOONSHOT_API_KEY"]);
+    process.env.MOONSHOT_API_KEY = "test-key";
+
+    try {
+      const providers = await resolveImplicitProviders({ agentDir });
+      expect(providers?.moonshot).toBeDefined();
+      expect(providers?.moonshot?.baseUrl).toBe("https://api.moonshot.ai/v1");
+      expect(providers?.moonshot?.apiKey).toBe("MOONSHOT_API_KEY");
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("respects an explicit baseUrl for CN users (api.moonshot.cn)", async () => {
+    const agentDir = createAgentDir();
+    const envSnapshot = captureEnv(["MOONSHOT_API_KEY"]);
+    process.env.MOONSHOT_API_KEY = "test-key";
+
+    try {
+      const providers = await resolveImplicitProviders({
+        agentDir,
+        explicitProviders: {
+          moonshot: {
+            baseUrl: "https://api.moonshot.cn/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      });
+      expect(providers?.moonshot?.baseUrl).toBe("https://api.moonshot.cn/v1");
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("does not include moonshot when no API key is configured", async () => {
+    const agentDir = createAgentDir();
+    const envSnapshot = captureEnv(["MOONSHOT_API_KEY"]);
+    delete process.env.MOONSHOT_API_KEY;
+
+    try {
+      const providers = await resolveImplicitProviders({ agentDir });
+      expect(providers?.moonshot).toBeUndefined();
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -948,7 +948,12 @@ export async function resolveImplicitProviders(params: {
     resolveEnvApiKeyVarName("moonshot") ??
     resolveApiKeyFromProfiles({ provider: "moonshot", store: authStore });
   if (moonshotKey) {
-    providers.moonshot = { ...buildMoonshotProvider(), apiKey: moonshotKey };
+    const configuredMoonshotBaseUrl = params.explicitProviders?.moonshot?.baseUrl;
+    providers.moonshot = {
+      ...buildMoonshotProvider(),
+      ...(configuredMoonshotBaseUrl ? { baseUrl: configuredMoonshotBaseUrl } : {}),
+      apiKey: moonshotKey,
+    };
   }
 
   const kimiCodingKey =


### PR DESCRIPTION
## Summary

- **Problem:** `resolveImplicitProviders` always calls `buildMoonshotProvider()` which hardcodes `baseUrl = "https://api.moonshot.ai/v1"`. CN users who set `baseUrl: "https://api.moonshot.cn/v1"` in their config find it silently overwritten.
- **Why it matters:** CN API keys are only valid on `api.moonshot.cn`. Every request with a CN key hits the international endpoint and returns HTTP 401. 100% reproducible for any CN user.
- **What changed:** Read `params.explicitProviders?.moonshot?.baseUrl` and use it when present, falling back to the hardcoded international URL otherwise. Same pattern already used by Ollama and vLLM in the same function.
- **What did NOT change:** International users unaffected (no explicit `baseUrl` → same default). All other providers untouched.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Fixes #32607

## User-visible / Behavior Changes

Moonshot CN users who configure `baseUrl: "https://api.moonshot.cn/v1"` in `openclaw.json` will have that URL honoured. Requests no longer silently go to the international endpoint.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — the destination URL was always user-configurable; we now correctly read it
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node 22+
- Model/provider: Moonshot CN (`api.moonshot.cn`)

### Steps

1. Set `baseUrl: "https://api.moonshot.cn/v1"` in `openclaw.json` under `models.providers.moonshot`
2. Set a valid CN API key
3. Check `~/.openclaw/agents/main/agent/models.json` — observe `baseUrl` field

### Expected

- `models.json` shows `"baseUrl": "https://api.moonshot.cn/v1"`

### Actual (before fix)

- `models.json` always shows `"baseUrl": "https://api.moonshot.ai/v1"` regardless of config

## Evidence

- [x] Failing test/log before + passing after

Added `models-config.providers.moonshot.test.ts` with three cases: default URL, CN override, no-key case. All 3 pass. Existing kimi-coding tests unaffected.

## Human Verification (required)

- Verified scenarios: traced `resolveImplicitProviders` → `buildMoonshotProvider()` spread → `explicitProviders?.moonshot?.baseUrl` override; confirmed priority order matches Ollama pattern
- Edge cases checked: `explicitProviders` absent, `explicitProviders.moonshot` present but `baseUrl` absent — both correctly fall through to the hardcoded default
- What you did **not** verify: live CN API key (requires a China-region account)

## Compatibility / Migration

- Backward compatible? Yes — international users with no explicit `baseUrl` see no change
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert quickly: revert 5-line change in `src/agents/models-config.providers.ts`
- Files/config to restore: `models-config.providers.ts` only
- Known bad symptoms: CN users getting 401 again → revert and they return to previous (broken) state

## Risks and Mitigations

None. Reading a user-supplied config value that was previously ignored cannot introduce new risks.