### PR TITLE
docs(zh-CN): add Chinese translation for wizard-cli-automation.md

### DIFF
--- a/docs/zh-CN/start/wizard-cli-automation.md
+++ b/docs/zh-CN/start/wizard-cli-automation.md
@@ -1,0 +1,211 @@
+---
+summary: "OpenClaw CLI 的脚本化入门和代理设置"
+read_when:
+  - 在脚本或 CI 中自动化入门
+  - 需要特定提供商的非交互式示例
+title: "CLI 自动化"
+sidebarTitle: "CLI 自动化"
+---
+
+# CLI 自动化
+
+使用 `--non-interactive` 来自动化 `openclaw onboard`。
+
+<Note>
+`--json` 不意味着非交互模式。对于脚本，请使用 `--non-interactive`（和 `--workspace`）。
+</Note>
+
+## 基准非交互式示例
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice apiKey \
+  --anthropic-api-key "$ANTHROPIC_API_KEY" \
+  --secret-input-mode plaintext \
+  --gateway-port 18789 \
+  --gateway-bind loopback \
+  --install-daemon \
+  --daemon-runtime node \
+  --skip-skills
+```
+
+添加 `--json` 以获取机器可读的摘要。
+
+使用 `--secret-input-mode ref` 将环境变量引用存储在 auth profiles 中，而不是明文值。
+在入门向导流程中，可以在环境变量引用和配置的 provider 引用（`file` 或 `exec`）之间进行交互式选择。
+
+在非交互式 `ref` 模式下，provider 环境变量必须在进程环境中设置。
+现在，如果没有匹配的环境变量，传递内联密钥标志会快速失败。
+
+示例：
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice openai-api-key \
+  --secret-input-mode ref \
+  --accept-risk
+```
+
+## 特定提供商示例
+
+<AccordionGroup>
+  <Accordion title="Gemini 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice gemini-api-key \
+      --gemini-api-key "$GEMINI_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  
+  <Accordion title="Z.AI 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice zai-api-key \
+      --zai-api-key "$ZAI_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  
+  <Accordion title="Vercel AI Gateway 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice ai-gateway-api-key \
+      --ai-gateway-api-key "$AI_GATEWAY_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  
+  <Accordion title="Cloudflare AI Gateway 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice cloudflare-ai-gateway-api-key \
+      --cloudflare-ai-gateway-account-id "your-account-id" \
+      --cloudflare-ai-gateway-gateway-id "your-gateway-id" \
+      --cloudflare-ai-gateway-api-key "$CLOUDFLARE_AI_GATEWAY_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  
+  <Accordion title="Moonshot 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice moonshot-api-key \
+      --moonshot-api-key "$MOONSHOT_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  
+  <Accordion title="Mistral 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice mistral-api-key \
+      --mistral-api-key "$MISTRAL_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  
+  <Accordion title="Synthetic 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice synthetic-api-key \
+      --synthetic-api-key "$SYNTHETIC_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  
+  <Accordion title="OpenCode Zen 示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice opencode-zen \
+      --opencode-zen-api-key "$OPENCODE_API_KEY" \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
+  
+  <Accordion title="自定义提供商示例">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice custom-api-key \
+      --custom-base-url "https://llm.example.com/v1" \
+      --custom-model-id "foo-large" \
+      --custom-api-key "$CUSTOM_API_KEY" \
+      --custom-provider-id "my-custom" \
+      --custom-compatibility anthropic \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+
+    `--custom-api-key` 是可选的。如果省略，入门程序会检查 `CUSTOM_API_KEY`。
+
+    Ref-mode 变体：
+
+    ```bash
+    export CUSTOM_API_KEY="your-key"
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice custom-api-key \
+      --custom-base-url "https://llm.example.com/v1" \
+      --custom-model-id "foo-large" \
+      --secret-input-mode ref \
+      --custom-provider-id "my-custom" \
+      --custom-compatibility anthropic \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+
+    在此模式下，入门程序将 `apiKey` 存储为 `{ source: "env", provider: "default", id: "CUSTOM_API_KEY" }`。
+
+  </Accordion>
+</AccordionGroup>
+
+## 添加另一个代理
+
+使用 `openclaw agents add <name>` 创建一个具有自己工作区、会话和 auth profiles 的独立代理。
+不带 `--workspace` 运行将启动向导。
+
+```bash
+openclaw agents add work \
+  --workspace ~/.openclaw/workspace-work \
+  --model openai/gpt-5.2 \
+  --bind whatsapp:biz \
+  --non-interactive \
+  --json
+```
+
+设置内容：
+
+- `agents.list[].name`
+- `agents.list[].workspace`
+- `agents.list[].agentDir`
+
+注意：
+
+- 默认工作区遵循 `~/.openclaw/workspace-<agentId>`。
+- 添加 `bindings` 来路由入站消息（向导可以执行此操作）。
+- 非交互式标志：`--model`、`--agent-dir`、`--bind`、`--non-interactive`。
+
+## 相关文档
+
+- 入门中心：[入门向导 (CLI)](/start/wizard)
+- 完整参考：[CLI 入门参考](/start/wizard-cli-reference)
+- 命令参考：[`openclaw onboard`](/cli/onboard)


### PR DESCRIPTION
## What
Adds the missing Chinese translation for the CLI automation documentation page.

## Why
The Chinese documentation was missing this file compared to the English version:
- docs/start/wizard-cli-automation.md exists
- docs/zh-CN/start/wizard-cli-automation.md was missing

## Changes
- Full translation of the CLI automation guide
- Preserved all code blocks and CLI flags
- Preserved provider names and technical terms
- Kept UI component tags (Accordion, Note, etc.)

## Content
- Non-interactive onboarding basics
- Provider-specific examples (Gemini, Z.AI, Vercel, Cloudflare, Moonshot, Mistral, Synthetic, OpenCode Zen, Custom)
- Adding additional agents
- Related documentation links