### PR TITLE
docs: clarify agent workspace paths vs media whitelist (#34161)

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -31,7 +31,12 @@ inside a sandbox workspace under `~/.openclaw/sandboxes`, not your host workspac
 ```json5
 {
   agent: {
-    workspace: "~/.openclaw/workspace",
+    // Recommended: keep workspaces under the shared workspace root
+    // so media/file tools stay within the default security whitelist.
+    // For example:
+    //   "~/.openclaw/workspace/main"
+    //   "~/.openclaw/workspace/code"
+    workspace: "~/.openclaw/workspace/main",
   },
 }
 ```
@@ -50,7 +55,8 @@ file creation:
 
 ## Extra workspace folders
 
-Older installs may have created `~/openclaw`. Keeping multiple workspace
+Older installs may have created `~/openclaw` or additional `workspace-*`
+directories next to the default workspace root. Keeping multiple workspace
 directories around can cause confusing auth or state drift, because only one
 workspace is active at a time.
 


### PR DESCRIPTION
﻿Fixes #34161.

This PR clarifies how agent workspaces interact with the media/file security whitelist, so docs no longer suggest paths that appear to be allowed but are actually guarded.

## Changes

- `docs/concepts/agent-workspace.md`:
  - Recommend placing per-agent workspaces under the shared `~/.openclaw/workspace` root, e.g. `~/.openclaw/workspace/main` or `~/.openclaw/workspace/code`, so media/file tools stay within the default whitelist.
  - Call out that older installs may have extra `workspace-*` directories next to the root and that keeping multiple roots can cause confusing state drift.

This keeps the existing runtime security behavior (workspace-* roots still require explicit agent-scoped mediaLocalRoots) while making the recommended workspace paths match what the security whitelist expects by default.
