### PR TITLE
fix(subagent): trigger main turn for group/topic announce delivery

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -1012,6 +1012,49 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.threadId).toBe("42");
   });
 
+  it("prefers agent turn over direct-send for group/topic requester sessions", async () => {
+    sendSpy.mockClear();
+    agentSpy.mockClear();
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: "child-session-topic-parent",
+      },
+      "agent:main:telegram:group:-100123:topic:42": {
+        sessionId: "requester-session-topic-parent",
+        lastChannel: "telegram",
+        lastTo: "-100123",
+        lastThreadId: 42,
+      },
+    };
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-topic-parent-turn",
+      requesterSessionKey: "agent:main:telegram:group:-100123:topic:42",
+      requesterDisplayKey: "telegram:group:-100123:topic:42",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "-100123",
+        threadId: 42,
+      },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.sessionKey).toBe("agent:main:telegram:group:-100123:topic:42");
+    expect(call?.params?.deliver).toBe(true);
+    expect(call?.params?.channel).toBe("telegram");
+    expect(call?.params?.to).toBe("-100123");
+    expect(call?.params?.threadId).toBe("42");
+  });
+
   it("uses hook-provided thread target across requester thread variants", async () => {
     const cases = [
       {

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -1055,6 +1055,58 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.threadId).toBe("42");
   });
 
+  it("keeps group/topic requester on agent turn even when hook would force bound direct-send", async () => {
+    sendSpy.mockClear();
+    agentSpy.mockClear();
+    hasSubagentDeliveryTargetHook = true;
+    subagentDeliveryTargetHookMock.mockResolvedValueOnce({
+      origin: {
+        channel: "telegram",
+        to: "-100123",
+        threadId: "42",
+      },
+    });
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: "child-session-topic-bound",
+      },
+      "agent:main:telegram:group:-100123:topic:42": {
+        sessionId: "requester-session-topic-bound",
+        lastChannel: "telegram",
+        lastTo: "-100123",
+        lastThreadId: 42,
+      },
+    };
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-topic-bound-hook",
+      requesterSessionKey: "agent:main:telegram:group:-100123:topic:42",
+      requesterDisplayKey: "telegram:group:-100123:topic:42",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "-100123",
+        threadId: 42,
+      },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      spawnMode: "session",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.sessionKey).toBe("agent:main:telegram:group:-100123:topic:42");
+    expect(call?.params?.deliver).toBe(true);
+    expect(call?.params?.channel).toBe("telegram");
+    expect(call?.params?.to).toBe("-100123");
+    expect(call?.params?.threadId).toBe("42");
+  });
+
   it("uses hook-provided thread target across requester thread variants", async () => {
     const cases = [
       {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -727,6 +727,10 @@ async function maybeQueueSubagentAnnounce(params: {
   return "none";
 }
 
+function isGroupOrTopicRequesterSessionKey(sessionKey: string): boolean {
+  return sessionKey.includes(":group:") || sessionKey.includes(":topic:");
+}
+
 async function sendSubagentAnnounceDirectly(params: {
   targetRequesterSessionKey: string;
   triggerMessage: string;
@@ -778,8 +782,11 @@ async function sendSubagentAnnounceDirectly(params: {
       const forceBoundSessionDirectDelivery =
         params.spawnMode === "session" &&
         (params.completionRouteMode === "bound" || params.completionRouteMode === "hook");
-      let shouldSendCompletionDirectly = true;
-      if (!forceBoundSessionDirectDelivery) {
+      const preferAgentTurnForGroupOrTopic = isGroupOrTopicRequesterSessionKey(
+        canonicalRequesterSessionKey,
+      );
+      let shouldSendCompletionDirectly = !preferAgentTurnForGroupOrTopic;
+      if (!forceBoundSessionDirectDelivery && shouldSendCompletionDirectly) {
         let pendingDescendantRuns = 0;
         try {
           const { countPendingDescendantRuns, countPendingDescendantRunsExcludingRun } =


### PR DESCRIPTION
## Summary
- prefer main-agent turn injection (agent call) over direct completion send for requester sessions that are group/topic scoped
- keep existing direct-send behavior for non-group/non-topic requester sessions
- add regression coverage for group/topic requester session key path

## Why
Issue #34160 reports that subagent announce completion in group/topic contexts can arrive without triggering a main-agent processing turn. By forcing agent-turn routing for group/topic requester session keys, completion handling remains push-based and the orchestrator gets a turn to process/report.

## Notes
- Targeted behavior change only for requester session keys containing `:group:` or `:topic:`
- Existing direct-send test for Telegram forum topics via non-group main session remains intact

Closes #34160
