### PR TITLE
fix(update): re-bootstrap launchd service during restart

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -97,9 +97,15 @@ describe("restart-helper", () => {
       });
       expect(scriptPath.endsWith(".sh")).toBe(true);
       expect(content).toContain("#!/bin/sh");
-      expect(content).toContain("launchctl kickstart -k 'gui/501/ai.openclaw.gateway'");
-      // Should fall back to bootstrap when kickstart fails (service deregistered after bootout)
-      expect(content).toContain("launchctl bootstrap 'gui/501'");
+      const bootout = "launchctl bootout 'gui/501/ai.openclaw.gateway'";
+      const bootstrap = "launchctl bootstrap 'gui/501'";
+      const kickstart = "launchctl kickstart -k 'gui/501/ai.openclaw.gateway'";
+      const bootoutIndex = content.indexOf(bootout);
+      const bootstrapIndex = content.indexOf(bootstrap);
+      const kickstartIndex = content.indexOf(kickstart);
+      expect(bootoutIndex).toBeGreaterThanOrEqual(0);
+      expect(bootstrapIndex).toBeGreaterThan(bootoutIndex);
+      expect(kickstartIndex).toBeGreaterThan(bootstrapIndex);
       expect(content).toContain('rm -f "$0"');
       await cleanupScript(scriptPath);
     });

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -93,12 +93,11 @@ rm -f "$0"
 # Standalone restart script — survives parent process termination.
 # Wait briefly to ensure file locks are released after update.
 sleep 1
-# Try kickstart first (works when the service is still registered).
-# If it fails (e.g. after bootout), re-register via bootstrap then kickstart.
-if ! launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null; then
-  launchctl bootstrap 'gui/${uid}' '${escapedPlistPath}' 2>/dev/null
-  launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null || true
-fi
+# Always refresh launchd registration before kickstart so updated plist/env
+# is applied after package updates.
+launchctl bootout 'gui/${uid}/${escaped}' 2>/dev/null || true
+launchctl bootstrap 'gui/${uid}' '${escapedPlistPath}' 2>/dev/null || true
+launchctl kickstart -k 'gui/${uid}/${escaped}' 2>/dev/null || true
 # Self-cleanup
 rm -f "$0"
 `;


### PR DESCRIPTION
## Summary
- fix macOS update restart helper to always refresh launchd registration in the restart script
- switch restart sequence from conditional `kickstart -> bootstrap fallback` to deterministic `bootout -> bootstrap -> kickstart` (best-effort)
- update restart-helper macOS test to assert operation ordering in generated script

## Why
Issue: https://github.com/openclaw/openclaw/issues/34534

During auto-update, the gateway receives SIGTERM as expected, but in affected cases launchd does not reliably restart the service. Running `kickstart` first can succeed without ensuring the LaunchAgent is re-registered with updated plist/env state. By always attempting `bootout` + `bootstrap` before `kickstart`, the restart path consistently re-registers the service after update.

## Testing
- `pnpm test src/cli/update-cli/restart-helper.test.ts`
- `pnpm build`
- `pnpm check`
- `pnpm test`

This PR is AI-assisted. Code has been fully tested locally. I understand what this code does.
