### PR TITLE
fix(channels): reset finished flag in restoreInitial so subsequent state changes work

### DIFF
--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -365,6 +365,7 @@ export function createStatusReactionController(params: {
     }
 
     clearAllTimers();
+    finished = false; // allow new state transitions after restore
     await enqueue(async () => {
       await applyEmoji(initialEmoji);
       pendingEmoji = "";


### PR DESCRIPTION
## Summary
- `restoreInitial()` restores the initial emoji but did not reset the `finished` flag. After `setDone()` or `setError()` set `finished = true`, calling `restoreInitial()` followed by `setThinking()` etc. would silently ignore the new state because `scheduleEmoji` early-returns when `finished` is true.
- Now resets `finished = false` so the reaction lifecycle can restart after a restore.

## Test plan
- [ ] Verify status reactions work correctly after message edit/re-process (restoreInitial → setThinking → setDone)
- [ ] Run `pnpm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)