### PR TITLE
agents: preserve totalTokens on request failure instead of using contextWindow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/session usage tracking: preserve accumulated usage metadata on embedded Pi runner error exits so failed turns still update session `totalTokens` from real usage instead of stale prior values. (#34275) thanks @RealKai42.
 - Nodes/system.run approval hardening: use explicit argv-mutation signaling when regenerating prepared `rawCommand`, and cover the `system.run.prepare -> system.run` handoff so direct PATH-based `nodes.run` commands no longer fail with `rawCommand does not match command`. (#33137) thanks @Sid-Qin.
 - Models/custom provider headers: propagate `models.providers.<name>.headers` across inline, fallback, and registry-found model resolution so header-authenticated proxies consistently receive configured request headers. (#27490) thanks @Sid-Qin.
 - Ollama/custom provider headers: forward resolved model headers into native Ollama stream requests so header-authenticated Ollama proxies receive configured request headers. (#24337) thanks @echoVic.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -715,6 +715,8 @@ export async function runEmbeddedPiAgent(
       };
       try {
         let authRetryPending = false;
+        // Hoisted so the retry-limit error path can use the most recent API total.
+        let lastTurnTotal: number | undefined;
         while (true) {
           if (runLoopIterations >= MAX_RUN_LOOP_ITERATIONS) {
             const message =
@@ -742,6 +744,7 @@ export async function runEmbeddedPiAgent(
                   model: model.id,
                   usageAccumulator,
                   lastRunPromptUsage,
+                  lastTurnTotal,
                 }),
                 error: { kind: "retry_limit", message },
               },
@@ -845,7 +848,7 @@ export async function runEmbeddedPiAgent(
           // Keep prompt size from the latest model call so session totalTokens
           // reflects current context usage, not accumulated tool-loop usage.
           lastRunPromptUsage = lastAssistantUsage ?? attemptUsage;
-          const lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
+          lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
           const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
           autoCompactionCount += attemptCompactionCount;
           const activeErrorContext = resolveActiveErrorContext({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -200,6 +200,36 @@ function resolveActiveErrorContext(params: {
   };
 }
 
+/**
+ * Build agentMeta for error return paths, preserving accumulated usage so that
+ * session totalTokens reflects the actual context size rather than going stale.
+ * Without this, error returns omit usage and the session keeps whatever
+ * totalTokens was set by the previous successful run.
+ */
+function buildErrorAgentMeta(params: {
+  sessionId: string;
+  provider: string;
+  model: string;
+  usageAccumulator: UsageAccumulator;
+  lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
+  lastAssistant?: { usage?: unknown } | null;
+}): EmbeddedPiAgentMeta {
+  const usage = toNormalizedUsage(params.usageAccumulator);
+  const lastCallUsage = params.lastAssistant
+    ? normalizeUsage(params.lastAssistant.usage as UsageLike)
+    : undefined;
+  const promptTokens = derivePromptTokens(params.lastRunPromptUsage);
+  return {
+    sessionId: params.sessionId,
+    provider: params.provider,
+    model: params.model,
+    // Only include usage fields when we have actual data from prior API calls.
+    ...(usage ? { usage } : {}),
+    ...(lastCallUsage ? { lastCallUsage } : {}),
+    ...(promptTokens ? { promptTokens } : {}),
+  };
+}
+
 export async function runEmbeddedPiAgent(
   params: RunEmbeddedPiAgentParams,
 ): Promise<EmbeddedPiRunResult> {
@@ -699,11 +729,13 @@ export async function runEmbeddedPiAgent(
               ],
               meta: {
                 durationMs: Date.now() - started,
-                agentMeta: {
+                agentMeta: buildErrorAgentMeta({
                   sessionId: params.sessionId,
                   provider,
                   model: model.id,
-                },
+                  usageAccumulator,
+                  lastRunPromptUsage,
+                }),
                 error: { kind: "retry_limit", message },
               },
             };
@@ -998,11 +1030,14 @@ export async function runEmbeddedPiAgent(
               ],
               meta: {
                 durationMs: Date.now() - started,
-                agentMeta: {
+                agentMeta: buildErrorAgentMeta({
                   sessionId: sessionIdUsed,
                   provider,
                   model: model.id,
-                },
+                  usageAccumulator,
+                  lastRunPromptUsage,
+                  lastAssistant,
+                }),
                 systemPromptReport: attempt.systemPromptReport,
                 error: { kind, message: errorText },
               },
@@ -1028,11 +1063,14 @@ export async function runEmbeddedPiAgent(
                 ],
                 meta: {
                   durationMs: Date.now() - started,
-                  agentMeta: {
+                  agentMeta: buildErrorAgentMeta({
                     sessionId: sessionIdUsed,
                     provider,
                     model: model.id,
-                  },
+                    usageAccumulator,
+                    lastRunPromptUsage,
+                    lastAssistant,
+                  }),
                   systemPromptReport: attempt.systemPromptReport,
                   error: { kind: "role_ordering", message: errorText },
                 },
@@ -1056,11 +1094,14 @@ export async function runEmbeddedPiAgent(
                 ],
                 meta: {
                   durationMs: Date.now() - started,
-                  agentMeta: {
+                  agentMeta: buildErrorAgentMeta({
                     sessionId: sessionIdUsed,
                     provider,
                     model: model.id,
-                  },
+                    usageAccumulator,
+                    lastRunPromptUsage,
+                    lastAssistant,
+                  }),
                   systemPromptReport: attempt.systemPromptReport,
                   error: { kind: "image_size", message: errorText },
                 },

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -213,8 +213,15 @@ function buildErrorAgentMeta(params: {
   usageAccumulator: UsageAccumulator;
   lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
   lastAssistant?: { usage?: unknown } | null;
+  /** API-reported total from the most recent call, mirroring the success path correction. */
+  lastTurnTotal?: number;
 }): EmbeddedPiAgentMeta {
   const usage = toNormalizedUsage(params.usageAccumulator);
+  // Apply the same lastTurnTotal correction the success path uses so
+  // usage.total reflects the API-reported context size, not accumulated totals.
+  if (usage && params.lastTurnTotal && params.lastTurnTotal > 0) {
+    usage.total = params.lastTurnTotal;
+  }
   const lastCallUsage = params.lastAssistant
     ? normalizeUsage(params.lastAssistant.usage as UsageLike)
     : undefined;
@@ -1037,6 +1044,7 @@ export async function runEmbeddedPiAgent(
                   usageAccumulator,
                   lastRunPromptUsage,
                   lastAssistant,
+                  lastTurnTotal,
                 }),
                 systemPromptReport: attempt.systemPromptReport,
                 error: { kind, message: errorText },
@@ -1070,6 +1078,7 @@ export async function runEmbeddedPiAgent(
                     usageAccumulator,
                     lastRunPromptUsage,
                     lastAssistant,
+                    lastTurnTotal,
                   }),
                   systemPromptReport: attempt.systemPromptReport,
                   error: { kind: "role_ordering", message: errorText },
@@ -1101,6 +1110,7 @@ export async function runEmbeddedPiAgent(
                     usageAccumulator,
                     lastRunPromptUsage,
                     lastAssistant,
+                    lastTurnTotal,
                   }),
                   systemPromptReport: attempt.systemPromptReport,
                   error: { kind: "image_size", message: errorText },


### PR DESCRIPTION
## Summary

Fixes #15150.

When a request fails (e.g. `CONTENT_LENGTH_EXCEEDS_THRESHOLD`, image too large, role ordering error, or retry limit hit), the error return paths in `runEmbeddedPiAgent()` returned `agentMeta` without any usage fields. This caused `totalTokens` in `sessions.json` to go stale — it kept whatever value was set by the previous successful run rather than reflecting the actual context size from the current (failed) run.

## Root cause

The four error return paths in `src/agents/pi-embedded-runner/run.ts` (`retry_limit`, `context_overflow`/`compaction_failure`, `role_ordering`, `image_size`) all returned a bare `agentMeta` containing only `{ sessionId, provider, model }`. Because the accumulated usage from prior API calls in the same run was discarded, `persistSessionUsageUpdate()` had no fresh usage data to compute `totalTokens` from, leaving it stale.

## What changed

- Added a `buildErrorAgentMeta()` helper that includes the accumulated `usage`, `lastCallUsage`, and `promptTokens` from the `UsageAccumulator` in error return paths.
- Updated all four error return paths to use `buildErrorAgentMeta()` so that session `totalTokens` reflects the actual token count even when the run ends in an error.

## Test plan

- [x] TypeScript type-check passes (`pnpm tsgo`)
- [x] Lint/format checks pass (`pnpm check`)
- [x] All tests pass (`pnpm test` — 811 passed, 1 pre-existing locale-dependent failure unrelated to this change)
- [ ] Manual verification: trigger a request failure (e.g. oversized context) and confirm `totalTokens` in `/status` reflects actual usage, not `contextWindow`