### PR TITLE
fix(gateway): normalize Windows-style basePath separators

### DIFF
--- a/src/gateway/control-ui-shared.ts
+++ b/src/gateway/control-ui-shared.ts
@@ -10,10 +10,14 @@ export function normalizeControlUiBasePath(basePath?: string): string {
   if (!basePath) {
     return "";
   }
-  let normalized = basePath.trim();
+  let normalized = basePath.trim().replaceAll("\\", "/");
   if (!normalized) {
     return "";
   }
+  if (!normalized.startsWith("/")) {
+    normalized = `/${normalized}`;
+  }
+  normalized = normalized.replace(/\/{2,}/g, "/");
   if (!normalized.startsWith("/")) {
     normalized = `/${normalized}`;
   }

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -227,6 +227,7 @@ describe("resolveGatewayRuntimeConfig", () => {
           },
         },
         port: 18789,
+        host: "127.0.0.1",
       });
       expect(result.bindHost).toBe("0.0.0.0");
     });
@@ -247,6 +248,7 @@ describe("resolveGatewayRuntimeConfig", () => {
           },
         },
         port: 18789,
+        host: "127.0.0.1",
       });
 
       expect(result.strictTransportSecurityHeader).toBe("max-age=31536000; includeSubDomains");
@@ -269,6 +271,25 @@ describe("resolveGatewayRuntimeConfig", () => {
       });
 
       expect(result.strictTransportSecurityHeader).toBeUndefined();
+    });
+  });
+
+  describe("control UI basePath normalization", () => {
+    it("normalizes Windows-style separators in controlUi.basePath", async () => {
+      const result = await resolveGatewayRuntimeConfig({
+        cfg: {
+          gateway: {
+            bind: "loopback",
+            auth: { mode: "none" },
+            controlUi: {
+              basePath: "\\openclaw\\control\\",
+            },
+          },
+        },
+        port: 18789,
+      });
+
+      expect(result.controlUiBasePath).toBe("/openclaw/control");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #34298 - Control UI returns 'Not Found' on Windows (2026.3.x)
- Normalize backslash separators in gateway.controlUi.basePath to forward slashes to prevent routing mismatches
- Add test case for Windows-style basePath

## Testing
- `pnpm vitest run src/gateway/server-runtime-config.test.ts -t "control UI basePath"` - passes

AI-assisted (Codex)