### PR TITLE
fix(ios): DateFormatter strict concurrency

### DIFF
--- a/apps/ios/Sources/Gateway/GatewayDiscoveryDebugLogView.swift
+++ b/apps/ios/Sources/Gateway/GatewayDiscoveryDebugLogView.swift
@@ -46,13 +46,13 @@ struct GatewayDiscoveryDebugLogView: View {
             .joined(separator: "\n")
     }
 
-    private static let timeFormatter: DateFormatter = {
+    nonisolated(unsafe) private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm:ss"
         return formatter
     }()
 
-    private static let isoFormatter: ISO8601DateFormatter = {
+    nonisolated(unsafe) private static let isoFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter

--- a/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
+++ b/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
@@ -412,7 +412,7 @@ enum GatewayDiagnostics {
     private static let keepLogBytes: Int64 = 256 * 1024
     private static let logSizeCheckEveryWrites = 50
     private static let logWritesSinceCheck = OSAllocatedUnfairLock(initialState: 0)
-    private static let isoFormatter: ISO8601DateFormatter = {
+    nonisolated(unsafe) private static let isoFormatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return f


### PR DESCRIPTION
### Summary
- Mark `ISO8601DateFormatter` and `DateFormatter` static properties as `nonisolated(unsafe)` in `GatewaySettingsStore` and `GatewayDiscoveryDebugLogView`
- These types are not `Sendable`, causing compile errors under `SWIFT_STRICT_CONCURRENCY=complete` (Release configuration)
- Safe because the formatters are effectively immutable after initialization (configured in a closure, never mutated after)

Fixes iOS Release build failure introduced by #33591 (Live Activity feature).