### PR TITLE
Discord: avoid implicit allowlist from systemPrompt-only channels

### DIFF
--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -641,6 +641,13 @@ describe("discord groupPolicy gating", () => {
     ).toBe(false);
   });
 
+  it("ignores allow keys with undefined values", () => {
+    const channelAllowlistConfigured = isDiscordChannelAllowlistConfigured({
+      coder: { allow: undefined } as unknown as { allow?: boolean },
+    });
+    expect(channelAllowlistConfigured).toBe(false);
+  });
+
   it("does not deny fallback channels when access groups are enabled without explicit allow flags", () => {
     expect(
       shouldDenyDiscordChannelByAllowFlag({
@@ -659,6 +666,17 @@ describe("discord groupPolicy gating", () => {
         channelAllowed: false,
         useAccessGroups: true,
         channelAllowlistConfigured: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("denies channel when access groups are disabled and channel is not allowed", () => {
+    expect(
+      shouldDenyDiscordChannelByAllowFlag({
+        isGuildMessage: true,
+        channelAllowed: false,
+        useAccessGroups: false,
+        channelAllowlistConfigured: false,
       }),
     ).toBe(true);
   });

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -611,11 +611,11 @@ describe("discord groupPolicy gating", () => {
     }
   });
 
-  it("keeps guild open when channel entries only add prompts", () => {
+  it("treats prompt-only channel entries as an allowlist under allowlist mode", () => {
     const channelAllowlistConfigured = isDiscordChannelAllowlistConfigured({
       coder: { systemPrompt: "Use short answers." },
     });
-    expect(channelAllowlistConfigured).toBe(false);
+    expect(channelAllowlistConfigured).toBe(true);
     expect(
       isDiscordGroupAllowedByPolicy({
         groupPolicy: "allowlist",
@@ -623,7 +623,7 @@ describe("discord groupPolicy gating", () => {
         channelAllowlistConfigured,
         channelAllowed: false,
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("treats explicit allow flags as channel allowlist entries", () => {

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -17,6 +17,7 @@ import {
   resolveDiscordShouldRequireMention,
   resolveGroupDmAllow,
   sanitizeDiscordThreadName,
+  shouldDenyDiscordChannelByAllowFlag,
   shouldEmitDiscordReactionNotification,
 } from "./monitor.js";
 import { DiscordMessageListener, DiscordReactionListener } from "./monitor/listeners.js";
@@ -638,6 +639,28 @@ describe("discord groupPolicy gating", () => {
         channelAllowed: false,
       }),
     ).toBe(false);
+  });
+
+  it("does not deny fallback channels when access groups are enabled without explicit allow flags", () => {
+    expect(
+      shouldDenyDiscordChannelByAllowFlag({
+        isGuildMessage: true,
+        channelAllowed: false,
+        useAccessGroups: true,
+        channelAllowlistConfigured: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("denies fallback channels when explicit allow flags are configured", () => {
+    expect(
+      shouldDenyDiscordChannelByAllowFlag({
+        isGuildMessage: true,
+        channelAllowed: false,
+        useAccessGroups: true,
+        channelAllowlistConfigured: true,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -5,6 +5,7 @@ import {
   allowListMatches,
   buildDiscordMediaPayload,
   type DiscordGuildEntryResolved,
+  isDiscordChannelAllowlistConfigured,
   isDiscordGroupAllowedByPolicy,
   normalizeDiscordAllowList,
   normalizeDiscordSlug,
@@ -607,6 +608,36 @@ describe("discord groupPolicy gating", () => {
     for (const testCase of cases) {
       expect(isDiscordGroupAllowedByPolicy(testCase.input), testCase.name).toBe(testCase.expected);
     }
+  });
+
+  it("keeps guild open when channel entries only add prompts", () => {
+    const channelAllowlistConfigured = isDiscordChannelAllowlistConfigured({
+      coder: { systemPrompt: "Use short answers." },
+    });
+    expect(channelAllowlistConfigured).toBe(false);
+    expect(
+      isDiscordGroupAllowedByPolicy({
+        groupPolicy: "allowlist",
+        guildAllowlisted: true,
+        channelAllowlistConfigured,
+        channelAllowed: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats explicit allow flags as channel allowlist entries", () => {
+    const channelAllowlistConfigured = isDiscordChannelAllowlistConfigured({
+      coder: { allow: true },
+    });
+    expect(channelAllowlistConfigured).toBe(true);
+    expect(
+      isDiscordGroupAllowedByPolicy({
+        groupPolicy: "allowlist",
+        guildAllowlisted: true,
+        channelAllowlistConfigured,
+        channelAllowed: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -15,6 +15,7 @@ export {
   resolveDiscordGuildEntry,
   resolveDiscordShouldRequireMention,
   resolveGroupDmAllow,
+  shouldDenyDiscordChannelByAllowFlag,
   shouldEmitDiscordReactionNotification,
 } from "./monitor/allow-list.js";
 export type { DiscordMessageEvent, DiscordMessageHandler } from "./monitor/listeners.js";

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -5,6 +5,7 @@ export type {
 } from "./monitor/allow-list.js";
 export {
   allowListMatches,
+  isDiscordChannelAllowlistConfigured,
   isDiscordGroupAllowedByPolicy,
   normalizeDiscordAllowList,
   normalizeDiscordSlug,

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -387,7 +387,9 @@ function hasConfiguredDiscordChannels(
 }
 
 function hasExplicitAllowFlag(entry: DiscordChannelEntry | undefined): boolean {
-  return Boolean(entry && Object.prototype.hasOwnProperty.call(entry, "allow"));
+  return Boolean(
+    entry && Object.prototype.hasOwnProperty.call(entry, "allow") && entry.allow !== undefined,
+  );
 }
 
 export function isDiscordChannelAllowlistConfigured(

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -386,6 +386,19 @@ function hasConfiguredDiscordChannels(
   return Boolean(channels && Object.keys(channels).length > 0);
 }
 
+function hasExplicitAllowFlag(entry: DiscordChannelEntry | undefined): boolean {
+  return Boolean(entry && Object.prototype.hasOwnProperty.call(entry, "allow"));
+}
+
+export function isDiscordChannelAllowlistConfigured(
+  channels: DiscordGuildEntryResolved["channels"] | undefined,
+): boolean {
+  if (!hasConfiguredDiscordChannels(channels)) {
+    return false;
+  }
+  return Object.values(channels).some((entry) => hasExplicitAllowFlag(entry));
+}
+
 function resolveDiscordChannelConfigEntry(
   entry: DiscordChannelEntry,
 ): DiscordChannelConfigResolved {

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -541,6 +541,21 @@ export function isDiscordGroupAllowedByPolicy(params: {
   return channelAllowed;
 }
 
+export function shouldDenyDiscordChannelByAllowFlag(params: {
+  isGuildMessage: boolean;
+  channelAllowed: boolean;
+  useAccessGroups: boolean;
+  channelAllowlistConfigured: boolean;
+}): boolean {
+  if (!params.isGuildMessage || params.channelAllowed) {
+    return false;
+  }
+  if (!params.useAccessGroups) {
+    return true;
+  }
+  return params.channelAllowlistConfigured;
+}
+
 export function resolveGroupDmAllow(params: {
   channels?: string[];
   channelId: string;

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -386,19 +386,18 @@ function hasConfiguredDiscordChannels(
   return Boolean(channels && Object.keys(channels).length > 0);
 }
 
-function hasExplicitAllowFlag(entry: DiscordChannelEntry | undefined): boolean {
-  return Boolean(
-    entry && Object.prototype.hasOwnProperty.call(entry, "allow") && entry.allow !== undefined,
-  );
-}
-
 export function isDiscordChannelAllowlistConfigured(
   channels: DiscordGuildEntryResolved["channels"] | undefined,
 ): boolean {
   if (!hasConfiguredDiscordChannels(channels)) {
     return false;
   }
-  return Object.values(channels).some((entry) => hasExplicitAllowFlag(entry));
+  return Object.values(channels).some((entry) => {
+    if (!entry) {
+      return false;
+    }
+    return Object.entries(entry).some(([key, value]) => key !== "allow" || value !== undefined);
+  });
 }
 
 function resolveDiscordChannelConfigEntry(

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -728,6 +728,85 @@ describe("preflightDiscordMessage", () => {
     expect(result?.hasAnyMention).toBe(false);
   });
 
+  it("allows unlisted guild channels when only systemPrompt channel entries exist", async () => {
+    const channelId = "channel-systemprompt-fallback-1";
+    const guildId = "guild-systemprompt-fallback-1";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          return {
+            id: channelId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-systemprompt-fallback-1",
+      content: "hello from general",
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "allowlist",
+      threadBindings: createNoopThreadBindingManager("default"),
+      guildEntries: {
+        [guildId]: {
+          requireMention: false,
+          channels: {
+            coder: { systemPrompt: "Keep responses concise." },
+          },
+        },
+      },
+      data: {
+        channel_id: channelId,
+        guild_id: guildId,
+        guild: {
+          id: guildId,
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(result).not.toBeNull();
+  });
+
   it("uses attachment content_type for guild audio preflight mention detection", async () => {
     transcribeFirstAudioMock.mockResolvedValue("hey openclaw");
 

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -728,7 +728,7 @@ describe("preflightDiscordMessage", () => {
     expect(result?.hasAnyMention).toBe(false);
   });
 
-  it("allows unlisted guild channels when only systemPrompt channel entries exist", async () => {
+  it("blocks unlisted guild channels when any channel entries exist under allowlist mode", async () => {
     const channelId = "channel-systemprompt-fallback-1";
     const guildId = "guild-systemprompt-fallback-1";
     const client = {
@@ -804,7 +804,7 @@ describe("preflightDiscordMessage", () => {
       client,
     });
 
-    expect(result).not.toBeNull();
+    expect(result).toBeNull();
   });
 
   it("uses attachment content_type for guild audio preflight mention detection", async () => {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -39,6 +39,7 @@ import {
   resolveDiscordOwnerAccess,
   resolveDiscordShouldRequireMention,
   resolveGroupDmAllow,
+  shouldDenyDiscordChannelByAllowFlag,
 } from "./allow-list.js";
 import { resolveDiscordDmCommandAccess } from "./dm-command-auth.js";
 import { handleDiscordDmCommandDecision } from "./dm-command-decision.js";
@@ -519,7 +520,14 @@ export async function preflightDiscordMessage(
     return null;
   }
 
-  if (isGuildMessage && channelConfig?.allowed === false) {
+  if (
+    shouldDenyDiscordChannelByAllowFlag({
+      isGuildMessage,
+      channelAllowed,
+      useAccessGroups,
+      channelAllowlistConfigured,
+    })
+  ) {
     logDebug(`[discord-preflight] drop: channelConfig.allowed===false`);
     logVerbose(
       `Blocked discord channel ${messageChannelId} not in guild channel allowlist (${channelMatchMeta})`,

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -30,6 +30,7 @@ import { DEFAULT_ACCOUNT_ID, resolveAgentIdFromSessionKey } from "../../routing/
 import { fetchPluralKitMessageInfo } from "../pluralkit.js";
 import { sendMessageDiscord } from "../send.js";
 import {
+  isDiscordChannelAllowlistConfigured,
   isDiscordGroupAllowedByPolicy,
   normalizeDiscordSlug,
   resolveDiscordChannelConfigWithFallback,
@@ -488,8 +489,7 @@ export async function preflightDiscordMessage(
     return null;
   }
 
-  const channelAllowlistConfigured =
-    Boolean(guildInfo?.channels) && Object.keys(guildInfo?.channels ?? {}).length > 0;
+  const channelAllowlistConfigured = isDiscordChannelAllowlistConfigured(guildInfo?.channels);
   const channelAllowed = channelConfig?.allowed !== false;
   if (
     isGuildMessage &&

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -1336,10 +1336,11 @@ async function dispatchDiscordCommandInteraction(params: {
     return;
   }
   const channelAllowlistConfigured = isDiscordChannelAllowlistConfigured(guildInfo?.channels);
+  const channelAllowed = channelConfig?.allowed !== false;
   if (
     shouldDenyDiscordChannelByAllowFlag({
       isGuildMessage: Boolean(interaction.guild),
-      channelAllowed: channelConfig?.allowed !== false,
+      channelAllowed,
       useAccessGroups,
       channelAllowlistConfigured,
     })
@@ -1348,7 +1349,6 @@ async function dispatchDiscordCommandInteraction(params: {
     return;
   }
   if (useAccessGroups && interaction.guild) {
-    const channelAllowed = channelConfig?.allowed !== false;
     const { groupPolicy } = resolveOpenProviderRuntimeGroupPolicy({
       providerConfigPresent: cfg.channels?.discord !== undefined,
       groupPolicy: discordConfig?.groupPolicy,

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -63,6 +63,7 @@ import {
   resolveDiscordMemberAccessState,
   resolveDiscordOwnerAccess,
   resolveDiscordOwnerAllowFrom,
+  shouldDenyDiscordChannelByAllowFlag,
 } from "./allow-list.js";
 import { resolveDiscordDmCommandAccess } from "./dm-command-auth.js";
 import { handleDiscordDmCommandDecision } from "./dm-command-decision.js";
@@ -1334,12 +1335,19 @@ async function dispatchDiscordCommandInteraction(params: {
     await respond("This channel is disabled.");
     return;
   }
-  if (interaction.guild && channelConfig?.allowed === false) {
+  const channelAllowlistConfigured = isDiscordChannelAllowlistConfigured(guildInfo?.channels);
+  if (
+    shouldDenyDiscordChannelByAllowFlag({
+      isGuildMessage: Boolean(interaction.guild),
+      channelAllowed: channelConfig?.allowed !== false,
+      useAccessGroups,
+      channelAllowlistConfigured,
+    })
+  ) {
     await respond("This channel is not allowed.");
     return;
   }
   if (useAccessGroups && interaction.guild) {
-    const channelAllowlistConfigured = isDiscordChannelAllowlistConfigured(guildInfo?.channels);
     const channelAllowed = channelConfig?.allowed !== false;
     const { groupPolicy } = resolveOpenProviderRuntimeGroupPolicy({
       providerConfigPresent: cfg.channels?.discord !== undefined,

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -55,6 +55,7 @@ import { withTimeout } from "../../utils/with-timeout.js";
 import { loadWebMedia } from "../../web/media.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import {
+  isDiscordChannelAllowlistConfigured,
   isDiscordGroupAllowedByPolicy,
   normalizeDiscordSlug,
   resolveDiscordChannelConfigWithFallback,
@@ -1338,8 +1339,7 @@ async function dispatchDiscordCommandInteraction(params: {
     return;
   }
   if (useAccessGroups && interaction.guild) {
-    const channelAllowlistConfigured =
-      Boolean(guildInfo?.channels) && Object.keys(guildInfo?.channels ?? {}).length > 0;
+    const channelAllowlistConfigured = isDiscordChannelAllowlistConfigured(guildInfo?.channels);
     const channelAllowed = channelConfig?.allowed !== false;
     const { groupPolicy } = resolveOpenProviderRuntimeGroupPolicy({
       providerConfigPresent: cfg.channels?.discord !== undefined,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: With `channels.discord.groupPolicy=allowlist`, adding a per-channel `systemPrompt` entry in `guilds.<id>.channels` unintentionally enables channel allowlist gating for the whole guild.
- Why it matters: Teams cannot keep a guild open while applying a custom prompt to one channel; non-listed channels are incorrectly blocked.
- What changed: Added `isDiscordChannelAllowlistConfigured()` and switched Discord preflight + native command policy checks to treat channel allowlists as configured only when `allow` is explicitly present on at least one channel entry.
- What did NOT change (scope boundary): Channel matching, mention behavior, and existing explicit allowlist behavior (`allow: true/false`) are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34543
- Related #

## User-visible / Behavior Changes

Discord guilds using `groupPolicy=allowlist` can now add channel-specific `systemPrompt` entries without turning all unlisted channels into blocked channels. Channel allowlist enforcement still applies when `allow` is explicitly configured.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev workspace)
- Runtime/container: Node.js v22.22.0
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted):
  - `channels.discord.groupPolicy: allowlist`
  - `channels.discord.guilds.<guildId>.channels.<channelId>.systemPrompt: "Use short answers."`

### Steps

1. Configure Discord with `groupPolicy=allowlist` and allowlist the guild.
2. Add one `guilds.<id>.channels.<channelId>` entry that only sets `systemPrompt` (no explicit `allow`).
3. Send a message in a different channel in the same guild.

### Expected

- Message from the other channel is allowed (guild remains open), while the configured channel gets its custom prompt.

### Actual

- Message from the other channel is blocked because channel allowlist gating is incorrectly treated as configured.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced pre-fix policy result via code path (`policyAllowed:false`) for systemPrompt-only channel entries.
  - Verified post-fix policy result via code path (`policyAllowed:true`) for the same config.
  - Verified explicit allowlist behavior still blocks when `allow: true` config exists and channel is not allowed.
- Edge cases checked:
  - Explicit allowlist entries still activate channel allowlist gating.
  - systemPrompt-only channel entry no longer activates allowlist gating.
- What you did **not** verify:
  - Live Discord traffic against a real gateway instance (validated via unit tests and deterministic policy evaluation).

Verification commands run:

```bash
node --import tsx -e "import { isDiscordChannelAllowlistConfigured, isDiscordGroupAllowedByPolicy, resolveDiscordChannelConfigWithFallback } from './src/discord/monitor/allow-list.ts'; const guildInfo={channels:{coder:{systemPrompt:'Use short answers.'}}}; const channelConfig=resolveDiscordChannelConfigWithFallback({guildInfo, channelId:'123', channelName:'general', channelSlug:'general'}); const channelAllowlistConfigured=isDiscordChannelAllowlistConfigured(guildInfo.channels); const channelAllowed=channelConfig?.allowed!==false; console.log(JSON.stringify({channelAllowlistConfigured, channelAllowed, policyAllowed:isDiscordGroupAllowedByPolicy({groupPolicy:'allowlist',guildAllowlisted:true,channelAllowlistConfigured,channelAllowed})}));"
pnpm test -- src/discord/monitor.test.ts
pnpm check
```

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Discord: avoid implicit allowlist from systemPrompt-only channels`.
- Files/config to restore:
  - `src/discord/monitor/allow-list.ts`
  - `src/discord/monitor/message-handler.preflight.ts`
  - `src/discord/monitor/native-command.ts`
- Known bad symptoms reviewers should watch for:
  - Discord guild messages unexpectedly passing/denying when `groupPolicy=allowlist` + explicit `allow` entries are present.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Existing users who relied on implicit channel allowlisting via channel keys without explicit `allow` could now see broader channel access.
  - Mitigation: Explicit `allow` keeps previous strict behavior; regression tests added for both systemPrompt-only and explicit allowlist paths.
