### PR TITLE
feat(tts): per-agent TTS voice configuration

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import type { TtsConfig } from "../config/types.tts.js";
 import { resolvePluginTools } from "../plugins/tools.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveSessionAgentId } from "./agent-scope.js";
@@ -72,6 +73,8 @@ export function createOpenClawTools(options?: {
   senderIsOwner?: boolean;
   /** Ephemeral session UUID — regenerated on /new and /reset. */
   sessionId?: string;
+  /** Per-agent TTS overrides (from agent config). */
+  agentTts?: TtsConfig;
 }): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);
   const imageTool = options?.agentDir?.trim()
@@ -144,6 +147,7 @@ export function createOpenClawTools(options?: {
     createTtsTool({
       agentChannel: options?.agentChannel,
       config: options?.config,
+      agentTts: options?.agentTts,
     }),
     createGatewayTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -498,6 +498,7 @@ export function createOpenClawCodingTools(options?: {
       requesterSenderId: options?.senderId,
       senderIsOwner: options?.senderIsOwner,
       sessionId: options?.sessionId,
+      agentTts: options?.config?.agents?.list?.find((a) => a.id === agentId)?.tts,
     }),
   ];
   const toolsForMessageProvider = applyMessageProviderToolPolicy(tools, options?.messageProvider);

--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
+import type { TtsConfig } from "../../config/types.tts.js";
 import { textToSpeech } from "../../tts/tts.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import type { AnyAgentTool } from "./common.js";
@@ -17,6 +18,8 @@ const TtsToolSchema = Type.Object({
 export function createTtsTool(opts?: {
   config?: OpenClawConfig;
   agentChannel?: GatewayMessageChannel;
+  /** Per-agent TTS overrides (from agent config). */
+  agentTts?: TtsConfig;
 }): AnyAgentTool {
   return {
     label: "TTS",
@@ -31,6 +34,7 @@ export function createTtsTool(opts?: {
       const result = await textToSpeech({
         text,
         cfg,
+        agentTts: opts?.agentTts,
         channel: channel ?? opts?.agentChannel,
       });
 

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "../../config/config.js";
-import type { TtsAutoMode } from "../../config/types.tts.js";
+import type { TtsAutoMode, TtsConfig } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
 import { runMessageAction } from "../../infra/outbound/message-action-runner.js";
 import { maybeApplyTtsToPayload } from "../../tts/tts.js";
@@ -48,6 +48,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
   dispatcher: ReplyDispatcher;
   inboundAudio: boolean;
   sessionTtsAuto?: TtsAutoMode;
+  agentTts?: TtsConfig;
   ttsChannel?: string;
   shouldRouteToOriginating: boolean;
   originatingChannel?: string;
@@ -134,6 +135,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     const ttsPayload = await maybeApplyTtsToPayload({
       payload,
       cfg: params.cfg,
+      agentTts: params.agentTts,
       channel: params.ttsChannel,
       kind,
       inboundAudio: params.inboundAudio,

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -9,7 +9,7 @@ import {
 } from "../../acp/runtime/session-identity.js";
 import { readAcpSessionEntry } from "../../acp/runtime/session-meta.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { TtsAutoMode } from "../../config/types.tts.js";
+import type { TtsAutoMode, TtsConfig } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
@@ -150,6 +150,7 @@ export async function tryDispatchAcpReply(params: {
   sessionKey?: string;
   inboundAudio: boolean;
   sessionTtsAuto?: TtsAutoMode;
+  agentTts?: TtsConfig;
   ttsChannel?: string;
   shouldRouteToOriginating: boolean;
   originatingChannel?: string;
@@ -181,6 +182,7 @@ export async function tryDispatchAcpReply(params: {
     dispatcher: params.dispatcher,
     inboundAudio: params.inboundAudio,
     sessionTtsAuto: params.sessionTtsAuto,
+    agentTts: params.agentTts,
     ttsChannel: params.ttsChannel,
     shouldRouteToOriginating: params.shouldRouteToOriginating,
     originatingChannel: params.originatingChannel,
@@ -257,13 +259,14 @@ export async function tryDispatchAcpReply(params: {
     });
 
     await projector.flush(true);
-    const ttsMode = resolveTtsConfig(params.cfg).mode ?? "final";
+    const ttsMode = resolveTtsConfig(params.cfg, params.agentTts).mode ?? "final";
     const accumulatedBlockText = delivery.getAccumulatedBlockText();
     if (ttsMode === "final" && delivery.getBlockCount() > 0 && accumulatedBlockText.trim()) {
       try {
         const ttsSyntheticReply = await maybeApplyTtsToPayload({
           payload: { text: accumulatedBlockText },
           cfg: params.cfg,
+          agentTts: params.agentTts,
           channel: params.ttsChannel,
           kind: "final",
           inboundAudio: params.inboundAudio,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1,6 +1,7 @@
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadSessionStore, resolveStorePath, type SessionEntry } from "../../config/sessions.js";
+import type { TtsConfig } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
 import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
@@ -71,6 +72,8 @@ const resolveSessionStoreEntry = (
 ): {
   sessionKey?: string;
   entry?: SessionEntry;
+  agentId?: string;
+  agentTts?: TtsConfig;
 } => {
   const targetSessionKey =
     ctx.CommandSource === "native" ? ctx.CommandTargetSessionKey?.trim() : undefined;
@@ -79,16 +82,21 @@ const resolveSessionStoreEntry = (
     return {};
   }
   const agentId = resolveSessionAgentId({ sessionKey, config: cfg });
+  const agentTts = cfg.agents?.list?.find((agent) => agent.id === agentId)?.tts;
   const storePath = resolveStorePath(cfg.session?.store, { agentId });
   try {
     const store = loadSessionStore(storePath);
     return {
       sessionKey,
       entry: store[sessionKey.toLowerCase()] ?? store[sessionKey],
+      agentId,
+      agentTts,
     };
   } catch {
     return {
       sessionKey,
+      agentId,
+      agentTts,
     };
   }
 };
@@ -165,6 +173,7 @@ export async function dispatchReplyFromConfig(params: {
   }
 
   const sessionStoreEntry = resolveSessionStoreEntry(ctx, cfg);
+  const agentTts = sessionStoreEntry.agentTts;
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
   const hookRunner = getGlobalHookRunner();
@@ -331,6 +340,7 @@ export async function dispatchReplyFromConfig(params: {
       sessionKey,
       inboundAudio,
       sessionTtsAuto,
+      agentTts,
       ttsChannel,
       shouldRouteToOriginating,
       originatingChannel,
@@ -381,6 +391,7 @@ export async function dispatchReplyFromConfig(params: {
             const ttsPayload = await maybeApplyTtsToPayload({
               payload,
               cfg,
+              agentTts,
               channel: ttsChannel,
               kind: "tool",
               inboundAudio,
@@ -417,6 +428,7 @@ export async function dispatchReplyFromConfig(params: {
             const ttsPayload = await maybeApplyTtsToPayload({
               payload,
               cfg,
+              agentTts,
               channel: ttsChannel,
               kind: "block",
               inboundAudio,
@@ -447,6 +459,7 @@ export async function dispatchReplyFromConfig(params: {
       const ttsReply = await maybeApplyTtsToPayload({
         payload: reply,
         cfg,
+        agentTts,
         channel: ttsChannel,
         kind: "final",
         inboundAudio,
@@ -479,7 +492,7 @@ export async function dispatchReplyFromConfig(params: {
       }
     }
 
-    const ttsMode = resolveTtsConfig(cfg).mode ?? "final";
+    const ttsMode = resolveTtsConfig(cfg, agentTts).mode ?? "final";
     // Generate TTS-only reply after block streaming completes (when there's no final reply).
     // This handles the case where block streaming succeeds and drops final payloads,
     // but we still want TTS audio to be generated from the accumulated block content.
@@ -493,6 +506,7 @@ export async function dispatchReplyFromConfig(params: {
         const ttsSyntheticReply = await maybeApplyTtsToPayload({
           payload: { text: accumulatedBlockText },
           cfg,
+          agentTts,
           channel: ttsChannel,
           kind: "final",
           inboundAudio,

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -208,6 +208,7 @@ export async function handleInlineActions(params: {
         agentDir,
         workspaceDir,
         config: cfg,
+        agentTts: cfg.agents?.list?.find((a) => a.id === agentId)?.tts,
       });
       const authorizedTools = applyOwnerOnlyToolPolicy(tools, command.senderIsOwner);
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -204,6 +204,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Shared default settings inherited by agents unless overridden per entry in agents.list. Use defaults to enforce consistent baseline behavior and reduce duplicated per-agent configuration.",
   "agents.list":
     "Explicit list of configured agents with IDs and optional overrides for model, tools, identity, and workspace. Keep IDs stable over time so bindings, approvals, and session routing remain deterministic.",
+  "agents.list[].tts":
+    "Optional per-agent TTS overrides merged with messages.tts (agent values take precedence when set).",
   "agents.list[].identity.avatar":
     "Avatar image path (relative to the agent workspace only) or a remote URL/data URL.",
   "agents.defaults.heartbeat.suppressToolErrorWarnings":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -761,6 +761,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.mattermost.requireMention": "Mattermost Require Mention",
   "channels.signal.account": "Signal Account",
   "channels.imessage.cliPath": "iMessage CLI Path",
+  "agents.list[].tts": "Agent Text-to-Speech",
   "agents.list[].skills": "Agent Skill Filter",
   "agents.list[].identity.avatar": "Agent Avatar",
   "agents.list[].heartbeat.suppressToolErrorWarnings":

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -4,6 +4,7 @@ import type { AgentModelConfig, AgentSandboxConfig } from "./types.agents-shared
 import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
+import type { TtsConfig } from "./types.tts.js";
 
 export type AgentConfig = {
   id: string;
@@ -21,6 +22,8 @@ export type AgentConfig = {
   heartbeat?: AgentDefaultsConfig["heartbeat"];
   identity?: IdentityConfig;
   groupChat?: GroupChatConfig;
+  /** Optional per-agent TTS overrides (merged with messages.tts). */
+  tts?: TtsConfig;
   subagents?: {
     /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
     allowAgents?: string[];

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -7,6 +7,7 @@ import {
   HumanDelaySchema,
   IdentitySchema,
   SecretInputSchema,
+  TtsConfigSchema,
   ToolsLinksSchema,
   ToolsMediaSchema,
 } from "./zod-schema.core.js";
@@ -693,6 +694,7 @@ export const AgentEntrySchema = z
     heartbeat: HeartbeatSchema,
     identity: IdentitySchema,
     groupChat: GroupChatSchema,
+    tts: TtsConfigSchema,
     subagents: z
       .object({
         allowAgents: z.array(z.string()).optional(),

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -246,12 +246,14 @@ export async function handleToolsInvokeHttpRequest(
     : undefined;
 
   // Build tool list (core + plugin tools).
+  const agentTts = cfg.agents?.list?.find((a) => a.id === agentId)?.tts;
   const allTools = createOpenClawTools({
     agentSessionKey: sessionKey,
     agentChannel: messageChannel ?? undefined,
     agentAccountId: accountId,
     agentTo,
     agentThreadId,
+    agentTts,
     config: cfg,
     pluginToolAllowlist: collectExplicitAllowlist([
       profilePolicy,

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -236,6 +236,95 @@ describe("tts", () => {
     });
   });
 
+  describe("resolveTtsConfig agent overrides", () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+      messages: {
+        tts: {
+          provider: "edge",
+          elevenlabs: {
+            voiceId: "global-voice-id",
+            modelId: "global-model-id",
+          },
+          openai: {
+            model: "tts-1",
+            voice: "alloy",
+          },
+        },
+      },
+    };
+
+    it("agent-level voiceId overrides global voiceId", () => {
+      const resolved = resolveTtsConfig(cfg, {
+        elevenlabs: {
+          voiceId: "agent-voice-id",
+        },
+      });
+
+      expect(resolved.elevenlabs.voiceId).toBe("agent-voice-id");
+      expect(resolved.elevenlabs.modelId).toBe("global-model-id");
+    });
+
+    it("agent-level provider overrides global provider", () => {
+      const resolved = resolveTtsConfig(cfg, {
+        provider: "openai",
+      });
+
+      expect(resolved.provider).toBe("openai");
+      expect(resolved.providerSource).toBe("config");
+    });
+
+    it("falls back to global values when agent fields are unset", () => {
+      const resolved = resolveTtsConfig(cfg, {
+        openai: {
+          voice: "nova",
+        },
+      });
+
+      expect(resolved.provider).toBe("edge");
+      expect(resolved.openai.voice).toBe("nova");
+      expect(resolved.openai.model).toBe("tts-1");
+      expect(resolved.elevenlabs.voiceId).toBe("global-voice-id");
+    });
+
+    it("keeps backward-compatible behavior when agent TTS is not provided", () => {
+      expect(resolveTtsConfig(cfg, undefined)).toEqual(resolveTtsConfig(cfg));
+    });
+
+    it("deep-merges elevenlabs voiceSettings without losing global fields", () => {
+      const cfgWithSettings: OpenClawConfig = {
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: {
+          tts: {
+            elevenlabs: {
+              voiceId: "global-voice",
+              voiceSettings: {
+                stability: 0.7,
+                similarityBoost: 0.8,
+                style: 0.3,
+                useSpeakerBoost: true,
+                speed: 1.0,
+              },
+            },
+          },
+        },
+      };
+      const resolved = resolveTtsConfig(cfgWithSettings, {
+        elevenlabs: {
+          voiceSettings: {
+            stability: 0.9,
+          },
+        },
+      });
+
+      expect(resolved.elevenlabs.voiceSettings.stability).toBe(0.9);
+      expect(resolved.elevenlabs.voiceSettings.similarityBoost).toBe(0.8);
+      expect(resolved.elevenlabs.voiceSettings.style).toBe(0.3);
+      expect(resolved.elevenlabs.voiceSettings.useSpeakerBoost).toBe(true);
+      expect(resolved.elevenlabs.voiceSettings.speed).toBe(1.0);
+    });
+  });
+
   describe("parseTtsDirectives", () => {
     it("extracts overrides and strips directives when enabled", () => {
       const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -253,8 +253,61 @@ function resolveModelOverridePolicy(
   };
 }
 
-export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
-  const raw: TtsConfig = cfg.messages?.tts ?? {};
+function mergeDefinedShallow<T extends Record<string, unknown>>(
+  base: T | undefined,
+  override: Partial<T> | undefined,
+): T | undefined {
+  if (!base && !override) {
+    return undefined;
+  }
+  const merged: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override ?? {})) {
+    if (value !== undefined) {
+      merged[key] = value;
+    }
+  }
+  return merged as T;
+}
+
+function mergeTtsConfig(globalTts: TtsConfig, agentTts?: TtsConfig): TtsConfig {
+  if (!agentTts) {
+    return globalTts;
+  }
+  const merged: TtsConfig = mergeDefinedShallow({ ...globalTts }, agentTts) ?? {};
+
+  const modelOverrides = mergeDefinedShallow(globalTts.modelOverrides, agentTts.modelOverrides);
+  if (modelOverrides) {
+    merged.modelOverrides = modelOverrides;
+  }
+
+  const elevenlabs = mergeDefinedShallow(globalTts.elevenlabs, agentTts.elevenlabs);
+  if (elevenlabs) {
+    // Deep-merge voiceSettings so agent can override individual fields without losing global ones
+    const voiceSettings = mergeDefinedShallow(
+      globalTts.elevenlabs?.voiceSettings,
+      agentTts.elevenlabs?.voiceSettings,
+    );
+    if (voiceSettings) {
+      elevenlabs.voiceSettings = voiceSettings;
+    }
+    merged.elevenlabs = elevenlabs;
+  }
+
+  const openai = mergeDefinedShallow(globalTts.openai, agentTts.openai);
+  if (openai) {
+    merged.openai = openai;
+  }
+
+  const edge = mergeDefinedShallow(globalTts.edge, agentTts.edge);
+  if (edge) {
+    merged.edge = edge;
+  }
+
+  return merged;
+}
+
+export function resolveTtsConfig(cfg: OpenClawConfig, agentTts?: TtsConfig): ResolvedTtsConfig {
+  const raw: TtsConfig = mergeTtsConfig(cfg.messages?.tts ?? {}, agentTts);
   const providerSource = raw.provider ? "config" : "default";
   const edgeOutputFormat = raw.edge?.outputFormat?.trim();
   const auto = normalizeTtsAutoMode(raw.auto) ?? (raw.enabled ? "always" : "off");
@@ -549,11 +602,12 @@ function buildTtsFailureResult(errors: string[]): { success: false; error: strin
 export async function textToSpeech(params: {
   text: string;
   cfg: OpenClawConfig;
+  agentTts?: TtsConfig;
   prefsPath?: string;
   channel?: string;
   overrides?: TtsDirectiveOverrides;
 }): Promise<TtsResult> {
-  const config = resolveTtsConfig(params.cfg);
+  const config = resolveTtsConfig(params.cfg, params.agentTts);
   const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config);
   const channelId = resolveChannelId(params.channel);
   const output = resolveOutputFormat(channelId);
@@ -716,9 +770,10 @@ export async function textToSpeech(params: {
 export async function textToSpeechTelephony(params: {
   text: string;
   cfg: OpenClawConfig;
+  agentTts?: TtsConfig;
   prefsPath?: string;
 }): Promise<TtsTelephonyResult> {
-  const config = resolveTtsConfig(params.cfg);
+  const config = resolveTtsConfig(params.cfg, params.agentTts);
   const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config);
 
   if (params.text.length > config.maxTextLength) {
@@ -802,12 +857,13 @@ export async function textToSpeechTelephony(params: {
 export async function maybeApplyTtsToPayload(params: {
   payload: ReplyPayload;
   cfg: OpenClawConfig;
+  agentTts?: TtsConfig;
   channel?: string;
   kind?: "tool" | "block" | "final";
   inboundAudio?: boolean;
   ttsAuto?: string;
 }): Promise<ReplyPayload> {
-  const config = resolveTtsConfig(params.cfg);
+  const config = resolveTtsConfig(params.cfg, params.agentTts);
   const prefsPath = resolveTtsPrefsPath(config);
   const autoMode = resolveTtsAutoMode({
     config,
@@ -906,6 +962,7 @@ export async function maybeApplyTtsToPayload(params: {
   const result = await textToSpeech({
     text: textForAudio,
     cfg: params.cfg,
+    agentTts: params.agentTts,
     prefsPath,
     channel: params.channel,
     overrides: directives.overrides,


### PR DESCRIPTION
## Summary
Per-agent TTS voice configuration support. Each agent can have its own voice settings (provider, voice ID, model) in openclaw.json.

Closes #11483

## Changes
- Added `tts` section to agent runtime config schema
- Voice config resolution: agent-level > global-level > defaults
- Updated config help/labels
- Tests included

## Previous PR
Rebased from #32596 (closed due to upstream CI issues, not related to this PR's code)