### PR TITLE
fix(discord): use guild_id as source of truth for DM classification

### DIFF
--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -822,6 +822,82 @@ describe("preflightDiscordMessage", () => {
     expect(result).not.toBeNull();
     expect(result?.wasMentioned).toBe(true);
   });
+
+  it("drops guild messages without mention even when channelInfo reports DM type (stale cache)", async () => {
+    const channelId = "channel-guild-but-dm-type";
+    const guildId = "guild-requiremention-regression";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          return {
+            id: channelId,
+            type: ChannelType.DM,
+            name: undefined,
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-guild-dm-type",
+      content: "hello without mention",
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      guildEntries: {
+        [guildId]: {
+          requireMention: true,
+        },
+      },
+      data: {
+        channel_id: channelId,
+        guild_id: guildId,
+        guild: {
+          id: guildId,
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(result).toBeNull();
+  });
 });
 
 describe("shouldIgnoreBoundThreadWebhookMessage", () => {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -189,8 +189,8 @@ export async function preflightDiscordMessage(
   if (isPreflightAborted(params.abortSignal)) {
     return null;
   }
-  const isDirectMessage = channelInfo?.type === ChannelType.DM;
-  const isGroupDm = channelInfo?.type === ChannelType.GroupDM;
+  const isDirectMessage = !isGuildMessage && channelInfo?.type === ChannelType.DM;
+  const isGroupDm = !isGuildMessage && channelInfo?.type === ChannelType.GroupDM;
   logDebug(
     `[discord-preflight] channelId=${messageChannelId} guild_id=${params.data.guild_id} channelType=${channelInfo?.type} isGuild=${isGuildMessage} isDM=${isDirectMessage} isGroupDm=${isGroupDm}`,
   );


### PR DESCRIPTION
## Summary

- Problem: Discord `requireMention: true` stopped working — the agent responds and shows typing on every guild message even when not mentioned. The root cause is that `isDirectMessage` was derived solely from `channelInfo?.type === ChannelType.DM`, ignoring `params.data.guild_id`. When `channelInfo` returned `ChannelType.DM` for a guild channel (stale cache, API inconsistency, or Carbon library change), guild messages were classified as DMs, bypassing the `requireMention` gate entirely.
- Why it matters: Every Discord guild deployment with `requireMention: true` is broken — the bot responds to every message, flooding channels.
- What changed: In `message-handler.preflight.ts`, `isDirectMessage` and `isGroupDm` now require `!isGuildMessage` as a precondition. If `guild_id` is present, the message is never classified as DM or GroupDM — mirroring the existing pattern in `agent-components.ts` (line 214-217).
- What did NOT change (scope boundary): `resolveDiscordChannelInfo`, `resolveMentionGatingWithBypass`, guild config resolution, and all other preflight checks are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34353

## User-visible / Behavior Changes

Guild messages without an explicit bot mention are correctly dropped when `requireMention: true` is configured, restoring pre-regression behavior.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure Discord guild with `requireMention: true` in `guilds.<guildId>`.
2. Send a message in a guild channel without mentioning the bot.
3. Observe the agent behavior.

### Expected

- Agent ignores the message (no typing, no response).

### Actual

- Before: Agent shows typing and responds to every message regardless of mention.
- After: Agent correctly ignores messages without explicit mention.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test: "drops guild messages without mention even when channelInfo reports DM type (stale cache)" — simulates a guild message where `channelInfo.type` incorrectly returns `ChannelType.DM`, verifies the message is still dropped when `requireMention: true`.

## Human Verification (required)

- Verified scenarios: Guild message with `guild_id` + stale `channelInfo.type=DM` dropped. Guild message with correct `channelInfo.type=GuildText` still works. True DMs (no `guild_id`, `channelInfo.type=DM`) still accepted.
- Edge cases checked: `guild_id` present but `channelInfo` null results in `isDirectMessage` = false (correct). GroupDM with `guild_id` absent still works via `channelInfo.type`.
- What you did **not** verify: Live Discord API integration with actual stale channel cache scenario.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; `isDirectMessage` returns to `channelInfo?.type === ChannelType.DM`.
- Files/config to restore: `src/discord/monitor/message-handler.preflight.ts`

## Risks and Mitigations

- Risk: A guild message where `guild_id` is absent from the event payload would fail to be recognized as guild.
  - Mitigation: `guild_id` is a core Discord gateway field always present for guild messages. The same pattern is already proven in `agent-components.ts` for interactions.