### PR TITLE
fix(minimax): strip thinking parameter to prevent API timeout

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -411,6 +411,65 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]?.thinking).toBe("off");
   });
 
+  it("strips thinking parameter for MiniMax provider", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        thinking: { type: "enabled", budget_tokens: 1024 },
+      };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "minimax", "MiniMax-M2.5", undefined, undefined);
+
+    const model = {
+      api: "anthropic",
+      provider: "minimax",
+      id: "MiniMax-M2.5",
+    } as Model<"anthropic">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.thinking).toBeUndefined();
+  });
+
+  it("strips thinking parameter for minimax-portal provider", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        thinking: { type: "enabled", budget_tokens: 2048 },
+      };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "minimax-portal",
+      "MiniMax-M2.5",
+      undefined,
+      undefined,
+    );
+
+    const model = {
+      api: "anthropic",
+      provider: "minimax-portal",
+      id: "MiniMax-M2.5",
+    } as Model<"anthropic">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.thinking).toBeUndefined();
+  });
+
   it("maps thinkingLevel=off to Moonshot thinking.type=disabled", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -560,6 +560,29 @@ function createSiliconFlowThinkingWrapper(baseStreamFn: StreamFn | undefined): S
   };
 }
 
+/**
+ * MiniMax's Anthropic-compatible endpoint does not support the `thinking`
+ * parameter. When MiniMax models have `reasoning: true`, the Anthropic adapter
+ * injects `thinking: { type: "enabled", budget_tokens: … }` which causes the
+ * server to hang and eventually time out. Strip the thinking parameter entirely.
+ */
+function createMinimaxThinkingWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          const payloadObj = payload as Record<string, unknown>;
+          delete payloadObj.thinking;
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
 type MoonshotThinkingType = "enabled" | "disabled";
 
 function normalizeMoonshotThinkingType(value: unknown): MoonshotThinkingType | undefined {
@@ -900,6 +923,11 @@ export function applyExtraParamsToAgent(
       `applying Anthropic beta header for ${provider}/${modelId}: ${anthropicBetas.join(",")}`,
     );
     agent.streamFn = createAnthropicBetaHeadersWrapper(agent.streamFn, anthropicBetas);
+  }
+
+  if (provider === "minimax" || provider === "minimax-portal") {
+    log.debug(`stripping thinking parameter for MiniMax compatibility (${provider}/${modelId})`);
+    agent.streamFn = createMinimaxThinkingWrapper(agent.streamFn);
   }
 
   if (shouldApplySiliconFlowThinkingOffCompat({ provider, modelId, thinkingLevel })) {


### PR DESCRIPTION
## Summary

- Strip the `thinking` parameter from MiniMax API requests to prevent timeout regression introduced in v2026.3.2
- MiniMax M2.5 models have `reasoning: true`, causing the Anthropic adapter to inject `thinking: { type: "enabled", budget_tokens: … }` which MiniMax's endpoint does not support, leading to server hangs and timeouts
- Follows the existing SiliconFlow/Moonshot pattern using `onPayload` wrapper to remove the unsupported parameter
- Applies to both `minimax` and `minimax-portal` providers

Fixes #34487

## Test plan

- [x] Added tests for `minimax` and `minimax-portal` providers confirming `thinking` parameter is stripped
- [x] All 49 extra-params tests pass
- [ ] Manual verification with MiniMax API key (if available)