### PR TITLE
fix(webchat): clear chatStream before updating chatMessages to prevent duplicate rendering

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -566,3 +566,87 @@ describe("loadChatHistory", () => {
     expect(state.lastError).toBeNull();
   });
 });
+
+describe("handleChatEvent - duplicate rendering prevention", () => {
+  it("clears chatStream before updating chatMessages on final to prevent duplicate rendering", () => {
+    // Regression test for: Control UI webchat duplicate assistant messages rendered on every reply.
+    // Root cause: Lit's async batch rendering could see both chatStream and chatMessages
+    // containing the same content when chatMessages was updated before chatStream was cleared.
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Hello world",
+      chatStreamStartedAt: 100,
+    });
+
+    let capturedStreamAtMessageUpdate: string | null | undefined = undefined;
+    let messagesValue = state.chatMessages;
+    Object.defineProperty(state, "chatMessages", {
+      get() {
+        return messagesValue;
+      },
+      set(value) {
+        capturedStreamAtMessageUpdate = state.chatStream;
+        messagesValue = value;
+      },
+      configurable: true,
+    });
+
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+        timestamp: 101,
+      },
+    };
+
+    handleChatEvent(state, payload);
+
+    // chatStream must already be null at the moment chatMessages is written
+    expect(capturedStreamAtMessageUpdate).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(messagesValue).toEqual([payload.message]);
+  });
+
+  it("clears chatStream before updating chatMessages on aborted to prevent duplicate rendering", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Partial reply",
+      chatStreamStartedAt: 100,
+    });
+
+    let capturedStreamAtMessageUpdate: string | null | undefined = undefined;
+    let messagesValue = state.chatMessages;
+    Object.defineProperty(state, "chatMessages", {
+      get() {
+        return messagesValue;
+      },
+      set(value) {
+        capturedStreamAtMessageUpdate = state.chatStream;
+        messagesValue = value;
+      },
+      configurable: true,
+    });
+
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "aborted",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Partial reply" }],
+        timestamp: 101,
+      },
+    };
+
+    handleChatEvent(state, payload);
+
+    expect(capturedStreamAtMessageUpdate).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(messagesValue).toEqual([payload.message]);
+  });
+});

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -273,27 +273,36 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
+    // Clear stream state before appending to chatMessages so that Lit's async
+    // batch rendering never sees both chatStream and chatMessages containing the
+    // same content at the same time, which would cause duplicate rendering.
+    const streamSnapshot = state.chatStream;
+    state.chatStream = null;
+    state.chatRunId = null;
+    state.chatStreamStartedAt = null;
     if (finalMessage && !isAssistantSilentReply(finalMessage)) {
       state.chatMessages = [...state.chatMessages, finalMessage];
-    } else if (state.chatStream?.trim() && !isSilentReplyStream(state.chatStream)) {
+    } else if (streamSnapshot?.trim() && !isSilentReplyStream(streamSnapshot)) {
       state.chatMessages = [
         ...state.chatMessages,
         {
           role: "assistant",
-          content: [{ type: "text", text: state.chatStream }],
+          content: [{ type: "text", text: streamSnapshot }],
           timestamp: Date.now(),
         },
       ];
     }
+  } else if (payload.state === "aborted") {
+    const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
+    // Same ordering fix as "final": clear stream before updating chatMessages.
+    const streamSnapshot = state.chatStream;
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
-  } else if (payload.state === "aborted") {
-    const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
     if (normalizedMessage && !isAssistantSilentReply(normalizedMessage)) {
       state.chatMessages = [...state.chatMessages, normalizedMessage];
     } else {
-      const streamedText = state.chatStream ?? "";
+      const streamedText = streamSnapshot ?? "";
       if (streamedText.trim() && !isSilentReplyStream(streamedText)) {
         state.chatMessages = [
           ...state.chatMessages,
@@ -305,9 +314,6 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
         ];
       }
     }
-    state.chatStream = null;
-    state.chatRunId = null;
-    state.chatStreamStartedAt = null;
   } else if (payload.state === "error") {
     state.chatStream = null;
     state.chatRunId = null;


### PR DESCRIPTION
## Problem

In the Control UI webchat, assistant replies appear duplicated on every message (issue #5964).

## Root Cause

In `handleChatEvent()`, the `final` and `aborted` event handlers updated `chatMessages` **before** clearing `chatStream`. Because Lit batches reactive property updates asynchronously, a render cycle could be triggered after `chatMessages` was updated but before `chatStream` was cleared. This caused `buildChatItems()` to include the same assistant message in **both** the history list (from `chatMessages`) and the live stream bubble (from `chatStream`), visually appearing as a duplicate.

## Fix

Capture the stream text in a local snapshot, **clear `chatStream`/`chatRunId`/`chatStreamStartedAt` first**, then append to `chatMessages`. This guarantees that any render triggered by the `chatMessages` write sees `chatStream` as `null`.

The same fix is applied to both `final` and `aborted` event paths.

## Changes

- `ui/src/ui/controllers/chat.ts`: swap update order in `final` and `aborted` branches
- `ui/src/ui/controllers/chat.test.ts`: add 2 regression tests that verify `chatStream` is `null` at the exact moment `chatMessages` is written

## Testing

```
npx vitest run ui/src/ui/controllers/chat.test.ts
# 27 tests passed
```

Fixes #5964