### PR TITLE
docs(agents): update memory search descriptions to reflect recursive glob

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -47,7 +47,7 @@ function buildMemorySection(params: {
   }
   const lines = [
     "## Memory Recall",
-    "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
+    "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/**/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
   ];
   if (params.citationsMode === "off") {
     lines.push(

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -50,7 +50,7 @@ export function createMemorySearchTool(options: {
     label: "Memory Search",
     name: "memory_search",
     description:
-      "Mandatory recall step: semantically search MEMORY.md + memory/*.md (and optional session transcripts) before answering questions about prior work, decisions, dates, people, preferences, or todos; returns top snippets with path + lines. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user.",
+      "Mandatory recall step: semantically search MEMORY.md + memory/**/*.md (and optional session transcripts) before answering questions about prior work, decisions, dates, people, preferences, or todos; returns top snippets with path + lines. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user.",
     parameters: MemorySearchSchema,
     execute: async (_toolCallId, params) => {
       const query = readStringParam(params, "query", { required: true });
@@ -111,7 +111,7 @@ export function createMemoryGetTool(options: {
     label: "Memory Get",
     name: "memory_get",
     description:
-      "Safe snippet read from MEMORY.md or memory/*.md with optional from/lines; use after memory_search to pull only the needed lines and keep context small.",
+      "Safe snippet read from MEMORY.md or memory/**/*.md with optional from/lines; use after memory_search to pull only the needed lines and keep context small.",
     parameters: MemoryGetSchema,
     execute: async (_toolCallId, params) => {
       const relPath = readStringParam(params, "path", { required: true });

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -84,7 +84,7 @@ function emitMemorySecretResolveDiagnostics(
 function formatSourceLabel(source: string, workspaceDir: string, agentId: string): string {
   if (source === "memory") {
     return shortenHomeInString(
-      `memory (MEMORY.md + ${path.join(workspaceDir, "memory")}${path.sep}*.md)`,
+      `memory (MEMORY.md + ${path.join(workspaceDir, "memory")}${path.sep}**${path.sep}*.md)`,
     );
   }
   if (source === "sessions") {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -716,7 +716,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.envelopeElapsed": 'Include elapsed time in message envelopes ("on" or "off").',
   "agents.defaults.models": "Configured model catalog (keys are full provider/model IDs).",
   "agents.defaults.memorySearch":
-    "Vector search over MEMORY.md and memory/*.md (per-agent overrides supported).",
+    "Vector search over MEMORY.md and memory/**/*.md (per-agent overrides supported).",
   "agents.defaults.memorySearch.enabled":
     "Master toggle for memory search indexing and retrieval behavior on this agent profile. Keep enabled for semantic recall, and disable when you want fully stateless responses.",
   "agents.defaults.memorySearch.sources":


### PR DESCRIPTION
## Summary

- **Problem:** Tool descriptions, system prompt, config help, and CLI output reference `memory/*.md` (flat pattern), but the actual memory search backend already supports recursive subdirectory scanning via `walkDir`, `**/*.md` glob in backend-config.ts, and chokidar watcher.
- **Why it matters:** Users organizing daily memory files into monthly subdirectories (e.g. `memory/2026-02/2026-02-15.md`) are told by the agent that only flat-structure files are searchable, when in fact recursive search already works.
- **What changed:** Updated all user-facing `memory/*.md` references to `memory/**/*.md` across 4 files: system prompt, tool descriptions, config help text, and CLI output.
- **What did NOT change:** No runtime behavior change — the search backend already supports recursive glob. This is a documentation-only fix.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34400

## User-visible / Behavior Changes

- Agent system prompt now correctly tells the LLM that `memory/**/*.md` (recursive) is searchable
- `memory_search` and `memory_get` tool descriptions now say `memory/**/*.md`
- Config help text updated to `memory/**/*.md`
- CLI `openclaw memory` output path now shows `memory/**/\*.md`

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js
- Integration/channel: N/A (documentation only)

### Steps

1. Run `openclaw memory status` — verify CLI output shows `**/*.md`
2. Check agent system prompt includes `memory/**/*.md`
3. Verify `memory_search` tool description references `memory/**/*.md`

### Expected

- All user-facing strings reflect recursive glob pattern

### Actual

- Before fix: strings show `memory/*.md` (flat only)
- After fix: strings show `memory/**/*.md` (recursive)

## Evidence

Backend already uses recursive patterns:
- `src/memory/internal.ts`: `walkDir` recursively traverses `memory/` directory
- `src/memory/backend-config.ts`: QMD collections use `pattern: "**/*.md"` for memory directory
- `src/memory/manager-sync-ops.ts`: chokidar watches `memory/**/*.md`

## Human Verification (required)

- Verified scenarios: Grepped all `memory/*.md` references in `src/` to ensure complete coverage
- Edge cases checked: Confirmed `schema.help.ts` line 804 already uses `memory/**/*.md` (consistent)
- What I did **not** verify: Did not run the full memory search pipeline end-to-end

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the 4 string changes
- Files/config to restore: N/A
- Known bad symptoms: N/A (no runtime behavior change)

## Risks and Mitigations

None — this is a documentation-only change with no runtime impact.
