### PR TITLE
docs(zh-CN): add Chinese translation for loop-detection.md

### DIFF
--- a/docs/zh-CN/tools/loop-detection.md
+++ b/docs/zh-CN/tools/loop-detection.md
@@ -1,0 +1,101 @@
+---
+title: "工具循环检测"
+description: "配置可选的防护机制，防止重复或停滞的工具调用循环"
+summary: "如何启用和调整检测重复工具调用循环的防护机制"
+read_when:
+  - 用户报告代理陷入重复工具调用的困境
+  - 你需要调整重复调用保护
+  - 你正在编辑代理工具/运行时策略
+---
+
+# 工具循环检测
+
+OpenClaw 可以防止代理陷入重复的工具调用模式。
+该防护机制**默认禁用**。
+
+仅在需要的地方启用，因为在严格设置下它可能会阻止合法的重复调用。
+
+## 为什么存在这个功能
+
+- 检测没有进展的重复序列。
+- 检测高频无结果循环（相同工具、相同输入、重复错误）。
+- 检测已知轮询工具的特定重复调用模式。
+
+## 配置块
+
+全局默认值：
+
+```json5
+{
+  tools: {
+    loopDetection: {
+      enabled: false,
+      historySize: 30,
+      warningThreshold: 10,
+      criticalThreshold: 20,
+      globalCircuitBreakerThreshold: 30,
+      detectors: {
+        genericRepeat: true,
+        knownPollNoProgress: true,
+        pingPong: true,
+      },
+    },
+  },
+}
+```
+
+每个代理的覆盖（可选）：
+
+```json5
+{
+  agents: {
+    list: [
+      {
+        id: "safe-runner",
+        tools: {
+          loopDetection: {
+            enabled: true,
+            warningThreshold: 8,
+            criticalThreshold: 16,
+          },
+        },
+      },
+    ],
+  },
+}
+```
+
+### 字段行为
+
+- `enabled`：主开关。`false` 表示不执行循环检测。
+- `historySize`：保留用于分析的最近工具调用数量。
+- `warningThreshold`：将模式分类为仅警告之前的阈值。
+- `criticalThreshold`：阻止重复循环模式的阈值。
+- `globalCircuitBreakerThreshold`：全局无进展断路器阈值。
+- `detectors.genericRepeat`：检测重复相同工具 + 相同参数的模式。
+- `detectors.knownPollNoProgress`：检测没有状态变化的已知轮询类模式。
+- `detectors.pingPong`：检测交替的乒乓模式。
+
+## 推荐设置
+
+- 从 `enabled: true` 开始，保持默认设置不变。
+- 保持阈值顺序为 `warningThreshold < criticalThreshold < globalCircuitBreakerThreshold`。
+- 如果出现误报：
+  - 提高 `warningThreshold` 和/或 `criticalThreshold`
+  - （可选）提高 `globalCircuitBreakerThreshold`
+  - 仅禁用导致问题的检测器
+  - 减少 `historySize` 以降低严格的历史上下文要求
+
+## 日志和预期行为
+
+当检测到循环时，OpenClaw 会报告循环事件并根据严重程度阻止或抑制下一个工具周期。
+这可以保护用户免受失控的令牌消耗和死锁，同时保留正常的工具访问。
+
+- 优先使用警告和临时抑制。
+- 仅在重复证据积累时才升级。
+
+## 注意
+
+- `tools.loopDetection` 与代理级别的覆盖合并。
+- 每个代理的配置完全覆盖或扩展全局值。
+- 如果不存在配置，防护机制保持关闭。

--- a/src/config/cache-utils.test.ts
+++ b/src/config/cache-utils.test.ts
@@ -1,12 +1,8 @@
-import { describe, expect, it } from "vitest";
-import {
-  resolveCacheTtlMs,
-  isCacheEnabled,
-  getFileStatSnapshot,
-} from "./cache-utils.js";
 import fs from "node:fs";
