### PR TITLE
fix(feishu): deduplicate streaming card text by reusing shared merge helper

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -13,7 +13,10 @@ import type { MentionTarget } from "./mention.js";
 import { buildMentionedCardContent } from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMarkdownCardFeishu, sendMessageFeishu } from "./send.js";
-import { FeishuStreamingSession } from "./streaming-card.js";
+import {
+  FeishuStreamingSession,
+  mergeStreamingText as mergeStreamingTextBase,
+} from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
 
@@ -147,19 +150,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamingStartPromise: Promise<void> | null = null;
 
   const mergeStreamingText = (nextText: string) => {
-    if (!streamText) {
-      streamText = nextText;
-      return;
-    }
-    if (nextText.startsWith(streamText)) {
-      // Handle cumulative partial payloads where nextText already includes prior text.
-      streamText = nextText;
-      return;
-    }
-    if (streamText.endsWith(nextText)) {
-      return;
-    }
-    streamText += nextText;
+    streamText = mergeStreamingTextBase(streamText, nextText);
   };
 
   const queueStreamingUpdate = (


### PR DESCRIPTION
## Problem

The local `mergeStreamingText` closure in `reply-dispatcher.ts` used weaker duplicate detection (`startsWith`/`endsWith`) than the already-correct exported `mergeStreamingText` in `streaming-card.ts` (which uses `includes`). When cumulative partial payloads didn't exactly start with the prior text (e.g., due to whitespace normalization from block payloads), the local function fell through to `streamText += nextText`, appending the full cumulative text and causing 2-3x duplication in rendered cards.

## Fix

Replace the local 14-line closure with a one-liner that delegates to the existing, tested `mergeStreamingText` from `streaming-card.ts`. This function already handles:
- Cumulative payloads (`next.includes(previous)`)
- Subset payloads (`previous.includes(next)`)
- Fragmented delta chunks (append fallback)

**Before:** Local closure with `startsWith`/`endsWith` checks only
**After:** Delegates to `mergeStreamingTextBase` from `streaming-card.ts`

Existing tests in `streaming-card.test.ts` cover the merge logic.

Closes #34108