### PR TITLE
fix(daemon): handle generic 'command failed' error for systemctl --user

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,6 +79,21 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false when systemctl command fails generically (e.g. containers/WSL)", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & {
+        code?: number;
+      };
+      err.code = 1;
+      cb(err, "", "Command failed: systemctl --user is-enabled openclaw-gateway.service");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
   it("throws when systemctl is-enabled fails for non-state errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -155,7 +155,10 @@ function isSystemctlMissing(detail: string): boolean {
     normalized.includes("not found") ||
     normalized.includes("no such file or directory") ||
     normalized.includes("spawn systemctl enoent") ||
-    normalized.includes("spawn systemctl eacces")
+    normalized.includes("spawn systemctl eacces") ||
+    // On some Linux environments (e.g. Ubuntu in containers/WSL), systemctl --user
+    // may fail with a generic "command failed" error when user services are unavailable.
+    normalized.includes("command failed: systemctl")
   );
 }
 


### PR DESCRIPTION
## Summary

On some Linux environments like Ubuntu in containers or WSL, `systemctl --user` may fail with a generic error message rather than returning a specific systemd state:

```
Error: systemctl is-enabled unavailable: Command failed: systemctl --user is-enabled openclaw-gateway.service
```

This change adds pattern matching for `command failed: systemctl` to gracefully return `false` from `isSystemdServiceEnabled()` instead of throwing an error.

## Changes

- Added `command failed: systemctl` to the `isSystemctlMissing()` pattern matcher
- Added test case for this specific error scenario

## Testing

- `pnpm test src/daemon/systemd.test.ts` - all 20 tests pass

Fixes #34237