### PR TITLE
fix(plugins): deduplicate plugin registrations to suppress upgrade warning

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -130,7 +130,7 @@ afterEach(() => {
 });
 
 describe("loadPluginManifestRegistry", () => {
-  it("emits duplicate warning for truly distinct plugins with same id", () => {
+  it("deduplicates distinct-directory plugins with same id using precedence and emits info diagnostic", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "test-plugin", configSchema: { type: "object" } };
@@ -150,7 +150,45 @@ describe("loadPluginManifestRegistry", () => {
       }),
     ];
 
-    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
+    const registry = loadRegistry(candidates);
+    // No warn-level duplicate diagnostics
+    expect(countDuplicateWarnings(registry)).toBe(0);
+    // Info-level diagnostic emitted instead
+    const infoDiags = registry.diagnostics.filter(
+      (d) => d.level === "info" && d.message?.includes("duplicate plugin id"),
+    );
+    expect(infoDiags.length).toBe(1);
+    // Only one plugin record kept (deduplicated)
+    expect(registry.plugins.length).toBe(1);
+    // Higher precedence origin wins (global > bundled)
+    expect(registry.plugins[0]?.origin).toBe("global");
+  });
+
+  it("selects higher-precedence origin when distinct-directory duplicates appear in any order", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "feishu-dedup", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    // config origin comes second but has highest precedence
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "feishu-dedup",
+        rootDir: dirA,
+        origin: "bundled",
+      }),
+      createPluginCandidate({
+        idHint: "feishu-dedup",
+        rootDir: dirB,
+        origin: "config",
+      }),
+    ];
+
+    const registry = loadRegistry(candidates);
+    expect(countDuplicateWarnings(registry)).toBe(0);
+    expect(registry.plugins.length).toBe(1);
+    expect(registry.plugins[0]?.origin).toBe("config");
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -229,12 +229,30 @@ export function loadPluginManifestRegistry(params: {
         }
         continue;
       }
+      // Distinct-directory duplicate: apply precedence-based dedup.
+      // Keep the higher-precedence origin and skip the lower-precedence one
+      // instead of registering both. Downgrade to info since this is expected
+      // during upgrades (e.g. feishu in both legacy bundled and new global path).
+      const candidateRank = PLUGIN_ORIGIN_RANK[candidate.origin];
+      const existingRank = PLUGIN_ORIGIN_RANK[existing.candidate.origin];
+      if (candidateRank < existingRank) {
+        // Incoming candidate has higher precedence — replace the existing record
+        records[existing.recordIndex] = buildRecord({
+          manifest,
+          candidate,
+          manifestPath: manifestRes.manifestPath,
+          schemaCacheKey,
+          configSchema,
+        });
+        seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
+      }
       diagnostics.push({
-        level: "warn",
+        level: "info",
         pluginId: manifest.id,
         source: candidate.source,
-        message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
+        message: `duplicate plugin id "${manifest.id}" from distinct directory skipped in favor of ${candidateRank < existingRank ? candidate.origin : existing.candidate.origin} origin (${candidateRank < existingRank ? candidate.source : existing.candidate.source})`,
       });
+      continue;
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     }


### PR DESCRIPTION
## Summary

- **Problem:** After upgrading, the feishu extension was detected in both the legacy bundled path and the new global/config path, producing a confusing "duplicate plugin" warning.
- **Why it matters:** Users see a scary warning after every upgrade that suggests something is broken when it's just a path migration artifact.
- **What changed:** Applied precedence-based deduplication for distinct-directory duplicates. The duplicate is skipped instead of registered, and the diagnostic is downgraded from `warn` to `info`.
- **What did NOT change:** Same-directory duplicate detection unchanged. Plugin loading order unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34394

## User-visible / Behavior Changes

- No more "duplicate plugin" warning after upgrade
- Duplicate detection downgraded from warn to info level

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Feishu extension

### Steps

1. Upgrade OpenClaw with feishu extension
2. Start gateway

### Expected

- No duplicate plugin warning

### Actual

- Before fix: Warning about duplicate feishu plugin
- After fix: Info-level log, no user-facing warning

## Evidence

2 tests: existing test updated to verify dedup, new test for precedence selection. All 8 tests pass.

## Human Verification (required)

- Verified scenarios: Same plugin in two dirs → deduplicated with precedence; same dir → existing behavior preserved
- Edge cases checked: Precedence ordering
- What I did **not** verify: Live upgrade test

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert commit
- Files/config to restore: 2 files
- Known bad symptoms: Duplicate plugin warning returns

## Risks and Mitigations

- Low risk: Only changes diagnostic level and adds dedup skip.
