### PR TITLE
fix(test): increase plugin-sdk root-alias test timeout for Windows CI

### DIFF
--- a/src/plugin-sdk/root-alias.test.ts
+++ b/src/plugin-sdk/root-alias.test.ts
@@ -13,7 +13,11 @@ type EmptySchema = {
       };
 };
 
-describe("plugin-sdk root alias", () => {
+// The lazy proxy triggers a full jiti transpile of plugin-sdk/index.ts (196 exports)
+// on first access to a legacy property. On Windows CI runners this routinely
+// exceeds the default 120 s per-test timeout, so we raise the suite timeout to
+// 5 minutes to prevent flaky failures.
+describe("plugin-sdk root alias", { timeout: 300_000 }, () => {
   it("exposes the fast empty config schema helper", () => {
     const factory = rootSdk.emptyPluginConfigSchema as (() => EmptySchema) | undefined;
     expect(typeof factory).toBe("function");


### PR DESCRIPTION
## Problem

The `root-alias.test.ts` test (introduced in 802b9f6b1) consistently fails on Windows CI shard 6/6 with a 120s timeout.

The lazy proxy in `root-alias.cjs` triggers a full jiti transpile of `plugin-sdk/index.ts` (196 exports) on first access to a legacy property. On Windows CI runners (`blacksmith-32vcpu-windows-2025`) this routinely takes ~133s, exceeding the default 120s per-test timeout.

This affects **every PR that touches `src/`** — the `checks-windows` job is skipped for docs-only or native-only changes, which is why `main` appears green.

### Evidence

- macOS (M-series): ~9s for the lazy-load test
- Windows CI (32 vCPU): ~133s consistently → exceeds 120s timeout
- Shard 6/6 fails with: `Error: Test timed out in 120000ms`

## Fix

Raise the `describe`-level timeout to 300s (5 min) to accommodate the slower Windows transpilation while keeping a reasonable upper bound.

## Changelog

Included in `changelog/fragments/`.
