### PR TITLE
Daemon: handle generic systemctl is-enabled failures gracefully

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,6 +79,19 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false when is-enabled fails with generic command output", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & { code?: number };
+      err.code = 1;
+      cb(err, "", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
   it("throws when systemctl is-enabled fails for non-state errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -167,6 +167,11 @@ function isSystemdUnitNotEnabled(detail: string): boolean {
     return false;
   }
   const normalized = detail.toLowerCase();
+  const hasGenericIsEnabledFailure =
+    normalized.includes("command failed: systemctl --user is-enabled") &&
+    !normalized.includes("failed to connect to bus") &&
+    !normalized.includes("not been booted") &&
+    !normalized.includes("permission denied");
   return (
     normalized.includes("disabled") ||
     normalized.includes("static") ||
@@ -174,7 +179,8 @@ function isSystemdUnitNotEnabled(detail: string): boolean {
     normalized.includes("masked") ||
     normalized.includes("not-found") ||
     normalized.includes("could not be found") ||
-    normalized.includes("failed to get unit file state")
+    normalized.includes("failed to get unit file state") ||
+    hasGenericIsEnabledFailure
   );
 }
 


### PR DESCRIPTION
## Summary
- treat generic `systemctl --user is-enabled` command-failed output as "not enabled" instead of "unavailable"
- keep hard failures (for example user-bus unavailable) as explicit errors
- add regression coverage for code=1 with only generic `Command failed: systemctl --user is-enabled ...` output

## Testing
- pnpm test src/daemon/systemd.test.ts

Closes #34464
