### PR TITLE
fix: treat systemd is-enabled soft failures as non-fatal (closes #34464)

### DIFF
--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -326,11 +326,24 @@ export async function restartSystemdService({
 export async function isSystemdServiceEnabled(args: {
   env?: Record<string, string | undefined>;
 }): Promise<boolean> {
-  await assertSystemdAvailable();
   const serviceName = resolveSystemdServiceName(args.env ?? {});
   const unitName = `${serviceName}.service`;
   const res = await execSystemctl(["--user", "is-enabled", unitName]);
-  return res.code === 0;
+  if (res.code === 0) {
+    return true;
+  }
+  const detail = `${res.stderr} ${res.stdout}`.toLowerCase();
+  if (
+    detail.includes("not found") ||
+    detail.includes("could not be found") ||
+    detail.includes("no such file") ||
+    detail.includes("disabled") ||
+    detail.includes("failed to connect") ||
+    detail.includes("no bus")
+  ) {
+    return false;
+  }
+  throw new Error(`systemctl is-enabled unavailable: ${res.stderr || res.stdout}`.trim());
 }
 
 export async function readSystemdServiceRuntime(


### PR DESCRIPTION
Closes #34464

## Problem
Installer checks could treat `systemctl --user is-enabled` failures as fatal in no-user-bus / non-login Linux sessions, causing false rollback paths.

## Fix
Handle expected `is-enabled` failures (`not found`, `disabled`, `failed to connect`, `no bus`) as non-fatal `false`, and only throw for unexpected errors.