### PR TITLE
fix(whatsapp): unwrap Baileys v7 lastDisconnect wrapper in getStatusCode

### DIFF
--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -186,7 +186,9 @@ export async function waitForWaConnection(sock: ReturnType<typeof makeWASocket>)
 export function getStatusCode(err: unknown) {
   return (
     (err as { output?: { statusCode?: number } })?.output?.statusCode ??
-    (err as { status?: number })?.status
+    (err as { status?: number })?.status ??
+    // Unwrap Baileys v7 lastDisconnect wrapper: { error: BoomError, date }
+    (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode
   );
 }
 


### PR DESCRIPTION
## Summary

WhatsApp QR pairing fails 100% on Baileys v7 because `getStatusCode()` never unwraps the lastDisconnect wrapper `{ error: BoomError, date }`. The 515 'restart required' signal is never detected, so `restartLoginSocket` is never called.

## Fix

This fix adds `err.error?.output?.statusCode` fallback to `getStatusCode()` so it properly unwraps the Baileys v7 lastDisconnect wrapper.

## Testing

The existing test in `login-qr.test.ts` mocks `getStatusCode` to verify the 515 restart behavior. This fix ensures the real implementation matches the test expectations.

## Fixes

Fixes #33961