### PR TITLE
perf(routing): enable route cache when identityLinks is configured

### DIFF
--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -550,8 +550,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       }
     : null;
 
-  const routeCache =
-    !shouldLogDebug && !identityLinks ? resolveRouteCacheForConfig(input.cfg) : null;
+  const routeCache = !shouldLogDebug ? resolveRouteCacheForConfig(input.cfg) : null;
   const routeCacheKey = routeCache
     ? buildResolvedRouteCacheKey({
         channel,


### PR DESCRIPTION
## Summary
- Route resolution cache was completely disabled whenever `session.identityLinks` was configured
- This is unnecessary because the cache key already includes the peer (channel + id), and `identityLinks` deterministically maps each peer to its linked identity for session key computation
- The cache is already invalidated when `cfg.session` changes (via `sessionRef` check), so identity link config changes are handled correctly
- Removes the `!identityLinks` guard, allowing route caching to work for users who configure identity links

## Test plan
- [ ] Existing tests pass (`pnpm test`)
- [ ] Route resolution with `identityLinks` still produces correct session keys
- [ ] Multiple linked peers resolve to the same agent session as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)