### PR TITLE
fix(telegram): prevent duplicate messages on sendMessage network errors

### DIFF
--- a/src/infra/retry-policy.test.ts
+++ b/src/infra/retry-policy.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTelegramRetryRunner } from "./retry-policy.js";
+
+describe("createTelegramRetryRunner", () => {
+  describe("strictShouldRetry", () => {
+    it("without strictShouldRetry: ECONNRESET is retried via regex fallback even when predicate returns false", async () => {
+      const fn = vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }));
+      const runner = createTelegramRetryRunner({
+        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+        shouldRetry: () => false, // predicate says no
+        // strictShouldRetry not set — regex fallback still applies
+      });
+      await expect(runner(fn, "test")).rejects.toThrow("ECONNRESET");
+      // Regex matches "reset" so it retried despite shouldRetry returning false
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it("with strictShouldRetry=true: ECONNRESET is NOT retried when predicate returns false", async () => {
+      const fn = vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }));
+      const runner = createTelegramRetryRunner({
+        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+        shouldRetry: () => false,
+        strictShouldRetry: true, // predicate is authoritative
+      });
+      await expect(runner(fn, "test")).rejects.toThrow("ECONNRESET");
+      // No retry — predicate returned false and regex fallback was suppressed
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("with strictShouldRetry=true: ECONNREFUSED is still retried when predicate returns true", async () => {
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" }))
+        .mockResolvedValue("ok");
+      const runner = createTelegramRetryRunner({
+        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+        shouldRetry: (err) => (err as { code?: string }).code === "ECONNREFUSED",
+        strictShouldRetry: true,
+      });
+      await expect(runner(fn, "test")).resolves.toBe("ok");
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/infra/retry-policy.ts
+++ b/src/infra/retry-policy.ts
@@ -76,13 +76,23 @@ export function createTelegramRetryRunner(params: {
   configRetry?: RetryConfig;
   verbose?: boolean;
   shouldRetry?: (err: unknown) => boolean;
+  /**
+   * When true, the custom shouldRetry predicate is used exclusively —
+   * the default TELEGRAM_RETRY_RE fallback regex is NOT OR'd in.
+   * Use this for non-idempotent operations (e.g. sendMessage) where
+   * the regex fallback would cause duplicate message delivery.
+   */
+  strictShouldRetry?: boolean;
 }): RetryRunner {
   const retryConfig = resolveRetryConfig(TELEGRAM_RETRY_DEFAULTS, {
     ...params.configRetry,
     ...params.retry,
   });
   const shouldRetry = params.shouldRetry
-    ? (err: unknown) => params.shouldRetry?.(err) || TELEGRAM_RETRY_RE.test(formatErrorMessage(err))
+    ? params.strictShouldRetry
+      ? params.shouldRetry
+      : (err: unknown) =>
+          params.shouldRetry?.(err) || TELEGRAM_RETRY_RE.test(formatErrorMessage(err))
     : (err: unknown) => TELEGRAM_RETRY_RE.test(formatErrorMessage(err));
 
   return <T>(fn: () => Promise<T>, label?: string) =>

--- a/src/telegram/network-errors.test.ts
+++ b/src/telegram/network-errors.test.ts
@@ -114,6 +114,16 @@ describe("isSafeToRetrySendError", () => {
     expect(isSafeToRetrySendError(err)).toBe(true);
   });
 
+  it("allows retry for ENETUNREACH (no route to host, message not sent)", () => {
+    const err = Object.assign(new Error("connect ENETUNREACH"), { code: "ENETUNREACH" });
+    expect(isSafeToRetrySendError(err)).toBe(true);
+  });
+
+  it("allows retry for EHOSTUNREACH (host unreachable, message not sent)", () => {
+    const err = Object.assign(new Error("connect EHOSTUNREACH"), { code: "EHOSTUNREACH" });
+    expect(isSafeToRetrySendError(err)).toBe(true);
+  });
+
   it("does NOT allow retry for ECONNRESET (message may already be delivered)", () => {
     const err = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
     expect(isSafeToRetrySendError(err)).toBe(false);

--- a/src/telegram/network-errors.test.ts
+++ b/src/telegram/network-errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isRecoverableTelegramNetworkError } from "./network-errors.js";
+import { isRecoverableTelegramNetworkError, isSafeToRetrySendError } from "./network-errors.js";
 
 describe("isRecoverableTelegramNetworkError", () => {
   it("detects recoverable error codes", () => {
@@ -95,5 +95,53 @@ describe("isRecoverableTelegramNetworkError", () => {
 
       expect(isRecoverableTelegramNetworkError(httpError)).toBe(false);
     });
+  });
+});
+
+describe("isSafeToRetrySendError", () => {
+  it("allows retry for ECONNREFUSED (pre-connect, message not sent)", () => {
+    const err = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+    expect(isSafeToRetrySendError(err)).toBe(true);
+  });
+
+  it("allows retry for ENOTFOUND (DNS failure, message not sent)", () => {
+    const err = Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" });
+    expect(isSafeToRetrySendError(err)).toBe(true);
+  });
+
+  it("allows retry for EAI_AGAIN (transient DNS, message not sent)", () => {
+    const err = Object.assign(new Error("getaddrinfo EAI_AGAIN"), { code: "EAI_AGAIN" });
+    expect(isSafeToRetrySendError(err)).toBe(true);
+  });
+
+  it("does NOT allow retry for ECONNRESET (message may already be delivered)", () => {
+    const err = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    expect(isSafeToRetrySendError(err)).toBe(false);
+  });
+
+  it("does NOT allow retry for ETIMEDOUT (message may already be delivered)", () => {
+    const err = Object.assign(new Error("connect ETIMEDOUT"), { code: "ETIMEDOUT" });
+    expect(isSafeToRetrySendError(err)).toBe(false);
+  });
+
+  it("does NOT allow retry for EPIPE (connection broken mid-transfer, message may be delivered)", () => {
+    const err = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    expect(isSafeToRetrySendError(err)).toBe(false);
+  });
+
+  it("does NOT allow retry for UND_ERR_CONNECT_TIMEOUT (ambiguous timing)", () => {
+    const err = Object.assign(new Error("connect timeout"), { code: "UND_ERR_CONNECT_TIMEOUT" });
+    expect(isSafeToRetrySendError(err)).toBe(false);
+  });
+
+  it("does NOT allow retry for non-network errors", () => {
+    expect(isSafeToRetrySendError(new Error("400: Bad Request"))).toBe(false);
+    expect(isSafeToRetrySendError(null)).toBe(false);
+  });
+
+  it("detects pre-connect error nested in cause chain", () => {
+    const root = Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" });
+    const wrapped = Object.assign(new Error("fetch failed"), { cause: root });
+    expect(isSafeToRetrySendError(wrapped)).toBe(true);
   });
 });

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -24,6 +24,24 @@ const RECOVERABLE_ERROR_CODES = new Set([
   "ERR_NETWORK",
 ]);
 
+/**
+ * Error codes that are safe to retry for non-idempotent send operations (e.g. sendMessage).
+ *
+ * These represent failures that occur *before* the request reaches Telegram's servers,
+ * meaning the message was definitely not delivered and it is safe to retry.
+ *
+ * Contrast with RECOVERABLE_ERROR_CODES which includes codes like ECONNRESET and ETIMEDOUT
+ * that can fire *after* Telegram has already received and delivered a message — retrying
+ * those would cause duplicate messages.
+ */
+const PRE_CONNECT_ERROR_CODES = new Set([
+  "ECONNREFUSED", // Server actively refused the connection (never reached Telegram)
+  "ENOTFOUND", // DNS resolution failed (never sent)
+  "EAI_AGAIN", // Transient DNS failure (never sent)
+  "ENETUNREACH", // No route to host (never sent)
+  "EHOSTUNREACH", // Host unreachable (never sent)
+]);
+
 const RECOVERABLE_ERROR_NAMES = new Set([
   "AbortError",
   "TimeoutError",
@@ -68,6 +86,36 @@ function getErrorCode(err: unknown): string | undefined {
 }
 
 export type TelegramNetworkErrorContext = "polling" | "send" | "webhook" | "unknown";
+
+/**
+ * Returns true if the error is safe to retry for a non-idempotent Telegram send operation
+ * (e.g. sendMessage). Only matches errors that are guaranteed to have occurred *before*
+ * the request reached Telegram's servers, preventing duplicate message delivery.
+ *
+ * Use this instead of isRecoverableTelegramNetworkError for sendMessage/sendPhoto/etc.
+ * calls where a retry would create a duplicate visible message.
+ */
+export function isSafeToRetrySendError(err: unknown): boolean {
+  if (!err) {
+    return false;
+  }
+  for (const candidate of collectErrorGraphCandidates(err, (current) => {
+    const nested: Array<unknown> = [current.cause, current.reason];
+    if (Array.isArray(current.errors)) {
+      nested.push(...current.errors);
+    }
+    if (readErrorName(current) === "HttpError") {
+      nested.push(current.error);
+    }
+    return nested;
+  })) {
+    const code = normalizeCode(getErrorCode(candidate));
+    if (code && PRE_CONNECT_ERROR_CODES.has(code)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 export function isRecoverableTelegramNetworkError(
   err: unknown,

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -27,7 +27,7 @@ import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";
-import { isRecoverableTelegramNetworkError } from "./network-errors.js";
+import { isRecoverableTelegramNetworkError, isSafeToRetrySendError } from "./network-errors.js";
 import { makeProxyFetch } from "./proxy.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 import { maybePersistResolvedTelegramTarget } from "./target-writeback.js";
@@ -488,7 +488,7 @@ export async function sendMessageTelegram(
     account,
     retry: opts.retry,
     verbose: opts.verbose,
-    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
+    shouldRetry: (err) => isSafeToRetrySendError(err),
   });
   const requestWithChatNotFound = createRequestWithChatNotFound({
     requestWithDiag,
@@ -1094,7 +1094,7 @@ export async function sendPollTelegram(
     account,
     retry: opts.retry,
     verbose: opts.verbose,
-    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
+    shouldRetry: (err) => isSafeToRetrySendError(err),
   });
   const requestWithChatNotFound = createRequestWithChatNotFound({
     requestWithDiag,
@@ -1213,7 +1213,7 @@ export async function createForumTopicTelegram(
     retry: opts.retry,
     configRetry: account.config.retry,
     verbose: opts.verbose,
-    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
+    shouldRetry: (err) => isSafeToRetrySendError(err),
   });
   const logHttpError = createTelegramHttpLogger(cfg);
   const requestWithDiag = <T>(fn: () => Promise<T>, label?: string) =>

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -489,6 +489,7 @@ export async function sendMessageTelegram(
     retry: opts.retry,
     verbose: opts.verbose,
     shouldRetry: (err) => isSafeToRetrySendError(err),
+    strictShouldRetry: true,
   });
   const requestWithChatNotFound = createRequestWithChatNotFound({
     requestWithDiag,
@@ -1095,6 +1096,7 @@ export async function sendPollTelegram(
     retry: opts.retry,
     verbose: opts.verbose,
     shouldRetry: (err) => isSafeToRetrySendError(err),
+    strictShouldRetry: true,
   });
   const requestWithChatNotFound = createRequestWithChatNotFound({
     requestWithDiag,
@@ -1214,6 +1216,7 @@ export async function createForumTopicTelegram(
     configRetry: account.config.retry,
     verbose: opts.verbose,
     shouldRetry: (err) => isSafeToRetrySendError(err),
+    strictShouldRetry: true,
   });
   const logHttpError = createTelegramHttpLogger(cfg);
   const requestWithDiag = <T>(fn: () => Promise<T>, label?: string) =>


### PR DESCRIPTION
## Problem

When a `sendMessage` (or `sendPoll`/`createForumTopic`) call experiences a network error like `ECONNRESET` or `ETIMEDOUT`, the current retry logic treats these as recoverable and retries up to 3 times (`TELEGRAM_RETRY_DEFAULTS.attempts = 3`).

The issue: **these errors can fire *after* Telegram has already received and delivered the message**. The TCP connection drops before the client receives the response, but the message was sent. Retrying then delivers the same message 2 or 3 times.

This was observed in production: a single short assistant reply was delivered 3 times to the user on a flaky connection.

## Root Cause

In `send.ts`, `sendMessageTelegram`, `sendPollTelegram`, and `createForumTopicTelegram` all use:
```ts
shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" })
```

Even with `context: "send"` (which disables message-snippet matching), error *codes* like `ECONNRESET`, `ETIMEDOUT`, `EPIPE`, `UND_ERR_BODY_TIMEOUT` etc. still match — and these can all occur post-delivery.

## Fix

Introduce `isSafeToRetrySendError()` that only retries on **pre-connect errors** where we can be certain the request never reached Telegram's servers:

- `ECONNREFUSED` — server refused (never connected)
- `ENOTFOUND` / `EAI_AGAIN` — DNS failure (never sent)
- `ENETUNREACH` / `EHOSTUNREACH` — no route to host (never sent)

Ambiguous errors (`ECONNRESET`, `ETIMEDOUT`, `EPIPE`, `UND_ERR_*`) are intentionally excluded — these can occur mid-transfer after delivery.

Idempotent operations (`reactMessageTelegram`, `deleteMessageTelegram`, `editMessageTelegram`) are **unaffected** — they keep using `isRecoverableTelegramNetworkError` since retrying them is always safe.

## Tests

9 new unit tests added covering both the safe-retry and must-not-retry cases. All 21 tests pass.

## Checklist
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All existing network-errors tests pass
- [x] New tests for `isSafeToRetrySendError`
- [x] Idempotent operations unaffected