### PR TITLE
fix(config): preserve custom secret keys during doctor --fix (#33623)

### DIFF
--- a/src/commands/doctor-config-flow.secrets-passthrough.test.ts
+++ b/src/commands/doctor-config-flow.secrets-passthrough.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { runDoctorConfigWithInput } from "./doctor-config-flow.test-utils.js";
+
+vi.mock("../terminal/note.js", () => ({
+  note: vi.fn(),
+}));
+
+import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
+
+describe("doctor config flow secrets passthrough", () => {
+  it("preserves custom user-defined keys in the secrets section during --fix", async () => {
+    const result = await runDoctorConfigWithInput({
+      repair: true,
+      config: {
+        secrets: {
+          brave_news_api_key: "sk-test-brave",
+          my_custom_token: "tok-123",
+          providers: {
+            myVault: { source: "exec", command: "vault read" },
+          },
+        },
+      },
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    const cfg = result.cfg as {
+      secrets?: Record<string, unknown>;
+    };
+    expect(cfg.secrets).toBeDefined();
+    expect(cfg.secrets!.brave_news_api_key).toBe("sk-test-brave");
+    expect(cfg.secrets!.my_custom_token).toBe("tok-123");
+    expect(cfg.secrets!.providers).toEqual({
+      myVault: { source: "exec", command: "vault read" },
+    });
+  });
+});

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -177,7 +177,7 @@ export const SecretsConfigSchema = z
       .strict()
       .optional(),
   })
-  .strict()
+  .passthrough()
   .optional();
 
 export const ModelApiSchema = z.enum(MODEL_APIS);


### PR DESCRIPTION
## Summary

`openclaw doctor --fix` deletes user-defined custom API keys from the `secrets` section of `openclaw.json`.

Fixes #33623.

## Root Cause

`SecretsConfigSchema` in `src/config/zod-schema.core.ts` uses `.strict()` on the top-level object. When `stripUnknownConfigKeys()` runs during `doctor --fix`, Zod flags any key not explicitly in the schema (like `brave_news_api_key`, `football_data_api_key`, etc.) as "unrecognized" and they get deleted.

## Fix

Changed the top-level `.strict()` on `SecretsConfigSchema` to `.passthrough()` so arbitrary user-defined secret keys are preserved. Nested objects (`defaults`, `resolution`) remain `.strict()` — only the top-level allows passthrough.

```diff
- .strict()
+ .passthrough()
```

## Test

Added `src/commands/doctor-config-flow.secrets-passthrough.test.ts` — verifies custom keys survive a doctor `--fix` / config parse cycle.

```
pnpm test -- "doctor-config-flow.secrets"

 ✓ src/commands/doctor-config-flow.secrets-passthrough.test.ts (1 test) 26ms
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

## Verification

- `pnpm build` ✅
- `pnpm test -- "doctor-config-flow.secrets"` ✅
- One-line schema change + 36-line test file
- No other files touched