### PR TITLE
fix(telegram): resolve env SecretRef token for status path

### DIFF
--- a/src/telegram/token.test.ts
+++ b/src/telegram/token.test.ts
@@ -127,7 +127,23 @@ describe("resolveTelegramToken", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("resolves top-level env SecretRef object when env var is available", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "resolved-from-env");
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const res = resolveTelegramToken(cfg);
+    expect(res.token).toBe("resolved-from-env");
+    expect(res.source).toBe("config");
+  });
+
   it("throws when botToken is an unresolved SecretRef object", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
     const cfg = {
       channels: {
         telegram: {

--- a/src/telegram/token.ts
+++ b/src/telegram/token.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs";
 import type { BaseTokenResolution } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { normalizeResolvedSecretInputString } from "../config/types.secrets.js";
+import {
+  DEFAULT_SECRET_PROVIDER_ALIAS,
+  normalizeResolvedSecretInputString,
+  resolveSecretInputRef,
+} from "../config/types.secrets.js";
 import type { TelegramAccountConfig } from "../config/types.telegram.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 
@@ -16,6 +20,23 @@ type ResolveTelegramTokenOpts = {
   accountId?: string | null;
   logMissingFile?: (message: string) => void;
 };
+
+function resolveTelegramSecretInputToken(params: { value: unknown; path: string }): string | undefined {
+  const { ref } = resolveSecretInputRef({
+    value: params.value,
+    defaults: { env: DEFAULT_SECRET_PROVIDER_ALIAS },
+  });
+  if (ref?.source === "env" && ref.provider === DEFAULT_SECRET_PROVIDER_ALIAS) {
+    const envToken = process.env[ref.id]?.trim();
+    if (envToken) {
+      return envToken;
+    }
+  }
+  return normalizeResolvedSecretInputString({
+    value: params.value,
+    path: params.path,
+  });
+}
 
 export function resolveTelegramToken(
   cfg?: OpenClawConfig,
@@ -66,7 +87,7 @@ export function resolveTelegramToken(
     return { token: "", source: "none" };
   }
 
-  const accountToken = normalizeResolvedSecretInputString({
+  const accountToken = resolveTelegramSecretInputToken({
     value: accountCfg?.botToken,
     path: `channels.telegram.accounts.${accountId}.botToken`,
   });
@@ -92,7 +113,7 @@ export function resolveTelegramToken(
     }
   }
 
-  const configToken = normalizeResolvedSecretInputString({
+  const configToken = resolveTelegramSecretInputToken({
     value: telegramCfg?.botToken,
     path: "channels.telegram.botToken",
   });

--- a/src/telegram/token.ts
+++ b/src/telegram/token.ts
@@ -21,7 +21,10 @@ type ResolveTelegramTokenOpts = {
   logMissingFile?: (message: string) => void;
 };
 
-function resolveTelegramSecretInputToken(params: { value: unknown; path: string }): string | undefined {
+function resolveTelegramSecretInputToken(params: {
+  value: unknown;
+  path: string;
+}): string | undefined {
   const { ref } = resolveSecretInputRef({
     value: params.value,
     defaults: { env: DEFAULT_SECRET_PROVIDER_ALIAS },


### PR DESCRIPTION
## Summary
Fixes #34292.

`openclaw status` could fail with:

`channels.telegram.botToken: unresolved SecretRef "env:default:TELEGRAM_BOT_TOKEN"`

even when Telegram was healthy and `doctor` reported OK.  
Root cause: Telegram token resolution in this path treated env `SecretRef` as unresolved instead of resolving from process env.

## What changed
- Updated Telegram token resolution to handle env `SecretRef` values (`source=env`, `provider=default`) by reading `process.env[ref.id]`.
- Applied this to:
  - `channels.telegram.botToken`
  - `channels.telegram.accounts.<id>.botToken`
- Kept existing behavior for unresolved refs when env value is missing.

## Files
- `src/telegram/token.ts`
- `src/telegram/token.test.ts`

## Tests
Added/updated tests to cover:
- env `SecretRef` token resolves correctly when env variable is present
- unresolved behavior remains when env variable is missing

## Risk
Low, small scope:
- Telegram token resolution path only
- no schema/config format changes
- no changes to other channel providers