### PR TITLE
fix(ui): add confirmation dialog for New Session button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/mobile UX: add confirmation dialog to "New Session" button to prevent accidental session resets on mobile devices. (#34407)
 - Gateway/HTTP tools invoke media compatibility: preserve raw media payload access for direct `/tools/invoke` clients by allowing media `nodes` invoke commands only in HTTP tool context, while keeping agent-context media invoke blocking to prevent base64 prompt bloat. (#34365) Thanks @obviyus.
 - Agents/Nodes media outputs: add dedicated `photos_latest` action handling, block media-returning `nodes invoke` commands, keep metadata-only `camera.list` invoke allowed, and normalize empty `photos_latest` results to a consistent response shape to prevent base64 context bloat. (#34332) Thanks @obviyus.
 - TUI/session-key canonicalization: normalize `openclaw tui --session` values to lowercase so uppercase session names no longer drop real-time streaming updates due to gateway/TUI key mismatches. (#33866, #34013) thanks @lynnzc.

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -206,6 +206,7 @@ describe("chat view", () => {
   it("shows a new session button when aborting is unavailable", () => {
     const container = document.createElement("div");
     const onNewSession = vi.fn();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     render(
       renderChat(
         createProps({
@@ -221,7 +222,36 @@ describe("chat view", () => {
     );
     expect(newSessionButton).not.toBeUndefined();
     newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(confirmSpy).toHaveBeenCalledWith(
+      "Start a new session? This will reset the current conversation.",
+    );
     expect(onNewSession).toHaveBeenCalledTimes(1);
     expect(container.textContent).not.toContain("Stop");
+    confirmSpy.mockRestore();
+  });
+
+  it("does not start new session when confirmation is cancelled", () => {
+    const container = document.createElement("div");
+    const onNewSession = vi.fn();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(
+      renderChat(
+        createProps({
+          canAbort: false,
+          onNewSession,
+        }),
+      ),
+      container,
+    );
+
+    const newSessionButton = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.textContent?.trim() === "New session",
+    );
+    expect(newSessionButton).not.toBeUndefined();
+    newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(onNewSession).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
   });
 });

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -461,7 +461,17 @@ export function renderChat(props: ChatProps) {
             <button
               class="btn"
               ?disabled=${!props.connected || (!canAbort && props.sending)}
-              @click=${canAbort ? props.onAbort : props.onNewSession}
+              @click=${
+                canAbort
+                  ? props.onAbort
+                  : () => {
+                      if (
+                        confirm("Start a new session? This will reset the current conversation.")
+                      ) {
+                        props.onNewSession();
+                      }
+                    }
+              }
             >
               ${canAbort ? "Stop" : "New session"}
             </button>


### PR DESCRIPTION
## Summary

Adds a confirmation dialog to the "New Session" button in the Control UI to prevent accidental session resets on mobile devices.

## Problem

On mobile devices, the "New Session" button in the Control UI is positioned next to the "Send" button and lacks any confirmation mechanism. This makes it easy to accidentally tap when trying to send messages or interact with nearby UI elements, resulting in:
- Interrupted workflows
- Lost session context
- Poor user experience

## Changes

- Added a confirmation dialog ("Start a new session? This will reset the current conversation.") before executing the new session action
- Updated existing test to verify confirmation dialog is shown
- Added new test to verify session is not reset when confirmation is cancelled

## Test Plan

1. Unit tests pass (9/9 tests in chat.test.ts)
2. Lint and format checks pass
3. Manual verification: The "New Session" button now shows a confirmation dialog before resetting the session

## Effect on User Experience

**Before:** Tapping "New Session" immediately resets the session without warning
**After:** Tapping "New Session" shows a confirmation dialog; session only resets if user confirms

This change provides protection against accidental taps while maintaining the same functionality for intentional use.

Fixes #34407