### PR TITLE
fix(telegram): cap sent-message-cache to 1000 chats with FIFO eviction

### DIFF
--- a/src/telegram/sent-message-cache.ts
+++ b/src/telegram/sent-message-cache.ts
@@ -4,6 +4,7 @@
  */
 
 const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const MAX_CHATS = 1000;
 
 type CacheEntry = {
   timestamps: Map<number, number>;
@@ -31,6 +32,13 @@ export function recordSentMessage(chatId: number | string, messageId: number): v
   const key = getChatKey(chatId);
   let entry = sentMessages.get(key);
   if (!entry) {
+    // Evict oldest chat if at capacity
+    if (sentMessages.size >= MAX_CHATS) {
+      const oldest = sentMessages.keys().next().value;
+      if (oldest !== undefined) {
+        sentMessages.delete(oldest);
+      }
+    }
     entry = { timestamps: new Map() };
     sentMessages.set(key, entry);
   }


### PR DESCRIPTION
## Summary
- The outer `sentMessages` Map tracked per-chat entries but had no size limit. Stale chats (inactive bots, old group chats) accumulated indefinitely.
- Added a cap of 1000 chats with FIFO eviction when adding a new chat entry.

## Test plan
- [ ] Verify sent message tracking still works for bot reaction filtering
- [ ] Run `pnpm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)