### PR TITLE
test(infra): clean up exec-approvals temp dirs after each test

### DIFF
--- a/src/infra/exec-approvals-test-helpers.ts
+++ b/src/infra/exec-approvals-test-helpers.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { afterEach } from "vitest";
 
 export function makePathEnv(binDir: string): NodeJS.ProcessEnv {
   if (process.platform !== "win32") {
@@ -9,8 +10,23 @@ export function makePathEnv(binDir: string): NodeJS.ProcessEnv {
   return { PATH: binDir, PATHEXT: ".EXE;.CMD;.BAT;.COM" };
 }
 
+const trackedTempDirs = new Set<string>();
+
+afterEach(() => {
+  for (const dir of trackedTempDirs) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup for temp test fixtures.
+    }
+  }
+  trackedTempDirs.clear();
+});
+
 export function makeTempDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-exec-approvals-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-exec-approvals-"));
+  trackedTempDirs.add(dir);
+  return dir;
 }
 
 export type ShellParserParityFixtureCase = {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `src/infra/exec-approvals-test-helpers.ts` created `/tmp/openclaw-exec-approvals-*` via `makeTempDir()` but did not centrally clean them up.
- Why it matters: exec-approvals test suites call this helper many times, so repeated local/CI runs leak stale temp dirs.
- What changed: added a test-local tracked directory set plus `afterEach` cleanup in the helper module; `makeTempDir()` now auto-registers created dirs.
- What did NOT change (scope boundary): no runtime/production code changes; no behavior changes outside infra test helpers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #34286
- Related #34303
- Related #34305

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.6 (arm64)
- Runtime/container: Node.js + Vitest (local)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local test env

### Steps

1. Run focused exec-approvals tests:
   `pnpm -s vitest run src/infra/exec-approvals.test.ts src/infra/exec-approvals-config.test.ts src/infra/exec-approvals-allow-always.test.ts src/infra/exec-approvals-safe-bins.test.ts`
2. Confirm all tests pass.
3. Review helper flow: `makeTempDir()` records dirs and `afterEach` removes tracked dirs.

### Expected

- All exec-approvals tests continue to pass.
- Temp dirs created by `makeTempDir()` are removed after each test.

### Actual

- Pass: all focused suites passed (108 tests).
- Helper now cleans tracked temp dirs in `afterEach`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing log (excerpt):

```text
✓ src/infra/exec-approvals-config.test.ts (9 tests)
✓ src/infra/exec-approvals-allow-always.test.ts (11 tests)
✓ src/infra/exec-approvals-safe-bins.test.ts (47 tests)
✓ src/infra/exec-approvals.test.ts (41 tests)
Test Files 4 passed (4)
Tests 108 passed (108)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran focused vitest suites listed above locally; all passed.
- Edge cases checked: cleanup is best-effort (`force: true`) and isolated to helper-created tracked dirs.
- What you did **not** verify: full repository-wide temp-dir cleanup and all remaining mkdtemp call-sites.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `a533398e4`.
- Files/config to restore: `src/infra/exec-approvals-test-helpers.ts`.
- Known bad symptoms reviewers should watch for: tests unexpectedly depending on temp dirs surviving across test boundaries.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: if a test intentionally needs a temp dir across test boundaries, automatic cleanup may remove it too early.
  - Mitigation: helper is used for per-test fixtures in exec-approvals suites; cleanup runs at `afterEach`, matching fixture lifetime.
