### PR TITLE
fix(detectMarker): skip path-like strings to avoid false-positive marker detection

### DIFF
--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -61,11 +61,45 @@ type Marker = (typeof EXTRA_MARKERS)[number];
 
 function detectMarker(content: string): Marker | null {
   const lower = content.toLowerCase();
-  for (const marker of EXTRA_MARKERS) {
-    if (lower.includes(marker)) {
-      return marker;
+
+  // Check for markers inside <string>...</string> tags (real markers)
+  const stringMatches = content.match(/<string>([^<]+)<\/string>/g) || [];
+  for (const match of stringMatches) {
+    const value = match
+      .replace(/<\/?string>/g, "")
+      .toLowerCase()
+      .trim();
+
+    // Skip paths (e.g., /Users/openclaw/...) — only match actual labels
+    if (value.includes("/") || value.includes("application support") || value.includes(".app/")) {
+      continue;
+    }
+
+    for (const marker of EXTRA_MARKERS) {
+      if (
+        value === marker ||
+        value.startsWith(marker + ".") ||
+        (marker === "openclaw" && value.includes("openclaw."))
+      ) {
+        return marker;
+      }
     }
   }
+
+  // Fallback: check full content (legacy labels)
+  if (
+    stringMatches.length === 0 ||
+    lower.includes("openclaw_service_marker") ||
+    lower.includes("clawdbot") ||
+    lower.includes("moltbot")
+  ) {
+    for (const marker of EXTRA_MARKERS) {
+      if (lower.includes(marker)) {
+        return marker;
+      }
+    }
+  }
+
   return null;
 }
 


### PR DESCRIPTION
### Bug

`openclaw gateway status` falsely detects `com.google.GoogleUpdater.wake` as a 'gateway-like service' and shows cleanup hints for the OpenClaw gateway, even though it's the only real gateway running.

### Root cause

`detectMarker()` in `src/daemon/inspect.ts` uses `includes()` on the entire plist content, which matches \`openclaw\` inside **paths** like `/Users/openclaw/Library/...`.

Example: The GoogleUpdater plist contains paths with `/Users/openclaw/...`, triggering a false-positive \`openclaw\` marker.

### Fix

- First, extract only `<string>...\</string>` tag contents (real markers are in Label/Program strings)  
- Skip any value that looks like a path (`/`, `.app/`, `application support`)  
- Only match real labels (e.g., `ai.openclaw.gateway`, `clawdbot.wake`)  
- Fallback to full-content search only for legacy labels (no `<string>` tags)

### Test

Before:
```
Other gateway-like services detected (best effort):
- com.google.GoogleUpdater.wake (user, plist: ...)
Cleanup hint: launchctl bootout gui/$UID/ai.openclaw.gateway
```

After:
No warnings — `com.google.GoogleUpdater.wake` is correctly ignored.

### Breaking changes

None — this only fixes false positives.