### PR TITLE
fix: strip synthetic :reaction: suffix from Feishu message IDs

### DIFF
--- a/src/channels/plugins/actions/reaction-message-id.test.ts
+++ b/src/channels/plugins/actions/reaction-message-id.test.ts
@@ -22,4 +22,29 @@ describe("resolveReactionMessageId", () => {
     });
     expect(result).toBe("9001");
   });
+
+  it("strips synthetic :reaction: suffix from message ID", () => {
+    const result = resolveReactionMessageId({
+      args: { messageId: "om_abc123:reaction:THUMBSUP:550e8400-e29b-41d4-a716-446655440000" },
+    });
+    expect(result).toBe("om_abc123");
+  });
+
+  it("strips :reaction: suffix from toolContext.currentMessageId", () => {
+    const result = resolveReactionMessageId({
+      args: {},
+      toolContext: { currentMessageId: "om_xyz:reaction:HEART:deadbeef" },
+    });
+    expect(result).toBe("om_xyz");
+  });
+
+  it("leaves normal message IDs unchanged", () => {
+    const result = resolveReactionMessageId({ args: { messageId: "om_normal456" } });
+    expect(result).toBe("om_normal456");
+  });
+
+  it("preserves numeric message IDs (coerced to string by readStringOrNumberParam)", () => {
+    const result = resolveReactionMessageId({ args: { messageId: 12345 } });
+    expect(result).toBe("12345");
+  });
 });

--- a/src/channels/plugins/actions/reaction-message-id.ts
+++ b/src/channels/plugins/actions/reaction-message-id.ts
@@ -8,5 +8,10 @@ export function resolveReactionMessageId(params: {
   args: Record<string, unknown>;
   toolContext?: ReactionToolContext;
 }): string | number | undefined {
-  return readStringOrNumberParam(params.args, "messageId") ?? params.toolContext?.currentMessageId;
+  const raw =
+    readStringOrNumberParam(params.args, "messageId") ?? params.toolContext?.currentMessageId;
+  if (typeof raw === "string") {
+    return raw.split(":reaction:")[0];
+  }
+  return raw;
 }


### PR DESCRIPTION
## Summary

When users react to Feishu messages, the monitor creates synthetic message IDs with a `:reaction:TYPE:uuid` suffix for internal tracking. This suffix was not stripped before Feishu API calls, causing HTTP 400 errors on reply lookups and reaction management.

## Changes

- `resolveReactionMessageId()` now strips `:reaction:*` suffix before returning the message ID
- Added tests for synthetic ID stripping and normal ID passthrough

## Testing

All relevant tests pass (`reaction-message-id.test.ts` — 7/7 passing).

Fixes #34528