### PR TITLE
fix(agents): avoid /v1beta/v1beta duplication in Gemini PDF URL

### DIFF
--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -141,7 +141,9 @@ export async function geminiAnalyzePdf(params: {
     /\/+$/,
     "",
   );
-  const url = `${baseUrl}/v1beta/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
+  // Avoid /v1beta/v1beta duplication if baseUrl already includes /v1beta
+  const versionedBase = baseUrl.includes("/v1beta") ? baseUrl : `${baseUrl}/v1beta`;
+  const url = `${versionedBase}/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 
   const res = await fetch(url, {
     method: "POST",

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -628,6 +628,28 @@ describe("native PDF provider API calls", () => {
     expect(body.contents[0].parts[1].text).toBe("Summarize this");
   });
 
+  it("geminiAnalyzePdf avoids /v1beta/v1beta duplication when baseUrl already includes /v1beta", async () => {
+    const { geminiAnalyzePdf } = await import("./pdf-native-providers.js");
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      }),
+    });
+
+    // baseUrl already includes /v1beta - should NOT duplicate
+    await geminiAnalyzePdf(
+      makeGeminiAnalyzeParams({
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      }),
+    );
+
+    const [url] = fetchMock.mock.calls[0];
+    // Should have single /v1beta, not /v1beta/v1beta
+    expect(url).toContain("/v1beta/models/");
+    expect(url).not.toContain("/v1beta/v1beta/");
+  });
+
   it("geminiAnalyzePdf throws on API error", async () => {
     const { geminiAnalyzePdf } = await import("./pdf-native-providers.js");
     mockFetchResponse({


### PR DESCRIPTION
## Summary
- Fixes #34312 - Gemini native PDF analysis fails with 404 when baseUrl already includes /v1beta (e.g., in subagent paths)
- Check if baseUrl already contains /v1beta before appending version segment
- Add regression test for the fix

## Testing
- `pnpm vitest run src/agents/tools/pdf-tool.test.ts -t "geminiAnalyzePdf"` - all 5 tests pass

AI-assisted (Codex)