### PR TITLE
fix(agents): prevent /v1beta duplication in Gemini PDF URL

### DIFF
--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -137,10 +137,9 @@ export async function geminiAnalyzePdf(params: {
   }
   parts.push({ text: params.prompt });
 
-  const baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com").replace(
-    /\/+$/,
-    "",
-  );
+  const baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com")
+    .replace(/\/+$/, "")
+    .replace(/\/v1beta$/, "");
   const url = `${baseUrl}/v1beta/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 
   const res = await fetch(url, {

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -711,6 +711,26 @@ describe("native PDF provider API calls", () => {
       "apiKey required",
     );
   });
+
+  it("geminiAnalyzePdf does not duplicate /v1beta when baseUrl already includes it", async () => {
+    const { geminiAnalyzePdf } = await import("./pdf-native-providers.js");
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      }),
+    });
+
+    await geminiAnalyzePdf(
+      makeGeminiAnalyzeParams({
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      }),
+    );
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("/v1beta/models/");
+    expect(url).not.toContain("/v1beta/v1beta");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Strip trailing `/v1beta` from `baseUrl` in `geminiAnalyzePdf` before appending the version segment, preventing `/v1beta/v1beta/models/…` URLs that cause 404 errors from the Gemini API.
- Add regression test asserting no `/v1beta` duplication when `baseUrl` already includes the version prefix.

Closes #34312

## Test plan

- [x] Existing 50 PDF tool tests pass
- [x] New regression test: `geminiAnalyzePdf does not duplicate /v1beta when baseUrl already includes it`
- [ ] Manual: configure `pdfModel` as `google/gemini-3.1-pro-preview` with a baseUrl ending in `/v1beta`, invoke PDF tool via subagent path, verify 200 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)