### PR TITLE
fix(line): use getRegistry callback in plugin HTTP handler to prevent stale-route 404

### DIFF
--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -5,6 +5,7 @@ import { type CanvasHostHandler, createCanvasHostHandler } from "../canvas-host/
 import type { CliDeps } from "../cli/deps.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
+import { requireActivePluginRegistry } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
@@ -115,12 +116,15 @@ export async function createGatewayRuntimeState(params: {
     logHooks: params.logHooks,
   });
 
+  // Use requireActivePluginRegistry() on every request so that routes
+  // registered after a plugin config change (which calls setActivePluginRegistry
+  // with a fresh registry object) are always visible without a gateway restart.
   const handlePluginRequest = createGatewayPluginRequestHandler({
-    registry: params.pluginRegistry,
+    getRegistry: requireActivePluginRegistry,
     log: params.logPlugins,
   });
   const shouldEnforcePluginGatewayAuth = (pathContext: PluginRoutePathContext): boolean => {
-    return shouldEnforceGatewayAuthForPluginPath(params.pluginRegistry, pathContext);
+    return shouldEnforceGatewayAuthForPluginPath(requireActivePluginRegistry(), pathContext);
   };
 
   const bindHosts = await resolveGatewayListenHosts(params.bindHost);

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -42,8 +42,9 @@ function buildRepeatedEncodedSlash(depth: number): string {
 describe("createGatewayPluginRequestHandler", () => {
   it("returns false when no routes are registered", async () => {
     const log = createPluginLog();
+    const registry = createTestRegistry();
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry(),
+      getRegistry: () => registry,
       log,
     });
     const { res } = makeMockHttpResponse();
@@ -55,10 +56,11 @@ describe("createGatewayPluginRequestHandler", () => {
     const routeHandler = vi.fn(async (_req, res: ServerResponse) => {
       res.statusCode = 200;
     });
+    const registry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/demo", handler: routeHandler })],
+    });
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry({
-        httpRoutes: [createRoute({ path: "/demo", handler: routeHandler })],
-      }),
+      getRegistry: () => registry,
       log: createPluginLog(),
     });
 
@@ -73,13 +75,14 @@ describe("createGatewayPluginRequestHandler", () => {
       res.statusCode = 200;
     });
     const prefixHandler = vi.fn(async () => true);
+    const registry = createTestRegistry({
+      httpRoutes: [
+        createRoute({ path: "/api", match: "prefix", handler: prefixHandler }),
+        createRoute({ path: "/api/demo", match: "exact", handler: exactHandler }),
+      ],
+    });
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry({
-        httpRoutes: [
-          createRoute({ path: "/api", match: "prefix", handler: prefixHandler }),
-          createRoute({ path: "/api/demo", match: "exact", handler: exactHandler }),
-        ],
-      }),
+      getRegistry: () => registry,
       log: createPluginLog(),
     });
 
@@ -93,13 +96,14 @@ describe("createGatewayPluginRequestHandler", () => {
   it("supports route fallthrough when handler returns false", async () => {
     const first = vi.fn(async () => false);
     const second = vi.fn(async () => true);
+    const registry = createTestRegistry({
+      httpRoutes: [
+        createRoute({ path: "/hook", match: "exact", handler: first }),
+        createRoute({ path: "/hook", match: "prefix", handler: second }),
+      ],
+    });
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry({
-        httpRoutes: [
-          createRoute({ path: "/hook", match: "exact", handler: first }),
-          createRoute({ path: "/hook", match: "prefix", handler: second }),
-        ],
-      }),
+      getRegistry: () => registry,
       log: createPluginLog(),
     });
 
@@ -114,10 +118,11 @@ describe("createGatewayPluginRequestHandler", () => {
     const routeHandler = vi.fn(async (_req, res: ServerResponse) => {
       res.statusCode = 200;
     });
+    const registry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/api/demo", handler: routeHandler })],
+    });
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry({
-        httpRoutes: [createRoute({ path: "/api/demo", handler: routeHandler })],
-      }),
+      getRegistry: () => registry,
       log: createPluginLog(),
     });
 
@@ -127,19 +132,49 @@ describe("createGatewayPluginRequestHandler", () => {
     expect(routeHandler).toHaveBeenCalledTimes(1);
   });
 
