### PR TITLE
feat(hooks): add agent-to-agent communication logging

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import { Type } from "@sinclair/typebox";
 import { loadConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
 import {
@@ -260,6 +261,7 @@ export function createSessionsSendTool(opts?: {
           if (typeof response?.runId === "string" && response.runId) {
             runId = response.runId;
           }
+          emitA2AHookEvent(opts?.agentSessionKey, resolvedKey, displayKey, message);
           startA2AFlow(undefined, runId);
           return jsonResult({
             runId,
@@ -288,6 +290,7 @@ export function createSessionsSendTool(opts?: {
         if (typeof response?.runId === "string" && response.runId) {
           runId = response.runId;
         }
+        emitA2AHookEvent(opts?.agentSessionKey, resolvedKey, displayKey, message);
       } catch (err) {
         const messageText =
           err instanceof Error ? err.message : typeof err === "string" ? err : "error";
@@ -358,4 +361,28 @@ export function createSessionsSendTool(opts?: {
       });
     },
   };
+}
+
+function emitA2AHookEvent(
+  sourceSessionKey: string | undefined,
+  resolvedTargetKey: string,
+  displayTargetKey: string,
+  message: string,
+): void {
+  if (!sourceSessionKey) {
+    return;
+  }
+  const sourceAgentId = resolveAgentIdFromSessionKey(sourceSessionKey);
+  const targetAgentId = resolveAgentIdFromSessionKey(resolvedTargetKey);
+  if (sourceAgentId && targetAgentId && sourceAgentId !== targetAgentId) {
+    void triggerInternalHook(
+      createInternalHookEvent("agent_to_agent", "send", sourceSessionKey ?? "", {
+        sourceSessionKey: sourceSessionKey ?? "",
+        sourceAgentId,
+        targetSessionKey: displayTargetKey,
+        targetAgentId,
+        message,
+      }),
+    );
+  }
 }

--- a/src/hooks/bundled/a2a-logging/HOOK.md
+++ b/src/hooks/bundled/a2a-logging/HOOK.md
@@ -1,0 +1,63 @@
+---
+name: a2a-logging
+description: "Log agent-to-agent messages to a Telegram topic"
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "📨",
+        "events": ["agent_to_agent:send"],
+        "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
+      },
+  }
+---
+
+# Agent-to-Agent Logging Hook
+
+Logs cross-agent `sessions_send` messages to a configurable Telegram topic for visibility and debugging.
+
+## What It Does
+
+When one agent sends a message to a different agent via `sessions_send`, this hook posts a formatted log entry to a Telegram topic so you can see inter-agent communication in real time.
+
+## Log Format
+
+```
+[14:32] finance -> dev
+Summarize today's transactions and flag any anomalies...
+```
+
+## Configuration
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "entries": {
+        "a2a-logging": {
+          "enabled": true,
+          "chatId": "-1001234567890",
+          "topicId": 12345
+        }
+      }
+    }
+  }
+}
+```
+
+- **chatId**: Telegram group chat ID (required)
+- **topicId**: Telegram forum topic/thread ID (required for forum groups)
+- **token**: Telegram bot token override (optional, defaults to `channels.telegram.botToken`)
+
+The bot must be a member of the target group with permission to post in the topic.
+
+## Requirements
+
+- Telegram channel must be configured (bot token available)
+- Bot must have access to the target chat/topic
+
+## Disabling
+
+```bash
+openclaw hooks disable a2a-logging
+```

--- a/src/hooks/bundled/a2a-logging/handler.test.ts
+++ b/src/hooks/bundled/a2a-logging/handler.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInternalHookEvent, type AgentToAgentHookContext } from "../../internal-hooks.js";
+
+// Mock external dependencies before imports
+vi.mock("../../../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    hooks: {
+      internal: {
+        entries: {
+          "a2a-logging": {
+            enabled: true,
+            chatId: "-1001234567890",
+            topicId: 12345,
+          },
+        },
+      },
+    },
+    channels: {
+      telegram: {
+        botToken: "fake-bot-token",
+      },
+    },
+  })),
+}));
+
+vi.mock("../../../telegram/token.js", () => ({
+  resolveTelegramToken: vi.fn(() => ({ token: "fake-bot-token", source: "config" })),
+}));
+
+vi.mock("../../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+describe("a2a-logging handler", () => {
+  describe("formatA2ALogMessage", () => {
+    it("should format message with agent IDs and UTC timestamp", async () => {
+      const { formatA2ALogMessage } = await import("./handler.js");
+      const timestamp = new Date("2026-03-04T14:32:00Z");
+      const result = formatA2ALogMessage("finance", "dev", "Review transactions", timestamp);
+
+      expect(result).toContain("<code>[14:32]</code>");
+      expect(result).toContain("<b>finance</b>");
+      expect(result).toContain("<b>dev</b>");
+      expect(result).toContain("->");
+      expect(result).toContain("Review transactions");
+    });
+
+    it("should truncate long messages to 200 chars", async () => {
+      const { formatA2ALogMessage } = await import("./handler.js");
+      const longMessage = "x".repeat(300);
+      const result = formatA2ALogMessage("a", "b", longMessage, new Date());
+
+      expect(result).toContain("x".repeat(200) + "...");
+      expect(result).not.toContain("x".repeat(300));
+    });
+
+    it("should escape HTML in agent IDs and messages", async () => {
+      const { formatA2ALogMessage } = await import("./handler.js");
+      const result = formatA2ALogMessage("test<script>", "b&c", "<b>bold</b> & stuff", new Date());
+
+      expect(result).toContain("test&lt;script&gt;");
+      expect(result).toContain("b&amp;c");
+      expect(result).toContain("&lt;b&gt;bold&lt;/b&gt; &amp; stuff");
+    });
+  });
+
+  describe("postToTelegram", () => {
+    let fetchSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      fetchSpy = vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve("{}"),
+        }),
+      );
+      vi.stubGlobal("fetch", fetchSpy);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("should POST to Telegram API with correct params", async () => {
+      const { postToTelegram } = await import("./handler.js");
+      await postToTelegram("my-token", "-100123", 456, "Hello");
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.telegram.org/botmy-token/sendMessage");
+      const body = JSON.parse(options.body as string) as Record<string, unknown>;
+      expect(body.chat_id).toBe("-100123");
+      expect(body.message_thread_id).toBe(456);
+      expect(body.text).toBe("Hello");
+      expect(body.parse_mode).toBe("HTML");
+      expect(body.disable_notification).toBe(true);
+    });
+
+    it("should omit message_thread_id when topicId is undefined", async () => {
+      const { postToTelegram } = await import("./handler.js");
+      await postToTelegram("my-token", "-100123", undefined, "Hello");
+
+      const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(options.body as string) as Record<string, unknown>;
+      expect(body.message_thread_id).toBeUndefined();
+    });
+
+    it("should throw on non-ok response", async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve("Forbidden"),
+      });
+
+      const { postToTelegram } = await import("./handler.js");
+      await expect(postToTelegram("t", "c", 1, "x")).rejects.toThrow("Telegram API 403: Forbidden");
+    });
+  });
+
+  describe("handler integration", () => {
+    let fetchSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      fetchSpy = vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve("{}"),
+        }),
+      );
+      vi.stubGlobal("fetch", fetchSpy);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("should post to Telegram for agent_to_agent:send events", async () => {
+      const { default: handler } = await import("./handler.js");
+      const context: AgentToAgentHookContext = {
+        sourceSessionKey: "agent:finance:main",
+        sourceAgentId: "finance",
+        targetSessionKey: "agent:dev:main",
+        targetAgentId: "dev",
+        message: "Please review",
+      };
+      const event = createInternalHookEvent(
+        "agent_to_agent",
+        "send",
+        "agent:finance:main",
+        context,
+      );
+      await handler(event);
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url] = fetchSpy.mock.calls[0] as [string];
+      expect(url).toContain("sendMessage");
+    });
+
+    it("should skip non-agent_to_agent events", async () => {
+      const { default: handler } = await import("./handler.js");
+      const event = createInternalHookEvent("message", "sent", "test", {
+        to: "someone",
+        content: "hello",
+        success: true,
+        channelId: "telegram",
+      });
+      await handler(event);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("should not throw on Telegram API errors", async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("Server error"),
+      });
+
+      const { default: handler } = await import("./handler.js");
+      const context: AgentToAgentHookContext = {
+        sourceSessionKey: "agent:a:main",
+        sourceAgentId: "a",
+        targetSessionKey: "agent:b:main",
+        targetAgentId: "b",
+        message: "test",
+      };
+      const event = createInternalHookEvent("agent_to_agent", "send", "agent:a:main", context);
+      await expect(handler(event)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/hooks/bundled/a2a-logging/handler.ts
+++ b/src/hooks/bundled/a2a-logging/handler.ts
@@ -1,0 +1,157 @@
+/**
+ * Agent-to-Agent Logging Hook Handler
+ *
+ * Posts formatted log entries to a Telegram topic when agents
+ * communicate via sessions_send, providing real-time visibility
+ * into inter-agent messaging.
+ */
+
+import { loadConfig } from "../../../config/config.js";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import { resolveTelegramToken } from "../../../telegram/token.js";
+import { resolveHookConfig } from "../../config.js";
+import type { InternalHookHandler } from "../../internal-hooks.js";
+
+const log = createSubsystemLogger("a2a-logging");
+
+const warningSuppressed = new Set<string>();
+
+export type A2ALoggingConfig = {
+  enabled?: boolean;
+  chatId?: string;
+  topicId?: number;
+  token?: string;
+};
+
+export function resolveA2AConfig(): A2ALoggingConfig | undefined {
+  const cfg = loadConfig();
+  const hookConfig = resolveHookConfig(cfg, "a2a-logging");
+  if (!hookConfig || hookConfig.enabled === false) {
+    return undefined;
+  }
+  return hookConfig as A2ALoggingConfig;
+}
+
+export function resolveToken(hookToken: string | undefined): string {
+  if (hookToken) {
+    return hookToken;
+  }
+  try {
+    const cfg = loadConfig();
+    const resolved = resolveTelegramToken(cfg);
+    return resolved.token;
+  } catch {
+    return "";
+  }
+}
+
+export function formatA2ALogMessage(
+  sourceAgentId: string,
+  targetAgentId: string,
+  message: string,
+  timestamp: Date,
+): string {
+  const time = formatTimestamp(timestamp);
+  const preview = truncateMessage(message, 200);
+  return `<code>[${time}]</code> <b>${escapeHtml(sourceAgentId)}</b> -> <b>${escapeHtml(targetAgentId)}</b>\n${escapeHtml(preview)}`;
+}
+
+function formatTimestamp(date: Date): string {
+  const h = String(date.getUTCHours()).padStart(2, "0");
+  const m = String(date.getUTCMinutes()).padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+function truncateMessage(msg: string, maxLen: number): string {
+  if (msg.length <= maxLen) {
+    return msg;
+  }
+  return msg.slice(0, maxLen) + "...";
+}
+
+export async function postToTelegram(
+  token: string,
+  chatId: string,
+  topicId: number | undefined,
+  text: string,
+): Promise<void> {
+  const url = `https://api.telegram.org/bot${token}/sendMessage`;
+  const body: Record<string, unknown> = {
+    chat_id: chatId,
+    text,
+    parse_mode: "HTML",
+    disable_notification: true,
+  };
+  if (topicId !== undefined) {
+    body.message_thread_id = topicId;
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => "");
+    throw new Error(`Telegram API ${response.status}: ${errorBody}`);
+  }
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+const handler: InternalHookHandler = async (event) => {
+  if (event.type !== "agent_to_agent" || event.action !== "send") {
+    return;
+  }
+
+  try {
+    const config = resolveA2AConfig();
+    if (!config) {
+      return;
+    }
+
+    const { chatId, topicId } = config;
+    if (!chatId) {
+      if (!warningSuppressed.has("chatId")) {
+        log.warn(
+          "a2a-logging enabled but chatId not configured. Set hooks.internal.entries.a2a-logging.chatId",
+        );
+        warningSuppressed.add("chatId");
+      }
+      return;
+    }
+
+    const token = resolveToken(config.token);
+    if (!token) {
+      if (!warningSuppressed.has("token")) {
+        log.warn(
+          "a2a-logging enabled but no Telegram bot token found. Set hooks.internal.entries.a2a-logging.token or configure channels.telegram.botToken",
+        );
+        warningSuppressed.add("token");
+      }
+      return;
+    }
+
+    const ctx = event.context as {
+      sourceAgentId?: string;
+      targetAgentId?: string;
+      message?: string;
+    };
+
+    const source = ctx.sourceAgentId ?? "unknown";
+    const target = ctx.targetAgentId ?? "unknown";
+    const msg = ctx.message ?? "";
+
+    const text = formatA2ALogMessage(source, target, msg, event.timestamp);
+    await postToTelegram(token, chatId, topicId, text);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(`Failed to log A2A message: ${message}`);
+  }
+};
+
+export default handler;

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -4,6 +4,7 @@ import {
   createInternalHookEvent,
   getRegisteredEventKeys,
   isAgentBootstrapEvent,
+  isAgentToAgentEvent,
   isGatewayStartupEvent,
   isMessageReceivedEvent,
   isMessageSentEvent,
@@ -11,6 +12,7 @@ import {
   triggerInternalHook,
   unregisterInternalHook,
   type AgentBootstrapHookContext,
+  type AgentToAgentHookContext,
   type GatewayStartupHookContext,
   type MessageReceivedHookContext,
   type MessageSentHookContext,
@@ -442,6 +444,89 @@ describe("hooks", () => {
       // Both handlers were called
       expect(errorHandler).toHaveBeenCalled();
       expect(successHandler).toHaveBeenCalled();
+    });
+  });
+
+  describe("agent-to-agent hooks", () => {
+    it("should trigger agent_to_agent:send handlers", async () => {
+      const handler = vi.fn();
+      registerInternalHook("agent_to_agent:send", handler);
+
+      const context: AgentToAgentHookContext = {
+        sourceSessionKey: "agent:finance:main",
+        sourceAgentId: "finance",
+        targetSessionKey: "agent:dev:main",
+        targetAgentId: "dev",
+        message: "Please review the latest transactions",
+      };
+      const event = createInternalHookEvent(
+        "agent_to_agent",
+        "send",
+        "agent:finance:main",
+        context,
+      );
+      await triggerInternalHook(event);
+
+      expect(handler).toHaveBeenCalledWith(event);
+    });
+
+    it("should match with isAgentToAgentEvent type guard", () => {
+      const context: AgentToAgentHookContext = {
+        sourceSessionKey: "agent:finance:main",
+        sourceAgentId: "finance",
+        targetSessionKey: "agent:dev:main",
+        targetAgentId: "dev",
+        message: "test",
+      };
+      const event = createInternalHookEvent(
+        "agent_to_agent",
+        "send",
+        "agent:finance:main",
+        context,
+      );
+      expect(isAgentToAgentEvent(event)).toBe(true);
+    });
+
+    it("should not match non-agent_to_agent events with type guard", () => {
+      const event = createInternalHookEvent("message", "sent", "test", {
+        to: "someone",
+        content: "hello",
+        success: true,
+        channelId: "telegram",
+      });
+      expect(isAgentToAgentEvent(event)).toBe(false);
+    });
+
+    it("should not match agent_to_agent event with missing context fields", () => {
+      const event = createInternalHookEvent("agent_to_agent", "send", "test", {
+        sourceSessionKey: "agent:finance:main",
+      });
+      expect(isAgentToAgentEvent(event)).toBe(false);
+    });
+
+    it("should also trigger general agent_to_agent handlers", async () => {
+      const generalHandler = vi.fn();
+      const specificHandler = vi.fn();
+      registerInternalHook("agent_to_agent", generalHandler);
+      registerInternalHook("agent_to_agent:send", specificHandler);
+
+      const context: AgentToAgentHookContext = {
+        sourceSessionKey: "agent:finance:main",
+        sourceAgentId: "finance",
+        targetSessionKey: "agent:dev:main",
+        targetAgentId: "dev",
+        message: "test",
+      };
+      const event = createInternalHookEvent(
+        "agent_to_agent",
+        "send",
+        "agent:finance:main",
+        context,
+      );
+      await triggerInternalHook(event);
+
+      expect(generalHandler).toHaveBeenCalledWith(event);
+      expect(specificHandler).toHaveBeenCalledWith(event);
     });
   });
 

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -10,7 +10,13 @@ import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "message"
+  | "agent_to_agent";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -37,6 +43,29 @@ export type GatewayStartupHookEvent = InternalHookEvent & {
   type: "gateway";
   action: "startup";
   context: GatewayStartupHookContext;
+};
+
+// ============================================================================
+// Agent-to-Agent Hook Events
+// ============================================================================
+
+export type AgentToAgentHookContext = {
+  /** Session key of the sending agent */
+  sourceSessionKey: string;
+  /** Agent ID extracted from source session key (e.g. "dev", "finance") */
+  sourceAgentId: string;
+  /** Session key of the target agent */
+  targetSessionKey: string;
+  /** Agent ID extracted from target session key */
+  targetAgentId: string;
+  /** The message content sent */
+  message: string;
+};
+
+export type AgentToAgentHookEvent = InternalHookEvent & {
+  type: "agent_to_agent";
+  action: "send";
+  context: AgentToAgentHookContext;
 };
 
 // ============================================================================
