### PR TITLE
feat(feishu): add groupReplyMode to prevent topic auto-collapse on multi-turn responses

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1357,17 +1357,7 @@ export async function handleFeishuMessage(params: {
       isTopicSession || configReplyInThread ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
     const groupReplyMode = isGroup
-      ? ((groupConfig as Record<string, unknown> | undefined)?.groupReplyMode as
-          | "reply"
-          | "create"
-          | "auto"
-          | undefined) ??
-        ((feishuCfg as Record<string, unknown> | undefined)?.groupReplyMode as
-          | "reply"
-          | "create"
-          | "auto"
-          | undefined) ??
-        "reply"
+      ? (groupConfig?.groupReplyMode ?? feishuCfg?.groupReplyMode ?? "reply")
       : "reply";
 
     if (broadcastAgents) {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1356,6 +1356,19 @@ export async function handleFeishuMessage(params: {
     const replyTargetMessageId =
       isTopicSession || configReplyInThread ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
+    const groupReplyMode = isGroup
+      ? ((groupConfig as Record<string, unknown> | undefined)?.groupReplyMode as
+          | "reply"
+          | "create"
+          | "auto"
+          | undefined) ??
+        ((feishuCfg as Record<string, unknown> | undefined)?.groupReplyMode as
+          | "reply"
+          | "create"
+          | "auto"
+          | undefined) ??
+        "reply"
+      : "reply";
 
     if (broadcastAgents) {
       // Cross-account dedup: in multi-account setups, Feishu delivers the same
@@ -1413,6 +1426,7 @@ export async function handleFeishuMessage(params: {
             mentionTargets: ctx.mentionTargets,
             accountId: account.accountId,
             messageCreateTimeMs,
+            groupReplyMode,
           });
 
           log(
@@ -1511,6 +1525,7 @@ export async function handleFeishuMessage(params: {
         mentionTargets: ctx.mentionTargets,
         accountId: account.accountId,
         messageCreateTimeMs,
+        groupReplyMode,
       });
 
       log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -131,6 +131,16 @@ const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();
  */
 const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 
+/**
+ * Controls how the bot sends messages in group chats.
+ * - "reply" (default): Messages use `im.message.reply()` to associate with the triggering message.
+ * - "create": Messages use `im.message.create()` as standalone messages (pre-2026.3.1 behavior).
+ *   Avoids Feishu auto-collapsing multiple replies into a topic thread.
+ * - "auto": First message per agent turn uses `reply`, subsequent messages use `create`.
+ *   Preserves reply context while preventing topic auto-collapse on multi-turn responses.
+ */
+const GroupReplyModeSchema = z.enum(["reply", "create", "auto"]).optional();
+
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
@@ -142,6 +152,7 @@ export const FeishuGroupSchema = z
     groupSessionScope: GroupSessionScopeSchema,
     topicSessionMode: TopicSessionModeSchema,
     replyInThread: ReplyInThreadSchema,
+    groupReplyMode: GroupReplyModeSchema,
   })
   .strict();
 
@@ -171,6 +182,7 @@ const FeishuSharedConfigShape = {
   streaming: StreamingModeSchema,
   tools: FeishuToolsConfigSchema,
   replyInThread: ReplyInThreadSchema,
+  groupReplyMode: GroupReplyModeSchema,
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -385,7 +385,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             )) {
               // In "auto" mode, only the first chunk replies; subsequent chunks
               // use create to avoid topic-folding every chunk under the parent.
-              const chunkReplyTo = first ? deliveryReplyTo : (groupReplyMode === "auto" ? undefined : deliveryReplyTo);
+              const chunkReplyTo = first
+                ? deliveryReplyTo
+                : groupReplyMode === "auto"
+                  ? undefined
+                  : deliveryReplyTo;
               const chunkReplyInThread = chunkReplyTo ? deliveryReplyInThread : undefined;
               await sendMarkdownCardFeishu({
                 cfg,
@@ -413,7 +417,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             )) {
               // In "auto" mode, only the first chunk replies; subsequent chunks
               // use create to avoid topic-folding every chunk under the parent.
-              const chunkReplyTo = first ? deliveryReplyTo : (groupReplyMode === "auto" ? undefined : deliveryReplyTo);
+              const chunkReplyTo = first
+                ? deliveryReplyTo
+                : groupReplyMode === "auto"
+                  ? undefined
+                  : deliveryReplyTo;
               const chunkReplyInThread = chunkReplyTo ? deliveryReplyInThread : undefined;
               await sendMessageFeishu({
                 cfg,
@@ -440,7 +448,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           for (const mediaUrl of mediaList) {
             // When only media is sent (no text), the first media acts as
             // the "first message" for auto mode.
-            const mediaReplyTo = mediaFirst ? deliveryReplyTo : (groupReplyMode === "auto" && !hasText ? undefined : deliveryReplyTo);
+            const mediaReplyTo = mediaFirst
+              ? deliveryReplyTo
+              : groupReplyMode === "auto" && !hasText
+                ? undefined
+                : deliveryReplyTo;
             const mediaReplyInThread = mediaReplyTo ? deliveryReplyInThread : undefined;
             await sendMediaFeishu({
               cfg,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -84,10 +84,16 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
 
   // Track whether the first message has been sent (for "auto" mode).
+  // The flag is only committed when the actual send path is determined
+  // (non-streaming text delivery or streaming.start success) to avoid
+  // a race where deliver() consumes the flag before the streaming card
+  // has a chance to read it.
   let firstMessageSent = false;
 
   /**
-   * Resolve whether this delivery should use reply or create, based on groupReplyMode.
+   * Peek at whether this delivery should use reply or create, based on groupReplyMode.
+   * Does NOT commit the firstMessageSent flag — call commitFirstMessageSent() after
+   * the message is actually sent.
    * Returns the effective replyToMessageId (undefined = use create, string = use reply).
    */
   const resolveEffectiveReplyTo = (): string | undefined => {
@@ -98,11 +104,17 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (firstMessageSent) {
         return undefined; // subsequent messages → create (standalone)
       }
-      firstMessageSent = true;
-      return sendReplyToMessageId; // first message → reply
+      return sendReplyToMessageId; // first message → reply (flag committed later)
     }
     // "reply" mode (default): always reply
     return sendReplyToMessageId;
+  };
+
+  /** Commit the firstMessageSent flag after the actual send succeeds. */
+  const commitFirstMessageSent = () => {
+    if (groupReplyMode === "auto") {
+      firstMessageSent = true;
+    }
   };
 
   /**
@@ -110,6 +122,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
    * For "create" mode: no reply context (standalone card, pre-2026.3.1 behavior).
    * For "auto" mode: first streaming card uses reply, subsequent don't.
    * For "reply" mode: always use reply context.
+   *
+   * Note: this peeks at the flag but does NOT commit it. The streaming start
+   * handler commits the flag after the card is successfully created.
    */
   const resolveStreamingReplyOptions = (): {
     replyToMessageId?: string;
@@ -122,9 +137,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     if (groupReplyMode === "auto" && firstMessageSent) {
       return {}; // subsequent cards → standalone
     }
-    if (groupReplyMode === "auto") {
-      firstMessageSent = true;
-    }
+    // "auto" first or "reply" mode — use reply context.
+    // Flag is committed after streaming.start() succeeds.
     return { replyToMessageId, replyInThread: effectiveReplyInThread, rootId };
   };
   const account = resolveFeishuAccount({ cfg, accountId });
@@ -250,6 +264,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       );
       try {
         await streaming.start(chatId, resolveReceiveIdType(chatId), resolveStreamingReplyOptions());
+        // Commit flag only after the streaming card is successfully created,
+        // so the flag is not consumed prematurely by deliver() calls that
+        // arrive before streaming.start() resolves.
+        commitFirstMessageSent();
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);
         streaming = null;
@@ -365,16 +383,23 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               textChunkLimit,
               chunkMode,
             )) {
+              // In "auto" mode, only the first chunk replies; subsequent chunks
+              // use create to avoid topic-folding every chunk under the parent.
+              const chunkReplyTo = first ? deliveryReplyTo : (groupReplyMode === "auto" ? undefined : deliveryReplyTo);
+              const chunkReplyInThread = chunkReplyTo ? deliveryReplyInThread : undefined;
               await sendMarkdownCardFeishu({
                 cfg,
                 to: chatId,
                 text: chunk,
-                replyToMessageId: deliveryReplyTo,
-                replyInThread: deliveryReplyInThread,
+                replyToMessageId: chunkReplyTo,
+                replyInThread: chunkReplyInThread,
                 mentions: first ? mentionTargets : undefined,
                 accountId,
               });
-              first = false;
+              if (first) {
+                commitFirstMessageSent();
+                first = false;
+              }
             }
             if (info?.kind === "final") {
               deliveredFinalTexts.add(text);
@@ -386,16 +411,23 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               textChunkLimit,
               chunkMode,
             )) {
+              // In "auto" mode, only the first chunk replies; subsequent chunks
+              // use create to avoid topic-folding every chunk under the parent.
+              const chunkReplyTo = first ? deliveryReplyTo : (groupReplyMode === "auto" ? undefined : deliveryReplyTo);
+              const chunkReplyInThread = chunkReplyTo ? deliveryReplyInThread : undefined;
               await sendMessageFeishu({
                 cfg,
                 to: chatId,
                 text: chunk,
-                replyToMessageId: deliveryReplyTo,
-                replyInThread: deliveryReplyInThread,
+                replyToMessageId: chunkReplyTo,
+                replyInThread: chunkReplyInThread,
                 mentions: first ? mentionTargets : undefined,
                 accountId,
               });
-              first = false;
+              if (first) {
+                commitFirstMessageSent();
+                first = false;
+              }
             }
             if (info?.kind === "final") {
               deliveredFinalTexts.add(text);
@@ -404,15 +436,24 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         }
 
         if (hasMedia) {
+          let mediaFirst = true;
           for (const mediaUrl of mediaList) {
+            // When only media is sent (no text), the first media acts as
+            // the "first message" for auto mode.
+            const mediaReplyTo = mediaFirst ? deliveryReplyTo : (groupReplyMode === "auto" && !hasText ? undefined : deliveryReplyTo);
+            const mediaReplyInThread = mediaReplyTo ? deliveryReplyInThread : undefined;
             await sendMediaFeishu({
               cfg,
               to: chatId,
               mediaUrl,
-              replyToMessageId: deliveryReplyTo,
-              replyInThread: deliveryReplyInThread,
+              replyToMessageId: mediaReplyTo,
+              replyInThread: mediaReplyInThread,
               accountId,
             });
+            if (mediaFirst) {
+              commitFirstMessageSent();
+              mediaFirst = false;
+            }
           }
         }
       },

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -36,6 +36,8 @@ function normalizeEpochMs(timestamp: number | undefined): number | undefined {
   return timestamp < MS_EPOCH_MIN ? timestamp * 1000 : timestamp;
 }
 
+export type GroupReplyMode = "reply" | "create" | "auto";
+
 export type CreateFeishuReplyDispatcherParams = {
   cfg: ClawdbotConfig;
   agentId: string;
@@ -53,6 +55,13 @@ export type CreateFeishuReplyDispatcherParams = {
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
+  /**
+   * Controls how the bot sends messages in group chats.
+   * - "reply": All messages use im.message.reply() (default, current behavior).
+   * - "create": All messages use im.message.create() (standalone, pre-2026.3.1 behavior).
+   * - "auto": First message per turn uses reply, subsequent use create.
+   */
+  groupReplyMode?: GroupReplyMode;
 };
 
 export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams) {
@@ -68,10 +77,56 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     rootId,
     mentionTargets,
     accountId,
+    groupReplyMode = "reply",
   } = params;
   const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
   const threadReplyMode = threadReply === true;
   const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
+
+  // Track whether the first message has been sent (for "auto" mode).
+  let firstMessageSent = false;
+
+  /**
+   * Resolve whether this delivery should use reply or create, based on groupReplyMode.
+   * Returns the effective replyToMessageId (undefined = use create, string = use reply).
+   */
+  const resolveEffectiveReplyTo = (): string | undefined => {
+    if (groupReplyMode === "create") {
+      return undefined;
+    }
+    if (groupReplyMode === "auto") {
+      if (firstMessageSent) {
+        return undefined; // subsequent messages → create (standalone)
+      }
+      firstMessageSent = true;
+      return sendReplyToMessageId; // first message → reply
+    }
+    // "reply" mode (default): always reply
+    return sendReplyToMessageId;
+  };
+
+  /**
+   * Resolve whether streaming card should use reply context, based on groupReplyMode.
+   * For "create" mode: no reply context (standalone card, pre-2026.3.1 behavior).
+   * For "auto" mode: first streaming card uses reply, subsequent don't.
+   * For "reply" mode: always use reply context.
+   */
+  const resolveStreamingReplyOptions = (): {
+    replyToMessageId?: string;
+    replyInThread?: boolean;
+    rootId?: string;
+  } => {
+    if (groupReplyMode === "create") {
+      return {}; // standalone card
+    }
+    if (groupReplyMode === "auto" && firstMessageSent) {
+      return {}; // subsequent cards → standalone
+    }
+    if (groupReplyMode === "auto") {
+      firstMessageSent = true;
+    }
+    return { replyToMessageId, replyInThread: effectiveReplyInThread, rootId };
+  };
   const account = resolveFeishuAccount({ cfg, accountId });
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
@@ -194,11 +249,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         params.runtime.log?.(`feishu[${account.accountId}] ${message}`),
       );
       try {
-        await streaming.start(chatId, resolveReceiveIdType(chatId), {
-          replyToMessageId,
-          replyInThread: effectiveReplyInThread,
-          rootId,
-        });
+        await streaming.start(chatId, resolveReceiveIdType(chatId), resolveStreamingReplyOptions());
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);
         streaming = null;
@@ -254,6 +305,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           return;
         }
 
+        // Resolve reply target based on groupReplyMode (may be undefined for "create" / "auto" subsequent).
+        const deliveryReplyTo = resolveEffectiveReplyTo();
+        const deliveryReplyInThread = deliveryReplyTo ? effectiveReplyInThread : undefined;
+
         if (shouldDeliverText) {
           const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
@@ -294,8 +349,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                   cfg,
                   to: chatId,
                   mediaUrl,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread: effectiveReplyInThread,
+                  replyToMessageId: deliveryReplyTo,
+                  replyInThread: deliveryReplyInThread,
                   accountId,
                 });
               }
@@ -314,8 +369,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 cfg,
                 to: chatId,
                 text: chunk,
-                replyToMessageId: sendReplyToMessageId,
-                replyInThread: effectiveReplyInThread,
+                replyToMessageId: deliveryReplyTo,
+                replyInThread: deliveryReplyInThread,
                 mentions: first ? mentionTargets : undefined,
                 accountId,
               });
