### PR TITLE
fix(whatsapp): recover relink on wrapped disconnect status + stale auth

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -61,7 +61,7 @@ runs:
       if: inputs.install-bun == 'true'
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: "1.3.9+cf6cdbbba"
+        bun-version: "1.3.9"
 
     - name: Runtime versions
       shell: bash

--- a/src/web/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/src/web/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -203,7 +203,11 @@ describe("web auto-reply connection", () => {
 
   it("clears stale auth when logged-out close reasons are reported", async () => {
     const sessionModule = await import("./session.js");
+    const waitForCredsSpy = vi
+      .spyOn(sessionModule, "waitForCredsSaveQueue")
+      .mockResolvedValue(undefined);
     const logoutSpy = vi.spyOn(sessionModule, "logoutWeb").mockResolvedValue(true);
+    let closeSpy: ReturnType<typeof vi.fn> | undefined;
 
     try {
       const closeResolvers: Array<(reason?: unknown) => void> = [];
@@ -212,7 +216,8 @@ describe("web auto-reply connection", () => {
         const onClose = new Promise<unknown>((res) => {
           closeResolvers.push(res);
         });
-        return { close: vi.fn(), onClose };
+        closeSpy = vi.fn(async () => {});
+        return { close: closeSpy, onClose };
       });
 
       const { runtime, run } = startMonitorWebChannel({
@@ -234,11 +239,24 @@ describe("web auto-reply connection", () => {
       await run;
 
       expect(logoutSpy).toHaveBeenCalledTimes(1);
+      expect(waitForCredsSpy).toHaveBeenCalledTimes(1);
       expect(listenerFactory).toHaveBeenCalledTimes(1);
       expect(sleep).not.toHaveBeenCalled();
       expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("session logged out"));
+      if (!closeSpy) {
+        throw new Error("expected listener close spy");
+      }
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+      const logoutArgs = logoutSpy.mock.calls[0]?.[0] as { authDir: string };
+      expect(waitForCredsSpy).toHaveBeenCalledWith(logoutArgs.authDir);
+      const closeOrder = closeSpy.mock.invocationCallOrder[0];
+      const waitOrder = waitForCredsSpy.mock.invocationCallOrder[0];
+      const logoutOrder = logoutSpy.mock.invocationCallOrder[0];
+      expect(closeOrder).toBeLessThan(waitOrder);
+      expect(waitOrder).toBeLessThan(logoutOrder);
     } finally {
       logoutSpy.mockRestore();
+      waitForCredsSpy.mockRestore();
     }
   });
 

--- a/src/web/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/src/web/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -201,6 +201,47 @@ describe("web auto-reply connection", () => {
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Stopping web monitoring"));
   });
 
+  it("clears stale auth when logged-out close reasons are reported", async () => {
+    const sessionModule = await import("./session.js");
+    const logoutSpy = vi.spyOn(sessionModule, "logoutWeb").mockResolvedValue(true);
+
+    try {
+      const closeResolvers: Array<(reason?: unknown) => void> = [];
+      const sleep = vi.fn(async () => {});
+      const listenerFactory = vi.fn(async () => {
+        const onClose = new Promise<unknown>((res) => {
+          closeResolvers.push(res);
+        });
+        return { close: vi.fn(), onClose };
+      });
+
+      const { runtime, run } = startMonitorWebChannel({
+        monitorWebChannelFn: monitorWebChannel as never,
+        listenerFactory,
+        sleep,
+        reconnect: { initialMs: 10, maxMs: 10, maxAttempts: 3, factor: 1.1 },
+      });
+
+      await Promise.resolve();
+      expect(listenerFactory).toHaveBeenCalledTimes(1);
+
+      closeResolvers.shift()?.({
+        status: 401,
+        isLoggedOut: true,
+        error: "Connection Failure",
+      });
+
+      await run;
+
+      expect(logoutSpy).toHaveBeenCalledTimes(1);
+      expect(listenerFactory).toHaveBeenCalledTimes(1);
+      expect(sleep).not.toHaveBeenCalled();
+      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("session logged out"));
+    } finally {
+      logoutSpy.mockRestore();
+    }
+  });
+
   it("forces reconnect when watchdog closes without onClose", async () => {
     vi.useFakeTimers();
     try {

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -22,7 +22,7 @@ import {
   resolveReconnectPolicy,
   sleepWithAbort,
 } from "../reconnect.js";
-import { formatError, getWebAuthAgeMs, readWebSelfId } from "../session.js";
+import { formatError, getWebAuthAgeMs, logoutWeb, readWebSelfId } from "../session.js";
 import { DEFAULT_WEB_MEDIA_BYTES } from "./constants.js";
 import { whatsappHeartbeatLog, whatsappLog } from "./loggers.js";
 import { buildMentionConfig } from "./mentions.js";
@@ -401,6 +401,24 @@ export async function monitorWebChannel(
     });
 
     if (loggedOut) {
+      try {
+        const cleared = await logoutWeb({
+          authDir: account.authDir,
+          isLegacyAuthDir: account.isLegacyAuthDir,
+          runtime,
+        });
+        if (!cleared) {
+          reconnectLogger.warn(
+            { connectionId },
+            "web reconnect: failed to clear stale auth on logged-out disconnect",
+          );
+        }
+      } catch (err) {
+        reconnectLogger.warn(
+          { connectionId, error: String(err) },
+          "web reconnect: auth cleanup failed on logged-out disconnect",
+        );
+      }
       runtime.error(
         `WhatsApp session logged out. Run \`${formatCliCommand("openclaw channels login --channel web")}\` to relink.`,
       );

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -22,7 +22,13 @@ import {
   resolveReconnectPolicy,
   sleepWithAbort,
 } from "../reconnect.js";
-import { formatError, getWebAuthAgeMs, logoutWeb, readWebSelfId } from "../session.js";
+import {
+  formatError,
+  getWebAuthAgeMs,
+  logoutWeb,
+  readWebSelfId,
+  waitForCredsSaveQueue,
+} from "../session.js";
 import { DEFAULT_WEB_MEDIA_BYTES } from "./constants.js";
 import { whatsappHeartbeatLog, whatsappLog } from "./loggers.js";
 import { buildMentionConfig } from "./mentions.js";
@@ -401,7 +407,9 @@ export async function monitorWebChannel(
     });
 
     if (loggedOut) {
+      await closeListener();
       try {
+        await waitForCredsSaveQueue(account.authDir);
         const cleared = await logoutWeb({
           authDir: account.authDir,
           isLegacyAuthDir: account.isLegacyAuthDir,
@@ -422,7 +430,6 @@ export async function monitorWebChannel(
       runtime.error(
         `WhatsApp session logged out. Run \`${formatCliCommand("openclaw channels login --channel web")}\` to relink.`,
       );
-      await closeListener();
       break;
     }
 

--- a/src/web/login-qr.test.ts
+++ b/src/web/login-qr.test.ts
@@ -69,5 +69,6 @@ describe("login-qr", () => {
     expect(createWaSocketMock).toHaveBeenCalledTimes(2);
     expect(logoutWebMock).not.toHaveBeenCalled();
     expect(waitForCredsSaveQueueMock).toHaveBeenCalledTimes(1);
+    expect(waitForCredsSaveQueueMock).toHaveBeenCalledWith(expect.any(String));
   });
 });

--- a/src/web/login-qr.test.ts
+++ b/src/web/login-qr.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { startWebLoginWithQr, waitForWebLogin } from "./login-qr.js";
-import { createWaSocket, logoutWeb, waitForWaConnection } from "./session.js";
+import {
+  createWaSocket,
+  logoutWeb,
+  waitForCredsSaveQueue,
+  waitForWaConnection,
+} from "./session.js";
 
 vi.mock("./session.js", () => {
   const createWaSocket = vi.fn(
@@ -17,11 +22,13 @@ vi.mock("./session.js", () => {
   const getStatusCode = vi.fn(
     (err: unknown) =>
       (err as { output?: { statusCode?: number } })?.output?.statusCode ??
+      (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode ??
       (err as { status?: number })?.status,
   );
   const webAuthExists = vi.fn(async () => false);
   const readWebSelfId = vi.fn(() => ({ e164: null, jid: null }));
   const logoutWeb = vi.fn(async () => true);
+  const waitForCredsSaveQueue = vi.fn(async () => {});
   return {
     createWaSocket,
     waitForWaConnection,
@@ -30,6 +37,7 @@ vi.mock("./session.js", () => {
     webAuthExists,
     readWebSelfId,
     logoutWeb,
+    waitForCredsSaveQueue,
   };
 });
 
@@ -40,6 +48,7 @@ vi.mock("./qr-image.js", () => ({
 const createWaSocketMock = vi.mocked(createWaSocket);
 const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
 const logoutWebMock = vi.mocked(logoutWeb);
+const waitForCredsSaveQueueMock = vi.mocked(waitForCredsSaveQueue);
 
 describe("login-qr", () => {
   beforeEach(() => {
@@ -48,7 +57,7 @@ describe("login-qr", () => {
 
   it("restarts login once on status 515 and completes", async () => {
     waitForWaConnectionMock
-      .mockRejectedValueOnce({ output: { statusCode: 515 } })
+      .mockRejectedValueOnce({ error: { output: { statusCode: 515 } }, date: new Date() })
       .mockResolvedValueOnce(undefined);
 
     const start = await startWebLoginWithQr({ timeoutMs: 5000 });
@@ -59,5 +68,6 @@ describe("login-qr", () => {
     expect(result.connected).toBe(true);
     expect(createWaSocketMock).toHaveBeenCalledTimes(2);
     expect(logoutWebMock).not.toHaveBeenCalled();
+    expect(waitForCredsSaveQueueMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/web/login-qr.test.ts
+++ b/src/web/login-qr.test.ts
@@ -71,4 +71,37 @@ describe("login-qr", () => {
     expect(waitForCredsSaveQueueMock).toHaveBeenCalledTimes(1);
     expect(waitForCredsSaveQueueMock).toHaveBeenCalledWith(expect.any(String));
   });
+
+  it("drains creds queue before clearing auth on logged-out errors", async () => {
+    waitForWaConnectionMock.mockRejectedValueOnce({
+      error: { output: { statusCode: 401 } },
+      date: new Date(),
+    });
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000 });
+    expect(start.qrDataUrl).toBe("data:image/png;base64,base64");
+
+    const result = await waitForWebLogin({ timeoutMs: 5000 });
+    expect(result.connected).toBe(false);
+    expect(result.message).toContain("logged out");
+
+    expect(createWaSocketMock).toHaveBeenCalledTimes(1);
+    expect(waitForCredsSaveQueueMock).toHaveBeenCalledTimes(1);
+    expect(waitForCredsSaveQueueMock).toHaveBeenCalledWith(expect.any(String));
+    expect(logoutWebMock).toHaveBeenCalledTimes(1);
+
+    const firstSocket = (await createWaSocketMock.mock.results[0]?.value) as
+      | { ws?: { close: ReturnType<typeof vi.fn> } }
+      | undefined;
+    if (!firstSocket?.ws?.close) {
+      throw new Error("expected login socket close spy");
+    }
+
+    expect(firstSocket.ws.close).toHaveBeenCalled();
+    const closeOrder = firstSocket.ws.close.mock.invocationCallOrder[0];
+    const waitOrder = waitForCredsSaveQueueMock.mock.invocationCallOrder[0];
+    const logoutOrder = logoutWebMock.mock.invocationCallOrder[0];
+    expect(closeOrder).toBeLessThan(waitOrder);
+    expect(waitOrder).toBeLessThan(logoutOrder);
+  });
 });

--- a/src/web/login-qr.ts
+++ b/src/web/login-qr.ts
@@ -89,7 +89,7 @@ async function restartLoginSocket(login: ActiveLogin, runtime: RuntimeEnv) {
     info("WhatsApp asked for a restart after pairing (code 515); retrying connection once…"),
   );
   closeSocket(login.sock);
-  await waitForCredsSaveQueue();
+  await waitForCredsSaveQueue(login.authDir);
   try {
     const sock = await createWaSocket(false, login.verbose, {
       authDir: login.authDir,

--- a/src/web/login-qr.ts
+++ b/src/web/login-qr.ts
@@ -12,6 +12,7 @@ import {
   getStatusCode,
   logoutWeb,
   readWebSelfId,
+  waitForCredsSaveQueue,
   waitForWaConnection,
   webAuthExists,
 } from "./session.js";
@@ -88,6 +89,7 @@ async function restartLoginSocket(login: ActiveLogin, runtime: RuntimeEnv) {
     info("WhatsApp asked for a restart after pairing (code 515); retrying connection once…"),
   );
   closeSocket(login.sock);
+  await waitForCredsSaveQueue();
   try {
     const sock = await createWaSocket(false, login.verbose, {
       authDir: login.authDir,

--- a/src/web/login-qr.ts
+++ b/src/web/login-qr.ts
@@ -262,6 +262,9 @@ export async function waitForWebLogin(
 
     if (login.error) {
       if (login.errorStatus === DisconnectReason.loggedOut) {
+        // Ensure the active socket is down and pending creds writes are drained before auth cleanup.
+        closeSocket(login.sock);
+        await waitForCredsSaveQueue(login.authDir);
         await logoutWeb({
           authDir: login.authDir,
           isLegacyAuthDir: login.isLegacyAuthDir,

--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -5,8 +5,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetLogger, setLoggerOverride } from "../logging.js";
 import { baileys, getLastSocket, resetBaileysMocks, resetLoadConfigMock } from "./test-helpers.js";
 
-const { createWaSocket, formatError, logWebSelfId, waitForWaConnection } =
-  await import("./session.js");
+const {
+  createWaSocket,
+  formatError,
+  getStatusCode,
+  logWebSelfId,
+  waitForCredsSaveQueue,
+  waitForWaConnection,
+} = await import("./session.js");
 const useMultiFileAuthStateMock = vi.mocked(baileys.useMultiFileAuthState);
 
 async function flushCredsUpdate() {
@@ -104,6 +110,12 @@ describe("web session", () => {
       lastDisconnect: new Error("bye"),
     });
     await expect(promise).rejects.toBeInstanceOf(Error);
+  });
+
+  it("extracts status codes from nested disconnect wrappers", () => {
+    expect(getStatusCode({ error: { output: { statusCode: 515 } } })).toBe(515);
+    expect(getStatusCode({ lastDisconnect: { error: { output: { statusCode: 401 } } } })).toBe(401);
+    expect(getStatusCode({ cause: { status: 440 } })).toBe(440);
   });
 
   it("logWebSelfId prints cached E.164 when creds exist", () => {
@@ -224,5 +236,38 @@ describe("web session", () => {
     expect(saveCreds).toHaveBeenCalled();
 
     creds.restore();
+  });
+
+  it("waitForCredsSaveQueue resolves after queued creds writes finish", async () => {
+    let releaseGate: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = () => resolve();
+    });
+
+    const saveCreds = vi.fn(async () => {
+      await gate;
+    });
+    useMultiFileAuthStateMock.mockResolvedValueOnce({
+      state: { creds: {} as never, keys: {} as never },
+      saveCreds,
+    });
+
+    await createWaSocket(false, false);
+    const sock = getLastSocket();
+    sock.ev.emit("creds.update", {});
+
+    await flushCredsUpdate();
+
+    let drained = false;
+    const waitPromise = waitForCredsSaveQueue().then(() => {
+      drained = true;
+    });
+
+    await flushCredsUpdate();
+    expect(drained).toBe(false);
+
+    releaseGate?.();
+    await waitPromise;
+    expect(drained).toBe(true);
   });
 });

--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -270,4 +270,65 @@ describe("web session", () => {
     await waitPromise;
     expect(drained).toBe(true);
   });
+
+  it("waitForCredsSaveQueue can scope waits to a single auth dir", async () => {
+    let releaseA: (() => void) | undefined;
+    const gateA = new Promise<void>((resolve) => {
+      releaseA = () => resolve();
+    });
+    let releaseB: (() => void) | undefined;
+    const gateB = new Promise<void>((resolve) => {
+      releaseB = () => resolve();
+    });
+
+    const saveCredsA = vi.fn(async () => {
+      await gateA;
+    });
+    const saveCredsB = vi.fn(async () => {
+      await gateB;
+    });
+    useMultiFileAuthStateMock
+      .mockResolvedValueOnce({
+        state: { creds: {} as never, keys: {} as never },
+        saveCreds: saveCredsA,
+      })
+      .mockResolvedValueOnce({
+        state: { creds: {} as never, keys: {} as never },
+        saveCreds: saveCredsB,
+      });
+
+    await createWaSocket(false, false, { authDir: "/tmp/wa-auth-a" });
+    const sockA = getLastSocket();
+    await createWaSocket(false, false, { authDir: "/tmp/wa-auth-b" });
+    const sockB = getLastSocket();
+
+    sockA.ev.emit("creds.update", {});
+    sockB.ev.emit("creds.update", {});
+    await flushCredsUpdate();
+
+    let drainedB = false;
+    const waitB = waitForCredsSaveQueue("/tmp/wa-auth-b").then(() => {
+      drainedB = true;
+    });
+    await flushCredsUpdate();
+    expect(drainedB).toBe(false);
+
+    releaseB?.();
+    await waitB;
+    expect(drainedB).toBe(true);
+
+    let drainedA = false;
+    const waitA = waitForCredsSaveQueue("/tmp/wa-auth-a").then(() => {
+      drainedA = true;
+    });
+    await flushCredsUpdate();
+    expect(drainedA).toBe(false);
+
+    releaseA?.();
+    await waitA;
+    expect(drainedA).toBe(true);
+
+    expect(saveCredsA).toHaveBeenCalledTimes(1);
+    expect(saveCredsB).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -331,4 +331,53 @@ describe("web session", () => {
     expect(saveCredsA).toHaveBeenCalledTimes(1);
     expect(saveCredsB).toHaveBeenCalledTimes(1);
   });
+
+  it("waitForCredsSaveQueue(authDir) drains late enqueues before returning", async () => {
+    let releaseA1: (() => void) | undefined;
+    const gateA1 = new Promise<void>((resolve) => {
+      releaseA1 = () => resolve();
+    });
+    let releaseA2: (() => void) | undefined;
+    const gateA2 = new Promise<void>((resolve) => {
+      releaseA2 = () => resolve();
+    });
+    let saveCalls = 0;
+    const saveCredsA = vi.fn(async () => {
+      saveCalls += 1;
+      if (saveCalls === 1) {
+        await gateA1;
+        return;
+      }
+      await gateA2;
+    });
+    useMultiFileAuthStateMock.mockResolvedValueOnce({
+      state: { creds: {} as never, keys: {} as never },
+      saveCreds: saveCredsA,
+    });
+
+    await createWaSocket(false, false, { authDir: "/tmp/wa-auth-a" });
+    const sockA = getLastSocket();
+
+    sockA.ev.emit("creds.update", {});
+    await flushCredsUpdate();
+
+    let drained = false;
+    const waitPromise = waitForCredsSaveQueue("/tmp/wa-auth-a").then(() => {
+      drained = true;
+    });
+
+    // Simulate a late creds.update that arrives while waiting on the first save.
+    sockA.ev.emit("creds.update", {});
+    await flushCredsUpdate();
+    expect(drained).toBe(false);
+
+    releaseA1?.();
+    await flushCredsUpdate();
+    expect(drained).toBe(false);
+
+    releaseA2?.();
+    await waitPromise;
+    expect(drained).toBe(true);
+    expect(saveCredsA).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -83,6 +83,10 @@ async function safeSaveCreds(
   }
 }
 
+export async function waitForCredsSaveQueue(): Promise<void> {
+  await credsSaveQueue;
+}
+
 /**
  * Create a Baileys socket backed by the multi-file auth store we keep on disk.
  * Consumers can opt into QR printing for interactive login flows.
@@ -184,10 +188,51 @@ export async function waitForWaConnection(sock: ReturnType<typeof makeWASocket>)
 }
 
 export function getStatusCode(err: unknown) {
-  return (
-    (err as { output?: { statusCode?: number } })?.output?.statusCode ??
-    (err as { status?: number })?.status
-  );
+  const queue: unknown[] = [err];
+  const seen = new Set<unknown>();
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || typeof current !== "object") {
+      continue;
+    }
+    if (seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+
+    const outputStatus = (current as { output?: { statusCode?: unknown } })?.output?.statusCode;
+    if (typeof outputStatus === "number") {
+      return outputStatus;
+    }
+
+    const statusCode = (current as { statusCode?: unknown })?.statusCode;
+    if (typeof statusCode === "number") {
+      return statusCode;
+    }
+
+    const status = (current as { status?: unknown })?.status;
+    if (typeof status === "number") {
+      return status;
+    }
+
+    const error = (current as { error?: unknown })?.error;
+    if (error) {
+      queue.push(error);
+    }
+
+    const lastDisconnect = (current as { lastDisconnect?: unknown })?.lastDisconnect;
+    if (lastDisconnect) {
+      queue.push(lastDisconnect);
+    }
+
+    const cause = (current as { cause?: unknown })?.cause;
+    if (cause) {
+      queue.push(cause);
+    }
+  }
+
+  return undefined;
 }
 
 function safeStringify(value: unknown, limit = 800): string {

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -31,17 +31,28 @@ export {
   webAuthExists,
 } from "./auth-store.js";
 
-let credsSaveQueue: Promise<void> = Promise.resolve();
+const credsSaveQueues = new Map<string, Promise<void>>();
+function getCredsSaveQueue(authDir: string): Promise<void> {
+  return credsSaveQueues.get(authDir) ?? Promise.resolve();
+}
+
 function enqueueSaveCreds(
   authDir: string,
   saveCreds: () => Promise<void> | void,
   logger: ReturnType<typeof getChildLogger>,
 ): void {
-  credsSaveQueue = credsSaveQueue
+  const nextQueue = getCredsSaveQueue(authDir)
     .then(() => safeSaveCreds(authDir, saveCreds, logger))
     .catch((err) => {
       logger.warn({ error: String(err) }, "WhatsApp creds save queue error");
     });
+  credsSaveQueues.set(authDir, nextQueue);
+  void nextQueue.finally(() => {
+    // Keep memory bounded: clear settled queue slots once no newer queue replaced them.
+    if (credsSaveQueues.get(authDir) === nextQueue) {
+      credsSaveQueues.delete(authDir);
+    }
+  });
 }
 
 async function safeSaveCreds(
@@ -83,8 +94,12 @@ async function safeSaveCreds(
   }
 }
 
-export async function waitForCredsSaveQueue(): Promise<void> {
-  await credsSaveQueue;
+export async function waitForCredsSaveQueue(authDir?: string): Promise<void> {
+  if (authDir) {
+    await getCredsSaveQueue(authDir);
+    return;
+  }
+  await Promise.all(credsSaveQueues.values());
 }
 
 /**

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -32,8 +32,8 @@ export {
 } from "./auth-store.js";
 
 const credsSaveQueues = new Map<string, Promise<void>>();
-function getCredsSaveQueue(authDir: string): Promise<void> {
-  return credsSaveQueues.get(authDir) ?? Promise.resolve();
+function getCredsSaveQueue(authDir: string): Promise<void> | undefined {
+  return credsSaveQueues.get(authDir);
 }
 
 function enqueueSaveCreds(
@@ -41,7 +41,7 @@ function enqueueSaveCreds(
   saveCreds: () => Promise<void> | void,
   logger: ReturnType<typeof getChildLogger>,
 ): void {
-  const nextQueue = getCredsSaveQueue(authDir)
+  const nextQueue = (getCredsSaveQueue(authDir) ?? Promise.resolve())
     .then(() => safeSaveCreds(authDir, saveCreds, logger))
     .catch((err) => {
       logger.warn({ error: String(err) }, "WhatsApp creds save queue error");
@@ -96,10 +96,30 @@ async function safeSaveCreds(
 
 export async function waitForCredsSaveQueue(authDir?: string): Promise<void> {
   if (authDir) {
-    await getCredsSaveQueue(authDir);
-    return;
+    while (true) {
+      const queue = getCredsSaveQueue(authDir);
+      if (!queue) {
+        return;
+      }
+      await queue;
+      // Late creds updates can enqueue a newer promise while we were waiting.
+      if (getCredsSaveQueue(authDir) === queue) {
+        return;
+      }
+    }
   }
-  await Promise.all(credsSaveQueues.values());
+
+  while (true) {
+    const snapshot = [...credsSaveQueues.values()];
+    if (snapshot.length === 0) {
+      return;
+    }
+    await Promise.all(snapshot);
+    const current = [...credsSaveQueues.values()];
+    if (current.every((queue) => snapshot.includes(queue))) {
+      return;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes the remaining relink dead-end for WhatsApp by handling three failure boundaries together:

- wrapped disconnect errors (for example `{ error: BoomError }`) now resolve status codes reliably
- QR restart-on-515 now waits for queued creds writes before opening the new socket
- monitor logged-out disconnects now clear cached auth before stopping

Fixes #4686
Fixes #33961

## Why this PR instead of existing related PRs

- #8409 is closed/unmerged
- #13696 adds CLI pairing-code UX but does not fix the stale-auth relink dead-end
- #30301 is open but stale/dirty and does not cover the 515 creds-flush boundary
- #27910, #34175, and #34178 split the 515 path into partial patches

This PR consolidates the required runtime fixes and test coverage in one merge-ready change.

## Changes

- `src/web/session.ts`
  - add `waitForCredsSaveQueue()` export
  - harden `getStatusCode()` to unwrap nested wrapper shapes (`error`, `lastDisconnect`, `cause`)
- `src/web/login-qr.ts`
  - await `waitForCredsSaveQueue()` before restart socket creation on 515
- `src/web/auto-reply/monitor.ts`
  - clear auth (`logoutWeb`) on logged-out close reason before monitor shutdown
- tests
  - `src/web/session.test.ts`: nested status extraction + creds queue wait regression
  - `src/web/login-qr.test.ts`: wrapped 515 shape + queue wait assertion
  - `src/web/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts`: logged-out cleanup regression

## Test plan

- `pnpm exec vitest run src/web/session.test.ts src/web/login-qr.test.ts`
- `pnpm exec vitest run --config vitest.e2e.config.ts src/web/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts`
- `pnpm check`
- `pnpm build`
