### PR TITLE
fix: include slack_channel_id in inbound metadata for DM reactions

### DIFF
--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -105,12 +105,19 @@ export async function handleSlackAction(
   cfg: OpenClawConfig,
   context?: SlackActionContext,
 ): Promise<AgentToolResult<unknown>> {
-  const resolveChannelId = () =>
-    resolveSlackChannelId(
-      readStringParam(params, "channelId", {
-        required: true,
-      }),
-    );
+  const resolveChannelId = () => {
+    // If channelId is explicitly provided, use it
+    const explicitChannelId = readStringParam(params, "channelId");
+    if (explicitChannelId) {
+      return resolveSlackChannelId(explicitChannelId);
+    }
+    // Otherwise, try to get slack_channel_id from tool context (issue #34414)
+    const slackChannelId = (params as { slack_channel_id?: string }).slack_channel_id;
+    if (slackChannelId) {
+      return slackChannelId;
+    }
+    throw new Error("Slack channel id is required (use channel:<id>).");
+  };
   const action = readStringParam(params, "action", { required: true });
   const accountId = readStringParam(params, "accountId");
   const account = resolveSlackAccount({ cfg, accountId });

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -727,6 +727,10 @@ export async function prepareSlackMessage(params: {
     CommandAuthorized: commandAuthorized,
     OriginatingChannel: "slack" as const,
     OriginatingTo: slackTo,
+    // Include actual Slack channel ID for reactions and other channel-specific operations.
+    // This is needed for DMs where OriginatingTo is user:<id> but reactions need
+    // to actual channel ID (issue #34414).
+    slack_channel_id: message.channel,
   }) satisfies FinalizedMsgContext;
   const pinnedMainDmOwner = isDirectMessage
     ? resolvePinnedMainDmOwnerFromAllowlist({


### PR DESCRIPTION
## Summary

- Problem: Slack DM reactions fail due to missing channel ID in inbound metadata
- Why it matters: Agents cannot react to messages in Slack DMs, limiting interactive feedback
- What changed: Added slack_channel_id to inbound metadata and updated message tool to use it

## Change Type

- [x] Bug fix

## Scope

- [x] Skills / tool execution
- [x] Slack

## Testing

- [x] Manual testing
- [x] Code review

## AI-Assisted

This PR was created with AI assistance.

- Testing: Fully tested (all tests pass)
- Code understanding: Confirmed understanding of changes

Fixes #34414