### PR TITLE
fix: treat HTTP 400 errors as permanent in delivery queue

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -387,6 +387,10 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  /message is too long/i,
+  /message to be replied not found/i,
+  /character limit exceeded/i,
+  /400:\s*Bad Request/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -166,6 +166,10 @@ describe("delivery-queue", () => {
       "Forbidden: bot was kicked from the group chat",
       "chat_id is empty",
       "Outbound not configured for channel: msteams",
+      "Telegram send failed: message is too long (chat_id=user:123)",
+      "message to be replied not found",
+      "character limit exceeded",
+      "400: Bad Request",
     ])("returns true for permanent error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(true);
     });
@@ -176,6 +180,7 @@ describe("delivery-queue", () => {
       "socket hang up",
       "rate limited",
       "500 Internal Server Error",
+      "429: Too Many Requests",
     ])("returns false for transient error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(false);
     });


### PR DESCRIPTION
## Summary

Messages failing with HTTP 400 errors (message too long, bad request, message to be replied not found) were retried indefinitely in the delivery queue. These are permanent failures that should not be retried.

## Changes

- Added patterns to `PERMANENT_ERROR_PATTERNS` for common HTTP 400 error messages:
  - `message is too long`
  - `message to be replied not found`
  - `character limit exceeded`
  - `400: Bad Request` (general pattern for Telegram 400s)
- Added test cases for each new pattern
- Added negative test for `429: Too Many Requests` to ensure rate limits remain retryable

## Testing

All delivery queue tests pass (63 tests).

Fixes #33461