### PR TITLE
refactor(memory): deduplicate table name and limit constants into shared module

### DIFF
--- a/src/memory/manager-constants.ts
+++ b/src/memory/manager-constants.ts
@@ -1,0 +1,5 @@
+/** Shared SQLite table names and limits for the memory index manager. */
+export const VECTOR_TABLE = "chunks_vec";
+export const FTS_TABLE = "chunks_fts";
+export const EMBEDDING_CACHE_TABLE = "embedding_cache";
+export const BATCH_FAILURE_LIMIT = 2;

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -17,19 +17,21 @@ import {
   type MemoryChunk,
   type MemoryFileEntry,
 } from "./internal.js";
+import {
+  BATCH_FAILURE_LIMIT,
+  EMBEDDING_CACHE_TABLE,
+  FTS_TABLE,
+  VECTOR_TABLE,
+} from "./manager-constants.js";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
 import type { SessionFileEntry } from "./session-files.js";
 import type { MemorySource } from "./types.js";
 
-const VECTOR_TABLE = "chunks_vec";
-const FTS_TABLE = "chunks_fts";
-const EMBEDDING_CACHE_TABLE = "embedding_cache";
 const EMBEDDING_BATCH_MAX_TOKENS = 8000;
 const EMBEDDING_INDEX_CONCURRENCY = 4;
 const EMBEDDING_RETRY_MAX_ATTEMPTS = 3;
 const EMBEDDING_RETRY_BASE_DELAY_MS = 500;
 const EMBEDDING_RETRY_MAX_DELAY_MS = 8000;
-const BATCH_FAILURE_LIMIT = 2;
 const EMBEDDING_QUERY_TIMEOUT_REMOTE_MS = 60_000;
 const EMBEDDING_QUERY_TIMEOUT_LOCAL_MS = 5 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_REMOTE_MS = 2 * 60_000;

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -62,10 +62,9 @@ type MemorySyncProgressState = {
   report: (update: MemorySyncProgressUpdate) => void;
 };
 
+import { EMBEDDING_CACHE_TABLE, FTS_TABLE, VECTOR_TABLE } from "./manager-constants.js";
+
 const META_KEY = "memory_index_meta_v1";
-const VECTOR_TABLE = "chunks_vec";
-const FTS_TABLE = "chunks_fts";
-const EMBEDDING_CACHE_TABLE = "embedding_cache";
 const SESSION_DIRTY_DEBOUNCE_MS = 5000;
 const SESSION_DELTA_READ_CHUNK_BYTES = 64 * 1024;
 const VECTOR_LOAD_TIMEOUT_MS = 30_000;

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -20,6 +20,12 @@ import {
 import { isFileMissingError, statRegularFile } from "./fs-utils.js";
 import { bm25RankToScore, buildFtsQuery, mergeHybridResults } from "./hybrid.js";
 import { isMemoryPath, normalizeExtraMemoryPaths } from "./internal.js";
+import {
+  BATCH_FAILURE_LIMIT,
+  EMBEDDING_CACHE_TABLE,
+  FTS_TABLE,
+  VECTOR_TABLE,
+} from "./manager-constants.js";
 import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
 import { searchKeyword, searchVector } from "./manager-search.js";
 import { extractKeywords } from "./query-expansion.js";
@@ -32,10 +38,6 @@ import type {
   MemorySyncProgressUpdate,
 } from "./types.js";
 const SNIPPET_MAX_CHARS = 700;
-const VECTOR_TABLE = "chunks_vec";
-const FTS_TABLE = "chunks_fts";
-const EMBEDDING_CACHE_TABLE = "embedding_cache";
-const BATCH_FAILURE_LIMIT = 2;
 
 const log = createSubsystemLogger("memory");
 


### PR DESCRIPTION
## Summary
- `VECTOR_TABLE`, `FTS_TABLE`, `EMBEDDING_CACHE_TABLE`, and `BATCH_FAILURE_LIMIT` were duplicated across `manager.ts`, `manager-embedding-ops.ts`, and `manager-sync-ops.ts`. If any copy drifted, it would cause silent data loss (writing to wrong table, wrong failure threshold).
- Extracted into a single `manager-constants.ts` file and imported everywhere.

## Test plan
- [ ] Run `pnpm build` to verify imports resolve correctly
- [ ] Run `pnpm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)