### PR TITLE
fix(daemon): correct systemd availability checks for degraded user sessions

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -337,6 +337,21 @@ describe("systemd service control", () => {
     expect(String(write.mock.calls[0]?.[0])).toContain("Stopped systemd service");
   });
 
+  it("throws when systemd bus is unavailable during service stop", async () => {
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      // assertSystemdAvailable: bus unreachable
+      const err = new Error("Failed to connect to bus") as Error & { code?: number };
+      err.code = 1;
+      cb(err, "", "Failed to connect to bus");
+    });
+    const write = vi.fn();
+    const stdout = { write } as unknown as NodeJS.WritableStream;
+
+    await expect(stopSystemdService({ stdout, env: {} })).rejects.toThrow(
+      "systemctl --user unavailable",
+    );
+  });
+
   it("surfaces stop failures with systemctl detail", async () => {
     execFileMock
       .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -51,6 +51,15 @@ describe("systemd availability", () => {
     await expect(isSystemdUserServiceAvailable()).resolves.toBe(false);
   });
 
+  it("returns false when systemctl binary is missing (ENOENT)", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const err = new Error("spawn systemctl ENOENT") as Error & { code?: string };
+      err.code = "ENOENT";
+      cb(err, "", "");
+    });
+    await expect(isSystemdUserServiceAvailable()).resolves.toBe(false);
+  });
+
   it("falls back to machine user scope when --user bus is unavailable", async () => {
     execFileMock
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
@@ -338,8 +347,8 @@ describe("systemd service control", () => {
   });
 
   it("throws when systemd bus is unavailable during service stop", async () => {
-    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
-      // assertSystemdAvailable: bus unreachable
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      // assertSystemdAvailable: bus unreachable (both direct and machine-scope fallback)
       const err = new Error("Failed to connect to bus") as Error & { code?: number };
       err.code = 1;
       cb(err, "", "Failed to connect to bus");

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -29,6 +29,15 @@ describe("systemd availability", () => {
     await expect(isSystemdUserServiceAvailable()).resolves.toBe(true);
   });
 
+  it("returns true when systemd has degraded units (non-zero exit)", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const err = new Error("Command failed: systemctl --user status") as Error & { code?: number };
+      err.code = 1;
+      cb(err, "● user.slice - User Slice\n   State: degraded\n", "");
+    });
+    await expect(isSystemdUserServiceAvailable()).resolves.toBe(true);
+  });
+
   it("returns false when systemd user bus is unavailable", async () => {
     execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
       const err = new Error("Failed to connect to bus") as Error & {
@@ -305,6 +314,27 @@ describe("systemd service control", () => {
 
     expect(write).toHaveBeenCalledTimes(1);
     expect(String(write.mock.calls[0]?.[0])).toContain("Restarted systemd service");
+  });
+
+  it("stops the service even when systemd has degraded units", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => {
+        // assertSystemdAvailable: systemd available but degraded
+        const err = new Error("Command failed") as Error & { code?: number };
+        err.code = 1;
+        cb(err, "State: degraded", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "stop", "openclaw-gateway.service"]);
+        cb(null, "", "");
+      });
+    const write = vi.fn();
+    const stdout = { write } as unknown as NodeJS.WritableStream;
+
+    await stopSystemdService({ stdout, env: {} });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(String(write.mock.calls[0]?.[0])).toContain("Stopped systemd service");
   });
 
   it("surfaces stop failures with systemctl detail", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -289,8 +289,18 @@ async function assertSystemdAvailable(env: GatewayServiceEnv = process.env as Ga
   if (isSystemctlMissing(detail)) {
     throw new Error("systemctl not available; systemd user services are required on Linux.");
   }
-  // Non-zero exit without missing indicators means systemd is available
-  // but has degraded/failed units — acceptable for service operations.
+  // Check for bus-unavailability errors (matches isSystemdUserServiceAvailable checks).
+  const lower = detail.toLowerCase();
+  if (
+    lower.includes("failed to connect") ||
+    lower.includes("not been booted") ||
+    lower.includes("no such file or directory") ||
+    lower.includes("not supported")
+  ) {
+    throw new Error(`systemctl --user unavailable: ${detail || "unknown error"}`.trim());
+  }
+  // Non-zero exit without missing/unavailability indicators means systemd is
+  // available but has degraded/failed units — acceptable for service operations.
 }
 
 export async function installSystemdService({

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -275,6 +275,10 @@ export async function isSystemdUserServiceAvailable(
   if (detail.includes("not supported")) {
     return false;
   }
+  // Catch missing/blocked systemctl binary (e.g. "spawn systemctl ENOENT").
+  if (isSystemctlMissing(detail)) {
+    return false;
+  }
   // Non-zero exit without any unavailability indicator means systemd is
   // present but has degraded/failed units — still available for our purposes.
   return true;

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -275,7 +275,9 @@ export async function isSystemdUserServiceAvailable(
   if (detail.includes("not supported")) {
     return false;
   }
-  return false;
+  // Non-zero exit without any unavailability indicator means systemd is
+  // present but has degraded/failed units — still available for our purposes.
+  return true;
 }
 
 async function assertSystemdAvailable(env: GatewayServiceEnv = process.env as GatewayServiceEnv) {
@@ -287,7 +289,8 @@ async function assertSystemdAvailable(env: GatewayServiceEnv = process.env as Ga
   if (isSystemctlMissing(detail)) {
     throw new Error("systemctl not available; systemd user services are required on Linux.");
   }
-  throw new Error(`systemctl --user unavailable: ${detail || "unknown error"}`.trim());
+  // Non-zero exit without missing indicators means systemd is available
+  // but has degraded/failed units — acceptable for service operations.
 }
 
 export async function installSystemdService({


### PR DESCRIPTION
## Summary

`isSystemdUserServiceAvailable()` and `assertSystemdAvailable()` both incorrectly treat a degraded systemd user session as unavailable.

`systemctl --user status` returns a non-zero exit code when any user unit has failed, which is common on real Linux systems. The current code checks for specific unavailability indicators ("not found", "failed to connect", etc.) and correctly returns `false` for those, but the **fall-through** also returns `false` / throws, even though none of the unavailability patterns matched — meaning systemd IS available.

Compare with `isSystemctlAvailable()` (line 410) in the same file, which handles this correctly:
```ts
return !isSystemctlMissing(readSystemctlDetail(res));
```

### Root cause

- `isSystemdUserServiceAvailable()` line 202: fall-through returns `false` instead of `true`
- `assertSystemdAvailable()` line 214: throws instead of returning normally

### Impact

On Linux systems with any failed systemd user units:
- Onboarding wizard silently skips daemon installation
- `openclaw gateway install/stop/restart` throws "systemctl --user unavailable"
- Doctor reports systemd as unavailable

Related to #33633, #34237, #34464.

**Note:** This fixes different functions from the existing is-enabled PRs — those address `isSystemdServiceEnabled()` / `readSystemctlDetail()`, while this PR fixes `isSystemdUserServiceAvailable()` and `assertSystemdAvailable()`.

### Tests

- Added: degraded systemd returns `true` from `isSystemdUserServiceAvailable`
- Added: `stopSystemdService` succeeds when systemd is degraded
- All 21 systemd tests pass.