### PR TITLE
fix(exec): accept shell wrapper raw command for command validation

### DIFF
--- a/src/infra/system-run-command.test.ts
+++ b/src/infra/system-run-command.test.ts
@@ -107,6 +107,32 @@ describe("system run command helpers", () => {
     expect(res.ok).toBe(true);
   });
 
+  test("validateSystemRunCommandConsistency accepts shell wrapper rawCommand as full invocation when payload matches", () => {
+    const res = validateSystemRunCommandConsistency({
+      argv: ["/bin/sh", "-lc", "echo hello"],
+      rawCommand: '/bin/sh -lc "echo hello"',
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      throw new Error("unreachable");
+    }
+    expect(res.shellCommand).toBe('/bin/sh -lc "echo hello"');
+    expect(res.cmdText).toBe('/bin/sh -lc "echo hello"');
+  });
+
+  test("validateSystemRunCommandConsistency accepts powershell rawCommand as wrapper invocation when inline command matches", () => {
+    const res = validateSystemRunCommandConsistency({
+      argv: ["powershell", "-Command", "echo hello"],
+      rawCommand: 'powershell -Command "echo hello"',
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      throw new Error("unreachable");
+    }
+    expect(res.shellCommand).toBe('powershell -Command "echo hello"');
+    expect(res.cmdText).toBe('powershell -Command "echo hello"');
+  });
+
   test("validateSystemRunCommandConsistency rejects shell-only rawCommand for positional-argv carrier wrappers", () => {
     expectRawCommandMismatch({
       argv: ["/bin/sh", "-lc", '$0 "$1"', "/usr/bin/touch", "/tmp/marker"],

--- a/src/infra/system-run-command.ts
+++ b/src/infra/system-run-command.ts
@@ -1,3 +1,4 @@
+import { splitShellArgs } from "../utils/shell-argv.js";
 import {
   extractShellWrapperCommand,
   hasEnvManipulationBeforeShellWrapper,
@@ -54,6 +55,28 @@ export function formatExecCommand(argv: string[]): string {
 
 export function extractShellCommandFromArgv(argv: string[]): string | null {
   return extractShellWrapperCommand(argv).command;
+}
+
+function normalizeRawCommandForShellWrapperComparison(params: {
+  raw: string | null;
+  shellCommand: string | null;
+}): string | null {
+  if (!params.raw) {
+    return null;
+  }
+  if (!params.shellCommand) {
+    return params.raw;
+  }
+  const rawArgv = splitShellArgs(params.raw);
+  if (!rawArgv || rawArgv.length === 0) {
+    return params.raw;
+  }
+  const rawWrapper = extractShellWrapperCommand(rawArgv);
+  if (!rawWrapper.isWrapper || !rawWrapper.command) {
+    return params.raw;
+  }
+  const rawShellCommand = rawWrapper.command.trim();
+  return rawShellCommand === params.shellCommand.trim() ? rawShellCommand : params.raw;
 }
 
 const POSIX_OR_POWERSHELL_INLINE_WRAPPER_NAMES = new Set([
@@ -116,8 +139,15 @@ export function validateSystemRunCommandConsistency(params: {
     shellCommand !== null && !mustBindDisplayToFullArgv
       ? shellCommand.trim()
       : formatExecCommand(params.argv);
+  const compareRawCommand =
+    shellCommand !== null && !mustBindDisplayToFullArgv
+      ? normalizeRawCommandForShellWrapperComparison({
+          raw,
+          shellCommand: shellCommand.trim(),
+        })
+      : raw;
 
-  if (raw && raw !== inferred) {
+  if (compareRawCommand && compareRawCommand !== inferred) {
     return {
       ok: false,
       message: "INVALID_REQUEST: rawCommand does not match command",


### PR DESCRIPTION
## Summary
- Fixes #34658 - Agent exec tool broken with 'rawCommand mismatch' error in v2026.3.2
- Accept shell wrapper raw command text when it is a full inline invocation that parses to the same payload

## Changes
- `src/infra/system-run-command.ts`: Add normalizeRawCommandForShellWrapperComparison function
- `src/infra/system-run-command.test.ts`: Add regression tests

## Testing
- `pnpm vitest run src/infra/system-run-command.test.ts` - 33 tests pass

AI-assisted (Codex)