### PR TITLE
fix(whatsapp): configure aggressive keepalive interval to prevent stale connections

### DIFF
--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -116,6 +116,7 @@ export async function createWaSocket(
     browser: ["openclaw", "cli", VERSION],
     syncFullHistory: false,
     markOnlineOnConnect: false,
+    keepAliveIntervalMs: 20000,
   });
 
   sock.ev.on("creds.update", () => enqueueSaveCreds(authDir, saveCreds, sessionLogger));


### PR DESCRIPTION
## Summary

Set keepAliveIntervalMs to 20 seconds (from Baileys default 30s) to keep WhatsApp Web connections fresh before Meta's ~35-minute server-side idle timeout triggers.

## Problem

WhatsApp connections consistently go stale after ~35 minutes of no message traffic, triggering a `health-monitor: restarting (reason: stale-socket)` cycle. This happens with clockwork precision regardless of network conditions.

The keepalive mechanism IS working (Baileys sends pings every 30s), but Meta's server-side idle timeout (~35 minutes) is causing the connection to become half-dead. The socket appears "open" but stops receiving events. The health monitor detects this at 30 minutes and triggers a restart.

## Solution

Configured `keepAliveIntervalMs: 20000` in the Baileys socket creation (`src/web/session.ts`). This more aggressive interval (20 seconds instead of the default 30 seconds) ensures the connection stays fresh before Meta's timeout kicks in, preventing the half-dead socket scenario.

## Testing

- Verified the configuration is applied to the socket
- All lint and format checks pass
- Expected behavior: connections should remain stable indefinitely without the 35-minute restart cycle

Fixes #34155