### PR TITLE
fix(web): add clipboard fallback for insecure contexts (#34092)

### DIFF
--- a/ui/src/ui/chat/copy-as-markdown.ts
+++ b/ui/src/ui/chat/copy-as-markdown.ts
@@ -23,22 +23,27 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
     return true;
   } catch {
     // Fallback for non-secure contexts (HTTP on Windows/localhost)
-    try {
-      // Use textarea element fallback for insecure contexts
-      const textarea = document.createElement("textarea");
-      textarea.value = text;
-      textarea.style.position = "fixed";
-      textarea.style.left = "-9999px";
-      textarea.style.top = "-9999px";
-      document.body.appendChild(textarea);
-      textarea.focus();
-      textarea.select();
-      const success = document.execCommand("copy");
-      document.body.removeChild(textarea);
-      return success;
-    } catch {
-      return false;
-    }
+    return copyViaExecCommand(text);
+  }
+}
+
+function copyViaExecCommand(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "-9999px";
+  document.body.appendChild(textarea);
+
+  try {
+    textarea.focus();
+    textarea.select();
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    // Always clean up the textarea element to prevent DOM leak
+    document.body.removeChild(textarea);
   }
 }
 

--- a/ui/src/ui/chat/copy-as-markdown.ts
+++ b/ui/src/ui/chat/copy-as-markdown.ts
@@ -17,11 +17,28 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
     return false;
   }
 
+  // Try Clipboard API first (works in secure contexts/HTTPS)
   try {
     await navigator.clipboard.writeText(text);
     return true;
   } catch {
-    return false;
+    // Fallback for non-secure contexts (HTTP on Windows/localhost)
+    try {
+      // Use textarea element fallback for insecure contexts
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.style.position = "fixed";
+      textarea.style.left = "-9999px";
+      textarea.style.top = "-9999px";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      const success = document.execCommand("copy");
+      document.body.removeChild(textarea);
+      return success;
+    } catch {
+      return false;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- **Problem**: Chat copy button not working on Windows with HTTP (non-secure context)
- **Root Cause**: `navigator.clipboard.writeText()` requires secure context (HTTPS)
- **Fix**: Add textarea element fallback for non-secure contexts (HTTP on Windows)

## Changes

- Modified `ui/src/ui/chat/copy-as-markdown.ts`
- Added fallback using `document.execCommand('copy')` for HTTP environments

## Testing

- Works in secure contexts (HTTPS)
- Added fallback for insecure contexts (HTTP/localhost)

## Related

- Fixes #34092