### PR TITLE
fix(memory): differentiate error messages for path validation failures

### DIFF
--- a/src/memory/fs-utils.ts
+++ b/src/memory/fs-utils.ts
@@ -25,7 +25,7 @@ export async function statRegularFile(absPath: string): Promise<RegularFileStatR
     throw err;
   }
   if (stat.isSymbolicLink() || !stat.isFile()) {
-    throw new Error("path required");
+    throw new Error("path must be a regular file (not a symlink or directory)");
   }
   return { missing: false, stat };
 }

--- a/src/memory/index.test.ts
+++ b/src/memory/index.test.ts
@@ -1079,7 +1079,9 @@ describe("memory index", () => {
   it("rejects reading non-memory paths", async () => {
     const cfg = createCfg({ storePath: indexMainPath });
     const manager = await getPersistentManager(cfg);
-    await expect(manager.readFile({ relPath: "NOTES.md" })).rejects.toThrow("path required");
+    await expect(manager.readFile({ relPath: "NOTES.md" })).rejects.toThrow(
+      "path is outside the memory workspace",
+    );
   });
 
   it("allows reading from additional memory paths and blocks symlinks", async () => {
@@ -1107,7 +1109,7 @@ describe("memory index", () => {
     }
     if (symlinkOk) {
       await expect(manager.readFile({ relPath: "extra/linked.md" })).rejects.toThrow(
-        "path required",
+        "path must be a regular file",
       );
     }
   });

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -633,10 +633,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       }
     }
     if (!allowedWorkspace && !allowedAdditional) {
-      throw new Error("path required");
+      throw new Error("path is outside the memory workspace");
     }
     if (!absPath.endsWith(".md")) {
-      throw new Error("path required");
+      throw new Error("only .md files are supported");
     }
     const statResult = await statRegularFile(absPath);
     if (statResult.missing) {

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -2162,7 +2162,7 @@ describe("QmdMemoryManager", () => {
     const textPath = path.join(workspaceDir, "secret.txt");
     await fs.writeFile(textPath, "nope", "utf-8");
     await expect(manager.readFile({ relPath: "qmd/workspace-main/secret.txt" })).rejects.toThrow(
-      "path required",
+      "only .md files are supported",
     );
 
     const target = path.join(workspaceDir, "target.md");
@@ -2170,7 +2170,7 @@ describe("QmdMemoryManager", () => {
     const link = path.join(workspaceDir, "link.md");
     await fs.symlink(target, link);
     await expect(manager.readFile({ relPath: "qmd/workspace-main/link.md" })).rejects.toThrow(
-      "path required",
+      "path must be a regular file",
     );
 
     await manager.close();

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -889,7 +889,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     const absPath = this.resolveReadPath(relPath);
     if (!absPath.endsWith(".md")) {
-      throw new Error("path required");
+      throw new Error("only .md files are supported");
     }
     const statResult = await statRegularFile(absPath);
     if (statResult.missing) {


### PR DESCRIPTION
## Summary

The memory module reuses the generic `"path required"` error message for four distinct validation failures:

| Condition | Before | After |
|---|---|---|
| Empty path | `path required` | `path required` (unchanged) |
| Path outside workspace | `path required` | `path is outside the memory workspace` |
| Non-`.md` extension | `path required` | `only .md files are supported` |
| Symlink or non-regular file | `path required` | `path must be a regular file (not a symlink or directory)` |

When a user provides a valid-looking path like `notes.txt` and gets back `"path required"`, the error gives no clue about the actual problem. The differentiated messages tell the user exactly what went wrong.

### Files changed

- `src/memory/fs-utils.ts` — symlink/non-file check
- `src/memory/manager.ts` — workspace boundary + extension checks
- `src/memory/qmd-manager.ts` — extension check
- `src/memory/index.test.ts` — updated assertions
- `src/memory/qmd-manager.test.ts` — updated assertions

All 59 memory tests pass.