### PR TITLE
fix(cron): advance expired nextRunAtMs after gateway restart

### DIFF
--- a/src/cron/service.issue-13992-regression.test.ts
+++ b/src/cron/service.issue-13992-regression.test.ts
@@ -96,6 +96,51 @@ describe("issue #13992 regression - cron jobs skip execution", () => {
     expect(job.state.nextRunAtMs).toBe(futureTime);
   });
 
+  it("should advance past-due nextRunAtMs when job already executed (#34432)", () => {
+    const now = Date.now();
+    const pastDue = now - 60_000; // 1 minute ago
+    // lastRunAtMs is at or after nextRunAtMs — the job already ran for this slot.
+    const lastRun = pastDue + 500;
+
+    const job = createCronSystemEventJob(now, {
+      createdAtMs: now - 86400_000,
+      updatedAtMs: now - 86400_000,
+      state: {
+        nextRunAtMs: pastDue,
+        lastRunAtMs: lastRun,
+      },
+    });
+
+    const state = createMockCronStateForJobs({ jobs: [job], nowMs: now });
+    recomputeNextRunsForMaintenance(state);
+
+    // Should have advanced nextRunAtMs to a future time
+    expect(job.state.nextRunAtMs).not.toBe(pastDue);
+    expect(job.state.nextRunAtMs).toBeGreaterThan(now);
+  });
+
+  it("should NOT advance past-due nextRunAtMs when job has not executed yet (#34432 vs #13992)", () => {
+    const now = Date.now();
+    const pastDue = now - 60_000;
+    // lastRunAtMs is from a PREVIOUS time slot (before nextRunAtMs).
+    const lastRun = pastDue - 86400_000; // 1 day before
+
+    const job = createCronSystemEventJob(now, {
+      createdAtMs: now - 86400_000 * 2,
+      updatedAtMs: now - 86400_000 * 2,
+      state: {
+        nextRunAtMs: pastDue,
+        lastRunAtMs: lastRun,
+      },
+    });
+
+    const state = createMockCronStateForJobs({ jobs: [job], nowMs: now });
+    recomputeNextRunsForMaintenance(state);
+
+    // Should NOT have changed — the job hasn't executed for this time slot
+    expect(job.state.nextRunAtMs).toBe(pastDue);
+  });
+
   it("isolates schedule errors while filling missing nextRunAtMs", () => {
     const now = Date.now();
     const pastDue = now - 1_000;

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -399,20 +399,33 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
 
 /**
  * Maintenance-only version of recomputeNextRuns that handles disabled jobs
- * and stuck markers, but does NOT recompute nextRunAtMs for enabled jobs
- * with existing values. Used during timer ticks when no due jobs were found
- * to prevent silently advancing past-due nextRunAtMs values without execution
- * (see #13992).
+ * and stuck markers, but is conservative about advancing nextRunAtMs to
+ * prevent silently skipping past-due jobs that haven't run yet (#13992).
+ *
+ * Safe to advance when:
+ *  - nextRunAtMs is missing (undefined / non-finite)
+ *  - nextRunAtMs is past-due AND lastRunAtMs >= nextRunAtMs, meaning the
+ *    job already executed for this time slot but nextRunAtMs was not
+ *    advanced (e.g. after a gateway restart). Without this, the past-due
+ *    value persists and the job never fires again (#34432).
  */
 export function recomputeNextRunsForMaintenance(state: CronServiceState): boolean {
   return walkSchedulableJobs(state, ({ job, nowMs: now }) => {
     let changed = false;
-    // Only compute missing nextRunAtMs, do NOT recompute existing ones.
-    // If a job was past-due but not found by findDueJobs, recomputing would
-    // cause it to be silently skipped.
-    if (!isFiniteTimestamp(job.state.nextRunAtMs)) {
+    const nextRun = job.state.nextRunAtMs;
+    if (!isFiniteTimestamp(nextRun)) {
+      // Missing: compute from scratch.
       if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
         changed = true;
+      }
+    } else if (now >= nextRun) {
+      // Past-due: only advance if the job already ran for this time slot.
+      // Advancing a job that hasn't executed yet would silently skip it (#13992).
+      const lastRun = job.state.lastRunAtMs;
+      if (isFiniteTimestamp(lastRun) && lastRun >= nextRun) {
+        if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
+          changed = true;
+        }
       }
     }
     return changed;


### PR DESCRIPTION
## Summary

- **Problem:** After a gateway restart, cron jobs with an expired `nextRunAtMs` (scheduled time already passed) can get permanently stuck. The `recomputeNextRunsForMaintenance` function only recomputes `nextRunAtMs` when it is missing (undefined/non-finite), but never advances a past-due value — even when the job has already been executed for that time slot.
- **Why it matters:** Users experience cron jobs that "never fire again" after a gateway restart, requiring manual intervention. The timer keeps re-arming with a past `nextAt` value, and the scheduler spins without making progress.
- **What changed:** `recomputeNextRunsForMaintenance` now also advances `nextRunAtMs` when the job has already executed for the current time slot (`lastRunAtMs >= nextRunAtMs`). This is safe because the job already ran — advancing only schedules the next occurrence.
- **What did NOT change (scope boundary):** The `#13992` safety invariant is fully preserved: past-due jobs that have NOT been executed yet are never silently advanced. The `recomputeNextRuns` (full version), `applyJobResult`, `runMissedJobs`, and `armTimer` logic are untouched.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #34432

## User-visible / Behavior Changes

- Cron jobs that missed their scheduled time (e.g., due to a gateway restart) and have already been executed for that time slot will now correctly advance to the next scheduled time instead of remaining stuck with an expired `nextRunAtMs`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OS: macOS (Darwin 25.3.0, arm64)
- Runtime/container: Node 22+ / pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Any cron job configuration (e.g., `0 8 * * *`)

### Steps
1. Create a cron job scheduled for a specific time (e.g., `0 8 * * *` for 08:00 daily)
2. Let the job execute at the scheduled time
3. Restart the gateway shortly after (e.g., at 08:01)
4. Observe `openclaw cron list` — before fix, `nextRunAtMs` stays at the past time and the timer re-arms with a past `nextAt`

### Expected
After restart, `nextRunAtMs` is advanced to the next future scheduled time (tomorrow 08:00)

### Actual (before fix)
`nextRunAtMs` remains at the expired time (today 08:00), timer keeps re-arming with past `nextAt`, job appears stuck

## Evidence

- [x] Failing test/log before + passing after

All 380 cron tests pass, including:
- Existing `#13992` regression test (past-due without execution → NOT advanced) ✅
- Existing `#17852` regression test (daily jobs don't skip days) ✅
- **New** `#34432` test: past-due WITH prior execution → advanced to future ✅
- **New** negative test: past-due with last run from a PREVIOUS time slot → NOT advanced ✅

Full suite: 6579 passed, 1 skipped, 1 pre-existing failure (unrelated locale test)

## Human Verification (required)

- Verified scenarios: All 380 cron tests pass (`pnpm vitest run src/cron/`), full test suite passes (`pnpm build && pnpm check && pnpm test`)
- Edge cases checked: (1) past-due job never executed → preserved as-is (#13992 invariant), (2) past-due job with `lastRunAtMs` from a previous slot → NOT advanced, (3) past-due job with `lastRunAtMs` at or after `nextRunAtMs` → advanced correctly, (4) disabled jobs → cleared as before, (5) stuck running markers → cleared as before
- What you did **not** verify: Live gateway restart testing with real cron jobs (would require a running gateway instance)

> **Note:** This PR was created with AI assistance (Claude Code). The code changes have been reviewed and understood.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert <commit-hash>`
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: (1) Cron jobs executing twice for the same time slot (would indicate `lastRunAtMs >= nextRunAtMs` check is too permissive), (2) Cron jobs skipping scheduled runs (would indicate the #13992 invariant was broken)

## Risks and Mitigations

- Risk: The `lastRunAtMs >= nextRunAtMs` heuristic could theoretically misidentify a job as "already executed" if timestamps are manipulated or clock drift occurs.
- Mitigation: The check is conservative — it only advances when there is positive evidence of a prior execution. The worst case is that a stuck job remains stuck (same as current behavior), not that a job is silently skipped.