### PR TITLE
docs(tools): add plugin tools section with Feishu reference

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -562,3 +562,13 @@ Tools are exposed in two parallel channels:
 
 That means the agent sees both “what tools exist” and “how to call them.” If a tool
 doesn’t appear in the system prompt or the schema, the model cannot call it.
+
+## Plugin Tools
+
+Plugin-provided tools are available when the corresponding plugin is installed:
+
+- **Feishu tools** (`@openclaw/feishu`): `feishu_doc`, `feishu_chat`, `feishu_wiki`, `feishu_drive`, `feishu_bitable`, `feishu_perm`, `feishu_reaction`
+- **Slack tools** (built-in): `slack_*` actions
+- **Discord tools** (built-in): `discord_*` actions
+
+For Feishu tool documentation, see [Feishu Channel](/channels/feishu#available-tools).


### PR DESCRIPTION
## Summary

Add plugin tools documentation to the main tools index.

**What changed:**
- Document plugin-provided tools
- List Feishu plugin tools (doc, chat, wiki, drive, bitable, perm, reaction)
- Link to Feishu channel documentation

**Related:**
- Part of Feishu documentation improvements (#34099)
- Complements #34100, #34101, #34210, #34245, #34268, #34270