### PR TITLE
Fix: add exec tool to loop detection repeat hash

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -199,6 +199,12 @@ describe("tool-loop-detection", () => {
       expect(hash.startsWith("read:")).toBe(true);
       expect(hash.length).toBe("read:".length + 64);
     });
+
+    it("normalizes exec timing knobs so repeats hash the same", () => {
+      const hash1 = hashToolCall("exec", { command: "ls", timeout: 30, yieldMs: 250 });
+      const hash2 = hashToolCall("exec", { command: "ls", timeout: 120, yieldMs: 1000 });
+      expect(hash1).toBe(hash2);
+    });
   });
 
   describe("recordToolCall", () => {
@@ -296,6 +302,32 @@ describe("tool-loop-detection", () => {
         expect(result.count).toBe(WARNING_THRESHOLD);
         expect(result.message).toContain("WARNING");
         expect(result.message).toContain(`${WARNING_THRESHOLD} times`);
+      }
+    });
+
+    it("warns on repeated exec calls even when timeout/yield vary", () => {
+      const state = createState();
+      for (let i = 0; i < WARNING_THRESHOLD; i += 1) {
+        recordToolCall(
+          state,
+          "exec",
+          { command: "npm test", timeout: 30 + i, yieldMs: 100 + i * 10 },
+          `exec-${i}`,
+        );
+      }
+
+      const result = detectToolCallLoop(
+        state,
+        "exec",
+        { command: "npm test", timeout: 999, yieldMs: 5000 },
+        enabledLoopDetectionConfig,
+      );
+
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.level).toBe("warning");
+        expect(result.detector).toBe("generic_repeat");
+        expect(result.count).toBe(WARNING_THRESHOLD);
       }
     });
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -104,7 +104,7 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
  * Uses tool name + deterministic JSON serialization digest of params.
  */
 export function hashToolCall(toolName: string, params: unknown): string {
-  return `${toolName}:${digestStable(params)}`;
+  return `${toolName}:${digestStable(normalizeParamsForLoopHash(toolName, params))}`;
 }
 
 function stableStringify(value: unknown): string {
@@ -142,6 +142,33 @@ function stableStringifyFallback(value: unknown): string {
     }
     return Object.prototype.toString.call(value);
   }
+}
+
+function normalizeParamsForLoopHash(toolName: string, params: unknown): unknown {
+  if (toolName !== "exec" || !isPlainObject(params)) {
+    return params;
+  }
+  // Keep exec repeat detection focused on semantic command identity.
+  // Timing/streaming knobs (timeout/yield/background) are intentionally ignored.
+  const normalized: Record<string, unknown> = {};
+  const semanticKeys = [
+    "command",
+    "cmd",
+    "workdir",
+    "env",
+    "host",
+    "security",
+    "pty",
+    "node",
+    "elevated",
+    "ask",
+  ] as const;
+  for (const key of semanticKeys) {
+    if (key in params) {
+      normalized[key] = params[key];
+    }
+  }
+  return normalized;
 }
 
 function isKnownPollToolCall(toolName: string, params: unknown): boolean {


### PR DESCRIPTION
## Summary
- Add  to normalize exec tool params for loop detection hash
- Ignore timing knobs (timeout/yieldMs/background) so repeated exec calls with same command are detected
- Add tests for exec repeat detection with varying timeouts

## Security Impact
None. This is a bug fix for internal loop detection.

## Repro + Verification
1. Enable loop detection config
2. Make repeated exec calls with same command but different timeout
3. Observe loop detection now triggers (previously it didn't)

## Testing
bun test v1.3.10 (30e609e0)

## AI Assisted
This change was assisted by AI (Codex).

Fixes #34574