### PR TITLE
feat(commands): include model call count in /usage output

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1241,6 +1241,7 @@ export async function runEmbeddedPiAgent(
             lastCallUsage: lastCallUsage ?? undefined,
             promptTokens,
             compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
+            modelCallCount: runLoopIterations > 0 ? runLoopIterations : undefined,
           };
 
           const payloads = buildEmbeddedRunPayloads({

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -28,6 +28,8 @@ export type EmbeddedPiAgentMeta = {
     cacheWrite?: number;
     total?: number;
   };
+  /** Number of LLM API calls made during this run (tool-use loop iterations). */
+  modelCallCount?: number;
 };
 
 export type EmbeddedPiRunMeta = {

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -90,6 +90,7 @@ export const formatResponseUsageLine = (params: {
     cacheRead: number;
     cacheWrite: number;
   };
+  modelCallCount?: number;
 }): string | null => {
   const usage = params.usage;
   if (!usage) {
@@ -115,8 +116,15 @@ export const formatResponseUsageLine = (params: {
         })
       : undefined;
   const costLabel = params.showCost ? formatUsd(cost) : undefined;
-  const suffix = costLabel ? ` · est ${costLabel}` : "";
-  return `Usage: ${inputLabel} in / ${outputLabel} out${suffix}`;
+  const callCount = params.modelCallCount;
+  const parts = [`Usage: ${inputLabel} in / ${outputLabel} out`];
+  if (typeof callCount === "number" && callCount > 1) {
+    parts.push(`(${callCount} calls)`);
+  }
+  if (costLabel) {
+    parts.push(`· est ${costLabel}`);
+  }
+  return parts.join(" ");
 };
 
 export const appendUsageLine = (payloads: ReplyPayload[], line: string): ReplyPayload[] => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -582,6 +582,7 @@ export async function runReplyAgent(params: {
         usage,
         showCost,
         costConfig,
+        modelCallCount: runResult.meta?.agentMeta?.modelCallCount,
       });
       if (formatted && responseUsageMode === "full" && sessionKey) {
         formatted = `${formatted} · session \`${sessionKey}\``;


### PR DESCRIPTION
## Summary

- **Problem:** The `/usage` footer aggregates token counts across all LLM calls in a single turn, making it impossible to distinguish between one large context request and multiple smaller tool-use iterations.
- **Why it matters:** Users cannot debug agent behavior, optimize token usage, or understand cost without knowing how many API calls were made. A `Usage: 60k in / 150 out` line could mean 1 call or 10 — the user has no way to tell.
- **What changed:** Added `modelCallCount` field to `EmbeddedPiAgentMeta` (sourced from `runLoopIterations`), passed it through `formatResponseUsageLine`, and displayed it in the usage footer when > 1 call (e.g. `Usage: 60k in / 150 out (3 calls)`).
- **What did NOT change:** Single-call turns display identically to before (no `(1 call)` suffix). Token counting, cost estimation, and session-key display are untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34500

## User-visible / Behavior Changes

- Single-call turns: `Usage: 30k in / 150 out` (unchanged)
- Multi-call turns: `Usage: 60k in / 150 out (2 calls)` (new)
- With cost: `Usage: 60k in / 150 out (3 calls) · est $0.12`

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js
- Integration/channel: Any (webchat, Telegram, Discord, etc.)

### Steps

1. Send a message that triggers tool use (e.g. "Read file X and summarize it")
2. Wait for the agent to complete the multi-step tool-use chain
3. Check the usage footer in the response

### Expected

- Usage line includes call count when > 1: `Usage: 60k in / 150 out (2 calls)`

### Actual

- Before fix: `Usage: 60k in / 150 out` (ambiguous)
- After fix: `Usage: 60k in / 150 out (2 calls)` (clear)

## Evidence

```typescript
// types.ts — new field
export type EmbeddedPiAgentMeta = {
  // ... existing fields ...
  modelCallCount?: number;
};

// run.ts — populate from runLoopIterations
const agentMeta: EmbeddedPiAgentMeta = {
  // ... existing fields ...
  modelCallCount: runLoopIterations > 0 ? runLoopIterations : undefined,
};

// agent-runner-utils.ts — format with call count
const parts = [`Usage: ${inputLabel} in / ${outputLabel} out`];
if (typeof callCount === "number" && callCount > 1) {
  parts.push(`(${callCount} calls)`);
}
```

## Human Verification (required)

- Verified scenarios: Traced data flow from `runLoopIterations` → `agentMeta.modelCallCount` → `formatResponseUsageLine` → usage footer string
- Edge cases checked: `callCount === 1` (no suffix), `callCount === 0` (no suffix), `callCount === undefined` (no suffix), cost + callCount formatting
- What I did **not** verify: End-to-end run with actual LLM provider (verified via code path analysis)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert 4 file changes
- Files/config to restore: `types.ts`, `run.ts`, `agent-runner-utils.ts`, `agent-runner.ts`
- Known bad symptoms: N/A — `modelCallCount` is optional and omitted when undefined

## Risks and Mitigations

None — additive change with optional field. Existing behavior preserved for single-call turns.
