### PR TITLE
fix(skills): refresh snapshots when eligibility changes

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -43,13 +43,13 @@ function resolveEligibilitySignature(params: {
   return crypto.createHash("sha256").update(stableStringify(payload)).digest("hex");
 }
 
-export async function prependSystemEvents(params: {
+/** Drain queued system events, format as `System:` lines, return the block (or undefined). */
+export async function drainFormattedSystemEvents(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   isMainSession: boolean;
   isNewSession: boolean;
-  prefixedBodyBase: string;
-}): Promise<string> {
+}): Promise<string | undefined> {
   const compactSystemEvent = (line: string): string | null => {
     const trimmed = line.trim();
     if (!trimmed) {
@@ -134,11 +134,38 @@ export async function prependSystemEvents(params: {
     }
   }
   if (systemLines.length === 0) {
-    return params.prefixedBodyBase;
+    return undefined;
   }
 
-  const block = systemLines.map((l) => `System: ${l}`).join("\n");
-  return `${block}\n\n${params.prefixedBodyBase}`;
+  // Format events as trusted System: lines for the message timeline.
+  // Inbound sanitization rewrites any user-supplied "System:" to "System (untrusted):",
+  // so these gateway-originated lines are distinguishable by the model.
+  // Each sub-line of a multi-line event gets its own System: prefix so continuation
+  // lines can't be mistaken for user content.
+  return systemLines
+    .flatMap((line) => line.split("\n").map((subline) => `System: ${subline}`))
+    .join("\n");
+}
+
+async function persistSessionEntryUpdate(params: {
+  sessionStore?: Record<string, SessionEntry>;
+  sessionKey?: string;
+  storePath?: string;
+  nextEntry: SessionEntry;
+}) {
+  if (!params.sessionStore || !params.sessionKey) {
+    return;
+  }
+  params.sessionStore[params.sessionKey] = {
+    ...params.sessionStore[params.sessionKey],
+    ...params.nextEntry,
+  };
+  if (!params.storePath) {
+    return;
+  }
+  await updateSessionStore(params.storePath, (store) => {
+    store[params.sessionKey!] = { ...store[params.sessionKey!], ...params.nextEntry };
+  });
 }
 
 export async function ensureSkillSnapshot(params: {
@@ -214,12 +241,7 @@ export async function ensureSkillSnapshot(params: {
       systemSent: true,
       skillsSnapshot: skillSnapshot,
     };
-    sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...nextEntry };
-    if (storePath) {
-      await updateSessionStore(storePath, (store) => {
-        store[sessionKey] = { ...store[sessionKey], ...nextEntry };
-      });
-    }
+    await persistSessionEntryUpdate({ sessionStore, sessionKey, storePath, nextEntry });
     systemSent = true;
   }
 
@@ -264,12 +286,7 @@ export async function ensureSkillSnapshot(params: {
       updatedAt: Date.now(),
       skillsSnapshot,
     };
-    sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...nextEntry };
-    if (storePath) {
-      await updateSessionStore(storePath, (store) => {
-        store[sessionKey] = { ...store[sessionKey], ...nextEntry };
-      });
-    }
+    await persistSessionEntryUpdate({ sessionStore, sessionKey, storePath, nextEntry });
   }
 
   return { sessionEntry: nextEntry, skillsSnapshot, systemSent };
@@ -281,6 +298,7 @@ export async function incrementCompactionCount(params: {
   sessionKey?: string;
   storePath?: string;
   now?: number;
+  amount?: number;
   /** Token count after compaction - if provided, updates session token counts */
   tokensAfter?: number;
 }): Promise<number | undefined> {
@@ -290,6 +308,7 @@ export async function incrementCompactionCount(params: {
     sessionKey,
     storePath,
     now = Date.now(),
+    amount = 1,
     tokensAfter,
   } = params;
   if (!sessionStore || !sessionKey) {
@@ -299,7 +318,8 @@ export async function incrementCompactionCount(params: {
   if (!entry) {
     return undefined;
   }
-  const nextCount = (entry.compactionCount ?? 0) + 1;
+  const incrementBy = Math.max(0, amount);
+  const nextCount = (entry.compactionCount ?? 0) + incrementBy;
   // Build update payload with compaction count and optionally updated token counts
   const updates: Partial<SessionEntry> = {
     compactionCount: nextCount,

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -223,18 +223,19 @@ export async function ensureSkillSnapshot(params: {
     systemSent = true;
   }
 
-  const skillsSnapshot = shouldRefreshSnapshot
-    ? {
-        ...buildWorkspaceSkillSnapshot(workspaceDir, {
-          config: cfg,
-          skillFilter,
-          eligibility: { remote: remoteEligibility },
-          snapshotVersion,
-        }),
-        eligibilitySignature,
-      }
-    : (nextEntry?.skillsSnapshot ??
-      (isFirstTurnInSession
+  const skillsSnapshot =
+    nextEntry?.skillsSnapshot ??
+    (shouldRefreshSnapshot
+      ? {
+          ...buildWorkspaceSkillSnapshot(workspaceDir, {
+            config: cfg,
+            skillFilter,
+            eligibility: { remote: remoteEligibility },
+            snapshotVersion,
+          }),
+          eligibilitySignature,
+        }
+      : isFirstTurnInSession
         ? undefined
         : {
             ...buildWorkspaceSkillSnapshot(workspaceDir, {
@@ -244,7 +245,7 @@ export async function ensureSkillSnapshot(params: {
               snapshotVersion,
             }),
             eligibilitySignature,
-          }));
+          });
   if (
     skillsSnapshot &&
     sessionStore &&

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -223,10 +223,10 @@ export async function ensureSkillSnapshot(params: {
     systemSent = true;
   }
 
-  const skillsSnapshot =
-    nextEntry?.skillsSnapshot ??
-    (shouldRefreshSnapshot
-      ? {
+  const skillsSnapshot = shouldRefreshSnapshot
+    ? isFirstTurnInSession && nextEntry?.skillsSnapshot
+      ? nextEntry.skillsSnapshot
+      : {
           ...buildWorkspaceSkillSnapshot(workspaceDir, {
             config: cfg,
             skillFilter,
@@ -235,7 +235,8 @@ export async function ensureSkillSnapshot(params: {
           }),
           eligibilitySignature,
         }
-      : isFirstTurnInSession
+    : (nextEntry?.skillsSnapshot ??
+      (isFirstTurnInSession
         ? undefined
         : {
             ...buildWorkspaceSkillSnapshot(workspaceDir, {
@@ -245,7 +246,7 @@ export async function ensureSkillSnapshot(params: {
               snapshotVersion,
             }),
             eligibilitySignature,
-          });
+          }));
   if (
     skillsSnapshot &&
     sessionStore &&

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import { resolveUserTimezone } from "../../agents/date-time.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
+import { normalizeSkillFilterForComparison } from "../../agents/skills/filter.js";
 import { ensureSkillsWatcher, getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { type SessionEntry, updateSessionStore } from "../../config/sessions.js";
@@ -12,6 +13,35 @@ import {
 } from "../../infra/format-time/format-datetime.ts";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 import { drainSystemEventEntries } from "../../infra/system-events.js";
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>).toSorted(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  return `{${entries
+    .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`)
+    .join(",")}}`;
+}
+
+function resolveEligibilitySignature(params: {
+  cfg: OpenClawConfig;
+  skillFilter?: string[];
+  remoteEligibility: ReturnType<typeof getRemoteSkillEligibility>;
+}): string {
+  const payload = {
+    skills: params.cfg.skills ?? {},
+    skillFilter: normalizeSkillFilterForComparison(params.skillFilter),
+    path: process.env.PATH ?? "",
+    remote: params.remoteEligibility,
+  };
+  return crypto.createHash("sha256").update(stableStringify(payload)).digest("hex");
+}
 
 export async function prependSystemEvents(params: {
   cfg: OpenClawConfig;
@@ -152,10 +182,12 @@ export async function ensureSkillSnapshot(params: {
   let nextEntry = sessionEntry;
   let systemSent = sessionEntry?.systemSent ?? false;
   const remoteEligibility = getRemoteSkillEligibility();
+  const eligibilitySignature = resolveEligibilitySignature({ cfg, skillFilter, remoteEligibility });
   const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   ensureSkillsWatcher({ workspaceDir, config: cfg });
   const shouldRefreshSnapshot =
-    snapshotVersion > 0 && (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion;
+    (snapshotVersion > 0 && (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion) ||
+    nextEntry?.skillsSnapshot?.eligibilitySignature !== eligibilitySignature;
 
   if (isFirstTurnInSession && sessionStore && sessionKey) {
     const current = nextEntry ??
@@ -165,12 +197,15 @@ export async function ensureSkillSnapshot(params: {
       };
     const skillSnapshot =
       isFirstTurnInSession || !current.skillsSnapshot || shouldRefreshSnapshot
-        ? buildWorkspaceSkillSnapshot(workspaceDir, {
-            config: cfg,
-            skillFilter,
-            eligibility: { remote: remoteEligibility },
-            snapshotVersion,
-          })
+        ? {
+            ...buildWorkspaceSkillSnapshot(workspaceDir, {
+              config: cfg,
+              skillFilter,
+              eligibility: { remote: remoteEligibility },
+              snapshotVersion,
+            }),
+            eligibilitySignature,
+          }
         : current.skillsSnapshot;
     nextEntry = {
       ...current,
@@ -189,21 +224,27 @@ export async function ensureSkillSnapshot(params: {
   }
 
   const skillsSnapshot = shouldRefreshSnapshot
-    ? buildWorkspaceSkillSnapshot(workspaceDir, {
-        config: cfg,
-        skillFilter,
-        eligibility: { remote: remoteEligibility },
-        snapshotVersion,
-      })
+    ? {
+        ...buildWorkspaceSkillSnapshot(workspaceDir, {
+          config: cfg,
+          skillFilter,
+          eligibility: { remote: remoteEligibility },
+          snapshotVersion,
+        }),
+        eligibilitySignature,
+      }
     : (nextEntry?.skillsSnapshot ??
       (isFirstTurnInSession
         ? undefined
-        : buildWorkspaceSkillSnapshot(workspaceDir, {
-            config: cfg,
-            skillFilter,
-            eligibility: { remote: remoteEligibility },
-            snapshotVersion,
-          })));
+        : {
+            ...buildWorkspaceSkillSnapshot(workspaceDir, {
+              config: cfg,
+              skillFilter,
+              eligibility: { remote: remoteEligibility },
+              snapshotVersion,
+            }),
+            eligibilitySignature,
+          }));
   if (
     skillsSnapshot &&
     sessionStore &&

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -22,6 +22,49 @@ export type SessionOrigin = {
   threadId?: string | number;
 };
 
+export type SessionAcpIdentitySource = "ensure" | "status" | "event";
+
+export type SessionAcpIdentityState = "pending" | "resolved";
+
+export type SessionAcpIdentity = {
+  state: SessionAcpIdentityState;
+  acpxRecordId?: string;
+  acpxSessionId?: string;
+  agentSessionId?: string;
+  source: SessionAcpIdentitySource;
+  lastUpdatedAt: number;
+};
+
+export type SessionAcpMeta = {
+  backend: string;
+  agent: string;
+  runtimeSessionName: string;
+  identity?: SessionAcpIdentity;
+  mode: "persistent" | "oneshot";
+  runtimeOptions?: AcpSessionRuntimeOptions;
+  cwd?: string;
+  state: "idle" | "running" | "error";
+  lastActivityAt: number;
+  lastError?: string;
+};
+
+export type AcpSessionRuntimeOptions = {
+  /**
+   * ACP runtime mode set via session/set_mode (for example: "plan", "normal", "auto").
+   */
+  runtimeMode?: string;
+  /** ACP runtime config option: model id. */
+  model?: string;
+  /** Working directory override for ACP session turns. */
+  cwd?: string;
+  /** ACP runtime config option: permission profile id. */
+  permissionProfile?: string;
+  /** ACP runtime config option: per-turn timeout in seconds. */
+  timeoutSeconds?: number;
+  /** Backend-specific option bag mapped through session/set_config_option. */
+  backendExtras?: Record<string, string>;
+};
+
 export type SessionEntry = {
   /**
    * Last delivered heartbeat payload (used to suppress duplicate heartbeat notifications).
@@ -35,14 +78,29 @@ export type SessionEntry = {
   sessionFile?: string;
   /** Parent session key that spawned this session (used for sandbox session-tool scoping). */
   spawnedBy?: string;
+  /** Workspace inherited by spawned sessions and reused on later turns for the same child session. */
+  spawnedWorkspaceDir?: string;
   /** True after a thread/topic session has been forked from its parent transcript once. */
   forkedFromParent?: boolean;
   /** Subagent spawn depth (0 = main, 1 = sub-agent, 2 = sub-sub-agent). */
   spawnDepth?: number;
+  /** Explicit role assigned at spawn time for subagent tool policy/control decisions. */
+  subagentRole?: "orchestrator" | "leaf";
+  /** Explicit control scope assigned at spawn time for subagent control decisions. */
+  subagentControlScope?: "children" | "none";
   systemSent?: boolean;
   abortedLastRun?: boolean;
+  /**
+   * Session-level stop cutoff captured when /stop is received.
+   * Messages at/before this boundary are skipped to avoid replaying
+   * queued pre-stop backlog.
+   */
+  abortCutoffMessageSid?: string;
+  /** Epoch ms cutoff paired with abortCutoffMessageSid when available. */
+  abortCutoffTimestamp?: number;
   chatType?: SessionChatType;
   thinkingLevel?: string;
+  fastMode?: boolean;
   verboseLevel?: string;
   reasoningLevel?: string;
   elevatedLevel?: string;
@@ -112,18 +170,124 @@ export type SessionEntry = {
   lastThreadId?: string | number;
   skillsSnapshot?: SessionSkillSnapshot;
   systemPromptReport?: SessionSystemPromptReport;
+  acp?: SessionAcpMeta;
 };
+
+function normalizeRuntimeField(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function normalizeSessionRuntimeModelFields(entry: SessionEntry): SessionEntry {
+  const normalizedModel = normalizeRuntimeField(entry.model);
+  const normalizedProvider = normalizeRuntimeField(entry.modelProvider);
+  let next = entry;
+
+  if (!normalizedModel) {
+    if (entry.model !== undefined || entry.modelProvider !== undefined) {
+      next = { ...next };
+      delete next.model;
+      delete next.modelProvider;
+    }
+    return next;
+  }
+
+  if (entry.model !== normalizedModel) {
+    if (next === entry) {
+      next = { ...next };
+    }
+    next.model = normalizedModel;
+  }
+
+  if (!normalizedProvider) {
+    if (entry.modelProvider !== undefined) {
+      if (next === entry) {
+        next = { ...next };
+      }
+      delete next.modelProvider;
+    }
+    return next;
+  }
+
+  if (entry.modelProvider !== normalizedProvider) {
+    if (next === entry) {
+      next = { ...next };
+    }
+    next.modelProvider = normalizedProvider;
+  }
+  return next;
+}
+
+export function setSessionRuntimeModel(
+  entry: SessionEntry,
+  runtime: { provider: string; model: string },
+): boolean {
+  const provider = runtime.provider.trim();
+  const model = runtime.model.trim();
+  if (!provider || !model) {
+    return false;
+  }
+  entry.modelProvider = provider;
+  entry.model = model;
+  return true;
+}
+
+export type SessionEntryMergePolicy = "touch-activity" | "preserve-activity";
+
+type MergeSessionEntryOptions = {
+  policy?: SessionEntryMergePolicy;
+  now?: number;
+};
+
+function resolveMergedUpdatedAt(
+  existing: SessionEntry | undefined,
+  patch: Partial<SessionEntry>,
+  options?: MergeSessionEntryOptions,
+): number {
+  if (options?.policy === "preserve-activity" && existing) {
+    return existing.updatedAt ?? patch.updatedAt ?? options.now ?? Date.now();
+  }
+  return Math.max(existing?.updatedAt ?? 0, patch.updatedAt ?? 0, options?.now ?? Date.now());
+}
+
+export function mergeSessionEntryWithPolicy(
+  existing: SessionEntry | undefined,
+  patch: Partial<SessionEntry>,
+  options?: MergeSessionEntryOptions,
+): SessionEntry {
+  const sessionId = patch.sessionId ?? existing?.sessionId ?? crypto.randomUUID();
+  const updatedAt = resolveMergedUpdatedAt(existing, patch, options);
+  if (!existing) {
+    return normalizeSessionRuntimeModelFields({ ...patch, sessionId, updatedAt });
+  }
+  const next = { ...existing, ...patch, sessionId, updatedAt };
+
+  // Guard against stale provider carry-over when callers patch runtime model
+  // without also patching runtime provider.
+  if (Object.hasOwn(patch, "model") && !Object.hasOwn(patch, "modelProvider")) {
+    const patchedModel = normalizeRuntimeField(patch.model);
+    const existingModel = normalizeRuntimeField(existing.model);
+    if (patchedModel && patchedModel !== existingModel) {
+      delete next.modelProvider;
+    }
+  }
+  return normalizeSessionRuntimeModelFields(next);
+}
 
 export function mergeSessionEntry(
   existing: SessionEntry | undefined,
   patch: Partial<SessionEntry>,
 ): SessionEntry {
-  const sessionId = patch.sessionId ?? existing?.sessionId ?? crypto.randomUUID();
-  const updatedAt = Math.max(existing?.updatedAt ?? 0, patch.updatedAt ?? 0, Date.now());
-  if (!existing) {
-    return { ...patch, sessionId, updatedAt };
-  }
-  return { ...existing, ...patch, sessionId, updatedAt };
+  return mergeSessionEntryWithPolicy(existing, patch);
+}
+
+export function mergeSessionEntryPreserveActivity(
+  existing: SessionEntry | undefined,
+  patch: Partial<SessionEntry>,
+): SessionEntry {
+  return mergeSessionEntryWithPolicy(existing, patch, {
+    policy: "preserve-activity",
+  });
 }
 
 export function resolveFreshSessionTotalTokens(
@@ -176,6 +340,15 @@ export type SessionSystemPromptReport = {
   workspaceDir?: string;
   bootstrapMaxChars?: number;
   bootstrapTotalMaxChars?: number;
+  bootstrapTruncation?: {
+    warningMode?: "off" | "once" | "always";
+    warningShown?: boolean;
+    promptWarningSignature?: string;
+    warningSignaturesSeen?: string[];
+    truncatedFiles?: number;
+    nearLimitFiles?: number;
+    totalNearLimit?: boolean;
+  };
   sandbox?: {
     mode?: string;
     sandboxed?: boolean;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -157,6 +157,11 @@ export type SessionSkillSnapshot = {
   skills: Array<{ name: string; primaryEnv?: string; requiredEnv?: string[] }>;
   /** Normalized agent-level filter used to build this snapshot; undefined means unrestricted. */
   skillFilter?: string[];
+  /**
+   * Runtime eligibility fingerprint used for cache invalidation when skill
+   * availability changes without a SKILL.md file watch event.
+   */
+  eligibilitySignature?: string;
   resolvedSkills?: Skill[];
   version?: number;
 };


### PR DESCRIPTION
## Summary
- add an eligibility/config signature to cached `skillsSnapshot` entries so session caches invalidate when runtime skill eligibility changes without a `SKILL.md` watcher bump
- refresh skill snapshots in `ensureSkillSnapshot` when either watcher version advances or the new signature differs from the cached value
- persist the signature in `SessionSkillSnapshot` metadata for future refresh decisions

## Test plan
- [x] `pnpm exec tsc -p tsconfig.json --noEmit`
- [x] `pnpm exec vitest run src/agents/skills.buildworkspaceskillsnapshot.test.ts src/cron/isolated-agent/run.skill-filter.test.ts`
- [x] manual E2E in isolated dev gateway profile:
  - create session snapshot with `nano-banana-pro` disabled
  - enable `nano-banana-pro` via config + env eligibility only (no `SKILL.md` touch)
  - send a normal follow-up message (not `/new`)
  - verify existing session snapshot refreshes and now includes `nano-banana-pro`

Fixes #26396

Made with [Cursor](https://cursor.com)