### PR TITLE
Clarify sessions_spawn thread-bound guidance and fallbacks

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -488,6 +488,7 @@ Notes:
   - Supports one-shot mode (`mode: "run"`) and persistent thread-bound mode (`mode: "session"` with `thread: true`).
   - If `thread: true` and `mode` is omitted, mode defaults to `session`.
   - `mode: "session"` requires `thread: true`.
+  - Persistent `mode: "session"` only works when the requester channel supports thread bindings. Otherwise use `mode: "run"`.
   - If `runTimeoutSeconds` is omitted, OpenClaw uses `agents.defaults.subagents.runTimeoutSeconds` when set; otherwise timeout defaults to `0` (no timeout).
   - Discord thread-bound flows depend on `session.threadBindings.*` and `channels.discord.threadBindings.*`.
   - Reply format includes `Status`, `Result`, and compact stats.

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -89,6 +89,7 @@ Tool params:
   - default is `run`
   - if `thread: true` and `mode` omitted, default becomes `session`
   - `mode: "session"` requires `thread: true`
+  - if thread binding is unavailable for the requester channel, fall back to `mode: "run"` instead of claiming a persistent session exists
 - `cleanup?` (`delete|keep`, default `keep`)
 - `sandbox?` (`inherit|require`, default `inherit`; `require` rejects spawn unless target child runtime is sandboxed)
 - `sessions_spawn` does **not** accept channel-delivery params (`target`, `channel`, `to`, `threadId`, `replyTo`, `transport`). For delivery, use `message`/`sessions_send` from the spawned run.
@@ -108,6 +109,8 @@ Quick flow:
 3. Replies and follow-up messages in that thread route to the bound session.
 4. Use `/session idle` to inspect/update inactivity auto-unfocus and `/session max-age` to control the hard cap.
 5. Use `/unfocus` to detach manually.
+
+If the requester channel does not support thread bindings, `thread: true` will fail. In that case use `mode: "run"` for one-shot work instead of retrying impossible thread-bound combinations.
 
 Manual controls:
 

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -279,7 +279,8 @@ export async function spawnAcpDirect(
   if (spawnMode === "session" && !requestThreadBinding) {
     return {
       status: "error",
-      error: 'mode="session" requires thread=true so the ACP session can stay bound to a thread.',
+      error:
+        'mode="session" requires thread=true so the ACP session can stay bound to a thread. For one-shot ACP work, use mode="run" instead.',
     };
   }
 

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1041,6 +1041,7 @@ export function buildSubagentSystemPrompt(params: {
             "Do not use `exec` (`openclaw ...`, `acpx ...`) to spawn ACP sessions.",
             'Use `subagents` only for OpenClaw subagents (`runtime: "subagent"`).',
             "Subagent results auto-announce back to you; ACP sessions continue in their bound thread.",
+            'Only request `mode: "session"` when thread binding is actually available for the requester channel. Otherwise use `mode: "run"` and treat the ACP session as one-shot.',
             "Avoid polling loops; spawn, orchestrate, and synthesize results.",
           ]
         : []),

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -201,7 +201,7 @@ async function ensureThreadBindingForSubagentSpawn(params: {
     return {
       status: "error",
       error:
-        "thread=true is unavailable because no channel plugin registered subagent_spawning hooks.",
+        'thread=true is unavailable because the current requester channel does not provide thread-binding hooks. Use mode="run" for one-shot work, or spawn from a thread-capable channel.',
     };
   }
 
@@ -272,7 +272,8 @@ export async function spawnSubagentDirect(
   if (spawnMode === "session" && !requestThreadBinding) {
     return {
       status: "error",
-      error: 'mode="session" requires thread=true so the subagent can stay bound to a thread.',
+      error:
+        'mode="session" requires thread=true so the subagent can stay bound to a thread. For one-shot background work, use mode="run" instead.',
     };
   }
   const cleanup =

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -263,6 +263,9 @@ describe("buildAgentSystemPrompt", () => {
       'On Discord, default ACP harness requests to thread-bound persistent sessions (`thread: true`, `mode: "session"`)',
     );
     expect(prompt).toContain(
+      'Outside thread-capable channels, do not request persistent ACP sessions; fall back to one-shot `mode: "run"`',
+    );
+    expect(prompt).toContain(
       "do not route ACP harness requests through `subagents`/`agents_list` or local PTY exec flows",
     );
     expect(prompt).toContain(
@@ -695,6 +698,9 @@ describe("buildSubagentSystemPrompt", () => {
     expect(prompt).toContain("Do not use `exec` (`openclaw ...`, `acpx ...`)");
     expect(prompt).toContain("Use `subagents` only for OpenClaw subagents");
     expect(prompt).toContain("Subagent results auto-announce back to you");
+    expect(prompt).toContain(
+      'Only request `mode: "session"` when thread binding is actually available for the requester channel.',
+    );
     expect(prompt).toContain("Avoid polling loops");
     expect(prompt).toContain("spawned by the main agent");
     expect(prompt).toContain("reported to the main agent");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -451,6 +451,7 @@ export function buildAgentSystemPrompt(params: {
       ? [
           'For requests like "do this in codex/claude code/gemini", treat it as ACP harness intent and call `sessions_spawn` with `runtime: "acp"`.',
           'On Discord, default ACP harness requests to thread-bound persistent sessions (`thread: true`, `mode: "session"`) unless the user asks otherwise.',
+          'Outside thread-capable channels, do not request persistent ACP sessions; fall back to one-shot `mode: "run"` and do not claim thread binding exists.',
           "Set `agentId` explicitly unless `acp.defaultAgent` is configured, and do not route ACP harness requests through `subagents`/`agents_list` or local PTY exec flows.",
           'For ACP harness thread spawns, do not call `message` with `action=thread-create`; use `sessions_spawn` (`runtime: "acp"`, `thread: true`) as the single thread creation path.',
         ]

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -75,7 +75,7 @@ export function createSessionsSpawnTool(opts?: {
     label: "Sessions",
     name: "sessions_spawn",
     description:
-      'Spawn an isolated session (runtime="subagent" or runtime="acp"). mode="run" is one-shot and mode="session" is persistent/thread-bound.',
+      'Spawn an isolated session (runtime="subagent" or runtime="acp"). mode="run" is one-shot. mode="session" is persistent/thread-bound and only works when the requester channel supports thread bindings.',
     parameters: SessionsSpawnToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- clarify that persistent `mode: "session"` only works when the requester channel supports thread bindings
- improve `sessions_spawn` error copy to suggest `mode: "run"` fallback for one-shot work
- update agent prompt guidance so models stop claiming thread-bound ACP/subagent sessions on unsupported channels
- document the fallback in the subagent and tool docs

## Why
OpenClaw currently validates these cases correctly, but the prompt and tool copy still steer agents toward impossible thread-bound combinations. In practice that leads to repeated `sessions_spawn` errors such as:
- `mode="session" requires thread=true ...`
- `thread=true is unavailable because no channel plugin registered subagent_spawning hooks`

This patch keeps the runtime behavior the same while making the contract and fallback explicit, which should reduce false success claims and improve autonomous recovery.

## Validation
- source diff reviewed locally
- repo tests not run in this checkout because dependencies are not installed yet (`vitest` unavailable without a full install)
