### PR TITLE
fix(gateway): /new session inherits stale delivery context causing cross-channel replies

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -510,8 +510,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         sendPolicy: entry?.sendPolicy,
         label: entry?.label,
         origin: snapshotSessionOrigin(entry),
-        lastChannel: entry?.lastChannel,
-        lastTo: entry?.lastTo,
+        lastChannel: commandReason === "new" ? undefined : entry?.lastChannel,
+        lastTo: commandReason === "new" ? undefined : entry?.lastTo,
         skillsSnapshot: entry?.skillsSnapshot,
         // Reset token counts to 0 on session reset (#1523)
         inputTokens: 0,

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1134,6 +1134,62 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
+  test("sessions.reset with reason=new clears lastChannel and lastTo", async () => {
+    const { dir } = await createSessionStoreDir();
+    await writeSingleLineSession(dir, "sess-main", "hello");
+
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+          lastChannel: "imessage",
+          lastTo: "user@example.com",
+        },
+      },
+    });
+
+    const { ws } = await openClient();
+    const reset = await rpcReq<{ ok: true; key: string; entry: Record<string, unknown> }>(
+      ws,
+      "sessions.reset",
+      { key: "main", reason: "new" },
+    );
+    expect(reset.ok).toBe(true);
+    expect(reset.payload?.entry).toBeDefined();
+    expect(reset.payload?.entry?.lastChannel).toBeUndefined();
+    expect(reset.payload?.entry?.lastTo).toBeUndefined();
+    ws.close();
+  });
+
+  test("sessions.reset without reason=new preserves lastChannel and lastTo", async () => {
+    const { dir } = await createSessionStoreDir();
+    await writeSingleLineSession(dir, "sess-main", "hello");
+
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+          lastChannel: "whatsapp",
+          lastTo: "+1555",
+        },
+      },
+    });
+
+    const { ws } = await openClient();
+    const reset = await rpcReq<{ ok: true; key: string; entry: Record<string, unknown> }>(
+      ws,
+      "sessions.reset",
+      { key: "main" },
+    );
+    expect(reset.ok).toBe(true);
+    expect(reset.payload?.entry).toBeDefined();
+    expect(reset.payload?.entry?.lastChannel).toBe("whatsapp");
+    expect(reset.payload?.entry?.lastTo).toBe("+1555");
+    ws.close();
+  });
+
   test("sessions.reset returns unavailable when active run does not stop", async () => {
     const { dir, storePath } = await seedActiveMainSession();
 


### PR DESCRIPTION
Fixes #34182

### Root Cause

`sessions.reset` with `reason="new"` unconditionally preserved `lastChannel` and `lastTo` from the previous session. When a user received an iMessage and then created a new session via Web UI's `/new`, the new session inherited `lastChannel=imessage` and `lastTo=<iMessage recipient>`. Agent replies were then routed to **both** the Web UI and the stale iMessage target.

### Fix

Clear `lastChannel` and `lastTo` when `commandReason === "new"`. Regular resets (without `reason="new"`) preserve these fields for continuity.

### Changes

- `src/gateway/server-methods/sessions.ts`: conditional clear of delivery fields on "/new"
- Added two tests: one verifying fields are cleared on `reason="new"`, one verifying fields are preserved on regular reset