### PR TITLE
fix(ui): add fallback clipboard copy for Windows

### DIFF
--- a/ui/src/ui/chat/copy-as-markdown.ts
+++ b/ui/src/ui/chat/copy-as-markdown.ts
@@ -17,11 +17,34 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
     return false;
   }
 
+  // Try modern Clipboard API first
   try {
     await navigator.clipboard.writeText(text);
     return true;
   } catch {
+    // Fallback for browsers/contexts where Clipboard API fails (e.g., some Windows Chrome configurations)
+    return fallbackCopyToClipboard(text);
+  }
+}
+
+// Fallback copy method using textarea and execCommand
+function fallbackCopyToClipboard(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  try {
+    const success = document.execCommand("copy");
+    return success;
+  } catch {
     return false;
+  } finally {
+    document.body.removeChild(textarea);
   }
 }
 


### PR DESCRIPTION

## Summary

Fixes #34092 - Chat "copy button" not working on Windows

When `navigator.clipboard.writeText` fails (e.g., on some Windows Chrome
configurations), fall back to using a textarea element with
`document.execCommand("copy")` to ensure the copy button works reliably.

## Changes

- Added `fallbackCopyToClipboard()` function that uses a hidden textarea
  and `execCommand("copy")` as a fallback
- Modified `copyTextToClipboard()` to call the fallback when the modern
  Clipboard API fails

## Testing

The change adds a fallback mechanism without modifying the existing
behavior for browsers that support the modern Clipboard API.
