### PR TITLE
fix(auth): read apiKey field from api_key credential profiles

### DIFF
--- a/src/agents/auth-profiles/credential-state.test.ts
+++ b/src/agents/auth-profiles/credential-state.test.ts
@@ -62,6 +62,31 @@ describe("evaluateStoredCredentialEligibility", () => {
     expect(result).toEqual({ eligible: true, reasonCode: "ok" });
   });
 
+  it("marks api_key with apiKey (legacy field) as eligible", () => {
+    const result = evaluateStoredCredentialEligibility({
+      credential: {
+        type: "api_key",
+        provider: "openai",
+        apiKey: "sk-legacy-123",
+      },
+      now,
+    });
+    expect(result).toEqual({ eligible: true, reasonCode: "ok" });
+  });
+
+  it("prefers apiKey over key when both are present", () => {
+    const result = evaluateStoredCredentialEligibility({
+      credential: {
+        type: "api_key",
+        provider: "openai",
+        apiKey: "sk-from-apiKey",
+        key: "sk-from-key",
+      },
+      now,
+    });
+    expect(result).toEqual({ eligible: true, reasonCode: "ok" });
+  });
+
   it("marks token with invalid expires as ineligible", () => {
     const result = evaluateStoredCredentialEligibility({
       credential: {

--- a/src/agents/auth-profiles/credential-state.ts
+++ b/src/agents/auth-profiles/credential-state.ts
@@ -39,7 +39,7 @@ export function evaluateStoredCredentialEligibility(params: {
   const credential = params.credential;
 
   if (credential.type === "api_key") {
-    const hasKey = hasConfiguredSecretString(credential.key);
+    const hasKey = hasConfiguredSecretString(credential.apiKey ?? credential.key);
     const hasKeyRef = hasConfiguredSecretRef(credential.keyRef);
     if (!hasKey && !hasKeyRef) {
       return { eligible: false, reasonCode: "missing_credential" };

--- a/src/agents/auth-profiles/oauth.test.ts
+++ b/src/agents/auth-profiles/oauth.test.ts
@@ -227,6 +227,57 @@ describe("resolveApiKeyForProfile token expiry handling", () => {
   });
 });
 
+describe("resolveApiKeyForProfile apiKey legacy field", () => {
+  it("resolves api_key credential when key is stored as apiKey", async () => {
+    const profileId = "openai:legacy";
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "api_key",
+          provider: "openai",
+          apiKey: "sk-legacy-key",
+        },
+      },
+    };
+    const result = await resolveApiKeyForProfile({
+      cfg: cfgFor(profileId, "openai", "api_key"),
+      store,
+      profileId,
+    });
+    expect(result).toEqual({
+      apiKey: "sk-legacy-key",
+      provider: "openai",
+      email: undefined,
+    });
+  });
+
+  it("prefers apiKey over key when both are present", async () => {
+    const profileId = "openai:both-fields";
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "api_key",
+          provider: "openai",
+          apiKey: "sk-from-apiKey",
+          key: "sk-from-key",
+        },
+      },
+    };
+    const result = await resolveApiKeyForProfile({
+      cfg: cfgFor(profileId, "openai", "api_key"),
+      store,
+      profileId,
+    });
+    expect(result).toEqual({
+      apiKey: "sk-from-apiKey",
+      provider: "openai",
+      email: undefined,
+    });
+  });
+});
+
 describe("resolveApiKeyForProfile secret refs", () => {
   it("resolves api_key keyRef from env", async () => {
     const profileId = "openai:default";

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -313,7 +313,7 @@ export async function resolveApiKeyForProfile(
     const key = await resolveProfileSecretString({
       profileId,
       provider: cred.provider,
-      value: cred.key,
+      value: cred.apiKey ?? cred.key,
       valueRef: cred.keyRef,
       refDefaults,
       configForRefResolution,

--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -6,6 +6,8 @@ export type ApiKeyCredential = {
   type: "api_key";
   provider: string;
   key?: string;
+  /** @deprecated Older persisted profiles may store the key as `apiKey`. Read `apiKey ?? key`. */
+  apiKey?: string;
   keyRef?: SecretRef;
   email?: string;
   /** Optional provider-specific metadata (e.g., account IDs, gateway IDs). */


### PR DESCRIPTION
## Summary

- **Problem:** `resolveAuthProfileOrder()` and `resolveApiKeyForProfile()` read `cred.key` but persisted api_key profiles store the key in `cred.apiKey`. All api_key profiles silently drop from the auth order, breaking model failover.
- **Why it matters:** Users with Google/Anthropic API key profiles configured via onboarding cannot use them for failover — the system treats them as if they don't exist.
- **What changed:** Both functions now read `cred.apiKey ?? cred.key` for backward compatibility. Added `apiKey` to the `ApiKeyCredential` type. Added 4 unit tests.
- **What did NOT change:** No changes to profile persistence, onboarding flow, or OAuth logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34654

## User-visible / Behavior Changes

- api_key profiles with `apiKey` field now correctly participate in auth order and failover
- Existing profiles using `key` field continue to work (backward compatible)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` (reads existing field with different name)
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Multi-provider failover

### Steps

1. Configure a Google API key profile via onboarding (stores as `apiKey` field)
2. Set up failover chain: Anthropic → Google → Anthropic backup
3. Trigger primary provider rate limit

### Expected

- Failover uses Google API key profile

### Actual

- Before fix: `No API key found for provider "google"` — profile silently filtered out
- After fix: Google API key profile correctly used in failover

## Evidence

4 new tests pass:
- `apiKey field eligible in credential-state`
- `apiKey preferred over key when both present`
- `resolveApiKey with apiKey only`
- `resolveApiKey prefers apiKey when both present`

### Files changed (5 files)

1. `src/agents/auth-profiles/types.ts` — Added `apiKey?: string` to ApiKeyCredential
2. `src/agents/auth-profiles/credential-state.ts` — Read `apiKey ?? key`
3. `src/agents/auth-profiles/oauth.ts` — Read `apiKey ?? key`
4. `src/agents/auth-profiles/credential-state.test.ts` — 2 new tests
5. `src/agents/auth-profiles/oauth.test.ts` — 2 new tests

## Human Verification (required)

- Verified scenarios: apiKey only, key only, both present (apiKey preferred), neither present
- Edge cases checked: Whitespace-only apiKey, empty string
- What I did **not** verify: Live multi-provider failover test

## Compatibility / Migration

- Backward compatible? `Yes` — `key` field still works
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: 5 files listed above
- Known bad symptoms: api_key profiles not found in auth order

## Risks and Mitigations

- Low risk: Additive change with fallback. Both field names accepted.