-import path from "node:path";
 import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveCacheTtlMs, isCacheEnabled, getFileStatSnapshot } from "./cache-utils.js";
 
 describe("cache-utils", () => {
   describe("resolveCacheTtlMs", () => {
@@ -72,11 +68,11 @@ describe("cache-utils", () => {
     it("returns snapshot for existing file", () => {
       const tmpDir = os.tmpdir();
       const testFile = path.join(tmpDir, `cache-utils-test-${Date.now()}.txt`);
-      
+
       try {
         fs.writeFileSync(testFile, "test content");
         const result = getFileStatSnapshot(testFile);
-        
+
         expect(result).toBeDefined();
         expect(result?.mtimeMs).toBeGreaterThan(0);
         expect(result?.sizeBytes).toBe(13); // "test content".length
@@ -92,11 +88,11 @@ describe("cache-utils", () => {
     it("returns correct size for empty file", () => {
       const tmpDir = os.tmpdir();
       const testFile = path.join(tmpDir, `cache-utils-empty-test-${Date.now()}.txt`);
-      
+
       try {
         fs.writeFileSync(testFile, "");
         const result = getFileStatSnapshot(testFile);
-        
+
         expect(result).toBeDefined();
         expect(result?.sizeBytes).toBe(0);
       } finally {

--- a/src/config/cache-utils.test.ts
+++ b/src/config/cache-utils.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveCacheTtlMs,
+  isCacheEnabled,
+  getFileStatSnapshot,
+} from "./cache-utils.js";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+describe("cache-utils", () => {
+  describe("resolveCacheTtlMs", () => {
+    it("returns default when envValue is undefined", () => {
+      expect(resolveCacheTtlMs({ envValue: undefined, defaultTtlMs: 3600000 })).toBe(3600000);
+    });
+
+    it("returns default when envValue is empty string", () => {
+      expect(resolveCacheTtlMs({ envValue: "", defaultTtlMs: 3600000 })).toBe(3600000);
+    });
+
+    it("returns parsed value when valid", () => {
+      expect(resolveCacheTtlMs({ envValue: "7200000", defaultTtlMs: 3600000 })).toBe(7200000);
+    });
+
+    it("returns zero when envValue is 0", () => {
+      expect(resolveCacheTtlMs({ envValue: "0", defaultTtlMs: 3600000 })).toBe(0);
+    });
+
+    it("returns default for negative numbers", () => {
+      expect(resolveCacheTtlMs({ envValue: "-1", defaultTtlMs: 3600000 })).toBe(3600000);
+    });
+
+    it("returns default for invalid strings", () => {
+      expect(resolveCacheTtlMs({ envValue: "invalid", defaultTtlMs: 3600000 })).toBe(3600000);
+    });
+
+    it("returns default for NaN", () => {
+      expect(resolveCacheTtlMs({ envValue: "NaN", defaultTtlMs: 3600000 })).toBe(3600000);
+    });
+
+    it("returns default for Infinity", () => {
+      expect(resolveCacheTtlMs({ envValue: "Infinity", defaultTtlMs: 3600000 })).toBe(3600000);
+    });
+
+    it("parses decimal numbers (floors them)", () => {
+      expect(resolveCacheTtlMs({ envValue: "3600.7", defaultTtlMs: 1000 })).toBe(3600);
+    });
+  });
+
+  describe("isCacheEnabled", () => {
+    it("returns true for positive numbers", () => {
+      expect(isCacheEnabled(1)).toBe(true);
+      expect(isCacheEnabled(3600000)).toBe(true);
+    });
+
+    it("returns false for zero", () => {
+      expect(isCacheEnabled(0)).toBe(false);
+    });
+
+    it("returns false for negative numbers", () => {
+      expect(isCacheEnabled(-1)).toBe(false);
+      expect(isCacheEnabled(-3600000)).toBe(false);
+    });
+  });
+
+  describe("getFileStatSnapshot", () => {
+    it("returns undefined for non-existent file", () => {
+      const result = getFileStatSnapshot("/nonexistent/path/to/file.txt");
+      expect(result).toBeUndefined();
+    });
+
+    it("returns snapshot for existing file", () => {
+      const tmpDir = os.tmpdir();
+      const testFile = path.join(tmpDir, `cache-utils-test-${Date.now()}.txt`);
+      
+      try {
+        fs.writeFileSync(testFile, "test content");
+        const result = getFileStatSnapshot(testFile);
+        
+        expect(result).toBeDefined();
+        expect(result?.mtimeMs).toBeGreaterThan(0);
+        expect(result?.sizeBytes).toBe(13); // "test content".length
+      } finally {
+        try {
+          fs.unlinkSync(testFile);
+        } catch {
+          // ignore cleanup errors
+        }
+      }
+    });
+
+    it("returns correct size for empty file", () => {
+      const tmpDir = os.tmpdir();
+      const testFile = path.join(tmpDir, `cache-utils-empty-test-${Date.now()}.txt`);
+      
+      try {
+        fs.writeFileSync(testFile, "");
+        const result = getFileStatSnapshot(testFile);
+        
+        expect(result).toBeDefined();
+        expect(result?.sizeBytes).toBe(0);
+      } finally {
+        try {
+          fs.unlinkSync(testFile);
+        } catch {
+          // ignore cleanup errors
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What
Adds Chinese localization for the tool-loop detection documentation.

## Why
Helps Chinese users understand how to configure guardrails for preventing repetitive tool-call loops.

## Changes
- Full translation of the loop-detection guide
- Preserved all configuration examples and JSON5 blocks
- Kept technical terms consistent with other zh-CN docs