### PR TITLE
fix: remove double Markdown-to-mrkdwn conversion in Slack native streaming

### DIFF
--- a/src/slack/streaming.test.ts
+++ b/src/slack/streaming.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SlackStreamSession } from "./streaming.js";
+import { appendSlackStream, startSlackStream, stopSlackStream } from "./streaming.js";
+
+function createMockStreamer() {
+  const append = vi.fn(async () => {});
+  const stop = vi.fn(async () => {});
+  return { append, stop };
+}
+
+function createMockClient(streamer: ReturnType<typeof createMockStreamer>) {
+  return {
+    chatStream: vi.fn(() => streamer),
+  } as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- mock
+}
+
+function createMockSession(streamer: ReturnType<typeof createMockStreamer>): SlackStreamSession {
+  return {
+    streamer: streamer as any, // eslint-disable-line @typescript-eslint/no-explicit-any -- mock
+    channel: "C123",
+    threadTs: "1000.1",
+    stopped: false,
+  };
+}
+
+describe("slack native streaming does not double-convert markdown", () => {
+  it("startSlackStream passes raw markdown to markdown_text", async () => {
+    const streamer = createMockStreamer();
+    const client = createMockClient(streamer);
+
+    await startSlackStream({
+      client,
+      channel: "C123",
+      threadTs: "1000.1",
+      text: "**bold** and *italic*",
+    });
+
+    expect(streamer.append).toHaveBeenCalledWith({
+      markdown_text: "**bold** and *italic*",
+    });
+  });
+
+  it("appendSlackStream passes raw markdown to markdown_text", async () => {
+    const streamer = createMockStreamer();
+    const session = createMockSession(streamer);
+
+    await appendSlackStream({
+      session,
+      text: "**bold** and ~~strike~~",
+    });
+
+    expect(streamer.append).toHaveBeenCalledWith({
+      markdown_text: "**bold** and ~~strike~~",
+    });
+  });
+
+  it("stopSlackStream passes raw markdown to markdown_text", async () => {
+    const streamer = createMockStreamer();
+    const session = createMockSession(streamer);
+
+    await stopSlackStream({
+      session,
+      text: "**final bold**",
+    });
+
+    expect(streamer.stop).toHaveBeenCalledWith({
+      markdown_text: "**final bold**",
+    });
+  });
+
+  it("does not convert **bold** to *bold* (mrkdwn)", async () => {
+    const streamer = createMockStreamer();
+    const client = createMockClient(streamer);
+
+    await startSlackStream({
+      client,
+      channel: "C123",
+      threadTs: "1000.1",
+      text: "**important text**",
+    });
+
+    const call = streamer.append.mock.calls[0] as unknown as [{ markdown_text: string }];
+    // Must NOT be mrkdwn-converted "*important text*"
+    expect(call[0].markdown_text).toBe("**important text**");
+    expect(call[0].markdown_text).not.toBe("*important text*");
+  });
+});

--- a/src/slack/streaming.ts
+++ b/src/slack/streaming.ts
@@ -14,7 +14,6 @@
 import type { WebClient } from "@slack/web-api";
 import type { ChatStreamer } from "@slack/web-api/dist/chat-stream.js";
 import { logVerbose } from "../globals.js";
-import { normalizeSlackOutboundText } from "./format.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -100,7 +99,7 @@ export async function startSlackStream(
   // If initial text is provided, send it as the first append which will
   // trigger the ChatStreamer to call chat.startStream under the hood.
   if (text) {
-    await streamer.append({ markdown_text: normalizeSlackOutboundText(text) });
+    await streamer.append({ markdown_text: text });
     logVerbose(`slack-stream: appended initial text (${text.length} chars)`);
   }
 
@@ -122,7 +121,7 @@ export async function appendSlackStream(params: AppendSlackStreamParams): Promis
     return;
   }
 
-  await session.streamer.append({ markdown_text: normalizeSlackOutboundText(text) });
+  await session.streamer.append({ markdown_text: text });
   logVerbose(`slack-stream: appended ${text.length} chars`);
 }
 
