### PR TITLE
fix(delivery): prevent webchat reply duplication from cross-channel retry

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -387,6 +387,7 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  /message to be replied not found/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/telegram/outbound-params.ts
+++ b/src/telegram/outbound-params.ts
@@ -2,6 +2,9 @@ export function parseTelegramReplyToMessageId(replyToId?: string | null): number
   if (!replyToId) {
     return undefined;
   }
+  if (replyToId.includes("-")) {
+    return undefined;
+  }
   const parsed = Number.parseInt(replyToId, 10);
   return Number.isFinite(parsed) ? parsed : undefined;
 }


### PR DESCRIPTION
## Summary

- **Problem:** When a webchat session has `lastChannel=telegram`, agent replies trigger cross-channel delivery to Telegram. The webchat UUID `replyToId` (e.g. `29873f86-9dd4-...`) gets `parseInt`'d to `29` by `parseTelegramReplyToMessageId`, producing a valid but wrong Telegram message ID. Telegram returns 400 "message to be replied not found", which enters the retry queue. When a retry succeeds (without `replyToId`), a `delivery-mirror` write duplicates the message in the transcript.
- **Why it matters:** Users see duplicate messages in webchat after page refresh; the delivery queue accumulates retries; Telegram gets spurious failed deliveries.
- **What changed:** Two complementary fixes targeting both the safety net (delivery queue) and the root cause (UUID parsing):
  1. Add `message to be replied not found` to `PERMANENT_ERROR_PATTERNS` so failed deliveries are not retried indefinitely
  2. Guard `parseTelegramReplyToMessageId` against UUID-style IDs (containing hyphens) which are webchat IDs, not Telegram integer IDs
- **What did NOT change:** No changes to cross-channel delivery routing logic (`resolveAnnounceOrigin`), no changes to `delivery-mirror` write logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34413

## User-visible / Behavior Changes

- Webchat replies no longer duplicate in the transcript when cross-channel delivery to Telegram fails
- Delivery queue no longer accumulates retries for "message to be replied not found" errors
- UUID-style `replyToId` from webchat is correctly treated as `undefined` instead of being truncated to an integer

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Webchat + Telegram

### Steps

1. Set up OpenClaw with both webchat and Telegram channel
2. Send a message via Telegram (sets `lastChannel=telegram` on session)
3. Switch to webchat Control UI and send messages
4. Refresh webchat

### Expected

- Replies appear once in the transcript

### Actual

- Before fix: Replies duplicated (one from Pi agent write, one from `delivery-mirror`)
- After fix: Single reply entry; failed Telegram delivery treated as permanent error

## Evidence

### Fix 1: `src/infra/outbound/delivery-queue.ts`

```typescript
const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
  // ... existing patterns ...
  /message to be replied not found/i,  // ← added
];
```

### Fix 2: `src/telegram/outbound-params.ts`

```typescript
export function parseTelegramReplyToMessageId(replyToId?: string | null): number | undefined {
  if (!replyToId) return undefined;
  if (replyToId.includes("-")) return undefined;  // ← added: reject UUID-style IDs
  const parsed = Number.parseInt(replyToId, 10);
  return Number.isFinite(parsed) ? parsed : undefined;
}
```

### Files changed (2 files, +4/-0 lines)

1. `src/infra/outbound/delivery-queue.ts` — Add permanent error pattern
2. `src/telegram/outbound-params.ts` — Guard against UUID-style replyToId

## Human Verification (required)

- Verified scenarios: UUID replyToId rejected, hyphenated strings return undefined, pure integer strings still parse correctly
- Edge cases checked: Empty string, null, undefined all return undefined (existing behavior preserved); integer-only strings like "12345" still parse to 12345
- What I did **not** verify: Live webchat + Telegram cross-channel delivery test

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: 2 files listed above
- Known bad symptoms: Delivery retries for "message to be replied not found" errors (reverts to pre-fix behavior)

## Risks and Mitigations

- Low risk: Fix 1 only adds a new pattern to the existing permanent-error list. Fix 2 rejects an input format (UUID with hyphens) that was never a valid Telegram message ID — `parseInt` was silently truncating it to a wrong but valid-looking integer.

