### PR TITLE
fix(agents): mount bundled skills directory in sandbox containers

### DIFF
--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -48,6 +48,7 @@ export const DEFAULT_SANDBOX_BROWSER_NOVNC_PORT = 6080;
 export const DEFAULT_SANDBOX_BROWSER_AUTOSTART_TIMEOUT_MS = 12_000;
 
 export const SANDBOX_AGENT_WORKSPACE_MOUNT = "/agent";
+export const SANDBOX_BUNDLED_SKILLS_MOUNT = "/openclaw-bundled-skills";
 
 export const SANDBOX_STATE_DIR = path.join(STATE_DIR, "sandbox");
 export const SANDBOX_REGISTRY_PATH = path.join(SANDBOX_STATE_DIR, "containers.json");

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -163,8 +163,9 @@ export function execDockerRaw(
 
 import { formatCliCommand } from "../../cli/command-format.js";
 import { defaultRuntime } from "../../runtime.js";
+import { resolveBundledSkillsDir } from "../skills/bundled-dir.js";
 import { computeSandboxConfigHash } from "./config-hash.js";
-import { DEFAULT_SANDBOX_IMAGE } from "./constants.js";
+import { DEFAULT_SANDBOX_IMAGE, SANDBOX_BUNDLED_SKILLS_MOUNT } from "./constants.js";
 import { readRegistry, updateRegistry } from "./registry.js";
 import { resolveSandboxAgentId, resolveSandboxScopeKey, slugifySessionKey } from "./shared.js";
 import type { SandboxConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
@@ -460,6 +461,10 @@ async function createSandboxContainer(params: {
     workdir: cfg.workdir,
     workspaceAccess: params.workspaceAccess,
   });
+  const bundledSkillsDir = resolveBundledSkillsDir();
+  if (bundledSkillsDir) {
+    args.push("-v", `${bundledSkillsDir}:${SANDBOX_BUNDLED_SKILLS_MOUNT}:ro`);
+  }
   appendCustomBinds(args, cfg);
   args.push(cfg.image, "sleep", "infinity");
 

--- a/src/agents/sandbox/fs-paths.test.ts
+++ b/src/agents/sandbox/fs-paths.test.ts
@@ -122,4 +122,39 @@ describe("resolveSandboxFsPathWithMounts", () => {
     expect(resolved.hostPath).toBe(path.join(path.resolve("/tmp/override"), "docs", "AGENTS.md"));
     expect(resolved.writable).toBe(false);
   });
+
+  it("includes bundled skills dir as read-only mount when outside workspace", async () => {
+    const { resolveBundledSkillsDir } = await import("../skills/bundled-dir.js");
+    const bundledDir = resolveBundledSkillsDir();
+    if (!bundledDir) {
+      return;
+    }
+    const sandbox = createSandbox();
+    const mounts = buildSandboxFsMounts(sandbox);
+    const skillsMount = mounts.find((m) => m.source === "bundled-skills");
+    expect(skillsMount).toBeDefined();
+    expect(skillsMount!.hostRoot).toBe(path.resolve(bundledDir));
+    expect(skillsMount!.containerRoot).toBe("/openclaw-bundled-skills");
+    expect(skillsMount!.writable).toBe(false);
+  });
+
+  it("resolves bundled skills host path to container path via mount", async () => {
+    const { resolveBundledSkillsDir } = await import("../skills/bundled-dir.js");
+    const bundledDir = resolveBundledSkillsDir();
+    if (!bundledDir) {
+      return;
+    }
+    const sandbox = createSandbox();
+    const mounts = buildSandboxFsMounts(sandbox);
+    const skillFile = path.join(bundledDir, "skill-creator", "SKILL.md");
+    const resolved = resolveSandboxFsPathWithMounts({
+      filePath: skillFile,
+      cwd: sandbox.workspaceDir,
+      defaultWorkspaceRoot: sandbox.workspaceDir,
+      defaultContainerRoot: sandbox.containerWorkdir,
+      mounts,
+    });
+    expect(resolved.containerPath).toBe("/openclaw-bundled-skills/skill-creator/SKILL.md");
+    expect(resolved.writable).toBe(false);
+  });
 });

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
 import { resolveSandboxInputPath, resolveSandboxPath } from "../sandbox-paths.js";
+import { resolveBundledSkillsDir } from "../skills/bundled-dir.js";
 import { splitSandboxBindSpec } from "./bind-spec.js";
