### PR TITLE
fix(auto-reply): skip sender metadata for Control UI messages

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -331,4 +331,22 @@ describe("buildInboundUserContextPrefix", () => {
     const conversationInfo = parseConversationInfoPayload(text);
     expect(conversationInfo["sender"]).toBe("user@example.com");
   });
+
+  it("skips sender metadata block for Control UI messages", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      OriginatingChannel: "telegram",
+      SenderId: "openclaw-control-ui",
+      SenderName: "Control UI",
+      MessageSid: "msg-123",
+    } as TemplateContext);
+
+    // Should still include conversation info
+    expect(text).toContain("Conversation info (untrusted metadata):");
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["sender_id"]).toBe("openclaw-control-ui");
+
+    // Should NOT include sender metadata block for Control UI
+    expect(text).not.toContain("Sender (untrusted metadata):");
+  });
 });

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -1,5 +1,6 @@
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveSenderLabel } from "../../channels/sender-label.js";
+import { GATEWAY_CLIENT_IDS } from "../../gateway/protocol/client-info.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js";
 import type { TemplateContext } from "../templating.js";
 
@@ -149,7 +150,10 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
     tag: safeTrim(ctx.SenderTag),
     e164: safeTrim(ctx.SenderE164),
   };
-  if (senderInfo?.label) {
+  // Skip sender metadata for Control UI messages - these are internal system messages
+  // and the sender info (openclaw-control-ui) is not meaningful for the LLM.
+  const isControlUiMessage = ctx.SenderId === GATEWAY_CLIENT_IDS.CONTROL_UI;
+  if (senderInfo?.label && !isControlUiMessage) {
     blocks.push(
       ["Sender (untrusted metadata):", "```json", JSON.stringify(senderInfo, null, 2), "```"].join(
         "\n",


### PR DESCRIPTION
## Summary

Skip adding 'Sender (untrusted metadata)' block when the message is from the Control UI (SenderId = 'openclaw-control-ui'). These metadata are not meaningful for the LLM and just waste tokens.

## Changes

- Modified `src/auto-reply/reply/inbound-meta.ts` to check if the sender is Control UI and skip adding the sender metadata block
- Added test case to verify Control UI sender metadata is skipped

## Fixes

Fixes #34153