### PR TITLE
fix(matrix): thread accountId through action dispatch chain

### DIFF
--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -54,7 +54,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
     return { to };
   },
   handleAction: async (ctx: ChannelMessageActionContext) => {
-    const { action, params, cfg } = ctx;
+    const { action, params, cfg, accountId } = ctx;
     const resolveRoomId = () =>
       readStringParam(params, "roomId") ??
       readStringParam(params, "channelId") ??
@@ -77,6 +77,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyTo ?? undefined,
           threadId: threadId ?? undefined,
+          accountId,
         },
         cfg as CoreConfig,
       );
@@ -93,6 +94,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           messageId,
           emoji,
           remove,
+          accountId,
         },
         cfg as CoreConfig,
       );
@@ -107,6 +109,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           roomId: resolveRoomId(),
           messageId,
           limit,
+          accountId,
         },
         cfg as CoreConfig,
       );
@@ -121,6 +124,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           limit,
           before: readStringParam(params, "before"),
           after: readStringParam(params, "after"),
+          accountId,
         },
         cfg as CoreConfig,
       );
@@ -135,6 +139,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           roomId: resolveRoomId(),
           messageId,
           content,
+          accountId,
         },
         cfg as CoreConfig,
       );
@@ -147,6 +152,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           action: "deleteMessage",
           roomId: resolveRoomId(),
           messageId,
+          accountId,
         },
         cfg as CoreConfig,
       );
@@ -163,6 +169,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
             action === "pin" ? "pinMessage" : action === "unpin" ? "unpinMessage" : "listPins",
           roomId: resolveRoomId(),
           messageId,
+          accountId,
         },
         cfg as CoreConfig,
       );
@@ -175,6 +182,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           action: "memberInfo",
           userId,
           roomId: readStringParam(params, "roomId") ?? readStringParam(params, "channelId"),
+          accountId,
         },
         cfg as CoreConfig,
       );
