### PR TITLE
fix(media): return cleanup timer from attachMediaRoutes for proper teardown

### DIFF
--- a/src/media/server.ts
+++ b/src/media/server.ts
@@ -29,7 +29,7 @@ export function attachMediaRoutes(
   app: Express,
   ttlMs = DEFAULT_TTL_MS,
   _runtime: RuntimeEnv = defaultRuntime,
-) {
+): { cleanupTimer: ReturnType<typeof setInterval> } {
   const mediaDir = getMediaDir();
 
   app.get("/media/:id", async (req, res) => {
@@ -94,10 +94,12 @@ export function attachMediaRoutes(
     }
   });
 
-  // periodic cleanup
-  setInterval(() => {
+  // periodic cleanup — return handle so callers can clearInterval on shutdown
+  const cleanupTimer = setInterval(() => {
     void cleanOldMedia(ttlMs);
-  }, ttlMs).unref();
+  }, ttlMs);
+  cleanupTimer.unref();
+  return { cleanupTimer };
 }
 
 export async function startMediaServer(


### PR DESCRIPTION
## Summary
- `attachMediaRoutes` created a `setInterval` for periodic media cleanup but discarded the timer reference, making it impossible for callers to `clearInterval` on shutdown.
- Now returns `{ cleanupTimer }` so callers can clean up properly. Existing callers that ignore the return value are unaffected.

## Test plan
- [ ] Verify media cleanup still runs periodically
- [ ] Verify no leaked intervals in test environments with repeated server init
- [ ] Run `pnpm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)