@@ -148,9 +147,7 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
     }`,
   );
 
-  await session.streamer.stop(
-    text ? { markdown_text: normalizeSlackOutboundText(text) } : undefined,
-  );
+  await session.streamer.stop(text ? { markdown_text: text } : undefined);
 
   logVerbose("slack-stream: stream stopped");
 }


### PR DESCRIPTION
## Summary

- Problem: Slack native streaming passes LLM output through `normalizeSlackOutboundText()` before sending it to the ChatStreamer SDK's `markdown_text` parameter. Since `markdown_text` expects standard Markdown (not Slack mrkdwn), the text is double-converted: `**bold**` → `*bold*` (mrkdwn) → Slack interprets as Markdown italic.
- Why it matters: All bold text renders as italic, and all inline formatting is systematically broken for any Slack agent with native streaming enabled (the default).
- What changed: Removed `normalizeSlackOutboundText()` from `startSlackStream`, `appendSlackStream`, and `stopSlackStream` in `src/slack/streaming.ts`. LLM Markdown output is now passed directly to `markdown_text`. Added tests to verify no conversion occurs.
- What did NOT change (scope boundary): The non-streaming `chat.postMessage` path (which correctly uses the `text` parameter expecting mrkdwn) is unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

Closes #34690

## User-visible / Behavior Changes

- Slack native streaming messages now render bold, italic, strikethrough, and other Markdown formatting correctly.
- Previously, `**bold**` rendered as italic; now it renders as bold.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Docker (Node.js)
- Model/provider: Any LLM (GPT-series, Claude)
- Integration/channel: Slack (native streaming enabled)
- Relevant config: Default Slack channel configuration (nativeStreaming defaults to true)

### Steps

1. Configure a Slack channel agent (native streaming is enabled by default)
2. Send a message that prompts the LLM to output bold text
3. LLM outputs `**important**` (standard Markdown bold)
4. Before fix: text renders as italic in Slack
5. After fix: text renders as bold in Slack

### Expected

- Text appears as **bold** in Slack

### Actual

- Before fix: text appears as *italic* due to double conversion

## Evidence

- [x] Trace/log snippets

The double conversion chain:

| Step | Text | Format |
|---|---|---|
| LLM output | `**bold**` | Markdown |
| After `normalizeSlackOutboundText()` | `*bold*` | Slack mrkdwn |
| ChatStreamer interprets `markdown_text` | `*bold*` → italic | Markdown |

The non-streaming path correctly uses `text` (expects mrkdwn), so conversion is appropriate there. The bug is specific to the native streaming path where `markdown_text` expects Markdown.

- [x] Failing test/log before + passing after

Added `src/slack/streaming.test.ts` with 4 tests verifying that `startSlackStream`, `appendSlackStream`, and `stopSlackStream` pass raw Markdown to `markdown_text` without conversion.

## Human Verification (required)

- Verified scenarios: `pnpm check` passes; all 4 new streaming tests pass; confirmed `normalizeSlackOutboundText("**bold**")` returns `"*bold*"` (demonstrating the conversion that was incorrectly applied)
- Edge cases checked: `stopSlackStream` with no text (undefined path unchanged); stopped session guard (unchanged)
- What you did **not** verify: End-to-end Slack native streaming rendering (requires live Slack workspace with streaming enabled)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Re-add `normalizeSlackOutboundText()` calls to the three functions in `src/slack/streaming.ts`
- Files/config to restore: `src/slack/streaming.ts`
- Known bad symptoms reviewers should watch for: Raw Markdown syntax appearing in Slack messages (would indicate `markdown_text` does not interpret Markdown as expected)

## Risks and Mitigations

- Risk: If the ChatStreamer SDK's `markdown_text` parameter does not actually interpret standard Markdown, raw Markdown syntax would appear in messages.
  - Mitigation: The parameter is named `markdown_text` and documented for Markdown input. The non-streaming path already demonstrates that the pipeline's mrkdwn output is designed for the `text` parameter, not `markdown_text`. PR #31889 explicitly noted "Native streaming (`markdown_text`) is unchanged" — acknowledging the different semantics.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)