### PR TITLE
fix(feishu): prevent duplicate text in streaming card updates

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -156,9 +156,18 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       streamText = nextText;
       return;
     }
+    // Detect cumulative payloads even when leading whitespace/directives cause
+    // a prefix mismatch.  If nextText contains the current streamText as a
+    // substring, it is almost certainly the full cumulative output and should
+    // replace rather than append (fixes #34108 / #33883).
+    if (nextText.includes(streamText)) {
+      streamText = nextText;
+      return;
+    }
     if (streamText.endsWith(nextText)) {
       return;
     }
+    // True delta — append only the new portion.
     streamText += nextText;
   };
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -156,12 +156,18 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       streamText = nextText;
       return;
     }
-    // Detect cumulative payloads even when leading whitespace/directives cause
-    // a prefix mismatch.  If nextText contains the current streamText as a
-    // substring, it is almost certainly the full cumulative output and should
-    // replace rather than append (fixes #34108 / #33883).
-    if (nextText.includes(streamText)) {
+    // Detect cumulative payloads even when leading whitespace or directive
+    // stripping causes a prefix mismatch.  Trim before comparing to handle
+    // minor leading-whitespace divergence without the false-positive risk of
+    // a broad String.includes check on short streamText values (#34108 / #33883).
+    if (nextText.trimStart().startsWith(streamText.trimStart())) {
       streamText = nextText;
+      return;
+    }
+    // Also handle the case where streamText has extra leading content stripped
+    // by directive processing — if trimmed streamText starts with trimmed nextText
+    // prefix, nextText is likely a subset we already have.
+    if (streamText.trimStart().startsWith(nextText.trimStart())) {
       return;
     }
     if (streamText.endsWith(nextText)) {


### PR DESCRIPTION
## Summary

Fixes #34108 and #33883 — streaming card updates rendering the same content 3+ times.

## Root Cause

`mergeStreamingText` in `reply-dispatcher.ts` uses `nextText.startsWith(streamText)` to detect cumulative payloads. When this check fails (e.g., leading whitespace or directive stripping changes the prefix), the function falls through to `streamText += nextText` — appending the entire cumulative text again instead of replacing.

## Fix

Add a `nextText.includes(streamText)` check before the append fallback. If the incoming text contains the current stream text as a substring, it is the full cumulative output and should replace rather than append.

## Testing

All 16 existing reply-dispatcher tests pass.