### PR TITLE
fix(message-tool): accept provider-prefixed channel values

### DIFF
--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -29,6 +29,19 @@ describe("resolveMessageChannelSelection", () => {
     });
   });
 
+  it("accepts provider-prefixed channel values for explicit cross-channel routing", async () => {
+    const selection = await resolveMessageChannelSelection({
+      cfg: {} as never,
+      channel: "discord:123456789012345678",
+    });
+
+    expect(selection).toEqual({
+      channel: "discord",
+      configured: [],
+      source: "explicit",
+    });
+  });
+
   it("falls back to tool context channel when explicit channel is unknown", async () => {
     const selection = await resolveMessageChannelSelection({
       cfg: {} as never,

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -25,13 +25,26 @@ function resolveKnownChannel(value?: string | null): MessageChannelId | undefine
   if (!normalized) {
     return undefined;
   }
-  if (!isDeliverableMessageChannel(normalized)) {
+  if (isDeliverableMessageChannel(normalized) && isKnownChannel(normalized)) {
+    return normalized as MessageChannelId;
+  }
+
+  const trimmed = value?.trim();
+  const separator = trimmed?.indexOf(":") ?? -1;
+  if (separator <= 0) {
     return undefined;
   }
-  if (!isKnownChannel(normalized)) {
+  const prefixed = normalizeMessageChannel(trimmed?.slice(0, separator));
+  if (!prefixed) {
     return undefined;
   }
-  return normalized as MessageChannelId;
+  if (!isDeliverableMessageChannel(prefixed)) {
+    return undefined;
+  }
+  if (!isKnownChannel(prefixed)) {
+    return undefined;
+  }
+  return prefixed as MessageChannelId;
 }
 
 function isAccountEnabled(account: unknown): boolean {
@@ -94,7 +107,8 @@ export async function resolveMessageChannelSelection(params: {
 }> {
   const normalized = normalizeMessageChannel(params.channel);
   if (normalized) {
-    if (!isKnownChannel(normalized)) {
+    const explicit = resolveKnownChannel(params.channel);
+    if (!explicit) {
       const fallback = resolveKnownChannel(params.fallbackChannel);
       if (fallback) {
         return {
@@ -106,7 +120,7 @@ export async function resolveMessageChannelSelection(params: {
       throw new Error(`Unknown channel: ${String(normalized)}`);
     }
     return {
-      channel: normalized as MessageChannelId,
+      channel: explicit,
       configured: await listConfiguredMessageChannels(params.cfg),
       source: "explicit",
     };


### PR DESCRIPTION
## Summary
- Fixes #31476 - message tool returns 'Unknown channel' for valid Discord channels after upgrading to 3.1
- Accept provider-prefixed channel values like 'discord:123...' for cross-channel routing

## Changes
- `src/infra/outbound/channel-selection.ts`: Fix channel resolution to handle prefixed values
- `src/infra/outbound/channel-selection.test.ts`: Add regression test

AI-assisted (Codex)