### PR TITLE
fix(webchat): clear chatStream before updating chatMessages to prevent duplicate rendering

### DIFF
--- a/apps/ios/ActivityWidget/Assets.xcassets/Contents.json
+++ b/apps/ios/ActivityWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/ios/ActivityWidget/Info.plist
+++ b/apps/ios/ActivityWidget/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>OpenClaw Activity</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2026.3.2</string>
+	<key>CFBundleVersion</key>
+	<string>20260301</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/ios/ActivityWidget/OpenClawActivityWidgetBundle.swift
+++ b/apps/ios/ActivityWidget/OpenClawActivityWidgetBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct OpenClawActivityWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        OpenClawLiveActivity()
+    }
+}

--- a/apps/ios/ActivityWidget/OpenClawLiveActivity.swift
+++ b/apps/ios/ActivityWidget/OpenClawLiveActivity.swift
@@ -1,0 +1,84 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+struct OpenClawLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: OpenClawActivityAttributes.self) { context in
+            lockScreenView(context: context)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    statusDot(state: context.state)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    Text(context.state.statusText)
+                        .font(.subheadline)
+                        .lineLimit(1)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    trailingView(state: context.state)
+                }
+            } compactLeading: {
+                statusDot(state: context.state)
+            } compactTrailing: {
+                Text(context.state.statusText)
+                    .font(.caption2)
+                    .lineLimit(1)
+                    .frame(maxWidth: 64)
+            } minimal: {
+                statusDot(state: context.state)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func lockScreenView(context: ActivityViewContext<OpenClawActivityAttributes>) -> some View {
+        HStack(spacing: 8) {
+            statusDot(state: context.state)
+                .frame(width: 10, height: 10)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("OpenClaw")
+                    .font(.subheadline.bold())
+                Text(context.state.statusText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            trailingView(state: context.state)
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func trailingView(state: OpenClawActivityAttributes.ContentState) -> some View {
+        if state.isConnecting {
+            ProgressView().controlSize(.small)
+        } else if state.isDisconnected {
+            Image(systemName: "wifi.slash")
+                .foregroundStyle(.red)
+        } else if state.isIdle {
+            Image(systemName: "antenna.radiowaves.left.and.right")
+                .foregroundStyle(.green)
+        } else {
+            Text(state.startedAt, style: .timer)
+                .font(.caption)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private func statusDot(state: OpenClawActivityAttributes.ContentState) -> some View {
+        Circle()
+            .fill(dotColor(state: state))
+            .frame(width: 6, height: 6)
+    }
+
+    private func dotColor(state: OpenClawActivityAttributes.ContentState) -> Color {
+        if state.isDisconnected { return .red }
+        if state.isConnecting { return .gray }
+        if state.isIdle { return .green }
+        return .blue
+    }
+}

--- a/apps/ios/Config/Signing.xcconfig
+++ b/apps/ios/Config/Signing.xcconfig
@@ -4,6 +4,7 @@ OPENCLAW_IOS_SELECTED_TEAM = $(OPENCLAW_IOS_DEFAULT_TEAM)
 OPENCLAW_APP_BUNDLE_ID = ai.openclaw.ios
 OPENCLAW_WATCH_APP_BUNDLE_ID = ai.openclaw.ios.watchkitapp
 OPENCLAW_WATCH_EXTENSION_BUNDLE_ID = ai.openclaw.ios.watchkitapp.extension
+OPENCLAW_ACTIVITY_WIDGET_BUNDLE_ID = ai.openclaw.ios.activitywidget
 
 // Local contributors can override this by running scripts/ios-configure-signing.sh.
 // Keep include after defaults: xcconfig is evaluated top-to-bottom.

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -54,6 +54,8 @@
 	<string>OpenClaw needs microphone access for voice wake.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>OpenClaw uses on-device speech recognition for voice wake.</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/apps/ios/Sources/LiveActivity/LiveActivityManager.swift
+++ b/apps/ios/Sources/LiveActivity/LiveActivityManager.swift
@@ -1,0 +1,125 @@
+import ActivityKit
+import Foundation
+import os
+
+/// Minimal Live Activity lifecycle focused on connection health + stale cleanup.
+@MainActor
+final class LiveActivityManager {
+    static let shared = LiveActivityManager()
+
+    private let logger = Logger(subsystem: "ai.openclaw.ios", category: "LiveActivity")
+    private var currentActivity: Activity<OpenClawActivityAttributes>?
+    private var activityStartDate: Date = .now
+
+    private init() {
+        self.hydrateCurrentAndPruneDuplicates()
+    }
+
+    var isActive: Bool {
+        guard let activity = self.currentActivity else { return false }
+        guard activity.activityState == .active else {
+            self.currentActivity = nil
+            return false
+        }
+        return true
+    }
+
+    func startActivity(agentName: String, sessionKey: String) {
+        self.hydrateCurrentAndPruneDuplicates()
+
+        if self.currentActivity != nil {
+            self.handleConnecting()
+            return
+        }
+
+        let authInfo = ActivityAuthorizationInfo()
+        guard authInfo.areActivitiesEnabled else {
+            self.logger.info("Live Activities disabled; skipping start")
+            return
+        }
+
+        self.activityStartDate = .now
+        let attributes = OpenClawActivityAttributes(agentName: agentName, sessionKey: sessionKey)
+
+        do {
+            let activity = try Activity.request(
+                attributes: attributes,
+                content: ActivityContent(state: self.connectingState(), staleDate: nil),
+                pushType: nil)
+            self.currentActivity = activity
+            self.logger.info("started live activity id=\(activity.id, privacy: .public)")
+        } catch {
+            self.logger.error("failed to start live activity: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func handleConnecting() {
+        self.updateCurrent(state: self.connectingState())
+    }
+
+    func handleReconnect() {
+        self.updateCurrent(state: self.idleState())
+    }
+
+    func handleDisconnect() {
+        self.updateCurrent(state: self.disconnectedState())
+    }
+
+    private func hydrateCurrentAndPruneDuplicates() {
+        let active = Activity<OpenClawActivityAttributes>.activities
+        guard !active.isEmpty else {
+            self.currentActivity = nil
+            return
+        }
+
+        let keeper = active.max { lhs, rhs in
+            lhs.content.state.startedAt < rhs.content.state.startedAt
+        } ?? active[0]
+
+        self.currentActivity = keeper
+        self.activityStartDate = keeper.content.state.startedAt
+
+        let stale = active.filter { $0.id != keeper.id }
+        for activity in stale {
+            Task {
+                await activity.end(
+                    ActivityContent(state: self.disconnectedState(), staleDate: nil),
+                    dismissalPolicy: .immediate)
+            }
+        }
+    }
+
+    private func updateCurrent(state: OpenClawActivityAttributes.ContentState) {
+        guard let activity = self.currentActivity else { return }
+        Task {
+            await activity.update(ActivityContent(state: state, staleDate: nil))
+        }
+    }
+
+    private func connectingState() -> OpenClawActivityAttributes.ContentState {
+        OpenClawActivityAttributes.ContentState(
+            statusText: "Connecting...",
+            isIdle: false,
+            isDisconnected: false,
+            isConnecting: true,
+            startedAt: self.activityStartDate)
+    }
+
+    private func idleState() -> OpenClawActivityAttributes.ContentState {
+        OpenClawActivityAttributes.ContentState(
+            statusText: "Idle",
+            isIdle: true,
+            isDisconnected: false,
+            isConnecting: false,
+            startedAt: self.activityStartDate)
+    }
+
+    private func disconnectedState() -> OpenClawActivityAttributes.ContentState {
+        OpenClawActivityAttributes.ContentState(
+            statusText: "Disconnected",
+            isIdle: false,
+            isDisconnected: true,
+            isConnecting: false,
+            startedAt: self.activityStartDate)
+    }
+}

--- a/apps/ios/Sources/LiveActivity/OpenClawActivityAttributes.swift
+++ b/apps/ios/Sources/LiveActivity/OpenClawActivityAttributes.swift
@@ -1,0 +1,45 @@
+import ActivityKit
+import Foundation
+
+/// Shared schema used by iOS app + Live Activity widget extension.
+struct OpenClawActivityAttributes: ActivityAttributes {
+    var agentName: String
+    var sessionKey: String
+
+    struct ContentState: Codable, Hashable {
+        var statusText: String
+        var isIdle: Bool
+        var isDisconnected: Bool
+        var isConnecting: Bool
+        var startedAt: Date
+    }
+}
+
+#if DEBUG
+extension OpenClawActivityAttributes {
+    static let preview = OpenClawActivityAttributes(agentName: "main", sessionKey: "main")
+}
+
+extension OpenClawActivityAttributes.ContentState {
+    static let connecting = OpenClawActivityAttributes.ContentState(
+        statusText: "Connecting...",
+        isIdle: false,
+        isDisconnected: false,
+        isConnecting: true,
+        startedAt: .now)
+
+    static let idle = OpenClawActivityAttributes.ContentState(
+        statusText: "Idle",
+        isIdle: true,
+        isDisconnected: false,
+        isConnecting: false,
+        startedAt: .now)
+
+    static let disconnected = OpenClawActivityAttributes.ContentState(
+        statusText: "Disconnected",
+        isIdle: false,
+        isDisconnected: true,
+        isConnecting: false,
+        startedAt: .now)
+}
+#endif

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -1695,6 +1695,7 @@ extension NodeAppModel {
         self.operatorGatewayTask = nil
         self.voiceWakeSyncTask?.cancel()
         self.voiceWakeSyncTask = nil
+        LiveActivityManager.shared.handleDisconnect()
         self.gatewayHealthMonitor.stop()
         Task {
             await self.operatorGateway.disconnect()
@@ -1731,6 +1732,7 @@ private extension NodeAppModel {
         self.operatorConnected = false
         self.voiceWakeSyncTask?.cancel()
         self.voiceWakeSyncTask = nil
+        LiveActivityManager.shared.handleDisconnect()
         self.gatewayDefaultAgentId = nil
         self.gatewayAgents = []
         self.selectedAgentId = GatewaySettingsStore.loadGatewaySelectedAgentId(stableID: stableID)
@@ -1811,6 +1813,7 @@ private extension NodeAppModel {
                             await self.refreshAgentsFromGateway()
                             await self.refreshShareRouteFromGateway()
                             await self.startVoiceWakeSync()
+                            await MainActor.run { LiveActivityManager.shared.handleReconnect() }
                             await MainActor.run { self.startGatewayHealthMonitor() }
                         },
                         onDisconnected: { [weak self] reason in
@@ -1818,6 +1821,7 @@ private extension NodeAppModel {
                             await MainActor.run {
                                 self.operatorConnected = false
                                 self.talkMode.updateGatewayConnected(false)
+                                LiveActivityManager.shared.handleDisconnect()
                             }
                             GatewayDiagnostics.log("operator gateway disconnected reason=\(reason)")
                             await MainActor.run { self.stopGatewayHealthMonitor() }
@@ -1882,6 +1886,14 @@ private extension NodeAppModel {
                     self.gatewayStatusText = (attempt == 0) ? "Connecting…" : "Reconnecting…"
                     self.gatewayServerName = nil
                     self.gatewayRemoteAddress = nil
+                    let liveActivity = LiveActivityManager.shared
+                    if liveActivity.isActive {
+                        liveActivity.handleConnecting()
+                    } else {
+                        liveActivity.startActivity(
+                            agentName: self.selectedAgentId ?? "main",
+                            sessionKey: self.mainSessionKey)
+                    }
                 }
 
                 do {

--- a/apps/ios/SwiftSources.input.xcfilelist
+++ b/apps/ios/SwiftSources.input.xcfilelist
@@ -62,3 +62,7 @@ Sources/Voice/VoiceWakePreferences.swift
 ../../Swabble/Sources/SwabbleKit/WakeWordGate.swift
 Sources/Voice/TalkModeManager.swift
 Sources/Voice/TalkOrbOverlay.swift
+Sources/LiveActivity/OpenClawActivityAttributes.swift
+Sources/LiveActivity/LiveActivityManager.swift
+ActivityWidget/OpenClawActivityWidgetBundle.swift
+ActivityWidget/OpenClawLiveActivity.swift

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -38,6 +38,8 @@ targets:
     dependencies:
       - target: OpenClawShareExtension
         embed: true
+      - target: OpenClawActivityWidget
+        embed: true
       - target: OpenClawWatchApp
       - package: OpenClawKit
       - package: OpenClawKit
@@ -84,6 +86,7 @@ targets:
         TARGETED_DEVICE_FAMILY: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete
+        SUPPORTS_LIVE_ACTIVITIES: YES
         ENABLE_APPINTENTS_METADATA: NO
         ENABLE_APP_INTENTS_METADATA_GENERATION: NO
     info:
@@ -115,6 +118,7 @@ targets:
         NSLocationAlwaysAndWhenInUseUsageDescription: OpenClaw can share your location in the background when you enable Always.
         NSMicrophoneUsageDescription: OpenClaw needs microphone access for voice wake.
         NSSpeechRecognitionUsageDescription: OpenClaw uses on-device speech recognition for voice wake.
+        NSSupportsLiveActivities: true
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
           - UIInterfaceOrientationPortraitUpsideDown
@@ -163,6 +167,37 @@ targets:
               NSExtensionActivationSupportsWebURLWithMaxCount: 1
               NSExtensionActivationSupportsImageWithMaxCount: 10
               NSExtensionActivationSupportsMovieWithMaxCount: 1
+
+  OpenClawActivityWidget:
+    type: app-extension
+    platform: iOS
+    configFiles:
+      Debug: Signing.xcconfig
+      Release: Signing.xcconfig
+    sources:
+      - path: ActivityWidget
+      - path: Sources/LiveActivity/OpenClawActivityAttributes.swift
+    dependencies:
+      - sdk: WidgetKit.framework
+      - sdk: ActivityKit.framework
+    settings:
+      base:
+        CODE_SIGN_IDENTITY: "Apple Development"
+        CODE_SIGN_STYLE: "$(OPENCLAW_CODE_SIGN_STYLE)"
+        DEVELOPMENT_TEAM: "$(OPENCLAW_DEVELOPMENT_TEAM)"
+        PRODUCT_BUNDLE_IDENTIFIER: "$(OPENCLAW_ACTIVITY_WIDGET_BUNDLE_ID)"
+        SWIFT_VERSION: "6.0"
+        SWIFT_STRICT_CONCURRENCY: complete
+        SUPPORTS_LIVE_ACTIVITIES: YES
+    info:
+      path: ActivityWidget/Info.plist
+      properties:
+        CFBundleDisplayName: OpenClaw Activity
+        CFBundleShortVersionString: "2026.3.2"
+        CFBundleVersion: "20260301"
+        NSSupportsLiveActivities: true
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.widgetkit-extension
 
   OpenClawWatchApp:
     type: application.watchapp2

--- a/changelog/fragments/ios-live-activity-status-cleanup.md
+++ b/changelog/fragments/ios-live-activity-status-cleanup.md
@@ -1,0 +1,1 @@
+- iOS: add Live Activity connection status (connecting/idle/disconnected) on Lock Screen and Dynamic Island, and clean up duplicate/stale activities before starting a new one (#33591) (thanks @mbelinky, @leepokai)

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -566,3 +566,89 @@ describe("loadChatHistory", () => {
     expect(state.lastError).toBeNull();
   });
 });
+
+describe("handleChatEvent - duplicate rendering prevention", () => {
+  it("clears chatStream before appending to chatMessages on final to prevent duplicate rendering", () => {
+    // Regression test for: webchat duplicate assistant messages rendered on every reply
+    // Root cause: Lit's async batch rendering could see both chatStream and chatMessages
+    // containing the same content when chatMessages was updated before chatStream was cleared.
+
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Hello world",
+      chatStreamStartedAt: 100,
+    });
+
+    // Intercept chatMessages setter to capture chatStream value at the moment of assignment
+    let capturedStreamAtMessageUpdate: string | null | undefined = undefined;
+    let messagesValue = state.chatMessages;
+    Object.defineProperty(state, "chatMessages", {
+      get() {
+        return messagesValue;
+      },
+      set(value) {
+        capturedStreamAtMessageUpdate = state.chatStream;
+        messagesValue = value;
+      },
+      configurable: true,
+    });
+
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+        timestamp: 101,
+      },
+    };
+
+    handleChatEvent(state, payload);
+
+    // chatStream must already be null when chatMessages is updated
+    expect(capturedStreamAtMessageUpdate).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(messagesValue).toEqual([payload.message]);
+  });
+
+  it("clears chatStream before appending to chatMessages on aborted to prevent duplicate rendering", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Partial reply",
+      chatStreamStartedAt: 100,
+    });
+
+    let capturedStreamAtMessageUpdate: string | null | undefined = undefined;
+    let messagesValue = state.chatMessages;
+    Object.defineProperty(state, "chatMessages", {
+      get() {
+        return messagesValue;
+      },
+      set(value) {
+        capturedStreamAtMessageUpdate = state.chatStream;
+        messagesValue = value;
+      },
+      configurable: true,
+    });
+
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "aborted",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Partial reply" }],
+        timestamp: 101,
+      },
+    };
+
+    handleChatEvent(state, payload);
+
+    expect(capturedStreamAtMessageUpdate).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(messagesValue).toEqual([payload.message]);
+  });
+});

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -273,27 +273,36 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
+    // Clear stream state before appending to chatMessages so that Lit's async
+    // batch rendering never sees both chatStream and chatMessages containing the
+    // same content at the same time, which would cause duplicate rendering.
+    const streamSnapshot = state.chatStream;
+    state.chatStream = null;
+    state.chatRunId = null;
+    state.chatStreamStartedAt = null;
     if (finalMessage && !isAssistantSilentReply(finalMessage)) {
       state.chatMessages = [...state.chatMessages, finalMessage];
-    } else if (state.chatStream?.trim() && !isSilentReplyStream(state.chatStream)) {
+    } else if (streamSnapshot?.trim() && !isSilentReplyStream(streamSnapshot)) {
       state.chatMessages = [
         ...state.chatMessages,
         {
           role: "assistant",
-          content: [{ type: "text", text: state.chatStream }],
+          content: [{ type: "text", text: streamSnapshot }],
           timestamp: Date.now(),
         },
       ];
     }
+  } else if (payload.state === "aborted") {
+    const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
+    // Same ordering fix as "final": clear stream before updating chatMessages.
+    const streamSnapshot = state.chatStream;
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
-  } else if (payload.state === "aborted") {
-    const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
     if (normalizedMessage && !isAssistantSilentReply(normalizedMessage)) {
       state.chatMessages = [...state.chatMessages, normalizedMessage];
     } else {
-      const streamedText = state.chatStream ?? "";
+      const streamedText = streamSnapshot ?? "";
       if (streamedText.trim() && !isSilentReplyStream(streamedText)) {
         state.chatMessages = [
           ...state.chatMessages,
@@ -305,9 +314,6 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
         ];
       }
     }
-    state.chatStream = null;
-    state.chatRunId = null;
-    state.chatStreamStartedAt = null;
   } else if (payload.state === "error") {
     state.chatStream = null;
     state.chatRunId = null;


### PR DESCRIPTION
## Problem

In the Control UI webchat, assistant replies appear duplicated on every message (issue #5964).

## Root Cause

In `handleChatEvent()`, the `final` and `aborted` event handlers updated `chatMessages` **before** clearing `chatStream`. Because Lit batches reactive property updates asynchronously, a render cycle could be triggered after `chatMessages` was updated but before `chatStream` was cleared. This caused `buildChatItems()` to include the same assistant message in **both** the history list (from `chatMessages`) and the live stream bubble (from `chatStream`), visually appearing as a duplicate.

## Fix

Capture the stream text in a local snapshot, **clear `chatStream`/`chatRunId`/`chatStreamStartedAt` first**, then append to `chatMessages`. This guarantees that any render triggered by the `chatMessages` write sees `chatStream` as `null`.

The same fix is applied to both `final` and `aborted` event paths.

## Changes

- `ui/src/ui/controllers/chat.ts`: swap update order in `final` and `aborted` branches
- `ui/src/ui/controllers/chat.test.ts`: add 2 regression tests that verify `chatStream` is `null` at the exact moment `chatMessages` is written

## Testing

```
npx vitest run ui/src/ui/controllers/chat.test.ts
# 27 tests passed
```

Fixes #5964