### PR TITLE
fix(telegram): resolve relative MEDIA paths against localRoots

### DIFF
--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -361,6 +361,15 @@ describe("local media root guard", () => {
     expect(result.kind).toBe("image");
   });
 
+  it("resolves relative media path against localRoots", async () => {
+    const rootDir = resolvePreferredOpenClawTmpDir();
+    const relPath = "./" + path.relative(rootDir, tinyPngFile);
+    const result = await loadWebMedia(relPath, 1024 * 1024, {
+      localRoots: [rootDir],
+    });
+    expect(result.kind).toBe("image");
+  });
+
   it("accepts win32 dev=0 stat mismatch for local file loads", async () => {
     const actualLstat = await fs.lstat(tinyPngFile);
     const actualStat = await fs.stat(tinyPngFile);

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -78,6 +78,26 @@ export function getDefaultLocalRoots(): readonly string[] {
   return getDefaultMediaLocalRoots();
 }
 
+function isRelativePath(p: string): boolean {
+  return p.startsWith("./") || p.startsWith("../");
+}
+
+async function resolveRelativeMediaAgainstRoots(
+  mediaPath: string,
+  roots: readonly string[],
+): Promise<string> {
+  for (const root of roots) {
+    const candidate = path.resolve(root, mediaPath);
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // file not at this root
+    }
+  }
+  return mediaPath;
+}
+
 async function assertLocalMediaAllowed(
   mediaPath: string,
   localRoots: readonly string[] | "any" | undefined,
@@ -340,6 +360,10 @@ async function loadWebMediaInternal(
   // Expand tilde paths to absolute paths (e.g., ~/Downloads/photo.jpg)
   if (mediaUrl.startsWith("~")) {
     mediaUrl = resolveUserPath(mediaUrl);
+  }
+
+  if (isRelativePath(mediaUrl) && localRoots && localRoots !== "any") {
+    mediaUrl = await resolveRelativeMediaAgainstRoots(mediaUrl, localRoots);
   }
 
   if ((sandboxValidated || localRoots === "any") && !readFileOverride) {


### PR DESCRIPTION
## Summary

- Problem: `MEDIA:./somefile.vcf` attachments fail in Telegram group chats with `LocalMediaAccessError: Local media path is not under an allowed directory`. DMs work because agent tools typically emit absolute paths there. When the agent outputs a relative `MEDIA:` path, `path.resolve("./…")` resolves against the process CWD (not the agent workspace), and the resulting absolute path falls outside all allowed `localRoots`.
- Why it matters: Users in Telegram groups see "No response generated. Please try again." whenever the agent reply includes a local media attachment. This is a P1 user-facing regression for group deployments.
- What changed: In `loadWebMediaInternal` (src/web/media.ts), relative media paths (`./…`, `../…`) are now resolved against each `localRoots` directory before validation. The first root where the file actually exists wins. If no root matches, the original path is passed through unchanged (preserving existing error behavior).
- What did NOT change (scope boundary): HTTP URL fetching, `assertLocalMediaAllowed` validation logic, tilde expansion, sandbox validation, and the `localRoots` resolution pipeline are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34358

## User-visible / Behavior Changes

`MEDIA:./relative-path` attachments in Telegram group chats now load successfully when the file exists under a configured `localRoots` directory (e.g., the agent workspace).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No — resolution only considers already-allowed `localRoots` directories.

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure Telegram bot and enable group replies.
2. Have the agent emit a `MEDIA:./somefile.vcf` reply in a group chat.
3. Observe the result.

### Expected

- The file is sent as a Telegram document.

### Actual

- Before: `LocalMediaAccessError: Local media path is not under an allowed directory: ./somefile.vcf`. User sees "No response generated."
- After: File is found in the agent workspace root, validated against `localRoots`, and sent successfully.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test: "resolves relative media path against localRoots" — creates a file in the temp root, constructs a relative path from that root, and verifies `loadWebMedia` loads it successfully.

## Human Verification (required)

- Verified scenarios: Relative path `./filename` resolved against localRoots works. Absolute paths unchanged. HTTP URLs unchanged. Relative path not found in any root falls through to original error.
- Edge cases checked: Multiple roots — first match wins. Path with `../` traversal. Empty `localRoots` array → no resolution attempted. `localRoots === "any"` → no resolution attempted.
- What you did **not** verify: Live Telegram bot sending relative media in an actual group chat.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit. Relative paths revert to process-CWD resolution.
- Files/config to restore: `src/web/media.ts`

## Risks and Mitigations

- Risk: A relative path resolving to a file in a localRoot that the agent didn't intend.
  - Mitigation: All roots in `localRoots` are already trusted and explicitly allowed. The file must physically exist at the resolved path. `assertLocalMediaAllowed` still validates the final absolute path.