### PR TITLE
refactor(utils): use replaceAll instead of split().join()

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -363,7 +363,7 @@ export function shortenHomeInString(input: string): string {
   if (!display) {
     return input;
   }
-  return input.split(display.home).join(display.prefix);
+  return input.replaceAll(display.home, display.prefix);
 }
 
 export function displayPath(input: string): string {


### PR DESCRIPTION
## Summary
- `shortenHomeInString()` used `input.split(x).join(y)` pattern to replace all occurrences
- Replaced with the idiomatic `String.prototype.replaceAll()` which is clearer and avoids unnecessary array allocation

## Test plan
- [ ] Existing tests pass (`pnpm test`)
- [ ] `displayString()` / `shortenHomeInString()` still correctly replaces home directory paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)