### PR TITLE
fix(channels): suppress implicit mentions when requireMention is true

### DIFF
--- a/src/channels/mention-gating.test.ts
+++ b/src/channels/mention-gating.test.ts
@@ -2,13 +2,36 @@ import { describe, expect, it } from "vitest";
 import { resolveMentionGating, resolveMentionGatingWithBypass } from "./mention-gating.js";
 
 describe("resolveMentionGating", () => {
-  it("combines explicit, implicit, and bypass mentions", () => {
+  it("suppresses implicit mention when requireMention is true", () => {
     const res = resolveMentionGating({
       requireMention: true,
       canDetectMention: true,
       wasMentioned: false,
       implicitMention: true,
       shouldBypassMention: false,
+    });
+    expect(res.effectiveWasMentioned).toBe(false);
+    expect(res.shouldSkip).toBe(true);
+  });
+
+  it("allows implicit mention when requireMention is false", () => {
+    const res = resolveMentionGating({
+      requireMention: false,
+      canDetectMention: true,
+      wasMentioned: false,
+      implicitMention: true,
+      shouldBypassMention: false,
+    });
+    expect(res.effectiveWasMentioned).toBe(true);
+    expect(res.shouldSkip).toBe(false);
+  });
+
+  it("allows explicit mention even when requireMention is true", () => {
+    const res = resolveMentionGating({
+      requireMention: true,
+      canDetectMention: true,
+      wasMentioned: true,
+      implicitMention: false,
     });
     expect(res.effectiveWasMentioned).toBe(true);
     expect(res.shouldSkip).toBe(false);
@@ -32,6 +55,18 @@ describe("resolveMentionGating", () => {
       canDetectMention: false,
       wasMentioned: false,
     });
+    expect(res.shouldSkip).toBe(false);
+  });
+
+  it("allows bypass even when requireMention suppresses implicit", () => {
+    const res = resolveMentionGating({
+      requireMention: true,
+      canDetectMention: true,
+      wasMentioned: false,
+      implicitMention: true,
+      shouldBypassMention: true,
+    });
+    expect(res.effectiveWasMentioned).toBe(true);
     expect(res.shouldSkip).toBe(false);
   });
 });

--- a/src/channels/mention-gating.ts
+++ b/src/channels/mention-gating.ts
@@ -30,7 +30,8 @@ export type MentionGateWithBypassResult = MentionGateResult & {
 export function resolveMentionGating(params: MentionGateParams): MentionGateResult {
   const implicit = params.implicitMention === true;
   const bypass = params.shouldBypassMention === true;
-  const effectiveWasMentioned = params.wasMentioned || implicit || bypass;
+  const effectiveImplicit = params.requireMention ? false : implicit;
+  const effectiveWasMentioned = params.wasMentioned || effectiveImplicit || bypass;
   const shouldSkip = params.requireMention && params.canDetectMention && !effectiveWasMentioned;
   return { effectiveWasMentioned, shouldSkip };
 }


### PR DESCRIPTION
## Summary

- **Problem:** When `requireMention` is enabled and `canDetectMention` is true, the bot should only respond to explicit @mentions. However, `implicitMention` (e.g. thread replies where the bot is a participant) bypasses this gate, causing the bot to respond in threads even when the user expects silence
- **Why it matters:** Users who set `requireMention: true` expect the bot to stay quiet unless explicitly @mentioned; implicit thread mentions break this expectation and create unwanted noise
- **What changed:** Modified `resolveMentionGating` to suppress `implicitMention` when `requireMention` is true, so only explicit mentions or bypass conditions trigger a response
- **What did NOT change:** Behavior when `requireMention` is false (implicit mentions still work); explicit mentions and bypass always work regardless of config

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34389

## User-visible / Behavior Changes

When `requireMention: true`, the bot no longer responds to implicit thread mentions (e.g. being a thread participant). Only explicit @mentions or bypass conditions trigger responses.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 20+
- Integration/channel: Slack, Discord, or any channel with mention detection

### Steps

1. Set `requireMention: true` for a channel
2. Reply in a thread where the bot is a participant (without @mentioning)

### Expected

- Bot stays silent (implicit mention suppressed)

### Actual

- Before fix: Bot responds (implicit mention bypasses requireMention)
- After fix: Bot stays silent

## Evidence

```typescript
const effectiveImplicit = params.requireMention ? false : implicit;
const effectiveWasMentioned = params.wasMentioned || effectiveImplicit || bypass;
```

Tests added/updated:
- Suppresses implicit mention when requireMention is true
- Allows implicit mention when requireMention is false
- Explicit mentions still work with requireMention true
- Bypass still works with requireMention true

## Human Verification (required)

- Verified scenarios: requireMention true/false × implicitMention true/false × wasMentioned true/false
- Edge cases checked: bypass overrides, canDetectMention false, all combinations of the 5 boolean params
- What I did **not** verify: Live channel mention behavior

## Compatibility / Migration

- Backward compatible? `Yes - only changes behavior when requireMention is explicitly true`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the effectiveImplicit guard line
- Files/config to restore: src/channels/mention-gating.ts
- Known bad symptoms: If broken, bot might not respond to any implicit mentions even when requireMention is false

## Risks and Mitigations

Risk: Users relying on implicit thread mentions with requireMention: true will see changed behavior. Mitigation: This is the intended behavior per the config semantics; users wanting thread responses should set requireMention: false.
