### PR TITLE
feat(telegram): persist inbound webhooks to survive restarts

### DIFF
--- a/src/infra/webhook-queue.test.ts
+++ b/src/infra/webhook-queue.test.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { dequeueWebhook, enqueueWebhook, replayPendingWebhooks } from "./webhook-queue.js";
+
+describe("webhook-queue", () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "webhook-queue-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(stateDir, { recursive: true, force: true });
+  });
+
+  const payload = { update_id: 100, message: { text: "hello" } };
+
+  it("enqueue writes a file and dequeue removes it", async () => {
+    await enqueueWebhook("telegram", "100", payload, stateDir);
+
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const files = await fs.promises.readdir(queueDir);
+    expect(files).toEqual(["telegram-100.json"]);
+
+    const content = JSON.parse(await fs.promises.readFile(path.join(queueDir, files[0]), "utf-8"));
+    expect(content.channelId).toBe("telegram");
+    expect(content.deduplicationId).toBe("100");
+    expect(content.payload).toEqual(payload);
+    expect(typeof content.enqueuedAt).toBe("number");
+
+    await dequeueWebhook("telegram", "100", stateDir);
+    const remaining = await fs.promises.readdir(queueDir);
+    expect(remaining).toEqual([]);
+  });
+
+  it("dequeue is idempotent (no error on missing file)", async () => {
+    await expect(dequeueWebhook("telegram", "999", stateDir)).resolves.toBeUndefined();
+  });
+
+  it("replayPendingWebhooks returns entries sorted by enqueue time", async () => {
+    const now = Date.now();
+    await enqueueWebhook("telegram", "1", { update_id: 1 }, stateDir);
+    // Ensure distinct timestamps.
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const file1 = path.join(queueDir, "telegram-1.json");
+    const entry1 = JSON.parse(await fs.promises.readFile(file1, "utf-8"));
+    entry1.enqueuedAt = now - 2000;
+    await fs.promises.writeFile(file1, JSON.stringify(entry1));
+
+    await enqueueWebhook("telegram", "2", { update_id: 2 }, stateDir);
+    const file2 = path.join(queueDir, "telegram-2.json");
+    const entry2 = JSON.parse(await fs.promises.readFile(file2, "utf-8"));
+    entry2.enqueuedAt = now - 5000; // Earlier timestamp.
+    await fs.promises.writeFile(file2, JSON.stringify(entry2));
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(2);
+    expect(pending[0].deduplicationId).toBe("2"); // Earlier first.
+    expect(pending[1].deduplicationId).toBe("1");
+  });
+
+  it("replayPendingWebhooks deduplicates by deduplicationId", async () => {
+    await enqueueWebhook("telegram", "100", { update_id: 100, v: 1 }, stateDir);
+    // Write a second file with the same deduplicationId but different channelId
+    // to test dedup across channels — only the earliest should survive.
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const dup: Record<string, unknown> = {
+      channelId: "other",
+      deduplicationId: "100",
+      enqueuedAt: Date.now() + 1000,
+      payload: { update_id: 100, v: 2 },
+    };
+    await fs.promises.writeFile(path.join(queueDir, "other-100.json"), JSON.stringify(dup));
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(1);
+    expect((pending[0].payload as Record<string, unknown>).v).toBe(1);
+  });
+
+  it("replayPendingWebhooks filters by channelId when specified", async () => {
+    await enqueueWebhook("telegram", "1", { update_id: 1 }, stateDir);
+    await enqueueWebhook("whatsapp", "2", { id: "abc" }, stateDir);
+
+    const telegramOnly = await replayPendingWebhooks("telegram", stateDir);
+    expect(telegramOnly).toHaveLength(1);
+    expect(telegramOnly[0].channelId).toBe("telegram");
+  });
+
+  it("replayPendingWebhooks cleans up entries older than 1 hour", async () => {
+    await enqueueWebhook("telegram", "old", { update_id: 1 }, stateDir);
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const oldFile = path.join(queueDir, "telegram-old.json");
+    const entry = JSON.parse(await fs.promises.readFile(oldFile, "utf-8"));
+    entry.enqueuedAt = Date.now() - 2 * 60 * 60 * 1000; // 2 hours ago.
+    await fs.promises.writeFile(oldFile, JSON.stringify(entry));
+
+    await enqueueWebhook("telegram", "fresh", { update_id: 2 }, stateDir);
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].deduplicationId).toBe("fresh");
+
+    // Old file should be deleted.
+    await expect(fs.promises.access(oldFile)).rejects.toThrow();
+  });
+
+  it("replayPendingWebhooks returns empty array when queue dir does not exist", async () => {
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toEqual([]);
+  });
+
+  it("replayPendingWebhooks skips malformed files", async () => {
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    await fs.promises.writeFile(path.join(queueDir, "bad-file.json"), "not json{{{");
+    await enqueueWebhook("telegram", "1", { update_id: 1 }, stateDir);
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].deduplicationId).toBe("1");
+  });
+
+  it("handles many queued messages replayed in order", async () => {
+    const now = Date.now();
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    for (let i = 0; i < 50; i++) {
+      const entry = {
+        channelId: "telegram",
+        deduplicationId: String(i),
+        enqueuedAt: now - (50 - i) * 100, // Reverse ID order to test sorting.
+        payload: { update_id: i },
+      };
+      await fs.promises.writeFile(path.join(queueDir, `telegram-${i}.json`), JSON.stringify(entry));
+    }
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(50);
+    // Sorted by enqueuedAt ascending: update_id 0 has earliest enqueuedAt.
+    expect(pending[0].deduplicationId).toBe("0");
+    expect(pending[49].deduplicationId).toBe("49");
+  });
+
+  it("replayPendingWebhooks breaks timestamp ties by deduplicationId", async () => {
+    const now = Date.now();
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    // Three entries with the same timestamp — order must be deterministic.
+    for (const id of ["300", "100", "200"]) {
+      const entry = { channelId: "telegram", deduplicationId: id, enqueuedAt: now, payload: {} };
+      await fs.promises.writeFile(
+        path.join(queueDir, `telegram-${id}.json`),
+        JSON.stringify(entry),
+      );
+    }
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending.map((e) => e.deduplicationId)).toEqual(["100", "200", "300"]);
+  });
+
+  it("replayPendingWebhooks cleans up orphaned .tmp files", async () => {
+    const queueDir = path.join(stateDir, "webhook-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true });
+    // Simulate an orphaned temp file from an interrupted write.
+    await fs.promises.writeFile(path.join(queueDir, "telegram-42.json.12345.tmp"), "partial");
+    await enqueueWebhook("telegram", "1", { update_id: 1 }, stateDir);
+
+    const pending = await replayPendingWebhooks(undefined, stateDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].deduplicationId).toBe("1");
+
+    // Orphaned tmp file should be deleted.
+    const remaining = await fs.promises.readdir(queueDir);
+    expect(remaining.some((f) => f.endsWith(".tmp"))).toBe(false);
+  });
+
+  it("enqueue overwrites existing entry with same deduplicationId", async () => {
+    await enqueueWebhook("telegram", "100", { update_id: 100, v: 1 }, stateDir);
+    await enqueueWebhook("telegram", "100", { update_id: 100, v: 2 }, stateDir);
+
+    const queueDir = path.join(stateDir, "webhook-queue");
+    const files = await fs.promises.readdir(queueDir);
+    expect(files).toHaveLength(1);
+
+    const content = JSON.parse(await fs.promises.readFile(path.join(queueDir, files[0]), "utf-8"));
+    expect(content.payload.v).toBe(2);
+  });
+});

