### PR TITLE
feat(plugins): add appendSystemPrompt to hook results

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -462,6 +462,9 @@ export async function resolvePromptBuildHookResult(params: {
       : undefined);
   return {
     systemPrompt: promptBuildResult?.systemPrompt ?? legacyResult?.systemPrompt,
+    appendSystemPrompt: [promptBuildResult?.appendSystemPrompt, legacyResult?.appendSystemPrompt]
+      .filter((value): value is string => Boolean(value))
+      .join("\n\n"),
     prependContext: [promptBuildResult?.prependContext, legacyResult?.prependContext]
       .filter((value): value is string => Boolean(value))
       .join("\n\n"),
@@ -1410,6 +1413,17 @@ export async function runEmbeddedAttempt(
             applySystemPromptOverrideToSession(activeSession, legacySystemPrompt);
             systemPromptText = legacySystemPrompt;
             log.debug(`hooks: applied systemPrompt override (${legacySystemPrompt.length} chars)`);
+          }
+          const appendedSystemPrompt =
+            typeof hookResult?.appendSystemPrompt === "string"
+              ? hookResult.appendSystemPrompt.trim()
+              : "";
+          if (appendedSystemPrompt) {
+            systemPromptText = `${systemPromptText}\n\n${appendedSystemPrompt}`;
+            applySystemPromptOverrideToSession(activeSession, systemPromptText);
+            log.debug(
+              `hooks: appended system prompt context (${appendedSystemPrompt.length} chars)`,
+            );
           }
         }
 

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -140,6 +140,10 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     next: PluginHookBeforePromptBuildResult,
   ): PluginHookBeforePromptBuildResult => ({
     systemPrompt: next.systemPrompt ?? acc?.systemPrompt,
+    appendSystemPrompt:
+      acc?.appendSystemPrompt && next.appendSystemPrompt
+        ? `${acc.appendSystemPrompt}\n\n${next.appendSystemPrompt}`
+        : (next.appendSystemPrompt ?? acc?.appendSystemPrompt),
     prependContext:
       acc?.prependContext && next.prependContext
         ? `${acc.prependContext}\n\n${next.prependContext}`

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -368,6 +368,7 @@ export type PluginHookBeforePromptBuildEvent = {
 
 export type PluginHookBeforePromptBuildResult = {
   systemPrompt?: string;
+  appendSystemPrompt?: string;
   prependContext?: string;
 };
 


### PR DESCRIPTION
## Summary

Adds `appendSystemPrompt?: string` to `PluginHookBeforePromptBuildResult`, allowing plugins to append content to the system prompt rather than replacing it.

Fixes #34727

## Problem

Plugins currently have `systemPrompt` (replaces entire prompt — destructive) and `prependContext` (prepends to user message — causes transcript bloat and wrong semantic position). Neither works for plugins that need to inject persistent background context.

## Solution

`appendSystemPrompt` appends to the system prompt after it's fully built. This is:
- **Non-destructive** — doesn't replace SOUL.md/AGENTS.md/workspace context
- **No transcript bloat** — injected once into system prompt, not per-message
- **Correct priority** — background context that recent messages can override

## Changes

3 files, 19 lines added:
- `src/plugins/types.ts` — add field to `PluginHookBeforePromptBuildResult` (inherited by `PluginHookBeforeAgentStartResult`)
- `src/plugins/hooks.ts` — merge logic in `mergeBeforePromptBuild` (concatenate with `\n\n`, same pattern as `prependContext`)
- `src/agents/pi-embedded-runner/run/attempt.ts` — resolve from both hook phases, append after system prompt is finalized

## Use Case

We're building an observational memory plugin that injects conversation summaries as background context. `appendSystemPrompt` gives it the correct semantic position — alongside workspace context files, not inside user messages.