### PR TITLE
fix(telegram): reset imageRuntimePromise on import failure to allow retry

### DIFF
--- a/src/telegram/sticker-cache.ts
+++ b/src/telegram/sticker-cache.ts
@@ -147,9 +147,16 @@ let imageRuntimePromise: Promise<
   typeof import("../media-understanding/providers/image-runtime.js")
 > | null = null;
 
-function loadImageRuntime() {
-  imageRuntimePromise ??= import("../media-understanding/providers/image-runtime.js");
-  return imageRuntimePromise;
+async function loadImageRuntime() {
+  if (!imageRuntimePromise) {
+    imageRuntimePromise = import("../media-understanding/providers/image-runtime.js");
+  }
+  try {
+    return await imageRuntimePromise;
+  } catch {
+    imageRuntimePromise = null; // allow retry on next call
+    throw new Error("failed to load image runtime");
+  }
 }
 
 export interface DescribeStickerParams {


### PR DESCRIPTION
## Summary
- `loadImageRuntime()` cached the dynamic import promise permanently. If the first import failed (e.g., transient module resolution error), all subsequent calls would reuse the rejected promise, making sticker description permanently broken until gateway restart.
- Now clears the cached promise on failure so the next call retries the import.

## Test plan
- [ ] Verify sticker description still works when image runtime loads successfully
- [ ] Run `pnpm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)