### PR TITLE
telegram: trace streamed reply delivery + skip non-final draft fallback send

### DIFF
--- a/apps/android/app/src/debug/res/xml/network_security_config.xml
+++ b/apps/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+  <!-- Debug/dev: allow cleartext for local + tailnet endpoints. -->
+  <base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration" />
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">openclaw.local</domain>
+  </domain-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">ts.net</domain>
+  </domain-config>
+</network-security-config>

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
 
     <application
         android:name=".NodeApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -171,6 +171,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     runtime.handleCanvasA2UIActionFromWebView(payloadJson)
   }
 
+  fun onCanvasPageFinished(url: String?) {
+    runtime.onCanvasPageFinished(url)
+  }
+
   fun requestCanvasRehydrate(source: String = "screen_tab") {
     runtime.requestCanvasRehydrate(source = source, force = true)
   }

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -69,6 +69,11 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val gatewayToken: StateFlow<String> = runtime.gatewayToken
   val onboardingCompleted: StateFlow<Boolean> = runtime.onboardingCompleted
   val canvasDebugStatusEnabled: StateFlow<Boolean> = runtime.canvasDebugStatusEnabled
+  val backgroundBatteryHistoryEnabled: StateFlow<Boolean> = runtime.backgroundBatteryHistoryEnabled
+  val backgroundLocationHistoryEnabled: StateFlow<Boolean> = runtime.backgroundLocationHistoryEnabled
+  val telemetrySyncEnabled: StateFlow<Boolean> = runtime.telemetrySyncEnabled
+  val telemetrySamplingMode: StateFlow<TelemetrySamplingMode> = runtime.telemetrySamplingMode
+  val telemetryRetention: StateFlow<TelemetryRetention> = runtime.telemetryRetention
 
   val chatSessionKey: StateFlow<String> = runtime.chatSessionKey
   val chatSessionId: StateFlow<String?> = runtime.chatSessionId
@@ -137,6 +142,26 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {
     runtime.setCanvasDebugStatusEnabled(value)
+  }
+
+  fun setBackgroundBatteryHistoryEnabled(value: Boolean) {
+    runtime.setBackgroundBatteryHistoryEnabled(value)
+  }
+
+  fun setBackgroundLocationHistoryEnabled(value: Boolean) {
+    runtime.setBackgroundLocationHistoryEnabled(value)
+  }
+
+  fun setTelemetrySyncEnabled(value: Boolean) {
+    runtime.setTelemetrySyncEnabled(value)
+  }
+
+  fun setTelemetrySamplingMode(mode: TelemetrySamplingMode) {
+    runtime.setTelemetrySamplingMode(mode)
+  }
+
+  fun setTelemetryRetention(retention: TelemetryRetention) {
+    runtime.setTelemetryRetention(retention)
   }
 
   fun setVoiceScreenActive(active: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -3,6 +3,7 @@ package ai.openclaw.android
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import ai.openclaw.android.gateway.GatewayEndpoint
+import ai.openclaw.android.chat.ChatConnectionState
 import ai.openclaw.android.chat.OutgoingAttachment
 import ai.openclaw.android.node.CameraCaptureManager
 import ai.openclaw.android.node.CanvasController
@@ -32,6 +33,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val serverName: StateFlow<String?> = runtime.serverName
   val remoteAddress: StateFlow<String?> = runtime.remoteAddress
   val pendingGatewayTrust: StateFlow<NodeRuntime.GatewayTrustPrompt?> = runtime.pendingGatewayTrust
+  val gatewayReconnectAttempts: StateFlow<Int> = runtime.gatewayReconnectAttempts
+  val lastGatewayError: StateFlow<String?> = runtime.lastGatewayError
+  val lastGatewayConnectedAtMs: StateFlow<Long?> = runtime.lastGatewayConnectedAtMs
+  val lastGatewayDisconnectedAtMs: StateFlow<Long?> = runtime.lastGatewayDisconnectedAtMs
   val isForeground: StateFlow<Boolean> = runtime.isForeground
   val seamColorArgb: StateFlow<Long> = runtime.seamColorArgb
   val mainSessionKey: StateFlow<String> = runtime.mainSessionKey
@@ -69,6 +74,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val chatMessages = runtime.chatMessages
   val chatError: StateFlow<String?> = runtime.chatError
   val chatHealthOk: StateFlow<Boolean> = runtime.chatHealthOk
+  val chatConnectionState: StateFlow<ChatConnectionState> = runtime.chatConnectionState
   val chatThinkingLevel: StateFlow<String> = runtime.chatThinkingLevel
   val chatStreamingAssistantText: StateFlow<String?> = runtime.chatStreamingAssistantText
   val chatPendingToolCalls = runtime.chatPendingToolCalls
@@ -155,6 +161,14 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     runtime.connectManual()
   }
 
+  fun gatewayDebugSummary(): String {
+    return runtime.gatewayDebugSummary()
+  }
+
+  fun resetGatewayDiagnostics() {
+    runtime.resetGatewayDiagnostics()
+  }
+
   fun disconnect() {
     runtime.disconnect()
   }
@@ -201,6 +215,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun abortChat() {
     runtime.abortChat()
+  }
+
+  fun retryLastChatMessage(): Boolean {
+    return runtime.retryLastChatMessage()
   }
 
   fun sendChat(message: String, thinking: String, attachments: List<OutgoingAttachment>) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import ai.openclaw.android.gateway.GatewayEndpoint
 import ai.openclaw.android.chat.ChatConnectionState
+import ai.openclaw.android.chat.ChatQueuedOutbound
 import ai.openclaw.android.chat.OutgoingAttachment
 import ai.openclaw.android.node.CameraCaptureManager
 import ai.openclaw.android.node.CanvasController
@@ -78,6 +79,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val chatThinkingLevel: StateFlow<String> = runtime.chatThinkingLevel
   val chatStreamingAssistantText: StateFlow<String?> = runtime.chatStreamingAssistantText
   val chatPendingToolCalls = runtime.chatPendingToolCalls
+  val chatQueuedItems: StateFlow<List<ChatQueuedOutbound>> = runtime.chatQueuedItems
   val chatSessions = runtime.chatSessions
   val pendingRunCount: StateFlow<Int> = runtime.pendingRunCount
 
@@ -221,7 +223,17 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     return runtime.retryLastChatMessage()
   }
 
