### PR TITLE
fix(agents): replace blank tool names with sentinel to prevent dispatch loops

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -414,6 +414,7 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     expect(result).toBe(finalMessage);
   });
 
+<<<<<<< HEAD
   it("infers tool names from malformed toolCallId variants when allowlist is present", async () => {
     const partialToolCall = { type: "toolCall", id: "functions.read:0", name: "" };
     const finalToolCallA = { type: "toolCall", id: "functionsread3", name: "" };
@@ -687,7 +688,7 @@ describe("wrapStreamFnTrimToolCallNames", () => {
 
     expect(finalToolCall.name).toBe("");
   });
-  it("does not collapse whitespace-only tool names to empty strings", async () => {
+  it("replaces blank/whitespace-only tool names with _blank sentinel to prevent dispatch loops", async () => {
     const partialToolCall = { type: "toolCall", name: "   " };
     const finalToolCall = { type: "toolCall", name: "\t  " };
     const event = {
@@ -703,8 +704,10 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     }
     await stream.result();
 
-    expect(partialToolCall.name).toBe("   ");
-    expect(finalToolCall.name).toBe("\t  ");
+    // Blank names are replaced with "_blank" so pi-agent-core produces a
+    // clear "Tool _blank not found" error instead of looping (#34129).
+    expect(partialToolCall.name).toBe("_blank");
+    expect(finalToolCall.name).toBe("_blank");
     expect(baseFn).toHaveBeenCalledTimes(1);
   });
 

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -414,7 +414,6 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     expect(result).toBe(finalMessage);
   });
 
-<<<<<<< HEAD
   it("infers tool names from malformed toolCallId variants when allowlist is present", async () => {
     const partialToolCall = { type: "toolCall", id: "functions.read:0", name: "" };
     const finalToolCallA = { type: "toolCall", id: "functionsread3", name: "" };

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -616,9 +616,10 @@ function normalizeToolCallNameForDispatch(
 ): string {
   const trimmed = rawName.trim();
   if (!trimmed) {
-    // Keep whitespace-only placeholders unchanged unless we can safely infer
-    // a canonical name from toolCallId and allowlist.
-    return inferToolNameFromToolCallId(rawToolCallId, allowedToolNames) ?? rawName;
+    // Return a clearly-invalid sentinel so tool dispatch produces a single
+    // descriptive "Tool _blank not found" error instead of looping on an
+    // empty name that the model keeps retrying (#34129, #29965).
+    return inferToolNameFromToolCallId(rawToolCallId, allowedToolNames) ?? "_blank";
   }
   if (!allowedToolNames || allowedToolNames.size === 0) {
     return trimmed;


### PR DESCRIPTION
## Summary

- Problem: When models (e.g. nvidia/moonshotai/kimi-k2.5 via NVIDIA endpoint) emit tool calls with empty/blank tool names, `normalizeToolCallNameForDispatch` returns the raw empty string. pi-agent-core then fails to match any tool, returns "Tool not found", and the model retries the same empty tool call — creating an infinite loop that floods logs and leaks raw `call_auto_*` tokens to the user's chat.
- Why it matters: Users see repeated "Tool not found" errors and leaked internal tokens in their Telegram/Discord chat. The agent session gets stuck in an unrecoverable retry loop until timeout.
- What changed: `normalizeToolCallNameForDispatch` now returns a `_blank` sentinel string when the raw tool name is empty or whitespace-only. This causes pi-agent-core to produce a single, clear "Tool _blank not found" error that the model can interpret and stop retrying. Updated the existing test to verify the new behavior.
- What did NOT change (scope boundary): Non-blank tool name normalization (trimming, case-insensitive matching, snake_case normalization) is unchanged. Tool dispatch logic in pi-agent-core is unchanged. The `call_auto_*` ID fallback logic is unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #34129
- Related #29965

## User-visible / Behavior Changes

- When a model emits a blank tool name, the agent now returns a single "Tool _blank not found" error instead of looping indefinitely. The model can then recover or produce a text response.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OS: macOS
- Runtime/container: Node 22+
- Model/provider: nvidia / moonshotai/kimi-k2.5 (openai-completions API mode)
- Integration/channel (if any): Telegram (reported), any channel affected
- Relevant config (redacted): N/A

### Steps
1. Configure nvidia provider with kimi-k2.5 model
2. Send a message that triggers tool use
3. Model emits a tool call with empty `name` field

### Expected
Agent returns a single "Tool _blank not found" error; model stops retrying or produces text response.

### Actual (before fix)
Agent enters infinite "Tool not found" retry loop. `call_auto_*` tokens leak into user chat. Logs show repeated errors every ~20 seconds until session timeout.

## Evidence

- [x] Failing test/log before + passing after

```
 ✓ src/agents/pi-embedded-runner/run/attempt.test.ts (27 tests) 4ms

 Test Files  1 passed (1)
      Tests  27 passed (27)
```

Full suite: 6576 passed, 1 pre-existing failure (unrelated: `ui.presenter-next-run`).

## Human Verification (required)

- Verified scenarios: Local test suite passes (`pnpm build && pnpm check && pnpm test`). The blank tool name test now verifies `_blank` sentinel is used.
- Edge cases checked: (1) Empty string `""` → `_blank`. (2) Whitespace-only `"   "` → `_blank`. (3) Tab + spaces `"\t  "` → `_blank`. (4) Normal tool names with leading/trailing whitespace → still trimmed correctly. (5) Valid tool names → unchanged.
- What you did **not** verify: Live testing with NVIDIA kimi-k2.5 model and real API credentials.

> **Note:** This PR was created with AI assistance (Claude Code). The code changes have been reviewed and understood.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert <commit-hash>`
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms reviewers should watch for: If a legitimate tool is somehow named with only whitespace (extremely unlikely), it would be replaced with `_blank` and fail to dispatch. No real-world tool should have a blank name.

## Risks and Mitigations

- Risk: The `_blank` sentinel could theoretically collide with a real tool named `_blank`.
- Mitigation: No such tool exists in OpenClaw's tool registry. The underscore-prefixed name clearly signals it's a synthetic placeholder, and the fix is strictly better than the current behavior (infinite loop).