### PR TITLE
fix(feishu): prevent reaction suffix in API message_id calls

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -116,6 +116,9 @@ export async function resolveReactionSyntheticEvent(
     },
     message: {
       message_id: `${messageId}:reaction:${emoji}:${uuid()}`,
+      // Point root_id at the original message so the bot handler uses the
+      // base message_id (not the suffixed synthetic one) for API reply calls.
+      root_id: messageId,
       chat_id: syntheticChatId,
       chat_type: syntheticChatType,
       message_type: "text",

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -291,6 +291,7 @@ describe("resolveReactionSyntheticEvent", () => {
       },
       message: {
         message_id: "om_msg1:reaction:THUMBSUP:fixed-uuid",
+        root_id: "om_msg1",
         chat_id: "oc_group_from_event",
         chat_type: "group",
         message_type: "text",


### PR DESCRIPTION
## Summary

- Set `root_id` on reaction synthetic events to point to the original base `message_id`
- The bot handler uses `ctx.rootId ?? ctx.messageId` for reply targeting (bot.ts:1340), so with `root_id` set, it picks the clean base message_id instead of the suffixed synthetic one
- The suffixed `message_id` (e.g. `om_xxx:reaction:THUMBSUP:uuid`) is preserved for deduplication

## Root cause

`resolveReactionSyntheticEvent()` creates a synthetic event with a unique `message_id` that includes a `:reaction:EMOJI:uuid` suffix for deduplication. But the synthetic event had no `root_id`, so the bot handler fell back to using the suffixed `message_id` as the reply target. This suffixed ID was then passed to Feishu API calls (reply, get message, etc.), causing 400 errors because Feishu only accepts base `om_xxx` format message IDs.

Fixes #34528

## Test plan

- [x] All 16 Feishu reaction tests pass
- [x] All 297 Feishu extension tests pass
- [x] Updated snapshot test to include `root_id` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)