### PR TITLE
fix: keep control-ui inbound channel on webchat metadata

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -99,6 +99,17 @@ describe("buildInboundMetaSystemPrompt", () => {
     const payload = parseInboundMetaPayload(prompt);
     expect(payload["sender_id"]).toBeUndefined();
   });
+
+  it("uses webchat channel for control-ui sender when route channel is missing", () => {
+    const prompt = buildInboundMetaSystemPrompt({
+      SenderId: "openclaw-control-ui",
+      Provider: "slack",
+      ChatType: "direct",
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["channel"]).toBe("webchat");
+  });
 });
 
 describe("buildInboundUserContextPrefix", () => {
@@ -120,6 +131,17 @@ describe("buildInboundUserContextPrefix", () => {
     } as TemplateContext);
 
     expect(text).toBe("");
+  });
+
+  it("hides conversation info for direct control-ui chats when provider is stale", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      SenderId: "openclaw-control-ui",
+      Provider: "slack",
+      MessageSid: "short-id",
+    } as TemplateContext);
+
+    expect(text).not.toContain("Conversation info (untrusted metadata):");
   });
 
   it("includes message identifiers for direct external-channel chats", () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -31,8 +31,19 @@ function formatConversationTimestamp(value: unknown): string | undefined {
   }
 }
 
+function isControlUiSenderId(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "openclaw-control-ui" || normalized === "webchat-ui";
+}
+
 function resolveInboundChannel(ctx: TemplateContext): string | undefined {
   let channelValue = safeTrim(ctx.OriginatingChannel) ?? safeTrim(ctx.Surface);
+  if (!channelValue && isControlUiSenderId(safeTrim(ctx.SenderId))) {
+    // Control-UI is an internal webchat surface. If upstream route metadata is missing,
+    // prefer the internal webchat channel identity instead of inheriting a stale
+    // external provider (e.g. slack) from prior session routing.
+    channelValue = "webchat";
+  }
   if (!channelValue) {
     const provider = safeTrim(ctx.Provider);
     if (provider !== "webchat" && ctx.Surface !== "webchat") {


### PR DESCRIPTION
## Summary
- treat `openclaw-control-ui` / `webchat-ui` sender IDs as internal webchat when inbound route channel is missing
- avoid inheriting stale external provider channel (for example `slack`) into inbound metadata for control-ui sessions
- add regression tests for system prompt channel resolution and direct-chat conversation info behavior

## Testing
- pnpm -s vitest run src/auto-reply/reply/inbound-meta.test.ts

Fixes openclaw/openclaw#34647
