### PR TITLE
Fix: identify control UI and webchat UI as webchat clients

### DIFF
--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
+import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../gateway/protocol/client-info.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createMSTeamsTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { resolveGatewayMessageChannel } from "./message-channel.js";
+import { isWebchatClient, resolveGatewayMessageChannel } from "./message-channel.js";
 
 const emptyRegistry = createTestRegistry([]);
 const msteamsPlugin: ChannelPlugin = {
@@ -30,5 +31,17 @@ describe("message-channel", () => {
       createTestRegistry([{ pluginId: "msteams", plugin: msteamsPlugin, source: "test" }]),
     );
     expect(resolveGatewayMessageChannel("teams")).toBe("msteams");
+  });
+
+  it("identifies control UI and webchat UI as webchat clients", () => {
+    expect(
+      isWebchatClient({ id: GATEWAY_CLIENT_IDS.WEBCHAT_UI, mode: GATEWAY_CLIENT_MODES.WEBCHAT }),
+    ).toBe(true);
+    expect(
+      isWebchatClient({ id: GATEWAY_CLIENT_IDS.CONTROL_UI, mode: GATEWAY_CLIENT_MODES.WEBCHAT }),
+    ).toBe(true);
+    expect(
+      isWebchatClient({ id: GATEWAY_CLIENT_IDS.CONTROL_UI, mode: GATEWAY_CLIENT_MODES.UI }),
+    ).toBe(true);
   });
 });

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -5,6 +5,7 @@ import {
   normalizeChatChannelId,
 } from "../channels/registry.js";
 import {
+  GATEWAY_CLIENT_IDS,
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
   type GatewayClientMode,
@@ -49,7 +50,10 @@ export function isWebchatClient(client?: GatewayClientInfoLike | null): boolean 
   if (mode === GATEWAY_CLIENT_MODES.WEBCHAT) {
     return true;
   }
-  return normalizeGatewayClientName(client?.id) === GATEWAY_CLIENT_NAMES.WEBCHAT_UI;
+  const clientName = normalizeGatewayClientName(client?.id);
+  return (
+    clientName === GATEWAY_CLIENT_NAMES.WEBCHAT_UI || clientName === GATEWAY_CLIENT_IDS.CONTROL_UI
+  );
 }
 
 export function normalizeMessageChannel(raw?: string | null): string | undefined {


### PR DESCRIPTION
## Summary
- Extend isWebchatClient to recognize control UI clients
- Fix channel routing to use web instead of slack for control-ui/webchat

## Security Impact
None. This is a bug fix for message routing.

## Repro + Verification
1. Open web dashboard (control-ui)
2. Send message to agent
3. Check inbound metadata - channel should be web, not slack

## Testing
pnpm test src/utils/message-channel.test.ts

## AI Assisted
This change was assisted by AI (Codex).

Fixes #34647