### PR TITLE
fix(pdf): strip trailing /v1beta from baseUrl before appending version segment

### DIFF
--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -137,10 +137,9 @@ export async function geminiAnalyzePdf(params: {
   }
   parts.push({ text: params.prompt });
 
-  const baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com").replace(
-    /\/+$/,
-    "",
-  );
+  const baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com")
+    .replace(/\/+$/, "")
+    .replace(/\/v1beta$/, "");
   const url = `${baseUrl}/v1beta/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 
   const res = await fetch(url, {

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -711,6 +711,26 @@ describe("native PDF provider API calls", () => {
       "apiKey required",
     );
   });
+
+  it("geminiAnalyzePdf does not double-append /v1beta when baseUrl already contains it", async () => {
+    const { geminiAnalyzePdf } = await import("./pdf-native-providers.js");
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      }),
+    });
+
+    await geminiAnalyzePdf(
+      makeGeminiAnalyzeParams({
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      }),
+    );
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).not.toContain("/v1beta/v1beta");
+    expect(url).toContain("/v1beta/models/");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Problem:** When a Gemini provider's `baseUrl` already contains `/v1beta` (e.g. `https://generativelanguage.googleapis.com/v1beta`), `geminiAnalyzePdf` appends another `/v1beta`, producing `.../v1beta/v1beta/models/...generateContent` which Gemini rejects with HTTP 404.
- **Why it matters:** Any user who configures `pdfModel` with a Gemini provider using a standard versioned baseUrl hits a 404 on every PDF call. Affects subagent and session-orchestrated paths specifically.
- **What changed:** Strip any trailing `/v1beta` from the resolved `baseUrl` before the fixed version segment is appended, so the final URL is always a single `/v1beta` regardless of how the provider baseUrl is configured.
- **What did NOT change:** Default behaviour (no explicit `baseUrl`) is unchanged. Anthropic PDF path untouched.

## Change Type

- [x] Bug fix

## Scope

- [x] Skills / tool execution

## Linked Issue/PR

- Fixes #34312

## User-visible / Behavior Changes

Gemini native PDF analysis (`pdfModel: google/...`) no longer returns 404 when the provider `baseUrl` includes `/v1beta`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — same endpoint, just correct URL
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Model/provider: Google Gemini (any model)
- Relevant config: `agents.defaults.pdfModel: "google/gemini-3.1-pro-preview"` with provider `baseUrl` ending in `/v1beta`

### Steps

1. Configure `pdfModel` as a Gemini model
2. Set provider `baseUrl` to `https://generativelanguage.googleapis.com/v1beta`
3. Call the pdf tool with a local PDF via a subagent path

### Expected

- PDF analysis succeeds

### Actual (before fix)

- `Gemini PDF request failed (404 Not Found)`

## Evidence

- [x] Failing test/log before + passing after

Added a regression test in `pdf-tool.test.ts`: calls `geminiAnalyzePdf` with `baseUrl` ending in `/v1beta` and asserts the final URL contains `/v1beta/models/` exactly once (no `/v1beta/v1beta`). All 51 PDF tests pass.

## Human Verification (required)

- Verified scenarios: traced `baseUrl` through the two chained `.replace()` calls; confirmed that `"https://generativelanguage.googleapis.com/v1beta".replace(/\/+$/, "").replace(/\/v1beta$/, "")` produces `"https://generativelanguage.googleapis.com"`, then appending `/v1beta/models/...` yields the correct single-version URL
- Edge cases checked: trailing slash before `/v1beta` (handled by first replace); baseUrl without `/v1beta` (second replace is a no-op, original behaviour preserved); `/v1beta/` with trailing slash (`.replace(/\/+$/, "")` removes it first, then second replace matches)
- What you did **not** verify: live Gemini API call (requires API key + PDF file)

## Compatibility / Migration

- Backward compatible? Yes — users without explicit `baseUrl` see no change
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert quickly: revert 1-line change in `src/agents/tools/pdf-native-providers.ts` (remove `.replace(/\/v1beta$/, "")`)
- Files/config to restore: `pdf-native-providers.ts` only
- Known bad symptoms: revert returns to previous 404 behaviour for affected users; no new failure mode introduced

## Risks and Mitigations

- Risk: regex strips a legitimate `/v1beta` suffix users rely on
  - Mitigation: the function always appends `/v1beta` immediately after, so the net URL is identical to what a correctly configured user would get; no information is lost