### PR TITLE
test(plugin-sdk): increase root-alias test timeout to 180s

### DIFF
--- a/src/plugin-sdk/root-alias.test.ts
+++ b/src/plugin-sdk/root-alias.test.ts
@@ -13,7 +13,9 @@ type EmptySchema = {
       };
 };
 
-describe("plugin-sdk root alias", () => {
+// jiti transpiles the entire monolithic SDK on first lazy access, which can
+// take well over 60 s on slower CI runners.
+describe("plugin-sdk root alias", { timeout: 180_000 }, () => {
   it("exposes the fast empty config schema helper", () => {
     const factory = rootSdk.emptyPluginConfigSchema as (() => EmptySchema) | undefined;
     expect(typeof factory).toBe("function");


### PR DESCRIPTION
## Summary
- `root-alias.test.ts` frequently times out on CI (default 120s) because the "loads legacy root exports lazily through the proxy" test triggers `loadMonolithicSdk()`, which uses jiti to transpile the entire plugin SDK from TypeScript source
- On a local Mac this already takes ~71s; on slower CI runners it regularly exceeds 120s
- Increases the describe-level timeout from the default 120s to 180s

## Test plan
- [ ] `pnpm test -- --run src/plugin-sdk/root-alias.test.ts` passes locally
- [ ] CI no longer flakes on this test

🤖 Generated with [Claude Code](https://claude.com/claude-code)