+  it("picks up routes registered on a replacement registry (stale-registry regression)", async () => {
+    // Simulate what happens when loadOpenClawPlugins creates a new registry
+    // after a plugin config change: the handler must use the NEW active registry
+    // so that routes re-registered by channels (e.g. /line/webhook) are found.
+    let activeRegistry = createTestRegistry();
+
+    const handler = createGatewayPluginRequestHandler({
+      getRegistry: () => activeRegistry,
+      log: createPluginLog(),
+    });
+
+    // First registry — route not yet registered.
+    const { res: res1 } = makeMockHttpResponse();
+    expect(await handler({ url: "/line/webhook" } as IncomingMessage, res1)).toBe(false);
+
+    // Swap in a new registry (simulates setActivePluginRegistry after plugin config change).
+    const webhookHandler = vi.fn(async (_req: IncomingMessage, res: ServerResponse) => {
+      res.statusCode = 200;
+    });
+    activeRegistry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/line/webhook", auth: "plugin", handler: webhookHandler })],
+    });
+
+    // Handler must now resolve the route without any gateway restart.
+    const { res: res2 } = makeMockHttpResponse();
+    expect(await handler({ url: "/line/webhook" } as IncomingMessage, res2)).toBe(true);
+    expect(webhookHandler).toHaveBeenCalledTimes(1);
+  });
+
   it("logs and responds with 500 when a route throws", async () => {
     const log = createPluginLog();
+    const registry = createTestRegistry({
+      httpRoutes: [
+        createRoute({
+          path: "/boom",
+          handler: async () => {
+            throw new Error("boom");
+          },
+        }),
+      ],
+    });
     const handler = createGatewayPluginRequestHandler({
-      registry: createTestRegistry({
-        httpRoutes: [
-          createRoute({
-            path: "/boom",
-            handler: async () => {
-              throw new Error("boom");
-            },
-          }),
-        ],
-      }),
+      getRegistry: () => registry,
       log,
     });
 

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -27,11 +27,18 @@ export type PluginHttpRequestHandler = (
 ) => Promise<boolean>;
 
 export function createGatewayPluginRequestHandler(params: {
-  registry: PluginRegistry;
+  /**
+   * Callback that returns the current active plugin registry.
+   * Called on every request so that routes registered after a plugin config
+   * change (which replaces the active registry via setActivePluginRegistry)
+   * are always visible to the HTTP handler without a gateway restart.
+   */
+  getRegistry: () => PluginRegistry;
   log: SubsystemLogger;
 }): PluginHttpRequestHandler {
-  const { registry, log } = params;
+  const { getRegistry, log } = params;
   return async (req, res, providedPathContext) => {
+    const registry = getRegistry();
     const routes = registry.httpRoutes ?? [];
     if (routes.length === 0) {
       return false;


### PR DESCRIPTION
## Summary

- **Problem:** After a plugin config change (e.g. enabling/disabling a plugin via the Control UI), `loadOpenClawPlugins` is called again with a different cache key, creating a new `PluginRegistry` and calling `setActivePluginRegistry(newRegistry)`. The gateway HTTP handler (`createGatewayPluginRequestHandler`) still holds a reference to the original registry from startup. The LINE channel then re-registers `/line/webhook` on the *new* active registry, but all incoming requests are matched against the *old* (now empty) registry — returning 404 until a full gateway restart.
- **Why it matters:** LINE webhooks silently fail — messages are dropped, no sessions created — whenever the plugin registry diverges from the HTTP handler's captured snapshot. Only a full gateway restart recovers the route.
- **What changed:** `createGatewayPluginRequestHandler` now accepts a `getRegistry` callback (`() => PluginRegistry`) instead of a pinned `registry` object, and resolves the live registry on every request. `shouldEnforceGatewayAuthForPluginPath` in `server-runtime-state.ts` is updated to call `requireActivePluginRegistry()` inline as well.
- **What did NOT change:** Route registration/unregistration logic in `monitorLineProvider`, `registerPluginHttpRoute`, channel lifecycle, auth enforcement behaviour.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #34631

## User-visible / Behavior Changes

`/line/webhook` (and any other plugin-registered webhook path) remains reachable after plugin config edits without requiring a gateway restart.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (LaunchAgent gateway)
- Runtime/container: Node 22+
- Integration/channel: LINE

### Steps

1. Start gateway with LINE channel configured.
2. Enable or disable any plugin via `openclaw config set plugins.X.enabled true/false` (triggers `loadOpenClawPlugins` with a new cache key).
3. `curl -i http://127.0.0.1:18789/line/webhook`

### Expected

- HTTP 200 (webhook handler responds)

### Actual (before fix)

- HTTP 404 until `openclaw gateway restart`

## Evidence

- [ ] Failing test/log before + passing after *(WIP — tests to be added)*

## Human Verification (required)

- Verified scenarios: tracing the registry lifecycle through `loadOpenClawPlugins` → `setActivePluginRegistry` → `createGatewayPluginRequestHandler` in code review; confirmed that the captured `registry` reference goes stale on any cache-key change.
- Edge cases checked: cache-hit path (same key) — no behaviour change; cache-miss path (config change) — handler now always reads the current active registry.
- What you did **not** verify: live end-to-end on a real LINE bot (pending).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: revert `src/gateway/server/plugins-http.ts` and `src/gateway/server-runtime-state.ts` to the captured-registry pattern.
- Known bad symptoms: plugin HTTP routes not matched at all (would be caught immediately in smoke tests).

## Risks and Mitigations

- Risk: `requireActivePluginRegistry()` called on every HTTP request adds a negligible Map-lookup overhead.
  - Mitigation: The lookup is O(1) via a module-level singleton; no measurable latency impact.

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
