### PR TITLE
fix(heartbeat): enforce minimum cooldown between non-interval heartbeat runs

### DIFF
--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -282,4 +282,31 @@ describe("startHeartbeatRunner", () => {
 
     runner.stop();
   });
+
+  it("enforces minimum cooldown between non-interval heartbeat runs (#33057)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startDefaultRunner(runSpy);
+
+    // First exec-event wake fires normally
+    requestHeartbeatNow({ reason: "exec-event", coalesceMs: 0 });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    // Second exec-event 10s later should be skipped (cooldown not elapsed)
+    vi.advanceTimersByTime(10_000);
+    requestHeartbeatNow({ reason: "exec-event", coalesceMs: 0 });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    // After 60s total, cooldown has elapsed — next wake should fire
+    vi.advanceTimersByTime(50_000);
+    requestHeartbeatNow({ reason: "exec-event", coalesceMs: 0 });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runSpy).toHaveBeenCalledTimes(2);
+
+    runner.stop();
+  });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1166,7 +1166,14 @@ export function startHeartbeatRunner(opts: {
           sessionKey: requestedSessionKey,
           deps: { runtime: state.runtime },
         });
-        if (res.status !== "skipped" || res.reason !== "disabled") {
+        // Only advance the schedule when the heartbeat actually ran or was
+        // skipped for a definitive reason.  requests-in-flight means the main
+        // lane was busy — advancing lastRunMs here would block the retry from
+        // heartbeat-wake due to the cooldown check (#33057).
+        if (
+          res.status !== "skipped" ||
+          (res.reason !== "disabled" && res.reason !== "requests-in-flight")
+        ) {
           advanceAgentSchedule(targetAgent, now);
         }
         scheduleNext();
@@ -1182,6 +1189,7 @@ export function startHeartbeatRunner(opts: {
       }
     }
 
+    let allCooldown = !isInterval;
     for (const agent of state.agents.values()) {
       if (isInterval && now < agent.nextDueMs) {
         continue;
@@ -1193,6 +1201,7 @@ export function startHeartbeatRunner(opts: {
       ) {
         continue;
       }
+      allCooldown = false;
 
       let res: HeartbeatRunResult;
       try {
@@ -1230,7 +1239,10 @@ export function startHeartbeatRunner(opts: {
     if (ran) {
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
-    return { status: "skipped", reason: isInterval ? "not-due" : "disabled" };
+    return {
+      status: "skipped",
+      reason: isInterval ? "not-due" : allCooldown ? "cooldown" : "disabled",
+    };
   };
 
   const wakeHandler: HeartbeatWakeHandler = async (params) =>

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1135,12 +1135,27 @@ export function startHeartbeatRunner(opts: {
     const now = startedAt;
     let ran = false;
 
+    // Minimum cooldown between heartbeat runs for the same agent, even for
+    // non-interval reasons (exec-event, cron, wake). Without this, a burst of
+    // sub-agent completions or cron events can trigger dozens of heartbeat runs
+    // in seconds, inflating context and burning tokens. See #33057.
+    const MIN_HEARTBEAT_COOLDOWN_MS = 60_000;
+
     if (requestedSessionKey || requestedAgentId) {
       const targetAgentId = requestedAgentId ?? resolveAgentIdFromSessionKey(requestedSessionKey);
       const targetAgent = state.agents.get(targetAgentId);
       if (!targetAgent) {
         scheduleNext();
         return { status: "skipped", reason: "disabled" };
+      }
+      // Apply minimum cooldown for non-interval targeted wakes too (#33057).
+      if (
+        !isInterval &&
+        typeof targetAgent.lastRunMs === "number" &&
+        now - targetAgent.lastRunMs < MIN_HEARTBEAT_COOLDOWN_MS
+      ) {
+        scheduleNext();
+        return { status: "skipped", reason: "cooldown" };
       }
       try {
         const res = await runOnce({
@@ -1169,6 +1184,13 @@ export function startHeartbeatRunner(opts: {
 
     for (const agent of state.agents.values()) {
       if (isInterval && now < agent.nextDueMs) {
+        continue;
+      }
+      if (
+        !isInterval &&
+        typeof agent.lastRunMs === "number" &&
+        now - agent.lastRunMs < MIN_HEARTBEAT_COOLDOWN_MS
+      ) {
         continue;
       }
 


### PR DESCRIPTION
## What
Adds a 60-second minimum cooldown (`MIN_HEARTBEAT_COOLDOWN_MS`) for non-interval heartbeat wakes to prevent rapid-fire heartbeat polling.

## Why
Fixes #33057 — When multiple exec-events or cron-events fire in quick succession, each one can trigger a heartbeat wake, causing dozens of heartbeat polls within seconds. This wastes tokens and can overwhelm rate limits.

## How
- Added `MIN_HEARTBEAT_COOLDOWN_MS = 60_000` constant
- Before processing a non-interval heartbeat wake (both targeted and fan-out paths), check if the last heartbeat run was less than 60s ago; if so, skip
- Uses existing `lastHeartbeatRun` timestamp tracking

## Testing
- [x] `pnpm build && pnpm check` pass
- [x] All 100 heartbeat tests pass (`pnpm test -- heartbeat`)
- [x] AI-assisted (Claude, fully tested)
