### PR TITLE
fix(security): include Gemini/Grok/Kimi keys in web search audit check

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -329,7 +329,17 @@ function resolveToolPolicies(params: {
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+    search?.perplexity?.apiKey ||
+    env.BRAVE_API_KEY ||
+    env.PERPLEXITY_API_KEY ||
+    search?.gemini?.apiKey ||
+    env.GEMINI_API_KEY ||
+    search?.grok?.apiKey ||
+    env.XAI_API_KEY ||
+    search?.kimi?.apiKey ||
+    env.KIMI_API_KEY ||
+    env.MOONSHOT_API_KEY,
   );
 }
 


### PR DESCRIPTION
## Summary

`hasWebSearchKey` in the security audit only checked Brave and Perplexity API keys, causing false negatives when users configured Gemini, Grok, or Kimi as their web search provider.

## Changes

Added checks for:
- `search.gemini.apiKey` / `GEMINI_API_KEY`
- `search.grok.apiKey` / `XAI_API_KEY`
- `search.kimi.apiKey` / `KIMI_API_KEY` / `MOONSHOT_API_KEY`

Closes #34509