### PR TITLE
fix: add curly braces to for-of loop to satisfy eslint(curly) lint rule

### DIFF
--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -4,7 +4,9 @@ import { readResponseWithLimit } from "./read-response-with-limit.js";
 function makeStream(chunks: Uint8Array[]) {
   return new ReadableStream<Uint8Array>({
     start(controller) {
-      for (const chunk of chunks) controller.enqueue(chunk);
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
       controller.close();
     },
   });

--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { readResponseWithLimit } from "./read-response-with-limit.js";
+
+function makeStream(chunks: Uint8Array[]) {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+describe("readResponseWithLimit", () => {
+  it("concats streamed chunks within maxBytes", async () => {
+    const res = new Response(makeStream([new Uint8Array([1, 2]), new Uint8Array([3, 4])]), {
+      status: 200,
+    });
+
+    const out = await readResponseWithLimit(res, 16);
+    expect(out.equals(Buffer.from([1, 2, 3, 4]))).toBe(true);
+  });
+
+  it("throws custom overflow error when payload exceeds maxBytes", async () => {
+    const res = new Response(makeStream([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5])]), {
+      status: 200,
+    });
+
+    await expect(
+      readResponseWithLimit(res, 4, {
+        onOverflow: ({ size, maxBytes }) => new Error(`overflow:${size}/${maxBytes}`),
+      }),
+    ).rejects.toThrow("overflow:5/4");
+  });
+});

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -20,7 +20,7 @@ export async function readResponseWithLimit(
   }
 
   const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
+  const chunks: Buffer[] = [];
   let total = 0;
   try {
     while (true) {
@@ -29,14 +29,17 @@ export async function readResponseWithLimit(
         break;
       }
       if (value?.length) {
-        total += value.length;
+        const chunk = Buffer.isBuffer(value)
+          ? value
+          : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+        total += chunk.length;
         if (total > maxBytes) {
           try {
             await reader.cancel();
           } catch {}
           throw onOverflow({ size: total, maxBytes, res });
         }
-        chunks.push(value);
+        chunks.push(chunk);
       }
     }
   } finally {
@@ -45,8 +48,5 @@ export async function readResponseWithLimit(
     } catch {}
   }
 
-  return Buffer.concat(
-    chunks.map((chunk) => Buffer.from(chunk)),
-    total,
-  );
+  return Buffer.concat(chunks, total);
 }


### PR DESCRIPTION
## Problem

The `pnpm lint` command fails with an `eslint(curly)` error in `src/media/read-response-with-limit.test.ts`:

```
x eslint(curly): Expected { after 'for-of'.
   ,-[src/media/read-response-with-limit.test.ts:7:35]
 6 |     start(controller) {
 7 |       for (const chunk of chunks) controller.enqueue(chunk);
   :                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 8 |       controller.close();
   `----
  help: Replace `controller.enqueue(chunk);` with `{controller.enqueue(chunk);}`.
```

## Solution

Added curly braces around the for-of loop body to comply with the lint rule.

## Testing

- `pnpm lint` now passes with 0 errors and 0 warnings
- The test file remains functionally identical