### PR TITLE
fix: add Markdown formatting hints to Slack channel dock

### DIFF
--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -499,6 +499,15 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
       allowExplicitReplyTagsWhenOff: false,
       buildToolContext: (params) => buildSlackThreadingToolContext(params),
     },
+    agentPrompt: {
+      messageToolHints: () => [
+        "",
+        "### Slack Formatting",
+        "Use standard Markdown formatting (e.g., **bold**, *italic*, ~~strikethrough~~, `code`).",
+        "Do not use Slack mrkdwn syntax directly — OpenClaw converts Markdown to Slack-compatible formatting automatically.",
+        "In particular, do not use single *asterisks* for bold; use double **asterisks**.",
+      ],
+    },
   },
   signal: {
     id: "signal",


### PR DESCRIPTION
## Summary

- Problem: LLMs aware of being in Slack output Slack mrkdwn directly (e.g., `*text*` for bold). The Markdown→mrkdwn pipeline parses this as Markdown italic and converts it to `_text_`, reversing the intended formatting.
- Why it matters: All Slack channel agents with context-aware LLMs produce broken formatting. Bold becomes italic (or literal underscores in Japanese text without surrounding spaces).
- What changed: Added `agentPrompt.messageToolHints` to the Slack dock, instructing the LLM to use standard Markdown formatting. This follows the existing pattern used by Synology Chat, MS Teams, and LINE docks.
- What did NOT change (scope boundary): No changes to the Markdown→mrkdwn conversion pipeline itself. This is a prompt-level fix only.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

Closes #34609

## User-visible / Behavior Changes

- Slack channel agents now receive formatting guidance via `messageToolHints`, instructing them to use standard Markdown instead of Slack mrkdwn syntax.
- This changes LLM output behavior (not deterministic), so the fix is probabilistic — well-instructed models should comply.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Docker (Node.js)
- Model/provider: GPT-series / Claude (any model aware of Slack context)
- Integration/channel: Slack
- Relevant config: Default Slack channel configuration

### Steps

1. Configure a Slack channel agent with an LLM
2. Send a message that prompts the LLM to emphasize text
3. Observe the LLM outputs `*text*` (Slack mrkdwn bold)
4. The pipeline converts it to `_text_` (Markdown italic → Slack mrkdwn italic)

### Expected

- Text appears as **bold** in Slack

### Actual

- Text appears as `_text_` (literal underscores or italic), reversing the intended semantics

## Evidence

- [x] Trace/log snippets

The conflict is deterministic at the pipeline level:

| Syntax | Markdown meaning | Slack mrkdwn meaning |
|---|---|---|
| `*text*` | italic | **bold** |
| `**text**` | bold | (not valid mrkdwn) |
| `_text_` | italic | italic |

`*` is the only formatting character where the two formats conflict destructively (semantic reversal).

## Human Verification (required)

- Verified scenarios: `pnpm check` passes; `pnpm test -- --run src/channels/dock.test.ts` passes; confirmed existing docks (Synology Chat, MS Teams, LINE) use the same `messageToolHints` pattern
- Edge cases checked: Verified that `*` is the only destructive conflict between Markdown and Slack mrkdwn
- What you did **not** verify: End-to-end Slack message rendering with a live LLM (prompt-level fix effectiveness is model-dependent)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the `agentPrompt` block from the Slack dock entry in `src/channels/dock.ts`
- Files/config to restore: `src/channels/dock.ts`
- Known bad symptoms reviewers should watch for: LLM ignoring the formatting hints and continuing to output Slack mrkdwn

## Risks and Mitigations

- Risk: LLMs may ignore the formatting guidance and continue outputting Slack mrkdwn
  - Mitigation: This is an inherent limitation of prompt-based fixes. The hint follows an established pattern that works for other channel docks. A pipeline-level fix (detecting and handling mrkdwn input) would be more robust but is a larger change.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)