### PR TITLE
fix(acp): close runtime handle when agent dispatch fails after init

### DIFF
--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -406,6 +406,40 @@ describe("spawnAcpDirect", () => {
     expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
+  it("closes runtime when agent dispatch fails after session init", async () => {
+    hoisted.callGatewayMock.mockImplementation(async (argsUnknown: unknown) => {
+      const args = argsUnknown as { method?: string };
+      if (args.method === "sessions.patch") {
+        return { ok: true };
+      }
+      if (args.method === "agent") {
+        throw new Error("gateway dispatch timeout");
+      }
+      if (args.method === "sessions.delete") {
+        return { ok: true };
+      }
+      return {};
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "hello",
+        agentId: "codex",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("gateway dispatch timeout");
+
+    const initResult = await hoisted.initializeSessionMock.mock.results[0]?.value;
+    expect(initResult?.runtime?.close).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "spawn-failed" }),
+    );
+  });
+
   it('forbids sandbox="require" for runtime=acp', async () => {
     const result = await spawnAcpDirect(
       {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -437,6 +437,7 @@ export async function spawnAcpDirect(
       sessionKey,
       shouldDeleteSession: true,
       deleteTranscript: true,
+      runtimeCloseHandle: initializedRuntime,
     });
     return {
       status: "error",


### PR DESCRIPTION
## Summary

- Problem: When the initial agent dispatch (`callGateway method: "agent"`) fails after a successful `initializeSession`, the ACP runtime handle is not closed. Zombie acpx sessions accumulate in `~/.acpx/sessions/` and eventually block all ACP spawns with "max concurrent sessions reached (8/8)".
- Why it matters: Any transient gateway dispatch failure (timeout, network error) permanently leaks an ACP session slot, degrading the system over time until restart.
- What changed: Pass `runtimeCloseHandle: initializedRuntime` to `cleanupFailedAcpSpawn` in the agent dispatch error path (the first catch block already had it; the second was missing it).
- What did NOT change (scope boundary): The `initializeSession` error path, `runTurn` oneshot close logic, and idle eviction are untouched. Only the missing `runtimeCloseHandle` parameter was added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34054

## User-visible / Behavior Changes

ACP sessions are now properly cleaned up when the initial agent dispatch fails, preventing zombie session accumulation.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure ACP with `maxConcurrentSessions: 8`
2. Spawn an ACP oneshot session where the gateway agent dispatch times out
3. Repeat until 8 sessions are leaked
4. Attempt another ACP spawn

### Expected

- Leaked sessions are closed on dispatch failure

### Actual

- Before: Sessions leak, eventually hitting "max concurrent sessions reached (8/8)"
- After: `runtime.close()` is called with reason `"spawn-failed"`, freeing the session slot

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

1 new vitest test: `closes runtime when agent dispatch fails after session init` — verifies `runtime.close` is called with `reason: "spawn-failed"` when `callGateway({ method: "agent" })` throws.

## Human Verification (required)

- Verified scenarios: Agent dispatch timeout, agent dispatch network error
- Edge cases checked: First catch block (init error) already had the handle — confirmed no regression; second catch block now matches
- What you did **not** verify: Live ACP session accumulation on a production gateway

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/acp-spawn.ts`

## Risks and Mitigations

- Risk: None — this is a one-parameter addition to an existing cleanup call
  - Mitigation: The `runtimeCloseHandle` is already the same variable passed in the first catch block 10 lines above