### PR TITLE
line: enforce requireMention for group text events

### DIFF
--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -289,6 +289,119 @@ describe("handleLineWebhookEvents", () => {
     expect(buildLineMessageContextMock).not.toHaveBeenCalled();
   });
 
+  it("blocks group text messages when requireMention=true and bot is not mentioned", async () => {
+    const processMessage = vi.fn();
+    const event = {
+      type: "message",
+      message: { id: "m-mention-1", type: "text", text: "hello team" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-mention", userId: "user-mention" },
+      mode: "active",
+      webhookEventId: "evt-mention-1",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: { channels: { line: { groupPolicy: "open" } } },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { groupPolicy: "open", groups: { "*": { requireMention: true } } },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+      botUserId: "bot-user-id",
+    });
+
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(buildLineMessageContextMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks group text messages when mention targets another user (not this bot)", async () => {
+    const processMessage = vi.fn();
+    const event = {
+      type: "message",
+      message: {
+        id: "m-mention-2",
+        type: "text",
+        text: "@someone hello",
+        mention: {
+          mentionees: [{ type: "user", userId: "other-user-id", index: 0, length: 8 }],
+        },
+      },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-mention", userId: "user-mention" },
+      mode: "active",
+      webhookEventId: "evt-mention-2",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: { channels: { line: { groupPolicy: "open" } } },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { groupPolicy: "open", groups: { "*": { requireMention: true } } },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+      botUserId: "bot-user-id",
+    });
+
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(buildLineMessageContextMock).not.toHaveBeenCalled();
+  });
+
+  it("allows group text messages when mention targets this bot and requireMention=true", async () => {
+    const processMessage = vi.fn();
+    const event = {
+      type: "message",
+      message: {
+        id: "m-mention-3",
+        type: "text",
+        text: "@bot hello",
+        mention: {
+          mentionees: [{ type: "user", userId: "bot-user-id", index: 0, length: 4 }],
+        },
+      },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-mention", userId: "user-mention" },
+      mode: "active",
+      webhookEventId: "evt-mention-3",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: { channels: { line: { groupPolicy: "open" } } },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { groupPolicy: "open", groups: { "*": { requireMention: true } } },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+      botUserId: "bot-user-id",
+    });
+
+    expect(buildLineMessageContextMock).toHaveBeenCalledTimes(1);
+    expect(processMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("scopes DM pairing requests to accountId", async () => {
     const processMessage = vi.fn();
     const event = {

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -232,7 +232,10 @@ function resolveLineRequireMention(params: {
   return resolveLineGroupConfig(params)?.requireMention ?? false;
 }
 
-function resolveLineMentionMetadata(event: MessageEvent, botUserId?: string): {
+function resolveLineMentionMetadata(
+  event: MessageEvent,
+  botUserId?: string,
+): {
   canDetectMention: boolean;
   wasMentioned: boolean;
   hasAnyMention: boolean;
@@ -252,9 +255,11 @@ function resolveLineMentionMetadata(event: MessageEvent, botUserId?: string): {
     };
   }
   const mentionees =
-    (event.message as MessageEvent["message"] & {
-      mention?: { mentionees?: Array<{ type?: string; userId?: string }> };
-    }).mention?.mentionees ?? [];
+    (
+      event.message as MessageEvent["message"] & {
+        mention?: { mentionees?: Array<{ type?: string; userId?: string }> };
+      }
+    ).mention?.mentionees ?? [];
   const hasAnyMention = mentionees.length > 0;
   const normalizedBotUserId = botUserId.trim();
   const wasMentioned = mentionees.some((entry) => {

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -9,6 +9,7 @@ import type {
 } from "@line/bot-sdk";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import { resolveControlCommandGate } from "../channels/command-gating.js";
+import { resolveMentionGatingWithBypass } from "../channels/mention-gating.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveAllowlistProviderRuntimeGroupPolicy,
@@ -64,6 +65,7 @@ export interface LineHandlerContext {
   mediaMaxBytes: number;
   processMessage: (ctx: LineInboundContext) => Promise<void>;
   replayCache?: LineWebhookReplayCache;
+  botUserId?: string;
 }
 
 const LINE_WEBHOOK_REPLAY_WINDOW_MS = 10 * 60 * 1000;
@@ -222,6 +224,52 @@ function resolveLineGroupConfig(params: {
   return groups["*"];
 }
 
+function resolveLineRequireMention(params: {
+  config: ResolvedLineAccount["config"];
+  groupId?: string;
+  roomId?: string;
+}): boolean {
+  return resolveLineGroupConfig(params)?.requireMention ?? false;
+}
+
+function resolveLineMentionMetadata(event: MessageEvent, botUserId?: string): {
+  canDetectMention: boolean;
+  wasMentioned: boolean;
+  hasAnyMention: boolean;
+} {
+  if (event.message.type !== "text") {
+    return {
+      canDetectMention: false,
+      wasMentioned: false,
+      hasAnyMention: false,
+    };
+  }
+  if (!botUserId?.trim()) {
+    return {
+      canDetectMention: false,
+      wasMentioned: false,
+      hasAnyMention: false,
+    };
+  }
+  const mentionees =
+    (event.message as MessageEvent["message"] & {
+      mention?: { mentionees?: Array<{ type?: string; userId?: string }> };
+    }).mention?.mentionees ?? [];
+  const hasAnyMention = mentionees.length > 0;
+  const normalizedBotUserId = botUserId.trim();
+  const wasMentioned = mentionees.some((entry) => {
+    if (entry?.type === "all") {
+      return true;
+    }
+    return entry?.type === "user" && entry.userId === normalizedBotUserId;
+  });
+  return {
+    canDetectMention: true,
+    wasMentioned,
+    hasAnyMention,
+  };
+}
+
 async function sendLinePairingReply(params: {
   senderId: string;
   replyToken?: string;
@@ -360,6 +408,28 @@ async function shouldProcessLineEvent(
       allowTextCommands: true,
       hasControlCommand: hasControlCommand(rawText, cfg),
     });
+
+    if (event.type === "message") {
+      const requireMention = resolveLineRequireMention({
+        config: account.config,
+        groupId,
+        roomId,
+      });
+      const mentionMeta = resolveLineMentionMetadata(event, context.botUserId);
+      const mentionGate = resolveMentionGatingWithBypass({
+        isGroup: true,
+        requireMention,
+        canDetectMention: mentionMeta.canDetectMention,
+        wasMentioned: mentionMeta.wasMentioned,
+        hasAnyMention: mentionMeta.hasAnyMention,
+        allowTextCommands: true,
+        hasControlCommand: hasControlCommand(rawText, cfg),
+        commandAuthorized: commandGate.commandAuthorized,
+      });
+      if (mentionGate.shouldSkip) {
+        return denied;
+      }
+    }
     return { allowed: true, commandAuthorized: commandGate.commandAuthorized };
   }
 

--- a/src/line/bot.ts
+++ b/src/line/bot.ts
@@ -17,6 +17,7 @@ export interface LineBotOptions {
   runtime?: RuntimeEnv;
   config?: OpenClawConfig;
   mediaMaxMb?: number;
+  botUserId?: string;
   onMessage?: (ctx: LineInboundContext) => Promise<void>;
 }
 
@@ -55,6 +56,7 @@ export function createLineBot(opts: LineBotOptions): LineBot {
       mediaMaxBytes,
       processMessage,
       replayCache,
+      botUserId: opts.botUserId,
     });
   };
 

--- a/src/line/monitor.ts
+++ b/src/line/monitor.ts
@@ -28,6 +28,7 @@ import {
 import { buildTemplateMessageFromPayload } from "./template-messages.js";
 import type { LineChannelData, ResolvedLineAccount } from "./types.js";
 import { createLineNodeWebhookHandler } from "./webhook-node.js";
+import { probeLineBot } from "./probe.js";
 
 export interface MonitorLineProviderOptions {
   channelAccessToken: string;
@@ -151,12 +152,20 @@ export async function monitorLineProvider(
   });
 
   // Create the bot
+  let botUserId: string | undefined;
+  try {
+    const probe = await probeLineBot(token, 2500);
+    botUserId = probe.ok ? probe.bot?.userId?.trim() || undefined : undefined;
+  } catch {
+    botUserId = undefined;
+  }
   const bot = createLineBot({
     channelAccessToken: token,
     channelSecret: secret,
     accountId,
     runtime,
     config,
+    botUserId,
     onMessage: async (ctx) => {
       if (!ctx) {
         return;

--- a/src/line/monitor.ts
+++ b/src/line/monitor.ts
@@ -11,6 +11,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { deliverLineAutoReply } from "./auto-reply-delivery.js";
 import { createLineBot } from "./bot.js";
 import { processLineMessage } from "./markdown-to-line.js";
+import { probeLineBot } from "./probe.js";
 import { sendLineReplyChunks } from "./reply-chunks.js";
 import {
   replyMessageLine,
@@ -28,7 +29,6 @@ import {
 import { buildTemplateMessageFromPayload } from "./template-messages.js";
 import type { LineChannelData, ResolvedLineAccount } from "./types.js";
 import { createLineNodeWebhookHandler } from "./webhook-node.js";
-import { probeLineBot } from "./probe.js";
 
 export interface MonitorLineProviderOptions {
   channelAccessToken: string;


### PR DESCRIPTION
## Summary
- enforce LINE `groups[*].requireMention` gating in group text message handling
- consider LINE mention metadata (`message.mention.mentionees`) and only accept mentions that target this bot (or `@all`)
- prevent false bypass when mentioning other users in group chats
- wire optional `botUserId` into LINE webhook handler context for mention identity matching
- add coverage for three cases:
  - no mention -> blocked
  - mention other user -> blocked
  - mention bot user -> allowed

Fixes #34438

## Why
`requireMention` was defined in LINE config/types but not applied in `shouldProcessLineEvent`, so group messages were processed regardless of mention gating.

## Compatibility / Risk
- minimal scope: LINE message pre-processing only
- default behavior unchanged when `requireMention` is not enabled
- no schema/config migration changes

## Testing
- Added tests in `src/line/bot-handlers.test.ts`
- Local test execution could not be completed in this environment because `pnpm/corepack` are unavailable.
