### PR TITLE
fix(web-media): allow state workspace-* local media roots

### DIFF
--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -480,7 +480,7 @@ describe("local media root guard", () => {
 
   it("rejects workspace-* paths outside the OpenClaw state dir by default", async () => {
     const readFile = vi.fn(async () => Buffer.from("generated-media"));
-    const outsideDir = await fs.mkdtemp(path.join(tmpDir, "workspace-outside-"));
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "workspace-outside-"));
 
     await expect(
       loadWebMedia(path.join(outsideDir, "tmp", "render.bin"), {

--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -444,7 +444,7 @@ describe("local media root guard", () => {
     );
   });
 
-  it("rejects default OpenClaw state per-agent workspace-* roots without explicit local roots", async () => {
+  it("allows default OpenClaw state per-agent workspace-* roots", async () => {
     const stateDir = resolveStateDir();
     const readFile = vi.fn(async () => Buffer.from("generated-media"));
 
@@ -453,7 +453,11 @@ describe("local media root guard", () => {
         maxBytes: 1024 * 1024,
         readFile,
       }),
-    ).rejects.toMatchObject({ code: "path-not-allowed" });
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "unknown",
+      }),
+    );
   });
 
   it("allows per-agent workspace-* paths with explicit local roots", async () => {
@@ -472,5 +476,17 @@ describe("local media root guard", () => {
         kind: "unknown",
       }),
     );
+  });
+
+  it("rejects workspace-* paths outside the OpenClaw state dir by default", async () => {
+    const readFile = vi.fn(async () => Buffer.from("generated-media"));
+    const outsideDir = await fs.mkdtemp(path.join(tmpDir, "workspace-outside-"));
+
+    await expect(
+      loadWebMedia(path.join(outsideDir, "tmp", "render.bin"), {
+        maxBytes: 1024 * 1024,
+        readFile,
+      }),
+    ).rejects.toMatchObject({ code: "path-not-allowed" });
   });
 });

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -94,10 +94,9 @@ async function assertLocalMediaAllowed(
     resolved = path.resolve(mediaPath);
   }
 
-  // Hardening: the default allowlist includes the OpenClaw temp dir, and tests/CI may
-  // override the state dir into tmp. Avoid accidentally allowing per-agent
-  // `workspace-*` state roots via the temp-root prefix match; require explicit
-  // localRoots for those.
+  // Hardening: default roots include the OpenClaw temp dir, and tests/CI may
+  // override the state dir into tmp. Restrict implicit workspace-* allowance to
+  // stateDir/workspace-* only.
   if (localRoots === undefined) {
     const workspaceRoot = roots.find((root) => path.basename(root) === "workspace");
     if (workspaceRoot) {
@@ -106,10 +105,7 @@ async function assertLocalMediaAllowed(
       if (rel && !rel.startsWith("..") && !path.isAbsolute(rel)) {
         const firstSegment = rel.split(path.sep)[0] ?? "";
         if (firstSegment.startsWith("workspace-")) {
-          throw new LocalMediaAccessError(
-            "path-not-allowed",
-            `Local media path is not under an allowed directory: ${mediaPath}`,
-          );
+          return;
         }
       }
     }


### PR DESCRIPTION
## Summary
Fixes #34161.

Allow default local media reads from OpenClaw state per-profile workspaces (`~/.openclaw/workspace-<profile>`) to match documented workspace naming.

## Changes
- Allow `stateDir/workspace-*` paths in default local media root checks.
- Keep security boundary: `workspace-*` paths outside `stateDir` remain blocked.
- Update tests:
  - allow default `workspace-*` under state dir
  - reject `workspace-*` outside state dir by default

## Files
- src/web/media.ts
- src/web/media.test.ts

## Validation
- Targeted test execution was attempted, but CI-local registry access timed out in this environment.
