### PR TITLE
feat(feishu): parse interactive card content in merge_forward sub-messages

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -28,7 +28,7 @@ import {
 import { parsePostContent } from "./post.js";
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { getMessageFeishu, sendMessageFeishu } from "./send.js";
+import { getMessageFeishu, parseInteractiveCardContent, sendMessageFeishu } from "./send.js";
 import type { FeishuMessageContext, FeishuMediaInfo, ResolvedFeishuAccount } from "./types.js";
 import type { DynamicAgentCreationConfig } from "./types.js";
 
@@ -442,6 +442,8 @@ function formatSubMessageContent(content: string, contentType: string): string {
         return "[Sticker]";
       case "merge_forward":
         return "[Nested Merged Forward]";
+      case "interactive":
+        return parseInteractiveCardContent(parsed);
       default:
         return `[${contentType}]`;
     }

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -30,7 +30,7 @@ export type FeishuMessageInfo = {
   createTime?: number;
 };
 
-function parseInteractiveCardContent(parsed: unknown): string {
+export function parseInteractiveCardContent(parsed: unknown): string {
   if (!parsed || typeof parsed !== "object") {
     return "[Interactive Card]";
   }


### PR DESCRIPTION
## Summary

- **Problem:** When receiving a `merge_forward` (合并转发) message containing interactive cards, the card content is displayed as `[interactive]` instead of being parsed into readable text.
- **Why it matters:** Users forwarding messages with interactive cards lose all card content in the rendered output, making the forwarded message uninformative.
- **What changed:** Added an `interactive` case to `formatSubMessageContent()` in `bot.ts` that reuses the existing `parseInteractiveCardContent()` from `send.ts`. Exported `parseInteractiveCardContent` to make it available for import.
- **What did NOT change:** No changes to the card parsing logic itself — the same function already used in `parseQuotedMessageContent()` is reused. No changes to other message type handlers.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34571

## User-visible / Behavior Changes

- `merge_forward` messages containing interactive cards now display parsed card content (title, div text, markdown elements) instead of `[interactive]`
- Example: `[interactive]` → `Card text content from div and markdown elements`

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js
- Integration/channel: Feishu

### Steps

1. Configure a Feishu channel
2. Forward a merged message containing interactive cards to the bot
3. Observe the rendered sub-message content

### Expected

- Interactive card content is parsed and displayed as readable text

### Actual

- Before fix: `[interactive]` placeholder shown
- After fix: Card text elements (div, markdown) extracted and displayed

## Evidence

The `parseInteractiveCardContent()` function already handles interactive cards correctly in `send.ts` for quoted message parsing. The same function is now reused for merge_forward sub-messages:

```typescript
// send.ts - already exists and handles interactive cards
export function parseInteractiveCardContent(parsed: unknown): string {
  // Extracts div text.content and markdown content from card elements
  // Returns joined text or "[Interactive Card]" fallback
}

// bot.ts - new case added
case "interactive":
  return parseInteractiveCardContent(parsed);
```

## Human Verification (required)

- Verified scenarios: `parseInteractiveCardContent` is already tested in the `parseQuotedMessageContent` path; reusing it for `formatSubMessageContent` follows the same pattern
- Edge cases checked: Malformed card JSON falls through to the outer try/catch and returns raw content; empty cards return `[Interactive Card]` fallback
- What I did **not** verify: End-to-end test with actual Feishu merge_forward messages (no Feishu account available)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the 2 file changes
- Files/config to restore: `extensions/feishu/src/bot.ts`, `extensions/feishu/src/send.ts`
- Known bad symptoms: N/A — fallback to `[Interactive Card]` on parse failure

## Risks and Mitigations

None — reuses existing, proven parsing logic. Fallback handling preserves backward compatibility.
