### PR TITLE
fix(agents): recover reply when model omits <final> tags with enforceFinalTag

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -288,9 +288,12 @@ export function handleMessageEnd(
   let mediaUrls = parsedText?.mediaUrls;
   let hasMedia = Boolean(mediaUrls && mediaUrls.length > 0);
 
-  if (!cleanedText && !hasMedia && !ctx.params.enforceFinalTag) {
+  if (!cleanedText && !hasMedia) {
     const rawTrimmed = rawText.trim();
-    const rawStrippedFinal = rawTrimmed.replace(/<\s*\/?\s*final\s*>/gi, "").trim();
+    // Strip <think>…</think> blocks so reasoning content from thinking-enabled
+    // models does not leak into the reply when the model omits required <final> tags.
+    const rawNoThink = rawTrimmed.replace(/<think>[\s\S]*?<\/think>/gi, "").trim();
+    const rawStrippedFinal = rawNoThink.replace(/<\s*\/?\s*final\s*>/gi, "").trim();
     const rawCandidate = rawStrippedFinal || rawTrimmed;
     if (rawCandidate) {
       const parsedFallback = parseReplyDirectives(stripTrailingDirective(rawCandidate));

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
@@ -37,7 +37,7 @@ describe("subscribeEmbeddedPiSession", () => {
 
     expect(onPartialReply).not.toHaveBeenCalled();
   });
-  it("suppresses agent events on message_end without <final> tags when enforced", () => {
+  it("recovers plain text via fallback when model omits <final> tags even with enforceFinalTag", () => {
     const { session, emit } = createStubSessionHarness();
 
     const onAgentEvent = vi.fn();
@@ -49,10 +49,33 @@ describe("subscribeEmbeddedPiSession", () => {
       onAgentEvent,
     });
     emitMessageStartAndEndForAssistantText({ emit, text: "Hello world" });
-    // With enforceFinalTag, text without <final> tags is treated as leaked
-    // reasoning and should NOT be recovered by the message_end fallback.
+    // With enforceFinalTag, text without <final> tags is now recovered via the
+    // message_end fallback so non-compliant models (e.g. MiniMax-M2.5) still
+    // produce visible output instead of silently dropping the reply.
     const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads).toHaveLength(0);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].text).toBe("Hello world");
+  });
+
+  it("strips <think> blocks from fallback text when model omits <final> tags", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onAgentEvent,
+    });
+    emitMessageStartAndEndForAssistantText({
+      emit,
+      text: "<think>internal reasoning</think>visible reply",
+    });
+    // The <think> block should be stripped; only the user-visible reply emitted.
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].text).toBe("visible reply");
   });
   it("emits via streaming when <final> tags are present and enforcement is on", () => {
     const { session, emit } = createStubSessionHarness();


### PR DESCRIPTION
## Problem

When `enforceFinalTag` is `true` (set for reasoning-tag providers such as MiniMax-M2.5, QwQ, DeepSeek-R1, etc.), the `message_end` fallback in `handleMessageEnd` was gated behind a `!ctx.params.enforceFinalTag` check:

```typescript
// before
if (!cleanedText && !hasMedia && !ctx.params.enforceFinalTag) {
```

When a model outputs plain text **without** `<final>…</final>` wrappers:

1. `ctx.stripBlockTags(rawText, …)` returns `""` (no `<final>` tags found, enforcement is strict)
2. `cleanedText` is empty
3. The fallback is **skipped** because `enforceFinalTag === true`
4. No `stream=assistant` event is emitted → TUI/channel receives nothing

This was reported with MiniMax-M2.5 when a roleplay prompt causes it to respond without `<final>` tags, making the reply completely invisible to the user.

## Fix

Remove the `!ctx.params.enforceFinalTag` guard so the fallback runs whenever `cleanedText` is empty, regardless of enforcement mode.

Additionally, strip `<think>…</think>` blocks in the fallback path to prevent reasoning content from leaking into the reply when a thinking-enabled model emits `<think>` without `<final>`:

```typescript
// after
if (!cleanedText && !hasMedia) {
  const rawTrimmed = rawText.trim();
  // Strip <think>…</think> blocks so reasoning content does not leak
  const rawNoThink = rawTrimmed.replace(/<think>[\s\S]*?<\/think>/gi, "").trim();
  const rawStrippedFinal = rawNoThink.replace(/<\s*\/?\.final\s*>/gi, "").trim();
  const rawCandidate = rawStrippedFinal || rawTrimmed;
  …
}
```

Note: `extractAssistantText` already calls `stripThinkingTagsFromText` before `rawText` reaches this handler, so the explicit `<think>` strip is a defensive layer.

## Tests

Updated the existing test **"suppresses agent events on message_end without `<final>` tags when enforced"** → now correctly asserts that a plain-text reply **is** recovered even when `enforceFinalTag=true`.

Added a new test verifying that `<think>` blocks are stripped when the model uses thinking but omits `<final>`.

Fixes #34537