### PR TITLE
fix(models): apply updated provider baseUrl in merge mode

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -207,7 +207,7 @@ describe("models-config", () => {
     });
   });
 
-  it("preserves non-empty agent apiKey/baseUrl for matching providers in merge mode", async () => {
+  it("preserves non-empty agent apiKey but applies config baseUrl for matching providers in merge mode", async () => {
     await withTempHome(async () => {
       const parsed = await runCustomProviderMergeTest({
         baseUrl: "https://agent.example/v1",
@@ -216,7 +216,7 @@ describe("models-config", () => {
         models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
       });
       expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
-      expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
     });
   });
 

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -162,7 +162,10 @@ function mergeWithExistingProviderSecrets(params: {
     if (typeof existing.apiKey === "string" && existing.apiKey) {
       preserved.apiKey = existing.apiKey;
     }
-    if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+    const hasConfigBaseUrl =
+      typeof newEntry.baseUrl === "string" && newEntry.baseUrl.trim().length > 0;
+    // Keep existing baseUrl only when config does not provide one.
+    if (!hasConfigBaseUrl && typeof existing.baseUrl === "string" && existing.baseUrl) {
       preserved.baseUrl = existing.baseUrl;
     }
     mergedProviders[key] = { ...newEntry, ...preserved };


### PR DESCRIPTION
## Summary
- fix merge-mode provider reconciliation so `models.json` does not keep a stale provider `baseUrl` when `openclaw.json` specifies a new non-empty `baseUrl`
- keep existing `apiKey` preservation behavior unchanged for local secret continuity
- update regression coverage to assert that merge mode preserves existing `apiKey` while applying config `baseUrl`

## Problem
When users changed a third-party provider API address in `openclaw.json`, merge mode could still preserve the old non-empty `baseUrl` from `agent/models.json`. Runtime requests then continued to hit the outdated endpoint.

Fixes #34476

## Testing
- `pnpm test src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts`
- `pnpm build && pnpm check && pnpm test`

## AI disclosure
This PR is AI-assisted. Code has been fully tested locally. I understand what this code does.