@@ -335,8 +390,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 cfg,
                 to: chatId,
                 text: chunk,
-                replyToMessageId: sendReplyToMessageId,
-                replyInThread: effectiveReplyInThread,
+                replyToMessageId: deliveryReplyTo,
+                replyInThread: deliveryReplyInThread,
                 mentions: first ? mentionTargets : undefined,
                 accountId,
               });
@@ -354,8 +409,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               cfg,
               to: chatId,
               mediaUrl,
-              replyToMessageId: sendReplyToMessageId,
-              replyInThread: effectiveReplyInThread,
+              replyToMessageId: deliveryReplyTo,
+              replyInThread: deliveryReplyInThread,
               accountId,
             });
           }


### PR DESCRIPTION
## Problem

In 2026.3.1, streaming card messages in Feishu group chats are sent via the **reply API** (`im.message.reply`), whereas in 2026.2.26 they were sent via `im.message.create` (standalone messages). This causes a problem during multi-turn tool-use responses: each turn creates a new streaming card that replies to the same original message. Feishu automatically collapses multiple replies to the same message into a **topic thread (话题)**, making the bot's response disappear from the main chat timeline.

## Root Cause

`streaming-card.ts` → `start()` gained new parameters `{ replyToMessageId, replyInThread, rootId }` in 2026.3.1, and the streaming card is now sent via `im.message.reply()` instead of `im.message.create()`.

