### PR TITLE
fix(slack): always pass threadId to readSlackMessages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/message tool read action: always pass `threadId` parameter to `readSlackMessages` when provided, removing the conditional `includeReadThreadId` flag for consistent behavior across all message actions. (#34395)
 - Gateway/HTTP tools invoke media compatibility: preserve raw media payload access for direct `/tools/invoke` clients by allowing media `nodes` invoke commands only in HTTP tool context, while keeping agent-context media invoke blocking to prevent base64 prompt bloat. (#34365) Thanks @obviyus.
 - Agents/Nodes media outputs: add dedicated `photos_latest` action handling, block media-returning `nodes invoke` commands, keep metadata-only `camera.list` invoke allowed, and normalize empty `photos_latest` results to a consistent response shape to prevent base64 context bloat. (#34332) Thanks @obviyus.
 - TUI/session-key canonicalization: normalize `openclaw tui --session` values to lowercase so uppercase session names no longer drop real-time streaming updates due to gateway/TUI key mismatches. (#33866, #34013) thanks @lynnzc.

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -276,7 +276,6 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
       await handleSlackMessageAction({
         providerId: meta.id,
         ctx,
-        includeReadThreadId: true,
         invoke: async (action, cfg, toolContext) =>
           await getSlackRuntime().channel.slack.handleSlackAction(action, cfg, toolContext),
       }),

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -13,7 +13,6 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
         providerId,
         ctx,
         normalizeChannelId: resolveSlackChannelId,
-        includeReadThreadId: true,
         invoke: async (action, cfg, toolContext) =>
           await handleSlackAction(action, cfg, toolContext as SlackActionContext | undefined),
       });

--- a/src/plugin-sdk/slack-message-actions.test.ts
+++ b/src/plugin-sdk/slack-message-actions.test.ts
@@ -9,6 +9,34 @@ function createInvokeSpy() {
 }
 
 describe("handleSlackMessageAction", () => {
+  it("maps read action with threadId to readMessages", async () => {
+    const invoke = createInvokeSpy();
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "read",
+        cfg: {},
+        params: {
+          channelId: "C123",
+          threadId: "123.456",
+          limit: 10,
+        },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    expect(invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "readMessages",
+        channelId: "C123",
+        threadId: "123.456",
+        limit: 10,
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("maps download-file to the internal downloadFile action", async () => {
     const invoke = createInvokeSpy();
 

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -18,9 +18,8 @@ export async function handleSlackMessageAction(params: {
   ctx: ChannelMessageActionContext;
   invoke: SlackActionInvoke;
   normalizeChannelId?: (channelId: string) => string;
-  includeReadThreadId?: boolean;
 }): Promise<AgentToolResult<unknown>> {
-  const { providerId, ctx, invoke, normalizeChannelId, includeReadThreadId = false } = params;
+  const { providerId, ctx, invoke, normalizeChannelId } = params;
   const { action, cfg, params: actionParams } = ctx;
   const accountId = ctx.accountId ?? undefined;
   const resolveChannelId = () => {
@@ -99,18 +98,19 @@ export async function handleSlackMessageAction(params: {
 
   if (action === "read") {
     const limit = readNumberParam(actionParams, "limit", { integer: true });
-    const readAction: Record<string, unknown> = {
-      action: "readMessages",
-      channelId: resolveChannelId(),
-      limit,
-      before: readStringParam(actionParams, "before"),
-      after: readStringParam(actionParams, "after"),
-      accountId,
-    };
-    if (includeReadThreadId) {
-      readAction.threadId = readStringParam(actionParams, "threadId");
-    }
-    return await invoke(readAction, cfg);
+    const threadId = readStringParam(actionParams, "threadId");
+    return await invoke(
+      {
+        action: "readMessages",
+        channelId: resolveChannelId(),
+        limit,
+        before: readStringParam(actionParams, "before"),
+        after: readStringParam(actionParams, "after"),
+        threadId: threadId ?? undefined,
+        accountId,
+      },
+      cfg,
+    );
   }
 
   if (action === "edit") {


### PR DESCRIPTION
## Summary

Removes the conditional `includeReadThreadId` parameter from `handleSlackMessageAction` and always passes `threadId` to `readSlackMessages` when provided, making the behavior consistent with other message actions like `download-file`.

## Problem

The `message` tool's `read` action had a conditional `includeReadThreadId` parameter that defaulted to `false`. While both the core plugin and extension explicitly set it to `true`, this design was:
- Confusing and error-prone
- Inconsistent with other actions (e.g., `download-file` always passes `threadId`)
- Could cause issues if someone forgot to set the flag

## Changes

- Removed `includeReadThreadId` parameter from `handleSlackMessageAction`
- Always pass `threadId` in the `read` action when provided in params
- Updated callers in core plugin and extension to remove the flag
- Added test to verify `threadId` is passed correctly for `read` action

## Test Plan

- Added new test case: `maps read action with threadId to readMessages`
- Verified existing tests still pass
- Ran format and lint checks

## Effect on User Experience

Users can now reliably use `threadId` with the Slack message tool's `read` action without worrying about configuration flags. The behavior is now consistent across all message actions.

Fixes #34395