### PR TITLE
fix: handle systemctl 'command failed' error on Ubuntu 24+

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,6 +79,19 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false when systemctl reports command failed (Ubuntu 24+)", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & { code?: number };
+      err.code = 1;
+      cb(err, "", "Command failed: systemctl --user is-enabled openclaw-gateway.service");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
   it("throws when systemctl is-enabled fails for non-state errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -171,7 +171,8 @@ function isSystemdUnitNotEnabled(detail: string): boolean {
     normalized.includes("masked") ||
     normalized.includes("not-found") ||
     normalized.includes("could not be found") ||
-    normalized.includes("failed to get unit file state")
+    normalized.includes("failed to get unit file state") ||
+    normalized.includes("command failed")
   );
 }
 


### PR DESCRIPTION
Fixes #34237

## Summary

On Ubuntu 24, the `systemctl --user is-enabled` command may return a generic "Command failed" error message instead of more specific error messages. This caused OpenClaw to throw an error instead of gracefully handling the case where the service is not enabled.

## Changes

- Added `command failed` detection in `isSystemdUnitNotEnabled()` function
- Added test case for Ubuntu 24+ systemctl behavior

## Testing

All existing tests pass, including the new test case.