### PR TITLE
feat(config): make embedded agent LLM-request timeout configurable

### DIFF
--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 
 const DEFAULT_AGENT_TIMEOUT_SECONDS = 600;
+const DEFAULT_EMBEDDED_PI_TIMEOUT_MS = 15_000;
 const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 
 const normalizeNumber = (value: unknown): number | undefined =>
@@ -45,4 +46,12 @@ export function resolveAgentTimeoutMs(opts: {
     return clampTimeoutMs(overrideSeconds * 1000);
   }
   return defaultMs;
+}
+
+export function resolveEmbeddedPiTimeoutMs(cfg?: OpenClawConfig): number {
+  const raw = normalizeNumber(cfg?.agents?.defaults?.embeddedPi?.timeoutMs);
+  if (raw !== undefined && raw > 0) {
+    return Math.min(raw, MAX_SAFE_TIMEOUT_MS);
+  }
+  return DEFAULT_EMBEDDED_PI_TIMEOUT_MS;
 }

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -4,6 +4,7 @@ import {
   isEmbeddedPiRunActive,
   waitForEmbeddedPiRunEnd,
 } from "../../agents/pi-embedded.js";
+import { resolveEmbeddedPiTimeoutMs } from "../../agents/timeout.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   resolveFreshSessionTotalTokens,
@@ -66,7 +67,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   const sessionId = params.sessionEntry.sessionId;
   if (isEmbeddedPiRunActive(sessionId)) {
     abortEmbeddedPiRun(sessionId);
-    await waitForEmbeddedPiRunEnd(sessionId, 15_000);
+    await waitForEmbeddedPiRunEnd(sessionId, resolveEmbeddedPiTimeoutMs(params.cfg));
   }
   const customInstructions = extractCompactInstructions({
     rawBody: params.ctx.CommandBody ?? params.ctx.RawBody ?? params.ctx.Body,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -180,6 +180,8 @@ export type AgentDefaultsConfig = {
      * - trusted: trust project settings as-is
      */
     projectSettingsPolicy?: "trusted" | "sanitize" | "ignore";
+    /** Timeout in milliseconds for embedded Pi LLM requests (default: 15000). */
+    timeoutMs?: number;
   };
   /** Vector memory search configuration (per-agent overrides supported). */
   memorySearch?: MemorySearchConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -120,6 +120,7 @@ export const AgentDefaultsSchema = z
         projectSettingsPolicy: z
           .union([z.literal("trusted"), z.literal("sanitize"), z.literal("ignore")])
           .optional(),
+        timeoutMs: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -4,6 +4,7 @@ import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { clearBootstrapSnapshot } from "../../agents/bootstrap-cache.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../../agents/pi-embedded.js";
+import { resolveEmbeddedPiTimeoutMs } from "../../agents/timeout.js";
 import { stopSubagentsForRequester } from "../../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue.js";
 import { loadConfig } from "../../config/config.js";
@@ -198,7 +199,7 @@ async function ensureSessionRuntimeCleanup(params: {
     return undefined;
   }
   abortEmbeddedPiRun(params.sessionId);
-  const ended = await waitForEmbeddedPiRunEnd(params.sessionId, 15_000);
+  const ended = await waitForEmbeddedPiRunEnd(params.sessionId, resolveEmbeddedPiTimeoutMs(params.cfg));
   if (ended) {
     return undefined;
   }

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -14,6 +14,7 @@ import {
 import { DEFAULT_PROVIDER, DEFAULT_MODEL } from "../agents/defaults.js";
 import { parseModelRef } from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { resolveEmbeddedPiTimeoutMs } from "../agents/timeout.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
@@ -61,7 +62,7 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       prompt,
       provider,
       model,
-      timeoutMs: 15_000, // 15 second timeout
+      timeoutMs: resolveEmbeddedPiTimeoutMs(params.cfg),
       runId: `slug-gen-${Date.now()}`,
     });
 


### PR DESCRIPTION
## Summary

- **Problem:** The embedded Pi agent fallback uses a hardcoded 15-second timeout for LLM requests. When upstream providers (Anthropic, OpenAI) experience latency spikes, the entire fallback chain times out because each provider gets only 15s — producing `FailoverError: LLM request timed out`.
- **Why it matters:** Users with high-latency provider setups (relay proxies, geo-distant endpoints, loaded inference servers) cannot tune the timeout, causing session cleanup, `/compact`, and slug generation to fail unnecessarily.
- **What changed:** Added `agents.defaults.embeddedPi.timeoutMs` to the config schema (Zod + TypeScript types) and created `resolveEmbeddedPiTimeoutMs()` in `timeout.ts`. Wired it through all three call sites that previously hardcoded `15_000`:
  1. `sessions.ts` — gateway session cleanup wait
  2. `commands-compact.ts` — `/compact` command abort wait
  3. `llm-slug-generator.ts` — slug generation LLM call
- **What did NOT change:** The main agent timeout (`agents.defaults.timeoutSeconds`) is separate and unchanged. The default remains 15000ms for backward compatibility.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34644

## User-visible / Behavior Changes

- New config option: `agents.defaults.embeddedPi.timeoutMs` (integer, positive, optional)
- Example:
```json
{
  "agents": {
    "defaults": {
      "embeddedPi": {
        "timeoutMs": 30000
      }
    }
  }
}
```
- Without the config key, behavior is unchanged (15s default).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: any (embedded agent is provider-agnostic)

### Steps

1. Set `agents.defaults.embeddedPi.timeoutMs` to `30000` in `openclaw.json`
2. Simulate a slow provider (>15s response)
3. Observe that the embedded agent waits 30s before timing out

### Expected

- Embedded agent respects the configured timeout

### Actual

- Before fix: Hardcoded 15s, all providers time out under load
- After fix: Configurable, default unchanged

## Evidence

- TypeScript compiles cleanly (only pre-existing errors in `extensions/diffs`)
- 6 files changed, 18 insertions, 3 deletions

## Human Verification (required)

- Verified scenarios: TypeScript compilation, traced all `15_000` call sites, confirmed resolver returns default when config absent
- Edge cases checked: Missing config key returns 15000ms; zero/negative values rejected by Zod (`z.number().int().positive()`); very large values clamped to `MAX_SAFE_TIMEOUT_MS`
- What I did **not** verify: End-to-end test with a real slow provider

## Compatibility / Migration

- Backward compatible? `Yes` — default is unchanged at 15000ms
- Config/env changes? `No` (new optional field only)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `embeddedPi.timeoutMs` from config to restore 15s default
- Files/config to restore: `src/agents/timeout.ts`, `src/config/zod-schema.agent-defaults.ts`, `src/config/types.agent-defaults.ts`
- Known bad symptoms: Setting timeout too low causes more frequent `FailoverError`; setting too high delays error feedback

## Risks and Mitigations

- **Risk:** Users may set unreasonably high timeouts, delaying error feedback. **Mitigation:** Value is clamped to `MAX_SAFE_TIMEOUT_MS` (~25 days); documentation should recommend 15000-60000ms range.
