### PR TITLE
fix(agents): include exec tool in loop detection repeat hash

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -444,6 +444,93 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("detects repeated exec calls with identical output despite volatile details", () => {
+      const state = createState();
+      const params = { command: "echo hello", timeout: 10000 };
+      for (let i = 0; i < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; i += 1) {
+        const toolCallId = `exec-${i}`;
+        recordToolCall(state, "exec", params, toolCallId);
+        recordToolCallOutcome(state, {
+          toolName: "exec",
+          toolParams: params,
+          toolCallId,
+          result: {
+            content: [{ type: "text", text: "hello" }],
+            details: {
+              status: "completed",
+              exitCode: 0,
+              durationMs: 50 + i,
+              aggregated: "hello",
+              cwd: `/workspace/run-${i}`,
+            },
+          },
+        });
+      }
+
+      const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+      }
+    });
+
+    it("does not escalate exec to circuit breaker when output changes", () => {
+      const state = createState();
+      const params = { command: "date", timeout: 10000 };
+      for (let i = 0; i < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; i += 1) {
+        const toolCallId = `exec-${i}`;
+        recordToolCall(state, "exec", params, toolCallId);
+        recordToolCallOutcome(state, {
+          toolName: "exec",
+          toolParams: params,
+          toolCallId,
+          result: {
+            content: [{ type: "text", text: `output-${i}` }],
+            details: {
+              status: "completed",
+              exitCode: 0,
+              durationMs: 50 + i,
+              aggregated: `output-${i}`,
+              cwd: "/workspace",
+            },
+          },
+        });
+      }
+
+      const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.detector).toBe("generic_repeat");
+        expect(loopResult.level).toBe("warning");
+      }
+    });
+
+    it("warns on exec generic repeat at warning threshold", () => {
+      const params = { command: "ls /tmp", timeout: 10000 };
+      const result = {
+        content: [{ type: "text", text: "file1 file2" }],
+        details: {
+          status: "completed",
+          exitCode: 0,
+          durationMs: 42,
+          aggregated: "file1 file2",
+          cwd: "/workspace",
+        },
+      };
+      const loopResult = detectLoopAfterRepeatedCalls({
+        toolName: "exec",
+        toolParams: params,
+        result,
+        count: WARNING_THRESHOLD,
+      });
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+        expect(loopResult.detector).toBe("generic_repeat");
+      }
+    });
+
     it("warns on ping-pong alternating patterns", () => {
       const state = createState();
       const readParams = { path: "/a.txt" };

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -223,6 +223,14 @@ function hashToolOutcome(
     }
   }
 
+  if (toolName === "exec") {
+    return digestStable({
+      status: details.status,
+      exitCode: details.exitCode ?? null,
+      text,
+    });
+  }
+
   return digestStable({
     details,
     text,


### PR DESCRIPTION
## Summary

- **Problem:** Loop detection only tracked read/write/edit tools. The exec tool was excluded because `hashToolOutcome` hashed the entire `details` object which includes volatile fields (`durationMs`, `pid`, `cwd`) that differ on every invocation, making every exec call produce a unique hash.
- **Why it matters:** A model can call the same shell command 121+ times without being caught, wasting API tokens and potentially creating duplicates for write operations.
- **What changed:** Added exec-specific handling in `hashToolOutcome` that strips volatile fields and hashes only stable outcome (`status`, `exitCode`, output text). Added 3 tests.
- **What did NOT change:** Hash computation for other tools unchanged. Detection thresholds unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34574

## User-visible / Behavior Changes

- Repeated exec tool calls with identical output now trigger loop detection warnings and circuit breaker
- Existing loop detection behavior for other tools unchanged

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Any

### Steps

1. Configure loopDetection with default thresholds
2. Use a model that enters an exec tool loop (e.g. Kimi K2.5)
3. Observe: loop detected and circuit breaker fires

### Expected

- Loop detection catches repeated exec calls

### Actual

- Before fix: No detection, loop runs indefinitely
- After fix: Warning at threshold 2, critical at 3, circuit breaker at 5

## Evidence

3 new tests pass covering: identical output detection, changing output non-escalation, warning threshold

## Human Verification (required)

- Verified scenarios: Identical exec results trigger circuit breaker; different results don't escalate
- Edge cases checked: Volatile fields (durationMs, cwd, pid) stripped from hash
- What I did **not** verify: Live model loop test

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Set `tools.loopDetection.enabled: false` or revert commit
- Files/config to restore: 2 files
- Known bad symptoms: False positive loop detection on exec calls with stable output

## Risks and Mitigations

- Low risk: Only changes hash computation for exec tool; other tools unchanged. Volatile fields correctly excluded.