@@ -185,6 +193,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
         {
           action: "channelInfo",
           roomId: resolveRoomId(),
+          accountId,
         },
         cfg as CoreConfig,
       );

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -27,6 +27,7 @@ export async function sendMatrixMessage(
     threadId: opts.threadId,
     client: opts.client,
     timeoutMs: opts.timeoutMs,
+    accountId: opts.accountId ?? undefined,
   });
 }
 

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -586,7 +586,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           }),
         );
       if (shouldAckReaction() && messageId) {
-        reactMatrixMessage(roomId, messageId, ackReaction, client).catch((err) => {
+        reactMatrixMessage(roomId, messageId, ackReaction, { client }).catch((err) => {
           logVerboseMessage(`matrix react failed for room ${roomId}: ${String(err)}`);
         });
       }

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -241,13 +241,14 @@ export async function reactMatrixMessage(
   roomId: string,
   messageId: string,
   emoji: string,
-  client?: MatrixClient,
+  opts: { client?: MatrixClient; accountId?: string } = {},
 ): Promise<void> {
   if (!emoji.trim()) {
     throw new Error("Matrix reaction requires an emoji");
   }
   const { client: resolved, stopOnDone } = await resolveMatrixClient({
-    client,
+    client: opts.client,
+    accountId: opts.accountId,
   });
   try {
     const resolvedRoom = await resolveMatrixRoomId(resolved, roomId);

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -42,6 +42,7 @@ export async function handleMatrixAction(
   cfg: CoreConfig,
 ): Promise<AgentToolResult<unknown>> {
   const action = readStringParam(params, "action", { required: true });
+  const accountId = readStringParam(params, "accountId") ?? undefined;
   const isActionEnabled = createActionGate(cfg.channels?.matrix?.actions);
 
   if (reactionActions.has(action)) {
@@ -57,13 +58,14 @@ export async function handleMatrixAction(
       if (remove || isEmpty) {
         const result = await removeMatrixReactions(roomId, messageId, {
           emoji: remove ? emoji : undefined,
+          accountId,
         });
         return jsonResult({ ok: true, removed: result.removed });
       }
-      await reactMatrixMessage(roomId, messageId, emoji);
+      await reactMatrixMessage(roomId, messageId, emoji, { accountId });
       return jsonResult({ ok: true, added: emoji });
     }
-    const reactions = await listMatrixReactions(roomId, messageId);
+    const reactions = await listMatrixReactions(roomId, messageId, { accountId });
     return jsonResult({ ok: true, reactions });
   }
 
@@ -86,6 +88,7 @@ export async function handleMatrixAction(
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyToId ?? undefined,
           threadId: threadId ?? undefined,
+          accountId,
         });
         return jsonResult({ ok: true, result });
       }
@@ -93,14 +96,14 @@ export async function handleMatrixAction(
         const roomId = readRoomId(params);
         const messageId = readStringParam(params, "messageId", { required: true });
         const content = readStringParam(params, "content", { required: true });
-        const result = await editMatrixMessage(roomId, messageId, content);
+        const result = await editMatrixMessage(roomId, messageId, content, { accountId });
         return jsonResult({ ok: true, result });
       }
       case "deleteMessage": {
         const roomId = readRoomId(params);
         const messageId = readStringParam(params, "messageId", { required: true });
         const reason = readStringParam(params, "reason");
-        await deleteMatrixMessage(roomId, messageId, { reason: reason ?? undefined });
+        await deleteMatrixMessage(roomId, messageId, { reason: reason ?? undefined, accountId });
         return jsonResult({ ok: true, deleted: true });
       }
       case "readMessages": {
@@ -112,6 +115,7 @@ export async function handleMatrixAction(
           limit: limit ?? undefined,
           before: before ?? undefined,
           after: after ?? undefined,
+          accountId,
         });
         return jsonResult({ ok: true, ...result });
       }
@@ -127,15 +131,15 @@ export async function handleMatrixAction(
     const roomId = readRoomId(params);
     if (action === "pinMessage") {
       const messageId = readStringParam(params, "messageId", { required: true });
-      const result = await pinMatrixMessage(roomId, messageId);
+      const result = await pinMatrixMessage(roomId, messageId, { accountId });
       return jsonResult({ ok: true, pinned: result.pinned });
     }
     if (action === "unpinMessage") {
       const messageId = readStringParam(params, "messageId", { required: true });
-      const result = await unpinMatrixMessage(roomId, messageId);
+      const result = await unpinMatrixMessage(roomId, messageId, { accountId });
       return jsonResult({ ok: true, pinned: result.pinned });
     }
-    const result = await listMatrixPins(roomId);
+    const result = await listMatrixPins(roomId, { accountId });
     return jsonResult({ ok: true, pinned: result.pinned, events: result.events });
   }
 
@@ -147,6 +151,7 @@ export async function handleMatrixAction(
     const roomId = readStringParam(params, "roomId") ?? readStringParam(params, "channelId");
     const result = await getMatrixMemberInfo(userId, {
       roomId: roomId ?? undefined,
+      accountId,
     });
     return jsonResult({ ok: true, member: result });
   }
@@ -156,7 +161,7 @@ export async function handleMatrixAction(
       throw new Error("Matrix room info is disabled.");
     }
     const roomId = readRoomId(params);
-    const result = await getMatrixRoomInfo(roomId);
+    const result = await getMatrixRoomInfo(roomId, { accountId });
     return jsonResult({ ok: true, room: result });
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** In multi-account Matrix setups, all actions (send, react, edit, delete, pin, read, member-info, channel-info) route through the fallback account because `accountId` is never extracted from the action context or forwarded to downstream functions.
- **Why it matters:** Users with multiple Matrix accounts cannot control which account performs an action — every action silently uses the default fallback account, producing confusing results and breaking multi-account workflows.
- **What changed:** Thread `accountId` from `ChannelMessageActionContext` through `handleMatrixAction` and into every downstream action function call across 5 files.
- **What did NOT change:** No new config keys, no behavioral changes for single-account setups (accountId defaults to `undefined`, preserving existing fallback logic).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34616

## User-visible / Behavior Changes

- Multi-account Matrix setups now correctly route actions through the specified account instead of always falling back to the default account.
- Single-account setups are unaffected (`accountId` defaults to `undefined`, preserving existing behavior).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Matrix (multi-account)

### Steps

1. Configure two Matrix accounts in config
2. Send a message action targeting the non-default account
3. Observe which account actually sends the message

### Expected

- The action uses the specified account

### Actual

- Before fix: All actions route through the fallback account regardless of `accountId`
- After fix: Actions correctly use the specified `accountId` when provided

## Evidence

### Files changed (5 files, +28/-12 lines)

1. **`extensions/matrix/src/actions.ts`** — Destructure `accountId` from `ctx`, pass to all 10 `handleMatrixAction()` calls
2. **`extensions/matrix/src/tool-actions.ts`** — Read `accountId` from params, forward to all 12 downstream function calls
3. **`extensions/matrix/src/matrix/actions/messages.ts`** — Forward `accountId` from opts to `sendMessageMatrix()`
4. **`extensions/matrix/src/matrix/send.ts`** — Change `reactMatrixMessage` 4th param from positional `client?` to `opts: { client?, accountId? }` for consistency
5. **`extensions/matrix/src/matrix/monitor/handler.ts`** — Update `reactMatrixMessage` call site to match new opts-based signature

## Human Verification (required)

- Verified scenarios: All 10 action branches in `actions.ts` now pass `accountId`; all 12 call sites in `tool-actions.ts` forward `accountId`; `sendMatrixMessage` forwards to `sendMessageMatrix`; `reactMatrixMessage` signature updated with backward-compatible default
- Edge cases checked: Single-account setup (accountId=undefined, fallback preserved); empty/null accountId; handler.ts call site updated to match new signature
- What I did **not** verify: Live multi-account Matrix environment test (requires 2+ Matrix accounts configured)

## Compatibility / Migration

- Backward compatible? `Yes` — all new parameters are optional with `undefined` defaults
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; single-account behavior is unchanged
- Files/config to restore: 5 files listed above
- Known bad symptoms: Actions routing to wrong account in multi-account Matrix setups

## Risks and Mitigations

- Low risk: All changes are additive optional parameters flowing through existing plumbing. Downstream functions (`resolveMatrixClient`, `sendMessageMatrix`, etc.) already accept and handle `accountId`.
