### PR TITLE
fix(whatsapp): wait for creds flush before socket restart in Baileys v7

### DIFF
--- a/src/web/login-qr.test.ts
+++ b/src/web/login-qr.test.ts
@@ -17,11 +17,13 @@ vi.mock("./session.js", () => {
   const getStatusCode = vi.fn(
     (err: unknown) =>
       (err as { output?: { statusCode?: number } })?.output?.statusCode ??
-      (err as { status?: number })?.status,
+      (err as { status?: number })?.status ??
+      (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode,
   );
   const webAuthExists = vi.fn(async () => false);
   const readWebSelfId = vi.fn(() => ({ e164: null, jid: null }));
   const logoutWeb = vi.fn(async () => true);
+  const waitForCredsSaveQueue = vi.fn(async () => {});
   return {
     createWaSocket,
     waitForWaConnection,
@@ -30,6 +32,7 @@ vi.mock("./session.js", () => {
     webAuthExists,
     readWebSelfId,
     logoutWeb,
+    waitForCredsSaveQueue,
   };
 });
 

--- a/src/web/login-qr.ts
+++ b/src/web/login-qr.ts
@@ -12,6 +12,7 @@ import {
   getStatusCode,
   logoutWeb,
   readWebSelfId,
+  waitForCredsSaveQueue,
   waitForWaConnection,
   webAuthExists,
 } from "./session.js";
@@ -88,6 +89,8 @@ async function restartLoginSocket(login: ActiveLogin, runtime: RuntimeEnv) {
     info("WhatsApp asked for a restart after pairing (code 515); retrying connection once…"),
   );
   closeSocket(login.sock);
+  // Wait for pending creds writes to flush before creating new socket
+  await waitForCredsSaveQueue();
   try {
     const sock = await createWaSocket(false, login.verbose, {
       authDir: login.authDir,

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -32,6 +32,12 @@ export {
 } from "./auth-store.js";
 
 let credsSaveQueue: Promise<void> = Promise.resolve();
+
+// Export for login-qr.ts to wait for pending creds writes before restarting socket
+export async function waitForCredsSaveQueue(): Promise<void> {
+  await credsSaveQueue;
+}
+
 function enqueueSaveCreds(
   authDir: string,
   saveCreds: () => Promise<void> | void,

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -186,7 +186,9 @@ export async function waitForWaConnection(sock: ReturnType<typeof makeWASocket>)
 export function getStatusCode(err: unknown) {
   return (
     (err as { output?: { statusCode?: number } })?.output?.statusCode ??
-    (err as { status?: number })?.status
+    (err as { status?: number })?.status ??
+    // Unwrap Baileys v7 lastDisconnect wrapper: { error: BoomError, date }
+    (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode
   );
 }
 


### PR DESCRIPTION
## Summary

WhatsApp QR pairing fails 100% of the time on Baileys v7 because the 515 "restart required" signal is never detected, and the restart path reads stale/empty creds.

## Root Cause

1. `restartLoginSocket` creates a new socket immediately after closing the old one **without waiting for pending credential writes to flush**. Even if the 515 were detected, `useMultiFileAuthState` would read stale/empty creds.

## Fix

1. Export `waitForCredsSaveQueue()` from `session.ts` for use in `login-qr.ts`
2. `restartLoginSocket` now awaits `waitForCredsSaveQueue()` before creating a new socket, ensuring all pending creds writes complete

## Files Changed

- `src/web/session.ts`: Added export of `waitForCredsSaveQueue()`
- `src/web/login-qr.ts`: Import and call `waitForCredsSaveQueue()` in `restartLoginSocket()`
- `src/web/login-qr.test.ts`: Updated mock to include the new function

Fixes: #33961
