### PR TITLE
fix(webchat): use surface channel for inbound metadata instead of deliverable route

### DIFF
--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -32,7 +32,16 @@ function formatConversationTimestamp(value: unknown): string | undefined {
 }
 
 function resolveInboundChannel(ctx: TemplateContext): string | undefined {
-  let channelValue = safeTrim(ctx.OriginatingChannel) ?? safeTrim(ctx.Surface);
+  // When the message originates from a webchat/control-ui surface, report the
+  // channel as "webchat" so the agent routes its response back to the web
+  // dashboard — not to an unrelated deliverable channel (e.g. Slack) that the
+  // session may be scoped to.  See: #34647
+  const surface = safeTrim(ctx.Surface);
+  if (surface === "webchat") {
+    return "webchat";
+  }
+
+  let channelValue = safeTrim(ctx.OriginatingChannel) ?? surface;
   if (!channelValue) {
     const provider = safeTrim(ctx.Provider);
     if (provider !== "webchat" && ctx.Surface !== "webchat") {

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -329,7 +329,17 @@ function resolveToolPolicies(params: {
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+    search?.perplexity?.apiKey ||
+    env.BRAVE_API_KEY ||
+    env.PERPLEXITY_API_KEY ||
+    search?.gemini?.apiKey ||
+    env.GEMINI_API_KEY ||
+    search?.grok?.apiKey ||
+    env.XAI_API_KEY ||
+    search?.kimi?.apiKey ||
+    env.KIMI_API_KEY ||
+    env.MOONSHOT_API_KEY,
   );
 }
 


### PR DESCRIPTION
When a message arrives from the web dashboard (control-ui/webchat), the inbound metadata `channel` field was set to the session's deliverable route (e.g. `slack`) instead of `webchat`. This caused agents using the message tool to route responses to Slack instead of back to the web dashboard.

**Root cause:** `resolveInboundChannel` prioritized `OriginatingChannel` (the deliverable route) over `Surface` (the actual source). For channel-scoped webchat sessions, this leaked the routing target into agent-visible metadata.

**Fix:** Early-return `webchat` when Surface is `webchat`, so agents see the correct source channel and responses route back to the web dashboard.

Fixes #34647