### PR TITLE
fix: enforce git dependency check for npm installs in PS1 installer

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -297,7 +297,8 @@ function Main {
     } else {
         # npm method
         if (!(Ensure-Git)) {
-            Write-Host "Git is required for npm installs. Please install Git and try again." -Level warn
+            Write-Host "Git is required for npm installs. Please install Git and try again." -Level error
+            exit 1
         }
         
         if ($DryRun) {


### PR DESCRIPTION
## Problem

The PowerShell installer (`install.ps1`) only warns when git is missing for npm-method installs, then continues — leading to confusing npm errors downstream. The bash installer correctly enforces this check and exits on failure.

## Fix

Changed the npm-path git check from `warn` to `error` + `exit 1`, making behavior consistent with `install.sh` (which calls `install_git` or exits).

**Before:** `Write-Host ... -Level warn` (continues without git)
**After:** `Write-Host ... -Level error` + `exit 1` (fails clearly)

The git-method path already had `exit 1` on failure (line 289).

Closes #34098