### PR TITLE
fix(slack): stop typing indicator after silent NO_REPLY runs

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -291,72 +291,73 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     }
   };
 
-  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
-    ...prefixOptions,
-    humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
-    typingCallbacks,
-    deliver: async (payload) => {
-      if (useStreaming) {
-        await deliverWithStreaming(payload);
-        return;
-      }
-
-      const mediaCount = payload.mediaUrls?.length ?? (payload.mediaUrl ? 1 : 0);
-      const draftMessageId = draftStream?.messageId();
-      const draftChannelId = draftStream?.channelId();
-      const finalText = payload.text;
-      const canFinalizeViaPreviewEdit =
-        previewStreamingEnabled &&
-        streamMode !== "status_final" &&
-        mediaCount === 0 &&
-        !payload.isError &&
-        typeof finalText === "string" &&
-        finalText.trim().length > 0 &&
-        typeof draftMessageId === "string" &&
-        typeof draftChannelId === "string";
-
-      if (canFinalizeViaPreviewEdit) {
-        draftStream?.stop();
-        try {
-          await ctx.app.client.chat.update({
-            token: ctx.botToken,
-            channel: draftChannelId,
-            ts: draftMessageId,
-            text: normalizeSlackOutboundText(finalText.trim()),
-          });
+  const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
+    createReplyDispatcherWithTyping({
+      ...prefixOptions,
+      humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+      typingCallbacks,
+      deliver: async (payload) => {
+        if (useStreaming) {
+          await deliverWithStreaming(payload);
           return;
-        } catch (err) {
-          logVerbose(
-            `slack: preview final edit failed; falling back to standard send (${String(err)})`,
-          );
         }
-      } else if (previewStreamingEnabled && streamMode === "status_final" && hasStreamedMessage) {
-        try {
-          const statusChannelId = draftStream?.channelId();
-          const statusMessageId = draftStream?.messageId();
-          if (statusChannelId && statusMessageId) {
+
+        const mediaCount = payload.mediaUrls?.length ?? (payload.mediaUrl ? 1 : 0);
+        const draftMessageId = draftStream?.messageId();
+        const draftChannelId = draftStream?.channelId();
+        const finalText = payload.text;
+        const canFinalizeViaPreviewEdit =
+          previewStreamingEnabled &&
+          streamMode !== "status_final" &&
+          mediaCount === 0 &&
+          !payload.isError &&
+          typeof finalText === "string" &&
+          finalText.trim().length > 0 &&
+          typeof draftMessageId === "string" &&
+          typeof draftChannelId === "string";
+
+        if (canFinalizeViaPreviewEdit) {
+          draftStream?.stop();
+          try {
             await ctx.app.client.chat.update({
               token: ctx.botToken,
-              channel: statusChannelId,
-              ts: statusMessageId,
-              text: "Status: complete. Final answer posted below.",
+              channel: draftChannelId,
+              ts: draftMessageId,
+              text: normalizeSlackOutboundText(finalText.trim()),
             });
+            return;
+          } catch (err) {
+            logVerbose(
+              `slack: preview final edit failed; falling back to standard send (${String(err)})`,
+            );
           }
-        } catch (err) {
-          logVerbose(`slack: status_final completion update failed (${String(err)})`);
+        } else if (previewStreamingEnabled && streamMode === "status_final" && hasStreamedMessage) {
+          try {
+            const statusChannelId = draftStream?.channelId();
+            const statusMessageId = draftStream?.messageId();
+            if (statusChannelId && statusMessageId) {
+              await ctx.app.client.chat.update({
+                token: ctx.botToken,
+                channel: statusChannelId,
+                ts: statusMessageId,
+                text: "Status: complete. Final answer posted below.",
+              });
+            }
+          } catch (err) {
+            logVerbose(`slack: status_final completion update failed (${String(err)})`);
+          }
+        } else if (mediaCount > 0) {
+          await draftStream?.clear();
+          hasStreamedMessage = false;
         }
-      } else if (mediaCount > 0) {
-        await draftStream?.clear();
-        hasStreamedMessage = false;
-      }
 
-      await deliverNormally(payload);
-    },
-    onError: (err, info) => {
-      runtime.error?.(danger(`slack ${info.kind} reply failed: ${String(err)}`));
-      typingCallbacks.onIdle?.();
-    },
-  });
+        await deliverNormally(payload);
+      },
+      onError: (err, info) => {
+        runtime.error?.(danger(`slack ${info.kind} reply failed: ${String(err)}`));
+        typingCallbacks.onIdle?.();
+      },
+    });
 
   const draftStream = createSlackDraftStream({
     target: prepared.replyTarget,
@@ -454,6 +455,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   });
   await draftStream.flush();
   draftStream.stop();
+  markRunComplete();
   markDispatchIdle();
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Problem:** Slack channels configured with `requireMention: false` display a lingering typing indicator when the agent produces a NO_REPLY (silent gate) response. The bubble persists until TTL timeout instead of clearing immediately.
- **Why it matters:** Users see a permanent "typing..." indicator in Slack even though the bot has already decided not to reply, creating a broken UX.
- **What changed:** Added the missing `markRunComplete()` call in the Slack dispatch path before `markDispatchIdle()`, exactly mirroring the Discord fix from v2026.3.3 (commit `66d06bee`).
- **What did NOT change (scope boundary):** No changes to typing controller logic, reply dispatcher, streaming, or any other channel's dispatch path. The fix is a single additional function call.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #33951
- Related: Discord fix in commit `66d06bee` (v2026.3.3) — same pattern, different channel

## User-visible / Behavior Changes

Slack typing indicator now clears immediately after a NO_REPLY run instead of lingering until TTL timeout.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Slack
- Relevant config: `requireMention: false` on a Slack channel

### Steps

1. Configure a Slack channel with `requireMention: false`
2. Send a message that triggers a NO_REPLY (silent gate) response
3. Observe the typing indicator

### Expected

- Typing indicator clears immediately after the agent decides NO_REPLY

### Actual (before fix)

- Typing indicator stays visible until TTL timeout

## Evidence

- [x] Failing test/log before + passing after
- Root cause confirmed: `src/auto-reply/reply/typing.ts` → `maybeStopOnIdle()` requires both `markRunComplete()` and `markDispatchIdle()` before cleanup. Slack only called `markDispatchIdle()`.

## Human Verification (required)

- Verified scenarios: NO_REPLY path in Slack dispatch now calls `markRunComplete()` before `markDispatchIdle()`, matching Discord's pattern
- Edge cases checked: normal reply path unaffected (typing clears via deliver callback); streaming path unaffected
- What you did **not** verify: live Slack workspace end-to-end

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit; remove the `markRunComplete()` call at line 458
- Files/config to restore: `src/slack/monitor/message-handler/dispatch.ts`
- Known bad symptoms reviewers should watch for: typing indicator clearing too early during active streaming

## Risks and Mitigations

- Risk: Calling `markRunComplete()` before `markDispatchIdle()` could theoretically interfere with in-flight deliveries
  - Mitigation: This exact pattern is already proven in the Discord path (commit `66d06bee`). The call is placed after `draftStream.flush()` and `draftStream.stop()`, ensuring all pending work is complete.