### PR TITLE
fix(slack): fall back to inbound channel for react/reactions

### DIFF
--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -97,6 +97,7 @@ type SlackActionInput = Parameters<
 async function runSlackAction(
   action: SlackActionInput["action"],
   params: SlackActionInput["params"],
+  options?: { toolContext?: SlackActionInput["toolContext"] },
 ) {
   const { cfg, actions } = slackHarness();
   await actions.handleAction?.({
@@ -104,6 +105,7 @@ async function runSlackAction(
     action,
     cfg,
     params,
+    toolContext: options?.toolContext,
   });
   return { cfg, actions };
 }
@@ -1093,5 +1095,20 @@ describe("slack actions adapter", () => {
       }),
     ).rejects.toThrow(/edit requires message or blocks/i);
     expect(handleSlackAction).not.toHaveBeenCalled();
+  });
+
+  it("falls back to toolContext.currentChannelId for react when no explicit target", async () => {
+    await runSlackAction(
+      "react",
+      { messageId: "171234.567", emoji: "eyes" },
+      { toolContext: { currentChannelId: "D8SRXRDNF" } },
+    );
+
+    expectFirstSlackAction({
+      action: "react",
+      channelId: "D8SRXRDNF",
+      messageId: "171234.567",
+      emoji: "eyes",
+    });
   });
 });

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -26,7 +26,13 @@ export async function handleSlackMessageAction(params: {
   const resolveChannelId = () => {
     const channelId =
       readStringParam(actionParams, "channelId") ??
-      readStringParam(actionParams, "to", { required: true });
+      readStringParam(actionParams, "to") ??
+      ctx.toolContext?.currentChannelId;
+    if (!channelId) {
+      throw new Error(
+        "Slack action requires a target channel (pass channelId, to, or react from an active Slack conversation)",
+      );
+    }
     return normalizeChannelId ? normalizeChannelId(channelId) : channelId;
   };
 


### PR DESCRIPTION
When the agent calls react without an explicit `channelId` or `to` param, resolve the channel from `toolContext.currentChannelId` (the inbound Slack conversation). This fixes DM reactions failing with *'Action react requires a target'* because the agent only passes `messageId` + `emoji`.

**Changes:**
- `src/plugin-sdk/slack-message-actions.ts`: `resolveChannelId()` now falls back to `ctx.toolContext?.currentChannelId` before throwing, matching how other channels (Telegram, Discord) resolve the current context.
- Added test: Slack react falls back to `toolContext.currentChannelId` when no explicit target is provided.

Closes #34414