### PR TITLE
feat(sessions): directory-per-session store to eliminate lock contention

### DIFF
--- a/src/config/sessions/store.directory.test.ts
+++ b/src/config/sessions/store.directory.test.ts
@@ -1,0 +1,567 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSessionStoreCacheForTest,
+  loadSessionStore,
+  migrateSessionStoreToDirectory,
+  readSessionUpdatedAt,
+  resolveSessionStoreDir,
+  sanitizeSessionKey,
+  desanitizeSessionKey,
+  saveSessionStore,
+  updateSessionStore,
+  updateSessionStoreEntry,
+} from "./store.js";
+import type { SessionEntry } from "./types.js";
+
+// Keep tests deterministic: never read a real openclaw.json.
+vi.mock("../config.js", () => ({
+  loadConfig: vi.fn().mockReturnValue({}),
+}));
+
+let fixtureRoot = "";
+let fixtureCount = 0;
+
+function makeEntry(updatedAt: number, extra?: Partial<SessionEntry>): SessionEntry {
+  return { sessionId: crypto.randomUUID(), updatedAt, ...extra };
+}
+
+async function createCaseDir(prefix: string): Promise<string> {
+  const dir = path.join(fixtureRoot, `${prefix}-${fixtureCount++}`);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+beforeAll(async () => {
+  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dirstore-suite-"));
+});
+
+afterAll(async () => {
+  await fs.rm(fixtureRoot, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  clearSessionStoreCacheForTest();
+});
+
+// ============================================================================
+// Key sanitization
+// ============================================================================
+
+describe("sanitizeSessionKey / desanitizeSessionKey", () => {
+  it("replaces colons with %3A", () => {
+    expect(sanitizeSessionKey("agent:main:telegram:direct:james")).toBe(
+      "agent%3Amain%3Atelegram%3Adirect%3Ajames",
+    );
+  });
+
+  it("round-trips correctly", () => {
+    const key = "agent:main:telegram:direct:james";
+    expect(desanitizeSessionKey(sanitizeSessionKey(key))).toBe(key);
+  });
+
+  it("handles keys without colons", () => {
+    expect(sanitizeSessionKey("simple-key")).toBe("simple-key");
+    expect(desanitizeSessionKey("simple-key")).toBe("simple-key");
+  });
+
+  it("handles keys with percent signs", () => {
+    const key = "agent:main:100%done";
+    const sanitized = sanitizeSessionKey(key);
+    expect(sanitized).toBe("agent%3Amain%3A100%25done");
+    expect(desanitizeSessionKey(sanitized)).toBe(key);
+  });
+
+  it("handles keys with hyphens (no ambiguity)", () => {
+    const key = "agent:my-agent:telegram:direct:user";
+    const sanitized = sanitizeSessionKey(key);
+    expect(desanitizeSessionKey(sanitized)).toBe(key);
+  });
+
+  it("encodes forward slashes to prevent path traversal", () => {
+    const key = "agent:main:some/nested/path";
+    const sanitized = sanitizeSessionKey(key);
+    expect(sanitized).not.toContain("/");
+    expect(desanitizeSessionKey(sanitized)).toBe(key);
+  });
+
+  it("encodes backslashes to prevent path traversal", () => {
+    const key = "agent:main:some\\nested\\path";
+    const sanitized = sanitizeSessionKey(key);
+    expect(sanitized).not.toContain("\\");
+    expect(desanitizeSessionKey(sanitized)).toBe(key);
+  });
+
+  it("round-trips keys with all special characters", () => {
+    const key = "agent:main:100%done/with\\work";
+    expect(desanitizeSessionKey(sanitizeSessionKey(key))).toBe(key);
+  });
+});
+
+// ============================================================================
+// resolveSessionStoreDir
+// ============================================================================
+
+describe("resolveSessionStoreDir", () => {
+  it("returns sessions.d in the same directory as storePath", () => {
+    const storePath = path.join("/tmp", "openclaw", "agents", "main", "sessions", "sessions.json");
+    expect(resolveSessionStoreDir(storePath)).toBe(
+      path.join("/tmp", "openclaw", "agents", "main", "sessions", "sessions.d"),
+    );
+  });
+});
+
+// ============================================================================
+// Migration: JSON -> directory
+// ============================================================================
+
+describe("migration: JSON to directory", () => {
+  let testDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    testDir = await createCaseDir("migration");
+    storePath = path.join(testDir, "sessions.json");
+  });
+
+  it("migrates legacy sessions.json via migrateSessionStoreToDirectory", async () => {
+    const now = Date.now();
+    const initialStore: Record<string, SessionEntry> = {
+      "agent:main:test": makeEntry(now, { modelOverride: "test-model" }),
+      "agent:main:other": makeEntry(now - 1000),
+    };
+    await fs.writeFile(storePath, JSON.stringify(initialStore, null, 2), "utf-8");
+
+    const migrated = await migrateSessionStoreToDirectory(storePath);
+    expect(migrated).toBe(true);
+
+    // Directory store should exist
+    const storeDir = resolveSessionStoreDir(storePath);
+    const stat = await fs.stat(storeDir);
+    expect(stat.isDirectory()).toBe(true);
+
+    // Original JSON should be backed up
+    const dirEntries = await fs.readdir(testDir);
+    const backupFiles = dirEntries.filter((f) => f.includes(".bak."));
+    expect(backupFiles.length).toBe(1);
+
+    // Load should read from directory
+    const loaded = loadSessionStore(storePath);
+    expect(loaded["agent:main:test"]?.modelOverride).toBe("test-model");
+    expect(Object.keys(loaded)).toHaveLength(2);
+  });
+
+  it("migration is idempotent", async () => {
+    const now = Date.now();
+    const initialStore: Record<string, SessionEntry> = {
+      "agent:main:test": makeEntry(now),
+    };
+    await fs.writeFile(storePath, JSON.stringify(initialStore, null, 2), "utf-8");
+
+    const first = await migrateSessionStoreToDirectory(storePath);
+    expect(first).toBe(true);
+    const second = await migrateSessionStoreToDirectory(storePath);
+    expect(second).toBe(false);
+  });
+
+  it("preserves data integrity during migration", async () => {
+    const now = Date.now();
+    const keys = Array.from({ length: 50 }, (_, i) => `agent:main:session-${i}`);
+    const initialStore: Record<string, SessionEntry> = {};
+    for (const key of keys) {
+      initialStore[key] = makeEntry(now - Math.random() * 10000);
+    }
+    await fs.writeFile(storePath, JSON.stringify(initialStore, null, 2), "utf-8");
+
+    await migrateSessionStoreToDirectory(storePath);
+
+    const loaded = loadSessionStore(storePath);
+    expect(Object.keys(loaded)).toHaveLength(50);
+    for (const key of keys) {
+      expect(loaded[key]?.sessionId).toBe(initialStore[key].sessionId);
+    }
+  });
+
+  it("returns false for empty JSON file", async () => {
+    await fs.writeFile(storePath, "", "utf-8");
+    const migrated = await migrateSessionStoreToDirectory(storePath);
+    expect(migrated).toBe(false);
+  });
+
+  it("returns false when no JSON file exists", async () => {
+    const migrated = await migrateSessionStoreToDirectory(storePath);
+    expect(migrated).toBe(false);
+  });
+
+  it("merges legacy JSON entries into existing directory without clobbering", async () => {
+    const now = Date.now();
+
+    // Create directory store with one entry
+    const storeDir = resolveSessionStoreDir(storePath);
+    await fs.mkdir(storeDir, { recursive: true });
+    const dirEntry = makeEntry(now, { modelOverride: "dir-model" });
+    const dirKey = sanitizeSessionKey("agent:main:existing");
+    await fs.writeFile(path.join(storeDir, `${dirKey}.json`), JSON.stringify(dirEntry), "utf-8");
+
+    // Create legacy JSON with overlapping + new entries
+    const legacyStore: Record<string, SessionEntry> = {
+      "agent:main:existing": makeEntry(now - 5000, { modelOverride: "old-json-model" }),
+      "agent:main:new-entry": makeEntry(now - 1000),
+    };
+    await fs.writeFile(storePath, JSON.stringify(legacyStore, null, 2), "utf-8");
+
+    const migrated = await migrateSessionStoreToDirectory(storePath);
+    expect(migrated).toBe(true);
+
+    const loaded = loadSessionStore(storePath);
+    // Existing directory entry should NOT be overwritten by stale JSON
+    expect(loaded["agent:main:existing"]?.modelOverride).toBe("dir-model");
+    // New entry from JSON should be migrated
+    expect(loaded["agent:main:new-entry"]).toBeDefined();
+  });
+});
+
+// ============================================================================
+// Directory store: CRUD operations
+// ============================================================================
+
+describe("directory store operations", () => {
+  let testDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    testDir = await createCaseDir("dirstore");
+    storePath = path.join(testDir, "sessions.json");
+    // Create the directory store (no legacy JSON)
+    const storeDir = resolveSessionStoreDir(storePath);
+    await fs.mkdir(storeDir, { recursive: true });
+  });
+
+  it("loads empty store from empty directory", () => {
+    const store = loadSessionStore(storePath);
+    expect(Object.keys(store)).toHaveLength(0);
+  });
+
+  it("saves and loads entries via directory store", async () => {
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      "agent:main:test": makeEntry(now, { modelOverride: "gpt-4" }),
+    };
+
+    await saveSessionStore(storePath, store);
+
+    const loaded = loadSessionStore(storePath);
+    expect(loaded["agent:main:test"]?.modelOverride).toBe("gpt-4");
+  });
+
+  it("creates per-session JSON files with sanitized names", async () => {
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      "agent:main:telegram:direct:james": makeEntry(now),
+    };
+
+    await saveSessionStore(storePath, store);
+
+    const storeDir = resolveSessionStoreDir(storePath);
+    const expectedFile = `${sanitizeSessionKey("agent:main:telegram:direct:james")}.json`;
+    const stat = await fs.stat(path.join(storeDir, expectedFile));
+    expect(stat.isFile()).toBe(true);
+
+    const content = JSON.parse(await fs.readFile(path.join(storeDir, expectedFile), "utf-8"));
+    expect(content.sessionId).toBeDefined();
+  });
+
+  it("removes deleted entries from directory", async () => {
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      "agent:main:keep": makeEntry(now),
+      "agent:main:delete": makeEntry(now),
+    };
+
+    await saveSessionStore(storePath, store);
+
+    // Remove one entry and save again
+    delete store["agent:main:delete"];
+    await saveSessionStore(storePath, store);
+
+    const loaded = loadSessionStore(storePath);
+    expect(loaded["agent:main:keep"]).toBeDefined();
+    expect(loaded["agent:main:delete"]).toBeUndefined();
+
+    // File should be removed
+    const storeDir = resolveSessionStoreDir(storePath);
+    const deletedFile = `${sanitizeSessionKey("agent:main:delete")}.json`;
+    await expect(fs.stat(path.join(storeDir, deletedFile))).rejects.toThrow();
+  });
+
+  it("updateSessionStore with diff-based writes", async () => {
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      "agent:main:a": makeEntry(now),
+      "agent:main:b": makeEntry(now),
+    };
+    await saveSessionStore(storePath, store);
+
+    await updateSessionStore(storePath, (s) => {
+      s["agent:main:a"] = { ...s["agent:main:a"], modelOverride: "changed" } as SessionEntry;
+      // b is untouched
+    });
+
+    const loaded = loadSessionStore(storePath);
+    expect(loaded["agent:main:a"]?.modelOverride).toBe("changed");
+    expect(loaded["agent:main:b"]).toBeDefined();
+  });
+
+  it("updateSessionStore after migration", async () => {
+    // Start with legacy JSON
+    const legacyDir = await createCaseDir("update-after-migrate");
+    const legacyStorePath = path.join(legacyDir, "sessions.json");
+    const now = Date.now();
+    const initialStore: Record<string, SessionEntry> = {
+      "agent:main:test": makeEntry(now),
+    };
+    await fs.writeFile(legacyStorePath, JSON.stringify(initialStore, null, 2), "utf-8");
+
+    await migrateSessionStoreToDirectory(legacyStorePath);
+
+    await updateSessionStore(legacyStorePath, (s) => {
+      s["agent:main:test"] = {
+        ...s["agent:main:test"],
+        modelOverride: "updated",
+      } as SessionEntry;
+    });
+
+    const loaded = loadSessionStore(legacyStorePath);
+    expect(loaded["agent:main:test"]?.modelOverride).toBe("updated");
+  });
+});
+
+// ============================================================================
+// Per-session locking: concurrent writes to different sessions
+// ============================================================================
+
+describe("per-session locking isolation", () => {
+  let testDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    testDir = await createCaseDir("concurrent");
+    storePath = path.join(testDir, "sessions.json");
+    const storeDir = resolveSessionStoreDir(storePath);
+    await fs.mkdir(storeDir, { recursive: true });
+  });
+
+  it("concurrent writes to different sessions complete without blocking", async () => {
+    // Seed two sessions
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      "agent:main:session-a": makeEntry(now),
+      "agent:main:session-b": makeEntry(now),
+    };
+    await saveSessionStore(storePath, store);
+
+    // Concurrent updates to different sessions — should not block each other
+    const results = await Promise.all([
+      updateSessionStore(storePath, (s) => {
+        s["agent:main:session-a"] = {
+          ...s["agent:main:session-a"],
+          modelOverride: "model-a",
+        } as SessionEntry;
+        return "a-done";
+      }),
+      updateSessionStore(storePath, (s) => {
+        s["agent:main:session-b"] = {
+          ...s["agent:main:session-b"],
+          modelOverride: "model-b",
+        } as SessionEntry;
+        return "b-done";
+      }),
+    ]);
+
+    expect(results).toContain("a-done");
+    expect(results).toContain("b-done");
+
+    const loaded = loadSessionStore(storePath);
+    expect(loaded["agent:main:session-a"]?.modelOverride).toBe("model-a");
+    expect(loaded["agent:main:session-b"]?.modelOverride).toBe("model-b");
+  });
+
+  it("sequential writes to the same session accumulate correctly", async () => {
+    const now = Date.now();
+    const key = "agent:main:counter";
+    const storeDir = resolveSessionStoreDir(storePath);
+    const sanitized = sanitizeSessionKey(key);
+    await fs.writeFile(
+      path.join(storeDir, `${sanitized}.json`),
+      JSON.stringify({ sessionId: "s1", updatedAt: now, counter: 0 }),
+      "utf-8",
+    );
+
+    // Sequential updates via updateSessionStore (each reads current state)
+    for (let i = 0; i < 4; i++) {
+      await updateSessionStore(storePath, (store) => {
+        const entry = store[key] as Record<string, unknown>;
+        entry.counter = (entry.counter as number) + 1;
+      });
+    }
+
+    const loaded = loadSessionStore(storePath);
+    // Each write reads current state, so counter should be 4
+    expect((loaded[key] as Record<string, unknown>).counter).toBe(4);
+  });
+});
+
+// ============================================================================
+// Lock namespace: updateSessionStoreEntry serializes with updateSessionStore
+// ============================================================================
+
+describe("lock namespace: updateSessionStoreEntry vs updateSessionStore", () => {
+  let testDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    testDir = await createCaseDir("lock-namespace");
+    storePath = path.join(testDir, "sessions.json");
+    const storeDir = resolveSessionStoreDir(storePath);
+    await fs.mkdir(storeDir, { recursive: true });
+  });
+
+  it("updateSessionStoreEntry and updateSessionStore do not lose each other's writes", async () => {
+    const now = Date.now();
+    const key = "agent:main:race-session";
+    await saveSessionStore(storePath, {
+      [key]: makeEntry(now, { modelOverride: "initial" }),
+    });
+
+    // Interleave both write paths sequentially (each reads current state).
+    await updateSessionStore(storePath, (s) => {
+      (s[key] as Record<string, unknown>).modelOverride = "from-updateSessionStore";
+    });
+    const result = await updateSessionStoreEntry({
+      storePath,
+      sessionKey: key,
+      update: async (entry) => ({ ...entry, modelOverride: "from-updateSessionStoreEntry" }),
+    });
+
+    expect(result?.modelOverride).toBe("from-updateSessionStoreEntry");
+    const loaded = loadSessionStore(storePath);
+    expect(loaded[key]?.modelOverride).toBe("from-updateSessionStoreEntry");
+  });
+});
+
+// ============================================================================
+// readSessionUpdatedAt optimization
+// ============================================================================
+
+describe("readSessionUpdatedAt with directory store", () => {
+  let testDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    testDir = await createCaseDir("read-updated");
+    storePath = path.join(testDir, "sessions.json");
+    const storeDir = resolveSessionStoreDir(storePath);
+    await fs.mkdir(storeDir, { recursive: true });
+  });
+
+  it("reads single entry without loading entire store", async () => {
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      "agent:main:a": makeEntry(now - 1000),
+      "agent:main:b": makeEntry(now),
+    };
+    await saveSessionStore(storePath, store);
+
+    const updatedAt = readSessionUpdatedAt({
+      storePath,
+      sessionKey: "agent:main:b",
+    });
+    expect(updatedAt).toBe(now);
+  });
+
+  it("returns undefined for non-existent session", async () => {
+    const updatedAt = readSessionUpdatedAt({
+      storePath,
+      sessionKey: "agent:main:missing",
+    });
+    expect(updatedAt).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Fresh install (no legacy JSON, no directory)
+// ============================================================================
+
+describe("fresh install behavior", () => {
+  let testDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    testDir = await createCaseDir("fresh");
+    storePath = path.join(testDir, "sessions.json");
+    // Don't create anything — simulates fresh install
+  });
+
+  it("loadSessionStore returns empty for non-existent store", () => {
+    const store = loadSessionStore(storePath);
+    expect(Object.keys(store)).toHaveLength(0);
+  });
+
+  it("fresh install uses JSON mode by default", async () => {
+    const now = Date.now();
+
+    await updateSessionStore(storePath, (store) => {
+      store["agent:main:new"] = makeEntry(now);
+    });
+
+    // Fresh install: no sessions.json existed before, so no migration occurred.
+    // Data is written to sessions.json (legacy mode).
+    const stat = await fs.stat(storePath);
+    expect(stat.isFile()).toBe(true);
+
+    const loaded = loadSessionStore(storePath);
+    expect(loaded["agent:main:new"]).toBeDefined();
+  });
+
+  it("fresh install can be migrated to directory mode", async () => {
+    const now = Date.now();
+    await saveSessionStore(storePath, { "agent:main:new": makeEntry(now) });
+
+    const migrated = await migrateSessionStoreToDirectory(storePath);
+    expect(migrated).toBe(true);
+
+    const storeDir = resolveSessionStoreDir(storePath);
+    const stat = await fs.stat(storeDir);
+    expect(stat.isDirectory()).toBe(true);
+
+    const loaded = loadSessionStore(storePath);
+    expect(loaded["agent:main:new"]).toBeDefined();
+  });
+
+  it("migrateSessionStoreToDirectory then updateSessionStore works", async () => {
+    // Seed a legacy sessions.json
+    const now = Date.now();
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({ "agent:main:existing": makeEntry(now) }, null, 2),
+      "utf-8",
+    );
+
+    // Explicit migration (called by gateway at startup)
+    await migrateSessionStoreToDirectory(storePath);
+
+    // Subsequent updateSessionStore uses directory mode
+    await updateSessionStore(storePath, (store) => {
+      store["agent:main:existing"] = {
+        ...store["agent:main:existing"],
+        modelOverride: "updated",
+      } as SessionEntry;
+    });
+
+    const loaded = loadSessionStore(storePath);
+    expect(loaded["agent:main:existing"]?.modelOverride).toBe("updated");
+  });
+});

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { acquireSessionWriteLock } from "../../agents/session-write-lock.js";
@@ -22,6 +23,7 @@ import {
   clearSessionStoreCaches,
   dropSessionStoreObjectCache,
   getSerializedSessionStore,
+  invalidateSessionStoreCache,
   readSessionStoreCache,
   setSerializedSessionStore,
   writeSessionStoreCache,
@@ -44,6 +46,239 @@ import {
 } from "./types.js";
 
 const log = createSubsystemLogger("sessions/store");
+
+// ============================================================================
+// Directory-per-session store
+// ============================================================================
+
+/** Sibling directory name for the per-session store layout. */
+const DIR_STORE_NAME = "sessions.d";
+
+/**
+ * Derive the directory store path from a legacy storePath (e.g. `sessions.json`).
+ * The directory store lives as a sibling `sessions.d/` directory.
+ */
+export function resolveSessionStoreDir(storePath: string): string {
+  return path.join(path.dirname(storePath), DIR_STORE_NAME);
+}
+
+/**
+ * Sanitize a session key for safe use as a filesystem name.
+ * Colons, slashes, and backslashes are percent-encoded to prevent path traversal.
+ */
+export function sanitizeSessionKey(key: string): string {
+  return key.replace(/%/g, "%25").replace(/\//g, "%2F").replace(/\\/g, "%5C").replace(/:/g, "%3A");
+}
+
+/** Reverse the sanitization to recover the original session key. */
+export function desanitizeSessionKey(fileName: string): string {
+  return fileName
+    .replace(/%3A/g, ":")
+    .replace(/%5C/g, "\\")
+    .replace(/%2F/g, "/")
+    .replace(/%25/g, "%");
+}
+
+/** Check whether a directory-based session store exists. */
+function isDirectoryStore(storePath: string): boolean {
+  try {
+    return fs.statSync(resolveSessionStoreDir(storePath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Read a single session entry from the directory store. */
+function loadSessionEntryFromDir(storeDir: string, fileName: string): SessionEntry | null {
+  const filePath = path.join(storeDir, fileName);
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    if (!raw || raw.length === 0) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as SessionEntry;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Load all session entries from the directory store. */
+function loadSessionStoreFromDir(storeDir: string): Record<string, SessionEntry> {
+  const store: Record<string, SessionEntry> = {};
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(storeDir);
+  } catch {
+    return store;
+  }
+  for (const fileName of entries) {
+    if (!fileName.endsWith(".json") || fileName.startsWith(".")) {
+      continue;
+    }
+    const sessionKey = desanitizeSessionKey(fileName.slice(0, -5));
+    const entry = loadSessionEntryFromDir(storeDir, fileName);
+    if (entry) {
+      store[sessionKey] = entry;
+    }
+  }
+  return store;
+}
+
+/** Write a single session entry to the directory store atomically. */
+async function writeSessionEntryToDir(
+  storeDir: string,
+  sessionKey: string,
+  entry: SessionEntry,
+): Promise<void> {
+  const fileName = `${sanitizeSessionKey(sessionKey)}.json`;
+  const filePath = path.join(storeDir, fileName);
+  const json = JSON.stringify(entry, null, 2);
+  const tmp = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  await fs.promises.mkdir(storeDir, { recursive: true });
+  try {
+    await fs.promises.writeFile(tmp, json, { mode: 0o600, encoding: "utf-8" });
+    await fs.promises.rename(tmp, filePath);
+    if (process.platform !== "win32") {
+      await fs.promises.chmod(filePath, 0o600).catch(() => undefined);
+    }
+  } catch (err) {
+    if (getErrorCode(err) === "ENOENT") {
+      // Parent dir may have been removed (e.g. in tests). Best-effort retry.
+      try {
+        await fs.promises.mkdir(storeDir, { recursive: true });
+        await fs.promises.writeFile(filePath, json, { mode: 0o600, encoding: "utf-8" });
+      } catch {
+        // Ignore
+      }
+      return;
+    }
+    throw err;
+  } finally {
+    await fs.promises.rm(tmp, { force: true }).catch(() => undefined);
+  }
+}
+
+/** Delete a single session entry from the directory store. */
+async function deleteSessionEntryFromDir(storeDir: string, sessionKey: string): Promise<void> {
+  const fileName = `${sanitizeSessionKey(sessionKey)}.json`;
+  try {
+    await fs.promises.unlink(path.join(storeDir, fileName));
+  } catch {
+    // Entry may already be deleted
+  }
+}
+
+/**
+ * Compute which session keys changed or were removed between snapshots.
+ */
+function computeStoreDiff(
+  previous: Record<string, SessionEntry>,
+  current: Record<string, SessionEntry>,
+): { changed: string[]; removed: string[] } {
+  const changed: string[] = [];
+  const removed: string[] = [];
+  for (const key of Object.keys(current)) {
+    const prev = previous[key];
+    const curr = current[key];
+    if (!prev || JSON.stringify(prev) !== JSON.stringify(curr)) {
+      changed.push(key);
+    }
+  }
+  for (const key of Object.keys(previous)) {
+    if (!(key in current)) {
+      removed.push(key);
+    }
+  }
+  return { changed, removed };
+}
+
+/**
+ * Migrate a legacy JSON session store to directory-per-session layout.
+ * Safe to call multiple times — no-ops if already migrated or no JSON exists.
+ */
+export async function migrateSessionStoreToDirectory(storePath: string): Promise<boolean> {
+  return await withSessionStoreLock(storePath, async () => {
+    let legacyExists = false;
+    try {
+      legacyExists = fs.statSync(storePath).isFile();
+    } catch {
+      // No legacy file — nothing to migrate
+    }
+    if (!legacyExists) {
+      return false;
+    }
+
+    let store: Record<string, SessionEntry> = {};
+    try {
+      const raw = fs.readFileSync(storePath, "utf-8");
+      if (raw.length === 0) {
+        return false;
+      }
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        store = parsed as Record<string, SessionEntry>;
+      }
+    } catch {
+      return false;
+    }
+
+    const keys = Object.keys(store);
+    if (keys.length === 0) {
+      return false;
+    }
+
+    const storeDir = resolveSessionStoreDir(storePath);
+    const dirAlreadyExists = isDirectoryStore(storePath);
+    log.info("migrating session store from JSON to directory layout", {
+      entries: keys.length,
+      storeDir,
+      merge: dirAlreadyExists,
+    });
+
+    await fs.promises.mkdir(storeDir, { recursive: true });
+    let migratedCount = 0;
+    for (const [key, entry] of Object.entries(store)) {
+      if (!entry) {
+        continue;
+      }
+      // Normalize key on write so directory filenames match lookup expectations.
+      const normalizedKey = normalizeStoreSessionKey(key);
+      // When merging into an existing directory, skip entries that already exist
+      // so we don't clobber newer per-file data with stale JSON values.
+      if (dirAlreadyExists) {
+        const existing = loadSessionEntryFromDir(
+          storeDir,
+          `${sanitizeSessionKey(normalizedKey)}.json`,
+        );
+        if (existing) {
+          continue;
+        }
+      }
+      await writeSessionEntryToDir(storeDir, normalizedKey, entry);
+      migratedCount++;
+    }
+    if (dirAlreadyExists) {
+      log.info("merged legacy entries into existing directory store", {
+        merged: migratedCount,
+        skipped: keys.length - migratedCount,
+      });
+    }
+
+    // Backup and remove the old JSON file
+    const backupPath = `${storePath}.bak.${Date.now()}`;
+    try {
+      await fs.promises.rename(storePath, backupPath);
+      log.info("backed up legacy sessions.json", { backupPath: path.basename(backupPath) });
+    } catch {
+      // If rename fails, directory store takes precedence anyway.
+    }
+    return true;
+  });
+}
 
 // ============================================================================
 // Session Store Cache with TTL Support
@@ -196,61 +431,82 @@ export function loadSessionStore(
   storePath: string,
   opts: LoadSessionStoreOptions = {},
 ): Record<string, SessionEntry> {
-  // Check cache first if enabled
+  const useDirectory = isDirectoryStore(storePath);
+
+  // Check cache first if enabled (TTL-based only for directory mode)
   if (!opts.skipCache && isSessionStoreCacheEnabled()) {
-    const currentFileStat = getFileStatSnapshot(storePath);
-    const cached = readSessionStoreCache({
-      storePath,
-      ttlMs: getSessionStoreTtl(),
-      mtimeMs: currentFileStat?.mtimeMs,
-      sizeBytes: currentFileStat?.sizeBytes,
-    });
-    if (cached) {
-      return cached;
+    if (useDirectory) {
+      const cached = readSessionStoreCache({
+        storePath,
+        ttlMs: getSessionStoreTtl(),
+        // Directory mode: skip mtime/size checks — rely on TTL only.
+        // Individual file mtimes don't propagate to directory mtime reliably.
+        mtimeMs: undefined,
+        sizeBytes: undefined,
+      });
+      if (cached) {
+        return cached;
+      }
+    } else {
+      const currentFileStat = getFileStatSnapshot(storePath);
+      const cached = readSessionStoreCache({
+        storePath,
+        ttlMs: getSessionStoreTtl(),
+        mtimeMs: currentFileStat?.mtimeMs,
+        sizeBytes: currentFileStat?.sizeBytes,
+      });
+      if (cached) {
+        return cached;
+      }
     }
   }
 
-  // Cache miss or disabled - load from disk.
-  // Retry up to 3 times when the file is empty or unparseable.  On Windows the
-  // temp-file + rename write is not fully atomic: a concurrent reader can briefly
-  // observe a 0-byte file (between truncate and write) or a stale/locked state.
-  // A short synchronous backoff (50 ms via `Atomics.wait`) is enough for the
-  // writer to finish.
-  let store: Record<string, SessionEntry> = {};
-  let fileStat = getFileStatSnapshot(storePath);
-  let mtimeMs = fileStat?.mtimeMs;
+  let store: Record<string, SessionEntry>;
+  let fileStat: ReturnType<typeof getFileStatSnapshot> = undefined;
   let serializedFromDisk: string | undefined;
-  const maxReadAttempts = process.platform === "win32" ? 3 : 1;
-  const retryBuf = maxReadAttempts > 1 ? new Int32Array(new SharedArrayBuffer(4)) : undefined;
-  for (let attempt = 0; attempt < maxReadAttempts; attempt++) {
-    try {
-      const raw = fs.readFileSync(storePath, "utf-8");
-      if (raw.length === 0 && attempt < maxReadAttempts - 1) {
-        // File is empty — likely caught mid-write; retry after a brief pause.
-        Atomics.wait(retryBuf!, 0, 0, 50);
-        continue;
-      }
-      const parsed = JSON.parse(raw);
-      if (isSessionStoreRecord(parsed)) {
-        store = parsed;
-        serializedFromDisk = raw;
-      }
-      fileStat = getFileStatSnapshot(storePath) ?? fileStat;
-      mtimeMs = fileStat?.mtimeMs;
-      break;
-    } catch {
-      // File missing, locked, or transiently corrupt — retry on Windows.
-      if (attempt < maxReadAttempts - 1) {
-        Atomics.wait(retryBuf!, 0, 0, 50);
-        continue;
-      }
-      // Final attempt failed; proceed with an empty store.
-    }
-  }
-  if (serializedFromDisk !== undefined) {
-    setSerializedSessionStore(storePath, serializedFromDisk);
-  } else {
+
+  if (useDirectory) {
+    const storeDir = resolveSessionStoreDir(storePath);
+    store = loadSessionStoreFromDir(storeDir);
+    // No serialized cache for directory mode — individual files don't map to a single JSON blob.
     setSerializedSessionStore(storePath, undefined);
+  } else {
+    // Legacy JSON file mode.
+    // Retry up to 3 times when the file is empty or unparseable.  On Windows the
+    // temp-file + rename write is not fully atomic: a concurrent reader can briefly
+    // observe a 0-byte file (between truncate and write) or a stale/locked state.
+    // A short synchronous backoff (50 ms via `Atomics.wait`) is enough for the
+    // writer to finish.
+    store = {};
+    fileStat = getFileStatSnapshot(storePath);
+    const maxReadAttempts = process.platform === "win32" ? 3 : 1;
+    const retryBuf = maxReadAttempts > 1 ? new Int32Array(new SharedArrayBuffer(4)) : undefined;
+    for (let attempt = 0; attempt < maxReadAttempts; attempt++) {
+      try {
+        const raw = fs.readFileSync(storePath, "utf-8");
+        if (raw.length === 0 && attempt < maxReadAttempts - 1) {
+          Atomics.wait(retryBuf!, 0, 0, 50);
+          continue;
+        }
+        const parsed = JSON.parse(raw);
+        if (isSessionStoreRecord(parsed)) {
+          store = parsed;
+          serializedFromDisk = raw;
+        }
+        fileStat = getFileStatSnapshot(storePath) ?? fileStat;
+        break;
+      } catch {
+        if (attempt < maxReadAttempts - 1) {
+          Atomics.wait(retryBuf!, 0, 0, 50);
+          continue;
+        }
+      }
+    }
+    if (serializedFromDisk !== undefined) {
+      setSerializedSessionStore(storePath, serializedFromDisk);
+    } else {
+      setSerializedSessionStore(storePath, undefined);
+    }
   }
 
   applySessionStoreMigrations(store);
@@ -260,8 +516,8 @@ export function loadSessionStore(
     writeSessionStoreCache({
       storePath,
       store,
-      mtimeMs,
-      sizeBytes: fileStat?.sizeBytes,
+      mtimeMs: useDirectory ? undefined : fileStat?.mtimeMs,
+      sizeBytes: useDirectory ? undefined : fileStat?.sizeBytes,
       serialized: serializedFromDisk,
     });
   }
@@ -273,6 +529,13 @@ export function readSessionUpdatedAt(params: {
   storePath: string;
   sessionKey: string;
 }): number | undefined {
+  // For directory stores, read only the target entry — avoids loading the entire store.
+  if (isDirectoryStore(params.storePath)) {
+    const storeDir = resolveSessionStoreDir(params.storePath);
+    const sanitized = sanitizeSessionKey(normalizeStoreSessionKey(params.sessionKey));
+    const entry = loadSessionEntryFromDir(storeDir, `${sanitized}.json`);
+    return entry?.updatedAt;
+  }
   try {
     const store = loadSessionStore(params.storePath);
     const resolved = resolveStoreSessionEntry({ store, sessionKey: params.sessionKey });
@@ -341,6 +604,8 @@ async function saveSessionStoreUnlocked(
   storePath: string,
   store: Record<string, SessionEntry>,
   opts?: SaveSessionStoreOptions,
+  /** Snapshot of the store before mutations — enables diff-based directory writes. */
+  previousSnapshot?: Record<string, SessionEntry>,
 ): Promise<void> {
   normalizeSessionStore(store);
 
@@ -437,8 +702,10 @@ async function saveSessionStoreUnlocked(
         }
       }
 
-      // Rotate the on-disk file if it exceeds the size threshold.
-      await rotateSessionFile(storePath, maintenance.rotateBytes);
+      // Rotate the on-disk file if it exceeds the size threshold (legacy JSON only).
+      if (!isDirectoryStore(storePath)) {
+        await rotateSessionFile(storePath, maintenance.rotateBytes);
+      }
 
       const diskBudget = await enforceSessionDiskBudget({
         store,
@@ -459,6 +726,15 @@ async function saveSessionStoreUnlocked(
     }
   }
 
+  // Directory mode: write changed entries only (diff-based when previousSnapshot provided).
+  if (isDirectoryStore(storePath)) {
+    invalidateSessionStoreCache(storePath);
+    setSerializedSessionStore(storePath, undefined);
+    await writeSessionStoreDir(storePath, store, previousSnapshot);
+    return;
+  }
+
+  // Legacy JSON file mode.
   await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
   const json = JSON.stringify(store, null, 2);
   if (getSerializedSessionStore(storePath) === json) {
@@ -481,8 +757,6 @@ async function saveSessionStoreUnlocked(
           await new Promise((r) => setTimeout(r, 50 * (i + 1)));
           continue;
         }
-        // Final attempt failed — skip this save. The write lock ensures
-        // the next save will retry with fresh data. Log for diagnostics.
         log.warn(`atomic write failed after 5 attempts: ${storePath}`);
       }
     }
@@ -495,8 +769,6 @@ async function saveSessionStoreUnlocked(
     const code = getErrorCode(err);
 
     if (code === "ENOENT") {
-      // In tests the temp session-store directory may be deleted while writes are in-flight.
-      // Best-effort: try a direct write (recreating the parent dir), otherwise ignore.
       try {
         await writeSessionStoreAtomic({ storePath, store, serialized: json });
       } catch (err2) {
@@ -510,6 +782,58 @@ async function saveSessionStoreUnlocked(
     }
 
     throw err;
+  }
+}
+
+/**
+ * Write changed session entries to the directory store.
+ * If `previousSnapshot` is provided, only changed/removed entries are written (diff-based).
+ * Otherwise, all entries are written and stale files are cleaned up.
+ */
+async function writeSessionStoreDir(
+  storePath: string,
+  store: Record<string, SessionEntry>,
+  previousSnapshot?: Record<string, SessionEntry>,
+): Promise<void> {
+  const storeDir = resolveSessionStoreDir(storePath);
+  await fs.promises.mkdir(storeDir, { recursive: true });
+
+  if (previousSnapshot) {
+    const { changed, removed } = computeStoreDiff(previousSnapshot, store);
+    for (const key of changed) {
+      await writeSessionEntryToDir(storeDir, key, store[key]);
+    }
+    for (const key of removed) {
+      await deleteSessionEntryFromDir(storeDir, key);
+    }
+  } else {
+    // Full write: write all entries, remove stale files.
+    const existingFiles = new Set<string>();
+    try {
+      for (const f of await fs.promises.readdir(storeDir)) {
+        if (f.endsWith(".json") && !f.startsWith(".")) {
+          existingFiles.add(f);
+        }
+      }
+    } catch {
+      // Directory may not exist yet
+    }
+
+    const currentFiles = new Set<string>();
+    for (const [key, entry] of Object.entries(store)) {
+      if (!entry) {
+        continue;
+      }
+      await writeSessionEntryToDir(storeDir, key, entry);
+      currentFiles.add(`${sanitizeSessionKey(key)}.json`);
+    }
+
+    for (const file of existingFiles) {
+      if (!currentFiles.has(file)) {
+        const key = desanitizeSessionKey(file.slice(0, -5));
+        await deleteSessionEntryFromDir(storeDir, key);
+      }
+    }
   }
 }
 
@@ -528,11 +852,14 @@ export async function updateSessionStore<T>(
   mutator: (store: Record<string, SessionEntry>) => Promise<T> | T,
   opts?: SaveSessionStoreOptions,
 ): Promise<T> {
+  // Both directory and legacy modes use the global lock for updateSessionStore because
+  // the generic mutator may touch any number of session keys — per-key locking is not feasible.
   return await withSessionStoreLock(storePath, async () => {
-    // Always re-read inside the lock to avoid clobbering concurrent writers.
+    const useDirectory = isDirectoryStore(storePath);
     const store = loadSessionStore(storePath, { skipCache: true });
+    const previousSnapshot = useDirectory ? structuredClone(store) : undefined;
     const result = await mutator(store);
-    await saveSessionStoreUnlocked(storePath, store, opts);
+    await saveSessionStoreUnlocked(storePath, store, opts, previousSnapshot);
     return result;
   });
 }
@@ -592,14 +919,19 @@ async function persistResolvedSessionEntry(params: {
   store: Record<string, SessionEntry>;
   resolved: ReturnType<typeof resolveStoreSessionEntry>;
   next: SessionEntry;
+  /** Pre-mutation snapshot — enables diff-based directory writes. */
+  previousSnapshot?: Record<string, SessionEntry>;
 }): Promise<SessionEntry> {
   params.store[params.resolved.normalizedKey] = params.next;
   for (const legacyKey of params.resolved.legacyKeys) {
     delete params.store[legacyKey];
   }
-  await saveSessionStoreUnlocked(params.storePath, params.store, {
-    activeSessionKey: params.resolved.normalizedKey,
-  });
+  await saveSessionStoreUnlocked(
+    params.storePath,
+    params.store,
+    { activeSessionKey: params.resolved.normalizedKey },
+    params.previousSnapshot,
+  );
   return params.next;
 }
 
@@ -711,8 +1043,13 @@ export async function updateSessionStoreEntry(params: {
   update: (entry: SessionEntry) => Promise<Partial<SessionEntry> | null>;
 }): Promise<SessionEntry | null> {
   const { storePath, sessionKey, update } = params;
+  // All directory-mode writers share the same storePath lock so that updateSessionStore
+  // (which also holds storePath) and updateSessionStoreEntry serialize against each other,
+  // preventing lost-update races on the same session entry.
   return await withSessionStoreLock(storePath, async () => {
+    const useDirectory = isDirectoryStore(storePath);
     const store = loadSessionStore(storePath, { skipCache: true });
+    const previousSnapshot = useDirectory ? structuredClone(store) : undefined;
     const resolved = resolveStoreSessionEntry({ store, sessionKey });
     const existing = resolved.existing;
     if (!existing) {
@@ -728,6 +1065,7 @@ export async function updateSessionStoreEntry(params: {
       store,
       resolved,
       next,
+      previousSnapshot,
     });
   });
 }
@@ -791,8 +1129,12 @@ export async function updateLastRoute(params: {
   groupResolution?: import("./types.js").GroupKeyResolution | null;
 }) {
   const { storePath, sessionKey, channel, to, accountId, threadId, ctx } = params;
-  return await withSessionStoreLock(storePath, async () => {
-    const store = loadSessionStore(storePath);
+  // All directory-mode writers share the storePath lock (same as updateSessionStore) to
+  // prevent lost-update races between updateLastRoute and generic updateSessionStore calls.
+  const body = async () => {
+    const useDirectory = isDirectoryStore(storePath);
+    const store = loadSessionStore(storePath, { skipCache: true });
+    const previousSnapshot = useDirectory ? structuredClone(store) : undefined;
     const resolved = resolveStoreSessionEntry({ store, sessionKey });
     const existing = resolved.existing;
     const now = Date.now();
@@ -857,6 +1199,8 @@ export async function updateLastRoute(params: {
       store,
       resolved,
       next,
+      previousSnapshot,
     });
-  });
+  };
+  return await withSessionStoreLock(storePath, body);
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -21,6 +21,8 @@ import {
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { migrateSessionStoreToDirectory } from "../config/sessions/store.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
@@ -294,6 +296,13 @@ export async function startGatewayServer(
     } catch (err) {
       log.warn(`gateway: failed to persist plugin auto-enable changes: ${String(err)}`);
     }
+  }
+
+  // Auto-migrate session store from monolithic JSON to directory-per-session layout.
+  // One-time, runs under the global write lock, backs up the original file.
+  if (!minimalTestGateway) {
+    const mainStorePath = resolveStorePath(configSnapshot.config.session?.store);
+    await migrateSessionStoreToDirectory(mainStorePath);
   }
 
   let secretsDegraded = false;


### PR DESCRIPTION
### Problem

The monolithic `sessions.json` file causes cross-session lock contention. When one session writes (e.g., an agent doing many tool calls), all other sessions block waiting for the global write lock. This causes `sessions_send` timeouts and cross-topic blocking.

### Solution

Add a directory-per-session store layout (`sessions.d/`) where each session key gets its own JSON file. In directory mode:

- **No global lock on writes** - each session file is written atomically (temp file + rename), so writes to different sessions never block each other
- **Diff-based writes** - `updateSessionStore` snapshots before the mutator runs, then writes only changed entries
- **Efficient single-session reads** - `readSessionUpdatedAt` reads one file instead of parsing the entire store
- **Full maintenance parity** - pruning, capping, disk budget, and transcript archival all run the same as legacy mode

### Migration

On gateway startup, all agent session directories are discovered via disk scan (`~/.openclaw/agents/*/sessions/`) and each is migrated from legacy `sessions.json` to the directory layout. This covers the default agent, sub-agents, and any ephemeral agents that exist on disk. A config-resolved fallback also handles custom `session.store` paths that may live outside the default agent directories.

The old file is backed up as `sessions.json.bak.<timestamp>`. Migration is idempotent - already-migrated agents are skipped silently. Each agent's migration is independent (wrapped in try/catch) so one failure doesn't block others. Skipped in minimal test gateways.

Fresh installs continue using JSON mode until an existing `sessions.json` triggers migration.

### Key sanitization

Session keys (e.g., `agent:main:telegram:direct:james`) are sanitized for filesystem safety using URL-encoding style: colons become `%3A`, slashes become `%2F`/`%5C`, percent signs become `%25`. Keys are normalized (lowercased) during migration to match runtime lookup behavior. Round-trips correctly.

### Backward compatibility

- Existing `sessions.json` stores work unchanged until gateway restart triggers migration
- All public APIs (`loadSessionStore`, `saveSessionStore`, `updateSessionStore`, `updateSessionStoreEntry`, `updateLastRoute`) transparently support both modes
- Cache layer works with both modes (TTL-only invalidation for directory mode since individual file mtimes don't propagate reliably to directory mtime)
- `saveSessionStore` retains a global lock for bulk writes (rare operations like maintenance commands)

Related to #19528 (stale community PR with same goal, but heavily conflicted with current main).