### PR TITLE
feat(config): add baseUrl option for OpenAI TTS provider

### DIFF
--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -58,6 +58,7 @@ export type TtsConfig = {
   /** OpenAI configuration. */
   openai?: {
     apiKey?: SecretInput;
+    baseUrl?: string;
     model?: string;
     voice?: string;
   };

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -401,6 +401,7 @@ export const TtsConfigSchema = z
     openai: z
       .object({
         apiKey: SecretInputSchema.optional().register(sensitive),
+        baseUrl: z.string().optional(),
         model: z.string().optional(),
         voice: z.string().optional(),
       })

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -591,17 +591,20 @@ export async function elevenLabsTTS(params: {
 export async function openaiTTS(params: {
   text: string;
   apiKey: string;
+  baseUrl?: string;
   model: string;
   voice: string;
   responseFormat: "mp3" | "opus" | "pcm";
   timeoutMs: number;
 }): Promise<Buffer> {
   const { text, apiKey, model, voice, responseFormat, timeoutMs } = params;
+  const effectiveBaseUrl = params.baseUrl?.trim().replace(/\/+$/, "") || getOpenAITtsBaseUrl();
+  const isCustom = effectiveBaseUrl !== "https://api.openai.com/v1";
 
-  if (!isValidOpenAIModel(model)) {
+  if (!isCustom && !isValidOpenAIModel(model)) {
     throw new Error(`Invalid model: ${model}`);
   }
-  if (!isValidOpenAIVoice(voice)) {
+  if (!isCustom && !isValidOpenAIVoice(voice)) {
     throw new Error(`Invalid voice: ${voice}`);
   }
 
@@ -609,7 +612,7 @@ export async function openaiTTS(params: {
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(`${getOpenAITtsBaseUrl()}/audio/speech`, {
+    const response = await fetch(`${effectiveBaseUrl}/audio/speech`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${apiKey}`,

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -236,6 +236,30 @@ describe("tts", () => {
     });
   });
 
+  describe("resolveTtsConfig openai.baseUrl", () => {
+    it("resolves baseUrl from config", () => {
+      const cfg: OpenClawConfig = {
+        messages: { tts: { openai: { baseUrl: "http://localhost:8880/v1" } } },
+      };
+      const config = resolveTtsConfig(cfg);
+      expect(config.openai.baseUrl).toBe("http://localhost:8880/v1");
+    });
+
+    it("returns undefined when baseUrl is not configured", () => {
+      const cfg: OpenClawConfig = { messages: { tts: {} } };
+      const config = resolveTtsConfig(cfg);
+      expect(config.openai.baseUrl).toBeUndefined();
+    });
+
+    it("trims whitespace from baseUrl", () => {
+      const cfg: OpenClawConfig = {
+        messages: { tts: { openai: { baseUrl: "  http://my-tts.local/v1  " } } },
+      };
+      const config = resolveTtsConfig(cfg);
+      expect(config.openai.baseUrl).toBe("http://my-tts.local/v1");
+    });
+  });
+
   describe("parseTtsDirectives", () => {
     it("extracts overrides and strips directives when enabled", () => {
       const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -113,6 +113,7 @@ export type ResolvedTtsConfig = {
   };
   openai: {
     apiKey?: string;
+    baseUrl?: string;
     model: string;
     voice: string;
   };
@@ -294,6 +295,7 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
         value: raw.openai?.apiKey,
         path: "messages.tts.openai.apiKey",
       }),
+      baseUrl: raw.openai?.baseUrl?.trim() || undefined,
       model: raw.openai?.model ?? DEFAULT_OPENAI_MODEL,
       voice: raw.openai?.voice ?? DEFAULT_OPENAI_VOICE,
     },
@@ -681,6 +683,7 @@ export async function textToSpeech(params: {
         audioBuffer = await openaiTTS({
           text: params.text,
           apiKey,
+          baseUrl: config.openai.baseUrl,
           model: openaiModelOverride ?? config.openai.model,
           voice: openaiVoiceOverride ?? config.openai.voice,
           responseFormat: output.openai,
@@ -777,6 +780,7 @@ export async function textToSpeechTelephony(params: {
       const audioBuffer = await openaiTTS({
         text: params.text,
         apiKey,
+        baseUrl: config.openai.baseUrl,
         model: config.openai.model,
         voice: config.openai.voice,
         responseFormat: output.format,


### PR DESCRIPTION
## Summary

- **Problem:** Users running OpenAI-compatible TTS endpoints (e.g. local Whisper servers, Azure OpenAI) cannot redirect the TTS request URL
- **Why it matters:** Self-hosted and alternative TTS providers are unusable without a configurable base URL
- **What changed:** Added a `baseUrl` field to the OpenAI TTS config schema and wired it into the API client constructor
- **What did NOT change:** Default behavior (hitting api.openai.com) is unchanged when baseUrl is not set

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34314

## User-visible / Behavior Changes

New config option `messages.tts.openai.baseUrl` allows pointing TTS requests at a custom OpenAI-compatible endpoint.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes - TTS requests can now target a user-specified base URL`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 20+
- Integration/channel: Any channel with TTS enabled

### Steps

1. Set `messages.tts.openai.baseUrl` to a custom endpoint in openclaw.json
2. Trigger a TTS response

### Expected

- TTS request goes to the custom endpoint

### Actual

- Before fix: Always hits api.openai.com, no way to override
- After fix: Requests go to configured baseUrl

## Evidence

Schema addition and client constructor wiring for the baseUrl option.

## Human Verification (required)

- Verified scenarios: Default (no baseUrl), custom baseUrl set, empty string baseUrl
- Edge cases checked: Trailing slash handling, undefined vs empty string
- What I did **not** verify: Live TTS with a real custom endpoint

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Optional new config field messages.tts.openai.baseUrl`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove baseUrl from config; default behavior resumes
- Files/config to restore: Config schema and TTS client files
- Known bad symptoms: If broken, TTS requests would fail to reach the custom endpoint

## Risks and Mitigations

Risk: User could point baseUrl at a non-TTS endpoint causing confusing errors. Mitigation: The URL is user-configured and errors would surface as standard API failures.