--- a/src/infra/webhook-queue.ts
+++ b/src/infra/webhook-queue.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+const QUEUE_DIRNAME = "webhook-queue";
+const MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
+
+export interface WebhookQueueEntry {
+  channelId: string;
+  deduplicationId: string;
+  enqueuedAt: number;
+  payload: unknown;
+}
+
+function resolveQueueDir(stateDir?: string): string {
+  const base = stateDir ?? resolveStateDir();
+  return path.join(base, QUEUE_DIRNAME);
+}
+
+function entryFilename(channelId: string, deduplicationId: string): string {
+  return `${channelId}-${deduplicationId}.json`;
+}
+
+async function ensureQueueDir(queueDir: string): Promise<void> {
+  await fs.promises.mkdir(queueDir, { recursive: true, mode: 0o700 });
+}
+
+/**
+ * Persist an inbound webhook payload to disk before acknowledging receipt.
+ * Write failure must NOT block normal processing — callers should catch errors.
+ */
+export async function enqueueWebhook(
+  channelId: string,
+  deduplicationId: string,
+  payload: unknown,
+  stateDir?: string,
+): Promise<void> {
+  const queueDir = resolveQueueDir(stateDir);
+  await ensureQueueDir(queueDir);
+  const entry: WebhookQueueEntry = {
+    channelId,
+    deduplicationId,
+    enqueuedAt: Date.now(),
+    payload,
+  };
+  const filePath = path.join(queueDir, entryFilename(channelId, deduplicationId));
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  await fs.promises.writeFile(tmp, JSON.stringify(entry), { encoding: "utf-8", mode: 0o600 });
+  await fs.promises.rename(tmp, filePath);
+}
+
+/** Remove a processed webhook entry from the queue. */
+export async function dequeueWebhook(
+  channelId: string,
+  deduplicationId: string,
+  stateDir?: string,
+): Promise<void> {
+  const filePath = path.join(resolveQueueDir(stateDir), entryFilename(channelId, deduplicationId));
+  try {
+    await fs.promises.unlink(filePath);
+  } catch (err) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as { code?: string }).code === "ENOENT"
+    ) {
+      return; // Already removed — no-op.
+    }
+    throw err;
+  }
+}
+
+/**
+ * Load all pending webhook entries, sorted by enqueue time, deduplicated by
+ * deduplicationId. Entries older than 1 hour are deleted (cleanup).
+ */
+export async function replayPendingWebhooks(
+  channelId?: string,
+  stateDir?: string,
+): Promise<WebhookQueueEntry[]> {
+  const queueDir = resolveQueueDir(stateDir);
+  let files: string[];
+  try {
+    files = await fs.promises.readdir(queueDir);
+  } catch (err) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as { code?: string }).code === "ENOENT"
+    ) {
+      return [];
+    }
+    throw err;
+  }
+
+  const now = Date.now();
+  const entries: WebhookQueueEntry[] = [];
+
+  for (const file of files) {
+    // Clean up orphaned temp files from interrupted writes.
+    if (file.endsWith(".tmp")) {
+      await fs.promises.unlink(path.join(queueDir, file)).catch(() => {});
+      continue;
+    }
+    if (!file.endsWith(".json")) {
+      continue;
+    }
+    const filePath = path.join(queueDir, file);
+    try {
+      const raw = await fs.promises.readFile(filePath, "utf-8");
+      const entry = JSON.parse(raw) as WebhookQueueEntry;
+
+      // Cleanup: delete entries older than 1 hour.
+      if (now - entry.enqueuedAt > MAX_AGE_MS) {
+        await fs.promises.unlink(filePath).catch(() => {});
+        continue;
+      }
+
+      // Filter by channel if specified.
+      if (channelId && entry.channelId !== channelId) {
+        continue;
+      }
+
+      entries.push(entry);
+    } catch {
+      // Skip malformed or inaccessible entries.
+    }
+  }
+
+  // Sort oldest first; break timestamp ties deterministically by deduplicationId.
+  entries.sort(
+    (a, b) => a.enqueuedAt - b.enqueuedAt || a.deduplicationId.localeCompare(b.deduplicationId),
+  );
+
+  // Deduplicate by deduplicationId (keep earliest).
+  const seen = new Set<string>();
+  return entries.filter((e) => {
+    if (seen.has(e.deduplicationId)) {
+      return false;
+    }
+    seen.add(e.deduplicationId);
+    return true;
+  });
+}

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -56,6 +56,8 @@ export type TelegramBotOptions = {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
   };
