### PR TITLE
fix(plugin-sdk): narrow root alias fallback to legacy exports

### DIFF
--- a/src/plugin-sdk/root-alias.cjs
+++ b/src/plugin-sdk/root-alias.cjs
@@ -3,8 +3,12 @@
 const path = require("node:path");
 const fs = require("node:fs");
 
-let monolithicSdk = null;
-let jitiLoader = null;
+const MONOLITHIC_SDK_UNCHECKED = Symbol("monolithic-sdk-unchecked");
+const MONOLITHIC_SDK_UNAVAILABLE = Symbol("monolithic-sdk-unavailable");
+
+let monolithicSdk = MONOLITHIC_SDK_UNCHECKED;
+let legacyJiti = null;
+const legacyModuleCache = new Map();
 
 function emptyPluginConfigSchema() {
   function error(message) {
@@ -61,38 +65,36 @@ function resolveControlCommandGate(params) {
   return { commandAuthorized, shouldBlock };
 }
 
-function getJiti() {
-  if (jitiLoader) {
-    return jitiLoader;
+function createJitiLoader() {
+  if (legacyJiti) {
+    return legacyJiti;
   }
-
   const { createJiti } = require("jiti");
-  jitiLoader = createJiti(__filename, {
+  legacyJiti = createJiti(__filename, {
     interopDefault: true,
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
   });
-  return jitiLoader;
+  return legacyJiti;
 }
 
 function loadMonolithicSdk() {
-  if (monolithicSdk) {
-    return monolithicSdk;
+  if (monolithicSdk !== MONOLITHIC_SDK_UNCHECKED) {
+    return monolithicSdk === MONOLITHIC_SDK_UNAVAILABLE ? null : monolithicSdk;
   }
 
-  const jiti = getJiti();
+  monolithicSdk = MONOLITHIC_SDK_UNAVAILABLE;
 
   const distCandidate = path.resolve(__dirname, "..", "..", "dist", "plugin-sdk", "index.js");
-  if (fs.existsSync(distCandidate)) {
-    try {
-      monolithicSdk = jiti(distCandidate);
-      return monolithicSdk;
-    } catch {
-      // Fall through to source alias if dist is unavailable or stale.
-    }
+  if (!fs.existsSync(distCandidate)) {
+    return null;
   }
 
-  monolithicSdk = jiti(path.join(__dirname, "index.ts"));
-  return monolithicSdk;
+  try {
+    monolithicSdk = createJitiLoader()(distCandidate);
+    return monolithicSdk;
+  } catch {
+    return null;
+  }
 }
 
 function tryLoadMonolithicSdk() {
@@ -108,6 +110,51 @@ const fastExports = {
   resolveControlCommandGate,
 };
 
+const legacyExportMap = {
+  isDangerousNameMatchingEnabled: "../config/dangerous-name-matching.js",
+  createAccountListHelpers: "../channels/plugins/account-helpers.js",
+  buildAgentMediaPayload: "./agent-media-payload.js",
+  createReplyPrefixOptions: "../channels/reply-prefix.js",
+  createTypingCallbacks: "../channels/typing.js",
+  logInboundDrop: "../channels/logging.js",
+  logTypingFailure: "../channels/logging.js",
+  buildPendingHistoryContextFromMap: "../auto-reply/reply/history.js",
+  clearHistoryEntriesIfEnabled: "../auto-reply/reply/history.js",
+  recordPendingHistoryEntryIfEnabled: "../auto-reply/reply/history.js",
+  resolveControlCommandGate: "../channels/command-gating.js",
+  resolveDmGroupAccessWithLists: "../security/dm-policy-shared.js",
+  resolveAllowlistProviderRuntimeGroupPolicy: "../config/runtime-group-policy.js",
+  resolveDefaultGroupPolicy: "../config/runtime-group-policy.js",
+  resolveChannelMediaMaxBytes: "../channels/plugins/media-limits.js",
+  warnMissingProviderGroupPolicyFallbackOnce: "../config/runtime-group-policy.js",
+  normalizePluginHttpPath: "../plugins/http-path.js",
+  registerPluginHttpRoute: "../plugins/http-registry.js",
+  DEFAULT_ACCOUNT_ID: "../routing/session-key.js",
+  DEFAULT_GROUP_HISTORY_LIMIT: "../auto-reply/reply/history.js",
+};
+const legacyExportNames = new Set(Object.keys(legacyExportMap));
+
+function loadLegacyModule(specifier) {
+  if (legacyModuleCache.has(specifier)) {
+    return legacyModuleCache.get(specifier);
+  }
+  const loaded = createJitiLoader()(path.resolve(__dirname, specifier));
+  legacyModuleCache.set(specifier, loaded);
+  return loaded;
+}
+
+function loadLegacyExport(prop) {
+  const monolithic = loadMonolithicSdk();
+  if (monolithic) {
+    return monolithic[prop];
+  }
+  const specifier = legacyExportMap[prop];
+  if (!specifier) {
+    return undefined;
+  }
+  return loadLegacyModule(specifier)[prop];
+}
+
 const rootProxy = new Proxy(fastExports, {
   get(target, prop, receiver) {
     if (prop === "__esModule") {
@@ -119,7 +166,11 @@ const rootProxy = new Proxy(fastExports, {
     if (Reflect.has(target, prop)) {
       return Reflect.get(target, prop, receiver);
     }
-    return loadMonolithicSdk()[prop];
+    if (legacyExportNames.has(prop)) {
+      return loadLegacyExport(prop);
+    }
+    const monolithic = loadMonolithicSdk();
+    return monolithic ? monolithic[prop] : undefined;
   },
   has(target, prop) {
     if (prop === "__esModule" || prop === "default") {
@@ -128,15 +179,22 @@ const rootProxy = new Proxy(fastExports, {
     if (Reflect.has(target, prop)) {
       return true;
     }
+    if (legacyExportNames.has(prop)) {
+      return true;
+    }
     const monolithic = tryLoadMonolithicSdk();
     return monolithic ? prop in monolithic : false;
   },
   ownKeys(target) {
-    const keys = new Set([...Reflect.ownKeys(target), "default", "__esModule"]);
-    // Keep Object.keys/property reflection fast and deterministic.
-    // Only expose monolithic keys if it was already loaded by direct access.
-    if (monolithicSdk) {
-      for (const key of Reflect.ownKeys(monolithicSdk)) {
+    const keys = new Set([
+      ...Reflect.ownKeys(target),
+      ...legacyExportNames,
+      "default",
+      "__esModule",
+    ]);
+    const monolithic = tryLoadMonolithicSdk();
+    if (monolithic) {
+      for (const key of Reflect.ownKeys(monolithic)) {
         keys.add(key);
       }
     }
@@ -162,6 +220,15 @@ const rootProxy = new Proxy(fastExports, {
     const own = Object.getOwnPropertyDescriptor(target, prop);
     if (own) {
       return own;
+    }
+    if (legacyExportNames.has(prop)) {
+      return {
+        configurable: true,
+        enumerable: true,
+        get() {
+          return loadLegacyExport(prop);
+        },
+      };
     }
     const monolithic = tryLoadMonolithicSdk();
     if (!monolithic) {

--- a/src/plugin-sdk/root-alias.test.ts
+++ b/src/plugin-sdk/root-alias.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
+import { createJiti } from "jiti";
 import { describe, expect, it } from "vitest";
 
 const require = createRequire(import.meta.url);
@@ -26,6 +27,28 @@ function readRequiredRootExports() {
     throw new Error("requiredExports not found in check-plugin-sdk-exports.mjs");
   }
   return [...match[1].matchAll(/"([^"]+)"/g)].map((item) => item[1]);
+}
+
+function readLegacyExportMap() {
+  const shimPath = path.resolve(import.meta.dirname, "./root-alias.cjs");
+  const text = fs.readFileSync(shimPath, "utf8");
+  const match = text.match(/const legacyExportMap = \{([\s\S]*?)\n\};/);
+  if (!match) {
+    throw new Error("legacyExportMap not found in root-alias.cjs");
+  }
+  return Object.fromEntries(
+    [...match[1].matchAll(/^\s+([A-Za-z0-9_]+): "([^"]+)",$/gm)].map(([, key, specifier]) => [
+      key,
+      specifier,
+    ]),
+  );
+}
+
+function createSourceLoader() {
+  return createJiti(import.meta.url, {
+    interopDefault: true,
+    extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+  });
 }
 
 describe("plugin-sdk root alias", () => {
@@ -59,15 +82,25 @@ describe("plugin-sdk root alias", () => {
 
   it("exposes the required legacy root exports without loading the monolithic source entry", () => {
     const requiredExports = readRequiredRootExports();
+    const legacyExportMap = readLegacyExportMap();
+    const sourceLoader = createSourceLoader();
 
     for (const key of requiredExports) {
       expect(rootSdk, `missing root alias export ${key}`).toHaveProperty(key);
       const value = rootSdk[key];
-      if (key === "DEFAULT_ACCOUNT_ID" || key === "DEFAULT_GROUP_HISTORY_LIMIT") {
-        expect(value, `missing constant value for ${key}`).not.toBeUndefined();
+
+      if (key === "emptyPluginConfigSchema") {
+        expect(typeof value, `unexpected export type for ${key}`).toBe("function");
         continue;
       }
-      expect(typeof value, `unexpected export type for ${key}`).toBe("function");
+
+      const specifier = legacyExportMap[key];
+      expect(specifier, `missing legacy export mapping for ${key}`).toBeDefined();
+      const sourceModule = sourceLoader(path.resolve(import.meta.dirname, specifier));
+      const sourceValue = sourceModule[key];
+
+      expect(typeof value, `unexpected export type for ${key}`).toBe(typeof sourceValue);
+      expect(value, `missing export value for ${key}`).not.toBeUndefined();
     }
   });
 });

--- a/src/plugin-sdk/root-alias.test.ts
+++ b/src/plugin-sdk/root-alias.test.ts
@@ -1,4 +1,6 @@
+import fs from "node:fs";
 import { createRequire } from "node:module";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const require = createRequire(import.meta.url);
@@ -12,6 +14,19 @@ type EmptySchema = {
         error: { issues: Array<{ path: Array<string | number>; message: string }> };
       };
 };
+
+function readRequiredRootExports() {
+  const scriptPath = path.resolve(
+    import.meta.dirname,
+    "../../scripts/check-plugin-sdk-exports.mjs",
+  );
+  const text = fs.readFileSync(scriptPath, "utf8");
+  const match = text.match(/const requiredExports = \[(.*?)\];/s);
+  if (!match) {
+    throw new Error("requiredExports not found in check-plugin-sdk-exports.mjs");
+  }
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((item) => item[1]);
+}
 
 describe("plugin-sdk root alias", () => {
   it("exposes the fast empty config schema helper", () => {
@@ -40,5 +55,19 @@ describe("plugin-sdk root alias", () => {
     expect(keys).toContain("resolveControlCommandGate");
     const descriptor = Object.getOwnPropertyDescriptor(rootSdk, "resolveControlCommandGate");
     expect(descriptor).toBeDefined();
+  });
+
+  it("exposes the required legacy root exports without loading the monolithic source entry", () => {
+    const requiredExports = readRequiredRootExports();
+
+    for (const key of requiredExports) {
+      expect(rootSdk, `missing root alias export ${key}`).toHaveProperty(key);
+      const value = rootSdk[key];
+      if (key === "DEFAULT_ACCOUNT_ID" || key === "DEFAULT_GROUP_HISTORY_LIMIT") {
+        expect(value, `missing constant value for ${key}`).not.toBeUndefined();
+        continue;
+      }
+      expect(typeof value, `unexpected export type for ${key}`).toBe("function");
+    }
   });
 });


### PR DESCRIPTION
## Summary

This narrows the source-mode fallback in `src/plugin-sdk/root-alias.cjs` so it no longer loads the entire monolithic `src/plugin-sdk/index.ts` entry through `jiti(...)`.

Instead, when `dist/plugin-sdk/index.js` is unavailable, the root alias shim now only exposes the legacy root exports that OpenClaw already treats as required compatibility exports in `scripts/check-plugin-sdk-exports.mjs`.

## Why

The previous fallback loaded the full monolithic source entry, which now hangs the `plugin-sdk root alias` test on current mainline Windows CI.

This change keeps the runtime shim compatible for the required legacy exports while avoiding the expensive source-entry load.

## What changed

- keep the fast `emptyPluginConfigSchema` export
- keep the existing dist-first behavior
- replace source-mode `jiti(index.ts)` fallback with a controlled legacy export map
- lazily load legacy exports from leaf modules instead of the monolithic root entry
- add coverage that verifies the required legacy exports remain available through the root alias

## Validation

```bash
pnpm exec vitest run src/plugin-sdk/root-alias.test.ts
pnpm exec vitest run src/plugin-sdk/index.test.ts src/plugin-sdk/subpaths.test.ts src/plugins/loader.test.ts
```
