### PR TITLE
Feishu: buffer and send blocks on onIdle when streaming-card unavailable (#34093)

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -185,7 +185,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
-  it("suppresses internal block payload delivery", async () => {
+  it("suppresses internal block payload delivery in deliver (no onIdle)", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
@@ -200,6 +200,43 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
     expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("sends buffered blocks on onIdle when streaming-card cannot be used (#34093)", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: false,
+      },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      replyToMessageId: "om_msg",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "Hello " }, { kind: "block" });
+    await options.deliver({ text: "Hello world" }, { kind: "block" });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+
+    await options.onIdle?.();
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "oc_chat",
+        text: "Hello world",
+      }),
+    );
+    expect(streamingInstances).toHaveLength(0);
   });
 
   it("uses streaming session for auto mode markdown payloads", async () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -145,6 +145,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let lastPartial = "";
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
+  /** Buffered block text when streaming-card cannot be used (blockStreamingDefault path). */
+  let blockBufferText = "";
 
   const mergeStreamingText = (nextText: string) => {
     if (!streamText) {
@@ -265,14 +267,22 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
           if (info?.kind === "block") {
-            // Drop internal block chunks unless we can safely consume them as
-            // streaming-card fallback content.
-            if (!(streamingEnabled && useCard)) {
+            if (streamingEnabled && useCard) {
+              startStreaming();
+              if (streamingStartPromise) {
+                await streamingStartPromise;
+              }
+            } else {
+              // Buffer blocks when streaming-card cannot be used (e.g. blockStreamingDefault
+              // is on but Feishu streaming disabled). Send on onIdle (#34093).
+              if (!blockBufferText) {
+                blockBufferText = text;
+              } else if (text.startsWith(blockBufferText)) {
+                blockBufferText = text;
+              } else if (!blockBufferText.endsWith(text)) {
+                blockBufferText += text;
+              }
               return;
-            }
-            startStreaming();
-            if (streamingStartPromise) {
-              await streamingStartPromise;
             }
           }
 
@@ -309,6 +319,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             return;
           }
 
+          blockBufferText = ""; // Clear buffer when sending final (avoids duplicate in onIdle).
           let first = true;
           if (useCard) {
             for (const chunk of core.channel.text.chunkTextWithMode(
@@ -369,6 +380,48 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         typingCallbacks.onIdle?.();
       },
       onIdle: async () => {
+        if (blockBufferText.trim()) {
+          const useCard =
+            renderMode === "card" || (renderMode === "auto" && shouldUseCard(blockBufferText));
+          let first = true;
+          if (useCard) {
+            for (const chunk of core.channel.text.chunkTextWithMode(
+              blockBufferText,
+              textChunkLimit,
+              chunkMode,
+            )) {
+              await sendMarkdownCardFeishu({
+                cfg,
+                to: chatId,
+                text: chunk,
+                replyToMessageId: sendReplyToMessageId,
+                replyInThread: effectiveReplyInThread,
+                mentions: first ? mentionTargets : undefined,
+                accountId,
+              });
+              first = false;
+            }
+          } else {
+            const converted = core.channel.text.convertMarkdownTables(blockBufferText, tableMode);
+            for (const chunk of core.channel.text.chunkTextWithMode(
+              converted,
+              textChunkLimit,
+              chunkMode,
+            )) {
+              await sendMessageFeishu({
+                cfg,
+                to: chatId,
+                text: chunk,
+                replyToMessageId: sendReplyToMessageId,
+                replyInThread: effectiveReplyInThread,
+                mentions: first ? mentionTargets : undefined,
+                accountId,
+              });
+              first = false;
+            }
+          }
+          blockBufferText = "";
+        }
         await closeStreaming();
         typingCallbacks.onIdle?.();
       },


### PR DESCRIPTION
## Summary

- **Problem:** When `agents.defaults.blockStreamingDefault` is `"on"`, Feishu's `deliver` drops block payloads when `!(streamingEnabled && useCard)`, so agent replies never reach the Feishu chat.
- **Why it matters:** Users with block streaming enabled see no replies in Feishu; gateway logs show `dispatch complete (queuedFinal=false, replies=0)`.
- **What changed:** When streaming-card cannot be used, blocks are buffered in `blockBufferText` and sent in `onIdle`; the buffer is cleared when a final reply is sent to avoid duplicates.
- **What did NOT change:** Streaming-card behavior is unchanged; only the non-streaming fallback path was added.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #34093

## User-visible / Behavior Changes

With `blockStreamingDefault: "on"` and Feishu streaming disabled or non-card mode, agent replies are now delivered to Feishu instead of being dropped.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Integration/channel: Feishu (websocket)
- Relevant config: `agents.defaults.blockStreamingDefault: "on"`, `channels.feishu.streaming` not explicitly set

### Steps

1. Configure Feishu channel (websocket mode)
2. Set `agents.defaults.blockStreamingDefault: "on"`
3. Restart gateway
4. Send a message to the bot from Feishu DM

### Expected

Agent reply is delivered to the Feishu chat.

### Actual (before fix)

Reply is dropped; log shows `dispatch complete (queuedFinal=false, replies=0)`.

## Evidence

- [x] New test: `sends buffered blocks on onIdle when streaming-card cannot be used (#34093)`
- [x] All 17 reply-dispatcher tests pass

## Human Verification

- Verified: blocks are buffered and sent in `onIdle` when `streaming: false`
- Verified: cumulative block merge (e.g. `"Hello "` + `"Hello world"` → `"Hello world"`)
- Not verified: end-to-end behavior against a real Feishu instance

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery

- Revert: `git revert <commit>`
- Workaround: set `agents.defaults.blockStreamingDefault: "off"`

## Risks and Mitigations

- Risk: Feishu API failure during `onIdle` send could lose the reply
- Mitigation: Same error handling as existing `deliver` path; failures go through `onError`