### PR TITLE
fix(gateway): derive heartbeat delivery target from channel session key

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -637,7 +637,7 @@ export async function runHeartbeatOnce(opts: {
   }
   const { entry, sessionKey, storePath } = preflight.session;
   const previousUpdatedAt = entry?.updatedAt;
-  const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat });
+  const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat, sessionKey });
   const heartbeatAccountId = heartbeat?.accountId?.trim();
   if (delivery.reason === "unknown-account") {
     log.warn("heartbeat: unknown accountId", {

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -531,6 +531,29 @@ describe("resolveSessionDeliveryTarget", () => {
     expect(resolved.to).toBe("-10063448508");
     expect(resolved.threadId).toBe(1008013);
   });
+
+  it("derives delivery target from channel session key when entry has no delivery context", () => {
+    const cfg: OpenClawConfig = {};
+    const resolved = resolveHeartbeatDeliveryTarget({
+      cfg,
+      entry: undefined,
+      heartbeat: { target: "last" },
+      sessionKey: "agent:main:slack:channel:c0aka9rbsau",
+    });
+    expect(resolved.channel).toBe("slack");
+    expect(resolved.to).toBe("channel:c0aka9rbsau");
+  });
+
+  it("returns no-target when session key has no parseable channel info", () => {
+    const cfg: OpenClawConfig = {};
+    const resolved = resolveHeartbeatDeliveryTarget({
+      cfg,
+      entry: undefined,
+      heartbeat: { target: "last" },
+      sessionKey: "agent:main:main",
+    });
+    expect(resolved.channel).toBe("none");
+  });
 });
 
 describe("resolveSessionDeliveryTarget — cross-channel reply guard (#24152)", () => {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -5,7 +5,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import { parseDiscordTarget } from "../../discord/targets.js";
-import { normalizeAccountId } from "../../routing/session-key.js";
+import { normalizeAccountId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { parseSlackTarget } from "../../slack/targets.js";
 import { parseTelegramTarget, resolveTelegramTargetChatType } from "../../telegram/targets.js";
 import { deliveryContextFromSession } from "../../utils/delivery-context.js";
@@ -240,6 +240,7 @@ export function resolveHeartbeatDeliveryTarget(params: {
   cfg: OpenClawConfig;
   entry?: SessionEntry;
   heartbeat?: AgentDefaultsConfig["heartbeat"];
+  sessionKey?: string;
 }): OutboundTarget {
   const { cfg, entry } = params;
   const heartbeat = params.heartbeat ?? cfg.agents?.defaults?.heartbeat;
@@ -299,6 +300,16 @@ export function resolveHeartbeatDeliveryTarget(params: {
   }
 
   if (!resolvedTarget.channel || !resolvedTarget.to) {
+    const keyDerived = deriveDeliveryFromSessionKey(params.sessionKey);
+    if (keyDerived && isDeliverableMessageChannel(keyDerived.channel)) {
+      return {
+        channel: keyDerived.channel,
+        to: keyDerived.to,
+        accountId: effectiveAccountId,
+        chatType: keyDerived.kind === "group" ? ("group" as ChatType) : undefined,
+        threadId: undefined,
+      };
+    }
     return buildNoHeartbeatDeliveryTarget({
       reason: "no-target",
       accountId: effectiveAccountId,
@@ -546,4 +557,22 @@ export function resolveHeartbeatSenderContext(params: {
   });
 
   return { sender, provider, allowFrom };
+}
+
+function deriveDeliveryFromSessionKey(
+  sessionKey?: string,
+): { channel: string; to: string; kind: string } | undefined {
+  if (!sessionKey) {
+    return undefined;
+  }
+  const parsed = parseAgentSessionKey(sessionKey);
+  const rest = parsed?.rest ?? sessionKey;
+  const parts = rest.split(":").filter(Boolean);
+  if (parts.length >= 3) {
+    const [channel, kind, ...idParts] = parts;
+    if (kind === "group" || kind === "channel") {
+      return { channel, to: `${kind}:${idParts.join(":")}`, kind };
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary

- Problem: `requestHeartbeatNow({ sessionKey: "agent:main:slack:channel:CXXXXXXX" })` silently skips — no heartbeat turn fires, no error logged. Works for thread sessions but not channel/group sessions.
- Why it matters: Plugin developers relying on `requestHeartbeatNow` for channel-scoped sessions get no feedback and no delivery. The Hermes plugin had to revert to the `sessions_send` workaround.
- What changed: `resolveHeartbeatDeliveryTarget` now accepts an optional `sessionKey` parameter. When the session store entry has no delivery context (common for new channel sessions), the function parses the session key to extract channel and recipient (e.g. `slack` + `channel:CXXXXXXX`) and uses them as a fallback delivery target.
- What did NOT change (scope boundary): Entry-based resolution is still preferred. The session key fallback only activates when `resolvedTarget.channel` or `resolvedTarget.to` is missing. `resolveSessionDeliveryTarget`, `resolveOutboundTarget`, and the heartbeat preflight logic are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34338

## User-visible / Behavior Changes

`requestHeartbeatNow` with a channel/group session key now fires a heartbeat turn and delivers to the correct channel, matching the behavior already working for thread sessions.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Register a plugin that calls `requestHeartbeatNow({ sessionKey: "agent:main:slack:channel:CXXXXXXX" })`.
2. Observe the heartbeat behavior.

### Expected

- Heartbeat turn fires and delivers to the Slack channel.

### Actual

- Before: Heartbeat silently skipped — no turn, no error, no delivery.
- After: Heartbeat fires and delivers to the channel derived from the session key.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Two new tests:
1. "derives delivery target from channel session key when entry has no delivery context" — verifies `agent:main:slack:channel:c0aka9rbsau` yields `channel: "slack"`, `to: "channel:c0aka9rbsau"`.
2. "returns no-target when session key has no parseable channel info" — verifies `agent:main:main` correctly returns `channel: "none"`.

## Human Verification (required)

- Verified scenarios: Channel session key with no store entry → delivery target derived from key. Thread session key (already worked) → unchanged behavior. Main session key with existing entry → uses entry delivery context as before.
- Edge cases checked: Session key with no parseable channel info returns `no-target`. Session key with non-deliverable channel name returns `no-target`. Undefined sessionKey is handled gracefully.
- What you did **not** verify: Live Slack/Telegram integration with actual plugin calling `requestHeartbeatNow`.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit. The previous silent-skip behavior is restored.
- Files/config to restore: `src/infra/outbound/targets.ts`, `src/infra/heartbeat-runner.ts`

## Risks and Mitigations

- Risk: Session key format changes could break the parser.
  - Mitigation: The parser uses the same `parseAgentSessionKey` utility used throughout the codebase. It only activates as a fallback when entry-based resolution fails.