### PR TITLE
fix(feishu): preserve [[reply_to_current]] in duplicate suppression

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -114,6 +114,25 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
+  it("keeps explicit [[reply_to_current]] replies for same-target generic sends", () => {
+    const { replyPayloads } = buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "[[reply_to_current]]hello world!" }],
+      replyToMode: "all",
+      replyToChannel: "feishu",
+      messageProvider: "heartbeat",
+      originatingChannel: "feishu",
+      originatingTo: "ou_abc123",
+      currentMessageId: "om_current",
+      messagingToolSentTexts: ["different message"],
+      messagingToolSentTargets: [{ tool: "message", provider: "message", to: "ou_abc123" }],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe("hello world!");
+    expect(replyPayloads[0]?.replyToId).toBe("om_current");
+  });
+
   it("does not suppress same-target replies when accountId differs", () => {
     const { replyPayloads } = buildReplyPayloads({
       ...baseParams,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -20,6 +20,21 @@ import {
   shouldSuppressMessagingToolReplies,
 } from "./reply-payloads.js";
 
+function isExplicitReplyToCurrentPayload(
+  payload: ReplyPayload,
+  currentMessageId?: string,
+): boolean {
+  if (payload.replyToCurrent === true) {
+    return true;
+  }
+  if (!payload.replyToTag) {
+    return false;
+  }
+  const currentId = currentMessageId?.trim();
+  const replyToId = payload.replyToId?.trim();
+  return Boolean(currentId && replyToId && currentId === replyToId);
+}
+
 export function buildReplyPayloads(params: {
   payloads: ReplyPayload[];
   isHeartbeat: boolean;
@@ -134,7 +149,11 @@ export function buildReplyPayloads(params: {
             (payload) => !params.directlySentBlockKeys!.has(createBlockReplyPayloadKey(payload)),
           )
         : mediaFilteredPayloads;
-  const replyPayloads = suppressMessagingToolReplies ? [] : filteredPayloads;
+  const replyPayloads = suppressMessagingToolReplies
+    ? filteredPayloads.filter((payload) =>
+        isExplicitReplyToCurrentPayload(payload, params.currentMessageId),
+      )
+    : filteredPayloads;
 
   return {
     replyPayloads,


### PR DESCRIPTION
## Summary
- Fixes #32953 - [[reply_to_current]] tag broken in Feishu DM after PR #31526
- Keep explicit [[reply_to_current]] replies when same-target duplicate suppression is active

## Changes
- `src/auto-reply/reply/agent-runner-payloads.ts`: Add isExplicitReplyToCurrentPayload helper
- `src/auto-reply/reply/agent-runner-payloads.test.ts`: Add regression test

AI-assisted (Codex)