### PR TITLE
fix(gateway): allow session rename from webchat clients

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -30,6 +30,7 @@ import {
   validateSessionsCompactParams,
   validateSessionsDeleteParams,
   validateSessionsListParams,
+  type SessionsPatchParams,
   validateSessionsPatchParams,
   validateSessionsPreviewParams,
   validateSessionsResetParams,
@@ -80,6 +81,7 @@ function resolveGatewaySessionTargetFromKey(key: string) {
 
 function rejectWebchatSessionMutation(params: {
   action: "patch" | "delete";
+  patch?: SessionsPatchParams;
   client: GatewayClient | null;
   isWebchatConnect: (params: GatewayClient["connect"] | null | undefined) => boolean;
   respond: RespondFn;
@@ -88,6 +90,9 @@ function rejectWebchatSessionMutation(params: {
     return false;
   }
   if (params.client.connect.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI) {
+    return false;
+  }
+  if (params.action === "patch" && isLabelOnlyPatch(params.patch)) {
     return false;
   }
   params.respond(
@@ -99,6 +104,13 @@ function rejectWebchatSessionMutation(params: {
     ),
   );
   return true;
+}
+
+function isLabelOnlyPatch(patch: SessionsPatchParams | undefined): boolean {
+  if (!patch || !("label" in patch)) {
+    return false;
+  }
+  return Object.keys(patch).every((key) => key === "label" || key === "key");
 }
 
 function migrateAndPruneSessionStoreKey(params: {
@@ -411,7 +423,15 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     if (!key) {
       return;
     }
-    if (rejectWebchatSessionMutation({ action: "patch", client, isWebchatConnect, respond })) {
+    if (
+      rejectWebchatSessionMutation({
+        action: "patch",
+        patch: p,
+        client,
+        isWebchatConnect,
+        respond,
+      })
+    ) {
       return;
     }
 

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1239,12 +1239,24 @@ describe("gateway server sessions", () => {
       scopes: ["operator.admin"],
     });
 
-    const patched = await rpcReq(ws, "sessions.patch", {
+    const patched = await rpcReq<{ ok: true; key: string; entry: { label?: string } }>(
+      ws,
+      "sessions.patch",
+      {
+        key: "agent:main:discord:group:dev",
+        label: "should-work",
+      },
+    );
+    expect(patched.ok).toBe(true);
+    expect(patched.payload?.key).toBe("agent:main:discord:group:dev");
+    expect(patched.payload?.entry.label).toBe("should-work");
+
+    const blocked = await rpcReq(ws, "sessions.patch", {
       key: "agent:main:discord:group:dev",
-      label: "should-fail",
+      thinkingLevel: "high",
     });
-    expect(patched.ok).toBe(false);
-    expect(patched.error?.message ?? "").toMatch(/webchat clients cannot patch sessions/i);
+    expect(blocked.ok).toBe(false);
+    expect(blocked.error?.message ?? "").toMatch(/webchat clients cannot patch sessions/i);
 
     const deleted = await rpcReq(ws, "sessions.delete", {
       key: "agent:main:discord:group:dev",


### PR DESCRIPTION
## Summary
- Fixes #26541 - Session rename feature broken
- Allow label-only sessions.patch updates from webchat clients while keeping other mutations restricted

## Changes
- `src/gateway/server-methods/sessions.ts`: Add isLabelOnlyPatch helper
- `src/gateway/server.sessions.gateway-server-sessions-a.test.ts`: Update regression test

AI-assisted (Codex)