### PR TITLE
fix(agents): allow workspace symlinks between sibling .openclaw directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/workspace symlinks: allow bootstrap file symlinks between sibling workspace directories under `.openclaw/` so shared AGENTS.md/TOOLS.md/SOUL.md files can be symlinked across workspace profiles without triggering boundary escape errors. (#34404)
 - Gateway/HTTP tools invoke media compatibility: preserve raw media payload access for direct `/tools/invoke` clients by allowing media `nodes` invoke commands only in HTTP tool context, while keeping agent-context media invoke blocking to prevent base64 prompt bloat. (#34365) Thanks @obviyus.
 - Agents/Nodes media outputs: add dedicated `photos_latest` action handling, block media-returning `nodes invoke` commands, keep metadata-only `camera.list` invoke allowed, and normalize empty `photos_latest` results to a consistent response shape to prevent base64 context bloat. (#34332) Thanks @obviyus.
 - TUI/session-key canonicalization: normalize `openclaw tui --session` values to lowercase so uppercase session names no longer drop real-time streaming updates due to gateway/TUI key mismatches. (#33866, #34013) thanks @lynnzc.

--- a/src/infra/boundary-path-workspace-symlink.test.ts
+++ b/src/infra/boundary-path-workspace-symlink.test.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveBoundaryPath } from "./boundary-path.js";
+
+async function withTempRoot<T>(prefix: string, run: (root: string) => Promise<T>): Promise<T> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  try {
+    return await run(root);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+describe("resolveBoundaryPath - workspace symlinks", () => {
+  it("allows symlinks to sibling workspace under common .openclaw parent", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withTempRoot("openclaw-workspace-symlink-", async (base) => {
+      // Simulate ~/.openclaw/ structure
+      const openclawDir = path.join(base, ".openclaw");
+      const workspace1 = path.join(openclawDir, "workspace");
+      const workspace2 = path.join(openclawDir, "workspace-llama");
+
+      await fs.mkdir(workspace1, { recursive: true });
+      await fs.mkdir(workspace2, { recursive: true });
+
+      // Create a bootstrap file in workspace1
+      const agentsFile = path.join(workspace1, "AGENTS.md");
+      await fs.writeFile(agentsFile, "# Shared agents config", "utf8");
+
+      // Create symlink in workspace2 pointing to workspace1's file
+      const symlinkPath = path.join(workspace2, "AGENTS.md");
+      await fs.symlink(agentsFile, symlinkPath);
+
+      // This should succeed because both workspaces are under .openclaw/
+      const result = await resolveBoundaryPath({
+        absolutePath: symlinkPath,
+        rootPath: workspace2,
+        boundaryLabel: "workspace root",
+      });
+
+      expect(result.exists).toBe(true);
+      expect(result.kind).toBe("file");
+
+      // The canonical path should resolve to the actual file
+      const agentsFileReal = await fs.realpath(agentsFile);
+      expect(result.canonicalPath).toBe(agentsFileReal);
+    });
+  });
+
+  it("blocks symlinks to non-workspace directories even under .openclaw", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withTempRoot("openclaw-workspace-symlink-", async (base) => {
+      // Simulate ~/.openclaw/ structure
+      const openclawDir = path.join(base, ".openclaw");
+      const workspace = path.join(openclawDir, "workspace");
+      const otherDir = path.join(openclawDir, "other-dir");
+
+      await fs.mkdir(workspace, { recursive: true });
+      await fs.mkdir(otherDir, { recursive: true });
+
+      // Create a file in the non-workspace directory
+      const targetFile = path.join(otherDir, "secret.txt");
+      await fs.writeFile(targetFile, "secret data", "utf8");
+
+      // Create symlink in workspace pointing to non-workspace file
+      const symlinkPath = path.join(workspace, "secret.txt");
+      await fs.symlink(targetFile, symlinkPath);
+
+      // This should fail because the target is not in a workspace directory
+      await expect(
+        resolveBoundaryPath({
+          absolutePath: symlinkPath,
+          rootPath: workspace,
+          boundaryLabel: "workspace root",
+        }),
+      ).rejects.toThrow(/Symlink escapes workspace root/i);
+    });
+  });
+
+  it("blocks symlinks to directories outside .openclaw", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withTempRoot("openclaw-workspace-symlink-", async (base) => {
+      const openclawDir = path.join(base, ".openclaw");
+      const workspace = path.join(openclawDir, "workspace");
+      const outsideDir = path.join(base, "outside");
+
+      await fs.mkdir(workspace, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+
+      // Create a file outside .openclaw
+      const targetFile = path.join(outsideDir, "external.txt");
+      await fs.writeFile(targetFile, "external data", "utf8");
+
+      // Create symlink in workspace pointing to external file
+      const symlinkPath = path.join(workspace, "external.txt");
+      await fs.symlink(targetFile, symlinkPath);
+
+      // This should fail because the target is outside .openclaw
+      await expect(
+        resolveBoundaryPath({
+          absolutePath: symlinkPath,
+          rootPath: workspace,
+          boundaryLabel: "workspace root",
+        }),
+      ).rejects.toThrow(/Symlink escapes workspace root/i);
+    });
+  });
+});

--- a/src/infra/boundary-path.ts
+++ b/src/infra/boundary-path.ts
@@ -302,13 +302,68 @@ function handleLexicalStatDisposition(params: {
   return "resolve-link";
 }
 
+function isWorkspaceSymlinkAllowed(params: {
+  rootCanonicalPath: string;
+  linkCanonical: string;
+  boundaryLabel: string;
+}): boolean {
+  // Allow symlinks between sibling workspace directories under .openclaw/
+  if (params.boundaryLabel !== "workspace root") {
+    return false;
+  }
+
+  // Check if both paths are under .openclaw/workspace*
+  const rootParts = params.rootCanonicalPath.split(path.sep);
+  const linkParts = params.linkCanonical.split(path.sep);
+
+  // Find .openclaw in both paths
+  const rootOpenclawIdx = rootParts.findIndex((p) => p === ".openclaw");
+  const linkOpenclawIdx = linkParts.findIndex((p) => p === ".openclaw");
+
+  if (rootOpenclawIdx === -1 || linkOpenclawIdx === -1) {
+    return false;
+  }
+
+  // Check if they share the same .openclaw parent path
+  const rootOpenclawParent = rootParts.slice(0, rootOpenclawIdx + 1).join(path.sep);
+  const linkOpenclawParent = linkParts.slice(0, linkOpenclawIdx + 1).join(path.sep);
+
+  if (rootOpenclawParent !== linkOpenclawParent) {
+    return false;
+  }
+
+  // Check if both are workspace directories (workspace or workspace-*)
+  const rootWorkspaceDir = rootParts[rootOpenclawIdx + 1];
+  const linkWorkspaceDir = linkParts[linkOpenclawIdx + 1];
+
+  if (!rootWorkspaceDir || !linkWorkspaceDir) {
+    return false;
+  }
+
+  const isRootWorkspace =
+    rootWorkspaceDir === "workspace" || rootWorkspaceDir.startsWith("workspace-");
+  const isLinkWorkspace =
+    linkWorkspaceDir === "workspace" || linkWorkspaceDir.startsWith("workspace-");
+
+  return isRootWorkspace && isLinkWorkspace;
+}
+
 function applyResolvedSymlinkHop(params: {
   state: LexicalTraversalState;
   linkCanonical: string;
   rootCanonicalPath: string;
   boundaryLabel: string;
 }): void {
-  if (!isPathInside(params.rootCanonicalPath, params.linkCanonical)) {
+  const isInside = isPathInside(params.rootCanonicalPath, params.linkCanonical);
+  const isWorkspaceAllowed =
+    !isInside &&
+    isWorkspaceSymlinkAllowed({
+      rootCanonicalPath: params.rootCanonicalPath,
+      linkCanonical: params.linkCanonical,
+      boundaryLabel: params.boundaryLabel,
+    });
+
+  if (!isInside && !isWorkspaceAllowed) {
     throw symlinkEscapeError({
       boundaryLabel: params.boundaryLabel,
       rootCanonicalPath: params.rootCanonicalPath,
@@ -776,6 +831,18 @@ function assertInsideBoundary(params: {
   if (isPathInside(params.rootCanonicalPath, params.candidatePath)) {
     return;
   }
+
+  // Allow workspace symlinks between sibling directories under .openclaw/
+  if (
+    isWorkspaceSymlinkAllowed({
+      rootCanonicalPath: params.rootCanonicalPath,
+      linkCanonical: params.candidatePath,
+      boundaryLabel: params.boundaryLabel,
+    })
+  ) {
+    return;
+  }
+
   throw new Error(
     `Path resolves outside ${params.boundaryLabel} (${shortPath(params.rootCanonicalPath)}): ${shortPath(params.absolutePath)}`,
   );


### PR DESCRIPTION
## Summary

Fixes symlinked bootstrap files (AGENTS.md, TOOLS.md, SOUL.md, etc.) between sibling workspace directories under `.openclaw/` that were incorrectly rejected as boundary escapes.

## Problem

When users create symlinks from one workspace to another (e.g., `~/.openclaw/workspace-llama/AGENTS.md` → `~/.openclaw/workspace/AGENTS.md`), the boundary path check in `resolveBoundaryPath()` rejects them with "Symlink escapes workspace root" even though both workspaces are under the same `.openclaw/` parent and owned by the same user.

This breaks the workaround suggested in #21802 for sharing bootstrap files across multiple agent workspaces.

## Changes

- Added `isWorkspaceSymlinkAllowed()` helper that checks if both the source and target paths are workspace directories under a common `.openclaw/` parent
- Modified `applyResolvedSymlinkHop()` to allow workspace-to-workspace symlinks when the boundary label is "workspace root"
- Modified `assertInsideBoundary()` to also allow workspace symlinks
- Added comprehensive tests covering:
  - Symlinks between sibling workspaces (allowed)
  - Symlinks to non-workspace directories under `.openclaw/` (blocked)
  - Symlinks to directories outside `.openclaw/` (blocked)

## Test Plan

**Before:**
```bash
# Create two workspaces
mkdir -p ~/.openclaw/workspace ~/.openclaw/workspace-llama
echo "# Shared config" > ~/.openclaw/workspace/AGENTS.md
ln -s ~/.openclaw/workspace/AGENTS.md ~/.openclaw/workspace-llama/AGENTS.md

# Start agent with workspace-llama
openclaw agent --workspace ~/.openclaw/workspace-llama

# Result: AGENTS.md shows [MISSING] in injected context
```

**After:**
```bash
# Same setup
# Result: AGENTS.md loads successfully from symlink target
```

**Tests:**
```bash
pnpm vitest run src/infra/boundary-path-workspace-symlink.test.ts
# ✓ allows symlinks to sibling workspace under common .openclaw parent
# ✓ blocks symlinks to non-workspace directories even under .openclaw
# ✓ blocks symlinks to directories outside .openclaw

pnpm vitest run src/infra/boundary-path.test.ts
# All existing boundary path tests still pass
```

## Effect on User Experience

Users can now use symlinks to share bootstrap files across multiple agent workspaces without manual copying or sync scripts. This enables the workflow described in #21802 where users maintain a main workspace with shared configuration and create profile-specific workspaces that symlink to shared files while overriding specific files like IDENTITY.md or USER.md.

Closes #34404
Related to #21802