### PR TITLE
fix(whatsapp): use fresh config per-message instead of stale handler-creation snapshot

### DIFF
--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -26,6 +26,7 @@ import { formatError, getWebAuthAgeMs, readWebSelfId } from "../session.js";
 import { DEFAULT_WEB_MEDIA_BYTES } from "./constants.js";
 import { whatsappHeartbeatLog, whatsappLog } from "./loggers.js";
 import { buildMentionConfig } from "./mentions.js";
+import { buildWhatsAppAccountConfig } from "./monitor/config.js";
 import { createEchoTracker } from "./monitor/echo.js";
 import { createWebOnMessageHandler } from "./monitor/on-message.js";
 import type { WebChannelStatus, WebInboundMsg, WebMonitorTuning } from "./types.js";
@@ -73,25 +74,10 @@ export async function monitorWebChannel(
     cfg: baseCfg,
     accountId: tuning.accountId,
   });
-  const cfg = {
-    ...baseCfg,
-    channels: {
-      ...baseCfg.channels,
-      whatsapp: {
-        ...baseCfg.channels?.whatsapp,
-        ackReaction: account.ackReaction,
-        messagePrefix: account.messagePrefix,
-        allowFrom: account.allowFrom,
-        groupAllowFrom: account.groupAllowFrom,
-        groupPolicy: account.groupPolicy,
-        textChunkLimit: account.textChunkLimit,
-        chunkMode: account.chunkMode,
-        mediaMaxMb: account.mediaMaxMb,
-        blockStreaming: account.blockStreaming,
-        groups: account.groups,
-      },
-    },
-  } satisfies ReturnType<typeof loadConfig>;
+  const cfg = buildWhatsAppAccountConfig({
+    cfg: baseCfg,
+    accountId: tuning.accountId,
+  });
 
   const configuredMaxMb = cfg.agents?.defaults?.mediaMaxMb;
   const maxMediaBytes =

--- a/src/web/auto-reply/monitor/config.ts
+++ b/src/web/auto-reply/monitor/config.ts
@@ -1,0 +1,36 @@
+/**
+ * Build a WhatsApp channel config with account-specific overrides merged in.
+ *
+ * Both `monitorWebChannel` (one-time at startup) and the per-message handler
+ * need to merge account overrides into a loaded config.  This helper keeps
+ * the merging logic in a single place so the two call-sites stay in sync.
+ */
+
+import type { loadConfig } from "../../../config/config.js";
+import { resolveWhatsAppAccount } from "../../accounts.js";
+
+export function buildWhatsAppAccountConfig(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  accountId?: string | null;
+}): ReturnType<typeof loadConfig> {
+  const account = resolveWhatsAppAccount(params);
+  return {
+    ...params.cfg,
+    channels: {
+      ...params.cfg.channels,
+      whatsapp: {
+        ...params.cfg.channels?.whatsapp,
+        ackReaction: account.ackReaction,
+        messagePrefix: account.messagePrefix,
+        allowFrom: account.allowFrom,
+        groupAllowFrom: account.groupAllowFrom,
+        groupPolicy: account.groupPolicy,
+        textChunkLimit: account.textChunkLimit,
+        chunkMode: account.chunkMode,
+        mediaMaxMb: account.mediaMaxMb,
+        blockStreaming: account.blockStreaming,
+        groups: account.groups,
+      },
+    },
+  } satisfies ReturnType<typeof loadConfig>;
+}

--- a/src/web/auto-reply/monitor/on-message.fresh-config.test.ts
+++ b/src/web/auto-reply/monitor/on-message.fresh-config.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   loadConfigMock,
+  buildWhatsAppAccountConfigMock,
   resolveAgentRouteMock,
   processMessageMock,
   updateLastRouteInBackgroundMock,