-import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
+import { SANDBOX_AGENT_WORKSPACE_MOUNT, SANDBOX_BUNDLED_SKILLS_MOUNT } from "./constants.js";
 import { resolveSandboxHostPathViaExistingAncestor } from "./host-paths.js";
 import { isPathInsideContainerRoot, normalizeContainerPath } from "./path-utils.js";
 import type { SandboxContext } from "./types.js";
@@ -10,7 +11,7 @@ export type SandboxFsMount = {
   hostRoot: string;
   containerRoot: string;
   writable: boolean;
-  source: "workspace" | "agent" | "bind";
+  source: "workspace" | "agent" | "bind" | "bundled-skills";
 };
 
 export type SandboxResolvedFsPath = {
@@ -90,6 +91,22 @@ export function buildSandboxFsMounts(sandbox: SandboxContext): SandboxFsMount[] 
       writable: parsed.writable,
       source: "bind",
     });
+  }
+
+  const bundledSkillsDir = resolveBundledSkillsDir();
+  if (bundledSkillsDir) {
+    const resolved = path.resolve(bundledSkillsDir);
+    const alreadyMounted = mounts.some(
+      (m) => resolved === m.hostRoot || resolved.startsWith(m.hostRoot + path.sep),
+    );
+    if (!alreadyMounted) {
+      mounts.push({
+        hostRoot: resolved,
+        containerRoot: SANDBOX_BUNDLED_SKILLS_MOUNT,
+        writable: false,
+        source: "bundled-skills",
+      });
+    }
   }
 
   return dedupeMounts(mounts);


### PR DESCRIPTION
## Summary

- Problem: Agents running in sandbox mode cannot access OpenClaw's pre-installed bundled skills (e.g. `skill-creator`). Reading skill files at paths like `~/.nvm/.../node_modules/openclaw/skills/skill-name/SKILL.md` fails with "Path escapes sandbox root" because the npm install directory is outside the sandbox workspace.
- Why it matters: Bundled skills are a core feature; sandbox users lose access to all pre-installed skills, degrading the agent experience significantly.
- What changed: The bundled skills directory (resolved via `resolveBundledSkillsDir()`) is now mounted read-only at `/openclaw-bundled-skills` inside the Docker container, and registered as a mount in `buildSandboxFsMounts` so the fs-bridge can resolve host paths to container paths.
- What did NOT change (scope boundary): Workspace skills, managed skills, and custom bind mounts are unchanged. The mount is only added when the bundled skills directory exists and is not already inside an existing mount.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34243

## User-visible / Behavior Changes

Agents in sandbox mode can now read and use bundled skills (e.g. `skill-creator`, `doc-coauthoring`) that are installed with the OpenClaw npm package.

## Security Impact (required)

- New permissions/capabilities? No — the mount is read-only and only exposes the pre-installed skills directory that agents already have access to outside sandbox mode.
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes — sandbox agents gain read-only access to the bundled skills directory. This is intentional and matches non-sandbox behavior.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (or any with Docker)
- Runtime: Node.js 22+

### Steps

1. Enable sandbox mode (`sandbox.mode = "all"`)
2. Configure an agent with default workspace
3. Trigger a scenario requiring bundled skills (e.g. invoke `/skill-creator`)
4. Agent attempts to read `SKILL.md` from the bundled skills path

### Expected

- Agent reads the skill file successfully

### Actual

- Before: `[tools] read failed: Path escapes sandbox root (~/.openclaw/workspace): /home/user/.nvm/.../openclaw/skills/skill-creator/SKILL.md`
- After: Skill file is read from `/openclaw-bundled-skills/skill-creator/SKILL.md` inside the container

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New tests in `fs-paths.test.ts`:
1. `includes bundled skills dir as read-only mount when outside workspace` — verifies the mount is added with correct host/container roots
2. `resolves bundled skills host path to container path via mount` — verifies end-to-end path resolution from host skill path to container path

## Human Verification (required)

- Verified scenarios: Sandbox with bundled skills outside workspace, path resolution for skill files, existing mounts unchanged
- Edge cases checked: Bundled skills dir already inside workspace (mount not duplicated), no bundled skills dir available (gracefully skipped)
- What you did **not** verify: Live Docker container with actual skill file reads

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No — existing sandbox containers will pick up the new mount on next recreation

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the mount additions in `fs-paths.ts`, `docker.ts`, and `constants.ts`
- Files/config to restore: `src/agents/sandbox/fs-paths.ts`, `src/agents/sandbox/docker.ts`, `src/agents/sandbox/constants.ts`

## Risks and Mitigations

- Risk: Additional Docker bind mount slightly increases container startup overhead
  - Mitigation: The mount is read-only and only added when the bundled skills directory exists; overhead is negligible