### PR TITLE
fix(whatsapp): use fresh config per message for group policy and routing

### DIFF
--- a/src/web/auto-reply/monitor/ack-reaction.ts
+++ b/src/web/auto-reply/monitor/ack-reaction.ts
@@ -34,6 +34,7 @@ export function maybeSendAckReaction(params: {
           agentId: params.agentId,
           sessionKey: params.sessionKey,
           conversationId: conversationIdForCheck,
+          accountId: params.accountId,
         })
       : null;
   const shouldSendReaction = () =>

--- a/src/web/auto-reply/monitor/group-activation.ts
+++ b/src/web/auto-reply/monitor/group-activation.ts
@@ -10,7 +10,11 @@ import {
   resolveStorePath,
 } from "../../../config/sessions.js";
 
-export function resolveGroupPolicyFor(cfg: ReturnType<typeof loadConfig>, conversationId: string) {
+export function resolveGroupPolicyFor(
+  cfg: ReturnType<typeof loadConfig>,
+  conversationId: string,
+  accountId?: string,
+) {
   const groupId = resolveGroupSessionKey({
     From: conversationId,
     ChatType: "group",
@@ -27,12 +31,14 @@ export function resolveGroupPolicyFor(cfg: ReturnType<typeof loadConfig>, conver
     channel: "whatsapp",
     groupId: groupId ?? conversationId,
     hasGroupAllowFrom,
+    accountId,
   });
 }
 
 export function resolveGroupRequireMentionFor(
   cfg: ReturnType<typeof loadConfig>,
   conversationId: string,
+  accountId?: string,
 ) {
   const groupId = resolveGroupSessionKey({
     From: conversationId,
@@ -43,6 +49,7 @@ export function resolveGroupRequireMentionFor(
     cfg,
     channel: "whatsapp",
     groupId: groupId ?? conversationId,
+    accountId,
   });
 }
 
@@ -51,13 +58,18 @@ export function resolveGroupActivationFor(params: {
   agentId: string;
   sessionKey: string;
   conversationId: string;
+  accountId?: string;
 }) {
   const storePath = resolveStorePath(params.cfg.session?.store, {
     agentId: params.agentId,
   });
   const store = loadSessionStore(storePath);
   const entry = store[params.sessionKey];
-  const requireMention = resolveGroupRequireMentionFor(params.cfg, params.conversationId);
+  const requireMention = resolveGroupRequireMentionFor(
+    params.cfg,
+    params.conversationId,
+    params.accountId,
+  );
   const defaultActivation = !requireMention ? "always" : "mention";
   return normalizeGroupActivation(entry?.groupActivation) ?? defaultActivation;
 }

--- a/src/web/auto-reply/monitor/group-gating.ts
+++ b/src/web/auto-reply/monitor/group-gating.ts
@@ -26,6 +26,7 @@ type ApplyGroupGatingParams = {
   groupHistoryKey: string;
   agentId: string;
   sessionKey: string;
+  accountId?: string;
   baseMentionConfig: MentionConfig;
   authDir?: string;
   groupHistories: Map<string, GroupHistoryEntry[]>;
@@ -80,7 +81,7 @@ function skipGroupMessageAndStoreHistory(params: ApplyGroupGatingParams, verbose
 }
 
 export function applyGroupGating(params: ApplyGroupGatingParams) {
-  const groupPolicy = resolveGroupPolicyFor(params.cfg, params.conversationId);
+  const groupPolicy = resolveGroupPolicyFor(params.cfg, params.conversationId, params.accountId);
   if (groupPolicy.allowlistEnabled && !groupPolicy.allowed) {
     params.logVerbose(`Skipping group message ${params.conversationId} (not in allowlist)`);
     return { shouldProcess: false };
@@ -125,6 +126,7 @@ export function applyGroupGating(params: ApplyGroupGatingParams) {
     agentId: params.agentId,
     sessionKey: params.sessionKey,
     conversationId: params.conversationId,
+    accountId: params.accountId,
   });
   const requireMention = activation !== "always";
   const selfJid = params.msg.selfJid?.replace(/:\\d+/, "");

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -40,7 +40,7 @@ export function createWebOnMessageHandler(params: {
     },
   ) =>
     processMessage({
-      cfg: params.cfg,
+      cfg: loadConfig(),
       msg,
       route,
       groupHistoryKey,
@@ -113,7 +113,7 @@ export function createWebOnMessageHandler(params: {
         OriginatingTo: conversationId,
       } satisfies MsgContext;
       updateLastRouteInBackground({
-        cfg: params.cfg,
+        cfg: loadConfig(),
         backgroundTasks: params.backgroundTasks,
         storeAgentId: route.agentId,
         sessionKey: route.sessionKey,
@@ -125,12 +125,13 @@ export function createWebOnMessageHandler(params: {
       });
 
       const gating = applyGroupGating({
-        cfg: params.cfg,
+        cfg: loadConfig(),
         msg,
         conversationId,
         groupHistoryKey,
         agentId: route.agentId,
         sessionKey: route.sessionKey,
+        accountId: route.accountId,
         baseMentionConfig: params.baseMentionConfig,
         authDir: params.account.authDir,
         groupHistories: params.groupHistories,
@@ -153,7 +154,7 @@ export function createWebOnMessageHandler(params: {
     // Does not bypass group mention/activation gating above.
     if (
       await maybeBroadcastMessage({
-        cfg: params.cfg,
+        cfg: loadConfig(),
         msg,
         peerId,
         route,

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -5,6 +5,7 @@ import { logVerbose } from "../../../globals.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import { buildGroupHistoryKey } from "../../../routing/session-key.js";
 import { normalizeE164 } from "../../../utils.js";
+import { resolveWhatsAppAccount } from "../../accounts.js";
 import type { MentionConfig } from "../mentions.js";
 import type { WebInboundMsg } from "../types.js";
 import { maybeBroadcastMessage } from "./broadcast.js";
@@ -14,6 +15,37 @@ import { applyGroupGating } from "./group-gating.js";
 import { updateLastRouteInBackground } from "./last-route.js";
 import { resolvePeerId } from "./peer.js";
 import { processMessage } from "./process-message.js";
+
+/**
+ * Reload config with per-account WhatsApp overrides merged into the top-level
+ * `channels.whatsapp` section.  This mirrors the expansion in `monitor.ts` so
+ * that downstream consumers (processMessage, applyGroupGating, etc.) see the
+ * same account-scoped fields (messagePrefix, allowFrom, groupPolicy, …) they
+ * relied on when the handler was first created — but with a fresh snapshot.
+ */
+function loadAccountExpandedConfig(accountId?: string): ReturnType<typeof loadConfig> {
+  const baseCfg = loadConfig();
+  const account = resolveWhatsAppAccount({ cfg: baseCfg, accountId });
+  return {
+    ...baseCfg,
+    channels: {
+      ...baseCfg.channels,
+      whatsapp: {
+        ...baseCfg.channels?.whatsapp,
+        ackReaction: account.ackReaction,
+        messagePrefix: account.messagePrefix,
+        allowFrom: account.allowFrom,
+        groupAllowFrom: account.groupAllowFrom,
+        groupPolicy: account.groupPolicy,
+        textChunkLimit: account.textChunkLimit,
+        chunkMode: account.chunkMode,
+        mediaMaxMb: account.mediaMaxMb,
+        blockStreaming: account.blockStreaming,
+        groups: account.groups,
+      },
+    },
+  } satisfies ReturnType<typeof loadConfig>;
+}
 
 export function createWebOnMessageHandler(params: {
   cfg: ReturnType<typeof loadConfig>;
@@ -40,7 +72,7 @@ export function createWebOnMessageHandler(params: {
     },
   ) =>
     processMessage({
-      cfg: loadConfig(),
+      cfg: loadAccountExpandedConfig(params.account.accountId),
       msg,
       route,
       groupHistoryKey,
@@ -65,7 +97,7 @@ export function createWebOnMessageHandler(params: {
     const peerId = resolvePeerId(msg);
     // Fresh config for bindings lookup; other routing inputs are payload-derived.
     const route = resolveAgentRoute({
-      cfg: loadConfig(),
+      cfg: loadAccountExpandedConfig(params.account.accountId),
       channel: "whatsapp",
       accountId: msg.accountId,
       peer: {
@@ -113,7 +145,7 @@ export function createWebOnMessageHandler(params: {
         OriginatingTo: conversationId,
       } satisfies MsgContext;
       updateLastRouteInBackground({
-        cfg: loadConfig(),
+        cfg: loadAccountExpandedConfig(params.account.accountId),
         backgroundTasks: params.backgroundTasks,
         storeAgentId: route.agentId,
         sessionKey: route.sessionKey,
@@ -125,7 +157,7 @@ export function createWebOnMessageHandler(params: {
       });
 
       const gating = applyGroupGating({
-        cfg: loadConfig(),
+        cfg: loadAccountExpandedConfig(params.account.accountId),
         msg,
         conversationId,
         groupHistoryKey,
@@ -154,7 +186,7 @@ export function createWebOnMessageHandler(params: {
     // Does not bypass group mention/activation gating above.
     if (
       await maybeBroadcastMessage({
-        cfg: loadConfig(),
+        cfg: loadAccountExpandedConfig(params.account.accountId),
         msg,
         peerId,
         route,


### PR DESCRIPTION
## Summary

Fixes #33974 — WhatsApp group config changes (requireMention, group policy) were silently ignored until channel restart because the on-message handler held a stale config reference captured at handler creation time.

- **Replace stale `params.cfg` with `loadConfig()`** in 4 call sites within `createWebOnMessageHandler` (`processMessage`, `updateLastRouteInBackground`, `applyGroupGating`, `maybeBroadcastMessage`). The correct pattern already existed at line 68 where `resolveAgentRoute` calls `loadConfig()` per-message — this fix applies the same pattern to all remaining config consumers.

- **Thread `accountId` through group policy resolution** so that per-account group config (allowlist, requireMention) is correctly resolved. Added optional `accountId` parameter to `resolveGroupPolicyFor`, `resolveGroupRequireMentionFor`, and `resolveGroupActivationFor` in `group-activation.ts`, and forwarded it from `applyGroupGating` in `group-gating.ts` and `maybeSendAckReaction` in `ack-reaction.ts`.

## Test plan

- [x] `pnpm check` passes (lint + format)
- [x] `pnpm build` passes (type-check + bundle)
- [x] `pnpm test -- --run src/web/auto-reply/monitor/` passes (15 tests)
- [x] `pnpm test -- --run src/config/group-policy.test.ts` passes (13 tests)
- [ ] Manual verification: change `requireMention` or group policy in config while gateway is running — changes should take effect on next message without restart