+  /** Called when a Telegram update has been fully processed (for webhook queue dequeue). */
+  onUpdateProcessed?: (updateId: number) => void;
 };
 
 export { getTelegramSequentialKey };
@@ -160,6 +162,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
           highestCompletedUpdateId = updateId;
         }
         maybePersistSafeWatermark();
+        opts.onUpdateProcessed?.(updateId);
       }
     }
   });

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { readJsonBodyWithLimit } from "../infra/http-body.js";
+import { dequeueWebhook, enqueueWebhook, replayPendingWebhooks } from "../infra/webhook-queue.js";
 import {
   logWebhookError,
   logWebhookProcessed,
@@ -87,6 +88,8 @@ export async function startTelegramWebhook(opts: {
   abortSignal?: AbortSignal;
   healthPath?: string;
   publicUrl?: string;
+  /** Override state directory for webhook queue (tests). */
+  stateDir?: string;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -107,12 +110,35 @@ export async function startTelegramWebhook(opts: {
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    onUpdateProcessed: (updateId) => {
+      dequeueWebhook("telegram", String(updateId), opts.stateDir).catch(() => {});
+    },
   });
   await initializeTelegramWebhookBot({
     bot,
     runtime,
     abortSignal: opts.abortSignal,
   });
+
+  // Replay any webhook payloads that were enqueued but not fully processed
+  // before the last shutdown.
+  const pending = await replayPendingWebhooks("telegram", opts.stateDir);
+  for (const entry of pending) {
+    try {
+      await bot.handleUpdate(entry.payload as Parameters<typeof bot.handleUpdate>[0]);
+    } catch (err) {
+      runtime.log?.(
+        `webhook replay failed for update ${entry.deduplicationId}: ${formatErrorMessage(err)}`,
+      );
+    }
+    // Dequeue happens via onUpdateProcessed in the bot middleware.
+    // If handleUpdate threw before middleware ran, dequeue manually.
+    await dequeueWebhook("telegram", entry.deduplicationId, opts.stateDir).catch(() => {});
+  }
+  if (pending.length > 0) {
+    runtime.log?.(`webhook queue: replayed ${pending.length} pending update(s)`);
+  }
+
   const handler = webhookCallback(bot, "callback", {
     secretToken: secret,
     onTimeout: "return",
@@ -190,6 +216,25 @@ export async function startTelegramWebhook(opts: {
       };
       const secretHeaderRaw = req.headers["x-telegram-bot-api-secret-token"];
       const secretHeader = Array.isArray(secretHeaderRaw) ? secretHeaderRaw[0] : secretHeaderRaw;
+
+      // Validate webhook secret before persisting anything to disk.
+      if (secretHeader !== secret) {
+        await unauthorized();
+        return;
+      }
+
+      // Persist payload to disk before processing so it survives a restart.
+      const updateId =
+        body.value && typeof body.value === "object" && "update_id" in body.value
+          ? (body.value as { update_id?: unknown }).update_id
+          : undefined;
+      if (typeof updateId === "number") {
+        try {
+          await enqueueWebhook("telegram", String(updateId), body.value, opts.stateDir);
+        } catch {
+          // Queue write failure must not block normal processing.
+        }
+      }
 
       await handler(body.value, reply, secretHeader, unauthorized);
       if (!replied) {


### PR DESCRIPTION
### Problem

Telegram webhook mode acknowledges messages with 200 OK immediately. If a gateway restart happens mid-processing, queued messages are lost permanently - Telegram already considers them delivered.

### Solution

Persist inbound webhook payloads to disk before processing. On restart, replay any unprocessed payloads.

### How it works

1. `enqueueWebhook()` writes the raw payload to `~/.openclaw/webhook-queue/<deduplicationId>.json` via atomic rename (write to `.tmp`, then `rename`)
2. Handler processes the message normally
3. `dequeueWebhook()` deletes the file after successful processing
4. On startup, `replayPendingWebhooks()` scans the queue directory and re-dispatches any remaining payloads in `enqueuedAt` order (with `deduplicationId` tie-breaking for same-timestamp bursts)

### Security

- Webhook secret validation happens BEFORE enqueue - unauthenticated payloads are never persisted
- Orphaned `.tmp` files (from crashes between write and rename) are cleaned up during replay

### Config

No config needed - webhook queue activates automatically for Telegram webhook mode. Queue directory is created lazily on first webhook.
