### PR TITLE
fix(cron): enable delivery context for systemEvent jobs with --wake now

### DIFF
--- a/src/cron/service.main-job-passes-heartbeat-target-last.test.ts
+++ b/src/cron/service.main-job-passes-heartbeat-target-last.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { CronService } from "./service.js";
 import { setupCronServiceSuite, writeCronStoreSnapshot } from "./service.test-harness.js";
-import type { CronJob } from "./types.js";
+import type { CronJob, CronMessageChannel } from "./types.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({
   prefix: "cron-main-heartbeat-target",
@@ -116,5 +116,121 @@ describe("cron main job passes heartbeat target=last", () => {
     expect(requestHeartbeatNow).toHaveBeenCalled();
     // runHeartbeatOnce should NOT have been called for next-heartbeat mode
     expect(runHeartbeatOnce).not.toHaveBeenCalled();
+  });
+
+  it("should pass explicit delivery channel to runHeartbeatOnce", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.now();
+
+    const job: CronJob = {
+      ...createMainCronJob({ now, id: "test-explicit-channel", wakeMode: "now" }),
+      delivery: {
+        mode: "announce",
+        channel: "discord" as CronMessageChannel,
+        to: "channel:123",
+      },
+    };
+
+    await writeCronStoreSnapshot({ storePath, jobs: [job] });
+
+    const runHeartbeatOnce = vi.fn<RunHeartbeatOnce>(async () => ({
+      status: "ran" as const,
+      durationMs: 50,
+    }));
+
+    const { cron } = createCronWithSpies({ storePath, runHeartbeatOnce });
+    await runSingleTick(cron);
+
+    expect(runHeartbeatOnce).toHaveBeenCalled();
+    const callArgs = runHeartbeatOnce.mock.calls[0]?.[0];
+    expect(callArgs?.heartbeat?.target).toBe("discord");
+    expect(callArgs?.heartbeat?.to).toBe("channel:123");
+  });
+
+  it("should pass explicit 'to' with default target when no channel specified", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.now();
+
+    const job: CronJob = {
+      ...createMainCronJob({ now, id: "test-explicit-to", wakeMode: "now" }),
+      delivery: {
+        mode: "announce",
+        to: "user456",
+      },
+    };
+
+    await writeCronStoreSnapshot({ storePath, jobs: [job] });
+
+    const runHeartbeatOnce = vi.fn<RunHeartbeatOnce>(async () => ({
+      status: "ran" as const,
+      durationMs: 50,
+    }));
+
+    const { cron } = createCronWithSpies({ storePath, runHeartbeatOnce });
+    await runSingleTick(cron);
+
+    expect(runHeartbeatOnce).toHaveBeenCalled();
+    const callArgs = runHeartbeatOnce.mock.calls[0]?.[0];
+    expect(callArgs?.heartbeat?.target).toBe("last");
+    expect(callArgs?.heartbeat?.to).toBe("user456");
+  });
+
+  it("should fall back to default when delivery.mode is 'none'", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.now();
+
+    const job: CronJob = {
+      ...createMainCronJob({ now, id: "test-mode-none", wakeMode: "now" }),
+      delivery: {
+        mode: "none",
+        channel: "discord" as CronMessageChannel,
+        to: "channel:123",
+      },
+    };
+
+    await writeCronStoreSnapshot({ storePath, jobs: [job] });
+
+    const runHeartbeatOnce = vi.fn<RunHeartbeatOnce>(async () => ({
+      status: "ran" as const,
+      durationMs: 50,
+    }));
+
+    const { cron } = createCronWithSpies({ storePath, runHeartbeatOnce });
+    await runSingleTick(cron);
+
+    expect(runHeartbeatOnce).toHaveBeenCalled();
+    const callArgs = runHeartbeatOnce.mock.calls[0]?.[0];
+    // mode: "none" should be respected — fall back to default "last"
+    expect(callArgs?.heartbeat?.target).toBe("last");
+    expect(callArgs?.heartbeat?.to).toBeUndefined();
+  });
+
+  it("should fall back to default when delivery.mode is 'webhook'", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.now();
+
+    const job: CronJob = {
+      ...createMainCronJob({ now, id: "test-mode-webhook", wakeMode: "now" }),
+      delivery: {
+        mode: "webhook",
+        to: "https://example.com/webhook",
+      },
+    };
+
+    await writeCronStoreSnapshot({ storePath, jobs: [job] });
+
+    const runHeartbeatOnce = vi.fn<RunHeartbeatOnce>(async () => ({
+      status: "ran" as const,
+      durationMs: 50,
+    }));
+
+    const { cron } = createCronWithSpies({ storePath, runHeartbeatOnce });
+    await runSingleTick(cron);
+
+    expect(runHeartbeatOnce).toHaveBeenCalled();
+    const callArgs = runHeartbeatOnce.mock.calls[0]?.[0];
+    // webhook URLs should NOT be forwarded as heartbeat targets
+    expect(callArgs?.heartbeat?.target).toBe("last");
+    expect(callArgs?.heartbeat?.to).toBeUndefined();
   });
 });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -40,6 +40,37 @@ const MIN_REFIRE_GAP_MS = 2_000;
 const DEFAULT_FAILURE_ALERT_AFTER = 2;
 const DEFAULT_FAILURE_ALERT_COOLDOWN_MS = 60 * 60_000; // 1 hour
 