During multi-turn tool use, the framework creates a new streaming card for each turn's text output. Each card calls `im.message.reply()` targeting the same original message. Feishu's UI automatically collapses multiple replies into a topic thread — this is Feishu platform behavior, not configurable.

## Solution

Add a `groupReplyMode` config option to control how the bot sends messages in group chats:

| Mode | Behavior | Use case |
|------|----------|----------|
| `"reply"` | All messages use `im.message.reply()` (current behavior, default) | Users who want reply context on every message |
| `"create"` | All messages use `im.message.create()` (pre-2026.3.1 behavior) | Users who want messages in main timeline without topic collapse |
| `"auto"` | First message per agent turn uses `reply`, subsequent messages use `create` | Best of both worlds — preserves reply context while preventing topic auto-collapse |

Configuration at top-level or per-group:

```jsonc
// Top-level
{ "channels": { "feishu": { "groupReplyMode": "create" } } }

// Per-group override
{ "channels": { "feishu": { "groups": { "oc_xxx": { "groupReplyMode": "auto" } } } } }
```

## Changes

- **`config-schema.ts`**: Add `GroupReplyModeSchema` (`"reply" | "create" | "auto"`) to `FeishuGroupSchema` and `FeishuSharedConfigShape`
- **`reply-dispatcher.ts`**: Add `groupReplyMode` parameter with `resolveEffectiveReplyTo()` and `resolveStreamingReplyOptions()` helpers that track per-turn state
- **`bot.ts`**: Read `groupReplyMode` from group/account config and pass to both dispatcher call sites (broadcast + single-agent)

## Related Issues

- Fixes the streaming card topic thread regression introduced in 2026.3.1
- Addresses #19784 (users who want `reply_in_thread` can keep `"reply"` mode)
- Related to #32980 (group reply targets root message)
- Related to #32958 (topic group thread creation)