### PR TITLE
macOS: add remote gateway token field for remote mode

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -61,7 +61,7 @@ runs:
       if: inputs.install-bun == 'true'
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: "1.3.9+cf6cdbbba"
+        bun-version: "1.3.9"
 
     - name: Runtime versions
       shell: bash

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -213,6 +213,10 @@ final class AppState {
         didSet { self.syncGatewayConfigIfNeeded() }
     }
 
+    var remoteToken: String {
+        didSet { self.syncGatewayConfigIfNeeded() }
+    }
+
     var remoteIdentity: String {
         didSet { self.ifNotPreview { UserDefaults.standard.set(self.remoteIdentity, forKey: remoteIdentityKey) } }
     }
@@ -297,6 +301,7 @@ final class AppState {
             self.remoteTarget = storedRemoteTarget
         }
         self.remoteUrl = configRemoteUrl ?? ""
+        self.remoteToken = GatewayRemoteConfig.resolveTokenString(root: configRoot) ?? ""
         self.remoteIdentity = UserDefaults.standard.string(forKey: remoteIdentityKey) ?? ""
         self.remoteProjectRoot = UserDefaults.standard.string(forKey: remoteProjectRootKey) ?? ""
         self.remoteCliPath = UserDefaults.standard.string(forKey: remoteCliPathKey) ?? ""
@@ -380,7 +385,8 @@ final class AppState {
         remoteUrl: String,
         remoteHost: String?,
         remoteTarget: String,
-        remoteIdentity: String) -> (remote: [String: Any], changed: Bool)
+        remoteIdentity: String,
+        remoteToken: String) -> (remote: [String: Any], changed: Bool)
     {
         var remote = current
         var changed = false
@@ -417,6 +423,8 @@ final class AppState {
             changed = Self.updateGatewayString(&remote, key: "sshIdentity", value: remoteIdentity) || changed
         }
 
+        changed = Self.updateGatewayString(&remote, key: "token", value: remoteToken) || changed
+
         return (remote, changed)
     }
 
