### PR TITLE
daemon/systemd: treat user-bus-unavailable is-enabled as disabled

### DIFF
--- a/changelog/fragments/systemd-is-enabled-user-bus-unavailable.md
+++ b/changelog/fragments/systemd-is-enabled-user-bus-unavailable.md
@@ -1,0 +1,1 @@
+- daemon/systemd: treat `systemctl --user is-enabled` "Failed to connect to bus" as unavailable (returns disabled) instead of throwing, improving Linux service checks in non-interactive shells.

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,15 +79,25 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
-  it("throws when systemctl is-enabled fails for non-state errors", async () => {
+  it("returns false when systemctl is-enabled fails because user bus is unavailable", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
       const err = new Error("Failed to connect to bus") as Error & { code?: number };
       err.code = 1;
       cb(err, "", "Failed to connect to bus");
     });
+    await expect(isSystemdServiceEnabled({ env: {} })).resolves.toBe(false);
+  });
+
+  it("throws when systemctl is-enabled fails for non-state errors", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error("Permission denied") as Error & { code?: number };
+      err.code = 1;
+      cb(err, "", "Permission denied");
+    });
     await expect(isSystemdServiceEnabled({ env: {} })).rejects.toThrow(
-      "systemctl is-enabled unavailable: Failed to connect to bus",
+      "systemctl is-enabled unavailable: Permission denied",
     );
   });
 });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -175,28 +175,30 @@ function isSystemdUnitNotEnabled(detail: string): boolean {
   );
 }
 
+function isSystemdUserUnavailable(detail: string): boolean {
+  if (!detail) {
+    return false;
+  }
+  const normalized = detail.toLowerCase();
+  return (
+    normalized.includes("failed to connect") ||
+    normalized.includes("not been booted with systemd") ||
+    normalized.includes("system has not been booted") ||
+    normalized.includes("no such file or directory") ||
+    normalized.includes("not supported")
+  );
+}
+
 export async function isSystemdUserServiceAvailable(): Promise<boolean> {
   const res = await execSystemctl(["--user", "status"]);
   if (res.code === 0) {
     return true;
   }
-  const detail = `${res.stderr} ${res.stdout}`.toLowerCase();
+  const detail = readSystemctlDetail(res);
   if (!detail) {
     return false;
   }
-  if (detail.includes("not found")) {
-    return false;
-  }
-  if (detail.includes("failed to connect")) {
-    return false;
-  }
-  if (detail.includes("not been booted")) {
-    return false;
-  }
-  if (detail.includes("no such file or directory")) {
-    return false;
-  }
-  if (detail.includes("not supported")) {
+  if (isSystemctlMissing(detail) || isSystemdUserUnavailable(detail)) {
     return false;
   }
   return false;
@@ -352,7 +354,11 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
     return true;
   }
   const detail = readSystemctlDetail(res);
-  if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
+  if (
+    isSystemctlMissing(detail) ||
+    isSystemdUnitNotEnabled(detail) ||
+    isSystemdUserUnavailable(detail)
+  ) {
     return false;
   }
   throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());


### PR DESCRIPTION
## Summary
Fix Linux service checks when `systemctl --user is-enabled` runs in environments without a user bus.

## Problem
Issue #34464 reports install/start flows failing with:

`systemctl is-enabled unavailable: Failed to connect to bus`

On some shells (especially non-interactive / no user session bus), this should be treated as "service unavailable/disabled", not a hard failure.

## Changes
- `src/daemon/systemd.ts`
  - add `isSystemdUserUnavailable(...)`
  - make `isSystemdServiceEnabled(...)` return `false` for user-bus-unavailable states
  - reuse the same helper in `isSystemdUserServiceAvailable(...)`
- `src/daemon/systemd.test.ts`
  - update expectation for `Failed to connect to bus` to resolve `false`
  - keep hard failure behavior for true non-state errors (e.g. `Permission denied`)
- changelog fragment added.

## Validation
- `corepack pnpm exec vitest run src/daemon/systemd.test.ts --reporter=dot`
- Result: 20 tests passed.
