### PR TITLE
fix(heartbeat): honor explicit DM targets over directPolicy block

### DIFF
--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -346,6 +346,22 @@ describe("resolveSessionDeliveryTarget", () => {
     expect(resolved.threadId).toBeUndefined();
   });
 
+  it("keeps explicit heartbeat Slack DM targets when directPolicy is block", () => {
+    const cfg: OpenClawConfig = {};
+    const resolved = resolveHeartbeatDeliveryTarget({
+      cfg,
+      heartbeat: {
+        target: "slack",
+        to: "user:U123",
+        directPolicy: "block",
+      },
+    });
+
+    expect(resolved.channel).toBe("slack");
+    expect(resolved.to).toBe("user:U123");
+    expect(resolved.reason).toBeUndefined();
+  });
+
   it("allows heartbeat delivery to Discord DMs by default", () => {
     const cfg: OpenClawConfig = {};
     const resolved = resolveHeartbeatDeliveryTarget({
@@ -390,6 +406,22 @@ describe("resolveSessionDeliveryTarget", () => {
 
     expect(resolved.channel).toBe("none");
     expect(resolved.reason).toBe("dm-blocked");
+  });
+
+  it("keeps explicit heartbeat Telegram direct targets when directPolicy is block", () => {
+    const cfg: OpenClawConfig = {};
+    const resolved = resolveHeartbeatDeliveryTarget({
+      cfg,
+      heartbeat: {
+        target: "telegram",
+        to: "5232990709",
+        directPolicy: "block",
+      },
+    });
+
+    expect(resolved.channel).toBe("telegram");
+    expect(resolved.to).toBe("5232990709");
+    expect(resolved.reason).toBeUndefined();
   });
 
   it("keeps heartbeat delivery to Telegram groups", () => {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -325,12 +325,18 @@ export function resolveHeartbeatDeliveryTarget(params: {
 
   const sessionChatTypeHint =
     target === "last" && !heartbeat?.to ? normalizeChatType(entry?.chatType) : undefined;
+  const hasExplicitHeartbeatTo =
+    typeof heartbeat?.to === "string" && heartbeat.to.trim().length > 0;
   const deliveryChatType = resolveHeartbeatDeliveryChatType({
     channel: resolvedTarget.channel,
     to: resolved.to,
     sessionChatType: sessionChatTypeHint,
   });
-  if (deliveryChatType === "direct" && heartbeat?.directPolicy === "block") {
+  if (
+    deliveryChatType === "direct" &&
+    heartbeat?.directPolicy === "block" &&
+    !hasExplicitHeartbeatTo
+  ) {
     return buildNoHeartbeatDeliveryTarget({
       reason: "dm-blocked",
       accountId: effectiveAccountId,


### PR DESCRIPTION
## Summary
- Fixes #26338 - dm-blocked incorrectly applies to explicit DM targets
- Skip directPolicy block when heartbeat.to is explicitly set

## Changes
- `src/infra/outbound/targets.ts`: Add hasExplicitHeartbeatTo check
- `src/infra/outbound/targets.test.ts`: Add regression tests
- `CHANGELOG.md`: Add fix entry

## Testing
- `pnpm test -- src/infra/outbound/targets.test.ts` - 49 tests passed

AI-assisted (Codex)