### PR TITLE
feat(session): gateway-level liveness triggers (fixes #34506)

### DIFF
--- a/src/auto-reply/liveness.test.ts
+++ b/src/auto-reply/liveness.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildLivenessResponse, checkLivenessTrigger } from "./liveness.js";
+
+describe("checkLivenessTrigger", () => {
+  it("matches case-insensitively", () => {
+    expect(checkLivenessTrigger("/ALIVE", ["/alive"])).toBe(true);
+  });
+
+  it("matches trimmed body", () => {
+    expect(checkLivenessTrigger("  /alive  ", ["/alive"])).toBe(true);
+  });
+
+  it("matches trigger as prefix with trailing content", () => {
+    expect(checkLivenessTrigger("/alive extra content", ["/alive"])).toBe(true);
+  });
+
+  it("does not match partial word overlap", () => {
+    expect(checkLivenessTrigger("/aliveness", ["/alive"])).toBe(false);
+  });
+
+  it("returns false when no trigger matches", () => {
+    expect(checkLivenessTrigger("hello", ["/alive"])).toBe(false);
+  });
+
+  it("skips empty triggers", () => {
+    expect(checkLivenessTrigger("/alive", ["", "/alive"])).toBe(true);
+  });
+
+  it("matches via mention-stripped body for group chats", () => {
+    // In group chat, body might be "@Bot status" but mentionStripped is "status"
+    expect(checkLivenessTrigger("@Bot status", ["status"], "status")).toBe(true);
+  });
+
+  it("does not match mention-stripped when trigger is absent", () => {
+    expect(checkLivenessTrigger("@Bot hello", ["status"], "hello")).toBe(false);
+  });
+});
+
+describe("buildLivenessResponse", () => {
+  it("returns the expected status message", () => {
+    expect(buildLivenessResponse()).toBe("✅ Online");
+  });
+});

