### PR TITLE
Fix: avoid double converting markdown for Slack native streaming

### DIFF
--- a/src/slack/streaming.test.ts
+++ b/src/slack/streaming.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import type { WebClient } from "@slack/web-api";
+import type { ChatStreamer } from "@slack/web-api/dist/chat-stream.js";
+import { appendSlackStream, startSlackStream, stopSlackStream } from "./streaming.js";
+
+describe("Slack streaming text passthrough", () => {
+  it("starts stream with raw markdown text payload", async () => {
+    const streamer: ChatStreamer = {
+      append: vi.fn(),
+      stop: vi.fn(),
+    } as ChatStreamer;
+
+    const client = {
+      chatStream: vi.fn().mockReturnValue(streamer),
+    } as unknown as WebClient;
+
+    await startSlackStream({
+      client,
+      channel: "C1",
+      threadTs: "123.456",
+      text: "**bold**",
+    });
+
+    expect(streamer.append).toHaveBeenCalledWith({ markdown_text: "**bold**" });
+    expect(streamer.append).not.toHaveBeenCalledWith({ markdown_text: "*bold*" });
+  });
+
+  it("appends subsequent markdown chunks without normalization", async () => {
+    const streamer: ChatStreamer = {
+      append: vi.fn(),
+      stop: vi.fn(),
+    } as ChatStreamer;
+
+    const streamSession = { streamer, channel: "C1", threadTs: "123.456", stopped: false };
+
+    await appendSlackStream({
+      session: streamSession,
+      text: "`code` and **bold**",
+    });
+
+    expect(streamer.append).toHaveBeenCalledWith({ markdown_text: "`code` and **bold**" });
+  });
+
+  it("stops stream without normalizing final text", async () => {
+    const streamer: ChatStreamer = {
+      append: vi.fn(),
+      stop: vi.fn(),
+    } as ChatStreamer;
+
+    const streamSession = { streamer, channel: "C1", threadTs: "123.456", stopped: false };
+
+    await stopSlackStream({
+      session: streamSession,
+      text: "**final**",
+    });
+
+    expect(streamer.stop).toHaveBeenCalledWith({ markdown_text: "**final**" });
+  });
+});

--- a/src/slack/streaming.ts
+++ b/src/slack/streaming.ts
@@ -14,7 +14,6 @@
 import type { WebClient } from "@slack/web-api";
 import type { ChatStreamer } from "@slack/web-api/dist/chat-stream.js";
 import { logVerbose } from "../globals.js";
-import { normalizeSlackOutboundText } from "./format.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -100,7 +99,9 @@ export async function startSlackStream(
   // If initial text is provided, send it as the first append which will
   // trigger the ChatStreamer to call chat.startStream under the hood.
   if (text) {
-    await streamer.append({ markdown_text: normalizeSlackOutboundText(text) });
+    // Slack native streaming API expects Markdown in `markdown_text` and will render it itself,
+    // so we pass text through unchanged to avoid double conversion.
+    await streamer.append({ markdown_text: text });
     logVerbose(`slack-stream: appended initial text (${text.length} chars)`);
   }
 
@@ -122,7 +123,7 @@ export async function appendSlackStream(params: AppendSlackStreamParams): Promis
     return;
   }
 
-  await session.streamer.append({ markdown_text: normalizeSlackOutboundText(text) });
+  await session.streamer.append({ markdown_text: text });
   logVerbose(`slack-stream: appended ${text.length} chars`);
 }
 
@@ -149,7 +150,7 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
   );
 
   await session.streamer.stop(
-    text ? { markdown_text: normalizeSlackOutboundText(text) } : undefined,
+    text ? { markdown_text: text } : undefined,
   );
 
   logVerbose("slack-stream: stream stopped");


### PR DESCRIPTION
## Summary
- Remove pre-conversion of markdown to mrkdwn for native streaming
- Let Slack native streaming API handle markdown rendering directly

## Security Impact
None.

## AI Assisted
This change was assisted by AI (Codex).

Fixes #34690