### PR TITLE
fix(feishu): use msg_type=media for video files to fix error 230055

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -113,7 +113,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     messageResourceGetMock.mockResolvedValue(Buffer.from("resource-bytes"));
   });
 
-  it("uses msg_type=file for mp4", async () => {
+  it("uses msg_type=media for mp4", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -129,7 +129,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "file" }),
+        data: expect.objectContaining({ msg_type: "media" }),
       }),
     );
   });
@@ -176,7 +176,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses msg_type=file when replying with mp4", async () => {
+  it("uses msg_type=media when replying with mp4", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -188,7 +188,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(messageReplyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { message_id: "om_parent" },
-        data: expect.objectContaining({ msg_type: "file" }),
+        data: expect.objectContaining({ msg_type: "media" }),
       }),
     );
 
@@ -208,7 +208,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(messageReplyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { message_id: "om_parent" },
-        data: expect.objectContaining({ msg_type: "file", reply_in_thread: true }),
+        data: expect.objectContaining({ msg_type: "media", reply_in_thread: true }),
       }),
     );
   });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -328,8 +328,8 @@ export async function sendFileFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
-  /** Use "audio" for audio files, "file" for documents and video */
-  msgType?: "file" | "audio";
+  /** Use "audio" for audio files, "media" for video, "file" for documents */
+  msgType?: "file" | "audio" | "media";
   replyToMessageId?: string;
   replyInThread?: boolean;
   accountId?: string;
@@ -467,8 +467,9 @@ export async function sendMediaFeishu(params: {
       fileType,
       accountId,
     });
-    // Feishu API: opus -> "audio", everything else (including video) -> "file"
-    const msgType = fileType === "opus" ? "audio" : "file";
+    // Feishu API: opus -> "audio", mp4/video -> "media", everything else -> "file"
+    // Using "file" for video types causes error 230055 (upload type mismatch).
+    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
     return sendFileFeishu({
       cfg,
       to,


### PR DESCRIPTION
## Problem

When sending an mp4 file via `openclaw message send --media`, the Feishu API returned **error 230055** ("The type of file upload does not match the type of message being sent.").

The upload correctly used `file_type=mp4` (video), but the subsequent message send used `msg_type="file"` (document), which Feishu rejects for video uploads.

**Observed request (broken):**
```json
{
  "content": "{\"file_key\":\"file_v3_xxx\"}",
  "msg_type": "file"
}
```

**Expected request (fixed):**
```json
{
  "content": "{\"file_key\":\"file_v3_xxx\"}",
  "msg_type": "media"
}
```

## Root Cause

In `sendMediaFeishu` (`extensions/feishu/src/media.ts`), the `msgType` was determined by:

```typescript
// Before
const msgType = fileType === "opus" ? "audio" : "file";
```

This mapped all non-audio file types — including video (`mp4`) — to `"file"`. Feishu's API requires `msg_type: "media"` for video content uploaded with `file_type: "mp4"`.

## Fix

Add a dedicated branch for the `mp4` file type that maps to `"media"`:

```typescript
// After
const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
```

Also updates:
- The `msgType` parameter type in `sendFileFeishu` to include `"media"`
- The corresponding tests to assert the correct `msg_type` for mp4 inputs

## Testing

All 297 Feishu tests pass (`pnpm vitest run extensions/feishu`).

Fixes #34188