### PR TITLE
fix(models): support MINIMAX_API_HOST env var for CN endpoint (#34487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/MiniMax: honor `MINIMAX_API_HOST` for implicit bundled MiniMax provider catalogs so China-hosted API-key setups pick `api.minimaxi.com/anthropic` without manual provider config. (#34524) Thanks @caiqinghua.
 - Usage/MiniMax: invert remaining-style `usage_percent` fields when MiniMax reports only remaining percentage data, so usage bars stop showing nearly-full remaining quota as nearly-exhausted usage. (#60254) Thanks @jwchmodx.
 - MiniMax: advertise image input on bundled `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` model definitions so image-capable flows can route through the M2.7 family correctly. (#54843) Thanks @MerlinMiao88888888.
 - Agents/exec approvals: let `exec-approvals.json` agent security override stricter gateway tool defaults so approved subagents can use `security: "full"` without falling back to allowlist enforcement again. (#60310) Thanks @lml2468.

--- a/extensions/minimax/index.ts
+++ b/extensions/minimax/index.ts
@@ -93,7 +93,7 @@ function resolvePortalCatalog(ctx: ProviderCatalogContext) {
 
   return {
     provider: buildPortalProviderCatalog({
-      baseUrl: explicitBaseUrl || DEFAULT_BASE_URL_GLOBAL,
+      baseUrl: explicitBaseUrl || buildMinimaxPortalProvider().baseUrl,
       apiKey,
     }),
   };

--- a/extensions/minimax/provider-catalog.ts
+++ b/extensions/minimax/provider-catalog.ts
@@ -5,14 +5,28 @@ import type {
 import {
   DEFAULT_MINIMAX_CONTEXT_WINDOW,
   DEFAULT_MINIMAX_MAX_TOKENS,
+  MINIMAX_API_BASE_URL,
   resolveMinimaxApiCost,
 } from "./model-definitions.js";
-import {
-  MINIMAX_TEXT_MODEL_CATALOG,
-  MINIMAX_TEXT_MODEL_ORDER,
-} from "./provider-models.js";
+import { MINIMAX_TEXT_MODEL_CATALOG, MINIMAX_TEXT_MODEL_ORDER } from "./provider-models.js";
 
-const MINIMAX_PORTAL_BASE_URL = "https://api.minimax.io/anthropic";
+function resolveMinimaxCatalogBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const rawHost = env.MINIMAX_API_HOST?.trim();
+  if (!rawHost) {
+    return MINIMAX_API_BASE_URL;
+  }
+
+  try {
+    const url = new URL(rawHost);
+    const basePath = url.pathname.replace(/\/+$/, "");
+    if (basePath.endsWith("/anthropic")) {
+      return `${url.origin}${basePath}`;
+    }
+    return `${url.origin}/anthropic`;
+  } catch {
+    return MINIMAX_API_BASE_URL;
+  }
+}
 
 function buildMinimaxModel(params: {
   id: string;
@@ -55,7 +69,7 @@ function buildMinimaxCatalog(): ModelDefinitionConfig[] {
 
 export function buildMinimaxProvider(): ModelProviderConfig {
   return {
-    baseUrl: MINIMAX_PORTAL_BASE_URL,
+    baseUrl: resolveMinimaxCatalogBaseUrl(),
     api: "anthropic-messages",
     authHeader: true,
     models: buildMinimaxCatalog(),
@@ -64,7 +78,7 @@ export function buildMinimaxProvider(): ModelProviderConfig {
 
 export function buildMinimaxPortalProvider(): ModelProviderConfig {
   return {
-    baseUrl: MINIMAX_PORTAL_BASE_URL,
+    baseUrl: resolveMinimaxCatalogBaseUrl(),
     api: "anthropic-messages",
     authHeader: true,
     models: buildMinimaxCatalog(),

--- a/src/agents/models-config.providers.nvidia.test.ts
+++ b/src/agents/models-config.providers.nvidia.test.ts
@@ -35,13 +35,26 @@ describe("NVIDIA provider", () => {
 describe("MiniMax implicit provider (#15275)", () => {
   it("should use anthropic-messages API for API-key provider", async () => {
     const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
-    await withEnvAsync({ MINIMAX_API_KEY: "test-key" }, async () => {
+    await withEnvAsync({ MINIMAX_API_KEY: "test-key", MINIMAX_API_HOST: undefined }, async () => {
       const providers = await resolveImplicitProvidersForTest({ agentDir });
       expect(providers?.minimax).toBeDefined();
       expect(providers?.minimax?.api).toBe("anthropic-messages");
       expect(providers?.minimax?.authHeader).toBe(true);
       expect(providers?.minimax?.baseUrl).toBe("https://api.minimax.io/anthropic");
     });
+  });
+
+  it("should respect MINIMAX_API_HOST env var for CN endpoint (#34487)", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    await withEnvAsync(
+      { MINIMAX_API_KEY: "test-key", MINIMAX_API_HOST: "https://api.minimaxi.com" },
+      async () => {
+        const providers = await resolveImplicitProvidersForTest({ agentDir });
+        expect(providers?.minimax).toBeDefined();
+        expect(providers?.minimax?.baseUrl).toBe("https://api.minimaxi.com/anthropic");
+        expect(providers?.["minimax-portal"]?.baseUrl).toBe("https://api.minimaxi.com/anthropic");
+      },
+    );
   });
 
   it("should set authHeader for minimax portal provider", async () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem**: MiniMax API timeout after 2026.3.2 for users with CN region API keys. The main LLM provider was hardcoded to use the global endpoint `api.minimax.io`, while CN API keys require the CN endpoint `api.minimaxi.com`.
- **Why it matters**: Users with CN API keys could not use MiniMax provider at all - requests would either timeout (with `authHeader: false`) or return 401 (with `authHeader: true`).
- **What changed**: Added `getMinimaxBaseUrl()` helper function that respects `MINIMAX_API_HOST` environment variable, allowing CN users to override the default baseUrl. Both `buildMinimaxProvider()` and `buildMinimaxPortalProvider()` now use this function.
- **What did NOT change**: Default behavior for global users remains unchanged - without `MINIMAX_API_HOST` set, the provider still uses `api.minimax.io/anthropic`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34487
- Related #28458 (MiniMax 401 auth issue fix)

## User-visible / Behavior Changes

- Users with CN region MiniMax API keys can now set `MINIMAX_API_HOST=https://api.minimaxi.com` environment variable to use the China endpoint
- Default behavior unchanged for global users - provider still uses `api.minimax.io/anthropic` when env var not set
- VLM endpoint already supported `MINIMAX_API_HOST`; this brings parity to the main LLM provider

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No` - only changes which endpoint is used based on env var)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS/Linux
- Model/provider: MiniMax (CN region API key, format `sk-cp-01...`)
- Integration/channel: CLI agent runner

### Steps

1. Set CN API key: `export MINIMAX_API_KEY=sk-cp-01...`
2. Set CN endpoint: `export MINIMAX_API_HOST=https://api.minimaxi.com`
3. Run: `openclaw agent --agent main --message "hello"`
4. Verify request goes to `api.minimaxi.com/anthropic/v1/messages`

### Expected

- Request succeeds with CN endpoint

### Actual

- Before fix: timeout or 401 (depending on `authHeader` setting)
- After fix: request succeeds when `MINIMAX_API_HOST` is set correctly

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios**:
  - Added test case `should respect MINIMAX_API_HOST env var for CN endpoint (#34487)` that verifies baseUrl is correctly set when env var is present
  - Ran all existing MiniMax-related tests - all pass
  - Verified default behavior unchanged when env var not set
  
- **Edge cases checked**:
  - Env var with trailing `/anthropic` path is preserved
  - Env var without path gets `/anthropic` appended
  - Invalid URL format falls back to default global endpoint
  
- **What I did not verify**:
  - Live testing with actual CN API key (requires valid key)
  - VLM endpoint behavior (already worked before)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Optional` - users can set `MINIMAX_API_HOST` env var)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - CN users: Set `export MINIMAX_API_HOST=https://api.minimaxi.com` before running OpenClaw

## Failure Recovery (if this breaks)

- **How to disable/revert**: Unset `MINIMAX_API_HOST` environment variable to use default global endpoint
- **Files/config to restore**: None - behavior controlled by env var
- **Known bad symptoms**: None - this only affects users who explicitly set `MINIMAX_API_HOST`

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- **Risk**: None - this is an opt-in feature via environment variable; default behavior unchanged
  - **Mitigation**: Not applicable - no risk to existing users