### PR TITLE
fix(discord): add task timeout to prevent channel queue stalling

### DIFF
--- a/src/discord/monitor/listeners.test.ts
+++ b/src/discord/monitor/listeners.test.ts
@@ -121,4 +121,31 @@ describe("DiscordMessageListener", () => {
       );
     });
   });
+
+  it("unblocks channel queue when handler hangs beyond timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = vi.fn(async () => {
+        await new Promise(() => {});
+      });
+      const logger = createLogger();
+      const listener = new DiscordMessageListener(handler as never, logger as never);
+
+      await listener.handle(fakeEvent("ch-1"), {} as never);
+      await listener.handle(fakeEvent("ch-1"), {} as never);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(120_001);
+
+      await vi.waitFor(() => {
+        expect(handler).toHaveBeenCalledTimes(2);
+      });
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("discord handler timed out"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -66,6 +66,7 @@ type DiscordReactionRoutingParams = {
 };
 
 const DISCORD_SLOW_LISTENER_THRESHOLD_MS = 30_000;
+const DISCORD_LISTENER_TASK_TIMEOUT_MS = 120_000;
 const discordEventQueueLog = createSubsystemLogger("discord/event-queue");
 
 function logSlowDiscordListener(params: {
@@ -89,6 +90,29 @@ function logSlowDiscordListener(params: {
     durationMs: params.durationMs,
     duration,
     consoleMessage: message,
+  });
+}
+
+function withTaskTimeout<T>(
+  task: () => Promise<T>,
+  timeoutMs: number,
+  onTimeout?: () => void,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      onTimeout?.();
+      reject(new Error(`Task timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    task().then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
   });
 }
 
@@ -144,16 +168,28 @@ export class DiscordMessageListener extends MessageCreateListener {
     // but allow different channels to proceed in parallel so that
     // channel-bound agents are not blocked by each other.
     void this.channelQueue.enqueue(channelId, () =>
-      runDiscordListenerWithSlowLog({
-        logger: this.logger,
-        listener: this.constructor.name,
-        event: this.type,
-        run: () => this.handler(data, client),
-        onError: (err) => {
+      withTaskTimeout(
+        () =>
+          runDiscordListenerWithSlowLog({
+            logger: this.logger,
+            listener: this.constructor.name,
+            event: this.type,
+            run: () => this.handler(data, client),
+            onError: (err) => {
+              const logger = this.logger ?? discordEventQueueLog;
+              logger.error(danger(`discord handler failed: ${String(err)}`));
+            },
+          }),
+        DISCORD_LISTENER_TASK_TIMEOUT_MS,
+        () => {
           const logger = this.logger ?? discordEventQueueLog;
-          logger.error(danger(`discord handler failed: ${String(err)}`));
+          logger.error(
+            danger(
+              `discord handler timed out after ${DISCORD_LISTENER_TASK_TIMEOUT_MS}ms for channel ${channelId}, unblocking queue`,
+            ),
+          );
         },
-      }),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary

- Problem: When a `DiscordMessageListener` handler hangs (e.g. due to API rate limits or provider init failures), all subsequent messages in the same channel are silently dropped because the per-channel `KeyedAsyncQueue` serializes tasks with no timeout.
- Why it matters: Users send voice/audio or text messages that are consumed by the event loop but never routed to a session — no error, no notification, complete silent drop.
- What changed: Wrapped each channelQueue task with a 120s `withTaskTimeout`. When the timeout fires, the task is rejected (logged as error) and the queue moves on to the next message.
- What did NOT change (scope boundary): Carbon EventQueue configuration, per-channel serialization semantics, and the `KeyedAsyncQueue` itself are untouched. Cross-channel parallelism is preserved. The timeout matches the existing Carbon `listenerTimeout` default.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33906

## User-visible / Behavior Changes

- Messages sent while a Discord channel handler is hung are now processed after the 120s timeout instead of being silently dropped.
- A timeout error is logged when the handler exceeds 120s, providing visibility into stalled handlers.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+
- Channel: Discord

### Steps

1. Trigger API overload / rate limit errors causing a message handler to hang
2. Send a new message to the same Discord channel while the handler is blocked

### Expected

- After 120s, the hung handler is timed out and the new message is processed

### Actual

- Before: New message silently dropped — no session init, no error, no notification
- After: Hung handler times out at 120s with error log; queued message proceeds to processing

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

1 new vitest test: `unblocks channel queue when handler hangs beyond timeout` — uses fake timers to advance 120s and verifies the second handler runs after timeout.

## Human Verification (required)

- Verified scenarios: Handler hangs indefinitely → second message processes after timeout; handler completes within timeout → normal flow; handler throws → normal error handling
- Edge cases checked: Multiple channels (parallel, not affected); logger fallback when no logger provided
- What you did **not** verify: Live Discord connection with actual API rate limits

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No — timeout matches existing Carbon `listenerTimeout` default (120s)
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; or increase `DISCORD_LISTENER_TASK_TIMEOUT_MS` to a very large value
- Files/config to restore: `src/discord/monitor/listeners.ts`

## Risks and Mitigations

- Risk: Legitimate long-running handlers (>120s) will be timed out and their response lost
  - Mitigation: 120s matches the existing Carbon listener timeout, so this aligns with the expected maximum handler duration. LLM calls with extended thinking that exceed 120s would already be timed out by Carbon. The actual message processing uses the queue/followup system which is independent of the listener timeout.