### PR TITLE
test(hooks): clean up temporary directories in hooks mapping tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12916,7 +12916,7 @@
         "filename": "src/telegram/monitor.test.ts",
         "hashed_secret": "5934c4d4a4fa5d66ddb3d3fc0bba84996c17a5b7",
         "is_verified": false,
-        "line_number": 603
+        "line_number": 641
       }
     ],
     "src/telegram/webhook.test.ts": [
@@ -13011,5 +13011,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-07T23:50:03Z"
+  "generated_at": "2026-03-08T00:41:51Z"
 }

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -405,10 +405,10 @@ describe("readSystemdServiceExecStart", () => {
         ].join("\n");
       }
       if (pathValue === "/home/test/.openclaw/first.env") {
-        return "OPENCLAW_GATEWAY_TOKEN=first-token\n";
+        return "OPENCLAW_GATEWAY_TOKEN=first-token\n"; // pragma: allowlist secret
       }
       if (pathValue === "/home/test/.openclaw/second env.env") {
-        return 'OPENCLAW_GATEWAY_PASSWORD="second password"\n';
+        return 'OPENCLAW_GATEWAY_PASSWORD="second password"\n'; // pragma: allowlist secret
       }
       throw new Error(`unexpected readFile path: ${pathValue}`);
     });
@@ -433,11 +433,11 @@ describe("readSystemdServiceExecStart", () => {
       if (pathValue.endsWith("/.config/systemd/user/gateway.env")) {
         return [
           "OPENCLAW_GATEWAY_TOKEN=relative-token",
-          "OPENCLAW_GATEWAY_PASSWORD=relative-password",
-        ].join("\n");
+          "OPENCLAW_GATEWAY_PASSWORD=relative-password", // pragma: allowlist secret
+        ].join("\n"); // pragma: allowlist secret
       }
       if (pathValue.endsWith("/.config/systemd/user/override.env")) {
-        return "OPENCLAW_GATEWAY_TOKEN=override-token\n";
+        return "OPENCLAW_GATEWAY_TOKEN=override-token\n"; // pragma: allowlist secret
       }
       throw new Error(`unexpected readFile path: ${pathValue}`);
     });
@@ -464,8 +464,8 @@ describe("readSystemdServiceExecStart", () => {
           "# comment",
           "; another comment",
           'OPENCLAW_GATEWAY_TOKEN="quoted token"',
-          "OPENCLAW_GATEWAY_PASSWORD=quoted-password",
-        ].join("\n");
+          "OPENCLAW_GATEWAY_PASSWORD=quoted-password", // pragma: allowlist secret
+        ].join("\n"); // pragma: allowlist secret
       }
       throw new Error(`unexpected readFile path: ${pathValue}`);
     });

