### PR TITLE
fix(telegram): remove replyToId from block reply dedup key

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
+import { createBlockReplyPayloadKey } from "./block-reply-pipeline.js";
 
 const baseParams = {
   isHeartbeat: false,
@@ -135,5 +136,25 @@ describe("buildReplyPayloads media filter integration", () => {
 
     expect(replyPayloads).toHaveLength(1);
     expect(replyPayloads[0]?.text).toBe("hello world!");
+  });
+});
+
+describe("createBlockReplyPayloadKey dedup (#33592)", () => {
+  it("produces the same key regardless of replyToId", () => {
+    const blockPayload = { text: "Hello!", replyToId: undefined };
+    const finalPayload = { text: "Hello!", replyToId: "msg-42" };
+    expect(createBlockReplyPayloadKey(blockPayload)).toBe(createBlockReplyPayloadKey(finalPayload));
+  });
+
+  it("still differentiates by text content", () => {
+    const a = { text: "Hello!" };
+    const b = { text: "Goodbye!" };
+    expect(createBlockReplyPayloadKey(a)).not.toBe(createBlockReplyPayloadKey(b));
+  });
+
+  it("still differentiates by media content", () => {
+    const a = { text: "photo", mediaUrl: "file:///a.jpg" };
+    const b = { text: "photo", mediaUrl: "file:///b.jpg" };
+    expect(createBlockReplyPayloadKey(a)).not.toBe(createBlockReplyPayloadKey(b));
   });
 });

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -44,7 +44,6 @@ export function createBlockReplyPayloadKey(payload: ReplyPayload): string {
   return JSON.stringify({
     text,
     mediaList,
-    replyToId: payload.replyToId ?? null,
   });
 }
 


### PR DESCRIPTION
## Summary

- Problem: `createBlockReplyPayloadKey` included `replyToId` in the dedup key. During streaming, block payloads are sent with `replyToId: null/undefined`, but after `applyReplyThreading` the final payload gets a concrete `replyToId` (e.g. `"msg-42"`). The differing keys caused `hasSentPayload` to miss the match, so identical content was delivered twice — once during streaming and once as the final payload.
- Why it matters: Users on Telegram (and other channels with block streaming) see every message duplicated.
- What changed: Removed `replyToId` from the `createBlockReplyPayloadKey` serialization, so dedup is based solely on text + media content.
- What did NOT change (scope boundary): The `replyToId` field is still applied to payloads for threading — only the dedup key computation is changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33592

## User-visible / Behavior Changes

- Messages are no longer sent twice on channels using block streaming (Telegram, etc.).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Enable block streaming on a Telegram session
2. Send a message that triggers a single-paragraph reply
3. Observe the reply delivery count

### Expected

- One reply message delivered

### Actual

- Before: Two identical messages delivered (block payload + final payload)
- After: Single message delivered; `hasSentPayload` correctly deduplicates

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added 3 unit tests for `createBlockReplyPayloadKey`: same-content-different-replyToId produces same key, different text produces different key, different media produces different key. All 12 tests pass.

## Human Verification (required)

- Verified scenarios: block payload with `replyToId: undefined` vs final payload with `replyToId: "msg-42"` — both produce identical keys.
- Edge cases checked: payloads with `mediaUrl`, `mediaUrls`, empty text, whitespace-only text.
- What you did **not** verify: end-to-end Telegram delivery (requires live bot).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit to restore `replyToId` in the dedup key.
- Files/config to restore: `src/auto-reply/reply/block-reply-pipeline.ts`

## Risks and Mitigations

- Risk: If two intentionally different messages have identical text+media but different `replyToId`, the second would be deduped as a false positive.
  - Mitigation: This scenario is not possible in practice — `replyToId` is a threading hint, not a content differentiator. Messages with different content will always have different keys.