### PR TITLE
fix(discord): only inject thread starter for new thread sessions

### DIFF
--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -453,6 +453,24 @@ describe("processDiscordMessage session routing", () => {
       accountId: "default",
     });
   });
+
+  it("does not re-inject ThreadStarterBody for existing thread sessions", async () => {
+    readSessionUpdatedAt.mockReturnValue(Date.now());
+
+    const ctx = await createBaseContext({
+      messageChannelId: "t-existing",
+      threadChannel: { id: "t-existing", name: "my-thread" },
+      threadParentId: "c1",
+      threadParentType: "GUILD_TEXT",
+      route: BASE_CHANNEL_ROUTE,
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    const dispatchCtx = getLastDispatchCtx();
+    expect(dispatchCtx?.ThreadStarterBody).toBeUndefined();
+  });
 });
 
 describe("processDiscordMessage draft streaming", () => {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -281,6 +281,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   let threadStarterBody: string | undefined;
   let threadLabel: string | undefined;
   let parentSessionKey: string | undefined;
+  let threadSessionPreviousTimestamp: number | undefined;
   if (threadChannel) {
     const includeThreadStarter = channelConfig?.includeThreadStarter !== false;
     if (includeThreadStarter) {
@@ -292,7 +293,6 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         resolveTimestampMs,
       });
       if (starter?.text) {
-        // Keep thread starter as raw text; metadata is provided out-of-band in the system prompt.
         threadStarterBody = starter.text;
       }
     }
@@ -315,6 +315,12 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     parentSessionKey,
     useSuffix: false,
   });
+  if (threadChannel && threadStarterBody) {
+    threadSessionPreviousTimestamp = readSessionUpdatedAt({
+      storePath,
+      sessionKey: threadKeys.sessionKey,
+    });
+  }
   const replyPlan = await resolveDiscordAutoThreadReplyPlan({
     client,
     message,
@@ -385,7 +391,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     ReplyToSender: replyContext?.sender,
     ParentSessionKey: autoThreadContext?.ParentSessionKey ?? threadKeys.parentSessionKey,
     MessageThreadId: threadChannel?.id ?? autoThreadContext?.createdThreadId ?? undefined,
-    ThreadStarterBody: threadStarterBody,
+    ThreadStarterBody: !threadSessionPreviousTimestamp ? threadStarterBody : undefined,
     ThreadLabel: threadLabel,
     Timestamp: resolveTimestampMs(message.timestamp),
     ...mediaPayload,


### PR DESCRIPTION
## Summary

- Problem: Discord thread sessions are silently reset on every new message because the thread starter message is re-injected as a new user message each time, causing transcript rotation and context loss.
- Why it matters: Thread conversations lose all prior context repeatedly — a thread session created at 09:12 was reset 5 times within 30 minutes of active use with no user-initiated resets.
- What changed: Added a `readSessionUpdatedAt` check for the thread session key before injecting `ThreadStarterBody`. When the thread session already exists (has a previous timestamp), `ThreadStarterBody` is set to `undefined`, matching Slack's implementation in `prepare-thread-context.ts`.
- What did NOT change (scope boundary): First-time thread session creation still includes the thread starter. Non-thread Discord messages are unchanged. Thread label and parent session key are still set on every message.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34228

## User-visible / Behavior Changes

Discord thread conversations now retain context across messages. The thread starter is injected only once (on first message) rather than on every message.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+

### Steps

1. Create a Discord thread from a channel message
2. Chat in the thread (agent responds normally)
3. Send another message in the thread
4. Check session transcript for duplicate thread starter injection

### Expected

- Thread starter injected once on first message only

### Actual

- Before: Thread starter re-injected on every message, causing session reset
- After: Thread starter injected only for new thread sessions

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test: `does not re-inject ThreadStarterBody for existing thread sessions` — mocks `readSessionUpdatedAt` to return a timestamp and verifies `ThreadStarterBody` is undefined in the dispatch context.

## Human Verification (required)

- Verified scenarios: New thread session (starter injected), existing thread session (starter not re-injected), bound thread sessions, non-thread messages
- Edge cases checked: Thread with no starter text, thread with `includeThreadStarter: false` config
- What you did **not** verify: Live Discord bot with real thread conversations across idle timeout boundaries

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the conditional check in `message-handler.process.ts` — change `!threadSessionPreviousTimestamp ? threadStarterBody : undefined` back to `threadStarterBody`
- Files/config to restore: `src/discord/monitor/message-handler.process.ts`

## Risks and Mitigations

- Risk: Edge case where session store is cleared but thread is still active — thread starter won't be re-injected
  - Mitigation: This matches Slack behavior and is acceptable; the agent still has access to prior transcript context