### PR TITLE
feat(gateway): signal typing indicator during context compaction

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -376,9 +376,13 @@ export async function runAgentTurnWithFallback(params: {
                     await params.opts?.onToolStart?.({ name, phase });
                   }
                 }
-                // Track auto-compaction completion
+                // Keep typing indicator active during auto-compaction so the
+                // user sees feedback instead of silence during long compactions.
                 if (evt.stream === "compaction") {
                   const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+                  if (phase === "start") {
+                    await params.typingSignals.signalToolStart();
+                  }
                   if (phase === "end") {
                     autoCompactionCompleted = true;
                   }


### PR DESCRIPTION
## Summary

- **Problem:** When the gateway compacts/compresses context between turns, users experience a long delay (30+ seconds) with no feedback. The agent appears frozen or broken from the user's perspective.
- **Why it matters:** Users on mobile channels (Telegram, WhatsApp) have no visibility into gateway internals. They rely on typing indicators and response time as health signals.
- **What changed:** Added a `signalToolStart()` call when a `compaction` stream event with `phase === "start"` is received in `onAgentEvent`. This activates the typing indicator during the compaction phase.
- **What did NOT change:** The compaction logic itself is untouched. The `phase === "end"` tracking (`autoCompactionCompleted`) and the post-run verbose notice (`🧹 Auto-compaction complete`) remain unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34372

## User-visible / Behavior Changes

- During context compaction, the typing indicator (e.g. "typing..." in Telegram, Discord) is now active instead of silence
- This provides visual feedback that the agent is processing, not frozen

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js
- Integration/channel: Telegram, Discord, WhatsApp (any channel with typing indicators)

### Steps

1. Have a long conversation to fill the context window
2. Send a message that triggers auto-compaction
3. Observe the typing indicator during the compaction phase

### Expected

- Typing indicator is active during compaction

### Actual

- Before fix: No feedback during compaction (30+ seconds of silence)
- After fix: Typing indicator active during compaction

## Evidence

```typescript
// agent-runner-execution.ts — handle compaction start
if (evt.stream === "compaction") {
  const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
  if (phase === "start") {
    await params.typingSignals.signalToolStart();
  }
  if (phase === "end") {
    autoCompactionCompleted = true;
  }
}
```

`signalToolStart()` starts the typing indicator loop or refreshes its TTL — the same mechanism used during tool execution. This ensures consistent typing behavior across all long-running operations.

## Human Verification (required)

- Verified scenarios: `signalToolStart` is the same signal used during tool execution; reusing it for compaction follows the existing pattern
- Edge cases checked: If compaction ends quickly, the typing indicator will be superseded by the agent's actual response; if compaction is already the last event before response, the indicator provides bridge feedback
- What I did **not** verify: End-to-end test with actual context compaction (verified via code path analysis)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the 1-file change
- Files/config to restore: `src/auto-reply/reply/agent-runner-execution.ts`
- Known bad symptoms: N/A

## Risks and Mitigations

None — reuses existing typing signal infrastructure. No new code paths or state changes.
