### PR TITLE
fix: avoid hard failure when systemctl --user is-enabled returns wrapper error

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,15 +79,39 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
-  it("throws when systemctl is-enabled fails for non-state errors", async () => {
+  it("returns false when systemctl cannot reach user bus", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
       const err = new Error("Failed to connect to bus") as Error & { code?: number };
       err.code = 1;
       cb(err, "", "Failed to connect to bus");
     });
+    await expect(isSystemdServiceEnabled({ env: {} })).resolves.toBe(false);
+  });
+
+  it("returns false when systemctl only reports command failed wrapper text", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & {
+        code?: number;
+      };
+      err.code = 1;
+      cb(err, "", "");
+    });
+    await expect(isSystemdServiceEnabled({ env: {} })).resolves.toBe(false);
+  });
+
+  it("throws when systemctl is-enabled fails for unknown errors", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error("permission denied") as Error & { code?: number };
+      err.code = 1;
+      cb(err, "", "permission denied");
+    });
     await expect(isSystemdServiceEnabled({ env: {} })).rejects.toThrow(
-      "systemctl is-enabled unavailable: Failed to connect to bus",
+      "systemctl is-enabled unavailable: permission denied",
     );
   });
 });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -103,6 +103,20 @@ describe("isSystemdServiceEnabled", () => {
     await expect(isSystemdServiceEnabled({ env: {} })).resolves.toBe(false);
   });
 
+  it("throws when command wrapper text includes real stderr diagnostics", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & { code?: number };
+      err.code = 1;
+      cb(err, "", "permission denied");
+    });
+    await expect(isSystemdServiceEnabled({ env: {} })).rejects.toThrow(
+      "systemctl is-enabled unavailable: permission denied",
+    );
+  });
+
   it("throws when systemctl is-enabled fails for unknown errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -175,6 +175,19 @@ function isSystemdUnitNotEnabled(detail: string): boolean {
   );
 }
 
+function isSystemdUserManagerUnavailable(detail: string): boolean {
+  if (!detail) {
+    return false;
+  }
+  const normalized = detail.toLowerCase();
+  return (
+    normalized.includes("failed to connect to bus") ||
+    normalized.includes("not been booted") ||
+    normalized.includes("no medium found") ||
+    normalized.includes("command failed: systemctl --user is-enabled")
+  );
+}
+
 export async function isSystemdUserServiceAvailable(): Promise<boolean> {
   const res = await execSystemctl(["--user", "status"]);
   if (res.code === 0) {
@@ -352,7 +365,11 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
     return true;
   }
   const detail = readSystemctlDetail(res);
-  if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
+  if (
+    isSystemctlMissing(detail) ||
+    isSystemdUnitNotEnabled(detail) ||
+    isSystemdUserManagerUnavailable(detail)
+  ) {
     return false;
   }
   throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -175,17 +175,32 @@ function isSystemdUnitNotEnabled(detail: string): boolean {
   );
 }
 
-function isSystemdUserManagerUnavailable(detail: string): boolean {
+function isSystemdUserManagerUnavailable(
+  detail: string,
+  res?: { code: number; stdout: string; stderr: string },
+): boolean {
   if (!detail) {
     return false;
   }
   const normalized = detail.toLowerCase();
-  return (
+  const hasKnownNoSessionSignal =
     normalized.includes("failed to connect to bus") ||
     normalized.includes("not been booted") ||
-    normalized.includes("no medium found") ||
-    normalized.includes("command failed: systemctl --user is-enabled")
-  );
+    // Seen in some user-session D-Bus failures where no user manager is reachable.
+    normalized.includes("no medium found");
+  if (hasKnownNoSessionSignal) {
+    return true;
+  }
+  const stderrText = res?.stderr?.trim().toLowerCase() ?? "";
+  const isWrapperOnlyStderr =
+    stderrText.startsWith("command failed: systemctl --user is-enabled") &&
+    !stderrText.includes("\n");
+  const isWrapperOnlyFailure =
+    normalized.includes("command failed: systemctl --user is-enabled") &&
+    (res?.code ?? -1) === 1 &&
+    !res?.stdout?.trim() &&
+    (isWrapperOnlyStderr || !stderrText);
+  return isWrapperOnlyFailure;
 }
 
 export async function isSystemdUserServiceAvailable(): Promise<boolean> {
@@ -368,7 +383,7 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
   if (
     isSystemctlMissing(detail) ||
     isSystemdUnitNotEnabled(detail) ||
-    isSystemdUserManagerUnavailable(detail)
+    isSystemdUserManagerUnavailable(detail, res)
   ) {
     return false;
   }


### PR DESCRIPTION
## Summary
Handle Linux user-systemd detection more defensively when `systemctl --user is-enabled` fails due to missing user bus/context and only returns generic wrapper text.

## Changes
- treat user-manager-unavailable errors (e.g. `Failed to connect to bus`) as not-enabled instead of fatal in `isSystemdServiceEnabled`
- also handle generic `Command failed: systemctl --user is-enabled ...` wrapper-only messages from Node execFile
- add tests for both cases and keep throwing for unknown real errors

## Testing
- pnpm vitest src/daemon/systemd.test.ts

Fixes openclaw/openclaw#34237