### PR TITLE
fix(agents): fall back to raw text when enforceFinalTag drops entire response

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -16,6 +16,7 @@ import {
   extractThinkingFromTaggedText,
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
+  stripThinkingTagsFromText,
 } from "./pi-embedded-utils.js";
 
 const stripTrailingDirective = (text: string): string => {
@@ -288,10 +289,20 @@ export function handleMessageEnd(
   let mediaUrls = parsedText?.mediaUrls;
   let hasMedia = Boolean(mediaUrls && mediaUrls.length > 0);
 
-  if (!cleanedText && !hasMedia && !ctx.params.enforceFinalTag) {
+  // Fallback: if no cleaned text was produced, try using the raw text.
+  // When enforceFinalTag is true, only fall back if no assistant event was
+  // emitted during streaming — otherwise the model simply didn't produce
+  // <final> tags and the response would be silently dropped (#34537).
+  if (
+    !cleanedText &&
+    !hasMedia &&
+    (!ctx.params.enforceFinalTag || !ctx.state.emittedAssistantUpdate)
+  ) {
     const rawTrimmed = rawText.trim();
     const rawStrippedFinal = rawTrimmed.replace(/<\s*\/?\s*final\s*>/gi, "").trim();
-    const rawCandidate = rawStrippedFinal || rawTrimmed;
+    // Strip thinking tags so reasoning content doesn't leak in the fallback.
+    const rawStripped = stripThinkingTagsFromText(rawStrippedFinal || rawTrimmed);
+    const rawCandidate = rawStripped.trim();
     if (rawCandidate) {
       const parsedFallback = parseReplyDirectives(stripTrailingDirective(rawCandidate));
       cleanedText = parsedFallback.text ?? rawCandidate;

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
@@ -37,7 +37,7 @@ describe("subscribeEmbeddedPiSession", () => {
 
     expect(onPartialReply).not.toHaveBeenCalled();
   });
-  it("suppresses agent events on message_end without <final> tags when enforced", () => {
+  it("falls back to raw text on message_end without <final> tags when enforced and nothing was streamed", () => {
     const { session, emit } = createStubSessionHarness();
 
     const onAgentEvent = vi.fn();
@@ -49,8 +49,29 @@ describe("subscribeEmbeddedPiSession", () => {
       onAgentEvent,
     });
     emitMessageStartAndEndForAssistantText({ emit, text: "Hello world" });
-    // With enforceFinalTag, text without <final> tags is treated as leaked
-    // reasoning and should NOT be recovered by the message_end fallback.
+    // When enforceFinalTag is true but no assistant event was emitted during
+    // streaming, the message_end fallback fires so the response isn't silently
+    // dropped (#34537).  Thinking tags are stripped in the fallback path.
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].text).toBe("Hello world");
+  });
+  it("suppresses thinking-only text on message_end when enforceFinalTag is true", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onAgentEvent,
+    });
+    emitMessageStartAndEndForAssistantText({
+      emit,
+      text: "<think>internal reasoning only</think>",
+    });
+    // Thinking-only content is correctly stripped and nothing is emitted.
     const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
     expect(payloads).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary

- When `enforceFinalTag` is true and the model produces text without `<final>` tags, the entire response was silently dropped — nothing shown in TUI
- Add a message_end fallback: if no assistant event was emitted during streaming, fall back to the raw text (with thinking tags stripped) instead of showing nothing
- This preserves the streaming-time enforcement (thinking content is still filtered during deltas) while preventing silent response drops

## Root cause

`stripBlockTags()` returns empty string when `enforceFinalTag` is true and no `<final>` tags are found. The `message_end` fallback that could recover the text was gated by `!ctx.params.enforceFinalTag`, so it was skipped entirely. This affected MiniMax M2.5 and Google providers that use tag-based reasoning.

## Changes

- `src/agents/pi-embedded-subscribe.handlers.messages.ts`: Allow message_end fallback when `enforceFinalTag` is true but nothing was streamed; strip thinking tags in fallback path
- Test: Updated expectation + added test for thinking-only suppression

Fixes #34537

## Test plan

- [x] All 6 final-tag enforcement tests pass (including 2 new tests)
- [x] All 133 subscribe tests pass across 27 test files
- [x] Thinking-only content (`<think>...</think>`) is correctly suppressed even in fallback
- [x] Normal text without `<final>` tags is shown as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)