### PR TITLE
fix(agents): strip leaked XML and ChatML tags from subagent output

### DIFF
--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   extractAssistantText,
   formatReasoningMessage,
+  stripChatMlDelimiters,
   stripDowngradedToolCallText,
+  stripGenericToolCallXml,
 } from "./pi-embedded-utils.js";
 
 function makeAssistantMessage(
@@ -549,9 +551,124 @@ describe("stripDowngradedToolCallText", () => {
   });
 });
 
+describe("stripGenericToolCallXml", () => {
+  it("strips full <tool_call> blocks", () => {
+    const text =
+      "Before<tool_call>\n<arg_name>command</arg_name>\n<arg_value>ls -la</arg_value>\n</tool_call>After";
+    expect(stripGenericToolCallXml(text)).toBe("BeforeAfter");
+  });
+
+  it("strips stray closing tags from partial streaming", () => {
+    expect(stripGenericToolCallXml("result text</arg_value></tool_call>")).toBe("result text");
+  });
+
+  it("strips stray opening tags", () => {
+    expect(stripGenericToolCallXml("<tool_call><arg_name>cmd")).toBe("cmd");
+  });
+
+  it("handles multiple tool_call blocks", () => {
+    const text = "A<tool_call>first</tool_call>B<tool_call>second</tool_call>C";
+    expect(stripGenericToolCallXml(text)).toBe("ABC");
+  });
+
+  it("preserves text without tool_call tags", () => {
+    expect(stripGenericToolCallXml("Normal response text.")).toBe("Normal response text.");
+  });
+
+  it("returns empty for empty input", () => {
+    expect(stripGenericToolCallXml("")).toBe("");
+  });
+});
+
+describe("stripChatMlDelimiters", () => {
+  it("strips <|assistant|> with trailing separator", () => {
+    expect(stripChatMlDelimiters("<|assistant|>---\nHello world")).toBe("Hello world");
+  });
+
+  it("strips <|assistant|> without trailing separator", () => {
+    expect(stripChatMlDelimiters("<|assistant|>Hello world")).toBe("Hello world");
+  });
+
+  it("strips <|im_start|> and <|im_end|> delimiters", () => {
+    expect(stripChatMlDelimiters("<|im_start|>assistant\nHello<|im_end|>")).toBe("Hello");
+  });
+
+  it("strips <|user|> and <|system|> delimiters", () => {
+    expect(stripChatMlDelimiters("<|user|>prompt<|system|>instructions")).toBe(
+      "promptinstructions",
+    );
+  });
+
+  it("strips <|end|> and <|endoftext|> delimiters", () => {
+    expect(stripChatMlDelimiters("Response<|end|>")).toBe("Response");
+    expect(stripChatMlDelimiters("Response<|endoftext|>")).toBe("Response");
+  });
+
+  it("preserves text without ChatML delimiters", () => {
+    expect(stripChatMlDelimiters("Normal response text.")).toBe("Normal response text.");
+  });
+
+  it("preserves legitimate pipe usage", () => {
+    expect(stripChatMlDelimiters("Use cmd | grep pattern")).toBe("Use cmd | grep pattern");
+  });
+
+  it("returns empty for empty input", () => {
+    expect(stripChatMlDelimiters("")).toBe("");
+  });
+});
+
+describe("extractAssistantText strips leaked XML and ChatML", () => {
+  it("strips generic tool_call XML from assistant text", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Here is the result.</arg_value></tool_call>",
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    expect(extractAssistantText(msg)).toBe("Here is the result.");
+  });
+
+  it("strips ChatML delimiters from assistant text", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "<|assistant|>---\nHello, how can I help?",
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    expect(extractAssistantText(msg)).toBe("Hello, how can I help?");
+  });
+
+  it("strips both XML and ChatML in the same message", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "<|assistant|>Result</arg_value></tool_call>",
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    expect(extractAssistantText(msg)).toBe("Result");
+  });
+});
+
 describe("empty input handling", () => {
   it("returns empty string", () => {
-    const helpers = [formatReasoningMessage, stripDowngradedToolCallText];
+    const helpers = [
+      formatReasoningMessage,
+      stripDowngradedToolCallText,
+      stripGenericToolCallXml,
+      stripChatMlDelimiters,
+    ];
     for (const helper of helpers) {
       expect(helper("")).toBe("");
     }

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -34,6 +34,58 @@ export function stripMinimaxToolCallXml(text: string): string {
 }
 
 /**
+ * Strip generic XML tool call tags that leak into text content.
+ * Some models (e.g., Qwen, local models via Ollama) emit tool calls as XML
+ * with `<tool_call>`, `<arg_name>`, `<arg_value>` tags. When streaming is
+ * interrupted or the model fails to produce proper structured tool calls,
+ * these tags leak into user-visible text.
+ */
+export function stripGenericToolCallXml(text: string): string {
+  if (!text) {
+    return text;
+  }
+  // Fast bail-out: skip regex work when no relevant tags are present.
+  if (!/(?:tool_call|arg_name|arg_value)/i.test(text)) {
+    return text;
+  }
+
+  // Remove full <tool_call>...</tool_call> blocks (non-greedy).
+  let cleaned = text.replace(/<tool_call>\s*[\s\S]*?<\/tool_call>/gi, "");
+
+  // Remove stray opening/closing tags that remain after partial streaming.
+  cleaned = cleaned.replace(/<\/?(?:tool_call|arg_name|arg_value)>/gi, "");
+
+  return cleaned.trim();
+}
+
+/**
+ * Strip ChatML-style template delimiters that leak into text content.
+ * Models using the ChatML format (e.g., Qwen, some local models) may
+ * emit delimiters like `<|assistant|>`, `<|im_start|>`, `<|im_end|>`
+ * into their text output. These must not reach the user.
+ */
+export function stripChatMlDelimiters(text: string): string {
+  if (!text) {
+    return text;
+  }
+  // Fast bail-out: the pipe-delimited syntax is distinctive enough.
+  if (!text.includes("<|")) {
+    return text;
+  }
+
+  // Handle <|im_start|> with its role argument (e.g. <|im_start|>assistant\n)
+  let cleaned = text.replace(/<\|im_start\|>\s*(?:assistant|user|system)\n?/gi, "");
+
+  // Handle all other known ChatML delimiters and optional trailing separators
+  cleaned = cleaned.replace(
+    /<\|(?:assistant|user|system|end|endoftext|im_end)\|>(?:\s*---)?/gi,
+    "",
+  );
+
+  return cleaned.trim();
+}
+
+/**
  * Strip downgraded tool call text representations that leak into text content.
  * When replaying history to Gemini, tool calls without `thought_signature` are
  * downgraded to text blocks like `[Tool Call: name (ID: ...)]`. These should
@@ -212,7 +264,9 @@ export function extractAssistantText(msg: AssistantMessage): string {
     extractTextFromChatContent(msg.content, {
       sanitizeText: (text) =>
         stripThinkingTagsFromText(
-          stripDowngradedToolCallText(stripMinimaxToolCallXml(text)),
+          stripChatMlDelimiters(
+            stripGenericToolCallXml(stripDowngradedToolCallText(stripMinimaxToolCallXml(text))),
+          ),
         ).trim(),
       joinWith: "\n",
       normalizeText: (text) => text.trim(),

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -30,7 +30,9 @@ export {
 import { extractTextFromChatContent } from "../../shared/chat-content.js";
 import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
 import {
+  stripChatMlDelimiters,
   stripDowngradedToolCallText,
+  stripGenericToolCallXml,
   stripMinimaxToolCallXml,
   stripThinkingTagsFromText,
 } from "../pi-embedded-utils.js";
@@ -142,7 +144,11 @@ export function sanitizeTextContent(text: string): string {
   if (!text) {
     return text;
   }
-  return stripThinkingTagsFromText(stripDowngradedToolCallText(stripMinimaxToolCallXml(text)));
+  return stripThinkingTagsFromText(
+    stripChatMlDelimiters(
+      stripGenericToolCallXml(stripDowngradedToolCallText(stripMinimaxToolCallXml(text))),
+    ),
+  );
 }
 
 export function extractAssistantText(message: unknown): string | undefined {


### PR DESCRIPTION
This PR fixes #34156 by adding sanitization to remove generic tool_call XML tags (e.g., `</arg_value></tool_call>`) and ChatML delimiters (e.g., `<|assistant|>`) from user-facing text.

## Problem

When subagent streaming is interrupted or a model produces malformed output, raw technical artifacts leak into the UI. The existing sanitization pipeline (`sanitizeTextContent` / `extractAssistantText`) only handled Minimax-specific XML, downgraded Gemini tool call markers, and `<think>` tags — but did **not** strip:

1. **Generic tool call XML** — `<tool_call>`, `<arg_name>`, `<arg_value>` and their closing tags, commonly emitted by Qwen and local models via Ollama.
2. **ChatML delimiters** — `<|assistant|>`, `<|im_start|>`, `<|im_end|>`, etc., used by Qwen and other ChatML-format models.

## Solution

- Adds `stripGenericToolCallXml()` — removes full `<tool_call>…</tool_call>` blocks and stray opening/closing tags from partial streaming.
- Adds `stripChatMlDelimiters()` — removes known ChatML delimiters and optional trailing separators (e.g., `<|assistant|>---`).
- Integrates both into the core sanitization pipeline in `sanitizeTextContent` (`sessions-helpers.ts`) and `extractAssistantText` (`pi-embedded-utils.ts`).

Both functions follow the existing pattern: fast bail-out check → regex strip → trim.

## Test Coverage

- 6 unit tests for `stripGenericToolCallXml` (full blocks, stray tags, multiple blocks, no-op, empty input).
- 8 unit tests for `stripChatMlDelimiters` (all delimiter variants, trailing separator, legitimate pipe usage, no-op, empty input).
- 3 integration tests for `extractAssistantText` (XML only, ChatML only, both combined).
- Updated `empty input handling` suite to include both new helpers.

## Files Changed

| File | Change |
|---|---|
| `src/agents/pi-embedded-utils.ts` | Added `stripGenericToolCallXml` and `stripChatMlDelimiters`; updated `extractAssistantText` sanitization chain |
| `src/agents/tools/sessions-helpers.ts` | Updated imports and `sanitizeTextContent` sanitization chain |
| `src/agents/pi-embedded-utils.test.ts` | Added 17 new test cases across 4 describe blocks |
