### PR TITLE
fix(web-fetch): allow RFC 2544 benchmark range IPs in SSRF guard

### DIFF
--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -130,6 +130,19 @@ describe("web_fetch SSRF protection", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("allows RFC 2544 benchmark range IPs (198.18.0.0/15) used by DNS proxy tools", async () => {
+    lookupMock.mockResolvedValue([{ address: "198.18.1.5", family: 4 }]);
+
+    setMockFetch().mockResolvedValue(textResponse("ok"));
+    const tool = await createWebFetchToolForTest();
+
+    const result = await tool?.execute?.("call", { url: "https://example.com" });
+    expect(result?.details).toMatchObject({
+      status: 200,
+      extractor: "raw",
+    });
+  });
+
   it("allows public hosts", async () => {
     lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
 

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -527,6 +527,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
+      policy: { allowRfc2544BenchmarkRange: true },
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",


### PR DESCRIPTION
## Summary

- Problem: The `web_fetch` tool's SSRF guard blocks DNS-resolved IPs in the `198.18.0.0/15` range (RFC 2544 benchmark), reporting `Blocked: resolves to private/internal/special-use IP address`. This range is commonly used by DNS proxy tools (e.g. Clash) as fake IPs for transparent proxying.
- Why it matters: Users running openclaw behind a Clash-like DNS proxy cannot use `web_fetch` at all, since every URL's DNS resolution returns a fake IP in this range.
- What changed: Pass `policy: { allowRfc2544BenchmarkRange: true }` in `runWebFetch`'s call to `fetchWithWebToolsNetworkGuard`, and add a corresponding SSRF test.
- What did NOT change (scope boundary): No other SSRF protections are weakened. Private IPs (`10.x`, `172.16.x`, `192.168.x`), loopback, link-local, and all other blocked ranges remain blocked. The `allowRfc2544BenchmarkRange` option is already used by Telegram, Slack, Discord media handlers, and `withTrustedWebToolsEndpoint`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

`web_fetch` no longer rejects URLs whose DNS resolves to the `198.18.0.0/15` range. Users behind Clash or similar DNS proxy tools can now use `web_fetch` without errors.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — the same fetch is made; only the IP validation policy is relaxed for one specific IANA range.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

The `198.18.0.0/15` range (RFC 2544) is designated for network benchmark testing and is not routable on the public internet. Allowing it in the SSRF guard does not expose any internal services. This is consistent with how other components (Telegram, Slack, Discord) already handle this range.

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node.js >= 22.12.0
- Model/provider: Any
- Integration/channel (if any): Any channel using `web_fetch`
- Relevant config (redacted): System-level DNS proxy (e.g. Clash) configured with fake-ip mode using `198.18.0.0/15`

### Steps

1. Configure Clash (or similar) with fake-ip mode (default pool: `198.18.0.0/15`)
2. Run openclaw and invoke `web_fetch` with any public URL (e.g. `https://example.com`)
3. Observe error: `Blocked: resolves to private/internal/special-use IP address`

### Expected

- `web_fetch` successfully fetches the URL content

### Actual

- `web_fetch` throws `SsrFBlockedError: Blocked: resolves to private/internal/special-use IP address`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test `allows RFC 2544 benchmark range IPs (198.18.0.0/15) used by DNS proxy tools` added in `web-fetch.ssrf.test.ts`. The test mocks DNS resolution to return `198.18.1.5` and verifies that `web_fetch` completes successfully instead of throwing.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Manually patched the compiled `dist/` JS file on a production server running behind Clash fake-ip DNS. Confirmed `web_fetch` works correctly after the fix.
- Edge cases checked: Other SSRF-blocked ranges (private, loopback, link-local) remain blocked.
- What you did **not** verify: Did not verify with IPv6 fake-ip configurations.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the `policy: { allowRfc2544BenchmarkRange: true }` line from `src/agents/tools/web-fetch.ts`
- Files/config to restore: `src/agents/tools/web-fetch.ts`
- Known bad symptoms reviewers should watch for: None expected. If reverted, users behind Clash-like DNS proxies will see the original SSRF error.

## Risks and Mitigations

- Risk: Slightly widens the SSRF allow surface by permitting `198.18.0.0/15`.
  - Mitigation: This range is non-routable and designated for benchmark testing (RFC 2544). It cannot reach internal services. All other channel-facing components already allow this range. The guard still blocks all RFC 1918 private, loopback, link-local, carrier-grade NAT, and other special-use ranges.
