### PR TITLE
fix(discord): add proxy support for Discord REST API via Carbon custom fetch

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -733,8 +733,12 @@ Default slash command settings:
 
   </Accordion>
 
-  <Accordion title="Gateway proxy">
-    Route Discord gateway WebSocket traffic and startup REST lookups (application ID + allowlist resolution) through an HTTP(S) proxy with `channels.discord.proxy`.
+  <Accordion title="Gateway and REST API proxy">
+    Route Discord gateway WebSocket traffic and all REST API calls through an HTTP(S) proxy with `channels.discord.proxy`. This includes:
+
+    - Gateway WebSocket connection
+    - Startup REST lookups (application ID, allowlist resolution)
+    - All Discord REST API requests (messages, reactions, etc.)
 
 ```json5
 {

--- a/src/discord/client.test.ts
+++ b/src/discord/client.test.ts
@@ -1,0 +1,175 @@
+import { RequestClient } from "@buape/carbon";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loadConfig } from "../config/config.js";
+import { resolveDiscordAccount } from "./accounts.js";
+import type { ResolvedDiscordAccount } from "./accounts.js";
+import { createDiscordRestClient } from "./client.js";
+
+// Mock dependencies
+vi.mock("../config/config.js");
+vi.mock("./accounts.js");
+
+const mockLoadConfig = vi.mocked(loadConfig);
+const mockResolveDiscordAccount = vi.mocked(resolveDiscordAccount);
+
+/**
+ * Helper to create a mock ResolvedDiscordAccount with sensible defaults.
+ */
+function mockAccount(overrides: Partial<ResolvedDiscordAccount> = {}): ResolvedDiscordAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    token: "test-token",
+    tokenSource: "config",
+    config: {},
+    ...overrides,
+  } as ResolvedDiscordAccount;
+}
+
+describe("Discord client with proxy support", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockLoadConfig.mockReturnValue({} as any);
+  });
+
+  describe("createDiscordRestClient", () => {
+    it("creates a RequestClient with custom fetch when proxy is configured", () => {
+      mockResolveDiscordAccount.mockReturnValue(
+        mockAccount({ config: { proxy: "http://proxy.example.com:8080" } }),
+      );
+
+      const { rest } = createDiscordRestClient({});
+
+      expect(rest).toBeInstanceOf(RequestClient);
+      // Verify custom fetch is injected
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((rest as any).customFetch).toBeDefined();
+    });
+
+    it("creates a RequestClient without custom fetch when no proxy is configured", () => {
+      mockResolveDiscordAccount.mockReturnValue(mockAccount({ config: {} }));
+
+      const { rest } = createDiscordRestClient({});
+
+      expect(rest).toBeInstanceOf(RequestClient);
+      // Verify no custom fetch is injected
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((rest as any).customFetch).toBeUndefined();
+    });
+
+    it("uses existing rest client when provided (ignores proxy config)", () => {
+      const existingRest = new RequestClient("existing-token");
+
+      mockResolveDiscordAccount.mockReturnValue(
+        mockAccount({ config: { proxy: "http://proxy.example.com:8080" } }),
+      );
+
+      const { rest } = createDiscordRestClient({ rest: existingRest });
+
+      expect(rest).toBe(existingRest);
+    });
+
+    it("returns the resolved account info", () => {
+      const account = mockAccount({
+        accountId: "custom-account",
+        config: { proxy: "http://proxy.example.com:8080" },
+      });
+      mockResolveDiscordAccount.mockReturnValue(account);
+
+      const { account: returnedAccount } = createDiscordRestClient({});
+
+      expect(returnedAccount).toBe(account);
+    });
+
+    it("returns the resolved token", () => {
+      mockResolveDiscordAccount.mockReturnValue(mockAccount({ token: "my-bot-token", config: {} }));
+
+      const { token } = createDiscordRestClient({});
+
+      expect(token).toBe("my-bot-token");
+    });
+
+    it("uses explicit token over account token", () => {
+      mockResolveDiscordAccount.mockReturnValue(
+        mockAccount({ token: "account-token", config: {} }),
+      );
+
+      const { token } = createDiscordRestClient({ token: "explicit-token" });
+
+      expect(token).toBe("explicit-token");
+    });
+  });
+
+  describe("proxy URL handling", () => {
+    it("trims whitespace from proxy URL", () => {
+      mockResolveDiscordAccount.mockReturnValue(
+        mockAccount({ config: { proxy: "  http://proxy.example.com:8080  " } }),
+      );
+
+      const { rest } = createDiscordRestClient({});
+
+      expect(rest).toBeInstanceOf(RequestClient);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((rest as any).customFetch).toBeDefined();
+    });
+
+    it("ignores empty proxy URL", () => {
+      mockResolveDiscordAccount.mockReturnValue(mockAccount({ config: { proxy: "" } }));
+
+      const { rest } = createDiscordRestClient({});
+
+      expect(rest).toBeInstanceOf(RequestClient);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((rest as any).customFetch).toBeUndefined();
+    });
+
+    it("ignores whitespace-only proxy URL", () => {
+      mockResolveDiscordAccount.mockReturnValue(mockAccount({ config: { proxy: "   " } }));
+
+      const { rest } = createDiscordRestClient({});
+
+      expect(rest).toBeInstanceOf(RequestClient);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((rest as any).customFetch).toBeUndefined();
+    });
+
+    it("supports HTTP proxy URLs", () => {
+      mockResolveDiscordAccount.mockReturnValue(
+        mockAccount({ config: { proxy: "http://proxy.example.com:8080" } }),
+      );
+
+      const { rest } = createDiscordRestClient({});
+
+      expect(rest).toBeInstanceOf(RequestClient);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((rest as any).customFetch).toBeDefined();
+    });
+
+    it("supports HTTPS proxy URLs", () => {
+      mockResolveDiscordAccount.mockReturnValue(
+        mockAccount({ config: { proxy: "https://secure-proxy.example.com:443" } }),
+      );
+
+      const { rest } = createDiscordRestClient({});
+
+      expect(rest).toBeInstanceOf(RequestClient);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((rest as any).customFetch).toBeDefined();
+    });
+
+    it("supports authenticated proxy URLs", () => {
+      mockResolveDiscordAccount.mockReturnValue(
+        mockAccount({
+          config: { proxy: "http://user:password@proxy.example.com:8080" },
+        }),
+      );
+
+      const { rest } = createDiscordRestClient({});
+
+      expect(rest).toBeInstanceOf(RequestClient);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((rest as any).customFetch).toBeDefined();
+    });
+  });
+});

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -1,4 +1,5 @@
 import { RequestClient } from "@buape/carbon";
+import { ProxyAgent, fetch as undiciFetch } from "undici";
 import { loadConfig } from "../config/config.js";
 import { createDiscordRetryRunner, type RetryRunner } from "../infra/retry-policy.js";
 import type { RetryConfig } from "../infra/retry.js";
@@ -27,8 +28,63 @@ function resolveToken(params: { explicit?: string; accountId: string; fallbackTo
   return fallback;
 }
 
-function resolveRest(token: string, rest?: RequestClient) {
-  return rest ?? new RequestClient(token);
+// Cache ProxyAgent instances keyed by proxy URL to avoid creating new agents per call
+const proxyAgentCache = new Map<string, ProxyAgent>();
+
+/**
+ * Gets or creates a ProxyAgent for the given proxy URL.
+ */
+function getOrCreateProxyAgent(proxyUrl: string): ProxyAgent {
+  const cached = proxyAgentCache.get(proxyUrl);
+  if (cached) {
+    return cached;
+  }
+  const agent = new ProxyAgent(proxyUrl);
+  proxyAgentCache.set(proxyUrl, agent);
+  return agent;
+}
+
+/**
+ * Creates a custom fetch function that routes requests through a proxy.
+ * Uses undici's ProxyAgent for HTTP/HTTPS proxy support.
+ * Reuses ProxyAgent instances by proxy URL for resource efficiency.
+ *
+ * @param proxyUrl - The proxy URL (e.g., "http://proxy.example.com:8080")
+ * @returns A fetch function configured to use the proxy
+ */
+export function makeDiscordProxyFetch(proxyUrl: string): typeof fetch {
+  const proxy = proxyUrl?.trim();
+  if (!proxy) {
+    return fetch;
+  }
+
+  const agent = getOrCreateProxyAgent(proxy);
+  return (input: RequestInfo | URL, init?: RequestInit) =>
+    undiciFetch(input as string | URL, {
+      ...(init as Record<string, unknown>),
+      dispatcher: agent,
+    }) as unknown as Promise<Response>;
+}
+
+/**
+ * Resolves the appropriate RequestClient for Discord REST API calls.
+ * If a proxy is configured, injects a custom fetch function via Carbon's
+ * requestOptions.fetch mechanism (based on Carbon PR #363).
+ */
+function resolveRest(token: string, proxyUrl?: string, rest?: RequestClient): RequestClient {
+  if (rest) {
+    return rest;
+  }
+
+  const proxy = proxyUrl?.trim();
+  if (proxy) {
+    const proxyFetch = makeDiscordProxyFetch(proxy);
+    return new RequestClient(token, {
+      fetch: proxyFetch,
+    });
+  }
+
+  return new RequestClient(token);
 }
 
 export function createDiscordRestClient(opts: DiscordClientOpts, cfg = loadConfig()) {
@@ -38,7 +94,7 @@ export function createDiscordRestClient(opts: DiscordClientOpts, cfg = loadConfi
     accountId: account.accountId,
     fallbackToken: account.token,
   });
-  const rest = resolveRest(token, opts.rest);
+  const rest = resolveRest(token, account.config.proxy, opts.rest);
   return { token, rest, account };
 }
 

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -41,6 +41,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getPluginCommandSpecs } from "../../plugins/commands.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
 import { resolveDiscordAccount } from "../accounts.js";
+import { makeDiscordProxyFetch } from "../client.js";
 import { fetchDiscordApplicationId } from "../probe.js";
 import { normalizeDiscordToken } from "../token.js";
 import { createDiscordVoiceCommand } from "../voice/command.js";
@@ -522,16 +523,28 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       listenerTimeout: 120_000,
       ...discordCfg.eventQueue,
     };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const clientOptions: any = {
+      baseUrl: "http://localhost",
+      deploySecret: "a",
+      clientId: applicationId,
+      publicKey: "a",
+      token,
+      autoDeploy: false,
+      eventQueue: eventQueueOpts,
+    };
+
+    // If proxy is configured, inject custom fetch for Carbon Client
+    const proxy = rawDiscordCfg.proxy?.trim();
+    if (proxy) {
+      clientOptions.requestOptions = {
+        fetch: makeDiscordProxyFetch(proxy),
+      };
+    }
+
     const client = new Client(
-      {
-        baseUrl: "http://localhost",
-        deploySecret: "a",
-        clientId: applicationId,
-        publicKey: "a",
-        token,
-        autoDeploy: false,
-        eventQueue: eventQueueOpts,
-      },
+      clientOptions,
       {
         commands,
         listeners: [new DiscordStatusReadyListener()],


### PR DESCRIPTION
## Background

When deploying OpenClaw in restricted network environments (e.g., behind corporate firewalls), users need to route Discord traffic through an HTTP(S) proxy. Currently, only the Gateway WebSocket connection supports proxying.

## Problem

Discord REST API calls (messages, reactions, interactions) cannot be proxied, limiting deployment flexibility.

## Solution

Uses Carbon's `requestOptions.fetch` mechanism (via [buape/carbon#363](https://github.com/buape/carbon/pull/363)) to inject a custom fetch function powered by undici's `ProxyAgent`. This enables:

- HTTP/HTTPS proxy support
- Proxy authentication (`http://user:pass@proxy:8080`)
- Routes all Discord REST calls through the configured proxy

## Status

**Stable in use for 5+ days.**