### PR TITLE
fix(signal): fall back to JSON-RPC version probe when REST health check is unavailable

### DIFF
--- a/src/signal/probe.test.ts
+++ b/src/signal/probe.test.ts
@@ -30,18 +30,36 @@ describe("probeSignal", () => {
     expect(res.status).toBe(200);
   });
 
-  it("returns ok=false when /check fails", async () => {
+  it("returns ok=false when /check fails and JSON-RPC is also unavailable", async () => {
     signalCheckMock.mockResolvedValueOnce({
       ok: false,
       status: 503,
       error: "HTTP 503",
     });
+    signalRpcRequestMock.mockRejectedValueOnce(new Error("connection refused"));
 
     const res = await probeSignal("http://127.0.0.1:8080", 1000);
 
     expect(res.ok).toBe(false);
     expect(res.status).toBe(503);
     expect(res.version).toBe(null);
+  });
+
+  it("returns ok=true via JSON-RPC fallback when REST check is unavailable", async () => {
+    // Regression test for: signal-cli JSON-RPC-only daemons where
+    // GET /api/v1/check returns 404/fetch-failed but POST /api/v1/rpc works.
+    signalCheckMock.mockResolvedValueOnce({
+      ok: false,
+      status: null,
+      error: "fetch failed",
+    });
+    signalRpcRequestMock.mockResolvedValueOnce({ version: "0.13.24" });
+
+    const res = await probeSignal("http://127.0.0.1:8080", 1000);
+
+    expect(res.ok).toBe(true);
+    expect(res.status).toBe(null);
+    expect(res.version).toBe("0.13.24");
   });
 });
 

--- a/src/signal/probe.ts
+++ b/src/signal/probe.ts
@@ -31,12 +31,30 @@ export async function probeSignal(baseUrl: string, timeoutMs: number): Promise<S
   };
   const check = await signalCheck(baseUrl, timeoutMs);
   if (!check.ok) {
-    return {
-      ...result,
-      status: check.status ?? null,
-      error: check.error ?? "unreachable",
-      elapsedMs: Date.now() - started,
-    };
+    // REST health check unavailable — fall back to a JSON-RPC version probe so
+    // that signal-cli daemons running in JSON-RPC-only mode (where
+    // GET /api/v1/check returns 404) are still reported as healthy when the
+    // RPC endpoint responds successfully.
+    try {
+      const version = await signalRpcRequest("version", undefined, {
+        baseUrl,
+        timeoutMs,
+      });
+      return {
+        ...result,
+        ok: true,
+        status: null,
+        version: parseSignalVersion(version),
+        elapsedMs: Date.now() - started,
+      };
+    } catch {
+      return {
+        ...result,
+        status: check.status ?? null,
+        error: check.error ?? "unreachable",
+        elapsedMs: Date.now() - started,
+      };
+    }
   }
   try {
     const version = await signalRpcRequest("version", undefined, {


### PR DESCRIPTION
## Problem

`openclaw channels status --probe` (and `doctor`) reports Signal as failed — showing `fetch failed` or `HTTP 404` — even when the signal-cli daemon is alive and successfully handling messages.

**Root cause:** The probe in `probeSignal()` calls `signalCheck()` which uses `GET /api/v1/check`. signal-cli daemons running in **JSON-RPC-only mode** (started with `--http`) do not expose this REST endpoint — `GET /` and `GET /api/v1/check` both return 404. The previous code returned `ok=false` immediately on any `signalCheck()` failure, never reaching the `signalRpcRequest("version")` call that already follows it on the success path.

```bash
# Probe endpoint — always 404 in JSON-RPC mode
curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8080/api/v1/check
# 404

# Actual JSON-RPC health check — works fine
curl -s -X POST -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","method":"version","id":1}' \
  http://127.0.0.1:8080/api/v1/rpc
# {"jsonrpc":"2.0","result":{"version":"0.13.24"},"id":1}
```

## Fix

When `signalCheck()` fails for any reason (404, network error, etc.), fall back to a JSON-RPC `version` call on `/api/v1/rpc`. A successful response means the daemon is reachable and healthy. Only if that also fails do we propagate the original REST error.

This is a purely additive change — the existing REST-first path is unchanged; the fallback only activates when REST is unavailable.

## Testing

- Updated existing `"returns ok=false when /check fails"` test: now also mocks `signalRpcRequest` to reject (so both paths fail as expected)
- Added new test: `"returns ok=true via JSON-RPC fallback when REST check is unavailable"` — verifies the fix
- All 105 Signal tests pass

Fixes #33841