### PR TITLE
fix(gateway): prevent webchat replies from routing to external channels

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -150,6 +150,7 @@ async function runNonStreamingChatSend(params: {
   sessionKey?: string;
   client?: unknown;
   expectBroadcast?: boolean;
+  isWebchatConnect?: boolean;
 }) {
   await chatHandlers["chat.send"]({
     params: {
@@ -162,7 +163,7 @@ async function runNonStreamingChatSend(params: {
     >[0]["respond"],
     req: {} as never,
     client: (params.client ?? null) as never,
-    isWebchatConnect: () => false,
+    isWebchatConnect: () => params.isWebchatConnect ?? false,
     context: params.context as GatewayRequestContext,
   });
 
@@ -574,6 +575,40 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       // "agent:main:work" only yields one rest token and does not hit that path.
       sessionKey: "agent:main:work:ticket-123",
       expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        AccountId: undefined,
+      }),
+    );
+  });
+
+  it("chat.send from webchat does not route replies to external channel even for channel-scoped sessions", async () => {
+    createTranscriptFixture("openclaw-chat-send-webchat-no-external-route-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "telegram",
+        to: "telegram:6812765697",
+        accountId: "default",
+      },
+      lastChannel: "telegram",
+      lastTo: "telegram:6812765697",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-webchat-no-external-route",
+      sessionKey: "agent:main:telegram:direct:6812765697",
+      expectBroadcast: false,
+      isWebchatConnect: true,
     });
 
     expect(mockState.lastDispatchCtx).toEqual(

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -719,7 +719,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       runIds: res.aborted ? [runId] : [],
     });
   },
-  "chat.send": async ({ params, respond, context, client }) => {
+  "chat.send": async ({ params, respond, context, client, isWebchatConnect }) => {
     if (!validateChatSendParams(params)) {
       respond(
         false,
@@ -889,7 +889,9 @@ export const chatHandlers: GatewayRequestHandlers = {
         !isChannelAgnosticSessionScope &&
         (isChannelScopedSession || hasLegacyChannelPeerShape),
       );
+      const isFromWebchat = isWebchatConnect(client?.connect);
       const hasDeliverableRoute =
+        !isFromWebchat &&
         canInheritDeliverableRoute &&
         routeChannelCandidate &&
         routeChannelCandidate !== INTERNAL_MESSAGE_CHANNEL &&


### PR DESCRIPTION
## Summary

- Problem: When using the Control UI / WebChat to chat with an agent on a channel-scoped session (e.g. `agent:main:telegram:direct:123`), replies are delivered to **both** WebChat and Telegram simultaneously, causing duplicate messages.
- Why it matters: Users see every reply duplicated across surfaces; the WebChat docs explicitly state routing should be deterministic and replies should only go back to WebChat.
- What changed: Added an `isFromWebchat` guard in `chat.send` that prevents inheriting the session's persisted external delivery route when the request originates from a WebChat connection. When `isWebchatConnect(client.connect)` is true, `hasDeliverableRoute` is forced to `false`, keeping `OriginatingChannel` as `INTERNAL_MESSAGE_CHANNEL` ("webchat").
- What did NOT change (scope boundary): Non-WebChat clients (TUI, API, channel-originated requests) still inherit external delivery routes as before. Session persistence (`deliveryContext`, `lastChannel`) is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34324

## User-visible / Behavior Changes

WebChat replies are no longer duplicated to external channels (Telegram, Discord, etc.) when viewing a channel-scoped session in the Control UI.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+

### Steps

1. Configure an agent with both WebChat and Telegram channels
2. Start a conversation via Telegram to create a channel-scoped session
3. Open the same session in WebChat / Control UI and send a message
4. Check Telegram for duplicate reply

### Expected

- Replies stay only in WebChat

### Actual

- Before: Replies sent to both WebChat and Telegram
- After: Replies sent only to WebChat

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test: `chat.send from webchat does not route replies to external channel even for channel-scoped sessions` — verifies OriginatingChannel stays "webchat" when isWebchatConnect is true, even with a Telegram-scoped session key and persisted Telegram deliveryContext.

## Human Verification (required)

- Verified scenarios: WebChat client with Telegram-scoped session, non-WebChat client with same session (unchanged behavior), shared main session, custom non-channel session
- Edge cases checked: Legacy channel-peer session shapes, sessions with threadId, Feishu routing metadata
- What you did **not** verify: Live multi-channel gateway with real Telegram + WebChat traffic

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single guard condition (`!isFromWebchat &&`) in chat.ts
- Files/config to restore: `src/gateway/server-methods/chat.ts`

## Risks and Mitigations

- Risk: WebChat users viewing a channel-scoped session can no longer trigger external delivery from the Control UI
  - Mitigation: This is the intended behavior per WebChat docs. If external delivery is needed, users should send from the actual channel.