### PR TITLE
Tlon: tighten history response parsing and avoid mis-parsing malformed shapes

### DIFF
--- a/extensions/tlon/src/monitor/history.ts
+++ b/extensions/tlon/src/monitor/history.ts
@@ -27,6 +27,69 @@ export type TlonHistoryEntry = {
   id?: string;
 };
 
+type TlonPostEssay = {
+  author?: string;
+  content?: unknown;
+  sent?: number;
+};
+
+type TlonPostSeal = {
+  id?: string;
+};
+
+type TlonPost = {
+  essay?: TlonPostEssay;
+  seal?: TlonPostSeal;
+  "r-post"?: {
+    set?: {
+      essay?: TlonPostEssay;
+      seal?: TlonPostSeal;
+    };
+  };
+};
+
+type TlonPostMap = Record<string, TlonPost>;
+
+type TlonChannelHistoryResponse =
+  | TlonPost[]
+  | {
+      posts?: TlonPostMap;
+    }
+  | TlonPostMap;
+
+type TlonReplyMemo = {
+  author?: string;
+  content?: unknown;
+  sent?: number;
+};
+
+type TlonReplySeal = {
+  id?: string;
+};
+
+type TlonReply = {
+  memo?: TlonReplyMemo;
+  seal?: TlonReplySeal;
+  "r-reply"?: {
+    set?: {
+      memo?: TlonReplyMemo;
+      seal?: TlonReplySeal;
+    };
+  };
+  id?: string;
+};
+
+type TlonReplyMap = Record<string, TlonReply>;
+
+type TlonThreadHistoryResponse =
+  | TlonReply[]
+  | {
+      replies?: TlonReply[] | TlonReplyMap;
+    }
+  | TlonReplyMap;
+
+type TlonPostLike = TlonPost | TlonReply;
+
 const messageCache = new Map<string, TlonHistoryEntry[]>();
 const MAX_CACHED_MESSAGES = 100;
 