--- a/src/auto-reply/liveness.ts
+++ b/src/auto-reply/liveness.ts
@@ -1,0 +1,41 @@
+function matchesTrigger(bodyLower: string, triggers: string[]): boolean {
+  for (const trigger of triggers) {
+    if (!trigger) {
+      continue;
+    }
+    const triggerLower = trigger.toLowerCase();
+    if (bodyLower === triggerLower) {
+      return true;
+    }
+    if (bodyLower.startsWith(`${triggerLower} `)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if a message body matches any liveness trigger.
+ * Accepts an optional mention-stripped body for group-chat support.
+ */
+export function checkLivenessTrigger(
+  body: string,
+  triggers: string[],
+  mentionStrippedBody?: string,
+): boolean {
+  const trimmedBodyLower = body.trim().toLowerCase();
+  if (matchesTrigger(trimmedBodyLower, triggers)) {
+    return true;
+  }
+  if (mentionStrippedBody) {
+    const strippedLower = mentionStrippedBody.trim().toLowerCase();
+    if (strippedLower !== trimmedBodyLower && matchesTrigger(strippedLower, triggers)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function buildLivenessResponse(): string {
+  return "✅ Online";
+}

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -142,9 +142,9 @@ export async function getReplyFromConfig(
     normalizedChatType != null && normalizedChatType !== "direct"
       ? true
       : Boolean(resolveGroupSessionKey(sessionCtxForState));
-  const commandSource =
+  const livenessCommandSource =
     finalized.BodyForCommands ?? finalized.CommandBody ?? finalized.RawBody ?? finalized.Body ?? "";
-  const triggerBodyNormalizedForLiveness = stripStructuralPrefixes(commandSource).trim();
+  const triggerBodyNormalizedForLiveness = stripStructuralPrefixes(livenessCommandSource).trim();
   const livenessTriggers = sessionCfg?.livenessTriggers;
   if (commandAuth.isAuthorizedSender && livenessTriggers?.length) {
     const mentionStripped = isGroupForLiveness

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -13,6 +13,7 @@ import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
+import { buildLivenessResponse, checkLivenessTrigger } from "../liveness.js";
 import type { MsgContext } from "../templating.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -22,6 +23,7 @@ import { resolveReplyDirectives } from "./get-reply-directives.js";
 import { handleInlineActions } from "./get-reply-inline-actions.js";
 import { runPreparedReply } from "./get-reply-run.js";
 import { finalizeInboundContext } from "./inbound-context.js";
+import { stripMentions } from "./mentions.js";
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
 import { applyResetModelOverride } from "./session-reset-model.js";
 import { initSessionState } from "./session.js";
@@ -143,7 +145,7 @@ export async function getReplyFromConfig(
   });
 
   const commandAuthorized = finalized.CommandAuthorized;
-  resolveCommandAuthorization({
+  const commandAuth = resolveCommandAuthorization({
     ctx: finalized,
     cfg,
     commandAuthorized,
@@ -171,6 +173,15 @@ export async function getReplyFromConfig(
     triggerBodyNormalized,
     bodyStripped,
   } = sessionState;
+  const livenessTriggers = sessionCfg?.livenessTriggers;
+  if (commandAuth.isAuthorizedSender && livenessTriggers?.length) {
+    const mentionStripped = isGroup
+      ? stripMentions(triggerBodyNormalized, finalized, cfg, agentId)
+      : undefined;
+    if (checkLivenessTrigger(triggerBodyNormalized, livenessTriggers, mentionStripped)) {
+      return { text: buildLivenessResponse() };
+    }
+  }
 
   await applyResetModelOverride({
     cfg,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -7,8 +7,10 @@ import {
 import { resolveModelRefFromString } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
+import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
+import { resolveGroupSessionKey } from "../../config/sessions.js";
 import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -23,7 +25,7 @@ import { resolveReplyDirectives } from "./get-reply-directives.js";
 import { handleInlineActions } from "./get-reply-inline-actions.js";
 import { runPreparedReply } from "./get-reply-run.js";
 import { finalizeInboundContext } from "./inbound-context.js";
-import { stripMentions } from "./mentions.js";
+import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
 import { applyResetModelOverride } from "./session-reset-model.js";
 import { initSessionState } from "./session.js";
@@ -125,6 +127,33 @@ export async function getReplyFromConfig(
   opts?.onTypingController?.(typing);
 
   const finalized = finalizeInboundContext(ctx);
+  const commandAuthorized = finalized.CommandAuthorized;
+  const commandAuth = resolveCommandAuthorization({
+    ctx: finalized,
+    cfg,
+    commandAuthorized,
+  });
+  const sessionCtxForState =
+    targetSessionKey && targetSessionKey !== finalized.SessionKey
+      ? { ...finalized, SessionKey: targetSessionKey }
+      : finalized;
+  const normalizedChatType = normalizeChatType(finalized.ChatType);
+  const isGroupForLiveness =
+    normalizedChatType != null && normalizedChatType !== "direct"
+      ? true
+      : Boolean(resolveGroupSessionKey(sessionCtxForState));
+  const commandSource =
+    finalized.BodyForCommands ?? finalized.CommandBody ?? finalized.RawBody ?? finalized.Body ?? "";
+  const triggerBodyNormalizedForLiveness = stripStructuralPrefixes(commandSource).trim();
+  const livenessTriggers = sessionCfg?.livenessTriggers;
+  if (commandAuth.isAuthorizedSender && livenessTriggers?.length) {
+    const mentionStripped = isGroupForLiveness
+      ? stripMentions(triggerBodyNormalizedForLiveness, finalized, cfg, agentId)
+      : undefined;
+    if (checkLivenessTrigger(triggerBodyNormalizedForLiveness, livenessTriggers, mentionStripped)) {
+      return { text: buildLivenessResponse() };
+    }
+  }
 
   if (!isFastTestEnv) {
     await applyMediaUnderstanding({
@@ -142,13 +171,6 @@ export async function getReplyFromConfig(
     ctx: finalized,
     cfg,
     isFastTestEnv,
-  });
-
-  const commandAuthorized = finalized.CommandAuthorized;
-  const commandAuth = resolveCommandAuthorization({
-    ctx: finalized,
-    cfg,
-    commandAuthorized,
   });
   const sessionState = await initSessionState({
     ctx: finalized,
@@ -173,15 +195,6 @@ export async function getReplyFromConfig(
     triggerBodyNormalized,
     bodyStripped,
   } = sessionState;
-  const livenessTriggers = sessionCfg?.livenessTriggers;
-  if (commandAuth.isAuthorizedSender && livenessTriggers?.length) {
-    const mentionStripped = isGroup
-      ? stripMentions(triggerBodyNormalized, finalized, cfg, agentId)
-      : undefined;
-    if (checkLivenessTrigger(triggerBodyNormalized, livenessTriggers, mentionStripped)) {
-      return { text: buildLivenessResponse() };
-    }
-  }
 
   await applyResetModelOverride({
     cfg,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -996,6 +996,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Maps canonical identities to provider-prefixed peer IDs so equivalent users resolve to one DM thread (example: telegram:123456). Use this when the same human appears across multiple channels or accounts.",
   "session.resetTriggers":
     "Lists message triggers that force a session reset when matched in inbound content. Use sparingly for explicit reset phrases so context is not dropped unexpectedly during normal conversation.",
+  "session.livenessTriggers":
+    "Lists message triggers that return an immediate gateway liveness response and skip the LLM pipeline for authorized senders.",
   "session.idleMinutes":
     "Applies a legacy idle reset window in minutes for session reuse behavior across inactivity gaps. Use this only for compatibility and prefer structured reset policies under session.reset/session.resetByType.",
   "session.reset":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -472,6 +472,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "session.dmScope": "DM Session Scope",
   "session.identityLinks": "Session Identity Links",
   "session.resetTriggers": "Session Reset Triggers",
+  "session.livenessTriggers": "Session Liveness Triggers",
   "session.idleMinutes": "Session Idle Minutes",
   "session.reset": "Session Reset Policy",
   "session.reset.mode": "Session Reset Mode",

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -109,6 +109,7 @@ export type SessionConfig = {
   /** Map platform-prefixed identities (e.g. "telegram:123") to canonical DM peers. */
   identityLinks?: Record<string, string[]>;
   resetTriggers?: string[];
+  livenessTriggers?: string[];
   idleMinutes?: number;
   reset?: SessionResetConfig;
   resetByType?: SessionResetByTypeConfig;

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -36,6 +36,7 @@ export const SessionSchema = z
       .optional(),
     identityLinks: z.record(z.string(), z.array(z.string())).optional(),
     resetTriggers: z.array(z.string()).optional(),
+    livenessTriggers: z.array(z.string()).optional(),
     idleMinutes: z.number().int().positive().optional(),
     reset: SessionResetConfigSchema.optional(),
     resetByType: z


### PR DESCRIPTION
## What changed

- New `session.livenessTriggers` config option: string array of trigger phrases
- New `src/auto-reply/liveness.ts` module with `checkLivenessTrigger()` and `buildLivenessResponse()`
- Liveness check runs **before** `initSessionState` in `get-reply.ts`, skipping all session I/O and LLM calls
- Group chat support via mention-stripped body matching
- Config schema aligned: zod, types, labels, and help text all updated

## Why

Health checks and monitoring pings currently waste LLM tokens and add latency. This gives authorized senders an instant "✅ Online" response for configured triggers like `/alive` or `/ping`, with zero session overhead.

## Tests

- 9 unit tests in `liveness.test.ts` covering:
  - Case-insensitive matching
  - Trimmed body matching
  - Prefix matching with trailing content
  - Partial word overlap rejection
  - Empty trigger skipping
  - Group chat mention-stripped body
- All pass: `npx vitest run src/auto-reply/liveness.test.ts`

## Files changed (7 files, +120 -7)

- `src/auto-reply/liveness.ts` — new module
- `src/auto-reply/liveness.test.ts` — new tests
- `src/auto-reply/reply/get-reply.ts` — integration before initSessionState
- `src/config/types.base.ts` — SessionConfig type
- `src/config/zod-schema.session.ts` — zod validation
- `src/config/schema.help.ts` — field help text
- `src/config/schema.labels.ts` — field label

Fixes #34506