### PR TITLE
fix(sandbox): mount bundled skills dir read-only so agents can read SKILL.md

### DIFF
--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -49,6 +49,9 @@ export const DEFAULT_SANDBOX_BROWSER_AUTOSTART_TIMEOUT_MS = 12_000;
 
 export const SANDBOX_AGENT_WORKSPACE_MOUNT = "/agent";
 
+/** Read-only mount point for bundled (npm-installed) skills inside the sandbox container. */
+export const SANDBOX_BUNDLED_SKILLS_MOUNT = "/openclaw-bundled-skills";
+
 export const SANDBOX_STATE_DIR = path.join(STATE_DIR, "sandbox");
 export const SANDBOX_REGISTRY_PATH = path.join(SANDBOX_STATE_DIR, "containers.json");
 export const SANDBOX_BROWSER_REGISTRY_PATH = path.join(SANDBOX_STATE_DIR, "browsers.json");

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -163,13 +163,14 @@ export function execDockerRaw(
 
 import { formatCliCommand } from "../../cli/command-format.js";
 import { defaultRuntime } from "../../runtime.js";
+import { resolveBundledSkillsDir } from "../skills/bundled-dir.js";
 import { computeSandboxConfigHash } from "./config-hash.js";
 import { DEFAULT_SANDBOX_IMAGE } from "./constants.js";
 import { readRegistry, updateRegistry } from "./registry.js";
 import { resolveSandboxAgentId, resolveSandboxScopeKey, slugifySessionKey } from "./shared.js";
 import type { SandboxConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
 import { validateSandboxSecurity } from "./validate-sandbox-security.js";
-import { appendWorkspaceMountArgs } from "./workspace-mounts.js";
+import { appendBundledSkillsMountArgs, appendWorkspaceMountArgs } from "./workspace-mounts.js";
 
 const log = createSubsystemLogger("docker");
 
@@ -460,6 +461,10 @@ async function createSandboxContainer(params: {
     workdir: cfg.workdir,
     workspaceAccess: params.workspaceAccess,
   });
+  const bundledSkillsDir = resolveBundledSkillsDir();
+  if (bundledSkillsDir) {
+    appendBundledSkillsMountArgs({ args, bundledSkillsDir });
+  }
   appendCustomBinds(args, cfg);
   args.push(cfg.image, "sleep", "infinity");
 

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
 import { resolveSandboxInputPath, resolveSandboxPath } from "../sandbox-paths.js";
+import { resolveBundledSkillsDir } from "../skills/bundled-dir.js";
 import { splitSandboxBindSpec } from "./bind-spec.js";
-import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
+import { SANDBOX_AGENT_WORKSPACE_MOUNT, SANDBOX_BUNDLED_SKILLS_MOUNT } from "./constants.js";
 import { resolveSandboxHostPathViaExistingAncestor } from "./host-paths.js";
 import { isPathInsideContainerRoot, normalizeContainerPath } from "./path-utils.js";
 import type { SandboxContext } from "./types.js";
@@ -88,6 +89,19 @@ export function buildSandboxFsMounts(sandbox: SandboxContext): SandboxFsMount[] 
       hostRoot: parsed.hostRoot,
       containerRoot: parsed.containerRoot,
       writable: parsed.writable,
+      source: "bind",
+    });
+  }
+
+  // Automatically expose the bundled skills directory so agents running inside
+  // the sandbox can read SKILL.md files referenced in the system prompt.
+  // The docker container is created with a matching read-only bind mount.
+  const bundledSkillsDir = resolveBundledSkillsDir();
+  if (bundledSkillsDir) {
+    mounts.push({
+      hostRoot: path.resolve(bundledSkillsDir),
+      containerRoot: SANDBOX_BUNDLED_SKILLS_MOUNT,
+      writable: false,
       source: "bind",
     });
   }

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -1,4 +1,4 @@
-import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
+import { SANDBOX_AGENT_WORKSPACE_MOUNT, SANDBOX_BUNDLED_SKILLS_MOUNT } from "./constants.js";
 import type { SandboxWorkspaceAccess } from "./types.js";
 
 function mainWorkspaceMountSuffix(access: SandboxWorkspaceAccess): "" | ":ro" {
@@ -25,4 +25,14 @@ export function appendWorkspaceMountArgs(params: {
       `${agentWorkspaceDir}:${SANDBOX_AGENT_WORKSPACE_MOUNT}${agentWorkspaceMountSuffix(workspaceAccess)}`,
     );
   }
+}
+
+/**
+ * Mount the bundled skills directory into the container as a read-only bind so that
+ * sandboxed agents can read `SKILL.md` files that are referenced in the system prompt.
+ * Without this, every skill invocation fails with "Path escapes sandbox root" because
+ * the skills live in the npm-installed package directory, not in the workspace.
+ */
+export function appendBundledSkillsMountArgs(params: { args: string[]; bundledSkillsDir: string }) {
+  params.args.push("-v", `${params.bundledSkillsDir}:${SANDBOX_BUNDLED_SKILLS_MOUNT}:ro`);
 }


### PR DESCRIPTION
## Problem

When `agents.defaults.sandbox.mode` is set to `"all"` or `"non-main"`, the system prompt instructs the agent to `read` SKILL.md files at their install-time location (e.g. `/opt/homebrew/lib/node_modules/openclaw/skills/` or `~/.nvm/versions/node/v22.x/lib/node_modules/openclaw/skills/`).

Because the Docker sandbox only mounts the workspace directory (`~/.openclaw/workspace`), every such read fails:

```
[tools] read failed: Path escapes sandbox root (~/.openclaw/workspace):
/home/user/.nvm/versions/node/v22.22.0/lib/node_modules/openclaw/skills/skill-creator/SKILL.md
```

This makes **all bundled skills unusable in sandbox mode**, even though the skills themselves are trusted, read-only system files.

## Root Cause

`buildSandboxFsMounts` (used by the sandbox fs-bridge for host↔container path translation) and the Docker container-creation code only register the workspace and agent-workspace mounts. The bundled skills directory is never exposed inside the container, so any path inside it is rejected as an escape attempt.

## Fix

1. **`constants.ts`** — add `SANDBOX_BUNDLED_SKILLS_MOUNT = "/openclaw-bundled-skills"`
2. **`workspace-mounts.ts`** — add `appendBundledSkillsMountArgs()` that appends `-v <hostSkillsDir>:/openclaw-bundled-skills:ro` to the Docker args
3. **`docker.ts`** — call `appendBundledSkillsMountArgs()` after workspace mounts when creating the container (skipped if `resolveBundledSkillsDir()` returns `undefined` — e.g. bun compile without a sibling `skills/` dir)
4. **`fs-paths.ts`** — push the same path into `buildSandboxFsMounts()` so the in-memory mount table can translate the host skill paths to their `/openclaw-bundled-skills/...` container equivalents

The existing path-escape guard is preserved — the skills directory is now a known, explicitly-registered mount rather than an unchecked bypass.

## Testing

```
pnpm vitest run src/agents/sandbox/
# 99 tests pass
```

Fixes #34243