### PR TITLE
feat(slack): add unfurl_links and unfurl_media config options

### DIFF
--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -189,6 +189,10 @@ export type SlackAccountConfig = {
   ackReaction?: string;
   /** Reaction emoji added while processing a reply (e.g. "hourglass_flowing_sand"). Removed when done. Useful as a typing indicator fallback when assistant mode is not enabled. */
   typingReaction?: string;
+  /** Disable link previews in outbound messages (Slack `unfurl_links`). */
+  unfurlLinks?: boolean;
+  /** Disable media previews in outbound messages (Slack `unfurl_media`). */
+  unfurlMedia?: boolean;
 };
 
 export type SlackConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -841,6 +841,8 @@ export const SlackAccountSchema = z
     responsePrefix: z.string().optional(),
     ackReaction: z.string().optional(),
     typingReaction: z.string().optional(),
+    unfurlLinks: z.boolean().optional(),
+    unfurlMedia: z.boolean().optional(),
   })
   .strict()
   .superRefine((value) => {

--- a/src/slack/accounts.test.ts
+++ b/src/slack/accounts.test.ts
@@ -83,3 +83,43 @@ describe("resolveSlackAccount allowFrom precedence", () => {
     expect(resolved.config.dm?.allowFrom).toEqual(["U123"]);
   });
 });
+
+describe("resolveSlackAccount unfurl config", () => {
+  it("resolves unfurlLinks and unfurlMedia from account config", () => {
+    const resolved = resolveSlackAccount({
+      cfg: {
+        channels: {
+          slack: {
+            unfurlLinks: false,
+            unfurlMedia: false,
+            accounts: {
+              default: { botToken: "xoxb-1", appToken: "xapp-1" },
+            },
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(resolved.config.unfurlLinks).toBe(false);
+    expect(resolved.config.unfurlMedia).toBe(false);
+  });
+
+  it("defaults unfurl to undefined when not configured", () => {
+    const resolved = resolveSlackAccount({
+      cfg: {
+        channels: {
+          slack: {
+            accounts: {
+              default: { botToken: "xoxb-1", appToken: "xapp-1" },
+            },
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(resolved.config.unfurlLinks).toBeUndefined();
+    expect(resolved.config.unfurlMedia).toBeUndefined();
+  });
+});

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -93,12 +93,16 @@ async function postSlackMessageBestEffort(params: {
   threadTs?: string;
   identity?: SlackSendIdentity;
   blocks?: (Block | KnownBlock)[];
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
 }) {
   const basePayload = {
     channel: params.channelId,
     text: params.text,
     thread_ts: params.threadTs,
     ...(params.blocks?.length ? { blocks: params.blocks } : {}),
+    ...(params.unfurlLinks !== undefined ? { unfurl_links: params.unfurlLinks } : {}),
+    ...(params.unfurlMedia !== undefined ? { unfurl_media: params.unfurlMedia } : {}),
   };
   try {
     // Slack Web API types model icon_url and icon_emoji as mutually exclusive.
@@ -289,6 +293,8 @@ export async function sendMessageSlack(
       threadTs: opts.threadTs,
       identity: opts.identity,
       blocks,
+      unfurlLinks: account.config.unfurlLinks,
+      unfurlMedia: account.config.unfurlMedia,
     });
     return {
       messageId: response.ts ?? "unknown",
@@ -337,6 +343,8 @@ export async function sendMessageSlack(
         text: chunk,
         threadTs: opts.threadTs,
         identity: opts.identity,
+        unfurlLinks: account.config.unfurlLinks,
+        unfurlMedia: account.config.unfurlMedia,
       });
       lastMessageId = response.ts ?? lastMessageId;
     }
@@ -348,6 +356,8 @@ export async function sendMessageSlack(
         text: chunk,
         threadTs: opts.threadTs,
         identity: opts.identity,
+        unfurlLinks: account.config.unfurlLinks,
+        unfurlMedia: account.config.unfurlMedia,
       });
       lastMessageId = response.ts ?? lastMessageId;
     }


### PR DESCRIPTION
## Summary

- **Problem:** Slack auto-unfurls URLs and media in bot messages, creating noisy previews that clutter the conversation
- **Why it matters:** Enterprise users with link-heavy bot responses get walls of unfurled previews that obscure the actual content
- **What changed:** Added `unfurl_links` and `unfurl_media` fields to the Slack channel schema and passed them through to the `chat.postMessage` API call
- **What did NOT change:** Default Slack behavior (unfurling enabled) is preserved when these options are not set

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34512

## User-visible / Behavior Changes

New Slack channel config options `unfurl_links` (default: true) and `unfurl_media` (default: true) control whether URLs and media are auto-previewed in bot messages.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No - same Slack API call, additional optional parameters`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 20+
- Integration/channel: Slack

### Steps

1. Set `unfurl_links: false` in Slack channel config
2. Send a message with a URL through the bot

### Expected

- URL is not auto-previewed in the Slack message

### Actual

- Before fix: No way to control unfurling
- After fix: Setting unfurl_links/unfurl_media to false suppresses previews

## Evidence

Schema addition for unfurl config fields and their propagation to the Slack Web API call.

## Human Verification (required)

- Verified scenarios: Both options true (default), both false, mixed combinations
- Edge cases checked: Options not set (defaults preserved), explicit true vs undefined
- What I did **not** verify: Live Slack workspace unfurl behavior

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Optional new config fields`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove unfurl fields from config; Slack defaults resume
- Files/config to restore: Slack channel schema and send files
- Known bad symptoms: If broken, messages might fail to send (invalid API params)

## Risks and Mitigations

None - these are standard Slack API parameters with well-documented behavior.
