### PR TITLE
fix(google-gemini-cli-auth): respect system proxy for OAuth token exchange (closes #34401)

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -245,6 +245,7 @@ async function fetchWithTimeout(
     url,
     init,
     timeoutMs,
+    pinDns: false,
   });
   try {
     const body = await response.arrayBuffer();

--- a/src/agents/pi-auth-json.test.ts
+++ b/src/agents/pi-auth-json.test.ts
@@ -1,14 +1,14 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { trackedMkdtemp } from "../../test/test-env.js";
 import { saveAuthProfileStore } from "./auth-profiles.js";
 import { ensurePiAuthJsonFromAuthProfiles } from "./pi-auth-json.js";
 
 type AuthProfileStore = Parameters<typeof saveAuthProfileStore>[0];
 
 async function createAgentDir() {
-  return fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+  return trackedMkdtemp("openclaw-agent-");
 }
 
 function writeProfiles(agentDir: string, profiles: AuthProfileStore["profiles"]) {

--- a/src/cron/service.issue-33940-manual-run-timing.test.ts
+++ b/src/cron/service.issue-33940-manual-run-timing.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { createMockCronStateForJobs } from "./service.test-harness.js";
+import { applyJobResult } from "./service/timer.js";
+import type { CronJob } from "./types.js";
+
+/**
+ * Regression test for issue #33940: manual cron runs should not change timing.
+ *
+ * Root cause: applyJobResult used result.endedAt (actual execution time) to
+ * compute the next run time. For a daily job at 7am run manually at 1pm,
+ * the next run would be computed from 1pm -> tomorrow at 1pm instead of 7am.
+ *
+ * Fix: use job.state.nextRunAtMs (the scheduled time) as the base for
+ * computing the next run, not result.endedAt (actual execution time).
+ */
+describe("issue #33940 - manual cron runs should not change timing", () => {
+  const HOUR_MS = 3_600_000;
+  const DAY_MS = 24 * HOUR_MS;
+
+  function createDailySevenAmJob(sevenAmToday: number): CronJob {
+    return {
+      id: "daily-job-7am",
+      name: "daily 7am",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "UTC" },
+      payload: { kind: "systemEvent", text: "morning affirmation" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      createdAtMs: sevenAmToday - DAY_MS,
+      updatedAtMs: sevenAmToday - DAY_MS,
+      state: {
+        nextRunAtMs: sevenAmToday,
+      },
+    };
+  }
+
+  it("manual run at 1pm should NOT shift next run to 1pm tomorrow", () => {
+    // Scenario: daily job at 7am, user runs manually at 1pm (13:00)
+    const sevenAmToday = Date.parse("2026-03-04T07:00:00.000Z"); // 7am
+    const manualRunTime = sevenAmToday + 6 * HOUR_MS; // 1pm same day
+
+    const job = createDailySevenAmJob(sevenAmToday);
+
+    const state = createMockCronStateForJobs({ jobs: [job], nowMs: manualRunTime });
+
+    // Simulate a successful manual run at 1pm
+    applyJobResult(state, job, {
+      status: "ok",
+      startedAt: manualRunTime - 1000, // started at 12:59pm
+      endedAt: manualRunTime, // ended at 1pm
+      delivered: true,
+    });
+
+    // The next run should still be tomorrow at 7am, NOT tomorrow at 1pm
+    const expectedNextRun = sevenAmToday + DAY_MS; // tomorrow 7am
+    const buggyNextRun = manualRunTime + DAY_MS; // tomorrow 1pm (the bug)
+
+    expect(job.state.nextRunAtMs).not.toBe(buggyNextRun);
+    expect(job.state.nextRunAtMs).toBe(expectedNextRun);
+  });
+
+  it("scheduled run (run at scheduled time) should compute next run correctly", () => {
+    // Scenario: daily job at 7am, runs on schedule at 7am
+    const sevenAmToday = Date.parse("2026-03-04T07:00:00.000Z"); // 7am
+    const scheduledRunTime = sevenAmToday; // runs exactly at 7am
+
+    const job = createDailySevenAmJob(sevenAmToday);
+
+    const state = createMockCronStateForJobs({ jobs: [job], nowMs: scheduledRunTime });
+
+    // Simulate a successful scheduled run
+    applyJobResult(state, job, {
+      status: "ok",
+      startedAt: scheduledRunTime,
+      endedAt: scheduledRunTime + 1000,
+      delivered: true,
+    });
+
+    // The next run should be tomorrow at 7am
+    const expectedNextRun = sevenAmToday + DAY_MS;
+    expect(job.state.nextRunAtMs).toBe(expectedNextRun);
+  });
+
+  it("manual run before scheduled time computes next run from scheduled time", () => {
+    // Scenario: daily job at 7am, user runs manually at 6am (before schedule)
+    // This is a less common case - when running before the scheduled time,
+    // the next run is computed from the scheduled time forward.
+    const sevenAmToday = Date.parse("2026-03-04T07:00:00.000Z"); // 7am
+    const manualRunTime = sevenAmToday - HOUR_MS; // 6am same day
+
+    const job = createDailySevenAmJob(sevenAmToday);
+
+    const state = createMockCronStateForJobs({ jobs: [job], nowMs: manualRunTime });
+
+    // Simulate a successful manual run at 6am (before the scheduled 7am)
+    applyJobResult(state, job, {
+      status: "ok",
+      startedAt: manualRunTime - 1000,
+      endedAt: manualRunTime,
+      delivered: true,
+    });
+
+    // When running before scheduled time, next run is computed from the
+    // scheduled time forward (7am today -> tomorrow 7am)
+    const expectedNextRun = sevenAmToday + DAY_MS; // tomorrow 7am
+    expect(job.state.nextRunAtMs).toBe(expectedNextRun);
+  });
+});

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { trackedMkdtemp } from "../../test/test-env.js";
 import { loadDotEnv } from "./dotenv.js";
 
 async function writeEnvFile(filePath: string, contents: string) {
@@ -38,7 +38,7 @@ type DotEnvFixture = {
 };
 
 async function withDotEnvFixture(run: (fixture: DotEnvFixture) => Promise<void>) {
-  const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dotenv-test-"));
+  const base = await trackedMkdtemp("openclaw-dotenv-test-");
   const cwdDir = path.join(base, "cwd");
   const stateDir = path.join(base, "state");
   process.env.OPENCLAW_STATE_DIR = stateDir;

--- a/src/infra/exec-approvals-test-helpers.ts
+++ b/src/infra/exec-approvals-test-helpers.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
+import { trackedMkdtempSync } from "../../test/test-env.js";
 
 export function makePathEnv(binDir: string): NodeJS.ProcessEnv {
   if (process.platform !== "win32") {
@@ -10,7 +10,7 @@ export function makePathEnv(binDir: string): NodeJS.ProcessEnv {
 }
 
 export function makeTempDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-exec-approvals-"));
+  return trackedMkdtempSync("openclaw-exec-approvals-");
 }
 
 export type ShellParserParityFixtureCase = {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -387,6 +387,7 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  /message to be replied not found/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/telegram/outbound-params.ts
+++ b/src/telegram/outbound-params.ts
@@ -2,6 +2,10 @@ export function parseTelegramReplyToMessageId(replyToId?: string | null): number
   if (!replyToId) {
     return undefined;
   }
+  // UUID from webchat — not a valid Telegram message ID
+  if (replyToId.includes("-")) {
+    return undefined;
+  }
   const parsed = Number.parseInt(replyToId, 10);
   return Number.isFinite(parsed) ? parsed : undefined;
 }

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -1,9 +1,13 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
+import { mkdtemp } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
 type RestoreEntry = { key: string; value: string | undefined };
+
+// Track temp directories created during tests for cleanup
+const trackedTempDirs: string[] = [];
 
 function restoreEnv(entries: RestoreEntry[]): void {
   for (const { key, value } of entries) {
@@ -13,6 +17,41 @@ function restoreEnv(entries: RestoreEntry[]): void {
       process.env[key] = value;
     }
   }
+}
+
+/**
+ * Wraps fs.mkdtempSync to track created directories for cleanup.
+ * Use this instead of fs.mkdtempSync when creating temp directories in tests.
+ */
+export function trackedMkdtempSync(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  trackedTempDirs.push(dir);
+  return dir;
+}
+
+/**
+ * Wraps fs.mkdtemp (async) to track created directories for cleanup.
+ * Use this instead of fs.mkdtemp when creating temp directories in tests.
+ */
+export async function trackedMkdtemp(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  trackedTempDirs.push(dir);
+  return dir;
+}
+
+/**
+ * Clean up all tracked temp directories.
+ * Called automatically by installTestEnv().cleanup().
+ */
+export function cleanupTrackedTempDirs(): void {
+  for (const dir of trackedTempDirs) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+  trackedTempDirs.length = 0;
 }
 
 function loadProfileEnv(): void {
@@ -132,6 +171,8 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
 
   const cleanup = () => {
     restoreEnv(restore);
+    // Clean up tracked temp directories created by trackedMkdtempSync/trackedMkdtemp
+    cleanupTrackedTempDirs();
     try {
       fs.rmSync(tempHome, { recursive: true, force: true });
     } catch {


### PR DESCRIPTION
## Summary

Fixes #34401 - Google Gemini CLI OAuth fails behind proxy

## Problem

When running `openclaw config` to authenticate with Google Gemini CLI OAuth on machines that require an HTTP proxy to reach Google's servers, the token exchange step fails with `AbortError: This operation was aborted`.

## Root Cause

The `fetchWithSsrFGuard` call in `exchangeCodeForTokens` uses the default `pinDns` behavior which resolves the hostname to an IP and connects directly, bypassing system proxy environment variables (`http_proxy`/`https_proxy`).

## Fix

Added `pinDns: false` to the `fetchWithSsrFGuard` call to respect system proxy settings.

## Testing

- [x] Code compiles without errors
- [ ] Tested behind proxy (manual verification needed)