### PR TITLE
fix(feishu): strip reaction suffix from message_id before API calls

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -7,6 +7,7 @@ import {
   buildFeishuAgentBody,
   handleFeishuMessage,
   resolveBroadcastAgents,
+  stripReactionSuffix,
   toMessageResourceType,
 } from "./bot.js";
 import { setFeishuRuntime } from "./runtime.js";
@@ -1913,6 +1914,45 @@ describe("broadcast dispatch", () => {
     expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
   });
 
+  it("strips reaction suffix from replyToMessageId in dispatch (#34528)", async () => {
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-reactor" } },
+      message: {
+        message_id: "om_msg1:reaction:THUMBSUP:some-uuid",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({
+          text: "[reacted with THUMBSUP to message om_msg1]",
+        }),
+      },
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event,
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_msg1",
+      }),
+    );
+  });
+
   it("skips unknown agents not in agents.list", async () => {
     const cfg: ClawdbotConfig = {
       broadcast: { "oc-broadcast-group": ["susan", "unknown-agent"] },
@@ -1950,5 +1990,28 @@ describe("broadcast dispatch", () => {
     const sessionKey = (mockFinalizeInboundContext.mock.calls[0]?.[0] as { SessionKey: string })
       .SessionKey;
     expect(sessionKey).toBe("agent:susan:feishu:group:oc-broadcast-group");
+  });
+});
+
+describe("stripReactionSuffix", () => {
+  it("strips :reaction: suffix from reaction message_id", () => {
+    expect(stripReactionSuffix("om_msg1:reaction:THUMBSUP:some-uuid")).toBe("om_msg1");
+  });
+
+  it("handles different emoji types", () => {
+    expect(stripReactionSuffix("om_abc:reaction:HEART:uuid-123")).toBe("om_abc");
+    expect(stripReactionSuffix("om_xyz:reaction:SMILE:uuid-456")).toBe("om_xyz");
+  });
+
+  it("returns plain message_id unchanged", () => {
+    expect(stripReactionSuffix("om_msg1")).toBe("om_msg1");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(stripReactionSuffix("")).toBe("");
+  });
+
+  it("preserves message_id with colons but no :reaction: segment", () => {
+    expect(stripReactionSuffix("om_msg1:topic:root")).toBe("om_msg1:topic:root");
   });
 });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -305,6 +305,15 @@ function resolveFeishuGroupSession(params: {
   };
 }
 
+/**
+ * Strip the `:reaction:<emoji>:<uuid>` suffix that resolveReactionSyntheticEvent
+ * appends to message_id for dedup. The raw Feishu API doesn't accept suffixed IDs.
+ */
+export function stripReactionSuffix(messageId: string): string {
+  const idx = messageId.indexOf(":reaction:");
+  return idx >= 0 ? messageId.slice(0, idx) : messageId;
+}
+
 function parseMessageContent(content: string, messageType: string): string {
   if (messageType === "post") {
     // Extract text content from rich text post
@@ -1337,7 +1346,7 @@ export async function handleFeishuMessage(params: {
     const messageCreateTimeMs = event.message.create_time
       ? parseInt(event.message.create_time, 10)
       : undefined;
-    const replyTargetMessageId = ctx.rootId ?? ctx.messageId;
+    const replyTargetMessageId = stripReactionSuffix(ctx.rootId ?? ctx.messageId);
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 
     if (broadcastAgents) {


### PR DESCRIPTION
## Summary

- **Problem:** When a user reacts to a message in Feishu, `resolveReactionSyntheticEvent` creates a synthetic `message_id` with a `:reaction:<emoji>:<uuid>` suffix for dedup. This suffixed ID flows through `handleFeishuMessage` as `replyTargetMessageId` and gets passed to Feishu API endpoints (reply, typing indicator, streaming card), causing HTTP 400 errors.
- **Why it matters:** Any emoji reaction in a Feishu group chat triggers 400 errors in the gateway log and prevents the agent from responding to the reaction event.
- **What changed:** Added `stripReactionSuffix()` utility that strips the `:reaction:*` suffix from `message_id` at the single point where it flows into the reply dispatcher. Includes 5 unit tests and 1 integration test.
- **What did NOT change:** The suffixed `message_id` is still used for dedup in session keys and `MessageSid`. Normal (non-reaction) message_ids pass through unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34528

## User-visible / Behavior Changes

- Feishu emoji reactions no longer trigger 400 errors in the gateway log
- The agent can now respond to reaction events normally

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime: Node.js
- Integration/channel: Feishu

### Steps

1. Configure a Feishu channel
2. Send a message to the bot
3. React to the bot reply with any emoji (e.g., thumbs up)

### Expected

- No 400 errors; agent processes the reaction normally

### Actual

- Before fix: 400 error with `Invalid ids: [om_xxx:reaction:THUMBSUP:xxx]`
- After fix: Reaction processed with base message_id `om_xxx`

## Evidence

### Unit tests

```
stripReactionSuffix
  ✓ strips :reaction: suffix from reaction message_id
  ✓ handles different emoji types
  ✓ returns plain message_id unchanged
  ✓ returns empty string unchanged
  ✓ preserves message_id with colons but no :reaction: segment

broadcast dispatch
  ✓ strips reaction suffix from replyToMessageId in dispatch (#34528)
```

### Files changed (2 files, +73/-1 lines)

1. `extensions/feishu/src/bot.ts` — Add `stripReactionSuffix()`, apply at `replyTargetMessageId` computation
2. `extensions/feishu/src/bot.test.ts` — 5 unit tests + 1 integration test

## Human Verification (required)

- Verified scenarios: Reaction suffix stripped correctly for THUMBSUP, HEART, SMILE; plain message_ids unchanged; empty string handled
- Edge cases checked: Message_ids with colons but no `:reaction:` segment preserved; integration test verifies dispatcher receives clean ID
- What I did **not** verify: Live Feishu reaction test (requires Feishu app configuration)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; reactions will return to 400 errors
- Files/config to restore: 2 files listed above
- Known bad symptoms: 400 errors on Feishu API calls with suffixed message_ids

## Risks and Mitigations

- Low risk: `stripReactionSuffix` only modifies strings containing `:reaction:`, all other strings pass through unchanged. The dedup suffix is still used in session keys and MessageSid where it matters.

