### PR TITLE
fix(gateway): enable delivery for inter-session messages to bound channels

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -597,4 +597,52 @@ describe("gateway agent handler", () => {
       }),
     );
   });
+
+  it("enables delivery for inter-session messages when target session has a bound channel", async () => {
+    mockMainSessionEntry({
+      sessionId: "existing-session-id",
+      lastChannel: "telegram",
+      lastTo: "telegram:6812765697",
+      lastAccountId: "default",
+    });
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": buildExistingMainStoreEntry({
+          lastChannel: "telegram",
+          lastTo: "telegram:6812765697",
+          lastAccountId: "default",
+        }),
+      };
+      return await updater(store);
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "inter-session message",
+        sessionKey: "agent:main:main",
+        deliver: false,
+        channel: "webchat",
+        idempotencyKey: "test-inter-session-delivery",
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:main:other-session",
+          sourceChannel: "webchat",
+          sourceTool: "sessions_send",
+        },
+      },
+      { reqId: "inter-session-1" },
+    );
+
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+      deliver?: boolean;
+    };
+    expect(callArgs.channel).toBe("telegram");
+    expect(callArgs.deliver).toBe(true);
+  });
 });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -497,7 +497,17 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    const wantsDelivery = request.deliver === true;
+    const interSessionHasBoundChannel =
+      !request.deliver &&
+      inputProvenance?.kind === "inter_session" &&
+      sessionEntry != null &&
+      isDeliverableMessageChannel(sessionEntry.lastChannel) &&
+      typeof sessionEntry.lastTo === "string" &&
+      sessionEntry.lastTo.trim().length > 0;
+    const wantsDelivery = request.deliver === true || interSessionHasBoundChannel;
+    const effectiveChannel = interSessionHasBoundChannel
+      ? "last"
+      : (request.replyChannel ?? request.channel);
     const explicitTo =
       typeof request.replyTo === "string" && request.replyTo.trim()
         ? request.replyTo.trim()
@@ -520,7 +530,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         : undefined;
     const deliveryPlan = resolveAgentDeliveryPlan({
       sessionEntry,
-      requestedChannel: request.replyChannel ?? request.channel,
+      requestedChannel: effectiveChannel,
       explicitTo,
       explicitThreadId,
       accountId: request.replyAccountId ?? request.accountId,
@@ -591,7 +601,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         ? INTERNAL_MESSAGE_CHANNEL
         : resolvedChannel);
 
-    const deliver = request.deliver === true && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
+    const deliver = wantsDelivery && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
 
     const accepted = {
       runId,


### PR DESCRIPTION
## Summary

- Problem: Agent responses triggered by `sessions_send` (inter-session communication) are stored in the target session's transcript but never delivered to the bound external channel (e.g. Telegram). This makes multi-agent collaboration completely non-functional for external-channel-bound sessions.
- Why it matters: Any workflow using `sessions_send` to coordinate multiple agents across Telegram/Discord/Slack sessions silently drops all responses — users never see the agent's reply.
- What changed: In the gateway `agent` method, when `inputProvenance.kind === "inter_session"` and the target session has a deliverable `lastChannel` + `lastTo`, `wantsDelivery` is set to `true` and the channel is overridden to `"last"` so `resolveAgentDeliveryPlan` resolves to the session's bound channel. The `deliver` flag now uses `wantsDelivery` instead of `request.deliver` directly.
- What did NOT change (scope boundary): Regular `sessions_send` to sessions without a bound channel continues to work as before (no delivery). Channel-originated messages are unaffected. The `sessions_send` tool itself is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34308

## User-visible / Behavior Changes

Agent responses to inter-session messages (`sessions_send`) are now delivered to the target session's bound Telegram/Discord/Slack channel, just like responses to direct channel messages.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — inter-session responses now trigger outbound delivery to the bound channel, same as regular channel responses
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+

### Steps

1. Set up two agents (A and B), with B's session bound to a Telegram channel
2. Have agent A send a message to agent B via `sessions_send`
3. Agent B processes and generates a response
4. Check Telegram for agent B's response

### Expected

- Agent B's response is delivered to the bound Telegram channel

### Actual

- Before: Response stored in session transcript only, not delivered to Telegram
- After: Response delivered to bound Telegram channel via delivery-mirror

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test: `enables delivery for inter-session messages when target session has a bound channel` — verifies that when `inputProvenance.kind === "inter_session"`, `deliver: false`, but `lastChannel: "telegram"` and `lastTo` are set, the agent command receives `deliver: true` and `channel: "telegram"`.

## Human Verification (required)

- Verified scenarios: Inter-session message to Telegram-bound session (delivery enabled), inter-session message to session without bound channel (no change), regular deliver=true requests (unchanged), webchat-only sessions (unchanged)
- Edge cases checked: Session with lastChannel but no lastTo (delivery not enabled), non-deliverable channels (webchat)
- What you did **not** verify: Live multi-agent flow with real Telegram delivery

## Compatibility / Migration

- Backward compatible? Yes — only adds delivery where it was missing; existing behavior for all other paths is preserved
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the `interSessionHasBoundChannel` check and restore `request.deliver === true` in both `wantsDelivery` and `deliver` lines
- Files/config to restore: `src/gateway/server-methods/agent.ts`

## Risks and Mitigations

- Risk: Unexpected delivery to external channels for sessions that previously had a bound channel but the user has since moved on
  - Mitigation: Only triggers for `inter_session` provenance; normal webchat and CLI flows are unaffected. The check requires both `lastChannel` and `lastTo` to be valid.