### PR TITLE
fix(gateway): include screen.record in macOS platform allowlist

### DIFF
--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -100,6 +100,7 @@ const PLATFORM_DEFAULTS: Record<string, string[]> = {
   macos: [
     ...CANVAS_COMMANDS,
     ...CAMERA_COMMANDS,
+    ...SCREEN_DANGEROUS_COMMANDS,
     ...LOCATION_COMMANDS,
     ...DEVICE_COMMANDS,
     ...CONTACTS_COMMANDS,


### PR DESCRIPTION
## Summary

- **Problem:** `screen.record` is blocked on macOS with "not in the allowlist for platform" even when the macOS node has screen recording permissions enabled (`screenRecording: true`).
- **Why it matters:** macOS nodes that have obtained user consent for screen recording via TCC (Transparency, Consent, and Control) should be able to use `screen.record` without additional gateway-level opt-in. Requiring `gateway.nodes.allowCommands` is redundant when macOS already gates this at the OS level.
- **What changed:** Added `SCREEN_DANGEROUS_COMMANDS` (`screen.record`) to the macOS platform defaults in `PLATFORM_DEFAULTS`. The command is now allowed by default on macOS nodes, matching the behavior of other platform-gated commands (camera, contacts, calendar).
- **What did NOT change:** `screen.record` remains "dangerous" for all other platforms (iOS, Android, Linux, Windows) — they still require explicit `gateway.nodes.allowCommands` opt-in. The `denyCommands` mechanism can still block it on macOS if needed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34561

## User-visible / Behavior Changes

- `screen.record` now works on macOS nodes without explicit `gateway.nodes.allowCommands` configuration
- All other platforms unchanged — `screen.record` still requires explicit opt-in

## Security Impact (required)

- New permissions/capabilities? `Yes — screen.record enabled by default on macOS (was opt-in)`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `Yes — macOS nodes gain screen.record by default`
- Data access scope changed? `No`

**Justification:** macOS already requires explicit user consent for screen recording via TCC. The OpenClaw macOS app reports `screenRecording: true` only when this OS-level permission has been granted. Adding `screen.record` to macOS defaults aligns the gateway allowlist with the OS-level permission model.

## Repro + Verification

### Environment

- OS: macOS 26.3.0 (Tahoe)
- Runtime: Node.js
- Integration/channel: Node host

### Steps

1. Configure a macOS node with screen recording permissions
2. Attempt `screen.record` command
3. Observe command is no longer blocked

### Expected

- `screen.record` executes successfully on macOS nodes with screen recording permission

### Actual

- Before fix: `node command not allowed: "screen.record" is not in the allowlist for platform "macOS 26.3.0"`
- After fix: Command allowed by default

## Evidence

```typescript
// node-command-policy.ts — macOS defaults now include screen commands
macos: [
  ...CANVAS_COMMANDS,
  ...CAMERA_COMMANDS,
  ...SCREEN_DANGEROUS_COMMANDS,  // ← added
  ...LOCATION_COMMANDS,
  ...DEVICE_COMMANDS,
  // ...
],
```

All 21 existing gateway tests pass.

## Human Verification (required)

- Verified scenarios: All 21 gateway-misc.test.ts tests pass, including the test that verifies dangerous commands can be explicitly allowed
- Edge cases checked: `denyCommands` can still block `screen.record` on macOS; other platforms unchanged
- What I did **not** verify: End-to-end test with actual macOS node (verified via code analysis and unit tests)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Add `screen.record` to `gateway.nodes.denyCommands`, or revert the 1-line change
- Files/config to restore: `src/gateway/node-command-policy.ts`
- Known bad symptoms: N/A

## Risks and Mitigations

Risk: Screen recording enabled by default on macOS without explicit gateway-level opt-in. Mitigated by: (1) macOS TCC already requires user consent, (2) `denyCommands` can block it, (3) only affects macOS platform.
