### PR TITLE
fix(installer): fail fast when git is missing for npm install

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -297,7 +297,9 @@ function Main {
     } else {
         # npm method
         if (!(Ensure-Git)) {
-            Write-Host "Git is required for npm installs. Please install Git and try again." -Level warn
+            Write-Host "Git is required for npm installs and was not found." -Level error
+            Write-Host "Install Git first (https://git-scm.com/download/win), then re-run this installer." -Level info
+            exit 1
         }
         
         if ($DryRun) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -296,9 +296,8 @@ function Main {
         }
     } else {
         # npm method
-        if (!(Ensure-Git)) {
-            Write-Host "Git is required for npm installs and was not found." -Level error
-            Write-Host "Install Git first (https://git-scm.com/download/win), then re-run this installer." -Level info
+        if (!(Get-GitVersion)) {
+            Write-Host "Git is required for npm installs. Install Git for Windows from: https://git-scm.com/download/win, then re-run this installer." -Level error
             exit 1
         }
         


### PR DESCRIPTION
## Problem
On Windows npm installs, the installer can continue after Git detection fails, leading to a later and less clear failure path.

## Root cause
In `scripts/install.ps1`, the npm install path only logged a warning when `Ensure-Git` failed and then proceeded.

## Fix
- Make Git a hard precondition for npm install path in the Windows installer.
- Emit a clear actionable message with the official Git for Windows download URL.
- Exit immediately when Git is unavailable.

## Impact
Users get an immediate and clear error before any partial install attempt, which avoids confusing mid-install failures.

Fixes #34098
