### PR TITLE
fix: strip orphaned XML tags and template delimiters from subagent output

### DIFF
--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -4,6 +4,7 @@ import {
   extractAssistantText,
   formatReasoningMessage,
   stripDowngradedToolCallText,
+  stripOrphanedToolXmlAndDelimiters,
 } from "./pi-embedded-utils.js";
 
 function makeAssistantMessage(
@@ -546,6 +547,47 @@ describe("stripDowngradedToolCallText", () => {
     for (const testCase of cases) {
       expect(stripDowngradedToolCallText(testCase.text), testCase.name).toBe(testCase.expected);
     }
+  });
+});
+
+describe("stripOrphanedToolXmlAndDelimiters", () => {
+  it("strips template boundary delimiters", () => {
+    expect(stripOrphanedToolXmlAndDelimiters("<|assistant|>Hello")).toBe("Hello");
+    expect(stripOrphanedToolXmlAndDelimiters("text<|tool_call_argument_begin|>more")).toBe(
+      "textmore",
+    );
+  });
+
+  it("strips orphaned tool call XML tags", () => {
+    expect(stripOrphanedToolXmlAndDelimiters("result</arg_value></tool_call>")).toBe("result");
+    expect(stripOrphanedToolXmlAndDelimiters("<tool_call>inner</tool_call>")).toBe("inner");
+    expect(stripOrphanedToolXmlAndDelimiters("text<arguments>data</arguments>end")).toBe(
+      "textdataend",
+    );
+  });
+
+  it("preserves normal text without tags", () => {
+    expect(stripOrphanedToolXmlAndDelimiters("Normal response text.")).toBe(
+      "Normal response text.",
+    );
+  });
+
+  it("preserves code blocks and legitimate HTML", () => {
+    expect(stripOrphanedToolXmlAndDelimiters("<div>content</div>")).toBe("<div>content</div>");
+    expect(stripOrphanedToolXmlAndDelimiters("```<tool_call>```")).toBe("``````");
+  });
+
+  it("handles empty/falsy input", () => {
+    expect(stripOrphanedToolXmlAndDelimiters("")).toBe("");
+  });
+
+  it("strips via extractAssistantText pipeline", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "Done.</arg_value></tool_call><|assistant|>" }],
+      timestamp: Date.now(),
+    });
+    expect(extractAssistantText(msg)).toBe("Done.");
   });
 });
 

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -199,6 +199,28 @@ export function stripDowngradedToolCallText(text: string): string {
 }
 
 /**
+ * Strip orphaned tool-call XML tags and template boundary delimiters that
+ * leak from some LLM providers (e.g., Kimi, nvidia models) into text content.
+ *
+ * Handles:
+ * - Orphaned tool XML: `</arg_value>`, `</tool_call>`, `<tool_call>`, etc.
+ * - Template delimiters: `<|assistant|>`, `<|tool_call_argument_begin|>`, etc.
+ */
+export function stripOrphanedToolXmlAndDelimiters(text: string): string {
+  if (!text || !text.includes("<")) {
+    return text;
+  }
+
+  // Strip template boundary delimiters: <|...|>
+  let cleaned = text.replace(/<\|[a-z_]+\|>/gi, "");
+
+  // Strip orphaned tool-call XML tags (opening and closing).
+  cleaned = cleaned.replace(/<\/?(?:tool_call|arg_value|tool_result|arguments)>/gi, "");
+
+  return cleaned;
+}
+
+/**
  * Strip thinking tags and their content from text.
  * This is a safety net for cases where the model outputs <think> tags
  * that slip through other filtering mechanisms.
@@ -212,7 +234,9 @@ export function extractAssistantText(msg: AssistantMessage): string {
     extractTextFromChatContent(msg.content, {
       sanitizeText: (text) =>
         stripThinkingTagsFromText(
-          stripDowngradedToolCallText(stripMinimaxToolCallXml(text)),
+          stripOrphanedToolXmlAndDelimiters(
+            stripDowngradedToolCallText(stripMinimaxToolCallXml(text)),
+          ),
         ).trim(),
       joinWith: "\n",
       normalizeText: (text) => text.trim(),

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -32,6 +32,7 @@ import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
 import {
   stripDowngradedToolCallText,
   stripMinimaxToolCallXml,
+  stripOrphanedToolXmlAndDelimiters,
   stripThinkingTagsFromText,
 } from "../pi-embedded-utils.js";
 
@@ -142,7 +143,9 @@ export function sanitizeTextContent(text: string): string {
   if (!text) {
     return text;
   }
-  return stripThinkingTagsFromText(stripDowngradedToolCallText(stripMinimaxToolCallXml(text)));
+  return stripThinkingTagsFromText(
+    stripOrphanedToolXmlAndDelimiters(stripDowngradedToolCallText(stripMinimaxToolCallXml(text))),
+  );
 }
 
 export function extractAssistantText(message: unknown): string | undefined {


### PR DESCRIPTION
## Problem

Raw XML tags (`</arg_value>`, `</tool_call>`) and template boundary delimiters (`<|assistant|>`, `<|tool_call_argument_begin|>`) from certain LLM providers (Kimi, nvidia models) leak into user-visible output during subagent completion events. These appear as HTML-encoded entities on channels like QQ bot, degrading UX.

## Root Cause

The text sanitization pipeline (`sanitizeTextContent` and `extractAssistantText`) only had vendor-specific strippers for:
- Minimax tool call XML (`stripMinimaxToolCallXml`)
- Gemini downgraded tool text (`stripDowngradedToolCallText`)
- Thinking tags (`stripThinkingTagsFromText`)

Generic tool-call XML tags and template delimiters from other providers were not caught.

## Fix

Added `stripOrphanedToolXmlAndDelimiters()` to the sanitization chain in both code paths:
- `src/agents/pi-embedded-utils.ts` (direct assistant text extraction)
- `src/agents/tools/sessions-helpers.ts` (session-level sanitization)

The function strips:
- Template delimiters: `<|...|>` pattern (common LLM template boundary markers)
- Orphaned tool XML: `<tool_call>`, `</arg_value>`, `<arguments>`, `</tool_result>` tags

Uses early-exit (`!text.includes("<")`) for performance on clean text.

## Tests

Added 6 test cases covering template delimiters, orphaned XML, normal text preservation, legitimate HTML preservation, empty input, and end-to-end pipeline integration.

Closes #34156