### PR TITLE
fix: enforce Discord requireMention gate in guild preflight (closes #34353)

### DIFF
--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -467,12 +467,18 @@ export async function preflightDiscordMessage(
   });
   const effectiveWasMentioned = mentionGate.effectiveWasMentioned;
   if (isGuildMessage && shouldRequireMention) {
-    if (botId && mentionGate.shouldSkip) {
-      logVerbose(`discord: drop guild message (mention required, botId=${botId})`);
+    if (mentionGate.shouldSkip) {
+      logVerbose(
+        `discord: drop guild message (mention required, botId=${botId ?? "unknown"})`,
+      );
       logger.info(
         {
           channelId: message.channelId,
           reason: "no-mention",
+          requireMention: Boolean(shouldRequireMention),
+          canDetectMention,
+          wasMentioned,
+          effectiveWasMentioned,
         },
         "discord: skipping guild message",
       );


### PR DESCRIPTION
Closes #34353

Problem
Discord guild messages could still enter the reply pipeline when requireMention=true if botId was unavailable, because the skip path was incorrectly gated on botId presence.

Fix
Apply mention gating strictly on mentionGate.shouldSkip for guild messages before processing, independent of botId presence, and add structured log fields (requireMention, canDetectMention, wasMentioned, effectiveWasMentioned) for easier diagnosis.