### PR TITLE
fix(hooks): preserve session history for webhook-triggered isolated runs

### DIFF
--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -117,11 +117,21 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
     ]);
   });
 
-  it("forces a fresh session for isolated cron runs", async () => {
+  it("forces a fresh session for scheduler-owned isolated cron runs", async () => {
     await runSkillFilterCase();
     expect(resolveCronSessionMock).toHaveBeenCalledOnce();
     expect(resolveCronSessionMock.mock.calls[0]?.[0]).toMatchObject({
       forceNew: true,
+    });
+  });
+
+  it("reuses session history for webhook-triggered isolated runs with stable sessionKey", async () => {
+    await runSkillFilterCase({
+      sessionKey: "hook:webhook:ticket-42",
+    });
+    expect(resolveCronSessionMock).toHaveBeenCalledOnce();
+    expect(resolveCronSessionMock.mock.calls[0]?.[0]).toMatchObject({
+      forceNew: false,
     });
   });
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -241,8 +241,10 @@ export async function runCronIsolatedAgentTurn(params: {
     sessionKey: agentSessionKey,
     agentId,
     nowMs: now,
-    // Isolated cron runs must not carry prior turn context across executions.
-    forceNew: params.job.sessionTarget === "isolated",
+    // Keep scheduler-owned isolated jobs (cron:<jobId>) stateless across runs,
+    // but allow hook/webhook-triggered isolated jobs with stable session keys
+    // to resume conversation history.
+    forceNew: params.job.sessionTarget === "isolated" && baseSessionKey.startsWith("cron:"),
   });
   const runSessionId = cronSession.sessionEntry.sessionId;
   const runSessionKey = baseSessionKey.startsWith("cron:")


### PR DESCRIPTION
## Summary
- Fixes #29518 - Webhook-triggered agent runs always start a new session and lose conversation history
- For isolated runs with sessionKey starting with 'cron:', keep forceNew=true (stateless)
- For webhook/hook triggered runs with stable sessionKey, allow session reuse (forceNew=false)

## Changes
- `src/cron/isolated-agent/run.ts`: Change forceNew logic
- `src/cron/isolated-agent/run.skill-filter.test.ts`: Add regression test
- `CHANGELOG.md`: Add fix entry

## Testing
- `pnpm vitest run src/cron/isolated-agent/run.skill-filter.test.ts src/cron/isolated-agent/session.test.ts` - 24 tests passed

AI-assisted (Codex)