### PR TITLE
fix: prevent webchat replies from leaking to stale session channel (#34182)

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -409,7 +409,7 @@ describe("gateway agent handler", () => {
     expect(callArgs.bestEffortDeliver).toBe(false);
   });
 
-  it("keeps origin messageChannel as webchat while delivery channel uses last session channel", async () => {
+  it("webchat origin suppresses stale session channel fallback (#34182)", async () => {
     mockMainSessionEntry({
       sessionId: "existing-session-id",
       lastChannel: "telegram",
@@ -452,7 +452,9 @@ describe("gateway agent handler", () => {
       messageChannel?: string;
       runContext?: { messageChannel?: string };
     };
-    expect(callArgs.channel).toBe("telegram");
+    // Webchat origin should NOT fall back to stale session channel;
+    // replies stay internal (webchat) to prevent cross-channel leakage.
+    expect(callArgs.channel).toBe("webchat");
     expect(callArgs.messageChannel).toBe("webchat");
     expect(callArgs.runContext?.messageChannel).toBe("webchat");
   });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -518,6 +518,12 @@ export const agentHandlers: GatewayRequestHandlers = {
       typeof request.accountId === "string" && request.accountId.trim()
         ? request.accountId.trim()
         : undefined;
+    // Treat "last" as unspecified — it is not an explicit channel and should
+    // not bypass the webchat stale-session guard (#34182).
+    const isWebchatOrigin =
+      (!turnSourceChannel || turnSourceChannel === "last") &&
+      client?.connect != null &&
+      isWebchatConnect(client.connect);
     const deliveryPlan = resolveAgentDeliveryPlan({
       sessionEntry,
       requestedChannel: request.replyChannel ?? request.channel,
@@ -529,6 +535,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       turnSourceTo,
       turnSourceAccountId,
       turnSourceThreadId: explicitThreadId,
+      webchatOrigin: isWebchatOrigin,
     });
 
     let resolvedChannel = deliveryPlan.resolvedChannel;

--- a/src/infra/outbound/agent-delivery.test.ts
+++ b/src/infra/outbound/agent-delivery.test.ts
@@ -133,4 +133,22 @@ describe("agent delivery helpers", () => {
     expect(plan.resolvedChannel).toBe("whatsapp");
     expect(plan.resolvedTo).toBeUndefined();
   });
+
+  it("webchatOrigin prevents fallback to stale session delivery context (#34182)", () => {
+    const plan = resolveAgentDeliveryPlan({
+      sessionEntry: {
+        sessionId: "s-webchat",
+        updatedAt: 6,
+        deliveryContext: { channel: "imessage", to: "+8613800138000" },
+      },
+      requestedChannel: undefined,
+      accountId: undefined,
+      wantsDelivery: false,
+      webchatOrigin: true,
+    });
+
+    // Should resolve to internal (webchat), not the stale iMessage channel.
+    expect(plan.resolvedChannel).toBe("webchat");
+    expect(plan.resolvedTo).toBeUndefined();
+  });
 });

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -46,6 +46,14 @@ export function resolveAgentDeliveryPlan(params: {
   turnSourceAccountId?: string;
   /** Turn-source `threadId` — paired with `turnSourceChannel`. */
   turnSourceThreadId?: string | number;
+  /**
+   * When true, the turn originates from webchat (control UI).  Prevents
+   * fallback to a stale session delivery context so replies stay in the
+   * UI instead of leaking to a previously-active external channel.
+   *
+   * @see https://github.com/openclaw/openclaw/issues/34182
+   */
+  webchatOrigin?: boolean;
 }): AgentDeliveryPlan {
   const requestedRaw =
     typeof params.requestedChannel === "string" ? params.requestedChannel.trim() : "";
@@ -58,9 +66,14 @@ export function resolveAgentDeliveryPlan(params: {
       : undefined;
 
   // Resolve turn-source channel for cross-channel safety.
+  // When the turn originates from webchat (INTERNAL_MESSAGE_CHANNEL), we still
+  // need to prevent fallback to a stale session lastChannel — so we propagate
+  // the internal marker to resolveSessionDeliveryTarget.
   const normalizedTurnSource = params.turnSourceChannel
     ? normalizeMessageChannel(params.turnSourceChannel)
     : undefined;
+  const turnSourceIsInternal =
+    params.webchatOrigin === true || normalizedTurnSource === INTERNAL_MESSAGE_CHANNEL;
   const turnSourceChannel =
     normalizedTurnSource && isDeliverableMessageChannel(normalizedTurnSource)
       ? normalizedTurnSource
@@ -84,6 +97,7 @@ export function resolveAgentDeliveryPlan(params: {
     turnSourceTo,
     turnSourceAccountId,
     turnSourceThreadId,
+    suppressSessionFallback: turnSourceIsInternal,
   });
 
   const resolvedChannel = (() => {

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -665,4 +665,23 @@ describe("resolveSessionDeliveryTarget — cross-channel reply guard (#24152)", 
     expect(resolved.channel).toBe("telegram");
     expect(resolved.to).toBe("+15550000000");
   });
+
+  it("suppresses session fallback when suppressSessionFallback is set (#34182)", () => {
+    // Simulate: webchat turn after an iMessage updated session lastChannel.
+    // Without suppressSessionFallback, replies would leak to iMessage.
+    const resolved = resolveSessionDeliveryTarget({
+      entry: {
+        sessionId: "sess-webchat",
+        updatedAt: 1,
+        lastChannel: "imessage",
+        lastTo: "+8613800138000",
+      },
+      requestedChannel: "last",
+      suppressSessionFallback: true,
+    });
+
+    // Should NOT resolve to the stale iMessage channel.
+    expect(resolved.channel).toBeUndefined();
+    expect(resolved.to).toBeUndefined();
+  });
 });

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -88,6 +88,15 @@ export function resolveSessionDeliveryTarget(params: {
   turnSourceAccountId?: string;
   /** Turn-source `threadId` — paired with `turnSourceChannel`. */
   turnSourceThreadId?: string | number;
+  /**
+   * When true, suppress fallback to the session's stored lastChannel/lastTo.
+   * Used when the turn originates from a non-deliverable source (e.g. webchat)
+   * to prevent stale session delivery context from routing replies to a
+   * previously-active external channel.
+   *
+   * @see https://github.com/openclaw/openclaw/issues/34182
+   */
+  suppressSessionFallback?: boolean;
 }): SessionDeliveryTarget {
   const context = deliveryContextFromSession(params.entry);
   const sessionLastChannel =
@@ -95,7 +104,10 @@ export function resolveSessionDeliveryTarget(params: {
 
   // When a turn-source channel is provided, use only turn-scoped metadata.
   // Falling back to mutable session fields would re-introduce routing races.
-  const hasTurnSourceChannel = params.turnSourceChannel != null;
+  // When suppressSessionFallback is set, treat it the same as having a turn
+  // source — don't fall back to potentially stale session delivery context.
+  const hasTurnSourceChannel =
+    params.turnSourceChannel != null || params.suppressSessionFallback === true;
   const lastChannel = hasTurnSourceChannel ? params.turnSourceChannel : sessionLastChannel;
   const lastTo = hasTurnSourceChannel ? params.turnSourceTo : context?.to;
   const lastAccountId = hasTurnSourceChannel ? params.turnSourceAccountId : context?.accountId;


### PR DESCRIPTION
## Problem

When a user receives an iMessage (or message from any external channel) and then opens the Web UI with `/new`, replies are sent to **both** the Web UI and the previous external channel. This happens because:

1. The inbound iMessage updates `lastChannel=imessage` and `deliveryContext.to` in the session store
2. When webchat sends a message, `request.channel` is empty → `turnSourceChannel` is `undefined`
3. `resolveAgentDeliveryPlan` filters out non-deliverable channels from `turnSourceChannel`, so `INTERNAL_MESSAGE_CHANNEL` (webchat) gets discarded
4. `resolveSessionDeliveryTarget` falls back to the stale session `lastChannel` (iMessage)
5. Replies route to iMessage instead of staying in the Web UI

## Fix

- Add `suppressSessionFallback` flag to `resolveSessionDeliveryTarget` — when set, prevents fallback to the session's stored `lastChannel`/`lastTo`
- Add `webchatOrigin` param to `resolveAgentDeliveryPlan` — propagates the webchat origin detection to set `suppressSessionFallback`
- In the gateway agent handler, detect webchat origin (via `isWebchatConnect`) when no explicit channel is provided and pass it through

This is a targeted extension of the cross-channel reply guard from #24152, which already handles the case where a *deliverable* turn-source channel is known but differs from the session's last channel.

## Tests

- Added test in `targets.test.ts`: verifies `suppressSessionFallback` prevents stale session routing
- Added test in `agent-delivery.test.ts`: verifies `webchatOrigin` results in webchat channel resolution instead of stale iMessage

All 55 existing + new tests pass.

Fixes #34182