### PR TITLE
fix(slack): auto-thread message tool replies in DM sessions

### DIFF
--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -6,10 +6,55 @@ import type { OpenClawConfig } from "../../config/config.js";
 import {
   hydrateAttachmentParamsForAction,
   normalizeSandboxMediaParams,
+  resolveSlackAutoThreadId,
 } from "./message-action-params.js";
 
 const cfg = {} as OpenClawConfig;
 const maybeIt = process.platform === "win32" ? it.skip : it;
+
+describe("resolveSlackAutoThreadId", () => {
+  const baseContext = {
+    currentThreadTs: "1234567890.000100",
+    replyToMode: "all" as const,
+  };
+
+  it("returns thread ts for channel target matching currentChannelId", () => {
+    const result = resolveSlackAutoThreadId({
+      to: "channel:C123456",
+      toolContext: { ...baseContext, currentChannelId: "C123456" },
+    });
+    expect(result).toBe("1234567890.000100");
+  });
+
+  it("returns thread ts for user: target in DM session (matching user id)", () => {
+    const result = resolveSlackAutoThreadId({
+      to: "user:U123456",
+      toolContext: { ...baseContext, currentChannelId: "U123456" },
+    });
+    expect(result).toBe("1234567890.000100");
+  });
+
+  it("returns undefined for user: target when user id does not match currentChannelId", () => {
+    const result = resolveSlackAutoThreadId({
+      to: "user:UOTHER",
+      toolContext: { ...baseContext, currentChannelId: "U123456" },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when toolContext has no currentChannelId", () => {
+    const result = resolveSlackAutoThreadId({
+      to: "user:U123456",
+      toolContext: { ...baseContext, currentChannelId: undefined },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when toolContext is missing", () => {
+    const result = resolveSlackAutoThreadId({ to: "user:U123456" });
+    expect(result).toBeUndefined();
+  });
+});
 
 describe("message action sandbox media hydration", () => {
   maybeIt("rejects symlink retarget escapes after sandbox media normalization", async () => {

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -30,7 +30,7 @@ export function resolveSlackAutoThreadId(params: {
     return undefined;
   }
   const parsedTarget = parseSlackTarget(params.to, { defaultKind: "channel" });
-  if (!parsedTarget || parsedTarget.kind !== "channel") {
+  if (!parsedTarget || (parsedTarget.kind !== "channel" && parsedTarget.kind !== "user")) {
     return undefined;
   }
   if (parsedTarget.id.toLowerCase() !== context.currentChannelId.toLowerCase()) {

--- a/src/slack/threading-tool-context.test.ts
+++ b/src/slack/threading-tool-context.test.ts
@@ -144,4 +144,31 @@ describe("buildSlackThreadingToolContext", () => {
     });
     expect(result.replyToMode).toBe("off");
   });
+
+  it("sets currentChannelId from channel: prefix target", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: emptyCfg,
+      accountId: null,
+      context: { To: "channel:C123456", ChatType: "channel" },
+    });
+    expect(result.currentChannelId).toBe("C123456");
+  });
+
+  it("sets currentChannelId from user: prefix target for DM sessions", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: emptyCfg,
+      accountId: null,
+      context: { To: "user:U123456", ChatType: "direct" },
+    });
+    expect(result.currentChannelId).toBe("U123456");
+  });
+
+  it("leaves currentChannelId undefined when To has no known prefix", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: emptyCfg,
+      accountId: null,
+      context: { To: "someOtherTarget", ChatType: "direct" },
+    });
+    expect(result.currentChannelId).toBeUndefined();
+  });
 });

--- a/src/slack/threading-tool-context.ts
+++ b/src/slack/threading-tool-context.ts
@@ -22,7 +22,9 @@ export function buildSlackThreadingToolContext(params: {
   return {
     currentChannelId: params.context.To?.startsWith("channel:")
       ? params.context.To.slice("channel:".length)
-      : undefined,
+      : params.context.To?.startsWith("user:")
+        ? params.context.To.slice("user:".length)
+        : undefined,
     currentThreadTs: threadId != null ? String(threadId) : undefined,
     replyToMode: effectiveReplyToMode,
     hasRepliedRef: params.hasRepliedRef,


### PR DESCRIPTION
## Problem

When an agent uses the `message` tool to send a file or formatted response from a Slack DM session, the reply lands at the **top level** of the DM instead of in the active thread. Regular auto-replies (without the message tool) work correctly.

## Root Cause

Two co-located bugs:

### 1. `buildSlackThreadingToolContext` — `src/slack/threading-tool-context.ts`

`currentChannelId` is only populated for `channel:` prefixed targets. DM sessions use `user:UXXXXX` format, so `currentChannelId` is always `undefined`:

```typescript
// Before
currentChannelId: params.context.To?.startsWith("channel:")
  ? params.context.To.slice("channel:".length)
  : undefined,  // <-- DM targets fall through here
```

This causes `resolveSlackAutoThreadId` to bail out immediately on its `!context.currentChannelId` guard.

### 2. `resolveSlackAutoThreadId` — `src/infra/outbound/message-action-params.ts`

User targets parse to `{ kind: "user", id: "UXXXXX" }` via `parseSlackTarget`, but the function only accepts `kind === "channel"`:

```typescript
// Before
if (!parsedTarget || parsedTarget.kind !== "channel") {
  return undefined;  // <-- rejects user: targets
}
```

## Fix

1. **`threading-tool-context.ts`**: extract the user ID from `user:` prefixed targets when populating `currentChannelId`
2. **`message-action-params.ts`**: accept `parsedTarget.kind === "user"` alongside `"channel"` so DM targets reach the ID-equality check

## Tests

Added 3 tests for `buildSlackThreadingToolContext` (channel target, user/DM target, unrecognized prefix) and 5 tests for `resolveSlackAutoThreadId` (channel match, DM match, DM mismatch, missing channel ID, missing context) — all 18 tests pass.

Reported with a production-verified patch in the issue.

Fixes #28742