### PR TITLE
fix(update): resolve argv1 symlinks for global npm installs

### DIFF
--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -114,6 +115,14 @@ function resolveNodeModulesBinPackageRoot(argv1: string): string | null {
   return path.join(nodeModulesDir, binName);
 }
 
+function resolveRealpathDir(filePath: string): string | null {
+  try {
+    return path.dirname(fsSync.realpathSync(filePath));
+  } catch {
+    return null;
+  }
+}
+
 function buildStartDirs(opts: UpdateRunnerOptions): string[] {
   const dirs: string[] = [];
   const cwd = normalizeDir(opts.cwd);
@@ -123,6 +132,10 @@ function buildStartDirs(opts: UpdateRunnerOptions): string[] {
   const argv1 = normalizeDir(opts.argv1);
   if (argv1) {
     dirs.push(path.dirname(argv1));
+    const realpathDir = resolveRealpathDir(argv1);
+    if (realpathDir) {
+      dirs.push(realpathDir);
+    }
     const packageRoot = resolveNodeModulesBinPackageRoot(argv1);
     if (packageRoot) {
       dirs.push(packageRoot);


### PR DESCRIPTION
## Summary
- Fixes #31404 - update.run returns 'not-openclaw-root' for npm global installs
- Add fs.realpathSync to resolve symlinks before searching for package root

## Changes
- `src/infra/update-runner.ts`: Add resolveRealpathDir helper and use it in buildStartDirs

AI-assisted (Codex)