### PR TITLE
test(config): add unit tests for cache-utils module

### DIFF
--- a/src/config/cache-utils.test.ts
+++ b/src/config/cache-utils.test.ts
@@ -1,12 +1,8 @@
-import { describe, expect, it } from "vitest";
-import {
-  resolveCacheTtlMs,
-  isCacheEnabled,
-  getFileStatSnapshot,
-} from "./cache-utils.js";
 import fs from "node:fs";
-import path from "node:path";
 import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveCacheTtlMs, isCacheEnabled, getFileStatSnapshot } from "./cache-utils.js";
 
 describe("cache-utils", () => {
   describe("resolveCacheTtlMs", () => {
@@ -72,11 +68,11 @@ describe("cache-utils", () => {
     it("returns snapshot for existing file", () => {
       const tmpDir = os.tmpdir();
       const testFile = path.join(tmpDir, `cache-utils-test-${Date.now()}.txt`);
-      
+
       try {
         fs.writeFileSync(testFile, "test content");
         const result = getFileStatSnapshot(testFile);
-        
+
         expect(result).toBeDefined();
         expect(result?.mtimeMs).toBeGreaterThan(0);
         expect(result?.sizeBytes).toBe(13); // "test content".length
@@ -92,11 +88,11 @@ describe("cache-utils", () => {
     it("returns correct size for empty file", () => {
       const tmpDir = os.tmpdir();
       const testFile = path.join(tmpDir, `cache-utils-empty-test-${Date.now()}.txt`);
-      
+
       try {
         fs.writeFileSync(testFile, "");
         const result = getFileStatSnapshot(testFile);
-        
+
         expect(result).toBeDefined();
         expect(result?.sizeBytes).toBe(0);
       } finally {

--- a/src/config/cache-utils.test.ts
+++ b/src/config/cache-utils.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveCacheTtlMs,
+  isCacheEnabled,
+  getFileStatSnapshot,
+} from "./cache-utils.js";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+describe("cache-utils", () => {
+  describe("resolveCacheTtlMs", () => {
+    it("returns default when envValue is undefined", () => {
+      expect(resolveCacheTtlMs({ envValue: undefined, defaultTtlMs: 3600000 })).toBe(3600000);
+    });
+
+    it("returns default when envValue is empty string", () => {
+      expect(resolveCacheTtlMs({ envValue: "", defaultTtlMs: 3600000 })).toBe(3600000);
+    });
+
+    it("returns parsed value when valid", () => {
+      expect(resolveCacheTtlMs({ envValue: "7200000", defaultTtlMs: 3600000 })).toBe(7200000);
+    });
+
+    it("returns zero when envValue is 0", () => {
+      expect(resolveCacheTtlMs({ envValue: "0", defaultTtlMs: 3600000 })).toBe(0);
+    });
+
+    it("returns default for negative numbers", () => {
+      expect(resolveCacheTtlMs({ envValue: "-1", defaultTtlMs: 3600000 })).toBe(3600000);
+    });
+
+    it("returns default for invalid strings", () => {
+      expect(resolveCacheTtlMs({ envValue: "invalid", defaultTtlMs: 3600000 })).toBe(3600000);
+    });
+
+    it("returns default for NaN", () => {
+      expect(resolveCacheTtlMs({ envValue: "NaN", defaultTtlMs: 3600000 })).toBe(3600000);
+    });
+
+    it("returns default for Infinity", () => {
+      expect(resolveCacheTtlMs({ envValue: "Infinity", defaultTtlMs: 3600000 })).toBe(3600000);
+    });
+
+    it("parses decimal numbers (floors them)", () => {
+      expect(resolveCacheTtlMs({ envValue: "3600.7", defaultTtlMs: 1000 })).toBe(3600);
+    });
+  });
+
+  describe("isCacheEnabled", () => {
+    it("returns true for positive numbers", () => {
+      expect(isCacheEnabled(1)).toBe(true);
+      expect(isCacheEnabled(3600000)).toBe(true);
+    });
+
+    it("returns false for zero", () => {
+      expect(isCacheEnabled(0)).toBe(false);
+    });
+
+    it("returns false for negative numbers", () => {
+      expect(isCacheEnabled(-1)).toBe(false);
+      expect(isCacheEnabled(-3600000)).toBe(false);
+    });
+  });
+
+  describe("getFileStatSnapshot", () => {
+    it("returns undefined for non-existent file", () => {
+      const result = getFileStatSnapshot("/nonexistent/path/to/file.txt");
+      expect(result).toBeUndefined();
+    });
+
+    it("returns snapshot for existing file", () => {
+      const tmpDir = os.tmpdir();
+      const testFile = path.join(tmpDir, `cache-utils-test-${Date.now()}.txt`);
+      
+      try {
+        fs.writeFileSync(testFile, "test content");
+        const result = getFileStatSnapshot(testFile);
+        
+        expect(result).toBeDefined();
+        expect(result?.mtimeMs).toBeGreaterThan(0);
+        expect(result?.sizeBytes).toBe(13); // "test content".length
+      } finally {
+        try {
+          fs.unlinkSync(testFile);
+        } catch {
+          // ignore cleanup errors
+        }
+      }
+    });
+
+    it("returns correct size for empty file", () => {
+      const tmpDir = os.tmpdir();
+      const testFile = path.join(tmpDir, `cache-utils-empty-test-${Date.now()}.txt`);
+      
+      try {
+        fs.writeFileSync(testFile, "");
+        const result = getFileStatSnapshot(testFile);
+        
+        expect(result).toBeDefined();
+        expect(result?.sizeBytes).toBe(0);
+      } finally {
+        try {
+          fs.unlinkSync(testFile);
+        } catch {
+          // ignore cleanup errors
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What
Adds comprehensive unit tests for the cache-utils module.

## Why
The cache-utils.ts module had no test coverage. This PR adds tests for:
- resolveCacheTtlMs() - parsing cache TTL from environment variables
- isCacheEnabled() - checking if cache is enabled based on TTL
- getFileStatSnapshot() - getting file metadata snapshots

## Test Coverage
- ✅ Undefined and empty string handling
- ✅ Valid integer parsing
- ✅ Zero value handling
- ✅ Negative number rejection
- ✅ Invalid string rejection
- ✅ NaN and Infinity handling
- ✅ Decimal number flooring
- ✅ Cache enabled/disabled checks
- ✅ File stat snapshot for existing files
- ✅ Undefined return for non-existent files