### PR TITLE
fix(audit): hasWebSearchKey now covers Gemini, Grok, and Kimi providers

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -326,10 +326,20 @@ function resolveToolPolicies(params: {
   return policies;
 }
 
-function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
+export function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+    search?.brave?.apiKey ||
+    search?.perplexity?.apiKey ||
+    search?.gemini?.apiKey ||
+    search?.grok?.apiKey ||
+    search?.kimi?.apiKey ||
+    env.BRAVE_API_KEY ||
+    env.PERPLEXITY_API_KEY ||
+    env.GEMINI_API_KEY ||
+    env.XAI_API_KEY ||
+    env.KIMI_API_KEY,
   );
 }
 

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -9,6 +9,7 @@ import {
   collectInstalledSkillsCodeSafetyFindings,
   collectPluginsCodeSafetyFindings,
 } from "./audit-extra.js";
+import { hasWebSearchKey } from "./audit-extra.sync.js";
 import type { SecurityAuditOptions, SecurityAuditReport } from "./audit.js";
 import { runSecurityAudit } from "./audit.js";
 import * as skillScanner from "./skill-scanner.js";
@@ -3210,6 +3211,64 @@ description: test skill
           expect(getAuth()?.password, testCase.name).toBe(testCase.expectedPassword);
         }),
       );
+    });
+  });
+
+  describe("hasWebSearchKey", () => {
+    it("returns true for Brave key in config (legacy top-level)", () => {
+      const cfg: OpenClawConfig = { tools: { web: { search: { apiKey: "brave-key" } } } };
+      expect(hasWebSearchKey(cfg, {})).toBe(true);
+    });
+
+    it("returns true for Brave key in nested config path", () => {
+      const cfg: OpenClawConfig = {
+        tools: { web: { search: { brave: { apiKey: "brave-key" } } } },
+      };
+      expect(hasWebSearchKey(cfg, {})).toBe(true);
+    });
+
+    it("returns true for Perplexity key in config", () => {
+      const cfg: OpenClawConfig = {
+        tools: { web: { search: { perplexity: { apiKey: "perplexity-key" } } } },
+      };
+      expect(hasWebSearchKey(cfg, {})).toBe(true);
+    });
+
+    it("returns true for Gemini key in config (#34509)", () => {
+      const cfg: OpenClawConfig = {
+        tools: { web: { search: { gemini: { apiKey: "gemini-key" } } } },
+      };
+      expect(hasWebSearchKey(cfg, {})).toBe(true);
+    });
+
+    it("returns true for Grok key in config (#34509)", () => {
+      const cfg: OpenClawConfig = {
+        tools: { web: { search: { grok: { apiKey: "grok-key" } } } },
+      };
+      expect(hasWebSearchKey(cfg, {})).toBe(true);
+    });
+
+    it("returns true for Kimi key in config (#34509)", () => {
+      const cfg: OpenClawConfig = {
+        tools: { web: { search: { kimi: { apiKey: "kimi-key" } } } },
+      };
+      expect(hasWebSearchKey(cfg, {})).toBe(true);
+    });
+
+    it("returns true for GEMINI_API_KEY env var (#34509)", () => {
+      expect(hasWebSearchKey({}, { GEMINI_API_KEY: "gemini-key" })).toBe(true);
+    });
+
+    it("returns true for XAI_API_KEY env var (#34509)", () => {
+      expect(hasWebSearchKey({}, { XAI_API_KEY: "xai-key" })).toBe(true);
+    });
+
+    it("returns true for KIMI_API_KEY env var (#34509)", () => {
+      expect(hasWebSearchKey({}, { KIMI_API_KEY: "kimi-key" })).toBe(true);
+    });
+
+    it("returns false when no web search key is configured", () => {
+      expect(hasWebSearchKey({}, {})).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Problem:** `hasWebSearchKey` only checked `tools.web.search.apiKey` (legacy Brave top-level), `tools.web.search.perplexity.apiKey`, `BRAVE_API_KEY`, and `PERPLEXITY_API_KEY`. Configs using Gemini, Grok, or Kimi as the sole web search provider were treated as having no search key, causing `isWebSearchEnabled()` to return `false` and `web_search` to appear as disabled in security audit output.
- **Why it matters:** `isWebSearchEnabled` is used both for the security audit surface summary and to gate `web_search` in the exposure matrix. A false negative means a provider-specific setup doesn't appear in the audit, silently undercounting the attack surface.
- **What changed:** Added the missing provider config paths (`brave.apiKey`, `gemini.apiKey`, `grok.apiKey`, `kimi.apiKey`) and env vars (`GEMINI_API_KEY`, `XAI_API_KEY`, `KIMI_API_KEY`) to `hasWebSearchKey`. Also exported `hasWebSearchKey` for direct unit testing.
- **What did NOT change:** `isWebSearchEnabled` logic, audit severity levels, all other audit checks.

## Change Type

- [x] Bug fix

## Scope

- [x] API / contracts

## Linked Issue/PR

- Fixes #34509

## User-visible / Behavior Changes

Security audit output (`openclaw audit` or Control UI security tab) now correctly reflects web search as enabled when Gemini, Grok, or Kimi is configured as the sole provider. Previously these configs were silently treated as having no web search key.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No — this makes the audit *more accurate*, not less restrictive

## Repro + Verification

### Environment

- OS: any
- Runtime: Node 22+

### Steps

1. Configure `tools.web.search.gemini.apiKey` (or grok/kimi) without any Brave/Perplexity key
2. Run `openclaw audit`
3. Check the tool exposure summary

### Expected

- `web_search` appears in the audit output as enabled

### Actual (before fix)

- `web_search` does not appear — audit treats it as disabled

## Evidence

- [x] Failing test/log before + passing after

Added 9 unit tests in `audit.test.ts` directly testing `hasWebSearchKey` for each provider (config path and env var). 100 audit tests pass.

## Human Verification (required)

- Verified scenarios: traced `hasWebSearchKey` → `isWebSearchEnabled` → `collectExposureMatrixFindings`; confirmed the config schema paths (`tools.web.search.gemini.apiKey` etc.) match the labels in `schema.labels.ts` and the env var names match what `web-search.ts` reads at runtime
- Edge cases checked: legacy `search.apiKey` (Brave top-level) still works; empty env (`{}`) returns false; each provider independently returns true
- What you did **not** verify: live `openclaw audit` CLI output (requires a full gateway environment)

## Compatibility / Migration

- Backward compatible? Yes — only adds more conditions to return `true`
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert quickly: revert the 8 added lines in `src/security/audit-extra.sync.ts`
- Files/config to restore: `audit-extra.sync.ts` only
- Known bad symptoms: Gemini/Grok/Kimi web search appears absent from audit again (returns to pre-fix state)

## Risks and Mitigations

- Risk: `search?.brave?.apiKey` — the `brave` nested path may not exist in the config schema
  - Mitigation: optional chaining (`?.`) makes it safe; if the path doesn't exist in the schema it simply evaluates to `undefined` without error. The Brave provider path is documented in `schema.labels.ts` line 213.