### PR TITLE
fix(browser): improve extension relay tab-not-found diagnostics for blocked CDP attach

### DIFF
--- a/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
+++ b/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
@@ -50,4 +50,56 @@ describe("pw-session getPageForTargetId", () => {
     await closePlaywrightBrowserConnection();
     expect(browserClose).toHaveBeenCalled();
   });
+
+  it("reports extension attach guidance when multiple pages exist and target is missing", async () => {
+    connectOverCdpSpy.mockClear();
+    getChromeWebSocketUrlSpy.mockClear();
+
+    const contextOn = vi.fn();
+    const browserOn = vi.fn();
+    const browserClose = vi.fn(async () => {});
+
+    const context = {
+      pages: () => [],
+      on: contextOn,
+      newCDPSession: vi.fn(async () => {
+        throw new Error(
+          'Protocol error (Target.attachToBrowserTarget): {"code":-32000,"message":"Not allowed"}',
+        );
+      }),
+    } as unknown as import("playwright-core").BrowserContext;
+
+    const page1 = {
+      on: vi.fn(),
+      context: () => context,
+      url: () => "https://example.com",
+    } as unknown as import("playwright-core").Page;
+
+    const page2 = {
+      on: vi.fn(),
+      context: () => context,
+      url: () => "https://example.org",
+    } as unknown as import("playwright-core").Page;
+
+    (context as unknown as { pages: () => unknown[] }).pages = () => [page1, page2];
+
+    const browser = {
+      contexts: () => [context],
+      on: browserOn,
+      close: browserClose,
+    } as unknown as import("playwright-core").Browser;
+
+    connectOverCdpSpy.mockResolvedValue(browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await expect(
+      getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "MISSING_TAB",
+      }),
+    ).rejects.toThrow(/badge is ON/i);
+
+    await closePlaywrightBrowserConnection();
+    expect(browserClose).toHaveBeenCalled();
+  });
 });

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -395,7 +395,7 @@ type FindPageByTargetIdResult = {
 
 function isCdpAttachBlockedError(err: unknown): boolean {
   const message = formatErrorMessage(err).toLowerCase();
-  return message.includes("target.attachtobrowsertarget") || message.includes("not allowed");
+  return message.includes("target.attachtobrowsertarget") && message.includes("not allowed");
 }
 
 async function findPageByTargetId(

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -388,30 +388,44 @@ async function pageTargetId(page: Page): Promise<string | null> {
   }
 }
 
+type FindPageByTargetIdResult = {
+  page: Page | null;
+  cdpAttachBlocked: boolean;
+};
+
+function isCdpAttachBlockedError(err: unknown): boolean {
+  const message = formatErrorMessage(err).toLowerCase();
+  return message.includes("target.attachtobrowsertarget") || message.includes("not allowed");
+}
+
 async function findPageByTargetId(
   browser: Browser,
   targetId: string,
   cdpUrl?: string,
-): Promise<Page | null> {
+): Promise<FindPageByTargetIdResult> {
   const pages = await getAllPages(browser);
   let resolvedViaCdp = false;
+  let cdpAttachBlocked = false;
   // First, try the standard CDP session approach
   for (const page of pages) {
     let tid: string | null = null;
     try {
       tid = await pageTargetId(page);
       resolvedViaCdp = true;
-    } catch {
+    } catch (err) {
+      if (isCdpAttachBlockedError(err)) {
+        cdpAttachBlocked = true;
+      }
       tid = null;
     }
     if (tid && tid === targetId) {
-      return page;
+      return { page, cdpAttachBlocked };
     }
   }
   // Extension relays can block CDP attachment APIs entirely. If that happens and
   // Playwright only exposes one page, return it as the best available mapping.
   if (!resolvedViaCdp && pages.length === 1) {
-    return pages[0];
+    return { page: pages[0], cdpAttachBlocked };
   }
   // If CDP sessions fail (e.g., extension relay blocks Target.attachToBrowserTarget),
   // fall back to URL-based matching using the /json/list endpoint
@@ -434,7 +448,7 @@ async function findPageByTargetId(
           // Try to find a page with matching URL
           const urlMatch = pages.filter((p) => p.url() === target.url);
           if (urlMatch.length === 1) {
-            return urlMatch[0];
+            return { page: urlMatch[0], cdpAttachBlocked };
           }
           // If multiple URL matches, use index-based matching as fallback
           // This works when Playwright and the relay enumerate tabs in the same order
@@ -443,7 +457,7 @@ async function findPageByTargetId(
             if (sameUrlTargets.length === urlMatch.length) {
               const idx = sameUrlTargets.findIndex((t) => t.id === targetId);
               if (idx >= 0 && idx < urlMatch.length) {
-                return urlMatch[idx];
+                return { page: urlMatch[idx], cdpAttachBlocked };
               }
             }
           }
@@ -453,7 +467,7 @@ async function findPageByTargetId(
       // Ignore fetch errors and fall through to return null
     }
   }
-  return null;
+  return { page: null, cdpAttachBlocked };
 }
 
 async function resolvePageByTargetIdOrThrow(opts: {
@@ -461,7 +475,7 @@ async function resolvePageByTargetIdOrThrow(opts: {
   targetId: string;
 }): Promise<Page> {
   const { browser } = await connectBrowser(opts.cdpUrl);
-  const page = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
+  const { page } = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
   if (!page) {
     throw new Error("tab not found");
   }
@@ -481,13 +495,23 @@ export async function getPageForTargetId(opts: {
   if (!opts.targetId) {
     return first;
   }
-  const found = await findPageByTargetId(browser, opts.targetId, opts.cdpUrl);
+  const { page: found, cdpAttachBlocked } = await findPageByTargetId(
+    browser,
+    opts.targetId,
+    opts.cdpUrl,
+  );
   if (!found) {
     // Extension relays can block CDP attachment APIs (e.g. Target.attachToBrowserTarget),
     // which prevents us from resolving a page's targetId via newCDPSession(). If Playwright
     // only exposes a single Page, use it as a best-effort fallback.
     if (pages.length === 1) {
       return first;
+    }
+    if (cdpAttachBlocked) {
+      throw new Error(
+        `tab not found: target "${opts.targetId}" is not attached in extension relay. ` +
+          "Open the tab in Chrome and click the OpenClaw Browser Relay toolbar icon so badge is ON, then retry.",
+      );
     }
     throw new Error("tab not found");
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: when extension relay blocks `Target.attachToBrowserTarget` ("Not allowed") and multiple pages exist, target resolution falls back to generic `tab not found`.
- Why it matters: users cannot tell whether failure is caused by missing attached tab (badge OFF) vs other tab lookup issues.
- What changed: detect blocked CDP-attach errors during target resolution and return a targeted diagnostic message with explicit relay attach action.
- What did NOT change (scope boundary): no protocol behavior changes, no retry policy changes, no extension/background runtime changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33650
- Related #33109

## User-visible / Behavior Changes

- For extension relay sessions where CDP attach is blocked and requested target cannot be mapped, error now includes concrete guidance: attach the tab via OpenClaw Browser Relay toolbar icon (badge ON).

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.6 (arm64)
- Runtime/container: Node.js + Vitest (local)
- Model/provider: N/A
- Integration/channel (if any): Browser tool / Chrome extension relay
- Relevant config (redacted): extension relay profile, loopback CDP URL

### Steps

1. Run focused tests:
   `pnpm -s vitest run src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts src/browser/server-context.remote-profile-tab-ops.test.ts`
2. Confirm added case simulating `Target.attachToBrowserTarget ... Not allowed` with multiple pages fails with attach guidance.
3. Confirm existing fallback case (single page) still succeeds.

### Expected

- Single-page extension fallback remains unchanged.
- Multi-page blocked-attach path surfaces actionable guidance instead of bare `tab not found`.

### Actual

- Pass: 2 files, 12 tests.
- New diagnostic message includes relay attach guidance.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing log (excerpt):

```text
✓ src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts (2 tests)
✓ src/browser/server-context.remote-profile-tab-ops.test.ts (10 tests)
Test Files 2 passed (2)
Tests 12 passed (12)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran focused tests above locally after change; all passed.
- Edge cases checked: retained existing single-page fallback behavior while improving only blocked-attach + unresolved target path.
- What you did **not** verify: end-to-end manual browser relay session against live Chrome/Brave extension.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `8ef529749`.
- Files/config to restore: `src/browser/pw-session.ts`, `src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts`.
- Known bad symptoms reviewers should watch for: non-extension contexts incorrectly matching attach-blocked diagnostics (mitigated by conservative error-string checks + unchanged fallback behavior).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: heuristic matching for attach-blocked errors could over-match unrelated errors containing "not allowed".
  - Mitigation: match also checks for `Target.attachToBrowserTarget`; fallback behavior remains unchanged unless attach-block condition is observed.
