### PR TITLE
docs(feishu): add testing guide and troubleshooting section

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -651,3 +651,39 @@ Key options:
 - ✅ Files
 - ✅ Audio
 - ⚠️ Rich text (partial support)
+
+## Testing Reaction Tool
+
+After enabling the reaction tool, you can test it with these examples:
+
+### Add a thumbs up reaction
+
+```bash
+openclaw agent --message "React to message msg_123 with thumbs up"
+```
+
+### List all reactions on a message
+
+```bash
+openclaw agent --message "Show me all reactions on message msg_123"
+```
+
+### Remove a reaction
+
+```bash
+openclaw agent --message "Remove the heart reaction from message msg_123"
+```
+
+## Troubleshooting
+
+### Bot doesn't respond to messages
+
+- Check if the bot is added to the chat
+- Verify `allowFrom` includes the chat ID or user
+- Check gateway logs: `openclaw logs --follow`
+
+### Reaction tool not available
+
+- Ensure `tools.reaction: true` in Feishu config
+- Check that the Feishu app has required permissions
+- Verify the message ID is valid


### PR DESCRIPTION
## Summary

Add testing guide and troubleshooting section to Feishu documentation.

**What changed:**
- Add quickstart examples for reaction tool testing
- Include common troubleshooting tips (bot not responding, tool not available)
- Improve user onboarding experience

**Related:**
- Part of Feishu reaction tool documentation (#34099)
- Complements #34100, #34101, #34210, #34245