### PR TITLE
fix(gateway): resolve provider-scoped model shorthand in sessions.patch

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -318,6 +318,86 @@ describe("model-selection", () => {
       });
     });
 
+    it("resolves provider-scoped shorthand to unique allowlisted model", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-sonnet-4-6" },
+            models: {
+              "nvidia/moonshotai/kimi-k2.5": {},
+              "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = resolveAllowedModelRef({
+        cfg,
+        catalog: [],
+        raw: "nvidia/kimi",
+        defaultProvider: "anthropic",
+      });
+
+      expect(result).toEqual({
+        key: "nvidia/moonshotai/kimi-k2.5",
+        ref: { provider: "nvidia", model: "moonshotai/kimi-k2.5" },
+      });
+    });
+
+    it("returns ambiguity error when provider-scoped shorthand matches multiple models", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-sonnet-4-6" },
+            models: {
+              "nvidia/moonshotai/kimi-k2.5": {},
+              "nvidia/kimi-pro": {},
+              "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = resolveAllowedModelRef({
+        cfg,
+        catalog: [],
+        raw: "nvidia/kimi",
+        defaultProvider: "anthropic",
+      });
+
+      expect("error" in result).toBe(true);
+      if ("error" in result) {
+        expect(result.error).toContain("ambiguous model shorthand");
+        expect(result.error).toContain("nvidia/kimi");
+      }
+    });
+
+    it("does not apply shorthand resolution for bare model names without provider", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-sonnet-4-6" },
+            models: {
+              "nvidia/moonshotai/kimi-k2.5": {},
+              "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = resolveAllowedModelRef({
+        cfg,
+        catalog: [],
+        raw: "kimi",
+        defaultProvider: "anthropic",
+      });
+
+      expect("error" in result).toBe(true);
+      if ("error" in result) {
+        expect(result.error).toContain("model not allowed");
+      }
+    });
+
     it("strips trailing auth profile suffix before allowlist matching", () => {
       const cfg: OpenClawConfig = {
         agents: {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -526,6 +526,47 @@ export function resolveAllowedModelRef(params: {
     defaultModel: params.defaultModel,
   });
   if (!status.allowed) {
+    // Provider-scoped shorthand resolution: when the raw input has an explicit
+    // provider (contains "/") and the model segment is a simple name (no "/"),
+    // try fuzzy-matching against allowlisted models under the same provider.
+    if (trimmed.includes("/") && !resolved.ref.model.includes("/")) {
+      const shorthandLower = resolved.ref.model.toLowerCase();
+      const allowed = buildAllowedModelSet({
+        cfg: params.cfg,
+        catalog: params.catalog,
+        defaultProvider: params.defaultProvider,
+        defaultModel: params.defaultModel,
+      });
+
+      if (!allowed.allowAny) {
+        const matches: ModelRef[] = [];
+        for (const key of allowed.allowedKeys) {
+          const slashIdx = key.indexOf("/");
+          if (slashIdx === -1) continue;
+          const keyProvider = key.slice(0, slashIdx);
+          const keyModel = key.slice(slashIdx + 1);
+          if (keyProvider !== resolved.ref.provider) continue;
+
+          const segments = keyModel.toLowerCase().split("/");
+          if (segments.some((seg) => seg.startsWith(shorthandLower))) {
+            matches.push({ provider: keyProvider, model: keyModel });
+          }
+        }
+
+        if (matches.length === 1) {
+          const match = matches[0]!;
+          const matchKey = modelKey(match.provider, match.model);
+          return { ref: match, key: matchKey };
+        }
+        if (matches.length > 1) {
+          const matchKeys = matches.map((m) => modelKey(m.provider, m.model)).join(", ");
+          return {
+            error: `ambiguous model shorthand "${trimmed}": matches ${matchKeys}`,
+          };
+        }
+      }
+    }
+
     return { error: `model not allowed: ${status.key}` };
   }
 

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -302,6 +302,59 @@ describe("gateway sessions patch", () => {
     expectPatchError(result, "invalid groupActivation");
   });
 
+  test("resolves provider-scoped shorthand (nvidia/kimi) to unique allowlisted model", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          models: {
+            "nvidia/moonshotai/kimi-k2.5": {},
+            "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const entry = expectPatchOk(
+      await runPatch({
+        cfg,
+        patch: { key: MAIN_SESSION_KEY, model: "nvidia/kimi" },
+        loadGatewayModelCatalog: async () => [
+          { provider: "anthropic", id: "claude-sonnet-4-6", name: "sonnet" },
+          { provider: "nvidia", id: "moonshotai/kimi-k2.5", name: "kimi" },
+        ],
+      }),
+    );
+    expect(entry.providerOverride).toBe("nvidia");
+    expect(entry.modelOverride).toBe("moonshotai/kimi-k2.5");
+  });
+
+  test("rejects ambiguous provider-scoped shorthand", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          models: {
+            "nvidia/moonshotai/kimi-k2.5": {},
+            "nvidia/kimi-pro": {},
+            "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await runPatch({
+      cfg,
+      patch: { key: MAIN_SESSION_KEY, model: "nvidia/kimi" },
+      loadGatewayModelCatalog: async () => [
+        { provider: "anthropic", id: "claude-sonnet-4-6", name: "sonnet" },
+        { provider: "nvidia", id: "moonshotai/kimi-k2.5", name: "kimi" },
+        { provider: "nvidia", id: "kimi-pro", name: "kimi-pro" },
+      ],
+    });
+    expectPatchError(result, "ambiguous model shorthand");
+  });
+
   test("allows target agent own model for subagent session even when missing from global allowlist", async () => {
     const cfg = makeKimiSubagentCfg({
       agentPrimaryModel: "synthetic/hf:moonshotai/Kimi-K2.5",


### PR DESCRIPTION
## Summary

- **Problem:** `sessions.patch` with `model: "nvidia/kimi"` returns "model not allowed" even when there's exactly one allowlisted model under that provider (`nvidia/moonshotai/kimi-k2.5`).
- **Why it matters:** Users cannot switch models using convenient shorthand names, forcing them to type full model paths.
- **What changed:** Added provider-scoped shorthand resolution in `resolveAllowedModelRef`: for refs like `provider/shorthand`, match against allowlisted models under the same provider. Accept if unique, return ambiguity error if multiple matches.
- **What did NOT change:** Exact match logic unchanged. Full model paths work as before.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34642

## User-visible / Behavior Changes

- `sessions.patch` now accepts provider-scoped shorthands (e.g. `nvidia/kimi`) when they uniquely map to one allowlisted model
- Ambiguous shorthands return a clear error listing all matches

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: WebSocket sessions.patch

### Steps

1. Allowlist `nvidia/moonshotai/kimi-k2.5`
2. Call `sessions.patch` with `model: "nvidia/kimi"`

### Expected

- Resolves to `nvidia/moonshotai/kimi-k2.5`

### Actual

- Before fix: "model not allowed: nvidia/kimi"
- After fix: Resolves correctly

## Evidence

5 new tests pass: unique match, ambiguous match, bare name, end-to-end resolution, ambiguity rejection

## Human Verification (required)

- Verified scenarios: Unique match resolves; ambiguous returns error with candidates; bare names without provider unchanged
- Edge cases checked: Case-insensitive matching; no-match falls through to original error
- What I did **not** verify: Live sessions.patch WebSocket test

## Compatibility / Migration

- Backward compatible? `Yes` — exact matches still work, shorthand is additive
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert commit; users use full model paths
- Files/config to restore: 3 files
- Known bad symptoms: Model shorthand not resolving or incorrectly resolving

## Risks and Mitigations

- Shorthand resolution only triggers when exact match fails and ref has explicit provider with no-slash model segment. Case-insensitive segment matching prevents false negatives.

