### PR TITLE
fix(cron): retry startup-interrupted jobs instead of silently skipping them

### DIFF
--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -81,7 +81,7 @@ describe("CronService restart catch-up", () => {
     await store.cleanup();
   });
 
-  it("clears stale running markers without replaying interrupted startup jobs", async () => {
+  it("retries startup-interrupted jobs instead of silently advancing schedule (#34432)", async () => {
     const store = await makeStorePath();
     const enqueueSystemEvent = vi.fn();
     const requestHeartbeatNow = vi.fn();
@@ -115,18 +115,21 @@ describe("CronService restart catch-up", () => {
 
     await cron.start();
 
-    expect(enqueueSystemEvent).not.toHaveBeenCalled();
     expect(noopLogger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ jobId: "restart-stale-running" }),
       "cron: clearing stale running marker on startup",
+    );
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      "resume stale marker",
+      expect.objectContaining({ agentId: undefined }),
     );
 
     const jobs = await cron.list({ includeDisabled: true });
     const updated = jobs.find((job) => job.id === "restart-stale-running");
     expect(updated?.state.runningAtMs).toBeUndefined();
-    expect(updated?.state.lastStatus).toBeUndefined();
-    expect(updated?.state.lastRunAtMs).toBeUndefined();
-    expect((updated?.state.nextRunAtMs ?? 0) > Date.parse("2025-12-13T17:00:00.000Z")).toBe(true);
+    expect(updated?.state.lastStatus).toBe("ok");
+    expect(updated?.state.lastRunAtMs).toBe(Date.parse("2025-12-13T17:00:00.000Z"));
+    expect(updated?.state.nextRunAtMs ?? 0).toBeGreaterThan(Date.parse("2025-12-13T17:00:00.000Z"));
 
     cron.stop();
     await store.cleanup();

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -92,7 +92,6 @@ export async function start(state: CronServiceState) {
     return;
   }
 
-  const startupInterruptedJobIds = new Set<string>();
   await locked(state, async () => {
     await ensureLoaded(state, { skipRecompute: true });
     const jobs = state.store?.jobs ?? [];
@@ -103,13 +102,12 @@ export async function start(state: CronServiceState) {
           "cron: clearing stale running marker on startup",
         );
         job.state.runningAtMs = undefined;
-        startupInterruptedJobIds.add(job.id);
       }
     }
     await persist(state);
   });
 
-  await runMissedJobs(state, { skipJobIds: startupInterruptedJobIds });
+  await runMissedJobs(state);
 
   await locked(state, async () => {
     await ensureLoaded(state, { forceReload: true, skipRecompute: true });


### PR DESCRIPTION
## Summary

- Problem: When the gateway crashes mid-execution of a cron job, the job's `runningAtMs` marker is cleared on restart but the job is excluded from the missed-jobs catch-up pass via `skipJobIds`. The subsequent `recomputeNextRuns` then silently advances the past-due `nextRunAtMs` to the next occurrence without ever executing the missed run.
- Why it matters: Users with daily/hourly cron schedules lose an entire execution cycle when the gateway restarts during a job run. The job appears stuck in `openclaw cron list` showing a stale `Last:` timestamp that never increments.
- What changed: Removed the `startupInterruptedJobIds` exclusion from the `runMissedJobs` call in `start()`. Startup-interrupted jobs (those that had `runningAtMs` set when the gateway crashed) are now retried during the restart catch-up pass, matching the existing behavior for jobs that were never started.
- What did NOT change (scope boundary): The `runningAtMs` clearing logic is preserved (still needed to make interrupted jobs eligible for `isRunnableJob`). The `recomputeNextRunsForMaintenance` function is untouched. Timer tick behavior, `onTimer`, and `runDueJobs` are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34432

## User-visible / Behavior Changes

Cron jobs that were interrupted by a gateway crash now execute on restart instead of being silently skipped until the next scheduled occurrence.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux / Windows
- Runtime: Node.js 22+

### Steps

1. Create a cron job scheduled for a specific time (e.g., `0 8 * * *` for 08:00 daily)
2. Let the timer fire and start executing the job
3. Kill/restart the gateway while the job is running (before `applyJobResult` persists)
4. Check `openclaw cron list` after restart

### Expected

- The interrupted job is retried during the restart catch-up pass
- `lastRunAtMs` reflects the catch-up execution time
- `nextRunAtMs` is advanced to the next scheduled occurrence

### Actual

- Before: Job is excluded from `runMissedJobs` via `skipJobIds`, `nextRunAtMs` silently advances without execution, job shows stale `Last:` timestamp
- After: Job is included in the `runMissedJobs` catch-up pass, executes, and `nextRunAtMs` correctly advances

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Updated existing test "clears stale running markers without replaying interrupted startup jobs" → "retries startup-interrupted jobs instead of silently advancing schedule (#34432)" to verify the corrected behavior. Full cron test suite (378 tests) passes.

## Human Verification (required)

- Verified scenarios: (1) Job with `runningAtMs` set and past-due `nextRunAtMs` is now executed on restart. (2) Job without `runningAtMs` but with past-due `nextRunAtMs` continues to work as before. (3) All 378 existing cron tests pass including #13992, #17852, and armtimer-tight-loop regression tests.
- Edge cases checked: Jobs with `runningAtMs` but future `nextRunAtMs` (would not be collected by `collectRunnableJobs`). One-shot `at` jobs with `skipAtIfAlreadyRan` still skip correctly.
- What you did **not** verify: Production gateway restart with real cron jobs. Multi-process concurrent startup scenarios.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit to restore the `skipJobIds` exclusion in `start()`
- Files/config to restore: `src/cron/service/ops.ts`

## Risks and Mitigations

- Risk: Interrupted jobs that partially completed (e.g., sent a message) may send a duplicate message on retry.
  - Mitigation: This matches standard cron at-least-once semantics. The previous behavior (silently dropping the execution) is strictly worse. Jobs using `bestEffortDeliver` or idempotent payloads are unaffected.