### PR TITLE
fix(signal): accept group envelopes with syncMessage null

### DIFF
--- a/src/signal/monitor/event-handler.inbound-contract.test.ts
+++ b/src/signal/monitor/event-handler.inbound-contract.test.ts
@@ -226,4 +226,31 @@ describe("signal createSignalEventHandler inbound contract", () => {
     expect(capture.ctx).toBeUndefined();
     expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
   });
+
+  it("accepts inbound group envelopes when syncMessage is present but null", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 } },
+          channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+        },
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        syncMessage: null,
+        dataMessage: {
+          message: "group hello",
+          attachments: [],
+          groupInfo: { groupId: "g1", groupName: "Ops" },
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.ChatType).toBe("group");
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -458,15 +458,16 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       return;
     }
 
-    // Filter all sync messages (sentTranscript, readReceipts, etc.).
-    // signal-cli may set syncMessage to null instead of omitting it, so
-    // check property existence rather than truthiness to avoid replaying
-    // the bot's own sent messages on daemon restart.
-    if ("syncMessage" in envelope) {
+    const dataMessage = envelope.dataMessage ?? envelope.editMessage?.dataMessage;
+    const maybeGroupId = dataMessage?.groupInfo?.groupId ?? undefined;
+
+    // Filter sync messages (sentTranscript, readReceipts, etc.).
+    // signal-cli can include `syncMessage: null` on regular group envelopes,
+    // so only apply the presence-based drop to non-group traffic.
+    if ("syncMessage" in envelope && !maybeGroupId) {
       return;
     }
 
-    const dataMessage = envelope.dataMessage ?? envelope.editMessage?.dataMessage;
     const reaction = deps.isSignalReactionMessage(envelope.reactionMessage)
       ? envelope.reactionMessage
       : deps.isSignalReactionMessage(dataMessage?.reaction)


### PR DESCRIPTION
## Summary
- Fixes #28322 - Signal group messages silently dropped in 2026.2.26
- Stop dropping regular group messages when signal-cli includes syncMessage: null on receive envelopes

## Changes
- `src/signal/monitor/event-handler.ts`: Fix group message filtering
- `src/signal/monitor/event-handler.inbound-contract.test.ts`: Add regression test
- `CHANGELOG.md`: Add fix entry

AI-assisted (Codex)