### PR TITLE
feat(slack): add per-message unfurl controls

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -516,6 +516,28 @@ Legacy keys:
 - Media and non-text payloads fall back to normal delivery.
 - If streaming fails mid-reply, OpenClaw falls back to normal delivery for remaining payloads.
 
+## Per-message unfurl controls (message tool)
+
+When using the `message` tool with Slack, you can now control link unfurl behavior per send:
+
+- `unfurlLinks` → maps to Slack `unfurl_links`
+- `unfurlMedia` → maps to Slack `unfurl_media`
+
+Both options are optional. If omitted, Slack/OpenClaw defaults are unchanged.
+
+Example:
+
+```json
+{
+  "action": "send",
+  "channel": "slack",
+  "target": "channel:C12345678",
+  "message": "Build log: https://example.com/build/123",
+  "unfurlLinks": false,
+  "unfurlMedia": false
+}
+```
+
 ## Configuration reference pointers
 
 Primary reference:

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -200,6 +200,8 @@ function buildSendSchema(options: {
     ),
     bestEffort: Type.Optional(Type.Boolean()),
     gifPlayback: Type.Optional(Type.Boolean()),
+    unfurlLinks: Type.Optional(Type.Boolean()),
+    unfurlMedia: Type.Optional(Type.Boolean()),
     buttons: Type.Optional(
       Type.Array(
         Type.Array(

--- a/src/channels/plugins/outbound/slack.test.ts
+++ b/src/channels/plugins/outbound/slack.test.ts
@@ -18,6 +18,8 @@ type SlackSendTextCtx = {
   text: string;
   accountId: string;
   replyToId: string;
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
   identity?: {
     name?: string;
     avatarUrl?: string;
@@ -111,6 +113,27 @@ describe("slack outbound hook wiring", () => {
     expectSlackSendCalledWith("hello", {
       identity: { iconEmoji: ":lobster:" },
     });
+  });
+
+  it("forwards unfurl controls when provided", async () => {
+    vi.mocked(getGlobalHookRunner).mockReturnValue(null);
+
+    await sendSlackTextWithDefaults({
+      text: "hello",
+      unfurlLinks: false,
+      unfurlMedia: false,
+    });
+
+    expect(sendMessageSlack).toHaveBeenCalledWith(
+      "C123",
+      "hello",
+      expect.objectContaining({
+        threadTs: "1111.2222",
+        accountId: "default",
+        unfurlLinks: false,
+        unfurlMedia: false,
+      }),
+    );
   });
 
   it("calls message_sending hook before sending", async () => {

--- a/src/channels/plugins/outbound/slack.ts
+++ b/src/channels/plugins/outbound/slack.ts
@@ -58,6 +58,8 @@ async function sendSlackOutboundMessage(params: {
   replyToId?: string | null;
   threadId?: string | number | null;
   identity?: OutboundIdentity;
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
 }) {
   const send = params.deps?.sendSlack ?? sendMessageSlack;
   // Use threadId fallback so routed tool notifications stay in the Slack thread.
@@ -88,6 +90,8 @@ async function sendSlackOutboundMessage(params: {
       ? { mediaUrl: params.mediaUrl, mediaLocalRoots: params.mediaLocalRoots }
       : {}),
     ...(slackIdentity ? { identity: slackIdentity } : {}),
+    ...(params.unfurlLinks !== undefined ? { unfurlLinks: params.unfurlLinks } : {}),
+    ...(params.unfurlMedia !== undefined ? { unfurlMedia: params.unfurlMedia } : {}),
   });
   return { channel: "slack" as const, ...result };
 }
@@ -98,7 +102,18 @@ export const slackOutbound: ChannelOutboundAdapter = {
   textChunkLimit: 4000,
   sendPayload: async (ctx) =>
     await sendTextMediaPayload({ channel: "slack", ctx, adapter: slackOutbound }),
-  sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, identity }) => {
+  sendText: async ({
+    cfg,
+    to,
+    text,
+    accountId,
+    deps,
+    replyToId,
+    threadId,
+    identity,
+    unfurlLinks,
+    unfurlMedia,
+  }) => {
     return await sendSlackOutboundMessage({
       cfg,
       to,
@@ -108,6 +123,8 @@ export const slackOutbound: ChannelOutboundAdapter = {
       replyToId,
       threadId,
       identity,
+      unfurlLinks,
+      unfurlMedia,
     });
   },
   sendMedia: async ({
@@ -121,6 +138,8 @@ export const slackOutbound: ChannelOutboundAdapter = {
     replyToId,
     threadId,
     identity,
+    unfurlLinks,
+    unfurlMedia,
   }) => {
     return await sendSlackOutboundMessage({
       cfg,
@@ -133,6 +152,8 @@ export const slackOutbound: ChannelOutboundAdapter = {
       replyToId,
       threadId,
       identity,
+      unfurlLinks,
+      unfurlMedia,
     });
   },
 };

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -98,6 +98,8 @@ export type ChannelOutboundContext = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   silent?: boolean;
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
 };
 
 export type ChannelOutboundPayloadContext = ChannelOutboundContext & {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -132,6 +132,8 @@ type ChannelHandlerParams = {
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
   silent?: boolean;
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
   mediaLocalRoots?: readonly string[];
 };
 
@@ -205,6 +207,8 @@ function createChannelOutboundContextBase(
     gifPlayback: params.gifPlayback,
     deps: params.deps,
     silent: params.silent,
+    unfurlLinks: params.unfurlLinks,
+    unfurlMedia: params.unfurlMedia,
     mediaLocalRoots: params.mediaLocalRoots,
   };
 }
@@ -222,6 +226,8 @@ type DeliverOutboundPayloadsCoreParams = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
   abortSignal?: AbortSignal;
   bestEffort?: boolean;
   onError?: (err: unknown, payload: NormalizedOutboundPayload) => void;
@@ -537,6 +543,8 @@ async function deliverOutboundPayloadsCore(
     identity: params.identity,
     gifPlayback: params.gifPlayback,
     silent: params.silent,
+    unfurlLinks: params.unfurlLinks,
+    unfurlMedia: params.unfurlMedia,
     mediaLocalRoots,
   });
   const configuredTextLimit = handler.chunker

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -478,6 +478,8 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   const gifPlayback = readBooleanParam(params, "gifPlayback") ?? false;
   const bestEffort = readBooleanParam(params, "bestEffort");
   const silent = readBooleanParam(params, "silent");
+  const unfurlLinks = readBooleanParam(params, "unfurlLinks");
+  const unfurlMedia = readBooleanParam(params, "unfurlMedia");
 
   const replyToId = readStringParam(params, "replyTo");
   const resolvedThreadId = resolveAndApplyOutboundThreadId(params, {
@@ -548,6 +550,8 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     bestEffort: bestEffort ?? undefined,
     replyToId: replyToId ?? undefined,
     threadId: resolvedThreadId ?? undefined,
+    unfurlLinks: unfurlLinks ?? undefined,
+    unfurlMedia: unfurlMedia ?? undefined,
   });
 
   return {

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -43,6 +43,8 @@ type MessageSendParams = {
   threadId?: string | number;
   dryRun?: boolean;
   bestEffort?: boolean;
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
   deps?: OutboundSendDeps;
   cfg?: OpenClawConfig;
   gateway?: MessageGatewayOptions;
@@ -225,6 +227,8 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       gifPlayback: params.gifPlayback,
       deps: params.deps,
       bestEffort: params.bestEffort,
+      unfurlLinks: params.unfurlLinks,
+      unfurlMedia: params.unfurlMedia,
       abortSignal: params.abortSignal,
       silent: params.silent,
       mirror: params.mirror
@@ -258,6 +262,8 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       accountId: params.accountId,
       agentId: params.agentId,
       channel,
+      unfurlLinks: params.unfurlLinks,
+      unfurlMedia: params.unfurlMedia,
       sessionKey: params.mirror?.sessionKey,
       idempotencyKey: params.idempotencyKey ?? randomIdempotencyKey(),
     },

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -91,6 +91,8 @@ export async function executeSendAction(params: {
   bestEffort?: boolean;
   replyToId?: string;
   threadId?: string | number;
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
 }): Promise<{
   handledBy: "plugin" | "core";
   payload: unknown;
@@ -137,6 +139,8 @@ export async function executeSendAction(params: {
     gifPlayback: params.gifPlayback,
     dryRun: params.ctx.dryRun,
     bestEffort: params.bestEffort ?? undefined,
+    unfurlLinks: params.unfurlLinks,
+    unfurlMedia: params.unfurlMedia,
     deps: params.ctx.deps,
     gateway: params.ctx.gateway,
     mirror: params.ctx.mirror,

--- a/src/slack/send.blocks.test.ts
+++ b/src/slack/send.blocks.test.ts
@@ -123,6 +123,39 @@ describe("sendMessageSlack blocks", () => {
     );
   });
 
+  it("passes unfurl controls to chat.postMessage", async () => {
+    const client = createSlackSendTestClient();
+    await sendMessageSlack("channel:C123", "Link: https://example.com", {
+      token: "xoxb-test",
+      client,
+      unfurlLinks: false,
+      unfurlMedia: false,
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        unfurl_links: false,
+        unfurl_media: false,
+      }),
+    );
+  });
+
+  it("omits unfurl params from API call when not provided", async () => {
+    const client = createSlackSendTestClient();
+    await sendMessageSlack("channel:C123", "Link: https://example.com", {
+      token: "xoxb-test",
+      client,
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        unfurl_links: expect.anything(),
+        unfurl_media: expect.anything(),
+      }),
+    );
+  });
+
   it("rejects blocks combined with mediaUrl", async () => {
     const client = createSlackSendTestClient();
     await expect(

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -54,6 +54,8 @@ type SlackSendOpts = {
   threadTs?: string;
   identity?: SlackSendIdentity;
   blocks?: (Block | KnownBlock)[];
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
 };
 
 function hasCustomIdentity(identity?: SlackSendIdentity): boolean {
@@ -93,12 +95,16 @@ async function postSlackMessageBestEffort(params: {
   threadTs?: string;
   identity?: SlackSendIdentity;
   blocks?: (Block | KnownBlock)[];
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
 }) {
   const basePayload = {
     channel: params.channelId,
     text: params.text,
     thread_ts: params.threadTs,
     ...(params.blocks?.length ? { blocks: params.blocks } : {}),
+    ...(params.unfurlLinks === undefined ? {} : { unfurl_links: params.unfurlLinks }),
+    ...(params.unfurlMedia === undefined ? {} : { unfurl_media: params.unfurlMedia }),
   };
   try {
     // Slack Web API types model icon_url and icon_emoji as mutually exclusive.
@@ -289,6 +295,8 @@ export async function sendMessageSlack(
       threadTs: opts.threadTs,
       identity: opts.identity,
       blocks,
+      unfurlLinks: opts.unfurlLinks,
+      unfurlMedia: opts.unfurlMedia,
     });
     return {
       messageId: response.ts ?? "unknown",
@@ -337,6 +345,8 @@ export async function sendMessageSlack(
         text: chunk,
         threadTs: opts.threadTs,
         identity: opts.identity,
+        unfurlLinks: opts.unfurlLinks,
+        unfurlMedia: opts.unfurlMedia,
       });
       lastMessageId = response.ts ?? lastMessageId;
     }
@@ -348,6 +358,8 @@ export async function sendMessageSlack(
         text: chunk,
         threadTs: opts.threadTs,
         identity: opts.identity,
+        unfurlLinks: opts.unfurlLinks,
+        unfurlMedia: opts.unfurlMedia,
       });
       lastMessageId = response.ts ?? lastMessageId;
     }


### PR DESCRIPTION
## Summary

Adds optional `unfurlLinks` and `unfurlMedia` parameters to the `message` tool for Slack, enabling clean control of link previews without formatting workarounds.

## Motivation

When sending messages with URLs to Slack via the `message.send` action, there's currently no way to control Slack's automatic link unfurling behavior. This forces users to use formatting workarounds (like wrapping URLs in code blocks) to prevent previews.

This PR adds native support for Slack's `unfurl_links` and `unfurl_media` API parameters.

## Changes

- Extended message tool schema with `unfurlLinks?: boolean` and `unfurlMedia?: boolean`
- Wired parameters through full outbound pipeline:
  - `message-action-runner.ts` → `outbound-send-service.ts` → `message.ts` → `deliver.ts`
  - `ChannelOutboundContext` type → Slack outbound adapter → `sendMessageSlack`
- Map to Slack API: `unfurlLinks` → `unfurl_links`, `unfurlMedia` → `unfurl_media`
- Parameters only included in API call when explicitly provided (backward-compatible)
- Added unit tests covering new functionality
- Added usage documentation and example

## Testing

- ✅ Unit tests: 56 passed (Slack send, outbound adapter, message action runner)
- ✅ Backward compatibility: defaults unchanged when params omitted
- ⏳ Manual testing recommended with live Slack workspace

## Example Usage

```json
{
  "action": "send",
  "channel": "slack",
  "target": "channel:C12345678",
  "message": "Build completed: https://example.com/build/123",
  "unfurlLinks": false,
  "unfurlMedia": false
}
```

## Backward Compatibility

✅ Fully backward-compatible. When `unfurlLinks` and `unfurlMedia` are omitted, Slack/OpenClaw defaults apply (no behavior change for existing code).

## Related

- Slack API: https://api.slack.com/methods/chat.postMessage#arg_unfurl_links
- Similar pattern exists for Telegram (`linkPreview` param)
