### PR TITLE
feat: add --session-key support to system wake/event

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -691,18 +691,22 @@ public struct AgentWaitParams: Codable, Sendable {
 public struct WakeParams: Codable, Sendable {
     public let mode: AnyCodable
     public let text: String
+    public let sessionkey: String?
 
     public init(
         mode: AnyCodable,
-        text: String)
+        text: String,
+        sessionkey: String? = nil)
     {
         self.mode = mode
         self.text = text
+        self.sessionkey = sessionkey
     }
 
     private enum CodingKeys: String, CodingKey {
         case mode
         case text
+        case sessionkey = "sessionKey"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -691,18 +691,22 @@ public struct AgentWaitParams: Codable, Sendable {
 public struct WakeParams: Codable, Sendable {
     public let mode: AnyCodable
     public let text: String
+    public let sessionkey: String?
 
     public init(
         mode: AnyCodable,
-        text: String)
+        text: String,
+        sessionkey: String? = nil)
     {
         self.mode = mode
         self.text = text
+        self.sessionkey = sessionkey
     }
 
     private enum CodingKeys: String, CodingKey {
         case mode
         case text
+        case sessionkey = "sessionKey"
     }
 }
 

--- a/src/cli/system-cli.test.ts
+++ b/src/cli/system-cli.test.ts
@@ -58,6 +58,37 @@ describe("system-cli", () => {
     expect(runtimeLogs).toEqual([JSON.stringify({ id: "wake-1" }, null, 2)]);
   });
 
+  it("passes --session-key through to wake params", async () => {
+    await runCli(["system", "event", "--text", "hello", "--session-key", "discord:channel:123"]);
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "wake",
+      expect.objectContaining({ text: "hello", sessionKey: "discord:channel:123" }),
+      { mode: "next-heartbeat", text: "hello", sessionKey: "discord:channel:123" },
+      { expectFinal: false },
+    );
+    expect(runtimeLogs).toEqual(["ok"]);
+  });
+
+  it("trims whitespace from --session-key", async () => {
+    await runCli(["system", "event", "--text", "hello", "--session-key", "  hook:abc  "]);
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "wake",
+      expect.any(Object),
+      { mode: "next-heartbeat", text: "hello", sessionKey: "hook:abc" },
+      { expectFinal: false },
+    );
+  });
+
+  it("omits sessionKey from params when not provided", async () => {
+    await runCli(["system", "event", "--text", "hello"]);
+
+    const params = callGatewayFromCli.mock.calls[0][2];
+    expect(params).toEqual({ mode: "next-heartbeat", text: "hello" });
+    expect("sessionKey" in params).toBe(false);
+  });
+
   it("handles invalid wake mode as runtime error", async () => {
     await runCli(["system", "event", "--text", "hello", "--mode", "later"]);
 

--- a/src/cli/system-cli.ts
+++ b/src/cli/system-cli.ts
@@ -6,7 +6,12 @@ import { theme } from "../terminal/theme.js";
 import type { GatewayRpcOpts } from "./gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "./gateway-rpc.js";
 
-type SystemEventOpts = GatewayRpcOpts & { text?: string; mode?: string; json?: boolean };
+type SystemEventOpts = GatewayRpcOpts & {
+  text?: string;
+  mode?: string;
+  sessionKey?: string;
+  json?: boolean;
+};
 type SystemGatewayOpts = GatewayRpcOpts & { json?: boolean };
 
 const normalizeWakeMode = (raw: unknown) => {
@@ -54,6 +59,7 @@ export function registerSystemCli(program: Command) {
       .description("Enqueue a system event and optionally trigger a heartbeat")
       .requiredOption("--text <text>", "System event text")
       .option("--mode <mode>", "Wake mode (now|next-heartbeat)", "next-heartbeat")
+      .option("--session-key <key>", "Target session key (routes event to specific session)")
       .option("--json", "Output JSON", false),
   ).action(async (opts: SystemEventOpts) => {
     await runSystemGatewayCommand(
@@ -64,7 +70,16 @@ export function registerSystemCli(program: Command) {
           throw new Error("--text is required");
         }
         const mode = normalizeWakeMode(opts.mode);
-        return await callGatewayFromCli("wake", opts, { mode, text }, { expectFinal: false });
+        const sessionKey =
+          typeof opts.sessionKey === "string" && opts.sessionKey.trim()
+            ? opts.sessionKey.trim()
+            : undefined;
+        return await callGatewayFromCli(
+          "wake",
+          opts,
+          { mode, text, ...(sessionKey ? { sessionKey } : {}) },
+          { expectFinal: false },
+        );
       },
       "ok",
     );

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -391,6 +391,93 @@ describe("hooks mapping", () => {
     }
   });
 
+  it("renders sessionKey template for agent mapping", async () => {
+    const mappings = resolveHookMappings({
+      mappings: [
+        {
+          id: "session-key-test",
+          match: { path: "gmail" },
+          action: "agent",
+          messageTemplate: "Subject: {{messages[0].subject}}",
+          sessionKey: "hook:gmail:{{messages[0].subject}}",
+        },
+      ],
+    });
+    const result = await applyHookMappings(mappings, {
+      payload: gmailPayload,
+      headers: {},
+      url: baseUrl,
+      path: "gmail",
+    });
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.sessionKey).toBe("hook:gmail:Hello");
+    }
+  });
+
+  it("renders sessionKey template for wake mapping", async () => {
+    const mappings = resolveHookMappings({
+      mappings: [
+        {
+          id: "wake-session-key",
+          match: { path: "gmail" },
+          action: "wake",
+          textTemplate: "Wake: {{messages[0].subject}}",
+          sessionKey: "hook:wake:{{messages[0].subject}}",
+        },
+      ],
+    });
+    const result = await applyHookMappings(mappings, {
+      payload: gmailPayload,
+      headers: {},
+      url: baseUrl,
+      path: "gmail",
+    });
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "wake") {
+      expect(result.action.sessionKey).toBe("hook:wake:Hello");
+    }
+  });
+
+  it("sets sessionKey to undefined when not configured in mapping", async () => {
+    const result = await applyGmailMappings({
+      mappings: [
+        createGmailAgentMapping({
+          id: "no-session-key",
+          messageTemplate: "Subject: {{messages[0].subject}}",
+        }),
+      ],
+    });
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.sessionKey).toBeUndefined();
+    }
+  });
+
+  it("sets sessionKey to undefined when template renders empty", async () => {
+    const mappings = resolveHookMappings({
+      mappings: [
+        {
+          id: "empty-session-key",
+          match: { path: "gmail" },
+          action: "agent",
+          messageTemplate: "Subject: {{messages[0].subject}}",
+          sessionKey: "{{missing_field}}",
+        },
+      ],
+    });
+    const result = await applyHookMappings(mappings, {
+      payload: gmailPayload,
+      headers: {},
+      url: baseUrl,
+      path: "gmail",
+    });
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.sessionKey).toBeUndefined();
+    }
+  });
+
   it("agentId is undefined when not set", async () => {
     const result = await applyGmailMappings({
       mappings: [

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -42,6 +42,7 @@ export type HookAction =
       kind: "wake";
       text: string;
       mode: "now" | "next-heartbeat";
+      sessionKey?: string;
     }
   | {
       kind: "agent";
@@ -248,6 +249,7 @@ function buildActionFromMapping(
         kind: "wake",
         text,
         mode: mapping.wakeMode ?? "now",
+        sessionKey: renderOptional(mapping.sessionKey, ctx),
       },
     };
   }
@@ -285,7 +287,9 @@ function mergeAction(
     const baseWake = base.kind === "wake" ? base : undefined;
     const text = typeof override.text === "string" ? override.text : (baseWake?.text ?? "");
     const mode = override.mode === "next-heartbeat" ? "next-heartbeat" : (baseWake?.mode ?? "now");
-    return validateAction({ kind: "wake", text, mode });
+    const sessionKey =
+      typeof override.sessionKey === "string" ? override.sessionKey : baseWake?.sessionKey;
+    return validateAction({ kind: "wake", text, mode, sessionKey });
   }
   const baseAgent = base.kind === "agent" ? base : undefined;
   const message =

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -94,6 +94,32 @@ describe("gateway hooks helpers", () => {
     expect(normalizeWakePayload({ text: "  ", mode: "now" }).ok).toBe(false);
   });
 
+  test("normalizeWakePayload extracts optional sessionKey", () => {
+    const withKey = normalizeWakePayload({ text: "hello", sessionKey: " agent:ops:main " });
+    expect(withKey.ok).toBe(true);
+    if (withKey.ok) {
+      expect(withKey.value.sessionKey).toBe("agent:ops:main");
+    }
+
+    const withoutKey = normalizeWakePayload({ text: "hello" });
+    expect(withoutKey.ok).toBe(true);
+    if (withoutKey.ok) {
+      expect(withoutKey.value.sessionKey).toBeUndefined();
+    }
+
+    const emptyKey = normalizeWakePayload({ text: "hello", sessionKey: "  " });
+    expect(emptyKey.ok).toBe(true);
+    if (emptyKey.ok) {
+      expect(emptyKey.value.sessionKey).toBeUndefined();
+    }
+
+    const nonStringKey = normalizeWakePayload({ text: "hello", sessionKey: 123 });
+    expect(nonStringKey.ok).toBe(true);
+    if (nonStringKey.ok) {
+      expect(nonStringKey.value.sessionKey).toBeUndefined();
+    }
+  });
+
   test("normalizeAgentPayload defaults + validates channel", () => {
     const ok = normalizeAgentPayload({ message: "hello" });
     expect(ok.ok).toBe(true);

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -209,14 +209,18 @@ export function normalizeHookHeaders(req: IncomingMessage) {
 export function normalizeWakePayload(
   payload: Record<string, unknown>,
 ):
-  | { ok: true; value: { text: string; mode: "now" | "next-heartbeat" } }
+  | { ok: true; value: { text: string; mode: "now" | "next-heartbeat"; sessionKey?: string } }
   | { ok: false; error: string } {
   const text = typeof payload.text === "string" ? payload.text.trim() : "";
   if (!text) {
     return { ok: false, error: "text required" };
   }
   const mode = payload.mode === "next-heartbeat" ? "next-heartbeat" : "now";
-  return { ok: true, value: { text, mode } };
+  const sessionKey =
+    typeof payload.sessionKey === "string" && payload.sessionKey.trim()
+      ? payload.sessionKey.trim()
+      : undefined;
+  return { ok: true, value: { text, mode, sessionKey } };
 }
 
 export type HookAgentPayload = {
@@ -297,7 +301,7 @@ export function isHookAgentAllowed(
 
 export const getHookAgentPolicyError = () => "agentId is not allowed by hooks.allowedAgentIds";
 export const getHookSessionKeyRequestPolicyError = () =>
-  "sessionKey is disabled for external /hooks/agent payloads; set hooks.allowRequestSessionKey=true to enable";
+  "sessionKey is disabled for external hook payloads; set hooks.allowRequestSessionKey=true to enable";
 export const getHookSessionKeyPrefixError = (prefixes: string[]) =>
   `sessionKey must start with one of: ${prefixes.join(", ")}`;
 

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -144,6 +144,7 @@ export const WakeParamsSchema = Type.Object(
   {
     mode: Type.Union([Type.Literal("now"), Type.Literal("next-heartbeat")]),
     text: NonEmptyString,
+    sessionKey: Type.Optional(NonEmptyString),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/protocol/wake-params.test.ts
+++ b/src/gateway/protocol/wake-params.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { validateWakeParams } from "./index.js";
+
+describe("validateWakeParams", () => {
+  it("accepts valid params without sessionKey", () => {
+    expect(validateWakeParams({ mode: "now", text: "hello" })).toBe(true);
+    expect(validateWakeParams({ mode: "next-heartbeat", text: "hi" })).toBe(true);
+  });
+
+  it("accepts valid params with sessionKey", () => {
+    expect(
+      validateWakeParams({ mode: "now", text: "hello", sessionKey: "discord:channel:123" }),
+    ).toBe(true);
+  });
+
+  it("rejects empty string sessionKey", () => {
+    expect(validateWakeParams({ mode: "now", text: "hello", sessionKey: "" })).toBe(false);
+  });
+
+  it("rejects missing text", () => {
+    expect(validateWakeParams({ mode: "now" })).toBe(false);
+  });
+
+  it("rejects empty text", () => {
+    expect(validateWakeParams({ mode: "now", text: "" })).toBe(false);
+  });
+
+  it("rejects invalid mode", () => {
+    expect(validateWakeParams({ mode: "invalid", text: "hello" })).toBe(false);
+  });
+
+  it("rejects non-string sessionKey", () => {
+    expect(validateWakeParams({ mode: "now", text: "hello", sessionKey: 123 })).toBe(false);
+  });
+
+  it("rejects additional properties", () => {
+    expect(validateWakeParams({ mode: "now", text: "hello", extra: true })).toBe(false);
+  });
+});

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -68,7 +68,11 @@ const HOOK_AUTH_FAILURE_LIMIT = 20;
 const HOOK_AUTH_FAILURE_WINDOW_MS = 60_000;
 
 type HookDispatchers = {
-  dispatchWakeHook: (value: { text: string; mode: "now" | "next-heartbeat" }) => void;
+  dispatchWakeHook: (value: {
+    text: string;
+    mode: "now" | "next-heartbeat";
+    sessionKey?: string;
+  }) => { ok: true } | { ok: false; error: string };
   dispatchAgentHook: (value: HookAgentDispatchPayload) => string;
 };
 
@@ -386,7 +390,32 @@ export function createHooksRequestHandler(
         sendJson(res, 400, { ok: false, error: normalized.error });
         return true;
       }
-      dispatchWakeHook(normalized.value);
+      // Validate session key policy when provided
+      if (normalized.value.sessionKey) {
+        const sessionKeyResult = resolveHookSessionKey({
+          hooksConfig,
+          source: "request",
+          sessionKey: normalized.value.sessionKey,
+        });
+        if (!sessionKeyResult.ok) {
+          sendJson(res, 400, { ok: false, error: sessionKeyResult.error });
+          return true;
+        }
+        const wakeResult = dispatchWakeHook({
+          ...normalized.value,
+          sessionKey: sessionKeyResult.value,
+        });
+        if (!wakeResult.ok) {
+          sendJson(res, 400, { ok: false, error: wakeResult.error });
+          return true;
+        }
+      } else {
+        const wakeResult = dispatchWakeHook(normalized.value);
+        if (!wakeResult.ok) {
+          sendJson(res, 400, { ok: false, error: wakeResult.error });
+          return true;
+        }
+      }
       sendJson(res, 200, { ok: true, mode: normalized.value.mode });
       return true;
     }
@@ -442,10 +471,35 @@ export function createHooksRequestHandler(
             return true;
           }
           if (mapped.action.kind === "wake") {
-            dispatchWakeHook({
-              text: mapped.action.text,
-              mode: mapped.action.mode,
-            });
+            if (mapped.action.sessionKey) {
+              const sessionKeyResult = resolveHookSessionKey({
+                hooksConfig,
+                source: "mapping",
+                sessionKey: mapped.action.sessionKey,
+              });
+              if (!sessionKeyResult.ok) {
+                sendJson(res, 400, { ok: false, error: sessionKeyResult.error });
+                return true;
+              }
+              const wakeResult = dispatchWakeHook({
+                text: mapped.action.text,
+                mode: mapped.action.mode,
+                sessionKey: sessionKeyResult.value,
+              });
+              if (!wakeResult.ok) {
+                sendJson(res, 400, { ok: false, error: wakeResult.error });
+                return true;
+              }
+            } else {
+              const wakeResult = dispatchWakeHook({
+                text: mapped.action.text,
+                mode: mapped.action.mode,
+              });
+              if (!wakeResult.ok) {
+                sendJson(res, 400, { ok: false, error: wakeResult.error });
+                return true;
+              }
+            }
             sendJson(res, 200, { ok: true, mode: mapped.action.mode });
             return true;
           }

--- a/src/gateway/server-methods/cron-wake-session-key.test.ts
+++ b/src/gateway/server-methods/cron-wake-session-key.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  canonicalizeWakeSessionKey: vi.fn((key: string) => `agent:main:${key}`),
+  enqueueSystemEvent: vi.fn(),
+  requestHeartbeatNow: vi.fn(),
+}));
+
+vi.mock("../session-utils.js", () => ({
+  canonicalizeWakeSessionKey: mocks.canonicalizeWakeSessionKey,
+}));
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: mocks.enqueueSystemEvent,
+}));
+
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: mocks.requestHeartbeatNow,
+}));
+
+// Dynamic import so mocks take effect
+const { cronHandlers } = await import("./cron.js");
+
+function callWake(params: Record<string, unknown>) {
+  const respond = vi.fn();
+  const cronWake = vi.fn(() => ({ ok: true }));
+  void cronHandlers.wake({
+    params,
+    respond: respond as never,
+    context: { cron: { wake: cronWake } } as never,
+    client: null,
+    req: { type: "req", id: "req-wake", method: "wake" },
+    isWebchatConnect: () => false,
+  });
+  return { respond, cronWake };
+}
+
+describe("cronHandlers.wake sessionKey support", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses fan-out path when no sessionKey is provided", () => {
+    const { respond, cronWake } = callWake({
+      mode: "now",
+      text: "hello",
+    });
+    expect(cronWake).toHaveBeenCalledWith({ mode: "now", text: "hello" });
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(mocks.requestHeartbeatNow).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { ok: true, mode: "now" }, undefined);
+  });
+
+  it("uses fan-out path when sessionKey is whitespace-only", () => {
+    const { respond, cronWake } = callWake({
+      mode: "now",
+      text: "hello",
+      sessionKey: "   ",
+    });
+    expect(cronWake).toHaveBeenCalledWith({ mode: "now", text: "hello" });
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { ok: true, mode: "now" }, undefined);
+  });
+
+  it("returns ok:false when fan-out path has whitespace-only text", () => {
+    const { respond, cronWake } = callWake({
+      mode: "now",
+      text: "   ",
+    });
+    expect(cronWake).not.toHaveBeenCalled();
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { ok: false, error: "text required" }, undefined);
+  });
+
+  it("dispatches to canonicalized sessionKey when provided (mode=now)", () => {
+    mocks.canonicalizeWakeSessionKey.mockReturnValue("agent:main:discord:channel:123");
+    const { respond, cronWake } = callWake({
+      mode: "now",
+      text: "wake up",
+      sessionKey: "discord:channel:123",
+    });
+    expect(cronWake).not.toHaveBeenCalled();
+    expect(mocks.canonicalizeWakeSessionKey).toHaveBeenCalledWith("discord:channel:123");
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("wake up", {
+      sessionKey: "agent:main:discord:channel:123",
+    });
+    expect(mocks.requestHeartbeatNow).toHaveBeenCalledWith({
+      reason: "wake",
+      sessionKey: "agent:main:discord:channel:123",
+    });
+    expect(respond).toHaveBeenCalledWith(true, { ok: true, mode: "now" }, undefined);
+  });
+
+  it("dispatches to canonicalized sessionKey without heartbeat for mode=next-heartbeat", () => {
+    mocks.canonicalizeWakeSessionKey.mockReturnValue("agent:main:hook:my-session");
+    const { respond, cronWake } = callWake({
+      mode: "next-heartbeat",
+      text: "deferred event",
+      sessionKey: "hook:my-session",
+    });
+    expect(cronWake).not.toHaveBeenCalled();
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("deferred event", {
+      sessionKey: "agent:main:hook:my-session",
+    });
+    expect(mocks.requestHeartbeatNow).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { ok: true, mode: "next-heartbeat" }, undefined);
+  });
+
+  it("returns ok:false when targeted path has whitespace-only text", () => {
+    const { respond, cronWake } = callWake({
+      mode: "now",
+      text: "   ",
+      sessionKey: "hook:my-session",
+    });
+    expect(cronWake).not.toHaveBeenCalled();
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(mocks.requestHeartbeatNow).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { ok: false, error: "text required" }, undefined);
+  });
+
+  it("trims sessionKey before canonicalizing", () => {
+    mocks.canonicalizeWakeSessionKey.mockReturnValue("agent:main:hook:padded");
+    callWake({
+      mode: "now",
+      text: "test",
+      sessionKey: "  hook:padded  ",
+    });
+    expect(mocks.canonicalizeWakeSessionKey).toHaveBeenCalledWith("hook:padded");
+  });
+
+  it("returns WS error frame when canonicalization throws", () => {
+    mocks.canonicalizeWakeSessionKey.mockImplementation(() => {
+      throw new Error(
+        'session key "agent:ops:test" targets agent "ops" but the default agent is "main". Cross-agent wake is not supported.',
+      );
+    });
+    const { respond, cronWake } = callWake({
+      mode: "now",
+      text: "test",
+      sessionKey: "agent:ops:test",
+    });
+    expect(cronWake).not.toHaveBeenCalled();
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(mocks.requestHeartbeatNow).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("Cross-agent wake is not supported"),
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -6,6 +6,8 @@ import {
 } from "../../cron/run-log.js";
 import type { CronJobCreate, CronJobPatch } from "../../cron/types.js";
 import { validateScheduleTimestamp } from "../../cron/validate-timestamp.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
 import {
   ErrorCodes,
   errorShape,
@@ -19,6 +21,7 @@ import {
   validateCronUpdateParams,
   validateWakeParams,
 } from "../protocol/index.js";
+import { canonicalizeWakeSessionKey } from "../session-utils.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 export const cronHandlers: GatewayRequestHandlers = {
@@ -37,9 +40,40 @@ export const cronHandlers: GatewayRequestHandlers = {
     const p = params as {
       mode: "now" | "next-heartbeat";
       text: string;
+      sessionKey?: string;
     };
-    const result = context.cron.wake({ mode: p.mode, text: p.text });
-    respond(true, result, undefined);
+    const rawSessionKey =
+      typeof p.sessionKey === "string" && p.sessionKey.trim() ? p.sessionKey.trim() : undefined;
+
+    if (rawSessionKey) {
+      // Targeted dispatch — canonicalize and send directly
+      const trimmedText = p.text.trim();
+      if (!trimmedText) {
+        respond(true, { ok: false, error: "text required" }, undefined);
+        return;
+      }
+      let sessionKey: string;
+      try {
+        sessionKey = canonicalizeWakeSessionKey(rawSessionKey);
+      } catch (err) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, (err as Error).message));
+        return;
+      }
+      enqueueSystemEvent(trimmedText, { sessionKey });
+      if (p.mode === "now") {
+        requestHeartbeatNow({ reason: "wake", sessionKey });
+      }
+      respond(true, { ok: true, mode: p.mode }, undefined);
+    } else {
+      // Fan-out: all agents
+      const trimmedText = p.text.trim();
+      if (!trimmedText) {
+        respond(true, { ok: false, error: "text required" }, undefined);
+        return;
+      }
+      const result = context.cron.wake({ mode: p.mode, text: trimmedText });
+      respond(true, { ok: result.ok, mode: p.mode }, undefined);
+    }
   },
   "cron.list": async ({ params, respond, context }) => {
     if (!validateCronListParams(params)) {

--- a/src/gateway/server-methods/system-event-session-key.test.ts
+++ b/src/gateway/server-methods/system-event-session-key.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SystemPresence } from "../../infra/system-presence.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveMainSessionKeyFromConfig: vi.fn(() => "agent:main:main"),
+  canonicalizeWakeSessionKey: vi.fn((key: string) => `agent:main:${key}`),
+  enqueueSystemEvent: vi.fn(),
+  isSystemEventContextChanged: vi.fn(() => false),
+  updateSystemPresence: vi.fn(() => ({
+    key: "device-1",
+    next: {},
+    changedKeys: [] as (keyof SystemPresence)[],
+  })),
+  broadcastPresenceSnapshot: vi.fn(),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  resolveMainSessionKeyFromConfig: mocks.resolveMainSessionKeyFromConfig,
+}));
+
+vi.mock("../session-utils.js", () => ({
+  canonicalizeWakeSessionKey: mocks.canonicalizeWakeSessionKey,
+}));
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: mocks.enqueueSystemEvent,
+  isSystemEventContextChanged: mocks.isSystemEventContextChanged,
+}));
+
+vi.mock("../../infra/system-presence.js", () => ({
+  updateSystemPresence: mocks.updateSystemPresence,
+  listSystemPresence: vi.fn(() => []),
+}));
+
+vi.mock("../server/presence-events.js", () => ({
+  broadcastPresenceSnapshot: mocks.broadcastPresenceSnapshot,
+}));
+
+vi.mock("../../infra/heartbeat-events.js", () => ({
+  getLastHeartbeatEvent: vi.fn(),
+}));
+
+vi.mock("../../infra/heartbeat-runner.js", () => ({
+  setHeartbeatsEnabled: vi.fn(),
+}));
+
+const { systemHandlers } = await import("./system.js");
+
+function callSystemEvent(params: Record<string, unknown>) {
+  const respond = vi.fn();
+  const context = {
+    broadcast: vi.fn(),
+    incrementPresenceVersion: vi.fn(),
+    getHealthVersion: vi.fn(),
+  };
+  void systemHandlers["system-event"]({
+    params,
+    respond: respond as never,
+    context: context as never,
+    client: null,
+    req: { type: "req", id: "req-sys-event", method: "system-event" },
+    isWebchatConnect: () => false,
+  });
+  return { respond };
+}
+
+describe("systemHandlers.system-event sessionKey support", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveMainSessionKeyFromConfig.mockReturnValue("agent:main:main");
+    mocks.updateSystemPresence.mockReturnValue({
+      key: "device-1",
+      next: {},
+      changedKeys: [],
+    });
+  });
+
+  it("uses mainSessionKey when no sessionKey is provided", () => {
+    const { respond } = callSystemEvent({ text: "hello world" });
+    expect(mocks.canonicalizeWakeSessionKey).not.toHaveBeenCalled();
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("hello world", {
+      sessionKey: "agent:main:main",
+    });
+    expect(respond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+  });
+
+  it("uses mainSessionKey when sessionKey is whitespace-only", () => {
+    callSystemEvent({ text: "hello", sessionKey: "   " });
+    expect(mocks.canonicalizeWakeSessionKey).not.toHaveBeenCalled();
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("hello", {
+      sessionKey: "agent:main:main",
+    });
+  });
+
+  it("canonicalizes and uses provided sessionKey for non-node-presence events", () => {
+    mocks.canonicalizeWakeSessionKey.mockReturnValue("agent:main:discord:channel:123");
+    const { respond } = callSystemEvent({
+      text: "deployment complete",
+      sessionKey: "discord:channel:123",
+    });
+    expect(mocks.canonicalizeWakeSessionKey).toHaveBeenCalledWith("discord:channel:123");
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("deployment complete", {
+      sessionKey: "agent:main:discord:channel:123",
+    });
+    expect(respond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+  });
+
+  it("trims sessionKey before canonicalizing", () => {
+    mocks.canonicalizeWakeSessionKey.mockReturnValue("agent:main:hook:padded");
+    callSystemEvent({
+      text: "test event",
+      sessionKey: "  hook:padded  ",
+    });
+    expect(mocks.canonicalizeWakeSessionKey).toHaveBeenCalledWith("hook:padded");
+  });
+
+  it("always uses mainSessionKey for node presence lines even when sessionKey is provided", () => {
+    mocks.updateSystemPresence.mockReturnValue({
+      key: "device-1",
+      next: { host: "my-host", ip: "1.2.3.4" },
+      changedKeys: ["host"],
+    });
+    callSystemEvent({
+      text: "Node: my-host (1.2.3.4)",
+      sessionKey: "discord:channel:123",
+    });
+    // Node presence should NOT canonicalize a custom sessionKey
+    expect(mocks.canonicalizeWakeSessionKey).not.toHaveBeenCalled();
+    // Should use mainSessionKey for node presence
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ sessionKey: "agent:main:main" }),
+    );
+  });
+
+  it("returns error when text is empty", () => {
+    const { respond } = callSystemEvent({ text: "", sessionKey: "hook:test" });
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(false, undefined, expect.any(Object));
+  });
+
+  it("returns error when text is missing", () => {
+    const { respond } = callSystemEvent({ sessionKey: "hook:test" });
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(false, undefined, expect.any(Object));
+  });
+
+  it("returns WS error frame when canonicalization throws", () => {
+    mocks.canonicalizeWakeSessionKey.mockImplementation(() => {
+      throw new Error(
+        'session key "agent:ops:test" targets agent "ops" but the default agent is "main". Cross-agent wake is not supported.',
+      );
+    });
+    const { respond } = callSystemEvent({
+      text: "test event",
+      sessionKey: "agent:ops:test",
+    });
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("Cross-agent wake is not supported"),
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/system.ts
+++ b/src/gateway/server-methods/system.ts
@@ -5,6 +5,7 @@ import { enqueueSystemEvent, isSystemEventContextChanged } from "../../infra/sys
 import { listSystemPresence, updateSystemPresence } from "../../infra/system-presence.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
 import { broadcastPresenceSnapshot } from "../server/presence-events.js";
+import { canonicalizeWakeSessionKey } from "../session-utils.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 export const systemHandlers: GatewayRequestHandlers = {
@@ -37,7 +38,11 @@ export const systemHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "text required"));
       return;
     }
