### PR TITLE
fix(discovery): guard tailscale JSON.parse against malformed output

### DIFF
--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -11,10 +11,14 @@ function parsePossiblyNoisyJsonObject(stdout: string): Record<string, unknown> {
   const trimmed = stdout.trim();
   const start = trimmed.indexOf("{");
   const end = trimmed.lastIndexOf("}");
-  if (start >= 0 && end > start) {
-    return JSON.parse(trimmed.slice(start, end + 1)) as Record<string, unknown>;
+  if (start === -1 || end <= start) {
+    return {};
   }
-  return JSON.parse(trimmed) as Record<string, unknown>;
+  try {
+    return JSON.parse(trimmed.slice(start, end + 1)) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
 }
 
 /**


### PR DESCRIPTION
**Problem:** `parseTailscaleStatusIPv4s` in `bonjour-discovery.ts` calls `JSON.parse(stdout)` without a try/catch. If `tailscale status --json` returns truncated or garbled output (timeout, pipe break, etc.), this throws an unhandled exception that crashes the entire discovery flow.

**Fix:** Wrap in try/catch and return `[]` on parse failure — matching the defensive style used in `json-files.ts` and other parsers.

**Impact:** Prevents discovery crashes on flaky Tailscale CLI output. Zero behavior change on valid JSON.