### PR TITLE
test(config): add unit tests for agent-limits module

### DIFF
--- a/docs/zh-CN/start/onboarding-overview.md
+++ b/docs/zh-CN/start/onboarding-overview.md
@@ -1,0 +1,59 @@
+---
+summary: "OpenClaw 入门选项和流程概述"
+read_when:
+  - 选择入门路径
+  - 设置新环境
+title: "入门概述"
+sidebarTitle: "入门概述"
+---
+
+# 入门概述
+
+OpenClaw 支持多种入门路径，取决于 Gateway 的运行位置和你配置提供商的偏好。
+
+## 选择你的入门路径
+
+- **CLI 向导** 适用于 macOS、Linux 和 Windows（通过 WSL2）。
+- **macOS 应用** 适用于 Apple Silicon 或 Intel Mac 的引导式首次运行。
+
+## CLI 入门向导
+
+在终端中运行向导：
+
+```bash
+openclaw onboard
+```
+
+当你想要完全控制 Gateway、工作区、频道和技能时，使用 CLI 向导。文档：
+
+- [入门向导 (CLI)](/start/wizard)
+- [`openclaw onboard` 命令](/cli/onboard)
+
+## macOS 应用入门
+
+在 macOS 上想要完全引导式设置时，使用 OpenClaw 应用。文档：
+
+- [入门 (macOS 应用)](/start/onboarding)
+
+## 自定义提供商
+
+如果你需要一个未列出的端点，包括暴露标准 OpenAI 或 Anthropic API 的托管提供商，请在 CLI 向导中选择**自定义提供商**。你需要：
+
+- 选择 OpenAI 兼容、Anthropic 兼容或**未知**（自动检测）。
+- 输入 base URL 和 API 密钥（如果提供商需要）。
+- 提供模型 ID 和可选别名。
+- 选择端点 ID，以便多个自定义端点可以共存。
+
+## 远程 Gateway
+
+如果你已经在其他地方运行了 Gateway，可以使用远程模式将此机器配置为连接到该 Gateway。这不会在此主机上安装或修改任何内容。
+
+```bash
+openclaw onboard --mode remote --remote-url ws://host:18789
+```
+
+## 下一步
+
+- [CLI 向导](/start/wizard) - 完整的交互式设置指南
+- [macOS 应用入门](/start/onboarding) - 使用 macOS 应用进行设置
+- [快速开始](/start/getting-started) - 最短的从零到聊天路径

--- a/src/config/agent-limits.test.ts
+++ b/src/config/agent-limits.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_AGENT_MAX_CONCURRENT,
+  DEFAULT_SUBAGENT_MAX_CONCURRENT,
+  DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH,
+  resolveAgentMaxConcurrent,
+  resolveSubagentMaxConcurrent,
+} from "./agent-limits.js";
+import type { OpenClawConfig } from "./types.js";
+
+describe("agent-limits", () => {
+  describe("resolveAgentMaxConcurrent", () => {
+    it("returns default when config is undefined", () => {
+      expect(resolveAgentMaxConcurrent(undefined)).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+    });
+
+    it("returns default when config has no agents", () => {
+      const cfg: OpenClawConfig = {};
+      expect(resolveAgentMaxConcurrent(cfg)).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+    });
+
+    it("returns default when maxConcurrent is not set", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: {} },
+      };
+      expect(resolveAgentMaxConcurrent(cfg)).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+    });
+
+    it("returns configured value when valid", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { maxConcurrent: 8 } },
+      };
+      expect(resolveAgentMaxConcurrent(cfg)).toBe(8);
+    });
+
+    it("floors decimal values", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { maxConcurrent: 5.7 } },
+      };
+      expect(resolveAgentMaxConcurrent(cfg)).toBe(5);
+    });
+
+    it("returns 1 for values less than 1", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { maxConcurrent: 0 } },
+      };
+      expect(resolveAgentMaxConcurrent(cfg)).toBe(1);
+    });
+
+    it("returns 1 for negative values", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { maxConcurrent: -5 } },
+      };
+      expect(resolveAgentMaxConcurrent(cfg)).toBe(1);
+    });
+
+    it("returns default for NaN", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { maxConcurrent: NaN } },
+      };
+      expect(resolveAgentMaxConcurrent(cfg)).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+    });
+
+    it("returns default for Infinity", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { maxConcurrent: Infinity } },
+      };
+      expect(resolveAgentMaxConcurrent(cfg)).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+    });
+  });
+
+  describe("resolveSubagentMaxConcurrent", () => {
+    it("returns default when config is undefined", () => {
+      expect(resolveSubagentMaxConcurrent(undefined)).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
+    });
+
+    it("returns default when config has no subagents", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: {} },
+      };
+      expect(resolveSubagentMaxConcurrent(cfg)).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
+    });
+
+    it("returns configured value when valid", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { subagents: { maxConcurrent: 12 } } },
+      };
+      expect(resolveSubagentMaxConcurrent(cfg)).toBe(12);
+    });
+
+    it("floors decimal values", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { subagents: { maxConcurrent: 10.9 } } },
+      };
+      expect(resolveSubagentMaxConcurrent(cfg)).toBe(10);
+    });
+
+    it("returns 1 for values less than 1", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { subagents: { maxConcurrent: 0 } } },
+      };
+      expect(resolveSubagentMaxConcurrent(cfg)).toBe(1);
+    });
+
+    it("returns default for NaN", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { subagents: { maxConcurrent: NaN } } },
+      };
+      expect(resolveSubagentMaxConcurrent(cfg)).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
+    });
+  });
+
+  describe("constants", () => {
+    it("has expected default values", () => {
+      expect(DEFAULT_AGENT_MAX_CONCURRENT).toBe(4);
+      expect(DEFAULT_SUBAGENT_MAX_CONCURRENT).toBe(8);
+      expect(DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## What
Adds comprehensive unit tests for the agent-limits configuration module.

## Why
The agent-limits.ts module had no test coverage. This PR adds tests for:
- resolveAgentMaxConcurrent() - default values, valid configs, edge cases
- resolveSubagentMaxConcurrent() - default values, valid configs, edge cases
- Constants verification

## Test Coverage
- ✅ Undefined config handling
- ✅ Missing config properties
- ✅ Valid numeric values
- ✅ Decimal value flooring
- ✅ Minimum value enforcement (clamping to 1)
- ✅ NaN handling
- ✅ Infinity handling
- ✅ Negative value handling

## Notes
The tests follow the existing patterns in src/config/*.test.ts files and use the same testing framework (vitest).