### PR TITLE
ci: remove stale google-antigravity-auth labeler entry

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -204,10 +204,6 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/diagnostics-otel/**"
-"extensions: google-antigravity-auth":
-  - changed-files:
-      - any-glob-to-any-file:
-          - "extensions/google-antigravity-auth/**"
 "extensions: google-gemini-cli-auth":
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## Summary

The labeler config references `extensions/google-antigravity-auth/**` which does not exist on disk. The actual extension is `extensions/google-gemini-cli-auth/` which already has its own correct labeler entry.

This stale entry was likely left behind when the extension was renamed. Removing it to keep the labeler config accurate.