### PR TITLE
test(infra): cleanup dotenv temp fixtures to avoid /tmp accumulation

### DIFF
--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -37,6 +37,22 @@ type DotEnvFixture = {
   stateDir: string;
 };
 
+async function cleanupTempDir(base: string) {
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    try {
+      await fs.rm(base, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if ((code === "EBUSY" || code === "EPERM" || code === "ENOTEMPTY") && attempt < 5) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 50));
+        continue;
+      }
+      throw error;
+    }
+  }
+}
+
 async function withDotEnvFixture(run: (fixture: DotEnvFixture) => Promise<void>) {
   const prevCwd = process.cwd();
   const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dotenv-test-"));
@@ -52,7 +68,7 @@ async function withDotEnvFixture(run: (fixture: DotEnvFixture) => Promise<void>)
     if (cwd === base || cwd.startsWith(`${base}${path.sep}`)) {
       process.chdir(prevCwd);
     }
-    await fs.rm(base, { recursive: true, force: true });
+    await cleanupTempDir(base);
   }
 }
 

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -41,12 +41,16 @@ async function withDotEnvFixture(run: (fixture: DotEnvFixture) => Promise<void>)
   const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dotenv-test-"));
   const cwdDir = path.join(base, "cwd");
   const stateDir = path.join(base, "state");
-  process.env.OPENCLAW_STATE_DIR = stateDir;
-  await fs.mkdir(cwdDir, { recursive: true });
-  await fs.mkdir(stateDir, { recursive: true });
   try {
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    await fs.mkdir(cwdDir, { recursive: true });
+    await fs.mkdir(stateDir, { recursive: true });
     await run({ base, cwdDir, stateDir });
   } finally {
+    const cwd = process.cwd();
+    if (cwd === cwdDir || cwd.startsWith(`${cwdDir}${path.sep}`)) {
+      process.chdir(base);
+    }
     await fs.rm(base, { recursive: true, force: true });
   }
 }

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -44,7 +44,11 @@ async function withDotEnvFixture(run: (fixture: DotEnvFixture) => Promise<void>)
   process.env.OPENCLAW_STATE_DIR = stateDir;
   await fs.mkdir(cwdDir, { recursive: true });
   await fs.mkdir(stateDir, { recursive: true });
-  await run({ base, cwdDir, stateDir });
+  try {
+    await run({ base, cwdDir, stateDir });
+  } finally {
+    await fs.rm(base, { recursive: true, force: true });
+  }
 }
 
 describe("loadDotEnv", () => {

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -38,6 +38,7 @@ type DotEnvFixture = {
 };
 
 async function withDotEnvFixture(run: (fixture: DotEnvFixture) => Promise<void>) {
+  const prevCwd = process.cwd();
   const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dotenv-test-"));
   const cwdDir = path.join(base, "cwd");
   const stateDir = path.join(base, "state");
@@ -48,8 +49,8 @@ async function withDotEnvFixture(run: (fixture: DotEnvFixture) => Promise<void>)
     await run({ base, cwdDir, stateDir });
   } finally {
     const cwd = process.cwd();
-    if (cwd === cwdDir || cwd.startsWith(`${cwdDir}${path.sep}`)) {
-      process.chdir(base);
+    if (cwd === base || cwd.startsWith(`${base}${path.sep}`)) {
+      process.chdir(prevCwd);
     }
     await fs.rm(base, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `withDotEnvFixture` in `src/infra/dotenv.test.ts` created `/tmp/openclaw-dotenv-test-*` dirs via `fs.mkdtemp(...)` but never removed them.
- Why it matters: repeated local/CI test runs accumulate stale temp dirs and create avoidable disk clutter.
- What changed: wrapped fixture body in `try/finally` and added `await fs.rm(base, { recursive: true, force: true })` cleanup.
- What did NOT change (scope boundary): no production/runtime code changes; no global test harness refactor; no behavior change outside this dotenv test fixture.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #34286
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.6 (arm64)
- Runtime/container: Node.js + Vitest (local)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local test env

### Steps

1. Run `pnpm -s vitest run src/infra/dotenv.test.ts`.
2. Confirm tests pass and fixture exits normally.
3. Inspect test code path to verify `finally` cleanup always runs after fixture body.

### Expected

- Dotenv tests pass.
- Temp fixture directory is removed after test execution.

### Actual

- Pass (3/3 tests), with cleanup in `finally` now guaranteed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing log:

```text
✓ src/infra/dotenv.test.ts (3 tests)
Test Files 1 passed (1)
Tests 3 passed (3)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm -s vitest run src/infra/dotenv.test.ts` locally; all tests passed.
- Edge cases checked: cleanup executes through `finally` regardless of assertion success/failure in fixture body.
- What you did **not** verify: full repository-wide temp-dir cleanup migration across all other test files.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `test(infra): clean up dotenv fixture temp dirs`.
- Files/config to restore: `src/infra/dotenv.test.ts`.
- Known bad symptoms reviewers should watch for: unexpected test failures if fixture cleanup path throws (mitigated via `force: true`).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Cleanup could remove wrong path if fixture base were malformed.
  - Mitigation: `base` is created by `fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dotenv-test-"))` and scoped to that fixture invocation.
