### PR TITLE
fix: Anthropic 529 overloaded_error failover + thinking block corruption on retry

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -479,6 +479,7 @@ describe("classifyFailoverReason", () => {
     );
     expect(classifyFailoverReason("Missing scopes: model.request")).toBe("auth");
     expect(classifyFailoverReason("429 too many requests")).toBe("rate_limit");
+    expect(classifyFailoverReason("529 Overloaded")).toBe("rate_limit");
     expect(classifyFailoverReason("resource has been exhausted")).toBe("rate_limit");
     expect(
       classifyFailoverReason("model_cooldown: All credentials for model gpt-5 are cooling down"),

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -384,6 +384,33 @@ describe("sanitizeSessionMessagesImages", () => {
       expect((content?.[1] as { thought_signature?: unknown })?.thought_signature).toBe("AQID");
     });
   });
+
+  it("preserves latest assistant thinking message verbatim when requested", async () => {
+    const protectedAssistant = {
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "chain of thought",
+          thought_signature: "msg_immutable",
+        },
+        { type: "text", text: "" },
+      ],
+      stopReason: "error",
+      timestamp: nextTimestamp(),
+    };
+    const input = castAgentMessages([
+      { role: "user", content: "hello", timestamp: nextTimestamp() },
+      protectedAssistant,
+      { role: "user", content: "retry this", timestamp: nextTimestamp() },
+    ]);
+
+    const out = await sanitizeSessionMessagesImages(input, "test", {
+      preserveLatestAssistantThinking: true,
+    });
+
+    expect(out[1]).toEqual(protectedAssistant);
+  });
 });
 
 describe("sanitizeGoogleTurnOrdering", () => {

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -385,6 +385,46 @@ describe("sanitizeSessionMessagesImages", () => {
     });
   });
 
+  it("does not preserve older thinking assistant when a newer plain assistant follows", async () => {
+    const olderThinkingAssistant = {
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "chain of thought",
+          thought_signature: "msg_immutable",
+        },
+        { type: "text", text: "I will use a tool" },
+      ],
+      stopReason: "stop",
+      timestamp: nextTimestamp(),
+    };
+    const newerPlainAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "Plain follow-up" }],
+      stopReason: "stop",
+      timestamp: nextTimestamp(),
+    };
+    const input = castAgentMessages([
+      { role: "user", content: "hello", timestamp: nextTimestamp() },
+      olderThinkingAssistant,
+      { role: "user", content: "retry", timestamp: nextTimestamp() },
+      newerPlainAssistant,
+    ]);
+
+    const out = await sanitizeSessionMessagesImages(input, "test", {
+      preserveLatestAssistantThinking: true,
+    });
+
+    // The older thinking assistant should NOT be preserved verbatim
+    // because the latest assistant (newerPlainAssistant) has no thinking blocks.
+    // Its msg_-prefixed thought_signature should be stripped (normal sanitization).
+    const olderContent = (out[1] as { content?: Array<Record<string, unknown>> }).content;
+    const thinkingBlock = olderContent?.find((b) => b.type === "thinking");
+    expect(thinkingBlock).toBeDefined();
+    expect("thought_signature" in (thinkingBlock ?? {})).toBe(false);
+  });
+
   it("preserves latest assistant thinking message verbatim when requested", async () => {
     const protectedAssistant = {
       role: "assistant",

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -485,6 +485,29 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     expect(assistantContent).toEqual([{ type: "toolUse", id: "tool-1", name: "test", input: {} }]);
   });
 
+  it("preserves latest assistant message with thinking blocks exactly", () => {
+    const latestAssistant = {
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "need to call a tool",
+          thinkingSignature: "sig_123",
+        },
+        { type: "toolUse", id: "tool-1", name: "test", input: {} },
+      ],
+    };
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use a tool" }] },
+      latestAssistant,
+      { role: "user", content: [{ type: "text", text: "retry" }] },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual(latestAssistant.content);
+  });
+
   it("is replay-safe across repeated validation passes", () => {
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Use tools" }] },

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -485,6 +485,38 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     expect(assistantContent).toEqual([{ type: "toolUse", id: "tool-1", name: "test", input: {} }]);
   });
 
