### PR TITLE
fix(gateway): add screen.record to macOS platform allowlist (#34561)

### DIFF
--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -108,6 +108,7 @@ const PLATFORM_DEFAULTS: Record<string, string[]> = {
     ...PHOTOS_COMMANDS,
     ...MOTION_COMMANDS,
     ...SYSTEM_COMMANDS,
+    "screen.record",
   ],
   linux: [...SYSTEM_COMMANDS],
   windows: [...SYSTEM_COMMANDS],


### PR DESCRIPTION
## Summary

- Problem: macOS users cannot use `screen.record` command without explicitly adding it to `gateway.nodes.allowCommands` config
- Why it matters: Screen recording is a common macOS system feature; requiring manual configuration creates poor UX
- What changed: Added `"screen.record"` to `PLATFORM_DEFAULTS.macos` allowlist
- What did NOT change: Other platform allowlists remain unchanged; security model unchanged (macOS system permissions still required)

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #34561

## User-visible / Behavior Changes

macOS users can now use `screen.record` node command without manual configuration.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes` - screen.record is now allowlisted on macOS by default)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - `screen.record` was already available on macOS but required explicit configuration. This change makes it available by default, consistent with other macOS system features. The actual screen recording still requires macOS system permissions (screen recording permission) which is enforced by the OS.

## Repro + Verification

### Environment

- OS: macOS 26.3.0 (Tahoe)
- Runtime/container: npm global install

### Steps

1. Configure OpenClaw on macOS without explicit `gateway.nodes.allowCommands`
2. Try to use `screen.record` command
3. Observe error: `node command not allowed: "screen.record" is not in the allowlist for platform "macOS 26.3.0"`

### Expected

`screen.record` should work on macOS (with system permissions)

### Actual

Command is blocked by allowlist

## Evidence

Code inspection shows `SCREEN_DANGEROUS_COMMANDS` includes `"screen.record"` but `PLATFORM_DEFAULTS.macos` does not include it.

## Human Verification (required)

- Verified scenarios: Code change adds screen.record to macOS platform defaults
- Edge cases checked: N/A - simple allowlist addition
- What you did **not** verify: Actual screen recording on physical macOS device (code-only change)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit
- Files/config to restore: src/gateway/node-command-policy.ts
- Known bad symptoms reviewers should watch for: N/A

## Risks and Mitigations

- Risk: Users may inadvertently trigger screen recording
  - Mitigation: macOS system-level screen recording permission is still required; this change only affects OpenClaw's internal allowlist

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)