@@ -445,4 +474,18 @@ export function isMessagePreprocessedEvent(
     return false;
   }
   return hasStringContextField(context, "channelId");
+}
+
+export function isAgentToAgentEvent(event: InternalHookEvent): event is AgentToAgentHookEvent {
+  if (!isHookEventTypeAndAction(event, "agent_to_agent", "send")) {
+    return false;
+  }
+  const context = getHookContext<AgentToAgentHookContext>(event);
+  if (!context) {
+    return false;
+  }
+  return (
+    hasStringContextField(context, "sourceAgentId") &&
+    hasStringContextField(context, "targetAgentId")
+  );
 }


### PR DESCRIPTION
### Summary

- Add `agent_to_agent` event type to the internal hook system
- Emit the event from `sessions_send` on cross-agent sends (fire-and-forget, never blocks the send)
- Ship a bundled `a2a-logging` handler that posts formatted log entries to a configurable Telegram topic
- Add Control UI labels and help text for hook config fields (chatId, topicId, token)

### Motivation

Inter-agent communication via `sessions_send` is invisible to operators. When agent A tells agent B to do something, there's no audit trail unless agents self-report (which they skip ~90% of the time). This hook provides automatic, zero-LLM-cost visibility.

### Log format

```
[14:32] finance -> dev
Summarize today's transactions and flag any anomalies...
```

### Configuration

```json
{
  "hooks": {
    "internal": {
      "entries": {
        "a2a-logging": {
          "enabled": true,
          "chatId": "-1001234567890",
          "topicId": 12345
        }
      }
    }
  }
}
```

Disabled by default. Token reuses existing `channels.telegram.botToken`. Token field is auto-detected as sensitive and masked in the UI.

### Design decisions

- Only cross-agent sends are logged (sourceAgentId != targetAgentId)
- Event emitted at send time, not after response (keeps it simple and non-blocking)
- Handler uses raw `fetch()` to Telegram Bot API (no coupling to channel internals, no recursion risk)
- Best-effort: all errors caught and logged, never blocks sessions_send
- Message preview truncated to 200 chars
- Hook context emits the canonical resolved session key (not the display alias) so downstream handlers can correlate with stored sessions