### PR TITLE
fix(models): apply updated config apiKey in merge mode

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -207,7 +207,7 @@ describe("models-config", () => {
     });
   });
 
-  it("preserves non-empty agent apiKey/baseUrl for matching providers in merge mode", async () => {
+  it("applies config apiKey when non-empty but preserves agent baseUrl in merge mode", async () => {
     await withTempHome(async () => {
       const parsed = await runCustomProviderMergeTest({
         baseUrl: "https://agent.example/v1",
@@ -215,8 +215,49 @@ describe("models-config", () => {
         api: "openai-responses",
         models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
       });
-      expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
+      expect(parsed.providers.custom?.apiKey).toBe("CONFIG_KEY");
       expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
+    });
+  });
+
+  it("preserves existing agent apiKey when config apiKey is absent", async () => {
+    await withTempHome(async () => {
+      await writeAgentModelsJson({
+        providers: {
+          custom: {
+            baseUrl: "https://agent.example/v1",
+            apiKey: "AGENT_KEY",
+            api: "openai-responses",
+            models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
+          },
+        },
+      });
+      await ensureOpenClawModelsJson({
+        models: {
+          mode: "merge",
+          providers: {
+            custom: {
+              baseUrl: "https://config.example/v1",
+              api: "openai-responses",
+              models: [
+                {
+                  id: "config-model",
+                  name: "Config model",
+                  input: ["text"] as Array<"text" | "image">,
+                  reasoning: false,
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 2048,
+                },
+              ],
+            },
+          },
+        },
+      });
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<string, { apiKey?: string; baseUrl?: string }>;
+      }>();
+      expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
     });
   });
 

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -159,7 +159,10 @@ function mergeWithExistingProviderSecrets(params: {
       continue;
     }
     const preserved: Record<string, unknown> = {};
-    if (typeof existing.apiKey === "string" && existing.apiKey) {
+    const hasConfigApiKey =
+      typeof newEntry.apiKey === "string" && newEntry.apiKey.trim().length > 0;
+    // Keep existing apiKey only when config does not provide one.
+    if (!hasConfigApiKey && typeof existing.apiKey === "string" && existing.apiKey) {
       preserved.apiKey = existing.apiKey;
     }
     if (typeof existing.baseUrl === "string" && existing.baseUrl) {


### PR DESCRIPTION
## Summary

- **Problem:** In merge mode, `mergeWithExistingProviderSecrets()` unconditionally preserved the existing `apiKey` from `models.json`, silently ignoring `apiKey` updates made in `openclaw.json`. When users rotated or changed their API key (e.g. switching from a global MiniMax key to a CN-region key), the stale key in `models.json` always took precedence, causing HTTP 401 `authentication_error: invalid api key` on every LLM request.
- **Why it matters:** Users cannot update API keys through the config file alone — the old key persists across gateway restarts, breaking all message sends until the user manually deletes `models.json`.
- **What changed:** `mergeWithExistingProviderSecrets()` now only preserves the existing `apiKey` when the config does not provide a non-empty replacement. When config specifies a new `apiKey`, it takes precedence over the stale `models.json` value.
- **What did NOT change (scope boundary):** `baseUrl` preservation logic is untouched (addressed separately in #34558). Model list merging, implicit provider discovery, and auth profile resolution are all unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Auth / tokens

## Linked Issue/PR

- Closes #34656
- Related #34558 (same pattern applied to `baseUrl`)

## User-visible / Behavior Changes

API key changes in `openclaw.json` now take effect after gateway restart without requiring manual deletion of the agent's `models.json`. Previously, stale keys in `models.json` silently overrode config-level changes.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — config-provided `apiKey` now takes precedence over stale `models.json` value
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: The change only affects which `apiKey` value is written to `models.json` during merge. When config provides a non-empty key, it is used instead of the existing one. When config does not provide a key, existing behavior is preserved. This is the same pattern already used for `baseUrl` in #34558.

## Repro + Verification

### Environment

- OS: Any (macOS, Linux, Windows)
- Runtime/container: Node 22+
- Model/provider: Any provider with `apiKey` in `openclaw.json` (e.g. MiniMax, Moonshot)
- Relevant config: `models.providers.<provider>.apiKey` in `openclaw.json`

### Steps

1. Configure a provider (e.g. MiniMax) via onboarding — key is stored in `models.json`
2. Update the `apiKey` in `openclaw.json` (e.g. rotate key or switch regions)
3. Run `openclaw gateway restart`
4. Send a message

### Expected

- Gateway uses the new API key from config; message succeeds

### Actual (before fix)

- Gateway uses the stale API key from `models.json`; HTTP 401 `authentication_error: invalid api key`

## Evidence

- [x] Failing test/log before + passing after
  - Modified test `applies config apiKey when non-empty but preserves agent baseUrl in merge mode` — previously expected `AGENT_KEY` (stale), now correctly expects `CONFIG_KEY` (from config)
  - New test `preserves existing agent apiKey when config apiKey is absent` — verifies backward compatibility

## Human Verification (required)

- Verified scenarios: Config provides new apiKey → new key written to models.json; Config omits apiKey → existing key preserved; Config provides empty apiKey → existing key preserved
- Edge cases checked: Empty string apiKey in config, whitespace-only apiKey in config
- What I did **not** verify: Live gateway restart with real provider keys (no access to test environment)

## Compatibility / Migration

- Backward compatible? Yes — existing behavior preserved when config does not specify apiKey
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; restore unconditional apiKey preservation in `mergeWithExistingProviderSecrets()`
- Files/config to restore: `src/agents/models-config.ts`
- Known bad symptoms reviewers should watch for: If a user relies on models.json apiKey being preserved over env-derived keys, the env key would now take precedence. This is unlikely since env keys are the fresh/canonical source.

## Risks and Mitigations

- Risk: Users who intentionally set apiKey only in models.json (not in config/env) and later add a different config-level key may see their models.json key overwritten
  - Mitigation: This is the expected behavior — config is the authoritative source. The existing key is still preserved when config doesn't specify one. Same pattern as the baseUrl fix in #34558.