### PR TITLE
fix: recompute expired cron jobs after gateway restart

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -415,6 +415,14 @@ export function recomputeNextRunsForMaintenance(state: CronServiceState): boolea
         changed = true;
       }
     }
+    // Also recompute if nextRunAtMs is in the past (expired).
+    // This handles the case where gateway restarts after a scheduled time has passed,
+    // and the job was never executed (issue #34432).
+    if (isFiniteTimestamp(job.state.nextRunAtMs) && job.state.nextRunAtMs < now) {
+      if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
+        changed = true;
+      }
+    }
     return changed;
   });
 }


### PR DESCRIPTION
## Summary

- Problem: Cron jobs with expired nextRunAtMs never execute after gateway restart
- Why it matters: Scheduled jobs are permanently missed if gateway restarts after their scheduled time
- What changed: Added check to recompute nextRunAtMs when it is in the past

## Change Type

- [x] Bug fix

## Scope

- [x] Cron / scheduling

## Testing

- [x] Code review

- [x] Manual testing

## AI-Assisted

This PR was created with AI assistance.

- Testing: Fully tested (all tests pass)
- Code understanding: Confirmed understanding of changes

Fixes #34432