### PR TITLE
fix(gateway): prevent duplicate delivery of queued messages

### DIFF
--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -116,13 +116,13 @@ export function scheduleFollowupDrain(
             summary,
             renderItem: (item, idx) => `---\nQueued #${idx + 1}\n${item.prompt}`.trim(),
           });
+          queue.items.splice(0, items.length);
           await runFollowup({
             prompt,
             run,
             enqueuedAt: Date.now(),
             ...routing,
           });
-          queue.items.splice(0, items.length);
           if (summary) {
             clearQueueSummaryState(queue);
           }

--- a/src/utils/queue-helpers.test.ts
+++ b/src/utils/queue-helpers.test.ts
@@ -4,6 +4,7 @@ import {
   buildQueueSummaryPrompt,
   clearQueueSummaryState,
   drainCollectItemIfNeeded,
+  drainNextQueueItem,
   previewQueueSummaryPrompt,
 } from "./queue-helpers.js";
 
@@ -110,6 +111,37 @@ describe("queue summary helpers", () => {
     clearQueueSummaryState(state);
     expect(state.droppedCount).toBe(0);
     expect(state.summaryLines).toEqual([]);
+  });
+});
+
+describe("drainNextQueueItem", () => {
+  it("removes item from queue before calling run to prevent duplicate delivery", async () => {
+    const items = [1, 2, 3];
+    let itemsDuringRun: number[] = [];
+
+    await drainNextQueueItem(items, async () => {
+      itemsDuringRun = [...items];
+    });
+
+    expect(itemsDuringRun).toEqual([2, 3]);
+    expect(items).toEqual([2, 3]);
+  });
+
+  it("does not re-add item when run throws", async () => {
+    const items = [1, 2];
+
+    await expect(
+      drainNextQueueItem(items, async () => {
+        throw new Error("delivery failed");
+      }),
+    ).rejects.toThrow("delivery failed");
+
+    expect(items).toEqual([2]);
+  });
+
+  it("returns false for empty queue", async () => {
+    const result = await drainNextQueueItem([], async () => {});
+    expect(result).toBe(false);
   });
 });
 

--- a/src/utils/queue-helpers.ts
+++ b/src/utils/queue-helpers.ts
@@ -152,8 +152,8 @@ export async function drainNextQueueItem<T>(
   if (!next) {
     return false;
   }
-  await run(next);
   items.shift();
+  await run(next);
   return true;
 }
 


### PR DESCRIPTION
## Summary

- Problem: When messages queue while the agent is busy (shown as "[Queued messages while agent was busy]"), they are delivered twice — causing the agent to respond to the same batch of messages twice.
- Why it matters: Duplicate responses confuse users and waste tokens/compute. Observed on Telegram and Discord when rapid-fire messages are sent during an active agent run.
- What changed: Moved `items.splice()` and `items.shift()` before the `runFollowup` call in the queue drain loop. Items are now consumed before delivery so a `runFollowup` failure does not trigger re-delivery of already-sent messages.
- What did NOT change (scope boundary): Enqueue-time deduplication (`isRunAlreadyQueued`) is untouched. Queue debounce timing, collect-mode batching logic, and cross-channel routing are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34041

## User-visible / Behavior Changes

Queued messages are delivered exactly once. Previously, a transient error in the followup runner would cause the entire batch to be re-delivered.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+
- Channels: Telegram, Discord (any channel with queued-message support)

### Steps

1. Send 3+ messages rapidly while the agent is processing a turn
2. Wait for the agent to finish its turn
3. Observe responses

### Expected

- Agent responds once to the collected "[Queued messages while agent was busy]" batch

### Actual

- Before: Agent responds twice to the same batch (identical "[Queued messages while agent was busy]" prompt delivered twice)
- After: Single response

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

3 new vitest tests in `queue-helpers.test.ts`:
1. `removes item from queue before calling run to prevent duplicate delivery` — verifies items are shifted before `run` executes
2. `does not re-add item when run throws` — verifies items stay removed on error
3. `returns false for empty queue` — edge case coverage

## Human Verification (required)

- Verified scenarios: Collect-mode batch delivery, individual-mode drain, error during delivery
- Edge cases checked: Empty queue, single item, multiple items with cross-channel routing
- What you did **not** verify: Full integration test with live Telegram/Discord (large reply-flow.test.ts takes >3 minutes; verified unit-level behavior via queue-helpers.test.ts)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/auto-reply/reply/queue/drain.ts`, `src/utils/queue-helpers.ts`

## Risks and Mitigations

- Risk: Delivery semantics change from at-least-once to at-most-once — if `runFollowup` fails after items are spliced, messages are lost
  - Mitigation: `runFollowup` failures are already logged and do not retry at the agent level. The previous "at-least-once" behavior caused visible user-facing duplicates, which is worse than a rare silent drop on transient errors.