### PR TITLE
fix(doctor): avoid orphan false positives for fresh session transcripts

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -143,7 +143,10 @@ describe("doctor state integrity oauth dir checks", () => {
     const cfg: OpenClawConfig = {};
     setupSessionState(cfg, process.env, process.env.HOME ?? "");
     const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
-    fs.writeFileSync(path.join(sessionsDir, "orphan-session.jsonl"), '{"type":"session"}\n');
+    const orphanPath = path.join(sessionsDir, "orphan-session.jsonl");
+    fs.writeFileSync(orphanPath, '{"type":"session"}\n');
+    const staleTime = new Date(Date.now() - 1000 * 60 * 60 * 7);
+    fs.utimesSync(orphanPath, staleTime, staleTime);
     const confirmSkipInNonInteractive = vi.fn(async (params: { message: string }) =>
       params.message.includes("orphan transcript file"),
     );
@@ -156,6 +159,17 @@ describe("doctor state integrity oauth dir checks", () => {
     );
     const files = fs.readdirSync(sessionsDir);
     expect(files.some((name) => name.startsWith("orphan-session.jsonl.deleted."))).toBe(true);
+  });
+
+  it("does not flag fresh unreferenced transcripts as orphaned", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, process.env.HOME ?? "");
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    fs.writeFileSync(path.join(sessionsDir, "recent-untracked.jsonl"), '{"type":"session"}\n');
+
+    await noteStateIntegrity(cfg, { confirmSkipInNonInteractive: vi.fn(async () => false) });
+
+    expect(stateIntegrityText()).not.toContain("orphan transcript file");
   });
 
   it("prints openclaw-only verification hints when recent sessions are missing transcripts", async () => {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -27,6 +27,8 @@ type DoctorPrompterLike = {
   }) => Promise<boolean>;
 };
 
+const ORPHAN_TRANSCRIPT_MIN_AGE_MS = 1000 * 60 * 60 * 6; // 6h
+
 function existsDir(dir: string): boolean {
   try {
     return fs.existsSync(dir) && fs.statSync(dir).isDirectory();
@@ -765,10 +767,21 @@ export async function noteStateIntegrity(
       }
     }
     const sessionDirEntries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+    const now = Date.now();
     const orphanTranscriptPaths = sessionDirEntries
       .filter((entry) => entry.isFile() && isPrimarySessionTranscriptFileName(entry.name))
       .map((entry) => path.resolve(path.join(sessionsDir, entry.name)))
-      .filter((filePath) => !referencedTranscriptPaths.has(filePath));
+      .filter((filePath) => {
+        if (referencedTranscriptPaths.has(filePath)) {
+          return false;
+        }
+        try {
+          const stat = fs.statSync(filePath);
+          return now - stat.mtimeMs >= ORPHAN_TRANSCRIPT_MIN_AGE_MS;
+        } catch {
+          return true;
+        }
+      });
     if (orphanTranscriptPaths.length > 0) {
       warnings.push(
         `- Found ${orphanTranscriptPaths.length} orphan transcript file(s) in ${displaySessionsDir}. They are not referenced by sessions.json and can consume disk over time.`,


### PR DESCRIPTION
## Problem
`openclaw doctor` can report orphan transcript warnings for newly-created active session transcript files that are not yet represented in `sessions.json`.

## Root cause
Orphan detection currently flags every unreferenced `*.jsonl` transcript file in the session transcript directory, regardless of how recently it was modified.

## Fix
- Introduce a minimum-age guard for orphan transcript detection (`6h`).
- Only classify unreferenced transcript files as orphan candidates when they are older than the threshold.
- Keep existing archival flow unchanged for genuinely stale orphan files.

## Tests
Updated `src/commands/doctor-state-integrity.test.ts`:
- existing orphan detection test now sets mtime old enough to remain orphan-eligible
- added regression test to verify freshly-created untracked transcripts are not flagged

Test command run:
- `bunx vitest run src/commands/doctor-state-integrity.test.ts`
- Result: `8 passed`

Fixes #34636
