### PR TITLE
fix: seed controlUi.allowedOrigins for non-interactive non-loopback onboard

### DIFF
--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -257,6 +257,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
           bind?: string;
           port?: number;
           auth?: { mode?: string; token?: string };
+          controlUi?: { allowedOrigins?: string[] };
         };
       }>(configPath);
 
@@ -264,6 +265,8 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       expect(cfg.gateway?.port).toBe(port);
       expect(cfg.gateway?.auth?.mode).toBe("token");
       expect((cfg.gateway?.auth?.token ?? "").length).toBeGreaterThan(8);
+      expect(cfg.gateway?.controlUi?.allowedOrigins).toContain(`http://localhost:${port}`);
+      expect(cfg.gateway?.controlUi?.allowedOrigins).toContain(`http://127.0.0.1:${port}`);
     });
   }, 60_000);
 });

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../../config/config.js";
+import { ensureControlUiAllowedOriginsForNonLoopbackBind } from "../../../config/gateway-control-ui-origins.js";
 import type { RuntimeEnv } from "../../../runtime.js";
 import { normalizeGatewayTokenInput, randomToken } from "../../onboard-helpers.js";
 import type { OnboardOptions } from "../../onboard-types.js";
@@ -104,6 +105,10 @@ export function applyNonInteractiveGatewayConfig(params: {
       },
     },
   };
+
+  nextConfig = ensureControlUiAllowedOriginsForNonLoopbackBind(nextConfig, {
+    requireControlUiEnabled: true,
+  }).config;
 
   return {
     nextConfig,


### PR DESCRIPTION
## Summary
Fixes #34166.

Non-interactive local onboarding could write a non-loopback gateway bind (`lan`/`tailnet`/`custom`) without seeding `gateway.controlUi.allowedOrigins`, which later trips the startup guard:

- `non-loopback Control UI requires gateway.controlUi.allowedOrigins ...`

Interactive onboarding already seeded these origins via `ensureControlUiAllowedOriginsForNonLoopbackBind`, but non-interactive local onboarding did not.

## What changed
- In `applyNonInteractiveGatewayConfig`, call `ensureControlUiAllowedOriginsForNonLoopbackBind(nextConfig, { requireControlUiEnabled: true })` before returning.
- Extend the existing LAN non-interactive onboarding test to assert `gateway.controlUi.allowedOrigins` includes:
  - `http://localhost:<port>`
  - `http://127.0.0.1:<port>`

## Why this fixes it
When onboarding selects a non-loopback bind in non-interactive mode, config now gets the same default Control UI origin seeding as interactive mode, so gateway runtime startup checks pass without requiring manual config edits.

## Validation
- `pnpm build && pnpm check && pnpm test` (pass)

## AI disclosure
This PR is AI-assisted. Code has been fully tested locally. I understand what this code does.