--- a/src/discord/monitor/exec-approvals.test.ts
+++ b/src/discord/monitor/exec-approvals.test.ts
@@ -27,24 +27,26 @@ const writeStore = (store: Record<string, unknown>) => {
 beforeEach(() => {
   writeStore({});
   mockGatewayClientCtor.mockClear();
-  mockResolveGatewayConnectionAuth.mockReset().mockImplementation(async (params: {
-    config?: {
-      gateway?: {
-        auth?: {
-          token?: string;
-          password?: string;
+  mockResolveGatewayConnectionAuth.mockReset().mockImplementation(
+    async (params: {
+      config?: {
+        gateway?: {
+          auth?: {
+            token?: string;
+            password?: string;
+          };
         };
       };
-    };
-    env: NodeJS.ProcessEnv;
-  }) => {
-    const configToken = params.config?.gateway?.auth?.token;
-    const configPassword = params.config?.gateway?.auth?.password;
-    const envToken = params.env.OPENCLAW_GATEWAY_TOKEN ?? params.env.CLAWDBOT_GATEWAY_TOKEN;
-    const envPassword =
-      params.env.OPENCLAW_GATEWAY_PASSWORD ?? params.env.CLAWDBOT_GATEWAY_PASSWORD;
-    return { token: envToken ?? configToken, password: envPassword ?? configPassword };
-  });
+      env: NodeJS.ProcessEnv;
+    }) => {
+      const configToken = params.config?.gateway?.auth?.token;
+      const configPassword = params.config?.gateway?.auth?.password;
+      const envToken = params.env.OPENCLAW_GATEWAY_TOKEN ?? params.env.CLAWDBOT_GATEWAY_TOKEN;
+      const envPassword =
+        params.env.OPENCLAW_GATEWAY_PASSWORD ?? params.env.CLAWDBOT_GATEWAY_PASSWORD;
+      return { token: envToken ?? configToken, password: envPassword ?? configPassword };
+    },
+  );
 });
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────

--- a/src/gateway/connection-auth.test.ts
+++ b/src/gateway/connection-auth.test.ts
@@ -62,7 +62,7 @@ describe("resolveGatewayConnectionAuth", () => {
       env: DEFAULT_ENV,
       options: {
         localTokenPrecedence: "config-first",
-        localPasswordPrecedence: "config-first",
+        localPasswordPrecedence: "config-first", // pragma: allowlist secret
       },
       expected: {
         token: "config-token",
@@ -84,7 +84,7 @@ describe("resolveGatewayConnectionAuth", () => {
       env: DEFAULT_ENV,
       options: {
         localTokenPrecedence: "env-first",
-        localPasswordPrecedence: "config-first",
+        localPasswordPrecedence: "config-first", // pragma: allowlist secret
       },
       expected: {
         token: "env-token",
@@ -132,7 +132,7 @@ describe("resolveGatewayConnectionAuth", () => {
       env: DEFAULT_ENV,
       options: {
         remoteTokenPrecedence: "env-first",
-        remotePasswordPrecedence: "remote-first",
+        remotePasswordPrecedence: "remote-first", // pragma: allowlist secret
       },
       expected: {
         token: "env-token",
@@ -157,7 +157,7 @@ describe("resolveGatewayConnectionAuth", () => {
       env: DEFAULT_ENV,
       options: {
         remoteTokenFallback: "remote-only",
-        remotePasswordFallback: "remote-only",
+        remotePasswordFallback: "remote-only", // pragma: allowlist secret
       },
       expected: {
         token: "remote-token",
@@ -184,7 +184,7 @@ describe("resolveGatewayConnectionAuth", () => {
       options: {
         modeOverride: "remote",
         remoteTokenPrecedence: "remote-first",
-        remotePasswordPrecedence: "remote-first",
+        remotePasswordPrecedence: "remote-first", // pragma: allowlist secret
       },
       expected: {
         token: "remote-token",
@@ -267,7 +267,7 @@ describe("resolveGatewayConnectionAuth", () => {
     });
     const env = {
       CLAWDBOT_GATEWAY_TOKEN: "legacy-token",
-      LOCAL_SECRET_TOKEN: "resolved-from-secretref",
+      LOCAL_SECRET_TOKEN: "resolved-from-secretref", // pragma: allowlist secret
     } as NodeJS.ProcessEnv;
 
     const resolved = await resolveGatewayConnectionAuth({
@@ -336,7 +336,7 @@ describe("resolveGatewayConnectionAuth", () => {
       config,
       env,
       includeLegacyEnv: false,
-      localPasswordPrecedence: "config-first",
+      localPasswordPrecedence: "config-first", // pragma: allowlist secret
     });
     expect(resolved).toEqual({
       token: undefined,

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -7,6 +7,8 @@ import { applyHookMappings, resolveHookMappings } from "./hooks-mapping.js";
 const baseUrl = new URL("http://127.0.0.1:18789/hooks/gmail");
 
 const trackedTempDirs: string[] = [];
+// Prefix each temporary directory with a run marker so cleanup assertions can
+// verify we only remove temp dirs created by this test run.
 const cleanupRunPrefix = `hooks-mapping-test-${Date.now()}-${process.pid}-`;
 
 function trackedMkdtempSync(prefix: string): string {

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -7,9 +7,10 @@ import { applyHookMappings, resolveHookMappings } from "./hooks-mapping.js";
 const baseUrl = new URL("http://127.0.0.1:18789/hooks/gmail");
 
 const trackedTempDirs: string[] = [];
+const cleanupRunPrefix = `hooks-mapping-test-${Date.now()}-${process.pid}-`;
 
 function trackedMkdtempSync(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `${cleanupRunPrefix}${prefix}`));
   trackedTempDirs.push(dir);
   return dir;
 }
@@ -20,6 +21,7 @@ afterEach(() => {
     if (!dir) {
       continue;
     }
+    expect(path.basename(dir)).toContain(cleanupRunPrefix);
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -1,10 +1,28 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { applyHookMappings, resolveHookMappings } from "./hooks-mapping.js";
 
 const baseUrl = new URL("http://127.0.0.1:18789/hooks/gmail");
+
+const trackedTempDirs: string[] = [];
+
+function trackedMkdtempSync(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  trackedTempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (trackedTempDirs.length > 0) {
+    const dir = trackedTempDirs.pop();
+    if (!dir) {
+      continue;
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe("hooks mapping", () => {
   const gmailPayload = { messages: [{ subject: "Hello" }] };
@@ -145,7 +163,7 @@ describe("hooks mapping", () => {
   });
 
   it("runs transform module", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-"));
+    const configDir = trackedMkdtempSync("openclaw-config-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "transform.mjs");
@@ -183,7 +201,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transform module traversal outside transformsDir", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-traversal-"));
+    const configDir = trackedMkdtempSync("openclaw-config-traversal-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -203,7 +221,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects absolute transform module path outside transformsDir", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-abs-"));
+    const configDir = trackedMkdtempSync("openclaw-config-abs-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const outside = path.join(os.tmpdir(), "evil.mjs");
@@ -224,7 +242,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir traversal outside the transforms root", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-trav-"));
+    const configDir = trackedMkdtempSync("openclaw-config-xformdir-trav-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -245,7 +263,7 @@ describe("hooks mapping", () => {
   });
 
   it("rejects transformsDir absolute path outside the transforms root", () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-abs-"));
+    const configDir = trackedMkdtempSync("openclaw-config-xformdir-abs-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     expect(() =>
@@ -266,7 +284,7 @@ describe("hooks mapping", () => {
   });
 
   it("accepts transformsDir subdirectory within the transforms root", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xformdir-ok-"));
+    const configDir = trackedMkdtempSync("openclaw-config-xformdir-ok-");
     const result = await applyNullTransformFromTempConfig({ configDir, transformsDir: "subdir" });
     expectSkippedTransformResult(result);
   });
@@ -274,10 +292,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transform module symlink escape outside transformsDir",
     () => {
-      const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-module-"));
+      const configDir = trackedMkdtempSync("openclaw-config-symlink-module-");
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-outside-module-"));
+      const outsideDir = trackedMkdtempSync("openclaw-outside-module-");
       const outsideModule = path.join(outsideDir, "evil.mjs");
       fs.writeFileSync(outsideModule, 'export default () => ({ kind: "wake", text: "owned" });');
       fs.symlinkSync(outsideModule, path.join(transformsRoot, "linked.mjs"));
@@ -301,10 +319,10 @@ describe("hooks mapping", () => {
   it.runIf(process.platform !== "win32")(
     "rejects transformsDir symlink escape outside transforms root",
     () => {
-      const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-dir-"));
+      const configDir = trackedMkdtempSync("openclaw-config-symlink-dir-");
       const transformsRoot = path.join(configDir, "hooks", "transforms");
       fs.mkdirSync(transformsRoot, { recursive: true });
-      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-outside-dir-"));
+      const outsideDir = trackedMkdtempSync("openclaw-outside-dir-");
       fs.writeFileSync(path.join(outsideDir, "transform.mjs"), "export default () => null;");
       fs.symlinkSync(outsideDir, path.join(transformsRoot, "escape"), "dir");
       expect(() =>
@@ -326,7 +344,7 @@ describe("hooks mapping", () => {
   );
 
   it.runIf(process.platform !== "win32")("accepts in-root transform module symlink", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-symlink-ok-"));
+    const configDir = trackedMkdtempSync("openclaw-config-symlink-ok-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     const nestedDir = path.join(transformsRoot, "nested");
     fs.mkdirSync(nestedDir, { recursive: true });
@@ -357,7 +375,7 @@ describe("hooks mapping", () => {
   });
 
   it("treats null transform as a handled skip", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-skip-"));
+    const configDir = trackedMkdtempSync("openclaw-config-skip-");
     const result = await applyNullTransformFromTempConfig({ configDir });
     expectSkippedTransformResult(result);
   });
@@ -407,7 +425,7 @@ describe("hooks mapping", () => {
   });
 
   it("caches transform functions by module path and export name", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-export-"));
+    const configDir = trackedMkdtempSync("openclaw-hooks-export-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "multi-export.mjs");

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -121,9 +121,9 @@ export async function resolveNodeHostGatewayCredentials(params: {
     env: params.env,
     includeLegacyEnv: false,
     localTokenPrecedence: "env-first",
-    localPasswordPrecedence: "env-first",
+    localPasswordPrecedence: "env-first", // pragma: allowlist secret
     remoteTokenPrecedence: "env-first",
-    remotePasswordPrecedence: "env-first",
+    remotePasswordPrecedence: "env-first", // pragma: allowlist secret
   });
 }
 


### PR DESCRIPTION
## Problem
Issue #34286 reports accumulated `/tmp/openclaw-*` directories from tests that call `mkdtemp` without cleanup.

## Scope
This PR tackles one uncovered area not addressed by the currently open infra-focused PRs: `src/gateway/hooks-mapping.test.ts`.

## Fix
- Added tracked temp-dir helper in the test file:
  - `trackedMkdtempSync(prefix)`
- Added `afterEach` cleanup that removes all tracked temp directories with `fs.rmSync(..., { recursive: true, force: true })`.
- Migrated all local `mkdtempSync(path.join(os.tmpdir(), ...))` calls in this file to `trackedMkdtempSync(...)`.

## Tests
- `bunx vitest run src/gateway/hooks-mapping.test.ts`
- Result: `21 passed`

## Impact
Prevents temp-directory leaks from hooks mapping tests and reduces `/tmp/openclaw-*` accumulation over repeated local/CI runs.

Refs #34286
