### PR TITLE
Fix stale custom-provider API format for discovered models

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -61,7 +61,7 @@ runs:
       if: inputs.install-bun == 'true'
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: "1.3.9+cf6cdbbba"
+        bun-version: "1.3.9"
 
     - name: Runtime versions
       shell: bash

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -330,6 +330,46 @@ describe("resolveModel", () => {
     });
   });
 
+  it("prefers exact provider key over normalized alias when both are configured", () => {
+    mockDiscoveredModel({
+      provider: "zai",
+      modelId: "glm-4.7",
+      templateModel: buildForwardCompatTemplate({
+        id: "glm-4.7",
+        name: "GLM-4.7",
+        provider: "zai",
+        api: "openai-completions",
+        baseUrl: "https://registry-zai.example.com/v1",
+        input: ["text"],
+      }),
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          "z.ai": {
+            baseUrl: "https://alias-z-ai.example.com/v1",
+            headers: { "X-Provider-Key": "alias" },
+            models: [],
+          },
+          zai: {
+            baseUrl: "https://canonical-zai.example.com/v1",
+            headers: { "X-Provider-Key": "exact" },
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("zai", "glm-4.7", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model?.baseUrl).toBe("https://canonical-zai.example.com/v1");
+    expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
+      "X-Provider-Key": "exact",
+    });
+  });
+
   it("builds an openai-codex fallback for gpt-5.3-codex", () => {
     mockOpenAICodexTemplateModel();
 

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -278,6 +278,58 @@ describe("resolveModel", () => {
     expect(result.model?.reasoning).toBe(true);
   });
 
+  it("prefers configured provider api metadata over discovered registry model", () => {
+    mockDiscoveredModel({
+      provider: "onehub",
+      modelId: "glm-5",
+      templateModel: {
+        id: "glm-5",
+        name: "GLM-5 (cached)",
+        provider: "onehub",
+        api: "anthropic-messages",
+        baseUrl: "https://old-provider.example.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 2048,
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          onehub: {
+            baseUrl: "http://new-provider.example.com/v1",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("glm-5"),
+                api: "openai-completions",
+                reasoning: true,
+                contextWindow: 198000,
+                maxTokens: 16000,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("onehub", "glm-5", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "onehub",
+      id: "glm-5",
+      api: "openai-completions",
+      baseUrl: "http://new-provider.example.com/v1",
+      reasoning: true,
+      contextWindow: 198000,
+      maxTokens: 16000,
+    });
+  });
+
   it("builds an openai-codex fallback for gpt-5.3-codex", () => {
     mockOpenAICodexTemplateModel();
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -7,7 +7,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
 import { normalizeModelCompat } from "../model-compat.js";
 import { resolveForwardCompatModel } from "../model-forward-compat.js";
-import { normalizeProviderId } from "../model-selection.js";
+import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
 import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
 
 type InlineModelEntry = ModelDefinitionConfig & {
@@ -23,6 +23,40 @@ type InlineProviderConfig = {
 };
 
 export { buildModelAliasLines };
+
+function resolveConfiguredProviderConfig(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): InlineProviderConfig | undefined {
+  return findNormalizedProviderValue(cfg?.models?.providers, provider);
+}
+
+function applyConfiguredProviderOverrides(params: {
+  discoveredModel: Model<Api>;
+  providerConfig?: InlineProviderConfig;
+  modelId: string;
+}): Model<Api> {
+  const { discoveredModel, providerConfig, modelId } = params;
+  if (!providerConfig) {
+    return discoveredModel;
+  }
+  const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
+  if (!configuredModel && !providerConfig.baseUrl && !providerConfig.api) {
+    return discoveredModel;
+  }
+  return {
+    ...discoveredModel,
+    api: configuredModel?.api ?? providerConfig.api ?? discoveredModel.api,
+    baseUrl: providerConfig.baseUrl ?? discoveredModel.baseUrl,
+    reasoning: configuredModel?.reasoning ?? discoveredModel.reasoning,
+    input: configuredModel?.input ?? discoveredModel.input,
+    cost: configuredModel?.cost ?? discoveredModel.cost,
+    contextWindow: configuredModel?.contextWindow ?? discoveredModel.contextWindow,
+    maxTokens: configuredModel?.maxTokens ?? discoveredModel.maxTokens,
+    headers: configuredModel?.headers ?? discoveredModel.headers,
+    compat: configuredModel?.compat ?? discoveredModel.compat,
+  };
+}
 
 export function buildInlineProviderModels(
   providers: Record<string, InlineProviderConfig>,
@@ -59,6 +93,7 @@ export function resolveModel(
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
   const authStorage = discoverAuthStorage(resolvedAgentDir);
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
+  const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
   const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
 
   if (!model) {
@@ -100,7 +135,7 @@ export function resolveModel(
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }
-    const providerCfg = providers[provider];
+    const providerCfg = providerConfig;
     if (providerCfg || modelId.startsWith("mock-")) {
       const configuredModel = providerCfg?.models?.find((candidate) => candidate.id === modelId);
       const fallbackModel: Model<Api> = normalizeModelCompat({
@@ -133,21 +168,17 @@ export function resolveModel(
       modelRegistry,
     };
   }
-  const providerOverride = cfg?.models?.providers?.[provider] as InlineProviderConfig | undefined;
-  if (providerOverride?.baseUrl || providerOverride?.headers) {
-    const overridden: Model<Api> & { headers?: Record<string, string> } = { ...model };
-    if (providerOverride.baseUrl) {
-      overridden.baseUrl = providerOverride.baseUrl;
-    }
-    if (providerOverride.headers) {
-      overridden.headers = {
-        ...(model as Model<Api> & { headers?: Record<string, string> }).headers,
-        ...providerOverride.headers,
-      };
-    }
-    return { model: normalizeModelCompat(overridden), authStorage, modelRegistry };
-  }
-  return { model: normalizeModelCompat(model), authStorage, modelRegistry };
+  return {
+    model: normalizeModelCompat(
+      applyConfiguredProviderOverrides({
+        discoveredModel: model,
+        providerConfig,
+        modelId,
+      }),
+    ),
+    authStorage,
+    modelRegistry,
+  };
 }
 
 /**

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -7,7 +7,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
 import { normalizeModelCompat } from "../model-compat.js";
 import { resolveForwardCompatModel } from "../model-forward-compat.js";
-import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
+import { normalizeProviderId } from "../model-selection.js";
 import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
 
 type InlineModelEntry = ModelDefinitionConfig & {
@@ -28,7 +28,18 @@ function resolveConfiguredProviderConfig(
   cfg: OpenClawConfig | undefined,
   provider: string,
 ): InlineProviderConfig | undefined {
-  return findNormalizedProviderValue(cfg?.models?.providers, provider);
+  const providers = cfg?.models?.providers;
+  if (!providers) {
+    return undefined;
+  }
+  // Preserve explicit user intent when both alias keys (for example z.ai + zai) are present.
+  if (Object.hasOwn(providers, provider)) {
+    return providers[provider];
+  }
+  const normalizedProvider = normalizeProviderId(provider);
+  return Object.entries(providers).find(
+    ([key]) => normalizeProviderId(key) === normalizedProvider,
+  )?.[1];
 }
 
 function applyConfiguredProviderOverrides(params: {
@@ -41,10 +52,16 @@ function applyConfiguredProviderOverrides(params: {
     return discoveredModel;
   }
   const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
-  if (!configuredModel && !providerConfig.baseUrl && !providerConfig.api && !providerConfig.headers) {
+  if (
+    !configuredModel &&
+    !providerConfig.baseUrl &&
+    !providerConfig.api &&
+    !providerConfig.headers
+  ) {
     return discoveredModel;
   }
-  const discoveredHeaders = (discoveredModel as Model<Api> & { headers?: Record<string, string> }).headers;
+  const discoveredHeaders = (discoveredModel as Model<Api> & { headers?: Record<string, string> })
+    .headers;
   const mergedHeaders =
     discoveredHeaders || providerConfig.headers || configuredModel?.headers
       ? { ...discoveredHeaders, ...providerConfig.headers, ...configuredModel?.headers }

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -41,9 +41,14 @@ function applyConfiguredProviderOverrides(params: {
     return discoveredModel;
   }
   const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
-  if (!configuredModel && !providerConfig.baseUrl && !providerConfig.api) {
+  if (!configuredModel && !providerConfig.baseUrl && !providerConfig.api && !providerConfig.headers) {
     return discoveredModel;
   }
+  const discoveredHeaders = (discoveredModel as Model<Api> & { headers?: Record<string, string> }).headers;
+  const mergedHeaders =
+    discoveredHeaders || providerConfig.headers || configuredModel?.headers
+      ? { ...discoveredHeaders, ...providerConfig.headers, ...configuredModel?.headers }
+      : undefined;
   return {
     ...discoveredModel,
     api: configuredModel?.api ?? providerConfig.api ?? discoveredModel.api,
@@ -53,7 +58,7 @@ function applyConfiguredProviderOverrides(params: {
     cost: configuredModel?.cost ?? discoveredModel.cost,
     contextWindow: configuredModel?.contextWindow ?? discoveredModel.contextWindow,
     maxTokens: configuredModel?.maxTokens ?? discoveredModel.maxTokens,
-    headers: configuredModel?.headers ?? discoveredModel.headers,
+    headers: mergedHeaders,
     compat: configuredModel?.compat ?? discoveredModel.compat,
   };
 }


### PR DESCRIPTION
## Summary
- apply configured provider/model metadata (`api`, `baseUrl`, token limits, compat fields) even when the model is found in the discovered `models.json` registry
- resolve provider config by normalized provider id so custom providers still map correctly after normalization
- add a regression test that reproduces stale-registry behavior (`onehub/glm-5`) and verifies configured `openai-completions` metadata wins

## Problem
When a custom provider model already existed in `models.json` with older transport metadata, `resolveModel()` returned the cached registry entry directly and ignored fresh `openclaw.json` provider config.

That could leave requests serialized in an outdated format (for example `anthropic-messages`) after users switch provider compatibility to `openai-completions`, causing broken or empty responses.

## Verification
- `pnpm test src/agents/pi-embedded-runner/model.test.ts`
- `pnpm build`

Fixes #34134
