### PR TITLE
fix(agents): disable pi-coding-agent auto-retry to unblock 529 failover

### DIFF
--- a/src/agents/pi-project-settings.test.ts
+++ b/src/agents/pi-project-settings.test.ts
@@ -1,3 +1,4 @@
+import { SettingsManager } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import {
   buildEmbeddedPiSettingsSnapshot,
@@ -93,9 +94,13 @@ describe("createPreparedEmbeddedPiSettingsManager", () => {
       agentDir: "/tmp/agent",
     });
 
+    // Derive expected values from the upstream library so the test stays
+    // robust across library upgrades instead of hardcoding defaults.
+    const baseManager = SettingsManager.create("/tmp", "/tmp/agent-base");
+    const baseRetry = baseManager.getRetrySettings();
     const retrySettings = settingsManager.getRetrySettings();
-    expect(retrySettings.maxRetries).toBe(3);
-    expect(retrySettings.baseDelayMs).toBe(2000);
-    expect(retrySettings.maxDelayMs).toBe(60000);
+    const { enabled: _, ...baseWithoutEnabled } = baseRetry;
+    const { enabled: __, ...retryWithoutEnabled } = retrySettings;
+    expect(retryWithoutEnabled).toEqual(baseWithoutEnabled);
   });
 });

--- a/src/agents/pi-project-settings.test.ts
+++ b/src/agents/pi-project-settings.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildEmbeddedPiSettingsSnapshot,
+  createPreparedEmbeddedPiSettingsManager,
   DEFAULT_EMBEDDED_PI_PROJECT_SETTINGS_POLICY,
   resolveEmbeddedPiProjectSettingsPolicy,
 } from "./pi-project-settings.js";
@@ -72,5 +73,29 @@ describe("buildEmbeddedPiSettingsSnapshot", () => {
     expect(snapshot.shellCommandPrefix).toBe("echo hacked &&");
     expect(snapshot.compaction?.reserveTokens).toBe(32_000);
     expect(snapshot.hideThinkingBlock).toBe(true);
+  });
+});
+
+describe("createPreparedEmbeddedPiSettingsManager", () => {
+  it("disables auto-retry so OpenClaw failover handles transient errors", () => {
+    const settingsManager = createPreparedEmbeddedPiSettingsManager({
+      cwd: "/tmp",
+      agentDir: "/tmp/agent",
+    });
+
+    const retrySettings = settingsManager.getRetrySettings();
+    expect(retrySettings.enabled).toBe(false);
+  });
+
+  it("preserves other retry settings from the base manager", () => {
+    const settingsManager = createPreparedEmbeddedPiSettingsManager({
+      cwd: "/tmp",
+      agentDir: "/tmp/agent",
+    });
+
+    const retrySettings = settingsManager.getRetrySettings();
+    expect(retrySettings.maxRetries).toBe(3);
+    expect(retrySettings.baseDelayMs).toBe(2000);
+    expect(retrySettings.maxDelayMs).toBe(60000);
   });
 });

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -71,5 +71,15 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
     settingsManager,
     cfg: params.cfg,
   });
+  // Disable pi-coding-agent auto-retry for embedded runs. OpenClaw's own
+  // failover system (auth-profile rotation + model fallback) handles
+  // transient errors. The library's internal auto-retry consumes
+  // overloaded/529 errors before the failover classifier sees them,
+  // masking the original error as a timeout abort (#34535).
+  const baseGetRetrySettings = settingsManager.getRetrySettings.bind(settingsManager);
+  settingsManager.getRetrySettings = () => ({
+    ...baseGetRetrySettings(),
+    enabled: false,
+  });
   return settingsManager;
 }


### PR DESCRIPTION
## Summary

Fixes #34535

When Anthropic returns a 529 (overloaded) error, the pi-coding-agent library's built-in auto-retry mechanism (up to 3 retries with 2s/4s/8s exponential backoff) intercepts the error before OpenClaw's failover system can act. During the retry backoff, OpenClaw's timeout timer fires and aborts the session. The resulting abort error (`"aborted"`) is not recognized by `classifyFailoverReason`, so:

- Profile cooldown is not applied
- Model fallback chain is not triggered
- The user sees a generic timeout instead of a graceful failover

This PR disables the library's auto-retry for embedded runs by overriding `getRetrySettings()` on the settings manager instance. OpenClaw's own failover system (auth-profile rotation + model fallback) handles transient errors at a higher level with better visibility.

### Changes
- `src/agents/pi-project-settings.ts`: Override `getRetrySettings` in `createPreparedEmbeddedPiSettingsManager` to return `enabled: false`
- `src/agents/pi-project-settings.test.ts`: Add tests verifying auto-retry is disabled while other retry settings are preserved

## Test plan
- [x] Existing `pi-project-settings.test.ts` tests pass (7/7)
- [x] New tests verify `getRetrySettings().enabled === false`
- [x] New tests verify other retry settings (`maxRetries`, `baseDelayMs`, `maxDelayMs`) are preserved from base manager
- [ ] Manual verification: trigger 529 error and confirm failover kicks in without timeout delay