@@ -439,6 +447,7 @@ final class AppState {
         let gateway = root["gateway"] as? [String: Any]
         let modeRaw = (gateway?["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         let remoteUrl = GatewayRemoteConfig.resolveUrlString(root: root)
+        let remoteToken = GatewayRemoteConfig.resolveTokenString(root: root) ?? ""
         let hasRemoteUrl = !(remoteUrl?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .isEmpty ?? true)
@@ -469,6 +478,9 @@ final class AppState {
         let remoteUrlText = remoteUrl ?? ""
         if remoteUrlText != self.remoteUrl {
             self.remoteUrl = remoteUrlText
+        }
+        if remoteToken != self.remoteToken {
+            self.remoteToken = remoteToken
         }
 
         let targetMode = desiredMode ?? self.connectionMode
@@ -504,6 +516,7 @@ final class AppState {
         let remoteIdentity = self.remoteIdentity
         let remoteTransport = self.remoteTransport
         let remoteUrl = self.remoteUrl
+        let remoteToken = self.remoteToken
         let desiredMode: String? = switch connectionMode {
         case .local:
             "local"
@@ -541,7 +554,8 @@ final class AppState {
                     remoteUrl: remoteUrl,
                     remoteHost: remoteHost,
                     remoteTarget: remoteTarget,
-                    remoteIdentity: remoteIdentity)
+                    remoteIdentity: remoteIdentity,
+                    remoteToken: remoteToken)
                 if updated.changed {
                     gateway["remote"] = updated.remote
                     changed = true
@@ -697,12 +711,37 @@ extension AppState {
         state.canvasEnabled = true
         state.remoteTarget = "user@example.com"
         state.remoteUrl = "wss://gateway.example.ts.net"
+        state.remoteToken = "example-token"
         state.remoteIdentity = "~/.ssh/id_ed25519"
         state.remoteProjectRoot = "~/Projects/openclaw"
         state.remoteCliPath = ""
         return state
     }
 }
+
+#if DEBUG
+@MainActor
+extension AppState {
+    static func _testUpdatedRemoteGatewayConfig(
+        current: [String: Any],
+        transport: RemoteTransport,
+        remoteUrl: String,
+        remoteHost: String?,
+        remoteTarget: String,
+        remoteIdentity: String,
+        remoteToken: String) -> [String: Any]
+    {
+        Self.updatedRemoteGatewayConfig(
+            current: current,
+            transport: transport,
+            remoteUrl: remoteUrl,
+            remoteHost: remoteHost,
+            remoteTarget: remoteTarget,
+            remoteIdentity: remoteIdentity,
+            remoteToken: remoteToken).remote
+    }
+}
+#endif
 
 @MainActor
 enum AppStateStore {

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -508,6 +508,66 @@ final class AppState {
         }
     }
 
+    private static func syncedGatewayRoot(
+        currentRoot: [String: Any],
+        connectionMode: ConnectionMode,
+        remoteTransport: RemoteTransport,
+        remoteTarget: String,
+        remoteIdentity: String,
+        remoteUrl: String,
+        remoteToken: String) -> (root: [String: Any], changed: Bool)
+    {
+        var root = currentRoot
+        var gateway = root["gateway"] as? [String: Any] ?? [:]
+        var changed = false
+
+        let desiredMode: String? = switch connectionMode {
+        case .local:
+            "local"
+        case .remote:
+            "remote"
+        case .unconfigured:
+            nil
+        }
+
+        let currentMode = (gateway["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let desiredMode {
+            if currentMode != desiredMode {
+                gateway["mode"] = desiredMode
+                changed = true
+            }
+        } else if currentMode != nil {
+            gateway.removeValue(forKey: "mode")
+            changed = true
+        }
+
+        if connectionMode == .remote {
+            let remoteHost = CommandResolver.parseSSHTarget(remoteTarget)?.host
+            let currentRemote = gateway["remote"] as? [String: Any] ?? [:]
+            let updated = Self.updatedRemoteGatewayConfig(
+                current: currentRemote,
+                transport: remoteTransport,
+                remoteUrl: remoteUrl,
+                remoteHost: remoteHost,
+                remoteTarget: remoteTarget,
+                remoteIdentity: remoteIdentity,
+                remoteToken: remoteToken)
+            if updated.changed {
+                gateway["remote"] = updated.remote
+                changed = true
+            }
+        }
+
+        guard changed else { return (currentRoot, false) }
+
+        if gateway.isEmpty {
+            root.removeValue(forKey: "gateway")
+        } else {
+            root["gateway"] = gateway
+        }
+        return (root, true)
+    }
+
     private func syncGatewayConfigIfNeeded() {
         guard !self.isPreview, !self.isInitializing else { return }
 
@@ -517,58 +577,19 @@ final class AppState {
         let remoteTransport = self.remoteTransport
         let remoteUrl = self.remoteUrl
         let remoteToken = self.remoteToken
-        let desiredMode: String? = switch connectionMode {
-        case .local:
-            "local"
-        case .remote:
-            "remote"
-        case .unconfigured:
-            nil
-        }
-        let remoteHost = connectionMode == .remote
-            ? CommandResolver.parseSSHTarget(remoteTarget)?.host
-            : nil
 
         Task { @MainActor in
             // Keep app-only connection settings local to avoid overwriting remote gateway config.
-            var root = OpenClawConfigFile.loadDict()
-            var gateway = root["gateway"] as? [String: Any] ?? [:]
-            var changed = false
-
-            let currentMode = (gateway["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let desiredMode {
-                if currentMode != desiredMode {
-                    gateway["mode"] = desiredMode
-                    changed = true
-                }
-            } else if currentMode != nil {
-                gateway.removeValue(forKey: "mode")
-                changed = true
-            }
-
-            if connectionMode == .remote {
-                let currentRemote = gateway["remote"] as? [String: Any] ?? [:]
-                let updated = Self.updatedRemoteGatewayConfig(
-                    current: currentRemote,
-                    transport: remoteTransport,
-                    remoteUrl: remoteUrl,
-                    remoteHost: remoteHost,
-                    remoteTarget: remoteTarget,
-                    remoteIdentity: remoteIdentity,
-                    remoteToken: remoteToken)
-                if updated.changed {
-                    gateway["remote"] = updated.remote
-                    changed = true
-                }
-            }
-
-            guard changed else { return }
-            if gateway.isEmpty {
-                root.removeValue(forKey: "gateway")
-            } else {
-                root["gateway"] = gateway
-            }
-            OpenClawConfigFile.saveDict(root)
+            let synced = Self.syncedGatewayRoot(
+                currentRoot: OpenClawConfigFile.loadDict(),
+                connectionMode: connectionMode,
+                remoteTransport: remoteTransport,
+                remoteTarget: remoteTarget,
+                remoteIdentity: remoteIdentity,
+                remoteUrl: remoteUrl,
+                remoteToken: remoteToken)
+            guard synced.changed else { return }
+            OpenClawConfigFile.saveDict(synced.root)
         }
     }
 
@@ -739,6 +760,25 @@ extension AppState {
             remoteTarget: remoteTarget,
             remoteIdentity: remoteIdentity,
             remoteToken: remoteToken).remote
+    }
+
+    static func _testSyncedGatewayRoot(
+        currentRoot: [String: Any],
+        connectionMode: ConnectionMode,
+        remoteTransport: RemoteTransport,
+        remoteTarget: String,
+        remoteIdentity: String,
+        remoteUrl: String,
+        remoteToken: String) -> [String: Any]
+    {
+        Self.syncedGatewayRoot(
+            currentRoot: currentRoot,
+            connectionMode: connectionMode,
+            remoteTransport: remoteTransport,
+            remoteTarget: remoteTarget,
+            remoteIdentity: remoteIdentity,
+            remoteUrl: remoteUrl,
+            remoteToken: remoteToken).root
     }
 }
 #endif

--- a/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
@@ -24,6 +24,17 @@ enum GatewayRemoteConfig {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    static func resolveTokenString(root: [String: Any]) -> String? {
+        guard let gateway = root["gateway"] as? [String: Any],
+              let remote = gateway["remote"] as? [String: Any],
+              let tokenRaw = remote["token"] as? String
+        else {
+            return nil
+        }
+        let trimmed = tokenRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     static func resolveGatewayUrl(root: [String: Any]) -> URL? {
         guard let raw = self.resolveUrlString(root: root) else { return nil }
         return self.normalizeGatewayUrl(raw)

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -298,7 +298,7 @@ struct GeneralSettings: View {
                 Text("Gateway token")
                     .font(.callout.weight(.semibold))
                     .frame(width: self.remoteLabelWidth, alignment: .leading)
-                SecureField("token from gateway.auth.token", text: self.$state.remoteToken)
+                SecureField("remote gateway auth token (gateway.auth.token)", text: self.$state.remoteToken)
                     .textFieldStyle(.roundedBorder)
                     .frame(maxWidth: .infinity)
             }

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -149,6 +149,7 @@ struct GeneralSettings: View {
             } else {
                 self.remoteDirectRow
             }
+            self.remoteTokenRow
 
             GatewayDiscoveryInlineList(
                 discovery: self.gatewayDiscovery,
@@ -285,6 +286,23 @@ struct GeneralSettings: View {
             }
             Text(
                 "Direct mode requires wss:// for remote hosts. ws:// is only allowed for localhost/127.0.0.1.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.leading, self.remoteLabelWidth + 10)
+        }
+    }
+
+    private var remoteTokenRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 10) {
+                Text("Gateway token")
+                    .font(.callout.weight(.semibold))
+                    .frame(width: self.remoteLabelWidth, alignment: .leading)
+                SecureField("token from gateway.auth.token", text: self.$state.remoteToken)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: .infinity)
+            }
+            Text("Used when the remote gateway requires token auth.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .padding(.leading, self.remoteLabelWidth + 10)
@@ -692,6 +710,7 @@ extension GeneralSettings {
         state.remoteTransport = .ssh
         state.remoteTarget = "user@host:2222"
         state.remoteUrl = "wss://gateway.example.ts.net"
+        state.remoteToken = "example-token"
         state.remoteIdentity = "/tmp/id_ed25519"
         state.remoteProjectRoot = "/tmp/openclaw"
         state.remoteCliPath = "/tmp/openclaw"

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -203,7 +203,7 @@ extension OnboardingView {
                         Text("Gateway token")
                             .font(.callout.weight(.semibold))
                             .frame(width: labelWidth, alignment: .leading)
-                        SecureField("token from gateway.auth.token", text: self.$state.remoteToken)
+                        SecureField("remote gateway auth token (gateway.auth.token)", text: self.$state.remoteToken)
                             .textFieldStyle(.roundedBorder)
                             .frame(width: fieldWidth)
                     }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -199,6 +199,14 @@ extension OnboardingView {
                         .pickerStyle(.segmented)
                         .frame(width: fieldWidth)
                     }
+                    GridRow {
+                        Text("Gateway token")
+                            .font(.callout.weight(.semibold))
+                            .frame(width: labelWidth, alignment: .leading)
+                        SecureField("token from gateway.auth.token", text: self.$state.remoteToken)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: fieldWidth)
+                    }
                     if self.state.remoteTransport == .direct {
                         GridRow {
                             Text("Gateway URL")

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -57,6 +57,7 @@ struct AppStateRemoteConfigTests {
             remoteToken: "")
         let localGateway = localRoot["gateway"] as? [String: Any]
         let localRemoteConfig = localGateway?["remote"] as? [String: Any]
+        // Local mode should not discard remote token state; users can return to remote mode later.
         #expect(localGateway?["mode"] as? String == "local")
         #expect(localRemoteConfig?["token"] as? String == "persisted-token")
 

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct AppStateRemoteConfigTests {
+    @Test
+    func updatedRemoteGatewayConfigSetsTrimmedToken() {
+        let remote = AppState._testUpdatedRemoteGatewayConfig(
+            current: [:],
+            transport: .ssh,
+            remoteUrl: "",
+            remoteHost: "gateway.example",
+            remoteTarget: "alice@gateway.example",
+            remoteIdentity: "/tmp/id_ed25519",
+            remoteToken: "  secret-token  ")
+
+        #expect(remote["token"] as? String == "secret-token")
+    }
+
+    @Test
+    func updatedRemoteGatewayConfigClearsTokenWhenBlank() {
+        let remote = AppState._testUpdatedRemoteGatewayConfig(
+            current: ["token": "old-token"],
+            transport: .direct,
+            remoteUrl: "wss://gateway.example",
+            remoteHost: nil,
+            remoteTarget: "",
+            remoteIdentity: "",
+            remoteToken: "   ")
+
+        #expect((remote["token"] as? String) == nil)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -31,4 +31,44 @@ struct AppStateRemoteConfigTests {
 
         #expect((remote["token"] as? String) == nil)
     }
+
+    @Test
+    func syncedGatewayRootPreservesTokenAcrossModeToggleAndClearsOnBlankRemoteToken() {
+        let remoteRoot = AppState._testSyncedGatewayRoot(
+            currentRoot: [:],
+            connectionMode: .remote,
+            remoteTransport: .direct,
+            remoteTarget: "",
+            remoteIdentity: "",
+            remoteUrl: "wss://gateway.example",
+            remoteToken: "  persisted-token  ")
+        let remoteGateway = remoteRoot["gateway"] as? [String: Any]
+        let remoteConfig = remoteGateway?["remote"] as? [String: Any]
+        #expect(remoteGateway?["mode"] as? String == "remote")
+        #expect(remoteConfig?["token"] as? String == "persisted-token")
+
+        let localRoot = AppState._testSyncedGatewayRoot(
+            currentRoot: remoteRoot,
+            connectionMode: .local,
+            remoteTransport: .direct,
+            remoteTarget: "",
+            remoteIdentity: "",
+            remoteUrl: "",
+            remoteToken: "")
+        let localGateway = localRoot["gateway"] as? [String: Any]
+        let localRemoteConfig = localGateway?["remote"] as? [String: Any]
+        #expect(localGateway?["mode"] as? String == "local")
+        #expect(localRemoteConfig?["token"] as? String == "persisted-token")
+
+        let clearedRoot = AppState._testSyncedGatewayRoot(
+            currentRoot: localRoot,
+            connectionMode: .remote,
+            remoteTransport: .direct,
+            remoteTarget: "",
+            remoteIdentity: "",
+            remoteUrl: "wss://gateway.example",
+            remoteToken: "   ")
+        let clearedRemote = (clearedRoot["gateway"] as? [String: Any])?["remote"] as? [String: Any]
+        #expect((clearedRemote?["token"] as? String) == nil)
+    }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -61,6 +61,21 @@ import Testing
         #expect(token == nil)
     }
 
+    @Test func resolveGatewayTokenUsesRemoteConfigToken() {
+        let token = GatewayEndpointStore._testResolveGatewayToken(
+            isRemote: true,
+            root: [
+                "gateway": [
+                    "remote": [
+                        "token": "  remote-token  ",
+                    ],
+                ],
+            ],
+            env: [:],
+            launchdSnapshot: nil)
+        #expect(token == "remote-token")
+    }
+
     @Test func resolveGatewayPasswordFallsBackToLaunchd() {
         let snapshot = self.makeLaunchAgentSnapshot(
             env: ["OPENCLAW_GATEWAY_PASSWORD": "launchd-pass"],


### PR DESCRIPTION
## Summary

- Problem: In macOS remote mode, the companion app had no UI path to set `gateway.remote.token`, causing SSH/direct remote auth failures when gateway token auth is enabled (#13552).
- Why it matters: Users could establish transport but still fail handshake with `gateway token missing`, and had to hand-edit `~/.openclaw/openclaw.json`.
- What changed: Added a remote gateway token field to macOS Settings + Onboarding advanced remote config, and wired `AppState` sync so the value is persisted to `gateway.remote.token`.
- What did NOT change (scope boundary): No protocol/auth model changes on the gateway side; this PR is UI/config plumbing only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #13552
- Related #8545

## User-visible / Behavior Changes

- macOS Settings > General > Remote now includes a `Gateway token` field.
- Onboarding advanced remote setup now includes a `Gateway token` field.
- Token value is synced into `gateway.remote.token` in config via app state updates.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Risk: token input in UI could accidentally store whitespace/empty values.
  - Mitigation: token is trimmed, and blank values remove `gateway.remote.token` from config.

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Swift Package (`apps/macos`)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `gateway.mode=remote`, `gateway.remote.*`

### Steps

1. Open macOS Settings in Remote mode or Onboarding advanced remote setup.
2. Enter gateway token in the new token field.
3. Confirm app state writes `gateway.remote.token` and token-auth connection paths can use it.

### Expected

- Remote token can be set without manual config edits.

### Actual

- Implemented and covered by new/updated tests below.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `swift test --package-path apps/macos --filter AppStateRemoteConfigTests`
  - `swift test --package-path apps/macos --filter GatewayEndpointStoreTests`
  - `swift test --package-path apps/macos --filter SettingsViewSmokeTests`
  - `swift test --package-path apps/macos --filter OnboardingViewSmokeTests`
- Edge cases checked:
  - Token is trimmed before persistence.
  - Blank token removes `gateway.remote.token` key.
- What you did **not** verify:
  - Full `swift test --package-path apps/macos` run is not currently stable on this host due unrelated baseline failures/flakes (`ExecAllowlistTests` fixture mismatch; `LowCoverageViewSmokeTests` exclusivity crash).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Remove `gateway.remote.token` from config and/or revert this PR.
- Files/config to restore:
  - `apps/macos/Sources/OpenClaw/AppState.swift`
  - `apps/macos/Sources/OpenClaw/GeneralSettings.swift`
  - `apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift`
- Known bad symptoms reviewers should watch for:
  - Remote token field appears but does not persist to config.

## Risks and Mitigations

- Risk: Exposing token input in UI could increase accidental shoulder-surfing.
  - Mitigation: Uses `SecureField` and keeps scope limited to remote gateway token entry.
