### PR TITLE
fix(telegram): always apply final text in preview edits, bypassing regressive skip

### DIFF
--- a/src/telegram/lane-delivery.test.ts
+++ b/src/telegram/lane-delivery.test.ts
@@ -181,7 +181,7 @@ describe("createLaneTextDeliverer", () => {
     );
   });
 
-  it("keeps existing preview when final text regresses", async () => {
+  it("always applies final text even when it regresses (#33854)", async () => {
     const harness = createHarness({ answerMessageId: 999 });
     harness.lanes.answer.lastPartialText = "Recovered final answer.";
 
@@ -193,9 +193,14 @@ describe("createLaneTextDeliverer", () => {
     });
 
     expect(result).toBe("preview-finalized");
-    expect(harness.editPreview).not.toHaveBeenCalled();
+    expect(harness.editPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: 999,
+        text: "Recovered final answer",
+        context: "final",
+      }),
+    );
     expect(harness.sendPayload).not.toHaveBeenCalled();
-    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to normal delivery when final text exceeds preview edit limit", async () => {
@@ -336,6 +341,27 @@ describe("createLaneTextDeliverer", () => {
       expect.objectContaining({ text: "Choose one" }),
     );
     expect(harness.markDelivered).not.toHaveBeenCalled();
+  });
+
+  it("does not skip regressive preview update for final context (#33854)", async () => {
+    const harness = createHarness({ answerMessageId: 888 });
+    harness.lanes.answer.lastPartialText = "Let me check that for you in detail";
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Let me check",
+      payload: { text: "Let me check" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-finalized");
+    expect(harness.editPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: 888,
+        text: "Let me check",
+        context: "final",
+      }),
+    );
   });
 
   it("deletes consumed boundary previews after fallback final send", async () => {

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -258,16 +258,22 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       treatEditFailureAsDelivered: boolean,
       hadPreviewMessage: boolean,
     ): boolean | Promise<boolean> => {
-      const currentPreviewText = previewTextSnapshot ?? getLanePreviewText(lane);
-      const shouldSkipRegressive = shouldSkipRegressivePreviewUpdate({
-        currentPreviewText,
-        text,
-        skipRegressive,
-        hadPreviewMessage,
-      });
-      if (shouldSkipRegressive) {
-        params.markDelivered();
-        return true;
+      // Final delivery must always apply the authoritative content — never skip
+      // the edit for a "regressive" update.  The skip-regressive guard is only
+      // appropriate for mid-stream preview edits where a shorter partial would
+      // flicker over a longer one (#33854).
+      if (context !== "final") {
+        const currentPreviewText = previewTextSnapshot ?? getLanePreviewText(lane);
+        const shouldSkipRegressive = shouldSkipRegressivePreviewUpdate({
+          currentPreviewText,
+          text,
+          skipRegressive,
+          hadPreviewMessage,
+        });
+        if (shouldSkipRegressive) {
+          params.markDelivered();
+          return true;
+        }
       }
       return editPreview(previewMessageId, treatEditFailureAsDelivered);
     };


### PR DESCRIPTION
## Summary

- Problem: `shouldSkipRegressivePreviewUpdate` was applied to final deliveries. When an archived preview contained longer text than the final payload (e.g. streaming produced "Let me check that for you" but the final text was "Let me check"), the regressive-skip guard marked the reply as "delivered" via `markDelivered()` without editing the message — the user never saw the final content.
- Why it matters: Telegram users see the agent "respond" (preview appears) but the final text is silently dropped. The conversation appears broken.
- What changed: In `finalizePreview`, bypass `shouldSkipRegressivePreviewUpdate` when `context === "final"`. The skip-regressive guard now only applies to mid-stream preview updates (`context === "update"`).
- What did NOT change (scope boundary): Mid-stream preview flicker prevention is preserved. The `shouldSkipRegressivePreviewUpdate` function itself is unchanged. Only the call site in `finalizePreview` is guarded.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33854

## User-visible / Behavior Changes

- Telegram final replies are now always applied to the preview message, even when shorter than the current preview text.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Connect a Telegram bot
2. Trigger a reply that streams a long partial (e.g. "Let me check that for you in detail")
3. The final reply text is shorter (e.g. "Let me check") — this can happen when the model revises its response

### Expected

- The preview message is edited to show the final text "Let me check"

### Actual

- Before: The preview stays at the longer streaming text; `markDelivered()` is called without editing
- After: The preview is edited to the authoritative final text

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Updated 1 existing test and added 1 new test. All 14 tests in `lane-delivery.test.ts` pass.

## Human Verification (required)

- Verified scenarios: final text shorter than preview (regressive), final text longer than preview, final text equal to preview, final text with archived preview.
- Edge cases checked: empty preview text, no preview message (fallback to sendPayload), draft transport previews.
- What you did **not** verify: end-to-end Telegram delivery (requires live bot).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit to restore the regressive-skip for final context.
- Files/config to restore: `src/telegram/lane-delivery.ts`

## Risks and Mitigations

- Risk: Final text that is a prefix of the preview text will now trigger an edit, which could briefly show a shorter message before the user sees the final version.
  - Mitigation: This is the correct behavior — the final text IS the authoritative content. Users should see the final version, not a longer streaming artifact.