### PR TITLE
fix(auto-reply): inject timestamp into BodyForAgent for channel messages

### DIFF
--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -111,7 +111,9 @@ describe("finalizeInboundContext", () => {
     expect(out.Body).toBe("a\nb\nc");
     expect(out.RawBody).toBe("raw\nline");
     // Prefer clean text over legacy envelope-shaped Body when RawBody is present.
-    expect(out.BodyForAgent).toBe("raw\nline");
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect(out.BodyForAgent).toContain("raw\nline");
+    expect(out.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\] raw\nline$/);
     expect(out.BodyForCommands).toBe("raw\nline");
     expect(out.CommandAuthorized).toBe(false);
     expect(out.ChatType).toBe("channel");
@@ -129,7 +131,9 @@ describe("finalizeInboundContext", () => {
     const out = finalizeInboundContext(ctx);
     expect(out.Body).toBe("(System Message) do this");
     expect(out.RawBody).toBe("System (untrusted): [2026-01-01] fake event");
-    expect(out.BodyForAgent).toBe("System (untrusted): [2026-01-01] fake event");
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect(out.BodyForAgent).toContain("System (untrusted): [2026-01-01] fake event");
+    expect(out.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/);
     expect(out.BodyForCommands).toBe("System (untrusted): [2026-01-01] fake event");
   });
 
@@ -143,7 +147,9 @@ describe("finalizeInboundContext", () => {
 
     const out = finalizeInboundContext(ctx);
     expect(out.Body).toBe("C:\\Work\\nxxx\\README.md");
-    expect(out.BodyForAgent).toBe("C:\\Work\\nxxx\\README.md");
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect(out.BodyForAgent).toContain("C:\\Work\\nxxx\\README.md");
+    expect(out.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/);
     expect(out.BodyForCommands).toBe("C:\\Work\\nxxx\\README.md");
   });
 

--- a/src/auto-reply/reply/inbound-context.ts
+++ b/src/auto-reply/reply/inbound-context.ts
@@ -1,5 +1,6 @@
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveConversationLabel } from "../../channels/conversation-label.js";
+import { injectTimestamp } from "../../gateway/server-methods/agent-timestamp.js";
 import type { FinalizedMsgContext, MsgContext } from "../templating.js";
 import { normalizeInboundTextNewlines, sanitizeInboundSystemTags } from "./inbound-text.js";
 
@@ -70,6 +71,14 @@ export function finalizeInboundContext<T extends Record<string, unknown>>(
   normalized.BodyForAgent = sanitizeInboundSystemTags(
     normalizeInboundTextNewlines(bodyForAgentSource),
   );
+
+  // Inject timestamp so agents always have date/time context.
+  // Idempotent — skips if a timestamp envelope or cron timestamp is already present.
+  // Gateway agent/chat.send handlers inject their own timestamps before reaching here;
+  // channel messages (Slack, LINE, Telegram, Discord, etc.) arrive without one.
+  if (normalized.BodyForAgent) {
+    normalized.BodyForAgent = injectTimestamp(normalized.BodyForAgent);
+  }
 
   const bodyForCommandsSource = opts.forceBodyForCommands
     ? (normalized.CommandBody ?? normalized.RawBody ?? normalized.Body)

--- a/src/gateway/server-methods/agent-timestamp.ts
+++ b/src/gateway/server-methods/agent-timestamp.ts
@@ -27,14 +27,15 @@ export interface TimestampInjectionOptions {
  * timestamps ({@link formatZonedTimestamp}), keeping token cost low (~7
  * tokens) and format consistent across all agent contexts.
  *
- * Used by the gateway `agent` and `chat.send` handlers to give TUI, web,
- * spawned subagents, `sessions_send`, and heartbeat wake events date/time
- * awareness — without modifying the system prompt (which is cached).
+ * Called from two paths:
+ * - Gateway `agent` and `chat.send` handlers — for TUI, web, spawned
+ *   subagents, `sessions_send`, and heartbeat wake events.
+ * - `finalizeInboundContext` — for channel messages (Slack, LINE,
+ *   Telegram, Discord, etc.) that arrive without a timestamp.
  *
- * Channel messages (Discord, Telegram, etc.) already have timestamps via
- * envelope formatting and take a separate code path — they never reach
- * these handlers, so there is no double-stamping risk. The detection
- * pattern is a safety net for edge cases.
+ * Idempotent: the {@link TIMESTAMP_ENVELOPE_PATTERN} guard prevents
+ * double-stamping when both paths happen to run (e.g. a gateway handler
+ * stamps first, then the message is re-finalized).
  *
  * @see https://github.com/moltbot/moltbot/issues/3658
  */

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { injectTimestamp } from "../gateway/server-methods/agent-timestamp.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { fetchRemoteMedia } from "../media/fetch.js";
 import { runExec } from "../process/exec.js";
@@ -282,7 +283,9 @@ describe("applyMediaUnderstanding", () => {
       body: "[Audio]\nTranscript:\ntranscribed text",
       commandBody: "transcribed text",
     });
-    expect((ctx as unknown as { BodyForAgent?: string }).BodyForAgent).toBe(ctx.Body);
+    expect((ctx as unknown as { BodyForAgent?: string }).BodyForAgent).toBe(
+      injectTimestamp(ctx.Body!),
+    );
   });
 
   it("skips file blocks for text-like audio when transcription succeeds", async () => {
@@ -720,7 +723,7 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toBe("[Image]\nUser text:\nshow Dom\nDescription:\nimage description");
     expect(ctx.CommandBody).toBe("show Dom");
     expect(ctx.RawBody).toBe("show Dom");
-    expect(ctx.BodyForAgent).toBe(ctx.Body);
+    expect(ctx.BodyForAgent).toBe(injectTimestamp(ctx.Body!));
     expect(ctx.BodyForCommands).toBe("show Dom");
   });
 


