### PR TITLE
fix: avoid llama.cpp grammar failures from oversized maxLength tool constraints

### DIFF
--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolParameters } from "./pi-tools.schema.js";
+
+describe("normalizeToolParameters", () => {
+  it("drops oversized maxLength constraints that can break llama.cpp grammars", () => {
+    const tool = {
+      name: "sessions_spawn",
+      description: "test",
+      parameters: {
+        type: "object",
+        properties: {
+          attachments: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                content: { type: "string", maxLength: 6_700_000 },
+                name: { type: "string", maxLength: 255 },
+              },
+            },
+          },
+        },
+      },
+      execute: async () => ({ ok: true }),
+    } as const;
+
+    const normalized = normalizeToolParameters(tool as never) as {
+      parameters: {
+        properties: {
+          attachments: {
+            items: {
+              properties: {
+                content: { maxLength?: number };
+                name: { maxLength?: number };
+              };
+            };
+          };
+        };
+      };
+    };
+
+    expect(
+      normalized.parameters.properties.attachments.items.properties.content.maxLength,
+    ).toBeUndefined();
+    expect(normalized.parameters.properties.attachments.items.properties.name.maxLength).toBe(255);
+  });
+});

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -2,6 +2,31 @@ import type { AnyAgentTool } from "./pi-tools.types.js";
 import { cleanSchemaForGemini } from "./schema/clean-for-gemini.js";
 import { isXaiProvider, stripXaiUnsupportedKeywords } from "./schema/clean-for-xai.js";
 
+const TOOL_SCHEMA_MAX_LENGTH_FOR_GRAMMAR = 2048;
+
+function stripOversizedStringBounds(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    return schema.map((entry) => stripOversizedStringBounds(entry));
+  }
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+  const record = schema as Record<string, unknown>;
+  const next: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (
+      key === "maxLength" &&
+      typeof value === "number" &&
+      Number.isFinite(value) &&
+      value > TOOL_SCHEMA_MAX_LENGTH_FOR_GRAMMAR
+    ) {
+      continue;
+    }
+    next[key] = stripOversizedStringBounds(value);
+  }
+  return next;
+}
+
 function extractEnumValues(schema: unknown): unknown[] | undefined {
   if (!schema || typeof schema !== "object") {
     return undefined;
@@ -91,13 +116,14 @@ export function normalizeToolParameters(
   const isXai = isXaiProvider(options?.modelProvider, options?.modelId);
 
   function applyProviderCleaning(s: unknown): unknown {
+    let next = s;
     if (isGeminiProvider && !isAnthropicProvider) {
-      return cleanSchemaForGemini(s);
+      next = cleanSchemaForGemini(next);
     }
     if (isXai) {
-      return stripXaiUnsupportedKeywords(s);
+      next = stripXaiUnsupportedKeywords(next);
     }
-    return s;
+    return stripOversizedStringBounds(next);
   }
 
   // If schema already has type + properties (no top-level anyOf to merge),


### PR DESCRIPTION
## Summary
Fixes #34443.

Some tool schemas can include very large string `maxLength` values (e.g. multi-megabyte attachment payloads). When converted into llama.cpp-compatible grammars, those become huge repetition bounds (like `char{0,6700000}`), which llama.cpp rejects with:

> number of repetitions exceeds sane defaults

This patch makes `normalizeToolParameters` recursively strip only *oversized* string max-length constraints before provider-specific schema handoff. Smaller useful constraints are preserved.

## Root cause
`normalizeToolParameters` forwarded tool JSON schemas with large `maxLength` values intact. Downstream grammar generation turned those into repetition quantifiers beyond llama.cpp limits.

## Changes
- Add `stripOversizedStringBounds()` to recursively remove `maxLength` values above a grammar-safe cap.
- Apply that sanitization in `normalizeToolParameters` for all providers (after provider-specific cleaning).
- Add focused unit coverage in `src/agents/pi-tools.schema.test.ts`.

## Validation
- `pnpm exec vitest run src/agents/pi-tools.schema.test.ts src/agents/tools/sessions-spawn-tool.test.ts`
- Passed: 2 files, 7 tests.

## Risk
Low: only removes very large `maxLength` constraints that are not practical for grammar-constrained tool calling; smaller constraints remain unchanged.
