### PR TITLE
docs(feishu): add available tools section to Feishu channel docs

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -651,3 +651,16 @@ Key options:
 - ✅ Files
 - ✅ Audio
 - ⚠️ Rich text (partial support)
+
+## Available Tools
+
+The Feishu plugin provides the following tools for agents:
+
+- **feishu_doc** - Read/write Feishu documents
+- **feishu_chat** - Chat operations (get info, list members)
+- **feishu_wiki** - Knowledge base operations
+- **feishu_drive** - Cloud storage file management
+- **feishu_bitable** - Multidimensional table operations
+- **feishu_perm** - Permission management
+- **feishu_reaction** - Add/remove/list emoji reactions on messages
+


### PR DESCRIPTION
## Summary

Improve Feishu channel documentation by adding available tools section.

**What changed:**
- List all Feishu plugin tools (doc, chat, wiki, drive, bitable, perm, reaction)
- Add link to Feishu reactions documentation
- Improve discoverability of Feishu features

**Related:**
- Complements #34099 (Feishu reaction tool)
- Part of Feishu documentation improvements