### PR TITLE
fix(models): preserve api/authHeader/headers from models.json during merge-mode regen

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -220,6 +220,83 @@ describe("models-config", () => {
     });
   });
 
+  it("preserves api/authHeader/headers from existing models.json in merge mode", async () => {
+    // Regression: after a user changes baseUrl to a domestic endpoint and sets
+    // authHeader/api in models.json, a gateway restart would regenerate
+    // models.json from openclaw.json (which may have different api/authHeader),
+    // losing the user's endpoint-specific settings and causing HTTP 401.
+    await withTempHome(async () => {
+      await writeAgentModelsJson({
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimaxi.com/anthropic",
+            apiKey: "user-minimax-new-key",
+            api: "anthropic-messages",
+            authHeader: true,
+            headers: { "x-custom-header": "custom-value" },
+            models: [
+              {
+                id: "MiniMax-M2.5",
+                name: "MiniMax M2.5",
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
+                contextWindow: 200000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      });
+
+      // Simulate openclaw.json that was generated with a different api format
+      // (e.g. old Coding Plan config with openai-completions and no authHeader)
+      await ensureOpenClawModelsJson({
+        models: {
+          mode: "merge",
+          providers: {
+            minimax: {
+              baseUrl: "https://api.minimax.io/anthropic",
+              apiKey: "old-minimax-key",
+              api: "openai-completions",
+              models: [
+                {
+                  id: "MiniMax-M2.5",
+                  name: "MiniMax M2.5",
+                  reasoning: true,
+                  input: ["text"],
+                  cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
+                  contextWindow: 200000,
+                  maxTokens: 8192,
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<
+          string,
+          {
+            apiKey?: string;
+            baseUrl?: string;
+            api?: string;
+            authHeader?: boolean;
+            headers?: Record<string, string>;
+          }
+        >;
+      }>();
+
+      // User's credentials and endpoint-specific config must be preserved
+      expect(parsed.providers.minimax?.apiKey).toBe("user-minimax-new-key");
+      expect(parsed.providers.minimax?.baseUrl).toBe("https://api.minimaxi.com/anthropic");
+      expect(parsed.providers.minimax?.api).toBe("anthropic-messages");
+      expect(parsed.providers.minimax?.authHeader).toBe(true);
+      expect(parsed.providers.minimax?.headers).toEqual({ "x-custom-header": "custom-value" });
+    });
+  });
+
   it("uses config apiKey/baseUrl when existing agent values are empty", async () => {
     await withTempHome(async () => {
       const parsed = await runCustomProviderMergeTest({

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -165,6 +165,25 @@ function mergeWithExistingProviderSecrets(params: {
     if (typeof existing.baseUrl === "string" && existing.baseUrl) {
       preserved.baseUrl = existing.baseUrl;
     }
+    // Preserve endpoint protocol and auth settings alongside baseUrl so that a
+    // user who pointed a provider at a different endpoint (e.g. a domestic
+    // MiniMax endpoint) keeps the matching api/authHeader/headers values.
+    // Without this, regenerating models.json after a gateway restart could
+    // replace the user's "anthropic-messages" + authHeader:true with whatever
+    // the built-in catalog emits, causing HTTP 401 on every request.
+    if (typeof existing.api === "string" && existing.api) {
+      preserved.api = existing.api;
+    }
+    if (typeof existing.authHeader === "boolean") {
+      preserved.authHeader = existing.authHeader;
+    }
+    if (
+      existing.headers &&
+      typeof existing.headers === "object" &&
+      !Array.isArray(existing.headers)
+    ) {
+      preserved.headers = existing.headers;
+    }
     mergedProviders[key] = { ...newEntry, ...preserved };
   }
   return mergedProviders;


### PR DESCRIPTION
## Summary

Fixes #34656 — HTTP 401 `authentication_error: invalid api key` on every message send after modifying `models.json` (e.g. switching to a domestic MiniMax endpoint) and restarting the gateway.

### Root cause

`mergeWithExistingProviderSecrets` in `models-config.ts` only preserved `apiKey` and `baseUrl` from the user's existing `models.json` during merge-mode regeneration. Fields like `api`, `authHeader`, and `headers` were silently overwritten by whatever `openclaw.json` (or the built-in implicit provider catalog) emitted.

Concretely: a user who changed their `minimax` provider's `baseUrl` to `https://api.minimaxi.com/anthropic` (domestic endpoint) and set `api: "anthropic-messages"` + `authHeader: true` in `models.json` would have those settings erased the next time `ensureOpenClawModelsJson` ran (e.g. on the first agent run after gateway restart). If `openclaw.json` still referenced an older Coding Plan config with `api: "openai-completions"` and no `authHeader`, the regenerated `models.json` would use the wrong protocol and missing auth header, causing MiniMax to return HTTP 401.

### Fix

Extend `mergeWithExistingProviderSecrets` to also preserve `api`, `authHeader`, and `headers` from the existing `models.json` entry. These are endpoint-specific settings the user has explicitly configured for their provider — the same rationale as preserving `apiKey` and `baseUrl`.

Model-level catalog data (model lists, context windows, costs, capabilities) continues to be refreshed from the implicit catalog.

### Test

Added a regression test that seeds `models.json` with a MiniMax provider using the domestic endpoint (`api: "anthropic-messages"`, `authHeader: true`, custom headers), then calls `ensureOpenClawModelsJson` with an `openclaw.json` config using the global endpoint and `api: "openai-completions"`. The test asserts that the user's endpoint-specific settings survive the merge.

## Test plan

- [x] New regression test passes (`models-config > preserves api/authHeader/headers from existing models.json in merge mode`)
- [x] All existing `models-config.fills-missing-provider-apikey-from-env-var` tests pass
- [x] No lint/format errors introduced

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