-  fun sendChat(message: String, thinking: String, attachments: List<OutgoingAttachment>) {
-    runtime.sendChat(message = message, thinking = thinking, attachments = attachments)
+  fun sendChat(
+    message: String,
+    thinking: String,
+    attachments: List<OutgoingAttachment>,
+    reEvaluateOnReconnect: Boolean = false,
+  ) {
+    runtime.sendChat(
+      message = message,
+      thinking = thinking,
+      attachments = attachments,
+      reEvaluateOnReconnect = reEvaluateOnReconnect,
+    )
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeForegroundService.kt
@@ -10,6 +10,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
+import android.os.SystemClock
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
@@ -17,14 +19,20 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 class NodeForegroundService : Service() {
   private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
   private var notificationJob: Job? = null
+  private var reconnectHeartbeatJob: Job? = null
   private var lastRequiresMic = false
   private var didStartForeground = false
+  private var heartbeatOfflineSinceElapsedMs: Long = 0L
+  private var heartbeatLastAttemptElapsedMs: Long = 0L
+  private var heartbeatBackoffMs: Long = RECONNECT_HEARTBEAT_INTERVAL_MS
 
   override fun onCreate() {
     super.onCreate()
@@ -61,6 +69,18 @@ class NodeForegroundService : Service() {
           )
         }
       }
+
+    reconnectHeartbeatJob =
+      scope.launch(Dispatchers.IO) {
+        while (isActive) {
+          delay(RECONNECT_HEARTBEAT_INTERVAL_MS)
+          runCatching {
+            runReconnectHeartbeat(runtime)
+          }.onFailure {
+            Log.w("OpenClawNode", "service reconnect heartbeat failed", it)
+          }
+        }
+      }
   }
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -77,11 +97,59 @@ class NodeForegroundService : Service() {
 
   override fun onDestroy() {
     notificationJob?.cancel()
+    reconnectHeartbeatJob?.cancel()
     scope.cancel()
     super.onDestroy()
   }
 
   override fun onBind(intent: Intent?) = null
+
+  private suspend fun runReconnectHeartbeat(runtime: NodeRuntime) {
+    if (!runtime.hasCachedEndpointForRecovery()) {
+      heartbeatOfflineSinceElapsedMs = 0L
+      heartbeatLastAttemptElapsedMs = 0L
+      heartbeatBackoffMs = RECONNECT_HEARTBEAT_INTERVAL_MS
+      return
+    }
+
+    if (!runtime.hasUsableNetworkForRecovery()) {
+      return
+    }
+
+    val operatorConnected = runtime.isConnected.value
+    val nodeConnected = runtime.nodeConnected.value
+    val probeHealthy = runtime.serviceHeartbeatProbeHealthy(reason = "fgs_heartbeat")
+    if (probeHealthy) {
+      heartbeatOfflineSinceElapsedMs = 0L
+      heartbeatLastAttemptElapsedMs = 0L
+      heartbeatBackoffMs = RECONNECT_HEARTBEAT_INTERVAL_MS
+      return
+    }
+
+    val now = SystemClock.elapsedRealtime()
+    if (heartbeatOfflineSinceElapsedMs == 0L) {
+      heartbeatOfflineSinceElapsedMs = now
+      Log.i(
+        "OpenClawNode",
+        "service heartbeat: unhealthy detected opConnected=$operatorConnected nodeConnected=$nodeConnected",
+      )
+      return
+    }
+
+    val offlineForMs = now - heartbeatOfflineSinceElapsedMs
+    val sinceLastAttemptMs = now - heartbeatLastAttemptElapsedMs
+    if (offlineForMs < RECONNECT_HEARTBEAT_GRACE_MS) return
+    if (heartbeatLastAttemptElapsedMs != 0L && sinceLastAttemptMs < heartbeatBackoffMs) return
+
+    heartbeatLastAttemptElapsedMs = now
+    val backoffUsedMs = heartbeatBackoffMs
+    heartbeatBackoffMs = (heartbeatBackoffMs * 2).coerceAtMost(RECONNECT_HEARTBEAT_MAX_BACKOFF_MS)
+    Log.i(
+      "OpenClawNode",
+      "service heartbeat reconnect: offlineFor=${offlineForMs}ms backoff=${backoffUsedMs}ms opConnected=$operatorConnected nodeConnected=$nodeConnected",
+    )
+    runtime.requestServiceHeartbeatReconnect(reason = "fgs_heartbeat")
+  }
 
   private fun ensureChannel() {
     val mgr = getSystemService(NotificationManager::class.java)
@@ -162,6 +230,9 @@ class NodeForegroundService : Service() {
   companion object {
     private const val CHANNEL_ID = "connection"
     private const val NOTIFICATION_ID = 1
+    private const val RECONNECT_HEARTBEAT_INTERVAL_MS = 15_000L
+    private const val RECONNECT_HEARTBEAT_GRACE_MS = 20_000L
+    private const val RECONNECT_HEARTBEAT_MAX_BACKOFF_MS = 120_000L
 
     private const val ACTION_STOP = "ai.openclaw.android.action.STOP"
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeForegroundService.kt
@@ -54,7 +54,7 @@ class NodeForegroundService : Service() {
           val text = (server?.let { "$status · $it" } ?: status) + micSuffix
 
           val requiresMic =
-            micEnabled && hasRecordAudioPermission()
+            micListening && hasRecordAudioPermission()
           startForegroundWithTypes(
             notification = buildNotification(title = title, text = text),
             requiresMic = requiresMic,

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -290,6 +290,8 @@ class NodeRuntime(context: Context) {
   private var nodeStatusText: String = "Offline"
   private var nodeOfflineSinceMs: Long? = null
   private var lastNodeRepairAttemptMs: Long = 0L
+  private var operatorOfflineSinceMs: Long? = null
+  private var lastOperatorRepairAttemptMs: Long = 0L
   private val connectivityManager = appContext.getSystemService(ConnectivityManager::class.java)
   private var lastNetworkRepairAttemptElapsedMs: Long = 0L
   private var networkCallbackRegistered = false
@@ -314,6 +316,8 @@ class NodeRuntime(context: Context) {
       onConnected = { name, remote, mainSessionKey ->
         operatorConnected = true
         operatorStatusText = "Connected"
+        operatorOfflineSinceMs = null
+        lastOperatorRepairAttemptMs = 0L
         _lastGatewayConnectedAtMs.value = System.currentTimeMillis()
         _lastGatewayError.value = null
         _serverName.value = name
@@ -332,6 +336,7 @@ class NodeRuntime(context: Context) {
       onDisconnected = { message ->
         operatorConnected = false
         operatorStatusText = message
+        operatorOfflineSinceMs = System.currentTimeMillis()
         nodeOfflineSinceMs = null
         lastNodeRepairAttemptMs = 0L
         _lastGatewayDisconnectedAtMs.value = System.currentTimeMillis()
@@ -522,16 +527,33 @@ class NodeRuntime(context: Context) {
   }
 
   private fun onNetworkChanged(reason: String) {
-    if (connectedEndpoint == null) return
+    if (connectedEndpoint == null) {
+      Log.d("OpenClawNode", "network changed ($reason): no cached endpoint, skip")
+      return
+    }
+    if (!hasUsableNetwork()) {
+      Log.d("OpenClawNode", "network changed ($reason): no usable network, skip")
+      return
+    }
     val now = SystemClock.elapsedRealtime()
-    if (now - lastNetworkRepairAttemptElapsedMs < 12_000L) return
+    val sinceLastMs = now - lastNetworkRepairAttemptElapsedMs
+    if (sinceLastMs < 12_000L) {
+      Log.d("OpenClawNode", "network changed ($reason): throttled (${sinceLastMs}ms since last attempt)")
+      return
+    }
     lastNetworkRepairAttemptElapsedMs = now
 
     scope.launch(Dispatchers.IO) {
       delay(1_500)
       if (connectedEndpoint == null) return@launch
-      if (operatorConnected && _nodeConnected.value) return@launch
-      Log.i("OpenClawNode", "network changed ($reason): refreshing gateway session")
+      if (operatorConnected && _nodeConnected.value) {
+        Log.d("OpenClawNode", "network changed ($reason): already healthy after settle, skip")
+        return@launch
+      }
+      Log.i(
+        "OpenClawNode",
+        "network changed ($reason): refreshing gateway session opConnected=$operatorConnected nodeConnected=${_nodeConnected.value}",
+      )
       refreshGatewayConnection()
     }
   }
@@ -548,20 +570,96 @@ class NodeRuntime(context: Context) {
     }
   }
 
+  private fun hasUsableNetwork(): Boolean {
+    val manager = connectivityManager ?: return true
+    return runCatching {
+      val active = manager.activeNetwork ?: return false
+      val capabilities = manager.getNetworkCapabilities(active) ?: return false
+      capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }.getOrDefault(true)
+  }
+
+  fun hasCachedEndpointForRecovery(): Boolean = connectedEndpoint != null
+
+  fun hasUsableNetworkForRecovery(): Boolean = hasUsableNetwork()
+
+  suspend fun serviceHeartbeatProbeHealthy(reason: String = "fgs_probe"): Boolean {
+    if (connectedEndpoint == null) return false
+    if (!hasUsableNetwork()) return false
+
+    val operatorOk =
+      runCatching {
+        operatorSession.request("config.get", "{}", timeoutMs = 4_000)
+        true
+      }.getOrElse {
+        Log.w("OpenClawNode", "service probe ($reason): operator RPC failed", it)
+        false
+      }
+    if (!operatorOk) return false
+
+    val nodeOk =
+      runCatching {
+        nodeSession.sendNodeEvent(event = "service.heartbeat.probe", payloadJson = null)
+      }.getOrElse {
+        Log.w("OpenClawNode", "service probe ($reason): node event probe threw", it)
+        false
+      }
+    if (!nodeOk) {
+      Log.w(
+        "OpenClawNode",
+        "service probe ($reason): node event probe failed opConnected=$operatorConnected nodeConnected=${_nodeConnected.value}",
+      )
+      return false
+    }
+    return true
+  }
+
+  fun requestServiceHeartbeatReconnect(reason: String = "fgs_heartbeat") {
+    if (connectedEndpoint == null) return
+    Log.i(
+      "OpenClawNode",
+      "service heartbeat reconnect ($reason): opConnected=$operatorConnected nodeConnected=${_nodeConnected.value}",
+    )
+    refreshGatewayConnection()
+  }
+
   private suspend fun repairNodeSessionIfNeeded() {
-    if (!operatorConnected || _nodeConnected.value) {
+    val endpoint = connectedEndpoint ?: return
+    if (!hasUsableNetwork()) return
+
+    val now = System.currentTimeMillis()
+
+    if (!operatorConnected) {
+      if (operatorOfflineSinceMs == null) operatorOfflineSinceMs = now
+      nodeOfflineSinceMs = null
+      lastNodeRepairAttemptMs = 0L
+
+      val operatorOfflineForMs = now - (operatorOfflineSinceMs ?: now)
+      val sinceOperatorRepairMs = now - lastOperatorRepairAttemptMs
+      if (operatorOfflineForMs < 12_000L || sinceOperatorRepairMs < 30_000L) return
+
+      lastOperatorRepairAttemptMs = now
+      Log.i(
+        "OpenClawNode",
+        "repair loop: operator offline ${operatorOfflineForMs}ms -> full reconnect (nodeConnected=${_nodeConnected.value})",
+      )
+      refreshGatewayConnection()
+      return
+    }
+
+    operatorOfflineSinceMs = null
+    lastOperatorRepairAttemptMs = 0L
+
+    if (_nodeConnected.value) {
       nodeOfflineSinceMs = null
       lastNodeRepairAttemptMs = 0L
       return
     }
 
-    val endpoint = connectedEndpoint ?: return
-    val now = System.currentTimeMillis()
     if (nodeOfflineSinceMs == null) nodeOfflineSinceMs = now
-
     val offlineForMs = now - (nodeOfflineSinceMs ?: now)
-    if (offlineForMs < 25_000L) return
-    if (now - lastNodeRepairAttemptMs < 30_000L) return
+    val sinceNodeRepairMs = now - lastNodeRepairAttemptMs
+    if (offlineForMs < 25_000L || sinceNodeRepairMs < 30_000L) return
 
     lastNodeRepairAttemptMs = now
     nodeStatusText = "Reconnecting node session..."
@@ -570,6 +668,10 @@ class NodeRuntime(context: Context) {
     val token = prefs.loadGatewayToken()
     val password = prefs.loadGatewayPassword()
     val tls = connectionManager.resolveTlsParams(endpoint)
+    Log.i(
+      "OpenClawNode",
+      "repair loop: node offline ${offlineForMs}ms -> node reconnect (operatorConnected=$operatorConnected)",
+    )
     nodeSession.connect(endpoint, token, password, connectionManager.buildNodeConnectOptions(), tls)
     nodeSession.reconnect()
   }
@@ -803,6 +905,14 @@ class NodeRuntime(context: Context) {
 
   fun setForeground(value: Boolean) {
     _isForeground.value = value
+    if (!value) return
+    if (connectedEndpoint == null) return
+    if (operatorConnected && _nodeConnected.value) return
+    Log.i(
+      "OpenClawNode",
+      "foreground resume: triggering network repair check opConnected=$operatorConnected nodeConnected=${_nodeConnected.value}",
+    )
+    onNetworkChanged("foreground_resume")
   }
 
   fun setDisplayName(value: String) {
@@ -907,6 +1017,10 @@ class NodeRuntime(context: Context) {
         _lastGatewayError.value = "Failed: no cached gateway endpoint"
         return
       }
+    Log.i(
+      "OpenClawNode",
+      "refreshGatewayConnection: endpoint=${endpoint.stableId} opConnected=$operatorConnected nodeConnected=${_nodeConnected.value}",
+    )
     _gatewayReconnectAttempts.value = _gatewayReconnectAttempts.value + 1
     operatorStatusText = "Connecting…"
     updateStatus()

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -457,6 +457,16 @@ class NodeRuntime(context: Context) {
     canvas.navigate("")
   }
 
+  fun onCanvasPageFinished(url: String?) {
+    val current = url?.trim().orEmpty()
+    if (current.isBlank()) return
+    if (!current.contains("/__openclaw__/a2ui/")) return
+
+    _canvasA2uiHydrated.value = true
+    _canvasRehydratePending.value = false
+    _canvasRehydrateErrorText.value = null
+  }
+
   fun requestCanvasRehydrate(source: String = "manual", force: Boolean = true) {
     scope.launch {
       if (!_nodeConnected.value) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -560,6 +560,11 @@ class NodeRuntime(context: Context) {
   fun setOnboardingCompleted(value: Boolean) = prefs.setOnboardingCompleted(value)
   val lastDiscoveredStableId: StateFlow<String> = prefs.lastDiscoveredStableId
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
+  val backgroundBatteryHistoryEnabled: StateFlow<Boolean> = prefs.backgroundBatteryHistoryEnabled
+  val backgroundLocationHistoryEnabled: StateFlow<Boolean> = prefs.backgroundLocationHistoryEnabled
+  val telemetrySyncEnabled: StateFlow<Boolean> = prefs.telemetrySyncEnabled
+  val telemetrySamplingMode: StateFlow<TelemetrySamplingMode> = prefs.telemetrySamplingMode
+  val telemetryRetention: StateFlow<TelemetryRetention> = prefs.telemetryRetention
 
   private var didAutoConnect = false
 
@@ -700,6 +705,26 @@ class NodeRuntime(context: Context) {
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {
     prefs.setCanvasDebugStatusEnabled(value)
+  }
+
+  fun setBackgroundBatteryHistoryEnabled(value: Boolean) {
+    prefs.setBackgroundBatteryHistoryEnabled(value)
+  }
+
+  fun setBackgroundLocationHistoryEnabled(value: Boolean) {
+    prefs.setBackgroundLocationHistoryEnabled(value)
+  }
+
+  fun setTelemetrySyncEnabled(value: Boolean) {
+    prefs.setTelemetrySyncEnabled(value)
+  }
+
+  fun setTelemetrySamplingMode(mode: TelemetrySamplingMode) {
+    prefs.setTelemetrySamplingMode(mode)
+  }
+
+  fun setTelemetryRetention(retention: TelemetryRetention) {
+    prefs.setTelemetryRetention(retention)
   }
 
   fun setVoiceScreenActive(active: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -719,12 +719,21 @@ class NodeRuntime(context: Context) {
 
   fun connect(endpoint: GatewayEndpoint) {
     val tls = connectionManager.resolveTlsParams(endpoint)
-    if (tls?.required == true && tls.expectedFingerprint.isNullOrBlank()) {
-      // First-time TLS: capture fingerprint, ask user to verify out-of-band, then store and connect.
+    if (tls?.required == true && tls.expectedFingerprint.isNullOrBlank() && !tls.allowTOFU) {
+      // First-time TLS (strict mode): capture fingerprint, ask user to verify out-of-band, then store and connect.
       _statusText.value = "Verify gateway TLS fingerprint…"
       scope.launch {
         val fp = probeGatewayTlsFingerprint(endpoint.host, endpoint.port) ?: run {
-          _statusText.value = "Failed: can't read TLS fingerprint"
+          val host = endpoint.host.trim()
+          val schemeHint = if (endpoint.port == 443) "https" else "wss"
+          val endpointHint = "$schemeHint://$host:${endpoint.port}"
+          val hint =
+            if (looksLikeIpLiteral(host)) {
+              "Tip: use your tailnet DNS hostname (not raw IP) for TLS, then try again."
+            } else {
+              "Check host/port and TLS mode, then try again."
+            }
+          _statusText.value = "Failed: can't read TLS fingerprint for $endpointHint. $hint"
           return@launch
         }
         _pendingGatewayTrust.value = GatewayTrustPrompt(endpoint = endpoint, fingerprintSha256 = fp)
@@ -759,6 +768,14 @@ class NodeRuntime(context: Context) {
       ContextCompat.checkSelfPermission(appContext, Manifest.permission.RECORD_AUDIO) ==
         PackageManager.PERMISSION_GRANTED
       )
+  }
+
+  private fun looksLikeIpLiteral(host: String): Boolean {
+    val trimmed = host.trim()
+    if (trimmed.isEmpty()) return false
+    val ipv4 = Regex("""^\d{1,3}(\.\d{1,3}){3}$""")
+    val ipv6 = Regex("""^[0-9a-fA-F:]+$""")
+    return ipv4.matches(trimmed) || (trimmed.contains(":") && ipv6.matches(trimmed))
   }
 
   fun connectManual() {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -527,7 +527,7 @@ class NodeRuntime(context: Context) {
   }
 
   private fun onNetworkChanged(reason: String) {
-    if (connectedEndpoint == null) {
+    ensureRecoveryEndpoint(reason = "network_$reason") ?: run {
       Log.d("OpenClawNode", "network changed ($reason): no cached endpoint, skip")
       return
     }
@@ -545,7 +545,7 @@ class NodeRuntime(context: Context) {
 
     scope.launch(Dispatchers.IO) {
       delay(1_500)
-      if (connectedEndpoint == null) return@launch
+      ensureRecoveryEndpoint(reason = "network_settle_$reason") ?: return@launch
       if (operatorConnected && _nodeConnected.value) {
         Log.d("OpenClawNode", "network changed ($reason): already healthy after settle, skip")
         return@launch
@@ -579,12 +579,43 @@ class NodeRuntime(context: Context) {
     }.getOrDefault(true)
   }
 
-  fun hasCachedEndpointForRecovery(): Boolean = connectedEndpoint != null
+  private fun recoverEndpointFromPrefs(): GatewayEndpoint? {
+    connectedEndpoint?.let { return it }
+
+    if (manualEnabled.value) {
+      val host = manualHost.value.trim()
+      val port = manualPort.value
+      if (host.isNotEmpty() && port in 1..65535 && manualTls.value) {
+        val endpoint = GatewayEndpoint.manual(host = host, port = port)
+        val storedFingerprint = prefs.loadGatewayTlsFingerprint(endpoint.stableId)?.trim().orEmpty()
+        if (storedFingerprint.isNotEmpty()) {
+          return endpoint
+        }
+      }
+    }
+
+    val targetStableId = lastDiscoveredStableId.value.trim()
+    if (targetStableId.isEmpty()) return null
+    val discoveredTarget = gateways.value.firstOrNull { it.stableId == targetStableId } ?: return null
+    val storedFingerprint = prefs.loadGatewayTlsFingerprint(discoveredTarget.stableId)?.trim().orEmpty()
+    if (storedFingerprint.isEmpty()) return null
+    return discoveredTarget
+  }
+
+  private fun ensureRecoveryEndpoint(reason: String): GatewayEndpoint? {
+    connectedEndpoint?.let { return it }
+    val recovered = recoverEndpointFromPrefs() ?: return null
+    connectedEndpoint = recovered
+    Log.i("OpenClawNode", "recovered endpoint for $reason: ${recovered.stableId}")
+    return recovered
+  }
+
+  fun hasCachedEndpointForRecovery(): Boolean = ensureRecoveryEndpoint(reason = "service_recovery_check") != null
 
   fun hasUsableNetworkForRecovery(): Boolean = hasUsableNetwork()
 
   suspend fun serviceHeartbeatProbeHealthy(reason: String = "fgs_probe"): Boolean {
-    if (connectedEndpoint == null) return false
+    ensureRecoveryEndpoint(reason = "service_probe_$reason") ?: return false
     if (!hasUsableNetwork()) return false
 
     val operatorOk =
@@ -615,7 +646,7 @@ class NodeRuntime(context: Context) {
   }
 
   fun requestServiceHeartbeatReconnect(reason: String = "fgs_heartbeat") {
-    if (connectedEndpoint == null) return
+    ensureRecoveryEndpoint(reason = "service_reconnect_$reason") ?: return
     Log.i(
       "OpenClawNode",
       "service heartbeat reconnect ($reason): opConnected=$operatorConnected nodeConnected=${_nodeConnected.value}",
@@ -624,7 +655,7 @@ class NodeRuntime(context: Context) {
   }
 
   private suspend fun repairNodeSessionIfNeeded() {
-    val endpoint = connectedEndpoint ?: return
+    val endpoint = ensureRecoveryEndpoint(reason = "repair_loop") ?: return
     if (!hasUsableNetwork()) return
 
     val now = System.currentTimeMillis()
@@ -906,7 +937,7 @@ class NodeRuntime(context: Context) {
   fun setForeground(value: Boolean) {
     _isForeground.value = value
     if (!value) return
-    if (connectedEndpoint == null) return
+    ensureRecoveryEndpoint(reason = "foreground_resume") ?: return
     if (operatorConnected && _nodeConnected.value) return
     Log.i(
       "OpenClawNode",
@@ -1012,7 +1043,7 @@ class NodeRuntime(context: Context) {
 
   fun refreshGatewayConnection() {
     val endpoint =
-      connectedEndpoint ?: run {
+      ensureRecoveryEndpoint(reason = "refresh_gateway") ?: run {
         _statusText.value = "Failed: no cached gateway endpoint"
         _lastGatewayError.value = "Failed: no cached gateway endpoint"
         return

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -39,9 +39,14 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.time.Instant
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
@@ -145,6 +150,20 @@ class NodeRuntime(context: Context) {
     getOperatorCanvasHostUrl = { operatorSession.currentCanvasHostUrl() },
   )
 
+
+  private val telemetryCollector: TelemetryCollector = TelemetryCollector(
+    appContext = appContext,
+    scope = scope,
+    locationCaptureManager = location,
+    batteryEnabled = { backgroundBatteryHistoryEnabled.value },
+    locationEnabled = { backgroundLocationHistoryEnabled.value },
+    locationMode = { locationMode.value },
+    locationPreciseEnabled = { locationPreciseEnabled.value },
+    samplingMode = { telemetrySamplingMode.value },
+    retention = { telemetryRetention.value },
+    syncEnabled = { telemetrySyncEnabled.value },
+  )
+
   private val connectionManager: ConnectionManager = ConnectionManager(
     prefs = prefs,
     cameraEnabled = { cameraEnabled.value },
@@ -195,6 +214,15 @@ class NodeRuntime(context: Context) {
     val fingerprintSha256: String,
   )
 
+  data class TelemetryStatus(
+    val batterySamples: Int = 0,
+    val locationSamples: Int = 0,
+    val lastBatteryAt: String? = null,
+    val lastLocationAt: String? = null,
+    val updatedAtMs: Long = System.currentTimeMillis(),
+  )
+
+
   private val _isConnected = MutableStateFlow(false)
   val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
   private val _nodeConnected = MutableStateFlow(false)
@@ -202,6 +230,9 @@ class NodeRuntime(context: Context) {
 
   private val _statusText = MutableStateFlow("Offline")
   val statusText: StateFlow<String> = _statusText.asStateFlow()
+
+  private val _telemetryStatus = MutableStateFlow(TelemetryStatus())
+  val telemetryStatus: StateFlow<TelemetryStatus> = _telemetryStatus.asStateFlow()
 
   private val _gatewayReconnectAttempts = MutableStateFlow(0)
   val gatewayReconnectAttempts: StateFlow<Int> = _gatewayReconnectAttempts.asStateFlow()
@@ -590,6 +621,22 @@ class NodeRuntime(context: Context) {
       prefs.loadGatewayToken()
     }
 
+    telemetryCollector.start()
+
+    scope.launch(Dispatchers.IO) {
+      while (true) {
+        refreshTelemetryStatus()
+        delay(15_000)
+      }
+    }
+
+    scope.launch(Dispatchers.IO) {
+      while (true) {
+        runCatching { syncTelemetryBacklog() }
+        delay(30_000)
+      }
+    }
+
     scope.launch {
       prefs.talkEnabled.collect { enabled ->
         // MicCaptureManager handles STT + send to gateway.
@@ -830,6 +877,85 @@ class NodeRuntime(context: Context) {
   fun declineGatewayTrustPrompt() {
     _pendingGatewayTrust.value = null
     _statusText.value = "Offline"
+  }
+
+  private fun refreshTelemetryStatus() {
+    val telemetryDir = File(appContext.filesDir, "telemetry")
+    val batteryFile = File(telemetryDir, "battery_history.jsonl")
+    val locationFile = File(telemetryDir, "location_history.jsonl")
+
+    fun parse(file: File): Pair<Int, String?> {
+      if (!file.exists()) return 0 to null
+      val lines = runCatching { file.readLines().filter { it.isNotBlank() } }.getOrElse { emptyList() }
+      val last = lines.lastOrNull()
+      val ts =
+        runCatching {
+          if (last == null) null
+          else {
+            val root = json.parseToJsonElement(last).jsonObject
+            root["capturedAt"]?.jsonPrimitive?.content
+          }
+        }.getOrNull()
+      return lines.size to ts
+    }
+
+    val (batteryCount, lastBattery) = parse(batteryFile)
+    val (locationCount, lastLocation) = parse(locationFile)
+    _telemetryStatus.value =
+      TelemetryStatus(
+        batterySamples = batteryCount,
+        locationSamples = locationCount,
+        lastBatteryAt = lastBattery,
+        lastLocationAt = lastLocation,
+        updatedAtMs = System.currentTimeMillis(),
+      )
+  }
+
+  private suspend fun syncTelemetryBacklog() {
+    if (!_nodeConnected.value) return
+    if (!telemetrySyncEnabled.value) return
+
+    val telemetryDir = File(appContext.filesDir, "telemetry")
+    syncStream(
+      stream = "battery",
+      file = File(telemetryDir, "battery_history.jsonl"),
+      eventName = "telemetry.battery.batch",
+    )
+    syncStream(
+      stream = "location",
+      file = File(telemetryDir, "location_history.jsonl"),
+      eventName = "telemetry.location.batch",
+    )
+  }
+
+  private suspend fun syncStream(stream: String, file: File, eventName: String) {
+    if (!file.exists()) return
+    val lines = runCatching { file.readLines().filter { it.isNotBlank() } }.getOrElse { emptyList() }
+    if (lines.isEmpty()) return
+
+    val cursor = prefs.loadTelemetrySyncCursor(stream)
+    val pending =
+      lines.mapNotNull { line ->
+        runCatching { json.parseToJsonElement(line).jsonObject }.getOrNull()
+      }.filter { obj ->
+        val ts = obj["capturedAt"]?.jsonPrimitive?.content
+        cursor == null || (ts != null && ts > cursor)
+      }.takeLast(50)
+
+    if (pending.isEmpty()) return
+
+    val payload =
+      buildJsonObject {
+        put("stream", JsonPrimitive(stream))
+        put("count", JsonPrimitive(pending.size))
+        put("samples", buildJsonArray { pending.forEach { add(it) } })
+      }.toString()
+
+    val sent = nodeSession.sendNodeEvent(event = eventName, payloadJson = payload)
+    if (!sent) return
+
+    val latest = pending.lastOrNull()?.get("capturedAt")?.jsonPrimitive?.content ?: return
+    prefs.saveTelemetrySyncCursor(stream, latest)
   }
 
   private fun hasRecordAudioPermission(): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -3,6 +3,10 @@ package ai.openclaw.android
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.Build
 import android.os.SystemClock
 import android.util.Log
 import androidx.core.content.ContextCompat
@@ -284,6 +288,23 @@ class NodeRuntime(context: Context) {
   private var operatorConnected = false
   private var operatorStatusText: String = "Offline"
   private var nodeStatusText: String = "Offline"
+  private var nodeOfflineSinceMs: Long? = null
+  private var lastNodeRepairAttemptMs: Long = 0L
+  private val connectivityManager = appContext.getSystemService(ConnectivityManager::class.java)
+  private var lastNetworkRepairAttemptElapsedMs: Long = 0L
+  private var networkCallbackRegistered = false
+  private val networkCallback =
+    object : ConnectivityManager.NetworkCallback() {
+      override fun onAvailable(network: Network) {
+        onNetworkChanged("available")
+      }
+
+      override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
+        if (networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
+          onNetworkChanged("capabilities")
+        }
+      }
+    }
 
   private val operatorSession =
     GatewaySession(
@@ -311,6 +332,8 @@ class NodeRuntime(context: Context) {
       onDisconnected = { message ->
         operatorConnected = false
         operatorStatusText = message
+        nodeOfflineSinceMs = null
+        lastNodeRepairAttemptMs = 0L
         _lastGatewayDisconnectedAtMs.value = System.currentTimeMillis()
         if (message.isNotBlank() && !message.equals("Offline", ignoreCase = true)) {
           _lastGatewayError.value = message
@@ -339,6 +362,8 @@ class NodeRuntime(context: Context) {
       onConnected = { _, _, _ ->
         _nodeConnected.value = true
         nodeStatusText = "Connected"
+        nodeOfflineSinceMs = null
+        lastNodeRepairAttemptMs = 0L
         didAutoRequestCanvasRehydrate = false
         _canvasA2uiHydrated.value = false
         _canvasRehydratePending.value = false
@@ -349,6 +374,11 @@ class NodeRuntime(context: Context) {
       onDisconnected = { message ->
         _nodeConnected.value = false
         nodeStatusText = message
+        if (operatorConnected) {
+          if (nodeOfflineSinceMs == null) nodeOfflineSinceMs = System.currentTimeMillis()
+        } else {
+          nodeOfflineSinceMs = null
+        }
         didAutoRequestCanvasRehydrate = false
         _canvasA2uiHydrated.value = false
         _canvasRehydratePending.value = false
@@ -491,6 +521,59 @@ class NodeRuntime(context: Context) {
       }
   }
 
+  private fun onNetworkChanged(reason: String) {
+    if (connectedEndpoint == null) return
+    val now = SystemClock.elapsedRealtime()
+    if (now - lastNetworkRepairAttemptElapsedMs < 12_000L) return
+    lastNetworkRepairAttemptElapsedMs = now
+
+    scope.launch(Dispatchers.IO) {
+      delay(1_500)
+      if (connectedEndpoint == null) return@launch
+      if (operatorConnected && _nodeConnected.value) return@launch
+      Log.i("OpenClawNode", "network changed ($reason): refreshing gateway session")
+      refreshGatewayConnection()
+    }
+  }
+
+  private fun registerNetworkMonitor() {
+    if (networkCallbackRegistered) return
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return
+    val manager = connectivityManager ?: return
+    runCatching {
+      manager.registerDefaultNetworkCallback(networkCallback)
+      networkCallbackRegistered = true
+    }.onFailure {
+      Log.w("OpenClawNode", "failed to register network monitor", it)
+    }
+  }
+
+  private suspend fun repairNodeSessionIfNeeded() {
+    if (!operatorConnected || _nodeConnected.value) {
+      nodeOfflineSinceMs = null
+      lastNodeRepairAttemptMs = 0L
+      return
+    }
+
+    val endpoint = connectedEndpoint ?: return
+    val now = System.currentTimeMillis()
+    if (nodeOfflineSinceMs == null) nodeOfflineSinceMs = now
+
+    val offlineForMs = now - (nodeOfflineSinceMs ?: now)
+    if (offlineForMs < 25_000L) return
+    if (now - lastNodeRepairAttemptMs < 30_000L) return
+
+    lastNodeRepairAttemptMs = now
+    nodeStatusText = "Reconnecting node session..."
+    updateStatus()
+
+    val token = prefs.loadGatewayToken()
+    val password = prefs.loadGatewayPassword()
+    val tls = connectionManager.resolveTlsParams(endpoint)
+    nodeSession.connect(endpoint, token, password, connectionManager.buildNodeConnectOptions(), tls)
+    nodeSession.reconnect()
+  }
+
   private fun resolveMainSessionKey(): String {
     val trimmed = _mainSessionKey.value.trim()
     return if (trimmed.isEmpty()) "main" else trimmed
@@ -621,6 +704,7 @@ class NodeRuntime(context: Context) {
       prefs.loadGatewayToken()
     }
 
+    registerNetworkMonitor()
     telemetryCollector.start()
 
     scope.launch(Dispatchers.IO) {
@@ -634,6 +718,13 @@ class NodeRuntime(context: Context) {
       while (true) {
         runCatching { syncTelemetryBacklog() }
         delay(30_000)
+      }
+    }
+
+    scope.launch(Dispatchers.IO) {
+      while (true) {
+        runCatching { repairNodeSessionIfNeeded() }
+        delay(15_000)
       }
     }
 
@@ -1120,6 +1211,8 @@ class NodeRuntime(context: Context) {
     return buildString {
       appendLine("OpenClaw Android diagnostics")
       appendLine("status: ${statusText.value}")
+      appendLine("operatorConnected: $operatorConnected")
+      appendLine("nodeConnected: ${_nodeConnected.value}")
       appendLine("endpoint: $endpointText")
       appendLine("manualTls: $tlsMode")
       appendLine("tokenPresent: $tokenPresent")

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -10,6 +10,7 @@ import ai.openclaw.android.chat.ChatController
 import ai.openclaw.android.chat.ChatConnectionState
 import ai.openclaw.android.chat.ChatMessage
 import ai.openclaw.android.chat.ChatPendingToolCall
+import ai.openclaw.android.chat.ChatQueuedOutbound
 import ai.openclaw.android.chat.ChatSessionEntry
 import ai.openclaw.android.chat.OutgoingAttachment
 import ai.openclaw.android.gateway.DeviceAuthStore
@@ -571,6 +572,7 @@ class NodeRuntime(context: Context) {
   val chatThinkingLevel: StateFlow<String> = chat.thinkingLevel
   val chatStreamingAssistantText: StateFlow<String?> = chat.streamingAssistantText
   val chatPendingToolCalls: StateFlow<List<ChatPendingToolCall>> = chat.pendingToolCalls
+  val chatQueuedItems: StateFlow<List<ChatQueuedOutbound>> = chat.queuedItems
   val chatSessions: StateFlow<List<ChatSessionEntry>> = chat.sessions
   val pendingRunCount: StateFlow<Int> = chat.pendingRunCount
 
@@ -940,8 +942,18 @@ class NodeRuntime(context: Context) {
     return chat.retryLastMessage()
   }
 
-  fun sendChat(message: String, thinking: String, attachments: List<OutgoingAttachment>) {
-    chat.sendMessage(message = message, thinkingLevel = thinking, attachments = attachments)
+  fun sendChat(
+    message: String,
+    thinking: String,
+    attachments: List<OutgoingAttachment>,
+    reEvaluateOnReconnect: Boolean = false,
+  ) {
+    chat.sendMessage(
+      message = message,
+      thinkingLevel = thinking,
+      attachments = attachments,
+      reEvaluateOnReconnect = reEvaluateOnReconnect,
+    )
   }
 
   fun gatewayDebugSummary(): String {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -7,6 +7,7 @@ import android.os.SystemClock
 import android.util.Log
 import androidx.core.content.ContextCompat
 import ai.openclaw.android.chat.ChatController
+import ai.openclaw.android.chat.ChatConnectionState
 import ai.openclaw.android.chat.ChatMessage
 import ai.openclaw.android.chat.ChatPendingToolCall
 import ai.openclaw.android.chat.ChatSessionEntry
@@ -38,6 +39,9 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 
@@ -129,6 +133,10 @@ class NodeRuntime(context: Context) {
     sms = sms,
   )
 
+  private val batteryHandler: BatteryHandler = BatteryHandler(
+    appContext = appContext,
+  )
+
   private val a2uiHandler: A2UIHandler = A2UIHandler(
     canvas = canvas,
     json = json,
@@ -161,6 +169,7 @@ class NodeRuntime(context: Context) {
     motionHandler = motionHandler,
     screenHandler = screenHandler,
     smsHandler = smsHandlerImpl,
+    batteryHandler = batteryHandler,
     a2uiHandler = a2uiHandler,
     debugHandler = debugHandler,
     appUpdateHandler = appUpdateHandler,
@@ -192,6 +201,15 @@ class NodeRuntime(context: Context) {
 
   private val _statusText = MutableStateFlow("Offline")
   val statusText: StateFlow<String> = _statusText.asStateFlow()
+
+  private val _gatewayReconnectAttempts = MutableStateFlow(0)
+  val gatewayReconnectAttempts: StateFlow<Int> = _gatewayReconnectAttempts.asStateFlow()
+  private val _lastGatewayError = MutableStateFlow<String?>(null)
+  val lastGatewayError: StateFlow<String?> = _lastGatewayError.asStateFlow()
+  private val _lastGatewayConnectedAtMs = MutableStateFlow<Long?>(null)
+  val lastGatewayConnectedAtMs: StateFlow<Long?> = _lastGatewayConnectedAtMs.asStateFlow()
+  private val _lastGatewayDisconnectedAtMs = MutableStateFlow<Long?>(null)
+  val lastGatewayDisconnectedAtMs: StateFlow<Long?> = _lastGatewayDisconnectedAtMs.asStateFlow()
 
   private val _pendingGatewayTrust = MutableStateFlow<GatewayTrustPrompt?>(null)
   val pendingGatewayTrust: StateFlow<GatewayTrustPrompt?> = _pendingGatewayTrust.asStateFlow()
@@ -243,6 +261,8 @@ class NodeRuntime(context: Context) {
       onConnected = { name, remote, mainSessionKey ->
         operatorConnected = true
         operatorStatusText = "Connected"
+        _lastGatewayConnectedAtMs.value = System.currentTimeMillis()
+        _lastGatewayError.value = null
         _serverName.value = name
         _remoteAddress.value = remote
         _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
@@ -259,6 +279,10 @@ class NodeRuntime(context: Context) {
       onDisconnected = { message ->
         operatorConnected = false
         operatorStatusText = message
+        _lastGatewayDisconnectedAtMs.value = System.currentTimeMillis()
+        if (message.isNotBlank() && !message.equals("Offline", ignoreCase = true)) {
+          _lastGatewayError.value = message
+        }
         _serverName.value = null
         _remoteAddress.value = null
         _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
@@ -543,6 +567,7 @@ class NodeRuntime(context: Context) {
   val chatMessages: StateFlow<List<ChatMessage>> = chat.messages
   val chatError: StateFlow<String?> = chat.errorText
   val chatHealthOk: StateFlow<Boolean> = chat.healthOk
+  val chatConnectionState: StateFlow<ChatConnectionState> = chat.connectionState
   val chatThinkingLevel: StateFlow<String> = chat.thinkingLevel
   val chatStreamingAssistantText: StateFlow<String?> = chat.streamingAssistantText
   val chatPendingToolCalls: StateFlow<List<ChatPendingToolCall>> = chat.pendingToolCalls
@@ -714,8 +739,10 @@ class NodeRuntime(context: Context) {
     val endpoint =
       connectedEndpoint ?: run {
         _statusText.value = "Failed: no cached gateway endpoint"
+        _lastGatewayError.value = "Failed: no cached gateway endpoint"
         return
       }
+    _gatewayReconnectAttempts.value = _gatewayReconnectAttempts.value + 1
     operatorStatusText = "Connecting…"
     updateStatus()
     val token = prefs.loadGatewayToken()
@@ -728,6 +755,9 @@ class NodeRuntime(context: Context) {
   }
 
   fun connect(endpoint: GatewayEndpoint) {
+    if (!operatorConnected) {
+      _gatewayReconnectAttempts.value = _gatewayReconnectAttempts.value + 1
+    }
     val tls = connectionManager.resolveTlsParams(endpoint)
     if (tls?.required == true && tls.expectedFingerprint.isNullOrBlank() && !tls.allowTOFU) {
       // First-time TLS (strict mode): capture fingerprint, ask user to verify out-of-band, then store and connect.
@@ -743,7 +773,9 @@ class NodeRuntime(context: Context) {
             } else {
               "Check host/port and TLS mode, then try again."
             }
-          _statusText.value = "Failed: can't read TLS fingerprint for $endpointHint. $hint"
+          val error = "Failed: can't read TLS fingerprint for $endpointHint. $hint"
+          _statusText.value = error
+          _lastGatewayError.value = error
           return@launch
         }
         _pendingGatewayTrust.value = GatewayTrustPrompt(endpoint = endpoint, fingerprintSha256 = fp)
@@ -792,7 +824,9 @@ class NodeRuntime(context: Context) {
     val host = manualHost.value.trim()
     val port = manualPort.value
     if (host.isEmpty() || port <= 0 || port > 65535) {
-      _statusText.value = "Failed: invalid manual host/port"
+      val error = "Failed: invalid manual host/port"
+      _statusText.value = error
+      _lastGatewayError.value = error
       return
     }
     connect(GatewayEndpoint.manual(host = host, port = port))
@@ -902,8 +936,42 @@ class NodeRuntime(context: Context) {
     chat.abort()
   }
 
+  fun retryLastChatMessage(): Boolean {
+    return chat.retryLastMessage()
+  }
+
   fun sendChat(message: String, thinking: String, attachments: List<OutgoingAttachment>) {
     chat.sendMessage(message = message, thinkingLevel = thinking, attachments = attachments)
+  }
+
+  fun gatewayDebugSummary(): String {
+    val endpoint = connectedEndpoint
+    val endpointText = endpoint?.let { "${if (it.tlsEnabled) "wss" else "ws"}://${it.host}:${it.port}" } ?: remoteAddress.value ?: "not set"
+    val tlsMode = if (manualTls.value) "on" else "off"
+    val tokenPresent = gatewayToken.value.trim().isNotEmpty()
+    val reconnects = gatewayReconnectAttempts.value
+    val lastError = lastGatewayError.value ?: "none"
+    val connectedAt = lastGatewayConnectedAtMs.value?.let { formatTimestamp(it) } ?: "n/a"
+    val disconnectedAt = lastGatewayDisconnectedAtMs.value?.let { formatTimestamp(it) } ?: "n/a"
+
+    return buildString {
+      appendLine("OpenClaw Android diagnostics")
+      appendLine("status: ${statusText.value}")
+      appendLine("endpoint: $endpointText")
+      appendLine("manualTls: $tlsMode")
+      appendLine("tokenPresent: $tokenPresent")
+      appendLine("reconnectAttempts: $reconnects")
+      appendLine("lastConnectedAt: $connectedAt")
+      appendLine("lastDisconnectedAt: $disconnectedAt")
+      appendLine("lastError: $lastError")
+    }.trim()
+  }
+
+  fun resetGatewayDiagnostics() {
+    _gatewayReconnectAttempts.value = 0
+    _lastGatewayError.value = null
+    _lastGatewayConnectedAtMs.value = null
+    _lastGatewayDisconnectedAtMs.value = null
   }
 
   private fun handleGatewayEvent(event: String, payloadJson: String?) {
@@ -955,6 +1023,11 @@ class NodeRuntime(context: Context) {
         if (_cameraHud.value?.token == token) _cameraHud.value = null
       }
     }
+  }
+
+  private fun formatTimestamp(epochMs: Long): String {
+    val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+    return formatter.format(Date(epochMs))
   }
 
 }

--- a/apps/android/app/src/main/java/ai/openclaw/android/PermissionRequester.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/PermissionRequester.kt
@@ -33,6 +33,7 @@ class PermissionRequester(private val activity: ComponentActivity) {
   suspend fun requestIfMissing(
     permissions: List<String>,
     timeoutMs: Long = 20_000,
+    contextHint: String? = null,
   ): Map<String, Boolean> =
     mutex.withLock {
       val missing =
@@ -46,7 +47,7 @@ class PermissionRequester(private val activity: ComponentActivity) {
       val needsRationale =
         missing.any { ActivityCompat.shouldShowRequestPermissionRationale(activity, it) }
       if (needsRationale) {
-        val proceed = showRationaleDialog(missing)
+        val proceed = showRationaleDialog(missing, contextHint = contextHint)
         if (!proceed) {
           return permissions.associateWith { perm ->
             ContextCompat.checkSelfPermission(activity, perm) == PackageManager.PERMISSION_GRANTED
@@ -78,18 +79,21 @@ class PermissionRequester(private val activity: ComponentActivity) {
           !ActivityCompat.shouldShowRequestPermissionRationale(activity, it)
         }
       if (denied.isNotEmpty()) {
-        showSettingsDialog(denied)
+        showSettingsDialog(denied, contextHint = contextHint)
       }
 
       return merged
     }
 
-  private suspend fun showRationaleDialog(permissions: List<String>): Boolean =
+  private suspend fun showRationaleDialog(
+    permissions: List<String>,
+    contextHint: String? = null,
+  ): Boolean =
     withContext(Dispatchers.Main) {
       suspendCancellableCoroutine { cont ->
         AlertDialog.Builder(activity)
           .setTitle("Permission required")
-          .setMessage(buildRationaleMessage(permissions))
+          .setMessage(buildRationaleMessage(permissions, contextHint = contextHint))
           .setPositiveButton("Continue") { _, _ -> cont.resume(true) }
           .setNegativeButton("Not now") { _, _ -> cont.resume(false) }
           .setOnCancelListener { cont.resume(false) }
@@ -97,10 +101,13 @@ class PermissionRequester(private val activity: ComponentActivity) {
       }
     }
 
-  private fun showSettingsDialog(permissions: List<String>) {
+  private fun showSettingsDialog(
+    permissions: List<String>,
+    contextHint: String? = null,
+  ) {
     AlertDialog.Builder(activity)
       .setTitle("Enable permission in Settings")
-      .setMessage(buildSettingsMessage(permissions))
+      .setMessage(buildSettingsMessage(permissions, contextHint = contextHint))
       .setPositiveButton("Open Settings") { _, _ ->
         val intent =
           Intent(
@@ -113,14 +120,24 @@ class PermissionRequester(private val activity: ComponentActivity) {
       .show()
   }
 
-  private fun buildRationaleMessage(permissions: List<String>): String {
+  private fun buildRationaleMessage(
+    permissions: List<String>,
+    contextHint: String? = null,
+  ): String {
     val labels = permissions.map { permissionLabel(it) }
-    return "OpenClaw needs ${labels.joinToString(", ")} permissions to continue."
+    val feature = contextHint?.trim().orEmpty()
+    val suffix = if (feature.isNotEmpty()) " for $feature" else ""
+    return "OpenClaw needs ${labels.joinToString(", ")} permission${if (labels.size > 1) "s" else ""}$suffix to continue."
   }
 
-  private fun buildSettingsMessage(permissions: List<String>): String {
+  private fun buildSettingsMessage(
+    permissions: List<String>,
+    contextHint: String? = null,
+  ): String {
     val labels = permissions.map { permissionLabel(it) }
-    return "Please enable ${labels.joinToString(", ")} in Android Settings to continue."
+    val feature = contextHint?.trim().orEmpty()
+    val suffix = if (feature.isNotEmpty()) " for $feature" else ""
+    return "Please enable ${labels.joinToString(", ")} in Android Settings$suffix to continue."
   }
 
   private fun permissionLabel(permission: String): String =

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -323,6 +323,17 @@ class SecurePrefs(context: Context) {
     _telemetryRetention.value = retention
   }
 
+
+  fun loadTelemetrySyncCursor(stream: String): String? {
+    val key = "telemetry.sync.cursor.$stream"
+    return plainPrefs.getString(key, null)?.trim()?.takeIf { it.isNotEmpty() }
+  }
+
+  fun saveTelemetrySyncCursor(stream: String, capturedAt: String) {
+    val key = "telemetry.sync.cursor.$stream"
+    plainPrefs.edit { putString(key, capturedAt.trim()) }
+  }
+
   private fun loadVoiceWakeMode(): VoiceWakeMode {
     val raw = plainPrefs.getString(voiceWakeModeKey, null)
     val resolved = VoiceWakeMode.fromRawValue(raw)

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -102,6 +102,26 @@ class SecurePrefs(context: Context) {
   private val _speakerEnabled = MutableStateFlow(plainPrefs.getBoolean("voice.speakerEnabled", true))
   val speakerEnabled: StateFlow<Boolean> = _speakerEnabled
 
+  private val _backgroundBatteryHistoryEnabled =
+    MutableStateFlow(plainPrefs.getBoolean("telemetry.battery.enabled", false))
+  val backgroundBatteryHistoryEnabled: StateFlow<Boolean> = _backgroundBatteryHistoryEnabled
+
+  private val _backgroundLocationHistoryEnabled =
+    MutableStateFlow(plainPrefs.getBoolean("telemetry.location.enabled", false))
+  val backgroundLocationHistoryEnabled: StateFlow<Boolean> = _backgroundLocationHistoryEnabled
+
+  private val _telemetrySyncEnabled =
+    MutableStateFlow(plainPrefs.getBoolean("telemetry.sync.enabled", true))
+  val telemetrySyncEnabled: StateFlow<Boolean> = _telemetrySyncEnabled
+
+  private val _telemetrySamplingMode =
+    MutableStateFlow(TelemetrySamplingMode.fromRawValue(plainPrefs.getString("telemetry.sampling.mode", null)))
+  val telemetrySamplingMode: StateFlow<TelemetrySamplingMode> = _telemetrySamplingMode
+
+  private val _telemetryRetention =
+    MutableStateFlow(TelemetryRetention.fromRawValue(plainPrefs.getString("telemetry.retention", null)))
+  val telemetryRetention: StateFlow<TelemetryRetention> = _telemetryRetention
+
   fun setLastDiscoveredStableId(value: String) {
     val trimmed = value.trim()
     plainPrefs.edit { putString("gateway.lastDiscoveredStableID", trimmed) }
@@ -276,6 +296,31 @@ class SecurePrefs(context: Context) {
   fun setSpeakerEnabled(value: Boolean) {
     plainPrefs.edit { putBoolean("voice.speakerEnabled", value) }
     _speakerEnabled.value = value
+  }
+
+  fun setBackgroundBatteryHistoryEnabled(value: Boolean) {
+    plainPrefs.edit { putBoolean("telemetry.battery.enabled", value) }
+    _backgroundBatteryHistoryEnabled.value = value
+  }
+
+  fun setBackgroundLocationHistoryEnabled(value: Boolean) {
+    plainPrefs.edit { putBoolean("telemetry.location.enabled", value) }
+    _backgroundLocationHistoryEnabled.value = value
+  }
+
+  fun setTelemetrySyncEnabled(value: Boolean) {
+    plainPrefs.edit { putBoolean("telemetry.sync.enabled", value) }
+    _telemetrySyncEnabled.value = value
+  }
+
+  fun setTelemetrySamplingMode(mode: TelemetrySamplingMode) {
+    plainPrefs.edit { putString("telemetry.sampling.mode", mode.rawValue) }
+    _telemetrySamplingMode.value = mode
+  }
+
+  fun setTelemetryRetention(retention: TelemetryRetention) {
+    plainPrefs.edit { putString("telemetry.retention", retention.rawValue) }
+    _telemetryRetention.value = retention
   }
 
   private fun loadVoiceWakeMode(): VoiceWakeMode {

--- a/apps/android/app/src/main/java/ai/openclaw/android/TelemetryCollector.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/TelemetryCollector.kt
@@ -1,0 +1,252 @@
+package ai.openclaw.android
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.location.LocationManager
+import android.os.BatteryManager
+import android.util.Log
+import androidx.core.content.ContextCompat
+import ai.openclaw.android.node.LocationCaptureManager
+import java.io.File
+import java.time.Instant
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+class TelemetryCollector(
+  private val appContext: Context,
+  private val scope: CoroutineScope,
+  private val locationCaptureManager: LocationCaptureManager,
+  private val batteryEnabled: () -> Boolean,
+  private val locationEnabled: () -> Boolean,
+  private val locationMode: () -> LocationMode,
+  private val locationPreciseEnabled: () -> Boolean,
+  private val samplingMode: () -> TelemetrySamplingMode,
+  private val retention: () -> TelemetryRetention,
+  private val syncEnabled: () -> Boolean,
+) {
+  private val json = Json { ignoreUnknownKeys = true }
+  private val telemetryDir: File = File(appContext.filesDir, "telemetry")
+  private val batteryHistoryFile = File(telemetryDir, "battery_history.jsonl")
+  private val locationHistoryFile = File(telemetryDir, "location_history.jsonl")
+  private var job: Job? = null
+  private var lastBatteryPercent: Int = -1
+  private var lastBatteryCharging: Boolean = false
+  private var lastBatterySampleAtMs: Long = 0L
+
+  fun start() {
+    if (job?.isActive == true) return
+    telemetryDir.mkdirs()
+    job =
+      scope.launch(Dispatchers.IO) {
+        while (isActive) {
+          val mode = effectiveSamplingMode()
+          try {
+            tick(mode)
+          } catch (t: Throwable) {
+            Log.w("OpenClawTelemetry", "telemetry tick failed", t)
+          }
+          delay(intervalMs(mode))
+        }
+      }
+  }
+
+  private suspend fun tick(mode: TelemetrySamplingMode) {
+    val now = Instant.now().toString()
+
+    if (batteryEnabled()) {
+      captureBattery(now, mode)
+    }
+
+    if (locationEnabled()) {
+      captureLocation(now, mode)
+    }
+
+    pruneByRetention(retention())
+  }
+
+  private fun captureBattery(nowIso: String, mode: TelemetrySamplingMode) {
+    val intent = appContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+    val level = intent?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+    val scale = intent?.getIntExtra(BatteryManager.EXTRA_SCALE, 100) ?: 100
+    val status = intent?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
+    val charging =
+      status == BatteryManager.BATTERY_STATUS_CHARGING ||
+        status == BatteryManager.BATTERY_STATUS_FULL
+    val percent = if (level >= 0 && scale > 0) ((level * 100f) / scale).toInt().coerceIn(0, 100) else -1
+
+    if (percent < 0) return
+
+    val prevPercent = lastBatteryPercent
+    val prevCharging = lastBatteryCharging
+    lastBatteryPercent = percent
+    lastBatteryCharging = charging
+
+    val nowMs = runCatching { Instant.parse(nowIso).toEpochMilli() }.getOrElse { System.currentTimeMillis() }
+    val unchanged = percent == prevPercent && charging == prevCharging
+    if (unchanged && lastBatterySampleAtMs > 0L) {
+      val ageMs = nowMs - lastBatterySampleAtMs
+      if (ageMs in 0 until unchangedBatteryWriteWindowMs(mode)) return
+    }
+
+    val line =
+      buildString {
+        append("{\"capturedAt\":\"").append(nowIso).append("\"")
+        append(",\"percent\":").append(percent)
+        append(",\"charging\":").append(charging)
+        append(",\"source\":\"battery_broadcast\"")
+        append(",\"syncEnabled\":").append(syncEnabled())
+        append("}")
+      }
+    appendLine(batteryHistoryFile, line)
+    lastBatterySampleAtMs = nowMs
+  }
+
+  private suspend fun captureLocation(nowIso: String, mode: TelemetrySamplingMode) {
+    if (locationMode() != LocationMode.Always) return
+
+    val fineOk =
+      ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_FINE_LOCATION) ==
+        PackageManager.PERMISSION_GRANTED
+    val coarseOk =
+      ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+        PackageManager.PERMISSION_GRANTED
+    if (!fineOk && !coarseOk) return
+
+    val backgroundOk =
+      ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
+        PackageManager.PERMISSION_GRANTED
+    if (!backgroundOk) return
+
+    val manager = appContext.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+    if (!manager.isProviderEnabled(LocationManager.GPS_PROVIDER) &&
+      !manager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+    ) {
+      return
+    }
+
+    val isPrecise =
+      when (mode) {
+        TelemetrySamplingMode.LowPower -> false
+        TelemetrySamplingMode.Balanced -> locationPreciseEnabled() && fineOk
+        TelemetrySamplingMode.HighDetail -> locationPreciseEnabled() && fineOk
+      }
+
+    val desiredProviders =
+      when (mode) {
+        TelemetrySamplingMode.LowPower -> listOf(LocationManager.NETWORK_PROVIDER, LocationManager.GPS_PROVIDER)
+        TelemetrySamplingMode.Balanced -> {
+          if (isPrecise) listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
+          else listOf(LocationManager.NETWORK_PROVIDER, LocationManager.GPS_PROVIDER)
+        }
+        TelemetrySamplingMode.HighDetail -> listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
+      }
+
+    val payload =
+      withContext(Dispatchers.Main) {
+        locationCaptureManager.getLocation(
+          desiredProviders = desiredProviders,
+          maxAgeMs = locationMaxAgeMs(mode),
+          timeoutMs = locationTimeoutMs(mode),
+          isPrecise = isPrecise,
+        )
+      }
+
+    val root = json.parseToJsonElement(payload.payloadJson) as? JsonObject ?: return
+    val lat = (root["lat"] as? JsonPrimitive)?.content ?: return
+    val lon = (root["lon"] as? JsonPrimitive)?.content ?: return
+    val accuracy = (root["accuracyMeters"] as? JsonPrimitive)?.content ?: "null"
+    val source = (root["source"] as? JsonPrimitive)?.content ?: "unknown"
+
+    val line =
+      buildString {
+        append("{\"capturedAt\":\"").append(nowIso).append("\"")
+        append(",\"lat\":").append(lat)
+        append(",\"lon\":").append(lon)
+        append(",\"accuracyMeters\":").append(accuracy)
+        append(",\"source\":\"").append(source).append("\"")
+        append(",\"syncEnabled\":").append(syncEnabled())
+        append("}")
+      }
+    appendLine(locationHistoryFile, line)
+  }
+
+  private fun appendLine(file: File, line: String) {
+    file.parentFile?.mkdirs()
+    file.appendText(line)
+    file.appendText("\n")
+  }
+
+  private fun pruneByRetention(retention: TelemetryRetention) {
+    val cutoffMs = System.currentTimeMillis() - retention.days * 24L * 60L * 60L * 1000L
+    pruneFile(batteryHistoryFile, cutoffMs)
+    pruneFile(locationHistoryFile, cutoffMs)
+  }
+
+  private fun pruneFile(file: File, cutoffMs: Long) {
+    if (!file.exists()) return
+    val kept =
+      file.readLines()
+        .filter { it.isNotBlank() }
+        .filter { line ->
+          val capturedAt =
+            runCatching {
+              val root = json.parseToJsonElement(line) as JsonObject
+              (root["capturedAt"] as? JsonPrimitive)?.content
+            }.getOrNull()
+          val ts = runCatching { capturedAt?.let { Instant.parse(it).toEpochMilli() } }.getOrNull()
+          ts == null || ts >= cutoffMs
+        }
+    file.writeText(if (kept.isEmpty()) "" else kept.joinToString("\n", postfix = "\n"))
+  }
+
+  private fun effectiveSamplingMode(): TelemetrySamplingMode {
+    val requested = samplingMode()
+    if (requested != TelemetrySamplingMode.Balanced) return requested
+    val percent = lastBatteryPercent
+    val charging = lastBatteryCharging
+    return if (!charging && percent in 0..35) TelemetrySamplingMode.LowPower else requested
+  }
+
+  private fun unchangedBatteryWriteWindowMs(mode: TelemetrySamplingMode): Long {
+    return when (mode) {
+      TelemetrySamplingMode.LowPower -> 30 * 60 * 1000L
+      TelemetrySamplingMode.Balanced -> 15 * 60 * 1000L
+      TelemetrySamplingMode.HighDetail -> 5 * 60 * 1000L
+    }
+  }
+
+  private fun locationTimeoutMs(mode: TelemetrySamplingMode): Long {
+    return when (mode) {
+      TelemetrySamplingMode.LowPower -> 4_000L
+      TelemetrySamplingMode.Balanced -> 6_000L
+      TelemetrySamplingMode.HighDetail -> 8_000L
+    }
+  }
+
+  private fun locationMaxAgeMs(mode: TelemetrySamplingMode): Long {
+    return when (mode) {
+      TelemetrySamplingMode.LowPower -> 20 * 60 * 1000L
+      TelemetrySamplingMode.Balanced -> 8 * 60 * 1000L
+      TelemetrySamplingMode.HighDetail -> 60 * 1000L
+    }
+  }
+
+  private fun intervalMs(mode: TelemetrySamplingMode): Long {
+    return when (mode) {
+      TelemetrySamplingMode.LowPower -> 20 * 60 * 1000L
+      TelemetrySamplingMode.Balanced -> 8 * 60 * 1000L
+      TelemetrySamplingMode.HighDetail -> 60 * 1000L
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/TelemetryRetention.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/TelemetryRetention.kt
@@ -1,0 +1,13 @@
+package ai.openclaw.android
+
+enum class TelemetryRetention(val rawValue: String, val days: Int) {
+  OneDay("1d", 1),
+  SevenDays("7d", 7),
+  ThirtyDays("30d", 30);
+
+  companion object {
+    fun fromRawValue(raw: String?): TelemetryRetention {
+      return entries.firstOrNull { it.rawValue == raw } ?: SevenDays
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/TelemetrySamplingMode.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/TelemetrySamplingMode.kt
@@ -1,0 +1,13 @@
+package ai.openclaw.android
+
+enum class TelemetrySamplingMode(val rawValue: String) {
+  LowPower("low_power"),
+  Balanced("balanced"),
+  HighDetail("high_detail");
+
+  companion object {
+    fun fromRawValue(raw: String?): TelemetrySamplingMode {
+      return entries.firstOrNull { it.rawValue == raw } ?: Balanced
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatController.kt
@@ -3,6 +3,7 @@ package ai.openclaw.android.chat
 import ai.openclaw.android.gateway.GatewaySession
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.min
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -61,6 +62,8 @@ class ChatController(
   private val queuedOutbox = mutableListOf<PendingOutbound>()
   private val _queuedItems = MutableStateFlow<List<ChatQueuedOutbound>>(emptyList())
   val queuedItems: StateFlow<List<ChatQueuedOutbound>> = _queuedItems.asStateFlow()
+  private val recentReplaySends = mutableMapOf<String, Long>()
+  private val replayDedupeWindowMs = 10_000L
 
   private val pendingRuns = mutableSetOf<String>()
   private val pendingRunTimeoutJobs = ConcurrentHashMap<String, Job>()
@@ -144,6 +147,8 @@ class ChatController(
         reEvaluateOnReconnect = reEvaluateOnReconnect,
         queuedAtMs = System.currentTimeMillis(),
         queuedReplay = false,
+        retryCount = 0,
+        nextAttemptAtMs = 0L,
       )
 
     // Optimistic user message.
@@ -176,7 +181,7 @@ class ChatController(
         )
 
     if (!_healthOk.value) {
-      enqueueOutbound(lastOutbound!!)
+      enqueueOutbound(lastOutbound!!.copy(queuedReplay = true, nextAttemptAtMs = 0L))
       _errorText.value = "Queued for send when gateway reconnects"
       return
     }
@@ -240,15 +245,38 @@ class ChatController(
         }
       } catch (_: Throwable) {
         clearPendingRun(runId)
-        enqueueOutbound(outbound)
-        _errorText.value = "Queued after send failure; will retry on reconnect"
+        enqueueForRetry(outbound)
+        _errorText.value = "Queued after send failure; will retry automatically"
       }
     }
   }
 
+  private fun enqueueForRetry(outbound: PendingOutbound) {
+    val retryCount = outbound.retryCount + 1
+    val delayMs = min(30_000L, 2_000L * (1L shl min(4, retryCount - 1)))
+    val nextAttempt = System.currentTimeMillis() + delayMs
+    enqueueOutbound(
+      outbound.copy(
+        queuedReplay = true,
+        retryCount = retryCount,
+        nextAttemptAtMs = nextAttempt,
+      ),
+    )
+
+    scope.launch {
+      delay(delayMs)
+      flushQueuedOutbox()
+    }
+  }
+
   private fun enqueueOutbound(outbound: PendingOutbound) {
-    queuedOutbox.removeAll { it.id == outbound.id }
-    queuedOutbox.add(outbound.copy(queuedReplay = true))
+    val fingerprint = outbound.fingerprint()
+    val exists = queuedOutbox.any { it.fingerprint() == fingerprint }
+    if (exists) {
+      _errorText.value = "Already queued; waiting to resend"
+      return
+    }
+    queuedOutbox.add(outbound)
     publishQueuedItems()
   }
 
@@ -270,11 +298,21 @@ class ChatController(
 
   private fun flushQueuedOutbox() {
     if (!_healthOk.value || queuedOutbox.isEmpty()) return
-    val ready = queuedOutbox.toList().sortedBy { it.queuedAtMs }
+
+    val now = System.currentTimeMillis()
+    recentReplaySends.entries.removeAll { now - it.value > replayDedupeWindowMs }
+
+    val (ready, waiting) = queuedOutbox.partition { it.nextAttemptAtMs <= now }
     queuedOutbox.clear()
+    queuedOutbox.addAll(waiting)
     publishQueuedItems()
-    for (item in ready) {
-      sendOutboundNow(item.copy(id = UUID.randomUUID().toString()))
+
+    for (item in ready.sortedBy { it.queuedAtMs }) {
+      val fp = item.fingerprint()
+      val lastSentAt = recentReplaySends[fp]
+      if (lastSentAt != null && now - lastSentAt < replayDedupeWindowMs) continue
+      recentReplaySends[fp] = now
+      sendOutboundNow(item.copy(id = UUID.randomUUID().toString(), queuedReplay = true))
     }
   }
 
@@ -688,4 +726,11 @@ private data class PendingOutbound(
   val reEvaluateOnReconnect: Boolean,
   val queuedAtMs: Long,
   val queuedReplay: Boolean,
-)
+  val retryCount: Int,
+  val nextAttemptAtMs: Long,
+) {
+  fun fingerprint(): String {
+    val attachmentSig = attachments.joinToString("|") { "${it.type}:${it.mimeType}:${it.fileName}:${it.base64.length}" }
+    return "${sessionKey}::${thinkingLevel}::${reEvaluateOnReconnect}::${text.trim()}::${attachmentSig}"
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatController.kt
@@ -39,6 +39,9 @@ class ChatController(
   private val _healthOk = MutableStateFlow(false)
   val healthOk: StateFlow<Boolean> = _healthOk.asStateFlow()
 
+  private val _connectionState = MutableStateFlow(ChatConnectionState.Connecting)
+  val connectionState: StateFlow<ChatConnectionState> = _connectionState.asStateFlow()
+
   private val _thinkingLevel = MutableStateFlow("off")
   val thinkingLevel: StateFlow<String> = _thinkingLevel.asStateFlow()
 
@@ -59,15 +62,21 @@ class ChatController(
   private val pendingRunTimeoutJobs = ConcurrentHashMap<String, Job>()
   private val pendingRunTimeoutMs = 120_000L
 
+  private var streamingPublishJob: Job? = null
+  private var latestStreamingText: String? = null
   private var lastHealthPollAtMs: Long? = null
+  private var lastOutbound: PendingOutbound? = null
 
   fun onDisconnected(message: String) {
     _healthOk.value = false
+    _connectionState.value = ChatConnectionState.Reconnecting
     // Not an error; keep connection status in the UI pill.
     _errorText.value = null
     clearPendingRuns()
     pendingToolCallsById.clear()
     publishPendingToolCalls()
+    latestStreamingText = null
+    streamingPublishJob?.cancel()
     _streamingAssistantText.value = null
     _sessionId.value = null
   }
@@ -125,6 +134,7 @@ class ChatController(
     val text = if (trimmed.isEmpty() && attachments.isNotEmpty()) "See attached." else trimmed
     val sessionKey = _sessionKey.value
     val thinking = normalizeThinking(thinkingLevel)
+    lastOutbound = PendingOutbound(text = text, thinkingLevel = thinking, attachments = attachments, sessionKey = sessionKey)
 
     // Optimistic user message.
     val userContent =
@@ -157,6 +167,8 @@ class ChatController(
     }
 
     _errorText.value = null
+    latestStreamingText = null
+    streamingPublishJob?.cancel()
     _streamingAssistantText.value = null
     pendingToolCallsById.clear()
     publishPendingToolCalls()
@@ -225,6 +237,19 @@ class ChatController(
     }
   }
 
+  fun retryLastMessage(): Boolean {
+    val outbound = lastOutbound ?: return false
+    if (_sessionKey.value != outbound.sessionKey) {
+      _sessionKey.value = outbound.sessionKey
+    }
+    sendMessage(
+      message = outbound.text,
+      thinkingLevel = outbound.thinkingLevel,
+      attachments = outbound.attachments,
+    )
+    return true
+  }
+
   fun handleGatewayEvent(event: String, payloadJson: String?) {
     when (event) {
       "tick" -> {
@@ -233,6 +258,7 @@ class ChatController(
       "health" -> {
         // If we receive a health snapshot, the gateway is reachable.
         _healthOk.value = true
+        _connectionState.value = ChatConnectionState.Connected
       }
       "seqGap" -> {
         _errorText.value = "Event stream interrupted; try refreshing."
@@ -252,9 +278,12 @@ class ChatController(
   private suspend fun bootstrap(forceHealth: Boolean) {
     _errorText.value = null
     _healthOk.value = false
+    _connectionState.value = ChatConnectionState.Connecting
     clearPendingRuns()
     pendingToolCallsById.clear()
     publishPendingToolCalls()
+    latestStreamingText = null
+    streamingPublishJob?.cancel()
     _streamingAssistantText.value = null
     _sessionId.value = null
 
@@ -300,8 +329,10 @@ class ChatController(
     try {
       session.request("health", null)
       _healthOk.value = true
+      _connectionState.value = ChatConnectionState.Connected
     } catch (_: Throwable) {
       _healthOk.value = false
+      _connectionState.value = ChatConnectionState.Reconnecting
     }
   }
 
@@ -321,7 +352,7 @@ class ChatController(
         if (!isPending) return
         val text = parseAssistantDeltaText(payload)
         if (!text.isNullOrEmpty()) {
-          _streamingAssistantText.value = text
+          queueStreamingText(text)
         }
       }
       "final", "aborted", "error" -> {
@@ -331,7 +362,7 @@ class ChatController(
         if (runId != null) clearPendingRun(runId) else clearPendingRuns()
         pendingToolCallsById.clear()
         publishPendingToolCalls()
-        _streamingAssistantText.value = null
+        flushStreamingText()
         scope.launch {
           try {
             val historyJson =
@@ -342,6 +373,10 @@ class ChatController(
             history.thinkingLevel?.trim()?.takeIf { it.isNotEmpty() }?.let { _thinkingLevel.value = it }
           } catch (_: Throwable) {
             // best-effort
+          } finally {
+            latestStreamingText = null
+            streamingPublishJob?.cancel()
+            _streamingAssistantText.value = null
           }
         }
       }
@@ -393,6 +428,25 @@ class ChatController(
         publishPendingToolCalls()
         _streamingAssistantText.value = null
       }
+    }
+  }
+
+  private fun queueStreamingText(text: String) {
+    latestStreamingText = text
+    if (streamingPublishJob?.isActive == true) return
+    streamingPublishJob =
+      scope.launch {
+        delay(60)
+        flushStreamingText()
+      }
+  }
+
+  private fun flushStreamingText() {
+    streamingPublishJob?.cancel()
+    streamingPublishJob = null
+    val next = latestStreamingText?.trim().orEmpty()
+    if (next.isNotEmpty()) {
+      _streamingAssistantText.value = next
     }
   }
 
@@ -535,3 +589,10 @@ private fun JsonElement?.asLongOrNull(): Long? =
     is JsonPrimitive -> content.toLongOrNull()
     else -> null
   }
+
+private data class PendingOutbound(
+  val text: String,
+  val thinkingLevel: String,
+  val attachments: List<OutgoingAttachment>,
+  val sessionKey: String,
+)

--- a/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatController.kt
@@ -58,6 +58,10 @@ class ChatController(
   private val _sessions = MutableStateFlow<List<ChatSessionEntry>>(emptyList())
   val sessions: StateFlow<List<ChatSessionEntry>> = _sessions.asStateFlow()
 
+  private val queuedOutbox = mutableListOf<PendingOutbound>()
+  private val _queuedItems = MutableStateFlow<List<ChatQueuedOutbound>>(emptyList())
+  val queuedItems: StateFlow<List<ChatQueuedOutbound>> = _queuedItems.asStateFlow()
+
   private val pendingRuns = mutableSetOf<String>()
   private val pendingRunTimeoutJobs = ConcurrentHashMap<String, Job>()
   private val pendingRunTimeoutMs = 120_000L
@@ -122,24 +126,35 @@ class ChatController(
     message: String,
     thinkingLevel: String,
     attachments: List<OutgoingAttachment>,
+    reEvaluateOnReconnect: Boolean = false,
   ) {
     val trimmed = message.trim()
     if (trimmed.isEmpty() && attachments.isEmpty()) return
-    if (!_healthOk.value) {
-      _errorText.value = "Gateway health not OK; cannot send"
-      return
-    }
-
     val runId = UUID.randomUUID().toString()
     val text = if (trimmed.isEmpty() && attachments.isNotEmpty()) "See attached." else trimmed
     val sessionKey = _sessionKey.value
     val thinking = normalizeThinking(thinkingLevel)
-    lastOutbound = PendingOutbound(text = text, thinkingLevel = thinking, attachments = attachments, sessionKey = sessionKey)
+    lastOutbound =
+      PendingOutbound(
+        id = runId,
+        text = text,
+        thinkingLevel = thinking,
+        attachments = attachments,
+        sessionKey = sessionKey,
+        reEvaluateOnReconnect = reEvaluateOnReconnect,
+        queuedAtMs = System.currentTimeMillis(),
+        queuedReplay = false,
+      )
 
     // Optimistic user message.
     val userContent =
       buildList {
-        add(ChatMessageContent(type = "text", text = text))
+        add(
+          ChatMessageContent(
+            type = "text",
+            text = if (!_healthOk.value) "[Queued offline] $text" else text,
+          ),
+        )
         for (att in attachments) {
           add(
             ChatMessageContent(
@@ -160,6 +175,18 @@ class ChatController(
           timestampMs = System.currentTimeMillis(),
         )
 
+    if (!_healthOk.value) {
+      enqueueOutbound(lastOutbound!!)
+      _errorText.value = "Queued for send when gateway reconnects"
+      return
+    }
+
+    sendOutboundNow(lastOutbound!!)
+  }
+
+  private fun sendOutboundNow(outbound: PendingOutbound) {
+    val runId = outbound.id
+
     armPendingRunTimeout(runId)
     synchronized(pendingRuns) {
       pendingRuns.add(runId)
@@ -177,16 +204,19 @@ class ChatController(
       try {
         val params =
           buildJsonObject {
-            put("sessionKey", JsonPrimitive(sessionKey))
-            put("message", JsonPrimitive(text))
-            put("thinking", JsonPrimitive(thinking))
+            put("sessionKey", JsonPrimitive(outbound.sessionKey))
+            put(
+              "message",
+              JsonPrimitive(buildReplayMessage(outbound)),
+            )
+            put("thinking", JsonPrimitive(outbound.thinkingLevel))
             put("timeoutMs", JsonPrimitive(30_000))
             put("idempotencyKey", JsonPrimitive(runId))
-            if (attachments.isNotEmpty()) {
+            if (outbound.attachments.isNotEmpty()) {
               put(
                 "attachments",
                 JsonArray(
-                  attachments.map { att ->
+                  outbound.attachments.map { att ->
                     buildJsonObject {
                       put("type", JsonPrimitive(att.type))
                       put("mimeType", JsonPrimitive(att.mimeType))
@@ -208,10 +238,43 @@ class ChatController(
             _pendingRunCount.value = pendingRuns.size
           }
         }
-      } catch (err: Throwable) {
+      } catch (_: Throwable) {
         clearPendingRun(runId)
-        _errorText.value = err.message
+        enqueueOutbound(outbound)
+        _errorText.value = "Queued after send failure; will retry on reconnect"
       }
+    }
+  }
+
+  private fun enqueueOutbound(outbound: PendingOutbound) {
+    queuedOutbox.removeAll { it.id == outbound.id }
+    queuedOutbox.add(outbound.copy(queuedReplay = true))
+    publishQueuedItems()
+  }
+
+  private fun publishQueuedItems() {
+    _queuedItems.value =
+      queuedOutbox
+        .sortedBy { it.queuedAtMs }
+        .map {
+          ChatQueuedOutbound(
+            id = it.id,
+            sessionKey = it.sessionKey,
+            text = it.text,
+            attachmentCount = it.attachments.size,
+            queuedAtMs = it.queuedAtMs,
+            reEvaluateOnReconnect = it.reEvaluateOnReconnect,
+          )
+        }
+  }
+
+  private fun flushQueuedOutbox() {
+    if (!_healthOk.value || queuedOutbox.isEmpty()) return
+    val ready = queuedOutbox.toList().sortedBy { it.queuedAtMs }
+    queuedOutbox.clear()
+    publishQueuedItems()
+    for (item in ready) {
+      sendOutboundNow(item.copy(id = UUID.randomUUID().toString()))
     }
   }
 
@@ -246,6 +309,7 @@ class ChatController(
       message = outbound.text,
       thinkingLevel = outbound.thinkingLevel,
       attachments = outbound.attachments,
+      reEvaluateOnReconnect = outbound.reEvaluateOnReconnect,
     )
     return true
   }
@@ -259,6 +323,7 @@ class ChatController(
         // If we receive a health snapshot, the gateway is reachable.
         _healthOk.value = true
         _connectionState.value = ChatConnectionState.Connected
+        flushQueuedOutbox()
       }
       "seqGap" -> {
         _errorText.value = "Event stream interrupted; try refreshing."
@@ -330,6 +395,7 @@ class ChatController(
       session.request("health", null)
       _healthOk.value = true
       _connectionState.value = ChatConnectionState.Connected
+      flushQueuedOutbox()
     } catch (_: Throwable) {
       _healthOk.value = false
       _connectionState.value = ChatConnectionState.Reconnecting
@@ -448,6 +514,29 @@ class ChatController(
     if (next.isNotEmpty()) {
       _streamingAssistantText.value = next
     }
+  }
+
+  private fun buildReplayMessage(outbound: PendingOutbound): String {
+    if (!(outbound.reEvaluateOnReconnect && outbound.queuedReplay)) {
+      return outbound.text
+    }
+
+    val ageMs = (System.currentTimeMillis() - outbound.queuedAtMs).coerceAtLeast(0)
+    val ageMinutes = ageMs / 60_000
+
+    return buildString {
+      appendLine("[Time Capsule v2]")
+      appendLine("Queued while offline $ageMinutes minute(s) ago.")
+      appendLine("Session: ${outbound.sessionKey}")
+      appendLine()
+      appendLine("Original queued user intent:")
+      appendLine(outbound.text)
+      appendLine()
+      appendLine("Instructions:")
+      appendLine("1) Re-evaluate this intent using current context and recency.")
+      appendLine("2) If still valid, proceed with best direct answer/action.")
+      appendLine("3) If likely stale/unsafe/ambiguous now, ask one concise clarification question instead of assuming.")
+    }.trim()
   }
 
   private fun parseAssistantDeltaText(payload: JsonObject): String? {
@@ -591,8 +680,12 @@ private fun JsonElement?.asLongOrNull(): Long? =
   }
 
 private data class PendingOutbound(
+  val id: String,
   val text: String,
   val thinkingLevel: String,
   val attachments: List<OutgoingAttachment>,
   val sessionKey: String,
+  val reEvaluateOnReconnect: Boolean,
+  val queuedAtMs: Long,
+  val queuedReplay: Boolean,
 )

--- a/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatModels.kt
@@ -42,3 +42,9 @@ data class OutgoingAttachment(
   val fileName: String,
   val base64: String,
 )
+
+enum class ChatConnectionState {
+  Connected,
+  Connecting,
+  Reconnecting,
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/chat/ChatModels.kt
@@ -48,3 +48,12 @@ enum class ChatConnectionState {
   Connecting,
   Reconnecting,
 }
+
+data class ChatQueuedOutbound(
+  val id: String,
+  val sessionKey: String,
+  val text: String,
+  val attachmentCount: Int,
+  val queuedAtMs: Long,
+  val reEvaluateOnReconnect: Boolean,
+)

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -141,11 +141,7 @@ class GatewaySession(
     val params =
       buildJsonObject {
         put("event", JsonPrimitive(event))
-        if (payloadJson != null) {
-          put("payloadJSON", JsonPrimitive(payloadJson))
-        } else {
-          put("payloadJSON", JsonNull)
-        }
+        put("payloadJSON", JsonPrimitive(payloadJson ?: "{}"))
       }
     try {
       conn.request("node.event", params, timeoutMs = 8_000)

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -138,13 +138,10 @@ class GatewaySession(
 
   suspend fun sendNodeEvent(event: String, payloadJson: String?): Boolean {
     val conn = currentConnection ?: return false
-    val parsedPayload = payloadJson?.let { parseJsonOrNull(it) }
     val params =
       buildJsonObject {
         put("event", JsonPrimitive(event))
-        if (parsedPayload != null) {
-          put("payload", parsedPayload)
-        } else if (payloadJson != null) {
+        if (payloadJson != null) {
           put("payloadJSON", JsonPrimitive(payloadJson))
         } else {
           put("payloadJSON", JsonNull)

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/BatteryHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/BatteryHandler.kt
@@ -1,0 +1,32 @@
+package ai.openclaw.android.node
+
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import ai.openclaw.android.gateway.GatewaySession
+
+class BatteryHandler(private val appContext: Context) {
+  fun handleBatteryGet(): GatewaySession.InvokeResult {
+    return try {
+      val intent = appContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+      val level = intent?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+      val scale = intent?.getIntExtra(BatteryManager.EXTRA_SCALE, 100) ?: 100
+      val status = intent?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
+
+      val percent = if (level >= 0 && scale > 0) ((level * 100f) / scale).toInt().coerceIn(0, 100) else -1
+      val charging =
+        status == BatteryManager.BATTERY_STATUS_CHARGING ||
+          status == BatteryManager.BATTERY_STATUS_FULL
+
+      GatewaySession.InvokeResult.ok(
+        """{"percent":${if (percent >= 0) percent else "null"},"charging":$charging,"status":$status,"level":$level,"scale":$scale}"""
+      )
+    } catch (e: Throwable) {
+      GatewaySession.InvokeResult.error(
+        code = "BATTERY_UNAVAILABLE",
+        message = "BATTERY_UNAVAILABLE: ${e.message ?: "unable to read battery"}",
+      )
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/CameraCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/CameraCaptureManager.kt
@@ -76,7 +76,10 @@ class CameraCaptureManager(private val context: Context) {
 
     val requester = permissionRequester
       ?: throw IllegalStateException("CAMERA_PERMISSION_REQUIRED: grant Camera permission")
-    val results = requester.requestIfMissing(listOf(Manifest.permission.CAMERA))
+    val results = requester.requestIfMissing(
+      permissions = listOf(Manifest.permission.CAMERA),
+      contextHint = "camera capture",
+    )
     if (results[Manifest.permission.CAMERA] != true) {
       throw IllegalStateException("CAMERA_PERMISSION_REQUIRED: grant Camera permission")
     }
@@ -88,7 +91,10 @@ class CameraCaptureManager(private val context: Context) {
 
     val requester = permissionRequester
       ?: throw IllegalStateException("MIC_PERMISSION_REQUIRED: grant Microphone permission")
-    val results = requester.requestIfMissing(listOf(Manifest.permission.RECORD_AUDIO))
+    val results = requester.requestIfMissing(
+      permissions = listOf(Manifest.permission.RECORD_AUDIO),
+      contextHint = "recording video with audio",
+    )
     if (results[Manifest.permission.RECORD_AUDIO] != true) {
       throw IllegalStateException("MIC_PERMISSION_REQUIRED: grant Microphone permission")
     }

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/CanvasController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/CanvasController.kt
@@ -2,6 +2,7 @@ package ai.openclaw.android.node
 
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.net.Uri
 import android.os.Looper
 import android.util.Log
 import android.webkit.WebView
@@ -65,8 +66,8 @@ class CanvasController {
   }
 
   fun navigate(url: String) {
-    val trimmed = url.trim()
-    this.url = if (trimmed.isBlank() || trimmed == "/") null else trimmed
+    val normalized = normalizeCanvasUrl(url)
+    this.url = normalized
     _currentUrl.value = this.url
     reload()
   }
@@ -88,6 +89,32 @@ class CanvasController {
 
   fun onPageFinished() {
     applyDebugStatus()
+  }
+
+  private fun normalizeCanvasUrl(raw: String): String? {
+    val trimmed = raw.trim()
+    if (trimmed.isBlank() || trimmed == "/") return null
+
+    // Internal session targets (for example agent:main:main) are not browser URLs.
+    // Treat them as "show canvas" without attempting WebView navigation.
+    if (trimmed.startsWith("agent:") || trimmed.startsWith("session:")) {
+      if (BuildConfig.DEBUG) {
+        Log.w("OpenClawCanvas", "ignore internal canvas target: $trimmed")
+      }
+      return null
+    }
+
+    val parsed = runCatching { Uri.parse(trimmed) }.getOrNull() ?: return null
+    val scheme = parsed.scheme?.lowercase().orEmpty()
+    return when (scheme) {
+      "http", "https", "file", "about", "data" -> trimmed
+      else -> {
+        if (BuildConfig.DEBUG) {
+          Log.w("OpenClawCanvas", "ignore unsupported canvas URL scheme: $trimmed")
+        }
+        null
+      }
+    }
   }
 
   private inline fun withWebViewOnMain(crossinline block: (WebView) -> Unit) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/CanvasController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/CanvasController.kt
@@ -66,6 +66,31 @@ class CanvasController {
   }
 
   fun navigate(url: String) {
+    val trimmed = url.trim()
+
+    // Blank navigate payload means "present current canvas". Do not drop to scaffold.
+    if (trimmed.isBlank() || trimmed == "/") {
+      if (BuildConfig.DEBUG) {
+        Log.d("OpenClawCanvas", "ignore blank canvas navigate payload")
+      }
+      if (!this.url.isNullOrBlank()) {
+        reload()
+      }
+      return
+    }
+
+    // Internal session targets (for example agent:main:main) are control targets,
+    // not navigable URLs. Keep the current canvas URL instead of dropping to scaffold.
+    if (trimmed.startsWith("agent:") || trimmed.startsWith("session:")) {
+      if (BuildConfig.DEBUG) {
+        Log.w("OpenClawCanvas", "ignore internal canvas target: $trimmed")
+      }
+      if (!this.url.isNullOrBlank()) {
+        reload()
+      }
+      return
+    }
+
     val normalized = normalizeCanvasUrl(url)
     this.url = normalized
     _currentUrl.value = this.url
@@ -94,15 +119,6 @@ class CanvasController {
   private fun normalizeCanvasUrl(raw: String): String? {
     val trimmed = raw.trim()
     if (trimmed.isBlank() || trimmed == "/") return null
-
-    // Internal session targets (for example agent:main:main) are not browser URLs.
-    // Treat them as "show canvas" without attempting WebView navigation.
-    if (trimmed.startsWith("agent:") || trimmed.startsWith("session:")) {
-      if (BuildConfig.DEBUG) {
-        Log.w("OpenClawCanvas", "ignore internal canvas target: $trimmed")
-      }
-      return null
-    }
 
     val parsed = runCatching { Uri.parse(trimmed) }.getOrNull() ?: return null
     val scheme = parsed.scheme?.lowercase().orEmpty()

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeCommandRegistry.kt
@@ -162,6 +162,9 @@ object InvokeCommandRegistry {
         name = OpenClawDeviceCommand.Health.rawValue,
       ),
       InvokeCommandSpec(
+        name = OpenClawDeviceCommand.Battery.rawValue,
+      ),
+      InvokeCommandSpec(
         name = OpenClawNotificationsCommand.List.rawValue,
       ),
       InvokeCommandSpec(

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeDispatcher.kt
@@ -27,6 +27,7 @@ class InvokeDispatcher(
   private val motionHandler: MotionHandler,
   private val screenHandler: ScreenHandler,
   private val smsHandler: SmsHandler,
+  private val batteryHandler: BatteryHandler,
   private val a2uiHandler: A2UIHandler,
   private val debugHandler: DebugHandler,
   private val appUpdateHandler: AppUpdateHandler,
@@ -166,6 +167,9 @@ class InvokeDispatcher(
 
       // SMS command
       OpenClawSmsCommand.Send.rawValue -> smsHandler.handleSmsSend(paramsJson)
+
+      // Device commands
+      OpenClawDeviceCommand.Battery.rawValue -> batteryHandler.handleBatteryGet()
 
       // Debug commands
       "debug.ed25519" -> debugHandler.handleEd25519()

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ScreenRecordManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ScreenRecordManager.kt
@@ -137,7 +137,10 @@ class ScreenRecordManager(private val context: Context) {
     val requester =
       permissionRequester
         ?: throw IllegalStateException("MIC_PERMISSION_REQUIRED: grant Microphone permission")
-    val results = requester.requestIfMissing(listOf(android.Manifest.permission.RECORD_AUDIO))
+    val results = requester.requestIfMissing(
+      permissions = listOf(android.Manifest.permission.RECORD_AUDIO),
+      contextHint = "screen recording with audio",
+    )
     if (results[android.Manifest.permission.RECORD_AUDIO] != true) {
       throw IllegalStateException("MIC_PERMISSION_REQUIRED: grant Microphone permission")
     }

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/SmsManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/SmsManager.kt
@@ -204,7 +204,10 @@ class SmsManager(private val context: Context) {
     private suspend fun ensureSmsPermission(): Boolean {
         if (hasSmsPermission()) return true
         val requester = permissionRequester ?: return false
-        val results = requester.requestIfMissing(listOf(Manifest.permission.SEND_SMS))
+        val results = requester.requestIfMissing(
+            permissions = listOf(Manifest.permission.SEND_SMS),
+            contextHint = "sending SMS",
+        )
         return results[Manifest.permission.SEND_SMS] == true
     }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/protocol/OpenClawProtocolConstants.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/protocol/OpenClawProtocolConstants.kt
@@ -84,6 +84,7 @@ enum class OpenClawDeviceCommand(val rawValue: String) {
   Info("device.info"),
   Permissions("device.permissions"),
   Health("device.health"),
+  Battery("device.battery"),
   ;
 
   companion object {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/CanvasScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/CanvasScreen.kt
@@ -93,6 +93,7 @@ fun CanvasScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
                 Log.d("OpenClawWebView", "onPageFinished: $url")
               }
               viewModel.canvas.onPageFinished()
+              viewModel.onCanvasPageFinished(url)
             }
 
             override fun onRenderProcessGone(

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/ConnectTabScreen.kt
@@ -40,6 +40,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
@@ -47,6 +52,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import ai.openclaw.android.MainViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 private enum class ConnectInputMode {
   SetupCode,
@@ -64,6 +72,12 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
   val manualEnabled by viewModel.manualEnabled.collectAsState()
   val gatewayToken by viewModel.gatewayToken.collectAsState()
   val pendingTrust by viewModel.pendingGatewayTrust.collectAsState()
+  val reconnectAttempts by viewModel.gatewayReconnectAttempts.collectAsState()
+  val lastGatewayError by viewModel.lastGatewayError.collectAsState()
+  val lastConnectedAtMs by viewModel.lastGatewayConnectedAtMs.collectAsState()
+  val lastDisconnectedAtMs by viewModel.lastGatewayDisconnectedAtMs.collectAsState()
+
+  val context = LocalContext.current
 
   var advancedOpen by rememberSaveable { mutableStateOf(false) }
   var inputMode by
@@ -82,6 +96,7 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
   var manualTlsInput by rememberSaveable { mutableStateOf(manualTls) }
   var passwordInput by rememberSaveable { mutableStateOf("") }
   var validationText by rememberSaveable { mutableStateOf<String?>(null) }
+  var actionFeedbackText by rememberSaveable { mutableStateOf<String?>(null) }
 
   if (pendingTrust != null) {
     val prompt = pendingTrust!!
@@ -158,6 +173,84 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
       Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Text("Gateway state", style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold), color = mobileTextSecondary)
         Text(statusText, style = mobileBody, color = mobileText)
+      }
+    }
+
+    Surface(
+      modifier = Modifier.fillMaxWidth(),
+      shape = RoundedCornerShape(14.dp),
+      color = mobileSurface,
+      border = BorderStroke(1.dp, mobileBorder),
+    ) {
+      Column(
+        modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        Text("Diagnostics", style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold), color = mobileTextSecondary)
+        Text("TLS: ${if (manualTlsInput) "enabled" else "disabled"}", style = mobileCallout, color = mobileText)
+        Text("Token: ${if (gatewayToken.isBlank()) "not set" else "set"}", style = mobileCallout, color = mobileText)
+        Text("Reconnect attempts: $reconnectAttempts", style = mobileCallout, color = mobileText)
+        Text(
+          "Last error: ${lastGatewayError ?: "none"}",
+          style = mobileCallout,
+          color = if (lastGatewayError.isNullOrBlank()) mobileTextSecondary else mobileWarning,
+        )
+        Text(
+          "Last connected: ${formatGatewayTime(lastConnectedAtMs)}",
+          style = mobileCaption1,
+          color = mobileTextSecondary,
+        )
+        Text(
+          "Last disconnected: ${formatGatewayTime(lastDisconnectedAtMs)}",
+          style = mobileCaption1,
+          color = mobileTextSecondary,
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(14.dp), verticalAlignment = Alignment.CenterVertically) {
+          TextButton(
+            onClick = {
+              val manager = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+              manager?.setPrimaryClip(
+                ClipData.newPlainText("OpenClaw diagnostics", viewModel.gatewayDebugSummary()),
+              )
+              actionFeedbackText = "Copied diagnostics"
+            },
+            contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp),
+          ) {
+            Text("Copy debug summary", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold), color = mobileAccent)
+          }
+
+          TextButton(
+            onClick = {
+              val summary = viewModel.gatewayDebugSummary()
+              val intent =
+                Intent(Intent.ACTION_SEND).apply {
+                  type = "text/plain"
+                  putExtra(Intent.EXTRA_SUBJECT, "OpenClaw Android diagnostics")
+                  putExtra(Intent.EXTRA_TEXT, summary)
+                  addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+              context.startActivity(Intent.createChooser(intent, "Share diagnostics").addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+              actionFeedbackText = "Opened share sheet"
+            },
+            contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp),
+          ) {
+            Text("Share", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold), color = mobileAccent)
+          }
+
+          TextButton(
+            onClick = {
+              viewModel.resetGatewayDiagnostics()
+              actionFeedbackText = "Diagnostics reset"
+            },
+            contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp),
+          ) {
+            Text("Reset", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold), color = mobileWarning)
+          }
+        }
+
+        if (!actionFeedbackText.isNullOrBlank()) {
+          Text(actionFeedbackText!!, style = mobileCaption1, color = mobileSuccess)
+        }
       }
     }
 
@@ -491,3 +584,9 @@ private fun outlinedColors() =
     unfocusedTextColor = mobileText,
     cursorColor = mobileAccent,
   )
+
+private fun formatGatewayTime(epochMs: Long?): String {
+  if (epochMs == null) return "n/a"
+  val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+  return formatter.format(Date(epochMs))
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/ConnectTabScreen.kt
@@ -65,6 +65,7 @@ private enum class ConnectInputMode {
 fun ConnectTabScreen(viewModel: MainViewModel) {
   val statusText by viewModel.statusText.collectAsState()
   val isConnected by viewModel.isConnected.collectAsState()
+  val isNodeConnected by viewModel.isNodeConnected.collectAsState()
   val remoteAddress by viewModel.remoteAddress.collectAsState()
   val manualHost by viewModel.manualHost.collectAsState()
   val manualPort by viewModel.manualPort.collectAsState()
@@ -136,7 +137,12 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
       }
     }
 
-  val primaryLabel = if (isConnected) "Disconnect Gateway" else "Connect Gateway"
+  val primaryLabel =
+    when {
+      isConnected && !isNodeConnected -> "Recover Node Session"
+      isConnected -> "Disconnect Gateway"
+      else -> "Connect Gateway"
+    }
 
   Column(
     modifier = Modifier.verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 16.dp),
@@ -190,6 +196,11 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
         Text("TLS: ${if (manualTlsInput) "enabled" else "disabled"}", style = mobileCallout, color = mobileText)
         Text("Token: ${if (gatewayToken.isBlank()) "not set" else "set"}", style = mobileCallout, color = mobileText)
         Text("Reconnect attempts: $reconnectAttempts", style = mobileCallout, color = mobileText)
+        Text(
+          "Node session: ${if (isNodeConnected) "online" else "offline"}",
+          style = mobileCallout,
+          color = if (isNodeConnected) mobileSuccess else mobileWarning,
+        )
         Text(
           "Last error: ${lastGatewayError ?: "none"}",
           style = mobileCallout,
@@ -256,6 +267,11 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
 
     Button(
       onClick = {
+        if (isConnected && !isNodeConnected) {
+          validationText = null
+          viewModel.refreshGatewayConnection()
+          return@Button
+        }
         if (isConnected) {
           viewModel.disconnect()
           validationText = null
@@ -303,7 +319,12 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
       shape = RoundedCornerShape(14.dp),
       colors =
         ButtonDefaults.buttonColors(
-          containerColor = if (isConnected) mobileDanger else mobileAccent,
+          containerColor =
+            when {
+              isConnected && !isNodeConnected -> mobileWarning
+              isConnected -> mobileDanger
+              else -> mobileAccent
+            },
           contentColor = Color.White,
         ),
     ) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/MobileUiTokens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/MobileUiTokens.kt
@@ -12,29 +12,29 @@ import ai.openclaw.android.R
 internal val mobileBackgroundGradient =
   Brush.verticalGradient(
     listOf(
-      Color(0xFFFFFFFF),
-      Color(0xFFF7F8FA),
-      Color(0xFFEFF1F5),
+      Color(0xFF0F1115),
+      Color(0xFF151821),
+      Color(0xFF1B1F29),
     ),
   )
 
-internal val mobileSurface = Color(0xFFF6F7FA)
-internal val mobileSurfaceStrong = Color(0xFFECEEF3)
-internal val mobileBorder = Color(0xFFE5E7EC)
-internal val mobileBorderStrong = Color(0xFFD6DAE2)
-internal val mobileText = Color(0xFF17181C)
-internal val mobileTextSecondary = Color(0xFF5D6472)
-internal val mobileTextTertiary = Color(0xFF99A0AE)
-internal val mobileAccent = Color(0xFF1D5DD8)
-internal val mobileAccentSoft = Color(0xFFECF3FF)
-internal val mobileSuccess = Color(0xFF2F8C5A)
-internal val mobileSuccessSoft = Color(0xFFEEF9F3)
-internal val mobileWarning = Color(0xFFC8841A)
-internal val mobileWarningSoft = Color(0xFFFFF8EC)
-internal val mobileDanger = Color(0xFFD04B4B)
-internal val mobileDangerSoft = Color(0xFFFFF2F2)
-internal val mobileCodeBg = Color(0xFF15171B)
-internal val mobileCodeText = Color(0xFFE8EAEE)
+internal val mobileSurface = Color(0xFF1E222B)
+internal val mobileSurfaceStrong = Color(0xFF272C37)
+internal val mobileBorder = Color(0xFF323847)
+internal val mobileBorderStrong = Color(0xFF41495D)
+internal val mobileText = Color(0xFFE6EBF5)
+internal val mobileTextSecondary = Color(0xFFB8C0D1)
+internal val mobileTextTertiary = Color(0xFF8C95A8)
+internal val mobileAccent = Color(0xFF5A8FFF)
+internal val mobileAccentSoft = Color(0xFF25395F)
+internal val mobileSuccess = Color(0xFF37B26C)
+internal val mobileSuccessSoft = Color(0xFF1F3A2B)
+internal val mobileWarning = Color(0xFFE3A23E)
+internal val mobileWarningSoft = Color(0xFF3A2D1A)
+internal val mobileDanger = Color(0xFFF06A6A)
+internal val mobileDangerSoft = Color(0xFF3F2528)
+internal val mobileCodeBg = Color(0xFF11141B)
+internal val mobileCodeText = Color(0xFFE7ECF8)
 
 internal val mobileFontFamily =
   FontFamily(
@@ -76,7 +76,7 @@ internal val mobileBody =
     fontFamily = mobileFontFamily,
     fontWeight = FontWeight.Medium,
     fontSize = 15.sp,
-    lineHeight = 22.sp,
+    lineHeight = 23.sp,
   )
 
 internal val mobileCallout =
@@ -93,7 +93,7 @@ internal val mobileCaption1 =
     fontWeight = FontWeight.Medium,
     fontSize = 12.sp,
     lineHeight = 16.sp,
-    letterSpacing = 0.2.sp,
+    letterSpacing = 0.1.sp,
   )
 
 internal val mobileCaption2 =
@@ -102,5 +102,5 @@ internal val mobileCaption2 =
     fontWeight = FontWeight.Medium,
     fontSize = 11.sp,
     lineHeight = 14.sp,
-    letterSpacing = 0.4.sp,
+    letterSpacing = 0.25.sp,
   )

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/OnboardingFlow.kt
@@ -1391,7 +1391,7 @@ private fun PermissionsStep(
 
   StepShell(title = "Permissions") {
     Text(
-      "Enable only what you need now. You can change everything later in Settings.",
+      "Connectivity permissions are requested now; mic/camera/SMS stay off until you use those features.",
       style = onboardingCalloutStyle,
       color = onboardingTextSecondary,
     )
@@ -1439,7 +1439,7 @@ private fun PermissionsStep(
     InlineDivider()
     PermissionToggleRow(
       title = "Microphone",
-      subtitle = "Voice tab transcription",
+      subtitle = "Voice tab transcription (requested on first use)",
       checked = enableMicrophone,
       granted = isPermissionGranted(context, Manifest.permission.RECORD_AUDIO),
       onCheckedChange = onMicrophoneChange,
@@ -1447,7 +1447,7 @@ private fun PermissionsStep(
     InlineDivider()
     PermissionToggleRow(
       title = "Camera",
-      subtitle = "camera.snap and camera.clip",
+      subtitle = "camera.snap and camera.clip (requested on first use)",
       checked = enableCamera,
       granted = isPermissionGranted(context, Manifest.permission.CAMERA),
       onCheckedChange = onCameraChange,
@@ -1490,7 +1490,7 @@ private fun PermissionsStep(
       InlineDivider()
       PermissionToggleRow(
         title = "SMS",
-        subtitle = "Allow gateway-triggered SMS sending",
+        subtitle = "Allow gateway-triggered SMS sending (requested on first use)",
         checked = enableSms,
         granted = isPermissionGranted(context, Manifest.permission.SEND_SMS),
         onCheckedChange = onSmsChange,

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
@@ -10,12 +10,14 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -25,6 +27,7 @@ import androidx.compose.material.icons.filled.ChatBubble
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.RecordVoiceOver
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.animation.core.tween
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -244,7 +247,7 @@ private fun TopStatusBar(
           mobileSuccessSoft,
           mobileSuccess,
           mobileSuccess,
-          Color(0xFFCFEBD8),
+          mobileSuccess.copy(alpha = 0.72f),
         )
       StatusVisual.Connecting ->
         listOf(
@@ -282,22 +285,17 @@ private fun TopStatusBar(
     shadowElevation = 0.dp,
   ) {
     Row(
-      modifier = Modifier.fillMaxWidth().padding(horizontal = 18.dp, vertical = 12.dp),
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 18.dp, vertical = 6.dp),
       verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.SpaceBetween,
+      horizontalArrangement = Arrangement.End,
     ) {
-      Text(
-        text = "OpenClaw",
-        style = mobileTitle2,
-        color = mobileText,
-      )
       Surface(
         shape = RoundedCornerShape(999.dp),
         color = chipBg,
         border = androidx.compose.foundation.BorderStroke(1.dp, chipBorder),
       ) {
         Row(
-          modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+          modifier = Modifier.padding(horizontal = 9.dp, vertical = 4.dp),
           horizontalArrangement = Arrangement.spacedBy(6.dp),
           verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -334,7 +332,7 @@ private fun BottomTabBar(
   ) {
     Surface(
       modifier = Modifier.fillMaxWidth(),
-      color = Color.White.copy(alpha = 0.97f),
+      color = mobileSurface.copy(alpha = 0.96f),
       shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
       border = BorderStroke(1.dp, mobileBorder),
       shadowElevation = 6.dp,
@@ -355,14 +353,19 @@ private fun BottomTabBar(
             modifier = Modifier.weight(1f).heightIn(min = 58.dp),
             shape = RoundedCornerShape(16.dp),
             color = if (active) mobileAccentSoft else Color.Transparent,
-            border = if (active) BorderStroke(1.dp, Color(0xFFD5E2FA)) else null,
-            shadowElevation = 0.dp,
+            border = if (active) BorderStroke(1.dp, mobileAccent.copy(alpha = 0.55f)) else null,
+            shadowElevation = if (active) 3.dp else 0.dp,
           ) {
             Column(
               modifier = Modifier.fillMaxWidth().padding(horizontal = 6.dp, vertical = 7.dp),
               horizontalAlignment = Alignment.CenterHorizontally,
               verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
+              if (active) {
+                Box(
+                  modifier = Modifier.width(18.dp).height(2.dp).background(mobileAccent.copy(alpha = 0.75f), RoundedCornerShape(999.dp)),
+                )
+              }
               Icon(
                 imageVector = tab.icon,
                 contentDescription = tab.label,

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -45,6 +46,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import ai.openclaw.android.MainViewModel
+import kotlinx.coroutines.delay
 
 private enum class HomeTab(
   val label: String,
@@ -139,13 +141,67 @@ private fun ScreenTabScreen(viewModel: MainViewModel) {
   val canvasA2uiHydrated by viewModel.canvasA2uiHydrated.collectAsState()
   val canvasRehydratePending by viewModel.canvasRehydratePending.collectAsState()
   val canvasRehydrateErrorText by viewModel.canvasRehydrateErrorText.collectAsState()
-  val isA2uiUrl = canvasUrl?.contains("/__openclaw__/a2ui/") == true
-  val showRestoreCta = isConnected && isNodeConnected && (canvasUrl.isNullOrBlank() || (isA2uiUrl && !canvasA2uiHydrated))
+
+  // Auto-rehydrate once per Screen-tab entry to avoid retry loops.
+  var autoRehydrateArmed by rememberSaveable { mutableStateOf(true) }
+  var hydrationRetryArmed by rememberSaveable { mutableStateOf(true) }
+
+  LaunchedEffect(isConnected, isNodeConnected) {
+    if (!isConnected || !isNodeConnected) {
+      autoRehydrateArmed = true
+      hydrationRetryArmed = true
+    }
+  }
+
+  LaunchedEffect(isConnected, isNodeConnected, canvasUrl, canvasA2uiHydrated, canvasRehydratePending, autoRehydrateArmed) {
+    if (!autoRehydrateArmed) return@LaunchedEffect
+    if (!isConnected || !isNodeConnected) return@LaunchedEffect
+    if (canvasRehydratePending) return@LaunchedEffect
+
+    val needsAutoRestore = canvasUrl.isNullOrBlank() || !canvasA2uiHydrated
+    if (!needsAutoRestore) {
+      autoRehydrateArmed = false
+      return@LaunchedEffect
+    }
+
+    autoRehydrateArmed = false
+    viewModel.requestCanvasRehydrate(source = "screen_tab_auto")
+  }
+
+  // One-shot hydration retry when URL is set but A2UI has not hydrated yet.
+  LaunchedEffect(isConnected, isNodeConnected, canvasUrl, canvasA2uiHydrated, canvasRehydratePending, hydrationRetryArmed) {
+    if (!hydrationRetryArmed) return@LaunchedEffect
+    if (!isConnected || !isNodeConnected) return@LaunchedEffect
+    if (canvasRehydratePending) return@LaunchedEffect
+    if (canvasUrl.isNullOrBlank()) return@LaunchedEffect
+
+    if (canvasA2uiHydrated) {
+      hydrationRetryArmed = false
+      return@LaunchedEffect
+    }
+
+    delay(2500)
+    if (canvasRehydratePending || canvasA2uiHydrated) {
+      hydrationRetryArmed = false
+      return@LaunchedEffect
+    }
+
+    hydrationRetryArmed = false
+    viewModel.requestCanvasRehydrate(source = "screen_tab_hydration_retry")
+  }
+
+  // Keep CTA out of the way once URL exists, but show it for initial blank state,
+  // pending requests, or explicit errors.
+  val showRestoreCta =
+    isConnected &&
+      isNodeConnected &&
+      (canvasUrl.isNullOrBlank() || canvasRehydratePending || !canvasRehydrateErrorText.isNullOrBlank())
   val restoreCtaText =
     when {
       canvasRehydratePending -> "Restore requested. Waiting for agent…"
       !canvasRehydrateErrorText.isNullOrBlank() -> canvasRehydrateErrorText!!
-      else -> "Canvas reset. Tap to restore dashboard."
+      !canvasUrl.isNullOrBlank() && !canvasA2uiHydrated -> "Loading dashboard…"
+      else -> "No canvas update yet. Tap to retry."
     }
 
   Box(modifier = Modifier.fillMaxSize()) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/PostOnboardingTabs.kt
@@ -81,12 +81,14 @@ fun PostOnboardingTabs(viewModel: MainViewModel, modifier: Modifier = Modifier) 
 
   val statusText by viewModel.statusText.collectAsState()
   val isConnected by viewModel.isConnected.collectAsState()
+  val isNodeConnected by viewModel.isNodeConnected.collectAsState()
 
   val statusVisual =
-    remember(statusText, isConnected) {
+    remember(statusText, isConnected, isNodeConnected) {
       val lower = statusText.lowercase()
       when {
-        isConnected -> StatusVisual.Connected
+        isConnected && isNodeConnected -> StatusVisual.Connected
+        isConnected && !isNodeConnected -> StatusVisual.Warning
         lower.contains("connecting") || lower.contains("reconnecting") -> StatusVisual.Connecting
         lower.contains("pairing") || lower.contains("approval") || lower.contains("auth") -> StatusVisual.Warning
         lower.contains("error") || lower.contains("failed") -> StatusVisual.Error

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -69,6 +69,8 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import ai.openclaw.android.BuildConfig
 import ai.openclaw.android.LocationMode
 import ai.openclaw.android.MainViewModel
+import ai.openclaw.android.TelemetryRetention
+import ai.openclaw.android.TelemetrySamplingMode
 import ai.openclaw.android.node.DeviceNotificationListenerService
 
 @Composable
@@ -82,6 +84,11 @@ fun SettingsSheet(viewModel: MainViewModel) {
   val locationPreciseEnabled by viewModel.locationPreciseEnabled.collectAsState()
   val preventSleep by viewModel.preventSleep.collectAsState()
   val canvasDebugStatusEnabled by viewModel.canvasDebugStatusEnabled.collectAsState()
+  val backgroundBatteryHistoryEnabled by viewModel.backgroundBatteryHistoryEnabled.collectAsState()
+  val backgroundLocationHistoryEnabled by viewModel.backgroundLocationHistoryEnabled.collectAsState()
+  val telemetrySyncEnabled by viewModel.telemetrySyncEnabled.collectAsState()
+  val telemetrySamplingMode by viewModel.telemetrySamplingMode.collectAsState()
+  val telemetryRetention by viewModel.telemetryRetention.collectAsState()
 
   val listState = rememberLazyListState()
   val deviceModel =
@@ -865,6 +872,141 @@ fun SettingsSheet(viewModel: MainViewModel) {
         color = mobileTextSecondary,
       )
     }
+
+      item { HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f)) }
+
+    // Telemetry
+      item {
+        Text(
+          "TELEMETRY",
+          style = mobileCaption1.copy(fontWeight = FontWeight.Bold, letterSpacing = 1.sp),
+          color = mobileAccent,
+        )
+      }
+    item {
+      ListItem(
+        modifier = settingsRowModifier(),
+        colors = listItemColors,
+        headlineContent = { Text("Background battery history", style = mobileHeadline) },
+        supportingContent = { Text("Collect battery level in background for local history.", style = mobileCallout) },
+        trailingContent = {
+          Switch(
+            checked = backgroundBatteryHistoryEnabled,
+            onCheckedChange = viewModel::setBackgroundBatteryHistoryEnabled,
+          )
+        },
+      )
+    }
+    item {
+      ListItem(
+        modifier = settingsRowModifier(),
+        colors = listItemColors,
+        headlineContent = { Text("Background location history", style = mobileHeadline) },
+        supportingContent = { Text("Collect location history in background (requires Location: Always).", style = mobileCallout) },
+        trailingContent = {
+          Switch(
+            checked = backgroundLocationHistoryEnabled,
+            onCheckedChange = viewModel::setBackgroundLocationHistoryEnabled,
+          )
+        },
+      )
+    }
+    item {
+      ListItem(
+        modifier = settingsRowModifier(),
+        colors = listItemColors,
+        headlineContent = { Text("Sync telemetry to gateway", style = mobileHeadline) },
+        supportingContent = { Text("If disabled, telemetry stays local on device.", style = mobileCallout) },
+        trailingContent = {
+          Switch(
+            checked = telemetrySyncEnabled,
+            onCheckedChange = viewModel::setTelemetrySyncEnabled,
+          )
+        },
+      )
+    }
+      item {
+        Column(modifier = settingsRowModifier(), verticalArrangement = Arrangement.spacedBy(0.dp)) {
+          ListItem(
+            modifier = Modifier.fillMaxWidth(),
+            colors = listItemColors,
+            headlineContent = { Text("Sampling: Low power", style = mobileHeadline) },
+            supportingContent = { Text("Best battery life; coarser updates.", style = mobileCallout) },
+            trailingContent = {
+              RadioButton(
+                selected = telemetrySamplingMode == TelemetrySamplingMode.LowPower,
+                onClick = { viewModel.setTelemetrySamplingMode(TelemetrySamplingMode.LowPower) },
+              )
+            },
+          )
+          HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f))
+          ListItem(
+            modifier = Modifier.fillMaxWidth(),
+            colors = listItemColors,
+            headlineContent = { Text("Sampling: Balanced", style = mobileHeadline) },
+            supportingContent = { Text("Default mix of quality and battery use.", style = mobileCallout) },
+            trailingContent = {
+              RadioButton(
+                selected = telemetrySamplingMode == TelemetrySamplingMode.Balanced,
+                onClick = { viewModel.setTelemetrySamplingMode(TelemetrySamplingMode.Balanced) },
+              )
+            },
+          )
+          HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f))
+          ListItem(
+            modifier = Modifier.fillMaxWidth(),
+            colors = listItemColors,
+            headlineContent = { Text("Sampling: High detail", style = mobileHeadline) },
+            supportingContent = { Text("More frequent updates; higher battery use.", style = mobileCallout) },
+            trailingContent = {
+              RadioButton(
+                selected = telemetrySamplingMode == TelemetrySamplingMode.HighDetail,
+                onClick = { viewModel.setTelemetrySamplingMode(TelemetrySamplingMode.HighDetail) },
+              )
+            },
+          )
+        }
+      }
+      item {
+        Column(modifier = settingsRowModifier(), verticalArrangement = Arrangement.spacedBy(0.dp)) {
+          ListItem(
+            modifier = Modifier.fillMaxWidth(),
+            colors = listItemColors,
+            headlineContent = { Text("Retention: 1 day", style = mobileHeadline) },
+            trailingContent = {
+              RadioButton(
+                selected = telemetryRetention == TelemetryRetention.OneDay,
+                onClick = { viewModel.setTelemetryRetention(TelemetryRetention.OneDay) },
+              )
+            },
+          )
+          HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f))
+          ListItem(
+            modifier = Modifier.fillMaxWidth(),
+            colors = listItemColors,
+            headlineContent = { Text("Retention: 7 days", style = mobileHeadline) },
+            trailingContent = {
+              RadioButton(
+                selected = telemetryRetention == TelemetryRetention.SevenDays,
+                onClick = { viewModel.setTelemetryRetention(TelemetryRetention.SevenDays) },
+              )
+            },
+          )
+          HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f))
+          ListItem(
+            modifier = Modifier.fillMaxWidth(),
+            colors = listItemColors,
+            headlineContent = { Text("Retention: 30 days", style = mobileHeadline) },
+            trailingContent = {
+              RadioButton(
+                selected = telemetryRetention == TelemetryRetention.ThirtyDays,
+                onClick = { viewModel.setTelemetryRetention(TelemetryRetention.ThirtyDays) },
+              )
+            },
+          )
+        }
+      }
+      item { Text("Telemetry collection service implementation is in progress.", style = mobileCallout, color = mobileTextSecondary) }
 
       item { HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f)) }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -102,7 +102,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
     }
   val listItemColors =
     ListItemDefaults.colors(
-      containerColor = Color.Transparent,
+      containerColor = mobileSurfaceStrong.copy(alpha = 0.35f),
       headlineColor = mobileText,
       supportingColor = mobileTextSecondary,
       trailingIconColor = mobileTextSecondary,
@@ -389,7 +389,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
           )
         }
       }
-      item { HorizontalDivider(color = mobileBorder) }
+      item { HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f)) }
 
     // Order parity: Node → Voice → Camera → Messaging → Location → Screen.
       item {
@@ -413,7 +413,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
       item { Text("Device: $deviceModel", style = mobileCallout, color = mobileTextSecondary) }
       item { Text("Version: $appVersion", style = mobileCallout, color = mobileTextSecondary) }
 
-      item { HorizontalDivider(color = mobileBorder) }
+      item { HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f)) }
 
       // Voice
       item {
@@ -466,7 +466,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
         )
       }
 
-      item { HorizontalDivider(color = mobileBorder) }
+      item { HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f)) }
 
     // Camera
       item {
@@ -493,7 +493,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
       )
     }
 
-      item { HorizontalDivider(color = mobileBorder) }
+      item { HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f)) }
 
     // Messaging
       item {
@@ -544,7 +544,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
       )
     }
 
-      item { HorizontalDivider(color = mobileBorder) }
+      item { HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f)) }
 
     // Notifications
       item {
@@ -816,7 +816,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
               )
             },
           )
-          HorizontalDivider(color = mobileBorder)
+          HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f))
           ListItem(
             modifier = Modifier.fillMaxWidth(),
             colors = listItemColors,
@@ -829,7 +829,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
               )
             },
           )
-          HorizontalDivider(color = mobileBorder)
+          HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f))
           ListItem(
             modifier = Modifier.fillMaxWidth(),
             colors = listItemColors,
@@ -842,7 +842,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
               )
             },
           )
-          HorizontalDivider(color = mobileBorder)
+          HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f))
           ListItem(
             modifier = Modifier.fillMaxWidth(),
             colors = listItemColors,
@@ -866,7 +866,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
       )
     }
 
-      item { HorizontalDivider(color = mobileBorder) }
+      item { HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f)) }
 
     // Screen
       item {
@@ -886,7 +886,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
       )
     }
 
-      item { HorizontalDivider(color = mobileBorder) }
+      item { HorizontalDivider(color = mobileBorder.copy(alpha = 0.78f)) }
 
     // Debug
       item {
@@ -919,10 +919,10 @@ fun SettingsSheet(viewModel: MainViewModel) {
 @Composable
 private fun settingsTextFieldColors() =
   OutlinedTextFieldDefaults.colors(
-    focusedContainerColor = mobileSurface,
-    unfocusedContainerColor = mobileSurface,
+    focusedContainerColor = mobileSurfaceStrong,
+    unfocusedContainerColor = mobileSurfaceStrong,
     focusedBorderColor = mobileAccent,
-    unfocusedBorderColor = mobileBorder,
+    unfocusedBorderColor = mobileBorderStrong,
     focusedTextColor = mobileText,
     unfocusedTextColor = mobileText,
     cursorColor = mobileAccent,
@@ -931,8 +931,8 @@ private fun settingsTextFieldColors() =
 private fun Modifier.settingsRowModifier() =
   this
     .fillMaxWidth()
-    .border(width = 1.dp, color = mobileBorder, shape = RoundedCornerShape(14.dp))
-    .background(Color.White, RoundedCornerShape(14.dp))
+    .border(width = 1.dp, color = mobileBorderStrong, shape = RoundedCornerShape(14.dp))
+    .background(mobileSurfaceStrong, RoundedCornerShape(14.dp))
 
 @Composable
 private fun settingsPrimaryButtonColors() =

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -885,7 +885,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
       }
     item {
       ListItem(
-        modifier = settingsRowModifier(),
+        modifier = Modifier.settingsRowModifier(),
         colors = listItemColors,
         headlineContent = { Text("Background battery history", style = mobileHeadline) },
         supportingContent = { Text("Collect battery level in background for local history.", style = mobileCallout) },
@@ -899,7 +899,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
     }
     item {
       ListItem(
-        modifier = settingsRowModifier(),
+        modifier = Modifier.settingsRowModifier(),
         colors = listItemColors,
         headlineContent = { Text("Background location history", style = mobileHeadline) },
         supportingContent = { Text("Collect location history in background (requires Location: Always).", style = mobileCallout) },
@@ -913,7 +913,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
     }
     item {
       ListItem(
-        modifier = settingsRowModifier(),
+        modifier = Modifier.settingsRowModifier(),
         colors = listItemColors,
         headlineContent = { Text("Sync telemetry to gateway", style = mobileHeadline) },
         supportingContent = { Text("If disabled, telemetry stays local on device.", style = mobileCallout) },
@@ -926,7 +926,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
       )
     }
       item {
-        Column(modifier = settingsRowModifier(), verticalArrangement = Arrangement.spacedBy(0.dp)) {
+        Column(modifier = Modifier.settingsRowModifier(), verticalArrangement = Arrangement.spacedBy(0.dp)) {
           ListItem(
             modifier = Modifier.fillMaxWidth(),
             colors = listItemColors,
@@ -968,7 +968,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
         }
       }
       item {
-        Column(modifier = settingsRowModifier(), verticalArrangement = Arrangement.spacedBy(0.dp)) {
+        Column(modifier = Modifier.settingsRowModifier(), verticalArrangement = Arrangement.spacedBy(0.dp)) {
           ListItem(
             modifier = Modifier.fillMaxWidth(),
             colors = listItemColors,

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -931,7 +931,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
             modifier = Modifier.fillMaxWidth(),
             colors = listItemColors,
             headlineContent = { Text("Sampling: Low power", style = mobileHeadline) },
-            supportingContent = { Text("Best battery life; coarser updates.", style = mobileCallout) },
+            supportingContent = { Text("Best battery life (~20 min); network-first location.", style = mobileCallout) },
             trailingContent = {
               RadioButton(
                 selected = telemetrySamplingMode == TelemetrySamplingMode.LowPower,
@@ -944,7 +944,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
             modifier = Modifier.fillMaxWidth(),
             colors = listItemColors,
             headlineContent = { Text("Sampling: Balanced", style = mobileHeadline) },
-            supportingContent = { Text("Default mix of quality and battery use.", style = mobileCallout) },
+            supportingContent = { Text("Default mix (~8 min); auto-throttles to Low Power at low battery.", style = mobileCallout) },
             trailingContent = {
               RadioButton(
                 selected = telemetrySamplingMode == TelemetrySamplingMode.Balanced,
@@ -957,7 +957,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
             modifier = Modifier.fillMaxWidth(),
             colors = listItemColors,
             headlineContent = { Text("Sampling: High detail", style = mobileHeadline) },
-            supportingContent = { Text("More frequent updates; higher battery use.", style = mobileCallout) },
+            supportingContent = { Text("Frequent updates (~1 min); highest battery use.", style = mobileCallout) },
             trailingContent = {
               RadioButton(
                 selected = telemetrySamplingMode == TelemetrySamplingMode.HighDetail,

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/VoiceTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/VoiceTabScreen.kt
@@ -10,6 +10,12 @@ import android.net.Uri
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -21,11 +27,14 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -35,13 +44,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MicOff
-import androidx.compose.material.icons.automirrored.filled.VolumeOff
-import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -69,7 +74,9 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import ai.openclaw.android.MainViewModel
 import ai.openclaw.android.voice.VoiceConversationEntry
 import ai.openclaw.android.voice.VoiceConversationRole
+import kotlin.math.PI
 import kotlin.math.max
+import kotlin.math.sin
 
 @Composable
 fun VoiceTabScreen(viewModel: MainViewModel) {
@@ -78,10 +85,9 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
   val activity = remember(context) { context.findActivity() }
   val listState = rememberLazyListState()
 
+  val isConnected by viewModel.isConnected.collectAsState()
   val gatewayStatus by viewModel.statusText.collectAsState()
   val micEnabled by viewModel.micEnabled.collectAsState()
-  val micCooldown by viewModel.micCooldown.collectAsState()
-  val speakerEnabled by viewModel.speakerEnabled.collectAsState()
   val micStatusText by viewModel.micStatusText.collectAsState()
   val micLiveTranscript by viewModel.micLiveTranscript.collectAsState()
   val micQueuedMessages by viewModel.micQueuedMessages.collectAsState()
@@ -103,11 +109,7 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
         }
       }
     lifecycleOwner.lifecycle.addObserver(observer)
-    onDispose {
-      lifecycleOwner.lifecycle.removeObserver(observer)
-      // Stop TTS when leaving the voice screen
-      viewModel.setVoiceScreenActive(false)
-    }
+    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
   }
 
   val requestMicPermission =
@@ -136,6 +138,33 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
         .padding(horizontal = 20.dp, vertical = 14.dp),
     verticalArrangement = Arrangement.spacedBy(10.dp),
   ) {
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+          "VOICE",
+          style = mobileCaption1.copy(fontWeight = FontWeight.Bold, letterSpacing = 1.sp),
+          color = mobileAccent,
+        )
+        Text("Voice mode", style = mobileTitle2, color = mobileText)
+      }
+      Surface(
+        shape = RoundedCornerShape(999.dp),
+        color = if (isConnected) mobileSuccessSoft else mobileSurfaceStrong,
+        border = BorderStroke(1.dp, if (isConnected) mobileSuccess.copy(alpha = 0.6f) else mobileBorderStrong),
+      ) {
+        Text(
+          if (isConnected) "Connected" else "Offline",
+          modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+          style = mobileCaption1,
+          color = if (isConnected) mobileSuccess else mobileTextSecondary,
+        )
+      }
+    }
+
     LazyColumn(
       state = listState,
       modifier = Modifier.fillMaxWidth().weight(1f),
@@ -144,31 +173,15 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
     ) {
       if (micConversation.isEmpty() && !showThinkingBubble) {
         item {
-          Box(
-            modifier = Modifier.fillParentMaxHeight().fillMaxWidth(),
-            contentAlignment = Alignment.Center,
+          Column(
+            modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
           ) {
-            Column(
-              horizontalAlignment = Alignment.CenterHorizontally,
-              verticalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-              Icon(
-                imageVector = Icons.Default.Mic,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = mobileTextTertiary,
-              )
-              Text(
-                "Tap the mic to start",
-                style = mobileHeadline,
-                color = mobileTextSecondary,
-              )
-              Text(
-                "Each pause sends a turn automatically.",
-                style = mobileCallout,
-                color = mobileTextTertiary,
-              )
-            }
+            Text(
+              "Tap the mic and speak. Each pause sends a turn automatically.",
+              style = mobileCallout,
+              color = mobileTextSecondary,
+            )
           }
         }
       }
@@ -184,144 +197,122 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
       }
     }
 
-    Column(
+    Surface(
       modifier = Modifier.fillMaxWidth(),
-      horizontalAlignment = Alignment.CenterHorizontally,
-      verticalArrangement = Arrangement.spacedBy(6.dp),
+      shape = RoundedCornerShape(20.dp),
+      color = mobileSurfaceStrong,
+      border = BorderStroke(1.dp, mobileBorderStrong),
     ) {
-      if (!micLiveTranscript.isNullOrBlank()) {
+      Column(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
         Surface(
-          modifier = Modifier.fillMaxWidth(),
-          shape = RoundedCornerShape(14.dp),
-          color = mobileAccentSoft,
-          border = BorderStroke(1.dp, mobileAccent.copy(alpha = 0.2f)),
+          shape = RoundedCornerShape(999.dp),
+          color = mobileSurface,
+          border = BorderStroke(1.dp, mobileBorder),
         ) {
+          val queueCount = micQueuedMessages.size
+          val stateText =
+            when {
+              queueCount > 0 -> "$queueCount queued"
+              micIsSending -> "Sending"
+              micEnabled -> "Listening"
+              else -> "Mic off"
+            }
           Text(
-            micLiveTranscript!!.trim(),
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-            style = mobileCallout,
-            color = mobileText,
+            "$gatewayStatus · $stateText",
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+            style = mobileCaption1,
+            color = mobileTextSecondary,
           )
         }
-      }
 
-      // Mic button with input-reactive ring + speaker toggle
-      Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically,
-      ) {
-        // Speaker toggle
-        IconButton(
-          onClick = { viewModel.setSpeakerEnabled(!speakerEnabled) },
-          modifier = Modifier.size(48.dp),
+        if (!micLiveTranscript.isNullOrBlank()) {
+          Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(14.dp),
+            color = mobileAccentSoft,
+            border = BorderStroke(1.dp, mobileAccent.copy(alpha = 0.2f)),
+          ) {
+            Text(
+              micLiveTranscript!!.trim(),
+              modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+              style = mobileCallout,
+              color = mobileText,
+            )
+          }
+        }
+
+        MicWaveform(level = micInputLevel, active = micEnabled)
+
+        Button(
+          onClick = {
+            if (micEnabled) {
+              viewModel.setMicEnabled(false)
+              return@Button
+            }
+            if (hasMicPermission) {
+              viewModel.setMicEnabled(true)
+            } else {
+              pendingMicEnable = true
+              requestMicPermission.launch(Manifest.permission.RECORD_AUDIO)
+            }
+          },
+          shape = CircleShape,
+          contentPadding = PaddingValues(0.dp),
+          modifier = Modifier.size(86.dp),
           colors =
-            IconButtonDefaults.iconButtonColors(
-              containerColor = if (speakerEnabled) mobileSurface else mobileDangerSoft,
+            ButtonDefaults.buttonColors(
+              containerColor = if (micEnabled) mobileDanger else mobileAccent,
+              contentColor = Color.White,
             ),
         ) {
           Icon(
-            imageVector = if (speakerEnabled) Icons.AutoMirrored.Filled.VolumeUp else Icons.AutoMirrored.Filled.VolumeOff,
-            contentDescription = if (speakerEnabled) "Mute speaker" else "Unmute speaker",
-            modifier = Modifier.size(22.dp),
-            tint = if (speakerEnabled) mobileTextSecondary else mobileDanger,
+            imageVector = if (micEnabled) Icons.Default.MicOff else Icons.Default.Mic,
+            contentDescription = if (micEnabled) "Turn microphone off" else "Turn microphone on",
+            modifier = Modifier.size(30.dp),
           )
         }
 
-        // Ring size = 68dp base + up to 22dp driven by mic input level.
-        // The outer Box is fixed at 90dp (max ring size) so the ring never shifts the button.
-        Box(
-          modifier = Modifier.padding(horizontal = 16.dp).size(90.dp),
-          contentAlignment = Alignment.Center,
-        ) {
-          if (micEnabled) {
-            val ringLevel = micInputLevel.coerceIn(0f, 1f)
-            val ringSize = 68.dp + (22.dp * max(ringLevel, 0.05f))
-            Box(
-              modifier =
-                Modifier
-                  .size(ringSize)
-                  .background(mobileAccent.copy(alpha = 0.12f + 0.14f * ringLevel), CircleShape),
-            )
-          }
-          Button(
-            onClick = {
-              if (micCooldown) return@Button
-              if (micEnabled) {
-                viewModel.setMicEnabled(false)
-                return@Button
-              }
-              if (hasMicPermission) {
-                viewModel.setMicEnabled(true)
-              } else {
-                pendingMicEnable = true
-                requestMicPermission.launch(Manifest.permission.RECORD_AUDIO)
-              }
-            },
-            enabled = !micCooldown,
-            shape = CircleShape,
-            contentPadding = PaddingValues(0.dp),
-            modifier = Modifier.size(60.dp),
-            colors =
-              ButtonDefaults.buttonColors(
-                containerColor = if (micCooldown) mobileTextSecondary else if (micEnabled) mobileDanger else mobileAccent,
-                contentColor = Color.White,
-                disabledContainerColor = mobileTextSecondary,
-                disabledContentColor = Color.White.copy(alpha = 0.5f),
-              ),
-          ) {
-            Icon(
-              imageVector = if (micEnabled) Icons.Default.MicOff else Icons.Default.Mic,
-              contentDescription = if (micEnabled) "Turn microphone off" else "Turn microphone on",
-              modifier = Modifier.size(24.dp),
-            )
-          }
-        }
-
-        // Invisible spacer to balance the row (same size as speaker button)
-        Box(modifier = Modifier.size(48.dp))
-      }
-
-      // Status + labels
-      val queueCount = micQueuedMessages.size
-      val stateText =
-        when {
-          queueCount > 0 -> "$queueCount queued"
-          micIsSending -> "Sending"
-          micCooldown -> "Cooldown"
-          micEnabled -> "Listening"
-          else -> "Mic off"
-        }
-      Text(
-        "$gatewayStatus · $stateText",
-        style = mobileCaption1,
-        color = mobileTextSecondary,
-      )
-
-      if (!hasMicPermission) {
-        val showRationale =
-          if (activity == null) {
-            false
-          } else {
-            ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.RECORD_AUDIO)
-          }
         Text(
-          if (showRationale) {
-            "Microphone permission is required for voice mode."
-          } else {
-            "Microphone blocked. Open app settings to enable it."
-          },
-          style = mobileCaption1,
-          color = mobileWarning,
-          textAlign = TextAlign.Center,
+          if (micEnabled) "Tap to stop" else "Tap to speak",
+          style = mobileCallout,
+          color = mobileTextSecondary,
         )
-        Button(
-          onClick = { openAppSettings(context) },
-          shape = RoundedCornerShape(12.dp),
-          colors = ButtonDefaults.buttonColors(containerColor = mobileSurfaceStrong, contentColor = mobileText),
-        ) {
-          Text("Open settings", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold))
+
+        if (!hasMicPermission) {
+          val showRationale =
+            if (activity == null) {
+              false
+            } else {
+              ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.RECORD_AUDIO)
+            }
+          Text(
+            if (showRationale) {
+              "Microphone permission is required for voice mode."
+            } else {
+              "Microphone blocked. Open app settings to enable it."
+            },
+            style = mobileCaption1,
+            color = mobileWarning,
+            textAlign = TextAlign.Center,
+          )
+          Button(
+            onClick = { openAppSettings(context) },
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = mobileSurfaceStrong, contentColor = mobileText),
+          ) {
+            Text("Open settings", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold))
+          }
         }
+
+        Text(
+          micStatusText,
+          style = mobileCaption1,
+          color = mobileTextTertiary,
+        )
       }
     }
   }
@@ -336,18 +327,18 @@ private fun VoiceTurnBubble(entry: VoiceConversationEntry) {
   ) {
     Surface(
       modifier = Modifier.fillMaxWidth(0.90f),
-      shape = RoundedCornerShape(12.dp),
-      color = if (isUser) mobileAccentSoft else Color.White,
-      border = BorderStroke(1.dp, if (isUser) mobileAccent else mobileBorderStrong),
+      shape = RoundedCornerShape(14.dp),
+      color = if (isUser) mobileAccentSoft else mobileSurfaceStrong,
+      border = BorderStroke(1.dp, if (isUser) mobileAccent.copy(alpha = 0.35f) else mobileBorderStrong),
     ) {
       Column(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 11.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(3.dp),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
       ) {
         Text(
           if (isUser) "You" else "OpenClaw",
-          style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold, letterSpacing = 0.6.sp),
-          color = if (isUser) mobileAccent else mobileTextSecondary,
+          style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
+          color = mobileTextSecondary,
         )
         Text(
           if (entry.isStreaming && entry.text.isBlank()) "Listening response…" else entry.text,
@@ -364,12 +355,12 @@ private fun VoiceThinkingBubble() {
   Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
     Surface(
       modifier = Modifier.fillMaxWidth(0.68f),
-      shape = RoundedCornerShape(12.dp),
-      color = Color.White,
+      shape = RoundedCornerShape(14.dp),
+      color = mobileSurfaceStrong,
       border = BorderStroke(1.dp, mobileBorderStrong),
     ) {
       Row(
-        modifier = Modifier.padding(horizontal = 11.dp, vertical = 8.dp),
+        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
       ) {
@@ -396,6 +387,44 @@ private fun ThinkingDot(alpha: Float, color: Color) {
     shape = CircleShape,
     color = color,
   ) {}
+}
+
+@Composable
+private fun MicWaveform(level: Float, active: Boolean) {
+  val transition = rememberInfiniteTransition(label = "voiceWave")
+  val phase by
+    transition.animateFloat(
+      initialValue = 0f,
+      targetValue = 1f,
+      animationSpec = infiniteRepeatable(animation = tween(1_000, easing = LinearEasing), repeatMode = RepeatMode.Restart),
+      label = "voiceWavePhase",
+    )
+
+  val effective = if (active) level.coerceIn(0f, 1f) else 0f
+  val base = max(effective, if (active) 0.05f else 0f)
+
+  Row(
+    modifier = Modifier.fillMaxWidth().heightIn(min = 40.dp),
+    horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    repeat(16) { index ->
+      val pulse =
+        if (!active) {
+          0f
+        } else {
+          ((sin(((phase * 2f * PI) + (index * 0.55f)).toDouble()) + 1.0) * 0.5).toFloat()
+        }
+      val barHeight = 6.dp + (24.dp * (base * pulse))
+      Box(
+        modifier =
+          Modifier
+            .width(5.dp)
+            .height(barHeight)
+            .background(if (active) mobileAccent else mobileBorderStrong, RoundedCornerShape(999.dp)),
+      )
+    }
+  }
 }
 
 private fun Context.hasRecordAudioPermission(): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatComposer.kt
@@ -1,6 +1,11 @@
 package ai.openclaw.android.ui.chat
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -9,12 +14,14 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -22,8 +29,6 @@ import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -46,8 +51,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ai.openclaw.android.ui.mobileAccent
@@ -58,6 +65,7 @@ import ai.openclaw.android.ui.mobileCallout
 import ai.openclaw.android.ui.mobileCaption1
 import ai.openclaw.android.ui.mobileHeadline
 import ai.openclaw.android.ui.mobileSurface
+import ai.openclaw.android.ui.mobileSurfaceStrong
 import ai.openclaw.android.ui.mobileText
 import ai.openclaw.android.ui.mobileTextSecondary
 import ai.openclaw.android.ui.mobileTextTertiary
@@ -87,11 +95,16 @@ fun ChatComposer(
   val sendBusy = pendingRunCount > 0
   val canRetryLast = !errorText.isNullOrBlank() && pendingRunCount == 0
   val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
-  val compactMode = imeVisible
   var showActionsMenu by remember { mutableStateOf(false) }
+  val compactMode = imeVisible || showActionsMenu
+  val sendAlpha by animateFloatAsState(
+    targetValue = if (canSend) 1f else 0.75f,
+    animationSpec = tween(durationMillis = 100),
+    label = "sendAlpha",
+  )
 
   Column(
-    modifier = Modifier.fillMaxWidth(),
+    modifier = Modifier.fillMaxWidth().animateContentSize(),
     verticalArrangement = Arrangement.spacedBy(if (compactMode) 6.dp else 8.dp),
   ) {
     Row(
@@ -102,7 +115,7 @@ fun ChatComposer(
       Box(modifier = Modifier.weight(1f)) {
         Surface(
           onClick = { showThinkingMenu = true },
-          shape = RoundedCornerShape(14.dp),
+          shape = RoundedCornerShape(16.dp),
           color = mobileAccentSoft,
           border = BorderStroke(1.dp, mobileBorderStrong),
         ) {
@@ -120,7 +133,11 @@ fun ChatComposer(
           }
         }
 
-        DropdownMenu(expanded = showThinkingMenu, onDismissRequest = { showThinkingMenu = false }) {
+        DropdownMenu(
+          expanded = showThinkingMenu,
+          onDismissRequest = { showThinkingMenu = false },
+          containerColor = mobileSurfaceStrong,
+        ) {
           ThinkingMenuItem("off", thinkingLevel, onSetThinkingLevel) { showThinkingMenu = false }
           ThinkingMenuItem("low", thinkingLevel, onSetThinkingLevel) { showThinkingMenu = false }
           ThinkingMenuItem("medium", thinkingLevel, onSetThinkingLevel) { showThinkingMenu = false }
@@ -133,11 +150,18 @@ fun ChatComposer(
         icon = Icons.Default.AttachFile,
         enabled = true,
         compact = compactMode,
+        containerColor = mobileSurfaceStrong,
+        borderColor = mobileBorderStrong,
+        textColor = mobileText,
         onClick = onPickImages,
       )
     }
 
-    if (attachments.isNotEmpty()) {
+    AnimatedVisibility(
+      visible = attachments.isNotEmpty(),
+      enter = fadeIn(animationSpec = tween(90)),
+      exit = fadeOut(animationSpec = tween(90)),
+    ) {
       AttachmentsStrip(attachments = attachments, onRemoveAttachment = onRemoveAttachment)
     }
 
@@ -152,11 +176,15 @@ fun ChatComposer(
       minLines = if (compactMode) 1 else 2,
       maxLines = if (compactMode) 4 else 5,
       textStyle = mobileBodyStyle().copy(color = mobileText),
-      shape = RoundedCornerShape(14.dp),
+      shape = RoundedCornerShape(16.dp),
       colors = chatTextFieldColors(),
     )
 
-    if (!healthOk) {
+    AnimatedVisibility(
+      visible = !healthOk,
+      enter = fadeIn(animationSpec = tween(90)),
+      exit = fadeOut(animationSpec = tween(90)),
+    ) {
       Text(
         text = "Dead Zone mode: messages queue locally and auto-send on reconnect.",
         style = mobileCallout,
@@ -164,7 +192,11 @@ fun ChatComposer(
       )
     }
 
-    if (queuedCount > 0) {
+    AnimatedVisibility(
+      visible = queuedCount > 0,
+      enter = fadeIn(animationSpec = tween(90)),
+      exit = fadeOut(animationSpec = tween(90)),
+    ) {
       Text(
         text = "Queued offline: $queuedCount",
         style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
@@ -172,47 +204,25 @@ fun ChatComposer(
       )
     }
 
-    Row(
-      modifier = Modifier.fillMaxWidth(),
-      horizontalArrangement = Arrangement.spacedBy(8.dp),
-      verticalAlignment = Alignment.CenterVertically,
-    ) {
+    if (!compactMode && showTimeCapsuleDetails) {
       Surface(
-        shape = RoundedCornerShape(999.dp),
-        color = if (reEvaluateOnReconnect) mobileAccentSoft else Color.White,
-        border = BorderStroke(1.dp, if (reEvaluateOnReconnect) mobileAccent else mobileBorderStrong),
-        onClick = {
-          reEvaluateOnReconnect = !reEvaluateOnReconnect
-          showTimeCapsuleDetails = true
-        },
-      ) {        Text(
-          text = if (reEvaluateOnReconnect) "TC: ON" else "TC: OFF",
-          style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
-          color = if (reEvaluateOnReconnect) mobileAccent else mobileTextSecondary,
-          modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        color = mobileAccentSoft,
+        border = BorderStroke(1.dp, mobileBorder),
+        onClick = { showTimeCapsuleDetails = false },
+      ) {
+        Text(
+          text =
+            if (reEvaluateOnReconnect) {
+              "Re-evaluate queued messages before send"
+            } else {
+              "Send queued messages as-written"
+            },
+          style = mobileCaption1,
+          color = mobileText,
+          modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
         )
-      }
-
-      if (!compactMode && showTimeCapsuleDetails) {
-        Surface(
-          modifier = Modifier.weight(1f),
-          shape = RoundedCornerShape(12.dp),
-          color = mobileAccentSoft,
-          border = BorderStroke(1.dp, mobileBorder),
-          onClick = { showTimeCapsuleDetails = false },
-        ) {
-          Text(
-            text =
-              if (reEvaluateOnReconnect) {
-                "Re-evaluate queued messages before send"
-              } else {
-                "Send queued messages as-written"
-              },
-            style = mobileCaption1,
-            color = mobileText,
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
-          )
-        }
       }
     }
 
@@ -221,65 +231,63 @@ fun ChatComposer(
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-      if (compactMode) {
-        Box {
-          SecondaryActionButton(
-            label = "More",
-            icon = Icons.Default.MoreVert,
-            enabled = true,
-            compact = true,
-            onClick = { showActionsMenu = true },
+      Surface(
+        onClick = {
+          reEvaluateOnReconnect = !reEvaluateOnReconnect
+          showTimeCapsuleDetails = !compactMode
+        },
+        modifier = Modifier.size(44.dp),
+        shape = RoundedCornerShape(16.dp),
+        color = if (reEvaluateOnReconnect) mobileAccentSoft else mobileSurfaceStrong,
+        border = BorderStroke(1.dp, if (reEvaluateOnReconnect) mobileAccent else mobileBorderStrong),
+      ) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+          Text(
+            text = "TC",
+            style = mobileCaption1.copy(fontWeight = FontWeight.Bold),
+            color = if (reEvaluateOnReconnect) mobileAccent else mobileTextSecondary,
           )
-          DropdownMenu(expanded = showActionsMenu, onDismissRequest = { showActionsMenu = false }) {
-            DropdownMenuItem(
-              text = { Text("Refresh") },
-              onClick = {
-                showActionsMenu = false
-                onRefresh()
-              },
-            )
-            DropdownMenuItem(
-              text = { Text("Abort") },
-              enabled = pendingRunCount > 0,
-              onClick = {
-                showActionsMenu = false
-                onAbort()
-              },
-            )
-            DropdownMenuItem(
-              text = { Text("Retry") },
-              enabled = canRetryLast,
-              onClick = {
-                showActionsMenu = false
-                onRetryLast()
-              },
-            )
-          }
         }
-      } else {
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-          SecondaryActionButton(
-            label = "Refresh",
-            icon = Icons.Default.Refresh,
-            enabled = true,
-            compact = true,
-            onClick = onRefresh,
-          )
+      }
 
-          SecondaryActionButton(
-            label = "Abort",
-            icon = Icons.Default.Stop,
+      Box {
+        SecondaryActionButton(
+          label = "Actions",
+          icon = Icons.Default.MoreVert,
+          enabled = true,
+          compact = true,
+          containerColor = mobileSurfaceStrong,
+          borderColor = mobileBorderStrong,
+          textColor = mobileText,
+          onClick = { showActionsMenu = true },
+        )
+        DropdownMenu(
+          expanded = showActionsMenu,
+          onDismissRequest = { showActionsMenu = false },
+          properties = PopupProperties(focusable = false),
+        ) {
+          DropdownMenuItem(
+            text = { Text("Refresh") },
+            onClick = {
+              showActionsMenu = false
+              onRefresh()
+            },
+          )
+          DropdownMenuItem(
+            text = { Text("Abort") },
             enabled = pendingRunCount > 0,
-            compact = true,
-            onClick = onAbort,
+            onClick = {
+              showActionsMenu = false
+              onAbort()
+            },
           )
-
-          SecondaryActionButton(
-            label = "Retry",
-            icon = Icons.Default.Refresh,
+          DropdownMenuItem(
+            text = { Text("Retry") },
             enabled = canRetryLast,
-            compact = true,
-            onClick = onRetryLast,
+            onClick = {
+              showActionsMenu = false
+              onRetryLast()
+            },
           )
         }
       }
@@ -291,8 +299,8 @@ fun ChatComposer(
           onSend(text, reEvaluateOnReconnect)
         },
         enabled = canSend,
-        modifier = Modifier.weight(1f).height(48.dp),
-        shape = RoundedCornerShape(14.dp),
+        modifier = Modifier.weight(1f).height(48.dp).graphicsLayer { alpha = sendAlpha },
+        shape = RoundedCornerShape(16.dp),
         colors =
           ButtonDefaults.buttonColors(
             containerColor = mobileAccent,
@@ -325,21 +333,24 @@ private fun SecondaryActionButton(
   icon: androidx.compose.ui.graphics.vector.ImageVector,
   enabled: Boolean,
   compact: Boolean = false,
+  containerColor: Color = Color.White,
+  borderColor: Color = mobileBorderStrong,
+  textColor: Color = mobileTextSecondary,
   onClick: () -> Unit,
 ) {
   Button(
     onClick = onClick,
     enabled = enabled,
     modifier = if (compact) Modifier.size(44.dp) else Modifier.height(44.dp),
-    shape = RoundedCornerShape(14.dp),
+    shape = RoundedCornerShape(16.dp),
     colors =
       ButtonDefaults.buttonColors(
-        containerColor = Color.White,
-        contentColor = mobileTextSecondary,
-        disabledContainerColor = Color.White,
+        containerColor = containerColor,
+        contentColor = textColor,
+        disabledContainerColor = containerColor,
         disabledContentColor = mobileTextTertiary,
       ),
-    border = BorderStroke(1.dp, mobileBorderStrong),
+    border = BorderStroke(1.dp, borderColor),
     contentPadding = if (compact) PaddingValues(0.dp) else ButtonDefaults.ContentPadding,
   ) {
     Icon(icon, contentDescription = label, modifier = Modifier.size(14.dp))
@@ -362,6 +373,12 @@ private fun ThinkingMenuItem(
   onDismiss: () -> Unit,
 ) {
   DropdownMenuItem(
+    colors =
+      androidx.compose.material3.MenuDefaults.itemColors(
+        textColor = mobileText,
+        leadingIconColor = mobileText,
+        trailingIconColor = mobileAccent,
+      ),
     text = { Text(thinkingLabel(value), style = mobileCallout, color = mobileText) },
     onClick = {
       onSet(value)
@@ -446,7 +463,7 @@ private fun chatTextFieldColors() =
     focusedContainerColor = mobileSurface,
     unfocusedContainerColor = mobileSurface,
     focusedBorderColor = mobileAccent,
-    unfocusedBorderColor = mobileBorder,
+    unfocusedBorderColor = mobileBorder.copy(alpha = 0.78f),
     focusedTextColor = mobileText,
     unfocusedTextColor = mobileText,
     cursorColor = mobileAccent,

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatComposer.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -19,6 +21,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.Button
@@ -42,6 +45,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -63,6 +67,7 @@ fun ChatComposer(
   healthOk: Boolean,
   thinkingLevel: String,
   pendingRunCount: Int,
+  queuedCount: Int,
   errorText: String?,
   attachments: List<PendingImageAttachment>,
   onPickImages: () -> Unit,
@@ -71,16 +76,24 @@ fun ChatComposer(
   onRefresh: () -> Unit,
   onAbort: () -> Unit,
   onRetryLast: () -> Unit,
-  onSend: (text: String) -> Unit,
+  onSend: (text: String, reEvaluateOnReconnect: Boolean) -> Unit,
 ) {
   var input by rememberSaveable { mutableStateOf("") }
   var showThinkingMenu by remember { mutableStateOf(false) }
+  var reEvaluateOnReconnect by rememberSaveable { mutableStateOf(true) }
+  var showTimeCapsuleDetails by rememberSaveable { mutableStateOf(false) }
 
-  val canSend = pendingRunCount == 0 && (input.trim().isNotEmpty() || attachments.isNotEmpty()) && healthOk
+  val canSend = pendingRunCount == 0 && (input.trim().isNotEmpty() || attachments.isNotEmpty())
   val sendBusy = pendingRunCount > 0
   val canRetryLast = !errorText.isNullOrBlank() && pendingRunCount == 0
+  val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
+  val compactMode = imeVisible
+  var showActionsMenu by remember { mutableStateOf(false) }
 
-  Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+  Column(
+    modifier = Modifier.fillMaxWidth(),
+    verticalArrangement = Arrangement.spacedBy(if (compactMode) 6.dp else 8.dp),
+  ) {
     Row(
       modifier = Modifier.fillMaxWidth(),
       verticalAlignment = Alignment.CenterVertically,
@@ -119,6 +132,7 @@ fun ChatComposer(
         label = "Attach",
         icon = Icons.Default.AttachFile,
         enabled = true,
+        compact = compactMode,
         onClick = onPickImages,
       )
     }
@@ -129,19 +143,14 @@ fun ChatComposer(
 
     HorizontalDivider(color = mobileBorder)
 
-    Text(
-      text = "MESSAGE",
-      style = mobileCaption1.copy(fontWeight = FontWeight.Bold, letterSpacing = 0.9.sp),
-      color = mobileTextSecondary,
-    )
 
     OutlinedTextField(
       value = input,
       onValueChange = { input = it },
-      modifier = Modifier.fillMaxWidth().height(92.dp),
+      modifier = Modifier.fillMaxWidth().height(if (compactMode) 68.dp else 82.dp),
       placeholder = { Text("Type a message", style = mobileBodyStyle(), color = mobileTextTertiary) },
-      minLines = 2,
-      maxLines = 5,
+      minLines = if (compactMode) 1 else 2,
+      maxLines = if (compactMode) 4 else 5,
       textStyle = mobileBodyStyle().copy(color = mobileText),
       shape = RoundedCornerShape(14.dp),
       colors = chatTextFieldColors(),
@@ -149,10 +158,62 @@ fun ChatComposer(
 
     if (!healthOk) {
       Text(
-        text = "Gateway is offline. Connect first in the Connect tab.",
+        text = "Dead Zone mode: messages queue locally and auto-send on reconnect.",
         style = mobileCallout,
         color = ai.openclaw.android.ui.mobileWarning,
       )
+    }
+
+    if (queuedCount > 0) {
+      Text(
+        text = "Queued offline: $queuedCount",
+        style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
+        color = ai.openclaw.android.ui.mobileWarning,
+      )
+    }
+
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Surface(
+        shape = RoundedCornerShape(999.dp),
+        color = if (reEvaluateOnReconnect) mobileAccentSoft else Color.White,
+        border = BorderStroke(1.dp, if (reEvaluateOnReconnect) mobileAccent else mobileBorderStrong),
+        onClick = {
+          reEvaluateOnReconnect = !reEvaluateOnReconnect
+          showTimeCapsuleDetails = true
+        },
+      ) {        Text(
+          text = if (reEvaluateOnReconnect) "TC: ON" else "TC: OFF",
+          style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
+          color = if (reEvaluateOnReconnect) mobileAccent else mobileTextSecondary,
+          modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+        )
+      }
+
+      if (!compactMode && showTimeCapsuleDetails) {
+        Surface(
+          modifier = Modifier.weight(1f),
+          shape = RoundedCornerShape(12.dp),
+          color = mobileAccentSoft,
+          border = BorderStroke(1.dp, mobileBorder),
+          onClick = { showTimeCapsuleDetails = false },
+        ) {
+          Text(
+            text =
+              if (reEvaluateOnReconnect) {
+                "Re-evaluate queued messages before send"
+              } else {
+                "Send queued messages as-written"
+              },
+            style = mobileCaption1,
+            color = mobileText,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
+          )
+        }
+      }
     }
 
     Row(
@@ -160,37 +221,74 @@ fun ChatComposer(
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-      Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        SecondaryActionButton(
-          label = "Refresh",
-          icon = Icons.Default.Refresh,
-          enabled = true,
-          compact = true,
-          onClick = onRefresh,
-        )
+      if (compactMode) {
+        Box {
+          SecondaryActionButton(
+            label = "More",
+            icon = Icons.Default.MoreVert,
+            enabled = true,
+            compact = true,
+            onClick = { showActionsMenu = true },
+          )
+          DropdownMenu(expanded = showActionsMenu, onDismissRequest = { showActionsMenu = false }) {
+            DropdownMenuItem(
+              text = { Text("Refresh") },
+              onClick = {
+                showActionsMenu = false
+                onRefresh()
+              },
+            )
+            DropdownMenuItem(
+              text = { Text("Abort") },
+              enabled = pendingRunCount > 0,
+              onClick = {
+                showActionsMenu = false
+                onAbort()
+              },
+            )
+            DropdownMenuItem(
+              text = { Text("Retry") },
+              enabled = canRetryLast,
+              onClick = {
+                showActionsMenu = false
+                onRetryLast()
+              },
+            )
+          }
+        }
+      } else {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          SecondaryActionButton(
+            label = "Refresh",
+            icon = Icons.Default.Refresh,
+            enabled = true,
+            compact = true,
+            onClick = onRefresh,
+          )
 
-        SecondaryActionButton(
-          label = "Abort",
-          icon = Icons.Default.Stop,
-          enabled = pendingRunCount > 0,
-          compact = true,
-          onClick = onAbort,
-        )
+          SecondaryActionButton(
+            label = "Abort",
+            icon = Icons.Default.Stop,
+            enabled = pendingRunCount > 0,
+            compact = true,
+            onClick = onAbort,
+          )
 
-        SecondaryActionButton(
-          label = "Retry",
-          icon = Icons.Default.Refresh,
-          enabled = canRetryLast,
-          compact = true,
-          onClick = onRetryLast,
-        )
+          SecondaryActionButton(
+            label = "Retry",
+            icon = Icons.Default.Refresh,
+            enabled = canRetryLast,
+            compact = true,
+            onClick = onRetryLast,
+          )
+        }
       }
 
       Button(
         onClick = {
           val text = input
           input = ""
-          onSend(text)
+          onSend(text, reEvaluateOnReconnect)
         },
         enabled = canSend,
         modifier = Modifier.weight(1f).height(48.dp),
@@ -211,7 +309,7 @@ fun ChatComposer(
         }
         Spacer(modifier = Modifier.width(8.dp))
         Text(
-          text = "Send",
+          text = if (healthOk) "Send" else "Queue",
           style = mobileHeadline.copy(fontWeight = FontWeight.Bold),
           maxLines = 1,
           overflow = TextOverflow.Ellipsis,

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatComposer.kt
@@ -63,12 +63,14 @@ fun ChatComposer(
   healthOk: Boolean,
   thinkingLevel: String,
   pendingRunCount: Int,
+  errorText: String?,
   attachments: List<PendingImageAttachment>,
   onPickImages: () -> Unit,
   onRemoveAttachment: (id: String) -> Unit,
   onSetThinkingLevel: (level: String) -> Unit,
   onRefresh: () -> Unit,
   onAbort: () -> Unit,
+  onRetryLast: () -> Unit,
   onSend: (text: String) -> Unit,
 ) {
   var input by rememberSaveable { mutableStateOf("") }
@@ -76,6 +78,7 @@ fun ChatComposer(
 
   val canSend = pendingRunCount == 0 && (input.trim().isNotEmpty() || attachments.isNotEmpty()) && healthOk
   val sendBusy = pendingRunCount > 0
+  val canRetryLast = !errorText.isNullOrBlank() && pendingRunCount == 0
 
   Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
     Row(
@@ -172,6 +175,14 @@ fun ChatComposer(
           enabled = pendingRunCount > 0,
           compact = true,
           onClick = onAbort,
+        )
+
+        SecondaryActionButton(
+          label = "Retry",
+          icon = Icons.Default.Refresh,
+          enabled = canRetryLast,
+          compact = true,
+          onClick = onRetryLast,
         )
       }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMarkdown.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMarkdown.kt
@@ -93,7 +93,8 @@ private val markdownParser: Parser by lazy {
 
 @Composable
 fun ChatMarkdown(text: String, textColor: Color) {
-  val document = remember(text) { markdownParser.parse(text) as Document }
+  val normalized = remember(text) { normalizeMarkdownInput(text) }
+  val document = remember(normalized) { markdownParser.parse(normalized) as Document }
   val inlineStyles = InlineStyles(inlineCodeBg = mobileCodeBg, inlineCodeColor = mobileCodeText)
 
   Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -430,7 +431,7 @@ private fun AnnotatedString.Builder.appendInlineNode(
   while (current != null) {
     when (current) {
       is MarkdownTextNode -> append(current.literal)
-      is SoftLineBreak -> append('\n')
+      is SoftLineBreak -> append(' ')
       is HardLineBreak -> append('\n')
       is Code -> {
         withStyle(
@@ -543,6 +544,13 @@ private data class ParsedDataImage(
   val mimeType: String,
   val base64: String,
 )
+
+private fun normalizeMarkdownInput(raw: String): String {
+  return raw
+    .replace("\r\n", "\n")
+    .replace(Regex("\n{3,}"), "\n\n")
+    .trimEnd()
+}
 
 @Composable
 private fun InlineBase64Image(base64: String, mimeType: String?) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMessageListCard.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMessageListCard.kt
@@ -20,6 +20,7 @@ import ai.openclaw.android.chat.ChatPendingToolCall
 import ai.openclaw.android.ui.mobileBorder
 import ai.openclaw.android.ui.mobileCallout
 import ai.openclaw.android.ui.mobileHeadline
+import ai.openclaw.android.ui.mobileSurface
 import ai.openclaw.android.ui.mobileText
 import ai.openclaw.android.ui.mobileTextSecondary
 
@@ -85,7 +86,7 @@ private fun EmptyChatHint(modifier: Modifier = Modifier, healthOk: Boolean) {
   Surface(
     modifier = modifier.fillMaxWidth(),
     shape = RoundedCornerShape(14.dp),
-    color = androidx.compose.ui.graphics.Color.White.copy(alpha = 0.9f),
+    color = mobileSurface.copy(alpha = 0.92f),
     border = androidx.compose.foundation.BorderStroke(1.dp, mobileBorder),
   ) {
     androidx.compose.foundation.layout.Column(

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMessageViews.kt
@@ -50,6 +50,7 @@ import ai.openclaw.android.ui.mobileCodeBg
 import ai.openclaw.android.ui.mobileCodeText
 import ai.openclaw.android.ui.mobileHeadline
 import ai.openclaw.android.ui.mobileSuccess
+import ai.openclaw.android.ui.mobileSurfaceStrong
 import ai.openclaw.android.ui.mobileText
 import ai.openclaw.android.ui.mobileTextSecondary
 import ai.openclaw.android.ui.mobileWarning
@@ -315,7 +316,7 @@ private fun bubbleStyle(role: String): ChatBubbleStyle {
     else ->
       ChatBubbleStyle(
         alignEnd = false,
-        containerColor = Color.White,
+        containerColor = mobileSurfaceStrong,
         borderColor = mobileBorderStrong,
         roleColor = mobileTextSecondary,
       )
@@ -339,7 +340,7 @@ private fun ChatBase64Image(base64: String, mimeType: String?) {
     Surface(
       shape = RoundedCornerShape(10.dp),
       border = BorderStroke(1.dp, mobileBorder),
-      color = Color.White,
+      color = mobileSurfaceStrong,
       modifier = Modifier.fillMaxWidth(),
     ) {
       Image(

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMessageViews.kt
@@ -24,7 +24,11 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMessageViews.kt
@@ -13,9 +13,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -86,10 +90,17 @@ fun ChatMessageBubble(message: ChatMessage) {
       .filter { it.isNotEmpty() }
       .joinToString("\n\n")
       .trim()
+  val shortUserCompact =
+    role == "user" &&
+      displayableContent.size == 1 &&
+      displayableContent.first().type == "text" &&
+      copyPayload.length in 1..42 &&
+      !copyPayload.contains('\n')
 
   ChatBubbleContainer(
     style = style,
     roleLabel = roleLabel(role),
+    compact = shortUserCompact,
     copyPayload = copyPayload.takeIf { it.isNotEmpty() },
   ) {
     ChatMessageBody(content = displayableContent, textColor = mobileText)
@@ -100,6 +111,7 @@ fun ChatMessageBubble(message: ChatMessage) {
 private fun ChatBubbleContainer(
   style: ChatBubbleStyle,
   roleLabel: String,
+  compact: Boolean = false,
   copyPayload: String? = null,
   modifier: Modifier = Modifier,
   content: @Composable () -> Unit,
@@ -123,35 +135,50 @@ private fun ChatBubbleContainer(
       color = style.containerColor,
       tonalElevation = 0.dp,
       shadowElevation = 0.dp,
-      modifier = Modifier.fillMaxWidth(0.90f),
+      modifier =
+        if (compact) {
+          Modifier.widthIn(max = 220.dp)
+        } else {
+          Modifier.fillMaxWidth(0.86f)
+        },
     ) {
       Column(
-        modifier = Modifier.padding(horizontal = 11.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(3.dp),
+        modifier = Modifier.padding(horizontal = 9.dp, vertical = 6.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
       ) {
-        Row(
-          modifier = Modifier.fillMaxWidth(),
-          horizontalArrangement = Arrangement.SpaceBetween,
-          verticalAlignment = Alignment.CenterVertically,
-        ) {
-          Text(
-            text = roleLabel,
-            style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold, letterSpacing = 0.6.sp),
-            color = style.roleColor,
-          )
-          if (!copyPayload.isNullOrBlank()) {
-            TextButton(
-              onClick = {
-                val manager = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
-                manager?.setPrimaryClip(ClipData.newPlainText("chat-message", copyPayload))
-                copied = true
-              },
-            ) {
-              Text(
-                text = if (copied) "Copied" else "Copy",
-                style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold),
-                color = if (copied) mobileSuccess else mobileAccent,
-              )
+        if (!compact) {
+          Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text(
+              text = roleLabel,
+              style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold, letterSpacing = 0.4.sp),
+              color = style.roleColor,
+            )
+            if (!copyPayload.isNullOrBlank()) {
+              TextButton(
+                onClick = {
+                  val manager = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+                  manager?.setPrimaryClip(ClipData.newPlainText("chat-message", copyPayload))
+                  copied = true
+                },
+              ) {
+                if (copied) {
+                  Text(
+                    text = "Copied",
+                    style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold),
+                    color = mobileSuccess,
+                  )
+                } else {
+                  Icon(
+                    imageVector = Icons.Default.ContentCopy,
+                    contentDescription = "Copy message",
+                    tint = mobileTextSecondary,
+                  )
+                }
+              }
             }
           }
         }

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatMessageViews.kt
@@ -1,5 +1,10 @@
 package ai.openclaw.android.ui.chat
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.graphics.BitmapFactory
+import android.util.Base64
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
@@ -13,6 +18,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -39,6 +45,7 @@ import ai.openclaw.android.ui.mobileCaption2
 import ai.openclaw.android.ui.mobileCodeBg
 import ai.openclaw.android.ui.mobileCodeText
 import ai.openclaw.android.ui.mobileHeadline
+import ai.openclaw.android.ui.mobileSuccess
 import ai.openclaw.android.ui.mobileText
 import ai.openclaw.android.ui.mobileTextSecondary
 import ai.openclaw.android.ui.mobileWarning
@@ -51,6 +58,9 @@ private data class ChatBubbleStyle(
   val borderColor: Color,
   val roleColor: Color,
 )
+
+private const val COLLAPSE_CHAR_THRESHOLD = 1400
+private const val COLLAPSE_PREVIEW_CHARS = 700
 
 @Composable
 fun ChatMessageBubble(message: ChatMessage) {
@@ -68,7 +78,20 @@ fun ChatMessageBubble(message: ChatMessage) {
 
   if (displayableContent.isEmpty()) return
 
-  ChatBubbleContainer(style = style, roleLabel = roleLabel(role)) {
+  val copyPayload =
+    displayableContent
+      .asSequence()
+      .filter { it.type == "text" }
+      .mapNotNull { it.text?.trim() }
+      .filter { it.isNotEmpty() }
+      .joinToString("\n\n")
+      .trim()
+
+  ChatBubbleContainer(
+    style = style,
+    roleLabel = roleLabel(role),
+    copyPayload = copyPayload.takeIf { it.isNotEmpty() },
+  ) {
     ChatMessageBody(content = displayableContent, textColor = mobileText)
   }
 }
@@ -77,9 +100,19 @@ fun ChatMessageBubble(message: ChatMessage) {
 private fun ChatBubbleContainer(
   style: ChatBubbleStyle,
   roleLabel: String,
+  copyPayload: String? = null,
   modifier: Modifier = Modifier,
   content: @Composable () -> Unit,
 ) {
+  val context = LocalContext.current
+  var copied by remember(copyPayload) { mutableStateOf(false) }
+
+  LaunchedEffect(copied) {
+    if (!copied) return@LaunchedEffect
+    kotlinx.coroutines.delay(1500)
+    copied = false
+  }
+
   Row(
     modifier = modifier.fillMaxWidth(),
     horizontalArrangement = if (style.alignEnd) Arrangement.End else Arrangement.Start,
@@ -96,11 +129,32 @@ private fun ChatBubbleContainer(
         modifier = Modifier.padding(horizontal = 11.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(3.dp),
       ) {
-        Text(
-          text = roleLabel,
-          style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold, letterSpacing = 0.6.sp),
-          color = style.roleColor,
-        )
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.SpaceBetween,
+          verticalAlignment = Alignment.CenterVertically,
+        ) {
+          Text(
+            text = roleLabel,
+            style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold, letterSpacing = 0.6.sp),
+            color = style.roleColor,
+          )
+          if (!copyPayload.isNullOrBlank()) {
+            TextButton(
+              onClick = {
+                val manager = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+                manager?.setPrimaryClip(ClipData.newPlainText("chat-message", copyPayload))
+                copied = true
+              },
+            ) {
+              Text(
+                text = if (copied) "Copied" else "Copy",
+                style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold),
+                color = if (copied) mobileSuccess else mobileAccent,
+              )
+            }
+          }
+        }
         content()
       }
     }
@@ -114,13 +168,32 @@ private fun ChatMessageBody(content: List<ChatMessageContent>, textColor: Color)
       when (part.type) {
         "text" -> {
           val text = part.text ?: continue
-          ChatMarkdown(text = text, textColor = textColor)
+          ChatMessageTextPart(text = text, textColor = textColor)
         }
         else -> {
           val b64 = part.base64 ?: continue
           ChatBase64Image(base64 = b64, mimeType = part.mimeType)
         }
       }
+    }
+  }
+}
+
+@Composable
+private fun ChatMessageTextPart(text: String, textColor: Color) {
+  var expanded by remember(text) { mutableStateOf(false) }
+  val shouldCollapse = text.length > COLLAPSE_CHAR_THRESHOLD
+  val previewText = remember(text) { text.take(COLLAPSE_PREVIEW_CHARS).trimEnd() + "\n\n…" }
+
+  ChatMarkdown(text = if (shouldCollapse && !expanded) previewText else text, textColor = textColor)
+
+  if (shouldCollapse) {
+    TextButton(onClick = { expanded = !expanded }, modifier = Modifier.padding(top = 2.dp)) {
+      Text(
+        text = if (expanded) "Show less" else "Show more",
+        style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
+        color = mobileAccent,
+      )
     }
   }
 }
@@ -274,6 +347,15 @@ private fun PulseDot(alpha: Float, color: Color) {
 
 @Composable
 fun ChatCodeBlock(code: String, language: String?) {
+  val context = LocalContext.current
+  var copied by remember(code) { mutableStateOf(false) }
+
+  LaunchedEffect(copied) {
+    if (!copied) return@LaunchedEffect
+    kotlinx.coroutines.delay(2_000)
+    copied = false
+  }
+
   Surface(
     shape = RoundedCornerShape(8.dp),
     color = mobileCodeBg,
@@ -281,17 +363,44 @@ fun ChatCodeBlock(code: String, language: String?) {
     modifier = Modifier.fillMaxWidth(),
   ) {
     Column(modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-      if (!language.isNullOrBlank()) {
-        Text(
-          text = language.uppercase(Locale.US),
-          style = mobileCaption2.copy(letterSpacing = 0.4.sp),
-          color = mobileTextSecondary,
-        )
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        if (!language.isNullOrBlank()) {
+          Text(
+            text = language.uppercase(Locale.US),
+            style = mobileCaption2.copy(letterSpacing = 0.4.sp),
+            color = mobileTextSecondary,
+          )
+        } else {
+          Text(
+            text = "CODE",
+            style = mobileCaption2.copy(letterSpacing = 0.4.sp),
+            color = mobileTextSecondary,
+          )
+        }
+
+        TextButton(
+          onClick = {
+            val manager = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+            manager?.setPrimaryClip(ClipData.newPlainText("code", code.trimEnd()))
+            copied = true
+          },
+        ) {
+          Text(
+            text = if (copied) "Copied" else "Copy",
+            style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
+            color = if (copied) mobileSuccess else mobileAccent,
+          )
+        }
       }
+
       Text(
         text = code.trimEnd(),
         fontFamily = FontFamily.Monospace,
-        style = mobileCallout,
+        style = mobileCallout.copy(lineHeight = 20.sp),
         color = mobileCodeText,
       )
     }

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatSheetContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatSheetContent.kt
@@ -55,6 +55,7 @@ import ai.openclaw.android.ui.mobileCaption2
 import ai.openclaw.android.ui.mobileDanger
 import ai.openclaw.android.ui.mobileSuccess
 import ai.openclaw.android.ui.mobileSuccessSoft
+import ai.openclaw.android.ui.mobileSurfaceStrong
 import ai.openclaw.android.ui.mobileText
 import ai.openclaw.android.ui.mobileTextSecondary
 import ai.openclaw.android.ui.mobileWarning
@@ -234,47 +235,49 @@ private fun ChatThreadSelector(
     }
 
   Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-    Row(
-      modifier = Modifier.fillMaxWidth(),
-      horizontalArrangement = Arrangement.SpaceBetween,
-      verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
-    ) {
-      Text(
-        text = "SESSION",
-        style = mobileCaption1.copy(fontWeight = FontWeight.Bold, letterSpacing = 0.8.sp),
-        color = mobileTextSecondary,
-      )
-      Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+    if (!compactMode) {
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+      ) {
         Text(
-          text = currentSessionLabel,
-          style = mobileCallout.copy(fontWeight = FontWeight.SemiBold),
-          color = mobileText,
-          maxLines = 1,
-          overflow = TextOverflow.Ellipsis,
+          text = "SESSION",
+          style = mobileCaption1.copy(fontWeight = FontWeight.Bold, letterSpacing = 0.8.sp),
+          color = mobileTextSecondary,
         )
-        if (threadTranscript.isNotBlank()) {
-          Surface(
-            shape = RoundedCornerShape(999.dp),
-            color = if (copiedAll) mobileSuccessSoft else Color.White,
-            border = BorderStroke(1.dp, if (copiedAll) mobileSuccess.copy(alpha = 0.4f) else mobileBorder),
-            onClick = {
-              val manager = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
-              manager?.setPrimaryClip(ClipData.newPlainText("chat-thread", threadTranscript))
-              copiedAll = true
-            },
-          ) {
-            Text(
-              text = if (copiedAll) "Copied all" else "Copy all",
-              style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold),
-              color = if (copiedAll) mobileSuccess else mobileTextSecondary,
-              modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-            )
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+          Text(
+            text = currentSessionLabel,
+            style = mobileCallout.copy(fontWeight = FontWeight.SemiBold),
+            color = mobileText,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+          )
+          if (threadTranscript.isNotBlank()) {
+            Surface(
+              shape = RoundedCornerShape(999.dp),
+              color = if (copiedAll) mobileSuccessSoft else mobileSurfaceStrong,
+              border = BorderStroke(1.dp, if (copiedAll) mobileSuccess.copy(alpha = 0.4f) else mobileBorder),
+              onClick = {
+                val manager = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+                manager?.setPrimaryClip(ClipData.newPlainText("chat-thread", threadTranscript))
+                copiedAll = true
+              },
+            ) {
+              Text(
+                text = if (copiedAll) "Copied all" else "Copy all",
+                style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold),
+                color = if (copiedAll) mobileSuccess else mobileTextSecondary,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+              )
+            }
           }
+          ChatConnectionPill(
+            healthOk = healthOk,
+            connectionState = connectionState,
+          )
         }
-        ChatConnectionPill(
-          healthOk = healthOk,
-          connectionState = connectionState,
-        )
       }
     }
 
@@ -282,7 +285,7 @@ private fun ChatThreadSelector(
       Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(12.dp),
-        color = Color.White,
+        color = mobileSurfaceStrong,
         border = BorderStroke(1.dp, mobileBorder),
       ) {
         Row(
@@ -315,7 +318,7 @@ private fun ChatThreadSelector(
           Surface(
             onClick = { onSelectSession(entry.key) },
             shape = RoundedCornerShape(14.dp),
-            color = if (active) mobileAccent else Color.White,
+            color = if (active) mobileAccent else mobileSurfaceStrong,
             border = BorderStroke(1.dp, if (active) Color(0xFF154CAD) else mobileBorderStrong),
             tonalElevation = 0.dp,
             shadowElevation = 0.dp,
@@ -383,13 +386,13 @@ private fun ChatSurfaceHint(onDismiss: () -> Unit) {
       Surface(
         onClick = onDismiss,
         shape = RoundedCornerShape(999.dp),
-        color = Color.White.copy(alpha = 0.65f),
-        border = BorderStroke(1.dp, mobileBorder),
+        color = mobileSurfaceStrong,
+        border = BorderStroke(1.dp, mobileBorderStrong),
       ) {
         Text(
           text = "Dismiss",
           style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold),
-          color = mobileTextSecondary,
+          color = mobileText,
           modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
         )
       }

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatSheetContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatSheetContent.kt
@@ -1,6 +1,9 @@
 package ai.openclaw.android.ui.chat
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.ContentResolver
+import android.content.Context
 import android.net.Uri
 import android.util.Base64
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -23,8 +26,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -33,6 +38,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ai.openclaw.android.MainViewModel
+import ai.openclaw.android.chat.ChatConnectionState
+import ai.openclaw.android.chat.ChatMessage
 import ai.openclaw.android.chat.ChatSessionEntry
 import ai.openclaw.android.chat.OutgoingAttachment
 import ai.openclaw.android.ui.mobileAccent
@@ -59,6 +66,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
   val errorText by viewModel.chatError.collectAsState()
   val pendingRunCount by viewModel.pendingRunCount.collectAsState()
   val healthOk by viewModel.chatHealthOk.collectAsState()
+  val connectionState by viewModel.chatConnectionState.collectAsState()
   val sessionKey by viewModel.chatSessionKey.collectAsState()
   val mainSessionKey by viewModel.mainSessionKey.collectAsState()
   val thinkingLevel by viewModel.chatThinkingLevel.collectAsState()
@@ -105,8 +113,10 @@ fun ChatSheetContent(viewModel: MainViewModel) {
     ChatThreadSelector(
       sessionKey = sessionKey,
       sessions = sessions,
+      messages = messages,
       mainSessionKey = mainSessionKey,
       healthOk = healthOk,
+      connectionState = connectionState,
       onSelectSession = { key -> viewModel.switchChatSession(key) },
     )
 
@@ -128,6 +138,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
         healthOk = healthOk,
         thinkingLevel = thinkingLevel,
         pendingRunCount = pendingRunCount,
+        errorText = errorText,
         attachments = attachments,
         onPickImages = { pickImages.launch("image/*") },
         onRemoveAttachment = { id -> attachments.removeAll { it.id == id } },
@@ -137,6 +148,12 @@ fun ChatSheetContent(viewModel: MainViewModel) {
           viewModel.refreshChatSessions(limit = 200)
         },
         onAbort = { viewModel.abortChat() },
+        onRetryLast = {
+          val retried = viewModel.retryLastChatMessage()
+          if (!retried) {
+            viewModel.refreshChat()
+          }
+        },
         onSend = { text ->
           val outgoing =
             attachments.map { att ->
@@ -159,13 +176,41 @@ fun ChatSheetContent(viewModel: MainViewModel) {
 private fun ChatThreadSelector(
   sessionKey: String,
   sessions: List<ChatSessionEntry>,
+  messages: List<ChatMessage>,
   mainSessionKey: String,
   healthOk: Boolean,
+  connectionState: ChatConnectionState,
   onSelectSession: (String) -> Unit,
 ) {
   val sessionOptions = resolveSessionChoices(sessionKey, sessions, mainSessionKey = mainSessionKey)
   val currentSessionLabel =
     friendlySessionName(sessionOptions.firstOrNull { it.key == sessionKey }?.displayName ?: sessionKey)
+  val context = LocalContext.current
+  var copiedAll by remember(messages, sessionKey) { mutableStateOf(false) }
+
+  LaunchedEffect(copiedAll) {
+    if (!copiedAll) return@LaunchedEffect
+    kotlinx.coroutines.delay(1500)
+    copiedAll = false
+  }
+
+  val threadTranscript =
+    remember(messages) {
+      messages
+        .mapNotNull { msg ->
+          val text =
+            msg.content
+              .asSequence()
+              .filter { it.type == "text" }
+              .mapNotNull { it.text?.trim() }
+              .filter { it.isNotEmpty() }
+              .joinToString("\n\n")
+              .trim()
+          if (text.isBlank()) null else "${msg.role.uppercase()}:\n$text"
+        }
+        .joinToString("\n\n")
+        .trim()
+    }
 
   Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
     Row(
@@ -186,7 +231,29 @@ private fun ChatThreadSelector(
           maxLines = 1,
           overflow = TextOverflow.Ellipsis,
         )
-        ChatConnectionPill(healthOk = healthOk)
+        if (threadTranscript.isNotBlank()) {
+          Surface(
+            shape = RoundedCornerShape(999.dp),
+            color = if (copiedAll) mobileSuccessSoft else Color.White,
+            border = BorderStroke(1.dp, if (copiedAll) mobileSuccess.copy(alpha = 0.4f) else mobileBorder),
+            onClick = {
+              val manager = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+              manager?.setPrimaryClip(ClipData.newPlainText("chat-thread", threadTranscript))
+              copiedAll = true
+            },
+          ) {
+            Text(
+              text = if (copiedAll) "Copied all" else "Copy all",
+              style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold),
+              color = if (copiedAll) mobileSuccess else mobileTextSecondary,
+              modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+          }
+        }
+        ChatConnectionPill(
+          healthOk = healthOk,
+          connectionState = connectionState,
+        )
       }
     }
 
@@ -219,16 +286,26 @@ private fun ChatThreadSelector(
 }
 
 @Composable
-private fun ChatConnectionPill(healthOk: Boolean) {
+private fun ChatConnectionPill(
+  healthOk: Boolean,
+  connectionState: ChatConnectionState,
+) {
+  val (label, fg, bg) =
+    when {
+      healthOk -> Triple("Connected", mobileSuccess, mobileSuccessSoft)
+      connectionState == ChatConnectionState.Connecting -> Triple("Connecting…", mobileWarning, mobileWarningSoft)
+      else -> Triple("Reconnecting…", mobileWarning, mobileWarningSoft)
+    }
+
   Surface(
     shape = RoundedCornerShape(999.dp),
-    color = if (healthOk) mobileSuccessSoft else mobileWarningSoft,
-    border = BorderStroke(1.dp, if (healthOk) mobileSuccess.copy(alpha = 0.35f) else mobileWarning.copy(alpha = 0.35f)),
+    color = bg,
+    border = BorderStroke(1.dp, fg.copy(alpha = 0.35f)),
   ) {
     Text(
-      text = if (healthOk) "Connected" else "Offline",
+      text = label,
       style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
-      color = if (healthOk) mobileSuccess else mobileWarning,
+      color = fg,
       modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
     )
   }

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatSheetContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/chat/ChatSheetContent.kt
@@ -13,8 +13,10 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -29,10 +31,12 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -72,6 +76,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
   val thinkingLevel by viewModel.chatThinkingLevel.collectAsState()
   val streamingAssistantText by viewModel.chatStreamingAssistantText.collectAsState()
   val pendingToolCalls by viewModel.chatPendingToolCalls.collectAsState()
+  val queuedItems by viewModel.chatQueuedItems.collectAsState()
   val sessions by viewModel.chatSessions.collectAsState()
 
   LaunchedEffect(mainSessionKey) {
@@ -84,6 +89,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
   val scope = rememberCoroutineScope()
 
   val attachments = remember { mutableStateListOf<PendingImageAttachment>() }
+  var showSurfaceHint by rememberSaveable { mutableStateOf(true) }
 
   val pickImages =
     rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { uris ->
@@ -103,12 +109,15 @@ fun ChatSheetContent(viewModel: MainViewModel) {
       }
     }
 
+  val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
+  val compactMode = imeVisible
+
   Column(
     modifier =
       Modifier
         .fillMaxSize()
-        .padding(horizontal = 20.dp, vertical = 12.dp),
-    verticalArrangement = Arrangement.spacedBy(8.dp),
+        .padding(horizontal = if (compactMode) 16.dp else 20.dp, vertical = if (compactMode) 8.dp else 12.dp),
+    verticalArrangement = Arrangement.spacedBy(if (compactMode) 6.dp else 8.dp),
   ) {
     ChatThreadSelector(
       sessionKey = sessionKey,
@@ -117,8 +126,13 @@ fun ChatSheetContent(viewModel: MainViewModel) {
       mainSessionKey = mainSessionKey,
       healthOk = healthOk,
       connectionState = connectionState,
+      compactMode = compactMode,
       onSelectSession = { key -> viewModel.switchChatSession(key) },
     )
+
+    if (showSurfaceHint) {
+      ChatSurfaceHint(onDismiss = { showSurfaceHint = false })
+    }
 
     if (!errorText.isNullOrBlank()) {
       ChatErrorRail(errorText = errorText!!)
@@ -138,6 +152,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
         healthOk = healthOk,
         thinkingLevel = thinkingLevel,
         pendingRunCount = pendingRunCount,
+        queuedCount = queuedItems.size,
         errorText = errorText,
         attachments = attachments,
         onPickImages = { pickImages.launch("image/*") },
@@ -154,7 +169,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
             viewModel.refreshChat()
           }
         },
-        onSend = { text ->
+        onSend = { text, reEvaluateOnReconnect ->
           val outgoing =
             attachments.map { att ->
               OutgoingAttachment(
@@ -164,7 +179,12 @@ fun ChatSheetContent(viewModel: MainViewModel) {
                 base64 = att.base64,
               )
             }
-          viewModel.sendChat(message = text, thinking = thinkingLevel, attachments = outgoing)
+          viewModel.sendChat(
+            message = text,
+            thinking = thinkingLevel,
+            attachments = outgoing,
+            reEvaluateOnReconnect = reEvaluateOnReconnect,
+          )
           attachments.clear()
         },
       )
@@ -180,6 +200,7 @@ private fun ChatThreadSelector(
   mainSessionKey: String,
   healthOk: Boolean,
   connectionState: ChatConnectionState,
+  compactMode: Boolean,
   onSelectSession: (String) -> Unit,
 ) {
   val sessionOptions = resolveSessionChoices(sessionKey, sessions, mainSessionKey = mainSessionKey)
@@ -257,28 +278,57 @@ private fun ChatThreadSelector(
       }
     }
 
-    Row(
-      modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
-      horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-      for (entry in sessionOptions) {
-        val active = entry.key == sessionKey
-        Surface(
-          onClick = { onSelectSession(entry.key) },
-          shape = RoundedCornerShape(14.dp),
-          color = if (active) mobileAccent else Color.White,
-          border = BorderStroke(1.dp, if (active) Color(0xFF154CAD) else mobileBorderStrong),
-          tonalElevation = 0.dp,
-          shadowElevation = 0.dp,
+    if (compactMode) {
+      Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        color = Color.White,
+        border = BorderStroke(1.dp, mobileBorder),
+      ) {
+        Row(
+          modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
+          horizontalArrangement = Arrangement.SpaceBetween,
+          verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
         ) {
           Text(
-            text = friendlySessionName(entry.displayName ?: entry.key),
-            style = mobileCaption1.copy(fontWeight = if (active) FontWeight.Bold else FontWeight.SemiBold),
-            color = if (active) Color.White else mobileText,
+            text = "Session: $currentSessionLabel",
+            style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
+            color = mobileText,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            modifier = Modifier.weight(1f),
           )
+          Text(
+            text = "Typing mode",
+            style = mobileCaption2,
+            color = mobileTextSecondary,
+          )
+        }
+      }
+    } else {
+      Row(
+        modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        for (entry in sessionOptions) {
+          val active = entry.key == sessionKey
+          Surface(
+            onClick = { onSelectSession(entry.key) },
+            shape = RoundedCornerShape(14.dp),
+            color = if (active) mobileAccent else Color.White,
+            border = BorderStroke(1.dp, if (active) Color(0xFF154CAD) else mobileBorderStrong),
+            tonalElevation = 0.dp,
+            shadowElevation = 0.dp,
+          ) {
+            Text(
+              text = friendlySessionName(entry.displayName ?: entry.key),
+              style = mobileCaption1.copy(fontWeight = if (active) FontWeight.Bold else FontWeight.SemiBold),
+              color = if (active) Color.White else mobileText,
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis,
+              modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            )
+          }
         }
       }
     }
@@ -308,6 +358,42 @@ private fun ChatConnectionPill(
       color = fg,
       modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
     )
+  }
+}
+
+@Composable
+private fun ChatSurfaceHint(onDismiss: () -> Unit) {
+  Surface(
+    modifier = Modifier.fillMaxWidth(),
+    color = mobileWarningSoft,
+    shape = RoundedCornerShape(12.dp),
+    border = BorderStroke(1.dp, mobileWarning.copy(alpha = 0.35f)),
+  ) {
+    Row(
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+    ) {
+      Text(
+        text = "Tip: use one primary chat surface at a time (App or Telegram) to avoid overlap.",
+        style = mobileCaption1,
+        color = mobileText,
+        modifier = Modifier.weight(1f),
+      )
+      Surface(
+        onClick = onDismiss,
+        shape = RoundedCornerShape(999.dp),
+        color = Color.White.copy(alpha = 0.65f),
+        border = BorderStroke(1.dp, mobileBorder),
+      ) {
+        Text(
+          text = "Dismiss",
+          style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold),
+          color = mobileTextSecondary,
+          modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+        )
+      }
+    }
   }
 }
 

--- a/apps/android/app/src/main/res/xml/backup_rules.xml
+++ b/apps/android/app/src/main/res/xml/backup_rules.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-  <include domain="file" path="." />
+  <!-- Do not include app files in cloud/device backups. -->
+  <exclude domain="file" path="." />
+  <exclude domain="database" path="." />
+  <exclude domain="sharedpref" path="." />
+  <exclude domain="external" path="." />
 </full-backup-content>

--- a/apps/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/apps/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
   <cloud-backup>
-    <include domain="file" path="." />
+    <!-- Keep app data local-only; do not extract in cloud backup. -->
+    <exclude domain="file" path="." />
+    <exclude domain="database" path="." />
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="external" path="." />
   </cloud-backup>
   <device-transfer>
-    <include domain="file" path="." />
+    <!-- Keep app data local-only during device-to-device transfer. -->
+    <exclude domain="file" path="." />
+    <exclude domain="database" path="." />
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="external" path="." />
   </device-transfer>
 </data-extraction-rules>

--- a/apps/android/app/src/release/res/xml/network_security_config.xml
+++ b/apps/android/app/src/release/res/xml/network_security_config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <!-- Release: secure-by-default (no cleartext traffic). -->
+  <base-config cleartextTrafficPermitted="false" />
+</network-security-config>

--- a/apps/android/scripts/ux-smoke.sh
+++ b/apps/android/scripts/ux-smoke.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# OpenClaw Android UX smoke test helper (operator-guided)
+# - Builds/install app
+# - Launches app
+# - Prints concise manual verification checklist
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ -z "${JAVA_HOME:-}" && -x /opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home/bin/java ]]; then
+  export JAVA_HOME="/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home"
+  export PATH="$JAVA_HOME/bin:$PATH"
+fi
+
+if ! command -v adb >/dev/null 2>&1; then
+  echo "❌ adb not found. Install Android platform-tools and try again."
+  exit 1
+fi
+
+echo "==> Checking connected Android devices"
+adb devices -l
+
+DEVICE_COUNT="$(adb devices -l | awk 'NR>1 && /(^|[[:space:]])device([[:space:]]|$)/ {count++} END {print count+0}')"
+if [[ "$DEVICE_COUNT" -lt 1 ]]; then
+  echo "❌ No authorized device found. Connect phone/emulator and accept USB debug prompt."
+  exit 1
+fi
+
+echo "==> Building + installing debug APK"
+./gradlew :app:installDebug -q
+
+echo "==> Launching app"
+adb shell am start -n ai.openclaw.android/.MainActivity >/dev/null
+
+cat <<'EOF'
+
+✅ App launched. Run this 5-minute smoke checklist:
+
+[1] Onboarding flow
+  - Confirm 4-step flow appears and navigation works (Back/Next).
+  - Gateway step: QR button visible + Advanced panel expandable.
+  - Permissions step copy says mic/camera/SMS are requested on first use.
+
+[2] Connect flow
+  - Enter setup code or manual endpoint and connect.
+  - Status reaches connected; if pairing needed, approve via:
+      openclaw nodes pending
+      openclaw nodes approve <requestId>
+
+[3] Chat UX
+  - Send a prompt and verify streaming appears smoothly (no jitter bursts).
+  - During network interruption, status pill shows Connecting/Reconnecting.
+  - Trigger an error and verify Retry button appears and works.
+
+[4] First-use permission explainers
+  - Trigger camera.snap -> camera permission prompt should mention camera capture.
+  - Trigger screen/camera audio path -> mic prompt should mention recording audio context.
+  - Trigger SMS send -> prompt should mention sending SMS.
+
+[5] Regression sanity
+  - Re-open Connect tab and confirm advanced controls still work.
+  - Verify no crashes when switching tabs during/after chat stream.
+
+Tip: capture logs during testing:
+  adb logcat | grep -i "openclaw\|PermissionRequester\|ChatController"
+
+EOF

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "android:lint": "cd apps/android && ./gradlew :app:ktlintCheck :benchmark:ktlintCheck",
     "android:lint:android": "cd apps/android && ./gradlew :app:lintDebug",
     "android:run": "cd apps/android && ./gradlew :app:installDebug && adb shell am start -n ai.openclaw.android/.MainActivity",
+    "android:smoke": "bash apps/android/scripts/ux-smoke.sh",
     "android:test": "cd apps/android && ./gradlew :app:testDebugUnitTest",
     "android:test:integration": "OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_ANDROID_NODE=1 vitest run --config vitest.live.config.ts src/gateway/android-node.capabilities.live.test.ts",
     "build": "pnpm canvas:a2ui:bundle && tsdown && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-startup-metadata.ts && node --import tsx scripts/write-cli-compat.ts",

--- a/src/canvas-host/a2ui.ts
+++ b/src/canvas-host/a2ui.ts
@@ -181,10 +181,15 @@ export async function handleA2uiHttpRequest(
 
   try {
     const lower = result.realPath.toLowerCase();
+    const detectedMime = await detectMime({ filePath: result.realPath });
     const mime =
       lower.endsWith(".html") || lower.endsWith(".htm")
         ? "text/html"
-        : ((await detectMime({ filePath: result.realPath })) ?? "application/octet-stream");
+        : lower.endsWith(".js")
+          ? "application/javascript; charset=utf-8"
+          : detectedMime && detectedMime !== "application/octet-stream"
+            ? detectedMime
+            : "application/octet-stream";
     res.setHeader("Cache-Control", "no-store");
 
     if (req.method === "HEAD") {

--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -353,10 +353,15 @@ export async function createCanvasHostHandler(
       }
 
       const lower = realPath.toLowerCase();
+      const detectedMime = await detectMime({ filePath: realPath });
       const mime =
         lower.endsWith(".html") || lower.endsWith(".htm")
           ? "text/html"
-          : ((await detectMime({ filePath: realPath })) ?? "application/octet-stream");
+          : lower.endsWith(".js")
+            ? "application/javascript; charset=utf-8"
+            : detectedMime && detectedMime !== "application/octet-stream"
+              ? detectedMime
+              : "application/octet-stream";
 
       res.setHeader("Cache-Control", "no-store");
       if (mime === "text/html") {

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1186,7 +1186,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it("falls back to normal send when DM draft reasoning flush emits no preview update", async () => {
+  it("skips DM draft reasoning non-final fallback send when preview update is not emitted", async () => {
     const answerDraftStream = createDraftStream(999);
     const previewRevision = 0;
     const reasoningDraftStream = {
@@ -1218,7 +1218,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createReasoningStreamContext(), streamMode: "partial" });
 
     expect(reasoningDraftStream.flush).toHaveBeenCalled();
-    expect(deliverReplies).toHaveBeenCalledWith(
+    expect(deliverReplies).not.toHaveBeenCalledWith(
       expect.objectContaining({
         replies: [expect.objectContaining({ text: "Reasoning:\n_step one expanded_" })],
       }),

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -102,6 +102,7 @@ async function deliverTextReply(params: {
   replyToId?: number;
   replyToMode: ReplyToMode;
   progress: DeliveryProgress;
+  traceBase?: string;
 }): Promise<void> {
   const chunks = params.chunkText(params.replyText);
   for (let i = 0; i < chunks.length; i += 1) {
@@ -123,6 +124,9 @@ async function deliverTextReply(params: {
       plainText: chunk.text,
       linkPreview: params.linkPreview,
       replyMarkup: shouldAttachButtons ? params.replyMarkup : undefined,
+      traceTag: params.traceBase
+        ? `${params.traceBase}:chunk-${i + 1}/${chunks.length}`
+        : undefined,
     });
     markReplyApplied(params.progress, replyToForChunk);
     markDelivered(params.progress);
@@ -141,6 +145,7 @@ async function sendPendingFollowUpText(params: {
   replyToId?: number;
   replyToMode: ReplyToMode;
   progress: DeliveryProgress;
+  traceBase?: string;
 }): Promise<void> {
   const chunks = params.chunkText(params.text);
   for (let i = 0; i < chunks.length; i += 1) {
@@ -157,6 +162,9 @@ async function sendPendingFollowUpText(params: {
       plainText: chunk.text,
       linkPreview: params.linkPreview,
       replyMarkup: i === 0 ? params.replyMarkup : undefined,
+      traceTag: params.traceBase
+        ? `${params.traceBase}:followup-chunk-${i + 1}/${chunks.length}`
+        : undefined,
     });
     markReplyApplied(params.progress, replyToForFollowUp);
     markDelivered(params.progress);
@@ -227,6 +235,7 @@ async function deliverMediaReply(params: {
   replyToId?: number;
   replyToMode: ReplyToMode;
   progress: DeliveryProgress;
+  traceBase?: string;
 }): Promise<void> {
   let first = true;
   let pendingFollowUpText: string | undefined;
@@ -419,6 +428,7 @@ async function deliverMediaReply(params: {
         replyToId: params.replyToId,
         replyToMode: params.replyToMode,
         progress: params.progress,
+        traceBase: params.traceBase,
       });
       pendingFollowUpText = undefined;
     }
@@ -458,7 +468,8 @@ export async function deliverReplies(params: {
     chunkMode: params.chunkMode ?? "length",
     tableMode: params.tableMode,
   });
-  for (const originalReply of params.replies) {
+  for (let replyIndex = 0; replyIndex < params.replies.length; replyIndex += 1) {
+    const originalReply = params.replies[replyIndex];
     let reply = originalReply;
     const mediaList = reply?.mediaUrls?.length
       ? reply.mediaUrls
@@ -502,6 +513,7 @@ export async function deliverReplies(params: {
     }
 
     const contentForSentHook = reply.text || "";
+    const traceBase = `reply-${replyIndex + 1}/${params.replies.length}`;
 
     try {
       const deliveredCountBeforeReply = progress.deliveredCount;
@@ -525,6 +537,7 @@ export async function deliverReplies(params: {
           replyToId,
           replyToMode: params.replyToMode,
           progress,
+          traceBase,
         });
       } else {
         await deliverMediaReply({
@@ -544,6 +557,7 @@ export async function deliverReplies(params: {
           replyToId,
           replyToMode: params.replyToMode,
           progress,
+          traceBase,
         });
       }
 

--- a/src/telegram/bot/delivery.send.ts
+++ b/src/telegram/bot/delivery.send.ts
@@ -101,6 +101,7 @@ export async function sendTelegramText(
     plainText?: string;
     linkPreview?: boolean;
     replyMarkup?: ReturnType<typeof buildInlineKeyboard>;
+    traceTag?: string;
   },
 ): Promise<number> {
   const baseParams = buildTelegramSendParams({
@@ -113,6 +114,7 @@ export async function sendTelegramText(
   const textMode = opts?.textMode ?? "markdown";
   const htmlText = textMode === "html" ? text : markdownToTelegramHtml(text);
   const fallbackText = opts?.plainText ?? text;
+  const traceTag = opts?.traceTag ? ` trace=${opts.traceTag}` : "";
   const hasFallbackText = fallbackText.trim().length > 0;
   const sendPlainFallback = async () => {
     const res = await sendTelegramWithThreadFallback({
@@ -127,7 +129,9 @@ export async function sendTelegramText(
           ...effectiveParams,
         }),
     });
-    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id} (plain)`);
+    runtime.log?.(
+      `telegram sendMessage ok chat=${chatId} message=${res.message_id} (plain)${traceTag}`,
+    );
     return res.message_id;
   };
 
@@ -156,7 +160,7 @@ export async function sendTelegramText(
           ...effectiveParams,
         }),
     });
-    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id}`);
+    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id}${traceTag}`);
     return res.message_id;
   } catch (err) {
     const errText = formatErrorMessage(err);

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -143,6 +143,9 @@ export function createTelegramDraftStream(params: {
     sendGeneration,
   }: PreviewSendParams): Promise<boolean> => {
     if (typeof streamMessageId === "number") {
+      params.log?.(
+        `telegram draft-trace: editMessageText chat=${chatId} message=${streamMessageId} len=${renderedText.length} mode=${renderedParseMode ?? "plain"}`,
+      );
       if (renderedParseMode) {
         await params.api.editMessageText(chatId, streamMessageId, renderedText, {
           parse_mode: renderedParseMode,
@@ -160,6 +163,9 @@ export function createTelegramDraftStream(params: {
       : replyParams;
     let sent;
     try {
+      params.log?.(
+        `telegram draft-trace: sendMessage chat=${chatId} len=${renderedText.length} mode=${renderedParseMode ?? "plain"}`,
+      );
       sent = await params.api.sendMessage(chatId, renderedText, sendParams);
     } catch (err) {
       const hasThreadParam =
@@ -175,6 +181,9 @@ export function createTelegramDraftStream(params: {
       params.warn?.(
         "telegram stream preview send failed with message_thread_id, retrying without thread",
       );
+      params.log?.(
+        `telegram draft-trace: sendMessage retry-without-thread chat=${chatId} len=${renderedText.length} mode=${renderedParseMode ?? "plain"}`,
+      );
       sent = await params.api.sendMessage(
         chatId,
         renderedText,
@@ -189,6 +198,9 @@ export function createTelegramDraftStream(params: {
     }
     const normalizedMessageId = Math.trunc(sentMessageId);
     if (sendGeneration !== generation) {
+      params.log?.(
+        `telegram draft-trace: superseded-preview chat=${chatId} message=${normalizedMessageId} generation=${sendGeneration}->${generation}`,
+      );
       params.onSupersededPreview?.({
         messageId: normalizedMessageId,
         textSnapshot: renderedText,
@@ -197,6 +209,9 @@ export function createTelegramDraftStream(params: {
       return true;
     }
     streamMessageId = normalizedMessageId;
+    params.log?.(
+      `telegram draft-trace: sendMessage created preview chat=${chatId} message=${normalizedMessageId} generation=${generation}`,
+    );
     return true;
   };
   const sendDraftTransportPreview = async ({
@@ -211,6 +226,9 @@ export function createTelegramDraftStream(params: {
         : {}),
       ...(renderedParseMode ? { parse_mode: renderedParseMode } : {}),
     };
+    params.log?.(
+      `telegram draft-trace: sendMessageDraft chat=${chatId} draftId=${draftId} len=${renderedText.length} mode=${renderedParseMode ?? "plain"}`,
+    );
     await resolvedDraftApi!(
       chatId,
       draftId,
@@ -324,6 +342,9 @@ export function createTelegramDraftStream(params: {
   });
 
   const forceNewMessage = () => {
+    params.log?.(
+      `telegram draft-trace: forceNewMessage chat=${chatId} generation=${generation}->${generation + 1} hadMessage=${typeof streamMessageId === "number"}`,
+    );
     generation += 1;
     streamMessageId = undefined;
     if (previewTransport === "draft") {

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -387,10 +387,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         const previewUpdated = (lane.stream?.previewRevision?.() ?? 0) > previewRevisionBeforeFlush;
         if (!previewUpdated) {
           params.log(
-            `telegram: ${laneName} draft preview update not emitted; falling back to standard send`,
+            `telegram: ${laneName} draft preview update not emitted; skipping non-final fallback send`,
           );
-          const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
-          return delivered ? "sent" : "skipped";
+          return "skipped";
         }
         lane.lastPartialText = text;
         params.markDelivered();


### PR DESCRIPTION
## Summary
- add Telegram send trace tagging () to correlate reply path to final message IDs
- log draft-stream transport operations (send/edit/draft/superseded/forceNewMessage) at debug for easier flicker diagnosis
- avoid non-final DM draft fallback sends when preview update is not emitted (prevents potential transient duplicate sends)

## Why
Users report Telegram partial-streaming visual duplicate/disappear behavior. During investigation, backend often showed a single final send, making root-cause isolation hard.

This PR improves observability and tightens one fallback path that could emit extra non-final sends.

## Validation
- 
- undefined
/Users/nimble/.openclaw/workspace:
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "build" not found

## Related
- Closes #34383