### PR TITLE
fix(telegram): send fallback when reasoning-only reply is suppressed

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1146,6 +1146,23 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
+  it("sends empty-response fallback when reasoning-only reply is suppressed without media (#34373)", async () => {
+    setupDraftStreams({});
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Reasoning:\n_step one_" }, { kind: "final" });
+      return { queuedFinal: false };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ text: expect.stringContaining("No response") })],
+      }),
+    );
+  });
+
   it.each([undefined, null] as const)(
     "skips outbound send when final payload text is %s and has no media",
     async (emptyText) => {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -585,6 +585,10 @@ export const dispatchTelegramMessage = async ({
               const payloadWithoutSuppressedReasoning =
                 typeof payload.text === "string" ? { ...payload, text: "" } : payload;
               await sendPayload(payloadWithoutSuppressedReasoning);
+            } else if (info.kind === "final") {
+              // Reasoning was the only content and it was suppressed.  Mark as a
+              // non-silent skip so the empty-response fallback fires (#34373).
+              deliveryState.markNonSilentSkip();
             }
             if (info.kind === "final") {
               await flushBufferedFinalAnswer();


### PR DESCRIPTION
## Summary

- Problem: When `reasoningLevel` is `"off"` and a reply contains only reasoning text (no answer text, no media), the `suppressedReasoningOnly` code path in `bot-message-dispatch.ts` returned early without calling `sendPayload` or registering any delivery state event. This left `skippedNonSilent` at zero, so the `EMPTY_RESPONSE_FALLBACK` ("No response generated. Please try again.") never fired. The user received no feedback at all — no message, no error, no empty bubble.
- Why it matters: This is the default configuration (`reasoningLevel: "off"`). Any model response that contains only reasoning content (e.g. chain-of-thought with no final answer) silently disappears.
- What changed: When `suppressedReasoningOnly` is true, there is no media, and `info.kind === "final"`, we now call `deliveryState.markNonSilentSkip()`. This triggers the existing `EMPTY_RESPONSE_FALLBACK` mechanism at the end of dispatch, sending "No response generated. Please try again." to the user.
- What did NOT change (scope boundary): Media-carrying reasoning-only payloads still send the media with empty text. Mid-stream (`info.kind !== "final"`) suppressed reasoning is still silently dropped (correct behavior for partials). The fallback text itself is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34373

## User-visible / Behavior Changes

- When the model produces a reasoning-only response (no answer text) and reasoning display is off, Telegram DM users now see "No response generated. Please try again." instead of complete silence.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — the fallback uses the same `deliverReplies` path that already exists
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure a Telegram bot with `reasoningLevel: "off"` (default)
2. Trigger a model response that contains only reasoning text with no answer (e.g. `"Reasoning:\n_step one_"`)
3. Observe Telegram DM

### Expected

- User sees "No response generated. Please try again."

### Actual

- Before: No message delivered; user sees nothing
- After: Fallback message delivered

## Evidence

- [x] Failing test/log before + passing after

Added 1 test: "sends empty-response fallback when reasoning-only reply is suppressed without media (#34373)". All 59 tests in `bot-message-dispatch.test.ts` pass, plus 3 in `bot-message-dispatch.sticker-media.test.ts`.

## Human Verification (required)

- Verified scenarios: reasoning-only final with no media (fallback fires), reasoning-only final with media (media sent with empty text — unchanged), reasoning-only block/partial (silently dropped — unchanged), normal answer text (delivered normally — unchanged).
- Edge cases checked: `queuedFinal: true` with suppressed reasoning (existing test still passes — fallback text differs from reasoning text).
- What you did **not** verify: live Telegram delivery with a real model producing reasoning-only output.

## Compatibility / Migration

- Backward compatible? Yes — previously silent drops now produce a user-visible fallback message
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit to restore the silent-drop behavior.
- Files/config to restore: `src/telegram/bot-message-dispatch.ts`

## Risks and Mitigations

- Risk: Users who previously saw no response now see "No response generated" — could be surprising if they expected silence.
  - Mitigation: This matches the existing fallback behavior for other empty-response scenarios (delivery failures, skipped payloads). Silence is strictly worse UX than an explicit fallback.