### PR TITLE
Test: clean up leaked /tmp/openclaw-* temp dirs

### DIFF
--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -1,7 +1,5 @@
-import { mkdtemp } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { describe, expect, test } from "vitest";
+import { trackedMkdtemp } from "../../test/test-env.js";
 import {
   approveDevicePairing,
   clearDevicePairing,
@@ -26,7 +24,7 @@ async function setupPairedOperatorDevice(baseDir: string, scopes: string[]) {
 }
 
 async function setupOperatorToken(scopes: string[]) {
-  const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+  const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
   await setupPairedOperatorDevice(baseDir, scopes);
   const paired = await getPairedDevice("device-1", baseDir);
   const token = requireToken(paired?.tokens?.operator?.token);
@@ -53,7 +51,7 @@ function requireToken(token: string | undefined): string {
 
 describe("device pairing tokens", () => {
   test("reuses existing pending requests for the same device", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     const first = await requestDevicePairing(
       {
         deviceId: "device-1",
@@ -75,7 +73,7 @@ describe("device pairing tokens", () => {
   });
 
   test("merges pending roles/scopes for the same device before approval", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     const first = await requestDevicePairing(
       {
         deviceId: "device-1",
@@ -107,7 +105,7 @@ describe("device pairing tokens", () => {
   });
 
   test("generates base64url device tokens with 256-bit entropy output length", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);
 
     const paired = await getPairedDevice("device-1", baseDir);
@@ -117,7 +115,7 @@ describe("device pairing tokens", () => {
   });
 
   test("allows down-scoping from admin and preserves approved scope baseline", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);
 
     await rotateDeviceToken({
@@ -141,7 +139,7 @@ describe("device pairing tokens", () => {
   });
 
   test("preserves existing token scopes when approving a repair without requested scopes", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);
 
     const repair = await requestDevicePairing(
@@ -161,7 +159,7 @@ describe("device pairing tokens", () => {
   });
 
   test("rejects scope escalation when rotating a token and leaves state unchanged", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     await setupPairedOperatorDevice(baseDir, ["operator.read"]);
     const before = await getPairedDevice("device-1", baseDir);
 
@@ -232,7 +230,7 @@ describe("device pairing tokens", () => {
   });
 
   test("removes paired devices by device id", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     await setupPairedOperatorDevice(baseDir, ["operator.read"]);
 
     const removed = await removePairedDevice("device-1", baseDir);
@@ -243,7 +241,7 @@ describe("device pairing tokens", () => {
   });
 
   test("clears paired device state by device id", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     await setupPairedOperatorDevice(baseDir, ["operator.read"]);
 
     await expect(clearDevicePairing("device-1", baseDir)).resolves.toBe(true);

--- a/src/infra/node-pairing.test.ts
+++ b/src/infra/node-pairing.test.ts
@@ -1,7 +1,5 @@
-import { mkdtemp } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { describe, expect, test } from "vitest";
+import { trackedMkdtemp } from "../../test/test-env.js";
 import {
   approveNodePairing,
   getPairedNode,
@@ -29,7 +27,7 @@ async function setupPairedNode(baseDir: string): Promise<string> {
 
 describe("node pairing tokens", () => {
   test("reuses existing pending requests for the same node", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-node-pairing-");
     const first = await requestNodePairing(
       {
         nodeId: "node-1",
@@ -51,14 +49,14 @@ describe("node pairing tokens", () => {
   });
 
   test("generates base64url node tokens with 256-bit entropy output length", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-node-pairing-");
     const token = await setupPairedNode(baseDir);
     expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
     expect(Buffer.from(token, "base64url")).toHaveLength(32);
   });
 
   test("verifies token and rejects mismatches", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-node-pairing-");
     const token = await setupPairedNode(baseDir);
     await expect(verifyNodeToken("node-1", token, baseDir)).resolves.toEqual({
       ok: true,
@@ -70,7 +68,7 @@ describe("node pairing tokens", () => {
   });
 
   test("treats multibyte same-length token input as mismatch without throwing", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-node-pairing-");
     const token = await setupPairedNode(baseDir);
     const multibyteToken = "é".repeat(token.length);
     expect(Buffer.from(multibyteToken).length).not.toBe(Buffer.from(token).length);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -28,24 +28,6 @@ function installTrackedMkdtempHooks() {
   const originalMkdtempSync = fs.mkdtempSync.bind(fs);
   fs.mkdtempSync = ((...args: Parameters<typeof fs.mkdtempSync>) =>
     trackTempDir(originalMkdtempSync(...args))) as typeof fs.mkdtempSync;
-
-  const originalMkdtemp = fs.mkdtemp.bind(fs);
-  fs.mkdtemp = ((prefix: string, optionsOrCallback, maybeCallback) => {
-    if (typeof optionsOrCallback === "function") {
-      return originalMkdtemp(prefix, (error, folder) => {
-        if (!error && folder) {
-          trackTempDir(folder);
-        }
-        optionsOrCallback(error, folder);
-      });
-    }
-    return originalMkdtemp(prefix, optionsOrCallback, (error, folder) => {
-      if (!error && folder) {
-        trackTempDir(folder);
-      }
-      maybeCallback?.(error, folder);
-    });
-  }) as typeof fs.mkdtemp;
   syncBuiltinESMExports();
 
   const originalPromisesMkdtemp = fs.promises.mkdtemp.bind(fs.promises);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
 import { afterAll, afterEach, beforeAll, vi } from "vitest";
 
 // Ensure Vitest environment is properly set
@@ -19,9 +22,43 @@ import type {
 } from "../src/channels/plugins/types.js";
 import type { OpenClawConfig } from "../src/config/config.js";
 import type { OutboundSendDeps } from "../src/infra/outbound/deliver.js";
-import { withIsolatedTestHome } from "./test-env.js";
+import { trackTempDir, withIsolatedTestHome } from "./test-env.js";
+
+function installTrackedMkdtempHooks() {
+  const originalMkdtempSync = fs.mkdtempSync.bind(fs);
+  fs.mkdtempSync = ((...args: Parameters<typeof fs.mkdtempSync>) =>
+    trackTempDir(originalMkdtempSync(...args))) as typeof fs.mkdtempSync;
+
+  const originalMkdtemp = fs.mkdtemp.bind(fs);
+  fs.mkdtemp = ((prefix: string, optionsOrCallback, maybeCallback) => {
+    if (typeof optionsOrCallback === "function") {
+      return originalMkdtemp(prefix, (error, folder) => {
+        if (!error && folder) {
+          trackTempDir(folder);
+        }
+        optionsOrCallback(error, folder);
+      });
+    }
+    return originalMkdtemp(prefix, optionsOrCallback, (error, folder) => {
+      if (!error && folder) {
+        trackTempDir(folder);
+      }
+      maybeCallback?.(error, folder);
+    });
+  }) as typeof fs.mkdtemp;
+  syncBuiltinESMExports();
+
+  const originalPromisesMkdtemp = fs.promises.mkdtemp.bind(fs.promises);
+  fs.promises.mkdtemp = (async (...args: Parameters<typeof fs.promises.mkdtemp>) =>
+    trackTempDir(await originalPromisesMkdtemp(...args))) as typeof fs.promises.mkdtemp;
+
+  const originalFsPromisesMkdtemp = fsPromises.mkdtemp.bind(fsPromises);
+  fsPromises.mkdtemp = (async (...args: Parameters<typeof fsPromises.mkdtemp>) =>
+    trackTempDir(await originalFsPromisesMkdtemp(...args))) as typeof fsPromises.mkdtemp;
+}
 
 // Set HOME/state isolation before importing any runtime OpenClaw modules.
+installTrackedMkdtempHooks();
 const testEnv = withIsolatedTestHome();
 afterAll(() => testEnv.cleanup());
 

--- a/test/test-env.tracked-temp.test.ts
+++ b/test/test-env.tracked-temp.test.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+import { installTestEnv, trackedMkdtemp, trackedMkdtempSync } from "./test-env.js";
+
+describe("test-env tracked temp dirs", () => {
+  it("removes tracked temp dirs during cleanup", async () => {
+    const env = installTestEnv();
+    try {
+      const syncDir = trackedMkdtempSync("openclaw-tracked-sync-");
+      const asyncDir = await trackedMkdtemp("openclaw-tracked-async-");
+      expect(fs.existsSync(syncDir)).toBe(true);
+      expect(fs.existsSync(asyncDir)).toBe(true);
+
+      env.cleanup();
+
+      expect(fs.existsSync(syncDir)).toBe(false);
+      expect(fs.existsSync(asyncDir)).toBe(false);
+    } finally {
+      env.cleanup();
+    }
+  });
+});

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -4,6 +4,31 @@ import os from "node:os";
 import path from "node:path";
 
 type RestoreEntry = { key: string; value: string | undefined };
+const trackedTempDirs = new Set<string>();
+
+export function trackTempDir(tempDir: string): string {
+  trackedTempDirs.add(tempDir);
+  return tempDir;
+}
+
+export function trackedMkdtempSync(prefix: string): string {
+  return trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
+export async function trackedMkdtemp(prefix: string): Promise<string> {
+  return trackTempDir(await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix)));
+}
+
+function cleanupTrackedTempDirs(): void {
+  for (const tempDir of trackedTempDirs) {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+  trackedTempDirs.clear();
+}
 
 function restoreEnv(entries: RestoreEntry[]): void {
   for (const { key, value } of entries) {
@@ -61,7 +86,7 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
   // The default test env isolates HOME to avoid touching real state.
   if (live) {
     loadProfileEnv();
-    return { cleanup: () => {}, tempHome: process.env.HOME ?? "" };
+    return { cleanup: () => cleanupTrackedTempDirs(), tempHome: process.env.HOME ?? "" };
   }
 
   const restore: RestoreEntry[] = [
@@ -132,6 +157,7 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
 
   const cleanup = () => {
     restoreEnv(restore);
+    cleanupTrackedTempDirs();
     try {
       fs.rmSync(tempHome, { recursive: true, force: true });
     } catch {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Test suites create `/tmp/openclaw-*` dirs via `mkdtemp`/`mkdtempSync` that are not consistently cleaned up.
- Why it matters: Repeated local/CI test runs accumulate stale temp artifacts and waste disk.
- What changed: Added tracked temp-dir helpers in `test/test-env.ts`, installed global `mkdtemp` tracking hooks in `test/setup.ts`, and migrated pairing tests to explicit tracked helpers.
- What did NOT change (scope boundary): No runtime production behavior changes; this is test infrastructure + test-only migration.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #34286

## User-visible / Behavior Changes

- None (test-only change).

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run the focused test set:
   `pnpm test test/test-env.tracked-temp.test.ts src/infra/node-pairing.test.ts src/infra/device-pairing.test.ts src/infra/dotenv.test.ts`
2. Confirm all tests pass.

### Expected

- Tracked temp dirs are removed during test env cleanup.
- Existing pairing/dotenv tests still pass.

### Actual

- All targeted tests pass after the fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added test `test/test-env.tracked-temp.test.ts` to assert tracked temp dirs are removed in cleanup.
  - Ran focused suite covering new helper and migrated pairing tests.
- Edge cases checked:
  - Global setup tracks `fs.mkdtempSync`, `fs.mkdtemp`, and promises variants.
  - Named `node:fs` imports are synced via `syncBuiltinESMExports()`.
- What you did **not** verify:
  - Full repository test sweep.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `4b029c1e8`.
- Files/config to restore: `test/test-env.ts`, `test/setup.ts`, `src/infra/node-pairing.test.ts`, `src/infra/device-pairing.test.ts`, `test/test-env.tracked-temp.test.ts`.
- Known bad symptoms reviewers should watch for: unexpected behavior in tests relying on custom `mkdtemp` monkey-patching.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Hooking temp-dir creation in global test setup could interact with niche tests that inspect raw `mkdtemp` behavior.
  - Mitigation: kept hooks test-only (`test/setup.ts`), preserved original call signatures, and added targeted regression coverage.
