### PR TITLE
fix(gateway): avoid forced chat history reload after media-only finals

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -11,6 +11,7 @@ const mockState = vi.hoisted(() => ({
   transcriptPath: "",
   sessionId: "sess-1",
   finalText: "[[reply_to_current]]",
+  finalMediaUrl: undefined as string | undefined,
   triggerAgentRunStart: false,
   agentRunId: "run-agent-1",
   sessionEntry: {} as Record<string, unknown>,
@@ -48,7 +49,7 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
     async (params: {
       ctx: MsgContext;
       dispatcher: {
-        sendFinalReply: (payload: { text: string }) => boolean;
+        sendFinalReply: (payload: { text?: string; mediaUrl?: string }) => boolean;
         markComplete: () => void;
         waitForIdle: () => Promise<void>;
       };
@@ -60,7 +61,10 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
       if (mockState.triggerAgentRunStart) {
         params.replyOptions?.onAgentRunStart?.(mockState.agentRunId);
       }
-      params.dispatcher.sendFinalReply({ text: mockState.finalText });
+      params.dispatcher.sendFinalReply({
+        text: mockState.finalText || undefined,
+        mediaUrl: mockState.finalMediaUrl,
+      });
       params.dispatcher.markComplete();
       await params.dispatcher.waitForIdle();
       return { ok: true };
@@ -190,6 +194,7 @@ async function runNonStreamingChatSend(params: {
 describe("chat directive tag stripping for non-streaming final payloads", () => {
   afterEach(() => {
     mockState.finalText = "[[reply_to_current]]";
+    mockState.finalMediaUrl = undefined;
     mockState.triggerAgentRunStart = false;
     mockState.agentRunId = "run-agent-1";
     mockState.sessionEntry = {};
@@ -304,6 +309,32 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         runId: "idem-directive-only",
         state: "final",
         message: expect.any(Object),
+      }),
+    );
+    expect(extractFirstTextBlock(payload)).toBe("");
+  });
+
+  it("chat.send non-streaming media-only final keeps message defined", async () => {
+    createTranscriptFixture("openclaw-chat-send-media-only-final-");
+    mockState.finalText = "";
+    mockState.finalMediaUrl = "/tmp/voice.ogg";
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-media-only-final",
+    });
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        runId: "idem-media-only-final",
+        state: "final",
+        message: expect.objectContaining({
+          role: "assistant",
+          mediaUrl: "/tmp/voice.ogg",
+        }),
       }),
     );
     expect(extractFirstTextBlock(payload)).toBe("");

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -938,6 +938,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         channel: INTERNAL_MESSAGE_CHANNEL,
       });
       const finalReplyParts: string[] = [];
+      const finalReplyMediaUrls = new Set<string>();
       const dispatcher = createReplyDispatcher({
         ...prefixOptions,
         onError: (err) => {
@@ -948,10 +949,19 @@ export const chatHandlers: GatewayRequestHandlers = {
             return;
           }
           const text = payload.text?.trim() ?? "";
-          if (!text) {
-            return;
+          if (text) {
+            finalReplyParts.push(text);
           }
-          finalReplyParts.push(text);
+          const mediaCandidates = [
+            payload.mediaUrl,
+            ...(Array.isArray(payload.mediaUrls) ? payload.mediaUrls : []),
+          ];
+          for (const candidate of mediaCandidates) {
+            const mediaUrl = typeof candidate === "string" ? candidate.trim() : "";
+            if (mediaUrl) {
+              finalReplyMediaUrls.add(mediaUrl);
+            }
+          }
         },
       });
 
@@ -1023,6 +1033,19 @@ export const chatHandlers: GatewayRequestHandlers = {
                   usage: { input: 0, output: 0, totalTokens: 0 },
                 };
               }
+            } else if (finalReplyMediaUrls.size > 0) {
+              // Keep a defined assistant message so clients don't force-refresh history
+              // and interrupt media playback after media-only finals (for example /tts audio).
+              const mediaUrls = [...finalReplyMediaUrls];
+              message = {
+                role: "assistant",
+                content: [{ type: "text", text: "" }],
+                mediaUrl: mediaUrls[0],
+                mediaUrls,
+                timestamp: Date.now(),
+                stopReason: "stop",
+                usage: { input: 0, output: 0, totalTokens: 0 },
+              };
             }
             broadcastChatFinal({
               context,


### PR DESCRIPTION
## Summary
- keep non-streaming `chat.send` finals message-defined when the final payload is media-only (for example `/tts audio`)
- collect final media URLs in the webchat dispatch path and emit an assistant final payload instead of `message: undefined`
- add regression coverage for media-only non-streaming finals in `chat.directive-tags.test.ts`

## Root cause
For non-agent-run chat sends, the gateway only accumulated final **text**. Media-only finals were dropped, so `broadcastChatFinal` emitted `message: undefined`. The UI then treated it as a missing final payload and force-reloaded history, which can interrupt in-flight media playback.

## Fix
When a non-streaming final contains media but no text, emit a minimal assistant final message (`role: assistant`, empty text block, `mediaUrl/mediaUrls`) so clients don't trigger the forced refresh path.

## Testing
- `pnpm test src/gateway/server-methods/chat.directive-tags.test.ts`
- `pnpm build && pnpm check && pnpm test`

Closes #34527

This PR is AI-assisted. Code has been fully tested locally. I understand what this code does.
