### PR TITLE
perf(utils): cache LID reverse mapping lookups

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -158,7 +158,14 @@ function resolveLidMappingDirs(opts?: JidToE164Options): string[] {
   return [...dirs];
 }
 
+const lidCache = new Map<string, { value: string | null; ts: number }>();
+const LID_CACHE_TTL_MS = 60_000; // 1 minute
+
 function readLidReverseMapping(lid: string, opts?: JidToE164Options): string | null {
+  const cached = lidCache.get(lid);
+  if (cached && Date.now() - cached.ts < LID_CACHE_TTL_MS) {
+    return cached.value;
+  }
   const mappingFilename = `lid-mapping-${lid}_reverse.json`;
   const mappingDirs = resolveLidMappingDirs(opts);
   for (const dir of mappingDirs) {
@@ -169,11 +176,14 @@ function readLidReverseMapping(lid: string, opts?: JidToE164Options): string | n
       if (phone === null || phone === undefined) {
         continue;
       }
-      return normalizeE164(String(phone));
+      const result = normalizeE164(String(phone));
+      lidCache.set(lid, { value: result, ts: Date.now() });
+      return result;
     } catch {
       // Try the next location.
     }
   }
+  lidCache.set(lid, { value: null, ts: Date.now() });
   return null;
 }
 


### PR DESCRIPTION
## Summary
- `readLidReverseMapping()` uses synchronous `fs.readFileSync` to read LID mapping files on every WhatsApp inbound message
- Added an in-memory cache (`lidCache` Map) with a 1-minute TTL so repeated lookups for the same LID skip disk I/O
- Both successful lookups and misses are cached, reducing redundant file reads during bursts of messages from the same sender

## Test plan
- [ ] Existing tests pass (`pnpm test`)
- [ ] Verify WhatsApp inbound messages still resolve LID→E164 correctly
- [ ] Confirm cache expires after 1 minute (updated mappings picked up within TTL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)