### PR TITLE
fix(gateway): resolve gateway.auth.token SecretRef before startup auth

### DIFF
--- a/src/gateway/startup-auth.test.ts
+++ b/src/gateway/startup-auth.test.ts
@@ -132,6 +132,62 @@ describe("ensureGatewayStartupAuth", () => {
     expect(result.auth.password).toBe("resolved-password");
   });
 
+  it("resolves gateway.auth.token SecretRef before startup auth checks", async () => {
+    const result = await ensureGatewayStartupAuth({
+      cfg: {
+        gateway: {
+          auth: {
+            mode: "token",
+            token: { source: "env", provider: "default", id: "GW_TOKEN" },
+          },
+        },
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+      },
+      env: {
+        GW_TOKEN: "resolved-token",
+      } as NodeJS.ProcessEnv,
+      persist: true,
+    });
+
+    expect(result.generatedToken).toBeUndefined();
+    expect(result.auth.mode).toBe("token");
+    expect(result.auth.token).toBe("resolved-token");
+    expect(result.persistedGeneratedToken).toBe(false);
+    expect(mocks.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("uses OPENCLAW_GATEWAY_TOKEN without resolving configured token SecretRef", async () => {
+    const result = await ensureGatewayStartupAuth({
+      cfg: {
+        gateway: {
+          auth: {
+            mode: "token",
+            token: { source: "env", provider: "default", id: "MISSING_GW_TOKEN" },
+          },
+        },
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+      },
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: "token-from-env",
+      } as NodeJS.ProcessEnv,
+      persist: true,
+    });
+
+    expect(result.generatedToken).toBeUndefined();
+    expect(result.auth.mode).toBe("token");
+    expect(result.auth.token).toBe("token-from-env");
+    expect(result.persistedGeneratedToken).toBe(false);
+    expect(mocks.writeConfigFile).not.toHaveBeenCalled();
+  });
+
   it("uses OPENCLAW_GATEWAY_PASSWORD without resolving configured password SecretRef", async () => {
     const result = await ensureGatewayStartupAuth({
       cfg: {

--- a/src/gateway/startup-auth.ts
+++ b/src/gateway/startup-auth.ts
@@ -5,7 +5,7 @@ import type {
   OpenClawConfig,
 } from "../config/config.js";
 import { writeConfigFile } from "../config/config.js";
-import { resolveSecretInputRef } from "../config/types.secrets.js";
+import { hasConfiguredSecretInput, resolveSecretInputRef } from "../config/types.secrets.js";
 import { secretRefKey } from "../secrets/ref-contract.js";
 import { resolveSecretRefValues } from "../secrets/resolve.js";
 import { resolveGatewayAuth, type ResolvedGatewayAuth } from "./auth.js";
@@ -91,8 +91,7 @@ function shouldPersistGeneratedToken(params: {
   return true;
 }
 
-function hasGatewayTokenCandidate(params: {
-  cfg: OpenClawConfig;
+function hasGatewayTokenOverrideCandidate(params: {
   env: NodeJS.ProcessEnv;
   authOverride?: GatewayAuthConfig;
 }): boolean {
@@ -101,10 +100,20 @@ function hasGatewayTokenCandidate(params: {
   if (envToken) {
     return true;
   }
-  if (
-    typeof params.authOverride?.token === "string" &&
-    params.authOverride.token.trim().length > 0
-  ) {
+  return Boolean(
+    typeof params.authOverride?.token === "string" && params.authOverride.token.trim().length > 0,
+  );
+}
+
+function hasGatewayTokenCandidate(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  authOverride?: GatewayAuthConfig;
+}): boolean {
+  if (hasGatewayTokenOverrideCandidate(params)) {
+    return true;
+  }
+  if (hasConfiguredSecretInput(params.cfg.gateway?.auth?.token, params.cfg.secrets?.defaults)) {
     return true;
   }
   return (
@@ -150,6 +159,57 @@ function shouldResolveGatewayPasswordSecretRef(params: {
     return false;
   }
   return true;
+}
+
+function shouldResolveGatewayTokenSecretRef(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  authOverride?: GatewayAuthConfig;
+}): boolean {
+  if (hasGatewayTokenOverrideCandidate(params)) {
+    return false;
+  }
+  const explicitMode = params.authOverride?.mode ?? params.cfg.gateway?.auth?.mode;
+  if (explicitMode === "password" || explicitMode === "none" || explicitMode === "trusted-proxy") {
+    return false;
+  }
+  return true;
+}
+
+async function resolveGatewayTokenSecretRef(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+  authOverride?: GatewayAuthConfig,
+): Promise<OpenClawConfig> {
+  const authToken = cfg.gateway?.auth?.token;
+  const { ref } = resolveSecretInputRef({
+    value: authToken,
+    defaults: cfg.secrets?.defaults,
+  });
+  if (!ref) {
+    return cfg;
+  }
+  if (!shouldResolveGatewayTokenSecretRef({ cfg, env, authOverride })) {
+    return cfg;
+  }
+  const resolved = await resolveSecretRefValues([ref], {
+    config: cfg,
+    env,
+  });
+  const value = resolved.get(secretRefKey(ref));
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error("gateway.auth.token resolved to an empty or non-string value.");
+  }
+  return {
+    ...cfg,
+    gateway: {
+      ...cfg.gateway,
+      auth: {
+        ...cfg.gateway?.auth,
+        token: value.trim(),
+      },
+    },
+  };
 }
 
 async function resolveGatewayPasswordSecretRef(
@@ -202,7 +262,16 @@ export async function ensureGatewayStartupAuth(params: {
 }> {
   const env = params.env ?? process.env;
   const persistRequested = params.persist === true;
-  const cfgForAuth = await resolveGatewayPasswordSecretRef(params.cfg, env, params.authOverride);
+  const cfgWithResolvedToken = await resolveGatewayTokenSecretRef(
+    params.cfg,
+    env,
+    params.authOverride,
+  );
+  const cfgForAuth = await resolveGatewayPasswordSecretRef(
+    cfgWithResolvedToken,
+    env,
+    params.authOverride,
+  );
   const resolved = resolveGatewayAuthFromConfig({
     cfg: cfgForAuth,
     env,


### PR DESCRIPTION
## Summary
- Fixes #31481 - Gateway rejects WebSocket connections with 'token missing' despite correct config
- Resolve gateway.auth.token SecretRef before startup auth checks

## Changes
- `src/gateway/startup-auth.ts`: Add token SecretRef resolution
- `src/gateway/startup-auth.test.ts`: Add regression tests

AI-assisted (Codex)