### PR TITLE
fix(ollama): read thinking field from Ollama native API responses

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -104,7 +104,23 @@ describe("buildAssistantMessage", () => {
     expect(result.usage.totalTokens).toBe(15);
   });
 
-  it("falls back to reasoning when content is empty", () => {
+  it("falls back to thinking when content is empty", () => {
+    const response = {
+      model: "kimi-k2.5",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content: "",
+        thinking: "Thinking output",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toEqual([{ type: "text", text: "Thinking output" }]);
+  });
+
+  it("falls back to reasoning when content and thinking are empty", () => {
     const response = {
       model: "qwen3:32b",
       created_at: "2026-01-01T00:00:00Z",
@@ -397,7 +413,28 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
-  it("accumulates reasoning chunks when content is empty", async () => {
+  it("accumulates thinking chunks when content is empty", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":"thought"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":" output"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":2}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
+        const events = await collectStreamEvents(stream);
+
+        const doneEvent = events.at(-1);
+        if (!doneEvent || doneEvent.type !== "done") {
+          throw new Error("Expected done event");
+        }
+
+        expect(doneEvent.message.content).toEqual([{ type: "text", text: "thought output" }]);
+      },
+    );
+  });
+
+  it("accumulates reasoning chunks as fallback when content and thinking are empty", async () => {
     await withMockNdjsonFetch(
       [
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","reasoning":"reasoned"},"done":false}',

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -185,6 +185,9 @@ interface OllamaChatResponse {
   message: {
     role: "assistant";
     content: string;
+    // Ollama API uses `thinking` for reasoning/thinking content.
+    // Also accept `reasoning` for backward compatibility with older models.
+    thinking?: string;
     reasoning?: string;
     tool_calls?: OllamaToolCall[];
   };
@@ -323,10 +326,10 @@ export function buildAssistantMessage(
 ): AssistantMessage {
   const content: (TextContent | ToolCall)[] = [];
 
-  // Qwen 3 (and potentially other reasoning models) may return their final
-  // answer in a `reasoning` field with an empty `content`. Fall back to
-  // `reasoning` so the response isn't silently dropped.
-  const text = response.message.content || response.message.reasoning || "";
+  // Ollama's native API uses `thinking` for reasoning content. Also accept
+  // `reasoning` for backward compatibility with older model variants.
+  const text =
+    response.message.content || response.message.thinking || response.message.reasoning || "";
   if (text) {
     content.push({ type: "text", text });
   }
@@ -474,9 +477,9 @@ export function createOllamaStreamFn(
         for await (const chunk of parseNdjsonStream(reader)) {
           if (chunk.message?.content) {
             accumulatedContent += chunk.message.content;
-          } else if (chunk.message?.reasoning) {
-            // Qwen 3 reasoning mode: content may be empty, output in reasoning
-            accumulatedContent += chunk.message.reasoning;
+          } else if (chunk.message?.thinking || chunk.message?.reasoning) {
+            // Ollama uses `thinking` for reasoning content; accept `reasoning` as fallback
+            accumulatedContent += chunk.message.thinking || chunk.message.reasoning;
           }
 
           // Ollama sends tool_calls in intermediate (done:false) chunks,


### PR DESCRIPTION
## Summary

- Problem: Ollama's native `/api/chat` endpoint returns reasoning content in a `thinking` field, but OpenClaw reads `reasoning` — silently dropping all thinking output.
- Why it matters: Thinking-capable models (kimi-k2.5, glm-5, minimax-m2.5, etc.) served via Ollama's native API produce empty/blank responses when thinking content is all they return.
- What changed: Accept both `thinking` (correct per Ollama docs) and `reasoning` (backward compat) in the stream reader and response builder, with `thinking` checked first.
- What did NOT change (scope boundary): OpenAI-compatible Ollama endpoint (`/v1/chat/completions`) is unaffected. Tool call handling, content accumulation logic, and all other Ollama stream behavior remain unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #34722

## User-visible / Behavior Changes

Models served via Ollama's native API that return reasoning content in the `thinking` field (per Ollama docs) will now correctly surface that content instead of silently dropping it.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Model/provider: Any thinking-capable model via Ollama native API (e.g. kimi-k2.5, glm-5)
- Integration/channel (if any): Ollama native (`api: "ollama"`)

### Steps

1. Configure a custom provider with `api: "ollama"` pointing to an Ollama instance
2. Add a thinking-capable model (e.g. `kimi-k2.5`)
3. Send a message — the model returns `message.thinking` chunks but OpenClaw only checks `message.reasoning`

### Expected

- Thinking content is captured and included in the response

### Actual (before fix)

- Thinking content silently dropped; response appears empty if the model only outputs via `thinking`

## Evidence

- [x] Failing test/log before + passing after
- All 23 tests pass including new tests for `thinking` field in both streaming and non-streaming paths
- Ollama API docs confirm field name: https://github.com/ollama/ollama/blob/main/docs/api.md

## Human Verification (required)

- Verified scenarios: unit tests cover `thinking`-only response (non-streaming), `thinking` chunk accumulation (streaming), and backward-compat `reasoning` fallback for both paths
- Edge cases checked: empty `content` + `thinking` present; empty `content` + `reasoning` present (fallback); `content` present takes priority over both
- What you did **not** verify: live Ollama instance end-to-end (no local Ollama setup available)

## Compatibility / Migration

- Backward compatible? Yes — `reasoning` field is still accepted as fallback
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this single commit
- Files/config to restore: `src/agents/ollama-stream.ts`
- Known bad symptoms reviewers should watch for: blank responses from Ollama native API models

## Risks and Mitigations

- Risk: Some Ollama model variant may use a different field name than `thinking` or `reasoning`
  - Mitigation: Both fields are now accepted; the priority chain is `content` > `thinking` > `reasoning` > empty string