### PR TITLE
fix(discord): fall back to DM when channel:ID yields Unknown Channel

### DIFF
--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -24,6 +24,8 @@ import {
   createDiscordClient,
   normalizeDiscordPollInput,
   normalizeStickerIds,
+  DISCORD_UNKNOWN_CHANNEL,
+  getDiscordErrorCode,
   parseAndResolveRecipient,
   resolveChannelId,
   resolveDiscordChannelType,
@@ -262,12 +264,11 @@ export async function sendMessageDiscord(
     );
   }
 
-  let result: { id: string; channel_id: string } | { id: string | null; channel_id: string };
-  try {
+  const sendToChannel = async (targetChannelId: string) => {
     if (opts.mediaUrl) {
-      result = await sendDiscordMedia(
+      return sendDiscordMedia(
         rest,
-        channelId,
+        targetChannelId,
         textWithMentions,
         opts.mediaUrl,
         opts.mediaLocalRoots,
@@ -279,21 +280,50 @@ export async function sendMessageDiscord(
         chunkMode,
         opts.silent,
       );
-    } else {
-      result = await sendDiscordText(
-        rest,
-        channelId,
-        textWithMentions,
-        opts.replyTo,
-        request,
-        accountInfo.config.maxLinesPerMessage,
-        opts.components,
-        opts.embeds,
-        chunkMode,
-        opts.silent,
-      );
     }
+    return sendDiscordText(
+      rest,
+      targetChannelId,
+      textWithMentions,
+      opts.replyTo,
+      request,
+      accountInfo.config.maxLinesPerMessage,
+      opts.components,
+      opts.embeds,
+      chunkMode,
+      opts.silent,
+    );
+  };
+
+  let result: { id: string; channel_id: string } | { id: string | null; channel_id: string };
+  try {
+    result = await sendToChannel(channelId);
   } catch (err) {
+    if (recipient.kind === "channel" && getDiscordErrorCode(err) === DISCORD_UNKNOWN_CHANNEL) {
+      const dmFallback = await resolveChannelId(
+        rest,
+        { kind: "user", id: recipient.id },
+        request,
+      ).catch(() => null);
+      if (dmFallback?.channelId) {
+        try {
+          result = await sendToChannel(dmFallback.channelId);
+        } catch (retryErr) {
+          throw await buildDiscordSendError(retryErr, {
+            channelId: dmFallback.channelId,
+            rest,
+            token,
+            hasMedia: Boolean(opts.mediaUrl),
+          });
+        }
+        recordChannelActivity({
+          channel: "discord",
+          accountId: accountInfo.accountId,
+          direction: "outbound",
+        });
+        return toDiscordSendResult(result, dmFallback.channelId);
+      }
+    }
     throw await buildDiscordSendError(err, {
       channelId,
       rest,

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -307,6 +307,9 @@ export async function sendMessageDiscord(
       ).catch(() => null);
       if (dmFallback?.channelId) {
         try {
+          // replyTo is intentionally not cleared: the original message ID is invalid
+          // in a DM context, but fail_if_not_exists: false ensures Discord silently
+          // ignores the stale reference rather than erroring.
           result = await sendToChannel(dmFallback.channelId);
         } catch (retryErr) {
           throw await buildDiscordSendError(retryErr, {

--- a/src/discord/send.sends-basic-channel-messages.test.ts
+++ b/src/discord/send.sends-basic-channel-messages.test.ts
@@ -324,6 +324,28 @@ describe("sendMessageDiscord", () => {
     expectReplyReference(firstBody, "orig-123");
     expectReplyReference(secondBody, "orig-123");
   });
+
+  it("falls back to DM when channel:ID yields Unknown Channel (10003)", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });
+    postMock
+      .mockRejectedValueOnce({ code: 10003, message: "Unknown Channel" })
+      .mockResolvedValueOnce({ id: "dm-chan-1" })
+      .mockResolvedValueOnce({ id: "dm-msg-1", channel_id: "dm-chan-1" });
+
+    const res = await sendMessageDiscord("channel:123456", "hi from DM fallback", {
+      rest,
+      token: "t",
+    });
+
+    expect(res).toEqual({ messageId: "dm-msg-1", channelId: "dm-chan-1" });
+    expect(postMock).toHaveBeenCalledTimes(3);
+    expect(postMock.mock.calls[1]?.[0]).toBe(Routes.userChannels());
+    expect(postMock.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({ body: { recipient_id: "123456" } }),
+    );
+    expect(postMock.mock.calls[2]?.[0]).toBe(Routes.channelMessages("dm-chan-1"));
+  });
 });
 
 describe("reactMessageDiscord", () => {

--- a/src/discord/send.sends-basic-channel-messages.test.ts
+++ b/src/discord/send.sends-basic-channel-messages.test.ts
@@ -346,6 +346,44 @@ describe("sendMessageDiscord", () => {
     );
     expect(postMock.mock.calls[2]?.[0]).toBe(Routes.channelMessages("dm-chan-1"));
   });
+
+  it("propagates original error when DM channel creation also fails (10003)", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });
+    postMock
+      .mockRejectedValueOnce({ code: 10003, message: "Unknown Channel" })
+      .mockRejectedValueOnce(new Error("DM creation failed"));
+
+    await expect(
+      sendMessageDiscord("channel:123456", "hi", { rest, token: "t" }),
+    ).rejects.toMatchObject({ code: 10003 });
+  });
+
+  it("does not attempt DM fallback for non-10003 errors", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock
+      .mockResolvedValueOnce({ type: ChannelType.GuildText })
+      .mockResolvedValueOnce({
+        id: "789",
+        guild_id: "guild1",
+        type: 0,
+        permission_overwrites: [],
+      })
+      .mockResolvedValueOnce({ id: "bot1" })
+      .mockResolvedValueOnce({
+        id: "guild1",
+        roles: [{ id: "guild1", permissions: "0" }],
+      })
+      .mockResolvedValueOnce({ roles: [] });
+    postMock.mockRejectedValueOnce(
+      Object.assign(new Error("Missing Permissions"), { code: 50013, status: 403 }),
+    );
+
+    await expect(sendMessageDiscord("channel:789", "hello", { rest, token: "t" })).rejects.toThrow(
+      /missing permissions/i,
+    );
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("reactMessageDiscord", () => {

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -28,6 +28,7 @@ const DISCORD_POLL_MAX_ANSWERS = 10;
 const DISCORD_POLL_MAX_DURATION_HOURS = 32 * 24;
 const DISCORD_MISSING_PERMISSIONS = 50013;
 const DISCORD_CANNOT_DM = 50007;
+const DISCORD_UNKNOWN_CHANNEL = 10003;
 
 type DiscordRequest = RetryRunner;
 
@@ -492,6 +493,8 @@ export {
   buildDiscordSendError,
   buildReactionIdentifier,
   createDiscordClient,
+  DISCORD_UNKNOWN_CHANNEL,
+  getDiscordErrorCode,
   formatReactionEmoji,
   normalizeDiscordPollInput,
   normalizeEmojiName,


### PR DESCRIPTION
## Summary

- Problem: When a Discord DM user ID is stored as `channel:<numeric-id>` (e.g. via media delivery or session persistence), sending a message to that ID fails with Discord error 10003 (Unknown Channel), because the numeric user ID is not a valid channel ID.
- Why it matters: Media messages, replies, and inter-session sends to Discord DM users silently fail with "Unknown Channel", breaking agent-to-user communication.
- What changed: `sendMessageDiscord` now catches 10003 errors for `channel:` recipients, re-resolves the same ID as a DM user channel, and retries the send transparently.
- What did NOT change (scope boundary): `parseAndResolveRecipient`, `resolveChannelId`, and the target normalization pipeline are untouched. Only the error-recovery path in `sendMessageDiscord` is new.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33978

## User-visible / Behavior Changes

Messages that previously failed silently with "Unknown Channel" when sent to a Discord DM user via a `channel:<userId>` route now succeed by transparently creating a DM channel and retrying.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — on 10003 error, one additional `POST /users/@me/channels` call is made to create/fetch a DM channel, followed by a retry of the original message send.
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure a Discord agent session where a DM user's numeric ID is persisted as `channel:<userId>` in the delivery context.
2. Send a media message (or any message) targeting that recipient.
3. Observe the send result.

### Expected

- Message is delivered to the user's DM channel.

### Actual

- Before: `DiscordAPIError[10003]: Unknown Channel` — message silently dropped.
- After: Agent catches 10003 for `channel:` recipients, creates a DM channel, retries, and message is delivered.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test: "falls back to DM when channel:ID yields Unknown Channel (10003)" — mocks 10003 on first send, verifies DM channel creation and successful retry.

## Human Verification (required)

- Verified scenarios: Text message to `channel:<userId>` that yields 10003 → DM fallback succeeds. Media message follows the same `sendToChannel` helper path.
- Edge cases checked: DM channel creation itself fails → original error propagated. Non-10003 errors → no fallback attempted. `user:` recipients (already correct) → no change in behavior.
- What you did **not** verify: Live Discord API integration (only unit-tested with mocked REST client).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit. The original error-throwing behavior is restored.
- Files/config to restore: `src/discord/send.outbound.ts`, `src/discord/send.shared.ts`

## Risks and Mitigations

- Risk: False-positive DM fallback — a legitimate channel ID that happens to be deleted could trigger a DM to an unrelated user with the same numeric ID.
  - Mitigation: This scenario requires an exact ID collision between a deleted channel and an existing user, which is astronomically unlikely given Discord's snowflake ID scheme. Additionally, the fallback only activates for `channel:` recipients, not `user:` recipients.