### PR TITLE
fix: detect all web search provider api keys

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -221,11 +221,20 @@ function resolveToolPolicies(params: {
 
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
+  const hasConfigKey =
+    Object.values((search ?? {}) as Record<string, unknown>).some((value) => {
+      if (!value || typeof value !== "object") {
+        return false;
+      }
+      const apiKey = (value as { apiKey?: unknown }).apiKey;
+      return typeof apiKey === "string" ? apiKey.trim().length > 0 : Boolean(apiKey);
+    }) ||
+    (typeof search?.apiKey === "string" ? search.apiKey.trim().length > 0 : Boolean(search?.apiKey));
   return Boolean(
-    search?.apiKey ||
-    search?.perplexity?.apiKey ||
+    hasConfigKey ||
     env.BRAVE_API_KEY ||
     env.PERPLEXITY_API_KEY ||
+    env.XAI_API_KEY ||
     env.OPENROUTER_API_KEY,
   );
 }

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -238,6 +238,37 @@ describe("security audit", () => {
     expect(finding?.detail).toContain("browser");
   });
 
+  it("detects web_search from any provider apiKey and skips when all are empty", async () => {
+    const withKey = {
+      agents: { defaults: { model: { primary: "ollama/mistral-8b" } } },
+      tools: { web: { search: { kimi: { apiKey: "kimi-key" } }, fetch: { enabled: false } } },
+      browser: { enabled: false },
+    } as OpenClawConfig;
+    const noKey = {
+      agents: { defaults: { model: { primary: "ollama/mistral-8b" } } },
+      tools: { web: { search: { kimi: {} }, fetch: { enabled: false } } },
+      browser: { enabled: false },
+    } as OpenClawConfig;
+
+    const withKeyRes = await runSecurityAudit({
+      config: withKey,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+    const noKeyRes = await runSecurityAudit({
+      config: noKey,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(withKeyRes.findings.find((f) => f.checkId === "models.small_params")?.detail).toContain(
+      "web_search",
+    );
+    expect(noKeyRes.findings.find((f) => f.checkId === "models.small_params")?.detail).not.toContain(
+      "web_search",
+    );
+  });
+
   it("treats small models as safe when sandbox is on and web tools are disabled", async () => {
     const cfg: OpenClawConfig = {
       agents: { defaults: { model: { primary: "ollama/mistral-8b" }, sandbox: { mode: "all" } } },


### PR DESCRIPTION
Closes #34509

Problem
Security audit `hasWebSearchKey` only checked top-level/Perplexity keys, so provider-specific keys (for example Grok/Kimi or future providers under `tools.web.search`) were treated as missing.

Fix
Detect configured web search keys by scanning all object entries under `tools.web.search` for `apiKey`, and include `XAI_API_KEY` env fallback. Added a regression test for "any provider key => enabled" and "all empty => disabled".