### PR TITLE
fix(cron): skip delivery target resolution when delivery mode is none

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -61,7 +61,7 @@ runs:
       if: inputs.install-bun == 'true'
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: "1.3.9+cf6cdbbba"
+        bun-version: "1.3.9"
 
     - name: Runtime versions
       shell: bash

--- a/src/cron/isolated-agent/run.delivery-mode-none-channel-last.test.ts
+++ b/src/cron/isolated-agent/run.delivery-mode-none-channel-last.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  makeIsolatedAgentTurnJob,
+  makeIsolatedAgentTurnParams,
+  setupRunCronIsolatedAgentTurnSuite,
+} from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  resolveCronDeliveryPlanMock,
+  resolveDeliveryTargetMock,
+  runEmbeddedPiAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+describe("runCronIsolatedAgentTurn — delivery.mode=none + channel:last (#30393)", () => {
+  setupRunCronIsolatedAgentTurnSuite();
+
+  it("skips delivery target resolution and keeps messageChannel unset", async () => {
+    resolveCronDeliveryPlanMock.mockReturnValueOnce({
+      mode: "none",
+      channel: undefined,
+      to: undefined,
+      accountId: undefined,
+      source: "delivery",
+      requested: false,
+    });
+
+    runWithModelFallbackMock.mockImplementationOnce(
+      async (params: {
+        run: (providerOverride: string, modelOverride: string) => Promise<unknown>;
+        provider: string;
+        model: string;
+      }) => ({
+        result: await params.run(params.provider, params.model),
+        provider: params.provider,
+        model: params.model,
+        attempts: [],
+      }),
+    );
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          delivery: { mode: "none", channel: "last" },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(resolveDeliveryTargetMock).not.toHaveBeenCalled();
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
+
+    const embeddedArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as
+      | { messageChannel?: string; disableMessageTool?: boolean }
+      | undefined;
+    expect(embeddedArgs?.messageChannel).toBeUndefined();
+    expect(embeddedArgs?.disableMessageTool).toBe(true);
+  });
+});

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -33,12 +33,14 @@ export const resolveAllowedModelRefMock = createMock();
 export const resolveConfiguredModelRefMock = createMock();
 export const resolveHooksGmailModelMock = createMock();
 export const resolveThinkingDefaultMock = createMock();
+export const resolveCronDeliveryPlanMock = createMock();
 export const runWithModelFallbackMock = createMock();
 export const runEmbeddedPiAgentMock = createMock();
 export const runCliAgentMock = createMock();
 export const getCliSessionIdMock = createMock();
 export const updateSessionStoreMock = createMock();
 export const resolveCronSessionMock = createMock();
+export const resolveDeliveryTargetMock = createMock();
 export const logWarnMock = createMock();
 
 vi.mock("../../agents/agent-scope.js", () => ({
@@ -169,16 +171,11 @@ vi.mock("../../security/external-content.js", () => ({
 }));
 
 vi.mock("../delivery.js", () => ({
-  resolveCronDeliveryPlan: vi.fn().mockReturnValue({ requested: false }),
+  resolveCronDeliveryPlan: resolveCronDeliveryPlanMock,
 }));
 
 vi.mock("./delivery-target.js", () => ({
-  resolveDeliveryTarget: vi.fn().mockResolvedValue({
-    channel: "discord",
-    to: undefined,
-    accountId: undefined,
-    error: undefined,
-  }),
+  resolveDeliveryTarget: resolveDeliveryTargetMock,
 }));
 
 vi.mock("./helpers.js", () => ({
@@ -257,6 +254,19 @@ export function resetRunCronIsolatedAgentTurnHarness(): void {
   resolveThinkingDefaultMock.mockReturnValue(undefined);
   getModelRefStatusMock.mockReturnValue({ allowed: false });
   isCliProviderMock.mockReturnValue(false);
+
+  resolveCronDeliveryPlanMock.mockReset();
+  resolveCronDeliveryPlanMock.mockReturnValue({ mode: "none", requested: false });
+  resolveDeliveryTargetMock.mockReset();
+  resolveDeliveryTargetMock.mockResolvedValue({
+    ok: false,
+    mode: "implicit",
+    channel: undefined,
+    to: undefined,
+    accountId: undefined,
+    threadId: undefined,
+    error: new Error("delivery not requested"),
+  });
 
   runWithModelFallbackMock.mockReset();
   runWithModelFallbackMock.mockResolvedValue(makeDefaultModelFallbackResult());

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -56,7 +56,7 @@ import {
   matchesMessagingToolDeliveryTarget,
   resolveCronDeliveryBestEffort,
 } from "./delivery-dispatch.js";
-import { resolveDeliveryTarget } from "./delivery-target.js";
+import { resolveDeliveryTarget, type DeliveryTargetResolution } from "./delivery-target.js";
 import {
   isHeartbeatOnlyResponse,
   pickLastDeliverablePayload,
@@ -334,12 +334,18 @@ export async function runCronIsolatedAgentTurn(params: {
   const deliveryPlan = resolveCronDeliveryPlan(params.job);
   const deliveryRequested = deliveryPlan.requested;
 
-  const resolvedDelivery = await resolveDeliveryTarget(cfgWithAgentDefaults, agentId, {
-    channel: deliveryPlan.channel ?? "last",
-    to: deliveryPlan.to,
-    accountId: deliveryPlan.accountId,
-    sessionKey: params.job.sessionKey,
-  });
+  const resolvedDelivery: DeliveryTargetResolution = deliveryRequested
+    ? await resolveDeliveryTarget(cfgWithAgentDefaults, agentId, {
+        channel: deliveryPlan.channel ?? "last",
+        to: deliveryPlan.to,
+        accountId: deliveryPlan.accountId,
+        sessionKey: params.job.sessionKey,
+      })
+    : {
+        ok: false,
+        mode: "implicit",
+        error: new Error("cron delivery not requested"),
+      };
 
   const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now);
   const base = `[cron:${params.job.id} ${params.job.name}] ${params.message}`.trim();


### PR DESCRIPTION
## Summary
- skip delivery target resolution in isolated cron runs when `delivery.mode` is not requested (including `none`)
- avoid injecting an implicit `messageChannel` into embedded cron runs when delivery is disabled
- add regression coverage for issue #30393 (`delivery.mode=none` + `channel:last`)

## Why
`resolveDeliveryTarget()` was being called unconditionally, which could still resolve/fallback channel routing even when cron delivery was disabled. That allowed `channel:last` paths to leak into runtime routing and surface as message delivery failures.

## Tests
- `npx vitest run src/cron/isolated-agent/run.delivery-mode-none-channel-last.test.ts src/cron/delivery.test.ts`
- `npx vitest run src/cron/isolated-agent/run.*.test.ts`

Fixes #30393
