### PR TITLE
fix(agents): use correct Ollama thinking field instead of reasoning

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -104,20 +104,20 @@ describe("buildAssistantMessage", () => {
     expect(result.usage.totalTokens).toBe(15);
   });
 
-  it("falls back to reasoning when content is empty", () => {
+  it("falls back to thinking when content is empty", () => {
     const response = {
       model: "qwen3:32b",
       created_at: "2026-01-01T00:00:00Z",
       message: {
         role: "assistant" as const,
         content: "",
-        reasoning: "Reasoning output",
+        thinking: "Thinking output",
       },
       done: true,
     };
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.stopReason).toBe("stop");
-    expect(result.content).toEqual([{ type: "text", text: "Reasoning output" }]);
+    expect(result.content).toEqual([{ type: "text", text: "Thinking output" }]);
   });
 
   it("builds response with tool calls", () => {
@@ -397,11 +397,11 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
-  it("accumulates reasoning chunks when content is empty", async () => {
+  it("accumulates thinking chunks when content is empty", async () => {
     await withMockNdjsonFetch(
       [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","reasoning":"reasoned"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","reasoning":" output"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":"thinking"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":" output"},"done":false}',
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":2}',
       ],
       async () => {
@@ -413,7 +413,7 @@ describe("createOllamaStreamFn", () => {
           throw new Error("Expected done event");
         }
 
-        expect(doneEvent.message.content).toEqual([{ type: "text", text: "reasoned output" }]);
+        expect(doneEvent.message.content).toEqual([{ type: "text", text: "thinking output" }]);
       },
     );
   });

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -185,7 +185,7 @@ interface OllamaChatResponse {
   message: {
     role: "assistant";
     content: string;
-    reasoning?: string;
+    thinking?: string;
     tool_calls?: OllamaToolCall[];
   };
   done: boolean;
@@ -323,10 +323,10 @@ export function buildAssistantMessage(
 ): AssistantMessage {
   const content: (TextContent | ToolCall)[] = [];
 
-  // Qwen 3 (and potentially other reasoning models) may return their final
-  // answer in a `reasoning` field with an empty `content`. Fall back to
-  // `reasoning` so the response isn't silently dropped.
-  const text = response.message.content || response.message.reasoning || "";
+  // Qwen 3 (and potentially other thinking models) may return their final
+  // answer in a `thinking` field with an empty `content`. Fall back to
+  // `thinking` so the response isn't silently dropped.
+  const text = response.message.content || response.message.thinking || "";
   if (text) {
     content.push({ type: "text", text });
   }
@@ -474,9 +474,9 @@ export function createOllamaStreamFn(
         for await (const chunk of parseNdjsonStream(reader)) {
           if (chunk.message?.content) {
             accumulatedContent += chunk.message.content;
-          } else if (chunk.message?.reasoning) {
-            // Qwen 3 reasoning mode: content may be empty, output in reasoning
-            accumulatedContent += chunk.message.reasoning;
+          } else if (chunk.message?.thinking) {
+            // Qwen 3 thinking mode: content may be empty, output in thinking
+            accumulatedContent += chunk.message.thinking;
           }
 
           // Ollama sends tool_calls in intermediate (done:false) chunks,


### PR DESCRIPTION
## Summary

The Ollama native API (`/api/chat`) returns thinking content in `message.thinking`, but the stream handler reads `message.reasoning` — a field that doesn't exist in the native API schema. This causes thinking-capable models (Qwen 3, DeepSeek R1, kimi-k2.5, glm-5) to silently discard all thinking content when streamed through the native Ollama endpoint, potentially producing empty responses.

Fixes #34722

## Changes

- `OllamaChatResponse` interface: `reasoning` → `thinking`
- `buildAssistantMessage`: fallback field `reasoning` → `thinking`
- Streaming accumulator: `chunk.message?.reasoning` → `chunk.message?.thinking`
- Updated tests to match the corrected field name

## Test plan

- [x] `pnpm vitest run src/agents/ollama-stream.test.ts` — 20/20 tests pass
- [ ] Manual: stream a thinking model (e.g. `qwen3:32b`) via Ollama native API and verify thinking content appears