### PR TITLE
fix: prioritize explicit config api key over stale profiles (closes #34656)

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -67,6 +67,10 @@ function resolveProviderAuthOverride(
   return undefined;
 }
 
+function isLikelyEnvVarPlaceholder(value: string): boolean {
+  return /^[A-Z][A-Z0-9_]*$/.test(value.trim());
+}
+
 function resolveEnvSourceLabel(params: {
   applied: Set<string>;
   envVars: string[];
@@ -167,6 +171,14 @@ export async function resolveApiKeyForProvider(params: {
     return resolveAwsSdkAuthInfo();
   }
 
+  // Prefer explicit provider apiKey from config over stored profiles so
+  // key rotation in models config takes effect immediately after restart.
+  // Keep env-var placeholders (e.g. OPENAI_API_KEY) out of this fast path.
+  const customKey = getCustomProviderApiKey(cfg, provider);
+  if (customKey && !isLikelyEnvVarPlaceholder(customKey)) {
+    return { apiKey: customKey, source: "models.json", mode: "api-key" };
+  }
+
   const order = resolveAuthProfileOrder({
     cfg,
     store,
@@ -202,7 +214,6 @@ export async function resolveApiKeyForProvider(params: {
     };
   }
 
-  const customKey = getCustomProviderApiKey(cfg, provider);
   if (customKey) {
     return { apiKey: customKey, source: "models.json", mode: "api-key" };
   }


### PR DESCRIPTION
Closes #34656

## Problem
After rotating provider API key in models config, auth resolution could still prefer an older key from stored auth profiles. This makes dashboard and Telegram sends keep failing with 401 invalid_api_key even after restart.

## Fix
When models.providers.<provider>.apiKey is explicitly set to a real key value, resolve it before profile-based credentials so key rotation takes effect immediately. Kept env-var placeholders (for example OPENAI_API_KEY) on the existing fallback path to avoid treating placeholders as literal keys.