@@ -42,6 +105,104 @@ export function cacheMessage(channelNest: string, message: TlonHistoryEntry) {
   if (cache.length > MAX_CACHED_MESSAGES) {
     cache.pop();
   }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isTlonPostLike(value: unknown): value is TlonPostLike {
+  if (!isObject(value)) {
+    return false;
+  }
+
+  const maybeEssay = (value as TlonPost).essay;
+  const maybeMemo = (value as TlonReply).memo;
+
+  if (!maybeEssay && !maybeMemo && !("r-post" in value) && !("r-reply" in value)) {
+    return false;
+  }
+
+  return true;
+}
+
+function normalizeChannelHistoryResponse(data: unknown, runtime?: RuntimeEnv): TlonPost[] {
+  if (!data) {
+    return [];
+  }
+
+  const narrowed = data as TlonChannelHistoryResponse;
+
+  if (Array.isArray(narrowed)) {
+    return narrowed.filter(isTlonPostLike) as TlonPost[];
+  }
+
+  if (isObject(narrowed) && narrowed.posts && isObject(narrowed.posts)) {
+    return Object.values(narrowed.posts).filter(isTlonPostLike) as TlonPost[];
+  }
+
+  if (isObject(narrowed)) {
+    return Object.values(narrowed).filter(isTlonPostLike) as TlonPost[];
+  }
+
+  runtime?.log?.("[tlon] Unexpected channel history response shape, ignoring");
+  return [];
+}
+
+function extractHistoryEntryFromPost(post: TlonPost): TlonHistoryEntry {
+  const essay = post.essay ?? post["r-post"]?.set?.essay ?? {};
+  const seal = post.seal ?? post["r-post"]?.set?.seal ?? {};
+
+  const contentBlocks = Array.isArray(essay.content) ? essay.content : [];
+
+  return {
+    author: essay.author ?? "unknown",
+    content: extractMessageText(contentBlocks),
+    timestamp: essay.sent ?? Date.now(),
+    id: seal.id,
+  };
+}
+
+function normalizeThreadHistoryResponse(data: unknown, runtime?: RuntimeEnv): TlonReply[] {
+  if (!data) {
+    return [];
+  }
+
+  const narrowed = data as TlonThreadHistoryResponse;
+
+  if (Array.isArray(narrowed)) {
+    return narrowed.filter(isTlonPostLike) as TlonReply[];
+  }
+
+  if (isObject(narrowed) && narrowed.replies) {
+    const replies = Array.isArray(narrowed.replies)
+      ? narrowed.replies
+      : isObject(narrowed.replies)
+        ? Object.values(narrowed.replies)
+        : [];
+    return replies.filter(isTlonPostLike) as TlonReply[];
+  }
+
+  if (isObject(narrowed)) {
+    return Object.values(narrowed).filter(isTlonPostLike) as TlonReply[];
+  }
+
+  runtime?.log?.("[tlon] Unexpected thread history response shape, ignoring");
+  return [];
+}
+
+function extractHistoryEntryFromReply(reply: TlonReply): TlonHistoryEntry {
+  const memo = reply.memo ?? reply["r-reply"]?.set?.memo ?? {};
+  const seal = reply.seal ?? reply["r-reply"]?.set?.seal ?? {};
+
+  const contentBlocks = Array.isArray(memo.content) ? memo.content : [];
+
+  return {
+    author: memo.author ?? "unknown",
+    content: extractMessageText(contentBlocks),
+    timestamp: memo.sent ?? Date.now(),
+    id: seal.id ?? reply.id,
+  };
 }
 
 export async function fetchChannelHistory(


### PR DESCRIPTION
## Summary

This PR tightens the parsing logic for Tlon channel and thread history responses so that we don't accidentally interpret malformed or unexpected response shapes as valid messages.

- Introduces typed response helpers for channel history (`TlonChannelHistoryResponse`) and thread history (`TlonThreadHistoryResponse`).
- Adds small type guards and normalisation helpers to extract only "post-like" / "reply-like" items from the API responses.
- Refactors `fetchChannelHistory` and `fetchThreadHistory` to use these helpers instead of `any` + loose `Object.values(...)` parsing.
- Improves logging for unexpected response shapes and error cases.

## Motivation

Right now, `fetchChannelHistory` and `fetchThreadHistory` both rely on `any` plus broad `Object.values(...)` parsing to handle different Tlon API response shapes. If the backend adds extra keys or changes the shape slightly, we may end up:

- Treating non-post metadata objects as messages.
- Emitting entries with `"unknown"` authors or empty content where we should have dropped them.
- Making it harder to debug issues when the response shape drifts from what we expect.

The goal of this change is to be stricter and more explicit about what we consider a valid "post/reply" while still supporting the currently known shapes.

## Changes

- Define lightweight types for posts and replies:
  - `TlonPostEssay`, `TlonPostSeal`, `TlonPost`, `TlonChannelHistoryResponse`
  - `TlonReplyMemo`, `TlonReplySeal`, `TlonReply`, `TlonThreadHistoryResponse`
- Add small helpers:
  - `isObject` – defensive guard around `typeof value === "object"`.
  - `isTlonPostLike` – recognises objects that look like posts or replies (`essay`, `memo`, `r-post`, `r-reply`).
  - `normalizeChannelHistoryResponse` – normalises channel history responses from:
    - an array of posts,
    - `{ posts: { id: post } }`,
    - or `{ id: post }` maps,
    into a `TlonPost[]`.
  - `extractHistoryEntryFromPost` – converts a `TlonPost` into a `TlonHistoryEntry` using the existing `extractMessageText` helper.
  - `normalizeThreadHistoryResponse` – normalises thread replies from:
    - an array of replies,
    - `{ replies: [...] }`,
    - or `{ replies: { id: reply } }` / `{ id: reply }`,
    into a `TlonReply[]`.
  - `extractHistoryEntryFromReply` – converts a `TlonReply` into a `TlonHistoryEntry`.
- Refactor:
  - `fetchChannelHistory` to:
    - call `api.scry` as `unknown`,
    - normalise via `normalizeChannelHistoryResponse`,
    - map with `extractHistoryEntryFromPost`,
    - keep only entries with non-empty `content`,
    - and log how many posts vs messages were produced.
  - `fetchThreadHistory` to:
    - do the same with `normalizeThreadHistoryResponse` / `extractHistoryEntryFromReply`,
    - improve the fallback path by checking we really have replies before trying to read them,
    - and log how many replies vs messages were produced.
- Update error handling to avoid `error: any` and instead log via `error instanceof Error ? error.message : String(error)`.

## Behaviour

- For valid/known response shapes, the behaviour should be the same or slightly safer:
  - We still extract the same posts/replies and content.
  - We no longer risk converting arbitrary objects into `TlonHistoryEntry` just because they happened to be values of an object.
- For unknown/malformed response shapes:
  - We now log a clear message (`[tlon] Unexpected ... response shape, ignoring`) and drop those entries instead of trying to parse them as messages.
  - The functions still resolve to an empty array on failure, preserving the existing failure surface.

## Testing

- Manual / local testing against a Tlon deployment:
  - Verified `fetchChannelHistory` still returns recent messages for a channel.
  - Verified `fetchThreadHistory` returns replies for a thread with multiple replies.
- Unit tests are not yet added for these helpers; I’m happy to follow up with a small test-only PR if desired to cover:
  - normalisation of array vs `{ posts }` / `{ replies }`,
  - behaviour when extra keys/metadata are present in the response,
  - and the fallback path in `fetchThreadHistory`.