### PR TITLE
fix: inject current date/time into system prompt, not just timezone

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -115,7 +115,6 @@ function buildTimeSection(params: {
         day: "numeric",
         hour: "2-digit",
         minute: "2-digit",
-        second: "2-digit",
         hour12: true,
       });
       dateStr = formatter.format(now);

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -93,10 +93,7 @@ function buildOwnerIdentityLine(
   return `Authorized senders: ${displayOwnerNumbers.join(", ")}. These senders are allowlisted; do not assume they are the owner.`;
 }
 
-function buildTimeSection(params: {
-  userTimezone?: string;
-  userTime?: string;
-}) {
+function buildTimeSection(params: { userTimezone?: string; userTime?: string }) {
   if (!params.userTimezone) {
     return [];
   }

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -97,7 +97,25 @@ function buildTimeSection(params: { userTimezone?: string }) {
   if (!params.userTimezone) {
     return [];
   }
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const now = new Date();
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: params.userTimezone,
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  });
+  const dateStr = formatter.format(now);
+  return [
+    "## Current Date & Time",
+    `Current date and time: ${dateStr}`,
+    `Time zone: ${params.userTimezone}`,
+    "",
+  ];
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -93,23 +93,37 @@ function buildOwnerIdentityLine(
   return `Authorized senders: ${displayOwnerNumbers.join(", ")}. These senders are allowlisted; do not assume they are the owner.`;
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function buildTimeSection(params: {
+  userTimezone?: string;
+  userTime?: string;
+}) {
   if (!params.userTimezone) {
     return [];
   }
-  const now = new Date();
-  const formatter = new Intl.DateTimeFormat("en-US", {
-    timeZone: params.userTimezone,
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: true,
-  });
-  const dateStr = formatter.format(now);
+  let dateStr: string;
+  if (params.userTime) {
+    // Caller provided a pre-resolved timestamp — use it directly
+    dateStr = params.userTime;
+  } else {
+    const now = new Date();
+    try {
+      const formatter = new Intl.DateTimeFormat("en-US", {
+        timeZone: params.userTimezone,
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: true,
+      });
+      dateStr = formatter.format(now);
+    } catch {
+      // Invalid timezone — fall back to UTC representation
+      dateStr = now.toUTCString();
+    }
+  }
   return [
     "## Current Date & Time",
     `Current date and time: ${dateStr}`,
@@ -518,7 +532,7 @@ export function buildAgentSystemPrompt(params: {
       ? params.modelAliasLines.join("\n")
       : "",
     params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal ? "" : "",
-    userTimezone
+    !userTimezone
       ? "If you need the current date, time, or day of week, run session_status (📊 session_status)."
       : "",
     "## Workspace",
@@ -578,6 +592,7 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime: params.userTime,
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",


### PR DESCRIPTION
## Problem

`buildTimeSection()` only injects the timezone label into the system prompt:

```
## Current Date & Time
Time zone: UTC
```

Agents have no reliable way to know the current date without calling a tool first, leading to off-by-one-day errors when reasoning about time-sensitive content (scheduling, email triage, etc.).

## Fix

Use `Intl.DateTimeFormat` to render the full current datetime in the user's configured timezone:

```
## Current Date & Time
Current date and time: Wednesday, March 4, 2026 at 12:49:02 PM
Time zone: UTC
```

Single file change in `src/agents/system-prompt.ts`.

Fixes #34422