### PR TITLE
Fix web search key audit for Gemini, Grok, and Kimi

### DIFF
--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { collectAttackSurfaceSummaryFindings } from "./audit-extra.sync.js";
+import {
+  collectAttackSurfaceSummaryFindings,
+  collectSmallModelRiskFindings,
+} from "./audit-extra.sync.js";
 import { safeEqualSecret } from "./secret-equal.js";
 
 describe("collectAttackSurfaceSummaryFindings", () => {
@@ -51,5 +54,59 @@ describe("safeEqualSecret", () => {
     expect(safeEqualSecret(undefined, "secret")).toBe(false);
     expect(safeEqualSecret("secret", undefined)).toBe(false);
     expect(safeEqualSecret(null, "secret")).toBe(false);
+  });
+});
+
+describe("collectSmallModelRiskFindings", () => {
+  it.each([
+    {
+      name: "gemini config key",
+      cfgSearch: { gemini: { apiKey: "gemini-key" } },
+      env: {},
+    },
+    {
+      name: "grok config key",
+      cfgSearch: { grok: { apiKey: "xai-key" } },
+      env: {},
+    },
+    {
+      name: "kimi config key",
+      cfgSearch: { kimi: { apiKey: "kimi-key" } },
+      env: {},
+    },
+    {
+      name: "GEMINI_API_KEY env var",
+      cfgSearch: {},
+      env: { GEMINI_API_KEY: "gemini-key" },
+    },
+    {
+      name: "XAI_API_KEY env var",
+      cfgSearch: {},
+      env: { XAI_API_KEY: "xai-key" },
+    },
+    {
+      name: "KIMI_API_KEY env var",
+      cfgSearch: {},
+      env: { KIMI_API_KEY: "kimi-key" },
+    },
+    {
+      name: "MOONSHOT_API_KEY env var",
+      cfgSearch: {},
+      env: { MOONSHOT_API_KEY: "moonshot-key" },
+    },
+  ])("treats web search as enabled when $name is set", ({ cfgSearch, env }) => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "ollama/mistral-8b" } } },
+      tools: { web: { search: cfgSearch, fetch: { enabled: false } } },
+      browser: { enabled: false },
+    };
+
+    const finding = collectSmallModelRiskFindings({
+      cfg,
+      env: env as NodeJS.ProcessEnv,
+    }).find((entry) => entry.checkId === "models.small_params");
+
+    expect(finding?.severity).toBe("critical");
+    expect(finding?.detail).toContain("web_search");
   });
 });

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -329,7 +329,17 @@ function resolveToolPolicies(params: {
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+    search?.perplexity?.apiKey ||
+    search?.gemini?.apiKey ||
+    search?.grok?.apiKey ||
+    search?.kimi?.apiKey ||
+    env.BRAVE_API_KEY ||
+    env.PERPLEXITY_API_KEY ||
+    env.GEMINI_API_KEY ||
+    env.XAI_API_KEY ||
+    env.KIMI_API_KEY ||
+    env.MOONSHOT_API_KEY,
   );
 }
 


### PR DESCRIPTION
## Summary
- include Gemini/Grok/Kimi config keys in web search key audit
- include GEMINI_API_KEY/XAI_API_KEY/KIMI_API_KEY/MOONSHOT_API_KEY env vars
- add tests to assert small-model risk checks flag web_search when any of these keys exist

## Files
- src/security/audit-extra.sync.ts
- src/security/audit-extra.sync.test.ts

Fixes #34509