### PR TITLE
fix(memory): cap sessionWarm set to prevent unbounded growth

### DIFF
--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -107,6 +107,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     string,
     { lastSize: number; pendingBytes: number; pendingMessages: number }
   >();
+  private static readonly SESSION_WARM_MAX = 500;
   private sessionWarm = new Set<string>();
   private syncing: Promise<void> | null = null;
   private readonlyRecoveryAttempts = 0;
@@ -233,6 +234,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       log.warn(`memory sync failed (session-start): ${String(err)}`);
     });
     if (key) {
+      if (this.sessionWarm.size >= MemoryIndexManager.SESSION_WARM_MAX) {
+        // Evict oldest entry (first inserted)
+        const first = this.sessionWarm.values().next().value;
+        if (first !== undefined) {
+          this.sessionWarm.delete(first);
+        }
+      }
       this.sessionWarm.add(key);
     }
   }


### PR DESCRIPTION
## Summary
- `sessionWarm` Set in `MemoryIndexManager` tracks which session keys have been warmed, but never evicts entries. Over long gateway uptime with many sessions, this grows without bound.
- Added a cap of 500 entries with FIFO eviction of the oldest entry when the limit is reached.

## Test plan
- [ ] Verify session warming still skips already-warmed sessions
- [ ] Run `pnpm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)