@@ -14,6 +15,8 @@ const {
   maybeBroadcastMessageMock,
 } = vi.hoisted(() => ({
   loadConfigMock: vi.fn(),
+  // Pass-through: return the cfg from params so the tagged config propagates.
+  buildWhatsAppAccountConfigMock: vi.fn((p: { cfg: unknown }) => p.cfg),
   resolveAgentRouteMock: vi.fn(),
   processMessageMock: vi.fn(async () => true),
   updateLastRouteInBackgroundMock: vi.fn(),
@@ -26,6 +29,10 @@ const {
 // ---------------------------------------------------------------------------
 
 vi.mock("../../../config/config.js", () => ({ loadConfig: loadConfigMock }));
+
+vi.mock("./config.js", () => ({
+  buildWhatsAppAccountConfig: buildWhatsAppAccountConfigMock,
+}));
 
 vi.mock("../../../routing/resolve-route.js", () => ({
   resolveAgentRoute: resolveAgentRouteMock,
@@ -160,7 +167,7 @@ describe("createWebOnMessageHandler – fresh config per message", () => {
 
     // processMessage must receive the per-message config, NOT the creation-time config
     expect(processMessageMock).toHaveBeenCalledTimes(1);
-    const pmArgs = processMessageMock.mock.calls[0][0];
+    const pmArgs = (processMessageMock.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
     expect((pmArgs.cfg as Record<string, unknown>)._tag).toBe("per-message");
   });
 
@@ -182,7 +189,10 @@ describe("createWebOnMessageHandler – fresh config per message", () => {
     await handler(makeGroupMsg());
 
     expect(applyGroupGatingMock).toHaveBeenCalledTimes(1);
-    const gatingArgs = applyGroupGatingMock.mock.calls[0][0];
+    const gatingArgs = (applyGroupGatingMock.mock.calls as unknown[][])[0][0] as Record<
+      string,
+      unknown
+    >;
     expect((gatingArgs.cfg as Record<string, unknown>)._tag).toBe("fresh-group");
   });
 
@@ -194,7 +204,10 @@ describe("createWebOnMessageHandler – fresh config per message", () => {
     await handler(makeGroupMsg());
 
     expect(updateLastRouteInBackgroundMock).toHaveBeenCalledTimes(1);
-    const routeArgs = updateLastRouteInBackgroundMock.mock.calls[0][0];
+    const routeArgs = (updateLastRouteInBackgroundMock.mock.calls as unknown[][])[0][0] as Record<
+      string,
+      unknown
+    >;
     expect((routeArgs.cfg as Record<string, unknown>)._tag).toBe("fresh-route");
   });
 
@@ -206,7 +219,10 @@ describe("createWebOnMessageHandler – fresh config per message", () => {
     await handler(makeDmMsg());
 
     expect(maybeBroadcastMessageMock).toHaveBeenCalledTimes(1);
-    const broadcastArgs = maybeBroadcastMessageMock.mock.calls[0][0];
+    const broadcastArgs = (maybeBroadcastMessageMock.mock.calls as unknown[][])[0][0] as Record<
+      string,
+      unknown
+    >;
     expect((broadcastArgs.cfg as Record<string, unknown>)._tag).toBe("fresh-broadcast");
   });
 
@@ -224,11 +240,11 @@ describe("createWebOnMessageHandler – fresh config per message", () => {
     expect(loadConfigMock).toHaveBeenCalledTimes(2);
 
     // First message gets cfg1
-    const pm1 = processMessageMock.mock.calls[0][0];
+    const pm1 = (processMessageMock.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
     expect((pm1.cfg as Record<string, unknown>)._tag).toBe("msg-1");
 
     // Second message gets cfg2
-    const pm2 = processMessageMock.mock.calls[1][0];
+    const pm2 = (processMessageMock.mock.calls as unknown[][])[1][0] as Record<string, unknown>;
     expect((pm2.cfg as Record<string, unknown>)._tag).toBe("msg-2");
   });
 });

--- a/src/web/auto-reply/monitor/on-message.fresh-config.test.ts
+++ b/src/web/auto-reply/monitor/on-message.fresh-config.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks – vi.hoisted() makes these available inside vi.mock factories
+// which are hoisted to the top of the file by vitest.
+// ---------------------------------------------------------------------------
+
+const {
+  loadConfigMock,
+  resolveAgentRouteMock,
+  processMessageMock,
+  updateLastRouteInBackgroundMock,
+  applyGroupGatingMock,
+  maybeBroadcastMessageMock,
+} = vi.hoisted(() => ({
+  loadConfigMock: vi.fn(),
+  resolveAgentRouteMock: vi.fn(),
+  processMessageMock: vi.fn(async () => true),
+  updateLastRouteInBackgroundMock: vi.fn(),
+  applyGroupGatingMock: vi.fn(() => ({ shouldProcess: true })),
+  maybeBroadcastMessageMock: vi.fn(async () => false),
+}));
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../../config/config.js", () => ({ loadConfig: loadConfigMock }));
+
+vi.mock("../../../routing/resolve-route.js", () => ({
+  resolveAgentRoute: resolveAgentRouteMock,
+}));
+
+vi.mock("../../../routing/session-key.js", () => ({
+  buildGroupHistoryKey: vi.fn(() => "group-history-key"),
+}));
+
+vi.mock("../../../globals.js", () => ({ logVerbose: vi.fn() }));
+vi.mock("../../../utils.js", () => ({ normalizeE164: vi.fn((v: string) => v) }));
+
+vi.mock("./process-message.js", () => ({ processMessage: processMessageMock }));
+
+vi.mock("./last-route.js", () => ({
+  updateLastRouteInBackground: updateLastRouteInBackgroundMock,
+}));
+
+vi.mock("./group-gating.js", () => ({ applyGroupGating: applyGroupGatingMock }));
+
+vi.mock("./broadcast.js", () => ({
+  maybeBroadcastMessage: maybeBroadcastMessageMock,
+}));
+
+vi.mock("./peer.js", () => ({ resolvePeerId: vi.fn(() => "+1234567890") }));
+
+// ---------------------------------------------------------------------------
+// Import unit under test AFTER mocks are established.
+// ---------------------------------------------------------------------------
+
+import { createWebOnMessageHandler } from "./on-message.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal config stub – `_tag` marker lets us assert identity. */
+function makeConfig(tag: string) {
+  return {
+    _tag: tag,
+    channels: { whatsapp: {} },
+    agents: { list: [] },
+    session: {},
+  } as ReturnType<typeof loadConfigMock>;
+}
+
+function makeBaseParams(overrideCfg?: unknown) {
+  const noop = vi.fn();
+  return {
+    cfg: overrideCfg ?? makeConfig("creation-time"),
+    verbose: false,
+    connectionId: "conn-1",
+    maxMediaBytes: 10_000_000,
+    groupHistoryLimit: 50,
+    groupHistories: new Map(),
+    groupMemberNames: new Map(),
+    echoTracker: {
+      has: vi.fn(() => false),
+      forget: vi.fn(),
+      rememberText: vi.fn(),
+      buildCombinedKey: vi.fn(() => "echo-key"),
+    },
+    backgroundTasks: new Set<Promise<unknown>>(),
+    replyResolver: noop as never,
+    replyLogger: {
+      warn: { bind: vi.fn(() => noop) },
+      debug: noop,
+      info: noop,
+    } as never,
+    baseMentionConfig: { patterns: [] } as never,
+    account: { authDir: "/tmp/auth", accountId: "acct-1" },
+  };
+}
+
+const baseRoute = {
+  agentId: "main",
+  channel: "whatsapp" as const,
+  accountId: "default",
+  sessionKey: "agent:main:whatsapp:dm:+1234567890",
+  mainSessionKey: "agent:main:main",
+};
+
+function makeDmMsg(body = "hello"): Parameters<ReturnType<typeof createWebOnMessageHandler>>[0] {
+  return {
+    from: "+1234567890",
+    to: "+0987654321",
+    body,
+    chatType: "direct" as const,
+  } as never;
+}
+
+function makeGroupMsg(body = "hello"): Parameters<ReturnType<typeof createWebOnMessageHandler>>[0] {
+  return {
+    from: "+1234567890",
+    to: "+0987654321",
+    body,
+    chatType: "group" as const,
+    conversationId: "group-conv-1",
+    groupSubject: "Test Group",
+    senderName: "Alice",
+    senderJid: "alice@s.whatsapp.net",
+    senderE164: "+1234567890",
+    accountId: "acct-1",
+  } as never;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createWebOnMessageHandler – fresh config per message", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveAgentRouteMock.mockReturnValue(baseRoute);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls loadConfig() per message, not at handler creation time", async () => {
+    const creationCfg = makeConfig("creation-time");
+    const msgCfg = makeConfig("per-message");
+
+    loadConfigMock.mockReturnValue(msgCfg);
+
+    const handler = createWebOnMessageHandler(makeBaseParams(creationCfg));
+    await handler(makeDmMsg());
+
+    // loadConfig must have been called during message handling
+    expect(loadConfigMock).toHaveBeenCalledTimes(1);
+
+    // processMessage must receive the per-message config, NOT the creation-time config
+    expect(processMessageMock).toHaveBeenCalledTimes(1);
+    const pmArgs = processMessageMock.mock.calls[0][0];
+    expect((pmArgs.cfg as Record<string, unknown>)._tag).toBe("per-message");
+  });
+
+  it("passes fresh config to resolveAgentRoute", async () => {
+    const freshCfg = makeConfig("fresh");
+    loadConfigMock.mockReturnValue(freshCfg);
+
+    const handler = createWebOnMessageHandler(makeBaseParams(makeConfig("stale")));
+    await handler(makeDmMsg());
+
+    expect(resolveAgentRouteMock).toHaveBeenCalledWith(expect.objectContaining({ cfg: freshCfg }));
+  });
+
+  it("passes fresh config to applyGroupGating for group messages", async () => {
+    const freshCfg = makeConfig("fresh-group");
+    loadConfigMock.mockReturnValue(freshCfg);
+
+    const handler = createWebOnMessageHandler(makeBaseParams(makeConfig("stale")));
+    await handler(makeGroupMsg());
+
+    expect(applyGroupGatingMock).toHaveBeenCalledTimes(1);
+    const gatingArgs = applyGroupGatingMock.mock.calls[0][0];
+    expect((gatingArgs.cfg as Record<string, unknown>)._tag).toBe("fresh-group");
+  });
+
+  it("passes fresh config to updateLastRouteInBackground for group messages", async () => {
+    const freshCfg = makeConfig("fresh-route");
+    loadConfigMock.mockReturnValue(freshCfg);
+
+    const handler = createWebOnMessageHandler(makeBaseParams(makeConfig("stale")));
+    await handler(makeGroupMsg());
+
+    expect(updateLastRouteInBackgroundMock).toHaveBeenCalledTimes(1);
+    const routeArgs = updateLastRouteInBackgroundMock.mock.calls[0][0];
+    expect((routeArgs.cfg as Record<string, unknown>)._tag).toBe("fresh-route");
+  });
+
+  it("passes fresh config to maybeBroadcastMessage", async () => {
+    const freshCfg = makeConfig("fresh-broadcast");
+    loadConfigMock.mockReturnValue(freshCfg);
+
+    const handler = createWebOnMessageHandler(makeBaseParams(makeConfig("stale")));
+    await handler(makeDmMsg());
+
+    expect(maybeBroadcastMessageMock).toHaveBeenCalledTimes(1);
+    const broadcastArgs = maybeBroadcastMessageMock.mock.calls[0][0];
+    expect((broadcastArgs.cfg as Record<string, unknown>)._tag).toBe("fresh-broadcast");
+  });
+
+  it("uses different fresh configs across consecutive messages", async () => {
+    const cfg1 = makeConfig("msg-1");
+    const cfg2 = makeConfig("msg-2");
+
+    loadConfigMock.mockReturnValueOnce(cfg1).mockReturnValueOnce(cfg2);
+
+    const handler = createWebOnMessageHandler(makeBaseParams(makeConfig("stale")));
+
+    await handler(makeDmMsg("first"));
+    await handler(makeDmMsg("second"));
+
+    expect(loadConfigMock).toHaveBeenCalledTimes(2);
+
+    // First message gets cfg1
+    const pm1 = processMessageMock.mock.calls[0][0];
+    expect((pm1.cfg as Record<string, unknown>)._tag).toBe("msg-1");
+
+    // Second message gets cfg2
+    const pm2 = processMessageMock.mock.calls[1][0];
+    expect((pm2.cfg as Record<string, unknown>)._tag).toBe("msg-2");
+  });
+});

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -8,6 +8,7 @@ import { normalizeE164 } from "../../../utils.js";
 import type { MentionConfig } from "../mentions.js";
 import type { WebInboundMsg } from "../types.js";
 import { maybeBroadcastMessage } from "./broadcast.js";
+import { buildWhatsAppAccountConfig } from "./config.js";
 import type { EchoTracker } from "./echo.js";
 import type { GroupHistoryEntry } from "./group-gating.js";
 import { applyGroupGating } from "./group-gating.js";
@@ -34,7 +35,12 @@ export function createWebOnMessageHandler(params: {
     const conversationId = msg.conversationId ?? msg.from;
     const peerId = resolvePeerId(msg);
     // Fresh config per-message so runtime changes are picked up without restart.
-    const cfg = loadConfig();
+    // Merge account-specific overrides (groupPolicy, groupAllowFrom, etc.) so
+    // multi-account setups keep their per-account gating rules.
+    const cfg = buildWhatsAppAccountConfig({
+      cfg: loadConfig(),
+      accountId: params.account.accountId,
+    });
 
     const processForRoute = async (
       inMsg: WebInboundMsg,

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -30,42 +30,44 @@ export function createWebOnMessageHandler(params: {
   baseMentionConfig: MentionConfig;
   account: { authDir?: string; accountId?: string };
 }) {
-  const processForRoute = async (
-    msg: WebInboundMsg,
-    route: ReturnType<typeof resolveAgentRoute>,
-    groupHistoryKey: string,
-    opts?: {
-      groupHistory?: GroupHistoryEntry[];
-      suppressGroupHistoryClear?: boolean;
-    },
-  ) =>
-    processMessage({
-      cfg: params.cfg,
-      msg,
-      route,
-      groupHistoryKey,
-      groupHistories: params.groupHistories,
-      groupMemberNames: params.groupMemberNames,
-      connectionId: params.connectionId,
-      verbose: params.verbose,
-      maxMediaBytes: params.maxMediaBytes,
-      replyResolver: params.replyResolver,
-      replyLogger: params.replyLogger,
-      backgroundTasks: params.backgroundTasks,
-      rememberSentText: params.echoTracker.rememberText,
-      echoHas: params.echoTracker.has,
-      echoForget: params.echoTracker.forget,
-      buildCombinedEchoKey: params.echoTracker.buildCombinedKey,
-      groupHistory: opts?.groupHistory,
-      suppressGroupHistoryClear: opts?.suppressGroupHistoryClear,
-    });
-
   return async (msg: WebInboundMsg) => {
     const conversationId = msg.conversationId ?? msg.from;
     const peerId = resolvePeerId(msg);
-    // Fresh config for bindings lookup; other routing inputs are payload-derived.
+    // Fresh config per-message so runtime changes are picked up without restart.
+    const cfg = loadConfig();
+
+    const processForRoute = async (
+      inMsg: WebInboundMsg,
+      route: ReturnType<typeof resolveAgentRoute>,
+      ghKey: string,
+      opts?: {
+        groupHistory?: GroupHistoryEntry[];
+        suppressGroupHistoryClear?: boolean;
+      },
+    ) =>
+      processMessage({
+        cfg,
+        msg: inMsg,
+        route,
+        groupHistoryKey: ghKey,
+        groupHistories: params.groupHistories,
+        groupMemberNames: params.groupMemberNames,
+        connectionId: params.connectionId,
+        verbose: params.verbose,
+        maxMediaBytes: params.maxMediaBytes,
+        replyResolver: params.replyResolver,
+        replyLogger: params.replyLogger,
+        backgroundTasks: params.backgroundTasks,
+        rememberSentText: params.echoTracker.rememberText,
+        echoHas: params.echoTracker.has,
+        echoForget: params.echoTracker.forget,
+        buildCombinedEchoKey: params.echoTracker.buildCombinedKey,
+        groupHistory: opts?.groupHistory,
+        suppressGroupHistoryClear: opts?.suppressGroupHistoryClear,
+      });
+
     const route = resolveAgentRoute({
-      cfg: loadConfig(),
+      cfg,
       channel: "whatsapp",
       accountId: msg.accountId,
       peer: {
@@ -113,7 +115,7 @@ export function createWebOnMessageHandler(params: {
         OriginatingTo: conversationId,
       } satisfies MsgContext;
       updateLastRouteInBackground({
-        cfg: params.cfg,
+        cfg,
         backgroundTasks: params.backgroundTasks,
         storeAgentId: route.agentId,
         sessionKey: route.sessionKey,
@@ -125,7 +127,7 @@ export function createWebOnMessageHandler(params: {
       });
 
       const gating = applyGroupGating({
-        cfg: params.cfg,
+        cfg,
         msg,
         conversationId,
         groupHistoryKey,
@@ -153,7 +155,7 @@ export function createWebOnMessageHandler(params: {
     // Does not bypass group mention/activation gating above.
     if (
       await maybeBroadcastMessage({
-        cfg: params.cfg,
+        cfg,
         msg,
         peerId,
         route,


### PR DESCRIPTION
## Summary
- `createWebOnMessageHandler` captured `params.cfg` at handler creation time and passed it to all downstream calls (`processMessage`, `applyGroupGating`, `updateLastRouteInBackground`, `maybeBroadcastMessage`)
- Since the WhatsApp channel is declared as `noopPrefix`, config changes should take effect without a channel restart, but the stale reference silently ignored runtime changes (e.g. toggling `requireMention`, changing group policy)
- `resolveAgentRoute` already called `loadConfig()` per-message — this PR extends the same pattern to the remaining four call sites

## Changes
- Moved `processForRoute` inside the per-message handler closure so it captures a fresh `cfg` from `loadConfig()` instead of the stale `params.cfg`
- All 5 downstream config consumers now receive the same fresh config loaded once per incoming message
- Added regression test suite (`on-message.fresh-config.test.ts`) with 6 tests covering all downstream call sites

## Test plan
- [x] All 6 new regression tests pass — verify each downstream function receives fresh config
- [x] Consecutive messages receive independently loaded configs
- [x] TypeScript type check passes (`tsgo --noEmit`)
- [x] Linter passes (0 warnings, 0 errors)
- [ ] Manual: change `requireMention` while gateway is running and verify group messages respond without restart

Closes #33974

🤖 Generated with [Claude Code](https://claude.com/claude-code)