### PR TITLE
docs(workspace): clarify media allowlist behavior for workspace-<profile>

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -54,6 +54,24 @@ Older installs may have created `~/openclaw`. Keeping multiple workspace
 directories around can cause confusing auth or state drift, because only one
 workspace is active at a time.
 
+### Media allowlist note (`workspace-<profile>`)
+
+`workspace-<profile>` paths (for example `~/.openclaw/workspace-code`) are
+supported and valid.
+
+For local media reads/sends, OpenClaw uses layered allowlists:
+
+- A **default** global root set (intentionally conservative), and
+- **Agent-scoped roots** that add the active agent workspace.
+
+That means media under the active agent workspace should work even when the
+workspace is `workspace-<profile>`.
+
+If you see `Local media path is not under an allowed directory`, it usually
+indicates a specific call path that did not receive the active `agentId`
+(correct agent-scoped roots were not applied), not that `workspace-<profile>`
+itself is unsupported.
+
 **Recommendation:** keep a single active workspace. If you no longer use the
 extra folders, archive or move them to Trash (for example `trash ~/openclaw`).
 If you intentionally keep multiple workspaces, make sure


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: issue #34161 reports a mismatch between docs (`workspace-<profile>` is valid) and local media allowlist behavior.
- Why it matters: users can misdiagnose `path-not-allowed` errors as unsupported workspace naming, and apply the wrong fix.
- What changed: added a focused note in `docs/concepts/agent-workspace.md` explaining layered media allowlists (default roots + agent-scoped roots) and that `workspace-<profile>` is supported.
- What did NOT change (scope boundary): no runtime/security policy changes; no expansion of default global media roots; no channel delivery logic changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34161
- Related #34233

## User-visible / Behavior Changes

- Documentation now explicitly states `workspace-<profile>` is supported for active-agent media paths.
- Documentation clarifies that `path-not-allowed` usually points to missing `agentId` propagation in a call path, not unsupported workspace naming.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.6 (arm64)
- Runtime/container: docs-only change
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Read updated `docs/concepts/agent-workspace.md` section “Media allowlist note (`workspace-<profile>`).”
2. Confirm wording matches current implementation intent: conservative default roots + active agent workspace allowlist.
3. Confirm no code paths or tests changed.

### Expected

- Readers understand scope boundary: supported workspace naming vs specific routing/path errors.

### Actual

- Section now explicitly communicates this boundary and troubleshooting hint.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

N/A (docs-only PR; no runtime delta).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed existing docs plus current code comments/paths around media-root behavior; ensured wording does not claim wider access than implementation.
- Edge cases checked: explicitly avoids promising all `workspace-*` folders globally; keeps “active agent workspace” wording.
- What you did **not** verify: full end-to-end reproduction of every channel-specific `path-not-allowed` report.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `docs(workspace): clarify media allowlist behavior for workspace-profile dirs`.
- Files/config to restore: `docs/concepts/agent-workspace.md`.
- Known bad symptoms reviewers should watch for: none (docs-only).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Overstating behavior could mislead users about unsupported edge paths.
  - Mitigation: wording explicitly scopes support to active agent workspace and points to agentId propagation as likely fault.
