### PR TITLE
fix(slack): propagate threadId and toolContext for read action

### DIFF
--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -97,6 +97,7 @@ type SlackActionInput = Parameters<
 async function runSlackAction(
   action: SlackActionInput["action"],
   params: SlackActionInput["params"],
+  options?: { toolContext?: SlackActionInput["toolContext"] },
 ) {
   const { cfg, actions } = slackHarness();
   await actions.handleAction?.({
@@ -104,6 +105,7 @@ async function runSlackAction(
     action,
     cfg,
     params,
+    ...(options?.toolContext ? { toolContext: options.toolContext } : {}),
   });
   return { cfg, actions };
 }
@@ -955,6 +957,42 @@ describe("slack actions adapter", () => {
       channelId: "C1",
       threadId: "171234.567",
     });
+  });
+
+  it("falls back to currentThreadTs for read when threadId is omitted", async () => {
+    await runSlackAction(
+      "read",
+      { channelId: "C1" },
+      { toolContext: { currentThreadTs: "199999.000" } },
+    );
+
+    expectFirstSlackAction({
+      action: "readMessages",
+      channelId: "C1",
+      threadId: "199999.000",
+    });
+  });
+
+  it("prefers explicit threadId over currentThreadTs for read", async () => {
+    await runSlackAction(
+      "read",
+      { channelId: "C1", threadId: "explicit.123" },
+      { toolContext: { currentThreadTs: "context.456" } },
+    );
+
+    expectFirstSlackAction({
+      action: "readMessages",
+      channelId: "C1",
+      threadId: "explicit.123",
+    });
+  });
+
+  it("passes toolContext to invoke for read action", async () => {
+    const toolContext = { currentThreadTs: "199999.000", currentChannelId: "C1" };
+    await runSlackAction("read", { channelId: "C1" }, { toolContext });
+
+    const [, , passedContext] = handleSlackAction.mock.calls[0] ?? [];
+    expect(passedContext).toMatchObject(toolContext);
   });
 
   it("forwards normalized limit for emoji-list", async () => {

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -108,9 +108,10 @@ export async function handleSlackMessageAction(params: {
       accountId,
     };
     if (includeReadThreadId) {
-      readAction.threadId = readStringParam(actionParams, "threadId");
+      readAction.threadId =
+        readStringParam(actionParams, "threadId") ?? ctx.toolContext?.currentThreadTs;
     }
-    return await invoke(readAction, cfg);
+    return await invoke(readAction, cfg, ctx.toolContext);
   }
 
   if (action === "edit") {


### PR DESCRIPTION
## Summary

- **Problem:** The Slack message tool's `read` action does not fall back to `currentThreadTs` when no explicit `threadId` is provided, and omits `toolContext` from the invoke call
- **Why it matters:** Reads in a thread context silently return channel-level messages instead of thread replies, breaking conversational context for agents operating within threads
- **What changed:** Added `currentThreadTs` fallback for `threadId` when not explicitly specified, and passed `toolContext` through to the `invoke` function (consistent with the `send` action path)
- **What did NOT change:** Explicit `threadId` still takes precedence; `send` action behavior is unchanged

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34395

## User-visible / Behavior Changes

Slack message tool `read` action now correctly reads thread messages when invoked from within a thread context, without requiring the agent to explicitly pass `threadId`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 20+
- Integration/channel: Slack

### Steps

1. In a Slack thread, ask the agent to read recent messages
2. The agent invokes the `read` action without explicit `threadId`

### Expected

- Agent receives thread messages

### Actual

- Before fix: Agent receives channel-level messages (wrong context)
- After fix: Agent receives thread messages via `currentThreadTs` fallback

## Evidence

```typescript
// threadId fallback added
readAction.threadId = readStringParam(actionParams, "threadId") ?? ctx.toolContext?.currentThreadTs;
// toolContext now passed to invoke
return await invoke(readAction, cfg, ctx.toolContext);
```

Tests added:
- Falls back to currentThreadTs when threadId omitted
- Explicit threadId takes precedence over currentThreadTs
- toolContext is correctly passed to invoke

## Human Verification (required)

- Verified scenarios: Read with explicit threadId, read without threadId in thread context, read in channel context
- Edge cases checked: No toolContext, no currentThreadTs, both threadId and currentThreadTs present
- What I did **not** verify: Live Slack workspace thread read behavior

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the threadId fallback line
- Files/config to restore: src/plugin-sdk/slack-message-actions.ts
- Known bad symptoms: If broken, thread reads might unexpectedly use channel-level context

## Risks and Mitigations

Risk: Agents that previously relied on channel-level reads from thread context might get different results. Mitigation: This aligns with user intent (reading in thread should return thread messages).