-    const sessionKey = resolveMainSessionKeyFromConfig();
+    const mainSessionKey = resolveMainSessionKeyFromConfig();
+    const rawSessionKey =
+      typeof params.sessionKey === "string" && params.sessionKey.trim()
+        ? params.sessionKey.trim()
+        : undefined;
     const deviceId = typeof params.deviceId === "string" ? params.deviceId : undefined;
     const instanceId = typeof params.instanceId === "string" ? params.instanceId : undefined;
     const host = typeof params.host === "string" ? params.host : undefined;
@@ -97,7 +102,7 @@ export const systemHandlers: GatewayRequestHandlers = {
       const reasonChanged = changed.has("reason") && !ignoreReason;
       const hasChanges = hostChanged || ipChanged || versionChanged || modeChanged || reasonChanged;
       if (hasChanges) {
-        const contextChanged = isSystemEventContextChanged(sessionKey, presenceUpdate.key);
+        const contextChanged = isSystemEventContextChanged(mainSessionKey, presenceUpdate.key);
         const parts: string[] = [];
         if (contextChanged || hostChanged || ipChanged) {
           const hostLabel = next.host?.trim() || "Unknown";
@@ -116,13 +121,24 @@ export const systemHandlers: GatewayRequestHandlers = {
         const deltaText = parts.join(" · ");
         if (deltaText) {
           enqueueSystemEvent(deltaText, {
-            sessionKey,
+            sessionKey: mainSessionKey,
             contextKey: presenceUpdate.key,
           });
         }
       }
     } else {
-      enqueueSystemEvent(text, { sessionKey });
+      let targetSessionKey: string;
+      if (rawSessionKey) {
+        try {
+          targetSessionKey = canonicalizeWakeSessionKey(rawSessionKey);
+        } catch (err) {
+          respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, (err as Error).message));
+          return;
+        }
+      } else {
+        targetSessionKey = mainSessionKey;
+      }
+      enqueueSystemEvent(text, { sessionKey: targetSessionKey });
     }
     broadcastPresenceSnapshot({
       broadcast: context.broadcast,

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -351,6 +351,131 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("rejects wake request sessionKey unless hooks.allowRequestSessionKey is enabled", async () => {
+    testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
+    await withGatewayServer(async ({ port }) => {
+      const denied = await postHook(port, "/hooks/wake", {
+        text: "Ping",
+        sessionKey: "agent:main:dm:u99999",
+      });
+      expect(denied.status).toBe(400);
+      const deniedBody = (await denied.json()) as { error?: string };
+      expect(deniedBody.error).toContain("hooks.allowRequestSessionKey");
+    });
+  });
+
+  test("accepts wake request sessionKey when allowRequestSessionKey is enabled", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+    };
+    await withGatewayServer(async ({ port }) => {
+      const res = await postHook(port, "/hooks/wake", {
+        text: "Targeted ping",
+        sessionKey: "hook:my-session",
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean; mode?: string };
+      expect(body.ok).toBe(true);
+      // Event is enqueued under the canonicalized session key, not main
+      expect(peekSystemEvents(resolveMainKey()).length).toBe(0);
+    });
+  });
+
+  test("rejects wake sessionKey that does not match allowedSessionKeyPrefixes", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:"],
+    };
+    await withGatewayServer(async ({ port }) => {
+      const denied = await postHook(port, "/hooks/wake", {
+        text: "Bad prefix",
+        sessionKey: "agent:main:main",
+      });
+      expect(denied.status).toBe(400);
+      const deniedBody = (await denied.json()) as { error?: string };
+      expect(deniedBody.error).toContain("must start with");
+    });
+  });
+
+  test("wake without sessionKey bypasses policy check and succeeds", async () => {
+    testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
+    await withGatewayServer(async ({ port }) => {
+      const res = await postHook(port, "/hooks/wake", { text: "No key" });
+      expect(res.status).toBe(200);
+      await waitForSystemEvent();
+      drainSystemEvents(resolveMainKey());
+    });
+  });
+
+  test("rejects mapped wake sessionKey that violates allowedSessionKeyPrefixes", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowedSessionKeyPrefixes: ["hook:"],
+      mappings: [
+        {
+          match: { path: "mapped-wake-bad" },
+          action: "wake",
+          textTemplate: "Wake: {{payload.msg}}",
+          sessionKey: "agent:main:main",
+        },
+      ],
+    };
+    await withGatewayServer(async ({ port }) => {
+      const denied = await postHook(port, "/hooks/mapped-wake-bad", { msg: "hello" });
+      expect(denied.status).toBe(400);
+      const deniedBody = (await denied.json()) as { error?: string };
+      expect(deniedBody.error).toContain("must start with");
+    });
+  });
+
+  test("accepts mapped wake sessionKey that passes policy", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowedSessionKeyPrefixes: ["hook:"],
+      mappings: [
+        {
+          match: { path: "mapped-wake-ok" },
+          action: "wake",
+          textTemplate: "Wake: {{payload.msg}}",
+          sessionKey: "hook:wake:{{payload.id}}",
+        },
+      ],
+    };
+    await withGatewayServer(async ({ port }) => {
+      const res = await postHook(port, "/hooks/mapped-wake-ok", { msg: "hello", id: "99" });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean };
+      expect(body.ok).toBe(true);
+    });
+  });
+
+  test("mapped wake without sessionKey bypasses policy and succeeds", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowedSessionKeyPrefixes: ["hook:"],
+      mappings: [
+        {
+          match: { path: "mapped-wake-nokey" },
+          action: "wake",
+          textTemplate: "Wake: {{payload.msg}}",
+        },
+      ],
+    };
+    await withGatewayServer(async ({ port }) => {
+      const res = await postHook(port, "/hooks/mapped-wake-nokey", { msg: "hello" });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean };
+      expect(body.ok).toBe(true);
+    });
+  });
+
   test("throttles repeated hook auth failures and resets after success", async () => {
     testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
     await withGatewayServer(async ({ port }) => {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -13,6 +13,7 @@ import {
   type HooksConfigResolved,
 } from "../hooks.js";
 import { createHooksRequestHandler } from "../server-http.js";
+import { canonicalizeWakeSessionKey } from "../session-utils.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
@@ -25,12 +26,28 @@ export function createGatewayHooksRequestHandler(params: {
 }) {
   const { deps, getHooksConfig, bindHost, port, logHooks } = params;
 
-  const dispatchWakeHook = (value: { text: string; mode: "now" | "next-heartbeat" }) => {
-    const sessionKey = resolveMainSessionKeyFromConfig();
+  const dispatchWakeHook = (value: {
+    text: string;
+    mode: "now" | "next-heartbeat";
+    sessionKey?: string;
+  }): { ok: true } | { ok: false; error: string } => {
+    let sessionKey: string;
+    if (value.sessionKey) {
+      try {
+        sessionKey = canonicalizeWakeSessionKey(value.sessionKey);
+      } catch (err) {
+        const message = (err as Error).message;
+        logHooks.warn?.(`hook:wake canonicalization failed: ${message}`);
+        return { ok: false, error: message };
+      }
+    } else {
+      sessionKey = resolveMainSessionKeyFromConfig();
+    }
     enqueueSystemEvent(value.text, { sessionKey });
     if (value.mode === "now") {
-      requestHeartbeatNow({ reason: "hook:wake" });
+      requestHeartbeatNow({ reason: "hook:wake", sessionKey });
     }
+    return { ok: true };
   };
 
   const dispatchAgentHook = (value: HookAgentDispatchPayload) => {

--- a/src/gateway/session-utils.canonicalize-wake.test.ts
+++ b/src/gateway/session-utils.canonicalize-wake.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+let mockConfig: OpenClawConfig = {};
+
+const mockedLogger = vi.hoisted(() => ({
+  info: vi.fn<(msg: string) => void>(),
+  warn: vi.fn<(msg: string) => void>(),
+  error: vi.fn<(msg: string) => void>(),
+  debug: vi.fn<(msg: string, meta?: Record<string, unknown>) => void>(),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => mockedLogger,
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => mockConfig,
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: (cfg: OpenClawConfig) => {
+    const agents = cfg?.agents?.list ?? [];
+    const defaultAgent = agents.find((a) => a?.default) ?? agents[0];
+    return defaultAgent?.id ?? "main";
+  },
+  resolveAgentWorkspaceDir: () => "/tmp/workspace",
+}));
+
+const { canonicalizeWakeSessionKey } = await import("./session-utils.js");
+
+describe("canonicalizeWakeSessionKey", () => {
+  test("bare session key gets agent prefix", () => {
+    mockConfig = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    expect(canonicalizeWakeSessionKey("hook:my-session")).toBe("agent:main:hook:my-session");
+  });
+
+  test("channel key gets agent prefix", () => {
+    mockConfig = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    expect(canonicalizeWakeSessionKey("discord:channel:123")).toBe(
+      "agent:main:discord:channel:123",
+    );
+  });
+
+  test("'main' resolves to agent main session key", () => {
+    mockConfig = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    expect(canonicalizeWakeSessionKey("main")).toBe("agent:main:main");
+  });
+
+  test("scope=global resolves 'main' to 'global'", () => {
+    mockConfig = {
+      session: { scope: "global", mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    expect(canonicalizeWakeSessionKey("main")).toBe("global");
+  });
+
+  test("custom mainKey alias resolves correctly", () => {
+    mockConfig = {
+      session: { mainKey: "default" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    // "main" is an alias for the configured mainKey
+    expect(canonicalizeWakeSessionKey("main")).toBe("agent:main:default");
+  });
+
+  test("already fully qualified key passes through", () => {
+    mockConfig = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    expect(canonicalizeWakeSessionKey("agent:main:hook:x")).toBe("agent:main:hook:x");
+  });
+
+  test("key for different agent throws error", () => {
+    mockConfig = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    // Key references a different agent "ops" but default is "main"
+    expect(() => canonicalizeWakeSessionKey("agent:ops:hook:x")).toThrow(
+      /cross-agent wake is not supported/i,
+    );
+  });
+
+  test("non-default agent as default resolves correctly", () => {
+    mockConfig = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+    expect(canonicalizeWakeSessionKey("hook:my-session")).toBe("agent:ops:hook:my-session");
+  });
+
+  test("scope=global with non-main key still returns global", () => {
+    mockConfig = {
+      session: { scope: "global", mainKey: "work" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    // "main" is always a main alias, scope=global → "global"
+    expect(canonicalizeWakeSessionKey("main")).toBe("global");
+  });
+
+  test("scope=global with arbitrary channel key returns global (not agent-prefixed)", () => {
+    mockConfig = {
+      session: { scope: "global", mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    // Bug regression: without early-out, this returned "agent:main:discord:channel:123"
+    // but heartbeat runner returns "global" — causing silently lost events
+    expect(canonicalizeWakeSessionKey("discord:channel:123")).toBe("global");
+  });
+});

--- a/src/gateway/session-utils.canonicalize.test.ts
+++ b/src/gateway/session-utils.canonicalize.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn<() => Partial<OpenClawConfig>>(() => ({})),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+  CONFIG_PATH: "/tmp/test-config.yaml",
+}));
+
+const { canonicalizeWakeSessionKey } = await import("./session-utils.js");
+
+describe("canonicalizeWakeSessionKey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("prefixes a bare key with agent:{defaultAgentId}:", () => {
+    mocks.loadConfig.mockReturnValue({});
+    const result = canonicalizeWakeSessionKey("discord:channel:123");
+    expect(result).toBe("agent:main:discord:channel:123");
+  });
+
+  it("resolves 'main' alias to agent:{agentId}:main", () => {
+    mocks.loadConfig.mockReturnValue({});
+    const result = canonicalizeWakeSessionKey("main");
+    expect(result).toBe("agent:main:main");
+  });
+
+  it("resolves 'main' alias to configured mainKey", () => {
+    mocks.loadConfig.mockReturnValue({ session: { mainKey: "work" } });
+    const result = canonicalizeWakeSessionKey("main");
+    expect(result).toBe("agent:main:work");
+  });
+
+  it("canonicalizes agent:main:main alias to configured mainKey", () => {
+    mocks.loadConfig.mockReturnValue({ session: { mainKey: "work" } });
+    const result = canonicalizeWakeSessionKey("agent:main:main");
+    expect(result).toBe("agent:main:work");
+  });
+
+  it("preserves already-canonicalized key with matching agent", () => {
+    mocks.loadConfig.mockReturnValue({});
+    const result = canonicalizeWakeSessionKey("agent:main:hook:my-session");
+    expect(result).toBe("agent:main:hook:my-session");
+  });
+
+  it("throws when agent ID does not match", () => {
+    mocks.loadConfig.mockReturnValue({});
+    // Key with a different agent prefix than the default (main)
+    expect(() => canonicalizeWakeSessionKey("agent:other:discord:channel:1")).toThrow(
+      /cross-agent wake is not supported/i,
+    );
+  });
+
+  it("returns 'global' for global scope with main alias", () => {
+    mocks.loadConfig.mockReturnValue({ session: { scope: "global" } });
+    const result = canonicalizeWakeSessionKey("main");
+    expect(result).toBe("global");
+  });
+
+  it("uses configured default agent ID", () => {
+    mocks.loadConfig.mockReturnValue({
+      agents: { list: [{ id: "ops", default: true }] },
+    });
+    const result = canonicalizeWakeSessionKey("hook:test");
+    expect(result).toBe("agent:ops:hook:test");
+  });
+
+  it("throws when key targets different configured agent", () => {
+    mocks.loadConfig.mockReturnValue({
+      agents: { list: [{ id: "ops", default: true }] },
+    });
+    expect(() => canonicalizeWakeSessionKey("agent:other:hook:test")).toThrow(
+      /cross-agent wake is not supported/i,
+    );
+  });
+});

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -27,6 +27,8 @@ import {
   normalizeAgentId,
   normalizeMainKey,
   parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
+  toAgentStoreSessionKey,
 } from "../routing/session-key.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import {
@@ -66,6 +68,38 @@ export type {
   SessionsPreviewEntry,
   SessionsPreviewResult,
 } from "./session-utils.types.js";
+
+/**
+ * Canonicalize a raw session key for wake/system-event dispatch.
+ * Mirrors the two-step canonicalization that resolveHeartbeatSession
+ * performs, ensuring the key matches what the heartbeat runner will use.
+ */
+export function canonicalizeWakeSessionKey(rawKey: string): string {
+  const cfg = loadConfig();
+  if (cfg.session?.scope === "global") {
+    return "global";
+  }
+  const agentId = normalizeAgentId(resolveDefaultAgentId(cfg));
+  const candidate = toAgentStoreSessionKey({
+    agentId,
+    requestKey: rawKey,
+    mainKey: cfg.session?.mainKey,
+  });
+  const canonical = canonicalizeMainSessionAlias({
+    cfg,
+    agentId,
+    sessionKey: candidate,
+  });
+  if (canonical !== "global") {
+    const sessionAgentId = resolveAgentIdFromSessionKey(canonical);
+    if (normalizeAgentId(sessionAgentId) !== agentId) {
+      throw new Error(
+        `canonicalizeWakeSessionKey: session key "${rawKey}" targets agent "${sessionAgentId}" but the default agent is "${agentId}". Cross-agent wake is not supported.`,
+      );
+    }
+  }
+  return canonical;
+}
 
 const DERIVED_TITLE_MAX_LEN = 60;
 


### PR DESCRIPTION
Adds optional `--session-key` flag to `openclaw system event` CLI, `wake` WS method, `system-event` WS method, and `/hooks/wake` HTTP endpoint. Enables routing system events to specific agent sessions rather than always targeting main/all.

**Key implementation details:**
- `canonicalizeWakeSessionKey` helper mirrors heartbeat runner canonicalization (global scope, agent prefix, main-key aliases)
- Fan-out path preserved when no sessionKey is provided (goes through `context.cron.wake`)
- HTTP hook policy enforcement via `resolveHookSessionKey` for both direct and mapped wake actions
- Node presence events always route to mainSessionKey (not redirectable)
- 103+ tests across 9 test files

Supersedes #33482, #33765 (both closed due to stale base/diff issues).