### PR TITLE
status: show gateway Node version instead of CLI process version

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -206,6 +206,7 @@ public struct PresenceEntry: Codable, Sendable {
     public let host: String?
     public let ip: String?
     public let version: String?
+    public let nodeversion: String?
     public let platform: String?
     public let devicefamily: String?
     public let modelidentifier: String?
@@ -224,6 +225,7 @@ public struct PresenceEntry: Codable, Sendable {
         host: String?,
         ip: String?,
         version: String?,
+        nodeversion: String?,
         platform: String?,
         devicefamily: String?,
         modelidentifier: String?,
@@ -241,6 +243,7 @@ public struct PresenceEntry: Codable, Sendable {
         self.host = host
         self.ip = ip
         self.version = version
+        self.nodeversion = nodeversion
         self.platform = platform
         self.devicefamily = devicefamily
         self.modelidentifier = modelidentifier
@@ -260,6 +263,7 @@ public struct PresenceEntry: Codable, Sendable {
         case host
         case ip
         case version
+        case nodeversion = "nodeVersion"
         case platform
         case devicefamily = "deviceFamily"
         case modelidentifier = "modelIdentifier"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -206,6 +206,7 @@ public struct PresenceEntry: Codable, Sendable {
     public let host: String?
     public let ip: String?
     public let version: String?
+    public let nodeversion: String?
     public let platform: String?
     public let devicefamily: String?
     public let modelidentifier: String?
@@ -224,6 +225,7 @@ public struct PresenceEntry: Codable, Sendable {
         host: String?,
         ip: String?,
         version: String?,
+        nodeversion: String?,
         platform: String?,
         devicefamily: String?,
         modelidentifier: String?,
@@ -241,6 +243,7 @@ public struct PresenceEntry: Codable, Sendable {
         self.host = host
         self.ip = ip
         self.version = version
+        self.nodeversion = nodeversion
         self.platform = platform
         self.devicefamily = devicefamily
         self.modelidentifier = modelidentifier
@@ -260,6 +263,7 @@ public struct PresenceEntry: Codable, Sendable {
         case host
         case ip
         case version
+        case nodeversion = "nodeVersion"
         case platform
         case devicefamily = "deviceFamily"
         case modelidentifier = "modelIdentifier"

--- a/src/commands/gateway-presence.ts
+++ b/src/commands/gateway-presence.ts
@@ -2,6 +2,7 @@ export type GatewaySelfPresence = {
   host?: string;
   ip?: string;
   version?: string;
+  nodeVersion?: string;
   platform?: string;
 };
 
@@ -22,6 +23,7 @@ export function pickGatewaySelfPresence(presence: unknown): GatewaySelfPresence 
     host: typeof self.host === "string" ? self.host : undefined,
     ip: typeof self.ip === "string" ? self.ip : undefined,
     version: typeof self.version === "string" ? self.version : undefined,
+    nodeVersion: typeof self.nodeVersion === "string" ? self.nodeVersion : undefined,
     platform: typeof self.platform === "string" ? self.platform : undefined,
   };
 }

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -268,7 +268,7 @@ export async function statusAllCommand(
     const overviewRows = [
       { Item: "Version", Value: VERSION },
       { Item: "OS", Value: osSummary.label },
-      { Item: "Node", Value: process.versions.node },
+      { Item: "Node", Value: gatewaySelf?.nodeVersion ?? process.versions.node },
       {
         Item: "Config",
         Value: snap?.path?.trim() ? snap.path.trim() : "(unknown config path)",

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -394,7 +394,10 @@ export async function statusCommand(
 
   const overviewRows = [
     { Item: "Dashboard", Value: dashboard },
-    { Item: "OS", Value: `${osSummary.label} · node ${process.versions.node}` },
+    {
+      Item: "OS",
+      Value: `${osSummary.label} · node ${gatewaySelf?.nodeVersion ?? process.versions.node}`,
+    },
     {
       Item: "Tailscale",
       Value:

--- a/src/gateway/protocol/schema/snapshot.ts
+++ b/src/gateway/protocol/schema/snapshot.ts
@@ -6,6 +6,7 @@ export const PresenceEntrySchema = Type.Object(
     host: Type.Optional(NonEmptyString),
     ip: Type.Optional(NonEmptyString),
     version: Type.Optional(NonEmptyString),
+    nodeVersion: Type.Optional(NonEmptyString),
     platform: Type.Optional(NonEmptyString),
     deviceFamily: Type.Optional(NonEmptyString),
     modelIdentifier: Type.Optional(NonEmptyString),

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -7,6 +7,7 @@ export type SystemPresence = {
   host?: string;
   ip?: string;
   version?: string;
+  nodeVersion?: string;
   platform?: string;
   deviceFamily?: string;
   modelIdentifier?: string;
@@ -95,10 +96,12 @@ function initSelfPresence() {
     return p;
   })();
   const text = `Gateway: ${host}${ip ? ` (${ip})` : ""} · app ${version} · mode gateway · reason self`;
+  const nodeVersion = process.versions.node;
   const selfEntry: SystemPresence = {
     host,
     ip,
     version,
+    nodeVersion,
     platform,
     deviceFamily,
     modelIdentifier,
@@ -163,6 +166,7 @@ type SystemPresencePayload = {
   host?: string;
   ip?: string;
   version?: string;
+  nodeVersion?: string;
   platform?: string;
   deviceFamily?: string;
   modelIdentifier?: string;
@@ -209,6 +213,7 @@ export function updateSystemPresence(payload: SystemPresencePayload): SystemPres
     host: payload.host ?? parsed.host ?? existing.host,
     ip: payload.ip ?? parsed.ip ?? existing.ip,
     version: payload.version ?? parsed.version ?? existing.version,
+    nodeVersion: payload.nodeVersion ?? existing.nodeVersion,
     platform: payload.platform ?? existing.platform,
     deviceFamily: payload.deviceFamily ?? existing.deviceFamily,
     modelIdentifier: payload.modelIdentifier ?? existing.modelIdentifier,


### PR DESCRIPTION
## Summary

Fixes #25377

`openclaw status` previously displayed the CLI process's Node version (`process.versions.node`) in the OS row, which is incorrect when the CLI and the gateway run under different Node binaries.

This PR adds a `nodeVersion` field to the gateway's self-presence entry and uses it in the status output, falling back to the local `process.versions.node` only when the gateway is unreachable or the field is absent (backward compatibility with older gateways).

## What changed

- **`src/infra/system-presence.ts`** — Added `nodeVersion` to the `SystemPresence` type and `SystemPresencePayload` type; `initSelfPresence()` now captures `process.versions.node` on the gateway side.
- **`src/gateway/protocol/schema/snapshot.ts`** — Added `nodeVersion` to `PresenceEntrySchema` so it survives protocol validation.
- **`src/commands/gateway-presence.ts`** — Added `nodeVersion` to `GatewaySelfPresence` and extraction logic in `pickGatewaySelfPresence()`.
- **`src/commands/status.command.ts`** — OS row now reads `gatewaySelf?.nodeVersion ?? process.versions.node`.
- **`src/commands/status-all.ts`** — Node row now reads `gatewaySelf?.nodeVersion ?? process.versions.node`.

## Test plan

- [x] `pnpm vitest run src/infra/system-presence.test.ts` — passes
- [x] `pnpm vitest run src/infra/system-presence.version.test.ts` — passes
- [x] `pnpm vitest run src/gateway/probe.test.ts` — passes
- [x] TypeScript type-check passes (no new errors)
- [x] Formatting/lint clean (`pnpm format`)
- [ ] Manual: run `openclaw status` with gateway running — verify Node version matches gateway's runtime
- [ ] Manual: run `openclaw status` with gateway unreachable — verify fallback to CLI's Node version