### PR TITLE
Fix: TUI show reply directly for local runs

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -426,4 +426,30 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-silent");
     expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
   });
+
+  it("finalizes local run with streamed text when chat final has no message", () => {
+    const { state, chatLog, noteLocalRunId, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    noteLocalRunId("run-local");
+
+    handleChatEvent({
+      runId: "run-local",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "hello from stream" },
+    });
+    chatLog.finalizeAssistant.mockClear();
+    chatLog.dropAssistant.mockClear();
+
+    handleChatEvent({
+      runId: "run-local",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+    });
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("hello from stream", "run-local");
+    expect(chatLog.dropAssistant).not.toHaveBeenCalled();
+  });
 });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -179,7 +179,16 @@ export function createEventHandlers(context: EventHandlerContext) {
       const wasActiveRun = state.activeChatRunId === evt.runId;
       if (!evt.message) {
         maybeRefreshHistoryForRun(evt.runId);
-        chatLog.dropAssistant(evt.runId);
+        const finalText = isLocalRunId?.(evt.runId)
+          ? streamAssembler.finalize(evt.runId, evt.message, state.showThinking)
+          : "(no output)";
+        const suppressEmptyExternalPlaceholder =
+          finalText === "(no output)" && !isLocalRunId?.(evt.runId);
+        if (suppressEmptyExternalPlaceholder) {
+          chatLog.dropAssistant(evt.runId);
+        } else {
+          chatLog.finalizeAssistant(finalText, evt.runId);
+        }
         finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
         tui.requestRender();
         return;


### PR DESCRIPTION
## Summary
- Finalize assistant with streamed text when chat final has no message
- Regression fix for TUI not showing replies

## Security Impact
None.

## AI Assisted
This change was assisted by AI (Codex).

Fixes #34659