### PR TITLE
fix(tailscale): guard JSON.parse in infra/tailscale.ts against malformed CLI output

### DIFF
--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -11,10 +11,14 @@ function parsePossiblyNoisyJsonObject(stdout: string): Record<string, unknown> {
   const trimmed = stdout.trim();
   const start = trimmed.indexOf("{");
   const end = trimmed.lastIndexOf("}");
-  if (start >= 0 && end > start) {
-    return JSON.parse(trimmed.slice(start, end + 1)) as Record<string, unknown>;
+  if (start === -1 || end <= start) {
+    return {};
   }
-  return JSON.parse(trimmed) as Record<string, unknown>;
+  try {
+    return JSON.parse(trimmed.slice(start, end + 1)) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
 }
 
 /**


### PR DESCRIPTION
**Problem:** `parsePossiblyNoisyJsonObject` in `src/infra/tailscale.ts` calls `JSON.parse()` without a try/catch. If any tailscale CLI command (`funnel status`, `status --json`, IP resolution) returns truncated or garbled output, this throws an unhandled exception that crashes the caller.

Note: `src/shared/tailscale-status.ts` already has the safe version with try/catch. This PR brings `src/infra/tailscale.ts` to parity.

**Fix:** Return `{}` on missing braces or parse failure — matching `shared/tailscale-status.ts`.

**Impact:** Prevents crashes on flaky Tailscale CLI output across 3 call sites (`ensureFunnel`, `resolveNodeTailscaleIp`, `getTailscaleStatus`). Zero behavior change on valid JSON.

Relates to #34364 (which fixed the same pattern in `bonjour-discovery.ts`).