### PR TITLE
fix(heartbeat): allow requestHeartbeatNow to target channel sessions

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -268,10 +268,6 @@ function resolveHeartbeatSession(
   const store = loadSessionStore(storePath);
   const mainEntry = store[mainSessionKey];
 
-  if (scope === "global") {
-    return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry };
-  }
-
   const forced = forcedSessionKey?.trim();
   if (forced) {
     const forcedCandidate = toAgentStoreSessionKey({
@@ -295,6 +291,10 @@ function resolveHeartbeatSession(
         };
       }
     }
+  }
+
+  if (scope === "global") {
+    return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry };
   }
 
   const trimmed = heartbeat?.session?.trim() ?? "";


### PR DESCRIPTION
## Summary

- **Problem:** `requestHeartbeatNow({ sessionKey: "agent:main:slack:channel:*" })` silently skipped channel sessions. The heartbeat turn never ran for channel sessions despite the API call succeeding.
- **Why it matters:** Plugin developers using the `requestHeartbeatNow` API for channel-scoped event processing (e.g. Hermes watch dispatches) had to fall back to the deprecated `sessions_send` workaround.
- **What changed:** Moved the `forcedSessionKey` matching block above the `scope === "global"` early-return in `resolveHeartbeatSession`. The global scope fallback now only applies when no forced session key is provided.
- **What did NOT change:** Global/main session heartbeat behavior unchanged. Non-targeted heartbeat cycles unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34338

## User-visible / Behavior Changes

- `requestHeartbeatNow` now correctly targets channel sessions (Slack channel, Telegram channel, etc.)
- Global/main sessions continue to work as before

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Slack (or any channel with session binding)

### Steps

1. Create a channel session: `agent:main:slack:channel:CXXXXXXX`
2. Call `requestHeartbeatNow({ sessionKey: "agent:main:slack:channel:CXXXXXXX" })`
3. Observe heartbeat turn fires

### Expected

- Heartbeat turn runs on the targeted channel session

### Actual

- Before fix: Silently skipped, no turn fired
- After fix: Heartbeat turn runs correctly

## Evidence

All 78 heartbeat-related tests pass (58 runner + 20 wake)

### Files changed (1 file)

1. `src/infra/heartbeat-runner.ts` — Reordered forcedSessionKey check above scope=global early-return

## Human Verification (required)

- Verified scenarios: Channel session key targeted; global session fallback preserved; main session still works
- Edge cases checked: Invalid forced session key falls through to normal resolution
- What I did **not** verify: Live Slack channel heartbeat test

## Compatibility / Migration

- Backward compatible? `Yes` — global scope behavior unchanged when no forced key
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert commit; channel sessions return to silent skip
- Files/config to restore: 1 file
- Known bad symptoms: Heartbeat targeting wrong session for channel keys

## Risks and Mitigations

- The reorder is safe: forced session key was already designed to override scope, it was just checked too late. All existing tests pass.
