### PR TITLE
fix: prevent wrong recipient when channel changes (iMessage → Web UI)

### DIFF
--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -94,6 +94,16 @@ export function resolveLastToRaw(params: {
     }
   }
 
+  // Fix #34182: When channel changes (e.g., iMessage → Web UI), don't use the old
+  // persistedLastTo from a different channel, as it causes replies to be sent to
+  // the wrong recipient (the previous channel's sender instead of Web UI).
+  if (params.persistedLastTo && originatingChannel && persistedChannel) {
+    if (originatingChannel !== persistedChannel) {
+      // Channel changed - don't use old persistedLastTo from different channel
+      return params.originatingToRaw || params.toRaw;
+    }
+  }
+
   return params.originatingToRaw || params.toRaw || params.persistedLastTo;
 }
 


### PR DESCRIPTION
Fixes #34182

## Summary

When a user receives an iMessage and then replies via Web UI, the reply was incorrectly sent to both Web UI AND the iMessage sender. This happened because the session used the cached  from the previous iMessage interaction.

## Root Cause

In `resolveLastToRaw()`, when a new message arrives without an explicit `originatingTo`, it falls back to `persistedLastTo` regardless of whether the channel changed. This caused Web UI replies to use the iMessage sender's number.

## Fix

Add a check in `resolveLastToRaw()`: when the channel changes (e.g., from `imessage` to `webchat`), don't use the `persistedLastTo` from the previous channel.



## Testing

- Existing tests pass (935 passed, 27 failed - pre-existing issues unrelated to this fix)
- The fix follows the same pattern used in `resolveLastChannelRaw()` which already has similar channel-change logic