### PR TITLE
fix(daemon): Handle systemctl is-enabled exit code 4 for not-found state (#33633)

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,6 +79,17 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false when systemctl reports not-found (exit code 4)", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error("not-found") as Error & { code?: number };
+      err.code = 4;
+      cb(err, "not-found", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
   it("throws when systemctl is-enabled fails for non-state errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -351,6 +351,11 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
   if (res.code === 0) {
     return true;
   }
+  // Exit code 4 means the unit file could not be found (not-found state)
+  // This should be treated as "not enabled" rather than an error
+  if (res.code === 4) {
+    return false;
+  }
   const detail = readSystemctlDetail(res);
   if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
     return false;


### PR DESCRIPTION
## Summary

- Problem: On Ubuntu 24.04, `openclaw gateway install` fails when the systemd service does not exist. The `systemctl is-enabled` command returns exit code 4 (not-found state), which was not being handled correctly, causing an error to be thrown instead of returning `false`.
- Why it matters: This blocks fresh installations on Ubuntu 24.04 where the service hasn't been created yet.
- What changed: Added explicit handling for exit code 4 in `isSystemdServiceEnabled()` to treat it as "not enabled" rather than an error.
- What did NOT change: No changes to other systemd commands or service management logic.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #33633

## User-visible / Behavior Changes

`openclaw gateway install` now works correctly on fresh Ubuntu 24.04 installations.

## Security Impact (required)

- New permissions/cabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime: Node.js 22

### Steps

1. Fresh install OpenClaw on Ubuntu 24.04
2. Run `openclaw gateway install`

### Expected

Command succeeds and creates/enables the systemd service.

### Actual (before fix)

Error: `systemctl is-enabled unavailable: Command failed: systemctl --user is-enabled openclaw-gateway.service`

## Evidence

- Added test case: "returns false when systemctl reports not-found (exit code 4)"
- All 20 tests in `src/daemon/systemd.test.ts` pass

## Human Verification (required)

- Verified scenarios: 
  - Exit code 4 returns `false` instead of throwing
  - Existing behavior for other exit codes unchanged
- Edge cases checked: Exit code 0 (enabled), exit code 1 (disabled), exit code 4 (not-found)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

Revert this commit to restore previous behavior.

## Risks and Mitigations

None - this is a minimal fix that only adds handling for a previously unhandled exit code.