### PR TITLE
fix(plugins): reject async register() instead of silently loading incomplete plugin

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -801,12 +801,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     try {
       const result = register(api);
       if (result && typeof result.then === "function") {
-        registry.diagnostics.push({
-          level: "warn",
-          pluginId: record.id,
-          source: record.source,
-          message: "plugin register returned a promise; async registration is ignored",
-        });
+        pushPluginLoadError(
+          "plugin register() returned a promise; async registration is not supported — hooks/tools may be missing",
+        );
+        continue;
       }
       registry.plugins.push(record);
       seenIds.set(pluginId, candidate.origin);


### PR DESCRIPTION
## Summary
- When a plugin's `register()` function returned a Promise (async), the loader previously pushed a warning diagnostic but still marked the plugin as loaded. This meant hooks/tools registered asynchronously might not be available when messages arrive.
- Now treats async `register()` as a load error, preventing the plugin from being marked as loaded with potentially missing hooks/tools.

## Test plan
- [ ] Verify plugins with synchronous `register()` still load correctly
- [ ] Verify a plugin with async `register()` is rejected with a clear error message
- [ ] Run `pnpm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)