### PR TITLE
fix(cron): preserve telegram topic threadId when session lastTo has channel prefix (#15787)

### DIFF
--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -216,6 +216,43 @@ describe("resolveDeliveryTarget", () => {
     expect(result.threadId).toBe("thread-2");
   });
 
+  describe("Telegram topic threadId preservation", () => {
+    it("preserves lastThreadId when session lastTo has telegram: prefix but explicit delivery.to is bare chatId", async () => {
+      // Regression test for #15787: Telegram inbound sessions store lastTo as
+      // "telegram:-1003597428309" (with channel prefix) but cron delivery.to is
+      // the bare chat ID "-1003597428309". The strict equality check
+      // `resolved.to === resolved.lastTo` fails on this format mismatch, causing
+      // threadId to be dropped — so forum-topic announces land in the base group.
+      setMainSessionEntry({
+        sessionId: "sess-topic-1",
+        updatedAt: 1000,
+        lastChannel: "telegram",
+        lastTo: "telegram:123456", // real inbound session format
+        lastThreadId: 462,
+      });
+
+      const result = await resolveForAgent({ cfg: makeCfg({ bindings: [] }) });
+      // delivery.to = "123456" (DEFAULT_TARGET.to) should match "telegram:123456"
+      // and threadId 462 should be preserved.
+      expect(result.ok).toBe(true);
+      expect(result.threadId).toBe(462);
+    });
+
+    it("still drops threadId when explicit delivery.to targets a different chat", async () => {
+      setMainSessionEntry({
+        sessionId: "sess-topic-2",
+        updatedAt: 1000,
+        lastChannel: "telegram",
+        lastTo: "telegram:999999", // different chat
+        lastThreadId: 462,
+      });
+
+      const result = await resolveForAgent({ cfg: makeCfg({ bindings: [] }) });
+      // delivery.to = "123456" (DEFAULT_TARGET.to) — different from 999999
+      expect(result.threadId).toBeUndefined();
+    });
+  });
+
   it("uses single configured channel when neither explicit nor session channel exists", async () => {
     setMainSessionEntry(undefined);
 

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -36,6 +36,31 @@ export type DeliveryTargetResolution =
       error: Error;
     };
 
+/**
+ * Strips leading channel and chat-type prefixes from a stored target identifier
+ * so that values like `"telegram:-1003597428309"` and `"-1003597428309"` compare
+ * equal when checking whether a delivery target matches the session's lastTo.
+ *
+ * Channel outbound-session resolvers store `to` as `"<channel>:<id>"` or
+ * `"<channel>:<type>:<id>"` (e.g. `"telegram:group:-1003597428309"`), whereas
+ * explicit cron delivery.to values use the bare identifier.  Without this
+ * normalisation the strict-equality check drops lastThreadId for Telegram
+ * forum-topic groups, causing cron announces to land in the base group chat
+ * instead of the correct topic thread.
+ */
+function normalizeToForRecipientMatch(to: string | undefined): string {
+  if (!to) {
+    return "";
+  }
+  // Strip a leading word-colon prefix and an optional sub-type prefix.
+  // Matches patterns like:
+  //   "telegram:-100XXX"          → "-100XXX"
+  //   "telegram:group:-100XXX"    → "-100XXX"
+  //   "signal:+15551234567"       → "+15551234567"
+  //   "discord:channel:12345"     → "12345"
+  return to.replace(/^[a-z][a-z0-9-]*:(group:|channel:|direct:|room:)?/i, "");
+}
+
 export async function resolveDeliveryTarget(
   cfg: OpenClawConfig,
   agentId: string,
@@ -128,9 +153,17 @@ export async function resolveDeliveryTarget(
   // or when delivering to the same recipient as the session's last conversation.
   // Session-derived threadIds are dropped when the target differs to prevent
   // stale thread IDs from leaking to a different chat.
+  //
+  // NOTE: Session-stored `lastTo` values carry a channel prefix
+  // (e.g. "telegram:-1003597428309") while explicit delivery.to values are bare
+  // identifiers ("-1003597428309"). Normalise both before comparing so that a
+  // Telegram forum-topic session correctly carries its lastThreadId forward
+  // even when the cron job's delivery.to omits the channel prefix.
+  const normalizedTo = normalizeToForRecipientMatch(resolved.to);
+  const normalizedLastTo = normalizeToForRecipientMatch(resolved.lastTo);
+  const sameRecipient = Boolean(normalizedTo && normalizedTo === normalizedLastTo);
   const threadId =
-    resolved.threadId &&
-    (resolved.threadIdExplicit || (resolved.to && resolved.to === resolved.lastTo))
+    resolved.threadId && (resolved.threadIdExplicit || sameRecipient)
       ? resolved.threadId
       : undefined;
 

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -300,7 +300,7 @@ async function resolveImagesForRequest(
   for (const url of urls) {
     const source = parseImageUrlToSource(url);
     if (source.type === "base64") {
-      totalBytes += estimateBase64DecodedBytes(source.data);
+      totalBytes += estimateBase64DecodedBytes(source.data ?? "");
       if (totalBytes > limits.maxTotalImageBytes) {
         throw new Error(
           `Total image payload too large (${totalBytes}; limit ${limits.maxTotalImageBytes})`,


### PR DESCRIPTION
## Problem
Cron job announces targeting Telegram forum topics land in the base group chat instead of the correct topic thread. The topic thread ID (`lastThreadId`) is silently dropped during delivery target resolution.

## Root cause
`src/cron/isolated-agent/delivery-target.ts` preserves `lastThreadId` only when `resolved.to === resolved.lastTo`. This strict equality fails because Telegram sessions store `lastTo` as `"telegram:-1003597428309"` (with channel prefix) while explicit `delivery.to` values are bare identifiers like `"-1003597428309"`. The mismatch causes `threadId` to be dropped → `resolvedDelivery.threadId = undefined` → direct delivery path skipped → announce flow strips the topic ID → message lands in base group chat.

## Fix
Add `normalizeToForRecipientMatch()` in `delivery-target.ts` that strips leading channel/type prefixes (`telegram:`, `telegram:group:`, `signal:`, etc.) before the same-recipient comparison. Both values normalize to the bare chat ID so `lastThreadId = 462` is correctly preserved and routed via the topic-aware direct delivery path.

## Verification
- **Test:** `src/cron/isolated-agent/delivery-target.test.ts` — new "Telegram topic threadId preservation" describe block; fails on main (`undefined` vs `462`), passes on fix
- **Build:** clean compile (`build-output.log`)
- **Test suite:** no regressions (`test-output.log`)
- **Code proof:** old `resolved.to === resolved.lastTo` removed from source, `normalizeToForRecipientMatch` confirmed present (`step6-verify.log`)

Closes #15787