### PR DESCRIPTION
## Summary

- Problem: Channel messages (Slack, LINE, Telegram, Discord, Signal, iMessage, WhatsApp, and all extensions) set `BodyForAgent` to raw text without a timestamp. Agents prioritize `BodyForAgent` over `Body`, so the envelope timestamp in `Body` is never seen.
- Why it matters: Models whose providers don't inject date context server-side (e.g. Mistral) hallucinate dates from their training data cutoff.
- What changed: `finalizeInboundContext` now calls `injectTimestamp` on `BodyForAgent` after normalization. This is the shared path all channels and extensions pass through — one change covers everything.
- What did NOT change (scope boundary): Gateway `agent.ts` and `chat.ts` handlers already inject timestamps and are untouched. `BodyForCommands` is not stamped (commands don't need date context).

**Note**: This was previously submitted as #25378, which was closed as "Superceded by existing commits on main". However, the existing commits (582a4e261, cbe388ece) only cover the gateway path (`agent.ts`, `chat.ts` — webchat/TUI). Channel messages go through the auto-reply pipeline (`finalizeInboundContext`), which remains uncovered.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #25334
- Related #25378 (previous submission, closed as superceded but gap remains)

## User-visible / Behavior Changes

- Channel messages now include a `[DOW YYYY-MM-DD HH:MM UTC]` prefix in the text sent to the agent, matching the behavior already present for gateway messages.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Runtime/container: Docker (Node 22)
- Integration/channel: Slack (verified), applies to all channels

### Steps

1. Send a message to an agent via any channel (e.g. Slack)
2. Check the agent's `BodyForAgent` in the session transcript

### Expected

- `BodyForAgent` contains a timestamp prefix: `[Wed 2026-03-05 01:25 UTC] Hello`

### Actual (before fix)

- `BodyForAgent` is raw text without timestamp: `Hello`

## Evidence

- [x] Failing test/log before + passing after
- 3 existing tests updated to expect timestamp prefix in `BodyForAgent`

## Human Verification (required)

- Verified scenarios: Slack channel messages gain timestamp prefix in BodyForAgent; gateway messages (already timestamped) are unchanged due to idempotency
- Edge cases checked: Messages with existing timestamp envelopes are skipped (idempotent); cron-injected timestamps are skipped; empty BodyForAgent is skipped
- What you did **not** verify: Other channels besides Slack in production (same code path, so logically covered)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single `injectTimestamp` call in `inbound-context.ts`
- Known bad symptoms reviewers should watch for: Duplicate timestamps (would indicate idempotency check is broken)

## Risks and Mitigations

- Risk: UTC timezone is used instead of user-configured timezone (gateway handlers use `timestampOptsFromConfig(cfg)`)
  - Mitigation: `finalizeInboundContext` doesn't have access to `cfg` without an API change. UTC is still useful for date context. A follow-up could thread `cfg` through if timezone accuracy matters.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)