+  it("strips dangling toolUse from older thinking assistant when a newer plain assistant follows", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use a tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "reasoning", thinkingSignature: "sig_1" },
+          { type: "toolUse", id: "tool-1", name: "test", input: {} },
+        ],
+        stopReason: "error",
+      },
+      { role: "user", content: [{ type: "text", text: "retry" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Plain follow-up" }],
+      },
+      { role: "user", content: [{ type: "text", text: "thanks" }] },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    // The older thinking assistant at index 1 should NOT be protected
+    // because the latest assistant (index 3) has no thinking blocks.
+    // Its dangling toolUse should be stripped.
+    const olderAssistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(olderAssistantContent).not.toContainEqual(
+      expect.objectContaining({ type: "toolUse", id: "tool-1" }),
+    );
+    // The thinking block should remain (only toolUse without matching toolResult is stripped)
+    expect(olderAssistantContent).toContainEqual(expect.objectContaining({ type: "thinking" }));
+  });
+
   it("preserves latest assistant message with thinking blocks exactly", () => {
     const latestAssistant = {
       role: "assistant",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -790,6 +790,10 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isModelNotFoundErrorMessage(raw)) {
     return "model_not_found";
   }
+  const leadingStatus = extractLeadingHttpStatus(raw.trim());
+  if (leadingStatus?.code === 429 || leadingStatus?.code === 529) {
+    return "rate_limit";
+  }
   if (isTransientHttpError(raw)) {
     // Treat transient 5xx provider failures as retryable transport issues.
     return "timeout";

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -29,6 +29,35 @@ export function isEmptyAssistantMessageContent(
   });
 }
 
+function hasThinkingOrRedactedThinkingBlock(message: AgentMessage): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  if ((message as { role?: unknown }).role !== "assistant") {
+    return false;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const type = (block as { type?: unknown }).type;
+    return type === "thinking" || type === "redacted_thinking";
+  });
+}
+
+function resolveLatestAssistantThinkingIndex(messages: AgentMessage[]): number {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (hasThinkingOrRedactedThinkingBlock(messages[i])) {
+      return i;
+    }
+  }
+  return -1;
+}
+
 export async function sanitizeSessionMessagesImages(
   messages: AgentMessage[],
   label: string,
@@ -46,6 +75,7 @@ export async function sanitizeSessionMessagesImages(
       allowBase64Only?: boolean;
       includeCamelCase?: boolean;
     };
+    preserveLatestAssistantThinking?: boolean;
   } & ImageSanitizationLimits,
 ): Promise<AgentMessage[]> {
   const sanitizeMode = options?.sanitizeMode ?? "full";
@@ -60,8 +90,12 @@ export async function sanitizeSessionMessagesImages(
   const sanitizedIds = shouldSanitizeToolCallIds
     ? sanitizeToolCallIdsForCloudCodeAssist(messages, options.toolCallIdMode)
     : messages;
+  const protectedLatestAssistantThinkingIndex = options?.preserveLatestAssistantThinking
+    ? resolveLatestAssistantThinkingIndex(sanitizedIds)
+    : -1;
   const out: AgentMessage[] = [];
-  for (const msg of sanitizedIds) {
+  for (let index = 0; index < sanitizedIds.length; index += 1) {
+    const msg = sanitizedIds[index];
     if (!msg || typeof msg !== "object") {
       out.push(msg);
       continue;
@@ -96,6 +130,10 @@ export async function sanitizeSessionMessagesImages(
 
     if (role === "assistant") {
       const assistantMsg = msg as Extract<AgentMessage, { role: "assistant" }>;
+      if (index === protectedLatestAssistantThinkingIndex) {
+        out.push(assistantMsg);
+        continue;
+      }
       if (assistantMsg.stopReason === "error") {
         const content = assistantMsg.content;
         if (Array.isArray(content)) {

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -50,9 +50,12 @@ function hasThinkingOrRedactedThinkingBlock(message: AgentMessage): boolean {
 }
 
 function resolveLatestAssistantThinkingIndex(messages: AgentMessage[]): number {
+  // Find the actual latest assistant message first.
   for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (hasThinkingOrRedactedThinkingBlock(messages[i])) {
-      return i;
+    const msg = messages[i];
+    if (msg && typeof msg === "object" && (msg as { role?: unknown }).role === "assistant") {
+      // Only protect it if it contains thinking/redacted_thinking blocks.
+      return hasThinkingOrRedactedThinkingBlock(msg) ? i : -1;
     }
   }
   return -1;

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -1,12 +1,41 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 type AnthropicContentBlock = {
-  type: "text" | "toolUse" | "toolResult";
+  type?: string;
   text?: string;
   id?: string;
   name?: string;
   toolUseId?: string;
 };
+
+function hasThinkingOrRedactedThinkingBlocks(message: AgentMessage): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  if ((message as { role?: unknown }).role !== "assistant") {
+    return false;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const type = (block as { type?: unknown }).type;
+    return type === "thinking" || type === "redacted_thinking";
+  });
+}
+
+function resolveLatestAssistantThinkingIndex(messages: AgentMessage[]): number {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (hasThinkingOrRedactedThinkingBlocks(messages[i])) {
+      return i;
+    }
+  }
+  return -1;
+}
 
 /**
  * Strips dangling tool_use blocks from assistant messages when the immediately
@@ -15,6 +44,7 @@ type AnthropicContentBlock = {
  */
 function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[] {
   const result: AgentMessage[] = [];
+  const latestAssistantThinkingIndex = resolveLatestAssistantThinkingIndex(messages);
 
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
@@ -25,6 +55,14 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
 
     const msgRole = (msg as { role?: unknown }).role as string | undefined;
     if (msgRole !== "assistant") {
+      result.push(msg);
+      continue;
+    }
+
+    // Anthropic rejects retries when the latest assistant message contains
+    // thinking/redacted_thinking blocks that were modified in any way.
+    // Preserve that message exactly as-is.
+    if (i === latestAssistantThinkingIndex) {
       result.push(msg);
       continue;
     }

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -29,9 +29,12 @@ function hasThinkingOrRedactedThinkingBlocks(message: AgentMessage): boolean {
 }
 
 function resolveLatestAssistantThinkingIndex(messages: AgentMessage[]): number {
+  // Find the actual latest assistant message first.
   for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (hasThinkingOrRedactedThinkingBlocks(messages[i])) {
-      return i;
+    const msg = messages[i];
+    if (msg && typeof msg === "object" && (msg as { role?: unknown }).role === "assistant") {
+      // Only protect it if it contains thinking/redacted_thinking blocks.
+      return hasThinkingOrRedactedThinkingBlocks(msg) ? i : -1;
     }
   }
   return -1;

--- a/src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts
@@ -53,6 +53,27 @@ describe("sanitizeSessionHistory e2e smoke", () => {
     );
   });
 
+  it("passes preserveLatestAssistantThinking for anthropic transcripts", async () => {
+    vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
+
+    await sanitizeSessionHistory({
+      messages: mockMessages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      sessionManager: mockSessionManager,
+      sessionId: "test-session",
+    });
+
+    expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
+      mockMessages,
+      "session:history",
+      expect.objectContaining({
+        preserveLatestAssistantThinking: true,
+      }),
+    );
+  });
+
   it("downgrades openai reasoning blocks when the model snapshot changed", async () => {
     const result = await sanitizeSnapshotChangedOpenAIReasoning({
       sanitizeSessionHistory,

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -436,6 +436,7 @@ export async function sanitizeSessionHistory(params: {
       toolCallIdMode: policy.toolCallIdMode,
       preserveSignatures: policy.preserveSignatures,
       sanitizeThoughtSignatures: policy.sanitizeThoughtSignatures,
+      preserveLatestAssistantThinking: policy.validateAnthropicTurns,
       ...resolveImageSanitizationLimits(params.config),
     },
   );

--- a/src/agents/pi-project-settings.test.ts
+++ b/src/agents/pi-project-settings.test.ts
@@ -1,6 +1,10 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   buildEmbeddedPiSettingsSnapshot,
+  createPreparedEmbeddedPiSettingsManager,
   DEFAULT_EMBEDDED_PI_PROJECT_SETTINGS_POLICY,
   resolveEmbeddedPiProjectSettingsPolicy,
 } from "./pi-project-settings.js";
@@ -72,5 +76,21 @@ describe("buildEmbeddedPiSettingsSnapshot", () => {
     expect(snapshot.shellCommandPrefix).toBe("echo hacked &&");
     expect(snapshot.compaction?.reserveTokens).toBe(32_000);
     expect(snapshot.hideThinkingBlock).toBe(true);
+  });
+});
+
+describe("createPreparedEmbeddedPiSettingsManager", () => {
+  it("disables internal retry while preserving retry timing settings", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pi-settings-"));
+    const manager = createPreparedEmbeddedPiSettingsManager({
+      cwd: tempRoot,
+      agentDir: tempRoot,
+    });
+
+    const retry = manager.getRetrySettings();
+    expect(retry.enabled).toBe(false);
+    expect(retry.maxRetries).toBeGreaterThanOrEqual(0);
+    expect(retry.baseDelayMs).toBeGreaterThanOrEqual(0);
+    expect(retry.maxDelayMs).toBeGreaterThanOrEqual(0);
   });
 });

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -71,5 +71,19 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
     settingsManager,
     cfg: params.cfg,
   });
+
+  // Disable pi-coding-agent internal auto-retry for embedded OpenClaw runs.
+  // OpenClaw handles retries/failover at a higher layer (auth-profile cooldown
+  // + model fallback). Internal retries can hide 529 overloaded errors behind
+  // timeout aborts and mutate Anthropic thinking blocks during replay.
+  const baseGetRetrySettings = settingsManager.getRetrySettings.bind(settingsManager);
+  settingsManager.getRetrySettings = () => {
+    const current = baseGetRetrySettings();
+    return {
+      ...current,
+      enabled: false,
+    };
+  };
+
   return settingsManager;
 }


### PR DESCRIPTION
## Problem

When Anthropic returns HTTP 529 (`overloaded_error`), OpenClaw does not properly trigger model failover to the configured fallback. Instead, the request either times out or enters a broken retry loop. This is compounded by a second bug: when a response partially completes with `thinking`/`redacted_thinking` blocks and then hits a 529 mid-stream, the retry path mutates those thinking blocks in the conversation history. Anthropic then hard-rejects the retry with:

> `messages.X.content.Y: thinking or redacted_thinking blocks in the latest assistant message cannot be modified`

This makes recovery impossible even after Anthropic stabilizes — the session is permanently stuck.

Fixes #34535

## Root Cause

Three interacting issues:

1. **529 not classified as rate_limit** — `classifyFailoverReason()` checked for transient 5xx but treated 529 as a generic timeout rather than a rate-limit that should trigger auth-profile cooldown and model failover.

2. **Internal pi-coding-agent auto-retry conflicts with OpenClaw failover** — The embedded agent runtime has its own retry loop that fires before OpenClaw's higher-level failover. These internal retries mask 529s behind timeout/abort behavior and mutate the conversation history (including thinking blocks) during replay.

3. **Thinking block mutation on retry** — `sanitizeSessionMessagesImages()` and `stripDanglingAnthropicToolUses()` modify assistant messages during history sanitization, including the latest assistant message containing `thinking`/`redacted_thinking` blocks. Anthropic's API requires these blocks to remain exactly as returned in the original response.

## Changes

### 1. Classify 529 as `rate_limit` for failover (`errors.ts`)
- `classifyFailoverReason()` now explicitly maps HTTP 429 and 529 to `"rate_limit"` before the transient-5xx/timeout classification path.
- This triggers proper auth-profile cooldown and model fallback.

### 2. Disable internal auto-retry for embedded runs (`pi-project-settings.ts`)
- `createPreparedEmbeddedPiSettingsManager()` now wraps `getRetrySettings()` and forces `enabled: false`.
- OpenClaw handles retries/failover at the gateway layer (auth-profile cooldown + model fallback). Internal retries were hiding failures and corrupting conversation state.

### 3. Preserve latest assistant thinking blocks during sanitization (`images.ts`, `turns.ts`, `google.ts`)
- Added `preserveLatestAssistantThinking` option to `sanitizeSessionMessagesImages()`.
- When enabled, the latest assistant message containing `thinking`/`redacted_thinking` blocks is preserved verbatim — no content filtering, no block stripping.
- `stripDanglingAnthropicToolUses()` now also skips mutation for the protected latest assistant turn.
- Anthropic sanitize pipeline enables this via `policy.validateAnthropicTurns`.

## Tests

- `pi-embedded-helpers.isbillingerrormessage.test.ts` — 529 → `rate_limit` classification
- `pi-embedded-helpers.validate-turns.test.ts` — latest assistant with thinking blocks preserved
- `pi-embedded-helpers.sanitize-session-messages-images...preserves.test.ts` — `preserveLatestAssistantThinking` option
- `pi-embedded-runner.sanitize-session-history.policy.test.ts` — Anthropic history sanitize passes `preserveLatestAssistantThinking: true`
- `pi-project-settings.test.ts` — embedded settings disable internal retry

All existing tests pass. Formatter (`oxfmt`) clean.