### PR TITLE
fix(web): unwrap lastDisconnect error wrapper, flush creds before 515 restart

### DIFF
--- a/src/web/login-qr.test.ts
+++ b/src/web/login-qr.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { startWebLoginWithQr, waitForWebLogin } from "./login-qr.js";
-import { createWaSocket, logoutWeb, waitForWaConnection } from "./session.js";
+import {
+  createWaSocket,
+  logoutWeb,
+  waitForCredsSaveQueue,
+  waitForWaConnection,
+} from "./session.js";
 
 vi.mock("./session.js", () => {
   const createWaSocket = vi.fn(
@@ -17,8 +22,10 @@ vi.mock("./session.js", () => {
   const getStatusCode = vi.fn(
     (err: unknown) =>
       (err as { output?: { statusCode?: number } })?.output?.statusCode ??
+      (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode ??
       (err as { status?: number })?.status,
   );
+  const waitForCredsSaveQueue = vi.fn(async () => {});
   const webAuthExists = vi.fn(async () => false);
   const readWebSelfId = vi.fn(() => ({ e164: null, jid: null }));
   const logoutWeb = vi.fn(async () => true);
@@ -27,6 +34,7 @@ vi.mock("./session.js", () => {
     waitForWaConnection,
     formatError,
     getStatusCode,
+    waitForCredsSaveQueue,
     webAuthExists,
     readWebSelfId,
     logoutWeb,
@@ -39,6 +47,7 @@ vi.mock("./qr-image.js", () => ({
 
 const createWaSocketMock = vi.mocked(createWaSocket);
 const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
+const waitForCredsSaveQueueMock = vi.mocked(waitForCredsSaveQueue);
 const logoutWebMock = vi.mocked(logoutWeb);
 
 describe("login-qr", () => {
@@ -58,6 +67,24 @@ describe("login-qr", () => {
 
     expect(result.connected).toBe(true);
     expect(createWaSocketMock).toHaveBeenCalledTimes(2);
+    expect(waitForCredsSaveQueueMock).toHaveBeenCalledTimes(1);
     expect(logoutWebMock).not.toHaveBeenCalled();
+  });
+
+  it("restarts login on wrapped 515 error (Baileys v7 lastDisconnect shape)", async () => {
+    // Baileys v7 wraps the BoomError under .error in lastDisconnect,
+    // and waitForWaConnection rejects with the whole lastDisconnect object.
+    waitForWaConnectionMock
+      .mockRejectedValueOnce({ error: { output: { statusCode: 515 } }, date: new Date() })
+      .mockResolvedValueOnce(undefined);
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000 });
+    expect(start.qrDataUrl).toBe("data:image/png;base64,base64");
+
+    const result = await waitForWebLogin({ timeoutMs: 5000 });
+
+    expect(result.connected).toBe(true);
+    expect(createWaSocketMock).toHaveBeenCalledTimes(2);
+    expect(waitForCredsSaveQueueMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/web/login-qr.ts
+++ b/src/web/login-qr.ts
@@ -12,6 +12,7 @@ import {
   getStatusCode,
   logoutWeb,
   readWebSelfId,
+  waitForCredsSaveQueue,
   waitForWaConnection,
   webAuthExists,
 } from "./session.js";
@@ -88,6 +89,8 @@ async function restartLoginSocket(login: ActiveLogin, runtime: RuntimeEnv) {
     info("WhatsApp asked for a restart after pairing (code 515); retrying connection once…"),
   );
   closeSocket(login.sock);
+  // Flush any pending creds writes so the new socket reads up-to-date auth state.
+  await waitForCredsSaveQueue();
   try {
     const sock = await createWaSocket(false, login.verbose, {
       authDir: login.authDir,

--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetLogger, setLoggerOverride } from "../logging.js";
 import { baileys, getLastSocket, resetBaileysMocks, resetLoadConfigMock } from "./test-helpers.js";
 
-const { createWaSocket, formatError, logWebSelfId, waitForWaConnection } =
+const { createWaSocket, formatError, getStatusCode, logWebSelfId, waitForWaConnection } =
   await import("./session.js");
 const useMultiFileAuthStateMock = vi.mocked(baileys.useMultiFileAuthState);
 
@@ -151,6 +151,30 @@ describe("web session", () => {
     expect(formatError(err)).toContain("status=408");
     expect(formatError(err)).toContain("Request Time-out");
     expect(formatError(err)).toContain("QR refs attempts ended");
+  });
+
+  it("getStatusCode unwraps lastDisconnect .error wrapper (Baileys v7)", () => {
+    // waitForWaConnection rejects with the whole lastDisconnect object:
+    // { error: BoomError, date }. getStatusCode must reach into .error.
+    expect(getStatusCode({ error: { output: { statusCode: 515 } } })).toBe(515);
+    expect(getStatusCode({ error: { output: { statusCode: 408 } } })).toBe(408);
+  });
+
+  it("getStatusCode still works with a direct BoomError (backward compat)", () => {
+    expect(getStatusCode({ output: { statusCode: 401 } })).toBe(401);
+    expect(getStatusCode({ output: { statusCode: 515 } })).toBe(515);
+  });
+
+  it("getStatusCode falls back to .status (backward compat)", () => {
+    expect(getStatusCode({ status: 200 })).toBe(200);
+    expect(getStatusCode({ status: 503 })).toBe(503);
+  });
+
+  it("getStatusCode returns undefined for unrecognized shapes", () => {
+    expect(getStatusCode(null)).toBeUndefined();
+    expect(getStatusCode(undefined)).toBeUndefined();
+    expect(getStatusCode("string error")).toBeUndefined();
+    expect(getStatusCode({ message: "no code" })).toBeUndefined();
   });
 
   it("does not clobber creds backup when creds.json is corrupted", async () => {

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -32,6 +32,12 @@ export {
 } from "./auth-store.js";
 
 let credsSaveQueue: Promise<void> = Promise.resolve();
+
+/** Wait for any in-flight creds writes to complete before reading from disk. */
+export function waitForCredsSaveQueue(): Promise<void> {
+  return credsSaveQueue;
+}
+
 function enqueueSaveCreds(
   authDir: string,
   saveCreds: () => Promise<void> | void,
@@ -186,6 +192,9 @@ export async function waitForWaConnection(sock: ReturnType<typeof makeWASocket>)
 export function getStatusCode(err: unknown) {
   return (
     (err as { output?: { statusCode?: number } })?.output?.statusCode ??
+    // Baileys wraps BoomErrors under `.error` in lastDisconnect objects —
+    // unwrap so callers that pass the whole lastDisconnect still get the code.
+    (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode ??
     (err as { status?: number })?.status
   );
 }


### PR DESCRIPTION
## Summary

Fixes #33961 — WhatsApp QR pairing fails 100% on Baileys v7 because the 515 restart path is dead code.

Two root causes:

- **`getStatusCode` never unwraps `.error` wrapper**: `waitForWaConnection` rejects with the entire `lastDisconnect` object (`{ error: BoomError, date }`), not just `.error`. So `getStatusCode` receives `{ error: BoomError(515), date }` but only checks top-level `.output.statusCode` and `.status` — never finding the 515 code nested inside `.error.output.statusCode`. Added `.error?.output?.statusCode` as a fallback.

- **`restartLoginSocket` does not wait for creds flush**: On 515 restart, the old socket is closed and a new one is created immediately. But `credsSaveQueue` may still have pending writes. The new socket calls `useMultiFileAuthState` which reads from disk before those writes complete. Added `waitForCredsSaveQueue()` export and an `await` in the restart path.

## Changes

- `src/web/session.ts`: `getStatusCode` now checks `err.error?.output?.statusCode` before falling back to `.status`. New `waitForCredsSaveQueue()` export.
- `src/web/login-qr.ts`: `restartLoginSocket` awaits `waitForCredsSaveQueue()` after closing the old socket and before creating the new one.
- `src/web/session.test.ts`: 4 new tests for `getStatusCode` — wrapped error, direct BoomError, `.status` fallback, and unrecognized shapes.
- `src/web/login-qr.test.ts`: Updated mock to match new `getStatusCode` logic. Added test for Baileys v7 wrapped 515 error shape. Existing test now also verifies `waitForCredsSaveQueue` is called.

## Backward compatibility

- `getStatusCode` still works with direct BoomError objects (`.output.statusCode`) and plain `.status` — the `.error` unwrap is an additive fallback.
- `waitForCredsSaveQueue` resolves immediately when the queue is empty.

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] `pnpm test -- --run src/web/session.test.ts src/web/login-qr.test.ts` — 14/14 pass