+/**
+ * Resolve heartbeat delivery target for main-session cron jobs with wakeMode: "now".
+ * If the job has explicit delivery.channel/to/accountId, use those instead of "last".
+ * This enables cron callbacks to specify where the woken session should respond.
+ * See: https://github.com/openclaw/openclaw/issues/34572
+ */
+function resolveMainSessionHeartbeatTarget(job: CronJob): {
+  target: "last" | "none" | CronMessageChannel;
+  to?: string;
+  accountId?: string;
+} {
+  const delivery = job.delivery;
+  // If delivery has an explicit channel (not undefined and not "last" default),
+  // use that as the heartbeat target.
+  if (delivery?.channel && delivery.channel !== "last") {
+    return {
+      target: delivery.channel,
+      to: delivery.to,
+      accountId: delivery.accountId,
+    };
+  }
+  // If delivery has explicit "to" but channel is "last" or undefined,
+  // still use the "to" with "last" target (for backwards compatibility).
+  if (delivery?.to) {
+    return { target: "last", to: delivery.to, accountId: delivery.accountId };
+  }
+  // Default: deliver to last active channel (original behavior).
+  return { target: "last" };
+}
+
+
 type TimedCronRunOutcome = CronRunOutcome &
   CronRunTelemetry & {
     jobId: string;
@@ -916,11 +947,9 @@ export async function executeJobCore(
           reason,
           agentId: job.agentId,
           sessionKey: targetMainSessionKey,
-          // Cron-triggered heartbeats should deliver to the last active channel.
-          // Without this override, heartbeat target defaults to "none" (since
-          // e2362d35) and cron main-session responses are silently swallowed.
-          // See: https://github.com/openclaw/openclaw/issues/28508
-          heartbeat: { target: "last" },
+          // Resolve delivery target from job.delivery if explicit, otherwise fall back to "last".
+          // See: https://github.com/openclaw/openclaw/issues/28508 (original), #34572 (explicit delivery)
+          heartbeat: resolveMainSessionHeartbeatTarget(job),
         });
         if (
           heartbeatResult.status !== "skipped" ||

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -52,6 +52,17 @@ function resolveMainSessionHeartbeatTarget(job: CronJob): {
   accountId?: string;
 } {
   const delivery = job.delivery;
+  // If delivery mode is "none", respect the explicit opt-out.
+  // Fall back to default behavior (deliver to last active channel).
+  if (delivery?.mode === "none") {
+    return { target: "last" };
+  }
+  // If delivery mode is "webhook", delivery.to is an HTTP URL — not a
+  // channel target.  Don't pass it to heartbeat routing, which would
+  // cause Discord/Telegram to resolve no-target and drop the reply.
+  if (delivery?.mode === "webhook") {
+    return { target: "last" };
+  }
   // If delivery has an explicit channel (not undefined and not "last" default),
   // use that as the heartbeat target.
   if (delivery?.channel && delivery.channel !== "last") {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -70,7 +70,6 @@ function resolveMainSessionHeartbeatTarget(job: CronJob): {
   return { target: "last" };
 }
 
-
 type TimedCronRunOutcome = CronRunOutcome &
   CronRunTelemetry & {
     jobId: string;


### PR DESCRIPTION
## Summary
- **Problem:** When `--wake now` fires a systemEvent cron job, the agent wakes but has no inbound message, so it has no delivery context for its response
- **Why it matters:** Sub-agent callbacks rely on waking parent sessions and getting responses back to the correct channel (e.g., Discord); without delivery context, responses go to webchat/nowhere
- **What changed:** Added `resolveMainSessionHeartbeatTarget()` that checks `job.delivery.channel/to/accountId` and passes those to `runHeartbeatOnce` instead of hardcoded `{ target: "last" }`
- **What did NOT change:** Behavior for jobs without explicit delivery settings (still defaults to `"last"`), isolated session jobs (already had delivery support)

## Change Type
- [x] Bug fix
- [x] Feature

## Scope
- [x] Gateway / orchestration

## Linked Issue/PR
- Closes #34572

## User-visible / Behavior Changes
`--channel` and `--to` flags on `openclaw cron add` now work for systemEvent jobs with `--wake now`. Previously these flags were silently ignored for main-session jobs.

## Security Impact
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment
- OS: Linux (Docker container)
- Runtime/container: OpenClaw 2026.2.26
- Integration/channel: Discord

### Steps
1. Create a cron job: `openclaw cron add --at "5s" --session-key "agent:main:discord:channel:123" --system-event "[test] Hello" --wake now --channel discord --to "channel:123" --delete-after-run`
2. Wait for cron to fire
3. Check if agent response appears in the specified Discord channel

### Expected
- Agent response delivered to `channel:123`

### Actual (before fix)
- Agent response went to webchat/default, not the specified channel
- `deliveryStatus: "not-requested"` in cron run log
 
## Evidence
- [x] Trace/log snippets

Before: `deliveryStatus: "not-requested"` even with `--channel discord --to channel:123`
After: Delivery context passed to heartbeat runner

## Human Verification
- **Verified scenarios:** Traced code path from cron fire → heartbeat call, confirmed helper function logic
- **Edge cases checked:** Job without delivery (defaults to `"last"`), job with only `to` but no `channel`
- **What you did NOT verify:** Full end-to-end with running OpenClaw instance (code review only)

## Compatibility / Migration
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery
- **How to disable/revert:** Revert commit or replace `resolveMainSessionHeartbeatTarget(job)` back to `{ target: "last" }`
- **Files to restore:** `src/cron/service/timer.ts`
- **Bad symptoms:** Agent responses not being delivered (same as current behavior when delivery flags are used)

## Risks and Mitigations
- **Risk:** If `job.delivery.channel` is set to an invalid channel name, heartbeat may fail to deliver
- **Mitigation:** Same validation path as isolated jobs; existing heartbeat delivery error handling applies