### PR TITLE
fix(pdf): prevent /v1beta duplication in Gemini PDF URL construction

### DIFF
--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -137,11 +137,13 @@ export async function geminiAnalyzePdf(params: {
   }
   parts.push({ text: params.prompt });
 
-  const baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com").replace(
+  const rawBaseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com").replace(
     /\/+$/,
     "",
   );
-  const url = `${baseUrl}/v1beta/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
+  // Avoid double /v1beta when baseUrl already includes the version segment (#34312)
+  const baseUrl = rawBaseUrl.endsWith("/v1beta") ? rawBaseUrl : `${rawBaseUrl}/v1beta`;
+  const url = `${baseUrl}/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 
   const res = await fetch(url, {
     method: "POST",

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -711,6 +711,46 @@ describe("native PDF provider API calls", () => {
       "apiKey required",
     );
   });
+
+  it("geminiAnalyzePdf does not duplicate /v1beta when baseUrl already includes it", async () => {
+    const { geminiAnalyzePdf } = await import("./pdf-native-providers.js");
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      }),
+    });
+
+    await geminiAnalyzePdf({
+      ...makeGeminiAnalyzeParams({
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      }),
+    });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("/v1beta/models/");
+    expect(url).not.toContain("/v1beta/v1beta/");
+  });
+
+  it("geminiAnalyzePdf appends /v1beta when baseUrl omits it", async () => {
+    const { geminiAnalyzePdf } = await import("./pdf-native-providers.js");
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      }),
+    });
+
+    await geminiAnalyzePdf({
+      ...makeGeminiAnalyzeParams({
+        baseUrl: "https://generativelanguage.googleapis.com",
+      }),
+    });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("/v1beta/models/");
+    expect(url).not.toContain("/v1beta/v1beta/");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #34312

When `params.baseUrl` is `"https://generativelanguage.googleapis.com/v1beta"` (the standard default used throughout the codebase for Google models), `geminiAnalyzePdf` was producing a doubled path segment `/v1beta/v1beta/models/...`, causing a 404 error.

**Root cause:** The URL construction in `geminiAnalyzePdf` unconditionally prepended `/v1beta` to the path, but `baseUrl` often already includes it — other Gemini API paths in the codebase (video, audio, embeddings) correctly handle this by expecting `baseUrl` to already contain the version segment.

**Fix:** Strip trailing slashes from `baseUrl`, then only append `/v1beta` if it is not already present. This matches the pattern used by other Google API callers in the codebase.

## Changes

- `src/agents/tools/pdf-native-providers.ts`: Normalize `baseUrl` to avoid double `/v1beta` before constructing the Gemini `generateContent` URL.
- `src/agents/tools/pdf-tool.test.ts`: Added two tests verifying that:
  1. When `baseUrl` already includes `/v1beta`, the URL is not doubled.
  2. When `baseUrl` omits `/v1beta`, it is still appended correctly.

## Test plan

- [x] `pnpm check` passes (lint + format + typecheck)
- [x] `pnpm build` succeeds
- [x] `pnpm test -- --run src/agents/tools/pdf-tool.test.ts` — all 52 tests pass