### PR TITLE
fix(ui): add clipboard fallback for non-secure contexts (HTTP)

### DIFF
--- a/ui/src/ui/chat/copy-as-markdown.ts
+++ b/ui/src/ui/chat/copy-as-markdown.ts
@@ -17,9 +17,30 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
     return false;
   }
 
+  // Try modern Clipboard API first (requires secure context / HTTPS).
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Falls through to legacy fallback below.
+    }
+  }
+
+  // Legacy fallback for non-secure contexts (e.g. http://127.0.0.1 on Windows).
+  // Uses a temporary textarea + execCommand("copy") (#34092).
   try {
-    await navigator.clipboard.writeText(text);
-    return true;
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    textarea.style.top = "-9999px";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return ok;
   } catch {
     return false;
   }


### PR DESCRIPTION
Fixes #34092

The chat copy button silently fails on Windows when accessing the Control UI via `http://127.0.0.1:18789`. `navigator.clipboard.writeText()` requires a secure context (HTTPS), which Chrome on Windows doesn't grant to plain HTTP — even for localhost.

This adds a legacy fallback using a temporary `<textarea>` + `document.execCommand('copy')` when the Clipboard API is unavailable or throws.

1 file, +23/-2. Chat controller tests pass (25/25).

---

AI-assisted PR (Claude via OpenClaw agent). I understand what this code does.